### PR TITLE
Improve homepage layout and add herb validation

### DIFF
--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -349,7 +349,7 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
               {herb.tags?.length > 0 && (
                 <motion.div
                   variants={itemVariants}
-                  className='flex max-h-32 flex-wrap gap-2 overflow-y-auto pt-2'
+                  className='flex max-h-24 flex-wrap gap-2 overflow-y-auto pt-2 sm:max-h-32'
                 >
                   {herb.tags.slice(0, 10).map(tag => (
                     <TagBadge

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -5,21 +5,26 @@ import FloatingElements from './FloatingElements'
 
 export default function HeroSection() {
   return (
-    <section className='relative flex min-h-[60vh] items-center justify-center overflow-hidden py-16 text-center'>
+    <motion.section
+      className='relative flex min-h-screen flex-col items-center justify-center overflow-hidden px-4 text-center'
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 1 }}
+    >
       <ParticlesBackground />
       <HeroBackground />
       <FloatingElements />
       <motion.div
-        className='relative z-10 px-4'
-        initial={{ opacity: 0, y: 20 }}
+        className='relative z-10 space-y-2'
+        initial={{ opacity: 0, y: 40 }}
         animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.8 }}
+        transition={{ duration: 1, delay: 0.2 }}
       >
-        <h1 className='text-gradient animate-ripple mb-4 font-display text-5xl md:text-6xl'>
+        <h1 className='text-gradient mb-4 font-display text-5xl md:text-7xl'>
           The Hippie Scientist
         </h1>
-        <p className='text-lg text-opal'>Psychedelic Botany &amp; Conscious Exploration</p>
+        <p className='text-lg text-opal md:text-xl'>Psychedelic Botany &amp; Conscious Exploration</p>
       </motion.div>
-    </section>
+    </motion.section>
   )
 }

--- a/src/hooks/useHerbs.ts
+++ b/src/hooks/useHerbs.ts
@@ -6,25 +6,17 @@ export function useHerbs(): Herb[] {
   const [herbs] = React.useState<Herb[]>(herbsData)
 
   React.useEffect(() => {
-    const incomplete = herbsData.filter(
-      h =>
-        !h.affiliateLink ||
-        !h.activeConstituents?.length ||
-        !h.mechanismOfAction ||
-        !h.legalStatus
-    )
-    if (incomplete.length) {
-      console.groupCollapsed('Herb data missing fields')
-      incomplete.forEach(h => {
-        const missing: string[] = []
-        if (!h.affiliateLink) missing.push('affiliateLink')
-        if (!h.activeConstituents?.length) missing.push('activeConstituents')
-        if (!h.mechanismOfAction) missing.push('mechanismOfAction')
-        if (!h.legalStatus) missing.push('legalStatus')
-        console.log(`${h.name}: ${missing.join(', ')}`)
-      })
-      console.groupEnd()
-    }
+    if (!import.meta.env.DEV) return
+
+    herbsData.forEach(h => {
+      const missing: string[] = []
+      if (!h.affiliateLink) missing.push('affiliateLink')
+      if (!h.activeConstituents?.length) missing.push('activeConstituents')
+      if (!h.mechanismOfAction) missing.push('mechanismOfAction')
+      if (missing.length) {
+        console.warn(`${h.name} missing: ${missing.join(', ')}`)
+      }
+    })
   }, [])
 
   return herbs

--- a/src/pages/Compounds.tsx
+++ b/src/pages/Compounds.tsx
@@ -68,10 +68,11 @@ export default function Compounds() {
             {compounds.map(c => (
               <motion.article
                 key={c.name}
-                whileHover={{ scale: 1.03 }}
-                whileFocus={{ scale: 1.03 }}
+                whileHover={{ scale: 1.05, boxShadow: '0 0 20px rgba(34,197,94,0.5)' }}
+                whileTap={{ scale: 0.98 }}
+                whileFocus={{ scale: 1.05 }}
                 tabIndex={0}
-                className='glass-card hover-glow rounded-xl p-3 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-psychedelic-pink sm:p-6'
+                className='glass-card hover-glow rounded-xl p-3 text-left transition-shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-psychedelic-pink sm:p-6'
               >
                 <h2 className='max-w-xs truncate text-xl font-bold text-white'>{c.name}</h2>
                 <p className='text-sm text-moss'>

--- a/src/pages/HerbDetailView.tsx
+++ b/src/pages/HerbDetailView.tsx
@@ -115,10 +115,12 @@ export default function HerbDetailView() {
           {herb.dosage}
         </div>
       )}
-      {herb.affiliateLink && herb.affiliateLink.startsWith('http') && (
+      {herb.affiliateLink && herb.affiliateLink.startsWith('http') ? (
         <a href={herb.affiliateLink} target='_blank' rel='noopener noreferrer' className='text-sky-300 underline'>
           Buy Online
         </a>
+      ) : (
+        <span className='text-sm text-sand/60'>No affiliate link available.</span>
       )}
       <div>
         <h3 className='text-xl font-bold text-sky-300'>Usage Log</h3>

--- a/src/styles/tags.css
+++ b/src/styles/tags.css
@@ -2,7 +2,7 @@
   @apply rounded-xl bg-black/30 backdrop-blur-md p-2;
 }
 .tag-list {
-  @apply mt-2 flex flex-wrap gap-1 sm:gap-2 overflow-x-auto scroll-smooth snap-x snap-mandatory max-h-40 overflow-y-auto;
+  @apply mt-2 flex flex-wrap gap-1 sm:gap-2 overflow-x-auto scroll-smooth snap-x snap-mandatory max-h-32 overflow-y-auto;
 }
 .tag-label {
   @apply flex w-full items-center justify-between text-sm font-semibold text-violet-300;


### PR DESCRIPTION
## Summary
- animate hero section and center content
- warn during dev if herbs have missing fields
- enhance compound card animations
- cap tag list height on mobile
- show fallback text when no affiliate link

## Testing
- `npm run build`
- `npm test`
- `npm run validate-herbs`


------
https://chatgpt.com/codex/tasks/task_e_687bef3f06f483239b887b3eff97f348