### PR TITLE
vNext: interactive herb index improvements

### DIFF
--- a/src/components/HerbCard.tsx
+++ b/src/components/HerbCard.tsx
@@ -3,28 +3,16 @@ import type { Herb } from '../types';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ChevronDown } from 'lucide-react';
 import clsx from 'clsx';
+import { decodeTag, safetyColorClass } from '../utils/format';
 
 interface Props {
   herb: Herb;
 }
 
-function decodeTag(tag: string) {
-  try {
-    return JSON.parse(`"${tag}"`);
-  } catch {
-    return tag;
-  }
-}
-
 export default function HerbCard({ herb }: Props) {
   const [open, setOpen] = useState(false);
 
-  const safetyColor =
-    herb.safetyRating && herb.safetyRating <= 1
-      ? 'text-green-400'
-      : herb.safetyRating === 2
-        ? 'text-yellow-300'
-        : 'text-red-400';
+  const safetyColor = safetyColorClass(herb.safetyRating);
 
   return (
     <div className="glass-card overflow-hidden rounded-lg">
@@ -121,6 +109,25 @@ export default function HerbCard({ herb }: Props) {
                     <p className="mt-1 pl-2 text-gray-300">{content}</p>
                   </details>
                 ),
+            )}
+            {herb.sourceRefs && herb.sourceRefs.length > 0 && (
+              <div>
+                <strong>Sources:</strong>
+                <ul className="list-disc pl-5">
+                  {herb.sourceRefs.map((ref) => (
+                    <li key={ref}>
+                      <a
+                        href={ref}
+                        className="underline"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {ref}
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
             )}
           </motion.div>
         )}

--- a/src/components/HerbGrid.tsx
+++ b/src/components/HerbGrid.tsx
@@ -1,15 +1,34 @@
+import { useState } from 'react';
 import HerbCard from './HerbCard';
 import type { Herb } from '../types';
-import data from '../data/herbs.json';
 
-const herbs = data as Herb[];
+interface Props {
+  herbs: Herb[];
+}
 
-export default function HerbGrid() {
+export default function HerbGrid({ herbs }: Props) {
+  const [visible, setVisible] = useState(12);
+  const toShow = herbs.slice(0, visible);
+  const hasMore = visible < herbs.length;
+
   return (
-    <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-      {herbs.map((herb) => (
-        <HerbCard key={herb.id || herb.name} herb={herb} />
-      ))}
-    </div>
+    <>
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {toShow.map((herb) => (
+          <HerbCard key={herb.id || herb.name} herb={herb} />
+        ))}
+      </div>
+      {hasMore && (
+        <div className="mt-6 flex justify-center">
+          <button
+            type="button"
+            onClick={() => setVisible((v) => v + 12)}
+            className="rounded bg-purple-600 px-4 py-2 text-white"
+          >
+            Load More
+          </button>
+        </div>
+      )}
+    </>
   );
 }

--- a/src/components/SearchFilter.tsx
+++ b/src/components/SearchFilter.tsx
@@ -1,35 +1,115 @@
 import React from 'react';
 import type { Herb } from '../types';
+import { decodeTag } from '../utils/format';
 
 interface SearchFilterProps {
   herbs: Herb[];
   onFilter: (filtered: Herb[]) => void;
 }
 
+type SortKey = '' | 'intensity' | 'onset' | 'safetyRating';
+
 const SearchFilter: React.FC<SearchFilterProps> = ({ herbs, onFilter }) => {
   const [query, setQuery] = React.useState('');
+  const [selectedTags, setSelectedTags] = React.useState<string[]>([]);
+  const [sort, setSort] = React.useState<SortKey>('');
 
-  const handleSearch = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const allTags = React.useMemo(() => {
+    const tags = herbs.reduce((acc: string[], h: Herb) => acc.concat(h.tags), []);
+    return Array.from(new Set(tags));
+  }, [herbs]);
+
+  const handleAddTag = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const value = e.target.value;
-    setQuery(value);
-
-    const filtered = herbs.filter((herb) =>
-      herb.name.toLowerCase().includes(value.toLowerCase()) ||
-      herb.tags.some(tag => tag.toLowerCase().includes(value.toLowerCase()))
-    );
-
-    onFilter(filtered);
+    if (value && !selectedTags.includes(value)) {
+      setSelectedTags((t) => [...t, value]);
+    }
+    e.target.value = '';
   };
 
+  const removeTag = (tag: string) => {
+    setSelectedTags((tags) => tags.filter((t) => t !== tag));
+  };
+
+  const filtered = React.useMemo(() => {
+    const q = query.toLowerCase();
+    let res = herbs.filter((h: Herb) => {
+      if (q) {
+        const nameMatch = h.name.toLowerCase().includes(q) ||
+          (h.scientificName ?? '').toLowerCase().includes(q) ||
+          h.tags.some((t) => decodeTag(t).toLowerCase().includes(q));
+        if (!nameMatch) return false;
+      }
+
+      if (selectedTags.length && !selectedTags.every((t) => h.tags.includes(t))) {
+        return false;
+      }
+
+      return true;
+    });
+
+    if (sort === 'intensity') {
+      res = [...res].sort((a, b) => a.intensity.localeCompare(b.intensity));
+    } else if (sort === 'onset') {
+      res = [...res].sort((a, b) => a.onset.localeCompare(b.onset));
+    } else if (sort === 'safetyRating') {
+      res = [...res].sort(
+        (a, b) => (a.safetyRating ?? 0) - (b.safetyRating ?? 0)
+      );
+    }
+
+    return res;
+  }, [herbs, query, selectedTags, sort]);
+
+  React.useEffect(() => {
+    onFilter(filtered);
+  }, [filtered, onFilter]);
+
   return (
-    <div className="mb-8">
+    <div className="mb-8 space-y-4">
       <input
         type="text"
         placeholder="Search herbs..."
         value={query}
-        onChange={handleSearch}
-        className="w-full px-4 py-2 rounded-md bg-gray-900 text-white border border-gray-700 focus:outline-none focus:ring-2 focus:ring-purple-500"
+        onChange={(e) => setQuery(e.target.value)}
+        className="w-full rounded-md border border-gray-700 bg-gray-900 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-purple-500"
       />
+      <div className="flex flex-wrap items-center gap-2">
+        {selectedTags.map((tag) => (
+          <span
+            key={tag}
+            className="flex items-center gap-1 rounded-full bg-white/20 px-2 py-0.5 text-xs"
+          >
+            {decodeTag(tag)}
+            <button onClick={() => removeTag(tag)} aria-label="remove tag">
+              &times;
+            </button>
+          </span>
+        ))}
+        <select
+          onChange={handleAddTag}
+          className="rounded-md border border-gray-700 bg-gray-900 px-2 py-1 text-sm text-white"
+          defaultValue=""
+        >
+          <option value="">Add Tag Filter...</option>
+          {allTags.map((tag: string) => (
+            <option key={tag} value={tag}>
+              {decodeTag(tag)}
+            </option>
+          ))}
+        </select>
+
+        <select
+          value={sort}
+          onChange={(e) => setSort(e.target.value as SortKey)}
+          className="rounded-md border border-gray-700 bg-gray-900 px-2 py-1 text-sm text-white"
+        >
+          <option value="">Sort By...</option>
+          <option value="intensity">Intensity</option>
+          <option value="onset">Onset</option>
+          <option value="safetyRating">Safety</option>
+        </select>
+      </div>
     </div>
   );
 };

--- a/src/data/herbs.ts
+++ b/src/data/herbs.ts
@@ -1,0 +1,6 @@
+import type { Herb } from '../types';
+import data from './herbs.json';
+
+const herbs = data as Herb[];
+export default herbs;
+export { herbs };

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -3,18 +3,21 @@
 import React from 'react';
 import { Helmet } from 'react-helmet-async';
 import { motion } from 'framer-motion';
-import HerbCard from '../components/HerbCard';
-import data from '../data/herbs.json';
+import HerbGrid from '../components/HerbGrid';
+import SearchFilter from '../components/SearchFilter';
 import type { Herb } from '../types';
 
-const herbs: Herb[] = data as Herb[];
-
 export default function Database() {
-  const [query, setQuery] = React.useState('');
-  const filteredHerbs = herbs.filter((h) =>
-    h.name.toLowerCase().includes(query.toLowerCase()) ||
-    h.tags.some((t) => JSON.parse(`"${t}"`).toLowerCase().includes(query.toLowerCase()))
-  );
+  const [herbs, setHerbs] = React.useState<Herb[]>([]);
+  const [filtered, setFiltered] = React.useState<Herb[]>([]);
+
+  React.useEffect(() => {
+    import('../data/herbs.json').then((m) => {
+      const h = m.default as Herb[];
+      setHerbs(h);
+      setFiltered(h);
+    });
+  }, []);
 
   return (
     <>
@@ -40,19 +43,8 @@ export default function Database() {
             </p>
           </motion.div>
 
-          <input
-            type='text'
-            placeholder='Search herbs...'
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            className='mb-8 w-full rounded-md border border-gray-700 bg-gray-900 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-purple-500'
-          />
-
-          <div className='space-y-4'>
-            {filteredHerbs.map((herb) => (
-              <HerbCard key={herb.name} herb={herb} />
-            ))}
-          </div>
+          <SearchFilter herbs={herbs} onFilter={setFiltered} />
+          <HerbGrid herbs={filtered} />
         </div>
       </div>
     </>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,8 +1,18 @@
+import React from 'react';
 import { Helmet } from 'react-helmet-async';
 import HeroSection from '../components/HeroSection';
 import HerbGrid from '../components/HerbGrid';
+import type { Herb } from '../types';
 
 export default function Home() {
+  const [herbs, setHerbs] = React.useState<Herb[]>([]);
+
+  React.useEffect(() => {
+    import('../data/herbs.json').then((m) => {
+      setHerbs(m.default as Herb[]);
+    });
+  }, []);
+
   return (
     <>
       <Helmet>
@@ -14,7 +24,7 @@ export default function Home() {
       </Helmet>
       <HeroSection />
       <div className="mx-auto max-w-7xl px-4 py-20">
-        <HerbGrid />
+        <HerbGrid herbs={herbs} />
       </div>
     </>
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,4 +21,5 @@ export interface Herb {
   toxicityLD50?: string;
   description?: string;
   safetyRating?: number;
+  sourceRefs?: string[];
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,14 @@
+export function decodeTag(tag: string): string {
+  try {
+    return JSON.parse(`"${tag}"`);
+  } catch {
+    return tag;
+  }
+}
+
+export function safetyColorClass(rating?: number): string {
+  if (rating == null) return '';
+  if (rating <= 1) return 'text-green-400';
+  if (rating === 2) return 'text-yellow-300';
+  return 'text-red-400';
+}


### PR DESCRIPTION
## Summary
- add helper utils for tags and rating color
- implement data export as `herbs.ts`
- show full herb info with source links
- support pagination in `HerbGrid`
- overhaul `SearchFilter` with tag filters and sorting
- load herb data dynamically on Home and Database pages
- extend `Herb` type with `sourceRefs`

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876dad9725c83239c59f2bd2499355e