### PR TITLE
Fix TagFilterBar animation

### DIFF
--- a/src/components/TagFilterBar.tsx
+++ b/src/components/TagFilterBar.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import clsx from 'clsx'
-import { decodeTag, tagVariant } from '../utils/format'
+import { motion } from 'framer-motion'
 import TagBadge from './TagBadge'
-import { decodeTag } from '../utils/format'
+import { decodeTag, tagVariant } from '../utils/format'
 
 interface Props {
   tags: string[]
@@ -10,7 +10,7 @@ interface Props {
   onChange: (tags: string[]) => void
 }
 
-const TagFilterBar: React.FC<Props> = ({ tags, selected, onChange }) => {
+export default function TagFilterBar({ tags, selected, onChange }: Props) {
   const toggle = (tag: string) => {
     if (selected.includes(tag)) {
       onChange(selected.filter(t => t !== tag))
@@ -20,29 +20,24 @@ const TagFilterBar: React.FC<Props> = ({ tags, selected, onChange }) => {
   }
 
   return (
-    <div className='flex overflow-x-auto gap-2 pb-4'>
+    <div className='flex flex-wrap gap-2 overflow-x-auto pb-4'>
       {tags.map(tag => (
-        <button
+        <motion.button
           key={tag}
           type='button'
           onClick={() => toggle(tag)}
-          className={clsx('flex-shrink-0 focus:outline-none')}
+          whileHover={{ scale: 1.1 }}
+          whileTap={{ scale: 0.95 }}
+          aria-pressed={selected.includes(tag)}
+          className='flex-shrink-0 focus:outline-none'
         >
           <TagBadge
             label={decodeTag(tag)}
             variant={selected.includes(tag) ? 'green' : tagVariant(tag)}
-            className={clsx(selected.includes(tag) && 'ring-1 ring-emerald-300')}
+            className={clsx(selected.includes(tag) && 'ring-1 ring-emerald-400')}
           />
-          className={clsx(
-            'flex-shrink-0 bg-emerald-700/30 text-emerald-200 px-3 py-1 rounded-full text-xs shadow-md hover:bg-emerald-600/50 transition',
-            selected.includes(tag) && 'ring-1 ring-emerald-300 bg-emerald-600/50'
-          )}
-        >
-          {decodeTag(tag)}
-        </button>
+        </motion.button>
       ))}
     </div>
   )
 }
-
-export default TagFilterBar


### PR DESCRIPTION
## Summary
- overhaul `TagFilterBar` component
- animate tag buttons with Framer Motion
- ensure active tag ring styles

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879b4a155b48323992f3cc6943addd4