### PR TITLE
🎨 Improve visual clarity + UX animation polish – Round 7

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Righteous&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Comfortaa:wght@400;700&family=Inter:wght@400;700&family=Orbitron:wght@400;700&family=Righteous&family=Syne:wght@400;700&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -53,10 +53,10 @@ export default function HerbCardAccordion({ herb }: Props) {
       tabIndex={0}
       role='button'
       aria-expanded={open}
-      whileHover={{ scale: 1.03, rotateX: 1, rotateY: -1 }}
+      whileHover={{ scale: 1.03 }}
       whileTap={{ scale: 0.97 }}
       transition={{ layout: { duration: 0.4, ease: 'easeInOut' } }}
-      className='relative cursor-pointer overflow-hidden rounded-2xl bg-black/20 p-4 sm:p-6 ring-1 ring-white/10 shadow-xl backdrop-blur-lg transition-all hover:shadow-2xl focus:outline-none'
+      className='hover-glow relative cursor-pointer overflow-hidden rounded-2xl bg-black/30 p-4 sm:p-6 ring-1 ring-white/10 shadow-xl backdrop-blur-md focus:outline-none focus-visible:ring-2 focus-visible:ring-psychedelic-pink'
     >
       <motion.span
         initial={{ opacity: 0, y: -4 }}
@@ -68,9 +68,9 @@ export default function HerbCardAccordion({ herb }: Props) {
       </motion.span>
       <div className='flex items-start justify-between gap-4'>
         <div className='min-w-0'>
-          <h3 className='font-herb text-lg sm:text-xl text-white'>{herb.name}</h3>
+          <h3 className='font-herb text-xl sm:text-2xl text-white'>{herb.name}</h3>
           {herb.scientificName && <p className='text-xs italic text-sand'>{herb.scientificName}</p>}
-          <div className='mt-1 flex flex-wrap items-center gap-2 text-sm text-sand'>
+          <div className='mt-1 flex flex-wrap items-center gap-2 text-sm sm:text-base text-sand'>
             {herb.category && (
               <TagBadge label={herb.category} variant={categoryColors[herb.category] || 'purple'} />
             )}
@@ -125,14 +125,14 @@ export default function HerbCardAccordion({ herb }: Props) {
               collapsed: { opacity: 0, height: 0 },
             }}
             transition={{ duration: 0.4, ease: 'easeInOut' }}
-            className='mt-4 overflow-hidden text-sm sm:text-base text-sand'
+            className='mt-4 overflow-hidden text-sm sm:text-base text-sand break-words whitespace-pre-line'
           >
             <motion.div
               variants={containerVariants}
               initial='hidden'
               animate='visible'
               exit='hidden'
-              className='space-y-2'
+              className='space-y-3'
             >
               {[
                 'description',

--- a/src/components/TagBadge.tsx
+++ b/src/components/TagBadge.tsx
@@ -21,7 +21,7 @@ export default function TagBadge({ label, variant = 'purple', className }: Props
     <motion.span
       whileHover={{ scale: 1.05 }}
       className={clsx(
-        'inline-flex items-center rounded-full bg-gradient-to-br px-2 py-0.5 text-xs font-medium text-white shadow',
+        'inline-flex items-center rounded-full bg-gradient-to-br px-2 py-0.5 text-xs font-medium text-white shadow hover-glow',
         colorMap[variant],
         className,
       )}

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Pacifico&family=Righteous&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@400;700&family=Inter:wght@400;700&family=Orbitron:wght@400;700&family=Pacifico&family=Righteous&family=Syne:wght@400;700&display=swap');
 
 @tailwind base;
 @tailwind components;
@@ -94,4 +94,8 @@ html {
 
 .bg-rainbow-gradient {
   background-image: linear-gradient(90deg, #f00, #ff0, #0f0, #0ff, #00f, #f0f);
+}
+
+.hover-glow {
+  @apply transition-shadow hover:shadow-intense hover:ring-2 hover:ring-psychedelic-pink/60;
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -25,14 +25,14 @@ export default function Home() {
   return (
     <main className='min-h-screen bg-white text-black dark:bg-black dark:text-white px-4 py-10'>
       <HeroSection />
-      <section className='mx-auto max-w-4xl space-y-10'>
-        <p className='text-center text-lg text-opal'>
+      <section className='mx-auto max-w-4xl space-y-12'>
+        <p className='text-center text-lg sm:text-xl text-opal'>
           Discover visionary plants used throughout history. Search the database or browse page by
           page.
         </p>
         <SearchFilter herbs={herbs} onFilter={handleFilter} />
         <motion.div layout>
-          <h2 className='text-gradient mb-4 font-display text-3xl'>Herb Index</h2>
+          <h2 className='text-gradient mb-4 font-display text-3xl md:text-4xl'>Herb Index</h2>
           <HerbList herbs={paginated} />
           <Pagination currentPage={page} totalPages={totalPages} onPageChange={setPage} />
         </motion.div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -31,9 +31,9 @@ export default {
         intense: '0 0 24px rgba(79, 193, 233, 0.4)',
       },
       fontFamily: {
-        display: ['"Righteous"', 'cursive'],
+        display: ['"Syne"', '"Righteous"', 'cursive'],
         sans: ['"Inter"', 'sans-serif'],
-        herb: ['"Righteous"', 'cursive'],
+        herb: ['"Comfortaa"', '"Orbitron"', 'cursive'],
       },
     },
   },


### PR DESCRIPTION
## Summary
- add Comfortaa, Orbitron, Syne fonts
- glow utility for badges and accordion
- polish HerbCardAccordion layout and readability
- tweak Home page spacing and text sizes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a7510bff08323948f882ac6e5d3be