### PR TITLE
Fix mobile hero layout

### DIFF
--- a/docs/UPDATES.md
+++ b/docs/UPDATES.md
@@ -1,0 +1,4 @@
+[Hero Section Layout Fix - Mobile]
+	•	Raised site title position for visual balance
+	•	Limited hero to 1 featured herb preview card
+	•	Removed excessive bottom spacing for first-screen fit

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -7,7 +7,7 @@ import FeaturedHerbTeaser from './FeaturedHerbTeaser'
 export default function Hero() {
   return (
     <motion.section
-      className='relative flex min-h-[calc(100dvh-4rem)] flex-col items-center justify-center overflow-hidden gap-4 px-4 py-0 text-center md:min-h-screen-nav md:pt-12'
+      className='relative flex flex-col items-center justify-start overflow-hidden gap-4 px-4 pt-6 text-center md:min-h-screen-nav md:justify-center md:pt-12'
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 1 }}

--- a/src/components/StatsCounters.tsx
+++ b/src/components/StatsCounters.tsx
@@ -5,7 +5,7 @@ import { baseCompounds } from '../data/compoundData'
 
 export default function StatsCounters() {
   return (
-    <div className='mx-auto mt-8 flex max-w-4xl flex-col items-center justify-center gap-6 text-center sm:flex-row sm:gap-12'>
+    <div className='mx-auto mt-4 flex max-w-4xl flex-col items-center justify-center gap-6 text-center sm:flex-row sm:gap-12'>
       <div className='text-lg sm:text-xl'>
         <CountUp end={herbs.length} duration={2} />+ psychoactive herbs indexed
       </div>


### PR DESCRIPTION
## Summary
- adjust hero padding & remove full-screen height on small devices
- reduce spacing before stats block for better fit
- add update note in `docs/UPDATES.md`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c04c6a25c83238ef229e586e4d9f9