### PR TITLE
Improve deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,14 +11,19 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'npm'
-      - run: npm install
-      - run: npm run build
-      - uses: peaceiris/actions-gh-pages@v3
+      - name: Install dependencies
+        run: npm install --prefer-offline --no-audit
+      - name: Build site
+        run: rm -rf dist && npm run build
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "vite": "4.5.14",
         "gh-pages": "6.3.0",
-        "react": "18.3.1",
-        "react-dom": "18.3.1"
+        "react": "18.2.0",
+        "react-dom": "18.2.0"
       }
     },
     "node_modules/vite": {
@@ -25,13 +25,13 @@
       "integrity": "sha512-ghpageshash"
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-reacthash"
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-reactdomhash"
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "deploy": "npm run build && gh-pages -d dist"
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
   },
   "devDependencies": {
     "vite": "4.5.14",


### PR DESCRIPTION
## Summary
- add explicit names for steps in deploy workflow
- keep Node 18 with offline npm install and clean build
- pin dependencies to React 18.2.0 and Vite 4.5.14

## Testing
- `npm test` *(fails: Missing script)*
- `npm install --prefer-offline --no-audit` *(fails: tarball integrity)*

------
https://chatgpt.com/codex/tasks/task_e_6877c369bfb0832397a79416eaf0f9fe