### PR TITLE
Improve category UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import Navbar from './components/Navbar'
 import Footer from './components/Footer'
 import MouseTrail from './components/MouseTrail'
 import ScrollToTopButton from './components/ScrollToTopButton'
+import ScrollToTop from './components/ScrollToTop'
 const Home = React.lazy(() => import('./pages/Home'))
 const BlogIndex = React.lazy(() => import('./pages/BlogIndex'))
 const BlogPost = React.lazy(() => import('./pages/BlogPost'))
@@ -25,6 +26,7 @@ const Compare = React.lazy(() => import('./pages/Compare'))
 function App() {
   return (
     <>
+      <ScrollToTop />
       <Navbar />
       <MouseTrail />
       <main className='space-y-24 pt-16'>

--- a/src/components/CategoryAnalytics.tsx
+++ b/src/components/CategoryAnalytics.tsx
@@ -1,8 +1,9 @@
-import React from 'react'
+import React, { useState, useMemo } from 'react'
+import InfoTooltip from './InfoTooltip'
 import { herbs } from '../data/herbs'
 
 export default function CategoryAnalytics() {
-  const counts = React.useMemo(() => {
+  const counts = useMemo(() => {
     const c: Record<string, number> = {}
     herbs.forEach(h => {
       const main = h.category.split('/')[0].trim()
@@ -10,21 +11,44 @@ export default function CategoryAnalytics() {
     })
     return c
   }, [])
-  const max = Math.max(...Object.values(counts))
+  const entries = useMemo(() => Object.entries(counts).sort((a, b) => b[1] - a[1]), [counts])
+  const [showAll, setShowAll] = useState(false)
+  const [filter, setFilter] = useState('')
+  const filtered = useMemo(
+    () => entries.filter(([c]) => c.toLowerCase().includes(filter.toLowerCase())),
+    [entries, filter]
+  )
+  const list = showAll ? filtered : filtered.slice(0, 12)
+  const max = Math.max(...entries.map(([, c]) => c))
   return (
-    <div className='space-y-2'>
-      {Object.entries(counts).map(([cat, count]) => (
-        <div key={cat} className='flex items-center gap-2'>
-          <span className='w-40 text-sm'>{cat}</span>
-          <div className='flex-1 bg-slate-700/50 h-2 rounded'>
-            <div
-              className='h-2 rounded bg-fuchsia-500'
-              style={{ width: `${(count / max) * 100}%` }}
-            />
+    <div className='space-y-3'>
+      <div className='flex items-center gap-2'>
+        <input
+          type='text'
+          placeholder='Find category'
+          value={filter}
+          onChange={e => setFilter(e.target.value)}
+          className='w-36 flex-1 rounded-md bg-space-dark/50 px-2 py-1 text-sm backdrop-blur-md'
+        />
+        <button type='button' onClick={() => setShowAll(a => !a)} className='tag-pill'>
+          {showAll ? 'Collapse' : 'Show All'}
+        </button>
+      </div>
+      <div className='space-y-2'>
+        {list.map(([cat, count]) => (
+          <div key={cat} className='flex items-center gap-2'>
+            <InfoTooltip text={`${count} herbs`}>
+              <span className='w-40 truncate text-sm'>{cat}</span>
+            </InfoTooltip>
+            <div className='h-2 flex-1 rounded bg-slate-700/50'>
+              <div
+                className='h-2 rounded bg-fuchsia-500'
+                style={{ width: `${(count / max) * 100}%` }}
+              />
+            </div>
           </div>
-          <span className='text-sm'>{count}</span>
-        </div>
-      ))}
+        ))}
+      </div>
     </div>
   )
 }

--- a/src/components/CategoryFilter.tsx
+++ b/src/components/CategoryFilter.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import React, { useState } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
 import { herbs } from '../data/herbs'
 import { metaCategory } from '../hooks/useFilteredHerbs'
 
@@ -8,6 +9,7 @@ interface Props {
 }
 
 export default function CategoryFilter({ selected, onChange }: Props) {
+  const [open, setOpen] = useState(false)
   const counts = React.useMemo(() => {
     const c: Record<string, number> = {}
     herbs.forEach(h => {
@@ -22,7 +24,7 @@ export default function CategoryFilter({ selected, onChange }: Props) {
     onChange?.(next)
   }
 
-  return (
+  const list = (
     <div className='flex flex-wrap gap-2'>
       {Object.entries(counts)
         .sort((a, b) => b[1] - a[1])
@@ -31,11 +33,36 @@ export default function CategoryFilter({ selected, onChange }: Props) {
             key={cat}
             type='button'
             onClick={() => toggle(cat)}
-            className={`tag-pill ${selected.includes(cat) ? 'ring-2 ring-emerald-400' : ''}`}
+            className={`tag-pill max-w-[7rem] truncate ${selected.includes(cat) ? 'ring-2 ring-emerald-400' : ''}`}
           >
             {cat} ({count})
           </button>
         ))}
+    </div>
+  )
+
+  return (
+    <div>
+      <div className='sm:hidden'>
+        <button type='button' onClick={() => setOpen(o => !o)} className='tag-pill mb-2'>
+          {open ? 'Hide Categories' : 'Show Categories'}
+        </button>
+        <AnimatePresence initial={false}>
+          {open && (
+            <motion.div
+              key='cats'
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: 'auto', opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={{ duration: 0.3 }}
+              className='overflow-hidden'
+            >
+              {list}
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+      <div className='hidden sm:block'>{list}</div>
     </div>
   )
 }

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,10 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation()
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }, [pathname])
+  return null
+}

--- a/src/components/TagFilterBar.tsx
+++ b/src/components/TagFilterBar.tsx
@@ -5,6 +5,7 @@ import TagBadge from './TagBadge'
 import { decodeTag, tagVariant, tagCategory, TagCategory, normalizeTag } from '../utils/format'
 import { canonicalTag } from '../utils/tagUtils'
 import { useLocalStorage } from '../hooks/useLocalStorage'
+import { tagCategoryMap } from '../utils/tagCategoryMap'
 
 interface Props {
   tags: string[]
@@ -78,20 +79,14 @@ export default function TagFilterBar({
   }
 
   const labelFor = (cat: TagCategory) => {
-    switch (cat) {
-      case 'Effect':
-        return '⚡ Effects'
-      case 'Preparation':
-        return '🌿 Preparation'
-      case 'Safety':
-        return '⚠️ Safety'
-      case 'Chemistry':
-        return '🧪 Chemistry'
-      case 'Region':
-        return '📍 Region'
-      default:
-        return '✨ Other'
-    }
+    const info = tagCategoryMap[cat]
+    const Icon = info.icon
+    return (
+      <>
+        {Icon && <Icon className='mr-1 inline-block h-4 w-4' />}
+        {info.label}
+      </>
+    )
   }
 
   const renderTags = (cat: TagCategory) => {

--- a/src/hooks/useFilteredHerbs.ts
+++ b/src/hooks/useFilteredHerbs.ts
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useLocalStorage } from './useLocalStorage'
 import Fuse from 'fuse.js'
 import type { Herb } from '../types'
 import { extractAliases, extraAliases } from '../utils/herbAlias'
@@ -23,7 +24,7 @@ export function useFilteredHerbs(herbs: Herb[], options: Options = {}) {
   const [tags, setTags] = React.useState<string[]>([])
   const [tagMode, setTagMode] = React.useState<'AND' | 'OR'>('AND')
   const [favoritesOnly, setFavoritesOnly] = React.useState(false)
-  const [categories, setCategories] = React.useState<string[]>([])
+  const [categories, setCategories] = useLocalStorage<string[]>('dbCategories', [])
   const [sort, setSort] = React.useState('')
 
   const fuseData = React.useMemo(

--- a/src/utils/tagCategoryMap.ts
+++ b/src/utils/tagCategoryMap.ts
@@ -1,0 +1,16 @@
+import { TagCategory } from './format'
+import { LucideIcon, Zap, Leaf, AlertCircle, FlaskConical, Globe, Tag } from 'lucide-react'
+
+export interface CategoryInfo {
+  label: string
+  icon?: LucideIcon
+}
+
+export const tagCategoryMap: Record<TagCategory, CategoryInfo> = {
+  Effect: { label: 'Effects', icon: Zap },
+  Preparation: { label: 'Preparation', icon: Leaf },
+  Safety: { label: 'Safety', icon: AlertCircle },
+  Chemistry: { label: 'Chemistry', icon: FlaskConical },
+  Region: { label: 'Region', icon: Globe },
+  Other: { label: 'Other', icon: Tag },
+}


### PR DESCRIPTION
## Summary
- add `ScrollToTop` component for route changes
- persist category filter state
- add icon mapping for tag categories
- enhance tag filter labels with icons
- make category filter collapsible on mobile
- refine category analytics list with search, toggle and tooltips

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b050ba08083238a57cbee519c69c2