### PR TITLE
Refine hero layout and forest theme

### DIFF
--- a/src/components/FloatingElements.tsx
+++ b/src/components/FloatingElements.tsx
@@ -1,33 +1,32 @@
-
-import React, { useMemo } from 'react';
-import { motion } from 'framer-motion';
+import React, { useMemo } from 'react'
+import { motion } from 'framer-motion'
 
 const FloatingElements: React.FC = () => {
-  const elements = useMemo(() =>
-    Array.from({ length: 20 }, (_, i) => ({
-      id: i,
-      size: Math.random() * 60 + 20,
-      x: Math.random() * 100,
-      y: Math.random() * 100,
-      duration: Math.random() * 10 + 10,
-      delay: Math.random() * 5,
-    })), []);
+  const elements = useMemo(
+    () =>
+      Array.from({ length: 20 }, (_, i) => ({
+        id: i,
+        size: Math.random() * 60 + 20,
+        x: Math.random() * 100,
+        y: Math.random() * 100,
+        duration: Math.random() * 10 + 10,
+        delay: Math.random() * 5,
+      })),
+    []
+  )
 
   return (
-    <div
-      className="fixed inset-0 overflow-hidden pointer-events-none"
-      aria-hidden="true"
-    >
-      {elements.map((element) => (
+    <div className='pointer-events-none fixed inset-0 overflow-hidden' aria-hidden='true'>
+      {elements.map(element => (
         <motion.div
           key={element.id}
-          className="absolute rounded-full"
+          className='absolute rounded-full'
           style={{
             width: element.size,
             height: element.size,
             left: `${element.x}%`,
             top: `${element.y}%`,
-            background: `radial-gradient(circle, rgba(139, 92, 246, 0.1) 0%, transparent 70%)`,
+            background: `radial-gradient(circle, rgba(34, 197, 94, 0.15) 0%, transparent 70%)`,
             willChange: 'transform, opacity',
           }}
           animate={{
@@ -45,7 +44,7 @@ const FloatingElements: React.FC = () => {
         />
       ))}
     </div>
-  );
-};
+  )
+}
 
-export default FloatingElements;
+export default FloatingElements

--- a/src/components/HerbCard.tsx
+++ b/src/components/HerbCard.tsx
@@ -34,7 +34,7 @@ export default function HerbCard({ herb }: Props) {
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       whileHover={{ scale: 1.05 }}
-      className='glass-card overflow-hidden rounded-lg transition-shadow hover:shadow-glow hover:ring-2 hover:ring-lichen/50'
+      className='glass-card overflow-hidden rounded-lg shadow-md transition-shadow hover:shadow-lg hover:ring-2 hover:ring-forest-green/60'
     >
       <button
         type='button'
@@ -76,8 +76,8 @@ export default function HerbCard({ herb }: Props) {
           <button
             type='button'
             onClick={e => {
-              e.stopPropagation();
-              toggle(herb.id);
+              e.stopPropagation()
+              toggle(herb.id)
             }}
             aria-label='Toggle favorite'
             className='text-pink-400 transition hover:scale-110'
@@ -89,7 +89,9 @@ export default function HerbCard({ herb }: Props) {
               )}
             />
           </button>
-          <ChevronDown className={clsx('mt-1 h-5 w-5 transition-transform', open && 'rotate-180')} />
+          <ChevronDown
+            className={clsx('mt-1 h-5 w-5 transition-transform', open && 'rotate-180')}
+          />
         </div>
       </button>
       <AnimatePresence initial={false}>

--- a/src/components/HeroBackground.tsx
+++ b/src/components/HeroBackground.tsx
@@ -39,7 +39,7 @@ const HeroBackground: React.FC = () => {
             left: `${p.x}%`,
             top: `${p.y}%`,
           }}
-          className='absolute rounded-full bg-white/20'
+          className='absolute rounded-full bg-forest-green/20'
           animate={{ y: [-10, 10, -10] }}
           transition={{
             duration: 8,

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -4,25 +4,27 @@ import HeroBackground from './HeroBackground'
 
 export default function HeroSection() {
   return (
-    <section className='relative flex min-h-screen flex-col items-center justify-center overflow-hidden text-center'>
+    <section className='relative flex min-h-screen items-center justify-center overflow-hidden px-6 py-16 text-center sm:py-24'>
       <HeroBackground />
       <FloatingElements />
-      <motion.h1
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.8 }}
-        className='mb-4 bg-cosmic-forest bg-clip-text font-display text-6xl font-bold text-transparent md:text-8xl'
-      >
-        The Hippie Scientist
-      </motion.h1>
-      <motion.p
-        initial={{ opacity: 0, y: 10 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.8, delay: 0.2 }}
-        className='max-w-xl text-xl text-gray-200 md:text-2xl'
-      >
-        Psychedelic Botany &amp; Conscious Exploration
-      </motion.p>
+      <motion.div className='relative z-10 max-w-screen-sm'>
+        <motion.h1
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8 }}
+          className='mb-4 font-display text-4xl font-bold text-white drop-shadow md:text-6xl'
+        >
+          The Hippie Scientist
+        </motion.h1>
+        <motion.p
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8, delay: 0.2 }}
+          className='mx-auto max-w-prose text-gray-200'
+        >
+          Psychedelic Botany &amp; Conscious Exploration
+        </motion.p>
+      </motion.div>
     </section>
   )
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -15,40 +15,38 @@ const Navbar: React.FC = () => {
   const isActive = (path: string) => location.pathname === path
 
   return (
-    <nav className='glass-card fixed left-0 right-0 top-0 z-50 m-4 rounded-2xl backdrop-blur-lg'>
-      <div className='mx-auto max-w-7xl px-4 sm:px-6 lg:px-8'>
-        <div className='flex h-16 items-center justify-between'>
-          <Link to='/' className='flex items-center space-x-2'>
-            <Atom className='h-8 w-8 text-lichen drop-shadow-glow' aria-hidden='true' />
-            <span className='text-gradient text-xl font-bold'>Hippie Scientist</span>
-          </Link>
+    <nav className='fixed left-0 right-0 top-0 z-50 bg-midnight-blue/50 backdrop-blur-md'>
+      <div className='mx-auto flex h-16 items-center justify-between px-6'>
+        <Link to='/' className='flex items-center space-x-2'>
+          <Atom className='drop-shadow-glow h-8 w-8 text-lichen' aria-hidden='true' />
+          <span className='text-gradient text-xl font-bold'>Hippie Scientist</span>
+        </Link>
 
-          <div className='md:hidden'>
-            <button
-              onClick={() => setIsOpen(!isOpen)}
-              className='p-2'
-              aria-label='Toggle navigation menu'
-              aria-expanded={isOpen}
+        <div className='md:hidden'>
+          <button
+            onClick={() => setIsOpen(!isOpen)}
+            className='p-2'
+            aria-label='Toggle navigation menu'
+            aria-expanded={isOpen}
+          >
+            {isOpen ? <X /> : <Menu />}
+          </button>
+        </div>
+
+        <div className='hidden space-x-4 md:flex'>
+          {navItems.map(({ path, label }) => (
+            <Link
+              key={path}
+              to={path}
+              className={`rounded-md px-3 py-2 text-sm font-medium transition-shadow ${
+                isActive(path)
+                  ? 'bg-cosmic-forest text-white shadow-glow'
+                  : 'text-gray-300 hover:shadow-glow'
+              }`}
             >
-              {isOpen ? <X /> : <Menu />}
-            </button>
-          </div>
-
-          <div className='hidden space-x-4 md:flex'>
-            {navItems.map(({ path, label }) => (
-              <Link
-                key={path}
-                to={path}
-                className={`rounded-md px-3 py-2 text-sm font-medium transition-shadow ${
-                  isActive(path)
-                    ? 'bg-cosmic-forest text-white shadow-glow'
-                    : 'text-gray-300 hover:shadow-glow'
-                }`}
-              >
-                {label}
-              </Link>
-            ))}
-          </div>
+              {label}
+            </Link>
+          ))}
         </div>
         {isOpen && (
           <motion.div

--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,7 @@
 @tailwind utilities;
 
 body {
-  @apply m-0 bg-space-dark font-sans text-lg leading-relaxed tracking-tight text-spore;
+  @apply m-0 bg-midnight-blue font-sans text-lg leading-relaxed tracking-tight text-spore;
 }
 
 html {
@@ -18,7 +18,7 @@ html {
 }
 
 .glass-card {
-  @apply border border-white/10 bg-bark/60 shadow backdrop-blur-lg transition-shadow duration-300 hover:ring-2 hover:ring-lichen/50;
+  @apply border border-white/10 bg-midnight-blue/60 shadow backdrop-blur-lg transition-shadow duration-300 hover:ring-2 hover:ring-forest-green/50;
 }
 
 .ring-comet {
@@ -30,10 +30,10 @@ html {
 }
 
 .bg-cosmic-gradient {
-  background-image: radial-gradient(circle at 50% 50%, #7e22ce, #0f172a);
+  background-image: radial-gradient(circle at 50% 50%, #312e81, #0c1126);
 }
 .bg-cosmic-forest {
-  background-image: linear-gradient(135deg, #0f172a, #1B4D3E, #7e22ce);
+  background-image: linear-gradient(135deg, #0c1126, #1b4d3e, #312e81);
 }
 /* Animations and extra utilities */
 .tag-pill {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,8 +6,11 @@ export default {
     extend: {
       colors: {
         midnight: '#0C0F13',
+        'midnight-blue': '#0c1126',
         lichen: '#88C057',
         comet: '#4FC1E9',
+        'forest-green': '#1B4D3E',
+        'deep-indigo': '#312e81',
         spore: '#FAFAFA',
         moss: '#A4D4AE',
         fungal: '#F2785C',
@@ -28,4 +31,4 @@ export default {
     },
   },
   plugins: [],
-};
+}


### PR DESCRIPTION
## Summary
- center hero text better and add spacing
- use forest color gradients and dark midnight background
- make animated particles green
- adjust navbar container and background
- polish HerbCard appearance

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6877ecb9a52083238b2013c297c80a1c