### PR TITLE
Add hero CTA scroll and random featured herb

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" href="/favicon.ico" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Psychedelic Botany &amp; Consciousness Exploration" />
+    <meta name="description" content="Explore psychedelic botanicals, cognitive enhancers, and consciousness tools at The Hippie Scientist." />
     <meta property="og:title" content="The Hippie Scientist" />
     <meta property="og:description" content="Psychedelic Botany &amp; Conscious Exploration" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/components/FeaturedHerbCarousel.tsx
+++ b/src/components/FeaturedHerbCarousel.tsx
@@ -3,9 +3,14 @@ import { AnimatePresence, motion } from 'framer-motion'
 import { Link } from 'react-router-dom'
 import herbs from '../data/herbs'
 
-const featured = herbs.slice(0, 5)
+function pickFeatured() {
+  const psychedelic = herbs.filter(h => h.category.includes('Psychedelic'))
+  const pool = psychedelic.length > 0 ? psychedelic : herbs
+  return [...pool].sort(() => Math.random() - 0.5).slice(0, 5)
+}
 
 export default function FeaturedHerbCarousel() {
+  const [featured] = useState(() => pickFeatured())
   const [index, setIndex] = useState(0)
 
   useEffect(() => {
@@ -18,7 +23,12 @@ export default function FeaturedHerbCarousel() {
   const herb = featured[index]
 
   return (
-    <div className='relative mx-auto mt-8 max-w-md'>
+    <motion.div
+      id='featured-herb-carousel'
+      className='relative mx-auto mt-8 max-w-md'
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+    >
       <AnimatePresence mode='wait'>
         <motion.div
           key={herb.id}
@@ -44,6 +54,6 @@ export default function FeaturedHerbCarousel() {
           </Link>
         </motion.div>
       </AnimatePresence>
-    </div>
+    </motion.div>
   )
 }

--- a/src/components/FeaturedHerbTeaser.tsx
+++ b/src/components/FeaturedHerbTeaser.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from 'react'
+import { motion } from 'framer-motion'
+import { Link } from 'react-router-dom'
+import herbs from '../data/herbs'
+import type { Herb } from '../types'
+
+export default function FeaturedHerbTeaser() {
+  const [herb, setHerb] = useState<Herb | null>(null)
+
+  useEffect(() => {
+    const psychedelic = herbs.filter(h => h.category.includes('Psychedelic'))
+    const pool = psychedelic.length > 0 ? psychedelic : herbs
+    setHerb(pool[Math.floor(Math.random() * pool.length)])
+  }, [])
+
+  if (!herb) return null
+
+  return (
+    <motion.div
+      id='featured-herb'
+      className='glass-card mx-auto mt-8 max-w-sm rounded-xl p-4 shadow-lg'
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+    >
+      {herb.image && (
+        <img
+          src={herb.image}
+          alt={herb.name}
+          className='h-32 w-full rounded-md object-cover'
+        />
+      )}
+      <h3 className='mt-3 font-herb text-2xl'>{herb.name}</h3>
+      {herb.effects?.length > 0 && (
+        <p className='mt-1 text-sm text-sand'>{herb.effects.slice(0, 3).join(', ')}</p>
+      )}
+      <Link
+        to={`/herbs/${herb.id}`}
+        className='hover-glow mt-3 inline-block rounded-md bg-black/30 px-4 py-2 text-sand backdrop-blur-md hover:rotate-1'
+      >
+        Learn More
+      </Link>
+    </motion.div>
+  )
+}

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -2,6 +2,8 @@ import { motion } from 'framer-motion'
 import HeroBackground from './HeroBackground'
 import ParticlesBackground from './ParticlesBackground'
 import FloatingElements from './FloatingElements'
+import ScrollDownHint from './ScrollDownHint'
+import FeaturedHerbTeaser from './FeaturedHerbTeaser'
 
 export default function HeroSection() {
   return (
@@ -25,6 +27,8 @@ export default function HeroSection() {
         </h1>
         <p className='text-lg text-opal md:text-xl'>Psychedelic Botany &amp; Conscious Exploration</p>
       </motion.div>
+      <FeaturedHerbTeaser />
+      <ScrollDownHint />
     </motion.section>
   )
 }

--- a/src/components/ScrollDownHint.tsx
+++ b/src/components/ScrollDownHint.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import { motion } from 'framer-motion'
+import { ChevronDown } from 'lucide-react'
+
+interface Props {
+  targetId?: string
+}
+
+export default function ScrollDownHint({ targetId = 'featured-herb-carousel' }: Props) {
+  const handleClick = () => {
+    const el = document.getElementById(targetId)
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth' })
+    }
+  }
+
+  return (
+    <motion.button
+      onClick={handleClick}
+      initial={{ y: 0 }}
+      animate={{ y: [0, 10, 0] }}
+      transition={{ repeat: Infinity, duration: 2 }}
+      className='absolute bottom-6 left-1/2 z-20 -translate-x-1/2 rounded-full bg-black/40 p-3 text-white backdrop-blur-md hover:scale-105'
+      aria-label='Scroll down'
+    >
+      <ChevronDown className='h-6 w-6' />
+    </motion.button>
+  )
+}


### PR DESCRIPTION
## Summary
- add animated ScrollDownHint component
- display a random psychedelic herb in the hero
- randomize featured herb carousel order
- update meta description for SEO

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687bf73d72608323a661eba469be0614