### PR TITLE
Implement hover show more for category chart

### DIFF
--- a/src/components/CategoryAnalytics.tsx
+++ b/src/components/CategoryAnalytics.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { herbs } from '../data/herbs'
 
+const MIN_COUNT = 5
+
 export default function CategoryAnalytics() {
   const counts = React.useMemo(() => {
     const c: Record<string, number> = {}
@@ -10,10 +12,34 @@ export default function CategoryAnalytics() {
     })
     return c
   }, [])
-  const max = Math.max(...Object.values(counts))
+
+  const entries = React.useMemo(
+    () => Object.entries(counts).sort((a, b) => b[1] - a[1]),
+    [counts]
+  )
+
+  const [showAll, setShowAll] = React.useState(false)
+
+  const display = React.useMemo(
+    () =>
+      showAll ? entries : entries.filter(([, count]) => count >= MIN_COUNT),
+    [entries, showAll]
+  )
+
+  const hasMore = React.useMemo(
+    () => entries.some(([, count]) => count < MIN_COUNT),
+    [entries]
+  )
+
+  const max = Math.max(...entries.map(([, c]) => c))
+
   return (
-    <div className='space-y-2'>
-      {Object.entries(counts).map(([cat, count]) => (
+    <div
+      className='relative space-y-2'
+      onMouseEnter={() => setShowAll(true)}
+      onMouseLeave={() => setShowAll(false)}
+    >
+      {display.map(([cat, count]) => (
         <div key={cat} className='flex items-center gap-2'>
           <span className='w-40 text-sm'>{cat}</span>
           <div className='flex-1 bg-slate-700/50 h-2 rounded'>
@@ -25,6 +51,11 @@ export default function CategoryAnalytics() {
           <span className='text-sm'>{count}</span>
         </div>
       ))}
+      {hasMore && !showAll && (
+        <div className='pointer-events-none text-center text-xs text-moss'>
+          Hover to show more
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- hide category bars with less than 5 entries
- reveal hidden categories on hover with a hint

## Testing
- `npm test`
- `npm run validate-herbs`


------
https://chatgpt.com/codex/tasks/task_e_687c2bde939483239003cbc07589ba5f