### PR TITLE
Enhance homepage with animation, featured carousel, and interactivity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "gray-matter": "^4.0.3",
         "lucide-react": "^0.298.0",
         "react": "^18.2.0",
+        "react-countup": "^6.5.3",
         "react-dom": "^18.2.0",
         "react-helmet-async": "^1.3.0",
         "react-markdown": "^10.1.0",
@@ -1977,6 +1978,12 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/countup.js": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/countup.js/-/countup.js-2.9.0.tgz",
+      "integrity": "sha512-llqrvyXztRFPp6+i8jx25phHWcVWhrHO4Nlt0uAOSKHB8778zzQswa4MU3qKBvkXfJKftRYFJuVHez67lyKdHg==",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -4089,6 +4096,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-countup": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/react-countup/-/react-countup-6.5.3.tgz",
+      "integrity": "sha512-udnqVQitxC7QWADSPDOxVWULkLvKUWrDapn5i53HE4DPRVgs+Y5rr4bo25qEl8jSh+0l2cToJgGMx+clxPM3+w==",
+      "license": "MIT",
+      "dependencies": {
+        "countup.js": "^2.8.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.3.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "gray-matter": "^4.0.3",
     "lucide-react": "^0.298.0",
     "react": "^18.2.0",
+    "react-countup": "^6.5.3",
     "react-dom": "^18.2.0",
     "react-helmet-async": "^1.3.0",
     "react-markdown": "^10.1.0",

--- a/src/components/FeaturedHerbCarousel.tsx
+++ b/src/components/FeaturedHerbCarousel.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
+import { Link } from 'react-router-dom'
+import herbs from '../data/herbs'
+
+const featured = herbs.slice(0, 5)
+
+export default function FeaturedHerbCarousel() {
+  const [index, setIndex] = useState(0)
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setIndex(i => (i + 1) % featured.length)
+    }, 6000)
+    return () => clearInterval(id)
+  }, [])
+
+  const herb = featured[index]
+
+  return (
+    <div className='relative mx-auto mt-8 max-w-md'>
+      <AnimatePresence mode='wait'>
+        <motion.div
+          key={herb.id}
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -20 }}
+          transition={{ duration: 0.6 }}
+          className='glass-card cursor-pointer overflow-hidden rounded-xl p-4 shadow-lg'
+          whileHover={{ scale: 1.03, rotate: 0.5 }}
+        >
+          {herb.image && (
+            <img src={herb.image} alt={herb.name} className='h-40 w-full rounded-md object-cover' />
+          )}
+          <h3 className='mt-3 font-herb text-2xl'>{herb.name}</h3>
+          {herb.description && (
+            <p className='mt-1 line-clamp-2 text-sm text-sand'>{herb.description}</p>
+          )}
+          <Link
+            to={`/herbs/${herb.id}`}
+            className='hover-glow mt-3 inline-block rounded-md bg-black/30 px-4 py-2 text-sand backdrop-blur-md hover:rotate-1'
+          >
+            Learn More
+          </Link>
+        </motion.div>
+      </AnimatePresence>
+    </div>
+  )
+}

--- a/src/components/MouseTrail.tsx
+++ b/src/components/MouseTrail.tsx
@@ -3,6 +3,7 @@ import { motion, useMotionValue, useSpring } from 'framer-motion'
 
 const MouseTrail: React.FC = () => {
   const [isVisible, setIsVisible] = useState(false)
+  const [enabled, setEnabled] = useState(true)
   const mouseX = useMotionValue(0)
   const mouseY = useMotionValue(0)
 
@@ -11,6 +12,7 @@ const MouseTrail: React.FC = () => {
   const y = useSpring(mouseY, springConfig)
 
   useEffect(() => {
+    setEnabled(!window.matchMedia('(pointer: coarse)').matches)
     const updatePosition = (e: MouseEvent | TouchEvent) => {
       const xPos = 'touches' in e ? e.touches[0].clientX : e.clientX
       const yPos = 'touches' in e ? e.touches[0].clientY : e.clientY
@@ -41,6 +43,7 @@ const MouseTrail: React.FC = () => {
     }
   }, [mouseX, mouseY])
 
+  if (!enabled) return null
   return (
     <motion.div
       className='pointer-events-none fixed left-0 top-0 z-50 h-6 w-6'

--- a/src/components/StarfieldBackground.tsx
+++ b/src/components/StarfieldBackground.tsx
@@ -4,6 +4,9 @@ import type { Engine } from '@tsparticles/engine'
 import { loadFull } from 'tsparticles'
 
 export default function StarfieldBackground() {
+  if (typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches) {
+    return null
+  }
   const init = useCallback(async (engine: Engine) => {
     await loadFull(engine)
   }, [])

--- a/src/components/StatsCounters.tsx
+++ b/src/components/StatsCounters.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import CountUp from 'react-countup'
+import herbs from '../data/herbs'
+import { baseCompounds } from '../data/compoundData'
+
+export default function StatsCounters() {
+  return (
+    <div className='mx-auto mt-8 flex max-w-4xl flex-col items-center justify-center gap-6 text-center sm:flex-row sm:gap-12'>
+      <div className='text-lg sm:text-xl'>
+        <CountUp end={herbs.length} duration={2} />+ psychoactive herbs indexed
+      </div>
+      <div className='text-lg sm:text-xl'>
+        <CountUp end={baseCompounds.length} duration={2} />+ active compounds mapped
+      </div>
+      <div className='text-lg sm:text-xl'>Updated daily</div>
+    </div>
+  )
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -7,7 +7,7 @@ export default function ThemeToggle() {
   return (
     <button
       onClick={toggleTheme}
-      className='rounded-md p-2 text-sand transition-shadow hover:shadow-glow'
+      className={`rounded-md p-2 text-sand transition-shadow hover:shadow-glow ${theme === 'dark' ? 'shadow-psychedelic-pink/40' : 'shadow-cosmic-purple/40'}`}
       aria-label='Toggle theme'
     >
       {theme === 'dark' ? <Sun /> : <Moon />}

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,9 @@
 
 body {
   @apply m-0 font-sans text-lg leading-relaxed tracking-tight;
+  transition:
+    background-color 0.5s ease,
+    color 0.5s ease;
 }
 
 body.light {
@@ -19,6 +22,9 @@ body.dark {
 
 html {
   scroll-behavior: smooth;
+  transition:
+    background-color 0.5s ease,
+    color 0.5s ease;
 }
 
 /* Custom utility classes */
@@ -46,7 +52,7 @@ html {
 }
 /* Animations and extra utilities */
 .tag-pill {
-  @apply inline-flex items-center gap-1 rounded-full bg-black/10 px-2 py-0.5 text-xs shadow backdrop-blur-sm hover:bg-black/20 dark:bg-white/10 dark:hover:bg-white/20 text-shadow ring-1 ring-white/20 dark:ring-black/30;
+  @apply text-shadow inline-flex items-center gap-1 rounded-full bg-black/10 px-2 py-0.5 text-xs shadow ring-1 ring-white/20 backdrop-blur-sm hover:bg-black/20 dark:bg-white/10 dark:ring-black/30 dark:hover:bg-white/20;
 }
 
 @keyframes gradient-shift {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,16 +2,22 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import HeroSection from '../components/HeroSection'
 import StarfieldBackground from '../components/StarfieldBackground'
+import MouseTrail from '../components/MouseTrail'
+import FeaturedHerbCarousel from '../components/FeaturedHerbCarousel'
+import StatsCounters from '../components/StatsCounters'
 
 export default function Home() {
   return (
-    <main className='relative min-h-screen overflow-hidden bg-white text-black dark:bg-black dark:text-white px-4 py-10'>
+    <main className='relative min-h-screen overflow-hidden bg-white px-4 py-10 text-black dark:bg-black dark:text-white'>
       <StarfieldBackground />
+      <MouseTrail />
       <HeroSection />
+      <FeaturedHerbCarousel />
+      <StatsCounters />
       <section className='mx-auto max-w-4xl text-center'>
         <Link
           to='/database'
-          className='mt-8 inline-block rounded-md bg-black/30 px-6 py-3 text-white backdrop-blur-md hover:bg-white/10'
+          className='hover-glow mt-8 inline-block rounded-md bg-black/30 px-6 py-3 text-white backdrop-blur-md hover:rotate-1'
         >
           🌿 Browse Database
         </Link>


### PR DESCRIPTION
## Summary
- install `react-countup`
- animate theme transitions and apply glow when toggling themes
- add mouse trail and disable on mobile
- make starfield background optional for mobile
- create a featured herb carousel and animated stat counters
- update homepage to showcase animations and new components

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_687be53c92e883239b1f18d6b5eab997