### PR TITLE
Fix hash routing revert

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,16 +2,12 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <title>Redirecting…</title>
-    <script>
-      const cleanPath = window.location.pathname
-        .replace(/\/$/, '') +
-        window.location.search +
-        window.location.hash;
-      window.location.replace('/#' + cleanPath);
-    </script>
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Page Not Found - The Hippie Scientist</title>
   </head>
   <body>
-    <p>Redirecting…</p>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,20 +1,19 @@
-
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import { HashRouter } from 'react-router-dom';
-import { HelmetProvider } from 'react-helmet-async';
-import App from './App';
-import { ThemeProvider } from './contexts/theme';
-import './index.css';
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import { HelmetProvider } from 'react-helmet-async'
+import App from './App'
+import { ThemeProvider } from './contexts/theme'
+import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <HelmetProvider>
       <ThemeProvider>
-        <HashRouter>
+        <BrowserRouter>
           <App />
-        </HashRouter>
+        </BrowserRouter>
       </ThemeProvider>
     </HelmetProvider>
   </React.StrictMode>
-);
+)

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -41,7 +41,7 @@ export default function HerbDetail() {
     window.scrollTo({ top: 0, behavior: 'smooth' })
   }, [])
   const share = () => {
-    const url = `${window.location.origin}/#/herb/${herb?.id}`
+    const url = `${window.location.origin}/herb/${herb?.id}`
     navigator.clipboard.writeText(url)
     setCopied(true)
     setTimeout(() => setCopied(false), 1500)


### PR DESCRIPTION
## Summary
- revert hash routing for BrowserRouter
- restore index-based 404 page
- adjust share link

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687b1bad7ca88323a0d53e8160151777