### PR TITLE
Improve hero layout

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,13 +1,15 @@
 import { motion } from 'framer-motion'
+import { Link } from 'react-router-dom'
 import HeroBackground from './HeroBackground'
 import ParticlesBackground from './ParticlesBackground'
 import FloatingElements from './FloatingElements'
 import RotatingHerbCard from './RotatingHerbCard'
+import StatsCounters from './StatsCounters'
 
 export default function Hero() {
   return (
     <motion.section
-      className='relative flex flex-col items-center justify-start overflow-hidden gap-4 px-4 pt-6 text-center md:min-h-screen-nav md:justify-center md:pt-12'
+      className='hero-section pb-safe'
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 1 }}
@@ -15,19 +17,33 @@ export default function Hero() {
       <ParticlesBackground />
       <HeroBackground />
       <FloatingElements />
-      <motion.div
-        className='relative z-10 mx-auto max-w-2xl space-y-1'
-        initial={{ opacity: 0, y: 20, scale: 0.95 }}
-        animate={{ opacity: 1, y: 0, scale: 1 }}
-        transition={{ duration: 1, delay: 0.2, ease: 'easeOut' }}
-      >
-        <h1 className='text-gradient font-display text-4xl sm:text-5xl md:text-6xl lg:text-7xl'>
-          The Hippie Scientist
-        </h1>
-        <p className='text-opal text-base sm:text-lg md:text-xl'>Psychedelic Botany &amp; Conscious Exploration</p>
-      </motion.div>
-      <div className='relative z-10 mt-4'>
-        <RotatingHerbCard />
+
+      <div className='relative z-10 flex flex-1 flex-col items-center justify-center gap-4'>
+        <motion.div
+          className='mx-auto max-w-2xl space-y-1'
+          initial={{ opacity: 0, y: 20, scale: 0.95 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          transition={{ duration: 1, delay: 0.2, ease: 'easeOut' }}
+        >
+          <h1 className='text-gradient font-display text-4xl sm:text-5xl md:text-6xl lg:text-7xl'>
+            The Hippie Scientist
+          </h1>
+          <p className='text-opal text-base sm:text-lg md:text-xl'>Psychedelic Botany &amp; Conscious Exploration</p>
+        </motion.div>
+
+        <div className='mt-2'>
+          <RotatingHerbCard />
+        </div>
+      </div>
+
+      <div className='relative z-10 mb-4 flex flex-col items-center gap-4'>
+        <StatsCounters className='mt-0' />
+        <Link
+          to='/database'
+          className='hover-glow inline-block rounded-md bg-black/30 px-6 py-3 text-white backdrop-blur-md hover:rotate-1'
+        >
+          🌿 Browse Database
+        </Link>
       </div>
     </motion.section>
   )

--- a/src/components/StatsCounters.tsx
+++ b/src/components/StatsCounters.tsx
@@ -3,9 +3,11 @@ import CountUp from 'react-countup'
 import herbs from '../data/herbs'
 import { baseCompounds } from '../data/compoundData'
 
-export default function StatsCounters() {
+export default function StatsCounters({ className = '' }: { className?: string }) {
   return (
-    <div className='mx-auto mt-4 flex max-w-4xl flex-col items-center justify-center gap-6 text-center sm:flex-row sm:gap-12'>
+    <div
+      className={`mx-auto mt-4 flex max-w-4xl flex-col items-center justify-center gap-6 text-center sm:flex-row sm:gap-12 ${className}`}
+    >
       <div className='text-lg sm:text-xl'>
         <CountUp end={herbs.length} duration={2} />+ psychoactive herbs indexed
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -115,3 +115,12 @@ html {
 .text-shadow {
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
 }
+
+/* Hero layout utilities */
+.hero-section {
+  @apply relative flex min-h-hero flex-col items-center justify-between overflow-hidden px-4 text-center;
+}
+
+.pb-safe {
+  padding-bottom: env(safe-area-inset-bottom);
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,29 +1,22 @@
 import React from 'react'
-import { Link } from 'react-router-dom'
 import Hero from '../components/Hero'
 import StarfieldBackground from '../components/StarfieldBackground'
 import MouseTrail from '../components/MouseTrail'
 import FeaturedHerbCarousel from '../components/FeaturedHerbCarousel'
-import StatsCounters from '../components/StatsCounters'
 
 export default function Home() {
   return (
-    <main className='relative min-h-screen overflow-hidden bg-white px-4 pt-16 pb-0 md:pb-10 text-black dark:bg-black dark:text-white'>
+    <main
+      id='home'
+      aria-label='Site introduction'
+      className='relative min-h-screen overflow-hidden bg-white pt-16 text-black dark:bg-black dark:text-white'
+    >
       <StarfieldBackground />
       <MouseTrail />
       <Hero />
       <div className='hidden md:block'>
         <FeaturedHerbCarousel />
       </div>
-      <StatsCounters />
-      <section className='mx-auto max-w-4xl text-center'>
-        <Link
-          to='/database'
-          className='hover-glow mt-8 inline-block rounded-md bg-black/30 px-6 py-3 text-white backdrop-blur-md hover:rotate-1'
-        >
-          🌿 Browse Database
-        </Link>
-      </section>
     </main>
   )
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -37,6 +37,8 @@ export default {
       },
       minHeight: {
         'screen-nav': 'calc(100dvh - 5rem)',
+        // hero height accounts for fixed navbar (4rem) and safe area on modern devices
+        hero: 'calc(100dvh - 4rem - env(safe-area-inset-bottom))',
       },
     },
   },


### PR DESCRIPTION
## Summary
- add `min-h-hero` to Tailwind and utility classes for hero layouts
- refactor `StatsCounters` to accept className
- restructure `Hero` to keep card/metrics/CTA in a flex column
- adjust `Home` to expose `<main id="home" aria-label>`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687c123cdc40832384da15b2be0a4f51