### PR TITLE
Improve herb list search and layout

### DIFF
--- a/src/hooks/useFilteredHerbs.ts
+++ b/src/hooks/useFilteredHerbs.ts
@@ -62,12 +62,22 @@ export function useFilteredHerbs(herbs: Herb[] | undefined, options: Options = {
     [fuseData]
   )
 
+  const [matchMap, setMatchMap] = React.useState<Record<string, Fuse.FuseResultMatch[]>>({})
+
   const filtered = React.useMemo(() => {
-    let res = safeHerbs
+    let results: { item: Herb; matches?: Fuse.FuseResultMatch[] }[] = []
     const q = query.trim()
     if (q) {
-      res = fuse.search(q).map(r => r.item)
+      results = fuse.search(q)
+    } else {
+      results = safeHerbs.map(item => ({ item }))
     }
+    const map: Record<string, Fuse.FuseResultMatch[]> = {}
+    results.forEach(r => {
+      if (r.matches) map[r.item.id] = r.matches
+    })
+    setMatchMap(map)
+    let res = results.map(r => r.item)
     if (tags.length) {
       res = res.filter(h => {
         const matches = tags.map(t => h.tags.some(ht => canonicalTag(ht) === canonicalTag(t)))
@@ -88,6 +98,7 @@ export function useFilteredHerbs(herbs: Herb[] | undefined, options: Options = {
 
   return {
     filtered,
+    matches: matchMap,
     query,
     setQuery,
     tags,

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -16,6 +16,7 @@ import { useHerbFavorites } from '../hooks/useHerbFavorites'
 import SearchBar from '../components/SearchBar'
 import { useFilteredHerbs } from '../hooks/useFilteredHerbs'
 import { getLocal, setLocal } from '../utils/localStorage'
+import { useLocalStorage } from '../hooks/useLocalStorage'
 
 export default function Database() {
   const herbs = useHerbs()
@@ -23,6 +24,7 @@ export default function Database() {
   const { favorites } = useHerbFavorites()
   const {
     filtered,
+    matches,
     query,
     setQuery,
     tags: filteredTags,
@@ -35,6 +37,7 @@ export default function Database() {
     setFavoritesOnly,
     fuse,
   } = useFilteredHerbs(herbs, { favorites })
+  const [compactMode, setCompactMode] = useLocalStorage<boolean>('dbCompact', false)
   const [params, setParams] = useSearchParams()
 
   if (!herbs || herbs.length === 0) {
@@ -89,6 +92,12 @@ export default function Database() {
     })
     return counts
   }, [herbs])
+
+  React.useEffect(() => {
+    if (Object.keys(tagCounts).length) {
+      console.log('Tag usage counts', tagCounts)
+    }
+  }, [tagCounts])
 
   const [filtersOpen, setFiltersOpen] = React.useState(false)
   const [showBar, setShowBar] = React.useState(true)
@@ -196,6 +205,13 @@ export default function Database() {
             </button>
             <button
               type='button'
+              onClick={() => setCompactMode(c => !c)}
+              className='rounded-md bg-space-dark/70 px-3 py-2 text-sm text-sand backdrop-blur-md hover:bg-white/10'
+            >
+              {compactMode ? 'Full Cards' : 'Compact'}
+            </button>
+            <button
+              type='button'
               onClick={() => setFiltersOpen(o => !o)}
               className='rounded-md bg-space-dark/70 px-3 py-2 text-sm text-sand backdrop-blur-md hover:bg-white/10 sm:hidden'
             >
@@ -229,7 +245,7 @@ export default function Database() {
             </div>
           )}
           <CategoryAnalytics />
-          <HerbList herbs={filtered} highlightQuery={query} />
+          <HerbList herbs={filtered} highlightQuery={query} matches={matches} compact={compactMode} pageSize={30} />
         </div>
       </div>
     </>

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,3 +1,5 @@
+import { canonicalTag } from './tagUtils'
+
 export function decodeTag(tag: string): string {
   try {
     return JSON.parse(`"${tag}"`)
@@ -7,14 +9,14 @@ export function decodeTag(tag: string): string {
 }
 
 export function normalizeTag(tag: string): string {
-  const decoded = decodeTag(tag)
-  const key = decoded.toLowerCase()
+  const decoded = decodeTag(tag).trim()
+  const key = canonicalTag(decoded)
   if (key === 'ayahuasca-additive') return 'Ayahuasca'
   if (key === 'sleep') return 'Dream'
   if (key === 'sedative') return 'Sedation'
   if (/(intense|strong|powerful)/.test(key)) return '🔥 Intensity'
   if (/visionary|psychedelic|hallucinogenic/.test(key)) return 'Visionary'
-  return decoded
+  return key.charAt(0).toUpperCase() + key.slice(1)
 }
 
 export type TagCategory = 'Effect' | 'Preparation' | 'Safety' | 'Region' | 'Chemistry' | 'Other'


### PR DESCRIPTION
## Summary
- add fuzzy match tracking in `useFilteredHerbs`
- paginate `HerbList` and support compact cards
- enable highlight rendering from Fuse matches in `HerbCardAccordion`
- persist compact mode on the database page and log tag counts
- normalize tags using canonical names

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687b0ff72b008323b9e494b9a164eae9