### PR TITLE
Lighten herb card backgrounds

### DIFF
--- a/src/components/CategoryAnalytics.tsx
+++ b/src/components/CategoryAnalytics.tsx
@@ -5,7 +5,8 @@ export default function CategoryAnalytics() {
   const counts = React.useMemo(() => {
     const c: Record<string, number> = {}
     herbs.forEach(h => {
-      c[h.category] = (c[h.category] || 0) + 1
+      const main = h.category.split('/')[0].trim()
+      c[main] = (c[main] || 0) + 1
     })
     return c
   }, [])

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -56,7 +56,7 @@ export default function HerbCardAccordion({ herb }: Props) {
       whileHover={{ scale: 1.03, rotateX: 1, rotateY: -1 }}
       whileTap={{ scale: 0.97 }}
       transition={{ layout: { duration: 0.4, ease: 'easeInOut' } }}
-      className='relative cursor-pointer overflow-hidden rounded-2xl bg-black/40 p-4 sm:p-6 ring-1 ring-white/10 shadow-xl backdrop-blur-lg transition-all hover:shadow-2xl focus:outline-none'
+      className='relative cursor-pointer overflow-hidden rounded-2xl bg-black/20 p-4 sm:p-6 ring-1 ring-white/10 shadow-xl backdrop-blur-lg transition-all hover:shadow-2xl focus:outline-none'
     >
       <motion.span
         initial={{ opacity: 0, y: -4 }}

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -96,7 +96,7 @@ export default function HerbDetail() {
           <textarea
             value={notes}
             onChange={e => setNotes(e.target.value)}
-            className='mt-2 w-full rounded-md bg-black/40 p-2 text-white'
+            className='mt-2 w-full rounded-md bg-black/20 p-2 text-white'
             rows={5}
           />
         </div>


### PR DESCRIPTION
## Summary
- lighten herb card backgrounds
- simplify category analytics grouping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a70452ec48323b2de52ddc7c64e17