### PR TITLE
Add grid-based comparison table

### DIFF
--- a/src/pages/Compare.tsx
+++ b/src/pages/Compare.tsx
@@ -29,10 +29,48 @@ export default function Compare() {
       .filter(Boolean) as CompoundInfo[]
   }, [compoundNames])
 
-  const items = [
-    ...herbList.map(h => ({ type: 'herb' as const, herb: h })),
-    ...compoundList.map(c => ({ type: 'compound' as const, compound: c })),
-  ]
+  const items = React.useMemo(
+    () => [
+      ...herbList.map(h => ({ type: 'herb' as const, herb: h })),
+      ...compoundList.map(c => ({ type: 'compound' as const, compound: c })),
+    ],
+    [herbList, compoundList]
+  )
+
+  const compareRows = React.useMemo(() => {
+    return [
+      {
+        label: 'Name',
+        value: (i: typeof items[number]) =>
+          i.type === 'herb' ? i.herb?.name : i.compound?.name,
+      },
+      {
+        label: 'Effects',
+        value: (i: typeof items[number]) =>
+          i.type === 'herb'
+            ? (i.herb?.effects || []).join(', ')
+            : (i.compound?.tags || []).join(', '),
+      },
+      {
+        label: 'Safety',
+        value: (i: typeof items[number]) =>
+          i.type === 'herb' ? i.herb?.safetyRating ?? '' : '',
+      },
+      {
+        label: 'Active Constituents',
+        value: (i: typeof items[number]) => {
+          if (i.type === 'herb') {
+            return (i.herb?.activeConstituents || [])
+              .map(c => c.name)
+              .join(', ')
+          }
+          return (i.compound?.sourceHerbs || [])
+            .map(hid => herbs.find(h => h.id === hid)?.name || hid)
+            .join(', ')
+        },
+      },
+    ]
+  }, [herbs])
 
   const productsFor = (key: string) => compareData[key] || []
 
@@ -140,13 +178,42 @@ export default function Compare() {
       </Helmet>
       <div className='min-h-screen px-4 pt-20'>
         <h1 className='text-gradient mb-6 text-center text-5xl font-bold'>Comparison</h1>
-        <div className='flex gap-4 overflow-x-auto pb-4'>
-          {items.length > 0 ? (
-            items.map(renderCard)
-          ) : (
-            <p className='text-sand'>Add ?herbs=id1,id2 or ?compounds=name1,name2</p>
-          )}
-        </div>
+        {items.length > 0 ? (
+          <>
+            <div className='overflow-x-auto'>
+              <table className='glass-card w-full table-auto text-sm'>
+                <thead>
+                  <tr>
+                    <th className='p-2 text-left'>Field</th>
+                    {items.map(it => (
+                      <th key={it.type === 'herb' ? it.herb!.id : slugify(it.compound!.name)} className='p-2 text-left'>
+                        {it.type === 'herb' ? it.herb!.name : it.compound!.name}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {compareRows.map(row => (
+                    <tr key={row.label} className='border-t border-white/20'>
+                      <td className='p-2 font-semibold text-lime-300'>{row.label}</td>
+                      {items.map(it => (
+                        <td key={row.label + (it.type === 'herb' ? it.herb!.id : it.compound!.name)} className='p-2'>
+                          {row.value(it) || '—'}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <h2 className='mt-6 text-xl font-bold text-white'>Products</h2>
+            <div className='mt-2 grid gap-4 sm:grid-cols-2 md:grid-cols-3'>
+              {items.map(renderCard)}
+            </div>
+          </>
+        ) : (
+          <p className='text-sand'>Add ?herbs=id1,id2 or ?compounds=name1,name2</p>
+        )}
       </div>
     </>
   )


### PR DESCRIPTION
## Summary
- finalize comparison page with a table layout
- show product cards after the comparison grid

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b01f51bc48323a9802b26a7675a0f