### PR TITLE
Fix Hero mobile layout

### DIFF
--- a/docs/site-update-log.md
+++ b/docs/site-update-log.md
@@ -10,3 +10,7 @@ Files: HeroSection.tsx, FeaturedHerbTeaser.tsx, FeaturedHerbCarousel.tsx
 •Limited preview to 1 compound card (Cannabis sativa)
 •Removed scroll arrow and ensured everything fits above fold
 Files: Hero.tsx, Home.tsx, tailwind.config.js
+[2025-07-20] Mobile Hero Single Card Fix
+• Ensured only one compound card displays above the fold
+• Hid carousel on small screens and adjusted hero spacing
+Files: Hero.tsx, Home.tsx, FeaturedHerbTeaser.tsx

--- a/src/components/FeaturedHerbTeaser.tsx
+++ b/src/components/FeaturedHerbTeaser.tsx
@@ -4,14 +4,23 @@ import { Link } from 'react-router-dom'
 import herbs from '../data/herbs'
 import type { Herb } from '../types'
 
-export default function FeaturedHerbTeaser() {
+interface Props {
+  fixedId?: string
+}
+
+export default function FeaturedHerbTeaser({ fixedId = '' }: Props) {
   const [herb, setHerb] = useState<Herb | null>(null)
 
   useEffect(() => {
+    if (fixedId) {
+      const selected = herbs.find(h => h.id === fixedId || h.name === fixedId)
+      setHerb(selected ?? herbs[0])
+      return
+    }
     const psychedelic = herbs.filter(h => h.category.includes('Psychedelic'))
     const pool = psychedelic.length > 0 ? psychedelic : herbs
     setHerb(pool[Math.floor(Math.random() * pool.length)])
-  }, [])
+  }, [fixedId])
 
   if (!herb) return null
 

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -4,10 +4,10 @@ import ParticlesBackground from './ParticlesBackground'
 import FloatingElements from './FloatingElements'
 import FeaturedHerbTeaser from './FeaturedHerbTeaser'
 
-export default function HeroSection() {
+export default function Hero() {
   return (
     <motion.section
-      className='relative flex min-h-screen-nav flex-col items-center justify-start overflow-hidden px-4 pb-4 pt-8 text-center md:pt-12'
+      className='relative flex min-h-[100vh] md:min-h-screen-nav flex-col items-start md:items-center justify-start overflow-hidden gap-4 px-4 pt-8 pb-4 text-center md:pt-12'
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 1 }}
@@ -27,7 +27,7 @@ export default function HeroSection() {
         <p className='text-opal text-base sm:text-lg md:text-xl'>Psychedelic Botany &amp; Conscious Exploration</p>
       </motion.div>
       <div className='relative z-10'>
-        <FeaturedHerbTeaser />
+        <FeaturedHerbTeaser fixedId='Cannabis sativa' />
       </div>
     </motion.section>
   )

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
-import HeroSection from '../components/HeroSection'
+import Hero from '../components/Hero'
 import StarfieldBackground from '../components/StarfieldBackground'
 import MouseTrail from '../components/MouseTrail'
 import FeaturedHerbCarousel from '../components/FeaturedHerbCarousel'
@@ -11,8 +11,10 @@ export default function Home() {
     <main className='relative min-h-screen overflow-hidden bg-white px-4 pt-20 pb-0 md:pb-10 text-black dark:bg-black dark:text-white'>
       <StarfieldBackground />
       <MouseTrail />
-      <HeroSection />
-      <FeaturedHerbCarousel />
+      <Hero />
+      <div className='hidden md:block'>
+        <FeaturedHerbCarousel />
+      </div>
       <StatsCounters />
       <section className='mx-auto max-w-4xl text-center'>
         <Link


### PR DESCRIPTION
## Summary
- rename `HeroSection` to `Hero`
- update hero to use full screen on mobile and display Cannabis sativa card
- hide carousel on small screens
- allow `FeaturedHerbTeaser` to accept a fixed herb
- document update

## Testing
- `npm test`
- `npm run validate-herbs`


------
https://chatgpt.com/codex/tasks/task_e_687bff89f8d88323ac47f7b15588f145