### PR TITLE
Upgrade site with tag filters and affiliate links

### DIFF
--- a/Full150.json
+++ b/Full150.json
@@ -6,7 +6,11 @@
     "description": "A Taiwanese tree whose root bark is rich in DMT and related tryptamines. Commonly used in DIY Ayahuasca analogs or 'Anahuasca' brews.",
     "drugInteractions": "MAOIs, antidepressants — risky",
     "duration": "4–6 hrs",
-    "effects": ["Visual distortion", "mystical states", "introspection"],
+    "effects": [
+      "Visual distortion",
+      "mystical states",
+      "introspection"
+    ],
     "id": "acacia-confusa",
     "intensity": "Strong",
     "legalStatus": "DMT restricted in many countries",
@@ -18,7 +22,11 @@
     "safetyRating": "high",
     "scientificName": "Acacia confusa",
     "sideEffects": "Strong visuals, nausea, anxiety",
-    "tags": ["🧪 DMT", "⚠️ Caution", "🌿 Root bark"],
+    "tags": [
+      "🧪 DMT",
+      "⚠️ Caution",
+      "🌿 Root bark"
+    ],
     "therapeuticUses": "Spiritual exploration, traditional cleansing (when combined with MAOI)",
     "toxicity": "Low physiological, high psychological risk",
     "toxicityLD50": "Not established",
@@ -28,7 +36,8 @@
         "type": "tryptamine",
         "effect": "potent visionary"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Acorus gramineus",
@@ -37,7 +46,10 @@
     "description": "Asian sweet flag containing β-asarone, sometimes taken for cognition.",
     "drugInteractions": "May enhance CNS depressants.",
     "duration": "Unknown",
-    "effects": ["Cognitive clarity", "trippy effects (debated)"],
+    "effects": [
+      "Cognitive clarity",
+      "trippy effects (debated)"
+    ],
     "id": "acorus-gramineus",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -49,10 +61,16 @@
     "safetyRating": 1,
     "scientificName": "Unknown",
     "sideEffects": "Nausea at high doses, possible carcinogenic risk with long-term β-asarone exposure.",
-    "tags": ["\\u2615 Brewable", "\\ud83d\\udc8a Oral", "\\ud83e\\udde0 Cognitive", "\\u2705 Safe"],
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83d\\udc8a Oral",
+      "\\ud83e\\udde0 Cognitive",
+      "\\u2705 Safe"
+    ],
     "therapeuticUses": "Cognitive enhancement, anxiety, neuroprotective potential.",
     "toxicity": "Concerns over β-asarone carcinogenicity in some studies.",
-    "toxicityLD50": "β-asarone LD50 (rat, oral): ~310 mg/kg."
+    "toxicityLD50": "β-asarone LD50 (rat, oral): ~310 mg/kg.",
+    "affiliateLink": null
   },
   {
     "name": "African Dream Root",
@@ -61,7 +79,11 @@
     "description": "A sacred dream-enhancing root used by the Xhosa people of South Africa to induce powerful and meaningful dreams.",
     "drugInteractions": "Unknown",
     "duration": "During REM sleep",
-    "effects": ["Vivid dreams", "lucidity", "spiritual connection"],
+    "effects": [
+      "Vivid dreams",
+      "lucidity",
+      "spiritual connection"
+    ],
     "id": "african-dream-root",
     "intensity": "Mild to moderate",
     "legalStatus": "Legal",
@@ -73,10 +95,15 @@
     "safetyRating": "low",
     "scientificName": "Silene capensis",
     "sideEffects": "Mild nausea or grogginess if overdosed",
-    "tags": ["🌙 Dream", "🧘 Ancestral", "✅ Safe"],
+    "tags": [
+      "🌙 Dream",
+      "🧘 Ancestral",
+      "✅ Safe"
+    ],
     "therapeuticUses": "Dream recall, ancestral communication (traditional)",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Alchornea castaneifolia",
@@ -85,7 +112,11 @@
     "description": "Used in Amazonian shamanic rituals for its spiritual and anti-inflammatory effects. Often included in Ayahuasca blends.",
     "drugInteractions": "Unknown",
     "duration": "2–6 hrs",
-    "effects": ["Anti-inflammatory", "spiritual clarity", "energetic cleansing"],
+    "effects": [
+      "Anti-inflammatory",
+      "spiritual clarity",
+      "energetic cleansing"
+    ],
     "id": "alchornea-castaneifolia",
     "intensity": "Mild",
     "legalStatus": "Legal",
@@ -97,10 +128,15 @@
     "safetyRating": "low",
     "scientificName": "Alchornea castaneifolia",
     "sideEffects": "Minimal; bitter taste",
-    "tags": ["🌿 Amazon", "✅ Safe", "🧘 Cleanse"],
+    "tags": [
+      "🌿 Amazon",
+      "✅ Safe",
+      "🧘 Cleanse"
+    ],
     "therapeuticUses": "Rheumatism, arthritis, spiritual cleansing",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Anadenanthera colubrina (Cebíl)",
@@ -109,7 +145,10 @@
     "description": "South American tree whose snuffable seeds contain bufotenin.",
     "drugInteractions": "Concomitant use with SSRIs or MAOIs may risk serotonin syndrome [1, 0].",
     "duration": "Unknown",
-    "effects": ["Entheogenic snuff", "alternate reality feel"],
+    "effects": [
+      "Entheogenic snuff",
+      "alternate reality feel"
+    ],
     "id": "anadenanthera-colubrina-cebl",
     "intensity": "High",
     "legalStatus": "Restricted in many regions",
@@ -121,10 +160,13 @@
     "safetyRating": 1,
     "scientificName": "Unknown",
     "sideEffects": "Prominent cardiovascular changes, nausea, vomiting, and dizziness [1, 0, 1, 1].",
-    "tags": ["\\u26a0\\ufe0f Restricted"],
+    "tags": [
+      "\\u26a0\\ufe0f Restricted"
+    ],
     "therapeuticUses": "Traditionally used as a snuff for visionary and divinatory rituals in South American cultures [1, 1].",
     "toxicity": "No documented human LD50; rodent LD50 approximately 200–300 mg/kg (intraperitoneal) [1, 0].",
-    "toxicityLD50": "No documented human LD50; rodent LD50 approximately 200–300 mg/kg (intraperitoneal) [1, 0]."
+    "toxicityLD50": "No documented human LD50; rodent LD50 approximately 200–300 mg/kg (intraperitoneal) [1, 0].",
+    "affiliateLink": null
   },
   {
     "name": "Artemisia vulgaris (Mugwort)",
@@ -133,7 +175,10 @@
     "description": "Common European mugwort used in dream pillows and as bitter tonic.",
     "drugInteractions": "Not well documented",
     "duration": "Unknown",
-    "effects": ["Lucid dreaming", "light hallucinations"],
+    "effects": [
+      "Lucid dreaming",
+      "light hallucinations"
+    ],
     "id": "artemisia-vulgaris-mugwort",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -154,7 +199,8 @@
     ],
     "therapeuticUses": "Not well documented",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Bacopa monnieri",
@@ -163,7 +209,10 @@
     "description": "Aquatic herb taken long-term to improve memory and concentration.",
     "drugInteractions": "No major interactions documented; caution with sedatives [0, 5].",
     "duration": "Unknown",
-    "effects": ["Memory enhancer", "mild calming"],
+    "effects": [
+      "Memory enhancer",
+      "mild calming"
+    ],
     "id": "bacopa-monnieri",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -184,7 +233,8 @@
     ],
     "therapeuticUses": "Cognitive enhancement (memory, learning), anxiety reduction, ADHD management [0, 1, 0, 6].",
     "toxicity": "Generally non-toxic; no serious adverse effects at recommended doses; rodent LD50 not well established [0, 6].",
-    "toxicityLD50": "Generally non-toxic; no serious adverse effects at recommended doses; rodent LD50 not well established [0, 6]."
+    "toxicityLD50": "Generally non-toxic; no serious adverse effects at recommended doses; rodent LD50 not well established [0, 6].",
+    "affiliateLink": null
   },
   {
     "name": "Belladonna",
@@ -193,7 +243,10 @@
     "description": "Deadly nightshade once used for trance and as a cosmetic poison.",
     "drugInteractions": "CNS depressants, anticholinergic drugs.",
     "duration": "Unknown",
-    "effects": ["Hallucinations", "dreamlike confusion"],
+    "effects": [
+      "Hallucinations",
+      "dreamlike confusion"
+    ],
     "id": "belladonna",
     "intensity": "High",
     "legalStatus": "Controlled / Toxic",
@@ -205,10 +258,13 @@
     "safetyRating": 1,
     "scientificName": "Unknown",
     "sideEffects": "Dry mouth, hallucinations, delirium, elevated pulse.",
-    "tags": ["\\u2620\\ufe0f Toxic"],
+    "tags": [
+      "\\u2620\\ufe0f Toxic"
+    ],
     "therapeuticUses": "Historically used for pain, muscle spasms, and cosmetic dilation.",
     "toxicity": "Highly toxic; accidental ingestion can be fatal.",
-    "toxicityLD50": "Atropine LD50 (rat, oral): ~453 mg/kg."
+    "toxicityLD50": "Atropine LD50 (rat, oral): ~453 mg/kg.",
+    "affiliateLink": null
   },
   {
     "name": "Betel Nut",
@@ -217,7 +273,11 @@
     "description": "A widely used masticatory stimulant in Asia and the Pacific, often combined with lime and betel leaf.",
     "drugInteractions": "Stimulants, parasympathomimetics",
     "duration": "Unknown",
-    "effects": ["Stimulation", "warmth", "mild euphoria"],
+    "effects": [
+      "Stimulation",
+      "warmth",
+      "mild euphoria"
+    ],
     "id": "betel-nut",
     "intensity": "Unknown",
     "legalStatus": "Unknown",
@@ -232,7 +292,8 @@
     "tags": [],
     "therapeuticUses": "Traditional digestive stimulant",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Blue Lotus",
@@ -241,7 +302,11 @@
     "description": "Sacred Egyptian flower associated with dream states and aphrodisiac properties. Contains aporphine alkaloids.",
     "drugInteractions": "Avoid sedatives",
     "duration": "2–4 hrs",
-    "effects": ["Mild euphoria", "lucid dreaming", "relaxation"],
+    "effects": [
+      "Mild euphoria",
+      "lucid dreaming",
+      "relaxation"
+    ],
     "id": "blue-lotus",
     "intensity": "Mild",
     "legalStatus": "Legal in most countries",
@@ -253,10 +318,15 @@
     "safetyRating": "low",
     "scientificName": "Nymphaea caerulea",
     "sideEffects": "Mild drowsiness, vivid dreams",
-    "tags": ["🌸 Calm", "😊 Euphoria", "✅ Safe"],
+    "tags": [
+      "🌸 Calm",
+      "😊 Euphoria",
+      "✅ Safe"
+    ],
     "therapeuticUses": "Anxiety, mild sedation, aphrodisiac",
     "toxicity": "Low",
-    "toxicityLD50": "Not known"
+    "toxicityLD50": "Not known",
+    "affiliateLink": null
   },
   {
     "name": "Blue Lotus (Nymphaea caerulea)",
@@ -265,7 +335,11 @@
     "description": "Sacred water lily delivering gentle euphoria and relaxation.",
     "drugInteractions": "Potential additive effects with CNS depressants.",
     "duration": "Unknown",
-    "effects": ["Euphoria", "aphrodisiac", "dreamy calm"],
+    "effects": [
+      "Euphoria",
+      "aphrodisiac",
+      "dreamy calm"
+    ],
     "id": "blue-lotus-nymphaea-caerulea",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -285,7 +359,8 @@
     ],
     "therapeuticUses": "Mild euphoria, anxiety relief, and aphrodisiac in traditional use.",
     "toxicity": "Low toxicity; no serious effects reported from traditional use.",
-    "toxicityLD50": "Not established; no reported lethal doses."
+    "toxicityLD50": "Not established; no reported lethal doses.",
+    "affiliateLink": null
   },
   {
     "name": "Bobinsana",
@@ -294,7 +369,11 @@
     "description": "A flowering Amazonian shrub used in master plant dieta and as an adjunct to Ayahuasca ceremonies for emotional healing and dream clarity.",
     "drugInteractions": "Unknown; caution with serotonergics",
     "duration": "2–6 hrs",
-    "effects": ["Heart-opening", "emotional clarity", "mild euphoria"],
+    "effects": [
+      "Heart-opening",
+      "emotional clarity",
+      "mild euphoria"
+    ],
     "id": "bobinsana",
     "intensity": "Mild",
     "legalStatus": "Legal",
@@ -306,10 +385,15 @@
     "safetyRating": "low",
     "scientificName": "Calliandra angustifolia",
     "sideEffects": "Drowsiness, mild emotional vulnerability",
-    "tags": ["🌿 Herbal", "🧘 Calm", "✅ Safe"],
+    "tags": [
+      "🌿 Herbal",
+      "🧘 Calm",
+      "✅ Safe"
+    ],
     "therapeuticUses": "Emotional trauma healing, dream support",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Brugmansia",
@@ -318,7 +402,11 @@
     "description": "Powerful and dangerous deliriant used in South American shamanism. Highly toxic and not recommended for casual use.",
     "drugInteractions": "Anticholinergics, CNS depressants",
     "duration": "Unknown",
-    "effects": ["Hallucinations", "delirium", "disorientation"],
+    "effects": [
+      "Hallucinations",
+      "delirium",
+      "disorientation"
+    ],
     "id": "brugmansia",
     "intensity": "Unknown",
     "legalStatus": "Unknown",
@@ -333,7 +421,8 @@
     "tags": [],
     "therapeuticUses": "Historical use in asthma and pain (no modern safe use)",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Caapi",
@@ -342,7 +431,11 @@
     "description": "The vine of the soul used in Ayahuasca. Contains harmala alkaloids and facilitates DMT absorption in the brew.",
     "drugInteractions": "All serotonergic substances",
     "duration": "Unknown",
-    "effects": ["MAOI effects", "spiritual opening", "purging"],
+    "effects": [
+      "MAOI effects",
+      "spiritual opening",
+      "purging"
+    ],
     "id": "caapi",
     "intensity": "Unknown",
     "legalStatus": "Unknown",
@@ -357,7 +450,8 @@
     "tags": [],
     "therapeuticUses": "Ayahuasca therapy for PTSD, depression",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Calea zacatechichi",
@@ -366,7 +460,11 @@
     "description": "Known as the 'dream herb' of the Chontal people of Mexico, Calea is traditionally used to enhance dreams and mental clarity during sleep.",
     "drugInteractions": "Avoid sedatives, alcohol",
     "duration": "4–8 hrs",
-    "effects": ["Lucid dreaming", "dream recall", "hypnagogic imagery"],
+    "effects": [
+      "Lucid dreaming",
+      "dream recall",
+      "hypnagogic imagery"
+    ],
     "id": "calea-zacatechichi",
     "intensity": "Mild to moderate",
     "legalStatus": "Legal",
@@ -378,10 +476,15 @@
     "safetyRating": "low",
     "scientificName": "Calea ternifolia (zacatechichi)",
     "sideEffects": "Bitterness, mild nausea",
-    "tags": ["🌙 Dream", "🧘 Calm", "✅ Safe"],
+    "tags": [
+      "🌙 Dream",
+      "🧘 Calm",
+      "✅ Safe"
+    ],
     "therapeuticUses": "Sleep induction, dream work",
     "toxicity": "Low",
-    "toxicityLD50": "Not known"
+    "toxicityLD50": "Not known",
+    "affiliateLink": null
   },
   {
     "name": "California Poppy",
@@ -390,7 +493,10 @@
     "description": "California's state flower containing non-addictive sedative alkaloids.",
     "drugInteractions": "May amplify effects of benzodiazepines and alcohol.",
     "duration": "Unknown",
-    "effects": ["Gentle sedative", "dreamlike calm"],
+    "effects": [
+      "Gentle sedative",
+      "dreamlike calm"
+    ],
     "id": "california-poppy",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -410,7 +516,8 @@
     ],
     "therapeuticUses": "Used for anxiety, insomnia, and pain management.",
     "toxicity": "Low toxicity; non-habit-forming.",
-    "toxicityLD50": "No known LD50 in humans; safe at standard doses."
+    "toxicityLD50": "No known LD50 in humans; safe at standard doses.",
+    "affiliateLink": null
   },
   {
     "name": "Celastrus paniculatus",
@@ -419,7 +526,11 @@
     "description": "Often called the 'Intellect Tree', this Ayurvedic plant is used to support memory, learning, and vivid dreams. Contains sesquiterpenes that may stimulate cholinergic activity.",
     "drugInteractions": "None well documented",
     "duration": "4–6 hrs",
-    "effects": ["Cognitive clarity", "memory enhancement", "dream vividness"],
+    "effects": [
+      "Cognitive clarity",
+      "memory enhancement",
+      "dream vividness"
+    ],
     "id": "celastrus-paniculatus",
     "intensity": "Mild",
     "legalStatus": "Legal",
@@ -431,10 +542,15 @@
     "safetyRating": "low",
     "scientificName": "Celastrus paniculatus",
     "sideEffects": "Headache or stimulation at high doses",
-    "tags": ["🧠 Nootropic", "🌿 Herbal", "✅ Safe"],
+    "tags": [
+      "🧠 Nootropic",
+      "🌿 Herbal",
+      "✅ Safe"
+    ],
     "therapeuticUses": "Memory support, neuroprotection, dream recall",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Celastrus paniculatus (Intellect Tree)",
@@ -443,7 +559,10 @@
     "description": "Indian vine whose oil is consumed to sharpen memory and dream vividly.",
     "drugInteractions": "Not well documented",
     "duration": "Unknown",
-    "effects": ["Lucid dreaming", "cognitive enhancer"],
+    "effects": [
+      "Lucid dreaming",
+      "cognitive enhancer"
+    ],
     "id": "celastrus-paniculatus-intellect-tree",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -455,10 +574,14 @@
     "safetyRating": 1,
     "scientificName": "Unknown",
     "sideEffects": "Not well documented",
-    "tags": ["\\ud83e\\udde0 Cognitive", "\\u2705 Safe"],
+    "tags": [
+      "\\ud83e\\udde0 Cognitive",
+      "\\u2705 Safe"
+    ],
     "therapeuticUses": "Not well documented",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Chacruna",
@@ -467,7 +590,11 @@
     "description": "A key component of traditional Ayahuasca brews, Chacruna contains DMT and is often combined with MAOIs like Banisteriopsis caapi to make it orally active.",
     "drugInteractions": "Dangerous with antidepressants or stimulants",
     "duration": "4–6 hrs",
-    "effects": ["Visionary states", "spiritual insight", "hallucinations"],
+    "effects": [
+      "Visionary states",
+      "spiritual insight",
+      "hallucinations"
+    ],
     "id": "chacruna",
     "intensity": "Strong",
     "legalStatus": "DMT is controlled in most countries",
@@ -479,10 +606,15 @@
     "safetyRating": "high",
     "scientificName": "Psychotria viridis",
     "sideEffects": "Intense visuals, vomiting, nausea",
-    "tags": ["🧠 Vision", "⚠️ Caution", "🧪 DMT"],
+    "tags": [
+      "🧠 Vision",
+      "⚠️ Caution",
+      "🧪 DMT"
+    ],
     "therapeuticUses": "Spiritual healing, emotional release (as part of Ayahuasca)",
     "toxicity": "Low physical toxicity, high psychological risk",
-    "toxicityLD50": "Not established in humans"
+    "toxicityLD50": "Not established in humans",
+    "affiliateLink": null
   },
   {
     "name": "Chiric Sanango",
@@ -491,7 +623,10 @@
     "description": "Amazonian shrub added to ayahuasca for introspection and cleansing.",
     "drugInteractions": "Other serotonergic or cholinergic agents.",
     "duration": "Unknown",
-    "effects": ["Shadow work", "spiritual clearing"],
+    "effects": [
+      "Shadow work",
+      "spiritual clearing"
+    ],
     "id": "chiric-sanango",
     "intensity": "High",
     "legalStatus": "Legal / Unregulated",
@@ -503,10 +638,15 @@
     "safetyRating": 1,
     "scientificName": "Unknown",
     "sideEffects": "Dizziness, nausea, muscle tremors, delirium at high doses [0, 11].",
-    "tags": ["\\u2615 Brewable", "\\ud83c\\udf00 Dissociation", "\\u2705 Safe"],
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\u2705 Safe"
+    ],
     "therapeuticUses": "Potentiates ayahuasca, used in Amazonian rituals for introspection and mild hallucinations [0, 4].",
     "toxicity": "Toxic in high doses; caution advised.",
-    "toxicityLD50": "LD50 not established; considered mildly toxic in large doses due to cholinergic effects."
+    "toxicityLD50": "LD50 not established; considered mildly toxic in large doses due to cholinergic effects.",
+    "affiliateLink": null
   },
   {
     "name": "Clavo huasca",
@@ -515,7 +655,11 @@
     "description": "Amazonian vine used in both physical and spiritual medicine. Traditionally consumed as a libido enhancer and pre-Ayahuasca preparation.",
     "drugInteractions": "Avoid CNS depressants, alcohol",
     "duration": "3–6 hrs",
-    "effects": ["Aphrodisiac", "calming", "digestive"],
+    "effects": [
+      "Aphrodisiac",
+      "calming",
+      "digestive"
+    ],
     "id": "clavo-huasca",
     "intensity": "Mild",
     "legalStatus": "Legal",
@@ -527,10 +671,15 @@
     "safetyRating": "low",
     "scientificName": "Tynanthus panurensis",
     "sideEffects": "Mild hypotension or fatigue",
-    "tags": ["🔥 Aphrodisiac", "✅ Safe", "🌿 Amazonian"],
+    "tags": [
+      "🔥 Aphrodisiac",
+      "✅ Safe",
+      "🌿 Amazonian"
+    ],
     "therapeuticUses": "Aphrodisiac, digestive aid in Amazonian medicine",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Copal",
@@ -539,7 +688,11 @@
     "description": "Resin from Bursera trees burned ceremonially to purify and induce trance.",
     "drugInteractions": "Not well documented",
     "duration": "Unknown",
-    "effects": ["Purifying", "sacred aroma", "trance enhancement"],
+    "effects": [
+      "Purifying",
+      "sacred aroma",
+      "trance enhancement"
+    ],
     "id": "copal",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -551,10 +704,15 @@
     "safetyRating": 1,
     "scientificName": "Unknown",
     "sideEffects": "Not well documented",
-    "tags": ["\\ud83d\\udd6f\\ufe0f Ritual", "\\ud83d\\udd2e Ritual", "\\u2705 Safe"],
+    "tags": [
+      "\\ud83d\\udd6f\\ufe0f Ritual",
+      "\\ud83d\\udd2e Ritual",
+      "\\u2705 Safe"
+    ],
     "therapeuticUses": "Not well documented",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Cyperus articulatus",
@@ -563,7 +721,11 @@
     "description": "Known as Piripiri or Guinea Rush, this sedge is used in Afro-Caribbean and Amazonian rituals for mild visionary states and spiritual grounding.",
     "drugInteractions": "Unknown",
     "duration": "2–5 hrs",
-    "effects": ["Calm", "focus", "light trance"],
+    "effects": [
+      "Calm",
+      "focus",
+      "light trance"
+    ],
     "id": "cyperus-articulatus",
     "intensity": "Mild",
     "legalStatus": "Legal",
@@ -575,10 +737,15 @@
     "safetyRating": "low",
     "scientificName": "Cyperus articulatus",
     "sideEffects": "Rare; mild sedation",
-    "tags": ["🧘 Ritual", "✅ Safe", "🌿 Piripiri"],
+    "tags": [
+      "🧘 Ritual",
+      "✅ Safe",
+      "🌿 Piripiri"
+    ],
     "therapeuticUses": "Spiritual clarity, dream work, digestion",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Damiana",
@@ -587,7 +754,11 @@
     "description": "Used traditionally in Mexico and Central America for libido, relaxation, and mild stimulation. Sometimes blended in herbal smoking mixes.",
     "drugInteractions": "May interact with blood sugar meds",
     "duration": "2–4 hrs",
-    "effects": ["Mood boost", "aphrodisiac", "relaxation"],
+    "effects": [
+      "Mood boost",
+      "aphrodisiac",
+      "relaxation"
+    ],
     "id": "damiana",
     "intensity": "Mild",
     "legalStatus": "Legal",
@@ -599,10 +770,15 @@
     "safetyRating": "low",
     "scientificName": "Turnera diffusa",
     "sideEffects": "Mild headaches or GI discomfort",
-    "tags": ["😊 Mood", "🔥 Aphrodisiac", "✅ Safe"],
+    "tags": [
+      "😊 Mood",
+      "🔥 Aphrodisiac",
+      "✅ Safe"
+    ],
     "therapeuticUses": "Libido, nervous system support, mild stimulant",
     "toxicity": "Low",
-    "toxicityLD50": "Not well established"
+    "toxicityLD50": "Not well established",
+    "affiliateLink": null
   },
   {
     "name": "Desfontainia spinosa",
@@ -611,7 +787,11 @@
     "description": "A rare South American shrub used by the Mapuche and other indigenous groups in Chile and Colombia as a ritual intoxicant. Known for unpredictable and potent effects.",
     "drugInteractions": "Unknown; avoid CNS drugs",
     "duration": "3–6 hrs",
-    "effects": ["Hallucinations", "disorientation", "dreamlike state"],
+    "effects": [
+      "Hallucinations",
+      "disorientation",
+      "dreamlike state"
+    ],
     "id": "desfontainia-spinosa",
     "intensity": "Strong",
     "legalStatus": "Legal but obscure",
@@ -623,10 +803,15 @@
     "safetyRating": "high",
     "scientificName": "Desfontainia spinosa",
     "sideEffects": "Strong nausea, confusion, pupil dilation",
-    "tags": ["⚠️ Rare", "🧠 Vision", "🌿 Andes"],
+    "tags": [
+      "⚠️ Rare",
+      "🧠 Vision",
+      "🌿 Andes"
+    ],
     "therapeuticUses": "Traditional visionary plant; not clinically established",
     "toxicity": "Potentially high at ritual doses",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Eleutherococcus senticosus (Siberian Ginseng)",
@@ -635,7 +820,10 @@
     "description": "Adaptogenic root boosting stamina and immune function.",
     "drugInteractions": "May interact with stimulants, immunosuppressants, and anticoagulants.",
     "duration": "Unknown",
-    "effects": ["Balanced energy", "mood resilience"],
+    "effects": [
+      "Balanced energy",
+      "mood resilience"
+    ],
     "id": "eleutherococcus-senticosus-siberian-ginseng",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -647,10 +835,15 @@
     "safetyRating": 1,
     "scientificName": "Unknown",
     "sideEffects": "Mild insomnia, irritability, nervousness in high doses.",
-    "tags": ["\\u2615 Brewable", "\\ud83d\\udcab Euphoria", "\\u2705 Safe"],
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83d\\udcab Euphoria",
+      "\\u2705 Safe"
+    ],
     "therapeuticUses": "Fatigue, immune support, cognitive performance under stress.",
     "toxicity": "Generally considered safe when used short-term. Long-term effects less studied.",
-    "toxicityLD50": "No established LD50; high doses in animals show minimal acute toxicity."
+    "toxicityLD50": "No established LD50; high doses in animals show minimal acute toxicity.",
+    "affiliateLink": null
   },
   {
     "name": "Entada rheedii",
@@ -659,7 +852,10 @@
     "description": "Seed from a tropical vine used in African traditions to induce vivid dreams.",
     "drugInteractions": "May potentiate CNS depressants; caution with anticholinergics [0, 6].",
     "duration": "Unknown",
-    "effects": ["Dream enhancement", "trance"],
+    "effects": [
+      "Dream enhancement",
+      "trance"
+    ],
     "id": "entada-rheedii",
     "intensity": "Moderate",
     "legalStatus": "Legal / Unregulated",
@@ -671,10 +867,15 @@
     "safetyRating": 1,
     "scientificName": "Unknown",
     "sideEffects": "Mild GI upset, drowsiness; rare nausea [0, 6].",
-    "tags": ["\\ud83d\\udc8a Oral", "\\ud83e\\udde0 Dream", "\\u2705 Safe"],
+    "tags": [
+      "\\ud83d\\udc8a Oral",
+      "\\ud83e\\udde0 Dream",
+      "\\u2705 Safe"
+    ],
     "therapeuticUses": "Dream enhancement, lucid dreaming, traditional remedy for diarrhea and stomach aches [0, 6, 0, 11].",
     "toxicity": "Low; no severe toxicity reported in traditional use [0, 6].",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Eschscholzia californica (California poppy)",
@@ -683,7 +884,10 @@
     "description": "Gentle sedative flower used for anxiety and sleep support.",
     "drugInteractions": "Additive CNS depression with sedatives, barbiturates; caution with blood thinners and antihypertensives [2, 8].",
     "duration": "Unknown",
-    "effects": ["Sleep aid", "mild dreamlike calm"],
+    "effects": [
+      "Sleep aid",
+      "mild dreamlike calm"
+    ],
     "id": "eschscholzia-californica-california-poppy",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -703,7 +907,8 @@
     ],
     "therapeuticUses": "Anxiety reduction, insomnia aid, mild analgesic, vasomotor headache relief [2, 3, 2, 7].",
     "toxicity": "Low; no significant toxicity at therapeutic doses [2, 9].",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Frankincense (Boswellia)",
@@ -712,7 +917,10 @@
     "description": "Resin incense with boswellic acids studied for anti-inflammatory effects.",
     "drugInteractions": "Not well documented",
     "duration": "Unknown",
-    "effects": ["Trance", "meditative awareness"],
+    "effects": [
+      "Trance",
+      "meditative awareness"
+    ],
     "id": "frankincense-boswellia",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -724,10 +932,13 @@
     "safetyRating": 1,
     "scientificName": "Unknown",
     "sideEffects": "Not well documented",
-    "tags": ["\\u2705 Safe"],
+    "tags": [
+      "\\u2705 Safe"
+    ],
     "therapeuticUses": "Not well documented",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Guayusa",
@@ -736,7 +947,11 @@
     "description": "A caffeinated Amazonian holly used in dream rituals and for morning alertness. Known for smooth energy and calming clarity.",
     "drugInteractions": "Stimulants, caffeine",
     "duration": "3–5 hrs",
-    "effects": ["Stimulation", "mental clarity", "lucid dreaming"],
+    "effects": [
+      "Stimulation",
+      "mental clarity",
+      "lucid dreaming"
+    ],
     "id": "guayusa",
     "intensity": "Mild to moderate",
     "legalStatus": "Legal",
@@ -748,10 +963,15 @@
     "safetyRating": "low",
     "scientificName": "Ilex guayusa",
     "sideEffects": "Restlessness, jitteriness in sensitive individuals",
-    "tags": ["☕ Stimulant", "🌿 Herbal", "✅ Safe"],
+    "tags": [
+      "☕ Stimulant",
+      "🌿 Herbal",
+      "✅ Safe"
+    ],
     "therapeuticUses": "Energy, focus, lucid dreaming support",
     "toxicity": "Low",
-    "toxicityLD50": "~190 mg/kg (caffeine)"
+    "toxicityLD50": "~190 mg/kg (caffeine)",
+    "affiliateLink": null
   },
   {
     "name": "Heimia salicifolia (Sinicuichi)",
@@ -760,7 +980,10 @@
     "description": "Mexican shrub whose fermented leaves produce mild auditory shifts.",
     "drugInteractions": "None known; caution with psychiatric medications [9, 4].",
     "duration": "Unknown",
-    "effects": ["Auditory hallucinations", "slowed time"],
+    "effects": [
+      "Auditory hallucinations",
+      "slowed time"
+    ],
     "id": "heimia-salicifolia-sinicuichi",
     "intensity": "Moderate",
     "legalStatus": "Legal / Unregulated",
@@ -780,7 +1003,8 @@
     ],
     "therapeuticUses": "Divination, auditory changes, euphoria in folk practices [9, 4].",
     "toxicity": "Low toxicity; high doses may cause mild sedation or nausea [9, 4].",
-    "toxicityLD50": "Not well established; no fatal doses reported in traditional use."
+    "toxicityLD50": "Not well established; no fatal doses reported in traditional use.",
+    "affiliateLink": null
   },
   {
     "name": "Henbane",
@@ -789,7 +1013,11 @@
     "description": "Nightshade containing tropane alkaloids causing powerful delirium.",
     "drugInteractions": "Not well documented",
     "duration": "Unknown",
-    "effects": ["Delirium", "hallucinations", "anticholinergic"],
+    "effects": [
+      "Delirium",
+      "hallucinations",
+      "anticholinergic"
+    ],
     "id": "henbane",
     "intensity": "High",
     "legalStatus": "Controlled / Toxic",
@@ -801,10 +1029,14 @@
     "safetyRating": 1,
     "scientificName": "Unknown",
     "sideEffects": "Not well documented",
-    "tags": ["\\ud83d\\udd6f\\ufe0f Ritual", "\\u2620\\ufe0f Toxic"],
+    "tags": [
+      "\\ud83d\\udd6f\\ufe0f Ritual",
+      "\\u2620\\ufe0f Toxic"
+    ],
     "therapeuticUses": "Not well documented",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Hop Flowers",
@@ -813,7 +1045,10 @@
     "description": "Bitter cones of Humulus lupulus used for relaxation and sleep.",
     "drugInteractions": "May enhance sedatives, alcohol, and hypnotics.",
     "duration": "Unknown",
-    "effects": ["Relaxation", "dream enhancement"],
+    "effects": [
+      "Relaxation",
+      "dream enhancement"
+    ],
     "id": "hop-flowers",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -825,10 +1060,15 @@
     "safetyRating": 1,
     "scientificName": "Unknown",
     "sideEffects": "Drowsiness, mild headache, possible hormonal effects in large doses.",
-    "tags": ["\\u2615 Brewable", "\\ud83c\\udf00 Dissociation", "\\u2705 Safe"],
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\u2705 Safe"
+    ],
     "therapeuticUses": "Used as a mild sleep aid, anxiety reducer, and dream enhancer.",
     "toxicity": "Very low toxicity; generally regarded as safe.",
-    "toxicityLD50": "No human LD50; high safety margin reported in herbal use."
+    "toxicityLD50": "No human LD50; high safety margin reported in herbal use.",
+    "affiliateLink": null
   },
   {
     "name": "Indian Lotus",
@@ -837,7 +1077,11 @@
     "description": "Sacred flower in Buddhism and Hinduism, with mild psychoactive and calming properties. Often used in teas or tinctures.",
     "drugInteractions": "Sedatives, CNS depressants",
     "duration": "2–4 hrs",
-    "effects": ["Calm", "mild euphoria", "dreaminess"],
+    "effects": [
+      "Calm",
+      "mild euphoria",
+      "dreaminess"
+    ],
     "id": "Unknown",
     "intensity": "Mild",
     "legalStatus": "Legal",
@@ -849,10 +1093,15 @@
     "safetyRating": "low",
     "scientificName": "Nelumbo nucifera",
     "sideEffects": "Drowsiness, dizziness",
-    "tags": ["🌸 Sacred", "🧘 Calm", "🌊 Spiritual"],
+    "tags": [
+      "🌸 Sacred",
+      "🧘 Calm",
+      "🌊 Spiritual"
+    ],
     "therapeuticUses": "Stress, anxiety, spiritual use",
     "toxicity": "Low",
-    "toxicityLD50": "Not known"
+    "toxicityLD50": "Not known",
+    "affiliateLink": null
   },
   {
     "name": "Indian Pipe",
@@ -861,7 +1110,11 @@
     "description": "A ghostly white forest plant used in Native American medicine for pain and spiritual insight. Non-photosynthetic and mysterious.",
     "drugInteractions": "Possibly CNS depressants",
     "duration": "2–4 hrs",
-    "effects": ["Analgesia", "calm", "emotional detachment"],
+    "effects": [
+      "Analgesia",
+      "calm",
+      "emotional detachment"
+    ],
     "id": "Unknown",
     "intensity": "Mild",
     "legalStatus": "Legal (but rare and protected in places)",
@@ -873,10 +1126,15 @@
     "safetyRating": "medium",
     "scientificName": "Monotropa uniflora",
     "sideEffects": "Unknown at pharmacological doses; rare usage",
-    "tags": ["👻 Ghost Plant", "🌲 Pain Relief", "🧠 Emotional"],
+    "tags": [
+      "👻 Ghost Plant",
+      "🌲 Pain Relief",
+      "🧠 Emotional"
+    ],
     "therapeuticUses": "Pain relief, emotional trauma support (traditional)",
     "toxicity": "Unknown",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Ipomoea tricolor (Heavenly Blue)",
@@ -885,7 +1143,10 @@
     "description": "Ornamental morning glory whose seeds induce LSD-like visions.",
     "drugInteractions": "SSRIs/MAOIs [0, 5].",
     "duration": "Unknown",
-    "effects": ["LSD-like visuals", "spiritual confusion"],
+    "effects": [
+      "LSD-like visuals",
+      "spiritual confusion"
+    ],
     "id": "ipomoea-tricolor-heavenly-blue",
     "intensity": "High",
     "legalStatus": "Restricted in some countries",
@@ -897,10 +1158,13 @@
     "safetyRating": 1,
     "scientificName": "Unknown",
     "sideEffects": "Nausea, vasoconstriction, headache [0, 5].",
-    "tags": ["\\u26a0\\ufe0f Restricted"],
+    "tags": [
+      "\\u26a0\\ufe0f Restricted"
+    ],
     "therapeuticUses": "Visionary experiences, ethnobotanical use [0, 5].",
     "toxicity": "Low; rodent LD50 ~200–300 mg/kg [0, 5].",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Justicia pectoralis",
@@ -909,7 +1173,11 @@
     "description": "Aromatic herb called tilo, brewed or smoked for calming effects.",
     "drugInteractions": "Coumarin-sensitive meds (e.g., blood thinners)",
     "duration": "2–5 hrs",
-    "effects": ["Relaxation", "light euphoria", "spiritual dreams"],
+    "effects": [
+      "Relaxation",
+      "light euphoria",
+      "spiritual dreams"
+    ],
     "id": "justicia-pectoralis",
     "intensity": "Mild",
     "legalStatus": "Legal",
@@ -921,10 +1189,15 @@
     "safetyRating": "medium",
     "scientificName": "Justicia pectoralis",
     "sideEffects": "Liver risk in excess due to coumarin",
-    "tags": ["🧘 Calm", "🌿 Ayahuasca-additive", "✅ Legal"],
+    "tags": [
+      "🧘 Calm",
+      "🌿 Ayahuasca-additive",
+      "✅ Legal"
+    ],
     "therapeuticUses": "Anxiety, insomnia, spiritual enhancement",
     "toxicity": "Low–moderate with excess",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Kanna",
@@ -933,7 +1206,11 @@
     "description": "A South African succulent traditionally chewed or snuffed to reduce anxiety and induce euphoria.",
     "drugInteractions": "Antidepressants, serotonergic agents",
     "duration": "1–3 hrs",
-    "effects": ["Mood lift", "calm euphoria", "focus"],
+    "effects": [
+      "Mood lift",
+      "calm euphoria",
+      "focus"
+    ],
     "id": "Unknown",
     "intensity": "Mild to moderate",
     "legalStatus": "Legal",
@@ -945,10 +1222,15 @@
     "safetyRating": "medium",
     "scientificName": "Sceletium tortuosum",
     "sideEffects": "Headache, nausea, serotonin syndrome (in excess or with SSRIs)",
-    "tags": ["🌼 Euphoric", "🧘 Calm", "🧬 Natural SSRI"],
+    "tags": [
+      "🌼 Euphoric",
+      "🧘 Calm",
+      "🧬 Natural SSRI"
+    ],
     "therapeuticUses": "Anxiety, stress, social comfort",
     "toxicity": "Low",
-    "toxicityLD50": "Not established (safe in traditional use)"
+    "toxicityLD50": "Not established (safe in traditional use)",
+    "affiliateLink": null
   },
   {
     "name": "Kava",
@@ -957,7 +1239,11 @@
     "description": "South Pacific root brew known for its relaxing and anxiolytic effects.",
     "drugInteractions": "CNS depressants, alcohol, liver-metabolized drugs",
     "duration": "3–6 hrs",
-    "effects": ["Relaxation", "social ease", "mild euphoria"],
+    "effects": [
+      "Relaxation",
+      "social ease",
+      "mild euphoria"
+    ],
     "id": "kava",
     "intensity": "Mild to moderate",
     "legalStatus": "Legal; restricted in some EU countries",
@@ -969,7 +1255,11 @@
     "safetyRating": "medium",
     "scientificName": "Piper methysticum",
     "sideEffects": "Liver strain (rare), drowsiness",
-    "tags": ["🧘 Calm", "🌿 Root", "🍵 Social"],
+    "tags": [
+      "🧘 Calm",
+      "🌿 Root",
+      "🍵 Social"
+    ],
     "therapeuticUses": "Anxiety, stress, sleep aid",
     "toxicity": "Low to moderate; caution with prolonged use",
     "toxicityLD50": "~4.3 g/kg (rats, oral)",
@@ -979,7 +1269,8 @@
         "type": "alkaloid",
         "effect": "anxiolytic"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Kra Thum Na / Kok",
@@ -988,7 +1279,10 @@
     "description": "Southeast Asian tree related to kratom with stimulating leaves.",
     "drugInteractions": "Not well documented",
     "duration": "Unknown",
-    "effects": ["Stimulation", "kratom-like body feel"],
+    "effects": [
+      "Stimulation",
+      "kratom-like body feel"
+    ],
     "id": "kra-thum-na--kok",
     "intensity": "Moderate",
     "legalStatus": "Legal / Unregulated",
@@ -1000,10 +1294,16 @@
     "safetyRating": 1,
     "scientificName": "Unknown",
     "sideEffects": "Not well documented",
-    "tags": ["\\u2615 Brewable", "\\ud83d\\udc8a Oral", "\\ud83d\\udcab Euphoria", "\\u2705 Safe"],
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83d\\udc8a Oral",
+      "\\ud83d\\udcab Euphoria",
+      "\\u2705 Safe"
+    ],
     "therapeuticUses": "Not well documented",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Lactuca canadensis",
@@ -1012,7 +1312,11 @@
     "description": "Wild lettuce species containing lactucarium for gentle analgesia.",
     "drugInteractions": "CNS depressants, alcohol",
     "duration": "3–5 hrs",
-    "effects": ["Relaxation", "pain relief", "drowsiness"],
+    "effects": [
+      "Relaxation",
+      "pain relief",
+      "drowsiness"
+    ],
     "id": "lactuca-canadensis",
     "intensity": "Mild to moderate",
     "legalStatus": "Legal",
@@ -1024,10 +1328,15 @@
     "safetyRating": "low",
     "scientificName": "Lactuca canadensis",
     "sideEffects": "Drowsiness, GI upset at high doses",
-    "tags": ["🌿 Opium Lettuce", "😴 Sedative", "✅ Safe"],
+    "tags": [
+      "🌿 Opium Lettuce",
+      "😴 Sedative",
+      "✅ Safe"
+    ],
     "therapeuticUses": "Insomnia, pain, cough relief",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Mandrake Root",
@@ -1036,7 +1345,10 @@
     "description": "Mythic Mediterranean root with hallucinogenic tropane alkaloids.",
     "drugInteractions": "Potentiates other anticholinergics, CNS depressants.",
     "duration": "Unknown",
-    "effects": ["Narcotic", "visionary trance"],
+    "effects": [
+      "Narcotic",
+      "visionary trance"
+    ],
     "id": "mandrake-root",
     "intensity": "High",
     "legalStatus": "Controlled / Toxic",
@@ -1048,10 +1360,13 @@
     "safetyRating": 1,
     "scientificName": "Unknown",
     "sideEffects": "Dry mouth, confusion, hallucinations, elevated heart rate.",
-    "tags": ["\\u2620\\ufe0f Toxic"],
+    "tags": [
+      "\\u2620\\ufe0f Toxic"
+    ],
     "therapeuticUses": "Historically used as anesthetic, antispasmodic, and in witchcraft.",
     "toxicity": "Highly toxic in moderate doses.",
-    "toxicityLD50": "Scopolamine LD50 (rat, oral): ~310 mg/kg."
+    "toxicityLD50": "Scopolamine LD50 (rat, oral): ~310 mg/kg.",
+    "affiliateLink": null
   },
   {
     "name": "Melissa officinalis (Lemon balm)",
@@ -1060,7 +1375,10 @@
     "description": "Lemony herb easing anxiety and digestive upset while calming the mind.",
     "drugInteractions": "May potentiate sedatives, anticoagulants; caution with CNS depressants [0, 16].",
     "duration": "Unknown",
-    "effects": ["Anxiolytic", "cognitive calming"],
+    "effects": [
+      "Anxiolytic",
+      "cognitive calming"
+    ],
     "id": "melissa-officinalis-lemon-balm",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -1082,7 +1400,8 @@
     ],
     "therapeuticUses": "Anxiety, insomnia, nervous tension, digestive aid [0, 8].",
     "toxicity": "Low; safe at therapeutic doses [0, 0].",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Mimosa hostilis",
@@ -1091,7 +1410,11 @@
     "description": "Highly sought after for its DMT-rich root bark. Used in Anahuasca brews as a substitute for chacruna or yopo.",
     "drugInteractions": "MAOIs, antidepressants",
     "duration": "4–6 hrs",
-    "effects": ["Visionary states", "purging", "emotional release"],
+    "effects": [
+      "Visionary states",
+      "purging",
+      "emotional release"
+    ],
     "id": "mimosa-hostilis",
     "intensity": "Strong",
     "legalStatus": "DMT controlled in many countries",
@@ -1103,10 +1426,15 @@
     "safetyRating": "high",
     "scientificName": "Mimosa tenuiflora",
     "sideEffects": "Intense purging, nausea, anxiety",
-    "tags": ["🧪 DMT", "⚠️ Visionary", "🌿 Anahuasca"],
+    "tags": [
+      "🧪 DMT",
+      "⚠️ Visionary",
+      "🌿 Anahuasca"
+    ],
     "therapeuticUses": "Spiritual healing, insight, skin regeneration (topical)",
     "toxicity": "Low physiological, high psychological",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Nelumbo nucifera",
@@ -1115,7 +1443,11 @@
     "description": "Sacred lotus revered for tranquil, mildly euphoric properties.",
     "drugInteractions": "Avoid CNS depressants",
     "duration": "2–4 hrs",
-    "effects": ["Relaxation", "dream enhancement", "calm euphoria"],
+    "effects": [
+      "Relaxation",
+      "dream enhancement",
+      "calm euphoria"
+    ],
     "id": "nelumbo-nucifera",
     "intensity": "Mild",
     "legalStatus": "Legal",
@@ -1127,10 +1459,15 @@
     "safetyRating": "low",
     "scientificName": "Nelumbo nucifera",
     "sideEffects": "Sedation, mild dizziness",
-    "tags": ["🌸 Calm", "✅ Safe", "🧘 Meditation"],
+    "tags": [
+      "🌸 Calm",
+      "✅ Safe",
+      "🧘 Meditation"
+    ],
     "therapeuticUses": "Calm, aphrodisiac, meditation support",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Nymphaea ampla",
@@ -1139,7 +1476,11 @@
     "description": "Central American water lily providing mild euphoria and sedation.",
     "drugInteractions": "Not well documented",
     "duration": "Unknown",
-    "effects": ["Sedative", "euphoric", "dreamlike states"],
+    "effects": [
+      "Sedative",
+      "euphoric",
+      "dreamlike states"
+    ],
     "id": "nymphaea-ampla",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -1159,7 +1500,8 @@
     ],
     "therapeuticUses": "Not well documented",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Ocimum sanctum (Holy Basil / Tulsi)",
@@ -1168,7 +1510,11 @@
     "description": "Sacred basil revered in Ayurveda for uplifting and adaptogenic qualities.",
     "drugInteractions": "May potentiate anti-diabetic, anticoagulant, or sedative drugs.",
     "duration": "Unknown",
-    "effects": ["Mood lift", "sacred calm", "spiritual focus"],
+    "effects": [
+      "Mood lift",
+      "sacred calm",
+      "spiritual focus"
+    ],
     "id": "ocimum-sanctum-holy-basil--tulsi",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -1189,7 +1535,8 @@
     ],
     "therapeuticUses": "Adaptogen, anxiety, spiritual focus, blood sugar balance.",
     "toxicity": "Pending",
-    "toxicityLD50": "Pending"
+    "toxicityLD50": "Pending",
+    "affiliateLink": null
   },
   {
     "name": "Passionflower",
@@ -1198,7 +1545,11 @@
     "description": "Climbing vine traditionally brewed for anxiety relief and restful sleep.",
     "drugInteractions": "CNS depressants, MAOIs",
     "duration": "3–6 hrs",
-    "effects": ["Relaxation", "mild sedation", "anxiolytic"],
+    "effects": [
+      "Relaxation",
+      "mild sedation",
+      "anxiolytic"
+    ],
     "id": "passionflower",
     "intensity": "Mild",
     "legalStatus": "Legal",
@@ -1210,7 +1561,11 @@
     "safetyRating": "low",
     "scientificName": "Passiflora incarnata",
     "sideEffects": "Drowsiness, dizziness",
-    "tags": ["🧘 Calm", "🌿 Sedative", "✅ Safe"],
+    "tags": [
+      "🧘 Calm",
+      "🌿 Sedative",
+      "✅ Safe"
+    ],
     "therapeuticUses": "Anxiety, insomnia, nervous restlessness",
     "toxicity": "Low",
     "toxicityLD50": "Not established",
@@ -1220,7 +1575,8 @@
         "type": "alkaloid",
         "effect": "anxiolytic"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Pedicularis densiflora (Indian warrior)",
@@ -1229,7 +1585,10 @@
     "description": "North American wildflower smoked for muscle relaxation.",
     "drugInteractions": "Additive effects with CNS depressants [2, 0].",
     "duration": "Unknown",
-    "effects": ["Muscle relaxation", "mild body high"],
+    "effects": [
+      "Muscle relaxation",
+      "mild body high"
+    ],
     "id": "pedicularis-densiflora-indian-warrior",
     "intensity": "Moderate",
     "legalStatus": "Legal / Unregulated",
@@ -1249,7 +1608,8 @@
     ],
     "therapeuticUses": "Muscle tension, pain relief, sleep aid applications [2, 0].",
     "toxicity": "Low; limited data on long-term use [2, 0].",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Pedicularis groenlandica",
@@ -1258,7 +1618,10 @@
     "description": "High-elevation lousewort prized for soothing tense muscles.",
     "drugInteractions": "Additive with CNS depressants [0, 7].",
     "duration": "Unknown",
-    "effects": ["Stronger relaxation", "tension relief"],
+    "effects": [
+      "Stronger relaxation",
+      "tension relief"
+    ],
     "id": "pedicularis-groenlandica",
     "intensity": "Moderate",
     "legalStatus": "Legal / Unregulated",
@@ -1278,7 +1641,8 @@
     ],
     "therapeuticUses": "Muscle relaxant, antioxidant, antimicrobial, traditional remedy for pain and inflammation [0, 7].",
     "toxicity": "Low; no significant toxicity reported [0, 7].",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Petasites hybridus",
@@ -1287,7 +1651,11 @@
     "description": "Also known as Butterbur, this European root was historically used as a remedy for migraines and spasms. Contains pyrrolizidine alkaloids, so safe extracts must be purified.",
     "drugInteractions": "Avoid hepatotoxic meds",
     "duration": "4–6 hrs",
-    "effects": ["Relaxation", "muscle relief", "headache reduction"],
+    "effects": [
+      "Relaxation",
+      "muscle relief",
+      "headache reduction"
+    ],
     "id": "petasites-hybridus",
     "intensity": "Mild to moderate",
     "legalStatus": "Legal with restrictions (PA-free only)",
@@ -1299,10 +1667,15 @@
     "safetyRating": "medium",
     "scientificName": "Petasites hybridus",
     "sideEffects": "Liver toxicity risk from unpurified products",
-    "tags": ["🧠 Headache", "⚠️ PA toxins", "🌿 Herbal"],
+    "tags": [
+      "🧠 Headache",
+      "⚠️ PA toxins",
+      "🌿 Herbal"
+    ],
     "therapeuticUses": "Migraine prevention, allergies, anxiety",
     "toxicity": "Moderate to high (raw plant)",
-    "toxicityLD50": "~950 mg/kg (mouse, oral, unpurified)"
+    "toxicityLD50": "~950 mg/kg (mouse, oral, unpurified)",
+    "affiliateLink": null
   },
   {
     "name": "Piper auritum (Root beer plant)",
@@ -1311,7 +1684,11 @@
     "description": "Sassafras-scented leaf from Mexico used culinary and for mild mood lift.",
     "drugInteractions": "CYP450 substrates; caution with anticoagulants [0, 19].",
     "duration": "Unknown",
-    "effects": ["Calming", "warming", "euphoric"],
+    "effects": [
+      "Calming",
+      "warming",
+      "euphoric"
+    ],
     "id": "piper-auritum-root-beer-plant",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -1331,7 +1708,8 @@
     ],
     "therapeuticUses": "Digestive aid, anti-inflammatory, antimutagen, diuretic, antipyretic [0, 11].",
     "toxicity": "Safrole hepatotoxic; use sparingly [1, 11].",
-    "toxicityLD50": "LD50 (rats, oral) safrole ~1,950 mg/kg; safrole is hepatotoxic at high doses."
+    "toxicityLD50": "LD50 (rats, oral) safrole ~1,950 mg/kg; safrole is hepatotoxic at high doses.",
+    "affiliateLink": null
   },
   {
     "name": "Rhodiola rosea",
@@ -1340,7 +1718,11 @@
     "description": "Hardy root enhancing endurance and stress tolerance via adaptogens.",
     "drugInteractions": "May affect antidepressants, stimulants, or MAOIs.",
     "duration": "Unknown",
-    "effects": ["Focus", "reduced fatigue", "mind clarity"],
+    "effects": [
+      "Focus",
+      "reduced fatigue",
+      "mind clarity"
+    ],
     "id": "rhodiola-rosea",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -1360,7 +1742,8 @@
     ],
     "therapeuticUses": "Fatigue, stress resilience, cognitive enhancement, mild depression.",
     "toxicity": "Mild toxicity; high doses may cause irritability or insomnia.",
-    "toxicityLD50": "LD50 (rats, oral) >28,000 mg/kg; very low toxicity."
+    "toxicityLD50": "LD50 (rats, oral) >28,000 mg/kg; very low toxicity.",
+    "affiliateLink": null
   },
   {
     "name": "Rivea corymbosa",
@@ -1369,7 +1752,11 @@
     "description": "Morning glory species with LSA seeds used in ancient Mexican rituals.",
     "drugInteractions": "Serotonergic medications [0, 12].",
     "duration": "Unknown",
-    "effects": ["Dreamy visuals", "nausea", "traditional Mazatec use"],
+    "effects": [
+      "Dreamy visuals",
+      "nausea",
+      "traditional Mazatec use"
+    ],
     "id": "rivea-corymbosa",
     "intensity": "High",
     "legalStatus": "Restricted in some countries",
@@ -1381,10 +1768,13 @@
     "safetyRating": 1,
     "scientificName": "Unknown",
     "sideEffects": "Nausea, vasoconstriction, dizziness [0, 4].",
-    "tags": ["\\u26a0\\ufe0f Restricted"],
+    "tags": [
+      "\\u26a0\\ufe0f Restricted"
+    ],
     "therapeuticUses": "Entheogenic snuff (ololiuqui) in Mesoamerican rituals [0, 4].",
     "toxicity": "Low; moderate overdose risk [0, 12].",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Salvia divinorum",
@@ -1393,7 +1783,10 @@
     "description": "Mazatec entheogen with powerful, short-lived visionary effects.",
     "drugInteractions": "CNS depressants may potentiate sedative effects; caution when coadministered [3, 3].",
     "duration": "Unknown",
-    "effects": ["Total dissociation", "entity contact"],
+    "effects": [
+      "Total dissociation",
+      "entity contact"
+    ],
     "id": "salvia-divinorum",
     "intensity": "High",
     "legalStatus": "Restricted in many regions",
@@ -1412,7 +1805,8 @@
     ],
     "therapeuticUses": "Visionary experiences in traditional Mazatec rituals; investigated for analgesic and anti-inflammatory properties [3, 0].",
     "toxicity": "Low toxicity; animal studies show minimal organ damage even at high doses [3, 3].",
-    "toxicityLD50": "LD50 not established; salvinorin A active at microgram levels with no evidence of physical toxicity."
+    "toxicityLD50": "LD50 not established; salvinorin A active at microgram levels with no evidence of physical toxicity.",
+    "affiliateLink": null
   },
   {
     "name": "Sceletium tortuosum (Kanna)",
@@ -1421,7 +1815,11 @@
     "description": "South African succulent chewed to elevate mood and decrease tension.",
     "drugInteractions": "SSRIs, MAOIs, stimulants [9, 4].",
     "duration": "Unknown",
-    "effects": ["Mood lift", "empathy", "sociability"],
+    "effects": [
+      "Mood lift",
+      "empathy",
+      "sociability"
+    ],
     "id": "sceletium-tortuosum-kanna",
     "intensity": "Moderate",
     "legalStatus": "Legal, sometimes restricted",
@@ -1433,10 +1831,15 @@
     "safetyRating": 1,
     "scientificName": "Unknown",
     "sideEffects": "Headache, nausea, mild sedation [9, 4].",
-    "tags": ["\\ud83d\\udc8a Oral", "\\ud83d\\udcab Euphoria", "\\u26a0\\ufe0f Restricted"],
+    "tags": [
+      "\\ud83d\\udc8a Oral",
+      "\\ud83d\\udcab Euphoria",
+      "\\u26a0\\ufe0f Restricted"
+    ],
     "therapeuticUses": "Mood enhancement, anti-anxiety, social facilitation [9, 4].",
     "toxicity": "Low toxicity at traditional doses [9, 4].",
-    "toxicityLD50": "Not established in humans; high safety margin observed in animal studies."
+    "toxicityLD50": "Not established in humans; high safety margin observed in animal studies.",
+    "affiliateLink": null
   },
   {
     "name": "Scullcap (Scutellaria)",
@@ -1445,7 +1848,11 @@
     "description": "Calming mint-family herb rich in baicalin used as nerve tonic.",
     "drugInteractions": "Additive effects with sedatives or anxiolytics.",
     "duration": "Unknown",
-    "effects": ["Relaxing", "anxiety-reducing", "dream support"],
+    "effects": [
+      "Relaxing",
+      "anxiety-reducing",
+      "dream support"
+    ],
     "id": "scullcap-scutellaria",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -1457,10 +1864,15 @@
     "safetyRating": 1,
     "scientificName": "Unknown",
     "sideEffects": "Rarely causes liver enzyme elevation or drowsiness.",
-    "tags": ["\\u2615 Brewable", "\\ud83c\\udf00 Dissociation", "\\u2705 Safe"],
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\u2705 Safe"
+    ],
     "therapeuticUses": "Calming, anticonvulsant, neuroprotective.",
     "toxicity": "Generally safe, though adulterants in supplements have caused concern.",
-    "toxicityLD50": "No standard LD50 data; high therapeutic margin."
+    "toxicityLD50": "No standard LD50 data; high therapeutic margin.",
+    "affiliateLink": null
   },
   {
     "name": "Scutellaria lateriflora",
@@ -1469,7 +1881,11 @@
     "description": "Commonly known as Skullcap, this North American herb has a long history in Western herbalism for treating nervous tension and insomnia.",
     "drugInteractions": "CNS depressants, alcohol, benzodiazepines",
     "duration": "3–5 hrs",
-    "effects": ["Mild sedation", "anxiety relief", "mental clarity"],
+    "effects": [
+      "Mild sedation",
+      "anxiety relief",
+      "mental clarity"
+    ],
     "id": "scutellaria-lateriflora",
     "intensity": "Mild",
     "legalStatus": "Legal",
@@ -1481,10 +1897,15 @@
     "safetyRating": "low",
     "scientificName": "Scutellaria lateriflora",
     "sideEffects": "Drowsiness, dizziness at high doses",
-    "tags": ["😴 Sedative", "🌿 Herbal", "✅ Safe"],
+    "tags": [
+      "😴 Sedative",
+      "🌿 Herbal",
+      "✅ Safe"
+    ],
     "therapeuticUses": "Anxiety, stress, insomnia, PMS",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Silene capensis",
@@ -1493,7 +1914,11 @@
     "description": "Known as 'Xhosa Dream Root', Silene capensis is a sacred plant used by the Xhosa people of South Africa for initiating vivid and prophetic dreams.",
     "drugInteractions": "None well documented",
     "duration": "6–8 hrs",
-    "effects": ["Lucid dreaming", "enhanced dream recall", "vivid visions"],
+    "effects": [
+      "Lucid dreaming",
+      "enhanced dream recall",
+      "vivid visions"
+    ],
     "id": "silene-capensis",
     "intensity": "Mild to moderate",
     "legalStatus": "Legal",
@@ -1505,10 +1930,15 @@
     "safetyRating": "low",
     "scientificName": "Silene capensis",
     "sideEffects": "Mild nausea if taken in excess",
-    "tags": ["🌙 Dream", "✅ Safe", "🧠 Vision"],
+    "tags": [
+      "🌙 Dream",
+      "✅ Safe",
+      "🧠 Vision"
+    ],
     "therapeuticUses": "Dream enhancement, ancestral communication",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Silphium (extinct)",
@@ -1517,7 +1947,9 @@
     "description": "Famed classical herb believed to have contraceptive and psychoactive resins.",
     "drugInteractions": "Not well documented",
     "duration": "Unknown",
-    "effects": ["Ancient psychoactive/contraceptive herb"],
+    "effects": [
+      "Ancient psychoactive/contraceptive herb"
+    ],
     "id": "silphium-extinct",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -1529,10 +1961,13 @@
     "safetyRating": 1,
     "scientificName": "Unknown",
     "sideEffects": "Not well documented",
-    "tags": ["\\u2705 Safe"],
+    "tags": [
+      "\\u2705 Safe"
+    ],
     "therapeuticUses": "Not well documented",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Sinicuichi",
@@ -1541,7 +1976,11 @@
     "description": "Used traditionally in Central America as a 'sun opener,' believed to enhance memory and auditory perception. Alters sound and memory in dreamlike ways.",
     "drugInteractions": "Avoid CNS depressants or alcohol",
     "duration": "4–6 hrs",
-    "effects": ["Auditory distortion", "dreamy state", "euphoria"],
+    "effects": [
+      "Auditory distortion",
+      "dreamy state",
+      "euphoria"
+    ],
     "id": "sinicuichi",
     "intensity": "Mild to moderate",
     "legalStatus": "Legal",
@@ -1553,10 +1992,15 @@
     "safetyRating": "medium",
     "scientificName": "Heimia salicifolia",
     "sideEffects": "Dry mouth, yellow vision, dizziness",
-    "tags": ["🌞 Sun", "🎧 Auditory", "🧠 Dream"],
+    "tags": [
+      "🌞 Sun",
+      "🎧 Auditory",
+      "🧠 Dream"
+    ],
     "therapeuticUses": "Folk use for memory and dream recall",
     "toxicity": "Low to moderate; not well studied",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Sweetgrass",
@@ -1565,7 +2009,10 @@
     "description": "Vanilla-scented grass braided and burned to invite positive spirits.",
     "drugInteractions": "Not well documented",
     "duration": "Unknown",
-    "effects": ["Positive energy", "spiritual invocation"],
+    "effects": [
+      "Positive energy",
+      "spiritual invocation"
+    ],
     "id": "sweetgrass",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -1577,10 +2024,14 @@
     "safetyRating": 1,
     "scientificName": "Unknown",
     "sideEffects": "Not well documented",
-    "tags": ["\\ud83d\\udd2e Ritual", "\\u2705 Safe"],
+    "tags": [
+      "\\ud83d\\udd2e Ritual",
+      "\\u2705 Safe"
+    ],
     "therapeuticUses": "Not well documented",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Tagetes lucida (Mexican Tarragon)",
@@ -1589,7 +2040,10 @@
     "description": "Sweet marigold used as tea or incense for clear dreams and calm.",
     "drugInteractions": "Benzodiazepines and serotonergic drugs.",
     "duration": "Unknown",
-    "effects": ["Visionary dreams", "clarity"],
+    "effects": [
+      "Visionary dreams",
+      "clarity"
+    ],
     "id": "tagetes-lucida-mexican-tarragon",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -1610,7 +2064,8 @@
     ],
     "therapeuticUses": "Anxiolytic, digestive aid, ritual incense for purification [2, 10].",
     "toxicity": "Low; traditional use generally safe.",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Tilia europaea (Linden flower)",
@@ -1619,7 +2074,11 @@
     "description": "Soothing tree blossoms steeped as tea for relaxation and cold relief.",
     "drugInteractions": "Not well documented",
     "duration": "Unknown",
-    "effects": ["Calming", "relaxing", "mild dream aid"],
+    "effects": [
+      "Calming",
+      "relaxing",
+      "mild dream aid"
+    ],
     "id": "tilia-europaea-linden-flower",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -1639,7 +2098,8 @@
     ],
     "therapeuticUses": "Not well documented",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Toloache",
@@ -1648,7 +2108,11 @@
     "description": "A powerful and dangerous tropane alkaloid plant traditionally used in witchcraft and shamanic rituals. Highly toxic.",
     "drugInteractions": "All CNS-affecting meds",
     "duration": "8–24 hrs",
-    "effects": ["Delirium", "hallucinations", "disorientation"],
+    "effects": [
+      "Delirium",
+      "hallucinations",
+      "disorientation"
+    ],
     "id": "toloache",
     "intensity": "Extremely strong",
     "legalStatus": "Legal but restricted in many countries",
@@ -1660,10 +2124,15 @@
     "safetyRating": "very high",
     "scientificName": "Datura spp.",
     "sideEffects": "Severe hallucinations, amnesia, potential death",
-    "tags": ["☠️ Toxic", "🧠 Vision", "⚠️ Caution"],
+    "tags": [
+      "☠️ Toxic",
+      "🧠 Vision",
+      "⚠️ Caution"
+    ],
     "therapeuticUses": "Rarely used medically; historically for pain/spiritual rites",
     "toxicity": "Very high",
-    "toxicityLD50": "~50 mg/kg (atropine/scopolamine)"
+    "toxicityLD50": "~50 mg/kg (atropine/scopolamine)",
+    "affiliateLink": null
   },
   {
     "name": "Turnera diffusa",
@@ -1672,7 +2141,11 @@
     "description": "Fragrant shrub known as damiana, smoked or brewed as aphrodisiac and relaxant.",
     "drugInteractions": "Serotonergic medications.",
     "duration": "Unknown",
-    "effects": ["aphrodisiac", "mood-enhancing", "anxiolytic"],
+    "effects": [
+      "aphrodisiac",
+      "mood-enhancing",
+      "anxiolytic"
+    ],
     "id": "turnera-diffusa",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -1692,7 +2165,8 @@
     ],
     "therapeuticUses": "Aphrodisiac, mood enhancement, stress relief [8, 6].",
     "toxicity": "Low in traditional doses.",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Turnera ulmifolia",
@@ -1701,7 +2175,11 @@
     "description": "Closely related to Damiana (Turnera diffusa), this species is also used traditionally in folk medicine for reproductive health and mood.",
     "drugInteractions": "Unknown",
     "duration": "2–4 hrs",
-    "effects": ["Relaxation", "mood elevation", "aphrodisiac"],
+    "effects": [
+      "Relaxation",
+      "mood elevation",
+      "aphrodisiac"
+    ],
     "id": "turnera-ulmifolia",
     "intensity": "Mild",
     "legalStatus": "Legal",
@@ -1713,10 +2191,15 @@
     "safetyRating": "low",
     "scientificName": "Turnera ulmifolia",
     "sideEffects": "Mild sedation",
-    "tags": ["🌺 Aphrodisiac", "✅ Safe", "😊 Mood"],
+    "tags": [
+      "🌺 Aphrodisiac",
+      "✅ Safe",
+      "😊 Mood"
+    ],
     "therapeuticUses": "Libido, menstrual cramps, anxiety",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Urtica dioica",
@@ -1725,7 +2208,11 @@
     "description": "Known as stinging nettle, this European herb has been used for centuries to relieve joint pain, allergies, and fatigue. Its psychoactivity is subtle, mostly somatic.",
     "drugInteractions": "Diuretics, anticoagulants",
     "duration": "3–6 hrs",
-    "effects": ["Stimulation", "anti-inflammatory", "tonic"],
+    "effects": [
+      "Stimulation",
+      "anti-inflammatory",
+      "tonic"
+    ],
     "id": "urtica-dioica",
     "intensity": "Mild",
     "legalStatus": "Legal",
@@ -1737,10 +2224,15 @@
     "safetyRating": "low",
     "scientificName": "Urtica dioica",
     "sideEffects": "Mild stomach upset, skin irritation",
-    "tags": ["🌿 Anti-inflammatory", "✅ Safe", "🧘 Mild"],
+    "tags": [
+      "🌿 Anti-inflammatory",
+      "✅ Safe",
+      "🧘 Mild"
+    ],
     "therapeuticUses": "Allergies, joint pain, urinary tract support",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Viola odorata (Sweet violet)",
@@ -1749,7 +2241,11 @@
     "description": "Fragrant violet whose flowers are a mild sedative and expectorant.",
     "drugInteractions": "Minimal; theoretically additive with CNS depressants.",
     "duration": "Unknown",
-    "effects": ["Mild sedative", "calming", "gentle dreaminess"],
+    "effects": [
+      "Mild sedative",
+      "calming",
+      "gentle dreaminess"
+    ],
     "id": "viola-odorata-sweet-violet",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -1769,7 +2265,8 @@
     ],
     "therapeuticUses": "Cough suppressant, mild anxiolytic, anti-inflammatory, gentle sleep aid.",
     "toxicity": "Regarded as very safe in traditional herbalism.",
-    "toxicityLD50": "No human LD50 data; extremely low toxicity reported."
+    "toxicityLD50": "No human LD50 data; extremely low toxicity reported.",
+    "affiliateLink": null
   },
   {
     "name": "Virola spp.",
@@ -1778,7 +2275,9 @@
     "description": "Amazonian trees producing DMT-rich resins for shamanic snuffs.",
     "drugInteractions": "Dangerous with SSRIs, MAOIs, and other serotonergic substances.",
     "duration": "Unknown",
-    "effects": ["DMT-containing tree resin"],
+    "effects": [
+      "DMT-containing tree resin"
+    ],
     "id": "virola-spp",
     "intensity": "High",
     "legalStatus": "Restricted / Controlled",
@@ -1790,10 +2289,13 @@
     "safetyRating": 1,
     "scientificName": "Unknown",
     "sideEffects": "Nausea, intense hallucinations, elevated heart rate.",
-    "tags": ["\\u26a0\\ufe0f Restricted"],
+    "tags": [
+      "\\u26a0\\ufe0f Restricted"
+    ],
     "therapeuticUses": "Used in Amazonian shamanic healing rituals; possible antidepressant potential.",
     "toxicity": "Can be overwhelming; physical toxicity low but psychological risks high.",
-    "toxicityLD50": "No established LD50 for DMT in humans; low systemic toxicity at typical doses."
+    "toxicityLD50": "No established LD50 for DMT in humans; low systemic toxicity at typical doses.",
+    "affiliateLink": null
   },
   {
     "name": "Virola theiodora",
@@ -1802,7 +2304,11 @@
     "description": "A snuff plant from the Amazon containing DMT and 5-MeO-DMT. Used by Yanomami and other tribes for potent visionary rituals.",
     "drugInteractions": "MAOIs, antidepressants",
     "duration": "20–60 min",
-    "effects": ["Strong visuals", "spiritual experiences", "disorientation"],
+    "effects": [
+      "Strong visuals",
+      "spiritual experiences",
+      "disorientation"
+    ],
     "id": "virola-theiodora",
     "intensity": "Very strong",
     "legalStatus": "DMT controlled in most countries",
@@ -1814,10 +2320,15 @@
     "safetyRating": "high",
     "scientificName": "Virola theiodora",
     "sideEffects": "Nausea, tremors, vomiting",
-    "tags": ["🧠 DMT", "⚠️ Vision", "🌬️ Snuff"],
+    "tags": [
+      "🧠 DMT",
+      "⚠️ Vision",
+      "🌬️ Snuff"
+    ],
     "therapeuticUses": "Shamanic ritual; purging and vision work",
     "toxicity": "High psychological, moderate physical",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Voacanga africana",
@@ -1826,7 +2337,11 @@
     "description": "A powerful African plant containing voacangine and iboga alkaloids. Used traditionally in ritual contexts and studied as a potential ibogaine precursor.",
     "drugInteractions": "Avoid all stimulants, antidepressants, MAOIs",
     "duration": "6–12 hrs",
-    "effects": ["Stimulation", "psychedelic effects", "cardiovascular activation"],
+    "effects": [
+      "Stimulation",
+      "psychedelic effects",
+      "cardiovascular activation"
+    ],
     "id": "voacanga-africana",
     "intensity": "Strong",
     "legalStatus": "Unscheduled; may be regulated for alkaloids",
@@ -1838,10 +2353,15 @@
     "safetyRating": "high",
     "scientificName": "Voacanga africana",
     "sideEffects": "Vomiting, overstimulation, visual distortions",
-    "tags": ["⚠️ Caution", "🧠 Vision", "🌍 African"],
+    "tags": [
+      "⚠️ Caution",
+      "🧠 Vision",
+      "🌍 African"
+    ],
     "therapeuticUses": "Experimental use in addiction therapy (via ibogaine synthesis)",
     "toxicity": "High in overdose; cardiotoxic potential",
-    "toxicityLD50": "~90–120 mg/kg (est. voacangine)"
+    "toxicityLD50": "~90–120 mg/kg (est. voacangine)",
+    "affiliateLink": null
   },
   {
     "name": "White Lily",
@@ -1850,7 +2370,11 @@
     "description": "Related to Blue Lotus, this sacred flower from Mesoamerican traditions is used to promote meditation and lucid dreaming.",
     "drugInteractions": "Avoid CNS depressants",
     "duration": "2–4 hrs",
-    "effects": ["Calm", "light sedation", "dream potentiation"],
+    "effects": [
+      "Calm",
+      "light sedation",
+      "dream potentiation"
+    ],
     "id": "white-lily",
     "intensity": "Mild",
     "legalStatus": "Legal",
@@ -1862,10 +2386,15 @@
     "safetyRating": "low",
     "scientificName": "Nymphaea ampla",
     "sideEffects": "Drowsiness, vivid dreams",
-    "tags": ["🌸 Calm", "🌿 Sedative", "✅ Safe"],
+    "tags": [
+      "🌸 Calm",
+      "🌿 Sedative",
+      "✅ Safe"
+    ],
     "therapeuticUses": "Relaxation, aphrodisiac, dream enhancement",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "White Sage",
@@ -1874,7 +2403,11 @@
     "description": "Aromatic sage revered for cleansing rituals and mental clarity.",
     "drugInteractions": "None significant documented.",
     "duration": "Unknown",
-    "effects": ["Clarity", "purification", "spiritual reset"],
+    "effects": [
+      "Clarity",
+      "purification",
+      "spiritual reset"
+    ],
     "id": "white-sage",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -1894,7 +2427,8 @@
     ],
     "therapeuticUses": "Smudging rituals for purification, antimicrobial, respiratory support, mental clarity [0, 19].",
     "toxicity": "Very low; excessive inhalation may cause dizziness or nausea [0, 4].",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Wild Lettuce",
@@ -1903,7 +2437,11 @@
     "description": "Leafy plant exuding sedative latex historically called 'lettuce opium.'",
     "drugInteractions": "Avoid with sedatives, opioids",
     "duration": "3–6 hrs",
-    "effects": ["Sedation", "pain relief", "light euphoria"],
+    "effects": [
+      "Sedation",
+      "pain relief",
+      "light euphoria"
+    ],
     "id": "wild-lettuce",
     "intensity": "Mild to moderate",
     "legalStatus": "Legal",
@@ -1915,10 +2453,15 @@
     "safetyRating": "medium",
     "scientificName": "Lactuca virosa",
     "sideEffects": "Drowsiness, nausea at high doses",
-    "tags": ["😴 Sedative", "🌿 Herbal", "✅ Safe"],
+    "tags": [
+      "😴 Sedative",
+      "🌿 Herbal",
+      "✅ Safe"
+    ],
     "therapeuticUses": "Insomnia, pain relief, cough suppression",
     "toxicity": "Low in traditional doses",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Withania somnifera (Ashwagandha)",
@@ -1927,7 +2470,10 @@
     "description": "Indian nightshade root that reduces stress hormones and promotes sleep.",
     "drugInteractions": "Immunosuppressants, sedatives, thyroid medications [0, 24].",
     "duration": "Unknown",
-    "effects": ["Grounded calm", "dream support"],
+    "effects": [
+      "Grounded calm",
+      "dream support"
+    ],
     "id": "withania-somnifera-ashwagandha",
     "intensity": "Mild",
     "legalStatus": "Legal / Unregulated",
@@ -1948,7 +2494,8 @@
     ],
     "therapeuticUses": "Adaptogen, anti-stress, anxiolytic, neuroprotective, anti-inflammatory, immune support [0, 1, 0, 17].",
     "toxicity": "Low; well-tolerated in clinical studies [0, 1].",
-    "toxicityLD50": "LD50 (rats, oral) ~4650 mg/kg; relatively low acute toxicity."
+    "toxicityLD50": "LD50 (rats, oral) ~4650 mg/kg; relatively low acute toxicity.",
+    "affiliateLink": null
   },
   {
     "name": "Wormwood",
@@ -1957,7 +2504,11 @@
     "description": "Key ingredient in absinthe. Contains thujone, which is a GABA_A antagonist and neurostimulant in high doses. Historically used for dreaming, digestion, and ritual.",
     "drugInteractions": "Avoid alcohol, CNS drugs",
     "duration": "4–6 hrs",
-    "effects": ["Lucid dreams", "stimulating", "mental clarity"],
+    "effects": [
+      "Lucid dreams",
+      "stimulating",
+      "mental clarity"
+    ],
     "id": "wormwood",
     "intensity": "Mild to moderate",
     "legalStatus": "Restricted in high-thujone formulations",
@@ -1969,7 +2520,11 @@
     "safetyRating": "medium",
     "scientificName": "Artemisia absinthium",
     "sideEffects": "Headache, nausea, tremors at high doses",
-    "tags": ["🌙 Dream", "⚠️ Caution", "🌿 Bitter"],
+    "tags": [
+      "🌙 Dream",
+      "⚠️ Caution",
+      "🌿 Bitter"
+    ],
     "therapeuticUses": "Digestive tonic, dream work, antiparasitic",
     "toxicity": "Neurotoxic in large doses",
     "toxicityLD50": "~30 mg/kg (thujone)",
@@ -1979,7 +2534,8 @@
         "type": "terpenoid",
         "effect": "GABA_A antagonist"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Yerba Mate",
@@ -1988,7 +2544,11 @@
     "description": "South American herbal stimulant rich in caffeine, theobromine, and theophylline. Traditionally shared as a communal energizing tea.",
     "drugInteractions": "CNS stimulants, caffeine",
     "duration": "3–5 hrs",
-    "effects": ["Stimulation", "focus", "social energy"],
+    "effects": [
+      "Stimulation",
+      "focus",
+      "social energy"
+    ],
     "id": "yerba-mate",
     "intensity": "Mild to moderate",
     "legalStatus": "Legal",
@@ -2000,10 +2560,15 @@
     "safetyRating": "medium",
     "scientificName": "Ilex paraguariensis",
     "sideEffects": "Jitteriness, insomnia, GI discomfort in sensitive individuals",
-    "tags": ["☕ Stimulant", "🔥 Energy", "🌿 Social"],
+    "tags": [
+      "☕ Stimulant",
+      "🔥 Energy",
+      "🌿 Social"
+    ],
     "therapeuticUses": "Energy, mental clarity, digestion",
     "toxicity": "Low to moderate (long-term use linked to GI issues)",
-    "toxicityLD50": "~192 mg/kg (caffeine)"
+    "toxicityLD50": "~192 mg/kg (caffeine)",
+    "affiliateLink": null
   },
   {
     "name": "Yopo",
@@ -2012,7 +2577,11 @@
     "description": "Used in Amazonian rituals, Yopo seeds are ground and insufflated to induce powerful entheogenic experiences. Contains bufotenine, DMT, and 5-MeO-DMT.",
     "drugInteractions": "Avoid with antidepressants or MAOIs",
     "duration": "30–60 min",
-    "effects": ["Intense visions", "altered time perception", "spiritual insight"],
+    "effects": [
+      "Intense visions",
+      "altered time perception",
+      "spiritual insight"
+    ],
     "id": "yopo",
     "intensity": "Very strong",
     "legalStatus": "Controlled in many countries due to DMT content",
@@ -2024,17 +2593,29 @@
     "safetyRating": "high",
     "scientificName": "Anadenanthera peregrina",
     "sideEffects": "Intense nausea, disorientation, respiratory irritation",
-    "tags": ["⚠️ Caution", "🧠 Vision", "🌬️ Snuff"],
+    "tags": [
+      "⚠️ Caution",
+      "🧠 Vision",
+      "🌬️ Snuff"
+    ],
     "therapeuticUses": "Shamanic healing, insight rituals",
     "toxicity": "High risk with improper use; bufotenine toxic at high dose",
-    "toxicityLD50": "50–80 mg/kg (bufotenine, mice)"
+    "toxicityLD50": "50–80 mg/kg (bufotenine, mice)",
+    "affiliateLink": null
   },
   {
     "name": "Amanita muscaria",
     "scientificName": "Amanita muscaria",
     "category": "Ritual / Visionary",
-    "tags": ["🍄 Mushroom", "⚠️ Caution"],
-    "effects": ["Euphoria", "dissociation", "dreamlike state"],
+    "tags": [
+      "🍄 Mushroom",
+      "⚠️ Caution"
+    ],
+    "effects": [
+      "Euphoria",
+      "dissociation",
+      "dreamlike state"
+    ],
     "mechanismOfAction": "Ibotenic acid and muscimol act as GABA agonists and NMDA antagonists after decarboxylation.",
     "therapeuticUses": "Shamanic ritual, historical analgesic and sedative use.",
     "pharmacokinetics": "Onset 30–90 min; duration 4–8 hrs when ingested.",
@@ -2050,14 +2631,22 @@
     "contraindications": "Avoid with sedatives or psychiatric conditions.",
     "sideEffects": "Nausea, ataxia, delirium",
     "drugInteractions": "Potentiates sedatives and alcohol",
-    "description": "Iconic red-capped mushroom used in Siberian shamanism and folklore. Psychoactive when properly prepared."
+    "description": "Iconic red-capped mushroom used in Siberian shamanism and folklore. Psychoactive when properly prepared.",
+    "affiliateLink": null
   },
   {
     "name": "Valerian Root",
     "scientificName": "Valeriana officinalis",
     "category": "Sedative / Anxiolytic",
-    "tags": ["🌿 Root", "😴 Sleep"],
-    "effects": ["Relaxation", "improved sleep", "mild anxiolysis"],
+    "tags": [
+      "🌿 Root",
+      "😴 Sleep"
+    ],
+    "effects": [
+      "Relaxation",
+      "improved sleep",
+      "mild anxiolysis"
+    ],
     "mechanismOfAction": "Valerenic acid modulates GABA receptors and may inhibit GABA breakdown.",
     "therapeuticUses": "Insomnia, anxiety, muscle tension.",
     "pharmacokinetics": "Oral; onset ~30 min; peak 1–2 hrs; duration ~4 hrs.",
@@ -2073,14 +2662,21 @@
     "contraindications": "Avoid with other sedatives or during pregnancy.",
     "sideEffects": "Drowsiness, vivid dreams",
     "drugInteractions": "Additive with benzodiazepines or alcohol",
-    "description": "Traditional European herb valued for calming and sleep-promoting properties."
+    "description": "Traditional European herb valued for calming and sleep-promoting properties.",
+    "affiliateLink": null
   },
   {
     "name": "Huperzia serrata",
     "scientificName": "Huperzia serrata",
     "category": "Nootropic / Cognitive",
-    "tags": ["🧠 Memory", "⚗️ Alkaloid"],
-    "effects": ["Improved memory", "alertness"],
+    "tags": [
+      "🧠 Memory",
+      "⚗️ Alkaloid"
+    ],
+    "effects": [
+      "Improved memory",
+      "alertness"
+    ],
     "mechanismOfAction": "Provides huperzine A, a reversible acetylcholinesterase inhibitor.",
     "therapeuticUses": "Memory enhancement, research for Alzheimer’s disease.",
     "pharmacokinetics": "Oral; onset within 30 min; duration 6–8 hrs.",
@@ -2096,14 +2692,22 @@
     "contraindications": "Bradycardia, cholinergic medications.",
     "sideEffects": "Nausea, sweating, muscle twitching at high doses",
     "drugInteractions": "Potentiates cholinergic drugs or acetylcholinesterase inhibitors",
-    "description": "Club moss used in Traditional Chinese Medicine; source of huperzine A nootropic."
+    "description": "Club moss used in Traditional Chinese Medicine; source of huperzine A nootropic.",
+    "affiliateLink": null
   },
   {
     "name": "Syrian Rue",
     "scientificName": "Peganum harmala",
     "category": "Ritual / MAOI",
-    "tags": ["🌿 Seeds", "⚠️ MAOI"],
-    "effects": ["MAOI effects", "mild hallucinations", "dream enhancement"],
+    "tags": [
+      "🌿 Seeds",
+      "⚠️ MAOI"
+    ],
+    "effects": [
+      "MAOI effects",
+      "mild hallucinations",
+      "dream enhancement"
+    ],
     "mechanismOfAction": "Harmala alkaloids reversibly inhibit MAO-A and MAO-B.",
     "therapeuticUses": "Used in Middle Eastern rituals; sometimes combined with DMT for oral activity.",
     "pharmacokinetics": "Oral ingestion; onset 20–40 min; duration 4–6 hrs.",
@@ -2119,14 +2723,21 @@
     "contraindications": "Avoid with SSRIs, stimulants, or liver disease.",
     "sideEffects": "Nausea, vomiting, weakness",
     "drugInteractions": "Dangerous with other MAOIs or serotonergic drugs",
-    "description": "Potent MAOI seed used traditionally for protection and divination."
+    "description": "Potent MAOI seed used traditionally for protection and divination.",
+    "affiliateLink": null
   },
   {
     "name": "Wild Dagga",
     "scientificName": "Leonotis leonurus",
     "category": "Relaxant / Euphoric",
-    "tags": ["🌿 Smoke", "🦁 Dagga"],
-    "effects": ["Mild euphoria", "relaxation"],
+    "tags": [
+      "🌿 Smoke",
+      "🦁 Dagga"
+    ],
+    "effects": [
+      "Mild euphoria",
+      "relaxation"
+    ],
     "mechanismOfAction": "Contains leonurine; may act on serotonin and cannabinoid receptors.",
     "therapeuticUses": "Folk remedy for coughs, fever and as a mild psychoactive when smoked.",
     "pharmacokinetics": "Smoked or brewed; onset within minutes; duration ~1–3 hrs.",
@@ -2142,14 +2753,22 @@
     "contraindications": "Avoid during pregnancy or with heart conditions.",
     "sideEffects": "Dry mouth, slight dizziness",
     "drugInteractions": "May potentiate other sedatives",
-    "description": "Orange-flowered shrub also called lion’s tail; smoked traditionally for mild cannabis-like effects."
+    "description": "Orange-flowered shrub also called lion’s tail; smoked traditionally for mild cannabis-like effects.",
+    "affiliateLink": null
   },
   {
     "name": "Yohimbe",
     "scientificName": "Pausinystalia johimbe",
     "category": "Stimulant / Aphrodisiac",
-    "tags": ["🌳 Bark", "🔥 Libido"],
-    "effects": ["Stimulation", "increased libido", "elevated heart rate"],
+    "tags": [
+      "🌳 Bark",
+      "🔥 Libido"
+    ],
+    "effects": [
+      "Stimulation",
+      "increased libido",
+      "elevated heart rate"
+    ],
     "mechanismOfAction": "Yohimbine blocks alpha-2 adrenergic receptors leading to increased norepinephrine release.",
     "therapeuticUses": "Used for erectile dysfunction and as a stimulant.",
     "pharmacokinetics": "Oral; onset ~30 min; duration 2–4 hrs.",
@@ -2165,14 +2784,22 @@
     "contraindications": "Heart disease, anxiety disorders, MAOIs.",
     "sideEffects": "Increased blood pressure, jitteriness, insomnia",
     "drugInteractions": "Interacts with stimulants and antihypertensives",
-    "description": "West African tree bark rich in yohimbine, historically used as an aphrodisiac and stimulant."
+    "description": "West African tree bark rich in yohimbine, historically used as an aphrodisiac and stimulant.",
+    "affiliateLink": null
   },
   {
     "name": "Khat",
     "scientificName": "Catha edulis",
     "category": "Stimulant / Euphoric",
-    "tags": ["🌿 Leaves", "⚠️ Controlled"],
-    "effects": ["Euphoria", "alertness", "appetite suppression"],
+    "tags": [
+      "🌿 Leaves",
+      "⚠️ Controlled"
+    ],
+    "effects": [
+      "Euphoria",
+      "alertness",
+      "appetite suppression"
+    ],
     "mechanismOfAction": "Cathinone alkaloids release dopamine and norepinephrine.",
     "therapeuticUses": "Social stimulant chewed in East Africa and the Arabian Peninsula.",
     "pharmacokinetics": "Chewed fresh leaves; onset 15–30 min; duration 3–5 hrs.",
@@ -2188,14 +2815,21 @@
     "contraindications": "Heart issues, pregnancy, MAOIs.",
     "sideEffects": "Dry mouth, increased heart rate, insomnia",
     "drugInteractions": "Avoid with stimulants or MAOIs",
-    "description": "Evergreen shrub whose fresh leaves are chewed for stimulant and euphoric effects in social settings."
+    "description": "Evergreen shrub whose fresh leaves are chewed for stimulant and euphoric effects in social settings.",
+    "affiliateLink": null
   },
   {
     "name": "Camellia sinensis",
     "scientificName": "Camellia sinensis",
     "category": "Stimulant / Nootropic",
-    "tags": ["🍵 Tea", "☕ Caffeine"],
-    "effects": ["Alertness", "relaxed focus"],
+    "tags": [
+      "🍵 Tea",
+      "☕ Caffeine"
+    ],
+    "effects": [
+      "Alertness",
+      "relaxed focus"
+    ],
     "mechanismOfAction": "Caffeine antagonizes adenosine receptors; L-theanine modulates glutamate and GABA.",
     "therapeuticUses": "Improved cognition, antioxidant, metabolism boost.",
     "pharmacokinetics": "Beverage; onset 15 min; peak 30–60 min; duration 2–4 hrs.",
@@ -2211,14 +2845,21 @@
     "contraindications": "Heart conditions, pregnancy (high amounts).",
     "sideEffects": "Jitters, insomnia, digestive upset",
     "drugInteractions": "Potentiates other stimulants; may reduce sedative efficacy",
-    "description": "Source of green and black tea; contains caffeine and theanine for balanced stimulation."
+    "description": "Source of green and black tea; contains caffeine and theanine for balanced stimulation.",
+    "affiliateLink": null
   },
   {
     "name": "Ephedra sinica",
     "scientificName": "Ephedra sinica",
     "category": "Stimulant / Decongestant",
-    "tags": ["🌿 Ma Huang", "⚠️ Potent"],
-    "effects": ["Energy boost", "bronchodilation"],
+    "tags": [
+      "🌿 Ma Huang",
+      "⚠️ Potent"
+    ],
+    "effects": [
+      "Energy boost",
+      "bronchodilation"
+    ],
     "mechanismOfAction": "Ephedrine and pseudoephedrine stimulate adrenergic receptors and release norepinephrine.",
     "therapeuticUses": "Traditional Chinese medicine for asthma, colds, and as a stimulant.",
     "pharmacokinetics": "Oral; onset ~20 min; duration 4–6 hrs.",
@@ -2234,14 +2875,21 @@
     "contraindications": "Heart disease, hypertension, MAOIs.",
     "sideEffects": "Jitters, elevated heart rate, insomnia",
     "drugInteractions": "Dangerous with other stimulants or MAOIs",
-    "description": "Shrubby plant known as Ma Huang; source of ephedrine used both medicinally and recreationally."
+    "description": "Shrubby plant known as Ma Huang; source of ephedrine used both medicinally and recreationally.",
+    "affiliateLink": null
   },
   {
     "name": "Sassafras",
     "scientificName": "Sassafras albidum",
     "category": "Stimulant / Traditional",
-    "tags": ["🌳 Root bark", "🌿 Tea"],
-    "effects": ["Mild euphoria", "warmth"],
+    "tags": [
+      "🌳 Root bark",
+      "🌿 Tea"
+    ],
+    "effects": [
+      "Mild euphoria",
+      "warmth"
+    ],
     "mechanismOfAction": "Safrole may modulate dopamine release and acts as a mild hallucinogen at high doses.",
     "therapeuticUses": "Historically used as spring tonic, aromatic beverage, and folk medicine.",
     "pharmacokinetics": "Brewed as tea; onset 20–40 min; duration 2–4 hrs.",
@@ -2257,14 +2905,21 @@
     "contraindications": "Liver disease, pregnancy.",
     "sideEffects": "Nausea, possible hepatotoxicity",
     "drugInteractions": "May interact with MAOIs or increase hepatotoxic drugs",
-    "description": "Fragrant tree whose root bark and oil were once common flavorings; contains safrole with mild psychoactive properties."
+    "description": "Fragrant tree whose root bark and oil were once common flavorings; contains safrole with mild psychoactive properties.",
+    "affiliateLink": null
   },
   {
     "name": "Guarana",
     "scientificName": "Paullinia cupana",
     "category": "Stimulant / Nootropic",
-    "tags": ["🍫 Seed", "☕ High caffeine"],
-    "effects": ["Energy", "mental focus"],
+    "tags": [
+      "🍫 Seed",
+      "☕ High caffeine"
+    ],
+    "effects": [
+      "Energy",
+      "mental focus"
+    ],
     "mechanismOfAction": "Seeds contain high caffeine content that blocks adenosine receptors.",
     "therapeuticUses": "Fatigue reduction, weight loss aid, traditional tonic.",
     "pharmacokinetics": "Oral; onset 20 min; peak 1 hr; duration 4–6 hrs.",
@@ -2280,14 +2935,22 @@
     "contraindications": "Heart problems, pregnancy, sensitivity to caffeine.",
     "sideEffects": "Jitteriness, stomach upset",
     "drugInteractions": "Potentiates other stimulants; may interfere with sedatives",
-    "description": "Climbing plant native to Brazil; its seeds provide a potent caffeine kick and are popular in energy drinks."
+    "description": "Climbing plant native to Brazil; its seeds provide a potent caffeine kick and are popular in energy drinks.",
+    "affiliateLink": null
   },
   {
     "name": "Hawaiian Baby Woodrose",
     "scientificName": "Argyreia nervosa",
     "category": "Psychedelic / LSA",
-    "tags": ["🌱 Seeds", "⚠️ Nausea"],
-    "effects": ["Visual distortions", "euphoria", "introspection"],
+    "tags": [
+      "🌱 Seeds",
+      "⚠️ Nausea"
+    ],
+    "effects": [
+      "Visual distortions",
+      "euphoria",
+      "introspection"
+    ],
     "mechanismOfAction": "Seeds contain ergoline alkaloids (LSA) that act on serotonin receptors similarly to LSD but with milder potency.",
     "therapeuticUses": "Occasional spiritual or introspective use; historically as ornamental and traditional medicine.",
     "pharmacokinetics": "Oral; onset 30–90 min; duration 6–10 hrs.",
@@ -2303,14 +2966,22 @@
     "contraindications": "Pregnancy, liver issues, MAOIs.",
     "sideEffects": "Nausea, vasoconstriction, sedation",
     "drugInteractions": "Avoid with vasoconstrictors or other psychedelics",
-    "description": "Climber with heart-shaped leaves; its seeds contain LSA and are used as a legal alternative to LSD experiences."
+    "description": "Climber with heart-shaped leaves; its seeds contain LSA and are used as a legal alternative to LSD experiences.",
+    "affiliateLink": null
   },
   {
     "name": "Tabernanthe iboga",
     "scientificName": "Tabernanthe iboga",
     "category": "Ritual / Visionary",
-    "tags": ["🌿 Root bark", "⚠️ Intense"],
-    "effects": ["Powerful visions", "spiritual insight", "stimulation"],
+    "tags": [
+      "🌿 Root bark",
+      "⚠️ Intense"
+    ],
+    "effects": [
+      "Powerful visions",
+      "spiritual insight",
+      "stimulation"
+    ],
     "mechanismOfAction": "Ibogaine acts on NMDA, kappa-opioid, and serotonin systems while promoting neurotrophic factors.",
     "therapeuticUses": "Traditional Bwiti initiation; studied for addiction interruption.",
     "pharmacokinetics": "Oral; onset 1–3 hrs; duration 12–24 hrs.",
@@ -2326,19 +2997,28 @@
     "contraindications": "Heart conditions, psychiatric disorders, MAOIs.",
     "sideEffects": "Nausea, ataxia, prolonged recovery",
     "drugInteractions": "Dangerous with other stimulants or opioids",
-    "description": "Sacred shrub central to Bwiti ceremonies; contains ibogaine producing intense visionary states and potential addiction therapy."
+    "description": "Sacred shrub central to Bwiti ceremonies; contains ibogaine producing intense visionary states and potential addiction therapy.",
+    "affiliateLink": null
   },
   {
     "name": "LSD",
     "scientificName": "Lysergic acid diethylamide",
     "category": "Psychedelic",
-    "effects": ["Intense visuals", "ego dissolution", "synesthesia"],
+    "effects": [
+      "Intense visuals",
+      "ego dissolution",
+      "synesthesia"
+    ],
     "preparation": "Oral blotter or liquid",
     "intensity": "High",
     "onset": "30-90 min",
     "legalStatus": "Controlled / Illegal in many regions",
     "region": "🌎 Synthetic",
-    "tags": ["💊 Oral", "⚠️ Restricted", "🌀 Visionary"],
+    "tags": [
+      "💊 Oral",
+      "⚠️ Restricted",
+      "🌀 Visionary"
+    ],
     "mechanismOfAction": "Potent 5-HT2A receptor agonist affecting serotonin and dopamine systems.",
     "pharmacokinetics": "Oral administration with effects lasting 8-12 h; hepatic metabolism to inactive metabolites.",
     "therapeuticUses": "Investigated for cluster headaches, anxiety, and addiction therapy.",
@@ -2349,19 +3029,28 @@
     "toxicityLD50": ">14 mg/kg (mice, intravenous)",
     "id": "lsd",
     "description": "Semi-synthetic ergoline discovered in 1938; among the most potent psychedelics.",
-    "safetyRating": 2
+    "safetyRating": 2,
+    "affiliateLink": null
   },
   {
     "name": "Psilocybin",
     "scientificName": "Psilocybin",
     "category": "Psychedelic",
-    "effects": ["Visual patterns", "mystical insight", "emotional release"],
+    "effects": [
+      "Visual patterns",
+      "mystical insight",
+      "emotional release"
+    ],
     "preparation": "Consumed as dried mushrooms or extract",
     "intensity": "Moderate",
     "onset": "20-60 min",
     "legalStatus": "Controlled in many countries",
     "region": "🌎 Global",
-    "tags": ["💊 Oral", "🌀 Visionary", "⚠️ Restricted"],
+    "tags": [
+      "💊 Oral",
+      "🌀 Visionary",
+      "⚠️ Restricted"
+    ],
     "mechanismOfAction": "Converted to psilocin which acts as 5-HT2A agonist.",
     "pharmacokinetics": "Oral onset ~30 min; duration 4-6 h; metabolized hepatically.",
     "therapeuticUses": "Promising treatment for depression, addiction, and end-of-life anxiety.",
@@ -2372,19 +3061,28 @@
     "toxicityLD50": "285 mg/kg (rats, oral) for psilocybin",
     "id": "psilocybin",
     "description": "Active compound in psychedelic mushrooms producing profound perceptual changes.",
-    "safetyRating": 2
+    "safetyRating": 2,
+    "affiliateLink": null
   },
   {
     "name": "Mescaline",
     "scientificName": "3,4,5-trimethoxyphenethylamine",
     "category": "Psychedelic",
-    "effects": ["Color enhancement", "empathy", "spiritual visions"],
+    "effects": [
+      "Color enhancement",
+      "empathy",
+      "spiritual visions"
+    ],
     "preparation": "Ingested cactus buttons or purified sulfate",
     "intensity": "Moderate",
     "onset": "45-120 min",
     "legalStatus": "Controlled in many regions",
     "region": "🌎 Americas",
-    "tags": ["💊 Oral", "🌀 Visionary", "⚠️ Restricted"],
+    "tags": [
+      "💊 Oral",
+      "🌀 Visionary",
+      "⚠️ Restricted"
+    ],
     "mechanismOfAction": "Phenethylamine psychedelic acting on 5-HT2A and dopamine receptors.",
     "pharmacokinetics": "Oral absorption with peak at 2 h; duration 8-12 h; renal excretion.",
     "therapeuticUses": "Traditional sacrament; studied for alcoholism and psychotherapy.",
@@ -2395,14 +3093,23 @@
     "toxicityLD50": ">1,000 mg/kg (rats, oral)",
     "id": "mescaline",
     "description": "Classic phenethylamine psychedelic from peyote and San Pedro cacti.",
-    "safetyRating": 2
+    "safetyRating": 2,
+    "affiliateLink": null
   },
   {
     "name": "Acacia maidenii",
     "scientificName": "Acacia maidenii",
     "category": "Ritual / Visionary",
-    "tags": ["DMT", "Australian", "tree"],
-    "effects": ["strong visuals", "mystical experience", "euphoria"],
+    "tags": [
+      "DMT",
+      "Australian",
+      "tree"
+    ],
+    "effects": [
+      "strong visuals",
+      "mystical experience",
+      "euphoria"
+    ],
     "mechanismOfAction": "Root bark contains DMT that acts as a 5‑HT2A agonist; requires MAOI inhibition for oral activity",
     "therapeuticUses": "Used in entheogenic brews for introspection and spiritual healing",
     "pharmacokinetics": "Smoked onset 2–3 min, duration 15–30 min; oral with MAOI onset 20–45 min, duration 4–6 h",
@@ -2419,14 +3126,23 @@
     "sideEffects": "Nausea, anxiety, profound alterations of perception",
     "drugInteractions": "Dangerous with MAOIs or serotonergic drugs",
     "description": "Australian acacia tree whose bark is rich in DMT and sometimes used in ayahuasca analogues.",
-    "id": "acacia-maidenii"
+    "id": "acacia-maidenii",
+    "affiliateLink": null
   },
   {
     "name": "Acorus calamus",
     "scientificName": "Acorus calamus",
     "category": "Calming / Dream",
-    "tags": ["sedative", "dream", "root"],
-    "effects": ["calm", "mild euphoria", "dream enhancement"],
+    "tags": [
+      "sedative",
+      "dream",
+      "root"
+    ],
+    "effects": [
+      "calm",
+      "mild euphoria",
+      "dream enhancement"
+    ],
     "mechanismOfAction": "Contains beta‑asarone which may modulate GABA and serotonin receptors",
     "therapeuticUses": "Traditionally used for digestion, anxiety and divination",
     "pharmacokinetics": "Onset ~30 min orally, lasting 2–4 h",
@@ -2443,14 +3159,23 @@
     "sideEffects": "Nausea, vomiting at large doses",
     "drugInteractions": "Potential additive effects with other sedatives",
     "description": "Fragrant wetland herb known as Sweet Flag; historically used for relaxation and vivid dreams.",
-    "id": "acorus-calamus"
+    "id": "acorus-calamus",
+    "affiliateLink": null
   },
   {
     "name": "Albizia julibrissin",
     "scientificName": "Albizia julibrissin",
     "category": "Calming / Mood",
-    "tags": ["anxiolytic", "flower", "TCM"],
-    "effects": ["uplifted mood", "relaxation", "mild sedation"],
+    "tags": [
+      "anxiolytic",
+      "flower",
+      "TCM"
+    ],
+    "effects": [
+      "uplifted mood",
+      "relaxation",
+      "mild sedation"
+    ],
     "mechanismOfAction": "Contains saponins and flavonoids thought to modulate serotonin and GABA",
     "therapeuticUses": "Traditional Chinese medicine uses the bark and flowers as a calming antidepressant",
     "pharmacokinetics": "Onset 30–60 min orally; effects last 3–5 h",
@@ -2467,14 +3192,23 @@
     "sideEffects": "Rare drowsiness in sensitive individuals",
     "drugInteractions": "May enhance other sedatives or antidepressants",
     "description": "Often called Persian silk tree; valued in Asian herbalism for its tranquil and mood-brightening properties.",
-    "id": "albizia-julibrissin"
+    "id": "albizia-julibrissin",
+    "affiliateLink": null
   },
   {
     "name": "Anemone pulsatilla",
     "scientificName": "Pulsatilla vulgaris",
     "category": "Sedative / Analgesic",
-    "tags": ["sedative", "anodyne", "folk"],
-    "effects": ["calm", "pain relief", "mild altered awareness"],
+    "tags": [
+      "sedative",
+      "anodyne",
+      "folk"
+    ],
+    "effects": [
+      "calm",
+      "pain relief",
+      "mild altered awareness"
+    ],
     "mechanismOfAction": "Contains lactones derived from protoanemonin that depress the central nervous system",
     "therapeuticUses": "European folk remedy for anxiety, insomnia and menstrual pain",
     "pharmacokinetics": "Onset 20–30 min, lasting 2–4 h when taken orally",
@@ -2491,14 +3225,23 @@
     "sideEffects": "Nausea, stomach irritation if taken fresh",
     "drugInteractions": "May potentiate other sedatives or analgesics",
     "description": "Also called Pasque Flower; once used by herbalists for calming nerves and relieving pain.",
-    "id": "anemone-pulsatilla"
+    "id": "anemone-pulsatilla",
+    "affiliateLink": null
   },
   {
     "name": "Argemone mexicana",
     "scientificName": "Argemone mexicana",
     "category": "Sedative / Analgesic",
-    "tags": ["poppy", "folk medicine", "alkaloid"],
-    "effects": ["relaxation", "analgesia", "slight euphoria"],
+    "tags": [
+      "poppy",
+      "folk medicine",
+      "alkaloid"
+    ],
+    "effects": [
+      "relaxation",
+      "analgesia",
+      "slight euphoria"
+    ],
     "mechanismOfAction": "Isoquinoline alkaloids interact with opioid and dopamine receptors",
     "therapeuticUses": "Mexican and Ayurvedic traditions use it for pain, insomnia and mild narcotic effects",
     "pharmacokinetics": "Onset 20–30 min orally, lasting 3–6 h",
@@ -2515,14 +3258,23 @@
     "sideEffects": "Headache, stomach upset, potential liver damage",
     "drugInteractions": "Avoid combining with alcohol or other depressants",
     "description": "Spiny yellow poppy whose milky latex was historically used for pain relief and sedation.",
-    "id": "argemone-mexicana"
+    "id": "argemone-mexicana",
+    "affiliateLink": null
   },
   {
     "name": "Combretum quadrangulare",
     "scientificName": "Combretum quadrangulare",
     "category": "Stimulant",
-    "tags": ["Sakae Naa", "Southeast Asia", "energy"],
-    "effects": ["heightened alertness", "subtle euphoria", "increased focus"],
+    "tags": [
+      "Sakae Naa",
+      "Southeast Asia",
+      "energy"
+    ],
+    "effects": [
+      "heightened alertness",
+      "subtle euphoria",
+      "increased focus"
+    ],
     "mechanismOfAction": "Leaves contain combretol and related alkaloids acting on adrenergic systems",
     "therapeuticUses": "Traditional stimulant and tonic in Laos and Thailand",
     "pharmacokinetics": "Onset about 30 min orally; effects up to 4–6 h",
@@ -2539,14 +3291,23 @@
     "sideEffects": "Jitters, insomnia if overused",
     "drugInteractions": "May potentiate other stimulants",
     "description": "Often marketed as “Sakae Naa,” this plant is used as a mild energizing substitute for kratom.",
-    "id": "combretum-quadrangulare"
+    "id": "combretum-quadrangulare",
+    "affiliateLink": null
   },
   {
     "name": "Corydalis yanhusuo",
     "scientificName": "Corydalis yanhusuo",
     "category": "Sedative / Analgesic",
-    "tags": ["pain relief", "TCM", "dopamine"],
-    "effects": ["analgesia", "relaxation", "subtle dreaminess"],
+    "tags": [
+      "pain relief",
+      "TCM",
+      "dopamine"
+    ],
+    "effects": [
+      "analgesia",
+      "relaxation",
+      "subtle dreaminess"
+    ],
     "mechanismOfAction": "Alkaloids such as tetrahydropalmatine act on dopamine and GABA receptors",
     "therapeuticUses": "Traditional Chinese remedy for pain and insomnia",
     "pharmacokinetics": "Onset 20–40 min orally, lasting 3–5 h",
@@ -2563,14 +3324,23 @@
     "sideEffects": "Drowsiness, dizziness",
     "drugInteractions": "May potentiate sedatives or dopaminergic drugs",
     "description": "Tubers of this Asian herb provide notable pain relief and a tranquil state when used as tea or pills.",
-    "id": "corydalis-yanhusuo"
+    "id": "corydalis-yanhusuo",
+    "affiliateLink": null
   },
   {
     "name": "Desmanthus illinoensis",
     "scientificName": "Desmanthus illinoensis",
     "category": "Ritual / Visionary",
-    "tags": ["DMT", "American", "root bark"],
-    "effects": ["visual enhancements", "introspection", "altered perception"],
+    "tags": [
+      "DMT",
+      "American",
+      "root bark"
+    ],
+    "effects": [
+      "visual enhancements",
+      "introspection",
+      "altered perception"
+    ],
     "mechanismOfAction": "Root bark contains DMT; usually combined with MAOIs to be active orally",
     "therapeuticUses": "Used in underground ayahuasca analogs for spiritual exploration",
     "pharmacokinetics": "Smoked onset 2–3 min; oral with MAOI onset 20–45 min; duration up to 6 h",
@@ -2587,14 +3357,23 @@
     "sideEffects": "Nausea, anxiety, powerful visions",
     "drugInteractions": "Dangerous with MAOIs or serotonergic drugs",
     "description": "Also called Illinois Bundleflower; its root bark contains notable amounts of DMT.",
-    "id": "desmanthus-illinoensis"
+    "id": "desmanthus-illinoensis",
+    "affiliateLink": null
   },
   {
     "name": "Erythrina mulungu",
     "scientificName": "Erythrina mulungu",
     "category": "Sedative / Anxiolytic",
-    "tags": ["Brazil", "sleep", "bark"],
-    "effects": ["deep relaxation", "anxiety relief", "sleepiness"],
+    "tags": [
+      "Brazil",
+      "sleep",
+      "bark"
+    ],
+    "effects": [
+      "deep relaxation",
+      "anxiety relief",
+      "sleepiness"
+    ],
     "mechanismOfAction": "Erythrinan alkaloids interact with GABA receptors causing CNS depression",
     "therapeuticUses": "South American remedy for insomnia and stress",
     "pharmacokinetics": "Onset ~30 min orally; effects last 4–6 h",
@@ -2611,14 +3390,23 @@
     "sideEffects": "Drowsiness, lowered blood pressure",
     "drugInteractions": "May potentiate other CNS depressants",
     "description": "Flowering tree whose bark is prized in Brazilian folk medicine for calming nerves and promoting sleep.",
-    "id": "erythrina-mulungu"
+    "id": "erythrina-mulungu",
+    "affiliateLink": null
   },
   {
     "name": "Erythrina americana",
     "scientificName": "Erythrina americana",
     "category": "Sedative / Anxiolytic",
-    "tags": ["Mexico", "sleep", "flower"],
-    "effects": ["relaxation", "dreaminess", "reduced anxiety"],
+    "tags": [
+      "Mexico",
+      "sleep",
+      "flower"
+    ],
+    "effects": [
+      "relaxation",
+      "dreaminess",
+      "reduced anxiety"
+    ],
     "mechanismOfAction": "Contains erythrinan alkaloids acting as GABAergic depressants",
     "therapeuticUses": "Mexican folk remedy for insomnia and nervous tension",
     "pharmacokinetics": "Onset 30–45 min orally; duration 3–5 h",
@@ -2635,14 +3423,23 @@
     "sideEffects": "Drowsiness, dizziness",
     "drugInteractions": "May enhance effects of other sedatives",
     "description": "Known locally as Colorín; its red flowers are brewed into a soothing bedtime drink.",
-    "id": "erythrina-americana"
+    "id": "erythrina-americana",
+    "affiliateLink": null
   },
   {
     "name": "Galbulimima belgraveana",
     "scientificName": "Galbulimima belgraveana",
     "category": "Ritual / Visionary",
-    "tags": ["Papua New Guinea", "hallucinogen", "tree"],
-    "effects": ["dreamlike visions", "dizziness", "altered consciousness"],
+    "tags": [
+      "Papua New Guinea",
+      "hallucinogen",
+      "tree"
+    ],
+    "effects": [
+      "dreamlike visions",
+      "dizziness",
+      "altered consciousness"
+    ],
     "mechanismOfAction": "Contains himbacine-type alkaloids with muscarinic antagonist activity",
     "therapeuticUses": "Used by Papuan tribes for shamanic rituals and hunting magic",
     "pharmacokinetics": "Onset 30–60 min when consumed, lasting 4–8 h",
@@ -2659,14 +3456,23 @@
     "sideEffects": "Nausea, vertigo, intense dreams",
     "drugInteractions": "Avoid combining with other anticholinergics",
     "description": "Rare rainforest tree providing psychoactive bark traditionally used in New Guinea for visionary experiences.",
-    "id": "galbulimima-belgraveana"
+    "id": "galbulimima-belgraveana",
+    "affiliateLink": null
   },
   {
     "name": "Alpinia galanga",
     "scientificName": "Alpinia galanga",
     "category": "Stimulant",
-    "tags": ["galangal", "aromatic", "spice"],
-    "effects": ["warm stimulation", "mild euphoria", "enhanced circulation"],
+    "tags": [
+      "galangal",
+      "aromatic",
+      "spice"
+    ],
+    "effects": [
+      "warm stimulation",
+      "mild euphoria",
+      "enhanced circulation"
+    ],
     "mechanismOfAction": "Contains eugenol and cineole that increase circulation and mild CNS stimulation",
     "therapeuticUses": "Used in Southeast Asian medicine for digestion and fatigue",
     "pharmacokinetics": "Onset 20–40 min, duration 2–4 h",
@@ -2683,14 +3489,23 @@
     "sideEffects": "Heartburn or mild agitation at high doses",
     "drugInteractions": "May alter absorption of other stimulants or anticoagulants",
     "description": "A common culinary spice known as galangal that offers gentle stimulation and a warming effect.",
-    "id": "alpinia-galanga"
+    "id": "alpinia-galanga",
+    "affiliateLink": null
   },
   {
     "name": "Leonurus sibiricus",
     "scientificName": "Leonurus sibiricus",
     "category": "Calming / Dream",
-    "tags": ["marihuanilla", "mint family", "sedative"],
-    "effects": ["mild sedation", "light euphoria", "dream enhancement"],
+    "tags": [
+      "marihuanilla",
+      "mint family",
+      "sedative"
+    ],
+    "effects": [
+      "mild sedation",
+      "light euphoria",
+      "dream enhancement"
+    ],
     "mechanismOfAction": "Contains leonurine and other alkaloids that depress CNS activity",
     "therapeuticUses": "Used in Latin American and Asian folk medicine for relaxation and spiritual rituals",
     "pharmacokinetics": "Onset 20–30 min when smoked or brewed; effects last 2–4 h",
@@ -2707,14 +3522,23 @@
     "sideEffects": "Drowsiness at high doses",
     "drugInteractions": "May enhance effects of other sedatives",
     "description": "Sometimes called Marihuanilla or Siberian motherwort, providing gentle calming effects and subtle dreaminess.",
-    "id": "leonurus-sibiricus"
+    "id": "leonurus-sibiricus",
+    "affiliateLink": null
   },
   {
     "name": "Lagochilus inebrians",
     "scientificName": "Lagochilus inebrians",
     "category": "Sedative / Euphoric",
-    "tags": ["intoxicating mint", "Central Asia", "calming"],
-    "effects": ["relaxation", "mild euphoria", "reduced anxiety"],
+    "tags": [
+      "intoxicating mint",
+      "Central Asia",
+      "calming"
+    ],
+    "effects": [
+      "relaxation",
+      "mild euphoria",
+      "reduced anxiety"
+    ],
     "mechanismOfAction": "Contains lagochilin which depresses the CNS and may interact with GABA",
     "therapeuticUses": "Folk remedy in Uzbekistan and Kazakhstan for tension and insomnia",
     "pharmacokinetics": "Onset about 30 min orally or smoked; duration 3–5 h",
@@ -2731,14 +3555,23 @@
     "sideEffects": "Drowsiness",
     "drugInteractions": "Could potentiate other depressants",
     "description": "Known as intoxicating mint; produces a pleasant calm and slight euphoria when brewed.",
-    "id": "lagochilus-inebrians"
+    "id": "lagochilus-inebrians",
+    "affiliateLink": null
   },
   {
     "name": "Nicotiana rustica",
     "scientificName": "Nicotiana rustica",
     "category": "Stimulant / Ritual",
-    "tags": ["mapacho", "nicotine", "tobacco"],
-    "effects": ["alertness", "intense buzz", "clearing of thoughts"],
+    "tags": [
+      "mapacho",
+      "nicotine",
+      "tobacco"
+    ],
+    "effects": [
+      "alertness",
+      "intense buzz",
+      "clearing of thoughts"
+    ],
     "mechanismOfAction": "High nicotine plus MAO‑inhibiting beta‑carbolines stimulate nicotinic receptors and inhibit MAO",
     "therapeuticUses": "Used by Amazonian shamans for cleansing and focus",
     "pharmacokinetics": "Smoked onset immediate, duration 30–60 min; oral snuff onset ~5 min",
@@ -2755,14 +3588,23 @@
     "sideEffects": "Nausea, increased heart rate, dizziness",
     "drugInteractions": "Strongly potentiated by MAOIs; interacts with many medications",
     "description": "Potent tobacco species used ceremonially in the Amazon, far stronger than common N. tabacum.",
-    "id": "nicotiana-rustica"
+    "id": "nicotiana-rustica",
+    "affiliateLink": null
   },
   {
     "name": "Nymphaea lotus",
     "scientificName": "Nymphaea lotus",
     "category": "Calming / Dream",
-    "tags": ["Egyptian lotus", "sedative", "water lily"],
-    "effects": ["relaxation", "dream enhancement", "mild euphoria"],
+    "tags": [
+      "Egyptian lotus",
+      "sedative",
+      "water lily"
+    ],
+    "effects": [
+      "relaxation",
+      "dream enhancement",
+      "mild euphoria"
+    ],
     "mechanismOfAction": "Contains aporphine alkaloids that act on dopamine and serotonin receptors",
     "therapeuticUses": "Used in ancient Egypt for sedation and ritual ceremonies",
     "pharmacokinetics": "Onset 20–30 min when brewed; duration about 2–5 h",
@@ -2779,14 +3621,23 @@
     "sideEffects": "Drowsiness at high doses",
     "drugInteractions": "May add to effects of other sedatives",
     "description": "Also called the Egyptian white lotus, historically revered for its gentle calming and dreamlike qualities.",
-    "id": "nymphaea-lotus"
+    "id": "nymphaea-lotus",
+    "affiliateLink": null
   },
   {
     "name": "Psychotria carthagenensis",
     "scientificName": "Psychotria carthagenensis",
     "category": "Ritual / Visionary",
-    "tags": ["chaliponga", "Amazon", "DMT"],
-    "effects": ["visual effects", "introspection", "spiritual insight"],
+    "tags": [
+      "chaliponga",
+      "Amazon",
+      "DMT"
+    ],
+    "effects": [
+      "visual effects",
+      "introspection",
+      "spiritual insight"
+    ],
     "mechanismOfAction": "Leaves contain N,N-dimethyltryptamine acting as a serotonin agonist; requires MAO inhibition orally",
     "therapeuticUses": "Used in ayahuasca analogues for visionary experiences",
     "pharmacokinetics": "Onset 20–45 min orally with MAOI, duration 4–6 h",
@@ -2803,14 +3654,23 @@
     "sideEffects": "Nausea, intense visions, possible anxiety",
     "drugInteractions": "Dangerous with serotonergic drugs or other MAOIs",
     "description": "Amazonian shrub also known as Chaliponga; its DMT-rich leaves are valued in shamanic ceremonies.",
-    "id": "psychotria-carthagenensis"
+    "id": "psychotria-carthagenensis",
+    "affiliateLink": null
   },
   {
     "name": "Mucuna pruriens",
     "scientificName": "Mucuna pruriens",
     "category": "Stimulant / Nootropic",
-    "tags": ["velvet bean", "dopamine", "Ayurveda"],
-    "effects": ["increased motivation", "energy", "elevated mood"],
+    "tags": [
+      "velvet bean",
+      "dopamine",
+      "Ayurveda"
+    ],
+    "effects": [
+      "increased motivation",
+      "energy",
+      "elevated mood"
+    ],
     "mechanismOfAction": "Seeds contain L‑DOPA which increases brain dopamine levels",
     "therapeuticUses": "Used in Ayurveda for Parkinson's disease, mood disorders and vitality",
     "pharmacokinetics": "Onset around 30 min, duration 4–6 h",
@@ -2827,14 +3687,23 @@
     "sideEffects": "Nausea or headache with excessive intake",
     "drugInteractions": "Avoid with MAOIs or dopamine medications",
     "description": "Also called Velvet Bean; boosts dopamine and serves as a traditional tonic in Ayurvedic practice.",
-    "id": "mucuna-pruriens"
+    "id": "mucuna-pruriens",
+    "affiliateLink": null
   },
   {
     "name": "Paullinia yoco",
     "scientificName": "Paullinia yoco",
     "category": "Stimulant / Ritual",
-    "tags": ["Amazon", "caffeine", "vine"],
-    "effects": ["alertness", "energy", "reduced fatigue"],
+    "tags": [
+      "Amazon",
+      "caffeine",
+      "vine"
+    ],
+    "effects": [
+      "alertness",
+      "energy",
+      "reduced fatigue"
+    ],
     "mechanismOfAction": "Bark rich in caffeine acts as an adenosine receptor antagonist",
     "therapeuticUses": "Used by indigenous Amazonian peoples for stamina on hunts",
     "pharmacokinetics": "Onset 10–20 min when brewed; duration 2–4 h",
@@ -2851,14 +3720,23 @@
     "sideEffects": "Jitters, rapid heartbeat, sleeplessness",
     "drugInteractions": "Potentiates other stimulants and certain medications",
     "description": "Liana used by several Amazonian tribes; the bark yields a potent caffeinated beverage for energy.",
-    "id": "paullinia-yoco"
+    "id": "paullinia-yoco",
+    "affiliateLink": null
   },
   {
     "name": "Tetradenia riparia",
     "scientificName": "Tetradenia riparia",
     "category": "Calming / Analgesic",
-    "tags": ["Iboza", "African", "aromatic"],
-    "effects": ["relaxation", "pain relief", "lightheadedness"],
+    "tags": [
+      "Iboza",
+      "African",
+      "aromatic"
+    ],
+    "effects": [
+      "relaxation",
+      "pain relief",
+      "lightheadedness"
+    ],
     "mechanismOfAction": "Aromatic diterpenes may modulate GABA and opioid receptors",
     "therapeuticUses": "Used in African folk medicine for headaches and anxiety",
     "pharmacokinetics": "Onset 20–30 min as tea or smoked, lasting 2–4 h",
@@ -2875,14 +3753,23 @@
     "sideEffects": "Dizziness, low blood pressure",
     "drugInteractions": "May enhance sedatives or blood pressure medications",
     "description": "Fragrant African shrub sometimes called Iboza; provides a relaxing effect and mild pain relief.",
-    "id": "tetradenia-riparia"
+    "id": "tetradenia-riparia",
+    "affiliateLink": null
   },
   {
     "name": "Tabernaemontana undulata",
     "scientificName": "Tabernaemontana undulata",
     "category": "Analgesic / Visionary",
-    "tags": ["Uchu Sanango", "iboga alkaloids", "Amazon"],
-    "effects": ["tingling sensation", "dream enhancement", "altered perception"],
+    "tags": [
+      "Uchu Sanango",
+      "iboga alkaloids",
+      "Amazon"
+    ],
+    "effects": [
+      "tingling sensation",
+      "dream enhancement",
+      "altered perception"
+    ],
     "mechanismOfAction": "Contains iboga-type alkaloids affecting serotonin and NMDA receptors",
     "therapeuticUses": "Amazonian tribes use the bark for hunting preparation and pain",
     "pharmacokinetics": "Onset 15–30 min when chewed or brewed; duration 2–5 h",
@@ -2899,14 +3786,23 @@
     "sideEffects": "Nausea, numbness, dizziness",
     "drugInteractions": "Avoid with other serotonergic or stimulant substances",
     "description": "Also called Uchu Sanango; this rare shrub contains iboga-like compounds and is used in shamanic practices.",
-    "id": "tabernaemontana-undulata"
+    "id": "tabernaemontana-undulata",
+    "affiliateLink": null
   },
   {
     "name": "Aquilaria malaccensis",
     "scientificName": "Aquilaria malaccensis",
     "category": "Calming / Aromatic",
-    "tags": ["agarwood", "incense", "sedative"],
-    "effects": ["tranquil mind", "subtle euphoria", "aromatic relaxation"],
+    "tags": [
+      "agarwood",
+      "incense",
+      "sedative"
+    ],
+    "effects": [
+      "tranquil mind",
+      "subtle euphoria",
+      "aromatic relaxation"
+    ],
     "mechanismOfAction": "Resin rich in sesquiterpenes acts via GABAergic and dopaminergic pathways when inhaled",
     "therapeuticUses": "Used in traditional Asian medicine and incense for calming and meditation",
     "pharmacokinetics": "Effects appear within minutes when smoked or heated, lasting 1–2 h",
@@ -2923,14 +3819,23 @@
     "sideEffects": "Mild headache if smoke inhaled in excess",
     "drugInteractions": "Unknown; likely minimal",
     "description": "Source of precious agarwood resin, producing a soothing aroma and subtle psychoactive calm when burned.",
-    "id": "aquilaria-malaccensis"
+    "id": "aquilaria-malaccensis",
+    "affiliateLink": null
   },
   {
     "name": "Argyreia speciosa",
     "scientificName": "Argyreia speciosa",
     "category": "Ritual / Visionary",
-    "tags": ["Indian morning glory", "LSA", "seeds"],
-    "effects": ["closed-eye visuals", "euphoria", "enhanced introspection"],
+    "tags": [
+      "Indian morning glory",
+      "LSA",
+      "seeds"
+    ],
+    "effects": [
+      "closed-eye visuals",
+      "euphoria",
+      "enhanced introspection"
+    ],
     "mechanismOfAction": "Seeds contain lysergic acid amide (LSA) acting on serotonin receptors",
     "therapeuticUses": "Occasionally used in Ayurveda as a tonic and for spiritual rituals",
     "pharmacokinetics": "Onset 1–2 h orally, duration 6–8 h",
@@ -2947,14 +3852,23 @@
     "sideEffects": "Nausea, vasoconstriction, drowsiness",
     "drugInteractions": "Avoid with other serotonergic agents",
     "description": "Close relative of Hawaiian Baby Woodrose with LSA‑containing seeds used in some Indian traditions.",
-    "id": "argyreia-speciosa"
+    "id": "argyreia-speciosa",
+    "affiliateLink": null
   },
   {
     "name": "Zanthoxylum clava-herculis",
     "scientificName": "Zanthoxylum clava-herculis",
     "category": "Analgesic / Stimulant",
-    "tags": ["toothache tree", "tingling", "North America"],
-    "effects": ["mouth numbness", "mild stimulation", "pain relief"],
+    "tags": [
+      "toothache tree",
+      "tingling",
+      "North America"
+    ],
+    "effects": [
+      "mouth numbness",
+      "mild stimulation",
+      "pain relief"
+    ],
     "mechanismOfAction": "Bark contains sanshools that cause paresthesia and stimulate trigeminal nerves",
     "therapeuticUses": "Native American remedy for toothaches and sore throats; also used as a tonic",
     "pharmacokinetics": "Onset within minutes when chewed; duration 1–3 h",
@@ -2971,14 +3885,23 @@
     "sideEffects": "Tingling, salivation, mild stomach upset",
     "drugInteractions": "May interact with other numbing agents",
     "description": "Also called the toothache tree; its bark creates a tingling numbness and light stimulation when chewed.",
-    "id": "zanthoxylum-clava-herculis"
+    "id": "zanthoxylum-clava-herculis",
+    "affiliateLink": null
   },
   {
     "name": "Adhatoda vasica",
     "scientificName": "Justicia adhatoda",
     "category": "Stimulant / Bronchodilator",
-    "tags": ["vasaka", "Ayurveda", "respiratory"],
-    "effects": ["clear breathing", "mild stimulation", "warming"],
+    "tags": [
+      "vasaka",
+      "Ayurveda",
+      "respiratory"
+    ],
+    "effects": [
+      "clear breathing",
+      "mild stimulation",
+      "warming"
+    ],
     "mechanismOfAction": "Alkaloids such as vasicine act as bronchodilators and respiratory stimulants",
     "therapeuticUses": "Ayurvedic herb for asthma, coughs and general vitality",
     "pharmacokinetics": "Onset 30 min orally; effects last about 3–4 h",
@@ -2995,14 +3918,23 @@
     "sideEffects": "Digestive upset at large doses",
     "drugInteractions": "May potentiate other bronchodilators",
     "description": "Known as Vasaka or Malabar nut, this shrub’s leaves ease breathing and offer a subtle stimulating effect.",
-    "id": "adhatoda-vasica"
+    "id": "adhatoda-vasica",
+    "affiliateLink": null
   },
   {
     "name": "Amanita pantherina",
     "scientificName": "Amanita pantherina",
     "category": "Deliriant / Sedative",
-    "tags": ["panther cap", "muscimol", "mushroom"],
-    "effects": ["sedation", "confusion", "dizziness"],
+    "tags": [
+      "panther cap",
+      "muscimol",
+      "mushroom"
+    ],
+    "effects": [
+      "sedation",
+      "confusion",
+      "dizziness"
+    ],
     "mechanismOfAction": "Contains muscimol and ibotenic acid acting on GABA receptors",
     "therapeuticUses": "Traditional Siberian shamanic use; rarely employed medically",
     "sideEffects": "Nausea, loss of coordination, delirium",
@@ -3017,14 +3949,23 @@
     "legalStatus": "Varies; unscheduled in many countries",
     "toxicity": "Potentially toxic at high doses",
     "toxicityLD50": "Not well established",
-    "safetyRating": "Low"
+    "safetyRating": "Low",
+    "affiliateLink": null
   },
   {
     "name": "Cannabis sativa",
     "scientificName": "Cannabis sativa",
     "category": "Psychedelic / Relaxant",
-    "tags": ["marijuana", "THC", "CBD"],
-    "effects": ["euphoria", "relaxation", "altered perception"],
+    "tags": [
+      "marijuana",
+      "THC",
+      "CBD"
+    ],
+    "effects": [
+      "euphoria",
+      "relaxation",
+      "altered perception"
+    ],
     "mechanismOfAction": "THC acts on cannabinoid receptors CB1 and CB2",
     "therapeuticUses": "Pain relief, appetite stimulation, anxiety reduction",
     "sideEffects": "Dry mouth, short-term memory impairment, anxiety in high doses",
@@ -3039,14 +3980,23 @@
     "legalStatus": "Varies by jurisdiction",
     "toxicity": "Low physiological toxicity",
     "toxicityLD50": ">1 g/kg THC in animals",
-    "safetyRating": "Medium"
+    "safetyRating": "Medium",
+    "affiliateLink": null
   },
   {
     "name": "Claviceps purpurea",
     "scientificName": "Claviceps purpurea",
     "category": "Ergolines / Toxic",
-    "tags": ["ergot", "fungus", "vasoconstrictor"],
-    "effects": ["vasoconstriction", "hallucinations", "numbness"],
+    "tags": [
+      "ergot",
+      "fungus",
+      "vasoconstrictor"
+    ],
+    "effects": [
+      "vasoconstriction",
+      "hallucinations",
+      "numbness"
+    ],
     "mechanismOfAction": "Produces ergot alkaloids acting on serotonin and adrenergic receptors",
     "therapeuticUses": "Historically used to induce labor and treat migraines",
     "sideEffects": "Nausea, convulsions, gangrene in high doses",
@@ -3061,14 +4011,23 @@
     "legalStatus": "Controlled in many countries",
     "toxicity": "High; risk of ergotism",
     "toxicityLD50": "~5 mg/kg lysergic acid amide (mouse)",
-    "safetyRating": "Very Low"
+    "safetyRating": "Very Low",
+    "affiliateLink": null
   },
   {
     "name": "Coleus blumei",
     "scientificName": "Plectranthus scutellarioides",
     "category": "Psychedelic / Ornamental",
-    "tags": ["painted nettle", "visionary", "Lamiaceae"],
-    "effects": ["mild visuals", "color enhancement", "relaxation"],
+    "tags": [
+      "painted nettle",
+      "visionary",
+      "Lamiaceae"
+    ],
+    "effects": [
+      "mild visuals",
+      "color enhancement",
+      "relaxation"
+    ],
     "mechanismOfAction": "Unclear; may act on serotonergic pathways",
     "therapeuticUses": "Rarely used; some folk use for divination",
     "sideEffects": "Headache, nausea at high doses",
@@ -3083,14 +4042,23 @@
     "legalStatus": "Legal",
     "toxicity": "Low",
     "toxicityLD50": "Not established",
-    "safetyRating": "Medium"
+    "safetyRating": "Medium",
+    "affiliateLink": null
   },
   {
     "name": "Echinopsis pachanoi",
     "scientificName": "Echinopsis pachanoi",
     "category": "Psychedelic Cactus",
-    "tags": ["San Pedro", "mescaline", "cactus"],
-    "effects": ["visuals", "euphoria", "spiritual insight"],
+    "tags": [
+      "San Pedro",
+      "mescaline",
+      "cactus"
+    ],
+    "effects": [
+      "visuals",
+      "euphoria",
+      "spiritual insight"
+    ],
     "mechanismOfAction": "Contains mescaline, a 5‑HT2A agonist phenethylamine",
     "therapeuticUses": "Andean traditional medicine for divination and healing",
     "sideEffects": "Nausea, increased heart rate, anxiety",
@@ -3105,14 +4073,23 @@
     "legalStatus": "Cactus legal in many areas; mescaline often controlled",
     "toxicity": "Low physiological but intense psychological effects",
     "toxicityLD50": "Not well established",
-    "safetyRating": "Medium"
+    "safetyRating": "Medium",
+    "affiliateLink": null
   },
   {
     "name": "Erythroxylum coca",
     "scientificName": "Erythroxylum coca",
     "category": "Stimulant",
-    "tags": ["coca leaf", "alkaloid", "Andes"],
-    "effects": ["alertness", "reduced fatigue", "mild euphoria"],
+    "tags": [
+      "coca leaf",
+      "alkaloid",
+      "Andes"
+    ],
+    "effects": [
+      "alertness",
+      "reduced fatigue",
+      "mild euphoria"
+    ],
     "mechanismOfAction": "Leaves contain cocaine acting as a dopamine and norepinephrine reuptake inhibitor",
     "therapeuticUses": "Altitude sickness relief, energy boost, appetite suppression",
     "sideEffects": "Increased heart rate, insomnia, potential dependence",
@@ -3127,14 +4104,23 @@
     "legalStatus": "Cultivation regulated; cocaine controlled",
     "toxicity": "Low in leaf form; purified alkaloid is addictive",
     "toxicityLD50": "~95 mg/kg (rat, cocaine)",
-    "safetyRating": "Low"
+    "safetyRating": "Low",
+    "affiliateLink": null
   },
   {
     "name": "Ginkgo biloba",
     "scientificName": "Ginkgo biloba",
     "category": "Nootropic / Circulatory",
-    "tags": ["memory", "blood flow", "ancient"],
-    "effects": ["improved cognition", "circulation boost", "alertness"],
+    "tags": [
+      "memory",
+      "blood flow",
+      "ancient"
+    ],
+    "effects": [
+      "improved cognition",
+      "circulation boost",
+      "alertness"
+    ],
     "mechanismOfAction": "Flavone glycosides and terpenoids enhance blood flow and modulate neurotransmission",
     "therapeuticUses": "Used for memory loss, dementia, and circulatory issues",
     "sideEffects": "Headache, upset stomach, possible bleeding risk",
@@ -3149,14 +4135,23 @@
     "legalStatus": "Legal",
     "toxicity": "Low",
     "toxicityLD50": ">5 g/kg in animals",
-    "safetyRating": "High"
+    "safetyRating": "High",
+    "affiliateLink": null
   },
   {
     "name": "Helichrysum odoratissimum",
     "scientificName": "Helichrysum odoratissimum",
     "category": "Calming / Ritual",
-    "tags": ["imphepho", "South Africa", "smoke"],
-    "effects": ["relaxation", "mild euphoria", "dream enhancement"],
+    "tags": [
+      "imphepho",
+      "South Africa",
+      "smoke"
+    ],
+    "effects": [
+      "relaxation",
+      "mild euphoria",
+      "dream enhancement"
+    ],
     "mechanismOfAction": "Aromatic compounds interact with GABA and serotonin systems",
     "therapeuticUses": "Used by South African healers for cleansing and ancestor communication",
     "sideEffects": "Mild headache from smoke inhalation",
@@ -3171,14 +4166,23 @@
     "legalStatus": "Legal",
     "toxicity": "Low",
     "toxicityLD50": "Not established",
-    "safetyRating": "High"
+    "safetyRating": "High",
+    "affiliateLink": null
   },
   {
     "name": "Hypericum perforatum",
     "scientificName": "Hypericum perforatum",
     "category": "Antidepressant / Nootropic",
-    "tags": ["St. John's Wort", "mood", "MAOI"],
-    "effects": ["improved mood", "reduced anxiety", "light sedation"],
+    "tags": [
+      "St. John's Wort",
+      "mood",
+      "MAOI"
+    ],
+    "effects": [
+      "improved mood",
+      "reduced anxiety",
+      "light sedation"
+    ],
     "mechanismOfAction": "Hyperforin and hypericin inhibit reuptake of serotonin, dopamine, and norepinephrine",
     "therapeuticUses": "Mild to moderate depression, anxiety, sleep issues",
     "sideEffects": "Photosensitivity, dry mouth, gastrointestinal upset",
@@ -3193,14 +4197,23 @@
     "legalStatus": "Legal",
     "toxicity": "Low to moderate",
     "toxicityLD50": ">2 g/kg in rodents",
-    "safetyRating": "Medium"
+    "safetyRating": "Medium",
+    "affiliateLink": null
   },
   {
     "name": "Ilex vomitoria",
     "scientificName": "Ilex vomitoria",
     "category": "Stimulant / Ritual",
-    "tags": ["yaupon", "caffeine", "North America"],
-    "effects": ["alertness", "mild euphoria", "cleansing"],
+    "tags": [
+      "yaupon",
+      "caffeine",
+      "North America"
+    ],
+    "effects": [
+      "alertness",
+      "mild euphoria",
+      "cleansing"
+    ],
     "mechanismOfAction": "Contains caffeine and theobromine acting as adenosine receptor antagonists",
     "therapeuticUses": "Native American ceremonial drink for stimulation and purification",
     "sideEffects": "Nausea in excess, insomnia",
@@ -3215,20 +4228,28 @@
     "legalStatus": "Legal",
     "toxicity": "Low",
     "toxicityLD50": ">1 g/kg caffeine in animals",
-    "safetyRating": "Medium"
+    "safetyRating": "Medium",
+    "affiliateLink": null
   },
   {
     "name": "Centella asiatica",
     "scientificName": "Centella asiatica",
     "category": "Cognitive",
-    "effects": ["Mental clarity", "calm focus"],
+    "effects": [
+      "Mental clarity",
+      "calm focus"
+    ],
     "preparation": "Tea or capsules",
     "intensity": "Mild",
     "onset": "30 min",
     "duration": "4-6 hrs",
     "legalStatus": "Legal",
     "region": "Asia",
-    "tags": ["🧠 Cognitive", "🌿 Leaf", "✅ Safe"],
+    "tags": [
+      "🧠 Cognitive",
+      "🌿 Leaf",
+      "✅ Safe"
+    ],
     "mechanismOfAction": "Triterpenoids may modulate GABA and promote neurogenesis",
     "pharmacokinetics": "Oral; active compounds absorb within an hour",
     "therapeuticUses": "Memory enhancement, anxiety relief",
@@ -3246,20 +4267,28 @@
         "type": "triterpenoid",
         "effect": "nootropic"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Eschscholzia californica",
     "scientificName": "Eschscholzia californica",
     "category": "Dissociative / Sedative",
-    "effects": ["Sedation", "mild euphoria"],
+    "effects": [
+      "Sedation",
+      "mild euphoria"
+    ],
     "preparation": "Tincture or smoked",
     "intensity": "Mild",
     "onset": "20 min",
     "duration": "2-4 hrs",
     "legalStatus": "Legal",
     "region": "North America",
-    "tags": ["🌿 Flower", "💤 Sedation", "✅ Safe"],
+    "tags": [
+      "🌿 Flower",
+      "💤 Sedation",
+      "✅ Safe"
+    ],
     "mechanismOfAction": "Protopine alkaloids interact with GABA receptors",
     "pharmacokinetics": "Oral or smoked; quick onset",
     "therapeuticUses": "Anxiety and sleep support",
@@ -3277,20 +4306,28 @@
         "type": "alkaloid",
         "effect": "sedative"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Rhodiola rosea",
     "scientificName": "Rhodiola rosea",
     "category": "Stimulant / Adaptogen",
-    "effects": ["Stimulation", "stress resistance"],
+    "effects": [
+      "Stimulation",
+      "stress resistance"
+    ],
     "preparation": "Root extract or tea",
     "intensity": "Mild",
     "onset": "30 min",
     "duration": "4-5 hrs",
     "legalStatus": "Legal",
     "region": "Arctic regions",
-    "tags": ["🌿 Root", "⚡ Stimulant", "✅ Safe"],
+    "tags": [
+      "🌿 Root",
+      "⚡ Stimulant",
+      "✅ Safe"
+    ],
     "mechanismOfAction": "Rosavins influence serotonin and dopamine; adaptogenic",
     "pharmacokinetics": "Oral; active within 30 min",
     "therapeuticUses": "Fatigue reduction, cognitive enhancement",
@@ -3308,20 +4345,28 @@
         "type": "phenylpropanoid",
         "effect": "adaptogen"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Ginkgo biloba",
     "scientificName": "Ginkgo biloba",
     "category": "Cognitive",
-    "effects": ["Circulation boost", "memory support"],
+    "effects": [
+      "Circulation boost",
+      "memory support"
+    ],
     "preparation": "Leaf extract",
     "intensity": "Mild",
     "onset": "1 hr",
     "duration": "6 hrs",
     "legalStatus": "Legal",
     "region": "China",
-    "tags": ["🌿 Leaf", "🧠 Cognitive", "✅ Safe"],
+    "tags": [
+      "🌿 Leaf",
+      "🧠 Cognitive",
+      "✅ Safe"
+    ],
     "mechanismOfAction": "Terpene lactones improve blood flow and act as antioxidants",
     "pharmacokinetics": "Oral extracts; moderate absorption",
     "therapeuticUses": "Cognitive decline mitigation",
@@ -3339,20 +4384,28 @@
         "type": "terpenoid",
         "effect": "neuroprotective"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Hypericum perforatum",
     "scientificName": "Hypericum perforatum",
     "category": "Empathogen / Euphoriant",
-    "effects": ["Mood lift", "anxiolytic"],
+    "effects": [
+      "Mood lift",
+      "anxiolytic"
+    ],
     "preparation": "Flowering tops as tea or extract",
     "intensity": "Mild",
     "onset": "2 weeks (regular use)",
     "duration": "N/A",
     "legalStatus": "Legal",
     "region": "Europe",
-    "tags": ["🌿 Flower", "😊 Mood", "⚠️ Caution"],
+    "tags": [
+      "🌿 Flower",
+      "😊 Mood",
+      "⚠️ Caution"
+    ],
     "mechanismOfAction": "Hypericin inhibits reuptake of neurotransmitters",
     "pharmacokinetics": "Requires chronic use for effect; CYP inducer",
     "therapeuticUses": "Mild depression treatment",
@@ -3370,20 +4423,28 @@
         "type": "naphthodianthrone",
         "effect": "antidepressant"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Leonotis leonurus",
     "scientificName": "Leonotis leonurus",
     "category": "Ritual / Visionary",
-    "effects": ["Mild euphoria", "relaxation"],
+    "effects": [
+      "Mild euphoria",
+      "relaxation"
+    ],
     "preparation": "Dried leaves smoked",
     "intensity": "Mild",
     "onset": "Immediate when smoked",
     "duration": "1-2 hrs",
     "legalStatus": "Legal",
     "region": "South Africa",
-    "tags": ["🌿 Leaf", "🧪 Alkaloid", "✅ Safe"],
+    "tags": [
+      "🌿 Leaf",
+      "🧪 Alkaloid",
+      "✅ Safe"
+    ],
     "mechanismOfAction": "Leonurine may act on serotonin receptors",
     "pharmacokinetics": "Smoked; onset within minutes",
     "therapeuticUses": "Traditional relaxant and ritual smoke",
@@ -3401,20 +4462,27 @@
         "type": "alkaloid",
         "effect": "relaxant"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Uncaria tomentosa",
     "scientificName": "Uncaria tomentosa",
     "category": "Other",
-    "effects": ["Immune modulation"],
+    "effects": [
+      "Immune modulation"
+    ],
     "preparation": "Bark decoction or capsules",
     "intensity": "Mild",
     "onset": "1 hr",
     "duration": "Varies",
     "legalStatus": "Legal",
     "region": "Amazon",
-    "tags": ["🌿 Bark", "🛡️ Immune", "✅ Safe"],
+    "tags": [
+      "🌿 Bark",
+      "🛡️ Immune",
+      "✅ Safe"
+    ],
     "mechanismOfAction": "Oxindole alkaloids stimulate immune function",
     "pharmacokinetics": "Oral; absorption within an hour",
     "therapeuticUses": "Anti-inflammatory, immune support",
@@ -3432,20 +4500,28 @@
         "type": "alkaloid",
         "effect": "immunomodulator"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Ephedra sinica",
     "scientificName": "Ephedra sinica",
     "category": "Stimulant",
-    "effects": ["Stimulation", "appetite suppression"],
+    "effects": [
+      "Stimulation",
+      "appetite suppression"
+    ],
     "preparation": "Stem tea or extract",
     "intensity": "Moderate",
     "onset": "20 min",
     "duration": "3-5 hrs",
     "legalStatus": "Restricted in some countries",
     "region": "Asia",
-    "tags": ["🌿 Stem", "⚡ Stimulant", "⚠️ Caution"],
+    "tags": [
+      "🌿 Stem",
+      "⚡ Stimulant",
+      "⚠️ Caution"
+    ],
     "mechanismOfAction": "Ephedrine acts on adrenergic receptors",
     "pharmacokinetics": "Rapid oral absorption; urinary excretion",
     "therapeuticUses": "Traditional decongestant and stimulant",
@@ -3463,20 +4539,28 @@
         "type": "alkaloid",
         "effect": "stimulant"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Myristica fragrans",
     "scientificName": "Myristica fragrans",
     "category": "Ritual / Visionary",
-    "effects": ["Deliriant states", "nausea"],
+    "effects": [
+      "Deliriant states",
+      "nausea"
+    ],
     "preparation": "Ground seed orally",
     "intensity": "Strong",
     "onset": "2-3 hrs",
     "duration": "12 hrs or more",
     "legalStatus": "Legal",
     "region": "Indonesia",
-    "tags": ["🌿 Seed", "⚠️ Caution", "🧪 Phenethylamine"],
+    "tags": [
+      "🌿 Seed",
+      "⚠️ Caution",
+      "🧪 Phenethylamine"
+    ],
     "mechanismOfAction": "Myristicin metabolizes to MMDA-like compounds",
     "pharmacokinetics": "Slow oral absorption; long duration",
     "therapeuticUses": "Rarely used therapeutically",
@@ -3494,20 +4578,28 @@
         "type": "phenylpropene",
         "effect": "deliriant"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Pausinystalia yohimbe",
     "scientificName": "Pausinystalia yohimbe",
     "category": "Stimulant",
-    "effects": ["Aphrodisiac", "stimulant"],
+    "effects": [
+      "Aphrodisiac",
+      "stimulant"
+    ],
     "preparation": "Bark extract",
     "intensity": "Moderate",
     "onset": "30 min",
     "duration": "2-4 hrs",
     "legalStatus": "Regulated in some regions",
     "region": "Africa",
-    "tags": ["🌿 Bark", "🔥 Intensity", "⚠️ Caution"],
+    "tags": [
+      "🌿 Bark",
+      "🔥 Intensity",
+      "⚠️ Caution"
+    ],
     "mechanismOfAction": "Yohimbine is an adrenergic receptor antagonist",
     "pharmacokinetics": "Oral; peak plasma in 45 min",
     "therapeuticUses": "Erectile dysfunction treatment",
@@ -3525,20 +4617,28 @@
         "type": "alkaloid",
         "effect": "stimulant"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Eleutherococcus senticosus",
     "scientificName": "Eleutherococcus senticosus",
     "category": "Stimulant / Adaptogen",
-    "effects": ["Energy", "stress resistance"],
+    "effects": [
+      "Energy",
+      "stress resistance"
+    ],
     "preparation": "Root extract",
     "intensity": "Mild",
     "onset": "1 hr",
     "duration": "6 hrs",
     "legalStatus": "Legal",
     "region": "Siberia",
-    "tags": ["🌿 Root", "⚡ Stimulant", "✅ Safe"],
+    "tags": [
+      "🌿 Root",
+      "⚡ Stimulant",
+      "✅ Safe"
+    ],
     "mechanismOfAction": "Eleutherosides modulate stress hormones",
     "pharmacokinetics": "Oral; slow onset",
     "therapeuticUses": "Enhance stamina and immune function",
@@ -3556,20 +4656,28 @@
         "type": "phenylpropanoid",
         "effect": "adaptogen"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Ptychopetalum olacoides",
     "scientificName": "Ptychopetalum olacoides",
     "category": "Stimulant",
-    "effects": ["Libido boost", "mild stimulation"],
+    "effects": [
+      "Libido boost",
+      "mild stimulation"
+    ],
     "preparation": "Bark tincture",
     "intensity": "Mild",
     "onset": "30 min",
     "duration": "2-3 hrs",
     "legalStatus": "Legal",
     "region": "Amazon",
-    "tags": ["🌿 Bark", "⚡ Stimulant", "✅ Safe"],
+    "tags": [
+      "🌿 Bark",
+      "⚡ Stimulant",
+      "✅ Safe"
+    ],
     "mechanismOfAction": "Alkaloids may act on dopamine pathways",
     "pharmacokinetics": "Oral tincture; moderate onset",
     "therapeuticUses": "Aphrodisiac and tonic",
@@ -3587,20 +4695,28 @@
         "type": "alkaloid",
         "effect": "stimulant"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Claviceps purpurea",
     "scientificName": "Claviceps purpurea",
     "category": "Ritual / Visionary",
-    "effects": ["Powerful visions", "vasoconstriction"],
+    "effects": [
+      "Powerful visions",
+      "vasoconstriction"
+    ],
     "preparation": "Ergot sclerotia carefully processed",
     "intensity": "Strong",
     "onset": "1-2 hrs",
     "duration": "6-12 hrs",
     "legalStatus": "Controlled in many countries",
     "region": "Worldwide",
-    "tags": ["🍄 Fungus", "⚠️ Caution", "🧪 Alkaloid"],
+    "tags": [
+      "🍄 Fungus",
+      "⚠️ Caution",
+      "🧪 Alkaloid"
+    ],
     "mechanismOfAction": "Ergot alkaloids act on serotonin and adrenergic receptors",
     "pharmacokinetics": "Oral; metabolized in liver",
     "therapeuticUses": "Historical use in obstetrics and rituals",
@@ -3618,20 +4734,28 @@
         "type": "alkaloid",
         "effect": "hallucinogenic"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Cola nitida",
     "scientificName": "Cola nitida",
     "category": "Stimulant",
-    "effects": ["Alertness", "reduced fatigue"],
+    "effects": [
+      "Alertness",
+      "reduced fatigue"
+    ],
     "preparation": "Chewed seeds or beverages",
     "intensity": "Moderate",
     "onset": "Immediate when chewed",
     "duration": "2-3 hrs",
     "legalStatus": "Legal",
     "region": "Africa",
-    "tags": ["🌿 Seed", "⚡ Stimulant", "✅ Safe"],
+    "tags": [
+      "🌿 Seed",
+      "⚡ Stimulant",
+      "✅ Safe"
+    ],
     "mechanismOfAction": "Caffeine and kolanin stimulate CNS",
     "pharmacokinetics": "Chewed; caffeine absorbed quickly",
     "therapeuticUses": "Traditional energizer",
@@ -3649,20 +4773,28 @@
         "type": "alkaloid",
         "effect": "stimulant"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Camellia sinensis",
     "scientificName": "Camellia sinensis",
     "category": "Stimulant",
-    "effects": ["Alertness", "relaxation"],
+    "effects": [
+      "Alertness",
+      "relaxation"
+    ],
     "preparation": "Tea infusion",
     "intensity": "Mild",
     "onset": "10 min",
     "duration": "1-3 hrs",
     "legalStatus": "Legal",
     "region": "Asia",
-    "tags": ["🌿 Leaf", "⚡ Stimulant", "✅ Safe"],
+    "tags": [
+      "🌿 Leaf",
+      "⚡ Stimulant",
+      "✅ Safe"
+    ],
     "mechanismOfAction": "Caffeine and L-theanine affect adenosine and GABA",
     "pharmacokinetics": "Rapid absorption of caffeine; hepatic metabolism",
     "therapeuticUses": "Focus enhancement, relaxation",
@@ -3680,20 +4812,27 @@
         "type": "alkaloid",
         "effect": "stimulant"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Gynostemma pentaphyllum",
     "scientificName": "Gynostemma pentaphyllum",
     "category": "Other",
-    "effects": ["Adaptogenic", "anti-inflammatory"],
+    "effects": [
+      "Adaptogenic",
+      "anti-inflammatory"
+    ],
     "preparation": "Tea infusion",
     "intensity": "Mild",
     "onset": "30 min",
     "duration": "2-4 hrs",
     "legalStatus": "Legal",
     "region": "China",
-    "tags": ["🌿 Leaf", "✅ Safe"],
+    "tags": [
+      "🌿 Leaf",
+      "✅ Safe"
+    ],
     "mechanismOfAction": "Gypenosides modulate nitric oxide and cortisol",
     "pharmacokinetics": "Oral; moderate absorption",
     "therapeuticUses": "Stress resilience, metabolic support",
@@ -3711,20 +4850,26 @@
         "type": "saponin",
         "effect": "adaptogen"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Silybum marianum",
     "scientificName": "Silybum marianum",
     "category": "Other",
-    "effects": ["Liver protection"],
+    "effects": [
+      "Liver protection"
+    ],
     "preparation": "Seed extract",
     "intensity": "Mild",
     "onset": "1 hr",
     "duration": "4 hrs",
     "legalStatus": "Legal",
     "region": "Mediterranean",
-    "tags": ["🌿 Seed", "✅ Safe"],
+    "tags": [
+      "🌿 Seed",
+      "✅ Safe"
+    ],
     "mechanismOfAction": "Silymarin acts as antioxidant and hepatoprotective",
     "pharmacokinetics": "Oral; low bioavailability improved with extract",
     "therapeuticUses": "Liver detox support",
@@ -3742,20 +4887,28 @@
         "type": "flavonolignan",
         "effect": "hepatoprotective"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Piper methysticum",
     "scientificName": "Piper methysticum",
     "category": "Dissociative / Sedative",
-    "effects": ["Anxiolytic", "sedation"],
+    "effects": [
+      "Anxiolytic",
+      "sedation"
+    ],
     "preparation": "Root beverage",
     "intensity": "Moderate",
     "onset": "20 min",
     "duration": "3-6 hrs",
     "legalStatus": "Regulated in some countries",
     "region": "Pacific Islands",
-    "tags": ["🌿 Root", "💤 Sedation", "⚠️ Caution"],
+    "tags": [
+      "🌿 Root",
+      "💤 Sedation",
+      "⚠️ Caution"
+    ],
     "mechanismOfAction": "Kavalactones modulate GABA receptors",
     "pharmacokinetics": "Oral; active within 20-30 min",
     "therapeuticUses": "Anxiety relief, social relaxation",
@@ -3773,20 +4926,28 @@
         "type": "lactone",
         "effect": "anxiolytic"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Rivea corymbosa",
     "scientificName": "Rivea corymbosa",
     "category": "Ritual / Visionary",
-    "effects": ["Visionary states", "nausea"],
+    "effects": [
+      "Visionary states",
+      "nausea"
+    ],
     "preparation": "Seeds ground and taken orally",
     "intensity": "Strong",
     "onset": "1 hr",
     "duration": "6-8 hrs",
     "legalStatus": "Varies",
     "region": "Central America",
-    "tags": ["🌿 Seed", "🧪 Alkaloid", "⚠️ Caution"],
+    "tags": [
+      "🌿 Seed",
+      "🧪 Alkaloid",
+      "⚠️ Caution"
+    ],
     "mechanismOfAction": "Contains LSA, a serotonin receptor agonist",
     "pharmacokinetics": "Oral; converted to active amides",
     "therapeuticUses": "Shamanic visions, introspection",
@@ -3804,20 +4965,28 @@
         "type": "alkaloid",
         "effect": "psychedelic"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Uncaria rhynchophylla",
     "scientificName": "Uncaria rhynchophylla",
     "category": "Dissociative / Sedative",
-    "effects": ["Calming", "anticonvulsant"],
+    "effects": [
+      "Calming",
+      "anticonvulsant"
+    ],
     "preparation": "Hook vine decoction",
     "intensity": "Mild",
     "onset": "30 min",
     "duration": "3 hrs",
     "legalStatus": "Legal",
     "region": "China",
-    "tags": ["🌿 Vine", "💤 Sedation", "✅ Safe"],
+    "tags": [
+      "🌿 Vine",
+      "💤 Sedation",
+      "✅ Safe"
+    ],
     "mechanismOfAction": "Rhynchophylline blocks NMDA receptors",
     "pharmacokinetics": "Oral; moderate absorption",
     "therapeuticUses": "Traditional treatment for tremors and agitation",
@@ -3835,6 +5004,7 @@
         "type": "alkaloid",
         "effect": "calming"
       }
-    ]
+    ],
+    "affiliateLink": null
   }
 ]

--- a/Full190.json
+++ b/Full190.json
@@ -36,7 +36,8 @@
         "type": "tryptamine",
         "effect": "potent visionary"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Acorus gramineus",
@@ -68,7 +69,8 @@
     ],
     "therapeuticUses": "Cognitive enhancement, anxiety, neuroprotective potential.",
     "toxicity": "Concerns over β-asarone carcinogenicity in some studies.",
-    "toxicityLD50": "β-asarone LD50 (rat, oral): ~310 mg/kg."
+    "toxicityLD50": "β-asarone LD50 (rat, oral): ~310 mg/kg.",
+    "affiliateLink": null
   },
   {
     "name": "African Dream Root",
@@ -100,7 +102,8 @@
     ],
     "therapeuticUses": "Dream recall, ancestral communication (traditional)",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Alchornea castaneifolia",
@@ -132,7 +135,8 @@
     ],
     "therapeuticUses": "Rheumatism, arthritis, spiritual cleansing",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Anadenanthera colubrina (Cebíl)",
@@ -161,7 +165,8 @@
     ],
     "therapeuticUses": "Traditionally used as a snuff for visionary and divinatory rituals in South American cultures [1, 1].",
     "toxicity": "No documented human LD50; rodent LD50 approximately 200–300 mg/kg (intraperitoneal) [1, 0].",
-    "toxicityLD50": "No documented human LD50; rodent LD50 approximately 200–300 mg/kg (intraperitoneal) [1, 0]."
+    "toxicityLD50": "No documented human LD50; rodent LD50 approximately 200–300 mg/kg (intraperitoneal) [1, 0].",
+    "affiliateLink": null
   },
   {
     "name": "Artemisia vulgaris (Mugwort)",
@@ -194,7 +199,8 @@
     ],
     "therapeuticUses": "Not well documented",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Bacopa monnieri",
@@ -227,7 +233,8 @@
     ],
     "therapeuticUses": "Cognitive enhancement (memory, learning), anxiety reduction, ADHD management [0, 1, 0, 6].",
     "toxicity": "Generally non-toxic; no serious adverse effects at recommended doses; rodent LD50 not well established [0, 6].",
-    "toxicityLD50": "Generally non-toxic; no serious adverse effects at recommended doses; rodent LD50 not well established [0, 6]."
+    "toxicityLD50": "Generally non-toxic; no serious adverse effects at recommended doses; rodent LD50 not well established [0, 6].",
+    "affiliateLink": null
   },
   {
     "name": "Belladonna",
@@ -256,7 +263,8 @@
     ],
     "therapeuticUses": "Historically used for pain, muscle spasms, and cosmetic dilation.",
     "toxicity": "Highly toxic; accidental ingestion can be fatal.",
-    "toxicityLD50": "Atropine LD50 (rat, oral): ~453 mg/kg."
+    "toxicityLD50": "Atropine LD50 (rat, oral): ~453 mg/kg.",
+    "affiliateLink": null
   },
   {
     "name": "Betel Nut",
@@ -284,7 +292,8 @@
     "tags": [],
     "therapeuticUses": "Traditional digestive stimulant",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Blue Lotus",
@@ -316,7 +325,8 @@
     ],
     "therapeuticUses": "Anxiety, mild sedation, aphrodisiac",
     "toxicity": "Low",
-    "toxicityLD50": "Not known"
+    "toxicityLD50": "Not known",
+    "affiliateLink": null
   },
   {
     "name": "Blue Lotus (Nymphaea caerulea)",
@@ -349,7 +359,8 @@
     ],
     "therapeuticUses": "Mild euphoria, anxiety relief, and aphrodisiac in traditional use.",
     "toxicity": "Low toxicity; no serious effects reported from traditional use.",
-    "toxicityLD50": "Not established; no reported lethal doses."
+    "toxicityLD50": "Not established; no reported lethal doses.",
+    "affiliateLink": null
   },
   {
     "name": "Bobinsana",
@@ -381,7 +392,8 @@
     ],
     "therapeuticUses": "Emotional trauma healing, dream support",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Brugmansia",
@@ -409,7 +421,8 @@
     "tags": [],
     "therapeuticUses": "Historical use in asthma and pain (no modern safe use)",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Caapi",
@@ -437,7 +450,8 @@
     "tags": [],
     "therapeuticUses": "Ayahuasca therapy for PTSD, depression",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Calea zacatechichi",
@@ -469,7 +483,8 @@
     ],
     "therapeuticUses": "Sleep induction, dream work",
     "toxicity": "Low",
-    "toxicityLD50": "Not known"
+    "toxicityLD50": "Not known",
+    "affiliateLink": null
   },
   {
     "name": "California Poppy",
@@ -501,7 +516,8 @@
     ],
     "therapeuticUses": "Used for anxiety, insomnia, and pain management.",
     "toxicity": "Low toxicity; non-habit-forming.",
-    "toxicityLD50": "No known LD50 in humans; safe at standard doses."
+    "toxicityLD50": "No known LD50 in humans; safe at standard doses.",
+    "affiliateLink": null
   },
   {
     "name": "Celastrus paniculatus",
@@ -533,7 +549,8 @@
     ],
     "therapeuticUses": "Memory support, neuroprotection, dream recall",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Celastrus paniculatus (Intellect Tree)",
@@ -563,7 +580,8 @@
     ],
     "therapeuticUses": "Not well documented",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Chacruna",
@@ -595,7 +613,8 @@
     ],
     "therapeuticUses": "Spiritual healing, emotional release (as part of Ayahuasca)",
     "toxicity": "Low physical toxicity, high psychological risk",
-    "toxicityLD50": "Not established in humans"
+    "toxicityLD50": "Not established in humans",
+    "affiliateLink": null
   },
   {
     "name": "Chiric Sanango",
@@ -626,7 +645,8 @@
     ],
     "therapeuticUses": "Potentiates ayahuasca, used in Amazonian rituals for introspection and mild hallucinations [0, 4].",
     "toxicity": "Toxic in high doses; caution advised.",
-    "toxicityLD50": "LD50 not established; considered mildly toxic in large doses due to cholinergic effects."
+    "toxicityLD50": "LD50 not established; considered mildly toxic in large doses due to cholinergic effects.",
+    "affiliateLink": null
   },
   {
     "name": "Clavo huasca",
@@ -658,7 +678,8 @@
     ],
     "therapeuticUses": "Aphrodisiac, digestive aid in Amazonian medicine",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Copal",
@@ -690,7 +711,8 @@
     ],
     "therapeuticUses": "Not well documented",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Cyperus articulatus",
@@ -722,7 +744,8 @@
     ],
     "therapeuticUses": "Spiritual clarity, dream work, digestion",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Damiana",
@@ -754,7 +777,8 @@
     ],
     "therapeuticUses": "Libido, nervous system support, mild stimulant",
     "toxicity": "Low",
-    "toxicityLD50": "Not well established"
+    "toxicityLD50": "Not well established",
+    "affiliateLink": null
   },
   {
     "name": "Desfontainia spinosa",
@@ -786,7 +810,8 @@
     ],
     "therapeuticUses": "Traditional visionary plant; not clinically established",
     "toxicity": "Potentially high at ritual doses",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Eleutherococcus senticosus (Siberian Ginseng)",
@@ -817,7 +842,8 @@
     ],
     "therapeuticUses": "Fatigue, immune support, cognitive performance under stress.",
     "toxicity": "Generally considered safe when used short-term. Long-term effects less studied.",
-    "toxicityLD50": "No established LD50; high doses in animals show minimal acute toxicity."
+    "toxicityLD50": "No established LD50; high doses in animals show minimal acute toxicity.",
+    "affiliateLink": null
   },
   {
     "name": "Entada rheedii",
@@ -848,7 +874,8 @@
     ],
     "therapeuticUses": "Dream enhancement, lucid dreaming, traditional remedy for diarrhea and stomach aches [0, 6, 0, 11].",
     "toxicity": "Low; no severe toxicity reported in traditional use [0, 6].",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Eschscholzia californica (California poppy)",
@@ -880,7 +907,8 @@
     ],
     "therapeuticUses": "Anxiety reduction, insomnia aid, mild analgesic, vasomotor headache relief [2, 3, 2, 7].",
     "toxicity": "Low; no significant toxicity at therapeutic doses [2, 9].",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Frankincense (Boswellia)",
@@ -909,7 +937,8 @@
     ],
     "therapeuticUses": "Not well documented",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Guayusa",
@@ -941,7 +970,8 @@
     ],
     "therapeuticUses": "Energy, focus, lucid dreaming support",
     "toxicity": "Low",
-    "toxicityLD50": "~190 mg/kg (caffeine)"
+    "toxicityLD50": "~190 mg/kg (caffeine)",
+    "affiliateLink": null
   },
   {
     "name": "Heimia salicifolia (Sinicuichi)",
@@ -973,7 +1003,8 @@
     ],
     "therapeuticUses": "Divination, auditory changes, euphoria in folk practices [9, 4].",
     "toxicity": "Low toxicity; high doses may cause mild sedation or nausea [9, 4].",
-    "toxicityLD50": "Not well established; no fatal doses reported in traditional use."
+    "toxicityLD50": "Not well established; no fatal doses reported in traditional use.",
+    "affiliateLink": null
   },
   {
     "name": "Henbane",
@@ -1004,7 +1035,8 @@
     ],
     "therapeuticUses": "Not well documented",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Hop Flowers",
@@ -1035,7 +1067,8 @@
     ],
     "therapeuticUses": "Used as a mild sleep aid, anxiety reducer, and dream enhancer.",
     "toxicity": "Very low toxicity; generally regarded as safe.",
-    "toxicityLD50": "No human LD50; high safety margin reported in herbal use."
+    "toxicityLD50": "No human LD50; high safety margin reported in herbal use.",
+    "affiliateLink": null
   },
   {
     "name": "Indian Lotus",
@@ -1067,7 +1100,8 @@
     ],
     "therapeuticUses": "Stress, anxiety, spiritual use",
     "toxicity": "Low",
-    "toxicityLD50": "Not known"
+    "toxicityLD50": "Not known",
+    "affiliateLink": null
   },
   {
     "name": "Indian Pipe",
@@ -1099,7 +1133,8 @@
     ],
     "therapeuticUses": "Pain relief, emotional trauma support (traditional)",
     "toxicity": "Unknown",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Ipomoea tricolor (Heavenly Blue)",
@@ -1128,7 +1163,8 @@
     ],
     "therapeuticUses": "Visionary experiences, ethnobotanical use [0, 5].",
     "toxicity": "Low; rodent LD50 ~200–300 mg/kg [0, 5].",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Justicia pectoralis",
@@ -1160,7 +1196,8 @@
     ],
     "therapeuticUses": "Anxiety, insomnia, spiritual enhancement",
     "toxicity": "Low–moderate with excess",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Kanna",
@@ -1192,7 +1229,8 @@
     ],
     "therapeuticUses": "Anxiety, stress, social comfort",
     "toxicity": "Low",
-    "toxicityLD50": "Not established (safe in traditional use)"
+    "toxicityLD50": "Not established (safe in traditional use)",
+    "affiliateLink": null
   },
   {
     "name": "Kava",
@@ -1231,7 +1269,8 @@
         "type": "alkaloid",
         "effect": "anxiolytic"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Kra Thum Na / Kok",
@@ -1263,7 +1302,8 @@
     ],
     "therapeuticUses": "Not well documented",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Lactuca canadensis",
@@ -1295,7 +1335,8 @@
     ],
     "therapeuticUses": "Insomnia, pain, cough relief",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Mandrake Root",
@@ -1324,7 +1365,8 @@
     ],
     "therapeuticUses": "Historically used as anesthetic, antispasmodic, and in witchcraft.",
     "toxicity": "Highly toxic in moderate doses.",
-    "toxicityLD50": "Scopolamine LD50 (rat, oral): ~310 mg/kg."
+    "toxicityLD50": "Scopolamine LD50 (rat, oral): ~310 mg/kg.",
+    "affiliateLink": null
   },
   {
     "name": "Melissa officinalis (Lemon balm)",
@@ -1358,7 +1400,8 @@
     ],
     "therapeuticUses": "Anxiety, insomnia, nervous tension, digestive aid [0, 8].",
     "toxicity": "Low; safe at therapeutic doses [0, 0].",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Mimosa hostilis",
@@ -1390,7 +1433,8 @@
     ],
     "therapeuticUses": "Spiritual healing, insight, skin regeneration (topical)",
     "toxicity": "Low physiological, high psychological",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Nelumbo nucifera",
@@ -1422,7 +1466,8 @@
     ],
     "therapeuticUses": "Calm, aphrodisiac, meditation support",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Nymphaea ampla",
@@ -1455,7 +1500,8 @@
     ],
     "therapeuticUses": "Not well documented",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Ocimum sanctum (Holy Basil / Tulsi)",
@@ -1489,7 +1535,8 @@
     ],
     "therapeuticUses": "Adaptogen, anxiety, spiritual focus, blood sugar balance.",
     "toxicity": "Pending",
-    "toxicityLD50": "Pending"
+    "toxicityLD50": "Pending",
+    "affiliateLink": null
   },
   {
     "name": "Passionflower",
@@ -1528,7 +1575,8 @@
         "type": "alkaloid",
         "effect": "anxiolytic"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Pedicularis densiflora (Indian warrior)",
@@ -1560,7 +1608,8 @@
     ],
     "therapeuticUses": "Muscle tension, pain relief, sleep aid applications [2, 0].",
     "toxicity": "Low; limited data on long-term use [2, 0].",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Pedicularis groenlandica",
@@ -1592,7 +1641,8 @@
     ],
     "therapeuticUses": "Muscle relaxant, antioxidant, antimicrobial, traditional remedy for pain and inflammation [0, 7].",
     "toxicity": "Low; no significant toxicity reported [0, 7].",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Petasites hybridus",
@@ -1624,7 +1674,8 @@
     ],
     "therapeuticUses": "Migraine prevention, allergies, anxiety",
     "toxicity": "Moderate to high (raw plant)",
-    "toxicityLD50": "~950 mg/kg (mouse, oral, unpurified)"
+    "toxicityLD50": "~950 mg/kg (mouse, oral, unpurified)",
+    "affiliateLink": null
   },
   {
     "name": "Piper auritum (Root beer plant)",
@@ -1657,7 +1708,8 @@
     ],
     "therapeuticUses": "Digestive aid, anti-inflammatory, antimutagen, diuretic, antipyretic [0, 11].",
     "toxicity": "Safrole hepatotoxic; use sparingly [1, 11].",
-    "toxicityLD50": "LD50 (rats, oral) safrole ~1,950 mg/kg; safrole is hepatotoxic at high doses."
+    "toxicityLD50": "LD50 (rats, oral) safrole ~1,950 mg/kg; safrole is hepatotoxic at high doses.",
+    "affiliateLink": null
   },
   {
     "name": "Rhodiola rosea",
@@ -1690,7 +1742,8 @@
     ],
     "therapeuticUses": "Fatigue, stress resilience, cognitive enhancement, mild depression.",
     "toxicity": "Mild toxicity; high doses may cause irritability or insomnia.",
-    "toxicityLD50": "LD50 (rats, oral) >28,000 mg/kg; very low toxicity."
+    "toxicityLD50": "LD50 (rats, oral) >28,000 mg/kg; very low toxicity.",
+    "affiliateLink": null
   },
   {
     "name": "Rivea corymbosa",
@@ -1720,7 +1773,8 @@
     ],
     "therapeuticUses": "Entheogenic snuff (ololiuqui) in Mesoamerican rituals [0, 4].",
     "toxicity": "Low; moderate overdose risk [0, 12].",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Salvia divinorum",
@@ -1751,7 +1805,8 @@
     ],
     "therapeuticUses": "Visionary experiences in traditional Mazatec rituals; investigated for analgesic and anti-inflammatory properties [3, 0].",
     "toxicity": "Low toxicity; animal studies show minimal organ damage even at high doses [3, 3].",
-    "toxicityLD50": "LD50 not established; salvinorin A active at microgram levels with no evidence of physical toxicity."
+    "toxicityLD50": "LD50 not established; salvinorin A active at microgram levels with no evidence of physical toxicity.",
+    "affiliateLink": null
   },
   {
     "name": "Sceletium tortuosum (Kanna)",
@@ -1783,7 +1838,8 @@
     ],
     "therapeuticUses": "Mood enhancement, anti-anxiety, social facilitation [9, 4].",
     "toxicity": "Low toxicity at traditional doses [9, 4].",
-    "toxicityLD50": "Not established in humans; high safety margin observed in animal studies."
+    "toxicityLD50": "Not established in humans; high safety margin observed in animal studies.",
+    "affiliateLink": null
   },
   {
     "name": "Scullcap (Scutellaria)",
@@ -1815,7 +1871,8 @@
     ],
     "therapeuticUses": "Calming, anticonvulsant, neuroprotective.",
     "toxicity": "Generally safe, though adulterants in supplements have caused concern.",
-    "toxicityLD50": "No standard LD50 data; high therapeutic margin."
+    "toxicityLD50": "No standard LD50 data; high therapeutic margin.",
+    "affiliateLink": null
   },
   {
     "name": "Scutellaria lateriflora",
@@ -1847,7 +1904,8 @@
     ],
     "therapeuticUses": "Anxiety, stress, insomnia, PMS",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Silene capensis",
@@ -1879,7 +1937,8 @@
     ],
     "therapeuticUses": "Dream enhancement, ancestral communication",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Silphium (extinct)",
@@ -1907,7 +1966,8 @@
     ],
     "therapeuticUses": "Not well documented",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Sinicuichi",
@@ -1939,7 +1999,8 @@
     ],
     "therapeuticUses": "Folk use for memory and dream recall",
     "toxicity": "Low to moderate; not well studied",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Sweetgrass",
@@ -1969,7 +2030,8 @@
     ],
     "therapeuticUses": "Not well documented",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Tagetes lucida (Mexican Tarragon)",
@@ -2002,7 +2064,8 @@
     ],
     "therapeuticUses": "Anxiolytic, digestive aid, ritual incense for purification [2, 10].",
     "toxicity": "Low; traditional use generally safe.",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Tilia europaea (Linden flower)",
@@ -2035,7 +2098,8 @@
     ],
     "therapeuticUses": "Not well documented",
     "toxicity": "Unknown",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Toloache",
@@ -2067,7 +2131,8 @@
     ],
     "therapeuticUses": "Rarely used medically; historically for pain/spiritual rites",
     "toxicity": "Very high",
-    "toxicityLD50": "~50 mg/kg (atropine/scopolamine)"
+    "toxicityLD50": "~50 mg/kg (atropine/scopolamine)",
+    "affiliateLink": null
   },
   {
     "name": "Turnera diffusa",
@@ -2100,7 +2165,8 @@
     ],
     "therapeuticUses": "Aphrodisiac, mood enhancement, stress relief [8, 6].",
     "toxicity": "Low in traditional doses.",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Turnera ulmifolia",
@@ -2132,7 +2198,8 @@
     ],
     "therapeuticUses": "Libido, menstrual cramps, anxiety",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Urtica dioica",
@@ -2164,7 +2231,8 @@
     ],
     "therapeuticUses": "Allergies, joint pain, urinary tract support",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Viola odorata (Sweet violet)",
@@ -2197,7 +2265,8 @@
     ],
     "therapeuticUses": "Cough suppressant, mild anxiolytic, anti-inflammatory, gentle sleep aid.",
     "toxicity": "Regarded as very safe in traditional herbalism.",
-    "toxicityLD50": "No human LD50 data; extremely low toxicity reported."
+    "toxicityLD50": "No human LD50 data; extremely low toxicity reported.",
+    "affiliateLink": null
   },
   {
     "name": "Virola spp.",
@@ -2225,7 +2294,8 @@
     ],
     "therapeuticUses": "Used in Amazonian shamanic healing rituals; possible antidepressant potential.",
     "toxicity": "Can be overwhelming; physical toxicity low but psychological risks high.",
-    "toxicityLD50": "No established LD50 for DMT in humans; low systemic toxicity at typical doses."
+    "toxicityLD50": "No established LD50 for DMT in humans; low systemic toxicity at typical doses.",
+    "affiliateLink": null
   },
   {
     "name": "Virola theiodora",
@@ -2257,7 +2327,8 @@
     ],
     "therapeuticUses": "Shamanic ritual; purging and vision work",
     "toxicity": "High psychological, moderate physical",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Voacanga africana",
@@ -2289,7 +2360,8 @@
     ],
     "therapeuticUses": "Experimental use in addiction therapy (via ibogaine synthesis)",
     "toxicity": "High in overdose; cardiotoxic potential",
-    "toxicityLD50": "~90–120 mg/kg (est. voacangine)"
+    "toxicityLD50": "~90–120 mg/kg (est. voacangine)",
+    "affiliateLink": null
   },
   {
     "name": "White Lily",
@@ -2321,7 +2393,8 @@
     ],
     "therapeuticUses": "Relaxation, aphrodisiac, dream enhancement",
     "toxicity": "Low",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "White Sage",
@@ -2354,7 +2427,8 @@
     ],
     "therapeuticUses": "Smudging rituals for purification, antimicrobial, respiratory support, mental clarity [0, 19].",
     "toxicity": "Very low; excessive inhalation may cause dizziness or nausea [0, 4].",
-    "toxicityLD50": "Unknown"
+    "toxicityLD50": "Unknown",
+    "affiliateLink": null
   },
   {
     "name": "Wild Lettuce",
@@ -2386,7 +2460,8 @@
     ],
     "therapeuticUses": "Insomnia, pain relief, cough suppression",
     "toxicity": "Low in traditional doses",
-    "toxicityLD50": "Not established"
+    "toxicityLD50": "Not established",
+    "affiliateLink": null
   },
   {
     "name": "Withania somnifera (Ashwagandha)",
@@ -2419,7 +2494,8 @@
     ],
     "therapeuticUses": "Adaptogen, anti-stress, anxiolytic, neuroprotective, anti-inflammatory, immune support [0, 1, 0, 17].",
     "toxicity": "Low; well-tolerated in clinical studies [0, 1].",
-    "toxicityLD50": "LD50 (rats, oral) ~4650 mg/kg; relatively low acute toxicity."
+    "toxicityLD50": "LD50 (rats, oral) ~4650 mg/kg; relatively low acute toxicity.",
+    "affiliateLink": null
   },
   {
     "name": "Wormwood",
@@ -2458,7 +2534,8 @@
         "type": "terpenoid",
         "effect": "GABA_A antagonist"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Yerba Mate",
@@ -2490,7 +2567,8 @@
     ],
     "therapeuticUses": "Energy, mental clarity, digestion",
     "toxicity": "Low to moderate (long-term use linked to GI issues)",
-    "toxicityLD50": "~192 mg/kg (caffeine)"
+    "toxicityLD50": "~192 mg/kg (caffeine)",
+    "affiliateLink": null
   },
   {
     "name": "Yopo",
@@ -2522,7 +2600,8 @@
     ],
     "therapeuticUses": "Shamanic healing, insight rituals",
     "toxicity": "High risk with improper use; bufotenine toxic at high dose",
-    "toxicityLD50": "50–80 mg/kg (bufotenine, mice)"
+    "toxicityLD50": "50–80 mg/kg (bufotenine, mice)",
+    "affiliateLink": null
   },
   {
     "name": "Amanita muscaria",
@@ -2552,7 +2631,8 @@
     "contraindications": "Avoid with sedatives or psychiatric conditions.",
     "sideEffects": "Nausea, ataxia, delirium",
     "drugInteractions": "Potentiates sedatives and alcohol",
-    "description": "Iconic red-capped mushroom used in Siberian shamanism and folklore. Psychoactive when properly prepared."
+    "description": "Iconic red-capped mushroom used in Siberian shamanism and folklore. Psychoactive when properly prepared.",
+    "affiliateLink": null
   },
   {
     "name": "Valerian Root",
@@ -2582,7 +2662,8 @@
     "contraindications": "Avoid with other sedatives or during pregnancy.",
     "sideEffects": "Drowsiness, vivid dreams",
     "drugInteractions": "Additive with benzodiazepines or alcohol",
-    "description": "Traditional European herb valued for calming and sleep-promoting properties."
+    "description": "Traditional European herb valued for calming and sleep-promoting properties.",
+    "affiliateLink": null
   },
   {
     "name": "Huperzia serrata",
@@ -2611,7 +2692,8 @@
     "contraindications": "Bradycardia, cholinergic medications.",
     "sideEffects": "Nausea, sweating, muscle twitching at high doses",
     "drugInteractions": "Potentiates cholinergic drugs or acetylcholinesterase inhibitors",
-    "description": "Club moss used in Traditional Chinese Medicine; source of huperzine A nootropic."
+    "description": "Club moss used in Traditional Chinese Medicine; source of huperzine A nootropic.",
+    "affiliateLink": null
   },
   {
     "name": "Syrian Rue",
@@ -2641,7 +2723,8 @@
     "contraindications": "Avoid with SSRIs, stimulants, or liver disease.",
     "sideEffects": "Nausea, vomiting, weakness",
     "drugInteractions": "Dangerous with other MAOIs or serotonergic drugs",
-    "description": "Potent MAOI seed used traditionally for protection and divination."
+    "description": "Potent MAOI seed used traditionally for protection and divination.",
+    "affiliateLink": null
   },
   {
     "name": "Wild Dagga",
@@ -2670,7 +2753,8 @@
     "contraindications": "Avoid during pregnancy or with heart conditions.",
     "sideEffects": "Dry mouth, slight dizziness",
     "drugInteractions": "May potentiate other sedatives",
-    "description": "Orange-flowered shrub also called lion’s tail; smoked traditionally for mild cannabis-like effects."
+    "description": "Orange-flowered shrub also called lion’s tail; smoked traditionally for mild cannabis-like effects.",
+    "affiliateLink": null
   },
   {
     "name": "Yohimbe",
@@ -2700,7 +2784,8 @@
     "contraindications": "Heart disease, anxiety disorders, MAOIs.",
     "sideEffects": "Increased blood pressure, jitteriness, insomnia",
     "drugInteractions": "Interacts with stimulants and antihypertensives",
-    "description": "West African tree bark rich in yohimbine, historically used as an aphrodisiac and stimulant."
+    "description": "West African tree bark rich in yohimbine, historically used as an aphrodisiac and stimulant.",
+    "affiliateLink": null
   },
   {
     "name": "Khat",
@@ -2730,7 +2815,8 @@
     "contraindications": "Heart issues, pregnancy, MAOIs.",
     "sideEffects": "Dry mouth, increased heart rate, insomnia",
     "drugInteractions": "Avoid with stimulants or MAOIs",
-    "description": "Evergreen shrub whose fresh leaves are chewed for stimulant and euphoric effects in social settings."
+    "description": "Evergreen shrub whose fresh leaves are chewed for stimulant and euphoric effects in social settings.",
+    "affiliateLink": null
   },
   {
     "name": "Camellia sinensis",
@@ -2759,7 +2845,8 @@
     "contraindications": "Heart conditions, pregnancy (high amounts).",
     "sideEffects": "Jitters, insomnia, digestive upset",
     "drugInteractions": "Potentiates other stimulants; may reduce sedative efficacy",
-    "description": "Source of green and black tea; contains caffeine and theanine for balanced stimulation."
+    "description": "Source of green and black tea; contains caffeine and theanine for balanced stimulation.",
+    "affiliateLink": null
   },
   {
     "name": "Ephedra sinica",
@@ -2788,7 +2875,8 @@
     "contraindications": "Heart disease, hypertension, MAOIs.",
     "sideEffects": "Jitters, elevated heart rate, insomnia",
     "drugInteractions": "Dangerous with other stimulants or MAOIs",
-    "description": "Shrubby plant known as Ma Huang; source of ephedrine used both medicinally and recreationally."
+    "description": "Shrubby plant known as Ma Huang; source of ephedrine used both medicinally and recreationally.",
+    "affiliateLink": null
   },
   {
     "name": "Sassafras",
@@ -2817,7 +2905,8 @@
     "contraindications": "Liver disease, pregnancy.",
     "sideEffects": "Nausea, possible hepatotoxicity",
     "drugInteractions": "May interact with MAOIs or increase hepatotoxic drugs",
-    "description": "Fragrant tree whose root bark and oil were once common flavorings; contains safrole with mild psychoactive properties."
+    "description": "Fragrant tree whose root bark and oil were once common flavorings; contains safrole with mild psychoactive properties.",
+    "affiliateLink": null
   },
   {
     "name": "Guarana",
@@ -2846,7 +2935,8 @@
     "contraindications": "Heart problems, pregnancy, sensitivity to caffeine.",
     "sideEffects": "Jitteriness, stomach upset",
     "drugInteractions": "Potentiates other stimulants; may interfere with sedatives",
-    "description": "Climbing plant native to Brazil; its seeds provide a potent caffeine kick and are popular in energy drinks."
+    "description": "Climbing plant native to Brazil; its seeds provide a potent caffeine kick and are popular in energy drinks.",
+    "affiliateLink": null
   },
   {
     "name": "Hawaiian Baby Woodrose",
@@ -2876,7 +2966,8 @@
     "contraindications": "Pregnancy, liver issues, MAOIs.",
     "sideEffects": "Nausea, vasoconstriction, sedation",
     "drugInteractions": "Avoid with vasoconstrictors or other psychedelics",
-    "description": "Climber with heart-shaped leaves; its seeds contain LSA and are used as a legal alternative to LSD experiences."
+    "description": "Climber with heart-shaped leaves; its seeds contain LSA and are used as a legal alternative to LSD experiences.",
+    "affiliateLink": null
   },
   {
     "name": "Tabernanthe iboga",
@@ -2906,7 +2997,8 @@
     "contraindications": "Heart conditions, psychiatric disorders, MAOIs.",
     "sideEffects": "Nausea, ataxia, prolonged recovery",
     "drugInteractions": "Dangerous with other stimulants or opioids",
-    "description": "Sacred shrub central to Bwiti ceremonies; contains ibogaine producing intense visionary states and potential addiction therapy."
+    "description": "Sacred shrub central to Bwiti ceremonies; contains ibogaine producing intense visionary states and potential addiction therapy.",
+    "affiliateLink": null
   },
   {
     "name": "LSD",
@@ -2937,7 +3029,8 @@
     "toxicityLD50": ">14 mg/kg (mice, intravenous)",
     "id": "lsd",
     "description": "Semi-synthetic ergoline discovered in 1938; among the most potent psychedelics.",
-    "safetyRating": 2
+    "safetyRating": 2,
+    "affiliateLink": null
   },
   {
     "name": "Psilocybin",
@@ -2968,7 +3061,8 @@
     "toxicityLD50": "285 mg/kg (rats, oral) for psilocybin",
     "id": "psilocybin",
     "description": "Active compound in psychedelic mushrooms producing profound perceptual changes.",
-    "safetyRating": 2
+    "safetyRating": 2,
+    "affiliateLink": null
   },
   {
     "name": "Mescaline",
@@ -2999,7 +3093,8 @@
     "toxicityLD50": ">1,000 mg/kg (rats, oral)",
     "id": "mescaline",
     "description": "Classic phenethylamine psychedelic from peyote and San Pedro cacti.",
-    "safetyRating": 2
+    "safetyRating": 2,
+    "affiliateLink": null
   },
   {
     "name": "Acacia maidenii",
@@ -3031,7 +3126,8 @@
     "sideEffects": "Nausea, anxiety, profound alterations of perception",
     "drugInteractions": "Dangerous with MAOIs or serotonergic drugs",
     "description": "Australian acacia tree whose bark is rich in DMT and sometimes used in ayahuasca analogues.",
-    "id": "acacia-maidenii"
+    "id": "acacia-maidenii",
+    "affiliateLink": null
   },
   {
     "name": "Acorus calamus",
@@ -3063,7 +3159,8 @@
     "sideEffects": "Nausea, vomiting at large doses",
     "drugInteractions": "Potential additive effects with other sedatives",
     "description": "Fragrant wetland herb known as Sweet Flag; historically used for relaxation and vivid dreams.",
-    "id": "acorus-calamus"
+    "id": "acorus-calamus",
+    "affiliateLink": null
   },
   {
     "name": "Albizia julibrissin",
@@ -3095,7 +3192,8 @@
     "sideEffects": "Rare drowsiness in sensitive individuals",
     "drugInteractions": "May enhance other sedatives or antidepressants",
     "description": "Often called Persian silk tree; valued in Asian herbalism for its tranquil and mood-brightening properties.",
-    "id": "albizia-julibrissin"
+    "id": "albizia-julibrissin",
+    "affiliateLink": null
   },
   {
     "name": "Anemone pulsatilla",
@@ -3127,7 +3225,8 @@
     "sideEffects": "Nausea, stomach irritation if taken fresh",
     "drugInteractions": "May potentiate other sedatives or analgesics",
     "description": "Also called Pasque Flower; once used by herbalists for calming nerves and relieving pain.",
-    "id": "anemone-pulsatilla"
+    "id": "anemone-pulsatilla",
+    "affiliateLink": null
   },
   {
     "name": "Argemone mexicana",
@@ -3159,7 +3258,8 @@
     "sideEffects": "Headache, stomach upset, potential liver damage",
     "drugInteractions": "Avoid combining with alcohol or other depressants",
     "description": "Spiny yellow poppy whose milky latex was historically used for pain relief and sedation.",
-    "id": "argemone-mexicana"
+    "id": "argemone-mexicana",
+    "affiliateLink": null
   },
   {
     "name": "Combretum quadrangulare",
@@ -3191,7 +3291,8 @@
     "sideEffects": "Jitters, insomnia if overused",
     "drugInteractions": "May potentiate other stimulants",
     "description": "Often marketed as “Sakae Naa,” this plant is used as a mild energizing substitute for kratom.",
-    "id": "combretum-quadrangulare"
+    "id": "combretum-quadrangulare",
+    "affiliateLink": null
   },
   {
     "name": "Corydalis yanhusuo",
@@ -3223,7 +3324,8 @@
     "sideEffects": "Drowsiness, dizziness",
     "drugInteractions": "May potentiate sedatives or dopaminergic drugs",
     "description": "Tubers of this Asian herb provide notable pain relief and a tranquil state when used as tea or pills.",
-    "id": "corydalis-yanhusuo"
+    "id": "corydalis-yanhusuo",
+    "affiliateLink": null
   },
   {
     "name": "Desmanthus illinoensis",
@@ -3255,7 +3357,8 @@
     "sideEffects": "Nausea, anxiety, powerful visions",
     "drugInteractions": "Dangerous with MAOIs or serotonergic drugs",
     "description": "Also called Illinois Bundleflower; its root bark contains notable amounts of DMT.",
-    "id": "desmanthus-illinoensis"
+    "id": "desmanthus-illinoensis",
+    "affiliateLink": null
   },
   {
     "name": "Erythrina mulungu",
@@ -3287,7 +3390,8 @@
     "sideEffects": "Drowsiness, lowered blood pressure",
     "drugInteractions": "May potentiate other CNS depressants",
     "description": "Flowering tree whose bark is prized in Brazilian folk medicine for calming nerves and promoting sleep.",
-    "id": "erythrina-mulungu"
+    "id": "erythrina-mulungu",
+    "affiliateLink": null
   },
   {
     "name": "Erythrina americana",
@@ -3319,7 +3423,8 @@
     "sideEffects": "Drowsiness, dizziness",
     "drugInteractions": "May enhance effects of other sedatives",
     "description": "Known locally as Colorín; its red flowers are brewed into a soothing bedtime drink.",
-    "id": "erythrina-americana"
+    "id": "erythrina-americana",
+    "affiliateLink": null
   },
   {
     "name": "Galbulimima belgraveana",
@@ -3351,7 +3456,8 @@
     "sideEffects": "Nausea, vertigo, intense dreams",
     "drugInteractions": "Avoid combining with other anticholinergics",
     "description": "Rare rainforest tree providing psychoactive bark traditionally used in New Guinea for visionary experiences.",
-    "id": "galbulimima-belgraveana"
+    "id": "galbulimima-belgraveana",
+    "affiliateLink": null
   },
   {
     "name": "Alpinia galanga",
@@ -3383,7 +3489,8 @@
     "sideEffects": "Heartburn or mild agitation at high doses",
     "drugInteractions": "May alter absorption of other stimulants or anticoagulants",
     "description": "A common culinary spice known as galangal that offers gentle stimulation and a warming effect.",
-    "id": "alpinia-galanga"
+    "id": "alpinia-galanga",
+    "affiliateLink": null
   },
   {
     "name": "Leonurus sibiricus",
@@ -3415,7 +3522,8 @@
     "sideEffects": "Drowsiness at high doses",
     "drugInteractions": "May enhance effects of other sedatives",
     "description": "Sometimes called Marihuanilla or Siberian motherwort, providing gentle calming effects and subtle dreaminess.",
-    "id": "leonurus-sibiricus"
+    "id": "leonurus-sibiricus",
+    "affiliateLink": null
   },
   {
     "name": "Lagochilus inebrians",
@@ -3447,7 +3555,8 @@
     "sideEffects": "Drowsiness",
     "drugInteractions": "Could potentiate other depressants",
     "description": "Known as intoxicating mint; produces a pleasant calm and slight euphoria when brewed.",
-    "id": "lagochilus-inebrians"
+    "id": "lagochilus-inebrians",
+    "affiliateLink": null
   },
   {
     "name": "Nicotiana rustica",
@@ -3479,7 +3588,8 @@
     "sideEffects": "Nausea, increased heart rate, dizziness",
     "drugInteractions": "Strongly potentiated by MAOIs; interacts with many medications",
     "description": "Potent tobacco species used ceremonially in the Amazon, far stronger than common N. tabacum.",
-    "id": "nicotiana-rustica"
+    "id": "nicotiana-rustica",
+    "affiliateLink": null
   },
   {
     "name": "Nymphaea lotus",
@@ -3511,7 +3621,8 @@
     "sideEffects": "Drowsiness at high doses",
     "drugInteractions": "May add to effects of other sedatives",
     "description": "Also called the Egyptian white lotus, historically revered for its gentle calming and dreamlike qualities.",
-    "id": "nymphaea-lotus"
+    "id": "nymphaea-lotus",
+    "affiliateLink": null
   },
   {
     "name": "Psychotria carthagenensis",
@@ -3543,7 +3654,8 @@
     "sideEffects": "Nausea, intense visions, possible anxiety",
     "drugInteractions": "Dangerous with serotonergic drugs or other MAOIs",
     "description": "Amazonian shrub also known as Chaliponga; its DMT-rich leaves are valued in shamanic ceremonies.",
-    "id": "psychotria-carthagenensis"
+    "id": "psychotria-carthagenensis",
+    "affiliateLink": null
   },
   {
     "name": "Mucuna pruriens",
@@ -3575,7 +3687,8 @@
     "sideEffects": "Nausea or headache with excessive intake",
     "drugInteractions": "Avoid with MAOIs or dopamine medications",
     "description": "Also called Velvet Bean; boosts dopamine and serves as a traditional tonic in Ayurvedic practice.",
-    "id": "mucuna-pruriens"
+    "id": "mucuna-pruriens",
+    "affiliateLink": null
   },
   {
     "name": "Paullinia yoco",
@@ -3607,7 +3720,8 @@
     "sideEffects": "Jitters, rapid heartbeat, sleeplessness",
     "drugInteractions": "Potentiates other stimulants and certain medications",
     "description": "Liana used by several Amazonian tribes; the bark yields a potent caffeinated beverage for energy.",
-    "id": "paullinia-yoco"
+    "id": "paullinia-yoco",
+    "affiliateLink": null
   },
   {
     "name": "Tetradenia riparia",
@@ -3639,7 +3753,8 @@
     "sideEffects": "Dizziness, low blood pressure",
     "drugInteractions": "May enhance sedatives or blood pressure medications",
     "description": "Fragrant African shrub sometimes called Iboza; provides a relaxing effect and mild pain relief.",
-    "id": "tetradenia-riparia"
+    "id": "tetradenia-riparia",
+    "affiliateLink": null
   },
   {
     "name": "Tabernaemontana undulata",
@@ -3671,7 +3786,8 @@
     "sideEffects": "Nausea, numbness, dizziness",
     "drugInteractions": "Avoid with other serotonergic or stimulant substances",
     "description": "Also called Uchu Sanango; this rare shrub contains iboga-like compounds and is used in shamanic practices.",
-    "id": "tabernaemontana-undulata"
+    "id": "tabernaemontana-undulata",
+    "affiliateLink": null
   },
   {
     "name": "Aquilaria malaccensis",
@@ -3703,7 +3819,8 @@
     "sideEffects": "Mild headache if smoke inhaled in excess",
     "drugInteractions": "Unknown; likely minimal",
     "description": "Source of precious agarwood resin, producing a soothing aroma and subtle psychoactive calm when burned.",
-    "id": "aquilaria-malaccensis"
+    "id": "aquilaria-malaccensis",
+    "affiliateLink": null
   },
   {
     "name": "Argyreia speciosa",
@@ -3735,7 +3852,8 @@
     "sideEffects": "Nausea, vasoconstriction, drowsiness",
     "drugInteractions": "Avoid with other serotonergic agents",
     "description": "Close relative of Hawaiian Baby Woodrose with LSA‑containing seeds used in some Indian traditions.",
-    "id": "argyreia-speciosa"
+    "id": "argyreia-speciosa",
+    "affiliateLink": null
   },
   {
     "name": "Zanthoxylum clava-herculis",
@@ -3767,7 +3885,8 @@
     "sideEffects": "Tingling, salivation, mild stomach upset",
     "drugInteractions": "May interact with other numbing agents",
     "description": "Also called the toothache tree; its bark creates a tingling numbness and light stimulation when chewed.",
-    "id": "zanthoxylum-clava-herculis"
+    "id": "zanthoxylum-clava-herculis",
+    "affiliateLink": null
   },
   {
     "name": "Adhatoda vasica",
@@ -3799,7 +3918,8 @@
     "sideEffects": "Digestive upset at large doses",
     "drugInteractions": "May potentiate other bronchodilators",
     "description": "Known as Vasaka or Malabar nut, this shrub’s leaves ease breathing and offer a subtle stimulating effect.",
-    "id": "adhatoda-vasica"
+    "id": "adhatoda-vasica",
+    "affiliateLink": null
   },
   {
     "name": "Amanita pantherina",
@@ -3829,7 +3949,8 @@
     "legalStatus": "Varies; unscheduled in many countries",
     "toxicity": "Potentially toxic at high doses",
     "toxicityLD50": "Not well established",
-    "safetyRating": "Low"
+    "safetyRating": "Low",
+    "affiliateLink": null
   },
   {
     "name": "Cannabis sativa",
@@ -3859,7 +3980,8 @@
     "legalStatus": "Varies by jurisdiction",
     "toxicity": "Low physiological toxicity",
     "toxicityLD50": ">1 g/kg THC in animals",
-    "safetyRating": "Medium"
+    "safetyRating": "Medium",
+    "affiliateLink": null
   },
   {
     "name": "Claviceps purpurea",
@@ -3889,7 +4011,8 @@
     "legalStatus": "Controlled in many countries",
     "toxicity": "High; risk of ergotism",
     "toxicityLD50": "~5 mg/kg lysergic acid amide (mouse)",
-    "safetyRating": "Very Low"
+    "safetyRating": "Very Low",
+    "affiliateLink": null
   },
   {
     "name": "Coleus blumei",
@@ -3919,7 +4042,8 @@
     "legalStatus": "Legal",
     "toxicity": "Low",
     "toxicityLD50": "Not established",
-    "safetyRating": "Medium"
+    "safetyRating": "Medium",
+    "affiliateLink": null
   },
   {
     "name": "Echinopsis pachanoi",
@@ -3949,7 +4073,8 @@
     "legalStatus": "Cactus legal in many areas; mescaline often controlled",
     "toxicity": "Low physiological but intense psychological effects",
     "toxicityLD50": "Not well established",
-    "safetyRating": "Medium"
+    "safetyRating": "Medium",
+    "affiliateLink": null
   },
   {
     "name": "Erythroxylum coca",
@@ -3979,7 +4104,8 @@
     "legalStatus": "Cultivation regulated; cocaine controlled",
     "toxicity": "Low in leaf form; purified alkaloid is addictive",
     "toxicityLD50": "~95 mg/kg (rat, cocaine)",
-    "safetyRating": "Low"
+    "safetyRating": "Low",
+    "affiliateLink": null
   },
   {
     "name": "Ginkgo biloba",
@@ -4009,7 +4135,8 @@
     "legalStatus": "Legal",
     "toxicity": "Low",
     "toxicityLD50": ">5 g/kg in animals",
-    "safetyRating": "High"
+    "safetyRating": "High",
+    "affiliateLink": null
   },
   {
     "name": "Helichrysum odoratissimum",
@@ -4039,7 +4166,8 @@
     "legalStatus": "Legal",
     "toxicity": "Low",
     "toxicityLD50": "Not established",
-    "safetyRating": "High"
+    "safetyRating": "High",
+    "affiliateLink": null
   },
   {
     "name": "Hypericum perforatum",
@@ -4069,7 +4197,8 @@
     "legalStatus": "Legal",
     "toxicity": "Low to moderate",
     "toxicityLD50": ">2 g/kg in rodents",
-    "safetyRating": "Medium"
+    "safetyRating": "Medium",
+    "affiliateLink": null
   },
   {
     "name": "Ilex vomitoria",
@@ -4099,7 +4228,8 @@
     "legalStatus": "Legal",
     "toxicity": "Low",
     "toxicityLD50": ">1 g/kg caffeine in animals",
-    "safetyRating": "Medium"
+    "safetyRating": "Medium",
+    "affiliateLink": null
   },
   {
     "name": "Centella asiatica",
@@ -4137,7 +4267,8 @@
         "type": "triterpenoid",
         "effect": "nootropic"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Eschscholzia californica",
@@ -4175,7 +4306,8 @@
         "type": "alkaloid",
         "effect": "sedative"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Rhodiola rosea",
@@ -4213,7 +4345,8 @@
         "type": "phenylpropanoid",
         "effect": "adaptogen"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Ginkgo biloba",
@@ -4251,7 +4384,8 @@
         "type": "terpenoid",
         "effect": "neuroprotective"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Hypericum perforatum",
@@ -4289,7 +4423,8 @@
         "type": "naphthodianthrone",
         "effect": "antidepressant"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Leonotis leonurus",
@@ -4327,7 +4462,8 @@
         "type": "alkaloid",
         "effect": "relaxant"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Uncaria tomentosa",
@@ -4364,7 +4500,8 @@
         "type": "alkaloid",
         "effect": "immunomodulator"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Ephedra sinica",
@@ -4402,7 +4539,8 @@
         "type": "alkaloid",
         "effect": "stimulant"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Myristica fragrans",
@@ -4440,7 +4578,8 @@
         "type": "phenylpropene",
         "effect": "deliriant"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Pausinystalia yohimbe",
@@ -4478,7 +4617,8 @@
         "type": "alkaloid",
         "effect": "stimulant"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Eleutherococcus senticosus",
@@ -4516,7 +4656,8 @@
         "type": "phenylpropanoid",
         "effect": "adaptogen"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Ptychopetalum olacoides",
@@ -4554,7 +4695,8 @@
         "type": "alkaloid",
         "effect": "stimulant"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Claviceps purpurea",
@@ -4592,7 +4734,8 @@
         "type": "alkaloid",
         "effect": "hallucinogenic"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Cola nitida",
@@ -4630,7 +4773,8 @@
         "type": "alkaloid",
         "effect": "stimulant"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Camellia sinensis",
@@ -4668,7 +4812,8 @@
         "type": "alkaloid",
         "effect": "stimulant"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Gynostemma pentaphyllum",
@@ -4705,7 +4850,8 @@
         "type": "saponin",
         "effect": "adaptogen"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Silybum marianum",
@@ -4741,7 +4887,8 @@
         "type": "flavonolignan",
         "effect": "hepatoprotective"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Piper methysticum",
@@ -4779,7 +4926,8 @@
         "type": "lactone",
         "effect": "anxiolytic"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Rivea corymbosa",
@@ -4817,7 +4965,8 @@
         "type": "alkaloid",
         "effect": "psychedelic"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Uncaria rhynchophylla",
@@ -4855,7 +5004,8 @@
         "type": "alkaloid",
         "effect": "calming"
       }
-    ]
+    ],
+    "affiliateLink": null
   },
   {
     "name": "Mandrake",

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -29,6 +29,11 @@ export default function SearchBar({ query, setQuery, fuse }: Props) {
     return text.replace(regex, '<span class="font-bold">$1</span>')
   }
 
+  const labelFor = (s: ReturnType<typeof fuse.search>[0]) => {
+    const text = [s.item.name, ...(s.item as any).altNames || []].join(', ')
+    return highlight(text)
+  }
+
   return (
     <div className='relative w-full'>
       <input
@@ -44,9 +49,9 @@ export default function SearchBar({ query, setQuery, fuse }: Props) {
             <li key={s.item.id}>
               <button
                 type='button'
-                className='w-full text-left hover:bg-white/10 px-2 py-1 rounded'
+                className='w-full text-left rounded px-2 py-1 hover:bg-white/10'
                 onClick={() => setQuery(s.item.name)}
-                dangerouslySetInnerHTML={{ __html: highlight(s.item.name) }}
+                dangerouslySetInnerHTML={{ __html: labelFor(s) }}
               />
             </li>
           ))}

--- a/src/components/TagFilterBar.tsx
+++ b/src/components/TagFilterBar.tsx
@@ -135,7 +135,7 @@ export default function TagFilterBar({
   }
 
   return (
-    <div className='space-y-3 sticky top-16 z-20 sm:static'>
+    <div className='sticky top-16 z-20 space-y-3 bg-black/30 backdrop-blur-md p-2 rounded-xl sm:static sm:bg-transparent sm:p-0'>
       {CATEGORY_ORDER.map(cat => (
         <div key={cat} className='tag-section'>
           <button

--- a/src/hooks/useFilteredHerbs.ts
+++ b/src/hooks/useFilteredHerbs.ts
@@ -20,6 +20,7 @@ export function useFilteredHerbs(herbs: Herb[], options: Options = {}) {
   const { favorites = [] } = options
   const [query, setQuery] = React.useState('')
   const [tags, setTags] = React.useState<string[]>([])
+  const [matchAll, setMatchAll] = React.useState(true)
   const [favoritesOnly, setFavoritesOnly] = React.useState(false)
   const [categories, setCategories] = React.useState<string[]>([])
   const [sort, setSort] = React.useState('')
@@ -27,7 +28,7 @@ export function useFilteredHerbs(herbs: Herb[], options: Options = {}) {
   const fuse = React.useMemo(
     () =>
       new Fuse(herbs, {
-        keys: ['name', 'scientificName', 'effects', 'description', 'tags'],
+        keys: ['name', 'altNames', 'scientificName', 'effects', 'tags'],
         threshold: 0.4,
         includeMatches: true,
         isCaseSensitive: false,
@@ -44,7 +45,13 @@ export function useFilteredHerbs(herbs: Herb[], options: Options = {}) {
     }
     if (tags.length) {
       res = res.filter(h =>
-        tags.every(t => h.tags.some(ht => canonicalTag(ht) === canonicalTag(t)))
+        matchAll
+          ? tags.every(t =>
+              h.tags.some(ht => canonicalTag(ht) === canonicalTag(t))
+            )
+          : tags.some(t =>
+              h.tags.some(ht => canonicalTag(ht) === canonicalTag(t))
+            )
       )
     }
     if (categories.length) {
@@ -57,7 +64,7 @@ export function useFilteredHerbs(herbs: Herb[], options: Options = {}) {
       res = [...res].sort((a, b) => a.name.localeCompare(b.name))
     }
     return res
-  }, [herbs, query, tags, categories, favoritesOnly, favorites, sort, fuse])
+  }, [herbs, query, tags, categories, favoritesOnly, favorites, sort, fuse, matchAll])
 
   return {
     filtered,
@@ -65,6 +72,8 @@ export function useFilteredHerbs(herbs: Herb[], options: Options = {}) {
     setQuery,
     tags,
     setTags,
+    matchAll,
+    setMatchAll,
     categories,
     setCategories,
     favoritesOnly,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { HashRouter } from 'react-router-dom';
 import { HelmetProvider } from 'react-helmet-async';
 import App from './App';
 import { ThemeProvider } from './contexts/theme';
@@ -11,9 +11,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <HelmetProvider>
       <ThemeProvider>
-        <BrowserRouter>
+        <HashRouter>
           <App />
-        </BrowserRouter>
+        </HashRouter>
       </ThemeProvider>
     </HelmetProvider>
   </React.StrictMode>

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -25,6 +25,8 @@ export default function Database() {
     setQuery,
     tags: filteredTags,
     setTags: setFilteredTags,
+    matchAll,
+    setMatchAll,
     categories: filteredCategories,
     setCategories: setFilteredCategories,
     favoritesOnly,
@@ -89,10 +91,13 @@ export default function Database() {
     if (filteredTags.length === 0) return [] as string[]
     const counts: Record<string, number> = {}
     herbs.forEach(h => {
-      if (filteredTags.every(t => h.tags.includes(t))) {
+      if (filteredTags.every(t =>
+        h.tags.some(ht => canonicalTag(ht) === canonicalTag(t))
+      )) {
         h.tags.forEach(t => {
-          if (!filteredTags.includes(t)) {
-            counts[t] = (counts[t] || 0) + 1
+          const canon = canonicalTag(t)
+          if (!filteredTags.some(ft => canonicalTag(ft) === canon)) {
+            counts[canon] = (counts[canon] || 0) + 1
           }
         })
       }
@@ -140,6 +145,13 @@ export default function Database() {
               className='rounded-md bg-space-dark/70 px-3 py-2 text-sm text-yellow-300 backdrop-blur-md hover:bg-white/10'
             >
               {favoritesOnly ? 'All Herbs' : 'My Herbs'}
+            </button>
+            <button
+              type='button'
+              onClick={() => setMatchAll(m => !m)}
+              className='hover-glow rounded-md bg-space-dark/70 px-3 py-2 text-sm text-sand backdrop-blur-md hover:bg-white/10'
+            >
+              {matchAll ? 'Match ALL' : 'Match ANY'}
             </button>
             <button
               type='button'

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -94,6 +94,16 @@ export default function HerbDetail() {
               ))}
             </div>
           )}
+          {herb.affiliateLink && (
+            <a
+              href={herb.affiliateLink}
+              target='_blank'
+              rel='noopener noreferrer'
+              className='text-sky-300 underline'
+            >
+              Buy Online
+            </a>
+          )}
           <div className='flex flex-wrap gap-2 pt-2'>
             {herb.tags.map(tag => (
               <TagBadge key={tag} label={decodeTag(tag)} variant={tagVariant(tag)} />

--- a/src/utils/tagUtils.ts
+++ b/src/utils/tagUtils.ts
@@ -3,8 +3,8 @@ import { decodeTag } from './format'
 export const tagAliasMap: Record<string, string> = {
   'root bark': 'root',
   bark: 'root',
-  tryptamine: 'alkaloid',
-  phenethylamine: 'alkaloid',
+  tryptamine: 'psychedelic',
+  phenethylamine: 'psychedelic',
 }
 
 export function canonicalTag(tag: string): string {


### PR DESCRIPTION
## Summary
- add `affiliateLink` placeholders across herb data
- expose affiliate buy links on herb detail pages
- expand search suggestions to include alternate names
- support match ALL/ANY tag filters
- update tag alias logic and sticky filter styles
- switch to `HashRouter` for GitHub Pages compatibility

## Testing
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_687baeb15ea88323ae4bda361b0fbb07