### PR TITLE
Implement enhanced herb search and personalization

### DIFF
--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -9,6 +9,7 @@ import { useHerbFavorites } from '../hooks/useHerbFavorites'
 
 interface Props {
   herb: Herb
+  highlight?: string
 }
 
 const categoryColors: Record<string, Parameters<typeof TagBadge>[0]['variant']> = {
@@ -29,7 +30,7 @@ const itemVariants = {
   visible: { opacity: 1, y: 0 },
 }
 
-export default function HerbCardAccordion({ herb }: Props) {
+export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
   const [open, setOpen] = useState(false)
   const toggle = () => setOpen(v => !v)
   const { isFavorite, toggle: toggleFavorite } = useHerbFavorites()
@@ -39,6 +40,13 @@ export default function HerbCardAccordion({ herb }: Props) {
       e.preventDefault()
       toggle()
     }
+  }
+
+  const mark = (text: string) => {
+    if (!highlight) return text
+    const escaped = highlight.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const regex = new RegExp(`(${escaped})`, 'ig')
+    return text.replace(regex, '<span class="font-bold text-yellow-300">$1</span>')
   }
 
   return (
@@ -68,8 +76,16 @@ export default function HerbCardAccordion({ herb }: Props) {
       </motion.span>
       <div className='flex items-start justify-between gap-4'>
         <div className='min-w-0'>
-          <h3 className='font-herb text-xl sm:text-2xl text-white'>{herb.name}</h3>
-          {herb.scientificName && <p className='text-xs italic text-sand'>{herb.scientificName}</p>}
+          <h3
+            className='font-herb text-xl sm:text-2xl text-white'
+            dangerouslySetInnerHTML={{ __html: mark(herb.name) }}
+          />
+          {herb.scientificName && (
+            <p
+              className='text-xs italic text-sand'
+              dangerouslySetInnerHTML={{ __html: mark(herb.scientificName) }}
+            />
+          )}
           <div className='mt-1 flex flex-wrap items-center gap-2 text-sm sm:text-base text-sand'>
             {herb.category && (
               <TagBadge label={herb.category} variant={categoryColors[herb.category] || 'purple'} />

--- a/src/components/HerbList.tsx
+++ b/src/components/HerbList.tsx
@@ -5,24 +5,46 @@ import HerbCardAccordion from './HerbCardAccordion'
 
 interface Props {
   herbs: Herb[]
+  highlightQuery?: string
+  batchSize?: number
 }
+const HerbList: React.FC<Props> = ({ herbs, highlightQuery = '', batchSize = 24 }) => {
+  const [visible, setVisible] = React.useState(batchSize)
 
-const HerbList: React.FC<Props> = ({ herbs }) => {
+  const showMore = () => setVisible(v => Math.min(v + batchSize, herbs.length))
+
   if (herbs.length === 0) {
     return <p className='text-center text-sand/80'>No herbs match your search.</p>
   }
 
   return (
-    <motion.div
-      layout
-      className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'
-    >
-      <AnimatePresence>
-        {herbs.map(h => (
-          <HerbCardAccordion key={h.id || h.name} herb={h} />
-        ))}
-      </AnimatePresence>
-    </motion.div>
+    <>
+      <motion.div
+        layout
+        className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'
+      >
+        <AnimatePresence>
+          {herbs.slice(0, visible).map(h => (
+            <HerbCardAccordion
+              key={h.id || h.name}
+              herb={h}
+              highlight={highlightQuery}
+            />
+          ))}
+        </AnimatePresence>
+      </motion.div>
+      {visible < herbs.length && (
+        <div className='mt-6 text-center'>
+          <button
+            type='button'
+            onClick={showMore}
+            className='rounded-md bg-black/30 px-4 py-2 text-sand hover:bg-white/10 backdrop-blur-md'
+          >
+            Show More
+          </button>
+        </div>
+      )}
+    </>
   )
 }
 

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import type Fuse from 'fuse.js'
+import type { Herb } from '../types'
+
+interface Props {
+  query: string
+  setQuery: (q: string) => void
+  fuse: Fuse<Herb>
+}
+
+export default function SearchBar({ query, setQuery, fuse }: Props) {
+  const [suggestions, setSuggestions] = React.useState<ReturnType<typeof fuse.search>>([])
+
+  React.useEffect(() => {
+    const q = query.trim()
+    if (q) {
+      setSuggestions(fuse.search(q, { limit: 5 }))
+    } else {
+      setSuggestions([])
+    }
+  }, [query, fuse])
+
+  const highlight = (text: string) => {
+    if (!query) return text
+    const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const regex = new RegExp(`(${escaped})`, 'ig')
+    return text.replace(regex, '<span class="font-bold">$1</span>')
+  }
+
+  return (
+    <div className='relative w-full'>
+      <input
+        type='text'
+        placeholder='Search herbs...'
+        value={query}
+        onChange={e => setQuery(e.target.value)}
+        className='w-full rounded-md bg-space-dark/70 px-3 py-2 text-white backdrop-blur-md focus:outline-none'
+      />
+      {suggestions.length > 0 && (
+        <ul className='absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-black/80 p-2 text-sm text-sand backdrop-blur-md'>
+          {suggestions.map(s => (
+            <li key={s.item.id}>
+              <button
+                type='button'
+                className='w-full text-left hover:bg-white/10 px-2 py-1 rounded'
+                onClick={() => setQuery(s.item.name)}
+                dangerouslySetInnerHTML={{ __html: highlight(s.item.name) }}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src/hooks/useFilteredHerbs.ts
+++ b/src/hooks/useFilteredHerbs.ts
@@ -1,0 +1,56 @@
+import React from 'react'
+import Fuse from 'fuse.js'
+import type { Herb } from '../types'
+
+interface Options {
+  favorites?: string[]
+}
+
+export function useFilteredHerbs(herbs: Herb[], options: Options = {}) {
+  const { favorites = [] } = options
+  const [query, setQuery] = React.useState('')
+  const [tags, setTags] = React.useState<string[]>([])
+  const [favoritesOnly, setFavoritesOnly] = React.useState(false)
+  const [sort, setSort] = React.useState('')
+
+  const fuse = React.useMemo(
+    () =>
+      new Fuse(herbs, {
+        keys: ['name', 'scientificName', 'effects', 'description', 'tags'],
+        threshold: 0.4,
+        includeMatches: true,
+      }),
+    [herbs]
+  )
+
+  const filtered = React.useMemo(() => {
+    let res = herbs
+    const q = query.trim()
+    if (q) {
+      res = fuse.search(q).map(r => r.item)
+    }
+    if (tags.length) {
+      res = res.filter(h => tags.every(t => h.tags.includes(t)))
+    }
+    if (favoritesOnly) {
+      res = res.filter(h => favorites.includes(h.id))
+    }
+    if (sort === 'name') {
+      res = [...res].sort((a, b) => a.name.localeCompare(b.name))
+    }
+    return res
+  }, [herbs, query, tags, favoritesOnly, favorites, sort, fuse])
+
+  return {
+    filtered,
+    query,
+    setQuery,
+    tags,
+    setTags,
+    favoritesOnly,
+    setFavoritesOnly,
+    sort,
+    setSort,
+    fuse,
+  }
+}

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -1,0 +1,16 @@
+export function getLocal<T>(key: string, defaultValue: T): T {
+  try {
+    const stored = localStorage.getItem(key)
+    return stored ? (JSON.parse(stored) as T) : defaultValue
+  } catch {
+    return defaultValue
+  }
+}
+
+export function setLocal<T>(key: string, value: T) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value))
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
## Summary
- add SearchBar component with Fuse.js suggestions
- create useFilteredHerbs hook for reusable filtering
- persist scroll state with local storage helpers
- support lazy loading and highlighting in HerbList
- highlight matches in HerbCardAccordion
- integrate new search and favorites view in Database page

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687a7ba6e1ac8323bda7c363536a8787