### PR TITLE
Add blog post bookmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Source files live in `src/`. Pages are under `src/pages` and reusable components
 - **Community & Safety** – guidelines for responsible exploration
 - **Store** – upcoming merch and digital resources
 - **Theming** – light/dark modes persisted with local storage
+- **Bookmarks** – save favorite blog posts for later
 
 ## Educational Resources
 
@@ -47,7 +48,7 @@ This repository includes a variety of learning materials:
 ## Potential Upgrades
 
 - Add search and tag filters for blog posts.
-- Allow users to bookmark herbs or lessons.
+- Allow users to bookmark herbs or lessons. _(Posts can already be bookmarked)_
 - Integrate interactive quizzes from the Learn section.
 - Enable offline access via a service worker.
 - Expand the store with downloadable resources.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ const Lesson = React.lazy(() => import('./pages/Lesson'))
 const About = React.lazy(() => import('./pages/About'))
 const Store = React.lazy(() => import('./pages/Store'))
 const Research = React.lazy(() => import('./pages/Research'))
+const Bookmarks = React.lazy(() => import('./pages/Bookmarks'))
 
 function App() {
   return (
@@ -31,6 +32,7 @@ function App() {
             <Route path='/research' element={<Research />} />
             <Route path='/blog' element={<BlogIndex />} />
             <Route path='/blog/:slug' element={<BlogPost />} />
+            <Route path='/bookmarks' element={<Bookmarks />} />
             <Route path='/store' element={<Store />} />
             <Route path='*' element={<NotFound />} />
           </Routes>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -14,6 +14,7 @@ const Navbar: React.FC = () => {
     { path: '/learn', label: 'Learn' },
     { path: '/research', label: 'Research' },
     { path: '/blog', label: 'Blog' },
+    { path: '/bookmarks', label: 'Bookmarks' },
     { path: '/store', label: 'Store' },
   ]
 

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -2,12 +2,15 @@ import React from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { Helmet } from 'react-helmet-async'
 import { motion } from 'framer-motion'
+import { Star } from 'lucide-react'
 import PanelWrapper from '../components/PanelWrapper'
 import { posts } from '../data/posts'
+import { useFavorites } from '../hooks/useFavorites'
 
 const BlogPost: React.FC = () => {
   const { slug } = useParams<{ slug: string }>()
   const post = posts.find(p => p.slug === slug)
+  const { toggle, isFavorite } = useFavorites()
 
   if (!post) {
     return (
@@ -26,13 +29,23 @@ const BlogPost: React.FC = () => {
         <title>{post.title} - The Hippie Scientist</title>
       </Helmet>
       <PanelWrapper className='mx-auto max-w-3xl px-6 py-12'>
-        <motion.h1
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          className='text-gradient mb-6 text-4xl font-bold'
-        >
-          {post.title}
-        </motion.h1>
+        <div className='mb-6 flex items-start justify-between gap-4'>
+          <motion.h1
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            className='text-gradient flex-1 text-4xl font-bold'
+          >
+            {post.title}
+          </motion.h1>
+          <button
+            type='button'
+            onClick={() => toggle(post.slug)}
+            aria-label={isFavorite(post.slug) ? 'Remove bookmark' : 'Add bookmark'}
+            className='rounded-md p-2 text-yellow-300 transition hover:text-yellow-400'
+          >
+            <Star className={isFavorite(post.slug) ? 'fill-current' : 'stroke-current'} />
+          </button>
+        </div>
         <motion.p
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}

--- a/src/pages/Bookmarks.tsx
+++ b/src/pages/Bookmarks.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { Helmet } from 'react-helmet-async'
+import CardShell from '../components/CardShell'
+import { posts } from '../data/posts'
+import { useFavorites } from '../hooks/useFavorites'
+
+const Bookmarks: React.FC = () => {
+  const { favorites, toggle } = useFavorites()
+  const bookmarked = React.useMemo(() => posts.filter(p => favorites.includes(p.slug)), [favorites])
+
+  if (bookmarked.length === 0) {
+    return (
+      <div className='mx-auto max-w-3xl px-6 py-12 text-center'>
+        <Helmet>
+          <title>Bookmarks - The Hippie Scientist</title>
+        </Helmet>
+        <p className='mb-4'>No bookmarks yet.</p>
+        <Link to='/blog' className='text-comet underline'>
+          Browse posts
+        </Link>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <Helmet>
+        <title>Bookmarks - The Hippie Scientist</title>
+      </Helmet>
+      <div className='mx-auto max-w-3xl space-y-6 px-6 py-12'>
+        {bookmarked.map(post => (
+          <CardShell key={post.id} className='hover:shadow-intense'>
+            <div className='flex items-start justify-between gap-4'>
+              <Link to={`/blog/${post.slug}`} className='flex-1 space-y-2'>
+                <h2 className='text-gradient text-2xl font-bold'>{post.title}</h2>
+                <p className='text-moss'>{post.excerpt}</p>
+              </Link>
+              <button
+                type='button'
+                onClick={() => toggle(post.slug)}
+                aria-label='Remove bookmark'
+                className='rounded-md p-1 text-sm text-rose-300 hover:underline'
+              >
+                Remove
+              </button>
+            </div>
+          </CardShell>
+        ))}
+      </div>
+    </>
+  )
+}
+
+export default Bookmarks


### PR DESCRIPTION
## Summary
- allow saving blog posts via new Bookmarks page
- update navbar and routing
- add star toggle on blog posts
- document bookmark feature

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6879a3b248ec8323af4d2b8129e4f77b