### PR TITLE
Improved herb search and favorites

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ const Database = React.lazy(() => import('./pages/Database'))
 const Store = React.lazy(() => import('./pages/Store'))
 const Research = React.lazy(() => import('./pages/Research'))
 const Bookmarks = React.lazy(() => import('./pages/Bookmarks'))
+const Favorites = React.lazy(() => import('./pages/Favorites'))
 const Compounds = React.lazy(() => import('./pages/Compounds'))
 const Compare = React.lazy(() => import('./pages/Compare'))
 
@@ -39,6 +40,7 @@ function App() {
             <Route path='/blog/:slug' element={<BlogPost />} />
             <Route path='/herbs/:id' element={<HerbDetail />} />
             <Route path='/bookmarks' element={<Bookmarks />} />
+            <Route path='/favorites' element={<Favorites />} />
             <Route path='/compounds' element={<Compounds />} />
             <Route path='/compare' element={<Compare />} />
             <Route path='/store' element={<Store />} />

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -280,7 +280,7 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
                     <React.Fragment key={c.name}>
                       {i > 0 && ', '}
                       <Link
-                        to={`/compounds#${slugify(c.name)}`}
+                        to={`/compounds?compound=${slugify(c.name)}`}
                         onClick={e => e.stopPropagation()}
                         className='hover-glow inline-block rounded px-1 text-sky-300 underline'
                       >

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -13,6 +13,7 @@ const Navbar: React.FC = () => {
     { path: '/about', label: 'About' },
     { path: '/learn', label: 'Learn' },
     { path: '/database', label: 'Database' },
+    { path: '/favorites', label: 'My Herbs' },
     { path: '/research', label: 'Research' },
     { path: '/blog', label: 'Blog' },
     { path: '/bookmarks', label: 'Bookmarks' },

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,25 +1,30 @@
 import React from 'react'
 import type Fuse from 'fuse.js'
-import type { Herb } from '../types'
 
 interface Props {
   query: string
   setQuery: (q: string) => void
-  fuse: Fuse<Herb>
+  fuse: Fuse<any>
 }
 
 export default function SearchBar({ query, setQuery, fuse }: Props) {
   const [suggestions, setSuggestions] = React.useState<ReturnType<typeof fuse.search>>([])
+  const [loading, setLoading] = React.useState(false)
 
   React.useEffect(() => {
+    setLoading(true)
     const q = query.trim()
-    if (q) {
-      setSuggestions(
-        fuse.search(q, { limit: 5, isCaseSensitive: false, ignoreLocation: true })
-      )
-    } else {
-      setSuggestions([])
-    }
+    const handle = setTimeout(() => {
+      if (q) {
+        setSuggestions(
+          fuse.search(q, { limit: 5, isCaseSensitive: false, ignoreLocation: true })
+        )
+      } else {
+        setSuggestions([])
+      }
+      setLoading(false)
+    }, 200)
+    return () => clearTimeout(handle)
   }, [query, fuse])
 
   const highlight = (text: string) => {
@@ -38,13 +43,18 @@ export default function SearchBar({ query, setQuery, fuse }: Props) {
         onChange={e => setQuery(e.target.value)}
         className='w-full rounded-md bg-space-dark/70 px-3 py-2 text-white backdrop-blur-md focus:outline-none'
       />
-      {suggestions.length > 0 && (
+      {loading && (
+        <div className='absolute z-10 mt-1 w-full rounded-md bg-black/80 p-2 text-center text-sm text-sand backdrop-blur-md'>
+          Searching...
+        </div>
+      )}
+      {!loading && suggestions.length > 0 && (
         <ul className='absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-black/80 p-2 text-sm text-sand backdrop-blur-md'>
           {suggestions.map(s => (
             <li key={s.item.id}>
               <button
                 type='button'
-                className='w-full text-left hover:bg-white/10 px-2 py-1 rounded'
+                className='w-full rounded px-2 py-1 text-left hover:bg-white/10'
                 onClick={() => setQuery(s.item.name)}
                 dangerouslySetInnerHTML={{ __html: highlight(s.item.name) }}
               />

--- a/src/data/compoundData.ts
+++ b/src/data/compoundData.ts
@@ -2,13 +2,14 @@ export interface CompoundInfo {
   name: string
   type: string
   mechanism: string
+  aliases?: string[]
   sourceHerbs?: string[]
   affiliateLink?: string
 }
 
 export const baseCompounds: CompoundInfo[] = [
-  { name: 'DMT', type: 'tryptamine', mechanism: '5-HT2A agonist', affiliateLink: undefined },
-  { name: 'mescaline', type: 'phenethylamine', mechanism: '5-HT2A agonist', affiliateLink: undefined },
+  { name: 'DMT', type: 'tryptamine', mechanism: '5-HT2A agonist', aliases: ['N,N-Dimethyltryptamine'], affiliateLink: undefined },
+  { name: 'mescaline', type: 'phenethylamine', mechanism: '5-HT2A agonist', aliases: ['3,4,5-trimethoxyphenethylamine'], affiliateLink: undefined },
   { name: 'caffeine', type: 'xanthine', mechanism: 'Adenosine receptor antagonist' },
   { name: 'mitragynine', type: 'indole alkaloid', mechanism: 'Partial μ-opioid agonist' },
   { name: 'cocaine', type: 'alkaloid', mechanism: 'Blocks monoamine reuptake' },

--- a/src/hooks/useFilteredHerbs.ts
+++ b/src/hooks/useFilteredHerbs.ts
@@ -1,6 +1,7 @@
 import React from 'react'
 import Fuse from 'fuse.js'
 import type { Herb } from '../types'
+import { extractAliases } from '../utils/herbAlias'
 import { canonicalTag } from '../utils/tagUtils'
 
 interface Options {
@@ -25,16 +26,33 @@ export function useFilteredHerbs(herbs: Herb[], options: Options = {}) {
   const [categories, setCategories] = React.useState<string[]>([])
   const [sort, setSort] = React.useState('')
 
+  const fuseData = React.useMemo(
+    () =>
+      herbs.map(h => ({
+        ...h,
+        aliases: extractAliases(h.name),
+      })),
+    [herbs]
+  )
+
   const fuse = React.useMemo(
     () =>
-      new Fuse(herbs, {
-        keys: ['name', 'scientificName', 'effects', 'description', 'tags'],
+      new Fuse(fuseData, {
+        keys: [
+          'name',
+          'aliases',
+          'scientificName',
+          'activeConstituents.name',
+          'effects',
+          'description',
+          'tags',
+        ],
         threshold: 0.4,
         includeMatches: true,
         isCaseSensitive: false,
         ignoreLocation: true,
       }),
-    [herbs]
+    [fuseData]
   )
 
   const filtered = React.useMemo(() => {

--- a/src/pages/Compare.tsx
+++ b/src/pages/Compare.tsx
@@ -13,6 +13,9 @@ export default function Compare() {
   const herbInfo = herbParam ? herbs.find(h => h.id === herbParam) : undefined
   const name = herbInfo?.name || compound || herbParam || 'Item'
   const tags = herbInfo?.tags || []
+  const products = herbInfo?.affiliateLink
+    ? [herbInfo.affiliateLink]
+    : []
 
   return (
     <>
@@ -31,10 +34,23 @@ export default function Compare() {
                 ))}
               </div>
             )}
-            <p className='mb-4 text-sand'>Affiliate product comparison coming soon.</p>
+            {herbInfo?.description && (
+              <p className='mb-4 text-sand'>{herbInfo.description}</p>
+            )}
             <div className='grid grid-cols-2 gap-3 sm:grid-cols-3'>
-              {Array.from({ length: 3 }).map((_, i) => (
-                <div key={i} className='h-24 rounded-lg bg-black/20 dark:bg-white/10' />
+              {products.map((link, i) => (
+                <a
+                  key={i}
+                  href={link}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='hover-glow flex h-24 items-center justify-center rounded-lg bg-black/20 p-2 text-sky-300 underline dark:bg-white/10'
+                >
+                  Buy Online
+                </a>
+              ))}
+              {Array.from({ length: Math.max(0, 3 - products.length) }).map((_, i) => (
+                <div key={`p${i}`} className='h-24 rounded-lg bg-black/20 dark:bg-white/10' />
               ))}
             </div>
           </div>

--- a/src/pages/Favorites.tsx
+++ b/src/pages/Favorites.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { Helmet } from 'react-helmet-async'
+import HerbList from '../components/HerbList'
+import { useHerbs } from '../hooks/useHerbs'
+import { useHerbFavorites } from '../hooks/useHerbFavorites'
+
+export default function Favorites() {
+  const herbs = useHerbs()
+  const { favorites } = useHerbFavorites()
+  const saved = React.useMemo(() => herbs.filter(h => favorites.includes(h.id)), [herbs, favorites])
+
+  return (
+    <div className='min-h-screen px-4 pt-20 pb-12'>
+      <Helmet>
+        <title>My Herbs - The Hippie Scientist</title>
+      </Helmet>
+      <div className='mx-auto max-w-6xl'>
+        <h1 className='text-gradient mb-6 text-center text-5xl font-bold'>My Herbs</h1>
+        {saved.length === 0 ? (
+          <p className='text-center text-sand'>No saved herbs yet.</p>
+        ) : (
+          <HerbList herbs={saved} />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -73,7 +73,7 @@ export default function HerbDetail() {
               {herb.activeConstituents.map((c, i) => (
                 <React.Fragment key={c.name}>
                   {i > 0 && ', '}
-                  <Link className='text-sky-300 underline' to={`/compounds#${slugify(c.name)}`}>{c.name}</Link>
+                  <Link className='text-sky-300 underline' to={`/compounds?compound=${slugify(c.name)}`}>{c.name}</Link>
                 </React.Fragment>
               ))}
             </div>

--- a/src/utils/herbAlias.ts
+++ b/src/utils/herbAlias.ts
@@ -1,0 +1,8 @@
+export function extractAliases(name: string): string[] {
+  const match = name.match(/\(([^)]+)\)/)
+  if (!match) return []
+  return match[1]
+    .split(/[,/]| or /)
+    .map(a => a.trim())
+    .filter(Boolean)
+}


### PR DESCRIPTION
## Summary
- enhance search to support aliases and compounds
- add loading indicator for search
- link active compounds to query view and show compound details
- scaffold a favorites herbs page
- show affiliate links in comparison page

## Testing
- `npm test`
- `npx vite build` *(fails: Need to install vite)*

------
https://chatgpt.com/codex/tasks/task_e_687af9d7f42c83239f01bded6aeed1c4