### PR TITLE
Fix data fallback for GitHub Pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,13 +1,17 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Page Not Found - The Hippie Scientist</title>
+    <title>Redirecting…</title>
+    <script>
+      const cleanPath = window.location.pathname
+        .replace(/\/$/, '') +
+        window.location.search +
+        window.location.hash;
+      window.location.replace('/#' + cleanPath);
+    </script>
   </head>
   <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <p>Redirecting…</p>
   </body>
 </html>

--- a/src/hooks/useHerbs.ts
+++ b/src/hooks/useHerbs.ts
@@ -25,8 +25,14 @@ export function useHerbs(): Herb[] | undefined {
         const data = await fetchHerbs('/data/Full200.json')
         if (active) setHerbs(data)
       } catch (err) {
-        console.error('Failed to load herb data', err)
-        if (active) setHerbs([])
+        console.error('Failed to load Full200.json', err)
+        try {
+          const data = await fetchHerbs('/data/Full79.json')
+          if (active) setHerbs(data)
+        } catch (err2) {
+          console.error('Failed to load fallback herb data', err2)
+          if (active) setHerbs([])
+        }
       }
     }
     load()


### PR DESCRIPTION
## Summary
- use fallback herb JSON if the main file fails to load
- redirect deep links via 404.html, trimming trailing slashes

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687b19c15d0083238d6fdfd5238a8f23