### PR TITLE
Add Support page and update About

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ const Bookmarks = React.lazy(() => import('./pages/Bookmarks'))
 const Favorites = React.lazy(() => import('./pages/Favorites'))
 const Compounds = React.lazy(() => import('./pages/Compounds'))
 const Compare = React.lazy(() => import('./pages/Compare'))
+const Support = React.lazy(() => import('./pages/Support'))
 
 function App() {
   return (
@@ -44,6 +45,7 @@ function App() {
             <Route path='/favorites' element={<Favorites />} />
             <Route path='/compounds' element={<Compounds />} />
             <Route path='/compare' element={<Compare />} />
+            <Route path='/support' element={<Support />} />
             <Route path='/store' element={<Store />} />
             <Route path='*' element={<NotFound />} />
           </Routes>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -18,6 +18,7 @@ const Navbar: React.FC = () => {
     { path: '/blog', label: 'Blog' },
     { path: '/bookmarks', label: 'Bookmarks' },
     { path: '/compounds', label: 'Explore Compounds' },
+    { path: '/support', label: 'Support' },
     { path: '/store', label: 'Store' },
   ]
 

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -14,7 +14,13 @@ export default function About() {
       </Helmet>
 
       <div className='min-h-screen px-4 pt-20'>
-        <div className='mx-auto max-w-3xl space-y-8'>
+        <div className='mx-auto max-w-3xl'>
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8 }}
+            className='glass-card space-y-6 p-8'
+          >
           <motion.h1
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
@@ -62,7 +68,19 @@ export default function About() {
             If you have suggestions or wish to collaborate, please reach out through our contact
             links.
           </motion.p>
-        </div>
+          <motion.p
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8, delay: 1 }}
+            className='text-sm text-sand'
+          >
+            <strong>Affiliate Disclaimer:</strong> This site participates in Amazon Associates and
+            other affiliate programs, which means we may earn a small commission if you purchase
+            products through links on our pages. These earnings help keep the project running at no
+            extra cost to you.
+          </motion.p>
+        </motion.div>
+      </div>
       </div>
     </>
   )

--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Helmet } from 'react-helmet-async'
+import { motion } from 'framer-motion'
+
+export default function Support() {
+  return (
+    <>
+      <Helmet>
+        <title>Support Us - The Hippie Scientist</title>
+        <meta name='description' content='Ways to support The Hippie Scientist project.' />
+      </Helmet>
+
+      <div className='min-h-screen px-4 pt-20'>
+        <div className='mx-auto max-w-2xl'>
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.8 }}
+            className='glass-card space-y-6 p-8 text-center'
+          >
+            <h1 className='text-gradient text-5xl font-bold'>Support Us</h1>
+            <p className='text-lg text-sand'>
+              If you enjoy our content and want to help the project grow, consider leaving a tip or buying us a coffee.
+            </p>
+            <div className='mx-auto h-24 w-48 rounded-md bg-black/20 dark:bg-white/10' />
+            <p className='text-sm text-sand'>
+              Placeholder for BuyMeACoffee or other tipping platform integration.
+            </p>
+          </motion.div>
+        </div>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- enhance About page with glass-card layout and affiliate disclaimer
- add a new Support page for donations
- route Support page and expose in navbar

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b019624908323b01e023bde9cef5c