### PR TITLE
Add Amazon disclosure footer and filters

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,11 +1,25 @@
 export default function Footer() {
   return (
-    <footer className='relative py-6 text-center text-sm text-gray-600 dark:text-sand'>
+    <footer className='relative space-y-2 bg-space-dark/70 px-4 py-6 text-center text-sm text-sand backdrop-blur-md'>
       <div
         className='absolute inset-0 mx-auto my-0 h-full w-11/12 rounded-full border border-comet/40 blur-sm'
         aria-hidden='true'
       />
-      <span className='text-gradient relative'>
+      <p className='relative mx-auto max-w-3xl'>
+        <strong>The Hippie Scientist</strong> is an interactive, educational database of psychoactive herbs, natural nootropics, and traditional plant medicines. It helps users explore effects, preparation, safety, active compounds, and cultural context — with research-backed entries for over 200 botanicals.
+      </p>
+      <p className='relative mx-auto max-w-3xl'>
+        As an Amazon Associate, I earn from qualifying purchases. Some links on this site may be affiliate links.
+      </p>
+      <a
+        href='https://www.buymeacoffee.com/hippiescientist'
+        target='_blank'
+        rel='noopener noreferrer'
+        className='relative inline-block rounded-md bg-amber-600 px-3 py-2 font-medium text-white hover:bg-amber-500'
+      >
+        ☕ Buy Me a Coffee
+      </a>
+      <span className='text-gradient relative block pt-2'>
         © {new Date().getFullYear()} The Hippie Scientist
       </span>
     </footer>

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -328,7 +328,7 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
                     target='_blank'
                     rel='noopener noreferrer'
                     onClick={e => e.stopPropagation()}
-                    className='ml-4 text-sm text-sky-300 underline'
+                    className='ml-4 inline-block min-h-[44px] text-sm text-sky-300 underline'
                   >
                     🌐 Buy Online
                   </a>

--- a/src/components/SearchFilter.tsx
+++ b/src/components/SearchFilter.tsx
@@ -12,6 +12,7 @@ type SortKey = '' | 'intensity' | 'onset' | 'safetyRating'
 
 const SearchFilter: React.FC<SearchFilterProps> = ({ herbs, onFilter }) => {
   const [query, setQuery] = React.useState('')
+  const [debounced, setDebounced] = React.useState('')
   const [selectedTags, setSelectedTags] = React.useState<string[]>([])
   const [sort, setSort] = React.useState<SortKey>('')
 
@@ -23,6 +24,11 @@ const SearchFilter: React.FC<SearchFilterProps> = ({ herbs, onFilter }) => {
       }),
     [herbs]
   )
+
+  React.useEffect(() => {
+    const handle = setTimeout(() => setDebounced(query), 200)
+    return () => clearTimeout(handle)
+  }, [query])
 
   const pickRandom = () => {
     const item = herbs[Math.floor(Math.random() * herbs.length)]
@@ -54,7 +60,7 @@ const SearchFilter: React.FC<SearchFilterProps> = ({ herbs, onFilter }) => {
   }
 
   const filtered = React.useMemo(() => {
-    const q = query.trim()
+    const q = debounced.trim()
     let res: Herb[] = herbs
     if (q) {
       res = fuse.search(q).map(r => r.item)
@@ -72,7 +78,7 @@ const SearchFilter: React.FC<SearchFilterProps> = ({ herbs, onFilter }) => {
     }
 
     return res
-  }, [herbs, query, selectedTags, sort])
+  }, [herbs, debounced, selectedTags, sort])
 
   React.useEffect(() => {
     onFilter(filtered)

--- a/src/components/TagBadge.tsx
+++ b/src/components/TagBadge.tsx
@@ -25,7 +25,7 @@ export default function TagBadge({ label, variant = 'purple', className }: Props
       whileHover={{ scale: 1.05 }}
       whileTap={{ scale: 0.95 }}
       className={clsx(
-        'hover-glow text-shadow inline-flex items-center whitespace-nowrap rounded-full bg-gradient-to-br px-2 py-0.5 text-xs font-medium text-white/90 shadow ring-1 ring-white/40 backdrop-blur-sm dark:ring-black/40',
+        'hover-glow text-shadow inline-flex items-center break-words rounded-full bg-gradient-to-br px-2 py-0.5 text-xs font-medium text-white/90 shadow ring-1 ring-white/40 backdrop-blur-sm dark:ring-black/40',
         colorMap[variant],
         className
       )}

--- a/src/data/tagGroups.ts
+++ b/src/data/tagGroups.ts
@@ -1,0 +1,15 @@
+export const tagGroups = {
+  Effects: [
+    'Calming',
+    'Dream',
+    'Visionary',
+    'Euphoria',
+    'Stimulant',
+  ],
+  Safety: ['Safe', 'Caution', 'Toxic', 'Restricted'],
+  Preparation: ['Brewable', 'Oral', 'Smokable', 'Tea', 'Incense', 'Tincture'],
+  Region: ['Amazon', 'Africa', 'Asia', 'Europe', 'Pacific'],
+  'Compound Type': ['Alkaloid', 'Terpene', 'Tryptamine', 'Phenethylamine', 'MAOI'],
+} as const
+
+export type TagGroup = keyof typeof tagGroups

--- a/src/hooks/useFilteredHerbs.ts
+++ b/src/hooks/useFilteredHerbs.ts
@@ -1,7 +1,7 @@
 import React from 'react'
 import Fuse from 'fuse.js'
 import type { Herb } from '../types'
-import { extractAliases } from '../utils/herbAlias'
+import { extractAliases, extraAliases } from '../utils/herbAlias'
 import { canonicalTag } from '../utils/tagUtils'
 
 interface Options {
@@ -30,7 +30,10 @@ export function useFilteredHerbs(herbs: Herb[], options: Options = {}) {
     () =>
       herbs.map(h => ({
         ...h,
-        aliases: extractAliases(h.name),
+        aliases: [
+          ...extractAliases(h.name),
+          ...(extraAliases[h.id] || extraAliases[h.name.toLowerCase()] || []),
+        ],
       })),
     [herbs]
   )

--- a/src/index.css
+++ b/src/index.css
@@ -46,7 +46,7 @@ html {
 }
 /* Animations and extra utilities */
 .tag-pill {
-  @apply text-shadow inline-flex items-center gap-1 rounded-full bg-black/10 px-2 py-0.5 text-xs shadow ring-1 ring-white/20 backdrop-blur-sm hover:bg-black/20 dark:bg-white/10 dark:ring-black/30 dark:hover:bg-white/20;
+  @apply text-shadow inline-flex items-center gap-1 break-words rounded-full bg-black/10 px-2 py-0.5 text-xs shadow ring-1 ring-white/20 backdrop-blur-sm hover:bg-black/20 dark:bg-white/10 dark:ring-black/30 dark:hover:bg-white/20;
 }
 
 @keyframes gradient-shift {

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -29,9 +29,7 @@ export default function About() {
             transition={{ duration: 0.8, delay: 0.2 }}
             className='text-lg text-sand'
           >
-            The Hippie Scientist is a grassroots project exploring the world of visionary botanicals
-            and the science of consciousness. Our goal is to share accurate information, celebrate
-            traditional knowledge and encourage safe, responsible exploration.
+            <strong>The Hippie Scientist</strong> is an interactive, educational database of psychoactive herbs, natural nootropics, and traditional plant medicines. It helps users explore effects, preparation, safety, active compounds, and cultural context — with research-backed entries for over 200 botanicals.
           </motion.p>
           <motion.p
             initial={{ opacity: 0, y: 20 }}
@@ -62,6 +60,29 @@ export default function About() {
             If you have suggestions or wish to collaborate, please reach out through our contact
             links.
           </motion.p>
+          <motion.p
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8, delay: 1 }}
+            className='text-lg text-sand'
+          >
+            As an Amazon Associate, I earn from qualifying purchases. Some links on this site may be affiliate links.
+          </motion.p>
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8, delay: 1.2 }}
+            className='pt-4 text-center'
+          >
+            <a
+              href='https://www.buymeacoffee.com/hippiescientist'
+              target='_blank'
+              rel='noopener noreferrer'
+              className='inline-block rounded-md bg-amber-600 px-3 py-2 font-medium text-white hover:bg-amber-500'
+            >
+              ☕ Buy Me a Coffee
+            </a>
+          </motion.div>
         </div>
       </div>
     </>

--- a/src/pages/Compounds.tsx
+++ b/src/pages/Compounds.tsx
@@ -129,7 +129,7 @@ export default function Compounds() {
                   href={selectedCompound.affiliateLink}
                   target='_blank'
                   rel='noopener noreferrer'
-                  className='mt-1 inline-block text-sm text-sky-300 underline'
+                  className='mt-1 inline-block min-h-[44px] text-sm text-sky-300 underline'
                 >
                   Buy Online
                 </a>
@@ -198,7 +198,7 @@ export default function Compounds() {
                         href={c.affiliateLink}
                         target='_blank'
                         rel='noopener noreferrer'
-                        className='mt-1 inline-block text-sm text-sky-300 underline'
+                        className='mt-1 inline-block min-h-[44px] text-sm text-sky-300 underline'
                       >
                         Buy Online
                       </a>

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -9,6 +9,7 @@ import CategoryAnalytics from '../components/CategoryAnalytics'
 import CategoryFilter from '../components/CategoryFilter'
 import { decodeTag } from '../utils/format'
 import { canonicalTag } from '../utils/tagUtils'
+import { useSearchParams } from 'react-router-dom'
 import StarfieldBackground from '../components/StarfieldBackground'
 import { useHerbs } from '../hooks/useHerbs'
 import { useHerbFavorites } from '../hooks/useHerbFavorites'
@@ -33,6 +34,7 @@ export default function Database() {
     setFavoritesOnly,
     fuse,
   } = useFilteredHerbs(herbs, { favorites })
+  const [params, setParams] = useSearchParams()
 
   React.useEffect(() => {
     const pos = getLocal<number>('dbScroll', 0)
@@ -74,6 +76,24 @@ export default function Database() {
 
   const [filtersOpen, setFiltersOpen] = React.useState(false)
   const [showBar, setShowBar] = React.useState(true)
+
+  React.useEffect(() => {
+    const tagsParam = params.get('tags')
+    if (tagsParam) {
+      const list = tagsParam.split(',').map(t => decodeURIComponent(t))
+      setFilteredTags(list)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  React.useEffect(() => {
+    if (filteredTags.length > 0) {
+      params.set('tags', filteredTags.map(encodeURIComponent).join(','))
+    } else {
+      params.delete('tags')
+    }
+    setParams(params, { replace: true })
+  }, [filteredTags, params, setParams])
 
   React.useEffect(() => {
     let last = window.scrollY

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -32,6 +32,7 @@ export default function HerbDetail() {
   const herb = herbs.find(h => h.id === id)
   const [notes, setNotes] = useLocalStorage(`notes-${id}`, '')
   const [showSimilar, setShowSimilar] = React.useState(false)
+  const [showAllCompounds, setShowAllCompounds] = React.useState(false)
   const share = () => {
     const url = `${window.location.origin}/herb/${herb?.id}`
     navigator.clipboard.writeText(url)
@@ -91,12 +92,21 @@ export default function HerbDetail() {
           {herb.activeConstituents?.length > 0 && (
             <div>
               <span className='font-semibold text-lime-300'>Active Compounds:</span>{' '}
-              {herb.activeConstituents.map((c, i) => (
+              {(showAllCompounds ? herb.activeConstituents : herb.activeConstituents.slice(0, 5)).map((c, i) => (
                 <React.Fragment key={c.name}>
                   {i > 0 && ', '}
                   <Link className='text-sky-300 underline' to={`/compounds?compound=${slugify(c.name)}`}>{c.name}</Link>
                 </React.Fragment>
               ))}
+              {herb.activeConstituents.length > 5 && !showAllCompounds && (
+                <button
+                  type='button'
+                  onClick={() => setShowAllCompounds(true)}
+                  className='ml-2 underline'
+                >
+                  +{herb.activeConstituents.length - 5} more
+                </button>
+              )}
             </div>
           )}
         <div className='flex flex-wrap gap-2 pt-2'>
@@ -105,14 +115,19 @@ export default function HerbDetail() {
           ))}
         </div>
         {herb.affiliateLink && (
-          <a
-            href={herb.affiliateLink}
-            target='_blank'
-            rel='noopener noreferrer'
-            className='hover-glow mt-4 block rounded-md bg-gradient-to-r from-green-700 to-lime-600 px-4 py-2 text-center text-white'
-          >
-            🌐 Buy Online
-          </a>
+          <div className='mt-4 space-y-1'>
+            <a
+              href={herb.affiliateLink}
+              target='_blank'
+              rel='noopener noreferrer'
+              className='hover-glow block min-h-[44px] rounded-md bg-gradient-to-r from-green-700 to-lime-600 px-4 py-2 text-center text-white'
+            >
+              🌐 Buy Online
+            </a>
+            <p className='text-xs text-sand'>
+              As an Amazon Associate, I earn from qualifying purchases. Some links on this page may be affiliate links.
+            </p>
+          </div>
         )}
       </div>
         <button

--- a/src/utils/herbAlias.ts
+++ b/src/utils/herbAlias.ts
@@ -6,3 +6,7 @@ export function extractAliases(name: string): string[] {
     .map(a => a.trim())
     .filter(Boolean)
 }
+
+export const extraAliases: Record<string, string[]> = {
+  ayahuasca: ['chacruna', 'banisteriopsis caapi', 'psychotria viridis'],
+}


### PR DESCRIPTION
## Summary
- add Amazon affiliate notice and Buy Me a Coffee link
- enlarge Buy Online buttons and add disclosure on herb pages
- support query param filters in the herb database
- show extra compounds with `+X more` on detail pages
- debounce search filter input
- allow wrapping for tag badges

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b033ad6508323ac2e9b0d9929d11f