### PR TITLE
Add full herb database page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ const NotFound = React.lazy(() => import('./pages/NotFound'))
 const Learn = React.lazy(() => import('./pages/Learn'))
 const Lesson = React.lazy(() => import('./pages/Lesson'))
 const About = React.lazy(() => import('./pages/About'))
+const Database = React.lazy(() => import('./pages/Database'))
 const Store = React.lazy(() => import('./pages/Store'))
 const Research = React.lazy(() => import('./pages/Research'))
 const Bookmarks = React.lazy(() => import('./pages/Bookmarks'))
@@ -29,6 +30,7 @@ function App() {
             <Route path='/about' element={<About />} />
             <Route path='/learn' element={<Learn />} />
             <Route path='/learn/:slug' element={<Lesson />} />
+            <Route path='/database' element={<Database />} />
             <Route path='/research' element={<Research />} />
             <Route path='/blog' element={<BlogIndex />} />
             <Route path='/blog/:slug' element={<BlogPost />} />

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -72,7 +72,13 @@ export default function HerbCardAccordion({ herb }: Props) {
             )}
             {herb.effects?.length > 0 && <span>{herb.effects.join(', ')}</span>}
             {herb.safetyRating !== undefined && (
-              <span className={safetyColorClass(Number(herb.safetyRating))}>
+              <span
+                className={
+                  typeof herb.safetyRating === 'number'
+                    ? safetyColorClass(herb.safetyRating)
+                    : ''
+                }
+              >
                 {herb.safetyRating}
               </span>
             )}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -12,6 +12,7 @@ const Navbar: React.FC = () => {
     { path: '/', label: 'Home' },
     { path: '/about', label: 'About' },
     { path: '/learn', label: 'Learn' },
+    { path: '/database', label: 'Database' },
     { path: '/research', label: 'Research' },
     { path: '/blog', label: 'Blog' },
     { path: '/bookmarks', label: 'Bookmarks' },

--- a/src/hooks/useHerbs.ts
+++ b/src/hooks/useHerbs.ts
@@ -5,8 +5,9 @@ export function useHerbs() {
   const [herbs, setHerbs] = useState<Herb[]>([])
 
   useEffect(() => {
-    import('../data/herbs.json').then(m => {
-      setHerbs(m.default as Herb[])
+    import('../../Full79.json?raw').then(m => {
+      const cleaned = (m.default as string).replace(/NaN/g, 'null')
+      setHerbs(JSON.parse(cleaned) as Herb[])
     })
   }, [])
 


### PR DESCRIPTION
## Summary
- import the full 79-entry dataset and clean invalid JSON values
- expose the herb Database page in navigation and routes
- handle non-numeric safety ratings gracefully

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879b77358bc8323b9e5132f0ec94660