### PR TITLE
Fix Learn page routing and add more content

### DIFF
--- a/src/components/MouseTrail.tsx
+++ b/src/components/MouseTrail.tsx
@@ -11,22 +11,32 @@ const MouseTrail: React.FC = () => {
   const y = useSpring(mouseY, springConfig)
 
   useEffect(() => {
-    const handleMouseMove = (e: MouseEvent) => {
-      mouseX.set(e.clientX)
-      mouseY.set(e.clientY)
+    const updatePosition = (e: MouseEvent | TouchEvent) => {
+      const xPos = 'touches' in e ? e.touches[0].clientX : e.clientX
+      const yPos = 'touches' in e ? e.touches[0].clientY : e.clientY
+      mouseX.set(xPos)
+      mouseY.set(yPos)
       setIsVisible(true)
     }
 
-    const handleMouseLeave = () => {
+    const endTrail = () => {
       setIsVisible(false)
     }
 
-    window.addEventListener('mousemove', handleMouseMove)
-    window.addEventListener('mouseleave', handleMouseLeave)
+    window.addEventListener('mousemove', updatePosition)
+    window.addEventListener('touchstart', updatePosition)
+    window.addEventListener('touchmove', updatePosition)
+    window.addEventListener('mouseleave', endTrail)
+    window.addEventListener('touchend', endTrail)
+    window.addEventListener('touchcancel', endTrail)
 
     return () => {
-      window.removeEventListener('mousemove', handleMouseMove)
-      window.removeEventListener('mouseleave', handleMouseLeave)
+      window.removeEventListener('mousemove', updatePosition)
+      window.removeEventListener('touchstart', updatePosition)
+      window.removeEventListener('touchmove', updatePosition)
+      window.removeEventListener('mouseleave', endTrail)
+      window.removeEventListener('touchend', endTrail)
+      window.removeEventListener('touchcancel', endTrail)
     }
   }, [mouseX, mouseY])
 

--- a/src/pages/Learn.tsx
+++ b/src/pages/Learn.tsx
@@ -20,6 +20,12 @@ import {
   Library,
   TestTube2,
   LeafyGreen,
+  Atom,
+  Sparkles,
+  Flower2,
+  Lightbulb,
+  BookCheck,
+  Mic,
 } from 'lucide-react'
 
 const modules = [
@@ -93,6 +99,21 @@ const modules = [
     title: 'Medicinal Mushrooms',
     description: 'Explore adaptogenic fungi and their healing uses.',
   },
+  {
+    icon: Atom,
+    title: 'Psychedelic Chemistry',
+    description: 'Analyze molecular structures and biosynthetic pathways.',
+  },
+  {
+    icon: Sparkles,
+    title: 'Consciousness Studies',
+    description: 'Philosophical perspectives on awareness and mind.',
+  },
+  {
+    icon: Flower2,
+    title: 'Plant Morphology',
+    description: 'Examine the form and structure of botanical specimens.',
+  },
 ]
 
 const tutorials = [
@@ -120,6 +141,21 @@ const tutorials = [
     icon: Download,
     title: 'Downloadable Charts',
     description: 'Reference sheets for quick learning.',
+  },
+  {
+    icon: Mic,
+    title: 'Podcast Series',
+    description: 'Interviews with leading researchers and guides.',
+  },
+  {
+    icon: BookCheck,
+    title: 'Case Studies',
+    description: 'Real-world examples to reinforce key lessons.',
+  },
+  {
+    icon: Lightbulb,
+    title: 'Idea Workshops',
+    description: 'Exercises to spark creativity and insight.',
   },
 ]
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,17 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { resolve } from 'path'
 
 export default defineConfig({
   base: '/',
   plugins: [react()],
   build: {
     outDir: 'dist',
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        notFound: resolve(__dirname, '404.html'),
+      },
+    },
   }
 })


### PR DESCRIPTION
## Summary
- include 404.html in Vite build to keep client routing working
- show rainbow sparkles for touch events
- add new course modules and tutorials

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6879847b6ef88323a794ede92cb42cb8