### PR TITLE
Revamp UI with neon glass theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;700&family=Marcellus&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Righteous&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "test": "echo \"No tests specified\" && exit 0"
   },
   "dependencies": {
+    "@tsparticles/engine": "^3.8.1",
+    "@tsparticles/react": "^3.0.0",
     "autoprefixer": "^10.4.19",
     "clsx": "^2.1.1",
     "framer-motion": "^10.16.1",
@@ -20,11 +22,12 @@
     "react-helmet-async": "^1.3.0",
     "react-router-dom": "^6.22.3",
     "react-tooltip": "^5.20.0",
-    "react-tsparticles": "^2.11.1",
     "tailwindcss": "^3.4.3",
-    "tsparticles": "^3.1.0"
+    "tsparticles": "^3.8.1"
   },
   "devDependencies": {
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.2.1",
     "postcss": "^8.4.31",
     "vite": "^4.5.14"

--- a/src/components/FloatingParticles.tsx
+++ b/src/components/FloatingParticles.tsx
@@ -3,25 +3,25 @@ import Particles from '@tsparticles/react'
 import type { Engine } from '@tsparticles/engine'
 import { loadFull } from 'tsparticles'
 
-export default function ParticlesBackground() {
+export default function FloatingParticles() {
   const init = useCallback(async (engine: Engine) => {
     await loadFull(engine)
   }, [])
 
   return (
     <Particles
-      id='tsparticles'
+      id='floating-particles'
       init={init}
       options={{
-        fullScreen: { enable: true, zIndex: -1 },
+        fullScreen: { enable: true, zIndex: -10 },
+        background: { color: 'transparent' },
         particles: {
           color: { value: '#ffffff' },
-          number: { value: 40, density: { enable: true, area: 800 } },
-          size: { value: 1 },
-          move: { enable: true, speed: 0.3 },
-          opacity: { value: 0.2 },
+          number: { value: 20, density: { enable: true, area: 800 } },
+          size: { value: 2 },
+          move: { enable: true, speed: 0.2 },
+          opacity: { value: 0.15 },
         },
-        background: { color: '#0c0c1a' },
       }}
     />
   )

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -1,0 +1,208 @@
+import { useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { ChevronRight } from 'lucide-react'
+import type { Herb } from '../types'
+import { decodeTag, tagVariant } from '../utils/format'
+import TagBadge from './TagBadge'
+
+interface Props {
+  herb: Herb
+}
+
+const categoryColors: Record<string, Parameters<typeof TagBadge>[0]['variant']> = {
+  Oneirogen: 'blue',
+  'Dissociative / Sedative': 'purple',
+  'Empathogen / Euphoriant': 'pink',
+  'Ritual / Visionary': 'green',
+  Other: 'yellow',
+}
+
+export default function HerbCardAccordion({ herb }: Props) {
+  const [open, setOpen] = useState(false)
+
+  const toggle = () => setOpen(v => !v)
+
+  const handleKey = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      toggle()
+    }
+  }
+
+  const containerVariants = {
+    hidden: {},
+    visible: { transition: { staggerChildren: 0.05 } },
+  }
+
+  const itemVariants = {
+    hidden: { opacity: 0, y: 8 },
+    visible: { opacity: 1, y: 0 },
+  }
+
+  return (
+    <motion.div
+      layout
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      onClick={toggle}
+      onKeyDown={handleKey}
+      tabIndex={0}
+      role='button'
+      aria-expanded={open}
+      className='cursor-pointer overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-br from-purple-950/40 via-fuchsia-900/30 to-sky-900/40 p-6 shadow-xl backdrop-blur-lg transition-all duration-300 hover:scale-105 hover:shadow-2xl hover:ring-2 hover:ring-fuchsia-400/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-fuchsia-400/60'
+    >
+      <div className='flex items-start justify-between gap-4'>
+        <div className='min-w-0'>
+          <h3 className='font-display text-xl text-opal'>{herb.name}</h3>
+          {herb.scientificName && <p className='text-xs italic text-sand'>{herb.scientificName}</p>}
+        </div>
+        <motion.span
+          initial={false}
+          animate={{ rotate: open ? 90 : 0 }}
+          className='text-cyan-200 transition-transform'
+        >
+          <ChevronRight size={18} />
+        </motion.span>
+      </div>
+      <div className='mt-2 flex flex-wrap gap-2'>
+        {herb.tags.slice(0, 2).map(tag => (
+          <TagBadge key={tag} label={decodeTag(tag)} variant={tagVariant(tag)} />
+        ))}
+      </div>
+
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            key='content'
+            initial='collapsed'
+            animate='open'
+            exit='collapsed'
+            variants={{
+              open: { opacity: 1, height: 'auto' },
+              collapsed: { opacity: 0, height: 0 },
+            }}
+            transition={{ duration: 0.4, ease: 'easeInOut' }}
+            className='overflow-hidden text-sm text-sand'
+          >
+            <motion.div
+              variants={containerVariants}
+              initial='hidden'
+              animate='visible'
+              exit='hidden'
+              className='mt-4 space-y-2'
+            >
+              <motion.div variants={itemVariants}>
+                <span className='font-semibold text-lime-300'>Category:</span>{' '}
+                <TagBadge
+                  label={herb.category}
+                  variant={categoryColors[herb.category] || 'purple'}
+                  className='ml-1'
+                />
+              </motion.div>
+              <motion.div variants={itemVariants}>
+                <span className='font-semibold text-lime-300'>Effects:</span>{' '}
+                {herb.effects.join(', ')}
+              </motion.div>
+              {herb.description && (
+                <motion.div variants={itemVariants}>{herb.description}</motion.div>
+              )}
+              {herb.mechanismOfAction && (
+                <motion.div variants={itemVariants}>
+                  <span className='font-semibold text-lime-300'>Mechanism:</span>{' '}
+                  {herb.mechanismOfAction}
+                </motion.div>
+              )}
+              {herb.therapeuticUses && (
+                <motion.div variants={itemVariants}>
+                  <span className='font-semibold text-lime-300'>Therapeutic Uses:</span>{' '}
+                  {herb.therapeuticUses}
+                </motion.div>
+              )}
+              {herb.sideEffects && (
+                <motion.div variants={itemVariants}>
+                  <span className='font-semibold text-lime-300'>Side Effects:</span>{' '}
+                  {herb.sideEffects}
+                </motion.div>
+              )}
+              {herb.contraindications && (
+                <motion.div variants={itemVariants}>
+                  <span className='font-semibold text-lime-300'>Contraindications:</span>{' '}
+                  {herb.contraindications}
+                </motion.div>
+              )}
+              {herb.drugInteractions && (
+                <motion.div variants={itemVariants}>
+                  <span className='font-semibold text-lime-300'>Drug Interactions:</span>{' '}
+                  {herb.drugInteractions}
+                </motion.div>
+              )}
+              {herb.preparation && (
+                <motion.div variants={itemVariants}>
+                  <span className='font-semibold text-lime-300'>Preparation:</span>{' '}
+                  {herb.preparation}
+                </motion.div>
+              )}
+              {herb.pharmacokinetics && (
+                <motion.div variants={itemVariants}>
+                  <span className='font-semibold text-lime-300'>Pharmacokinetics:</span>{' '}
+                  {herb.pharmacokinetics}
+                </motion.div>
+              )}
+              {herb.onset && (
+                <motion.div variants={itemVariants}>
+                  <span className='font-semibold text-lime-300'>Onset:</span> {herb.onset}
+                </motion.div>
+              )}
+              {herb.duration && (
+                <motion.div variants={itemVariants}>
+                  <span className='font-semibold text-lime-300'>Duration:</span> {herb.duration}
+                </motion.div>
+              )}
+              {herb.intensity && (
+                <motion.div variants={itemVariants}>
+                  <span className='font-semibold text-lime-300'>Intensity:</span> {herb.intensity}
+                </motion.div>
+              )}
+              {herb.region && (
+                <motion.div variants={itemVariants}>
+                  <span className='font-semibold text-lime-300'>Region:</span> {herb.region}
+                </motion.div>
+              )}
+              {herb.legalStatus && (
+                <motion.div variants={itemVariants}>
+                  <span className='font-semibold text-lime-300'>Legal Status:</span>{' '}
+                  {herb.legalStatus}
+                </motion.div>
+              )}
+              {herb.toxicity && (
+                <motion.div variants={itemVariants}>
+                  <span className='font-semibold text-lime-300'>Toxicity:</span> {herb.toxicity}
+                </motion.div>
+              )}
+              {herb.toxicityLD50 && (
+                <motion.div variants={itemVariants}>
+                  <span className='font-semibold text-lime-300'>Toxicity LD50:</span>{' '}
+                  {herb.toxicityLD50}
+                </motion.div>
+              )}
+              {herb.safetyRating != null && (
+                <motion.div variants={itemVariants}>
+                  <span className='font-semibold text-lime-300'>Safety Rating:</span>{' '}
+                  {herb.safetyRating}
+                </motion.div>
+              )}
+              {herb.tags.length > 0 && (
+                <motion.div variants={itemVariants} className='flex flex-wrap gap-2 pt-2'>
+                  {herb.tags.map(tag => (
+                    <TagBadge key={tag} label={decodeTag(tag)} variant={tagVariant(tag)} />
+                  ))}
+                </motion.div>
+              )}
+            </motion.div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </motion.div>
+  )
+}

--- a/src/components/HerbList.tsx
+++ b/src/components/HerbList.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import type { Herb } from '../types'
+import HerbCardAccordion from './HerbCardAccordion'
+
+interface Props {
+  herbs: Herb[]
+}
+
+const HerbList: React.FC<Props> = ({ herbs }) => {
+  return (
+    <div className='space-y-4'>
+      {herbs.map(h => (
+        <HerbCardAccordion key={h.id || h.name} herb={h} />
+      ))}
+    </div>
+  )
+}
+
+export default HerbList

--- a/src/components/TagBadge.tsx
+++ b/src/components/TagBadge.tsx
@@ -1,0 +1,32 @@
+import clsx from 'clsx'
+import { motion } from 'framer-motion'
+
+interface Props {
+  label: string
+  variant?: 'pink' | 'blue' | 'purple' | 'green' | 'yellow' | 'red'
+  className?: string
+}
+
+const colorMap = {
+  pink: 'from-pink-600 via-fuchsia-500 to-pink-600 shadow-pink-500/40',
+  blue: 'from-sky-600 via-cyan-500 to-sky-600 shadow-cyan-500/40',
+  purple: 'from-purple-700 via-violet-600 to-purple-700 shadow-violet-600/40',
+  green: 'from-lime-600 via-emerald-500 to-lime-600 shadow-emerald-500/40',
+  yellow: 'from-amber-600 via-yellow-500 to-amber-600 shadow-amber-500/40',
+  red: 'from-rose-600 via-red-500 to-rose-600 shadow-red-500/40',
+}
+
+export default function TagBadge({ label, variant = 'purple', className }: Props) {
+  return (
+    <motion.span
+      whileHover={{ scale: 1.05 }}
+      className={clsx(
+        'inline-flex items-center rounded-full bg-gradient-to-br px-2 py-0.5 text-xs font-medium text-white shadow',
+        colorMap[variant],
+        className,
+      )}
+    >
+      {label}
+    </motion.span>
+  )
+}

--- a/src/components/TagFilterBar.tsx
+++ b/src/components/TagFilterBar.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import clsx from 'clsx'
+import { decodeTag, tagVariant } from '../utils/format'
+import TagBadge from './TagBadge'
+
+interface Props {
+  tags: string[]
+  selected: string[]
+  onChange: (tags: string[]) => void
+}
+
+const TagFilterBar: React.FC<Props> = ({ tags, selected, onChange }) => {
+  const toggle = (tag: string) => {
+    if (selected.includes(tag)) {
+      onChange(selected.filter(t => t !== tag))
+    } else {
+      onChange([...selected, tag])
+    }
+  }
+
+  return (
+    <div className='flex overflow-x-auto gap-2 pb-4'>
+      {tags.map(tag => (
+        <button
+          key={tag}
+          type='button'
+          onClick={() => toggle(tag)}
+          className={clsx('flex-shrink-0 focus:outline-none')}
+        >
+          <TagBadge
+            label={decodeTag(tag)}
+            variant={selected.includes(tag) ? 'green' : tagVariant(tag)}
+            className={clsx(selected.includes(tag) && 'ring-1 ring-emerald-300')}
+          />
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export default TagFilterBar

--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,11 @@
-@import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;700&family=Marcellus&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Righteous&display=swap');
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 body {
-  @apply m-0 bg-midnight font-sans text-lg leading-relaxed tracking-tight text-sand;
+  @apply m-0 bg-space-night font-sans text-lg leading-relaxed tracking-tight text-sand;
 }
 
 html {
@@ -14,11 +14,11 @@ html {
 
 /* Custom utility classes */
 .text-gradient {
-  @apply bg-gradient-to-r from-lichen to-comet bg-clip-text text-transparent;
+  @apply bg-gradient-to-r from-sky-400 via-fuchsia-500 to-purple-600 bg-clip-text text-transparent;
 }
 
 .glass-card {
-  @apply border border-white/10 bg-midnight-blue/60 shadow backdrop-blur-lg transition-shadow duration-300 hover:ring-2 hover:ring-forest-green/50;
+  @apply border border-white/10 bg-space-dark/60 shadow-lg backdrop-blur-xl transition-shadow duration-300 hover:ring-2 hover:ring-fuchsia-500/50;
 }
 
 .ring-comet {

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -3,17 +3,24 @@
 import React from 'react'
 import { Helmet } from 'react-helmet-async'
 import { motion } from 'framer-motion'
-import HerbGrid from '../components/HerbGrid'
-import SearchFilter from '../components/SearchFilter'
+import HerbList from '../components/HerbList'
+import TagFilterBar from '../components/TagFilterBar'
+import FloatingParticles from '../components/FloatingParticles'
 import { useHerbs } from '../hooks/useHerbs'
 
 export default function Database() {
   const herbs = useHerbs()
-  const [filtered, setFiltered] = React.useState<typeof herbs>([])
+  const [selectedTags, setSelectedTags] = React.useState<string[]>([])
 
-  React.useEffect(() => {
-    setFiltered(herbs)
+  const allTags = React.useMemo(() => {
+    const t = herbs.reduce<string[]>((acc, h) => acc.concat(h.tags), [])
+    return Array.from(new Set(t))
   }, [herbs])
+
+  const filtered = React.useMemo(() => {
+    if (!selectedTags.length) return herbs
+    return herbs.filter(h => selectedTags.every(t => h.tags.includes(t)))
+  }, [herbs, selectedTags])
 
   return (
     <>
@@ -25,8 +32,9 @@ export default function Database() {
         />
       </Helmet>
 
-      <div className='min-h-screen px-4 pt-20'>
-        <div className='mx-auto max-w-7xl'>
+      <div className='relative min-h-screen px-4 pt-20'>
+        <FloatingParticles />
+        <div className='relative mx-auto max-w-3xl'>
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
@@ -39,8 +47,8 @@ export default function Database() {
             </p>
           </motion.div>
 
-          <SearchFilter herbs={herbs} onFilter={setFiltered} />
-          <HerbGrid herbs={filtered} />
+          <TagFilterBar tags={allTags} selected={selectedTags} onChange={setSelectedTags} />
+          <HerbList herbs={filtered} />
         </div>
       </div>
     </>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,7 +2,9 @@ import React from 'react'
 import { Helmet } from 'react-helmet-async'
 import HeroSection from '../components/HeroSection'
 import { useHerbs } from '../hooks/useHerbs'
-import HerbCard from '../components/HerbCard'
+import HerbList from '../components/HerbList'
+import HerbCardAccordion from '../components/HerbCardAccordion'
+import FloatingParticles from '../components/FloatingParticles'
 
 export default function Home() {
   const herbs = useHerbs()
@@ -15,22 +17,21 @@ export default function Home() {
         <meta name='description' content='Explore psychedelic botany and conscious exploration.' />
       </Helmet>
       <HeroSection />
-      <section className='mx-auto max-w-6xl space-y-12 px-4 py-16'>
-        {featured && (
+      <div className='relative'>
+        <FloatingParticles />
+        <section className='relative mx-auto max-w-6xl space-y-12 px-4 py-16'>
+          {featured && (
+            <div>
+              <h2 className='mb-4 font-display text-3xl text-gold'>Featured Herb</h2>
+              <HerbCardAccordion herb={featured} />
+            </div>
+          )}
           <div>
-            <h2 className='mb-4 font-display text-3xl text-gold'>Featured Herb</h2>
-            <HerbCard herb={featured} />
+            <h2 className='mb-4 font-display text-3xl text-gold'>Herb Index</h2>
+            <HerbList herbs={herbs} />
           </div>
-        )}
-        <div>
-          <h2 className='mb-4 font-display text-3xl text-gold'>Herb Index</h2>
-          <div className='grid gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4'>
-            {herbs.map(h => (
-              <HerbCard key={h.id || h.name} herb={h} />
-            ))}
-          </div>
-        </div>
-      </section>
+        </section>
+      </div>
     </>
   )
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface Herb {
   preparation: string;
   intensity: string;
   onset: string;
+  duration?: string;
   legalStatus: string;
   region: string;
   tags: string[];

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -21,3 +21,25 @@ export function intensityColorClass(intensity: string): string {
     return 'bg-red-600';
   return 'bg-gray-600';
 }
+
+export type TagVariant =
+  | 'pink'
+  | 'blue'
+  | 'purple'
+  | 'green'
+  | 'yellow'
+  | 'red';
+
+export function tagVariant(tag: string): TagVariant {
+  const decoded = decodeTag(tag);
+  if (decoded.includes('Toxic') || decoded.includes('Restricted')) return 'red';
+  if (decoded.includes('Safe')) return 'green';
+  if (decoded.includes('Stimulant') || decoded.includes('Euphoria')) return 'pink';
+  if (decoded.includes('Dissociation') || decoded.includes('Sedation')) return 'purple';
+  if (decoded.includes('Dream')) return 'blue';
+  if (decoded.includes('Cognitive')) return 'yellow';
+  if (decoded.includes('Brewable') || decoded.includes('Smokable')) return 'blue';
+  if (decoded.includes('Oral') || decoded.includes('Fermented')) return 'yellow';
+  if (decoded.includes('Ritual')) return 'green';
+  return 'purple';
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,6 +21,7 @@ export default {
         'psychedelic-purple': '#8b5cf6',
         'psychedelic-pink': '#ec4899',
         'space-dark': '#0f172a',
+        'space-night': '#0c0c1a',
         'cosmic-purple': '#7e22ce',
       },
       boxShadow: {
@@ -28,8 +29,8 @@ export default {
         intense: '0 0 24px rgba(79, 193, 233, 0.4)',
       },
       fontFamily: {
-        display: ['"Marcellus"', 'serif'],
-        sans: ['"DM Sans"', 'sans-serif'],
+        display: ['"Righteous"', 'cursive'],
+        sans: ['"Inter"', 'sans-serif'],
       },
     },
   },


### PR DESCRIPTION
## Summary
- switch global fonts to Righteous and Inter
- add TagBadge component for glowing tag pills
- rework HerbCardAccordion with psychedelic gradient styling
- update tag filter bar to use the new badges
- apply deep space colors and particles on the home page
- improve tag coloring
- align tsParticles packages with modern imports
- polish herb accordion interactions
- format HerbCardAccordion

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68781d51b8248323b0c0eda8868d4e12