### PR TITLE
Add rotating herb card to hero

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -2,7 +2,7 @@ import { motion } from 'framer-motion'
 import HeroBackground from './HeroBackground'
 import ParticlesBackground from './ParticlesBackground'
 import FloatingElements from './FloatingElements'
-import FeaturedHerbTeaser from './FeaturedHerbTeaser'
+import RotatingHerbCard from './RotatingHerbCard'
 
 export default function Hero() {
   return (
@@ -27,7 +27,7 @@ export default function Hero() {
         <p className='text-opal text-base sm:text-lg md:text-xl'>Psychedelic Botany &amp; Conscious Exploration</p>
       </motion.div>
       <div className='relative z-10 mt-4'>
-        <FeaturedHerbTeaser fixedId='Cannabis sativa' />
+        <RotatingHerbCard />
       </div>
     </motion.section>
   )

--- a/src/components/RotatingHerbCard.tsx
+++ b/src/components/RotatingHerbCard.tsx
@@ -1,0 +1,80 @@
+import React, { useEffect, useState, useRef } from 'react'
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
+import { Link } from 'react-router-dom'
+import herbs from '../data/herbs'
+import type { Herb } from '../types'
+
+function shuffle<T>(arr: T[]): T[] {
+  const a = [...arr]
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[a[i], a[j]] = [a[j], a[i]]
+  }
+  return a
+}
+
+const INTERVAL = 6000
+
+export default function RotatingHerbCard() {
+  const reduceMotion = useReducedMotion()
+  const [items] = useState<Herb[]>(() => shuffle(herbs))
+  const [index, setIndex] = useState(0)
+  const [paused, setPaused] = useState(false)
+  const intervalRef = useRef<NodeJS.Timeout>()
+
+  useEffect(() => {
+    if (reduceMotion) return
+    intervalRef.current = setInterval(() => {
+      if (!paused) {
+        setIndex(i => (i + 1) % items.length)
+      }
+    }, INTERVAL)
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current)
+    }
+  }, [paused, reduceMotion, items])
+
+  const herb = items[index]
+  if (!herb) return null
+
+  const handleTouch = () => setPaused(p => !p)
+
+  return (
+    <motion.div
+      aria-live='polite'
+      className='relative mx-auto mt-6 max-w-sm h-96'
+      onMouseEnter={() => setPaused(true)}
+      onMouseLeave={() => setPaused(false)}
+      onTouchStart={handleTouch}
+    >
+      <AnimatePresence mode='wait'>
+        <motion.div
+          key={herb.id}
+          className='glass-card hover-glow absolute inset-0 flex flex-col rounded-xl p-4 shadow-lg'
+          initial={reduceMotion ? false : { opacity: 0, y: 20 }}
+          animate={reduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
+          exit={reduceMotion ? { opacity: 0 } : { opacity: 0, y: -20 }}
+          transition={{ duration: 0.6 }}
+        >
+          {herb.image && (
+            <img
+              src={herb.image}
+              alt={herb.name}
+              className='h-32 w-full rounded-md object-cover'
+            />
+          )}
+          <h3 className='mt-3 font-herb text-2xl'>{herb.name}</h3>
+          {herb.effects?.length > 0 && (
+            <p className='mt-1 text-sm text-sand'>{herb.effects.slice(0, 3).join(', ')}</p>
+          )}
+          <Link
+            to={`/herbs/${herb.id}`}
+            className='hover-glow mt-3 inline-block rounded-md bg-black/30 px-4 py-2 text-sand backdrop-blur-md hover:rotate-1'
+          >
+            Learn More
+          </Link>
+        </motion.div>
+      </AnimatePresence>
+    </motion.div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `RotatingHerbCard` with interval-based rotation
- show the new card in `Hero` instead of the static teaser

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c0ab017a083239c1e4dcd65dd5c9e