### PR TITLE
Add herb favorites and community notes

### DIFF
--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -96,7 +96,10 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
     if (!highlight) return text
     const escaped = highlight.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
     const regex = new RegExp(`(${escaped})`, 'ig')
-    return text.replace(regex, '<span class="font-bold text-yellow-300">$1</span>')
+    return text.replace(
+      regex,
+      '<mark class="rounded bg-yellow-500/40 px-1">$1</mark>'
+    )
   }
 
   const gradient = gradientForCategory(herb.category)
@@ -163,7 +166,9 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
             {herb.category && (
               <TagBadge label={herb.category} variant={categoryColors[herb.category] || 'purple'} />
             )}
-            {herb.effects?.length > 0 && <span>{herb.effects.join(', ')}</span>}
+            {herb.effects?.length > 0 && (
+              <span dangerouslySetInnerHTML={{ __html: mark(herb.effects.join(', ')) }} />
+            )}
           </div>
         </div>
         <div className='flex items-center gap-2'>

--- a/src/components/HerbList.tsx
+++ b/src/components/HerbList.tsx
@@ -11,6 +11,7 @@ const containerVariants = {
 const itemVariants = {
   hidden: { opacity: 0, y: 20 },
   visible: { opacity: 1, y: 0 },
+  exit: { opacity: 0, y: -20 },
 }
 
 interface Props {
@@ -39,7 +40,12 @@ const HerbList: React.FC<Props> = ({ herbs, highlightQuery = '', batchSize = 24 
       >
         <AnimatePresence>
           {herbs.slice(0, visible).map(h => (
-            <motion.div key={h.id || h.name} variants={itemVariants} layout>
+            <motion.div
+              key={h.id || h.name}
+              variants={itemVariants}
+              layout
+              exit='exit'
+            >
               <HerbCardAccordion herb={h} highlight={highlightQuery} />
             </motion.div>
           ))}

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -31,7 +31,10 @@ export default function SearchBar({ query, setQuery, fuse }: Props) {
     if (!query) return text
     const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
     const regex = new RegExp(`(${escaped})`, 'ig')
-    return text.replace(regex, '<span class="font-bold">$1</span>')
+    return text.replace(
+      regex,
+      '<mark class="rounded bg-yellow-500/40 px-1">$1</mark>'
+    )
   }
 
   return (

--- a/src/hooks/useHerbFavorites.ts
+++ b/src/hooks/useHerbFavorites.ts
@@ -2,7 +2,7 @@ import { useLocalStorage } from './useLocalStorage'
 
 export function useHerbFavorites() {
   const [favorites, setFavorites] = useLocalStorage<string[]>(
-    'herbFavorites',
+    'favorites',
     []
   )
 

--- a/src/index.css
+++ b/src/index.css
@@ -38,6 +38,10 @@ html {
   background-image: linear-gradient(135deg, #8b5cf6, #db2777);
 }
 
+mark {
+  @apply rounded bg-yellow-500/40 px-1 text-yellow-200;
+}
+
 .bg-cosmic-gradient {
   background-image: radial-gradient(circle at 50% 50%, #312e81, #0c1126);
 }

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useParams, Link } from 'react-router-dom'
-import { motion } from 'framer-motion'
+import { motion, AnimatePresence } from 'framer-motion'
 import { Share2 } from 'lucide-react'
 import { Helmet } from 'react-helmet-async'
 import { herbs } from '../data/herbs'
@@ -34,9 +34,16 @@ export default function HerbDetail() {
   const [notes, setNotes] = useLocalStorage(`notes-${id}`, '')
   const [showSimilar, setShowSimilar] = React.useState(false)
   const [showAllCompounds, setShowAllCompounds] = React.useState(false)
+  const [copied, setCopied] = React.useState(false)
+
+  React.useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }, [])
   const share = () => {
     const url = `${window.location.origin}/herb/${herb?.id}`
     navigator.clipboard.writeText(url)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1500)
   }
   if (!herb) {
     return (
@@ -66,14 +73,36 @@ export default function HerbDetail() {
           >
             ← Back
           </Link>
-          <button
-            type='button'
-            aria-label='Copy link'
-            onClick={share}
-            className='rounded-md p-1 text-sand hover:bg-white/20'
-          >
-            <Share2 size={18} />
-          </button>
+          <div className='relative flex items-center gap-2'>
+            <button
+              type='button'
+              aria-label='Copy link'
+              onClick={share}
+              className='rounded-md p-1 text-sand hover:bg-white/20'
+            >
+              <Share2 size={18} />
+            </button>
+            <AnimatePresence>
+              {copied && (
+                <motion.div
+                  initial={{ opacity: 0, y: -5 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -5 }}
+                  className='absolute right-0 top-full mt-1 rounded bg-black/80 px-2 py-1 text-xs text-white'
+                >
+                  Copied!
+                </motion.div>
+              )}
+            </AnimatePresence>
+            <a
+              href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(window.location.href)}&text=${encodeURIComponent(herb.name)}%20%23herbs`}
+              target='_blank'
+              rel='noopener noreferrer'
+              className='text-sky-300 underline'
+            >
+              Tweet
+            </a>
+          </div>
         </div>
         <h1 className='text-gradient text-4xl font-bold'>{herb.name}</h1>
         {herb.scientificName && <p className='italic'>{herb.scientificName}</p>}
@@ -160,6 +189,38 @@ export default function HerbDetail() {
             className='mt-2 w-full rounded-md bg-black/20 p-2 text-white'
             rows={5}
           />
+        </div>
+        <div className='space-y-2'>
+          <h2 className='text-2xl font-bold text-sky-300'>Community Notes</h2>
+          <div className='rounded-md bg-black/20 p-2 text-sm text-sand'>
+            <strong>Alice</strong>: Great for relaxation! <span className='float-right text-xs'>2024-05-01</span>
+          </div>
+          <div className='rounded-md bg-black/20 p-2 text-sm text-sand'>
+            <strong>Bob</strong>: Helped with sleep. <span className='float-right text-xs'>2024-05-02</span>
+          </div>
+          <form
+            onSubmit={e => {
+              e.preventDefault()
+              const form = e.target as HTMLFormElement
+              const data = (form.elements.namedItem('note') as HTMLInputElement).value
+              console.log('Submitted note:', data)
+              form.reset()
+            }}
+            className='space-y-2'
+          >
+            <textarea
+              name='note'
+              rows={3}
+              className='w-full rounded-md bg-black/20 p-2 text-white'
+              placeholder='Share your experience...'
+            />
+            <button
+              type='submit'
+              className='rounded bg-psychedelic-purple px-3 py-1 text-white hover:opacity-90'
+            >
+              Submit Note
+            </button>
+          </form>
         </div>
         <details className='bg-slate-800/40 p-4 rounded-md'>
           <summary className='cursor-pointer text-sky-300'>🧬 Summarize This Herb</summary>


### PR DESCRIPTION
## Summary
- use common `favorites` localStorage key for herb favorites
- highlight search terms in herb cards and search suggestions
- add fade transitions for herb list items
- style `<mark>` for highlighted text
- add share button tooltip and Twitter link to herb detail page
- include community notes placeholder with submit form
- smooth scroll to top on herb detail load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b08c4fa9c8323bb1e1bdccd8e5efb