### PR TITLE
UI polish and mobile fixes

### DIFF
--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -32,7 +32,7 @@ const itemVariants = {
   visible: { opacity: 1, y: 0 },
 }
 
-const TAG_LIMIT = 4
+const TAG_LIMIT = 3
 
 const fieldTooltips: Record<string, string> = {
   mechanismOfAction: 'How this herb produces its effects in the body.',
@@ -109,7 +109,7 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
       }}
       whileTap={{ scale: 0.97 }}
       transition={{ layout: { duration: 0.4, ease: 'easeInOut' } }}
-      className={`hover-glow card-contrast relative cursor-pointer overflow-hidden rounded-2xl bg-gradient-to-br ${gradient} border border-white/10 p-4 shadow-lg shadow-black/50 ring-1 ring-white/30 backdrop-blur-md hover:shadow-psychedelic-pink/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-psychedelic-pink sm:p-6`}
+      className={`hover-glow card-contrast relative cursor-pointer overflow-hidden rounded-2xl bg-gradient-to-br ${gradient} border border-white/10 p-4 shadow-lg shadow-black/50 ring-1 ring-white/30 backdrop-blur-md hover:drop-shadow-xl hover:shadow-psychedelic-pink/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-psychedelic-pink sm:p-6`}
     >
       <motion.span
         initial={{ opacity: 0, y: -4 }}
@@ -121,23 +121,25 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
       </motion.span>
       <div className='flex items-start justify-between gap-4'>
         <div className='min-w-0'>
-          <h3
-            className='text-shadow mb-0.5 font-herb text-xl text-white sm:text-2xl'
-            dangerouslySetInnerHTML={{ __html: mark(herb.name) }}
-          />
-          {tier && (
-            <span
-              className={`ml-1 rounded-full px-2 py-0.5 text-xs font-medium shadow ${
-                tier === 'safe'
-                  ? 'bg-green-700/40 text-green-200 ring-1 ring-green-400/60'
-                  : tier === 'caution'
-                    ? 'bg-yellow-700/40 text-yellow-200 ring-1 ring-yellow-400/60'
-                    : 'bg-red-700/40 text-red-200 ring-1 ring-red-500/60'
-              }`}
-            >
-              {tier === 'safe' ? '✅ Safe' : tier === 'caution' ? '⚠️ Caution' : '☠️ High Risk'}
-            </span>
-          )}
+          <div className='flex flex-wrap items-baseline gap-1'>
+            <h3
+              className='text-shadow mb-0.5 font-herb text-xl text-white sm:text-2xl'
+              dangerouslySetInnerHTML={{ __html: mark(herb.name) }}
+            />
+            {tier && (
+              <span
+                className={`rounded-full px-2 py-0.5 text-xs font-medium shadow ${
+                  tier === 'safe'
+                    ? 'bg-green-700/40 text-green-200 ring-1 ring-green-400/60'
+                    : tier === 'caution'
+                      ? 'bg-yellow-700/40 text-yellow-200 ring-1 ring-yellow-400/60'
+                      : 'bg-red-700/40 text-red-200 ring-1 ring-red-500/60'
+                }`}
+              >
+                {tier === 'safe' ? '✅ Safe' : tier === 'caution' ? '⚠️ Caution' : '☠️ High Risk'}
+              </span>
+            )}
+          </div>
           {herb.scientificName && (
             <p
               className='mt-0.5 text-xs italic text-sand'
@@ -175,13 +177,7 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
         </div>
       </div>
 
-      <div
-        className='mt-2 flex flex-wrap gap-2'
-        onClick={e => {
-          e.stopPropagation()
-          if (herb.tags.length > TAG_LIMIT) setTagsExpanded(t => !t)
-        }}
-      >
+      <div className='mt-2 flex flex-wrap gap-2'>
         {(tagsExpanded || herb.tags.length <= TAG_LIMIT
           ? herb.tags
           : herb.tags.slice(0, TAG_LIMIT)
@@ -193,11 +189,20 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
             className={open ? 'animate-pulse' : ''}
           />
         ))}
-        {herb.tags.length > TAG_LIMIT && !tagsExpanded && (
-          <TagBadge label={`+${herb.tags.length - TAG_LIMIT} more`} variant='yellow' />
-        )}
-        {herb.tags.length > TAG_LIMIT && tagsExpanded && (
-          <TagBadge label='Show Less' variant='yellow' />
+        {herb.tags.length > TAG_LIMIT && (
+          <button
+            type='button'
+            onClick={e => {
+              e.stopPropagation()
+              setTagsExpanded(t => !t)
+            }}
+            className='focus:outline-none'
+          >
+            <TagBadge
+              label={tagsExpanded ? 'Show Less' : `+${herb.tags.length - TAG_LIMIT} more`}
+              variant='yellow'
+            />
+          </button>
         )}
       </div>
 

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -21,7 +21,7 @@ const Pagination: React.FC<Props> = ({ currentPage, totalPages, onPageChange }) 
   }
   const pages = getPages()
   return (
-    <div className='mb-8 mt-4 inline-flex flex-nowrap justify-center gap-2 overflow-x-auto sm:flex-wrap'>
+    <div className='mb-8 mt-4 mx-auto inline-flex w-max flex-nowrap justify-center gap-2 overflow-x-auto sm:w-full sm:flex-wrap'>
       <button
         type='button'
         disabled={currentPage === 1}
@@ -36,12 +36,12 @@ const Pagination: React.FC<Props> = ({ currentPage, totalPages, onPageChange }) 
             whileHover={{ scale: 1.1 }}
             key={p}
             onClick={() => onPageChange(p)}
-            className={`min-w-[2rem] rounded px-2 py-1 text-center text-sm ${p === currentPage ? 'bg-cosmic-purple text-white' : 'text-sand'}`}
+            className={`w-8 rounded px-2 py-1 text-center text-sm ${p === currentPage ? 'bg-cosmic-purple text-white' : 'text-sand'}`}
           >
             {p}
           </motion.button>
         ) : (
-          <span key={`ellipsis-${i}`} className='min-w-[2rem] px-2 py-1 text-center text-sand'>
+          <span key={`ellipsis-${i}`} className='w-8 px-2 py-1 text-center text-sand'>
             {p}
           </span>
         )

--- a/src/components/TagBadge.tsx
+++ b/src/components/TagBadge.tsx
@@ -21,7 +21,7 @@ export default function TagBadge({ label, variant = 'purple', className }: Props
     <motion.span
       whileHover={{ scale: 1.05 }}
       className={clsx(
-        'hover-glow text-shadow inline-flex items-center rounded-full bg-gradient-to-br px-2 py-0.5 text-xs font-medium text-white shadow',
+        'hover-glow text-shadow inline-flex items-center rounded-full bg-gradient-to-br px-2 py-0.5 text-xs font-medium text-white shadow ring-1 ring-white/20 backdrop-blur-sm dark:ring-black/30',
         colorMap[variant],
         className
       )}

--- a/src/index.css
+++ b/src/index.css
@@ -46,7 +46,7 @@ html {
 }
 /* Animations and extra utilities */
 .tag-pill {
-  @apply inline-flex items-center gap-1 rounded-full bg-black/10 px-2 py-0.5 text-xs shadow backdrop-blur-sm hover:bg-black/20 dark:bg-white/10 dark:hover:bg-white/20;
+  @apply inline-flex items-center gap-1 rounded-full bg-black/10 px-2 py-0.5 text-xs shadow backdrop-blur-sm hover:bg-black/20 dark:bg-white/10 dark:hover:bg-white/20 text-shadow ring-1 ring-white/20 dark:ring-black/30;
 }
 
 @keyframes gradient-shift {

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -64,7 +64,11 @@ export default function Database() {
       if (window.scrollY > 150) setFiltersOpen(false)
     }
     window.addEventListener('scroll', close)
-    return () => window.removeEventListener('scroll', close)
+    window.addEventListener('touchmove', close)
+    return () => {
+      window.removeEventListener('scroll', close)
+      window.removeEventListener('touchmove', close)
+    }
   }, [])
 
   const relatedTags = React.useMemo(() => {


### PR DESCRIPTION
## Summary
- refine HerbCardAccordion headers and tag overflow controls
- improve badge styles for better readability
- center pagination on mobile and size buttons consistently
- add touchmove handler so filters close while scrolling on iOS
- tweak tag-pill style for consistent contrast

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ace25f8048323a5dfbd43762b2e31