### PR TITLE
Fix GitHub Pages routing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,3 +34,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
+          publish_branch: gh-pages

--- a/404.html
+++ b/404.html
@@ -4,11 +4,9 @@
     <meta charset="UTF-8" />
     <title>Redirecting…</title>
     <script>
-      const cleanPath = window.location.pathname
-        .replace(/\/$/, '') +
-        window.location.search +
-        window.location.hash;
-      window.location.replace('/#' + cleanPath);
+      const cleanPath =
+        location.pathname.replace(/\/$/, '') + location.search + location.hash
+      location.replace('/#' + cleanPath)
     </script>
   </head>
   <body>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Routes, Route } from 'react-router-dom'
+import { HashRouter as Router, Routes, Route } from 'react-router-dom'
 import { Suspense } from 'react'
 import { LoadingScreen } from './components/LoadingScreen'
 import Navbar from './components/Navbar'
@@ -26,7 +26,7 @@ const Compare = React.lazy(() => import('./pages/Compare'))
 
 function App() {
   return (
-    <>
+    <Router>
       <ScrollToTop />
       <Navbar />
       <MouseTrail />
@@ -56,7 +56,7 @@ function App() {
       </main>
       <Footer />
       <ScrollToTopButton />
-    </>
+    </Router>
   )
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import react from '@vitejs/plugin-react'
 import { resolve } from 'path'
 
 export default defineConfig({
-  base: '/',
+  base: './',
   plugins: [react()],
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary
- enable relative base path in `vite.config.ts`
- use `HashRouter` directly in `App.tsx`
- simplify 404 redirect page
- configure GH Pages deploy branch
- add missing git remote
- refine 404 redirect script

## Testing
- `npm run build`
- `npm test`
- `git push` *(fails: non-fast-forward)*

------
https://chatgpt.com/codex/tasks/task_e_687b1e64991083238c24c0d5fa21713d