### PR TITLE
Improve tag distribution UX

### DIFF
--- a/src/components/TagDistribution.tsx
+++ b/src/components/TagDistribution.tsx
@@ -1,13 +1,22 @@
 import React from 'react'
 import { motion } from 'framer-motion'
+import clsx from 'clsx'
 import { decodeTag } from '../utils/format'
+import { canonicalTag } from '../utils/tagUtils'
 
 interface Props {
   counts: Record<string, number>
   className?: string
+  selected?: string[]
+  onToggle?: (tag: string) => void
 }
 
-export default function TagDistribution({ counts, className = '' }: Props) {
+export default function TagDistribution({
+  counts,
+  className = '',
+  selected = [],
+  onToggle,
+}: Props) {
   const entries = React.useMemo(() => {
     return Object.entries(counts).sort((a, b) => b[1] - a[1])
   }, [counts])
@@ -19,30 +28,48 @@ export default function TagDistribution({ counts, className = '' }: Props) {
   const main = entries.filter(([, c]) => c > 1)
   const others = entries.filter(([, c]) => c <= 1)
 
-  const Row = ({ tag, count }: { tag: string; count: number }) => (
-    <div className='flex items-center gap-2'>
-      <span className='overflow-hidden text-ellipsis whitespace-nowrap text-xs sm:text-sm'>
-        {decodeTag(tag)}
-      </span>
-      <div className='flex-1'>
-        <div className='relative h-[8px] overflow-hidden rounded-full bg-zinc-800/50'>
-          <motion.div
-            className='h-[8px] rounded-full bg-gradient-to-r from-purple-400 via-pink-500 to-fuchsia-500'
-            initial={{ width: 0 }}
-            whileInView={{ width: `${(count / max) * 100}%` }}
-            viewport={{ once: true }}
-            transition={{ duration: 0.6 }}
-            role='progressbar'
-            aria-label={`${decodeTag(tag)} count`}
-            aria-valuenow={count}
-            aria-valuemin={0}
-            aria-valuemax={max}
-          />
-          <span className='absolute -top-1 right-1 text-[10px]'>{count}</span>
-        </div>
-      </div>
-    </div>
+  const selectedSet = React.useMemo(
+    () => new Set(selected.map(canonicalTag)),
+    [selected]
   )
+
+  const Row = ({ tag, count }: { tag: string; count: number }) => {
+    const active = selectedSet.has(canonicalTag(tag))
+    return (
+      <motion.button
+        type='button'
+        whileHover={{ scale: 1.02 }}
+        whileTap={{ scale: 0.98 }}
+        onClick={() => onToggle?.(canonicalTag(tag))}
+        aria-pressed={active}
+        className={clsx(
+          'flex w-full items-center gap-2 rounded focus:outline-none',
+          active ? 'hover-glow ring-1 ring-emerald-400' : 'opacity-80 hover:opacity-100'
+        )}
+      >
+        <span className='overflow-hidden text-ellipsis whitespace-nowrap text-xs sm:text-sm'>
+          {decodeTag(tag)}
+        </span>
+        <div className='flex-1'>
+          <div className='relative h-[8px] overflow-hidden rounded-full bg-zinc-800/50'>
+            <motion.div
+              className='h-[8px] rounded-full bg-gradient-to-r from-purple-400 via-pink-500 to-fuchsia-500'
+              initial={{ width: 0 }}
+              whileInView={{ width: `${(count / max) * 100}%` }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.6 }}
+              role='progressbar'
+              aria-label={`${decodeTag(tag)} count`}
+              aria-valuenow={count}
+              aria-valuemin={0}
+              aria-valuemax={max}
+            />
+            <span className='absolute -top-1 right-1 text-[10px]'>{count}</span>
+          </div>
+        </div>
+      </motion.button>
+    )
+  }
 
   const [open, setOpen] = React.useState(false)
 

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -89,6 +89,15 @@ export default function Database() {
     return counts
   }, [herbs])
 
+  const toggleTag = React.useCallback(
+    (tag: string) => {
+      setFilteredTags(prev =>
+        prev.includes(tag) ? prev.filter(t => t !== tag) : [...prev, tag]
+      )
+    },
+    [setFilteredTags]
+  )
+
   const [filtersOpen, setFiltersOpen] = React.useState(false)
   const [showBar, setShowBar] = React.useState(true)
 
@@ -215,7 +224,11 @@ export default function Database() {
             </div>
           )}
           <CategoryAnalytics />
-          <TagDistribution counts={tagCounts} />
+          <TagDistribution
+            counts={tagCounts}
+            selected={filteredTags}
+            onToggle={toggleTag}
+          />
           <HerbList herbs={filtered} highlightQuery={query} />
           <footer className='mt-4 text-center text-sm text-moss'>
             Total herbs: {summary.total} · Affiliate links: {summary.affiliates} · MOA documented:{' '}


### PR DESCRIPTION
## Summary
- animate tag bars and make them clickable
- allow tag distribution rows to toggle tag filters in Database page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c208cb84c8323a7bba8ec85bb7bce