### PR TITLE
Add search + tag filter for blog posts

### DIFF
--- a/src/components/PostFilter.tsx
+++ b/src/components/PostFilter.tsx
@@ -1,0 +1,108 @@
+import React from 'react'
+import Fuse from 'fuse.js'
+import { decodeTag } from '../utils/format'
+import type { Post } from '../data/posts'
+
+interface Props {
+  posts: Post[]
+  onFilter: (posts: Post[]) => void
+}
+
+const PostFilter: React.FC<Props> = ({ posts, onFilter }) => {
+  const [query, setQuery] = React.useState('')
+  const [selectedTags, setSelectedTags] = React.useState<string[]>([])
+
+  const fuse = React.useMemo(
+    () =>
+      new Fuse(posts, {
+        keys: ['title', 'excerpt', 'content', 'tags'],
+        threshold: 0.3,
+      }),
+    [posts]
+  )
+
+  const allTags = React.useMemo(() => {
+    const t = posts.reduce<string[]>((acc, p) => acc.concat(p.tags), [])
+    return Array.from(new Set(t))
+  }, [posts])
+
+  const handleAddTag = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value
+    if (value && !selectedTags.includes(value)) {
+      setSelectedTags(t => [...t, value])
+    }
+    e.target.value = ''
+  }
+
+  const removeTag = (tag: string) => {
+    setSelectedTags(t => t.filter(x => x !== tag))
+  }
+
+  const clearFilters = () => {
+    setQuery('')
+    setSelectedTags([])
+    onFilter(posts)
+  }
+
+  const filtered = React.useMemo(() => {
+    const q = query.trim()
+    let res: Post[] = posts
+    if (q) {
+      res = fuse.search(q).map(r => r.item)
+    }
+    if (selectedTags.length) {
+      res = res.filter(p => selectedTags.every(t => p.tags.includes(t)))
+    }
+    return res
+  }, [posts, query, selectedTags])
+
+  React.useEffect(() => {
+    onFilter(filtered)
+  }, [filtered, onFilter])
+
+  return (
+    <div className='mb-8 space-y-4'>
+      <input
+        type='text'
+        placeholder='Search posts...'
+        aria-label='Search posts'
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+        className='w-full rounded-md border border-gray-700 bg-gray-900 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-purple-500'
+      />
+      <div className='flex flex-wrap items-center gap-2'>
+        {selectedTags.map(tag => (
+          <button
+            type='button'
+            key={tag}
+            onClick={() => removeTag(tag)}
+            className='tag-pill'
+          >
+            {decodeTag(tag)}
+          </button>
+        ))}
+        <select
+          onChange={handleAddTag}
+          className='rounded-md border border-gray-700 bg-gray-900 px-2 py-1 text-sm text-white'
+          defaultValue=''
+        >
+          <option value=''>Add Tag Filter...</option>
+          {allTags.map(tag => (
+            <option key={tag} value={tag}>
+              {decodeTag(tag)}
+            </option>
+          ))}
+        </select>
+        <button
+          type='button'
+          onClick={clearFilters}
+          className='rounded-md border border-gray-700 bg-gray-900 px-2 py-1 text-sm text-white hover:bg-gray-700'
+        >
+          Clear Filters
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default PostFilter

--- a/src/data/posts.ts
+++ b/src/data/posts.ts
@@ -5,6 +5,7 @@ export interface Post {
   excerpt: string
   content: string
   date: string
+  tags: string[]
 }
 
 export const posts: Post[] = [
@@ -15,6 +16,7 @@ export const posts: Post[] = [
     excerpt: 'An introduction to our explorations of plants and consciousness.',
     content: `# Welcome\nThis is a sample post to demonstrate the new blog layout. Enjoy drifting through knowledge in our digital forest.`,
     date: '2024-05-01',
+    tags: ['intro', 'site'],
   },
   {
     id: 2,
@@ -23,6 +25,7 @@ export const posts: Post[] = [
     excerpt: 'Tips for documenting herbal finds during your adventures.',
     content: `Exploring nature requires preparation. Always record the location, habitat and any noticeable characteristics of the plant. Photograph specimens before collecting and respect local regulations.`,
     date: '2024-06-15',
+    tags: ['fieldwork', 'basics'],
   },
   {
     id: 3,
@@ -31,6 +34,7 @@ export const posts: Post[] = [
     excerpt: 'A brief overview of the current resurgence in research.',
     content: `Interest in psychedelic-assisted therapy has exploded in recent years. Universities around the globe are revisiting compounds such as psilocybin and MDMA to evaluate their therapeutic potential.`,
     date: '2024-07-01',
+    tags: ['research', 'culture'],
   },
   {
     id: 4,
@@ -39,6 +43,7 @@ export const posts: Post[] = [
     excerpt: 'How humans and plants have co-evolved through ritual and medicine.',
     content: `Ethnobotany explores the relationship between people and the plant kingdom. Traditional societies relied on botanical knowledge for healing, ceremony and daily subsistence. Modern researchers document these practices to preserve disappearing wisdom and uncover potential leads for new medicines.`,
     date: '2024-07-05',
+    tags: ['culture', 'basics'],
   },
   {
     id: 5,
@@ -47,6 +52,7 @@ export const posts: Post[] = [
     excerpt: 'An introduction to brain regions and neurotransmitters involved in altered states.',
     content: `Psychoactive plants and compounds influence our neural circuits. Key players include serotonin, dopamine and glutamate pathways. Understanding the limbic system and prefrontal cortex helps explain how these substances alter perception and mood.`,
     date: '2024-07-06',
+    tags: ['science', 'basics'],
   },
   {
     id: 6,
@@ -55,6 +61,7 @@ export const posts: Post[] = [
     excerpt: 'Methods for processing psychedelic experiences and applying insights.',
     content: `After a profound journey, integration brings lessons into everyday life. Journaling, meditation and community sharing circles can help translate fleeting visions into lasting growth. Therapists often recommend setting clear intentions and maintaining healthy routines.`,
     date: '2024-07-07',
+    tags: ['psychology', 'guidance'],
   },
   {
     id: 7,
@@ -63,6 +70,7 @@ export const posts: Post[] = [
     excerpt: 'Field tips for recognizing safe and useful plant species.',
     content: `Learning to identify herbs requires attention to leaf shape, aroma and habitat. Field guides and dichotomous keys provide step-by-step clues. Always cross-reference sources and consult local experts before harvesting unfamiliar plants.`,
     date: '2024-07-08',
+    tags: ['fieldwork', 'basics'],
   },
   {
     id: 8,
@@ -71,6 +79,7 @@ export const posts: Post[] = [
     excerpt: 'Fundamental techniques for analyzing plant compounds in a safe environment.',
     content: `From basic solvent extraction to thin-layer chromatography, laboratory methods reveal a plant's chemical profile. Proper safety gear and accurate measurements are vital. Beginners should practice with benign materials before attempting more complex analyses.`,
     date: '2024-07-09',
+    tags: ['science', 'lab'],
   },
   {
     id: 9,
@@ -79,6 +88,7 @@ export const posts: Post[] = [
     excerpt: 'A survey of ceremonial plant use around the world.',
     content: `Many cultures incorporate entheogenic plants into rites of passage and healing rituals. Examples range from Amazonian ayahuasca ceremonies to the use of peyote in Native American spiritual practice. Respect for these traditions is crucial when engaging with them today.`,
     date: '2024-07-10',
+    tags: ['culture'],
   },
   {
     id: 10,
@@ -87,6 +97,7 @@ export const posts: Post[] = [
     excerpt: 'Navigating the legal landscape and moral responsibilities of psychedelic study.',
     content: `Regulations for psychoactive substances vary widely across regions. Researchers must secure appropriate permits and remain informed about shifting policies. Ethical practice also involves informed consent and sensitivity to indigenous knowledge rights.`,
     date: '2024-07-11',
+    tags: ['law', 'guidance'],
   },
   {
     id: 11,
@@ -95,6 +106,7 @@ export const posts: Post[] = [
     excerpt: 'A deep dive into receptor dynamics underlying psychedelic effects.',
     content: `Compounds like psilocybin bind primarily to serotonin 5-HT2A receptors, triggering cascades that reshape neural connectivity. Recent imaging studies show increased cross-talk between normally segregated brain networks during these states, shedding light on therapeutic potential.`,
     date: '2024-07-12',
+    tags: ['science'],
   },
   {
     id: 12,
@@ -103,6 +115,7 @@ export const posts: Post[] = [
     excerpt: 'How to document ecological data responsibly while exploring the wild.',
     content: `Effective fieldwork blends careful observation with minimal environmental impact. Record GPS coordinates, soil conditions and associated species. Obtain proper permissions and follow leave-no-trace principles to preserve delicate habitats.`,
     date: '2024-07-13',
+    tags: ['fieldwork', 'methods'],
   },
   {
     id: 13,
@@ -111,6 +124,7 @@ export const posts: Post[] = [
     excerpt: 'Creating networks that foster education and mutual support.',
     content: `Grassroots groups, both online and in-person, can share resources and safety information. Hosting workshops or reading circles helps newcomers learn from experienced practitioners. Strong communities also advocate for responsible policy and research.`,
     date: '2024-07-14',
+    tags: ['community'],
   },
   {
     id: 14,
@@ -119,6 +133,7 @@ export const posts: Post[] = [
     excerpt: 'Strategies for minimizing risk during psychedelic exploration.',
     content: `Preparation, accurate dosing and a trusted sitter are key elements of harm reduction. Testing kits help confirm substance identity, and sober integration time allows the mind and body to recover. These practices support safer, more beneficial experiences.`,
     date: '2024-07-15',
+    tags: ['safety'],
   },
   {
     id: 15,
@@ -127,6 +142,7 @@ export const posts: Post[] = [
     excerpt: 'Study how active compounds interact with the body.',
     content: `Plants contain a wide array of alkaloids, terpenes and flavonoids. Understanding how these molecules are metabolized helps predict their therapeutic effects and potential interactions. Modern pharmacology builds on traditional knowledge to identify promising treatments.`,
     date: '2024-07-16',
+    tags: ['science', 'herbs'],
   },
   {
     id: 16,
@@ -135,6 +151,7 @@ export const posts: Post[] = [
     excerpt: 'Make tinctures, oils and concentrates at home.',
     content: `Simple methods like alcohol tincturing or oil infusion can preserve a plant's properties for later use. More advanced approaches involve reflux setups or supercritical extraction. Always prioritize safety and proper ventilation when concentrating botanical compounds.`,
     date: '2024-07-17',
+    tags: ['lab', 'herbs'],
   },
   {
     id: 17,
@@ -143,6 +160,7 @@ export const posts: Post[] = [
     excerpt: 'Explore adaptogenic fungi and their healing uses.',
     content: `Fungi such as Reishi, Lion's Mane and Turkey Tail are valued for their immunomodulating polysaccharides. Studies suggest potential benefits for cognitive health and stress resilience. Cultivation guides help ensure sustainable harvests.`,
     date: '2024-07-18',
+    tags: ['herbs'],
   },
   {
     id: 18,
@@ -151,6 +169,7 @@ export const posts: Post[] = [
     excerpt: 'Analyze molecular structures and biosynthetic pathways.',
     content: `Examining the molecular family tree reveals how slight modifications create distinct effects. Synthetic pathways often mimic natural biosynthesis, offering insight into potency and duration. Knowledge of chemistry also informs harm reduction by revealing impurities.`,
     date: '2024-07-19',
+    tags: ['science'],
   },
   {
     id: 19,
@@ -159,6 +178,7 @@ export const posts: Post[] = [
     excerpt: 'Philosophical perspectives on awareness and mind.',
     content: `Researchers debate whether consciousness arises solely from neural activity or if it has a transpersonal component. Comparative studies integrate neuroscience, meditation traditions and psychedelic experiences to broaden our understanding of awareness.`,
     date: '2024-07-20',
+    tags: ['philosophy'],
   },
   {
     id: 20,
@@ -167,5 +187,6 @@ export const posts: Post[] = [
     excerpt: 'Examine the form and structure of botanical specimens.',
     content: `Morphology looks at leaf arrangement, flower anatomy and root systems to classify plants. Detailed sketches or photos aid in species identification and provide clues to evolutionary relationships. Field microscopes reveal microscopic features like trichomes.`,
     date: '2024-07-21',
+    tags: ['herbs', 'science'],
   },
 ]

--- a/src/pages/BlogIndex.tsx
+++ b/src/pages/BlogIndex.tsx
@@ -3,26 +3,32 @@ import { Link } from 'react-router-dom'
 import { Helmet } from 'react-helmet-async'
 import { motion } from 'framer-motion'
 import CardShell from '../components/CardShell'
+import PostFilter from '../components/PostFilter'
 import { posts } from '../data/posts'
 
-const BlogIndex: React.FC = () => (
-  <>
-    <Helmet>
-      <title>Blog - The Hippie Scientist</title>
-    </Helmet>
-    <div className='mx-auto max-w-3xl space-y-6 px-6 py-12'>
-      {posts.map(post => (
-        <CardShell key={post.id} className='hover:shadow-intense'>
-          <Link to={`/blog/${post.slug}`} className='block space-y-2'>
-            <motion.h2 whileHover={{ x: 4 }} className='text-gradient text-2xl font-bold'>
-              {post.title}
-            </motion.h2>
-            <p className='text-moss'>{post.excerpt}</p>
-          </Link>
-        </CardShell>
-      ))}
-    </div>
-  </>
-)
+const BlogIndex: React.FC = () => {
+  const [filtered, setFiltered] = React.useState(posts)
+
+  return (
+    <>
+      <Helmet>
+        <title>Blog - The Hippie Scientist</title>
+      </Helmet>
+      <div className='mx-auto max-w-3xl space-y-6 px-6 py-12'>
+        <PostFilter posts={posts} onFilter={setFiltered} />
+        {filtered.map(post => (
+          <CardShell key={post.id} className='hover:shadow-intense'>
+            <Link to={`/blog/${post.slug}`} className='block space-y-2'>
+              <motion.h2 whileHover={{ x: 4 }} className='text-gradient text-2xl font-bold'>
+                {post.title}
+              </motion.h2>
+              <p className='text-moss'>{post.excerpt}</p>
+            </Link>
+          </CardShell>
+        ))}
+      </div>
+    </>
+  )
+}
 
 export default BlogIndex


### PR DESCRIPTION
## Summary
- extend Post interface with `tags`
- add tags to blog posts
- create `PostFilter` component for searching and filtering posts
- use new filter in BlogIndex

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879a0f3f9bc8323a8ebdb8f095e68cc