### PR TITLE
Fix data fallback for GitHub Pages

### DIFF
--- a/src/hooks/useHerbs.ts
+++ b/src/hooks/useHerbs.ts
@@ -25,8 +25,14 @@ export function useHerbs(): Herb[] | undefined {
         const data = await fetchHerbs('/data/Full200.json')
         if (active) setHerbs(data)
       } catch (err) {
-        console.error('Failed to load herb data', err)
-        if (active) setHerbs([])
+        console.error('Failed to load Full200.json', err)
+        try {
+          const data = await fetchHerbs('/data/Full79.json')
+          if (active) setHerbs(data)
+        } catch (err2) {
+          console.error('Failed to load fallback herb data', err2)
+          if (active) setHerbs([])
+        }
       }
     }
     load()


### PR DESCRIPTION
## Summary
- use fallback herb JSON if the main file fails to load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b19c15d0083238d6fdfd5238a8f23