### PR TITLE
Fix GitHub Pages routing

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { HashRouter } from 'react-router-dom';
 import { HelmetProvider } from 'react-helmet-async';
 import App from './App';
 import { ThemeProvider } from './contexts/theme';
@@ -11,9 +11,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <HelmetProvider>
       <ThemeProvider>
-        <BrowserRouter>
+        <HashRouter>
           <App />
-        </BrowserRouter>
+        </HashRouter>
       </ThemeProvider>
     </HelmetProvider>
   </React.StrictMode>

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -41,7 +41,7 @@ export default function HerbDetail() {
     window.scrollTo({ top: 0, behavior: 'smooth' })
   }, [])
   const share = () => {
-    const url = `${window.location.origin}/herb/${herb?.id}`
+    const url = `${window.location.origin}/#/herb/${herb?.id}`
     navigator.clipboard.writeText(url)
     setCopied(true)
     setTimeout(() => setCopied(false), 1500)


### PR DESCRIPTION
## Summary
- use `HashRouter` for SPA routing on GitHub Pages
- update HerbDetail share URL to include hash

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b1693e0088323a985721437985a06