### PR TITLE
Add persistent herb filters and favorites

### DIFF
--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -1,9 +1,10 @@
 import React, { useState, KeyboardEvent } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { ChevronRight } from 'lucide-react'
+import { ChevronRight, Star } from 'lucide-react'
 import type { Herb } from '../types'
 import { decodeTag, tagVariant, safetyColorClass } from '../utils/format'
 import TagBadge from './TagBadge'
+import { useHerbFavorites } from '../hooks/useHerbFavorites'
 
 interface Props {
   herb: Herb
@@ -30,6 +31,7 @@ const itemVariants = {
 export default function HerbCardAccordion({ herb }: Props) {
   const [open, setOpen] = useState(false)
   const toggle = () => setOpen(v => !v)
+  const { isFavorite, toggle: toggleFavorite } = useHerbFavorites()
 
   const handleKey = (e: KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Enter' || e.key === ' ') {
@@ -44,6 +46,7 @@ export default function HerbCardAccordion({ herb }: Props) {
       initial={{ opacity: 0, y: 20 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
+      exit={{ opacity: 0, scale: 0.9 }}
       onClick={toggle}
       onKeyDown={handleKey}
       tabIndex={0}
@@ -84,15 +87,28 @@ export default function HerbCardAccordion({ herb }: Props) {
             )}
           </div>
         </div>
-        <motion.span
-          layout
-          initial={false}
-          animate={{ rotate: open ? 90 : 0 }}
-          transition={{ duration: 0.3 }}
-          className='text-cyan-200 transition-transform'
-        >
-          <ChevronRight size={18} />
-        </motion.span>
+        <div className='flex items-center gap-2'>
+          <button
+            type='button'
+            onClick={e => {
+              e.stopPropagation()
+              toggleFavorite(herb.id)
+            }}
+            aria-label={isFavorite(herb.id) ? 'Remove favorite' : 'Add favorite'}
+            className='rounded-md p-1 text-yellow-400 hover:bg-white/10'
+          >
+            <Star fill={isFavorite(herb.id) ? 'currentColor' : 'none'} size={18} />
+          </button>
+          <motion.span
+            layout
+            initial={false}
+            animate={{ rotate: open ? 90 : 0 }}
+            transition={{ duration: 0.3 }}
+            className='text-cyan-200 transition-transform'
+          >
+            <ChevronRight size={18} />
+          </motion.span>
+        </div>
       </div>
 
       <div className='mt-2 flex flex-wrap gap-2'>

--- a/src/components/StarfieldBackground.tsx
+++ b/src/components/StarfieldBackground.tsx
@@ -1,0 +1,28 @@
+import { useCallback } from 'react'
+import Particles from '@tsparticles/react'
+import type { Engine } from '@tsparticles/engine'
+import { loadFull } from 'tsparticles'
+
+export default function StarfieldBackground() {
+  const init = useCallback(async (engine: Engine) => {
+    await loadFull(engine)
+  }, [])
+
+  return (
+    <Particles
+      id='starfield'
+      init={init}
+      options={{
+        fullScreen: { enable: true, zIndex: -10 },
+        background: { color: 'transparent' },
+        particles: {
+          number: { value: 100, density: { enable: true, area: 800 } },
+          color: { value: ['#ffffff', '#ffaadf', '#c1ffdd'] },
+          size: { value: { min: 0.5, max: 1.5 } },
+          move: { enable: true, speed: 0.15 },
+          opacity: { value: { min: 0.1, max: 0.6 } },
+        },
+      }}
+    />
+  )
+}

--- a/src/components/TagFilterBar.tsx
+++ b/src/components/TagFilterBar.tsx
@@ -1,22 +1,27 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import clsx from 'clsx'
 import { motion } from 'framer-motion'
 import TagBadge from './TagBadge'
 import { decodeTag, tagVariant } from '../utils/format'
+import { useLocalStorage } from '../hooks/useLocalStorage'
 
 interface Props {
   tags: string[]
-  selected: string[]
-  onChange: (tags: string[]) => void
+  onChange?: (tags: string[]) => void
+  storageKey?: string
 }
 
-export default function TagFilterBar({ tags, selected, onChange }: Props) {
+export default function TagFilterBar({ tags, onChange, storageKey = 'tagFilters' }: Props) {
+  const [selected, setSelected] = useLocalStorage<string[]>(storageKey, [])
+
+  useEffect(() => {
+    onChange?.(selected)
+  }, [selected, onChange])
+
   const toggle = (tag: string) => {
-    if (selected.includes(tag)) {
-      onChange(selected.filter(t => t !== tag))
-    } else {
-      onChange([...selected, tag])
-    }
+    setSelected(prev =>
+      prev.includes(tag) ? prev.filter(t => t !== tag) : [...prev, tag]
+    )
   }
 
   return (
@@ -28,6 +33,7 @@ export default function TagFilterBar({ tags, selected, onChange }: Props) {
           onClick={() => toggle(tag)}
           whileHover={{ scale: 1.1 }}
           whileTap={{ scale: 0.95 }}
+          animate={{ opacity: selected.includes(tag) ? 1 : 0.6 }}
           aria-pressed={selected.includes(tag)}
           className='flex-shrink-0 focus:outline-none'
         >

--- a/src/data/herbs.ts
+++ b/src/data/herbs.ts
@@ -1,6 +1,8 @@
-import type { Herb } from '../types';
-import data from './herbs.json';
+import type { Herb } from '../types'
+import raw from '../../Full79.json?raw'
 
-const herbs = data as Herb[];
-export default herbs;
-export { herbs };
+const cleaned = raw.replace(/NaN/g, 'null')
+const herbs = JSON.parse(cleaned) as Herb[]
+
+export default herbs
+export { herbs }

--- a/src/hooks/useHerbFavorites.ts
+++ b/src/hooks/useHerbFavorites.ts
@@ -1,0 +1,16 @@
+import { useLocalStorage } from './useLocalStorage'
+
+export function useHerbFavorites() {
+  const [favorites, setFavorites] = useLocalStorage<string[]>(
+    'herbFavorites',
+    []
+  )
+
+  const toggle = (id: string) => {
+    setFavorites(f => (f.includes(id) ? f.filter(x => x !== id) : [...f, id]))
+  }
+
+  const isFavorite = (id: string) => favorites.includes(id)
+
+  return { favorites, toggle, isFavorite }
+}

--- a/src/hooks/useHerbs.ts
+++ b/src/hooks/useHerbs.ts
@@ -1,15 +1,8 @@
-import { useState, useEffect } from 'react'
+import React from 'react'
 import type { Herb } from '../types'
+import herbsData from '../data/herbs'
 
-export function useHerbs() {
-  const [herbs, setHerbs] = useState<Herb[]>([])
-
-  useEffect(() => {
-    import('../../Full79.json?raw').then(m => {
-      const cleaned = (m.default as string).replace(/NaN/g, 'null')
-      setHerbs(JSON.parse(cleaned) as Herb[])
-    })
-  }, [])
-
+export function useHerbs(): Herb[] {
+  const [herbs] = React.useState<Herb[]>(herbsData)
   return herbs
 }

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,22 @@
+import { useState, useEffect } from 'react'
+
+export function useLocalStorage<T>(key: string, initialValue: T) {
+  const [value, setValue] = useState<T>(() => {
+    try {
+      const stored = localStorage.getItem(key)
+      return stored ? (JSON.parse(stored) as T) : initialValue
+    } catch {
+      return initialValue
+    }
+  })
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, JSON.stringify(value))
+    } catch {
+      // ignore
+    }
+  }, [key, value])
+
+  return [value, setValue] as const
+}

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -5,12 +5,29 @@ import { Helmet } from 'react-helmet-async'
 import { motion } from 'framer-motion'
 import HerbList from '../components/HerbList'
 import TagFilterBar from '../components/TagFilterBar'
-import FloatingParticles from '../components/FloatingParticles'
+import StarfieldBackground from '../components/StarfieldBackground'
 import { useHerbs } from '../hooks/useHerbs'
+import { useHerbFavorites } from '../hooks/useHerbFavorites'
+import { useLocalStorage } from '../hooks/useLocalStorage'
+import Fuse from 'fuse.js'
 
 export default function Database() {
   const herbs = useHerbs()
-  const [selectedTags, setSelectedTags] = React.useState<string[]>([])
+  const { favorites } = useHerbFavorites()
+  const [favoritesOnly, setFavoritesOnly] = useLocalStorage<boolean>(
+    'herbFavoritesOnly',
+    false
+  )
+  const [query, setQuery] = React.useState('')
+  const fuse = React.useMemo(
+    () =>
+      new Fuse(herbs, {
+        keys: ['name', 'tags', 'effects'],
+        threshold: 0.3,
+      }),
+    [herbs]
+  )
+  const [filteredTags, setFilteredTags] = React.useState<string[]>([])
 
   const allTags = React.useMemo(() => {
     const t = herbs.reduce<string[]>((acc, h) => acc.concat(h.tags), [])
@@ -18,9 +35,19 @@ export default function Database() {
   }, [herbs])
 
   const filtered = React.useMemo(() => {
-    if (!selectedTags.length) return herbs
-    return herbs.filter(h => selectedTags.every(t => h.tags.includes(t)))
-  }, [herbs, selectedTags])
+    let res = herbs
+    const q = query.trim()
+    if (q) {
+      res = fuse.search(q).map(r => r.item)
+    }
+    if (filteredTags.length) {
+      res = res.filter(h => filteredTags.every(t => h.tags.includes(t)))
+    }
+    if (favoritesOnly) {
+      res = res.filter(h => favorites.includes(h.id))
+    }
+    return res
+  }, [herbs, query, filteredTags, favoritesOnly, favorites])
 
   return (
     <>
@@ -33,7 +60,7 @@ export default function Database() {
       </Helmet>
 
       <div className='relative min-h-screen px-4 pt-20'>
-        <FloatingParticles />
+        <StarfieldBackground />
         <div className='relative mx-auto max-w-3xl'>
           <motion.div
             initial={{ opacity: 0, y: 20 }}
@@ -47,7 +74,24 @@ export default function Database() {
             </p>
           </motion.div>
 
-          <TagFilterBar tags={allTags} selected={selectedTags} onChange={setSelectedTags} />
+          <div className='sticky top-2 z-10 mb-4 flex items-center gap-2'>
+            <input
+              type='text'
+              placeholder='Search herbs...'
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              className='flex-1 rounded-md bg-space-dark/70 px-3 py-2 text-white backdrop-blur-md focus:outline-none'
+            />
+            <button
+              type='button'
+              onClick={() => setFavoritesOnly(f => !f)}
+              className='rounded-md bg-space-dark/70 px-3 py-2 text-sm text-yellow-300 backdrop-blur-md hover:bg-white/10'
+            >
+              {favoritesOnly ? 'All Herbs' : 'Favorites'}
+            </button>
+          </div>
+
+          <TagFilterBar tags={allTags} onChange={setFilteredTags} />
           <HerbList herbs={filtered} />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- parse herb data from `Full79.json`
- persist tag filters with new `useLocalStorage`
- allow starring herbs via `useHerbFavorites`
- add starfield background
- add search bar and favorites toggle on database page
- animate filter/favorite interactions

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879bd5717e08323a959b53d62b066c7