### PR TITLE
Fix router to use hash history

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { HashRouter } from 'react-router-dom';
 import { HelmetProvider } from 'react-helmet-async';
 import App from './App';
 import { ThemeProvider } from './contexts/theme';
@@ -11,9 +11,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <HelmetProvider>
       <ThemeProvider>
-        <BrowserRouter>
+        <HashRouter>
           <App />
-        </BrowserRouter>
+        </HashRouter>
       </ThemeProvider>
     </HelmetProvider>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- switch from `BrowserRouter` to `HashRouter` to avoid blank screens when navigating

## Testing
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_687b14bfb1408323ad50459f7be9f826