### PR TITLE
Improve herb accordion animations

### DIFF
--- a/src/components/HerbList.tsx
+++ b/src/components/HerbList.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
 import type { Herb } from '../types'
 import HerbCardAccordion from './HerbCardAccordion'
 
@@ -8,11 +9,13 @@ interface Props {
 
 const HerbList: React.FC<Props> = ({ herbs }) => {
   return (
-    <div className='space-y-4'>
-      {herbs.map(h => (
-        <HerbCardAccordion key={h.id || h.name} herb={h} />
-      ))}
-    </div>
+    <motion.div layout className='space-y-4'>
+      <AnimatePresence>
+        {herbs.map(h => (
+          <HerbCardAccordion key={h.id || h.name} herb={h} />
+        ))}
+      </AnimatePresence>
+    </motion.div>
   )
 }
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -12,16 +12,16 @@ export default function Home() {
       <section className="space-y-10 max-w-4xl mx-auto">
 
         {/* 🌟 Featured Herb */}
-        <div>
+        <motion.div layout>
           <h2 className="mb-4 font-display text-3xl text-gold">Featured Herb</h2>
           <HerbCardAccordion herb={featured} />
-        </div>
+        </motion.div>
 
         {/* 🌿 Herb Index */}
-        <div>
+        <motion.div layout>
           <h2 className="mb-4 font-display text-3xl text-gold">Herb Index</h2>
           <HerbList herbs={herbs} />
-        </div>
+        </motion.div>
 
       </section>
     </main>


### PR DESCRIPTION
## Summary
- enhance HerbCardAccordion layout animations and styling
- pulse TagBadges and add `+ More Info` hover cue
- animate herb list rendering on homepage
- add layout wrappers to featured and index sections

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687887f512708323961a09b43d75289d