### PR TITLE
Improve hero and restore herb details

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;700&family=Inter:wght@400;700&family=IBM+Plex+Mono:wght@400;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;700&family=Marcellus&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,6 @@ import { Suspense } from 'react'
 import { LoadingScreen } from './components/LoadingScreen'
 import Navbar from './components/Navbar'
 import Footer from './components/Footer'
-import ParticlesBackground from './components/ParticlesBackground'
 const Home = React.lazy(() => import('./pages/Home'))
 const BlogIndex = React.lazy(() => import('./pages/BlogIndex'))
 const BlogPost = React.lazy(() => import('./pages/BlogPost'))
@@ -13,9 +12,8 @@ const NotFound = React.lazy(() => import('./pages/NotFound'))
 function App() {
   return (
     <>
-      <ParticlesBackground />
       <Navbar />
-      <main className='pt-20'>
+      <main className='pt-16 space-y-24'>
         <Suspense fallback={<LoadingScreen />}>
           <Routes>
             <Route path='/' element={<Home />} />

--- a/src/components/HerbCard.tsx
+++ b/src/components/HerbCard.tsx
@@ -34,7 +34,7 @@ export default function HerbCard({ herb }: Props) {
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       whileHover={{ scale: 1.05 }}
-      className='glass-card overflow-hidden rounded-lg shadow-md transition-shadow hover:shadow-lg hover:ring-2 hover:ring-forest-green/60'
+      className='glass-card overflow-hidden rounded-xl transition-shadow hover:shadow-glow hover:ring-2 hover:ring-lichen/50'
     >
       <button
         type='button'
@@ -44,7 +44,7 @@ export default function HerbCard({ herb }: Props) {
       >
         <div>
           <h2
-            className='text-lg font-semibold leading-snug'
+            className='text-lg font-display font-semibold leading-snug text-gold'
             data-tooltip-id={`sci-${herb.id}`}
             data-tooltip-content={herb.scientificName || ''}
           >
@@ -76,8 +76,8 @@ export default function HerbCard({ herb }: Props) {
           <button
             type='button'
             onClick={e => {
-              e.stopPropagation()
-              toggle(herb.id)
+              e.stopPropagation();
+              toggle(herb.id);
             }}
             aria-label='Toggle favorite'
             className='text-pink-400 transition hover:scale-110'
@@ -89,9 +89,7 @@ export default function HerbCard({ herb }: Props) {
               )}
             />
           </button>
-          <ChevronDown
-            className={clsx('mt-1 h-5 w-5 transition-transform', open && 'rotate-180')}
-          />
+          <ChevronDown className={clsx('mt-1 h-5 w-5 transition-transform', open && 'rotate-180')} />
         </div>
       </button>
       <AnimatePresence initial={false}>
@@ -102,7 +100,7 @@ export default function HerbCard({ herb }: Props) {
             animate={{ height: 'auto', opacity: 1 }}
             exit={{ height: 0, opacity: 0 }}
             transition={{ duration: 0.3 }}
-            className='space-y-3 overflow-hidden px-4 pb-4 text-sm text-gray-200'
+            className='space-y-3 overflow-hidden px-4 pb-4 text-sm text-sand'
           >
             <div className='flex flex-wrap gap-x-6 gap-y-1'>
               <p>
@@ -207,7 +205,7 @@ export default function HerbCard({ herb }: Props) {
                           animate={{ height: 'auto', opacity: 1 }}
                           exit={{ height: 0, opacity: 0 }}
                           transition={{ duration: 0.3 }}
-                          className='overflow-hidden pl-6 text-gray-300'
+                          className='overflow-hidden pl-6 text-sand/80'
                         >
                           <p className='mt-1'>{content}</p>
                         </motion.div>
@@ -217,8 +215,8 @@ export default function HerbCard({ herb }: Props) {
                 )
             )}
             {herb.sourceRefs && herb.sourceRefs.length > 0 && (
-              <div className='text-xs text-gray-400'>
-                <strong className='text-sm text-gray-300'>Sources:</strong>
+              <div className='text-xs text-sand/60'>
+                <strong className='text-sm text-sand'>Sources:</strong>
                 <ul className='ml-4 list-decimal'>
                   {herb.sourceRefs.map((ref, i) => (
                     <li key={ref}>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,29 +1,17 @@
 import { motion } from 'framer-motion'
-import FloatingElements from './FloatingElements'
-import HeroBackground from './HeroBackground'
-
 export default function HeroSection() {
   return (
-    <section className='relative flex min-h-screen items-center justify-center overflow-hidden px-6 py-16 text-center sm:py-24'>
-      <HeroBackground />
-      <FloatingElements />
-      <motion.div className='relative z-10 max-w-screen-sm'>
-        <motion.h1
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8 }}
-          className='mb-4 font-display text-4xl font-bold text-white drop-shadow md:text-6xl'
-        >
-          The Hippie Scientist
-        </motion.h1>
-        <motion.p
-          initial={{ opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ duration: 0.8, delay: 0.2 }}
-          className='mx-auto max-w-prose text-gray-200'
-        >
-          Psychedelic Botany &amp; Conscious Exploration
-        </motion.p>
+    <section className='relative flex min-h-screen items-center justify-center overflow-hidden text-center'>
+      <div className='absolute inset-0 -z-10 bg-gradient-to-br from-deep-indigo via-midnight to-forest-green opacity-60' />
+      <div className='absolute inset-0 -z-20 bg-[radial-gradient(circle,rgba(215,181,109,0.15),transparent)] animate-ripple' />
+      <motion.div
+        className='glass-card relative z-10 px-6 py-12'
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.8 }}
+      >
+        <h1 className='mb-4 font-display text-5xl text-gold md:text-6xl'>The Hippie Scientist</h1>
+        <p className='text-lg text-opal'>Psychedelic Botany &amp; Conscious Exploration</p>
       </motion.div>
     </section>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,11 @@
-@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;700&family=Inter:wght@400;700&family=IBM+Plex+Mono:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;700&family=Marcellus&display=swap');
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 body {
-  @apply m-0 bg-midnight-blue font-sans text-lg leading-relaxed tracking-tight text-spore;
+  @apply m-0 bg-midnight font-sans text-lg leading-relaxed tracking-tight text-sand;
 }
 
 html {
@@ -18,7 +18,7 @@ html {
 }
 
 .glass-card {
-  @apply border border-white/10 bg-midnight-blue/60 shadow backdrop-blur-lg transition-shadow duration-300 hover:ring-2 hover:ring-forest-green/50;
+  @apply border border-white/10 bg-midnight/50 shadow backdrop-blur-lg transition-shadow duration-300 hover:shadow-glow hover:ring-2 hover:ring-forest-green/50;
 }
 
 .ring-comet {
@@ -52,4 +52,18 @@ html {
 .animate-gradient {
   background-size: 200% 200%;
   animation: gradient-shift 15s ease infinite;
+}
+
+@keyframes ripple {
+  0%, 100% {
+    transform: scale(0.95);
+    opacity: 0.8;
+  }
+  50% {
+    transform: scale(1.05);
+    opacity: 1;
+  }
+}
+.animate-ripple {
+  animation: ripple 8s ease-in-out infinite;
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import { Helmet } from 'react-helmet-async'
 import HeroSection from '../components/HeroSection'
-import HerbGrid from '../components/HerbGrid'
-import PanelWrapper from '../components/PanelWrapper'
 import { useHerbs } from '../hooks/useHerbs'
+import HerbCard from '../components/HerbCard'
 
 export default function Home() {
   const herbs = useHerbs()
+  const featured = herbs[0]
 
   return (
     <>
@@ -15,9 +15,22 @@ export default function Home() {
         <meta name='description' content='Explore psychedelic botany and conscious exploration.' />
       </Helmet>
       <HeroSection />
-      <PanelWrapper className='mx-auto max-w-7xl px-4 py-20'>
-        <HerbGrid herbs={herbs} />
-      </PanelWrapper>
+      <section className='mx-auto max-w-6xl space-y-12 px-4 py-16'>
+        {featured && (
+          <div>
+            <h2 className='mb-4 font-display text-3xl text-gold'>Featured Herb</h2>
+            <HerbCard herb={featured} />
+          </div>
+        )}
+        <div>
+          <h2 className='mb-4 font-display text-3xl text-gold'>Herb Index</h2>
+          <div className='grid gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4'>
+            {herbs.map(h => (
+              <HerbCard key={h.id || h.name} herb={h} />
+            ))}
+          </div>
+        </div>
+      </section>
     </>
   )
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,4 +22,5 @@ export interface Herb {
   description?: string;
   safetyRating?: number;
   sourceRefs?: string[];
+  image?: string;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,7 +5,10 @@ export default {
   theme: {
     extend: {
       colors: {
-        midnight: '#0C0F13',
+        midnight: '#0b1120',
+        sand: '#f1e9d0',
+        gold: '#d7b56d',
+        opal: '#b2d0c9',
         'midnight-blue': '#0c1126',
         lichen: '#88C057',
         comet: '#4FC1E9',
@@ -25,8 +28,8 @@ export default {
         intense: '0 0 24px rgba(79, 193, 233, 0.4)',
       },
       fontFamily: {
-        display: ['"Space Grotesk"', 'sans-serif'],
-        sans: ['Inter', '"IBM Plex Mono"', 'sans-serif'],
+        display: ['"Marcellus"', 'serif'],
+        sans: ['"DM Sans"', 'sans-serif'],
       },
     },
   },


### PR DESCRIPTION
## Summary
- bring back the accordion herb card layout
- give hero and cards a glass/glow treatment
- lighten glass-card style for new palette

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68780b4cc0b48323b4126e4a52ce59fe