### PR TITLE
Add herb detail overlay route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ function App() {
             <Route path='/blog' element={<BlogIndex />} />
             <Route path='/blog/:slug' element={<BlogPost />} />
             <Route path='/herbs/:id' element={<HerbDetail />} />
+            <Route path='/herb/:id' element={<HerbDetail />} />
             <Route path='/bookmarks' element={<Bookmarks />} />
             <Route path='/favorites' element={<Favorites />} />
             <Route path='/compounds' element={<Compounds />} />

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -1,6 +1,6 @@
 import React, { useState, KeyboardEvent } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { ChevronRight, Star } from 'lucide-react'
 import type { Herb } from '../types'
 import { decodeTag, tagVariant, safetyColorClass } from '../utils/format'
@@ -70,15 +70,19 @@ function safetyTier(rating: any, toxicity?: string): SafetyTier {
 }
 
 export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
-  const [open, setOpen] = useState(false)
   const [tagsExpanded, setTagsExpanded] = useState(false)
-  const toggle = () => setOpen(v => !v)
+  const navigate = useNavigate()
+  const open = false
+  const handleClick = () => {
+    localStorage.setItem('focusHerb', herb.id)
+    navigate(`/herb/${herb.id}`)
+  }
   const { isFavorite, toggle: toggleFavorite } = useHerbFavorites()
 
   const handleKey = (e: KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault()
-      toggle()
+      handleClick()
     }
   }
 
@@ -94,12 +98,13 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
 
   return (
     <motion.div
+      id={herb.id}
       layout
       initial={{ opacity: 0, y: 20 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       exit={{ opacity: 0, scale: 0.9 }}
-      onClick={toggle}
+      onClick={handleClick}
       onKeyDown={handleKey}
       tabIndex={0}
       role='button'
@@ -308,8 +313,11 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
               )}
               <motion.div variants={itemVariants} className='pt-2'>
                 <Link
-                  to={`/herbs/${herb.id}`}
-                  onClick={e => e.stopPropagation()}
+                  to={`/herb/${herb.id}`}
+                  onClick={e => {
+                    e.stopPropagation()
+                    localStorage.setItem('focusHerb', herb.id)
+                  }}
                   className='text-comet underline'
                 >
                   View full page

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -45,6 +45,17 @@ export default function Database() {
     }
   }, [])
 
+  React.useEffect(() => {
+    const focus = localStorage.getItem('focusHerb')
+    if (focus) {
+      const el = document.getElementById(focus)
+      if (el) {
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      }
+      localStorage.removeItem('focusHerb')
+    }
+  }, [])
+
   const allTags = React.useMemo(() => {
     const t = herbs.reduce<string[]>((acc, h) => acc.concat(h.tags), [])
     return Array.from(new Set(t.map(canonicalTag)))

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
+import { Share2 } from 'lucide-react'
 import { Helmet } from 'react-helmet-async'
 import { herbs } from '../data/herbs'
 import { decodeTag, tagVariant, safetyColorClass } from '../utils/format'
@@ -31,6 +32,10 @@ export default function HerbDetail() {
   const herb = herbs.find(h => h.id === id)
   const [notes, setNotes] = useLocalStorage(`notes-${id}`, '')
   const [showSimilar, setShowSimilar] = React.useState(false)
+  const share = () => {
+    const url = `${window.location.origin}/herb/${herb?.id}`
+    navigator.clipboard.writeText(url)
+  }
   if (!herb) {
     return (
       <div className='p-6 text-center'>
@@ -49,14 +54,30 @@ export default function HerbDetail() {
       <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
-        className='mx-auto max-w-3xl px-6 py-12 space-y-6'
+        className='glass-card mx-auto max-w-3xl space-y-6 overflow-y-auto px-6 py-8'
       >
-        <Link to='/database' className='text-comet underline'>← Back</Link>
+        <div className='flex items-center justify-between'>
+          <Link
+            to='/database'
+            onClick={() => localStorage.setItem('focusHerb', herb.id)}
+            className='text-comet underline'
+          >
+            ← Back
+          </Link>
+          <button
+            type='button'
+            aria-label='Copy link'
+            onClick={share}
+            className='rounded-md p-1 text-sand hover:bg-white/20'
+          >
+            <Share2 size={18} />
+          </button>
+        </div>
         <h1 className='text-gradient text-4xl font-bold'>{herb.name}</h1>
         {herb.scientificName && <p className='italic'>{herb.scientificName}</p>}
         <div className='space-y-2'>
           {[
-            'description','mechanismOfAction','therapeuticUses','sideEffects','contraindications','drugInteractions','preparation','dosage','pharmacokinetics','onset,'duration','intensity','region','legalStatus','safetyRating','toxicity','toxicityLD50'
+            'description','mechanismOfAction','therapeuticUses','sideEffects','contraindications','drugInteractions','preparation','dosage','pharmacokinetics','onset','duration','intensity','region','legalStatus','safetyRating','toxicity','toxicityLD50'
           ].map(key => {
             const raw = (herb as any)[key]
             if (!raw) return null
@@ -78,12 +99,22 @@ export default function HerbDetail() {
               ))}
             </div>
           )}
-          <div className='flex flex-wrap gap-2 pt-2'>
-            {herb.tags.map(tag => (
-              <TagBadge key={tag} label={decodeTag(tag)} variant={tagVariant(tag)} />
-            ))}
-          </div>
+        <div className='flex flex-wrap gap-2 pt-2'>
+          {herb.tags.map(tag => (
+            <TagBadge key={tag} label={decodeTag(tag)} variant={tagVariant(tag)} />
+          ))}
         </div>
+        {herb.affiliateLink && (
+          <a
+            href={herb.affiliateLink}
+            target='_blank'
+            rel='noopener noreferrer'
+            className='hover-glow mt-4 block rounded-md bg-gradient-to-r from-green-700 to-lime-600 px-4 py-2 text-center text-white'
+          >
+            🌐 Buy Online
+          </a>
+        )}
+      </div>
         <button
           type='button'
           className='rounded-md bg-gradient-to-r from-violet-900 to-sky-900 px-3 py-2 text-white hover:opacity-90'


### PR DESCRIPTION
## Summary
- support `/herb/:id` path
- link herb cards to the new detail route
- enhance HerbDetail with glassmorphic panel, share button and buy online link
- remember last viewed herb and auto-scroll to that card on the database page

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687afdcdca508323ab2d4e998b9a9273