### PR TITLE
Clean up tag system and improve tag UI

### DIFF
--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -34,7 +34,7 @@ const itemVariants = {
   visible: { opacity: 1, y: 0 },
 }
 
-const TAG_LIMIT = 6
+const TAG_LIMIT = 5
 
 const fieldTooltips: Record<string, string> = {
   mechanismOfAction: 'How this herb produces its effects in the body.',
@@ -92,9 +92,7 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
   }
 
   const sortedTags = React.useMemo(() => {
-    const active = new Set(
-      herb.activeConstituents?.map(c => canonicalTag(c.name)) || []
-    )
+    const active = new Set(herb.activeConstituents?.map(c => canonicalTag(c.name)) || [])
     return [...herb.tags].sort((a, b) => {
       const aActive = active.has(canonicalTag(a))
       const bActive = active.has(canonicalTag(b))
@@ -126,7 +124,7 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
       }}
       whileTap={{ scale: 0.97 }}
       transition={{ layout: { duration: 0.4, ease: 'easeInOut' } }}
-      className={`hover-glow card-contrast relative cursor-pointer overflow-hidden rounded-2xl bg-gradient-to-br ${gradient} border border-white/10 p-3 shadow-lg shadow-black/50 ring-1 ring-white/30 backdrop-blur-lg hover:shadow-psychedelic-pink/40 hover:drop-shadow-2xl focus:outline-none focus-visible:shadow-intense focus-visible:ring-2 focus-visible:ring-psychedelic-pink focus-visible:ring-offset-2 focus-visible:ring-offset-space-dark focus-visible:ring-sky-400 focus-visible:ring-4 sm:p-6`}
+      className={`hover-glow card-contrast relative cursor-pointer overflow-hidden rounded-2xl bg-gradient-to-br ${gradient} border border-white/10 p-3 shadow-lg shadow-black/50 ring-1 ring-white/30 backdrop-blur-lg hover:shadow-psychedelic-pink/40 hover:drop-shadow-2xl focus:outline-none focus-visible:shadow-intense focus-visible:ring-2 focus-visible:ring-4 focus-visible:ring-psychedelic-pink focus-visible:ring-sky-400 focus-visible:ring-offset-2 focus-visible:ring-offset-space-dark sm:p-6`}
     >
       <motion.span
         initial={{ opacity: 0, y: -4 }}
@@ -209,11 +207,13 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
         </div>
       </div>
 
-      <div className='mt-2 flex flex-wrap gap-1 text-xs sm:gap-2 sm:text-sm'>
-        {(tagsExpanded || sortedTags.length <= TAG_LIMIT
-          ? sortedTags
-          : sortedTags.slice(0, TAG_LIMIT)
-        ).map(tag => (
+      <motion.div
+        layout
+        onHoverStart={() => setTagsExpanded(true)}
+        onHoverEnd={() => setTagsExpanded(false)}
+        className='mt-2 flex flex-wrap gap-1 text-xs sm:gap-2 sm:text-sm'
+      >
+        {(tagsExpanded ? sortedTags : sortedTags.slice(0, TAG_LIMIT)).map(tag => (
           <TagBadge
             key={tag}
             label={decodeTag(tag)}
@@ -221,22 +221,10 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
             className={open ? 'animate-pulse' : ''}
           />
         ))}
-        {sortedTags.length > TAG_LIMIT && (
-          <button
-            type='button'
-            onClick={e => {
-              e.stopPropagation()
-              setTagsExpanded(t => !t)
-            }}
-            className='focus:outline-none'
-          >
-            <TagBadge
-              label={tagsExpanded ? 'Show Less' : `+${sortedTags.length - TAG_LIMIT} more`}
-              variant='yellow'
-            />
-          </button>
+        {sortedTags.length > TAG_LIMIT && !tagsExpanded && (
+          <TagBadge label={`+${sortedTags.length - TAG_LIMIT} more`} variant='yellow' />
         )}
-      </div>
+      </motion.div>
 
       <AnimatePresence initial={false}>
         {open && (
@@ -303,7 +291,7 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
                             setDescExpanded(d => !d)
                           }}
                           aria-expanded={descExpanded}
-                          className='ml-2 underline text-sky-300'
+                          className='ml-2 text-sky-300 underline'
                         >
                           {descExpanded ? 'Show Less' : 'Read More'}
                         </button>

--- a/src/components/TagFilterBar.tsx
+++ b/src/components/TagFilterBar.tsx
@@ -5,6 +5,7 @@ import TagBadge from './TagBadge'
 import { decodeTag, tagVariant, tagCategory, TagCategory, normalizeTag } from '../utils/format'
 import { canonicalTag } from '../utils/tagUtils'
 import { useLocalStorage } from '../hooks/useLocalStorage'
+import InfoTooltip from './InfoTooltip'
 
 const MIN_COUNT = 5
 
@@ -94,18 +95,11 @@ export default function TagFilterBar({
   const renderTags = (cat: TagCategory) => {
     const list = grouped[cat] || []
     const limit = 12
-    const frequent = list.filter(
-      t => (counts[canonicalTag(t)] || 0) >= MIN_COUNT
-    )
-    const infrequent = list.filter(
-      t => (counts[canonicalTag(t)] || 0) < MIN_COUNT
-    )
+    const frequent = list.filter(t => (counts[canonicalTag(t)] || 0) >= MIN_COUNT)
+    const infrequent = list.filter(t => (counts[canonicalTag(t)] || 0) < MIN_COUNT)
     const all = [...frequent, ...infrequent]
-    const display = showMore[cat]
-      ? all
-      : frequent.slice(0, limit)
-    const hasMore =
-      infrequent.length > 0 || frequent.length > limit
+    const display = showMore[cat] ? all : frequent.slice(0, limit)
+    const hasMore = infrequent.length > 0 || frequent.length > limit
     return (
       <>
         <div className='tag-list'>
@@ -120,17 +114,18 @@ export default function TagFilterBar({
               aria-pressed={selected.includes(tag)}
               tabIndex={0}
               className='flex-shrink-0 focus:outline-none'
-              title={
-                counts[tag]
-                  ? `${decodeTag(normalizeTag(tag))} — used in ${counts[tag]} herbs`
-                  : decodeTag(normalizeTag(tag))
-              }
             >
-              <TagBadge
-                label={decodeTag(normalizeTag(tag))}
-                variant={selected.includes(tag) ? 'green' : tagVariant(tag)}
-                className={clsx(selected.includes(tag) && 'ring-1 ring-emerald-400')}
-              />
+              <InfoTooltip
+                text={`${decodeTag(normalizeTag(tag))} — used in ${
+                  counts[tag] ?? counts[canonicalTag(tag)] ?? 0
+                } herbs`}
+              >
+                <TagBadge
+                  label={decodeTag(normalizeTag(tag))}
+                  variant={selected.includes(tag) ? 'green' : tagVariant(tag)}
+                  className={clsx(selected.includes(tag) && 'ring-1 ring-emerald-400')}
+                />
+              </InfoTooltip>
             </motion.button>
           ))}
           {hasMore && (
@@ -150,7 +145,7 @@ export default function TagFilterBar({
   }
 
   return (
-    <div className='sticky top-16 z-20 space-y-3 bg-black/30 backdrop-blur-md p-2 rounded-xl sm:static sm:bg-transparent sm:p-0'>
+    <div className='sticky top-16 z-20 space-y-3 rounded-xl bg-black/30 p-2 backdrop-blur-md sm:static sm:bg-transparent sm:p-0'>
       {CATEGORY_ORDER.map(cat => (
         <div key={cat} className='tag-section'>
           <button

--- a/src/data/herbs.ts
+++ b/src/data/herbs.ts
@@ -1,13 +1,22 @@
 import type { Herb } from '../types'
 import raw from '../../Full200.json?raw'
 import { canonicalTag } from '../utils/tagUtils'
+import { decodeTag } from '../utils/format'
+
+const RAW_PATTERN = /^(?:[\p{Emoji}\p{Extended_Pictographic}]|.*\b(?:tea|snuff|mood|flower)\b)/iu
 
 const cleaned = raw.replace(/NaN/g, 'null')
 const herbs = JSON.parse(cleaned) as Herb[]
 herbs.forEach(h => {
   if (Array.isArray(h.tags)) {
+    const filtered = h.tags.filter(t => {
+      const decoded = decodeTag(t).toLowerCase().trim()
+      if (/ritual/i.test(decoded)) return false
+      if (RAW_PATTERN.test(decoded)) return false
+      return true
+    })
     const map = new Map<string, string>()
-    h.tags.forEach(t => map.set(canonicalTag(t), t))
+    filtered.forEach(t => map.set(canonicalTag(t), t))
     h.tags = Array.from(map.values())
   }
   if (h.affiliateLink == null) h.affiliateLink = ''


### PR DESCRIPTION
## Summary
- filter out raw and ritual tags when loading herb data
- animate HerbCard tags on hover and limit default display
- show counts in tag filter tooltip

## Testing
- `npm test`
- `npm run validate-herbs`


------
https://chatgpt.com/codex/tasks/task_e_687c2f3e048c8323b68c368a89cce4eb