### PR TITLE
Add Learn section and UI upgrades

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,27 +5,31 @@ import { LoadingScreen } from './components/LoadingScreen'
 import Navbar from './components/Navbar'
 import Footer from './components/Footer'
 import MouseTrail from './components/MouseTrail'
+import ScrollToTopButton from './components/ScrollToTopButton'
 const Home = React.lazy(() => import('./pages/Home'))
 const BlogIndex = React.lazy(() => import('./pages/BlogIndex'))
 const BlogPost = React.lazy(() => import('./pages/BlogPost'))
 const NotFound = React.lazy(() => import('./pages/NotFound'))
+const Learn = React.lazy(() => import('./pages/Learn'))
 
 function App() {
   return (
     <>
       <Navbar />
       <MouseTrail />
-      <main className='pt-16 space-y-24'>
+      <main className='space-y-24 pt-16'>
         <Suspense fallback={<LoadingScreen />}>
           <Routes>
             <Route path='/' element={<Home />} />
             <Route path='/blog' element={<BlogIndex />} />
             <Route path='/blog/:slug' element={<BlogPost />} />
+            <Route path='/learn' element={<Learn />} />
             <Route path='*' element={<NotFound />} />
           </Routes>
         </Suspense>
       </main>
       <Footer />
+      <ScrollToTopButton />
     </>
   )
 }

--- a/src/components/FloatingParticles.tsx
+++ b/src/components/FloatingParticles.tsx
@@ -1,8 +1,6 @@
 import { useCallback } from 'react'
 import Particles from '@tsparticles/react'
 import type { Engine } from '@tsparticles/engine'
-import Particles from 'react-tsparticles'
-import type { Engine } from 'tsparticles-engine'
 import { loadFull } from 'tsparticles'
 
 export default function FloatingParticles() {

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import { Menu, X, Atom } from 'lucide-react'
+import ThemeToggle from './ThemeToggle'
 
 const Navbar: React.FC = () => {
   const [isOpen, setIsOpen] = useState(false)
@@ -10,6 +11,7 @@ const Navbar: React.FC = () => {
   const navItems = [
     { path: '/', label: 'Home' },
     { path: '/blog', label: 'Blog' },
+    { path: '/learn', label: 'Learn' },
   ]
 
   const isActive = (path: string) => location.pathname === path
@@ -22,7 +24,8 @@ const Navbar: React.FC = () => {
           <span className='text-gradient text-xl font-bold'>Hippie Scientist</span>
         </Link>
 
-        <div className='md:hidden'>
+        <div className='flex items-center space-x-2 md:hidden'>
+          <ThemeToggle />
           <button
             onClick={() => setIsOpen(!isOpen)}
             className='p-2'
@@ -33,7 +36,7 @@ const Navbar: React.FC = () => {
           </button>
         </div>
 
-        <div className='hidden space-x-4 md:flex'>
+        <div className='hidden items-center space-x-4 md:flex'>
           {navItems.map(({ path, label }) => (
             <Link
               key={path}
@@ -47,6 +50,7 @@ const Navbar: React.FC = () => {
               {label}
             </Link>
           ))}
+          <ThemeToggle />
         </div>
         {isOpen && (
           <motion.div
@@ -69,6 +73,7 @@ const Navbar: React.FC = () => {
                 {label}
               </Link>
             ))}
+            <ThemeToggle />
           </motion.div>
         )}
       </div>

--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect, useState } from 'react'
+import { motion } from 'framer-motion'
+import { ArrowUp } from 'lucide-react'
+
+export default function ScrollToTopButton() {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 300)
+    window.addEventListener('scroll', onScroll)
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
+
+  return (
+    <motion.button
+      onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: visible ? 1 : 0 }}
+      className='fixed bottom-6 right-6 z-40 rounded-full bg-psychedelic-purple p-3 text-white shadow-lg hover:scale-105'
+      aria-label='Scroll to top'
+    >
+      <ArrowUp />
+    </motion.button>
+  )
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,16 @@
+import { useContext } from 'react'
+import { ThemeContext } from '../contexts/theme'
+import { Sun, Moon } from 'lucide-react'
+
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useContext(ThemeContext)
+  return (
+    <button
+      onClick={toggleTheme}
+      className='rounded-md p-2 text-gray-300 transition-shadow hover:shadow-glow'
+      aria-label='Toggle theme'
+    >
+      {theme === 'dark' ? <Sun /> : <Moon />}
+    </button>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,7 @@
 @tailwind utilities;
 
 body {
-  @apply m-0 bg-space-night font-sans text-lg leading-relaxed tracking-tight text-sand;
+  @apply m-0 bg-space-night font-sans text-lg leading-relaxed tracking-tight text-sand dark:bg-black dark:text-sand;
 }
 
 html {
@@ -55,7 +55,8 @@ html {
 }
 
 @keyframes ripple {
-  0%, 100% {
+  0%,
+  100% {
     transform: scale(0.95);
     opacity: 0.8;
   }

--- a/src/pages/Learn.tsx
+++ b/src/pages/Learn.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import { Helmet } from 'react-helmet-async'
+import { motion } from 'framer-motion'
+import { BookOpen, BrainCircuit, Compass } from 'lucide-react'
+
+const modules = [
+  {
+    icon: BookOpen,
+    title: 'Intro to Ethnobotany',
+    description: 'Study the cultural history of visionary plants.',
+  },
+  {
+    icon: BrainCircuit,
+    title: 'Neuroscience Basics',
+    description: 'Explore how these compounds affect the brain.',
+  },
+  {
+    icon: Compass,
+    title: 'Integration Practices',
+    description: 'Techniques to ground and apply insights.',
+  },
+]
+
+export default function Learn() {
+  return (
+    <>
+      <Helmet>
+        <title>Learn - The Hippie Scientist</title>
+        <meta
+          name='description'
+          content='Educational resources to deepen your understanding of herbs and psychedelics.'
+        />
+      </Helmet>
+
+      <div className='min-h-screen px-4 pt-20'>
+        <div className='mx-auto max-w-7xl'>
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8 }}
+            className='mb-20 text-center'
+          >
+            <h1 className='text-gradient mb-6 text-5xl font-bold md:text-6xl'>Learn</h1>
+            <p className='mx-auto max-w-3xl text-xl text-gray-300'>
+              Self-paced lessons to expand your knowledge.
+            </p>
+          </motion.div>
+
+          <div className='grid grid-cols-1 gap-8 md:grid-cols-3'>
+            {modules.map(({ icon: Icon, title, description }, index) => (
+              <motion.div
+                key={title}
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.8, delay: index * 0.2 }}
+                className='glass-card p-6 text-center'
+              >
+                <Icon className='mx-auto mb-4 h-12 w-12 text-psychedelic-purple' />
+                <h3 className='mb-2 text-xl font-bold text-white'>{title}</h3>
+                <p className='text-gray-300'>{description}</p>
+              </motion.div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,6 +1,7 @@
 /* eslint-env node */
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- add a new **Learn** page with animated modules
- add a theme toggle and scroll-to-top button
- wire up Learn route and buttons in the navbar
- enable dark mode classes in Tailwind
- clean up FloatingParticles imports

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6878924138f48323b20c5b1799e93fbe