### PR TITLE
Fix deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,8 +16,8 @@ jobs:
         with:
           node-version: '18'
           cache: 'npm'
-      - run: npm install
-      - run: npm run build
+      - run: npm install --prefer-offline --no-audit
+      - run: rm -rf dist && npm run build
       - uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "vite": "4.5.14",
         "gh-pages": "6.3.0",
-        "react": "18.3.1",
-        "react-dom": "18.3.1"
+        "react": "18.2.0",
+        "react-dom": "18.2.0"
       }
     },
     "node_modules/vite": {
@@ -25,13 +25,13 @@
       "integrity": "sha512-ghpageshash"
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-reacthash"
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-reactdomhash"
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "deploy": "npm run build && gh-pages -d dist"
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
   },
   "devDependencies": {
     "vite": "4.5.14",


### PR DESCRIPTION
## Summary
- update deploy workflow to reduce npm integrity issues
- pin React dependencies and lockfile to 18.2.0

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6877c369bfb0832397a79416eaf0f9fe