### PR TITLE
Add interactive TagDistribution bars

### DIFF
--- a/src/components/TagDistribution.tsx
+++ b/src/components/TagDistribution.tsx
@@ -1,13 +1,22 @@
 import React from 'react'
+import clsx from 'clsx'
 import { motion } from 'framer-motion'
 import { decodeTag } from '../utils/format'
+import { canonicalTag } from '../utils/tagUtils'
 
 interface Props {
   counts: Record<string, number>
   className?: string
+  onClick?: (tag: string) => void
+  selected?: string[]
 }
 
-export default function TagDistribution({ counts, className = '' }: Props) {
+export default function TagDistribution({
+  counts,
+  className = '',
+  onClick,
+  selected = [],
+}: Props) {
   const entries = React.useMemo(() => {
     return Object.entries(counts).sort((a, b) => b[1] - a[1])
   }, [counts])
@@ -19,30 +28,43 @@ export default function TagDistribution({ counts, className = '' }: Props) {
   const main = entries.filter(([, c]) => c > 1)
   const others = entries.filter(([, c]) => c <= 1)
 
-  const Row = ({ tag, count }: { tag: string; count: number }) => (
-    <div className='flex items-center gap-2'>
-      <span className='overflow-hidden text-ellipsis whitespace-nowrap text-xs sm:text-sm'>
-        {decodeTag(tag)}
-      </span>
-      <div className='flex-1'>
-        <div className='relative h-[8px] overflow-hidden rounded-full bg-zinc-800/50'>
-          <motion.div
-            className='h-[8px] rounded-full bg-gradient-to-r from-purple-400 via-pink-500 to-fuchsia-500'
-            initial={{ width: 0 }}
-            whileInView={{ width: `${(count / max) * 100}%` }}
-            viewport={{ once: true }}
-            transition={{ duration: 0.6 }}
-            role='progressbar'
-            aria-label={`${decodeTag(tag)} count`}
-            aria-valuenow={count}
-            aria-valuemin={0}
-            aria-valuemax={max}
-          />
-          <span className='absolute -top-1 right-1 text-[10px]'>{count}</span>
+  const Row = ({ tag, count }: { tag: string; count: number }) => {
+    const canon = canonicalTag(tag)
+    const isSelected = selected.includes(canon)
+    return (
+      <button
+        type='button'
+        onClick={onClick ? () => onClick(canon) : undefined}
+        className={clsx(
+          'flex items-center gap-2 rounded-sm p-1 focus:outline-none',
+          onClick && 'cursor-pointer hover-glow',
+          isSelected ? 'opacity-100' : 'opacity-80 hover:opacity-100'
+        )}
+        aria-pressed={isSelected}
+      >
+        <span className='overflow-hidden text-ellipsis whitespace-nowrap text-xs sm:text-sm'>
+          {decodeTag(tag)}
+        </span>
+        <div className='flex-1'>
+          <div className='relative h-[8px] overflow-hidden rounded-full bg-zinc-800/50'>
+            <motion.div
+              className='h-[8px] rounded-full bg-gradient-to-r from-purple-400 via-pink-500 to-fuchsia-500'
+              initial={{ width: 0 }}
+              whileInView={{ width: `${(count / max) * 100}%` }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.6 }}
+              role='progressbar'
+              aria-label={`${decodeTag(tag)} count`}
+              aria-valuenow={count}
+              aria-valuemin={0}
+              aria-valuemax={max}
+            />
+            <span className='absolute -top-1 right-1 text-[10px]'>{count}</span>
+          </div>
         </div>
-      </div>
-    </div>
-  )
+      </button>
+    )
+  }
 
   const [open, setOpen] = React.useState(false)
 

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -215,7 +215,13 @@ export default function Database() {
             </div>
           )}
           <CategoryAnalytics />
-          <TagDistribution counts={tagCounts} />
+          <TagDistribution
+            counts={tagCounts}
+            selected={filteredTags}
+            onClick={tag =>
+              setFilteredTags(t => Array.from(new Set([...t, tag])))
+            }
+          />
           <HerbList herbs={filtered} highlightQuery={query} />
           <footer className='mt-4 text-center text-sm text-moss'>
             Total herbs: {summary.total} · Affiliate links: {summary.affiliates} · MOA documented:{' '}


### PR DESCRIPTION
## Summary
- tweak `TagDistribution` for optional interactivity and improved accessibility
- allow `Database` page to toggle tag filters via distribution bars

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687c210739308323a8024ac5b86d5ee6