### PR TITLE
Add new herbs and compound linking

### DIFF
--- a/Full170.json
+++ b/Full170.json
@@ -1,0 +1,5608 @@
+[
+  {
+    "name": "Acacia confusa",
+    "category": "Ritual / Visionary",
+    "contraindications": "Mental health conditions, SSRIs/MAOIs",
+    "description": "A Taiwanese tree whose root bark is rich in DMT and related tryptamines. Commonly used in DIY Ayahuasca analogs or 'Anahuasca' brews.",
+    "drugInteractions": "MAOIs, antidepressants — risky",
+    "duration": "4–6 hrs",
+    "effects": [
+      "Visual distortion",
+      "mystical states",
+      "introspection"
+    ],
+    "id": "acacia-confusa",
+    "intensity": "Strong",
+    "legalStatus": "DMT restricted in many countries",
+    "mechanismOfAction": "DMT – 5-HT2A agonist; requires MAOI for oral activity",
+    "onset": "20–45 min",
+    "pharmacokinetics": "Onset: 20–45 min (oral w/ MAOI); Duration: 4–6 hrs",
+    "preparation": "Root bark boiled with MAOI plant (e.g. Syrian Rue) to activate",
+    "region": "Taiwan, Philippines, Pacific Islands",
+    "safetyRating": "high",
+    "scientificName": "Acacia confusa",
+    "sideEffects": "Strong visuals, nausea, anxiety",
+    "tags": [
+      "🧪 DMT",
+      "⚠️ Caution",
+      "🌿 Root bark"
+    ],
+    "therapeuticUses": "Spiritual exploration, traditional cleansing (when combined with MAOI)",
+    "toxicity": "Low physiological, high psychological risk",
+    "toxicityLD50": "Not established",
+    "activeConstituents": [
+      {
+        "name": "DMT",
+        "type": "tryptamine",
+        "effect": "potent visionary"
+      }
+    ]
+  },
+  {
+    "name": "Acorus gramineus",
+    "category": "Ethnobotanical / Rare",
+    "contraindications": "Pregnancy, long-term use caution due to β-asarone.",
+    "description": "Asian sweet flag containing β-asarone, sometimes taken for cognition.",
+    "drugInteractions": "May enhance CNS depressants.",
+    "duration": "Unknown",
+    "effects": [
+      "Cognitive clarity",
+      "trippy effects (debated)"
+    ],
+    "id": "acorus-gramineus",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Contains β-asarone; may modulate acetylcholine and GABA pathways; traditional use for cognition.",
+    "onset": "15-45 min",
+    "pharmacokinetics": "Oral tea or tincture; slow onset (~1 hr); mild duration (2–3 hrs).",
+    "preparation": "Tea or chewed",
+    "region": "🇨🇳 East Asia",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Nausea at high doses, possible carcinogenic risk with long-term β-asarone exposure.",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83d\\udc8a Oral",
+      "\\ud83e\\udde0 Cognitive",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Cognitive enhancement, anxiety, neuroprotective potential.",
+    "toxicity": "Concerns over β-asarone carcinogenicity in some studies.",
+    "toxicityLD50": "β-asarone LD50 (rat, oral): ~310 mg/kg."
+  },
+  {
+    "name": "African Dream Root",
+    "category": "Oneirogen",
+    "contraindications": "None well established",
+    "description": "A sacred dream-enhancing root used by the Xhosa people of South Africa to induce powerful and meaningful dreams.",
+    "drugInteractions": "Unknown",
+    "duration": "During REM sleep",
+    "effects": [
+      "Vivid dreams",
+      "lucidity",
+      "spiritual connection"
+    ],
+    "id": "african-dream-root",
+    "intensity": "Mild to moderate",
+    "legalStatus": "Legal",
+    "mechanismOfAction": "Likely saponins and triterpenoids affecting sleep cycles",
+    "onset": "During sleep",
+    "pharmacokinetics": "Onset: Sleep onset; Duration: dream state",
+    "preparation": "Root is soaked and whipped into a frothy tea",
+    "region": "South Africa",
+    "safetyRating": "low",
+    "scientificName": "Silene capensis",
+    "sideEffects": "Mild nausea or grogginess if overdosed",
+    "tags": [
+      "🌙 Dream",
+      "🧘 Ancestral",
+      "✅ Safe"
+    ],
+    "therapeuticUses": "Dream recall, ancestral communication (traditional)",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established"
+  },
+  {
+    "name": "Alchornea castaneifolia",
+    "category": "Ritual / Visionary",
+    "contraindications": "Pregnancy",
+    "description": "Used in Amazonian shamanic rituals for its spiritual and anti-inflammatory effects. Often included in Ayahuasca blends.",
+    "drugInteractions": "Unknown",
+    "duration": "2–6 hrs",
+    "effects": [
+      "Anti-inflammatory",
+      "spiritual clarity",
+      "energetic cleansing"
+    ],
+    "id": "alchornea-castaneifolia",
+    "intensity": "Mild",
+    "legalStatus": "Legal",
+    "mechanismOfAction": "Unknown; may involve tannins and flavonoids",
+    "onset": "30–60 min",
+    "pharmacokinetics": "Onset: 30–60 min; Duration: 2–6 hrs",
+    "preparation": "Bark decoction or infused in Ayahuasca",
+    "region": "Amazon basin",
+    "safetyRating": "low",
+    "scientificName": "Alchornea castaneifolia",
+    "sideEffects": "Minimal; bitter taste",
+    "tags": [
+      "🌿 Amazon",
+      "✅ Safe",
+      "🧘 Cleanse"
+    ],
+    "therapeuticUses": "Rheumatism, arthritis, spiritual cleansing",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established"
+  },
+  {
+    "name": "Anadenanthera colubrina (Cebíl)",
+    "category": "Ethnobotanical / Rare",
+    "contraindications": "Cardiovascular disorders, psychiatric conditions, and pregnancy.",
+    "description": "South American tree whose snuffable seeds contain bufotenin.",
+    "drugInteractions": "Concomitant use with SSRIs or MAOIs may risk serotonin syndrome [1, 0].",
+    "duration": "Unknown",
+    "effects": [
+      "Entheogenic snuff",
+      "alternate reality feel"
+    ],
+    "id": "anadenanthera-colubrina-cebl",
+    "intensity": "High",
+    "legalStatus": "Restricted in many regions",
+    "mechanismOfAction": "Bufotenin acts as a potent and non-selective serotonin receptor agonist at 5-HT₁A, 5-HT₂A, 5-HT₂C, and 5-HT₃ receptors, and serves as a specific serotonin releasing agent [1, 0].",
+    "onset": "Varies",
+    "pharmacokinetics": "When insufflated, bufotenin is rapidly absorbed nasally with onset in 5–15 min and duration around 1–2 h [1, 1].",
+    "preparation": "South American use",
+    "region": "🌎 Unknown / Global",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Prominent cardiovascular changes, nausea, vomiting, and dizziness [1, 0, 1, 1].",
+    "tags": [
+      "\\u26a0\\ufe0f Restricted"
+    ],
+    "therapeuticUses": "Traditionally used as a snuff for visionary and divinatory rituals in South American cultures [1, 1].",
+    "toxicity": "No documented human LD50; rodent LD50 approximately 200–300 mg/kg (intraperitoneal) [1, 0].",
+    "toxicityLD50": "No documented human LD50; rodent LD50 approximately 200–300 mg/kg (intraperitoneal) [1, 0]."
+  },
+  {
+    "name": "Artemisia vulgaris (Mugwort)",
+    "category": "Oneirogen",
+    "contraindications": "Not well documented",
+    "description": "Common European mugwort used in dream pillows and as bitter tonic.",
+    "drugInteractions": "Not well documented",
+    "duration": "Unknown",
+    "effects": [
+      "Lucid dreaming",
+      "light hallucinations"
+    ],
+    "id": "artemisia-vulgaris-mugwort",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Unknown",
+    "onset": "5-15 min",
+    "pharmacokinetics": "Not well documented",
+    "preparation": "Smoke, tea, or ritual incense",
+    "region": "🇪🇺 Europe",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Not well documented",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\u2615 Brewable",
+      "\\ud83d\\udd6f\\ufe0f Ritual",
+      "\\ud83e\\udde0 Dream",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Not well documented",
+    "toxicity": "Unknown",
+    "toxicityLD50": "Unknown"
+  },
+  {
+    "name": "Bacopa monnieri",
+    "category": "Empathogen / Euphoriant",
+    "contraindications": "Pregnancy, lactation, hypersensitivity to any component [0, 5].",
+    "description": "Aquatic herb taken long-term to improve memory and concentration.",
+    "drugInteractions": "No major interactions documented; caution with sedatives [0, 5].",
+    "duration": "Unknown",
+    "effects": [
+      "Memory enhancer",
+      "mild calming"
+    ],
+    "id": "bacopa-monnieri",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Contains bacosides A and B which enhance cholinergic transmission, antioxidant defenses, and modulate neurotransmitter levels (serotonin, dopamine) [0, 0, 0, 2].",
+    "onset": "30-60 min",
+    "pharmacokinetics": "Oral preparations (extracts or powder); onset 30–60 min; requires chronic dosing for peak cognitive benefits [0, 5].",
+    "preparation": "Tea, capsule",
+    "region": "🇮🇳 India",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Gastrointestinal upset (nausea, increased motility), fatigue, dry mouth [0, 5].",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83d\\udc8a Oral",
+      "\\ud83d\\udcab Euphoria",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Cognitive enhancement (memory, learning), anxiety reduction, ADHD management [0, 1, 0, 6].",
+    "toxicity": "Generally non-toxic; no serious adverse effects at recommended doses; rodent LD50 not well established [0, 6].",
+    "toxicityLD50": "Generally non-toxic; no serious adverse effects at recommended doses; rodent LD50 not well established [0, 6]."
+  },
+  {
+    "name": "Belladonna",
+    "category": "Deliriant / Toxic",
+    "contraindications": "Cardiovascular disease, glaucoma, pregnancy.",
+    "description": "Deadly nightshade once used for trance and as a cosmetic poison.",
+    "drugInteractions": "CNS depressants, anticholinergic drugs.",
+    "duration": "Unknown",
+    "effects": [
+      "Hallucinations",
+      "dreamlike confusion"
+    ],
+    "id": "belladonna",
+    "intensity": "High",
+    "legalStatus": "Controlled / Toxic",
+    "mechanismOfAction": "Tropane alkaloids block acetylcholine; causes anticholinergic delirium.",
+    "onset": "Varies",
+    "pharmacokinetics": "Oral or topical; onset ~30–90 mins; effects last 4–12 hrs.",
+    "preparation": "Highly toxic – not for casual use",
+    "region": "🌎 Unknown / Global",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Dry mouth, hallucinations, delirium, elevated pulse.",
+    "tags": [
+      "\\u2620\\ufe0f Toxic"
+    ],
+    "therapeuticUses": "Historically used for pain, muscle spasms, and cosmetic dilation.",
+    "toxicity": "Highly toxic; accidental ingestion can be fatal.",
+    "toxicityLD50": "Atropine LD50 (rat, oral): ~453 mg/kg."
+  },
+  {
+    "name": "Betel Nut",
+    "category": "Empathogen / Euphoriant",
+    "contraindications": "Pregnancy, cardiovascular conditions",
+    "description": "A widely used masticatory stimulant in Asia and the Pacific, often combined with lime and betel leaf.",
+    "drugInteractions": "Stimulants, parasympathomimetics",
+    "duration": "Unknown",
+    "effects": [
+      "Stimulation",
+      "warmth",
+      "mild euphoria"
+    ],
+    "id": "betel-nut",
+    "intensity": "Unknown",
+    "legalStatus": "Unknown",
+    "mechanismOfAction": "Arecoline acts as a muscarinic cholinergic agonist",
+    "onset": "Unknown",
+    "pharmacokinetics": "Not well documented",
+    "preparation": "Chewed with lime and leaf",
+    "region": "South and Southeast Asia",
+    "safetyRating": "Unknown",
+    "scientificName": "Areca catechu",
+    "sideEffects": "Addiction, oral cancer with chronic use",
+    "tags": [],
+    "therapeuticUses": "Traditional digestive stimulant",
+    "toxicity": "Unknown",
+    "toxicityLD50": "Unknown"
+  },
+  {
+    "name": "Blue Lotus",
+    "category": "Oneirogen",
+    "contraindications": "Pregnancy",
+    "description": "Sacred Egyptian flower associated with dream states and aphrodisiac properties. Contains aporphine alkaloids.",
+    "drugInteractions": "Avoid sedatives",
+    "duration": "2–4 hrs",
+    "effects": [
+      "Mild euphoria",
+      "lucid dreaming",
+      "relaxation"
+    ],
+    "id": "blue-lotus",
+    "intensity": "Mild",
+    "legalStatus": "Legal in most countries",
+    "mechanismOfAction": "Aporphine acts as dopamine receptor agonist",
+    "onset": "20–40 min",
+    "pharmacokinetics": "Onset: 20–40 min; Duration: 2–4 hrs",
+    "preparation": "Tea, wine soak, or vaporized",
+    "region": "Egypt, India",
+    "safetyRating": "low",
+    "scientificName": "Nymphaea caerulea",
+    "sideEffects": "Mild drowsiness, vivid dreams",
+    "tags": [
+      "🌸 Calm",
+      "😊 Euphoria",
+      "✅ Safe"
+    ],
+    "therapeuticUses": "Anxiety, mild sedation, aphrodisiac",
+    "toxicity": "Low",
+    "toxicityLD50": "Not known"
+  },
+  {
+    "name": "Blue Lotus (Nymphaea caerulea)",
+    "category": "Other",
+    "contraindications": "Pregnancy, avoid with dopaminergic drugs.",
+    "description": "Sacred water lily delivering gentle euphoria and relaxation.",
+    "drugInteractions": "Potential additive effects with CNS depressants.",
+    "duration": "Unknown",
+    "effects": [
+      "Euphoria",
+      "aphrodisiac",
+      "dreamy calm"
+    ],
+    "id": "blue-lotus-nymphaea-caerulea",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Contains aporphine and nuciferine; dopamine receptor modulation and mild sedative effect.",
+    "onset": "1-5 min",
+    "pharmacokinetics": "Smoked or soaked in wine; onset rapid (5–20 min); duration ~1–3 hrs.",
+    "preparation": "Wine soak, smoke, tea",
+    "region": "🌎 Unknown / Global",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Drowsiness, mild dizziness at high doses.",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\u2615 Brewable",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Mild euphoria, anxiety relief, and aphrodisiac in traditional use.",
+    "toxicity": "Low toxicity; no serious effects reported from traditional use.",
+    "toxicityLD50": "Not established; no reported lethal doses."
+  },
+  {
+    "name": "Bobinsana",
+    "category": "Ritual / Visionary",
+    "contraindications": "Pregnancy, psychiatric disorders",
+    "description": "A flowering Amazonian shrub used in master plant dieta and as an adjunct to Ayahuasca ceremonies for emotional healing and dream clarity.",
+    "drugInteractions": "Unknown; caution with serotonergics",
+    "duration": "2–6 hrs",
+    "effects": [
+      "Heart-opening",
+      "emotional clarity",
+      "mild euphoria"
+    ],
+    "id": "bobinsana",
+    "intensity": "Mild",
+    "legalStatus": "Legal",
+    "mechanismOfAction": "Unknown; possibly serotonergic modulation or mild MAOI",
+    "onset": "30–60 min",
+    "pharmacokinetics": "Onset: 30–60 min; Duration: 2–6 hrs",
+    "preparation": "Decoction from bark or leaves in dieta; often macerated",
+    "region": "Amazon basin (Peru, Ecuador)",
+    "safetyRating": "low",
+    "scientificName": "Calliandra angustifolia",
+    "sideEffects": "Drowsiness, mild emotional vulnerability",
+    "tags": [
+      "🌿 Herbal",
+      "🧘 Calm",
+      "✅ Safe"
+    ],
+    "therapeuticUses": "Emotional trauma healing, dream support",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established"
+  },
+  {
+    "name": "Brugmansia",
+    "category": "Ritual / Visionary",
+    "contraindications": "All unsupervised use",
+    "description": "Powerful and dangerous deliriant used in South American shamanism. Highly toxic and not recommended for casual use.",
+    "drugInteractions": "Anticholinergics, CNS depressants",
+    "duration": "Unknown",
+    "effects": [
+      "Hallucinations",
+      "delirium",
+      "disorientation"
+    ],
+    "id": "brugmansia",
+    "intensity": "Unknown",
+    "legalStatus": "Unknown",
+    "mechanismOfAction": "Tropane alkaloids (scopolamine, atropine)",
+    "onset": "Unknown",
+    "pharmacokinetics": "Not well documented",
+    "preparation": "Smoked or brewed (shamanic contexts only)",
+    "region": "South America",
+    "safetyRating": "Unknown",
+    "scientificName": "Brugmansia suaveolens",
+    "sideEffects": "Extreme confusion, memory loss, risk of death",
+    "tags": [],
+    "therapeuticUses": "Historical use in asthma and pain (no modern safe use)",
+    "toxicity": "Unknown",
+    "toxicityLD50": "Unknown"
+  },
+  {
+    "name": "Caapi",
+    "category": "Ritual / Visionary",
+    "contraindications": "SSRIs, MAOIs, pregnancy",
+    "description": "The vine of the soul used in Ayahuasca. Contains harmala alkaloids and facilitates DMT absorption in the brew.",
+    "drugInteractions": "All serotonergic substances",
+    "duration": "Unknown",
+    "effects": [
+      "MAOI effects",
+      "spiritual opening",
+      "purging"
+    ],
+    "id": "caapi",
+    "intensity": "Unknown",
+    "legalStatus": "Unknown",
+    "mechanismOfAction": "Reversible MAO-A inhibition (harmine, harmaline)",
+    "onset": "Unknown",
+    "pharmacokinetics": "Not well documented",
+    "preparation": "Brewed with DMT-containing plants",
+    "region": "Amazon basin",
+    "safetyRating": "Unknown",
+    "scientificName": "Banisteriopsis caapi",
+    "sideEffects": "Nausea, purging, dizziness",
+    "tags": [],
+    "therapeuticUses": "Ayahuasca therapy for PTSD, depression",
+    "toxicity": "Unknown",
+    "toxicityLD50": "Unknown"
+  },
+  {
+    "name": "Calea zacatechichi",
+    "category": "Oneirogen",
+    "contraindications": "Pregnancy, sedative use",
+    "description": "Known as the 'dream herb' of the Chontal people of Mexico, Calea is traditionally used to enhance dreams and mental clarity during sleep.",
+    "drugInteractions": "Avoid sedatives, alcohol",
+    "duration": "4–8 hrs",
+    "effects": [
+      "Lucid dreaming",
+      "dream recall",
+      "hypnagogic imagery"
+    ],
+    "id": "calea-zacatechichi",
+    "intensity": "Mild to moderate",
+    "legalStatus": "Legal",
+    "mechanismOfAction": "May modulate GABAergic or cholinergic pathways; unclear",
+    "onset": "30–60 min",
+    "pharmacokinetics": "Onset: 30–60 min; Duration: 4–8 hrs",
+    "preparation": "Tea from dried leaves or smoked before bed",
+    "region": "Mexico, Central America",
+    "safetyRating": "low",
+    "scientificName": "Calea ternifolia (zacatechichi)",
+    "sideEffects": "Bitterness, mild nausea",
+    "tags": [
+      "🌙 Dream",
+      "🧘 Calm",
+      "✅ Safe"
+    ],
+    "therapeuticUses": "Sleep induction, dream work",
+    "toxicity": "Low",
+    "toxicityLD50": "Not known"
+  },
+  {
+    "name": "California Poppy",
+    "category": "Dissociative / Sedative",
+    "contraindications": "Not for use in pregnancy or with other CNS depressants.",
+    "description": "California's state flower containing non-addictive sedative alkaloids.",
+    "drugInteractions": "May amplify effects of benzodiazepines and alcohol.",
+    "duration": "Unknown",
+    "effects": [
+      "Gentle sedative",
+      "dreamlike calm"
+    ],
+    "id": "california-poppy",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Mild GABAergic activity and opioid receptor affinity (non-narcotic).",
+    "onset": "15-45 min",
+    "pharmacokinetics": "Oral (tea or tincture); onset ~30 min; lasts 2–3 hrs.",
+    "preparation": "Tea, tincture, or extract",
+    "region": "🌎 Unknown / Global",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Drowsiness, vivid dreams, dizziness.",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Used for anxiety, insomnia, and pain management.",
+    "toxicity": "Low toxicity; non-habit-forming.",
+    "toxicityLD50": "No known LD50 in humans; safe at standard doses."
+  },
+  {
+    "name": "Celastrus paniculatus",
+    "category": "Empathogen / Euphoriant",
+    "contraindications": "Pregnancy",
+    "description": "Often called the 'Intellect Tree', this Ayurvedic plant is used to support memory, learning, and vivid dreams. Contains sesquiterpenes that may stimulate cholinergic activity.",
+    "drugInteractions": "None well documented",
+    "duration": "4–6 hrs",
+    "effects": [
+      "Cognitive clarity",
+      "memory enhancement",
+      "dream vividness"
+    ],
+    "id": "celastrus-paniculatus",
+    "intensity": "Mild",
+    "legalStatus": "Legal",
+    "mechanismOfAction": "Cholinergic modulation; antioxidant and neuroprotective effects",
+    "onset": "45–90 min",
+    "pharmacokinetics": "Onset: 45–90 min; Duration: 4–6 hrs",
+    "preparation": "Seeds chewed, oil taken orally, or powdered for tea",
+    "region": "India, Sri Lanka, Southeast Asia",
+    "safetyRating": "low",
+    "scientificName": "Celastrus paniculatus",
+    "sideEffects": "Headache or stimulation at high doses",
+    "tags": [
+      "🧠 Nootropic",
+      "🌿 Herbal",
+      "✅ Safe"
+    ],
+    "therapeuticUses": "Memory support, neuroprotection, dream recall",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established"
+  },
+  {
+    "name": "Celastrus paniculatus (Intellect Tree)",
+    "category": "Other",
+    "contraindications": "Not well documented",
+    "description": "Indian vine whose oil is consumed to sharpen memory and dream vividly.",
+    "drugInteractions": "Not well documented",
+    "duration": "Unknown",
+    "effects": [
+      "Lucid dreaming",
+      "cognitive enhancer"
+    ],
+    "id": "celastrus-paniculatus-intellect-tree",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Unknown",
+    "onset": "Varies",
+    "pharmacokinetics": "Not well documented",
+    "preparation": "Oil or seeds consumed",
+    "region": "🌎 Unknown / Global",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Not well documented",
+    "tags": [
+      "\\ud83e\\udde0 Cognitive",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Not well documented",
+    "toxicity": "Unknown",
+    "toxicityLD50": "Unknown"
+  },
+  {
+    "name": "Chacruna",
+    "category": "Ritual / Visionary",
+    "contraindications": "Mental health disorders, SSRIs, MAOIs",
+    "description": "A key component of traditional Ayahuasca brews, Chacruna contains DMT and is often combined with MAOIs like Banisteriopsis caapi to make it orally active.",
+    "drugInteractions": "Dangerous with antidepressants or stimulants",
+    "duration": "4–6 hrs",
+    "effects": [
+      "Visionary states",
+      "spiritual insight",
+      "hallucinations"
+    ],
+    "id": "chacruna",
+    "intensity": "Strong",
+    "legalStatus": "DMT is controlled in most countries",
+    "mechanismOfAction": "DMT – 5-HT2A receptor agonist; requires MAOI to be active orally",
+    "onset": "20–40 min (oral with MAOI)",
+    "pharmacokinetics": "Onset: 20–40 min (with MAOI); Duration: 4–6 hrs",
+    "preparation": "Boiled with Banisteriopsis caapi in traditional Ayahuasca brews",
+    "region": "Amazon basin (Peru, Brazil, Colombia)",
+    "safetyRating": "high",
+    "scientificName": "Psychotria viridis",
+    "sideEffects": "Intense visuals, vomiting, nausea",
+    "tags": [
+      "🧠 Vision",
+      "⚠️ Caution",
+      "🧪 DMT"
+    ],
+    "therapeuticUses": "Spiritual healing, emotional release (as part of Ayahuasca)",
+    "toxicity": "Low physical toxicity, high psychological risk",
+    "toxicityLD50": "Not established in humans"
+  },
+  {
+    "name": "Chiric Sanango",
+    "category": "Dissociative / Sedative",
+    "contraindications": "Pregnancy, cardiovascular conditions.",
+    "description": "Amazonian shrub added to ayahuasca for introspection and cleansing.",
+    "drugInteractions": "Other serotonergic or cholinergic agents.",
+    "duration": "Unknown",
+    "effects": [
+      "Shadow work",
+      "spiritual clearing"
+    ],
+    "id": "chiric-sanango",
+    "intensity": "High",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Contains β-carboline alkaloids (harmine, harmaline) and coumarins (scopoletin) that may inhibit monoamine oxidase and modulate serotonergic/cholinergic systems [0, 11, 0, 1].",
+    "onset": "15-45 min",
+    "pharmacokinetics": "Traditionally infused or added to ayahuasca; alkaloids absorbed orally; onset ~30–60 min; duration several hours [0, 10].",
+    "preparation": "Amazonian brew; not casual use",
+    "region": "🌎 Unknown / Global",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Dizziness, nausea, muscle tremors, delirium at high doses [0, 11].",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Potentiates ayahuasca, used in Amazonian rituals for introspection and mild hallucinations [0, 4].",
+    "toxicity": "Toxic in high doses; caution advised.",
+    "toxicityLD50": "LD50 not established; considered mildly toxic in large doses due to cholinergic effects."
+  },
+  {
+    "name": "Clavo huasca",
+    "category": "Empathogen / Euphoriant",
+    "contraindications": "Pregnancy, blood pressure meds",
+    "description": "Amazonian vine used in both physical and spiritual medicine. Traditionally consumed as a libido enhancer and pre-Ayahuasca preparation.",
+    "drugInteractions": "Avoid CNS depressants, alcohol",
+    "duration": "3–6 hrs",
+    "effects": [
+      "Aphrodisiac",
+      "calming",
+      "digestive"
+    ],
+    "id": "clavo-huasca",
+    "intensity": "Mild",
+    "legalStatus": "Legal",
+    "mechanismOfAction": "Alkaloids may modulate dopamine and serotonin; warming vasodilator",
+    "onset": "30–60 min",
+    "pharmacokinetics": "Onset: 30–60 min; Duration: 2–4 hrs",
+    "preparation": "Bark decoction or tincture",
+    "region": "Amazon Basin",
+    "safetyRating": "low",
+    "scientificName": "Tynanthus panurensis",
+    "sideEffects": "Mild hypotension or fatigue",
+    "tags": [
+      "🔥 Aphrodisiac",
+      "✅ Safe",
+      "🌿 Amazonian"
+    ],
+    "therapeuticUses": "Aphrodisiac, digestive aid in Amazonian medicine",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established"
+  },
+  {
+    "name": "Copal",
+    "category": "Ritual / Visionary",
+    "contraindications": "Not well documented",
+    "description": "Resin from Bursera trees burned ceremonially to purify and induce trance.",
+    "drugInteractions": "Not well documented",
+    "duration": "Unknown",
+    "effects": [
+      "Purifying",
+      "sacred aroma",
+      "trance enhancement"
+    ],
+    "id": "copal",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Unknown",
+    "onset": "5-20 min",
+    "pharmacokinetics": "Not well documented",
+    "preparation": "Burned as incense",
+    "region": "🌐 Global / Ritual",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Not well documented",
+    "tags": [
+      "\\ud83d\\udd6f\\ufe0f Ritual",
+      "\\ud83d\\udd2e Ritual",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Not well documented",
+    "toxicity": "Unknown",
+    "toxicityLD50": "Unknown"
+  },
+  {
+    "name": "Cyperus articulatus",
+    "category": "Ritual / Visionary",
+    "contraindications": "Unknown",
+    "description": "Known as Piripiri or Guinea Rush, this sedge is used in Afro-Caribbean and Amazonian rituals for mild visionary states and spiritual grounding.",
+    "drugInteractions": "Unknown",
+    "duration": "2–5 hrs",
+    "effects": [
+      "Calm",
+      "focus",
+      "light trance"
+    ],
+    "id": "cyperus-articulatus",
+    "intensity": "Mild",
+    "legalStatus": "Legal",
+    "mechanismOfAction": "Unknown; may involve sesquiterpenes",
+    "onset": "20–40 min",
+    "pharmacokinetics": "Onset: 20–40 min; Duration: 2–5 hrs",
+    "preparation": "Rhizome decoction or powder",
+    "region": "Africa, Caribbean, Amazon",
+    "safetyRating": "low",
+    "scientificName": "Cyperus articulatus",
+    "sideEffects": "Rare; mild sedation",
+    "tags": [
+      "🧘 Ritual",
+      "✅ Safe",
+      "🌿 Piripiri"
+    ],
+    "therapeuticUses": "Spiritual clarity, dream work, digestion",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established"
+  },
+  {
+    "name": "Damiana",
+    "category": "Empathogen / Euphoriant",
+    "contraindications": "Pregnancy, urinary tract conditions",
+    "description": "Used traditionally in Mexico and Central America for libido, relaxation, and mild stimulation. Sometimes blended in herbal smoking mixes.",
+    "drugInteractions": "May interact with blood sugar meds",
+    "duration": "2–4 hrs",
+    "effects": [
+      "Mood boost",
+      "aphrodisiac",
+      "relaxation"
+    ],
+    "id": "damiana",
+    "intensity": "Mild",
+    "legalStatus": "Legal",
+    "mechanismOfAction": "May modulate serotonin and GABA; unclear primary target",
+    "onset": "20–40 min",
+    "pharmacokinetics": "Onset: 20–40 min; Duration: 2–4 hrs",
+    "preparation": "Tea, tincture, smoking blends",
+    "region": "Mexico, Texas, Central America",
+    "safetyRating": "low",
+    "scientificName": "Turnera diffusa",
+    "sideEffects": "Mild headaches or GI discomfort",
+    "tags": [
+      "😊 Mood",
+      "🔥 Aphrodisiac",
+      "✅ Safe"
+    ],
+    "therapeuticUses": "Libido, nervous system support, mild stimulant",
+    "toxicity": "Low",
+    "toxicityLD50": "Not well established"
+  },
+  {
+    "name": "Desfontainia spinosa",
+    "category": "Ritual / Visionary",
+    "contraindications": "Mental illness, cardiovascular risk, pregnancy",
+    "description": "A rare South American shrub used by the Mapuche and other indigenous groups in Chile and Colombia as a ritual intoxicant. Known for unpredictable and potent effects.",
+    "drugInteractions": "Unknown; avoid CNS drugs",
+    "duration": "3–6 hrs",
+    "effects": [
+      "Hallucinations",
+      "disorientation",
+      "dreamlike state"
+    ],
+    "id": "desfontainia-spinosa",
+    "intensity": "Strong",
+    "legalStatus": "Legal but obscure",
+    "mechanismOfAction": "Unknown; possibly tropane alkaloid activity or diterpenes",
+    "onset": "30–90 min",
+    "pharmacokinetics": "Onset: 30–90 min; Duration: 3–6 hrs",
+    "preparation": "Infusion of leaves or berries; sometimes smoked",
+    "region": "Chile, Colombia, Andes",
+    "safetyRating": "high",
+    "scientificName": "Desfontainia spinosa",
+    "sideEffects": "Strong nausea, confusion, pupil dilation",
+    "tags": [
+      "⚠️ Rare",
+      "🧠 Vision",
+      "🌿 Andes"
+    ],
+    "therapeuticUses": "Traditional visionary plant; not clinically established",
+    "toxicity": "Potentially high at ritual doses",
+    "toxicityLD50": "Not established"
+  },
+  {
+    "name": "Eleutherococcus senticosus (Siberian Ginseng)",
+    "category": "Empathogen / Euphoriant",
+    "contraindications": "Hypertension, pregnancy, hormone-sensitive conditions.",
+    "description": "Adaptogenic root boosting stamina and immune function.",
+    "drugInteractions": "May interact with stimulants, immunosuppressants, and anticoagulants.",
+    "duration": "Unknown",
+    "effects": [
+      "Balanced energy",
+      "mood resilience"
+    ],
+    "id": "eleutherococcus-senticosus-siberian-ginseng",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Adaptogenic modulation of HPA axis and immune response; contains eleutherosides influencing stress resilience.",
+    "onset": "30-60 min",
+    "pharmacokinetics": "Oral onset in 30–60 minutes; active glycosides metabolized hepatically.",
+    "preparation": "Tea or extract",
+    "region": "🇨🇳 East Asia",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Mild insomnia, irritability, nervousness in high doses.",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83d\\udcab Euphoria",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Fatigue, immune support, cognitive performance under stress.",
+    "toxicity": "Generally considered safe when used short-term. Long-term effects less studied.",
+    "toxicityLD50": "No established LD50; high doses in animals show minimal acute toxicity."
+  },
+  {
+    "name": "Entada rheedii",
+    "category": "Oneirogen",
+    "contraindications": "Pregnancy, lactation, hypersensitivity [0, 6].",
+    "description": "Seed from a tropical vine used in African traditions to induce vivid dreams.",
+    "drugInteractions": "May potentiate CNS depressants; caution with anticholinergics [0, 6].",
+    "duration": "Unknown",
+    "effects": [
+      "Dream enhancement",
+      "trance"
+    ],
+    "id": "entada-rheedii",
+    "intensity": "Moderate",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Unknown",
+    "onset": "30-60 min",
+    "pharmacokinetics": "Traditionally consumed as cold water infusion; onset ~1–2 h; effects last ~6–8 h [0, 11].",
+    "preparation": "Seed powder or chew",
+    "region": "🇲🇽 Latin America",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Mild GI upset, drowsiness; rare nausea [0, 6].",
+    "tags": [
+      "\\ud83d\\udc8a Oral",
+      "\\ud83e\\udde0 Dream",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Dream enhancement, lucid dreaming, traditional remedy for diarrhea and stomach aches [0, 6, 0, 11].",
+    "toxicity": "Low; no severe toxicity reported in traditional use [0, 6].",
+    "toxicityLD50": "Unknown"
+  },
+  {
+    "name": "Eschscholzia californica (California poppy)",
+    "category": "Dissociative / Sedative",
+    "contraindications": "Glaucoma, MAOI therapy, pregnancy, lactation [2, 9].",
+    "description": "Gentle sedative flower used for anxiety and sleep support.",
+    "drugInteractions": "Additive CNS depression with sedatives, barbiturates; caution with blood thinners and antihypertensives [2, 8].",
+    "duration": "Unknown",
+    "effects": [
+      "Sleep aid",
+      "mild dreamlike calm"
+    ],
+    "id": "eschscholzia-californica-california-poppy",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Unknown",
+    "onset": "15-45 min",
+    "pharmacokinetics": "Oral (tea, extract); onset 30–60 min; duration ~4 h; bioavailability of key alkaloids moderate [2, 3].",
+    "preparation": "Tea, tincture",
+    "region": "🌎 Unknown / Global",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "High doses may cause residual sedation (\"hangover\"), nausea, dizziness; avoid operating machinery [2, 8, 2, 9].",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Anxiety reduction, insomnia aid, mild analgesic, vasomotor headache relief [2, 3, 2, 7].",
+    "toxicity": "Low; no significant toxicity at therapeutic doses [2, 9].",
+    "toxicityLD50": "Unknown"
+  },
+  {
+    "name": "Frankincense (Boswellia)",
+    "category": "Other",
+    "contraindications": "Not well documented",
+    "description": "Resin incense with boswellic acids studied for anti-inflammatory effects.",
+    "drugInteractions": "Not well documented",
+    "duration": "Unknown",
+    "effects": [
+      "Trance",
+      "meditative awareness"
+    ],
+    "id": "frankincense-boswellia",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Unknown",
+    "onset": "Varies",
+    "pharmacokinetics": "Not well documented",
+    "preparation": "Resin burned",
+    "region": "🌐 Global / Ritual",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Not well documented",
+    "tags": [
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Not well documented",
+    "toxicity": "Unknown",
+    "toxicityLD50": "Unknown"
+  },
+  {
+    "name": "Guayusa",
+    "category": "Empathogen / Euphoriant",
+    "contraindications": "Pregnancy, heart conditions, anxiety",
+    "description": "A caffeinated Amazonian holly used in dream rituals and for morning alertness. Known for smooth energy and calming clarity.",
+    "drugInteractions": "Stimulants, caffeine",
+    "duration": "3–5 hrs",
+    "effects": [
+      "Stimulation",
+      "mental clarity",
+      "lucid dreaming"
+    ],
+    "id": "guayusa",
+    "intensity": "Mild to moderate",
+    "legalStatus": "Legal",
+    "mechanismOfAction": "Caffeine and theobromine – adenosine antagonists",
+    "onset": "15–30 min",
+    "pharmacokinetics": "Onset: 15–30 min; Duration: 3–5 hrs",
+    "preparation": "Brewed as tea from dried leaves",
+    "region": "Ecuador, Peru, Amazon",
+    "safetyRating": "low",
+    "scientificName": "Ilex guayusa",
+    "sideEffects": "Restlessness, jitteriness in sensitive individuals",
+    "tags": [
+      "☕ Stimulant",
+      "🌿 Herbal",
+      "✅ Safe"
+    ],
+    "therapeuticUses": "Energy, focus, lucid dreaming support",
+    "toxicity": "Low",
+    "toxicityLD50": "~190 mg/kg (caffeine)"
+  },
+  {
+    "name": "Heimia salicifolia (Sinicuichi)",
+    "category": "Dissociative / Sedative",
+    "contraindications": "Avoid with alcohol or CNS depressants, pregnancy [9, 4].",
+    "description": "Mexican shrub whose fermented leaves produce mild auditory shifts.",
+    "drugInteractions": "None known; caution with psychiatric medications [9, 4].",
+    "duration": "Unknown",
+    "effects": [
+      "Auditory hallucinations",
+      "slowed time"
+    ],
+    "id": "heimia-salicifolia-sinicuichi",
+    "intensity": "Moderate",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Alkaloids may affect auditory processing and blood flow, potentially modulating neurotransmission [9, 4].",
+    "onset": "15-45 min",
+    "pharmacokinetics": "Traditionally fermented sun tea; slow onset 15–45 min; duration ~2–3 h [9, 4].",
+    "preparation": "Fermented sun tea",
+    "region": "🌎 Unknown / Global",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Dry mouth, muscle relaxation, altered hearing [9, 4].",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83e\\uddea Fermented",
+      "\\ud83c\\udf00 Dissociation",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Divination, auditory changes, euphoria in folk practices [9, 4].",
+    "toxicity": "Low toxicity; high doses may cause mild sedation or nausea [9, 4].",
+    "toxicityLD50": "Not well established; no fatal doses reported in traditional use."
+  },
+  {
+    "name": "Henbane",
+    "category": "Deliriant / Toxic",
+    "contraindications": "Not well documented",
+    "description": "Nightshade containing tropane alkaloids causing powerful delirium.",
+    "drugInteractions": "Not well documented",
+    "duration": "Unknown",
+    "effects": [
+      "Delirium",
+      "hallucinations",
+      "anticholinergic"
+    ],
+    "id": "henbane",
+    "intensity": "High",
+    "legalStatus": "Controlled / Toxic",
+    "mechanismOfAction": "Unknown",
+    "onset": "Varies",
+    "pharmacokinetics": "Not well documented",
+    "preparation": "Historically ritual; dangerous/toxic",
+    "region": "🌎 Unknown / Global",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Not well documented",
+    "tags": [
+      "\\ud83d\\udd6f\\ufe0f Ritual",
+      "\\u2620\\ufe0f Toxic"
+    ],
+    "therapeuticUses": "Not well documented",
+    "toxicity": "Unknown",
+    "toxicityLD50": "Unknown"
+  },
+  {
+    "name": "Hop Flowers",
+    "category": "Dissociative / Sedative",
+    "contraindications": "Pregnancy, estrogen-sensitive conditions (e.g. breast cancer).",
+    "description": "Bitter cones of Humulus lupulus used for relaxation and sleep.",
+    "drugInteractions": "May enhance sedatives, alcohol, and hypnotics.",
+    "duration": "Unknown",
+    "effects": [
+      "Relaxation",
+      "dream enhancement"
+    ],
+    "id": "hop-flowers",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Binds to GABA-A receptors, promoting sedation and relaxation.",
+    "onset": "15-45 min",
+    "pharmacokinetics": "Oral or inhaled; onset ~20–40 min; duration ~2–4 hrs.",
+    "preparation": "Tea or herbal pillow",
+    "region": "🌎 Unknown / Global",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Drowsiness, mild headache, possible hormonal effects in large doses.",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Used as a mild sleep aid, anxiety reducer, and dream enhancer.",
+    "toxicity": "Very low toxicity; generally regarded as safe.",
+    "toxicityLD50": "No human LD50; high safety margin reported in herbal use."
+  },
+  {
+    "name": "Indian Lotus",
+    "category": "Dissociative / Sedative",
+    "contraindications": "Pregnancy (caution), hypotension",
+    "description": "Sacred flower in Buddhism and Hinduism, with mild psychoactive and calming properties. Often used in teas or tinctures.",
+    "drugInteractions": "Sedatives, CNS depressants",
+    "duration": "2–4 hrs",
+    "effects": [
+      "Calm",
+      "mild euphoria",
+      "dreaminess"
+    ],
+    "id": "Unknown",
+    "intensity": "Mild",
+    "legalStatus": "Legal",
+    "mechanismOfAction": "Likely GABAergic and dopaminergic effects (alkaloids: nuciferine, aporphine)",
+    "onset": "30–60 min",
+    "pharmacokinetics": "Onset: 30–60 min; Duration: 2–4 hrs",
+    "preparation": "Tea from flowers or stamens; also smoked",
+    "region": "India, Southeast Asia",
+    "safetyRating": "low",
+    "scientificName": "Nelumbo nucifera",
+    "sideEffects": "Drowsiness, dizziness",
+    "tags": [
+      "🌸 Sacred",
+      "🧘 Calm",
+      "🌊 Spiritual"
+    ],
+    "therapeuticUses": "Stress, anxiety, spiritual use",
+    "toxicity": "Low",
+    "toxicityLD50": "Not known"
+  },
+  {
+    "name": "Indian Pipe",
+    "category": "Dissociative / Sedative",
+    "contraindications": "Unknown; limited modern use",
+    "description": "A ghostly white forest plant used in Native American medicine for pain and spiritual insight. Non-photosynthetic and mysterious.",
+    "drugInteractions": "Possibly CNS depressants",
+    "duration": "2–4 hrs",
+    "effects": [
+      "Analgesia",
+      "calm",
+      "emotional detachment"
+    ],
+    "id": "Unknown",
+    "intensity": "Mild",
+    "legalStatus": "Legal (but rare and protected in places)",
+    "mechanismOfAction": "Contains monotropin; acts possibly on NMDA or opioid systems (hypothetical)",
+    "onset": "30–60 min",
+    "pharmacokinetics": "Onset: 30–60 min; Duration: 2–4 hrs",
+    "preparation": "Tincture of fresh or dried plant",
+    "region": "Temperate forests of North America and Asia",
+    "safetyRating": "medium",
+    "scientificName": "Monotropa uniflora",
+    "sideEffects": "Unknown at pharmacological doses; rare usage",
+    "tags": [
+      "👻 Ghost Plant",
+      "🌲 Pain Relief",
+      "🧠 Emotional"
+    ],
+    "therapeuticUses": "Pain relief, emotional trauma support (traditional)",
+    "toxicity": "Unknown",
+    "toxicityLD50": "Not established"
+  },
+  {
+    "name": "Ipomoea tricolor (Heavenly Blue)",
+    "category": "Ethnobotanical / Rare",
+    "contraindications": "Cardiovascular disorders, psychiatric conditions [0, 5].",
+    "description": "Ornamental morning glory whose seeds induce LSD-like visions.",
+    "drugInteractions": "SSRIs/MAOIs [0, 5].",
+    "duration": "Unknown",
+    "effects": [
+      "LSD-like visuals",
+      "spiritual confusion"
+    ],
+    "id": "ipomoea-tricolor-heavenly-blue",
+    "intensity": "High",
+    "legalStatus": "Restricted in some countries",
+    "mechanismOfAction": "Unknown",
+    "onset": "30-90 min",
+    "pharmacokinetics": "Oral ingestion onset 45–120 min; duration 4–10 h; hepatic metabolism [0, 5].",
+    "preparation": "Seeds ground and cold infused",
+    "region": "🌎 Unknown / Global",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Nausea, vasoconstriction, headache [0, 5].",
+    "tags": [
+      "\\u26a0\\ufe0f Restricted"
+    ],
+    "therapeuticUses": "Visionary experiences, ethnobotanical use [0, 5].",
+    "toxicity": "Low; rodent LD50 ~200–300 mg/kg [0, 5].",
+    "toxicityLD50": "Unknown"
+  },
+  {
+    "name": "Justicia pectoralis",
+    "category": "Ritual / Visionary",
+    "contraindications": "Liver disorders, pregnancy",
+    "description": "Aromatic herb called tilo, brewed or smoked for calming effects.",
+    "drugInteractions": "Coumarin-sensitive meds (e.g., blood thinners)",
+    "duration": "2–5 hrs",
+    "effects": [
+      "Relaxation",
+      "light euphoria",
+      "spiritual dreams"
+    ],
+    "id": "justicia-pectoralis",
+    "intensity": "Mild",
+    "legalStatus": "Legal",
+    "mechanismOfAction": "Likely GABAergic; coumarins may modulate CNS",
+    "onset": "15–45 min",
+    "pharmacokinetics": "Onset: 15–45 min; Duration: 2–5 hrs",
+    "preparation": "Smoked or made into tea",
+    "region": "Amazon basin",
+    "safetyRating": "medium",
+    "scientificName": "Justicia pectoralis",
+    "sideEffects": "Liver risk in excess due to coumarin",
+    "tags": [
+      "🧘 Calm",
+      "🌿 Ayahuasca-additive",
+      "✅ Legal"
+    ],
+    "therapeuticUses": "Anxiety, insomnia, spiritual enhancement",
+    "toxicity": "Low–moderate with excess",
+    "toxicityLD50": "Not established"
+  },
+  {
+    "name": "Kanna",
+    "category": "Empathogen / Euphoriant",
+    "contraindications": "SSRIs, MAOIs, bipolar disorder",
+    "description": "A South African succulent traditionally chewed or snuffed to reduce anxiety and induce euphoria.",
+    "drugInteractions": "Antidepressants, serotonergic agents",
+    "duration": "1–3 hrs",
+    "effects": [
+      "Mood lift",
+      "calm euphoria",
+      "focus"
+    ],
+    "id": "Unknown",
+    "intensity": "Mild to moderate",
+    "legalStatus": "Legal",
+    "mechanismOfAction": "Serotonin reuptake inhibition (mesembrine alkaloids)",
+    "onset": "15–30 min",
+    "pharmacokinetics": "Onset: 15–30 min; Duration: 1–3 hrs",
+    "preparation": "Fermented and dried material chewed, snuffed, or made into tincture",
+    "region": "Southern Africa",
+    "safetyRating": "medium",
+    "scientificName": "Sceletium tortuosum",
+    "sideEffects": "Headache, nausea, serotonin syndrome (in excess or with SSRIs)",
+    "tags": [
+      "🌼 Euphoric",
+      "🧘 Calm",
+      "🧬 Natural SSRI"
+    ],
+    "therapeuticUses": "Anxiety, stress, social comfort",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established (safe in traditional use)"
+  },
+  {
+    "name": "Kava",
+    "category": "Dissociative / Sedative",
+    "contraindications": "Liver conditions, alcohol, sedatives",
+    "description": "South Pacific root brew known for its relaxing and anxiolytic effects.",
+    "drugInteractions": "CNS depressants, alcohol, liver-metabolized drugs",
+    "duration": "3–6 hrs",
+    "effects": [
+      "Relaxation",
+      "social ease",
+      "mild euphoria"
+    ],
+    "id": "kava",
+    "intensity": "Mild to moderate",
+    "legalStatus": "Legal; restricted in some EU countries",
+    "mechanismOfAction": "Kavalactones modulate GABA, block sodium and calcium channels",
+    "onset": "20–40 min",
+    "pharmacokinetics": "Onset: 20–40 min; Duration: 3–6 hrs",
+    "preparation": "Pounded root mixed in water and strained",
+    "region": "Polynesia, Micronesia, Melanesia",
+    "safetyRating": "medium",
+    "scientificName": "Piper methysticum",
+    "sideEffects": "Liver strain (rare), drowsiness",
+    "tags": [
+      "🧘 Calm",
+      "🌿 Root",
+      "🍵 Social"
+    ],
+    "therapeuticUses": "Anxiety, stress, sleep aid",
+    "toxicity": "Low to moderate; caution with prolonged use",
+    "toxicityLD50": "~4.3 g/kg (rats, oral)",
+    "activeConstituents": [
+      {
+        "name": "Kavalactones",
+        "type": "alkaloid",
+        "effect": "anxiolytic"
+      }
+    ]
+  },
+  {
+    "name": "Kra Thum Na / Kok",
+    "category": "Empathogen / Euphoriant",
+    "contraindications": "Not well documented",
+    "description": "Southeast Asian tree related to kratom with stimulating leaves.",
+    "drugInteractions": "Not well documented",
+    "duration": "Unknown",
+    "effects": [
+      "Stimulation",
+      "kratom-like body feel"
+    ],
+    "id": "kra-thum-na--kok",
+    "intensity": "Moderate",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Unknown",
+    "onset": "15-45 min",
+    "pharmacokinetics": "Not well documented",
+    "preparation": "Capsule or tea",
+    "region": "🌎 Unknown / Global",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Not well documented",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83d\\udc8a Oral",
+      "\\ud83d\\udcab Euphoria",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Not well documented",
+    "toxicity": "Unknown",
+    "toxicityLD50": "Unknown"
+  },
+  {
+    "name": "Lactuca canadensis",
+    "category": "Dissociative / Sedative",
+    "contraindications": "Sedatives, pregnancy",
+    "description": "Wild lettuce species containing lactucarium for gentle analgesia.",
+    "drugInteractions": "CNS depressants, alcohol",
+    "duration": "3–5 hrs",
+    "effects": [
+      "Relaxation",
+      "pain relief",
+      "drowsiness"
+    ],
+    "id": "lactuca-canadensis",
+    "intensity": "Mild to moderate",
+    "legalStatus": "Legal",
+    "mechanismOfAction": "Mild opioid-like action via lactucin/lactucopicrin",
+    "onset": "30–60 min",
+    "pharmacokinetics": "Onset: 30–60 min; Duration: 3–5 hrs",
+    "preparation": "Latex or leaf infusion, tincture, or smoke",
+    "region": "North America",
+    "safetyRating": "low",
+    "scientificName": "Lactuca canadensis",
+    "sideEffects": "Drowsiness, GI upset at high doses",
+    "tags": [
+      "🌿 Opium Lettuce",
+      "😴 Sedative",
+      "✅ Safe"
+    ],
+    "therapeuticUses": "Insomnia, pain, cough relief",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established"
+  },
+  {
+    "name": "Mandrake Root",
+    "category": "Deliriant / Toxic",
+    "contraindications": "Pregnancy, glaucoma, heart conditions.",
+    "description": "Mythic Mediterranean root with hallucinogenic tropane alkaloids.",
+    "drugInteractions": "Potentiates other anticholinergics, CNS depressants.",
+    "duration": "Unknown",
+    "effects": [
+      "Narcotic",
+      "visionary trance"
+    ],
+    "id": "mandrake-root",
+    "intensity": "High",
+    "legalStatus": "Controlled / Toxic",
+    "mechanismOfAction": "Contains tropane alkaloids (scopolamine, atropine); anticholinergic deliriant.",
+    "onset": "Varies",
+    "pharmacokinetics": "Oral or transdermal; slow absorption; long-lasting (6–12 hrs).",
+    "preparation": "Traditional ceremonial use only",
+    "region": "🌎 Unknown / Global",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Dry mouth, confusion, hallucinations, elevated heart rate.",
+    "tags": [
+      "\\u2620\\ufe0f Toxic"
+    ],
+    "therapeuticUses": "Historically used as anesthetic, antispasmodic, and in witchcraft.",
+    "toxicity": "Highly toxic in moderate doses.",
+    "toxicityLD50": "Scopolamine LD50 (rat, oral): ~310 mg/kg."
+  },
+  {
+    "name": "Melissa officinalis (Lemon balm)",
+    "category": "Dissociative / Sedative",
+    "contraindications": "Pregnancy, known Asteraceae allergy [0, 16].",
+    "description": "Lemony herb easing anxiety and digestive upset while calming the mind.",
+    "drugInteractions": "May potentiate sedatives, anticoagulants; caution with CNS depressants [0, 16].",
+    "duration": "Unknown",
+    "effects": [
+      "Anxiolytic",
+      "cognitive calming"
+    ],
+    "id": "melissa-officinalis-lemon-balm",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Unknown",
+    "onset": "15-30 min",
+    "pharmacokinetics": "Oral onset 30–60 min; active compounds absorbed in GI tract; hepatic metabolism; renal excretion [0, 0].",
+    "preparation": "Tea, tincture, or smoke",
+    "region": "🌎 Unknown / Global",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Drowsiness; possible allergic reactions; GI upset at high doses [0, 0].",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\u2615 Brewable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\ud83e\\udde0 Cognitive",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Anxiety, insomnia, nervous tension, digestive aid [0, 8].",
+    "toxicity": "Low; safe at therapeutic doses [0, 0].",
+    "toxicityLD50": "Unknown"
+  },
+  {
+    "name": "Mimosa hostilis",
+    "category": "Ritual / Visionary",
+    "contraindications": "Mental disorders, MAOIs, SSRIs",
+    "description": "Highly sought after for its DMT-rich root bark. Used in Anahuasca brews as a substitute for chacruna or yopo.",
+    "drugInteractions": "MAOIs, antidepressants",
+    "duration": "4–6 hrs",
+    "effects": [
+      "Visionary states",
+      "purging",
+      "emotional release"
+    ],
+    "id": "mimosa-hostilis",
+    "intensity": "Strong",
+    "legalStatus": "DMT controlled in many countries",
+    "mechanismOfAction": "DMT – 5-HT2A agonist (requires MAOI orally)",
+    "onset": "20–40 min",
+    "pharmacokinetics": "Onset: 20–40 min (with MAOI); Duration: 4–6 hrs",
+    "preparation": "Bark decoction brewed with MAOI like Syrian Rue",
+    "region": "Brazil, Central America",
+    "safetyRating": "high",
+    "scientificName": "Mimosa tenuiflora",
+    "sideEffects": "Intense purging, nausea, anxiety",
+    "tags": [
+      "🧪 DMT",
+      "⚠️ Visionary",
+      "🌿 Anahuasca"
+    ],
+    "therapeuticUses": "Spiritual healing, insight, skin regeneration (topical)",
+    "toxicity": "Low physiological, high psychological",
+    "toxicityLD50": "Not established"
+  },
+  {
+    "name": "Nelumbo nucifera",
+    "category": "Oneirogen",
+    "contraindications": "Sedatives, pregnancy",
+    "description": "Sacred lotus revered for tranquil, mildly euphoric properties.",
+    "drugInteractions": "Avoid CNS depressants",
+    "duration": "2–4 hrs",
+    "effects": [
+      "Relaxation",
+      "dream enhancement",
+      "calm euphoria"
+    ],
+    "id": "nelumbo-nucifera",
+    "intensity": "Mild",
+    "legalStatus": "Legal",
+    "mechanismOfAction": "Dopamine receptor agonism (aporphine alkaloids)",
+    "onset": "20–40 min",
+    "pharmacokinetics": "Onset: 20–40 min; Duration: 2–4 hrs",
+    "preparation": "Petals steeped in wine, tea, or smoked",
+    "region": "India, China, Southeast Asia",
+    "safetyRating": "low",
+    "scientificName": "Nelumbo nucifera",
+    "sideEffects": "Sedation, mild dizziness",
+    "tags": [
+      "🌸 Calm",
+      "✅ Safe",
+      "🧘 Meditation"
+    ],
+    "therapeuticUses": "Calm, aphrodisiac, meditation support",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established"
+  },
+  {
+    "name": "Nymphaea ampla",
+    "category": "Empathogen / Euphoriant",
+    "contraindications": "Not well documented",
+    "description": "Central American water lily providing mild euphoria and sedation.",
+    "drugInteractions": "Not well documented",
+    "duration": "Unknown",
+    "effects": [
+      "Sedative",
+      "euphoric",
+      "dreamlike states"
+    ],
+    "id": "nymphaea-ampla",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Unknown",
+    "onset": "15-45 min",
+    "pharmacokinetics": "Not well documented",
+    "preparation": "Tea or smoke",
+    "region": "🌎 Unknown / Global",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Not well documented",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\u2615 Brewable",
+      "\\ud83d\\udcab Euphoria",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Not well documented",
+    "toxicity": "Unknown",
+    "toxicityLD50": "Unknown"
+  },
+  {
+    "name": "Ocimum sanctum (Holy Basil / Tulsi)",
+    "category": "Empathogen / Euphoriant",
+    "contraindications": "Pregnancy, diabetes medication.",
+    "description": "Sacred basil revered in Ayurveda for uplifting and adaptogenic qualities.",
+    "drugInteractions": "May potentiate anti-diabetic, anticoagulant, or sedative drugs.",
+    "duration": "Unknown",
+    "effects": [
+      "Mood lift",
+      "sacred calm",
+      "spiritual focus"
+    ],
+    "id": "ocimum-sanctum-holy-basil--tulsi",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Modulates cortisol, inflammation, and neurotransmitters; contains eugenol, ursolic acid, and apigenin.",
+    "onset": "15-30 min",
+    "pharmacokinetics": "Rapid absorption via oral tea/tincture; hepatic metabolism.",
+    "preparation": "Tea or incense",
+    "region": "🇮🇳 India",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "May lower blood sugar, mild sedation, mild nausea.",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83d\\udd6f\\ufe0f Ritual",
+      "\\ud83d\\udcab Euphoria",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Adaptogen, anxiety, spiritual focus, blood sugar balance.",
+    "toxicity": "Pending",
+    "toxicityLD50": "Pending"
+  },
+  {
+    "name": "Passionflower",
+    "category": "Dissociative / Sedative",
+    "contraindications": "Pregnancy, CNS depressants",
+    "description": "Climbing vine traditionally brewed for anxiety relief and restful sleep.",
+    "drugInteractions": "CNS depressants, MAOIs",
+    "duration": "3–6 hrs",
+    "effects": [
+      "Relaxation",
+      "mild sedation",
+      "anxiolytic"
+    ],
+    "id": "passionflower",
+    "intensity": "Mild",
+    "legalStatus": "Legal",
+    "mechanismOfAction": "GABAergic (modulation of GABA_A receptors), mild MAOI",
+    "onset": "30–60 min",
+    "pharmacokinetics": "Onset: 30–60 min; Duration: 3–6 hrs",
+    "preparation": "Tea from aerial parts or tincture",
+    "region": "Southeastern U.S., Latin America",
+    "safetyRating": "low",
+    "scientificName": "Passiflora incarnata",
+    "sideEffects": "Drowsiness, dizziness",
+    "tags": [
+      "🧘 Calm",
+      "🌿 Sedative",
+      "✅ Safe"
+    ],
+    "therapeuticUses": "Anxiety, insomnia, nervous restlessness",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established",
+    "activeConstituents": [
+      {
+        "name": "Flavonoids",
+        "type": "alkaloid",
+        "effect": "anxiolytic"
+      }
+    ]
+  },
+  {
+    "name": "Pedicularis densiflora (Indian warrior)",
+    "category": "Dissociative / Sedative",
+    "contraindications": "Pregnancy, use with other sedatives [2, 0].",
+    "description": "North American wildflower smoked for muscle relaxation.",
+    "drugInteractions": "Additive effects with CNS depressants [2, 0].",
+    "duration": "Unknown",
+    "effects": [
+      "Muscle relaxation",
+      "mild body high"
+    ],
+    "id": "pedicularis-densiflora-indian-warrior",
+    "intensity": "Moderate",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Muscle relaxant potential via GABAergic modulation [2, 0].",
+    "onset": "5-15 min",
+    "pharmacokinetics": "Smoked or tea; onset rapid (minutes); duration ~2–3 h [2, 0].",
+    "preparation": "Smoked or tea",
+    "region": "🌍 Africa, 🇮🇳 India",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Drowsiness, dizziness [2, 0].",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\u2615 Brewable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Muscle tension, pain relief, sleep aid applications [2, 0].",
+    "toxicity": "Low; limited data on long-term use [2, 0].",
+    "toxicityLD50": "Unknown"
+  },
+  {
+    "name": "Pedicularis groenlandica",
+    "category": "Dissociative / Sedative",
+    "contraindications": "Pregnancy, lactation [0, 7].",
+    "description": "High-elevation lousewort prized for soothing tense muscles.",
+    "drugInteractions": "Additive with CNS depressants [0, 7].",
+    "duration": "Unknown",
+    "effects": [
+      "Stronger relaxation",
+      "tension relief"
+    ],
+    "id": "pedicularis-groenlandica",
+    "intensity": "Moderate",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Unknown",
+    "onset": "5-15 min",
+    "pharmacokinetics": "Oral infusion onset ~30 min; duration ~4 h; metabolites excreted renally [0, 7].",
+    "preparation": "Smoked or tea",
+    "region": "🌍 Africa",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Rare; possible GI upset [0, 7].",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\u2615 Brewable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Muscle relaxant, antioxidant, antimicrobial, traditional remedy for pain and inflammation [0, 7].",
+    "toxicity": "Low; no significant toxicity reported [0, 7].",
+    "toxicityLD50": "Unknown"
+  },
+  {
+    "name": "Petasites hybridus",
+    "category": "Dissociative / Sedative",
+    "contraindications": "Liver conditions, pregnancy, raw extract use",
+    "description": "Also known as Butterbur, this European root was historically used as a remedy for migraines and spasms. Contains pyrrolizidine alkaloids, so safe extracts must be purified.",
+    "drugInteractions": "Avoid hepatotoxic meds",
+    "duration": "4–6 hrs",
+    "effects": [
+      "Relaxation",
+      "muscle relief",
+      "headache reduction"
+    ],
+    "id": "petasites-hybridus",
+    "intensity": "Mild to moderate",
+    "legalStatus": "Legal with restrictions (PA-free only)",
+    "mechanismOfAction": "Antispasmodic and anti-inflammatory effects; calcium channel modulation",
+    "onset": "30–60 min",
+    "pharmacokinetics": "Onset: 30–60 min; Duration: 4–6 hrs",
+    "preparation": "Purified root extracts or capsules (PA-free only)",
+    "region": "Europe, Asia",
+    "safetyRating": "medium",
+    "scientificName": "Petasites hybridus",
+    "sideEffects": "Liver toxicity risk from unpurified products",
+    "tags": [
+      "🧠 Headache",
+      "⚠️ PA toxins",
+      "🌿 Herbal"
+    ],
+    "therapeuticUses": "Migraine prevention, allergies, anxiety",
+    "toxicity": "Moderate to high (raw plant)",
+    "toxicityLD50": "~950 mg/kg (mouse, oral, unpurified)"
+  },
+  {
+    "name": "Piper auritum (Root beer plant)",
+    "category": "Empathogen / Euphoriant",
+    "contraindications": "Pregnancy; safrole-containing extracts discouraged [1, 11].",
+    "description": "Sassafras-scented leaf from Mexico used culinary and for mild mood lift.",
+    "drugInteractions": "CYP450 substrates; caution with anticoagulants [0, 19].",
+    "duration": "Unknown",
+    "effects": [
+      "Calming",
+      "warming",
+      "euphoric"
+    ],
+    "id": "piper-auritum-root-beer-plant",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Contains safrole and other volatile oils; possible mild dopaminergic stimulation and GI modulation.",
+    "onset": "15-30 min",
+    "pharmacokinetics": "Oral infusion or extract onset 30–60 min; hepatic metabolism; renal excretion [0, 11].",
+    "preparation": "Tea or culinary use",
+    "region": "🌎 Unknown / Global",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "High doses may cause GI upset; safrole is a potential carcinogen [1, 11].",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83d\\udcab Euphoria",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Digestive aid, anti-inflammatory, antimutagen, diuretic, antipyretic [0, 11].",
+    "toxicity": "Safrole hepatotoxic; use sparingly [1, 11].",
+    "toxicityLD50": "LD50 (rats, oral) safrole ~1,950 mg/kg; safrole is hepatotoxic at high doses."
+  },
+  {
+    "name": "Rhodiola rosea",
+    "category": "Empathogen / Euphoriant",
+    "contraindications": "Bipolar disorder, stimulants, pregnancy.",
+    "description": "Hardy root enhancing endurance and stress tolerance via adaptogens.",
+    "drugInteractions": "May affect antidepressants, stimulants, or MAOIs.",
+    "duration": "Unknown",
+    "effects": [
+      "Focus",
+      "reduced fatigue",
+      "mind clarity"
+    ],
+    "id": "rhodiola-rosea",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Influences serotonin, norepinephrine, dopamine; modulates HPA axis and stress adaptation via rosavins and salidroside.",
+    "onset": "30-60 min",
+    "pharmacokinetics": "Absorbed orally; peak plasma ~1-2 hours; active compounds metabolized in liver, excreted renally.",
+    "preparation": "Capsule, tincture",
+    "region": "🌎 Unknown / Global",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Irritability, dry mouth, dizziness (rare, dose-dependent).",
+    "tags": [
+      "\\ud83d\\udc8a Oral",
+      "\\ud83d\\udcab Euphoria",
+      "\\ud83e\\udde0 Cognitive",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Fatigue, stress resilience, cognitive enhancement, mild depression.",
+    "toxicity": "Mild toxicity; high doses may cause irritability or insomnia.",
+    "toxicityLD50": "LD50 (rats, oral) >28,000 mg/kg; very low toxicity."
+  },
+  {
+    "name": "Rivea corymbosa",
+    "category": "Ethnobotanical / Rare",
+    "contraindications": "Cardiovascular disease, pregnancy [0, 4].",
+    "description": "Morning glory species with LSA seeds used in ancient Mexican rituals.",
+    "drugInteractions": "Serotonergic medications [0, 12].",
+    "duration": "Unknown",
+    "effects": [
+      "Dreamy visuals",
+      "nausea",
+      "traditional Mazatec use"
+    ],
+    "id": "rivea-corymbosa",
+    "intensity": "High",
+    "legalStatus": "Restricted in some countries",
+    "mechanismOfAction": "Unknown",
+    "onset": "30-90 min",
+    "pharmacokinetics": "Insufflated or ingested; onset 20–60 min; duration 4–8 h; hepatic metabolism [0, 12].",
+    "preparation": "Seeds ground and cold infused",
+    "region": "🌎 Unknown / Global",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Nausea, vasoconstriction, dizziness [0, 4].",
+    "tags": [
+      "\\u26a0\\ufe0f Restricted"
+    ],
+    "therapeuticUses": "Entheogenic snuff (ololiuqui) in Mesoamerican rituals [0, 4].",
+    "toxicity": "Low; moderate overdose risk [0, 12].",
+    "toxicityLD50": "Unknown"
+  },
+  {
+    "name": "Salvia divinorum",
+    "category": "Dissociative / Sedative",
+    "contraindications": "Psychiatric disorders, cardiovascular instability; avoid in those at risk for psychosis [3, 2].",
+    "description": "Mazatec entheogen with powerful, short-lived visionary effects.",
+    "drugInteractions": "CNS depressants may potentiate sedative effects; caution when coadministered [3, 3].",
+    "duration": "Unknown",
+    "effects": [
+      "Total dissociation",
+      "entity contact"
+    ],
+    "id": "salvia-divinorum",
+    "intensity": "High",
+    "legalStatus": "Restricted in many regions",
+    "mechanismOfAction": "Unknown",
+    "onset": "1-5 min",
+    "pharmacokinetics": "Absorbed via oral mucosa, smoking or vaporization; rapid onset (seconds–minutes), short duration (~15–30 min), quickly metabolized to inactive salvinorin B [3, 1].",
+    "preparation": "Smoked, intense, short duration",
+    "region": "🇲🇽 Latin America",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Tiredness, dizziness, amnesia, potential for transient psychosis in vulnerable individuals [3, 2].",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\u26a0\\ufe0f Restricted"
+    ],
+    "therapeuticUses": "Visionary experiences in traditional Mazatec rituals; investigated for analgesic and anti-inflammatory properties [3, 0].",
+    "toxicity": "Low toxicity; animal studies show minimal organ damage even at high doses [3, 3].",
+    "toxicityLD50": "LD50 not established; salvinorin A active at microgram levels with no evidence of physical toxicity."
+  },
+  {
+    "name": "Sceletium tortuosum (Kanna)",
+    "category": "Empathogen / Euphoriant",
+    "contraindications": "Do not combine with other serotonergic substances; pregnancy [9, 4].",
+    "description": "South African succulent chewed to elevate mood and decrease tension.",
+    "drugInteractions": "SSRIs, MAOIs, stimulants [9, 4].",
+    "duration": "Unknown",
+    "effects": [
+      "Mood lift",
+      "empathy",
+      "sociability"
+    ],
+    "id": "sceletium-tortuosum-kanna",
+    "intensity": "Moderate",
+    "legalStatus": "Legal, sometimes restricted",
+    "mechanismOfAction": "Selective serotonin reuptake inhibition (SSRI) and phosphodiesterase-4 (PDE4) inhibition [9, 4].",
+    "onset": "30-60 min",
+    "pharmacokinetics": "Oral onset 20–60 min; duration 2–4 h [9, 4].",
+    "preparation": "Chew, snuff, extract",
+    "region": "🌎 Unknown / Global",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Headache, nausea, mild sedation [9, 4].",
+    "tags": [
+      "\\ud83d\\udc8a Oral",
+      "\\ud83d\\udcab Euphoria",
+      "\\u26a0\\ufe0f Restricted"
+    ],
+    "therapeuticUses": "Mood enhancement, anti-anxiety, social facilitation [9, 4].",
+    "toxicity": "Low toxicity at traditional doses [9, 4].",
+    "toxicityLD50": "Not established in humans; high safety margin observed in animal studies."
+  },
+  {
+    "name": "Scullcap (Scutellaria)",
+    "category": "Dissociative / Sedative",
+    "contraindications": "Liver issues; consult provider before long-term use.",
+    "description": "Calming mint-family herb rich in baicalin used as nerve tonic.",
+    "drugInteractions": "Additive effects with sedatives or anxiolytics.",
+    "duration": "Unknown",
+    "effects": [
+      "Relaxing",
+      "anxiety-reducing",
+      "dream support"
+    ],
+    "id": "scullcap-scutellaria",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Flavonoids and baicalin modulate GABA-A receptors and inhibit inflammation.",
+    "onset": "15-45 min",
+    "pharmacokinetics": "Taken orally; onset ~30 min; effects last ~2–4 hrs.",
+    "preparation": "Tea or tincture",
+    "region": "🌎 Unknown / Global",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Rarely causes liver enzyme elevation or drowsiness.",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Calming, anticonvulsant, neuroprotective.",
+    "toxicity": "Generally safe, though adulterants in supplements have caused concern.",
+    "toxicityLD50": "No standard LD50 data; high therapeutic margin."
+  },
+  {
+    "name": "Scutellaria lateriflora",
+    "category": "Dissociative / Sedative",
+    "contraindications": "Pregnancy, CNS depressants",
+    "description": "Commonly known as Skullcap, this North American herb has a long history in Western herbalism for treating nervous tension and insomnia.",
+    "drugInteractions": "CNS depressants, alcohol, benzodiazepines",
+    "duration": "3–5 hrs",
+    "effects": [
+      "Mild sedation",
+      "anxiety relief",
+      "mental clarity"
+    ],
+    "id": "scutellaria-lateriflora",
+    "intensity": "Mild",
+    "legalStatus": "Legal",
+    "mechanismOfAction": "GABA_A receptor modulation (baicalin and other flavonoids)",
+    "onset": "30–60 min",
+    "pharmacokinetics": "Onset: 30–60 min; Duration: 3–5 hrs",
+    "preparation": "Tea, tincture, capsules",
+    "region": "North America",
+    "safetyRating": "low",
+    "scientificName": "Scutellaria lateriflora",
+    "sideEffects": "Drowsiness, dizziness at high doses",
+    "tags": [
+      "😴 Sedative",
+      "🌿 Herbal",
+      "✅ Safe"
+    ],
+    "therapeuticUses": "Anxiety, stress, insomnia, PMS",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established"
+  },
+  {
+    "name": "Silene capensis",
+    "category": "Oneirogen",
+    "contraindications": "Pregnancy",
+    "description": "Known as 'Xhosa Dream Root', Silene capensis is a sacred plant used by the Xhosa people of South Africa for initiating vivid and prophetic dreams.",
+    "drugInteractions": "None well documented",
+    "duration": "6–8 hrs",
+    "effects": [
+      "Lucid dreaming",
+      "enhanced dream recall",
+      "vivid visions"
+    ],
+    "id": "silene-capensis",
+    "intensity": "Mild to moderate",
+    "legalStatus": "Legal",
+    "mechanismOfAction": "Likely acts on cholinergic and serotonergic systems; exact mechanism unknown",
+    "onset": "30–60 min",
+    "pharmacokinetics": "Onset: 30–60 min; Duration: 6–8 hrs",
+    "preparation": "Root is powdered and stirred into water until it foams; consumed before bed",
+    "region": "South Africa",
+    "safetyRating": "low",
+    "scientificName": "Silene capensis",
+    "sideEffects": "Mild nausea if taken in excess",
+    "tags": [
+      "🌙 Dream",
+      "✅ Safe",
+      "🧠 Vision"
+    ],
+    "therapeuticUses": "Dream enhancement, ancestral communication",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established"
+  },
+  {
+    "name": "Silphium (extinct)",
+    "category": "Other",
+    "contraindications": "Not well documented",
+    "description": "Famed classical herb believed to have contraceptive and psychoactive resins.",
+    "drugInteractions": "Not well documented",
+    "duration": "Unknown",
+    "effects": [
+      "Ancient psychoactive/contraceptive herb"
+    ],
+    "id": "silphium-extinct",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Unknown",
+    "onset": "Varies",
+    "pharmacokinetics": "Not well documented",
+    "preparation": "No longer available but worth note",
+    "region": "🌎 Unknown / Global",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Not well documented",
+    "tags": [
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Not well documented",
+    "toxicity": "Unknown",
+    "toxicityLD50": "Unknown"
+  },
+  {
+    "name": "Sinicuichi",
+    "category": "Oneirogen",
+    "contraindications": "Pregnancy, driving",
+    "description": "Used traditionally in Central America as a 'sun opener,' believed to enhance memory and auditory perception. Alters sound and memory in dreamlike ways.",
+    "drugInteractions": "Avoid CNS depressants or alcohol",
+    "duration": "4–6 hrs",
+    "effects": [
+      "Auditory distortion",
+      "dreamy state",
+      "euphoria"
+    ],
+    "id": "sinicuichi",
+    "intensity": "Mild to moderate",
+    "legalStatus": "Legal",
+    "mechanismOfAction": "Alkaloids may modulate GABA and acetylcholine systems",
+    "onset": "30–90 min",
+    "pharmacokinetics": "Onset: 30–90 min; Duration: 4–6 hrs",
+    "preparation": "Sun-fermented tea from leaves",
+    "region": "Mexico, Central America",
+    "safetyRating": "medium",
+    "scientificName": "Heimia salicifolia",
+    "sideEffects": "Dry mouth, yellow vision, dizziness",
+    "tags": [
+      "🌞 Sun",
+      "🎧 Auditory",
+      "🧠 Dream"
+    ],
+    "therapeuticUses": "Folk use for memory and dream recall",
+    "toxicity": "Low to moderate; not well studied",
+    "toxicityLD50": "Not established"
+  },
+  {
+    "name": "Sweetgrass",
+    "category": "Ritual / Visionary",
+    "contraindications": "Not well documented",
+    "description": "Vanilla-scented grass braided and burned to invite positive spirits.",
+    "drugInteractions": "Not well documented",
+    "duration": "Unknown",
+    "effects": [
+      "Positive energy",
+      "spiritual invocation"
+    ],
+    "id": "sweetgrass",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Unknown",
+    "onset": "Varies",
+    "pharmacokinetics": "Not well documented",
+    "preparation": "Burned or braided for ceremonies",
+    "region": "🌐 Global / Ritual",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Not well documented",
+    "tags": [
+      "\\ud83d\\udd2e Ritual",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Not well documented",
+    "toxicity": "Unknown",
+    "toxicityLD50": "Unknown"
+  },
+  {
+    "name": "Tagetes lucida (Mexican Tarragon)",
+    "category": "Other",
+    "contraindications": "Pregnancy, concurrent sedatives.",
+    "description": "Sweet marigold used as tea or incense for clear dreams and calm.",
+    "drugInteractions": "Benzodiazepines and serotonergic drugs.",
+    "duration": "Unknown",
+    "effects": [
+      "Visionary dreams",
+      "clarity"
+    ],
+    "id": "tagetes-lucida-mexican-tarragon",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Coumarins (dimethylfraxetin, herniarin) and essential oils (methyl eugenol, estragole) interact with GABAₐ and 5-HT₁ₐ receptors, producing anxiolytic and sedative effects [2, 2, 2, 10].",
+    "onset": "1-5 min",
+    "pharmacokinetics": "Consumed as tea or tincture; onset ~20–30 min; duration ~2–4 hours [2, 2].",
+    "preparation": "Tea, incense, or smoke",
+    "region": "🇲🇽 Latin America",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Mild GI upset, potential photosensitivity [2, 3].",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\u2615 Brewable",
+      "\\ud83d\\udd6f\\ufe0f Ritual",
+      "\\ud83e\\udde0 Cognitive",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Anxiolytic, digestive aid, ritual incense for purification [2, 10].",
+    "toxicity": "Low; traditional use generally safe.",
+    "toxicityLD50": "Unknown"
+  },
+  {
+    "name": "Tilia europaea (Linden flower)",
+    "category": "Dissociative / Sedative",
+    "contraindications": "Not well documented",
+    "description": "Soothing tree blossoms steeped as tea for relaxation and cold relief.",
+    "drugInteractions": "Not well documented",
+    "duration": "Unknown",
+    "effects": [
+      "Calming",
+      "relaxing",
+      "mild dream aid"
+    ],
+    "id": "tilia-europaea-linden-flower",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Unknown",
+    "onset": "15-30 min",
+    "pharmacokinetics": "Not well documented",
+    "preparation": "Tea",
+    "region": "🇪🇺 Europe",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Not well documented",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Not well documented",
+    "toxicity": "Unknown",
+    "toxicityLD50": "Unknown"
+  },
+  {
+    "name": "Toloache",
+    "category": "Ritual / Visionary",
+    "contraindications": "Everything — extremely risky",
+    "description": "A powerful and dangerous tropane alkaloid plant traditionally used in witchcraft and shamanic rituals. Highly toxic.",
+    "drugInteractions": "All CNS-affecting meds",
+    "duration": "8–24 hrs",
+    "effects": [
+      "Delirium",
+      "hallucinations",
+      "disorientation"
+    ],
+    "id": "toloache",
+    "intensity": "Extremely strong",
+    "legalStatus": "Legal but restricted in many countries",
+    "mechanismOfAction": "Anticholinergic – blocks acetylcholine via scopolamine, atropine",
+    "onset": "30–60 min",
+    "pharmacokinetics": "Onset: 30–60 min; Duration: 8–24 hrs",
+    "preparation": "Seeds, leaves or flowers ingested or smoked (strongly discouraged)",
+    "region": "Americas, Mediterranean",
+    "safetyRating": "very high",
+    "scientificName": "Datura spp.",
+    "sideEffects": "Severe hallucinations, amnesia, potential death",
+    "tags": [
+      "☠️ Toxic",
+      "🧠 Vision",
+      "⚠️ Caution"
+    ],
+    "therapeuticUses": "Rarely used medically; historically for pain/spiritual rites",
+    "toxicity": "Very high",
+    "toxicityLD50": "~50 mg/kg (atropine/scopolamine)"
+  },
+  {
+    "name": "Turnera diffusa",
+    "category": "Empathogen / Euphoriant",
+    "contraindications": "Pregnancy, MAOI coadministration.",
+    "description": "Fragrant shrub known as damiana, smoked or brewed as aphrodisiac and relaxant.",
+    "drugInteractions": "Serotonergic medications.",
+    "duration": "Unknown",
+    "effects": [
+      "aphrodisiac",
+      "mood-enhancing",
+      "anxiolytic"
+    ],
+    "id": "turnera-diffusa",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Likely modulates serotonin, dopamine, and GABA neurotransmission via flavonoids and tannins [8, 6].",
+    "onset": "1-5 min",
+    "pharmacokinetics": "Tea or smoked; onset ~30–45 min; duration ~2–4 hours [8, 6].",
+    "preparation": "Tea or smoke",
+    "region": "Texas, Mexico, Central America",
+    "safetyRating": 1,
+    "scientificName": "Turnera diffusa",
+    "sideEffects": "Mild headache, insomnia at high doses [8, 6].",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\u2615 Brewable",
+      "\\ud83d\\udcab Euphoria",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Aphrodisiac, mood enhancement, stress relief [8, 6].",
+    "toxicity": "Low in traditional doses.",
+    "toxicityLD50": "Unknown"
+  },
+  {
+    "name": "Turnera ulmifolia",
+    "category": "Empathogen / Euphoriant",
+    "contraindications": "Pregnancy",
+    "description": "Closely related to Damiana (Turnera diffusa), this species is also used traditionally in folk medicine for reproductive health and mood.",
+    "drugInteractions": "Unknown",
+    "duration": "2–4 hrs",
+    "effects": [
+      "Relaxation",
+      "mood elevation",
+      "aphrodisiac"
+    ],
+    "id": "turnera-ulmifolia",
+    "intensity": "Mild",
+    "legalStatus": "Legal",
+    "mechanismOfAction": "Unknown; may modulate GABA or serotonin",
+    "onset": "30–60 min",
+    "pharmacokinetics": "Onset: 30–60 min; Duration: 2–4 hrs",
+    "preparation": "Tea from dried leaves or tincture",
+    "region": "Central and South America",
+    "safetyRating": "low",
+    "scientificName": "Turnera ulmifolia",
+    "sideEffects": "Mild sedation",
+    "tags": [
+      "🌺 Aphrodisiac",
+      "✅ Safe",
+      "😊 Mood"
+    ],
+    "therapeuticUses": "Libido, menstrual cramps, anxiety",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established"
+  },
+  {
+    "name": "Urtica dioica",
+    "category": "Dissociative / Sedative",
+    "contraindications": "Pregnancy, blood thinners",
+    "description": "Known as stinging nettle, this European herb has been used for centuries to relieve joint pain, allergies, and fatigue. Its psychoactivity is subtle, mostly somatic.",
+    "drugInteractions": "Diuretics, anticoagulants",
+    "duration": "3–6 hrs",
+    "effects": [
+      "Stimulation",
+      "anti-inflammatory",
+      "tonic"
+    ],
+    "id": "urtica-dioica",
+    "intensity": "Mild",
+    "legalStatus": "Legal",
+    "mechanismOfAction": "Histamine release and anti-inflammatory cytokine modulation",
+    "onset": "30–60 min",
+    "pharmacokinetics": "Onset: 30–60 min; Duration: 3–6 hrs",
+    "preparation": "Dried leaves as tea or extract",
+    "region": "Europe, North America, Asia",
+    "safetyRating": "low",
+    "scientificName": "Urtica dioica",
+    "sideEffects": "Mild stomach upset, skin irritation",
+    "tags": [
+      "🌿 Anti-inflammatory",
+      "✅ Safe",
+      "🧘 Mild"
+    ],
+    "therapeuticUses": "Allergies, joint pain, urinary tract support",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established"
+  },
+  {
+    "name": "Viola odorata (Sweet violet)",
+    "category": "Dissociative / Sedative",
+    "contraindications": "None known in normal amounts; avoid if allergic.",
+    "description": "Fragrant violet whose flowers are a mild sedative and expectorant.",
+    "drugInteractions": "Minimal; theoretically additive with CNS depressants.",
+    "duration": "Unknown",
+    "effects": [
+      "Mild sedative",
+      "calming",
+      "gentle dreaminess"
+    ],
+    "id": "viola-odorata-sweet-violet",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Mild central sedative via salicylates and alkaloids; may influence serotonin and prostaglandin pathways.",
+    "onset": "15-30 min",
+    "pharmacokinetics": "Taken as tea or syrup; onset ~30 min; short duration.",
+    "preparation": "Tea or syrup",
+    "region": "🇪🇺 Europe",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Very rare; may include mild drowsiness or nausea.",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Cough suppressant, mild anxiolytic, anti-inflammatory, gentle sleep aid.",
+    "toxicity": "Regarded as very safe in traditional herbalism.",
+    "toxicityLD50": "No human LD50 data; extremely low toxicity reported."
+  },
+  {
+    "name": "Virola spp.",
+    "category": "Ethnobotanical / Rare",
+    "contraindications": "Mental health disorders, heart issues, MAOI interactions.",
+    "description": "Amazonian trees producing DMT-rich resins for shamanic snuffs.",
+    "drugInteractions": "Dangerous with SSRIs, MAOIs, and other serotonergic substances.",
+    "duration": "Unknown",
+    "effects": [
+      "DMT-containing tree resin"
+    ],
+    "id": "virola-spp",
+    "intensity": "High",
+    "legalStatus": "Restricted / Controlled",
+    "mechanismOfAction": "Contains DMT, 5-MeO-DMT, and beta-carbolines; classic tryptamine entheogen profile.",
+    "onset": "1-3 min",
+    "pharmacokinetics": "Insufflated or oral with MAOIs; fast onset if smoked or snuffed.",
+    "preparation": "Used in Amazonian snuffs",
+    "region": "🇲🇽 Latin America",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Nausea, intense hallucinations, elevated heart rate.",
+    "tags": [
+      "\\u26a0\\ufe0f Restricted"
+    ],
+    "therapeuticUses": "Used in Amazonian shamanic healing rituals; possible antidepressant potential.",
+    "toxicity": "Can be overwhelming; physical toxicity low but psychological risks high.",
+    "toxicityLD50": "No established LD50 for DMT in humans; low systemic toxicity at typical doses."
+  },
+  {
+    "name": "Virola theiodora",
+    "category": "Ritual / Visionary",
+    "contraindications": "MAOIs, mental health issues",
+    "description": "A snuff plant from the Amazon containing DMT and 5-MeO-DMT. Used by Yanomami and other tribes for potent visionary rituals.",
+    "drugInteractions": "MAOIs, antidepressants",
+    "duration": "20–60 min",
+    "effects": [
+      "Strong visuals",
+      "spiritual experiences",
+      "disorientation"
+    ],
+    "id": "virola-theiodora",
+    "intensity": "Very strong",
+    "legalStatus": "DMT controlled in most countries",
+    "mechanismOfAction": "DMT and 5-MeO-DMT – 5-HT2A agonists",
+    "onset": "1–3 min",
+    "pharmacokinetics": "Onset: 1–3 min; Duration: 20–60 min",
+    "preparation": "Bark resin dried and insufflated as snuff",
+    "region": "Amazon (Brazil, Venezuela)",
+    "safetyRating": "high",
+    "scientificName": "Virola theiodora",
+    "sideEffects": "Nausea, tremors, vomiting",
+    "tags": [
+      "🧠 DMT",
+      "⚠️ Vision",
+      "🌬️ Snuff"
+    ],
+    "therapeuticUses": "Shamanic ritual; purging and vision work",
+    "toxicity": "High psychological, moderate physical",
+    "toxicityLD50": "Unknown"
+  },
+  {
+    "name": "Voacanga africana",
+    "category": "Ritual / Visionary",
+    "contraindications": "Heart conditions, psychiatric disorders",
+    "description": "A powerful African plant containing voacangine and iboga alkaloids. Used traditionally in ritual contexts and studied as a potential ibogaine precursor.",
+    "drugInteractions": "Avoid all stimulants, antidepressants, MAOIs",
+    "duration": "6–12 hrs",
+    "effects": [
+      "Stimulation",
+      "psychedelic effects",
+      "cardiovascular activation"
+    ],
+    "id": "voacanga-africana",
+    "intensity": "Strong",
+    "legalStatus": "Unscheduled; may be regulated for alkaloids",
+    "mechanismOfAction": "Voacangine is a prodrug to ibogaine (NMDA antagonist, serotonin transporter blocker)",
+    "onset": "30–90 min",
+    "pharmacokinetics": "Onset: 30–90 min; Duration: 6–12 hrs",
+    "preparation": "Bark decoction or purified alkaloids; high potency",
+    "region": "West Africa",
+    "safetyRating": "high",
+    "scientificName": "Voacanga africana",
+    "sideEffects": "Vomiting, overstimulation, visual distortions",
+    "tags": [
+      "⚠️ Caution",
+      "🧠 Vision",
+      "🌍 African"
+    ],
+    "therapeuticUses": "Experimental use in addiction therapy (via ibogaine synthesis)",
+    "toxicity": "High in overdose; cardiotoxic potential",
+    "toxicityLD50": "~90–120 mg/kg (est. voacangine)"
+  },
+  {
+    "name": "White Lily",
+    "category": "Oneirogen",
+    "contraindications": "Pregnancy",
+    "description": "Related to Blue Lotus, this sacred flower from Mesoamerican traditions is used to promote meditation and lucid dreaming.",
+    "drugInteractions": "Avoid CNS depressants",
+    "duration": "2–4 hrs",
+    "effects": [
+      "Calm",
+      "light sedation",
+      "dream potentiation"
+    ],
+    "id": "white-lily",
+    "intensity": "Mild",
+    "legalStatus": "Legal",
+    "mechanismOfAction": "Contains aporphine alkaloids (dopamine agonist)",
+    "onset": "20–40 min",
+    "pharmacokinetics": "Onset: 20–40 min; Duration: 2–4 hrs",
+    "preparation": "Soaked in wine, steeped as tea, or smoked",
+    "region": "Mexico, Central America",
+    "safetyRating": "low",
+    "scientificName": "Nymphaea ampla",
+    "sideEffects": "Drowsiness, vivid dreams",
+    "tags": [
+      "🌸 Calm",
+      "🌿 Sedative",
+      "✅ Safe"
+    ],
+    "therapeuticUses": "Relaxation, aphrodisiac, dream enhancement",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established"
+  },
+  {
+    "name": "White Sage",
+    "category": "Ritual / Visionary",
+    "contraindications": "Asthma, pregnancy, respiratory disorders.",
+    "description": "Aromatic sage revered for cleansing rituals and mental clarity.",
+    "drugInteractions": "None significant documented.",
+    "duration": "Unknown",
+    "effects": [
+      "Clarity",
+      "purification",
+      "spiritual reset"
+    ],
+    "id": "white-sage",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "1,8-Cineole and α-thujone inhibit pro-inflammatory cytokines (TNFα, IL-1β) and arachidonic acid metabolism; antimicrobial and antiviral effects via NF-κB inhibition [0, 19, 0, 4].",
+    "onset": "5-20 min",
+    "pharmacokinetics": "Inhaled or topical; rapid local absorption; systemic exposure minimal; metabolites excreted renally [0, 4].",
+    "preparation": "Burned as incense",
+    "region": "🌐 Global / Ritual",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "Respiratory irritation, asthmatic exacerbation, headaches at high exposure [0, 19].",
+    "tags": [
+      "\\ud83d\\udd6f\\ufe0f Ritual",
+      "\\ud83d\\udd2e Ritual",
+      "\\ud83e\\udde0 Cognitive",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Smudging rituals for purification, antimicrobial, respiratory support, mental clarity [0, 19].",
+    "toxicity": "Very low; excessive inhalation may cause dizziness or nausea [0, 4].",
+    "toxicityLD50": "Unknown"
+  },
+  {
+    "name": "Wild Lettuce",
+    "category": "Dissociative / Sedative",
+    "contraindications": "Pregnancy, CNS depressants",
+    "description": "Leafy plant exuding sedative latex historically called 'lettuce opium.'",
+    "drugInteractions": "Avoid with sedatives, opioids",
+    "duration": "3–6 hrs",
+    "effects": [
+      "Sedation",
+      "pain relief",
+      "light euphoria"
+    ],
+    "id": "wild-lettuce",
+    "intensity": "Mild to moderate",
+    "legalStatus": "Legal",
+    "mechanismOfAction": "Lactucin and lactucopicrin may act as acetylcholinesterase inhibitors",
+    "onset": "30–60 min",
+    "pharmacokinetics": "Onset: 30–60 min; Duration: 3–6 hrs",
+    "preparation": "Tincture, dried leaf tea, smoked",
+    "region": "Europe, North America",
+    "safetyRating": "medium",
+    "scientificName": "Lactuca virosa",
+    "sideEffects": "Drowsiness, nausea at high doses",
+    "tags": [
+      "😴 Sedative",
+      "🌿 Herbal",
+      "✅ Safe"
+    ],
+    "therapeuticUses": "Insomnia, pain relief, cough suppression",
+    "toxicity": "Low in traditional doses",
+    "toxicityLD50": "Not established"
+  },
+  {
+    "name": "Withania somnifera (Ashwagandha)",
+    "category": "Dissociative / Sedative",
+    "contraindications": "Pregnancy, hyperthyroidism, autoimmune diseases [0, 1].",
+    "description": "Indian nightshade root that reduces stress hormones and promotes sleep.",
+    "drugInteractions": "Immunosuppressants, sedatives, thyroid medications [0, 24].",
+    "duration": "Unknown",
+    "effects": [
+      "Grounded calm",
+      "dream support"
+    ],
+    "id": "withania-somnifera-ashwagandha",
+    "intensity": "Mild",
+    "legalStatus": "Legal / Unregulated",
+    "mechanismOfAction": "Modulates GABAergic and serotonergic activity; reduces cortisol; withanolides are primary active compounds.",
+    "onset": "30-60 min",
+    "pharmacokinetics": "Oral onset 30–60 min; withanolides bioavailable; hepatic metabolism; renal excretion [0, 17].",
+    "preparation": "Tea or capsule",
+    "region": "🇮🇳 India",
+    "safetyRating": 1,
+    "scientificName": "Unknown",
+    "sideEffects": "GI upset, drowsiness, rare thyroid hormone changes [0, 9].",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83d\\udc8a Oral",
+      "\\ud83c\\udf00 Dissociation",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "therapeuticUses": "Adaptogen, anti-stress, anxiolytic, neuroprotective, anti-inflammatory, immune support [0, 1, 0, 17].",
+    "toxicity": "Low; well-tolerated in clinical studies [0, 1].",
+    "toxicityLD50": "LD50 (rats, oral) ~4650 mg/kg; relatively low acute toxicity."
+  },
+  {
+    "name": "Wormwood",
+    "category": "Oneirogen",
+    "contraindications": "Pregnancy, epilepsy, high doses",
+    "description": "Key ingredient in absinthe. Contains thujone, which is a GABA_A antagonist and neurostimulant in high doses. Historically used for dreaming, digestion, and ritual.",
+    "drugInteractions": "Avoid alcohol, CNS drugs",
+    "duration": "4–6 hrs",
+    "effects": [
+      "Lucid dreams",
+      "stimulating",
+      "mental clarity"
+    ],
+    "id": "wormwood",
+    "intensity": "Mild to moderate",
+    "legalStatus": "Restricted in high-thujone formulations",
+    "mechanismOfAction": "Thujone – GABA_A receptor antagonist",
+    "onset": "30–60 min",
+    "pharmacokinetics": "Onset: 30–60 min; Duration: 4–6 hrs",
+    "preparation": "Tincture, tea, or absinthe-style extract",
+    "region": "Europe, Asia, North America",
+    "safetyRating": "medium",
+    "scientificName": "Artemisia absinthium",
+    "sideEffects": "Headache, nausea, tremors at high doses",
+    "tags": [
+      "🌙 Dream",
+      "⚠️ Caution",
+      "🌿 Bitter"
+    ],
+    "therapeuticUses": "Digestive tonic, dream work, antiparasitic",
+    "toxicity": "Neurotoxic in large doses",
+    "toxicityLD50": "~30 mg/kg (thujone)",
+    "activeConstituents": [
+      {
+        "name": "Thujone",
+        "type": "terpenoid",
+        "effect": "GABA_A antagonist"
+      }
+    ]
+  },
+  {
+    "name": "Yerba Mate",
+    "category": "Empathogen / Euphoriant",
+    "contraindications": "Anxiety, heart conditions, ulcers",
+    "description": "South American herbal stimulant rich in caffeine, theobromine, and theophylline. Traditionally shared as a communal energizing tea.",
+    "drugInteractions": "CNS stimulants, caffeine",
+    "duration": "3–5 hrs",
+    "effects": [
+      "Stimulation",
+      "focus",
+      "social energy"
+    ],
+    "id": "yerba-mate",
+    "intensity": "Mild to moderate",
+    "legalStatus": "Legal",
+    "mechanismOfAction": "Adenosine receptor antagonism (via caffeine/theobromine)",
+    "onset": "10–30 min",
+    "pharmacokinetics": "Onset: 10–30 min; Duration: 3–5 hrs",
+    "preparation": "Hot infusion or cold-brewed (tereré)",
+    "region": "Argentina, Paraguay, Brazil",
+    "safetyRating": "medium",
+    "scientificName": "Ilex paraguariensis",
+    "sideEffects": "Jitteriness, insomnia, GI discomfort in sensitive individuals",
+    "tags": [
+      "☕ Stimulant",
+      "🔥 Energy",
+      "🌿 Social"
+    ],
+    "therapeuticUses": "Energy, mental clarity, digestion",
+    "toxicity": "Low to moderate (long-term use linked to GI issues)",
+    "toxicityLD50": "~192 mg/kg (caffeine)"
+  },
+  {
+    "name": "Yopo",
+    "category": "Ritual / Visionary",
+    "contraindications": "Asthma, mental health disorders, MAOIs",
+    "description": "Used in Amazonian rituals, Yopo seeds are ground and insufflated to induce powerful entheogenic experiences. Contains bufotenine, DMT, and 5-MeO-DMT.",
+    "drugInteractions": "Avoid with antidepressants or MAOIs",
+    "duration": "30–60 min",
+    "effects": [
+      "Intense visions",
+      "altered time perception",
+      "spiritual insight"
+    ],
+    "id": "yopo",
+    "intensity": "Very strong",
+    "legalStatus": "Controlled in many countries due to DMT content",
+    "mechanismOfAction": "5-HT2A receptor agonist (bufotenine, DMT, 5-MeO-DMT)",
+    "onset": "1–5 min",
+    "pharmacokinetics": "Onset: 1–5 min; Duration: 30–60 min",
+    "preparation": "Roasted, ground seeds mixed with alkaline ash and blown nasally",
+    "region": "South America (Orinoco, Amazon basin)",
+    "safetyRating": "high",
+    "scientificName": "Anadenanthera peregrina",
+    "sideEffects": "Intense nausea, disorientation, respiratory irritation",
+    "tags": [
+      "⚠️ Caution",
+      "🧠 Vision",
+      "🌬️ Snuff"
+    ],
+    "therapeuticUses": "Shamanic healing, insight rituals",
+    "toxicity": "High risk with improper use; bufotenine toxic at high dose",
+    "toxicityLD50": "50–80 mg/kg (bufotenine, mice)"
+  },
+  {
+    "name": "Amanita muscaria",
+    "scientificName": "Amanita muscaria",
+    "category": "Ritual / Visionary",
+    "tags": [
+      "🍄 Mushroom",
+      "⚠️ Caution"
+    ],
+    "effects": [
+      "Euphoria",
+      "dissociation",
+      "dreamlike state"
+    ],
+    "mechanismOfAction": "Ibotenic acid and muscimol act as GABA agonists and NMDA antagonists after decarboxylation.",
+    "therapeuticUses": "Shamanic ritual, historical analgesic and sedative use.",
+    "pharmacokinetics": "Onset 30–90 min; duration 4–8 hrs when ingested.",
+    "toxicity": "Can cause nausea, delirium, or poisoning if dose is high or raw mushrooms consumed.",
+    "toxicityLD50": "LD50 ~38 mg/kg (muscimol, mice)",
+    "intensity": "Moderate to strong",
+    "onset": "30–90 min",
+    "duration": "4–8 hrs",
+    "region": "Northern Hemisphere, boreal forests",
+    "legalStatus": "Legal in most countries",
+    "safetyRating": "medium",
+    "preparation": "Traditionally dried or parboiled to convert ibotenic acid to muscimol.",
+    "contraindications": "Avoid with sedatives or psychiatric conditions.",
+    "sideEffects": "Nausea, ataxia, delirium",
+    "drugInteractions": "Potentiates sedatives and alcohol",
+    "description": "Iconic red-capped mushroom used in Siberian shamanism and folklore. Psychoactive when properly prepared."
+  },
+  {
+    "name": "Valerian Root",
+    "scientificName": "Valeriana officinalis",
+    "category": "Sedative / Anxiolytic",
+    "tags": [
+      "🌿 Root",
+      "😴 Sleep"
+    ],
+    "effects": [
+      "Relaxation",
+      "improved sleep",
+      "mild anxiolysis"
+    ],
+    "mechanismOfAction": "Valerenic acid modulates GABA receptors and may inhibit GABA breakdown.",
+    "therapeuticUses": "Insomnia, anxiety, muscle tension.",
+    "pharmacokinetics": "Oral; onset ~30 min; peak 1–2 hrs; duration ~4 hrs.",
+    "toxicity": "Generally safe; high doses may cause headaches or dizziness.",
+    "toxicityLD50": "LD50 >3 g/kg (mouse, extract)",
+    "intensity": "Mild",
+    "onset": "30 min",
+    "duration": "4 hrs",
+    "region": "Europe, North America",
+    "legalStatus": "Legal",
+    "safetyRating": "low",
+    "preparation": "Dried root used as tea, tincture, or capsule.",
+    "contraindications": "Avoid with other sedatives or during pregnancy.",
+    "sideEffects": "Drowsiness, vivid dreams",
+    "drugInteractions": "Additive with benzodiazepines or alcohol",
+    "description": "Traditional European herb valued for calming and sleep-promoting properties."
+  },
+  {
+    "name": "Huperzia serrata",
+    "scientificName": "Huperzia serrata",
+    "category": "Nootropic / Cognitive",
+    "tags": [
+      "🧠 Memory",
+      "⚗️ Alkaloid"
+    ],
+    "effects": [
+      "Improved memory",
+      "alertness"
+    ],
+    "mechanismOfAction": "Provides huperzine A, a reversible acetylcholinesterase inhibitor.",
+    "therapeuticUses": "Memory enhancement, research for Alzheimer’s disease.",
+    "pharmacokinetics": "Oral; onset within 30 min; duration 6–8 hrs.",
+    "toxicity": "Generally safe at low doses; high doses may cause cholinergic effects.",
+    "toxicityLD50": "LD50 >2 mg/kg (rats, huperzine A)",
+    "intensity": "Mild",
+    "onset": "30 min",
+    "duration": "6–8 hrs",
+    "region": "China, Southeast Asia",
+    "legalStatus": "Legal in most countries",
+    "safetyRating": "medium",
+    "preparation": "Standardized extract or whole plant tea.",
+    "contraindications": "Bradycardia, cholinergic medications.",
+    "sideEffects": "Nausea, sweating, muscle twitching at high doses",
+    "drugInteractions": "Potentiates cholinergic drugs or acetylcholinesterase inhibitors",
+    "description": "Club moss used in Traditional Chinese Medicine; source of huperzine A nootropic."
+  },
+  {
+    "name": "Syrian Rue",
+    "scientificName": "Peganum harmala",
+    "category": "Ritual / MAOI",
+    "tags": [
+      "🌿 Seeds",
+      "⚠️ MAOI"
+    ],
+    "effects": [
+      "MAOI effects",
+      "mild hallucinations",
+      "dream enhancement"
+    ],
+    "mechanismOfAction": "Harmala alkaloids reversibly inhibit MAO-A and MAO-B.",
+    "therapeuticUses": "Used in Middle Eastern rituals; sometimes combined with DMT for oral activity.",
+    "pharmacokinetics": "Oral ingestion; onset 20–40 min; duration 4–6 hrs.",
+    "toxicity": "High doses cause nausea, tremors, or hallucinations.",
+    "toxicityLD50": "LD50 ~150 mg/kg (harmaline, mice)",
+    "intensity": "Moderate",
+    "onset": "20–40 min",
+    "duration": "4–6 hrs",
+    "region": "Middle East, Central Asia",
+    "legalStatus": "Restricted in some countries",
+    "safetyRating": "medium",
+    "preparation": "Seeds ground for tea or extracted.",
+    "contraindications": "Avoid with SSRIs, stimulants, or liver disease.",
+    "sideEffects": "Nausea, vomiting, weakness",
+    "drugInteractions": "Dangerous with other MAOIs or serotonergic drugs",
+    "description": "Potent MAOI seed used traditionally for protection and divination."
+  },
+  {
+    "name": "Wild Dagga",
+    "scientificName": "Leonotis leonurus",
+    "category": "Relaxant / Euphoric",
+    "tags": [
+      "🌿 Smoke",
+      "🦁 Dagga"
+    ],
+    "effects": [
+      "Mild euphoria",
+      "relaxation"
+    ],
+    "mechanismOfAction": "Contains leonurine; may act on serotonin and cannabinoid receptors.",
+    "therapeuticUses": "Folk remedy for coughs, fever and as a mild psychoactive when smoked.",
+    "pharmacokinetics": "Smoked or brewed; onset within minutes; duration ~1–3 hrs.",
+    "toxicity": "Low; high doses may cause dizziness or nausea.",
+    "toxicityLD50": "Not established",
+    "intensity": "Mild",
+    "onset": "Minutes",
+    "duration": "1–3 hrs",
+    "region": "Southern Africa",
+    "legalStatus": "Legal",
+    "safetyRating": "low",
+    "preparation": "Dried leaves or flowers smoked or brewed as tea.",
+    "contraindications": "Avoid during pregnancy or with heart conditions.",
+    "sideEffects": "Dry mouth, slight dizziness",
+    "drugInteractions": "May potentiate other sedatives",
+    "description": "Orange-flowered shrub also called lion’s tail; smoked traditionally for mild cannabis-like effects."
+  },
+  {
+    "name": "Yohimbe",
+    "scientificName": "Pausinystalia johimbe",
+    "category": "Stimulant / Aphrodisiac",
+    "tags": [
+      "🌳 Bark",
+      "🔥 Libido"
+    ],
+    "effects": [
+      "Stimulation",
+      "increased libido",
+      "elevated heart rate"
+    ],
+    "mechanismOfAction": "Yohimbine blocks alpha-2 adrenergic receptors leading to increased norepinephrine release.",
+    "therapeuticUses": "Used for erectile dysfunction and as a stimulant.",
+    "pharmacokinetics": "Oral; onset ~30 min; duration 2–4 hrs.",
+    "toxicity": "High doses cause anxiety, hypertension, or hallucinations.",
+    "toxicityLD50": "LD50 ~50 mg/kg (rats, yohimbine)",
+    "intensity": "Moderate",
+    "onset": "30 min",
+    "duration": "2–4 hrs",
+    "region": "West Africa",
+    "legalStatus": "Restricted or prescription in some countries",
+    "safetyRating": "medium",
+    "preparation": "Bark extracts or standardized tablets.",
+    "contraindications": "Heart disease, anxiety disorders, MAOIs.",
+    "sideEffects": "Increased blood pressure, jitteriness, insomnia",
+    "drugInteractions": "Interacts with stimulants and antihypertensives",
+    "description": "West African tree bark rich in yohimbine, historically used as an aphrodisiac and stimulant."
+  },
+  {
+    "name": "Khat",
+    "scientificName": "Catha edulis",
+    "category": "Stimulant / Euphoric",
+    "tags": [
+      "🌿 Leaves",
+      "⚠️ Controlled"
+    ],
+    "effects": [
+      "Euphoria",
+      "alertness",
+      "appetite suppression"
+    ],
+    "mechanismOfAction": "Cathinone alkaloids release dopamine and norepinephrine.",
+    "therapeuticUses": "Social stimulant chewed in East Africa and the Arabian Peninsula.",
+    "pharmacokinetics": "Chewed fresh leaves; onset 15–30 min; duration 3–5 hrs.",
+    "toxicity": "Excess use leads to insomnia, hypertension, or dependency.",
+    "toxicityLD50": "Cathinone LD50 ~75 mg/kg (rats)",
+    "intensity": "Moderate",
+    "onset": "15–30 min",
+    "duration": "3–5 hrs",
+    "region": "Horn of Africa, Yemen",
+    "legalStatus": "Illegal or controlled in many countries",
+    "safetyRating": "medium",
+    "preparation": "Fresh leaves chewed slowly.",
+    "contraindications": "Heart issues, pregnancy, MAOIs.",
+    "sideEffects": "Dry mouth, increased heart rate, insomnia",
+    "drugInteractions": "Avoid with stimulants or MAOIs",
+    "description": "Evergreen shrub whose fresh leaves are chewed for stimulant and euphoric effects in social settings."
+  },
+  {
+    "name": "Camellia sinensis",
+    "scientificName": "Camellia sinensis",
+    "category": "Stimulant / Nootropic",
+    "tags": [
+      "🍵 Tea",
+      "☕ Caffeine"
+    ],
+    "effects": [
+      "Alertness",
+      "relaxed focus"
+    ],
+    "mechanismOfAction": "Caffeine antagonizes adenosine receptors; L-theanine modulates glutamate and GABA.",
+    "therapeuticUses": "Improved cognition, antioxidant, metabolism boost.",
+    "pharmacokinetics": "Beverage; onset 15 min; peak 30–60 min; duration 2–4 hrs.",
+    "toxicity": "High intake can cause jitteriness or insomnia.",
+    "toxicityLD50": "Caffeine LD50 ~190 mg/kg (rats)",
+    "intensity": "Mild",
+    "onset": "15 min",
+    "duration": "2–4 hrs",
+    "region": "China, India, worldwide cultivation",
+    "legalStatus": "Legal",
+    "safetyRating": "low",
+    "preparation": "Leaves steeped in hot water; various fermentations (green, black, oolong).",
+    "contraindications": "Heart conditions, pregnancy (high amounts).",
+    "sideEffects": "Jitters, insomnia, digestive upset",
+    "drugInteractions": "Potentiates other stimulants; may reduce sedative efficacy",
+    "description": "Source of green and black tea; contains caffeine and theanine for balanced stimulation."
+  },
+  {
+    "name": "Ephedra sinica",
+    "scientificName": "Ephedra sinica",
+    "category": "Stimulant / Decongestant",
+    "tags": [
+      "🌿 Ma Huang",
+      "⚠️ Potent"
+    ],
+    "effects": [
+      "Energy boost",
+      "bronchodilation"
+    ],
+    "mechanismOfAction": "Ephedrine and pseudoephedrine stimulate adrenergic receptors and release norepinephrine.",
+    "therapeuticUses": "Traditional Chinese medicine for asthma, colds, and as a stimulant.",
+    "pharmacokinetics": "Oral; onset ~20 min; duration 4–6 hrs.",
+    "toxicity": "High doses can raise blood pressure and cause cardiovascular stress.",
+    "toxicityLD50": "Ephedrine LD50 ~50 mg/kg (rats)",
+    "intensity": "Strong",
+    "onset": "20 min",
+    "duration": "4–6 hrs",
+    "region": "China and Central Asia",
+    "legalStatus": "Regulated in many countries",
+    "safetyRating": "medium",
+    "preparation": "Dried stems brewed as tea or processed into extract.",
+    "contraindications": "Heart disease, hypertension, MAOIs.",
+    "sideEffects": "Jitters, elevated heart rate, insomnia",
+    "drugInteractions": "Dangerous with other stimulants or MAOIs",
+    "description": "Shrubby plant known as Ma Huang; source of ephedrine used both medicinally and recreationally."
+  },
+  {
+    "name": "Sassafras",
+    "scientificName": "Sassafras albidum",
+    "category": "Stimulant / Traditional",
+    "tags": [
+      "🌳 Root bark",
+      "🌿 Tea"
+    ],
+    "effects": [
+      "Mild euphoria",
+      "warmth"
+    ],
+    "mechanismOfAction": "Safrole may modulate dopamine release and acts as a mild hallucinogen at high doses.",
+    "therapeuticUses": "Historically used as spring tonic, aromatic beverage, and folk medicine.",
+    "pharmacokinetics": "Brewed as tea; onset 20–40 min; duration 2–4 hrs.",
+    "toxicity": "Safrole is hepatotoxic and potentially carcinogenic in high amounts.",
+    "toxicityLD50": "Safrole LD50 ~1.95 g/kg (rats)",
+    "intensity": "Mild",
+    "onset": "20–40 min",
+    "duration": "2–4 hrs",
+    "region": "Eastern North America",
+    "legalStatus": "Restricted as food additive in the U.S.",
+    "safetyRating": "medium",
+    "preparation": "Root bark traditionally brewed or distilled into oil of sassafras.",
+    "contraindications": "Liver disease, pregnancy.",
+    "sideEffects": "Nausea, possible hepatotoxicity",
+    "drugInteractions": "May interact with MAOIs or increase hepatotoxic drugs",
+    "description": "Fragrant tree whose root bark and oil were once common flavorings; contains safrole with mild psychoactive properties."
+  },
+  {
+    "name": "Guarana",
+    "scientificName": "Paullinia cupana",
+    "category": "Stimulant / Nootropic",
+    "tags": [
+      "🍫 Seed",
+      "☕ High caffeine"
+    ],
+    "effects": [
+      "Energy",
+      "mental focus"
+    ],
+    "mechanismOfAction": "Seeds contain high caffeine content that blocks adenosine receptors.",
+    "therapeuticUses": "Fatigue reduction, weight loss aid, traditional tonic.",
+    "pharmacokinetics": "Oral; onset 20 min; peak 1 hr; duration 4–6 hrs.",
+    "toxicity": "Overuse leads to restlessness, insomnia, or tachycardia.",
+    "toxicityLD50": "Caffeine LD50 ~190 mg/kg (rats)",
+    "intensity": "Moderate",
+    "onset": "20 min",
+    "duration": "4–6 hrs",
+    "region": "Amazon basin",
+    "legalStatus": "Legal",
+    "safetyRating": "low",
+    "preparation": "Roasted seeds ground into powder for drinks or capsules.",
+    "contraindications": "Heart problems, pregnancy, sensitivity to caffeine.",
+    "sideEffects": "Jitteriness, stomach upset",
+    "drugInteractions": "Potentiates other stimulants; may interfere with sedatives",
+    "description": "Climbing plant native to Brazil; its seeds provide a potent caffeine kick and are popular in energy drinks."
+  },
+  {
+    "name": "Hawaiian Baby Woodrose",
+    "scientificName": "Argyreia nervosa",
+    "category": "Psychedelic / LSA",
+    "tags": [
+      "🌱 Seeds",
+      "⚠️ Nausea"
+    ],
+    "effects": [
+      "Visual distortions",
+      "euphoria",
+      "introspection"
+    ],
+    "mechanismOfAction": "Seeds contain ergoline alkaloids (LSA) that act on serotonin receptors similarly to LSD but with milder potency.",
+    "therapeuticUses": "Occasional spiritual or introspective use; historically as ornamental and traditional medicine.",
+    "pharmacokinetics": "Oral; onset 30–90 min; duration 6–10 hrs.",
+    "toxicity": "Seeds can cause severe nausea and vasoconstriction at high doses.",
+    "toxicityLD50": "Not well established for humans; animal data scarce",
+    "intensity": "Strong",
+    "onset": "30–90 min",
+    "duration": "6–10 hrs",
+    "region": "India, tropical regions",
+    "legalStatus": "Seeds legal in many places; extraction may be controlled",
+    "safetyRating": "medium",
+    "preparation": "Seeds scraped and chewed or ground; often cold-water extracted.",
+    "contraindications": "Pregnancy, liver issues, MAOIs.",
+    "sideEffects": "Nausea, vasoconstriction, sedation",
+    "drugInteractions": "Avoid with vasoconstrictors or other psychedelics",
+    "description": "Climber with heart-shaped leaves; its seeds contain LSA and are used as a legal alternative to LSD experiences."
+  },
+  {
+    "name": "Tabernanthe iboga",
+    "scientificName": "Tabernanthe iboga",
+    "category": "Ritual / Visionary",
+    "tags": [
+      "🌿 Root bark",
+      "⚠️ Intense"
+    ],
+    "effects": [
+      "Powerful visions",
+      "spiritual insight",
+      "stimulation"
+    ],
+    "mechanismOfAction": "Ibogaine acts on NMDA, kappa-opioid, and serotonin systems while promoting neurotrophic factors.",
+    "therapeuticUses": "Traditional Bwiti initiation; studied for addiction interruption.",
+    "pharmacokinetics": "Oral; onset 1–3 hrs; duration 12–24 hrs.",
+    "toxicity": "Cardiotoxic and neurotoxic at high doses; medical supervision required.",
+    "toxicityLD50": "Ibogaine LD50 ~50 mg/kg (mice)",
+    "intensity": "Very strong",
+    "onset": "1–3 hrs",
+    "duration": "12–24 hrs",
+    "region": "Central Africa",
+    "legalStatus": "Controlled or prescription in many countries",
+    "safetyRating": "low",
+    "preparation": "Root bark chewed or made into extracts; used ceremonially.",
+    "contraindications": "Heart conditions, psychiatric disorders, MAOIs.",
+    "sideEffects": "Nausea, ataxia, prolonged recovery",
+    "drugInteractions": "Dangerous with other stimulants or opioids",
+    "description": "Sacred shrub central to Bwiti ceremonies; contains ibogaine producing intense visionary states and potential addiction therapy."
+  },
+  {
+    "name": "LSD",
+    "scientificName": "Lysergic acid diethylamide",
+    "category": "Psychedelic",
+    "effects": [
+      "Intense visuals",
+      "ego dissolution",
+      "synesthesia"
+    ],
+    "preparation": "Oral blotter or liquid",
+    "intensity": "High",
+    "onset": "30-90 min",
+    "legalStatus": "Controlled / Illegal in many regions",
+    "region": "🌎 Synthetic",
+    "tags": [
+      "💊 Oral",
+      "⚠️ Restricted",
+      "🌀 Visionary"
+    ],
+    "mechanismOfAction": "Potent 5-HT2A receptor agonist affecting serotonin and dopamine systems.",
+    "pharmacokinetics": "Oral administration with effects lasting 8-12 h; hepatic metabolism to inactive metabolites.",
+    "therapeuticUses": "Investigated for cluster headaches, anxiety, and addiction therapy.",
+    "sideEffects": "Anxiety, confusion, possible flashbacks at high doses.",
+    "contraindications": "Psychosis, severe cardiovascular disease.",
+    "drugInteractions": "SSRIs may blunt effects; MAOIs potentiate.",
+    "toxicity": "Very low physiological toxicity but strong psychological effects.",
+    "toxicityLD50": ">14 mg/kg (mice, intravenous)",
+    "id": "lsd",
+    "description": "Semi-synthetic ergoline discovered in 1938; among the most potent psychedelics.",
+    "safetyRating": 2
+  },
+  {
+    "name": "Psilocybin",
+    "scientificName": "Psilocybin",
+    "category": "Psychedelic",
+    "effects": [
+      "Visual patterns",
+      "mystical insight",
+      "emotional release"
+    ],
+    "preparation": "Consumed as dried mushrooms or extract",
+    "intensity": "Moderate",
+    "onset": "20-60 min",
+    "legalStatus": "Controlled in many countries",
+    "region": "🌎 Global",
+    "tags": [
+      "💊 Oral",
+      "🌀 Visionary",
+      "⚠️ Restricted"
+    ],
+    "mechanismOfAction": "Converted to psilocin which acts as 5-HT2A agonist.",
+    "pharmacokinetics": "Oral onset ~30 min; duration 4-6 h; metabolized hepatically.",
+    "therapeuticUses": "Promising treatment for depression, addiction, and end-of-life anxiety.",
+    "sideEffects": "Nausea, anxiety, transient increase in heart rate.",
+    "contraindications": "Psychosis, uncontrolled hypertension.",
+    "drugInteractions": "SSRIs may reduce effects; avoid MAOIs.",
+    "toxicity": "Low toxicity; wide margin of safety.",
+    "toxicityLD50": "285 mg/kg (rats, oral) for psilocybin",
+    "id": "psilocybin",
+    "description": "Active compound in psychedelic mushrooms producing profound perceptual changes.",
+    "safetyRating": 2
+  },
+  {
+    "name": "Mescaline",
+    "scientificName": "3,4,5-trimethoxyphenethylamine",
+    "category": "Psychedelic",
+    "effects": [
+      "Color enhancement",
+      "empathy",
+      "spiritual visions"
+    ],
+    "preparation": "Ingested cactus buttons or purified sulfate",
+    "intensity": "Moderate",
+    "onset": "45-120 min",
+    "legalStatus": "Controlled in many regions",
+    "region": "🌎 Americas",
+    "tags": [
+      "💊 Oral",
+      "🌀 Visionary",
+      "⚠️ Restricted"
+    ],
+    "mechanismOfAction": "Phenethylamine psychedelic acting on 5-HT2A and dopamine receptors.",
+    "pharmacokinetics": "Oral absorption with peak at 2 h; duration 8-12 h; renal excretion.",
+    "therapeuticUses": "Traditional sacrament; studied for alcoholism and psychotherapy.",
+    "sideEffects": "Nausea, increased heart rate, dilated pupils.",
+    "contraindications": "Heart disease, pregnancy.",
+    "drugInteractions": "MAOIs and sympathomimetics may potentiate.",
+    "toxicity": "Low physiological toxicity; psychological effects strong.",
+    "toxicityLD50": ">1,000 mg/kg (rats, oral)",
+    "id": "mescaline",
+    "description": "Classic phenethylamine psychedelic from peyote and San Pedro cacti.",
+    "safetyRating": 2
+  },
+  {
+    "name": "Acacia maidenii",
+    "scientificName": "Acacia maidenii",
+    "category": "Ritual / Visionary",
+    "tags": [
+      "DMT",
+      "Australian",
+      "tree"
+    ],
+    "effects": [
+      "strong visuals",
+      "mystical experience",
+      "euphoria"
+    ],
+    "mechanismOfAction": "Root bark contains DMT that acts as a 5‑HT2A agonist; requires MAOI inhibition for oral activity",
+    "therapeuticUses": "Used in entheogenic brews for introspection and spiritual healing",
+    "pharmacokinetics": "Smoked onset 2–3 min, duration 15–30 min; oral with MAOI onset 20–45 min, duration 4–6 h",
+    "toxicity": "Low physiological toxicity but intense psychological effects",
+    "toxicityLD50": "Not established",
+    "intensity": "Strong",
+    "onset": "2–45 min depending on route",
+    "duration": "15 min – 6 h depending on route",
+    "region": "Native to eastern Australia",
+    "legalStatus": "DMT restricted in many countries",
+    "safetyRating": "Medium",
+    "preparation": "Root bark traditionally combined with MAOI plants or smoked",
+    "contraindications": "Mental illness, MAOI or SSRI medication",
+    "sideEffects": "Nausea, anxiety, profound alterations of perception",
+    "drugInteractions": "Dangerous with MAOIs or serotonergic drugs",
+    "description": "Australian acacia tree whose bark is rich in DMT and sometimes used in ayahuasca analogues.",
+    "id": "acacia-maidenii"
+  },
+  {
+    "name": "Acorus calamus",
+    "scientificName": "Acorus calamus",
+    "category": "Calming / Dream",
+    "tags": [
+      "sedative",
+      "dream",
+      "root"
+    ],
+    "effects": [
+      "calm",
+      "mild euphoria",
+      "dream enhancement"
+    ],
+    "mechanismOfAction": "Contains beta‑asarone which may modulate GABA and serotonin receptors",
+    "therapeuticUses": "Traditionally used for digestion, anxiety and divination",
+    "pharmacokinetics": "Onset ~30 min orally, lasting 2–4 h",
+    "toxicity": "Beta‑asarone may be carcinogenic in high doses",
+    "toxicityLD50": "Exceeds 1 g/kg in rodents",
+    "intensity": "Mild",
+    "onset": "Around 30 min",
+    "duration": "2–4 h",
+    "region": "Europe, Asia, North America",
+    "legalStatus": "Generally legal, though some preparations restricted",
+    "safetyRating": "Low–Medium",
+    "preparation": "Dried rhizome chewed or made into tea",
+    "contraindications": "Pregnancy, high doses, liver disease",
+    "sideEffects": "Nausea, vomiting at large doses",
+    "drugInteractions": "Potential additive effects with other sedatives",
+    "description": "Fragrant wetland herb known as Sweet Flag; historically used for relaxation and vivid dreams.",
+    "id": "acorus-calamus"
+  },
+  {
+    "name": "Albizia julibrissin",
+    "scientificName": "Albizia julibrissin",
+    "category": "Calming / Mood",
+    "tags": [
+      "anxiolytic",
+      "flower",
+      "TCM"
+    ],
+    "effects": [
+      "uplifted mood",
+      "relaxation",
+      "mild sedation"
+    ],
+    "mechanismOfAction": "Contains saponins and flavonoids thought to modulate serotonin and GABA",
+    "therapeuticUses": "Traditional Chinese medicine uses the bark and flowers as a calming antidepressant",
+    "pharmacokinetics": "Onset 30–60 min orally; effects last 3–5 h",
+    "toxicity": "Low",
+    "toxicityLD50": "Not well established",
+    "intensity": "Mild",
+    "onset": "30–60 min",
+    "duration": "3–5 h",
+    "region": "Native to Asia, cultivated elsewhere",
+    "legalStatus": "Legal",
+    "safetyRating": "High",
+    "preparation": "Dried bark or flowers taken as teas or tinctures",
+    "contraindications": "None known, though caution with sedatives",
+    "sideEffects": "Rare drowsiness in sensitive individuals",
+    "drugInteractions": "May enhance other sedatives or antidepressants",
+    "description": "Often called Persian silk tree; valued in Asian herbalism for its tranquil and mood-brightening properties.",
+    "id": "albizia-julibrissin"
+  },
+  {
+    "name": "Anemone pulsatilla",
+    "scientificName": "Pulsatilla vulgaris",
+    "category": "Sedative / Analgesic",
+    "tags": [
+      "sedative",
+      "anodyne",
+      "folk"
+    ],
+    "effects": [
+      "calm",
+      "pain relief",
+      "mild altered awareness"
+    ],
+    "mechanismOfAction": "Contains lactones derived from protoanemonin that depress the central nervous system",
+    "therapeuticUses": "European folk remedy for anxiety, insomnia and menstrual pain",
+    "pharmacokinetics": "Onset 20–30 min, lasting 2–4 h when taken orally",
+    "toxicity": "Fresh plant is irritant and toxic until dried",
+    "toxicityLD50": "Not well established",
+    "intensity": "Mild",
+    "onset": "20–30 min",
+    "duration": "2–4 h",
+    "region": "Europe and western Asia",
+    "legalStatus": "Legal but not widely sold",
+    "safetyRating": "Medium due to fresh plant toxicity",
+    "preparation": "Only dried aerial parts are infused as tea",
+    "contraindications": "Pregnancy, open wounds, large doses",
+    "sideEffects": "Nausea, stomach irritation if taken fresh",
+    "drugInteractions": "May potentiate other sedatives or analgesics",
+    "description": "Also called Pasque Flower; once used by herbalists for calming nerves and relieving pain.",
+    "id": "anemone-pulsatilla"
+  },
+  {
+    "name": "Argemone mexicana",
+    "scientificName": "Argemone mexicana",
+    "category": "Sedative / Analgesic",
+    "tags": [
+      "poppy",
+      "folk medicine",
+      "alkaloid"
+    ],
+    "effects": [
+      "relaxation",
+      "analgesia",
+      "slight euphoria"
+    ],
+    "mechanismOfAction": "Isoquinoline alkaloids interact with opioid and dopamine receptors",
+    "therapeuticUses": "Mexican and Ayurvedic traditions use it for pain, insomnia and mild narcotic effects",
+    "pharmacokinetics": "Onset 20–30 min orally, lasting 3–6 h",
+    "toxicity": "Seeds and latex can be hepatotoxic in high doses",
+    "toxicityLD50": "Not well quantified",
+    "intensity": "Moderate",
+    "onset": "20–30 min",
+    "duration": "3–6 h",
+    "region": "Native to tropical America; naturalized worldwide",
+    "legalStatus": "Legal but sometimes regulated due to toxicity",
+    "safetyRating": "Low–Medium",
+    "preparation": "Dried leaves or latex smoked or brewed sparingly",
+    "contraindications": "Liver disorders, pregnancy, high doses",
+    "sideEffects": "Headache, stomach upset, potential liver damage",
+    "drugInteractions": "Avoid combining with alcohol or other depressants",
+    "description": "Spiny yellow poppy whose milky latex was historically used for pain relief and sedation.",
+    "id": "argemone-mexicana"
+  },
+  {
+    "name": "Combretum quadrangulare",
+    "scientificName": "Combretum quadrangulare",
+    "category": "Stimulant",
+    "tags": [
+      "Sakae Naa",
+      "Southeast Asia",
+      "energy"
+    ],
+    "effects": [
+      "heightened alertness",
+      "subtle euphoria",
+      "increased focus"
+    ],
+    "mechanismOfAction": "Leaves contain combretol and related alkaloids acting on adrenergic systems",
+    "therapeuticUses": "Traditional stimulant and tonic in Laos and Thailand",
+    "pharmacokinetics": "Onset about 30 min orally; effects up to 4–6 h",
+    "toxicity": "Limited data but appears low at customary doses",
+    "toxicityLD50": "Not established",
+    "intensity": "Mild to Moderate",
+    "onset": "30 min",
+    "duration": "4–6 h",
+    "region": "Laos, Cambodia, Thailand",
+    "legalStatus": "Legal with little regulation",
+    "safetyRating": "Medium",
+    "preparation": "Leaves brewed as tea or smoked similar to kratom",
+    "contraindications": "Hypertension, heart conditions",
+    "sideEffects": "Jitters, insomnia if overused",
+    "drugInteractions": "May potentiate other stimulants",
+    "description": "Often marketed as “Sakae Naa,” this plant is used as a mild energizing substitute for kratom.",
+    "id": "combretum-quadrangulare"
+  },
+  {
+    "name": "Corydalis yanhusuo",
+    "scientificName": "Corydalis yanhusuo",
+    "category": "Sedative / Analgesic",
+    "tags": [
+      "pain relief",
+      "TCM",
+      "dopamine"
+    ],
+    "effects": [
+      "analgesia",
+      "relaxation",
+      "subtle dreaminess"
+    ],
+    "mechanismOfAction": "Alkaloids such as tetrahydropalmatine act on dopamine and GABA receptors",
+    "therapeuticUses": "Traditional Chinese remedy for pain and insomnia",
+    "pharmacokinetics": "Onset 20–40 min orally, lasting 3–5 h",
+    "toxicity": "Overuse may cause liver stress",
+    "toxicityLD50": ">1 g/kg in rodents",
+    "intensity": "Moderate",
+    "onset": "20–40 min",
+    "duration": "3–5 h",
+    "region": "China and East Asia",
+    "legalStatus": "Legal",
+    "safetyRating": "Medium",
+    "preparation": "Rhizome taken in decoctions or powdered extracts",
+    "contraindications": "Pregnancy, liver disease, large doses",
+    "sideEffects": "Drowsiness, dizziness",
+    "drugInteractions": "May potentiate sedatives or dopaminergic drugs",
+    "description": "Tubers of this Asian herb provide notable pain relief and a tranquil state when used as tea or pills.",
+    "id": "corydalis-yanhusuo"
+  },
+  {
+    "name": "Desmanthus illinoensis",
+    "scientificName": "Desmanthus illinoensis",
+    "category": "Ritual / Visionary",
+    "tags": [
+      "DMT",
+      "American",
+      "root bark"
+    ],
+    "effects": [
+      "visual enhancements",
+      "introspection",
+      "altered perception"
+    ],
+    "mechanismOfAction": "Root bark contains DMT; usually combined with MAOIs to be active orally",
+    "therapeuticUses": "Used in underground ayahuasca analogs for spiritual exploration",
+    "pharmacokinetics": "Smoked onset 2–3 min; oral with MAOI onset 20–45 min; duration up to 6 h",
+    "toxicity": "Low physiological, high psychological risk",
+    "toxicityLD50": "Not established",
+    "intensity": "Strong",
+    "onset": "2–45 min depending on route",
+    "duration": "15 min – 6 h",
+    "region": "Central and southern United States",
+    "legalStatus": "DMT restricted in many countries",
+    "safetyRating": "Medium",
+    "preparation": "Root bark powdered for extraction or brewed with MAOI plant",
+    "contraindications": "Mental health issues, MAOI or SSRI medication",
+    "sideEffects": "Nausea, anxiety, powerful visions",
+    "drugInteractions": "Dangerous with MAOIs or serotonergic drugs",
+    "description": "Also called Illinois Bundleflower; its root bark contains notable amounts of DMT.",
+    "id": "desmanthus-illinoensis"
+  },
+  {
+    "name": "Erythrina mulungu",
+    "scientificName": "Erythrina mulungu",
+    "category": "Sedative / Anxiolytic",
+    "tags": [
+      "Brazil",
+      "sleep",
+      "bark"
+    ],
+    "effects": [
+      "deep relaxation",
+      "anxiety relief",
+      "sleepiness"
+    ],
+    "mechanismOfAction": "Erythrinan alkaloids interact with GABA receptors causing CNS depression",
+    "therapeuticUses": "South American remedy for insomnia and stress",
+    "pharmacokinetics": "Onset ~30 min orally; effects last 4–6 h",
+    "toxicity": "Relatively safe at moderate doses",
+    "toxicityLD50": "Not well documented",
+    "intensity": "Moderate",
+    "onset": "30 min",
+    "duration": "4–6 h",
+    "region": "Brazil and neighboring countries",
+    "legalStatus": "Legal",
+    "safetyRating": "High",
+    "preparation": "Bark decoction or tincture consumed before sleep",
+    "contraindications": "Pregnancy, combining with strong sedatives",
+    "sideEffects": "Drowsiness, lowered blood pressure",
+    "drugInteractions": "May potentiate other CNS depressants",
+    "description": "Flowering tree whose bark is prized in Brazilian folk medicine for calming nerves and promoting sleep.",
+    "id": "erythrina-mulungu"
+  },
+  {
+    "name": "Erythrina americana",
+    "scientificName": "Erythrina americana",
+    "category": "Sedative / Anxiolytic",
+    "tags": [
+      "Mexico",
+      "sleep",
+      "flower"
+    ],
+    "effects": [
+      "relaxation",
+      "dreaminess",
+      "reduced anxiety"
+    ],
+    "mechanismOfAction": "Contains erythrinan alkaloids acting as GABAergic depressants",
+    "therapeuticUses": "Mexican folk remedy for insomnia and nervous tension",
+    "pharmacokinetics": "Onset 30–45 min orally; duration 3–5 h",
+    "toxicity": "Low to moderate",
+    "toxicityLD50": "Not well established",
+    "intensity": "Mild to Moderate",
+    "onset": "30–45 min",
+    "duration": "3–5 h",
+    "region": "Mexico",
+    "legalStatus": "Legal",
+    "safetyRating": "Medium",
+    "preparation": "Flowers or bark steeped as tea",
+    "contraindications": "Pregnancy, combining with CNS depressants",
+    "sideEffects": "Drowsiness, dizziness",
+    "drugInteractions": "May enhance effects of other sedatives",
+    "description": "Known locally as Colorín; its red flowers are brewed into a soothing bedtime drink.",
+    "id": "erythrina-americana"
+  },
+  {
+    "name": "Galbulimima belgraveana",
+    "scientificName": "Galbulimima belgraveana",
+    "category": "Ritual / Visionary",
+    "tags": [
+      "Papua New Guinea",
+      "hallucinogen",
+      "tree"
+    ],
+    "effects": [
+      "dreamlike visions",
+      "dizziness",
+      "altered consciousness"
+    ],
+    "mechanismOfAction": "Contains himbacine-type alkaloids with muscarinic antagonist activity",
+    "therapeuticUses": "Used by Papuan tribes for shamanic rituals and hunting magic",
+    "pharmacokinetics": "Onset 30–60 min when consumed, lasting 4–8 h",
+    "toxicity": "Reports of toxicity at high doses; data limited",
+    "toxicityLD50": "Not established",
+    "intensity": "Moderate to Strong",
+    "onset": "30–60 min",
+    "duration": "4–8 h",
+    "region": "Papua New Guinea and northern Australia",
+    "legalStatus": "Little formal regulation",
+    "safetyRating": "Low–Medium",
+    "preparation": "Bark or leaves boiled into a decoction, sometimes mixed with ginger",
+    "contraindications": "Unknown; caution due to potent effects",
+    "sideEffects": "Nausea, vertigo, intense dreams",
+    "drugInteractions": "Avoid combining with other anticholinergics",
+    "description": "Rare rainforest tree providing psychoactive bark traditionally used in New Guinea for visionary experiences.",
+    "id": "galbulimima-belgraveana"
+  },
+  {
+    "name": "Alpinia galanga",
+    "scientificName": "Alpinia galanga",
+    "category": "Stimulant",
+    "tags": [
+      "galangal",
+      "aromatic",
+      "spice"
+    ],
+    "effects": [
+      "warm stimulation",
+      "mild euphoria",
+      "enhanced circulation"
+    ],
+    "mechanismOfAction": "Contains eugenol and cineole that increase circulation and mild CNS stimulation",
+    "therapeuticUses": "Used in Southeast Asian medicine for digestion and fatigue",
+    "pharmacokinetics": "Onset 20–40 min, duration 2–4 h",
+    "toxicity": "Generally safe as a culinary spice",
+    "toxicityLD50": ">3 g/kg in rodents",
+    "intensity": "Mild",
+    "onset": "20–40 min",
+    "duration": "2–4 h",
+    "region": "Indonesia, Thailand, Malaysia",
+    "legalStatus": "Legal",
+    "safetyRating": "High",
+    "preparation": "Rhizome chewed fresh, powdered in capsules, or brewed as tea",
+    "contraindications": "Gastric ulcers, anticoagulant medication",
+    "sideEffects": "Heartburn or mild agitation at high doses",
+    "drugInteractions": "May alter absorption of other stimulants or anticoagulants",
+    "description": "A common culinary spice known as galangal that offers gentle stimulation and a warming effect.",
+    "id": "alpinia-galanga"
+  },
+  {
+    "name": "Leonurus sibiricus",
+    "scientificName": "Leonurus sibiricus",
+    "category": "Calming / Dream",
+    "tags": [
+      "marihuanilla",
+      "mint family",
+      "sedative"
+    ],
+    "effects": [
+      "mild sedation",
+      "light euphoria",
+      "dream enhancement"
+    ],
+    "mechanismOfAction": "Contains leonurine and other alkaloids that depress CNS activity",
+    "therapeuticUses": "Used in Latin American and Asian folk medicine for relaxation and spiritual rituals",
+    "pharmacokinetics": "Onset 20–30 min when smoked or brewed; effects last 2–4 h",
+    "toxicity": "Considered safe in moderate amounts",
+    "toxicityLD50": "Not established",
+    "intensity": "Mild",
+    "onset": "20–30 min",
+    "duration": "2–4 h",
+    "region": "Native to Asia, cultivated in the Americas",
+    "legalStatus": "Legal",
+    "safetyRating": "High",
+    "preparation": "Leaves smoked or steeped as tea",
+    "contraindications": "None known",
+    "sideEffects": "Drowsiness at high doses",
+    "drugInteractions": "May enhance effects of other sedatives",
+    "description": "Sometimes called Marihuanilla or Siberian motherwort, providing gentle calming effects and subtle dreaminess.",
+    "id": "leonurus-sibiricus"
+  },
+  {
+    "name": "Lagochilus inebrians",
+    "scientificName": "Lagochilus inebrians",
+    "category": "Sedative / Euphoric",
+    "tags": [
+      "intoxicating mint",
+      "Central Asia",
+      "calming"
+    ],
+    "effects": [
+      "relaxation",
+      "mild euphoria",
+      "reduced anxiety"
+    ],
+    "mechanismOfAction": "Contains lagochilin which depresses the CNS and may interact with GABA",
+    "therapeuticUses": "Folk remedy in Uzbekistan and Kazakhstan for tension and insomnia",
+    "pharmacokinetics": "Onset about 30 min orally or smoked; duration 3–5 h",
+    "toxicity": "Little toxicity noted at customary doses",
+    "toxicityLD50": "Not established",
+    "intensity": "Mild",
+    "onset": "~30 min",
+    "duration": "3–5 h",
+    "region": "Central Asia",
+    "legalStatus": "Legal",
+    "safetyRating": "High",
+    "preparation": "Leaves brewed as tea or smoked alone or with other herbs",
+    "contraindications": "None documented but caution when operating machinery",
+    "sideEffects": "Drowsiness",
+    "drugInteractions": "Could potentiate other depressants",
+    "description": "Known as intoxicating mint; produces a pleasant calm and slight euphoria when brewed.",
+    "id": "lagochilus-inebrians"
+  },
+  {
+    "name": "Nicotiana rustica",
+    "scientificName": "Nicotiana rustica",
+    "category": "Stimulant / Ritual",
+    "tags": [
+      "mapacho",
+      "nicotine",
+      "tobacco"
+    ],
+    "effects": [
+      "alertness",
+      "intense buzz",
+      "clearing of thoughts"
+    ],
+    "mechanismOfAction": "High nicotine plus MAO‑inhibiting beta‑carbolines stimulate nicotinic receptors and inhibit MAO",
+    "therapeuticUses": "Used by Amazonian shamans for cleansing and focus",
+    "pharmacokinetics": "Smoked onset immediate, duration 30–60 min; oral snuff onset ~5 min",
+    "toxicity": "High nicotine content can be poisonous in large amounts",
+    "toxicityLD50": "Nicotine LD50 ~50 mg/kg (mouse)",
+    "intensity": "Strong",
+    "onset": "Immediate when smoked",
+    "duration": "30–60 min",
+    "region": "South America and worldwide cultivation",
+    "legalStatus": "Legal but regulated like tobacco",
+    "safetyRating": "Low–Medium",
+    "preparation": "Leaves dried and smoked, snuffed, or used in liquid extracts",
+    "contraindications": "Heart disease, pregnancy, hypertension",
+    "sideEffects": "Nausea, increased heart rate, dizziness",
+    "drugInteractions": "Strongly potentiated by MAOIs; interacts with many medications",
+    "description": "Potent tobacco species used ceremonially in the Amazon, far stronger than common N. tabacum.",
+    "id": "nicotiana-rustica"
+  },
+  {
+    "name": "Nymphaea lotus",
+    "scientificName": "Nymphaea lotus",
+    "category": "Calming / Dream",
+    "tags": [
+      "Egyptian lotus",
+      "sedative",
+      "water lily"
+    ],
+    "effects": [
+      "relaxation",
+      "dream enhancement",
+      "mild euphoria"
+    ],
+    "mechanismOfAction": "Contains aporphine alkaloids that act on dopamine and serotonin receptors",
+    "therapeuticUses": "Used in ancient Egypt for sedation and ritual ceremonies",
+    "pharmacokinetics": "Onset 20–30 min when brewed; duration about 2–5 h",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established",
+    "intensity": "Mild",
+    "onset": "20–30 min",
+    "duration": "2–5 h",
+    "region": "Africa and Southeast Asia",
+    "legalStatus": "Generally legal",
+    "safetyRating": "High",
+    "preparation": "Dried flowers steeped as tea or soaked in wine",
+    "contraindications": "None known but caution with sedatives",
+    "sideEffects": "Drowsiness at high doses",
+    "drugInteractions": "May add to effects of other sedatives",
+    "description": "Also called the Egyptian white lotus, historically revered for its gentle calming and dreamlike qualities.",
+    "id": "nymphaea-lotus"
+  },
+  {
+    "name": "Psychotria carthagenensis",
+    "scientificName": "Psychotria carthagenensis",
+    "category": "Ritual / Visionary",
+    "tags": [
+      "chaliponga",
+      "Amazon",
+      "DMT"
+    ],
+    "effects": [
+      "visual effects",
+      "introspection",
+      "spiritual insight"
+    ],
+    "mechanismOfAction": "Leaves contain N,N-dimethyltryptamine acting as a serotonin agonist; requires MAO inhibition orally",
+    "therapeuticUses": "Used in ayahuasca analogues for visionary experiences",
+    "pharmacokinetics": "Onset 20–45 min orally with MAOI, duration 4–6 h",
+    "toxicity": "Low physiological but intense psychological effects",
+    "toxicityLD50": "Not established",
+    "intensity": "Strong",
+    "onset": "20–45 min",
+    "duration": "4–6 h",
+    "region": "Amazon Basin",
+    "legalStatus": "DMT restricted in many countries",
+    "safetyRating": "Medium",
+    "preparation": "Leaves brewed with MAOI plants to form ayahuasca-style brews",
+    "contraindications": "Mental health conditions, MAOI or SSRI medication",
+    "sideEffects": "Nausea, intense visions, possible anxiety",
+    "drugInteractions": "Dangerous with serotonergic drugs or other MAOIs",
+    "description": "Amazonian shrub also known as Chaliponga; its DMT-rich leaves are valued in shamanic ceremonies.",
+    "id": "psychotria-carthagenensis"
+  },
+  {
+    "name": "Mucuna pruriens",
+    "scientificName": "Mucuna pruriens",
+    "category": "Stimulant / Nootropic",
+    "tags": [
+      "velvet bean",
+      "dopamine",
+      "Ayurveda"
+    ],
+    "effects": [
+      "increased motivation",
+      "energy",
+      "elevated mood"
+    ],
+    "mechanismOfAction": "Seeds contain L‑DOPA which increases brain dopamine levels",
+    "therapeuticUses": "Used in Ayurveda for Parkinson's disease, mood disorders and vitality",
+    "pharmacokinetics": "Onset around 30 min, duration 4–6 h",
+    "toxicity": "Generally safe at typical doses; high doses may cause nausea",
+    "toxicityLD50": ">6 g/kg in rodents",
+    "intensity": "Moderate",
+    "onset": "30 min",
+    "duration": "4–6 h",
+    "region": "Tropical Asia and Africa",
+    "legalStatus": "Legal",
+    "safetyRating": "High",
+    "preparation": "Powdered seeds or extract taken in capsules or smoothies",
+    "contraindications": "Psychosis, concurrent L‑DOPA medication",
+    "sideEffects": "Nausea or headache with excessive intake",
+    "drugInteractions": "Avoid with MAOIs or dopamine medications",
+    "description": "Also called Velvet Bean; boosts dopamine and serves as a traditional tonic in Ayurvedic practice.",
+    "id": "mucuna-pruriens"
+  },
+  {
+    "name": "Paullinia yoco",
+    "scientificName": "Paullinia yoco",
+    "category": "Stimulant / Ritual",
+    "tags": [
+      "Amazon",
+      "caffeine",
+      "vine"
+    ],
+    "effects": [
+      "alertness",
+      "energy",
+      "reduced fatigue"
+    ],
+    "mechanismOfAction": "Bark rich in caffeine acts as an adenosine receptor antagonist",
+    "therapeuticUses": "Used by indigenous Amazonian peoples for stamina on hunts",
+    "pharmacokinetics": "Onset 10–20 min when brewed; duration 2–4 h",
+    "toxicity": "Comparable to other caffeinated products",
+    "toxicityLD50": "Caffeine LD50 ~192 mg/kg in rats",
+    "intensity": "Moderate",
+    "onset": "10–20 min",
+    "duration": "2–4 h",
+    "region": "Amazon rainforest",
+    "legalStatus": "Generally legal",
+    "safetyRating": "High",
+    "preparation": "Bark strips boiled into a strong caffeinated drink",
+    "contraindications": "Heart problems, insomnia, sensitivity to caffeine",
+    "sideEffects": "Jitters, rapid heartbeat, sleeplessness",
+    "drugInteractions": "Potentiates other stimulants and certain medications",
+    "description": "Liana used by several Amazonian tribes; the bark yields a potent caffeinated beverage for energy.",
+    "id": "paullinia-yoco"
+  },
+  {
+    "name": "Tetradenia riparia",
+    "scientificName": "Tetradenia riparia",
+    "category": "Calming / Analgesic",
+    "tags": [
+      "Iboza",
+      "African",
+      "aromatic"
+    ],
+    "effects": [
+      "relaxation",
+      "pain relief",
+      "lightheadedness"
+    ],
+    "mechanismOfAction": "Aromatic diterpenes may modulate GABA and opioid receptors",
+    "therapeuticUses": "Used in African folk medicine for headaches and anxiety",
+    "pharmacokinetics": "Onset 20–30 min as tea or smoked, lasting 2–4 h",
+    "toxicity": "Limited research; appears safe in small amounts",
+    "toxicityLD50": "Not established",
+    "intensity": "Mild",
+    "onset": "20–30 min",
+    "duration": "2–4 h",
+    "region": "Eastern and southern Africa",
+    "legalStatus": "Legal",
+    "safetyRating": "Medium",
+    "preparation": "Leaves brewed as tea or smoked; also used as incense",
+    "contraindications": "Pregnancy, caution with hypotensive drugs",
+    "sideEffects": "Dizziness, low blood pressure",
+    "drugInteractions": "May enhance sedatives or blood pressure medications",
+    "description": "Fragrant African shrub sometimes called Iboza; provides a relaxing effect and mild pain relief.",
+    "id": "tetradenia-riparia"
+  },
+  {
+    "name": "Tabernaemontana undulata",
+    "scientificName": "Tabernaemontana undulata",
+    "category": "Analgesic / Visionary",
+    "tags": [
+      "Uchu Sanango",
+      "iboga alkaloids",
+      "Amazon"
+    ],
+    "effects": [
+      "tingling sensation",
+      "dream enhancement",
+      "altered perception"
+    ],
+    "mechanismOfAction": "Contains iboga-type alkaloids affecting serotonin and NMDA receptors",
+    "therapeuticUses": "Amazonian tribes use the bark for hunting preparation and pain",
+    "pharmacokinetics": "Onset 15–30 min when chewed or brewed; duration 2–5 h",
+    "toxicity": "High doses may be neurotoxic or cardiotoxic",
+    "toxicityLD50": "Not well known",
+    "intensity": "Moderate to Strong",
+    "onset": "15–30 min",
+    "duration": "2–5 h",
+    "region": "Western Amazon",
+    "legalStatus": "Mostly legal but little researched",
+    "safetyRating": "Low–Medium",
+    "preparation": "Bark or root pieces chewed or made into a tea",
+    "contraindications": "Heart problems, pregnancy, mental illness",
+    "sideEffects": "Nausea, numbness, dizziness",
+    "drugInteractions": "Avoid with other serotonergic or stimulant substances",
+    "description": "Also called Uchu Sanango; this rare shrub contains iboga-like compounds and is used in shamanic practices.",
+    "id": "tabernaemontana-undulata"
+  },
+  {
+    "name": "Aquilaria malaccensis",
+    "scientificName": "Aquilaria malaccensis",
+    "category": "Calming / Aromatic",
+    "tags": [
+      "agarwood",
+      "incense",
+      "sedative"
+    ],
+    "effects": [
+      "tranquil mind",
+      "subtle euphoria",
+      "aromatic relaxation"
+    ],
+    "mechanismOfAction": "Resin rich in sesquiterpenes acts via GABAergic and dopaminergic pathways when inhaled",
+    "therapeuticUses": "Used in traditional Asian medicine and incense for calming and meditation",
+    "pharmacokinetics": "Effects appear within minutes when smoked or heated, lasting 1–2 h",
+    "toxicity": "Considered safe in incense amounts",
+    "toxicityLD50": "Not established",
+    "intensity": "Mild",
+    "onset": "Within minutes when inhaled",
+    "duration": "1–2 h",
+    "region": "Southeast Asia",
+    "legalStatus": "Cultivation regulated due to overharvesting but use is legal",
+    "safetyRating": "High",
+    "preparation": "Resinous wood chips burned as incense or ground and smoked",
+    "contraindications": "Respiratory issues when inhaled heavily",
+    "sideEffects": "Mild headache if smoke inhaled in excess",
+    "drugInteractions": "Unknown; likely minimal",
+    "description": "Source of precious agarwood resin, producing a soothing aroma and subtle psychoactive calm when burned.",
+    "id": "aquilaria-malaccensis"
+  },
+  {
+    "name": "Argyreia speciosa",
+    "scientificName": "Argyreia speciosa",
+    "category": "Ritual / Visionary",
+    "tags": [
+      "Indian morning glory",
+      "LSA",
+      "seeds"
+    ],
+    "effects": [
+      "closed-eye visuals",
+      "euphoria",
+      "enhanced introspection"
+    ],
+    "mechanismOfAction": "Seeds contain lysergic acid amide (LSA) acting on serotonin receptors",
+    "therapeuticUses": "Occasionally used in Ayurveda as a tonic and for spiritual rituals",
+    "pharmacokinetics": "Onset 1–2 h orally, duration 6–8 h",
+    "toxicity": "Nausea common; large doses may be hepatotoxic",
+    "toxicityLD50": "Not established",
+    "intensity": "Moderate to Strong",
+    "onset": "1–2 h",
+    "duration": "6–8 h",
+    "region": "India and Southeast Asia",
+    "legalStatus": "Seeds legal though extraction of LSA may be restricted",
+    "safetyRating": "Medium",
+    "preparation": "Seeds ground and ingested after cold‑water extraction",
+    "contraindications": "Pregnancy, mental health disorders",
+    "sideEffects": "Nausea, vasoconstriction, drowsiness",
+    "drugInteractions": "Avoid with other serotonergic agents",
+    "description": "Close relative of Hawaiian Baby Woodrose with LSA‑containing seeds used in some Indian traditions.",
+    "id": "argyreia-speciosa"
+  },
+  {
+    "name": "Zanthoxylum clava-herculis",
+    "scientificName": "Zanthoxylum clava-herculis",
+    "category": "Analgesic / Stimulant",
+    "tags": [
+      "toothache tree",
+      "tingling",
+      "North America"
+    ],
+    "effects": [
+      "mouth numbness",
+      "mild stimulation",
+      "pain relief"
+    ],
+    "mechanismOfAction": "Bark contains sanshools that cause paresthesia and stimulate trigeminal nerves",
+    "therapeuticUses": "Native American remedy for toothaches and sore throats; also used as a tonic",
+    "pharmacokinetics": "Onset within minutes when chewed; duration 1–3 h",
+    "toxicity": "Low in customary doses",
+    "toxicityLD50": "Not established",
+    "intensity": "Mild",
+    "onset": "Within minutes",
+    "duration": "1–3 h",
+    "region": "Southeastern United States",
+    "legalStatus": "Legal",
+    "safetyRating": "High",
+    "preparation": "Fresh bark chewed or made into tincture",
+    "contraindications": "Mouth ulcers or sensitive gums",
+    "sideEffects": "Tingling, salivation, mild stomach upset",
+    "drugInteractions": "May interact with other numbing agents",
+    "description": "Also called the toothache tree; its bark creates a tingling numbness and light stimulation when chewed.",
+    "id": "zanthoxylum-clava-herculis"
+  },
+  {
+    "name": "Adhatoda vasica",
+    "scientificName": "Justicia adhatoda",
+    "category": "Stimulant / Bronchodilator",
+    "tags": [
+      "vasaka",
+      "Ayurveda",
+      "respiratory"
+    ],
+    "effects": [
+      "clear breathing",
+      "mild stimulation",
+      "warming"
+    ],
+    "mechanismOfAction": "Alkaloids such as vasicine act as bronchodilators and respiratory stimulants",
+    "therapeuticUses": "Ayurvedic herb for asthma, coughs and general vitality",
+    "pharmacokinetics": "Onset 30 min orally; effects last about 3–4 h",
+    "toxicity": "Generally safe at therapeutic doses",
+    "toxicityLD50": ">2 g/kg in rodents",
+    "intensity": "Mild",
+    "onset": "30 min",
+    "duration": "3–4 h",
+    "region": "Indian subcontinent",
+    "legalStatus": "Legal",
+    "safetyRating": "High",
+    "preparation": "Leaves brewed as tea or taken as syrup",
+    "contraindications": "Pregnancy; high doses may cause vomiting",
+    "sideEffects": "Digestive upset at large doses",
+    "drugInteractions": "May potentiate other bronchodilators",
+    "description": "Known as Vasaka or Malabar nut, this shrub’s leaves ease breathing and offer a subtle stimulating effect.",
+    "id": "adhatoda-vasica"
+  },
+  {
+    "name": "Amanita pantherina",
+    "scientificName": "Amanita pantherina",
+    "category": "Deliriant / Sedative",
+    "tags": [
+      "panther cap",
+      "muscimol",
+      "mushroom"
+    ],
+    "effects": [
+      "sedation",
+      "confusion",
+      "dizziness"
+    ],
+    "mechanismOfAction": "Contains muscimol and ibotenic acid acting on GABA receptors",
+    "therapeuticUses": "Traditional Siberian shamanic use; rarely employed medically",
+    "sideEffects": "Nausea, loss of coordination, delirium",
+    "contraindications": "Mental illness, combining with other depressants",
+    "drugInteractions": "Enhances effects of alcohol and sedatives",
+    "preparation": "Caps or dried material ingested carefully",
+    "pharmacokinetics": "Onset 30–90 min orally; duration 6–8 h",
+    "onset": "30–90 min",
+    "duration": "6–8 h",
+    "intensity": "Strong",
+    "region": "Northern Hemisphere",
+    "legalStatus": "Varies; unscheduled in many countries",
+    "toxicity": "Potentially toxic at high doses",
+    "toxicityLD50": "Not well established",
+    "safetyRating": "Low"
+  },
+  {
+    "name": "Cannabis sativa",
+    "scientificName": "Cannabis sativa",
+    "category": "Psychedelic / Relaxant",
+    "tags": [
+      "marijuana",
+      "THC",
+      "CBD"
+    ],
+    "effects": [
+      "euphoria",
+      "relaxation",
+      "altered perception"
+    ],
+    "mechanismOfAction": "THC acts on cannabinoid receptors CB1 and CB2",
+    "therapeuticUses": "Pain relief, appetite stimulation, anxiety reduction",
+    "sideEffects": "Dry mouth, short-term memory impairment, anxiety in high doses",
+    "contraindications": "Psychosis, heart conditions, pregnancy",
+    "drugInteractions": "May interact with CNS depressants and alcohol",
+    "preparation": "Smoked, vaporized, or ingested as edibles",
+    "pharmacokinetics": "Onset seconds to minutes when smoked; effects last 2–4 h",
+    "onset": "Seconds–30 min",
+    "duration": "2–6 h",
+    "intensity": "Variable",
+    "region": "Cultivated worldwide",
+    "legalStatus": "Varies by jurisdiction",
+    "toxicity": "Low physiological toxicity",
+    "toxicityLD50": ">1 g/kg THC in animals",
+    "safetyRating": "Medium"
+  },
+  {
+    "name": "Claviceps purpurea",
+    "scientificName": "Claviceps purpurea",
+    "category": "Ergolines / Toxic",
+    "tags": [
+      "ergot",
+      "fungus",
+      "vasoconstrictor"
+    ],
+    "effects": [
+      "vasoconstriction",
+      "hallucinations",
+      "numbness"
+    ],
+    "mechanismOfAction": "Produces ergot alkaloids acting on serotonin and adrenergic receptors",
+    "therapeuticUses": "Historically used to induce labor and treat migraines",
+    "sideEffects": "Nausea, convulsions, gangrene in high doses",
+    "contraindications": "Pregnancy, vascular disease",
+    "drugInteractions": "Potentiates triptans and other vasoconstrictors",
+    "preparation": "Dried sclerotia ground or extracted (not recommended)",
+    "pharmacokinetics": "Onset 30–60 min; duration 6–12 h",
+    "onset": "30–60 min",
+    "duration": "6–12 h",
+    "intensity": "Strong",
+    "region": "Worldwide on cereal grains",
+    "legalStatus": "Controlled in many countries",
+    "toxicity": "High; risk of ergotism",
+    "toxicityLD50": "~5 mg/kg lysergic acid amide (mouse)",
+    "safetyRating": "Very Low"
+  },
+  {
+    "name": "Coleus blumei",
+    "scientificName": "Plectranthus scutellarioides",
+    "category": "Psychedelic / Ornamental",
+    "tags": [
+      "painted nettle",
+      "visionary",
+      "Lamiaceae"
+    ],
+    "effects": [
+      "mild visuals",
+      "color enhancement",
+      "relaxation"
+    ],
+    "mechanismOfAction": "Unclear; may act on serotonergic pathways",
+    "therapeuticUses": "Rarely used; some folk use for divination",
+    "sideEffects": "Headache, nausea at high doses",
+    "contraindications": "None known",
+    "drugInteractions": "Unknown",
+    "preparation": "Leaves chewed or brewed as tea",
+    "pharmacokinetics": "Onset 20–40 min; duration 2–4 h",
+    "onset": "20–40 min",
+    "duration": "2–4 h",
+    "intensity": "Mild",
+    "region": "Tropical Asia",
+    "legalStatus": "Legal",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established",
+    "safetyRating": "Medium"
+  },
+  {
+    "name": "Echinopsis pachanoi",
+    "scientificName": "Echinopsis pachanoi",
+    "category": "Psychedelic Cactus",
+    "tags": [
+      "San Pedro",
+      "mescaline",
+      "cactus"
+    ],
+    "effects": [
+      "visuals",
+      "euphoria",
+      "spiritual insight"
+    ],
+    "mechanismOfAction": "Contains mescaline, a 5‑HT2A agonist phenethylamine",
+    "therapeuticUses": "Andean traditional medicine for divination and healing",
+    "sideEffects": "Nausea, increased heart rate, anxiety",
+    "contraindications": "Heart issues, mental disorders",
+    "drugInteractions": "Avoid combining with stimulants or MAOIs",
+    "preparation": "Fresh or dried cactus brewed or eaten",
+    "pharmacokinetics": "Onset 1–2 h; duration 10–14 h",
+    "onset": "1–2 h",
+    "duration": "10–14 h",
+    "intensity": "Strong",
+    "region": "Andes, cultivated worldwide",
+    "legalStatus": "Cactus legal in many areas; mescaline often controlled",
+    "toxicity": "Low physiological but intense psychological effects",
+    "toxicityLD50": "Not well established",
+    "safetyRating": "Medium"
+  },
+  {
+    "name": "Erythroxylum coca",
+    "scientificName": "Erythroxylum coca",
+    "category": "Stimulant",
+    "tags": [
+      "coca leaf",
+      "alkaloid",
+      "Andes"
+    ],
+    "effects": [
+      "alertness",
+      "reduced fatigue",
+      "mild euphoria"
+    ],
+    "mechanismOfAction": "Leaves contain cocaine acting as a dopamine and norepinephrine reuptake inhibitor",
+    "therapeuticUses": "Altitude sickness relief, energy boost, appetite suppression",
+    "sideEffects": "Increased heart rate, insomnia, potential dependence",
+    "contraindications": "Heart disease, pregnancy, hypertension",
+    "drugInteractions": "Dangerous with MAOIs or stimulants",
+    "preparation": "Leaves chewed with lime or brewed as tea",
+    "pharmacokinetics": "Onset within minutes when chewed; duration 1–2 h",
+    "onset": "Minutes",
+    "duration": "1–2 h",
+    "intensity": "Moderate",
+    "region": "Andean South America",
+    "legalStatus": "Cultivation regulated; cocaine controlled",
+    "toxicity": "Low in leaf form; purified alkaloid is addictive",
+    "toxicityLD50": "~95 mg/kg (rat, cocaine)",
+    "safetyRating": "Low"
+  },
+  {
+    "name": "Ginkgo biloba",
+    "scientificName": "Ginkgo biloba",
+    "category": "Nootropic / Circulatory",
+    "tags": [
+      "memory",
+      "blood flow",
+      "ancient"
+    ],
+    "effects": [
+      "improved cognition",
+      "circulation boost",
+      "alertness"
+    ],
+    "mechanismOfAction": "Flavone glycosides and terpenoids enhance blood flow and modulate neurotransmission",
+    "therapeuticUses": "Used for memory loss, dementia, and circulatory issues",
+    "sideEffects": "Headache, upset stomach, possible bleeding risk",
+    "contraindications": "Bleeding disorders, anticoagulant use",
+    "drugInteractions": "Potentiates blood thinners like warfarin",
+    "preparation": "Leaf extracts as tablets or tea",
+    "pharmacokinetics": "Onset gradual with regular dosing; effects build over weeks",
+    "onset": "Weeks of regular use",
+    "duration": "Chronic use required",
+    "intensity": "Mild",
+    "region": "China, cultivated worldwide",
+    "legalStatus": "Legal",
+    "toxicity": "Low",
+    "toxicityLD50": ">5 g/kg in animals",
+    "safetyRating": "High"
+  },
+  {
+    "name": "Helichrysum odoratissimum",
+    "scientificName": "Helichrysum odoratissimum",
+    "category": "Calming / Ritual",
+    "tags": [
+      "imphepho",
+      "South Africa",
+      "smoke"
+    ],
+    "effects": [
+      "relaxation",
+      "mild euphoria",
+      "dream enhancement"
+    ],
+    "mechanismOfAction": "Aromatic compounds interact with GABA and serotonin systems",
+    "therapeuticUses": "Used by South African healers for cleansing and ancestor communication",
+    "sideEffects": "Mild headache from smoke inhalation",
+    "contraindications": "Asthma or respiratory issues when smoked",
+    "drugInteractions": "Unknown",
+    "preparation": "Dried leaves burned as incense or smoked",
+    "pharmacokinetics": "Effects felt within minutes when inhaled; last 1–2 h",
+    "onset": "Within minutes",
+    "duration": "1–2 h",
+    "intensity": "Mild",
+    "region": "Southern Africa",
+    "legalStatus": "Legal",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established",
+    "safetyRating": "High"
+  },
+  {
+    "name": "Hypericum perforatum",
+    "scientificName": "Hypericum perforatum",
+    "category": "Antidepressant / Nootropic",
+    "tags": [
+      "St. John's Wort",
+      "mood",
+      "MAOI"
+    ],
+    "effects": [
+      "improved mood",
+      "reduced anxiety",
+      "light sedation"
+    ],
+    "mechanismOfAction": "Hyperforin and hypericin inhibit reuptake of serotonin, dopamine, and norepinephrine",
+    "therapeuticUses": "Mild to moderate depression, anxiety, sleep issues",
+    "sideEffects": "Photosensitivity, dry mouth, gastrointestinal upset",
+    "contraindications": "Use with SSRIs, pregnancy, strong sunlight exposure",
+    "drugInteractions": "Strong inducer of liver enzymes, reduces efficacy of many medications",
+    "preparation": "Dried flowering tops as tea or tincture",
+    "pharmacokinetics": "Onset weeks with regular use; duration ongoing",
+    "onset": "Weeks",
+    "duration": "Ongoing with daily use",
+    "intensity": "Mild",
+    "region": "Europe, naturalized elsewhere",
+    "legalStatus": "Legal",
+    "toxicity": "Low to moderate",
+    "toxicityLD50": ">2 g/kg in rodents",
+    "safetyRating": "Medium"
+  },
+  {
+    "name": "Ilex vomitoria",
+    "scientificName": "Ilex vomitoria",
+    "category": "Stimulant / Ritual",
+    "tags": [
+      "yaupon",
+      "caffeine",
+      "North America"
+    ],
+    "effects": [
+      "alertness",
+      "mild euphoria",
+      "cleansing"
+    ],
+    "mechanismOfAction": "Contains caffeine and theobromine acting as adenosine receptor antagonists",
+    "therapeuticUses": "Native American ceremonial drink for stimulation and purification",
+    "sideEffects": "Nausea in excess, insomnia",
+    "contraindications": "Heart conditions, pregnancy, anxiety disorders",
+    "drugInteractions": "Additive with other stimulants",
+    "preparation": "Leaves roasted and brewed as black drink",
+    "pharmacokinetics": "Onset 15–30 min; duration 2–4 h",
+    "onset": "15–30 min",
+    "duration": "2–4 h",
+    "intensity": "Moderate",
+    "region": "Southeastern United States",
+    "legalStatus": "Legal",
+    "toxicity": "Low",
+    "toxicityLD50": ">1 g/kg caffeine in animals",
+    "safetyRating": "Medium"
+  },
+  {
+    "name": "Centella asiatica",
+    "scientificName": "Centella asiatica",
+    "category": "Cognitive",
+    "effects": [
+      "Mental clarity",
+      "calm focus"
+    ],
+    "preparation": "Tea or capsules",
+    "intensity": "Mild",
+    "onset": "30 min",
+    "duration": "4-6 hrs",
+    "legalStatus": "Legal",
+    "region": "Asia",
+    "tags": [
+      "🧠 Cognitive",
+      "🌿 Leaf",
+      "✅ Safe"
+    ],
+    "mechanismOfAction": "Triterpenoids may modulate GABA and promote neurogenesis",
+    "pharmacokinetics": "Oral; active compounds absorb within an hour",
+    "therapeuticUses": "Memory enhancement, anxiety relief",
+    "sideEffects": "Rare headache or nausea",
+    "contraindications": "Pregnancy, liver issues",
+    "drugInteractions": "May potentiate sedatives",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established",
+    "description": "Known as gotu kola, used in Ayurvedic medicine to aid cognition.",
+    "safetyRating": 1,
+    "id": "centella-asiatica",
+    "activeConstituents": [
+      {
+        "name": "asiaticoside",
+        "type": "triterpenoid",
+        "effect": "nootropic"
+      }
+    ]
+  },
+  {
+    "name": "Eschscholzia californica",
+    "scientificName": "Eschscholzia californica",
+    "category": "Dissociative / Sedative",
+    "effects": [
+      "Sedation",
+      "mild euphoria"
+    ],
+    "preparation": "Tincture or smoked",
+    "intensity": "Mild",
+    "onset": "20 min",
+    "duration": "2-4 hrs",
+    "legalStatus": "Legal",
+    "region": "North America",
+    "tags": [
+      "🌿 Flower",
+      "💤 Sedation",
+      "✅ Safe"
+    ],
+    "mechanismOfAction": "Protopine alkaloids interact with GABA receptors",
+    "pharmacokinetics": "Oral or smoked; quick onset",
+    "therapeuticUses": "Anxiety and sleep support",
+    "sideEffects": "Drowsiness",
+    "contraindications": "Use caution with other sedatives",
+    "drugInteractions": "Potentiates CNS depressants",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established",
+    "description": "California poppy with gentle relaxing properties.",
+    "safetyRating": 1,
+    "id": "eschscholzia-californica",
+    "activeConstituents": [
+      {
+        "name": "protopine",
+        "type": "alkaloid",
+        "effect": "sedative"
+      }
+    ]
+  },
+  {
+    "name": "Rhodiola rosea",
+    "scientificName": "Rhodiola rosea",
+    "category": "Stimulant / Adaptogen",
+    "effects": [
+      "Stimulation",
+      "stress resistance"
+    ],
+    "preparation": "Root extract or tea",
+    "intensity": "Mild",
+    "onset": "30 min",
+    "duration": "4-5 hrs",
+    "legalStatus": "Legal",
+    "region": "Arctic regions",
+    "tags": [
+      "🌿 Root",
+      "⚡ Stimulant",
+      "✅ Safe"
+    ],
+    "mechanismOfAction": "Rosavins influence serotonin and dopamine; adaptogenic",
+    "pharmacokinetics": "Oral; active within 30 min",
+    "therapeuticUses": "Fatigue reduction, cognitive enhancement",
+    "sideEffects": "Insomnia at high doses",
+    "contraindications": "Bipolar disorder caution",
+    "drugInteractions": "May interact with antidepressants",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established",
+    "description": "Adaptogenic root improving resilience and energy.",
+    "safetyRating": 1,
+    "id": "rhodiola-rosea",
+    "activeConstituents": [
+      {
+        "name": "rosavin",
+        "type": "phenylpropanoid",
+        "effect": "adaptogen"
+      }
+    ]
+  },
+  {
+    "name": "Ginkgo biloba",
+    "scientificName": "Ginkgo biloba",
+    "category": "Cognitive",
+    "effects": [
+      "Circulation boost",
+      "memory support"
+    ],
+    "preparation": "Leaf extract",
+    "intensity": "Mild",
+    "onset": "1 hr",
+    "duration": "6 hrs",
+    "legalStatus": "Legal",
+    "region": "China",
+    "tags": [
+      "🌿 Leaf",
+      "🧠 Cognitive",
+      "✅ Safe"
+    ],
+    "mechanismOfAction": "Terpene lactones improve blood flow and act as antioxidants",
+    "pharmacokinetics": "Oral extracts; moderate absorption",
+    "therapeuticUses": "Cognitive decline mitigation",
+    "sideEffects": "Headache, dizziness",
+    "contraindications": "Blood thinners, surgery",
+    "drugInteractions": "May enhance anticoagulants",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established",
+    "description": "Ancient tree used to promote memory and brain circulation.",
+    "safetyRating": 1,
+    "id": "ginkgo-biloba",
+    "activeConstituents": [
+      {
+        "name": "ginkgolide B",
+        "type": "terpenoid",
+        "effect": "neuroprotective"
+      }
+    ]
+  },
+  {
+    "name": "Hypericum perforatum",
+    "scientificName": "Hypericum perforatum",
+    "category": "Empathogen / Euphoriant",
+    "effects": [
+      "Mood lift",
+      "anxiolytic"
+    ],
+    "preparation": "Flowering tops as tea or extract",
+    "intensity": "Mild",
+    "onset": "2 weeks (regular use)",
+    "duration": "N/A",
+    "legalStatus": "Legal",
+    "region": "Europe",
+    "tags": [
+      "🌿 Flower",
+      "😊 Mood",
+      "⚠️ Caution"
+    ],
+    "mechanismOfAction": "Hypericin inhibits reuptake of neurotransmitters",
+    "pharmacokinetics": "Requires chronic use for effect; CYP inducer",
+    "therapeuticUses": "Mild depression treatment",
+    "sideEffects": "Photosensitivity, drug interactions",
+    "contraindications": "SSRI or MAOI use",
+    "drugInteractions": "Induces CYP enzymes affecting many drugs",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established",
+    "description": "Also known as St. John's Wort, famous herbal antidepressant.",
+    "safetyRating": 2,
+    "id": "hypericum-perforatum",
+    "activeConstituents": [
+      {
+        "name": "hypericin",
+        "type": "naphthodianthrone",
+        "effect": "antidepressant"
+      }
+    ]
+  },
+  {
+    "name": "Leonotis leonurus",
+    "scientificName": "Leonotis leonurus",
+    "category": "Ritual / Visionary",
+    "effects": [
+      "Mild euphoria",
+      "relaxation"
+    ],
+    "preparation": "Dried leaves smoked",
+    "intensity": "Mild",
+    "onset": "Immediate when smoked",
+    "duration": "1-2 hrs",
+    "legalStatus": "Legal",
+    "region": "South Africa",
+    "tags": [
+      "🌿 Leaf",
+      "🧪 Alkaloid",
+      "✅ Safe"
+    ],
+    "mechanismOfAction": "Leonurine may act on serotonin receptors",
+    "pharmacokinetics": "Smoked; onset within minutes",
+    "therapeuticUses": "Traditional relaxant and ritual smoke",
+    "sideEffects": "Dizziness with heavy use",
+    "contraindications": "None known",
+    "drugInteractions": "Limited data",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established",
+    "description": "Also called Wild Dagga, smoked for gentle euphoric effects.",
+    "safetyRating": 1,
+    "id": "leonotis-leonurus",
+    "activeConstituents": [
+      {
+        "name": "leonurine",
+        "type": "alkaloid",
+        "effect": "relaxant"
+      }
+    ]
+  },
+  {
+    "name": "Uncaria tomentosa",
+    "scientificName": "Uncaria tomentosa",
+    "category": "Other",
+    "effects": [
+      "Immune modulation"
+    ],
+    "preparation": "Bark decoction or capsules",
+    "intensity": "Mild",
+    "onset": "1 hr",
+    "duration": "Varies",
+    "legalStatus": "Legal",
+    "region": "Amazon",
+    "tags": [
+      "🌿 Bark",
+      "🛡️ Immune",
+      "✅ Safe"
+    ],
+    "mechanismOfAction": "Oxindole alkaloids stimulate immune function",
+    "pharmacokinetics": "Oral; absorption within an hour",
+    "therapeuticUses": "Anti-inflammatory, immune support",
+    "sideEffects": "Stomach upset in some",
+    "contraindications": "Autoimmune conditions caution",
+    "drugInteractions": "May interact with immunosuppressants",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established",
+    "description": "Known as Cat's Claw, used in Peruvian medicine.",
+    "safetyRating": 1,
+    "id": "uncaria-tomentosa",
+    "activeConstituents": [
+      {
+        "name": "mitraphylline",
+        "type": "alkaloid",
+        "effect": "immunomodulator"
+      }
+    ]
+  },
+  {
+    "name": "Ephedra sinica",
+    "scientificName": "Ephedra sinica",
+    "category": "Stimulant",
+    "effects": [
+      "Stimulation",
+      "appetite suppression"
+    ],
+    "preparation": "Stem tea or extract",
+    "intensity": "Moderate",
+    "onset": "20 min",
+    "duration": "3-5 hrs",
+    "legalStatus": "Restricted in some countries",
+    "region": "Asia",
+    "tags": [
+      "🌿 Stem",
+      "⚡ Stimulant",
+      "⚠️ Caution"
+    ],
+    "mechanismOfAction": "Ephedrine acts on adrenergic receptors",
+    "pharmacokinetics": "Rapid oral absorption; urinary excretion",
+    "therapeuticUses": "Traditional decongestant and stimulant",
+    "sideEffects": "Increased heart rate, insomnia",
+    "contraindications": "Heart conditions, hypertension",
+    "drugInteractions": "Avoid with MAOIs or stimulants",
+    "toxicity": "Moderate",
+    "toxicityLD50": "Ephedrine LD50 ~600 mg/kg (rat)",
+    "description": "Potent herbal stimulant historically used in Chinese medicine.",
+    "safetyRating": 3,
+    "id": "ephedra-sinica",
+    "activeConstituents": [
+      {
+        "name": "ephedrine",
+        "type": "alkaloid",
+        "effect": "stimulant"
+      }
+    ]
+  },
+  {
+    "name": "Myristica fragrans",
+    "scientificName": "Myristica fragrans",
+    "category": "Ritual / Visionary",
+    "effects": [
+      "Deliriant states",
+      "nausea"
+    ],
+    "preparation": "Ground seed orally",
+    "intensity": "Strong",
+    "onset": "2-3 hrs",
+    "duration": "12 hrs or more",
+    "legalStatus": "Legal",
+    "region": "Indonesia",
+    "tags": [
+      "🌿 Seed",
+      "⚠️ Caution",
+      "🧪 Phenethylamine"
+    ],
+    "mechanismOfAction": "Myristicin metabolizes to MMDA-like compounds",
+    "pharmacokinetics": "Slow oral absorption; long duration",
+    "therapeuticUses": "Rarely used therapeutically",
+    "sideEffects": "Nausea, dehydration, delirium",
+    "contraindications": "Pregnancy, psychiatric conditions",
+    "drugInteractions": "Potential MAOI interaction",
+    "toxicity": "High at large doses",
+    "toxicityLD50": "Myristicin LD50 ~400 mg/kg (mouse)",
+    "description": "Nutmeg seeds can be psychoactive in large amounts.",
+    "safetyRating": 3,
+    "id": "myristica-fragrans",
+    "activeConstituents": [
+      {
+        "name": "myristicin",
+        "type": "phenylpropene",
+        "effect": "deliriant"
+      }
+    ]
+  },
+  {
+    "name": "Pausinystalia yohimbe",
+    "scientificName": "Pausinystalia yohimbe",
+    "category": "Stimulant",
+    "effects": [
+      "Aphrodisiac",
+      "stimulant"
+    ],
+    "preparation": "Bark extract",
+    "intensity": "Moderate",
+    "onset": "30 min",
+    "duration": "2-4 hrs",
+    "legalStatus": "Regulated in some regions",
+    "region": "Africa",
+    "tags": [
+      "🌿 Bark",
+      "🔥 Intensity",
+      "⚠️ Caution"
+    ],
+    "mechanismOfAction": "Yohimbine is an adrenergic receptor antagonist",
+    "pharmacokinetics": "Oral; peak plasma in 45 min",
+    "therapeuticUses": "Erectile dysfunction treatment",
+    "sideEffects": "Anxiety, hypertension",
+    "contraindications": "Heart disease, anxiety disorders",
+    "drugInteractions": "MAOIs, stimulants",
+    "toxicity": "Moderate",
+    "toxicityLD50": "Yohimbine LD50 ~50 mg/kg (mouse)",
+    "description": "Potent bark traditionally used as an aphrodisiac.",
+    "safetyRating": 3,
+    "id": "pausinystalia-yohimbe",
+    "activeConstituents": [
+      {
+        "name": "yohimbine",
+        "type": "alkaloid",
+        "effect": "stimulant"
+      }
+    ]
+  },
+  {
+    "name": "Eleutherococcus senticosus",
+    "scientificName": "Eleutherococcus senticosus",
+    "category": "Stimulant / Adaptogen",
+    "effects": [
+      "Energy",
+      "stress resistance"
+    ],
+    "preparation": "Root extract",
+    "intensity": "Mild",
+    "onset": "1 hr",
+    "duration": "6 hrs",
+    "legalStatus": "Legal",
+    "region": "Siberia",
+    "tags": [
+      "🌿 Root",
+      "⚡ Stimulant",
+      "✅ Safe"
+    ],
+    "mechanismOfAction": "Eleutherosides modulate stress hormones",
+    "pharmacokinetics": "Oral; slow onset",
+    "therapeuticUses": "Enhance stamina and immune function",
+    "sideEffects": "Insomnia in sensitive individuals",
+    "contraindications": "Hypertension",
+    "drugInteractions": "May interact with digoxin",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established",
+    "description": "Also called Siberian ginseng, popular adaptogen.",
+    "safetyRating": 1,
+    "id": "eleutherococcus-senticosus",
+    "activeConstituents": [
+      {
+        "name": "eleutheroside B",
+        "type": "phenylpropanoid",
+        "effect": "adaptogen"
+      }
+    ]
+  },
+  {
+    "name": "Ptychopetalum olacoides",
+    "scientificName": "Ptychopetalum olacoides",
+    "category": "Stimulant",
+    "effects": [
+      "Libido boost",
+      "mild stimulation"
+    ],
+    "preparation": "Bark tincture",
+    "intensity": "Mild",
+    "onset": "30 min",
+    "duration": "2-3 hrs",
+    "legalStatus": "Legal",
+    "region": "Amazon",
+    "tags": [
+      "🌿 Bark",
+      "⚡ Stimulant",
+      "✅ Safe"
+    ],
+    "mechanismOfAction": "Alkaloids may act on dopamine pathways",
+    "pharmacokinetics": "Oral tincture; moderate onset",
+    "therapeuticUses": "Aphrodisiac and tonic",
+    "sideEffects": "Rare insomnia",
+    "contraindications": "Pregnancy",
+    "drugInteractions": "None known",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established",
+    "description": "Known as Muira puama, used for vitality and libido.",
+    "safetyRating": 1,
+    "id": "ptychopetalum-olacoides",
+    "activeConstituents": [
+      {
+        "name": "muirapuamine",
+        "type": "alkaloid",
+        "effect": "stimulant"
+      }
+    ]
+  },
+  {
+    "name": "Claviceps purpurea",
+    "scientificName": "Claviceps purpurea",
+    "category": "Ritual / Visionary",
+    "effects": [
+      "Powerful visions",
+      "vasoconstriction"
+    ],
+    "preparation": "Ergot sclerotia carefully processed",
+    "intensity": "Strong",
+    "onset": "1-2 hrs",
+    "duration": "6-12 hrs",
+    "legalStatus": "Controlled in many countries",
+    "region": "Worldwide",
+    "tags": [
+      "🍄 Fungus",
+      "⚠️ Caution",
+      "🧪 Alkaloid"
+    ],
+    "mechanismOfAction": "Ergot alkaloids act on serotonin and adrenergic receptors",
+    "pharmacokinetics": "Oral; metabolized in liver",
+    "therapeuticUses": "Historical use in obstetrics and rituals",
+    "sideEffects": "Nausea, vasospasm",
+    "contraindications": "Pregnancy, cardiovascular disease",
+    "drugInteractions": "Triptans, vasoconstrictors",
+    "toxicity": "High",
+    "toxicityLD50": "Variable; ergotamine LD50 ~1 mg/kg (mouse)",
+    "description": "Fungus that produces ergot alkaloids, precursor to LSD.",
+    "safetyRating": 4,
+    "id": "claviceps-purpurea",
+    "activeConstituents": [
+      {
+        "name": "ergotamine",
+        "type": "alkaloid",
+        "effect": "hallucinogenic"
+      }
+    ]
+  },
+  {
+    "name": "Cola nitida",
+    "scientificName": "Cola nitida",
+    "category": "Stimulant",
+    "effects": [
+      "Alertness",
+      "reduced fatigue"
+    ],
+    "preparation": "Chewed seeds or beverages",
+    "intensity": "Moderate",
+    "onset": "Immediate when chewed",
+    "duration": "2-3 hrs",
+    "legalStatus": "Legal",
+    "region": "Africa",
+    "tags": [
+      "🌿 Seed",
+      "⚡ Stimulant",
+      "✅ Safe"
+    ],
+    "mechanismOfAction": "Caffeine and kolanin stimulate CNS",
+    "pharmacokinetics": "Chewed; caffeine absorbed quickly",
+    "therapeuticUses": "Traditional energizer",
+    "sideEffects": "Insomnia, jitteriness",
+    "contraindications": "Heart conditions, pregnancy",
+    "drugInteractions": "Other stimulants",
+    "toxicity": "Moderate",
+    "toxicityLD50": "Caffeine LD50 ~192 mg/kg (rat)",
+    "description": "Kola nut used in energy drinks and ceremonies.",
+    "safetyRating": 2,
+    "id": "cola-nitida",
+    "activeConstituents": [
+      {
+        "name": "caffeine",
+        "type": "alkaloid",
+        "effect": "stimulant"
+      }
+    ]
+  },
+  {
+    "name": "Camellia sinensis",
+    "scientificName": "Camellia sinensis",
+    "category": "Stimulant",
+    "effects": [
+      "Alertness",
+      "relaxation"
+    ],
+    "preparation": "Tea infusion",
+    "intensity": "Mild",
+    "onset": "10 min",
+    "duration": "1-3 hrs",
+    "legalStatus": "Legal",
+    "region": "Asia",
+    "tags": [
+      "🌿 Leaf",
+      "⚡ Stimulant",
+      "✅ Safe"
+    ],
+    "mechanismOfAction": "Caffeine and L-theanine affect adenosine and GABA",
+    "pharmacokinetics": "Rapid absorption of caffeine; hepatic metabolism",
+    "therapeuticUses": "Focus enhancement, relaxation",
+    "sideEffects": "Insomnia at high doses",
+    "contraindications": "Pregnancy sensitivity to caffeine",
+    "drugInteractions": "Potentiates other stimulants",
+    "toxicity": "Low",
+    "toxicityLD50": "Caffeine LD50 ~192 mg/kg (rat)",
+    "description": "Leaves brewed worldwide as stimulating tea.",
+    "safetyRating": 1,
+    "id": "camellia-sinensis",
+    "activeConstituents": [
+      {
+        "name": "caffeine",
+        "type": "alkaloid",
+        "effect": "stimulant"
+      }
+    ]
+  },
+  {
+    "name": "Gynostemma pentaphyllum",
+    "scientificName": "Gynostemma pentaphyllum",
+    "category": "Other",
+    "effects": [
+      "Adaptogenic",
+      "anti-inflammatory"
+    ],
+    "preparation": "Tea infusion",
+    "intensity": "Mild",
+    "onset": "30 min",
+    "duration": "2-4 hrs",
+    "legalStatus": "Legal",
+    "region": "China",
+    "tags": [
+      "🌿 Leaf",
+      "✅ Safe"
+    ],
+    "mechanismOfAction": "Gypenosides modulate nitric oxide and cortisol",
+    "pharmacokinetics": "Oral; moderate absorption",
+    "therapeuticUses": "Stress resilience, metabolic support",
+    "sideEffects": "Rare digestive upset",
+    "contraindications": "None known",
+    "drugInteractions": "May enhance anticoagulants",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established",
+    "description": "Called Jiaogulan, reputed longevity herb.",
+    "safetyRating": 1,
+    "id": "gynostemma-pentaphyllum",
+    "activeConstituents": [
+      {
+        "name": "gypenoside XL",
+        "type": "saponin",
+        "effect": "adaptogen"
+      }
+    ]
+  },
+  {
+    "name": "Silybum marianum",
+    "scientificName": "Silybum marianum",
+    "category": "Other",
+    "effects": [
+      "Liver protection"
+    ],
+    "preparation": "Seed extract",
+    "intensity": "Mild",
+    "onset": "1 hr",
+    "duration": "4 hrs",
+    "legalStatus": "Legal",
+    "region": "Mediterranean",
+    "tags": [
+      "🌿 Seed",
+      "✅ Safe"
+    ],
+    "mechanismOfAction": "Silymarin acts as antioxidant and hepatoprotective",
+    "pharmacokinetics": "Oral; low bioavailability improved with extract",
+    "therapeuticUses": "Liver detox support",
+    "sideEffects": "Digestive upset",
+    "contraindications": "Allergy to Asteraceae",
+    "drugInteractions": "May affect drug metabolism",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established",
+    "description": "Milk thistle seeds support liver function.",
+    "safetyRating": 1,
+    "id": "silybum-marianum",
+    "activeConstituents": [
+      {
+        "name": "silymarin",
+        "type": "flavonolignan",
+        "effect": "hepatoprotective"
+      }
+    ]
+  },
+  {
+    "name": "Piper methysticum",
+    "scientificName": "Piper methysticum",
+    "category": "Dissociative / Sedative",
+    "effects": [
+      "Anxiolytic",
+      "sedation"
+    ],
+    "preparation": "Root beverage",
+    "intensity": "Moderate",
+    "onset": "20 min",
+    "duration": "3-6 hrs",
+    "legalStatus": "Regulated in some countries",
+    "region": "Pacific Islands",
+    "tags": [
+      "🌿 Root",
+      "💤 Sedation",
+      "⚠️ Caution"
+    ],
+    "mechanismOfAction": "Kavalactones modulate GABA receptors",
+    "pharmacokinetics": "Oral; active within 20-30 min",
+    "therapeuticUses": "Anxiety relief, social relaxation",
+    "sideEffects": "Drowsiness, potential hepatotoxicity",
+    "contraindications": "Liver disease, heavy alcohol use",
+    "drugInteractions": "Potentiates sedatives and alcohol",
+    "toxicity": "Moderate",
+    "toxicityLD50": "Kavain LD50 ~920 mg/kg (mouse)",
+    "description": "Kava root beverage with calming properties.",
+    "safetyRating": 2,
+    "id": "piper-methysticum",
+    "activeConstituents": [
+      {
+        "name": "kavain",
+        "type": "lactone",
+        "effect": "anxiolytic"
+      }
+    ]
+  },
+  {
+    "name": "Rivea corymbosa",
+    "scientificName": "Rivea corymbosa",
+    "category": "Ritual / Visionary",
+    "effects": [
+      "Visionary states",
+      "nausea"
+    ],
+    "preparation": "Seeds ground and taken orally",
+    "intensity": "Strong",
+    "onset": "1 hr",
+    "duration": "6-8 hrs",
+    "legalStatus": "Varies",
+    "region": "Central America",
+    "tags": [
+      "🌿 Seed",
+      "🧪 Alkaloid",
+      "⚠️ Caution"
+    ],
+    "mechanismOfAction": "Contains LSA, a serotonin receptor agonist",
+    "pharmacokinetics": "Oral; converted to active amides",
+    "therapeuticUses": "Shamanic visions, introspection",
+    "sideEffects": "Nausea, vasoconstriction",
+    "contraindications": "Pregnancy, cardiovascular issues",
+    "drugInteractions": "Avoid with vasoconstrictors or SSRIs",
+    "toxicity": "Moderate",
+    "toxicityLD50": "LSA LD50 ~50 mg/kg (rat)",
+    "description": "Also called Ololiuqui, used by Aztecs for visionary rituals.",
+    "safetyRating": 3,
+    "id": "rivea-corymbosa",
+    "activeConstituents": [
+      {
+        "name": "lysergic acid amide",
+        "type": "alkaloid",
+        "effect": "psychedelic"
+      }
+    ]
+  },
+  {
+    "name": "Uncaria rhynchophylla",
+    "scientificName": "Uncaria rhynchophylla",
+    "category": "Dissociative / Sedative",
+    "effects": [
+      "Calming",
+      "anticonvulsant"
+    ],
+    "preparation": "Hook vine decoction",
+    "intensity": "Mild",
+    "onset": "30 min",
+    "duration": "3 hrs",
+    "legalStatus": "Legal",
+    "region": "China",
+    "tags": [
+      "🌿 Vine",
+      "💤 Sedation",
+      "✅ Safe"
+    ],
+    "mechanismOfAction": "Rhynchophylline blocks NMDA receptors",
+    "pharmacokinetics": "Oral; moderate absorption",
+    "therapeuticUses": "Traditional treatment for tremors and agitation",
+    "sideEffects": "Drowsiness",
+    "contraindications": "None documented",
+    "drugInteractions": "May potentiate sedatives",
+    "toxicity": "Low",
+    "toxicityLD50": "Not established",
+    "description": "Known as Gou Teng in Chinese medicine.",
+    "safetyRating": 1,
+    "id": "uncaria-rhynchophylla",
+    "activeConstituents": [
+      {
+        "name": "rhynchophylline",
+        "type": "alkaloid",
+        "effect": "calming"
+      }
+    ]
+  },
+  {
+    "name": "Mandrake",
+    "scientificName": "Mandragora officinarum",
+    "category": "Ritual / Visionary",
+    "effects": [
+      "hallucinations",
+      "sedation"
+    ],
+    "mechanismOfAction": "Tropane alkaloids block muscarinic acetylcholine receptors",
+    "activeConstituents": [
+      {
+        "name": "scopolamine",
+        "type": "alkaloid",
+        "effect": "deliriant"
+      }
+    ],
+    "preparation": "Dried root or wine infusion (rare due to toxicity)",
+    "dosage": "0.1–0.3 g dried root",
+    "onset": "20–60 min",
+    "duration": "4–8 hrs",
+    "safetyRating": 5,
+    "toxicityLD50": "~50 mg/kg (mice, scopolamine)",
+    "legalStatus": "Cultivation legal in most regions",
+    "region": "Mediterranean",
+    "tags": [
+      "☠️ Toxic",
+      "🌿 Root"
+    ],
+    "affiliateLink": "https://www.etsy.com/market/mandrake_root",
+    "description": "Legendary root used in magic rituals; highly toxic.",
+    "id": "mandrake",
+    "therapeuticUses": "Historical anesthetic",
+    "sideEffects": "Confusion, dry mouth, delirium",
+    "contraindications": "Heart conditions, pregnancy",
+    "drugInteractions": "Anticholinergic medications",
+    "toxicity": "High",
+    "pharmacokinetics": "Absorbed orally; hepatic metabolism"
+  },
+  {
+    "name": "Foxglove",
+    "scientificName": "Digitalis purpurea",
+    "category": "Other",
+    "effects": [
+      "cardiac stimulation"
+    ],
+    "mechanismOfAction": "Cardiac glycosides inhibit Na⁺/K⁺-ATPase",
+    "activeConstituents": [
+      {
+        "name": "digitoxin",
+        "type": "glycoside",
+        "effect": "cardiotonic"
+      }
+    ],
+    "preparation": "Carefully dosed leaf extract",
+    "dosage": "0.1 g dried leaf equivalent",
+    "onset": "30–60 min",
+    "duration": "6–12 hrs",
+    "safetyRating": 5,
+    "toxicityLD50": "3 mg/kg (digitoxin, oral)",
+    "legalStatus": "Regulated as medicinal",
+    "region": "Europe",
+    "tags": [
+      "☠️ Toxic",
+      "💊 Oral"
+    ],
+    "affiliateLink": null,
+    "description": "Source of cardiac glycosides used for heart failure; overdose is fatal.",
+    "id": "foxglove",
+    "therapeuticUses": "Heart failure medication",
+    "sideEffects": "Arrhythmia, vision changes",
+    "contraindications": "Existing heart disease without supervision",
+    "drugInteractions": "Diuretics, calcium channel blockers",
+    "toxicity": "Very high",
+    "pharmacokinetics": "Long half-life; renal excretion"
+  },
+  {
+    "name": "Henbane",
+    "scientificName": "Hyoscyamus niger",
+    "category": "Ritual / Visionary",
+    "effects": [
+      "delirium",
+      "visions"
+    ],
+    "mechanismOfAction": "Tropane alkaloids antagonize acetylcholine receptors",
+    "activeConstituents": [
+      {
+        "name": "hyoscyamine",
+        "type": "alkaloid",
+        "effect": "deliriant"
+      }
+    ],
+    "preparation": "Dried leaves smoked or brewed",
+    "dosage": "0.05–0.1 g dried leaf",
+    "onset": "15–30 min",
+    "duration": "4–6 hrs",
+    "safetyRating": 5,
+    "toxicityLD50": "~50 mg/kg (rats, atropine)",
+    "legalStatus": "Often restricted",
+    "region": "Europe, Asia",
+    "tags": [
+      "☠️ Toxic",
+      "🌿 Leaf"
+    ],
+    "affiliateLink": null,
+    "description": "Old world nightshade with intense psychoactive properties.",
+    "id": "henbane",
+    "therapeuticUses": "Historic analgesic",
+    "sideEffects": "Dry mouth, confusion, hallucinations",
+    "contraindications": "Glaucoma, heart disease",
+    "drugInteractions": "Anticholinergic drugs",
+    "toxicity": "High",
+    "pharmacokinetics": "Rapid absorption through mucous membranes"
+  },
+  {
+    "name": "Jimson Weed",
+    "scientificName": "Datura stramonium",
+    "category": "Ritual / Visionary",
+    "effects": [
+      "delirium",
+      "hallucinations"
+    ],
+    "mechanismOfAction": "Scopolamine and atropine block muscarinic receptors",
+    "activeConstituents": [
+      {
+        "name": "atropine",
+        "type": "alkaloid",
+        "effect": "deliriant"
+      }
+    ],
+    "preparation": "Seeds or leaves consumed (dangerous)",
+    "dosage": "5–15 seeds",
+    "onset": "30–60 min",
+    "duration": "8–24 hrs",
+    "safetyRating": 5,
+    "toxicityLD50": "~50 mg/kg (atropine)",
+    "legalStatus": "Unregulated but dangerous",
+    "region": "Worldwide",
+    "tags": [
+      "☠️ Toxic",
+      "⚠️ Caution"
+    ],
+    "affiliateLink": null,
+    "description": "Common weed producing powerful delirium when misused.",
+    "id": "datura-stramonium",
+    "therapeuticUses": "Historically asthma treatment",
+    "sideEffects": "Severe confusion, elevated heart rate",
+    "contraindications": "Heart conditions, mental illness",
+    "drugInteractions": "Anticholinergics, antihistamines",
+    "toxicity": "Very high",
+    "pharmacokinetics": "Oral absorption; hepatic metabolism"
+  },
+  {
+    "name": "Yellow Horned Poppy",
+    "scientificName": "Glaucium flavum",
+    "category": "Other",
+    "effects": [
+      "mild euphoria",
+      "sedation"
+    ],
+    "mechanismOfAction": "Contains glaucine, a bronchodilator acting on dopamine receptors",
+    "activeConstituents": [
+      {
+        "name": "glaucine",
+        "type": "alkaloid",
+        "effect": "sedative"
+      }
+    ],
+    "preparation": "Dried latex or seeds smoked",
+    "dosage": "10–20 mg glaucine",
+    "onset": "20–40 min",
+    "duration": "2–4 hrs",
+    "safetyRating": 3,
+    "toxicityLD50": ">300 mg/kg (mice)",
+    "legalStatus": "Varies",
+    "region": "Mediterranean",
+    "tags": [
+      "💊 Oral",
+      "🌀 Visionary"
+    ],
+    "affiliateLink": null,
+    "description": "Coastal poppy used occasionally for its glaucine content.",
+    "id": "glaucium-flavum",
+    "therapeuticUses": "Cough suppressant",
+    "sideEffects": "Dizziness, nausea",
+    "contraindications": "Pregnancy",
+    "drugInteractions": "CNS depressants",
+    "toxicity": "Moderate",
+    "pharmacokinetics": "Metabolized hepatically"
+  },
+  {
+    "name": "Carolina Jessamine",
+    "scientificName": "Gelsemium sempervirens",
+    "category": "Other",
+    "effects": [
+      "relaxation",
+      "sedation"
+    ],
+    "mechanismOfAction": "Gelsemine acts on glycine and nicotinic receptors",
+    "activeConstituents": [
+      {
+        "name": "gelsemine",
+        "type": "alkaloid",
+        "effect": "sedative"
+      }
+    ],
+    "preparation": "Low-dose tincture",
+    "dosage": "5–10 drops tincture",
+    "onset": "20–40 min",
+    "duration": "2–3 hrs",
+    "safetyRating": 4,
+    "toxicityLD50": ">10 mg/kg (mice)",
+    "legalStatus": "Ornamental; toxic",
+    "region": "Southern USA",
+    "tags": [
+      "⚠️ Caution"
+    ],
+    "affiliateLink": null,
+    "description": "Fragrant vine with toxic yet calming alkaloids.",
+    "id": "gelsemium-sempervirens",
+    "therapeuticUses": "Folk remedy for anxiety",
+    "sideEffects": "Respiratory depression in overdose",
+    "contraindications": "Pregnancy, heart issues",
+    "drugInteractions": "Sedatives, muscle relaxants",
+    "toxicity": "High",
+    "pharmacokinetics": "Unknown"
+  },
+  {
+    "name": "Opium Poppy",
+    "scientificName": "Papaver somniferum",
+    "category": "Other",
+    "effects": [
+      "analgesia",
+      "euphoria"
+    ],
+    "mechanismOfAction": "Morphine alkaloids activate mu-opioid receptors",
+    "activeConstituents": [
+      {
+        "name": "morphine",
+        "type": "alkaloid",
+        "effect": "analgesic"
+      }
+    ],
+    "preparation": "Dried latex smoked or eaten",
+    "dosage": "50–200 mg opium",
+    "onset": "10–30 min",
+    "duration": "4–6 hrs",
+    "safetyRating": 5,
+    "toxicityLD50": "~150 mg/kg (morphine, rats)",
+    "legalStatus": "Highly controlled",
+    "region": "Worldwide",
+    "tags": [
+      "💊 Oral",
+      "☠️ Addictive"
+    ],
+    "affiliateLink": null,
+    "description": "Primary source of medicinal opiates.",
+    "id": "papaver-somniferum",
+    "therapeuticUses": "Pain relief",
+    "sideEffects": "Respiratory depression, addiction",
+    "contraindications": "Respiratory issues, pregnancy",
+    "drugInteractions": "CNS depressants, alcohol",
+    "toxicity": "High",
+    "pharmacokinetics": "Metabolized in liver; renal excretion"
+  },
+  {
+    "name": "Coffee",
+    "scientificName": "Coffea arabica",
+    "category": "Stimulant",
+    "effects": [
+      "alertness",
+      "energy"
+    ],
+    "mechanismOfAction": "Caffeine blocks adenosine receptors increasing neurotransmitter release",
+    "activeConstituents": [
+      {
+        "name": "caffeine",
+        "type": "xanthine",
+        "effect": "stimulant"
+      }
+    ],
+    "preparation": "Roasted beans brewed",
+    "dosage": "50–150 mg caffeine",
+    "onset": "10–20 min",
+    "duration": "2–4 hrs",
+    "safetyRating": 2,
+    "toxicityLD50": "~192 mg/kg (rats)",
+    "legalStatus": "Legal",
+    "region": "Worldwide",
+    "tags": [
+      "☕ Brewable"
+    ],
+    "affiliateLink": "https://www.amazon.com/s?k=coffee+beans",
+    "description": "Beloved beverage plant containing caffeine.",
+    "id": "coffea-arabica",
+    "therapeuticUses": "Fatigue reduction",
+    "sideEffects": "Jitters, insomnia",
+    "contraindications": "Heart arrhythmia",
+    "drugInteractions": "Stimulants, MAOIs",
+    "toxicity": "Low",
+    "pharmacokinetics": "Rapid GI absorption; hepatic metabolism"
+  },
+  {
+    "name": "Asian Ginseng",
+    "scientificName": "Panax ginseng",
+    "category": "Empathogen / Euphoriant",
+    "effects": [
+      "vitality",
+      "adaptogen"
+    ],
+    "mechanismOfAction": "Ginsenosides modulate HPA axis and nitric oxide pathways",
+    "activeConstituents": [
+      {
+        "name": "ginsenosides",
+        "type": "triterpenoid",
+        "effect": "adaptogenic"
+      }
+    ],
+    "preparation": "Root decoction or capsules",
+    "dosage": "1–2 g dried root",
+    "onset": "30–60 min",
+    "duration": "6–8 hrs",
+    "safetyRating": 2,
+    "toxicityLD50": ">2000 mg/kg (rats)",
+    "legalStatus": "Legal",
+    "region": "Asia",
+    "tags": [
+      "💊 Oral",
+      "🌿 Root"
+    ],
+    "affiliateLink": "https://www.amazon.com/s?k=panax+ginseng",
+    "description": "Classic tonic herb for stamina and cognition.",
+    "id": "panax-ginseng",
+    "therapeuticUses": "Energy, immune support",
+    "sideEffects": "Headache, insomnia",
+    "contraindications": "Hypertension",
+    "drugInteractions": "Stimulants, anticoagulants",
+    "toxicity": "Low",
+    "pharmacokinetics": "Slow cumulative effects with regular use"
+  },
+  {
+    "name": "American Ginseng",
+    "scientificName": "Panax quinquefolius",
+    "category": "Empathogen / Euphoriant",
+    "effects": [
+      "calm energy"
+    ],
+    "mechanismOfAction": "Similar ginsenosides modulate neurotransmitters",
+    "activeConstituents": [
+      {
+        "name": "ginsenosides",
+        "type": "triterpenoid",
+        "effect": "adaptogenic"
+      }
+    ],
+    "preparation": "Chewed root or tea",
+    "dosage": "1–3 g dried root",
+    "onset": "30–60 min",
+    "duration": "4–6 hrs",
+    "safetyRating": 2,
+    "toxicityLD50": ">2000 mg/kg (rats)",
+    "legalStatus": "Legal",
+    "region": "North America",
+    "tags": [
+      "💊 Oral",
+      "🌿 Root"
+    ],
+    "affiliateLink": "https://www.amazon.com/s?k=american+ginseng",
+    "description": "North American species prized for restorative effects.",
+    "id": "panax-quinquefolius",
+    "therapeuticUses": "Energy, stress relief",
+    "sideEffects": "Headache, insomnia",
+    "contraindications": "Hypertension",
+    "drugInteractions": "Stimulants, anticoagulants",
+    "toxicity": "Low",
+    "pharmacokinetics": "Similar to Panax ginseng"
+  },
+  {
+    "name": "Kratom",
+    "scientificName": "Mitragyna speciosa",
+    "category": "Stimulant",
+    "effects": [
+      "euphoria",
+      "pain relief"
+    ],
+    "mechanismOfAction": "Mitragynine acts on opioid receptors",
+    "activeConstituents": [
+      {
+        "name": "mitragynine",
+        "type": "indole alkaloid",
+        "effect": "analgesic"
+      }
+    ],
+    "preparation": "Dried leaf powder or tea",
+    "dosage": "2–5 g leaf powder",
+    "onset": "10–30 min",
+    "duration": "3–6 hrs",
+    "safetyRating": 3,
+    "toxicityLD50": ">400 mg/kg (rats)",
+    "legalStatus": "Varies by country",
+    "region": "Southeast Asia",
+    "tags": [
+      "💊 Oral",
+      "🌀 Euphoric"
+    ],
+    "affiliateLink": "https://www.ethnobotanicalshaman.shop/kratom",
+    "description": "Popular herbal stimulant and analgesic.",
+    "id": "mitragyna-speciosa",
+    "therapeuticUses": "Pain management, energy",
+    "sideEffects": "Nausea, dependence",
+    "contraindications": "Opioid addiction recovery",
+    "drugInteractions": "Opioids, depressants",
+    "toxicity": "Moderate",
+    "pharmacokinetics": "Metabolized in liver via CYP enzymes"
+  },
+  {
+    "name": "Peruvian Torch",
+    "scientificName": "Echinopsis peruviana",
+    "category": "Psychedelic",
+    "effects": [
+      "visions",
+      "empathy"
+    ],
+    "mechanismOfAction": "Mescaline acts as a 5-HT2A agonist",
+    "activeConstituents": [
+      {
+        "name": "mescaline",
+        "type": "phenethylamine",
+        "effect": "psychedelic"
+      }
+    ],
+    "preparation": "Fresh or dried cactus consumed",
+    "dosage": "20–30 cm fresh cactus",
+    "onset": "1–2 hrs",
+    "duration": "8–12 hrs",
+    "safetyRating": 3,
+    "toxicityLD50": ">1 g/kg (rats)",
+    "legalStatus": "Cactus legal; mescaline controlled",
+    "region": "Andes",
+    "tags": [
+      "🌀 Visionary",
+      "🌵 Cactus"
+    ],
+    "affiliateLink": null,
+    "description": "Cactus rich in mescaline similar to San Pedro.",
+    "id": "echinopsis-peruviana",
+    "therapeuticUses": "Spiritual insight",
+    "sideEffects": "Nausea, dilated pupils",
+    "contraindications": "Heart issues, pregnancy",
+    "drugInteractions": "MAOIs, stimulants",
+    "toxicity": "Low",
+    "pharmacokinetics": "Slow GI absorption"
+  },
+  {
+    "name": "Chaliponga",
+    "scientificName": "Diplopterys cabrerana",
+    "category": "Ritual / Visionary",
+    "effects": [
+      "visions",
+      "introspection"
+    ],
+    "mechanismOfAction": "Leaves contain DMT and 5-MeO-DMT acting on serotonin receptors",
+    "activeConstituents": [
+      {
+        "name": "DMT",
+        "type": "tryptamine",
+        "effect": "visionary"
+      }
+    ],
+    "preparation": "Leaves brewed with MAOIs",
+    "dosage": "25–50 g leaves",
+    "onset": "30–60 min",
+    "duration": "4–6 hrs",
+    "safetyRating": 4,
+    "toxicityLD50": "Not established",
+    "legalStatus": "DMT restricted in most regions",
+    "region": "Amazon",
+    "tags": [
+      "🧪 DMT",
+      "⚠️ Caution"
+    ],
+    "affiliateLink": null,
+    "description": "Ayahuasca admixture leaf high in tryptamines.",
+    "id": "diplopterys-cabrerana",
+    "therapeuticUses": "Shamanic healing",
+    "sideEffects": "Nausea, intense visions",
+    "contraindications": "Mental health disorders",
+    "drugInteractions": "MAOIs, SSRIs",
+    "toxicity": "Low physiological",
+    "pharmacokinetics": "Requires MAOI for oral activity"
+  },
+  {
+    "name": "Mormon Tea",
+    "scientificName": "Ephedra nevadensis",
+    "category": "Stimulant",
+    "effects": [
+      "mild stimulation"
+    ],
+    "mechanismOfAction": "Contains ephedrine-like alkaloids releasing norepinephrine",
+    "activeConstituents": [
+      {
+        "name": "ephedrine analogs",
+        "type": "alkaloid",
+        "effect": "stimulant"
+      }
+    ],
+    "preparation": "Stems brewed as tea",
+    "dosage": "5–10 g dried stems",
+    "onset": "15–30 min",
+    "duration": "1–2 hrs",
+    "safetyRating": 2,
+    "toxicityLD50": ">500 mg/kg (mice)",
+    "legalStatus": "Legal",
+    "region": "North America",
+    "tags": [
+      "☕ Brewable"
+    ],
+    "affiliateLink": null,
+    "description": "Mild stimulant desert shrub without strong ephedra content.",
+    "id": "ephedra-nevadensis",
+    "therapeuticUses": "Decongestant",
+    "sideEffects": "Increased heart rate",
+    "contraindications": "Hypertension",
+    "drugInteractions": "Stimulants, decongestants",
+    "toxicity": "Low",
+    "pharmacokinetics": "Rapid onset when brewed"
+  },
+  {
+    "name": "Coca",
+    "scientificName": "Erythroxylum coca",
+    "category": "Stimulant",
+    "effects": [
+      "euphoria",
+      "energy"
+    ],
+    "mechanismOfAction": "Cocaine inhibits monoamine reuptake",
+    "activeConstituents": [
+      {
+        "name": "cocaine",
+        "type": "alkaloid",
+        "effect": "stimulant"
+      }
+    ],
+    "preparation": "Leaves chewed with lime or brewed",
+    "dosage": "1–3 g dried leaves",
+    "onset": "5–10 min",
+    "duration": "30–60 min",
+    "safetyRating": 4,
+    "toxicityLD50": "95 mg/kg (mice)",
+    "legalStatus": "Controlled in most countries",
+    "region": "Andes",
+    "tags": [
+      "⚠️ Restricted",
+      "🌿 Leaf"
+    ],
+    "affiliateLink": null,
+    "description": "Traditional Andean stimulant leaf.",
+    "id": "erythroxylum-coca",
+    "therapeuticUses": "Altitude sickness",
+    "sideEffects": "Elevated heart rate, insomnia",
+    "contraindications": "Heart issues, pregnancy",
+    "drugInteractions": "Stimulants, MAOIs",
+    "toxicity": "High in purified form",
+    "pharmacokinetics": "Rapid absorption through oral mucosa"
+  },
+  {
+    "name": "Sanango",
+    "scientificName": "Tabernaemontana sananho",
+    "category": "Ritual / Visionary",
+    "effects": [
+      "dream enhancement",
+      "mild stimulation"
+    ],
+    "mechanismOfAction": "Iboga-type alkaloids act on NMDA and serotonin receptors",
+    "activeConstituents": [
+      {
+        "name": "ibogamine",
+        "type": "indole alkaloid",
+        "effect": "visionary"
+      }
+    ],
+    "preparation": "Root or bark decoction",
+    "dosage": "10–20 g root",
+    "onset": "30–60 min",
+    "duration": "4–8 hrs",
+    "safetyRating": 3,
+    "toxicityLD50": "Not established",
+    "legalStatus": "Unregulated",
+    "region": "Amazon",
+    "tags": [
+      "🌿 Root"
+    ],
+    "affiliateLink": null,
+    "description": "Shamanic plant sometimes added to ayahuasca.",
+    "id": "tabernaemontana-sananho",
+    "therapeuticUses": "Traditional spiritual healer",
+    "sideEffects": "Nausea",
+    "contraindications": "Heart conditions",
+    "drugInteractions": "MAOIs",
+    "toxicity": "Low",
+    "pharmacokinetics": "Little studied"
+  },
+  {
+    "name": "Kieli",
+    "scientificName": "Solandra maxima",
+    "category": "Ritual / Visionary",
+    "effects": [
+      "visions",
+      "disorientation"
+    ],
+    "mechanismOfAction": "Tropane alkaloids similar to datura",
+    "activeConstituents": [
+      {
+        "name": "atropine",
+        "type": "alkaloid",
+        "effect": "deliriant"
+      }
+    ],
+    "preparation": "Flowers brewed or smoked (hazardous)",
+    "dosage": "unknown",
+    "onset": "20–40 min",
+    "duration": "6–12 hrs",
+    "safetyRating": 5,
+    "toxicityLD50": "Unknown",
+    "legalStatus": "Unregulated",
+    "region": "Mexico",
+    "tags": [
+      "☠️ Toxic"
+    ],
+    "affiliateLink": null,
+    "description": "Rarely used solanaceous vine with powerful effects.",
+    "id": "solandra-maxima",
+    "therapeuticUses": "Visionary rituals",
+    "sideEffects": "Severe confusion, amnesia",
+    "contraindications": "Pregnancy, heart issues",
+    "drugInteractions": "Anticholinergics",
+    "toxicity": "High",
+    "pharmacokinetics": "Likely similar to datura"
+  },
+  {
+    "name": "Flame Lily",
+    "scientificName": "Gloriosa superba",
+    "category": "Other",
+    "effects": [
+      "intense nausea",
+      "weak delirium"
+    ],
+    "mechanismOfAction": "Contains colchicine disrupting microtubules",
+    "activeConstituents": [
+      {
+        "name": "colchicine",
+        "type": "alkaloid",
+        "effect": "cytotoxic"
+      }
+    ],
+    "preparation": "Seeds or tubers occasionally ingested (dangerous)",
+    "dosage": "<5 seeds",
+    "onset": "1–3 hrs",
+    "duration": "12–24 hrs",
+    "safetyRating": 5,
+    "toxicityLD50": "20 mg/kg (mice)",
+    "legalStatus": "Ornamental; toxic",
+    "region": "Africa, Asia",
+    "tags": [
+      "☠️ Toxic"
+    ],
+    "affiliateLink": null,
+    "description": "Highly poisonous ornamental sometimes misused.",
+    "id": "gloriosa-superba",
+    "therapeuticUses": "Traditional poison and medicine",
+    "sideEffects": "Severe vomiting, organ failure",
+    "contraindications": "Any internal use",
+    "drugInteractions": "None documented",
+    "toxicity": "Very high",
+    "pharmacokinetics": "Rapid GI absorption"
+  },
+  {
+    "name": "Giant Reed",
+    "scientificName": "Arundo donax",
+    "category": "Ritual / Visionary",
+    "effects": [
+      "mild visions"
+    ],
+    "mechanismOfAction": "Root bark may contain DMT and bufotenine",
+    "activeConstituents": [
+      {
+        "name": "DMT",
+        "type": "tryptamine",
+        "effect": "visionary"
+      }
+    ],
+    "preparation": "Root bark extracted",
+    "dosage": "Unknown",
+    "onset": "20–60 min",
+    "duration": "2–4 hrs",
+    "safetyRating": 4,
+    "toxicityLD50": "Not established",
+    "legalStatus": "Invasive species control",
+    "region": "Mediterranean, Americas",
+    "tags": [
+      "🌿 Root bark"
+    ],
+    "affiliateLink": null,
+    "description": "Invasive reed rumored to contain tryptamines.",
+    "id": "arundo-donax",
+    "therapeuticUses": "Experimental entheogen",
+    "sideEffects": "Nausea",
+    "contraindications": "Limited data",
+    "drugInteractions": "MAOIs",
+    "toxicity": "Unknown",
+    "pharmacokinetics": "Poorly studied"
+  },
+  {
+    "name": "Bolivian Torch",
+    "scientificName": "Echinopsis lageniformis",
+    "category": "Psychedelic",
+    "effects": [
+      "visions",
+      "clarity"
+    ],
+    "mechanismOfAction": "Mescaline as 5-HT2A agonist",
+    "activeConstituents": [
+      {
+        "name": "mescaline",
+        "type": "phenethylamine",
+        "effect": "psychedelic"
+      }
+    ],
+    "preparation": "Fresh or dried cactus consumed",
+    "dosage": "20–40 cm fresh cactus",
+    "onset": "1–2 hrs",
+    "duration": "8–12 hrs",
+    "safetyRating": 3,
+    "toxicityLD50": ">1 g/kg (rats)",
+    "legalStatus": "Cactus legal; mescaline controlled",
+    "region": "Andes",
+    "tags": [
+      "🌵 Cactus"
+    ],
+    "affiliateLink": null,
+    "description": "Another mescaline-rich Andean cactus.",
+    "id": "echinopsis-lageniformis",
+    "therapeuticUses": "Visionary rituals",
+    "sideEffects": "Nausea",
+    "contraindications": "Heart conditions",
+    "drugInteractions": "MAOIs",
+    "toxicity": "Low",
+    "pharmacokinetics": "Similar to other mescaline cacti"
+  }
+]

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -8,6 +8,7 @@ import { UNKNOWN, NOT_WELL_DOCUMENTED } from '../utils/constants'
 import TagBadge from './TagBadge'
 import { useHerbFavorites } from '../hooks/useHerbFavorites'
 import InfoTooltip from './InfoTooltip'
+import { slugify } from '../utils/slugify'
 
 interface Props {
   herb: Herb
@@ -39,6 +40,7 @@ const fieldTooltips: Record<string, string> = {
   toxicity: 'Known adverse effects or poisoning information.',
   therapeuticUses: 'Traditional or potential healing applications.',
   contraindications: 'Situations where this herb should be avoided.',
+  dosage: 'Common oral or smoked amount for effects.',
 }
 
 function gradientForCategory(cat: string): string {
@@ -236,6 +238,7 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
                 'contraindications',
                 'drugInteractions',
                 'preparation',
+                'dosage',
                 'pharmacokinetics',
                 'onset',
                 'duration',
@@ -269,6 +272,24 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
                   </motion.div>
                 )
               })}
+
+              {herb.activeConstituents?.length > 0 && (
+                <motion.div variants={itemVariants}>
+                  <span className='font-semibold text-lime-300'>Active Compounds:</span>{' '}
+                  {herb.activeConstituents.map((c, i) => (
+                    <React.Fragment key={c.name}>
+                      {i > 0 && ', '}
+                      <Link
+                        to={`/compounds#${slugify(c.name)}`}
+                        onClick={e => e.stopPropagation()}
+                        className='text-sky-300 underline'
+                      >
+                        {c.name}
+                      </Link>
+                    </React.Fragment>
+                  ))}
+                </motion.div>
+              )}
 
               {herb.tags?.length > 0 && (
                 <motion.div

--- a/src/components/TagBadge.tsx
+++ b/src/components/TagBadge.tsx
@@ -23,6 +23,7 @@ export default function TagBadge({ label, variant = 'purple', className }: Props
   const content = (
     <motion.span
       whileHover={{ scale: 1.05 }}
+      whileTap={{ scale: 0.95 }}
       className={clsx(
         'hover-glow text-shadow inline-flex items-center whitespace-nowrap rounded-full bg-gradient-to-br px-2 py-0.5 text-xs font-medium text-white/90 shadow ring-1 ring-white/40 backdrop-blur-sm dark:ring-black/40',
         colorMap[variant],

--- a/src/data/compoundData.ts
+++ b/src/data/compoundData.ts
@@ -1,0 +1,18 @@
+export interface CompoundInfo {
+  name: string
+  type: string
+  mechanism: string
+  affiliateLink?: string
+}
+
+export const baseCompounds: CompoundInfo[] = [
+  { name: 'DMT', type: 'tryptamine', mechanism: '5-HT2A agonist', affiliateLink: undefined },
+  { name: 'mescaline', type: 'phenethylamine', mechanism: '5-HT2A agonist', affiliateLink: undefined },
+  { name: 'caffeine', type: 'xanthine', mechanism: 'Adenosine receptor antagonist' },
+  { name: 'mitragynine', type: 'indole alkaloid', mechanism: 'Partial μ-opioid agonist' },
+  { name: 'cocaine', type: 'alkaloid', mechanism: 'Blocks monoamine reuptake' },
+  { name: 'scopolamine', type: 'alkaloid', mechanism: 'Muscarinic acetylcholine antagonist' },
+  { name: 'digitoxin', type: 'glycoside', mechanism: 'Inhibits Na+/K+-ATPase' },
+]
+
+export default baseCompounds

--- a/src/data/herbs.ts
+++ b/src/data/herbs.ts
@@ -1,5 +1,5 @@
 import type { Herb } from '../types'
-import raw from '../../Full150.json?raw'
+import raw from '../../Full170.json?raw'
 
 const cleaned = raw.replace(/NaN/g, 'null')
 const herbs = JSON.parse(cleaned) as Herb[]

--- a/src/pages/Compounds.tsx
+++ b/src/pages/Compounds.tsx
@@ -1,24 +1,36 @@
 import React from 'react'
 import { Helmet } from 'react-helmet-async'
 import { herbs } from '../data/herbs'
+import baseCompounds, { CompoundInfo } from '../data/compoundData'
+import { Link } from 'react-router-dom'
+import { slugify } from '../utils/slugify'
 
-interface Compound {
-  name: string
-  type: string
-  effect: string
-  sources: string[]
+interface Compound extends CompoundInfo {
+  sources: { id: string; name: string }[]
 }
 
 export default function Compounds() {
   const compounds = React.useMemo(() => {
     const map = new Map<string, Compound>()
+    baseCompounds.forEach(c => {
+      map.set(c.name, { ...c, sources: [] })
+    })
     herbs.forEach(h => {
       h.activeConstituents?.forEach(c => {
         const key = c.name
         if (!map.has(key)) {
-          map.set(key, { name: c.name, type: c.type, effect: c.effect, sources: [h.name] })
+          map.set(key, {
+            name: c.name,
+            type: c.type,
+            mechanism: '',
+            affiliateLink: undefined,
+            sources: [{ id: h.id, name: h.name }],
+          })
         } else {
-          map.get(key)!.sources.push(h.name)
+          const entry = map.get(key)!
+          if (!entry.sources.find(s => s.id === h.id)) {
+            entry.sources.push({ id: h.id, name: h.name })
+          }
         }
       })
     })
@@ -30,7 +42,7 @@ export default function Compounds() {
       <Helmet>
         <title>Compounds - The Hippie Scientist</title>
       </Helmet>
-      <div className='min-h-screen px-4 pt-20'>
+      <div className='min-h-screen px-4 pt-20 pb-12'>
         <div className='mx-auto max-w-4xl text-center'>
           <h1 className='text-gradient mb-6 text-5xl font-bold'>Psychoactive Compounds</h1>
           <p className='mb-8 text-sand'>
@@ -40,10 +52,31 @@ export default function Compounds() {
             {compounds.map(c => (
               <div key={c.name} className='glass-card p-4 text-left'>
                 <h2 className='text-xl font-bold text-white'>{c.name}</h2>
-                <p className='text-sm text-moss'>
-                  Type: {c.type} — {c.effect}
+                <p className='text-sm text-moss'>Type: {c.type}</p>
+                {c.mechanism && (
+                  <p className='text-xs text-sand'>MOA: {c.mechanism}</p>
+                )}
+                <p className='text-xs text-sand'>
+                  Herbs:
+                  {c.sources.map((s, i) => (
+                    <React.Fragment key={s.id}>
+                      {i > 0 && ', '}
+                      <Link to={`/herbs/${s.id}`} className='underline'>
+                        {s.name}
+                      </Link>
+                    </React.Fragment>
+                  ))}
                 </p>
-                <p className='text-xs text-sand'>Sources: {c.sources.join(', ')}</p>
+                {c.affiliateLink && (
+                  <a
+                    href={c.affiliateLink}
+                    target='_blank'
+                    rel='noopener noreferrer'
+                    className='mt-1 inline-block text-sm text-sky-300 underline'
+                  >
+                    Buy Online
+                  </a>
+                )}
               </div>
             ))}
           </div>

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -60,6 +60,18 @@ export default function Database() {
   }, [herbs])
 
   const [filtersOpen, setFiltersOpen] = React.useState(false)
+  const [showBar, setShowBar] = React.useState(true)
+
+  React.useEffect(() => {
+    let last = window.scrollY
+    const onScroll = () => {
+      const cur = window.scrollY
+      setShowBar(cur < last || cur < 100)
+      last = cur
+    }
+    window.addEventListener('scroll', onScroll)
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [])
 
   React.useEffect(() => {
     const close = () => {
@@ -116,7 +128,11 @@ export default function Database() {
             </p>
           </motion.div>
 
-          <div className='sticky top-2 z-20 mb-4 flex flex-wrap items-center gap-2'>
+          <motion.div
+            className='sticky top-2 z-20 mb-4 flex flex-wrap items-center gap-2'
+            animate={{ y: showBar ? 0 : -60, opacity: showBar ? 1 : 0 }}
+            transition={{ duration: 0.3 }}
+          >
             <SearchBar query={query} setQuery={setQuery} fuse={fuse} />
             <button
               type='button'
@@ -132,7 +148,7 @@ export default function Database() {
             >
               {filtersOpen ? 'Hide Filters' : 'Show Filters'}
             </button>
-          </div>
+          </motion.div>
 
           <div className={`mb-4 space-y-4 ${filtersOpen ? '' : 'hidden sm:block'}`}>
             <CategoryFilter selected={filteredCategories} onChange={setFilteredCategories} />

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -5,6 +5,7 @@ import { Helmet } from 'react-helmet-async'
 import { herbs } from '../data/herbs'
 import { decodeTag, tagVariant, safetyColorClass } from '../utils/format'
 import TagBadge from '../components/TagBadge'
+import { slugify } from '../utils/slugify'
 import { useLocalStorage } from '../hooks/useLocalStorage'
 
 function findSimilar(current: any) {
@@ -55,7 +56,7 @@ export default function HerbDetail() {
         {herb.scientificName && <p className='italic'>{herb.scientificName}</p>}
         <div className='space-y-2'>
           {[
-            'description','mechanismOfAction','therapeuticUses','sideEffects','contraindications','drugInteractions','preparation','pharmacokinetics','onset','duration','intensity','region','legalStatus','safetyRating','toxicity','toxicityLD50'
+            'description','mechanismOfAction','therapeuticUses','sideEffects','contraindications','drugInteractions','preparation','dosage','pharmacokinetics','onset,'duration','intensity','region','legalStatus','safetyRating','toxicity','toxicityLD50'
           ].map(key => {
             const raw = (herb as any)[key]
             if (!raw) return null
@@ -66,6 +67,17 @@ export default function HerbDetail() {
               </div>
             )
           })}
+          {herb.activeConstituents?.length > 0 && (
+            <div>
+              <span className='font-semibold text-lime-300'>Active Compounds:</span>{' '}
+              {herb.activeConstituents.map((c, i) => (
+                <React.Fragment key={c.name}>
+                  {i > 0 && ', '}
+                  <Link className='text-sky-300 underline' to={`/compounds#${slugify(c.name)}`}>{c.name}</Link>
+                </React.Fragment>
+              ))}
+            </div>
+          )}
           <div className='flex flex-wrap gap-2 pt-2'>
             {herb.tags.map(tag => (
               <TagBadge key={tag} label={decodeTag(tag)} variant={tagVariant(tag)} />

--- a/src/styles/tags.css
+++ b/src/styles/tags.css
@@ -2,7 +2,7 @@
   @apply rounded-xl bg-black/30 backdrop-blur-md p-2;
 }
 .tag-list {
-  @apply mt-2 flex flex-wrap gap-1 sm:gap-2 overflow-x-auto;
+  @apply mt-2 flex flex-wrap gap-1 sm:gap-2 overflow-x-auto scroll-smooth snap-x snap-mandatory;
 }
 .tag-label {
   @apply flex w-full items-center justify-between text-sm font-semibold text-violet-300;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export interface Herb {
   category: string
   effects: string[]
   preparation: string
+  dosage?: string
   intensity: string
   onset: string
   duration?: string


### PR DESCRIPTION
## Summary
- add a Full170.json dataset with 20 additional herbs
- expose dosage on herb types and display active compounds
- create compoundData store and link compounds to herbs
- update Compounds view to show connected herbs
- improve tag overflow and badge tap animation
- animate filter bar on scroll

## Testing
- `npm test`
- `node - <<'NODE'
const fs=require('fs');
const data=JSON.parse(fs.readFileSync('Full170.json','utf8'));
console.log('Herbs:',data.length);
const compounds=new Set(data.flatMap(h=>h.activeConstituents?.map(c=>c.name)||[]));
console.log('Compounds:',compounds.size);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_687ae99565f08323938c039b3588deb8