### PR TITLE
Fix hero layout centering

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -8,7 +8,7 @@ import FeaturedHerbTeaser from './FeaturedHerbTeaser'
 export default function HeroSection() {
   return (
     <motion.section
-      className='relative flex min-h-screen flex-col items-center justify-center overflow-hidden px-4 text-center'
+      className='relative flex min-h-[70vh] flex-col items-center justify-center overflow-hidden px-4 text-center md:min-h-screen'
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 1 }}
@@ -18,8 +18,8 @@ export default function HeroSection() {
       <FloatingElements />
       <motion.div
         className='relative z-10 space-y-2'
-        initial={{ opacity: 0, y: 40 }}
-        animate={{ opacity: 1, y: 0 }}
+        initial={{ opacity: 0, y: 40, scale: 0.95 }}
+        animate={{ opacity: 1, y: 0, scale: 1 }}
         transition={{ duration: 1, delay: 0.2 }}
       >
         <h1 className='text-gradient mb-4 font-display text-5xl md:text-7xl'>
@@ -27,7 +27,9 @@ export default function HeroSection() {
         </h1>
         <p className='text-lg text-opal md:text-xl'>Psychedelic Botany &amp; Conscious Exploration</p>
       </motion.div>
-      <FeaturedHerbTeaser />
+      <div className='relative z-10'>
+        <FeaturedHerbTeaser />
+      </div>
       <ScrollDownHint />
     </motion.section>
   )

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,7 +8,7 @@ import StatsCounters from '../components/StatsCounters'
 
 export default function Home() {
   return (
-    <main className='relative min-h-screen overflow-hidden bg-white px-4 py-10 text-black dark:bg-black dark:text-white'>
+    <main className='relative min-h-screen overflow-hidden bg-white px-4 pt-20 pb-10 text-black dark:bg-black dark:text-white'>
       <StarfieldBackground />
       <MouseTrail />
       <HeroSection />


### PR DESCRIPTION
## Summary
- tweak hero text animation and mobile layout
- adjust home page padding for navbar offset

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687bf8af5b4c8323b265878d07c4ceb6