### PR TITLE
Fix GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,29 +6,20 @@ on:
 
 permissions:
   contents: write
-  pages: write
-  id-token: write
 
 jobs:
-  build:
+  deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '18'
           cache: 'npm'
-      - run: npm ci
+      - run: npm install
       - run: npm run build
-      - uses: actions/upload-pages-artifact@v3
+      - uses: peaceiris/actions-gh-pages@v3
         with:
-          path: ./dist
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
-    steps:
-      - uses: actions/deploy-pages@v4
-        id: deploy
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
+          publish_branch: gh-pages


### PR DESCRIPTION
## Summary
- fix the deploy workflow
  - use Node.js v18
  - run `npm install` instead of `npm ci`
  - build with `npm run build`
  - deploy `dist/` to `gh-pages` via `peaceiris/actions-gh-pages`

## Testing
- `npm install` *(fails: integrity checksum failed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6877b89b40c88323ba5aa50d7d0d81e4