### PR TITLE
Fix herb database page loading

### DIFF
--- a/src/data/herbs.ts
+++ b/src/data/herbs.ts
@@ -1,8 +1,14 @@
 import type { Herb } from '../types'
 import raw from '../../Full200.json?raw'
 
-const cleaned = raw.replace(/NaN/g, 'null')
-const herbs = JSON.parse(cleaned) as Herb[]
+let herbs: Herb[] = []
+try {
+  const cleaned = raw.replace(/NaN/g, 'null')
+  herbs = JSON.parse(cleaned) as Herb[]
+} catch (err) {
+  console.error('Failed to load herb data', err)
+  herbs = []
+}
 
 export default herbs
 export { herbs }

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -19,6 +19,7 @@ import { getLocal, setLocal } from '../utils/localStorage'
 
 export default function Database() {
   const herbs = useHerbs()
+  console.log('herbs length', herbs.length)
   const { favorites } = useHerbFavorites()
   const {
     filtered,
@@ -35,6 +36,20 @@ export default function Database() {
     fuse,
   } = useFilteredHerbs(herbs, { favorites })
   const [params, setParams] = useSearchParams()
+
+  if (herbs.length === 0) {
+    return (
+      <>
+        <Helmet>
+          <title>Database - The Hippie Scientist</title>
+        </Helmet>
+        <div className='relative min-h-screen px-4 pt-20'>
+          <StarfieldBackground />
+          <div className='text-center text-sand'>Unable to load herb data.</div>
+        </div>
+      </>
+    )
+  }
 
   React.useEffect(() => {
     const pos = getLocal<number>('dbScroll', 0)


### PR DESCRIPTION
## Summary
- guard herb data import with try/catch
- allow `useFilteredHerbs` to accept undefined data
- show fallback UI if herb data fails to load
- log herb count for debugging
- fix missing aliasFor import

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687b0b8c20408323ad13c77bcc34bca1