### PR TITLE
Fix navbar overlay issue

### DIFF
--- a/src/components/SearchFilter.tsx
+++ b/src/components/SearchFilter.tsx
@@ -79,7 +79,7 @@ const SearchFilter: React.FC<SearchFilterProps> = ({ herbs, onFilter }) => {
   }, [filtered, onFilter])
 
   return (
-    <div className='sticky top-2 z-10 mb-8 space-y-4 rounded-lg bg-space-dark/70 p-4 backdrop-blur-md'>
+    <div className='sticky top-20 z-10 mb-8 space-y-4 rounded-lg bg-space-dark/70 p-4 backdrop-blur-md'>
       <input
         type='text'
         placeholder='Search herbs...'


### PR DESCRIPTION
## Summary
- offset the sticky search filter to avoid covering the navbar

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a451675f88323b37c492b2eba4a4d