### PR TITLE
Fix data loading fallback

### DIFF
--- a/src/hooks/useHerbs.ts
+++ b/src/hooks/useHerbs.ts
@@ -2,10 +2,17 @@ import React from 'react'
 import type { Herb } from '../types'
 
 async function fetchHerbs(url: string): Promise<Herb[]> {
-  const res = await fetch(url)
-  if (!res.ok) throw new Error(`Failed to fetch ${url}`)
-  const text = await res.text()
-  return JSON.parse(text.replace(/NaN/g, 'null')) as Herb[]
+  try {
+    const res = await fetch(url)
+    if (!res.ok) {
+      throw new Error(`Failed to fetch ${url}: ${res.status}`)
+    }
+    const text = await res.text()
+    return JSON.parse(text.replace(/NaN/g, 'null')) as Herb[]
+  } catch (err) {
+    console.error('Error fetching herb data from', url, err)
+    throw err
+  }
 }
 
 export function useHerbs(): Herb[] | undefined {

--- a/src/pages/Compare.tsx
+++ b/src/pages/Compare.tsx
@@ -18,6 +18,17 @@ export default function Compare() {
 
   const herbs = useHerbs()
 
+  if (herbs === undefined) {
+    return (
+      <div className='min-h-screen px-4 pt-20 text-center text-sand'>
+        <Helmet>
+          <title>Compare - The Hippie Scientist</title>
+        </Helmet>
+        <p>Loading herb data…</p>
+      </div>
+    )
+  }
+
   const herbList = React.useMemo(
     () => (herbs ? herbIds.map(id => herbs.find(h => h.id === id)).filter(Boolean) : []),
     [herbIds, herbs]

--- a/src/pages/Compounds.tsx
+++ b/src/pages/Compounds.tsx
@@ -27,6 +27,17 @@ export default function Compounds() {
   const herbs = useHerbs()
   const [tagFilter, setTagFilter] = React.useState<string[]>([])
 
+  if (herbs === undefined) {
+    return (
+      <div className='min-h-screen px-4 pt-20 text-center text-sand'>
+        <Helmet>
+          <title>Psychoactive Compounds - The Hippie Scientist</title>
+        </Helmet>
+        <p>Loading herb data…</p>
+      </div>
+    )
+  }
+
   const compounds = React.useMemo(() => {
     const map = new Map<string, Compound>()
     baseCompounds.forEach(c => {

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -40,7 +40,21 @@ export default function Database() {
   const [compactMode, setCompactMode] = useLocalStorage<boolean>('dbCompact', false)
   const [params, setParams] = useSearchParams()
 
-  if (!herbs || herbs.length === 0) {
+  if (herbs === undefined) {
+    return (
+      <>
+        <Helmet>
+          <title>Database - The Hippie Scientist</title>
+        </Helmet>
+        <div className='relative min-h-screen px-4 pt-20'>
+          <StarfieldBackground />
+          <div className='text-center text-sand'>Loading herb data…</div>
+        </div>
+      </>
+    )
+  }
+
+  if (herbs.length === 0) {
     return (
       <>
         <Helmet>

--- a/src/pages/Favorites.tsx
+++ b/src/pages/Favorites.tsx
@@ -12,6 +12,17 @@ export default function Favorites() {
     [herbs, favorites]
   )
 
+  if (herbs === undefined) {
+    return (
+      <div className='min-h-screen px-4 pt-20 pb-12 text-center text-sand'>
+        <Helmet>
+          <title>My Herbs - The Hippie Scientist</title>
+        </Helmet>
+        <p>Loading herb data…</p>
+      </div>
+    )
+  }
+
   return (
     <div className='min-h-screen px-4 pt-20 pb-12'>
       <Helmet>

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -46,6 +46,13 @@ export default function HerbDetail() {
     setCopied(true)
     setTimeout(() => setCopied(false), 1500)
   }
+  if (herbs === undefined) {
+    return (
+      <div className='p-6 text-center'>
+        <p>Loading herb data…</p>
+      </div>
+    )
+  }
   if (!herb) {
     return (
       <div className='p-6 text-center'>


### PR DESCRIPTION
## Summary
- handle herb data fetch errors with try/catch
- add loading guards across herb pages
- show loading or error messages when herb data missing

## Testing
- `npm run build`
- `curl -I http://localhost:5000/`
- `curl -I http://localhost:5000/database`


------
https://chatgpt.com/codex/tasks/task_e_687b12dd55348323b9a28e90673ce538