### PR TITLE
Fix missing Community and Safety routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,8 @@ const NotFound = React.lazy(() => import('./pages/NotFound'))
 const Learn = React.lazy(() => import('./pages/Learn'))
 const Lesson = React.lazy(() => import('./pages/Lesson'))
 const About = React.lazy(() => import('./pages/About'))
+const Community = React.lazy(() => import('./pages/Community'))
+const Safety = React.lazy(() => import('./pages/Safety'))
 const Database = React.lazy(() => import('./pages/Database'))
 const Store = React.lazy(() => import('./pages/Store'))
 const Research = React.lazy(() => import('./pages/Research'))
@@ -36,6 +38,8 @@ function App() {
             <Routes>
               <Route path='/' element={<Home />} />
               <Route path='/about' element={<About />} />
+              <Route path='/community' element={<Community />} />
+              <Route path='/safety' element={<Safety />} />
               <Route path='/learn' element={<Learn />} />
               <Route path='/learn/:slug' element={<Lesson />} />
               <Route path='/database' element={<Database />} />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -11,6 +11,8 @@ const Navbar: React.FC = () => {
   const navItems = [
     { path: '/', label: 'Home' },
     { path: '/about', label: 'About' },
+    { path: '/community', label: 'Community' },
+    { path: '/safety', label: 'Safety' },
     { path: '/learn', label: 'Learn' },
     { path: '/database', label: 'Database' },
     { path: '/favorites', label: 'My Herbs' },


### PR DESCRIPTION
## Summary
- wire up Community and Safety pages
- expose them from the navigation

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b219213f48323abcb1b4729c2fa92