### PR TITLE
Enhance herb/compound views, add accessibility and prep personalization

### DIFF
--- a/scripts/validateHerbs.js
+++ b/scripts/validateHerbs.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const herbs = JSON.parse(fs.readFileSync('Full200.json', 'utf8'));
 
-const required = ['affiliateLink', 'activeConstituents', 'mechanismOfAction'];
+const required = ['affiliateLink', 'activeConstituents', 'mechanismOfAction', 'legalStatus'];
 let missing = [];
 herbs.forEach(h => {
   const missingKeys = required.filter(key => {

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -73,6 +73,7 @@ function safetyTier(rating: any, toxicity?: string): SafetyTier {
 export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
   const [open, setOpen] = useState(false)
   const [tagsExpanded, setTagsExpanded] = useState(false)
+  const [descExpanded, setDescExpanded] = useState(false)
   const toggle = () => setOpen(v => !v)
   const { isFavorite, toggle: toggleFavorite } = useHerbFavorites()
 
@@ -105,7 +106,7 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
   const tier = safetyTier(herb.safetyRating, herb.toxicity)
 
   return (
-    <motion.div
+    <motion.article
       id={`herb-${herb.id}`}
       layout
       initial={{ opacity: 0, y: 20 }}
@@ -117,6 +118,7 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
       tabIndex={0}
       role='button'
       aria-expanded={open}
+      aria-label={`Herb card for ${herb.name}`}
       whileHover={{
         scale: 1.03,
         boxShadow: '0 0 20px rgba(255,255,255,0.2)',
@@ -207,7 +209,7 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
         </div>
       </div>
 
-      <div className='mt-2 flex flex-wrap gap-2'>
+      <div className='mt-2 flex flex-wrap gap-1 text-xs sm:gap-2 sm:text-sm'>
         {(tagsExpanded || sortedTags.length <= TAG_LIMIT
           ? sortedTags
           : sortedTags.slice(0, TAG_LIMIT)
@@ -284,6 +286,31 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
                     : key === 'mechanismOfAction' || key === 'toxicity' || key === 'toxicityLD50'
                       ? UNKNOWN
                       : NOT_WELL_DOCUMENTED
+                if (key === 'description') {
+                  const truncated = value.slice(0, 200)
+                  return (
+                    <motion.div key={key} variants={itemVariants}>
+                      <span className='font-semibold text-lime-300'>
+                        Description:
+                        {fieldTooltips[key] && <InfoTooltip text={fieldTooltips[key]} />}
+                      </span>{' '}
+                      {descExpanded || value.length <= 200 ? value : truncated + '...'}
+                      {value.length > 200 && (
+                        <button
+                          type='button'
+                          onClick={e => {
+                            e.stopPropagation()
+                            setDescExpanded(d => !d)
+                          }}
+                          aria-expanded={descExpanded}
+                          className='ml-2 underline text-sky-300'
+                        >
+                          {descExpanded ? 'Show Less' : 'Read More'}
+                        </button>
+                      )}
+                    </motion.div>
+                  )
+                }
                 return (
                   <motion.div key={key} variants={itemVariants}>
                     <span className='font-semibold text-lime-300'>
@@ -360,6 +387,6 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
           </motion.div>
         )}
       </AnimatePresence>
-    </motion.div>
+    </motion.article>
   )
 }

--- a/src/components/InfoTooltip.tsx
+++ b/src/components/InfoTooltip.tsx
@@ -8,13 +8,23 @@ interface Props {
 
 export default function InfoTooltip({ text, children }: Props) {
   const [show, setShow] = React.useState(false)
+  const timer = React.useRef<NodeJS.Timeout>()
+
+  const showWithDelay = () => {
+    timer.current = setTimeout(() => setShow(true), 150)
+  }
+  const hide = () => {
+    if (timer.current) clearTimeout(timer.current)
+    setShow(false)
+  }
+
   return (
     <span
       className='relative inline-block'
-      onMouseEnter={() => setShow(true)}
-      onMouseLeave={() => setShow(false)}
-      onFocus={() => setShow(true)}
-      onBlur={() => setShow(false)}
+      onMouseEnter={showWithDelay}
+      onMouseLeave={hide}
+      onFocus={showWithDelay}
+      onBlur={hide}
       onTouchStart={() => setShow(s => !s)}
     >
       {children || <span className='ml-1 cursor-help select-none text-sand'>ℹ️</span>}
@@ -25,7 +35,7 @@ export default function InfoTooltip({ text, children }: Props) {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -4 }}
             transition={{ duration: 0.2 }}
-            className='absolute left-1/2 z-50 mt-1 max-w-[90vw] -translate-x-1/2 whitespace-normal break-words break-all rounded-md bg-black/80 p-2 text-xs text-white backdrop-blur sm:max-w-xs'
+            className='absolute left-1/2 z-50 mt-1 max-w-[90vw] -translate-x-1/2 whitespace-pre-line break-words rounded-md bg-black/80 p-2 text-xs text-white backdrop-blur sm:max-w-xs'
           >
             {text}
           </motion.div>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -39,6 +39,8 @@ export default function SearchBar({ query, setQuery, fuse }: Props) {
       <input
         type='text'
         placeholder='Search herbs...'
+        aria-label='Search herbs'
+        tabIndex={0}
         value={query}
         onChange={e => setQuery(e.target.value)}
         className='w-full rounded-md bg-space-dark/70 px-3 py-2 text-white backdrop-blur-md focus:outline-none'
@@ -49,6 +51,8 @@ export default function SearchBar({ query, setQuery, fuse }: Props) {
             <li key={s.item.id}>
               <button
                 type='button'
+                tabIndex={0}
+                aria-label={`Select ${s.item.name}`}
                 className='w-full text-left rounded px-2 py-1 hover:bg-white/10'
                 onClick={() => setQuery(s.item.name)}
                 dangerouslySetInnerHTML={{ __html: labelFor(s) }}

--- a/src/components/SearchFilter.tsx
+++ b/src/components/SearchFilter.tsx
@@ -84,6 +84,7 @@ const SearchFilter: React.FC<SearchFilterProps> = ({ herbs, onFilter }) => {
         type='text'
         placeholder='Search herbs...'
         aria-label='Search herbs'
+        tabIndex={0}
         value={query}
         onChange={e => setQuery(e.target.value)}
         className='w-full rounded-md border border-gray-300 bg-white px-4 py-2 text-black focus:outline-none focus:ring-2 focus:ring-purple-500 dark:border-gray-700 dark:bg-gray-900 dark:text-white'
@@ -96,6 +97,7 @@ const SearchFilter: React.FC<SearchFilterProps> = ({ herbs, onFilter }) => {
         ))}
         <select
           onChange={handleAddTag}
+          tabIndex={0}
           className='rounded-md border border-gray-300 bg-white px-2 py-1 text-sm text-black dark:border-gray-700 dark:bg-gray-900 dark:text-white'
           defaultValue=''
         >
@@ -108,6 +110,7 @@ const SearchFilter: React.FC<SearchFilterProps> = ({ herbs, onFilter }) => {
         </select>
         <button
           type='button'
+          tabIndex={0}
           onClick={pickRandom}
           className='rounded-md border border-gray-300 bg-white px-2 py-1 text-sm text-black hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-900 dark:text-white dark:hover:bg-gray-700'
         >
@@ -116,6 +119,7 @@ const SearchFilter: React.FC<SearchFilterProps> = ({ herbs, onFilter }) => {
 
         <select
           value={sort}
+          tabIndex={0}
           onChange={e => setSort(e.target.value as SortKey)}
           className='rounded-md border border-gray-300 bg-white px-2 py-1 text-sm text-black dark:border-gray-700 dark:bg-gray-900 dark:text-white'
         >
@@ -126,6 +130,7 @@ const SearchFilter: React.FC<SearchFilterProps> = ({ herbs, onFilter }) => {
         </select>
         <button
           type='button'
+          tabIndex={0}
           onClick={clearFilters}
           className='rounded-md border border-gray-300 bg-white px-2 py-1 text-sm text-black hover:bg-gray-100 dark:border-gray-700 dark:bg-gray-900 dark:text-white dark:hover:bg-gray-700'
         >

--- a/src/components/TagBadge.tsx
+++ b/src/components/TagBadge.tsx
@@ -24,6 +24,7 @@ export default function TagBadge({ label, variant = 'purple', className }: Props
     <motion.span
       whileHover={{ scale: 1.05 }}
       whileTap={{ scale: 0.95 }}
+      tabIndex={0}
       className={clsx(
         'hover-glow text-shadow inline-flex items-center whitespace-nowrap rounded-full bg-gradient-to-br px-2 py-0.5 text-xs font-medium text-white/90 shadow ring-1 ring-white/40 backdrop-blur-sm dark:ring-black/40',
         colorMap[variant],

--- a/src/components/TagFilterBar.tsx
+++ b/src/components/TagFilterBar.tsx
@@ -105,6 +105,7 @@ export default function TagFilterBar({
               whileTap={{ scale: 0.95 }}
               animate={{ opacity: selected.includes(tag) ? 1 : 0.6 }}
               aria-pressed={selected.includes(tag)}
+              tabIndex={0}
               className='flex-shrink-0 focus:outline-none'
               title={
                 counts[tag]
@@ -124,6 +125,7 @@ export default function TagFilterBar({
               type='button'
               whileHover={{ scale: 1.05 }}
               onClick={() => setShowMore(m => ({ ...m, [cat]: !m[cat] }))}
+              tabIndex={0}
               className='tag-pill mt-2'
             >
               {showMore[cat] ? 'Show Less' : 'Show More'}
@@ -141,6 +143,7 @@ export default function TagFilterBar({
           <button
             type='button'
             className='tag-label'
+            tabIndex={0}
             onClick={() => setExpanded(e => ({ ...e, [cat]: !e[cat] }))}
             aria-expanded={expanded[cat]}
           >

--- a/src/hooks/useHerbs.ts
+++ b/src/hooks/useHerbs.ts
@@ -7,7 +7,11 @@ export function useHerbs(): Herb[] {
 
   React.useEffect(() => {
     const incomplete = herbsData.filter(
-      h => !h.affiliateLink || !h.activeConstituents?.length || !h.mechanismOfAction
+      h =>
+        !h.affiliateLink ||
+        !h.activeConstituents?.length ||
+        !h.mechanismOfAction ||
+        !h.legalStatus
     )
     if (incomplete.length) {
       console.groupCollapsed('Herb data missing fields')
@@ -16,6 +20,7 @@ export function useHerbs(): Herb[] {
         if (!h.affiliateLink) missing.push('affiliateLink')
         if (!h.activeConstituents?.length) missing.push('activeConstituents')
         if (!h.mechanismOfAction) missing.push('mechanismOfAction')
+        if (!h.legalStatus) missing.push('legalStatus')
         console.log(`${h.name}: ${missing.join(', ')}`)
       })
       console.groupEnd()

--- a/src/hooks/useUserPrefs.ts
+++ b/src/hooks/useUserPrefs.ts
@@ -1,0 +1,22 @@
+import { useLocalStorage } from './useLocalStorage'
+
+export interface UserPrefs {
+  favoriteHerbs: string[]
+  preferredEffects: string[]
+  regions: string[]
+}
+
+const defaultPrefs: UserPrefs = {
+  favoriteHerbs: [],
+  preferredEffects: [],
+  regions: [],
+}
+
+export function useUserPrefs() {
+  const [prefs, setPrefs] = useLocalStorage<UserPrefs>('hippiePrefs', defaultPrefs)
+
+  return {
+    prefs,
+    setPrefs,
+  }
+}

--- a/src/pages/Compounds.tsx
+++ b/src/pages/Compounds.tsx
@@ -66,10 +66,12 @@ export default function Compounds() {
           </p>
           <div className='space-y-4'>
             {compounds.map(c => (
-              <motion.div
+              <motion.article
                 key={c.name}
                 whileHover={{ scale: 1.03 }}
-                className='glass-card hover-glow rounded-xl p-3 text-left sm:p-6'
+                whileFocus={{ scale: 1.03 }}
+                tabIndex={0}
+                className='glass-card hover-glow rounded-xl p-3 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-psychedelic-pink sm:p-6'
               >
                 <h2 className='max-w-xs truncate text-xl font-bold text-white'>{c.name}</h2>
                 <p className='text-sm text-moss'>
@@ -94,7 +96,7 @@ export default function Compounds() {
                     to={`/database?herbs=${c.sources.map(s => s.id).join(',')}`}
                     className='tag-pill mt-2 inline-block'
                   >
-                    Found in: {c.sources.map(s => s.name).join(', ')}
+                    Source Herbs
                   </Link>
                 )}
                 {c.affiliateLink && (
@@ -107,7 +109,7 @@ export default function Compounds() {
                     Buy Online
                   </a>
                 )}
-              </motion.div>
+              </motion.article>
             ))}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- improve InfoTooltip with delay and multiline support
- add aria labels and better semantics for herb cards
- adjust tag layout and add description toggle
- make search/filter controls keyboard navigable
- enhance compound cards with glow effect and source herbs button
- log missing legal status during data validation
- add placeholder user preferences hook

## Testing
- `npm run validate-herbs`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687be797fe3083238a6b37702272397f