### PR TITLE
Add animated herb index page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ const About = React.lazy(() => import('./pages/About'))
 const Store = React.lazy(() => import('./pages/Store'))
 const Research = React.lazy(() => import('./pages/Research'))
 const Bookmarks = React.lazy(() => import('./pages/Bookmarks'))
+const HerbIndex = React.lazy(() => import('./pages/HerbIndex'))
 
 function App() {
   return (
@@ -33,6 +34,7 @@ function App() {
             <Route path='/blog' element={<BlogIndex />} />
             <Route path='/blog/:slug' element={<BlogPost />} />
             <Route path='/bookmarks' element={<Bookmarks />} />
+            <Route path='/database' element={<HerbIndex />} />
             <Route path='/store' element={<Store />} />
             <Route path='*' element={<NotFound />} />
           </Routes>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -15,6 +15,7 @@ const Navbar: React.FC = () => {
     { path: '/research', label: 'Research' },
     { path: '/blog', label: 'Blog' },
     { path: '/bookmarks', label: 'Bookmarks' },
+    { path: '/database', label: 'Database' },
     { path: '/store', label: 'Store' },
   ]
 

--- a/src/components/TagFilterBar.tsx
+++ b/src/components/TagFilterBar.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import clsx from 'clsx'
-import { decodeTag, tagVariant } from '../utils/format'
+import { motion } from 'framer-motion'
 import TagBadge from './TagBadge'
-import { decodeTag } from '../utils/format'
+import { decodeTag, tagVariant } from '../utils/format'
 
 interface Props {
   tags: string[]
@@ -20,9 +20,11 @@ const TagFilterBar: React.FC<Props> = ({ tags, selected, onChange }) => {
   }
 
   return (
-    <div className='flex overflow-x-auto gap-2 pb-4'>
+    <div className='flex flex-wrap gap-2 overflow-x-auto pb-4'>
       {tags.map(tag => (
-        <button
+        <motion.button
+          layout
+          whileTap={{ scale: 0.95 }}
           key={tag}
           type='button'
           onClick={() => toggle(tag)}
@@ -33,13 +35,7 @@ const TagFilterBar: React.FC<Props> = ({ tags, selected, onChange }) => {
             variant={selected.includes(tag) ? 'green' : tagVariant(tag)}
             className={clsx(selected.includes(tag) && 'ring-1 ring-emerald-300')}
           />
-          className={clsx(
-            'flex-shrink-0 bg-emerald-700/30 text-emerald-200 px-3 py-1 rounded-full text-xs shadow-md hover:bg-emerald-600/50 transition',
-            selected.includes(tag) && 'ring-1 ring-emerald-300 bg-emerald-600/50'
-          )}
-        >
-          {decodeTag(tag)}
-        </button>
+        </motion.button>
       ))}
     </div>
   )

--- a/src/hooks/useFullHerbs.ts
+++ b/src/hooks/useFullHerbs.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react'
+import type { Herb } from '../types'
+import dataRaw from '../../Full79.json?raw'
+
+export default function useFullHerbs() {
+  const [herbs, setHerbs] = useState<Herb[]>([])
+
+  useEffect(() => {
+    try {
+      const sanitized = dataRaw.replace(/\bNaN\b/g, 'null')
+      setHerbs(JSON.parse(sanitized))
+    } catch (err) {
+      console.error('Failed to load herb data', err)
+    }
+  }, [])
+
+  return herbs
+}

--- a/src/pages/HerbIndex.tsx
+++ b/src/pages/HerbIndex.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { Helmet } from 'react-helmet-async'
+import { motion } from 'framer-motion'
+import HerbList from '../components/HerbList'
+import TagFilterBar from '../components/TagFilterBar'
+import FloatingParticles from '../components/FloatingParticles'
+import useFullHerbs from '../hooks/useFullHerbs'
+
+export default function HerbIndex() {
+  const herbs = useFullHerbs()
+  const [selectedTags, setSelectedTags] = React.useState<string[]>([])
+
+  const allTags = React.useMemo(() => {
+    const t = herbs.reduce<string[]>((acc, h) => acc.concat(h.tags), [])
+    return Array.from(new Set(t))
+  }, [herbs])
+
+  const filtered = React.useMemo(() => {
+    if (!selectedTags.length) return herbs
+    return herbs.filter(h => selectedTags.every(t => h.tags.includes(t)))
+  }, [herbs, selectedTags])
+
+  return (
+    <>
+      <Helmet>
+        <title>Herb Index - The Hippie Scientist</title>
+        <meta
+          name='description'
+          content='Browse detailed herbal information. Filter by tags and expand each card to learn more.'
+        />
+      </Helmet>
+
+      <div className='relative min-h-screen px-4 pt-20'>
+        <FloatingParticles />
+        <div className='relative mx-auto max-w-3xl'>
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8 }}
+            className='mb-8 text-center'
+          >
+            <h1 className='text-gradient mb-6 text-5xl font-bold'>Herb Index</h1>
+            <p className='mx-auto max-w-3xl text-xl text-gray-300'>
+              Explore our full collection of herbs. Click any entry for detailed information.
+            </p>
+          </motion.div>
+
+          <TagFilterBar tags={allTags} selected={selectedTags} onChange={setSelectedTags} />
+          <HerbList herbs={filtered} />
+        </div>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- rebuild `TagFilterBar` with framer-motion animations
- load full herb data with new `useFullHerbs` hook
- create `HerbIndex` page using `Full79.json`
- add `/database` route and navbar link

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879b66be3e08323b2eff8fafc32e37a