### PR TITLE
Improve tag filtering

### DIFF
--- a/src/components/TagFilterBar.tsx
+++ b/src/components/TagFilterBar.tsx
@@ -1,22 +1,75 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import clsx from 'clsx'
-import { motion } from 'framer-motion'
+import { AnimatePresence, motion } from 'framer-motion'
 import TagBadge from './TagBadge'
-import { decodeTag, tagVariant } from '../utils/format'
+import {
+  decodeTag,
+  tagVariant,
+  tagCategory,
+  TagCategory,
+  normalizeTag,
+} from '../utils/format'
 import { useLocalStorage } from '../hooks/useLocalStorage'
 
 interface Props {
   tags: string[]
   onChange?: (tags: string[]) => void
   storageKey?: string
+  counts?: Record<string, number>
 }
 
-export default function TagFilterBar({ tags, onChange, storageKey = 'tagFilters' }: Props) {
+const CATEGORY_ORDER: TagCategory[] = [
+  'Effect',
+  'Preparation',
+  'Safety',
+  'Chemistry',
+  'Region',
+  'Other',
+]
+
+export default function TagFilterBar({
+  tags,
+  onChange,
+  storageKey = 'tagFilters',
+  counts = {},
+}: Props) {
   const [selected, setSelected] = useLocalStorage<string[]>(storageKey, [])
+  const [expanded, setExpanded] = useState<Record<TagCategory, boolean>>({
+    Effect: true,
+    Preparation: false,
+    Safety: false,
+    Chemistry: false,
+    Region: false,
+    Other: false,
+  })
+  const [showMore, setShowMore] = useState<Record<TagCategory, boolean>>({
+    Effect: false,
+    Preparation: false,
+    Safety: false,
+    Chemistry: false,
+    Region: false,
+    Other: false,
+  })
 
   useEffect(() => {
     onChange?.(selected)
   }, [selected, onChange])
+
+  const grouped = useMemo(() => {
+    const map: Record<TagCategory, string[]> = {
+      Effect: [],
+      Preparation: [],
+      Safety: [],
+      Chemistry: [],
+      Region: [],
+      Other: [],
+    }
+    tags.forEach(t => {
+      const cat = tagCategory(t)
+      map[cat].push(t)
+    })
+    return map
+  }, [tags])
 
   const toggle = (tag: string) => {
     setSelected(prev =>
@@ -24,25 +77,102 @@ export default function TagFilterBar({ tags, onChange, storageKey = 'tagFilters'
     )
   }
 
+  const labelFor = (cat: TagCategory) => {
+    switch (cat) {
+      case 'Effect':
+        return '⚡ Effects'
+      case 'Preparation':
+        return '🌿 Preparation'
+      case 'Safety':
+        return '⚠️ Safety'
+      case 'Chemistry':
+        return '🧪 Chemistry'
+      case 'Region':
+        return '📍 Region'
+      default:
+        return '✨ Other'
+    }
+  }
+
+  const renderTags = (cat: TagCategory) => {
+    const list = grouped[cat] || []
+    const limit = 12
+    const display = showMore[cat] ? list : list.slice(0, limit)
+    return (
+      <>
+        <div className='tag-list'>
+          {display.map(tag => (
+            <motion.button
+              key={tag}
+              type='button'
+              onClick={() => toggle(tag)}
+              whileHover={{ scale: 1.1 }}
+              whileTap={{ scale: 0.95 }}
+              animate={{ opacity: selected.includes(tag) ? 1 : 0.6 }}
+              aria-pressed={selected.includes(tag)}
+              className='flex-shrink-0 focus:outline-none'
+              title={
+                counts[tag]
+                  ? `${decodeTag(normalizeTag(tag))} — used in ${counts[tag]} herbs`
+                  : decodeTag(normalizeTag(tag))
+              }
+            >
+              <TagBadge
+                label={decodeTag(normalizeTag(tag))}
+                variant={selected.includes(tag) ? 'green' : tagVariant(tag)}
+                className={clsx(selected.includes(tag) && 'ring-1 ring-emerald-400')}
+              />
+            </motion.button>
+          ))}
+          {list.length > limit && (
+            <motion.button
+              type='button'
+              whileHover={{ scale: 1.05 }}
+              onClick={() =>
+                setShowMore(m => ({ ...m, [cat]: !m[cat] }))
+              }
+              className='tag-pill mt-2'
+            >
+              {showMore[cat] ? 'Show Less' : 'Show More'}
+            </motion.button>
+          )}
+        </div>
+      </>
+    )
+  }
+
   return (
-    <div className='sticky top-16 z-10 flex flex-wrap gap-2 overflow-x-auto pb-4 backdrop-blur-md bg-black/30 rounded-xl px-2'>
-      {tags.map(tag => (
-        <motion.button
-          key={tag}
-          type='button'
-          onClick={() => toggle(tag)}
-          whileHover={{ scale: 1.1 }}
-          whileTap={{ scale: 0.95 }}
-          animate={{ opacity: selected.includes(tag) ? 1 : 0.6 }}
-          aria-pressed={selected.includes(tag)}
-          className='flex-shrink-0 focus:outline-none'
-        >
-          <TagBadge
-            label={decodeTag(tag)}
-            variant={selected.includes(tag) ? 'green' : tagVariant(tag)}
-            className={clsx(selected.includes(tag) && 'ring-1 ring-emerald-400')}
-          />
-        </motion.button>
+    <div className='space-y-3'>
+      {CATEGORY_ORDER.map(cat => (
+        <div key={cat} className='tag-section'>
+          <button
+            type='button'
+            className='tag-label'
+            onClick={() => setExpanded(e => ({ ...e, [cat]: !e[cat] }))}
+            aria-expanded={expanded[cat]}
+          >
+            {labelFor(cat)}
+            <motion.span
+              animate={{ rotate: expanded[cat] ? 90 : 0 }}
+              className='ml-1 text-xs'
+            >
+              ▶
+            </motion.span>
+          </button>
+          <AnimatePresence initial={false}>
+            {expanded[cat] && (
+              <motion.div
+                key='content'
+                initial={{ height: 0, opacity: 0 }}
+                animate={{ height: 'auto', opacity: 1 }}
+                exit={{ height: 0, opacity: 0 }}
+                transition={{ duration: 0.3 }}
+              >
+                {renderTags(cat)}
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
       ))}
     </div>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@400;700&family=Inter:wght@400;700&family=Orbitron:wght@400;700&family=Pacifico&family=Righteous&family=Syne:wght@400;700&display=swap');
+@import './styles/tags.css';
 
 @tailwind base;
 @tailwind components;

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -36,6 +36,16 @@ export default function Database() {
     return Array.from(new Set(t))
   }, [herbs])
 
+  const tagCounts = React.useMemo(() => {
+    const counts: Record<string, number> = {}
+    herbs.forEach(h => {
+      h.tags.forEach(t => {
+        counts[t] = (counts[t] || 0) + 1
+      })
+    })
+    return counts
+  }, [herbs])
+
   const filtered = React.useMemo(() => {
     let res = herbs
     const q = query.trim()
@@ -112,7 +122,11 @@ export default function Database() {
           </div>
 
           <div className='mb-4'>
-            <TagFilterBar tags={allTags} onChange={setFilteredTags} />
+            <TagFilterBar
+              tags={allTags}
+              counts={tagCounts}
+              onChange={setFilteredTags}
+            />
           </div>
           {relatedTags.length > 0 && (
             <div className='mb-4 flex flex-wrap items-center gap-2'>

--- a/src/styles/tags.css
+++ b/src/styles/tags.css
@@ -1,0 +1,9 @@
+.tag-section {
+  @apply rounded-xl bg-black/30 backdrop-blur-md p-2;
+}
+.tag-list {
+  @apply mt-2 flex flex-wrap gap-2 overflow-x-auto;
+}
+.tag-label {
+  @apply flex w-full items-center justify-between text-sm font-semibold text-violet-300;
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -6,6 +6,53 @@ export function decodeTag(tag: string): string {
   }
 }
 
+export function normalizeTag(tag: string): string {
+  const decoded = decodeTag(tag)
+  const key = decoded.toLowerCase()
+  if (key === 'ayahuasca-additive') return 'Ayahuasca'
+  if (key === 'sleep') return 'Dream'
+  if (key === 'sedative') return 'Sedation'
+  return decoded
+}
+
+export type TagCategory =
+  | 'Effect'
+  | 'Preparation'
+  | 'Safety'
+  | 'Region'
+  | 'Chemistry'
+  | 'Other'
+
+export function tagCategory(tag: string): TagCategory {
+  const t = normalizeTag(tag).toLowerCase()
+  if (/(toxic|caution|restricted|safe)/.test(t)) return 'Safety'
+  if (
+    /(brew|tea|smoke|smokable|oral|chew|snuff|ferment|tincture|capsule|decoction|seed|root|bark|flower|incense)/.test(
+      t
+    )
+  )
+    return 'Preparation'
+  if (
+    /(stimulant|euphoria|dream|sleep|sedat|vision|dissoci|cognit|anxiolytic|energy|hallucinogen|calming|pain relief)/.test(
+      t
+    )
+  )
+    return 'Effect'
+  if (
+    /(dmt|lsa|thc|alkaloid|maoi|caffeine|nicotine|muscimol|morphine|tryptamine)/.test(
+      t
+    )
+  )
+    return 'Chemistry'
+  if (
+    /(africa|america|europe|asia|amazon|andes|australia|brazil|mexico|peru|india|china|pacific|region|north|south|west|east)/.test(
+      t
+    )
+  )
+    return 'Region'
+  return 'Other'
+}
+
 export function safetyColorClass(rating?: number): string {
   if (rating == null) return '';
   if (rating <= 1) return 'text-green-400';
@@ -31,15 +78,15 @@ export type TagVariant =
   | 'red';
 
 export function tagVariant(tag: string): TagVariant {
-  const decoded = decodeTag(tag);
-  if (decoded.includes('Toxic') || decoded.includes('Restricted')) return 'red';
-  if (decoded.includes('Safe')) return 'green';
-  if (decoded.includes('Stimulant') || decoded.includes('Euphoria')) return 'pink';
-  if (decoded.includes('Dissociation') || decoded.includes('Sedation')) return 'purple';
-  if (decoded.includes('Dream')) return 'blue';
-  if (decoded.includes('Cognitive')) return 'yellow';
-  if (decoded.includes('Brewable') || decoded.includes('Smokable')) return 'blue';
-  if (decoded.includes('Oral') || decoded.includes('Fermented')) return 'yellow';
-  if (decoded.includes('Ritual')) return 'green';
-  return 'purple';
+  const decoded = normalizeTag(tag)
+  if (/toxic|restricted|caution/i.test(decoded)) return 'red'
+  if (/safe/i.test(decoded)) return 'green'
+  if (/stimulant|euphoria/i.test(decoded)) return 'pink'
+  if (/dissoci|sedat/i.test(decoded)) return 'purple'
+  if (/dream/i.test(decoded)) return 'blue'
+  if (/cognitive/i.test(decoded)) return 'yellow'
+  if (/brew|smok/i.test(decoded)) return 'blue'
+  if (/oral|ferment/i.test(decoded)) return 'yellow'
+  if (/ritual/i.test(decoded)) return 'green'
+  return 'purple'
 }


### PR DESCRIPTION
## Summary
- add category metadata and tag normalization helpers
- group tags into collapsible sections with show-more toggle
- surface tag usage counts in tooltips
- tweak layout styles for tag lists
- expose tag counts in Database page

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a77155b208323bda0e74fcb40a311