### PR TITLE
Collapse infrequent tags

### DIFF
--- a/src/components/TagFilterBar.tsx
+++ b/src/components/TagFilterBar.tsx
@@ -6,6 +6,8 @@ import { decodeTag, tagVariant, tagCategory, TagCategory, normalizeTag } from '.
 import { canonicalTag } from '../utils/tagUtils'
 import { useLocalStorage } from '../hooks/useLocalStorage'
 
+const MIN_COUNT = 5
+
 interface Props {
   tags: string[]
   onChange?: (tags: string[]) => void
@@ -92,7 +94,18 @@ export default function TagFilterBar({
   const renderTags = (cat: TagCategory) => {
     const list = grouped[cat] || []
     const limit = 12
-    const display = showMore[cat] ? list : list.slice(0, limit)
+    const frequent = list.filter(
+      t => (counts[canonicalTag(t)] || 0) >= MIN_COUNT
+    )
+    const infrequent = list.filter(
+      t => (counts[canonicalTag(t)] || 0) < MIN_COUNT
+    )
+    const all = [...frequent, ...infrequent]
+    const display = showMore[cat]
+      ? all
+      : frequent.slice(0, limit)
+    const hasMore =
+      infrequent.length > 0 || frequent.length > limit
     return (
       <>
         <div className='tag-list'>
@@ -120,7 +133,7 @@ export default function TagFilterBar({
               />
             </motion.button>
           ))}
-          {list.length > limit && (
+          {hasMore && (
             <motion.button
               type='button'
               whileHover={{ scale: 1.05 }}


### PR DESCRIPTION
## Summary
- tuck tags that occur in fewer than five herbs behind "Show More"
- support hiding low-count tags for both category and raw tag views

## Testing
- `npm run build`
- `npm test`
- `npm run validate-herbs`


------
https://chatgpt.com/codex/tasks/task_e_687c27e7c01c8323b5960b8853223a82