### PR TITLE
Improve site performance and fix Safety page types

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Psychedelic Botany &amp; Consciousness Exploration" />
     <meta property="og:title" content="The Hippie Scientist" />
-    <meta property="og:description" content="Psychedelic Botany &amp; Conscious Exploration broken!" />
+    <meta property="og:description" content="Psychedelic Botany &amp; Conscious Exploration" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://thehippiescientist.net" />
     <meta property="og:image" content="/icon-512x512.png" />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,27 @@
 import React from 'react'
 import { Routes, Route } from 'react-router-dom'
+import { Suspense } from 'react'
+import { LoadingScreen } from './components/LoadingScreen'
 import Navbar from './components/Navbar'
 import Footer from './components/Footer'
-import Home from './pages/Home'
-import BlogIndex from './pages/BlogIndex'
-import BlogPost from './pages/BlogPost'
-import NotFound from './pages/NotFound'
+const Home = React.lazy(() => import('./pages/Home'))
+const BlogIndex = React.lazy(() => import('./pages/BlogIndex'))
+const BlogPost = React.lazy(() => import('./pages/BlogPost'))
+const NotFound = React.lazy(() => import('./pages/NotFound'))
 
 function App() {
   return (
     <>
       <Navbar />
       <main className='pt-20'>
-        <Routes>
-          <Route path='/' element={<Home />} />
-          <Route path='/blog' element={<BlogIndex />} />
-          <Route path='/blog/:slug' element={<BlogPost />} />
-          <Route path='*' element={<NotFound />} />
-        </Routes>
+        <Suspense fallback={<LoadingScreen />}>
+          <Routes>
+            <Route path='/' element={<Home />} />
+            <Route path='/blog' element={<BlogIndex />} />
+            <Route path='/blog/:slug' element={<BlogPost />} />
+            <Route path='*' element={<NotFound />} />
+          </Routes>
+        </Suspense>
       </main>
       <Footer />
     </>

--- a/src/pages/Safety.tsx
+++ b/src/pages/Safety.tsx
@@ -56,34 +56,36 @@ const Safety: React.FC = () => {
 
           {/* Safety Guidelines */}
           <div className='grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3'>
-            {[
-              {
-                icon: Shield,
-                title: 'Set & Setting',
-                description:
-                  'Understanding the importance of mindset and environment for safe experiences.',
-              },
-              {
-                icon: Heart,
-                title: 'Health Screening',
-                description: 'Pre-experience health considerations and contraindications.',
-              },
-              {
-                icon: AlertTriangle,
-                title: 'Risk Assessment',
-                description: 'Identifying and mitigating potential risks and interactions.',
-              },
-            ].map((item, index) => (
+            {(
+              [
+                {
+                  icon: Shield,
+                  title: 'Set & Setting',
+                  description:
+                    'Understanding the importance of mindset and environment for safe experiences.',
+                },
+                {
+                  icon: Heart,
+                  title: 'Health Screening',
+                  description: 'Pre-experience health considerations and contraindications.',
+                },
+                {
+                  icon: AlertTriangle,
+                  title: 'Risk Assessment',
+                  description: 'Identifying and mitigating potential risks and interactions.',
+                },
+              ] as { icon: React.ElementType; title: string; description: string }[]
+            ).map(({ icon: Icon, title, description }, index) => (
               <motion.div
-                key={item.title}
+                key={title}
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.8, delay: index * 0.2 }}
                 className='glass-card p-6'
               >
-                <item.icon className='mx-auto mb-4 h-12 w-12 text-psychedelic-purple' />
-                <h3 className='mb-4 text-center text-xl font-bold text-white'>{item.title}</h3>
-                <p className='text-center text-gray-300'>{item.description}</p>
+                <Icon className='mx-auto mb-4 h-12 w-12 text-psychedelic-purple' />
+                <h3 className='mb-4 text-center text-xl font-bold text-white'>{title}</h3>
+                <p className='text-center text-gray-300'>{description}</p>
               </motion.div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- lazy load pages for better load times
- fix meta description and add compatibility meta
- type safety for icon map in Safety page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68778b8241848323bd8f814eaab1013f