### PR TITLE
Add animated TagDistribution

### DIFF
--- a/src/components/TagDistribution.tsx
+++ b/src/components/TagDistribution.tsx
@@ -1,0 +1,71 @@
+import React from 'react'
+import { motion } from 'framer-motion'
+import { decodeTag } from '../utils/format'
+
+interface Props {
+  counts: Record<string, number>
+  className?: string
+}
+
+export default function TagDistribution({ counts, className = '' }: Props) {
+  const entries = React.useMemo(() => {
+    return Object.entries(counts).sort((a, b) => b[1] - a[1])
+  }, [counts])
+
+  const max = React.useMemo(() => {
+    return Math.max(1, ...entries.map(([, c]) => c))
+  }, [entries])
+
+  const main = entries.filter(([, c]) => c > 1)
+  const others = entries.filter(([, c]) => c <= 1)
+
+  const Row = ({ tag, count }: { tag: string; count: number }) => (
+    <div className='flex items-center gap-2'>
+      <span className='overflow-hidden text-ellipsis whitespace-nowrap text-xs sm:text-sm'>
+        {decodeTag(tag)}
+      </span>
+      <div className='flex-1'>
+        <div className='relative h-[8px] overflow-hidden rounded-full bg-zinc-800/50'>
+          <motion.div
+            className='h-[8px] rounded-full bg-gradient-to-r from-purple-400 via-pink-500 to-fuchsia-500'
+            initial={{ width: 0 }}
+            whileInView={{ width: `${(count / max) * 100}%` }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.6 }}
+            role='progressbar'
+            aria-label={`${decodeTag(tag)} count`}
+            aria-valuenow={count}
+            aria-valuemin={0}
+            aria-valuemax={max}
+          />
+          <span className='absolute -top-1 right-1 text-[10px]'>{count}</span>
+        </div>
+      </div>
+    </div>
+  )
+
+  const [open, setOpen] = React.useState(false)
+
+  return (
+    <div className={`grid grid-cols-1 gap-x-4 gap-y-2 md:grid-cols-2 ${className}`}>
+      {main.map(([tag, count]) => (
+        <Row key={tag} tag={tag} count={count} />
+      ))}
+      {others.length > 0 && (
+        <details className='col-span-full' onToggle={e => setOpen(e.currentTarget.open)}>
+          <summary className='flex cursor-pointer items-center gap-1 text-xs sm:text-sm'>
+            Other Tags
+            <motion.span animate={{ rotate: open ? 90 : 0 }} className='inline-block'>
+              ▶
+            </motion.span>
+          </summary>
+          <div className='mt-2 grid grid-cols-1 gap-x-4 gap-y-2 md:grid-cols-2'>
+            {others.map(([tag, count]) => (
+              <Row key={tag} tag={tag} count={count} />
+            ))}
+          </div>
+        </details>
+      )}
+    </div>
+  )
+}

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -6,6 +6,7 @@ import { motion } from 'framer-motion'
 import HerbList from '../components/HerbList'
 import TagFilterBar from '../components/TagFilterBar'
 import CategoryAnalytics from '../components/CategoryAnalytics'
+import TagDistribution from '../components/TagDistribution'
 import CategoryFilter from '../components/CategoryFilter'
 import { decodeTag } from '../utils/format'
 import { canonicalTag } from '../utils/tagUtils'
@@ -70,7 +71,9 @@ export default function Database() {
   }, [herbs])
 
   const summary = React.useMemo(() => {
-    const affiliates = herbs.filter(h => h.affiliateLink && h.affiliateLink.startsWith('http')).length
+    const affiliates = herbs.filter(
+      h => h.affiliateLink && h.affiliateLink.startsWith('http')
+    ).length
     const moaCount = herbs.filter(h => h.mechanismOfAction && h.mechanismOfAction.trim()).length
     return { total: herbs.length, affiliates, moaCount }
   }, [herbs])
@@ -212,9 +215,11 @@ export default function Database() {
             </div>
           )}
           <CategoryAnalytics />
+          <TagDistribution counts={tagCounts} />
           <HerbList herbs={filtered} highlightQuery={query} />
           <footer className='mt-4 text-center text-sm text-moss'>
-            Total herbs: {summary.total} · Affiliate links: {summary.affiliates} · MOA documented: {summary.moaCount} · Updated: {new Date(__BUILD_TIME__).toLocaleDateString()}
+            Total herbs: {summary.total} · Affiliate links: {summary.affiliates} · MOA documented:{' '}
+            {summary.moaCount} · Updated: {new Date(__BUILD_TIME__).toLocaleDateString()}
           </footer>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add new animated TagDistribution component with compact layout
- integrate TagDistribution in Database page

## Testing
- `npm test`
- `npm run validate-herbs`


------
https://chatgpt.com/codex/tasks/task_e_687c1c3014488323b7b51a428007178e