### PR TITLE
Fix herb detail routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,6 @@ function App() {
               <Route path='/blog' element={<BlogIndex />} />
               <Route path='/blog/:slug' element={<BlogPost />} />
               <Route path='/herbs/:id' element={<HerbDetail />} />
-              <Route path='/herb/:id' element={<HerbDetail />} />
               <Route path='/bookmarks' element={<Bookmarks />} />
               <Route path='/favorites' element={<Favorites />} />
               <Route path='/compounds' element={<Compounds />} />

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -113,7 +113,7 @@ function HerbCardAccordionComponent({ herb, highlight = '', matches = [], compac
   const [open, setOpen] = useState(false)
   const handleClick = () => {
     localStorage.setItem('focusHerb', herb.id)
-    navigate(`/herb/${herb.id}`)
+    navigate(`/herbs/${herb.id}`)
   }
   const { isFavorite, toggle: toggleFavorite } = useHerbFavorites()
 
@@ -362,7 +362,7 @@ function HerbCardAccordionComponent({ herb, highlight = '', matches = [], compac
               )}
               <motion.div variants={itemVariants} className='pt-2'>
                 <Link
-                  to={`/herb/${herb.id}`}
+                  to={`/herbs/${herb.id}`}
                   onClick={e => {
                     e.stopPropagation()
                     localStorage.setItem('focusHerb', herb.id)

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -41,7 +41,7 @@ export default function HerbDetail() {
     window.scrollTo({ top: 0, behavior: 'smooth' })
   }, [])
   const share = () => {
-    const url = `${window.location.origin}/#/herb/${herb?.id}`
+    const url = `${window.location.origin}/#/herbs/${herb?.id}`
     navigator.clipboard.writeText(url)
     setCopied(true)
     setTimeout(() => setCopied(false), 1500)


### PR DESCRIPTION
## Summary
- ensure herb detail links use `/herbs/:id`
- drop legacy `/herb/:id` route
- update share link to match new route

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687b9569af948323a545474454c5d25b