### PR TITLE
Enhance styling and animations

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,7 +1,10 @@
 export default function Footer() {
   return (
-    <footer className="py-6 text-center text-sm text-gray-400">
-      © {new Date().getFullYear()} The Hippie Scientist
+    <footer className="relative py-6 text-center text-sm text-gray-400">
+      <div className="absolute inset-0 mx-auto my-0 h-full w-11/12 rounded-full border border-psychedelic-purple/40 blur-sm" aria-hidden="true" />
+      <span className="relative bg-gradient-to-r from-psychedelic-purple to-psychedelic-pink bg-clip-text text-transparent">
+        © {new Date().getFullYear()} The Hippie Scientist
+      </span>
     </footer>
   );
 }

--- a/src/components/HerbCard.tsx
+++ b/src/components/HerbCard.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import type { Herb } from '../types';
 import { motion, AnimatePresence } from 'framer-motion';
-import { ChevronDown } from 'lucide-react';
+import { ChevronDown, Dna, FlaskConical, Pill, AlertTriangle } from 'lucide-react';
 import clsx from 'clsx';
 import { decodeTag, safetyColorClass } from '../utils/format';
 
@@ -9,17 +9,29 @@ interface Props {
   herb: Herb;
 }
 
+const categoryColors: Record<string, string> = {
+  Oneirogen: 'text-pink-400',
+  'Dissociative / Sedative': 'text-blue-400',
+  'Empathogen / Euphoriant': 'text-green-400',
+  'Ritual / Visionary': 'text-violet-400',
+  Other: 'text-orange-400',
+};
+
 export default function HerbCard({ herb }: Props) {
   const [open, setOpen] = useState(false);
+  const [openSections, setOpenSections] = useState<Record<string, boolean>>({});
 
   const safetyColor = safetyColorClass(herb.safetyRating);
 
   return (
-    <div className="glass-card overflow-hidden rounded-lg">
+    <motion.div
+      whileHover={{ scale: 1.03 }}
+      className="glass-card overflow-hidden rounded-lg transition-shadow hover:shadow-purple-500/40"
+    >
       <button
         type="button"
         onClick={() => setOpen(!open)}
-        className="flex w-full items-start justify-between p-4 text-left"
+        className="flex w-full items-start justify-between p-4 text-left transition active:scale-95"
         aria-expanded={open}
       >
         <div>
@@ -28,14 +40,18 @@ export default function HerbCard({ herb }: Props) {
             <p className="text-xs italic text-gray-400">{herb.scientificName}</p>
           )}
           <div className="mt-2 flex flex-wrap gap-1">
-            {herb.tags.map((tag) => (
-              <span
-                key={tag}
-                className="rounded-full bg-white/10 px-2 py-0.5 text-xs"
-              >
-                {decodeTag(tag)}
-              </span>
-            ))}
+            {herb.tags.map((tag) => {
+              const decoded = decodeTag(tag);
+              const match = decoded.match(/^(\p{Extended_Pictographic})(.*)/u);
+              const icon = match?.[1] || '';
+              const label = match ? match[2].trim() : decoded;
+              const color = categoryColors[herb.category] ?? 'text-purple-300';
+              return (
+                <span key={tag} className="tag-pill">
+                  {icon && <span className={color}>{icon}</span>} {label}
+                </span>
+              );
+            })}
           </div>
         </div>
         <ChevronDown
@@ -80,8 +96,8 @@ export default function HerbCard({ herb }: Props) {
             </div>
             {herb.effects.length > 0 && (
               <div>
-                <strong>Effects:</strong>
-                <ul className="list-disc pl-5">
+                <strong className="bg-gradient-to-tr from-pink-400 to-violet-600 bg-clip-text text-transparent">Effects:</strong>
+                <ul className="ml-4 list-disc text-sm text-slate-300">
                   {herb.effects.map((e) => (
                     <li key={e}>{e}</li>
                   ))}
@@ -90,39 +106,59 @@ export default function HerbCard({ herb }: Props) {
             )}
             {herb.description && <p>{herb.description}</p>}
 
-            {[
-              ['Mechanism of Action', herb.mechanismOfAction],
-              ['Pharmacokinetics', herb.pharmacokinetics],
-              ['Therapeutic Uses', herb.therapeuticUses],
-              ['Side Effects', herb.sideEffects],
-              ['Contraindications', herb.contraindications],
-              ['Drug Interactions', herb.drugInteractions],
-              ['Toxicity', herb.toxicity],
-              ['Toxicity LD50', herb.toxicityLD50],
-            ].map(
-              ([title, content]) =>
-                content && (
-                  <details key={title} className="pt-1">
-                    <summary className="cursor-pointer select-none font-medium">
-                      {title}
-                    </summary>
-                    <p className="mt-1 pl-2 text-gray-300">{content}</p>
-                  </details>
-                ),
-            )}
+            {(
+              [
+                { key: 'moa', title: 'Mechanism of Action', content: herb.mechanismOfAction, icon: Dna },
+                { key: 'pk', title: 'Pharmacokinetics', content: herb.pharmacokinetics, icon: FlaskConical },
+                { key: 'thera', title: 'Therapeutic Uses', content: herb.therapeuticUses },
+                { key: 'side', title: 'Side Effects', content: herb.sideEffects },
+                { key: 'contra', title: 'Contraindications', content: herb.contraindications },
+                { key: 'drug', title: 'Drug Interactions', content: herb.drugInteractions, icon: Pill },
+                { key: 'tox', title: 'Toxicity / LD50', content: herb.toxicity || herb.toxicityLD50, icon: AlertTriangle },
+              ] as { key: string; title: string; content?: string; icon?: React.ComponentType<any> }[]
+            ).map(({ key, title, content, icon: Icon }) => (
+              content && (
+                <div key={key} className="pt-1">
+                  <button
+                    type="button"
+                    onClick={() => setOpenSections((s) => ({ ...s, [key]: !s[key] }))}
+                    className="flex w-full items-center gap-2 font-medium text-left transition active:scale-95"
+                    aria-expanded={openSections[key] ?? false}
+                  >
+                    {Icon && <Icon className="h-4 w-4 text-pink-400" />}
+                    <span>{title}</span>
+                    <ChevronDown className={clsx('ml-auto h-4 w-4 transition-transform', openSections[key] && 'rotate-180')} />
+                  </button>
+                  <AnimatePresence initial={false}>
+                    {openSections[key] && (
+                      <motion.div
+                        key="content"
+                        initial={{ height: 0, opacity: 0 }}
+                        animate={{ height: 'auto', opacity: 1 }}
+                        exit={{ height: 0, opacity: 0 }}
+                        transition={{ duration: 0.3 }}
+                        className="overflow-hidden pl-6 text-gray-300"
+                      >
+                        <p className="mt-1">{content}</p>
+                      </motion.div>
+                    )}
+                  </AnimatePresence>
+                </div>
+              )
+            ))}
             {herb.sourceRefs && herb.sourceRefs.length > 0 && (
-              <div>
-                <strong>Sources:</strong>
-                <ul className="list-disc pl-5">
-                  {herb.sourceRefs.map((ref) => (
+              <div className="text-xs text-gray-400">
+                <strong className="text-sm text-gray-300">Sources:</strong>
+                <ul className="ml-4 list-decimal">
+                  {herb.sourceRefs.map((ref, i) => (
                     <li key={ref}>
                       <a
                         href={ref}
-                        className="underline"
+                        className="underline decoration-dotted"
                         target="_blank"
                         rel="noopener noreferrer"
                       >
-                        {ref}
+                        [{i + 1}] {ref}
                       </a>
                     </li>
                   ))}
@@ -132,6 +168,6 @@ export default function HerbCard({ herb }: Props) {
           </motion.div>
         )}
       </AnimatePresence>
-    </div>
+    </motion.div>
   );
 }

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,8 +1,14 @@
 import { motion } from 'framer-motion';
+import FloatingElements from './FloatingElements';
 
 export default function HeroSection() {
   return (
-    <section className="bg-cosmic-gradient relative flex min-h-screen flex-col items-center justify-center text-center">
+    <section className="relative flex min-h-screen flex-col items-center justify-center text-center overflow-hidden">
+      <motion.div
+        className="absolute inset-0 -z-10 bg-cosmic-gradient animate-gradient"
+        aria-hidden="true"
+      />
+      <FloatingElements />
       <motion.h1
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}

--- a/src/components/SearchFilter.tsx
+++ b/src/components/SearchFilter.tsx
@@ -66,7 +66,7 @@ const SearchFilter: React.FC<SearchFilterProps> = ({ herbs, onFilter }) => {
   }, [filtered, onFilter]);
 
   return (
-    <div className="mb-8 space-y-4">
+    <div className="sticky top-2 z-10 mb-8 space-y-4 rounded-lg bg-space-dark/70 p-4 backdrop-blur-md">
       <input
         type="text"
         placeholder="Search herbs..."
@@ -76,15 +76,14 @@ const SearchFilter: React.FC<SearchFilterProps> = ({ herbs, onFilter }) => {
       />
       <div className="flex flex-wrap items-center gap-2">
         {selectedTags.map((tag) => (
-          <span
+          <button
+            type="button"
             key={tag}
-            className="flex items-center gap-1 rounded-full bg-white/20 px-2 py-0.5 text-xs"
+            onClick={() => removeTag(tag)}
+            className="tag-pill"
           >
             {decodeTag(tag)}
-            <button onClick={() => removeTag(tag)} aria-label="remove tag">
-              &times;
-            </button>
-          </span>
+          </button>
         ))}
         <select
           onChange={handleAddTag}

--- a/src/index.css
+++ b/src/index.css
@@ -25,3 +25,16 @@ body {
 .bg-cosmic-gradient {
   background-image: radial-gradient(circle at 50% 50%, #7e22ce, #0f172a);
 }
+/* Animations and extra utilities */
+.tag-pill {
+  @apply inline-flex items-center gap-1 rounded-full bg-white/10 px-2 py-0.5 text-xs shadow-sm backdrop-blur-sm transition hover:bg-white/20;
+}
+
+@keyframes gradient-shift {
+  0%, 100% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+}
+.animate-gradient {
+  background-size: 200% 200%;
+  animation: gradient-shift 15s ease infinite;
+}


### PR DESCRIPTION
## Summary
- animate hero background with floating particles
- polish herb card design with glassmorphism and animated sections
- add sticky search filter styling
- glow footer with gradient ring
- utility classes for tag pills and animated gradients

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876dd926df8832394e00c1a327fa319