### PR TITLE
Fix 404 redirect for blog links

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,6 +8,12 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      if (!window.location.hash) {
+        const path = window.location.pathname + window.location.search
+        window.location.replace('/#' + path)
+      }
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- redirect paths without `#` to hashed routes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687bd2e8d3088323945e6f962dcf36f1