### PR TITLE
Fix blank page by using development index

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,7 @@ import reactRefresh from "eslint-plugin-react-refresh";
 import prettier from "eslint-config-prettier";
 
 export default [
+  { ignores: ["dist/**", "node_modules/**"] },
   js.configs.recommended,
   ...tseslint.configs.recommended,
   {


### PR DESCRIPTION
## Summary
- remove generated `dist` output from repo
- restore development index and 404 pages referencing `main.tsx`
- ignore the dist folder again in `.gitignore`

## Testing
- `npm run type-check`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6876900211808323813658010efaca4e