### PR TITLE
Improve theme colors for readability

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,6 @@
 export default function Footer() {
   return (
-    <footer className='relative py-6 text-center text-sm text-gray-400'>
+    <footer className='relative py-6 text-center text-sm text-gray-600 dark:text-gray-400'>
       <div
         className='absolute inset-0 mx-auto my-0 h-full w-11/12 rounded-full border border-comet/40 blur-sm'
         aria-hidden='true'

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -56,7 +56,7 @@ export default function HerbCardAccordion({ herb }: Props) {
       whileHover={{ scale: 1.03, rotateX: 1, rotateY: -1 }}
       whileTap={{ scale: 0.97 }}
       transition={{ layout: { duration: 0.4, ease: 'easeInOut' } }}
-      className='relative cursor-pointer overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-br from-purple-950/40 via-fuchsia-900/30 to-sky-900/40 p-6 shadow-xl backdrop-blur-lg transition-all hover:shadow-2xl hover:ring-2 hover:ring-fuchsia-400/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-fuchsia-400/60'
+      className='relative cursor-pointer overflow-hidden rounded-2xl border border-gray-300 bg-white/60 p-6 shadow-xl backdrop-blur-lg transition-all hover:shadow-2xl hover:ring-2 hover:ring-fuchsia-400/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-fuchsia-400/60 dark:border-white/10 dark:bg-gradient-to-br dark:from-purple-950/40 dark:via-fuchsia-900/30 dark:to-sky-900/40'
     >
       <motion.span
         initial={{ opacity: 0, y: -4 }}
@@ -172,28 +172,28 @@ export default function HerbCardAccordion({ herb }: Props) {
 
               {herb.tags?.length > 0 && (
                 <motion.div variants={itemVariants} className='flex flex-wrap gap-2 pt-2'>
-              {herb.tags.map(tag => (
-                <TagBadge
-                  key={tag}
-                  label={decodeTag(tag)}
-                  variant={tagVariant(tag)}
-                  className={open ? 'animate-pulse' : ''}
-                />
-              ))}
+                  {herb.tags.map(tag => (
+                    <TagBadge
+                      key={tag}
+                      label={decodeTag(tag)}
+                      variant={tagVariant(tag)}
+                      className={open ? 'animate-pulse' : ''}
+                    />
+                  ))}
+                </motion.div>
+              )}
+              <motion.div variants={itemVariants} className='pt-2'>
+                <Link
+                  to={`/herbs/${herb.id}`}
+                  onClick={e => e.stopPropagation()}
+                  className='text-comet underline'
+                >
+                  View full page
+                </Link>
+              </motion.div>
             </motion.div>
-          )}
-          <motion.div variants={itemVariants} className='pt-2'>
-            <Link
-              to={`/herbs/${herb.id}`}
-              onClick={e => e.stopPropagation()}
-              className='text-comet underline'
-            >
-              View full page
-            </Link>
           </motion.div>
-        </motion.div>
-      </motion.div>
-    )}
+        )}
       </AnimatePresence>
     </motion.div>
   )

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -23,7 +23,7 @@ const Navbar: React.FC = () => {
     path === '/' ? location.pathname === '/' : location.pathname.startsWith(path)
 
   return (
-    <nav className='fixed left-0 right-0 top-0 z-50 bg-space-dark/70 backdrop-blur'>
+    <nav className='fixed left-0 right-0 top-0 z-50 bg-white/80 backdrop-blur dark:bg-space-dark/70'>
       <div className='mx-auto flex h-16 max-w-7xl items-center justify-between px-4'>
         <Link to='/' className='flex items-center space-x-2'>
           <Atom className='drop-shadow-glow h-8 w-8 text-lichen' aria-hidden='true' />
@@ -49,7 +49,7 @@ const Navbar: React.FC = () => {
                 className={`rounded-md px-3 py-2 text-sm font-medium transition-shadow ${
                   isActive(path)
                     ? 'bg-cosmic-forest text-white shadow-glow'
-                    : 'text-gray-300 hover:shadow-glow'
+                    : 'text-gray-700 hover:shadow-glow dark:text-gray-300'
                 }`}
               >
                 {label}
@@ -68,7 +68,7 @@ const Navbar: React.FC = () => {
             initial={{ height: 0 }}
             animate={{ height: 'auto' }}
             exit={{ height: 0 }}
-            className='flex flex-col space-y-2 overflow-hidden bg-space-dark/90 px-4 py-4 md:hidden'
+            className='flex flex-col space-y-2 overflow-hidden bg-white/90 px-4 py-4 dark:bg-space-dark/90 md:hidden'
           >
             {navItems.map(({ path, label }) => (
               <li key={path}>
@@ -78,7 +78,7 @@ const Navbar: React.FC = () => {
                   className={`block rounded-md px-4 py-2 text-base font-medium transition-shadow ${
                     isActive(path)
                       ? 'bg-cosmic-forest text-white shadow-glow'
-                      : 'text-gray-300 hover:shadow-glow'
+                      : 'text-gray-700 hover:shadow-glow dark:text-gray-300'
                   }`}
                 >
                   {label}

--- a/src/components/PanelWrapper.tsx
+++ b/src/components/PanelWrapper.tsx
@@ -11,7 +11,7 @@ const PanelWrapper: React.FC<Props> = ({ children, className }) => (
     initial={{ opacity: 0, y: 20 }}
     whileInView={{ opacity: 1, y: 0 }}
     viewport={{ once: true }}
-    className={`relative my-12 overflow-hidden rounded-xl border border-bark bg-bark/60 p-6 shadow-glow backdrop-blur-lg ${className ?? ''}`}
+    className={`relative my-12 overflow-hidden rounded-xl border border-gray-300 bg-white/60 p-6 shadow-glow backdrop-blur-lg dark:border-bark dark:bg-bark/60 ${className ?? ''}`}
   >
     <div className='absolute inset-x-0 top-0 h-px animate-pulse bg-gradient-to-r from-transparent via-lichen/30 to-transparent' />
     {children}

--- a/src/components/PostFilter.tsx
+++ b/src/components/PostFilter.tsx
@@ -68,22 +68,17 @@ const PostFilter: React.FC<Props> = ({ posts, onFilter }) => {
         aria-label='Search posts'
         value={query}
         onChange={e => setQuery(e.target.value)}
-        className='w-full rounded-md border border-gray-700 bg-gray-900 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-purple-500'
+        className='w-full rounded-md border border-gray-300 bg-white px-4 py-2 text-black focus:outline-none focus:ring-2 focus:ring-purple-500 dark:border-gray-700 dark:bg-gray-900 dark:text-white'
       />
       <div className='flex flex-wrap items-center gap-2'>
         {selectedTags.map(tag => (
-          <button
-            type='button'
-            key={tag}
-            onClick={() => removeTag(tag)}
-            className='tag-pill'
-          >
+          <button type='button' key={tag} onClick={() => removeTag(tag)} className='tag-pill'>
             {decodeTag(tag)}
           </button>
         ))}
         <select
           onChange={handleAddTag}
-          className='rounded-md border border-gray-700 bg-gray-900 px-2 py-1 text-sm text-white'
+          className='rounded-md border border-gray-300 bg-white px-2 py-1 text-sm text-black dark:border-gray-700 dark:bg-gray-900 dark:text-white'
           defaultValue=''
         >
           <option value=''>Add Tag Filter...</option>
@@ -96,7 +91,7 @@ const PostFilter: React.FC<Props> = ({ posts, onFilter }) => {
         <button
           type='button'
           onClick={clearFilters}
-          className='rounded-md border border-gray-700 bg-gray-900 px-2 py-1 text-sm text-white hover:bg-gray-700'
+          className='rounded-md border border-gray-300 bg-white px-2 py-1 text-sm text-black hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-900 dark:text-white dark:hover:bg-gray-700'
         >
           Clear Filters
         </button>

--- a/src/components/SearchFilter.tsx
+++ b/src/components/SearchFilter.tsx
@@ -79,14 +79,14 @@ const SearchFilter: React.FC<SearchFilterProps> = ({ herbs, onFilter }) => {
   }, [filtered, onFilter])
 
   return (
-    <div className='sticky top-20 z-10 mb-8 space-y-4 rounded-lg bg-space-dark/70 p-4 backdrop-blur-md'>
+    <div className='sticky top-20 z-10 mb-8 space-y-4 rounded-lg bg-white/70 p-4 backdrop-blur-md dark:bg-space-dark/70'>
       <input
         type='text'
         placeholder='Search herbs...'
         aria-label='Search herbs'
         value={query}
         onChange={e => setQuery(e.target.value)}
-        className='w-full rounded-md border border-gray-700 bg-gray-900 px-4 py-2 focus:outline-none focus:ring-2 focus:ring-purple-500'
+        className='w-full rounded-md border border-gray-300 bg-white px-4 py-2 text-black focus:outline-none focus:ring-2 focus:ring-purple-500 dark:border-gray-700 dark:bg-gray-900 dark:text-white'
       />
       <div className='flex flex-wrap items-center gap-2'>
         {selectedTags.map(tag => (
@@ -96,7 +96,7 @@ const SearchFilter: React.FC<SearchFilterProps> = ({ herbs, onFilter }) => {
         ))}
         <select
           onChange={handleAddTag}
-          className='rounded-md border border-gray-700 bg-gray-900 px-2 py-1 text-sm text-white'
+          className='rounded-md border border-gray-300 bg-white px-2 py-1 text-sm text-black dark:border-gray-700 dark:bg-gray-900 dark:text-white'
           defaultValue=''
         >
           <option value=''>Add Tag Filter...</option>
@@ -109,7 +109,7 @@ const SearchFilter: React.FC<SearchFilterProps> = ({ herbs, onFilter }) => {
         <button
           type='button'
           onClick={pickRandom}
-          className='rounded-md border border-gray-700 bg-gray-900 px-2 py-1 text-sm text-white hover:bg-gray-700'
+          className='rounded-md border border-gray-300 bg-white px-2 py-1 text-sm text-black hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-900 dark:text-white dark:hover:bg-gray-700'
         >
           Random Herb
         </button>
@@ -117,7 +117,7 @@ const SearchFilter: React.FC<SearchFilterProps> = ({ herbs, onFilter }) => {
         <select
           value={sort}
           onChange={e => setSort(e.target.value as SortKey)}
-          className='rounded-md border border-gray-700 bg-gray-900 px-2 py-1 text-sm text-white'
+          className='rounded-md border border-gray-300 bg-white px-2 py-1 text-sm text-black dark:border-gray-700 dark:bg-gray-900 dark:text-white'
         >
           <option value=''>Sort By...</option>
           <option value='intensity'>Intensity</option>
@@ -127,7 +127,7 @@ const SearchFilter: React.FC<SearchFilterProps> = ({ herbs, onFilter }) => {
         <button
           type='button'
           onClick={clearFilters}
-          className='rounded-md border border-gray-700 bg-gray-900 px-2 py-1 text-sm text-white hover:bg-gray-700'
+          className='rounded-md border border-gray-300 bg-white px-2 py-1 text-sm text-black hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-900 dark:text-white dark:hover:bg-gray-700'
         >
           Clear Filters
         </button>

--- a/src/index.css
+++ b/src/index.css
@@ -26,7 +26,7 @@ html {
 }
 
 .glass-card {
-  @apply border border-white/10 bg-space-dark/60 shadow-lg backdrop-blur-xl transition-shadow duration-300 hover:ring-2 hover:ring-fuchsia-500/50;
+  @apply border border-black/10 bg-white/60 text-black shadow-lg backdrop-blur-xl transition-shadow duration-300 hover:ring-2 hover:ring-fuchsia-500/50 dark:border-white/10 dark:bg-space-dark/60 dark:text-sand;
 }
 
 .ring-comet {
@@ -34,7 +34,7 @@ html {
 }
 
 .bg-psychedelic-gradient {
-  background-image: linear-gradient(135deg, #8b5cf6, #ec4899);
+  background-image: linear-gradient(135deg, #8b5cf6, #db2777);
 }
 
 .bg-cosmic-gradient {
@@ -45,7 +45,7 @@ html {
 }
 /* Animations and extra utilities */
 .tag-pill {
-  @apply inline-flex items-center gap-1 rounded-full bg-white/10 px-2 py-0.5 text-xs shadow backdrop-blur-sm hover:bg-white/20;
+  @apply inline-flex items-center gap-1 rounded-full bg-black/10 px-2 py-0.5 text-xs shadow backdrop-blur-sm hover:bg-black/20 dark:bg-white/10 dark:hover:bg-white/20;
 }
 
 @keyframes gradient-shift {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -20,7 +20,8 @@ export default {
         fungal: '#F2785C',
         bark: '#1A1D1B',
         'psychedelic-purple': '#8b5cf6',
-        'psychedelic-pink': '#ec4899',
+        // darkened slightly for better contrast in light mode
+        'psychedelic-pink': '#db2777',
         'space-dark': '#0f172a',
         'space-night': '#0c0c1a',
         'cosmic-purple': '#7e22ce',


### PR DESCRIPTION
## Summary
- darken pink brand color for better contrast
- tweak glass card style with light mode support
- adjust tag, navbar, filter and panel colors for light theme
- lighten footer text color
- refine gradient backgrounds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a50ee4b408323aff1e595587f94ac