### PR TITLE
Improve herb database styling

### DIFF
--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -56,7 +56,7 @@ export default function HerbCardAccordion({ herb }: Props) {
       whileHover={{ scale: 1.03, rotateX: 1, rotateY: -1 }}
       whileTap={{ scale: 0.97 }}
       transition={{ layout: { duration: 0.4, ease: 'easeInOut' } }}
-      className='relative cursor-pointer overflow-hidden rounded-2xl border border-gray-300 bg-white/60 p-6 shadow-xl backdrop-blur-lg transition-all hover:shadow-2xl hover:ring-2 hover:ring-fuchsia-400/60 focus:outline-none focus-visible:ring-2 focus-visible:ring-fuchsia-400/60 dark:border-white/10 dark:bg-gradient-to-br dark:from-purple-950/40 dark:via-fuchsia-900/30 dark:to-sky-900/40'
+      className='relative cursor-pointer overflow-hidden rounded-2xl bg-black/40 p-4 sm:p-6 ring-1 ring-white/10 shadow-xl backdrop-blur-lg transition-all hover:shadow-2xl focus:outline-none'
     >
       <motion.span
         initial={{ opacity: 0, y: -4 }}
@@ -68,7 +68,7 @@ export default function HerbCardAccordion({ herb }: Props) {
       </motion.span>
       <div className='flex items-start justify-between gap-4'>
         <div className='min-w-0'>
-          <h3 className='font-herb text-xl text-psychedelic-pink'>{herb.name}</h3>
+          <h3 className='font-herb text-lg sm:text-xl text-white'>{herb.name}</h3>
           {herb.scientificName && <p className='text-xs italic text-sand'>{herb.scientificName}</p>}
           <div className='mt-1 flex flex-wrap items-center gap-2 text-sm text-sand'>
             {herb.category && (
@@ -102,7 +102,7 @@ export default function HerbCardAccordion({ herb }: Props) {
       </div>
 
       <div className='mt-2 flex flex-wrap gap-2'>
-        {herb.tags.slice(0, 2).map(tag => (
+        {herb.tags.slice(0, 3).map(tag => (
           <TagBadge
             key={tag}
             label={decodeTag(tag)}
@@ -125,7 +125,7 @@ export default function HerbCardAccordion({ herb }: Props) {
               collapsed: { opacity: 0, height: 0 },
             }}
             transition={{ duration: 0.4, ease: 'easeInOut' }}
-            className='mt-4 overflow-hidden text-sm text-sand'
+            className='mt-4 overflow-hidden text-sm sm:text-base text-sand'
           >
             <motion.div
               variants={containerVariants}

--- a/src/components/HerbList.tsx
+++ b/src/components/HerbList.tsx
@@ -13,7 +13,10 @@ const HerbList: React.FC<Props> = ({ herbs }) => {
   }
 
   return (
-    <motion.div layout className='space-y-4'>
+    <motion.div
+      layout
+      className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'
+    >
       <AnimatePresence>
         {herbs.map(h => (
           <HerbCardAccordion key={h.id || h.name} herb={h} />

--- a/src/components/TagFilterBar.tsx
+++ b/src/components/TagFilterBar.tsx
@@ -25,7 +25,7 @@ export default function TagFilterBar({ tags, onChange, storageKey = 'tagFilters'
   }
 
   return (
-    <div className='flex flex-wrap gap-2 overflow-x-auto pb-4'>
+    <div className='sticky top-16 z-10 flex flex-wrap gap-2 overflow-x-auto pb-4 backdrop-blur-md bg-black/30 rounded-xl px-2'>
       {tags.map(tag => (
         <motion.button
           key={tag}

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -81,7 +81,7 @@ export default function Database() {
 
       <div className='relative min-h-screen px-4 pt-20'>
         <StarfieldBackground />
-        <div className='relative mx-auto max-w-3xl'>
+        <div className='relative mx-auto max-w-6xl'>
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
@@ -89,12 +89,12 @@ export default function Database() {
             className='mb-8 text-center'
           >
             <h1 className='text-gradient mb-6 text-5xl font-bold'>Herb Database</h1>
-            <p className='mx-auto max-w-3xl text-xl text-gray-300'>
+            <p className='mx-auto max-w-4xl text-xl text-gray-300'>
               Explore our collection of herbs. Click any entry to see detailed information.
             </p>
           </motion.div>
 
-          <div className='sticky top-2 z-10 mb-4 flex items-center gap-2'>
+          <div className='sticky top-2 z-20 mb-4 flex flex-wrap items-center gap-2'>
             <input
               type='text'
               placeholder='Search herbs...'
@@ -111,7 +111,9 @@ export default function Database() {
             </button>
           </div>
 
-          <TagFilterBar tags={allTags} onChange={setFilteredTags} />
+          <div className='mb-4'>
+            <TagFilterBar tags={allTags} onChange={setFilteredTags} />
+          </div>
           {relatedTags.length > 0 && (
             <div className='mb-4 flex flex-wrap items-center gap-2'>
               <span className='text-sm text-moss'>Related tags:</span>

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -74,7 +74,7 @@ export default function HerbDetail() {
         </div>
         <button
           type='button'
-          className='rounded-md bg-fuchsia-700 px-3 py-2 text-white hover:bg-fuchsia-600'
+          className='rounded-md bg-gradient-to-r from-violet-900 to-sky-900 px-3 py-2 text-white hover:opacity-90'
           onClick={() => setShowSimilar(s => !s)}
         >
           🧠 Smart Explore


### PR DESCRIPTION
## Summary
- clean up HerbCardAccordion styles for better readability
- convert herb list to grid layout
- keep TagFilterBar pinned and compact
- widen Database page for grid layout
- modernize HerbDetail button gradient

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a537871708323877230f451367d8b