### PR TITLE
Restore category badges and remove raw tags

### DIFF
--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -18,9 +18,10 @@ interface Props {
 
 const categoryColors: Record<string, Parameters<typeof TagBadge>[0]['variant']> = {
   Oneirogen: 'blue',
-  'Dissociative / Sedative': 'purple',
-  'Empathogen / Euphoriant': 'pink',
-  'Ritual / Visionary': 'green',
+  Dissociative: 'purple',
+  Psychedelic: 'purple',
+  Empathogen: 'pink',
+  Stimulant: 'yellow',
   Other: 'yellow',
 }
 
@@ -47,8 +48,10 @@ const fieldTooltips: Record<string, string> = {
 function gradientForCategory(cat: string): string {
   const c = cat.toLowerCase()
   if (c.includes('oneirogen')) return 'from-indigo-700/40 to-purple-700/40'
-  if (c.includes('ritual') || c.includes('visionary')) return 'from-green-800/40 to-blue-800/40'
-  if (c.includes('stimulant')) return 'from-orange-700/40 to-red-700/40'
+  if (c.includes('psychedelic')) return 'from-fuchsia-700/40 to-pink-700/40'
+  if (c.includes('dissociative')) return 'from-purple-700/40 to-violet-700/40'
+  if (c.includes('empathogen')) return 'from-rose-700/40 to-pink-600/40'
+  if (c.includes('stimulant')) return 'from-orange-700/40 to-amber-700/40'
   return 'from-white/10 to-white/5'
 }
 
@@ -83,7 +86,9 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
     })
   }, [herb])
 
-  const gradient = gradientForCategory(herb.category)
+  const gradient = gradientForCategory(
+    herb.normalizedCategories?.[0] || herb.category
+  )
 
   return (
     <motion.article
@@ -130,10 +135,14 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
               dangerouslySetInnerHTML={{ __html: mark(herb.scientificName) }}
             />
           )}
+          {herb.normalizedCategories?.length > 0 && (
+            <div className='flex flex-wrap gap-2 mt-2'>
+              {herb.normalizedCategories.slice(0, 3).map(tag => (
+                <TagBadge key={tag} label={tag} variant={categoryColors[tag] || 'purple'} />
+              ))}
+            </div>
+          )}
           <div className='mt-1 flex flex-wrap items-center gap-2 text-sm text-sand sm:text-base'>
-            {herb.category && (
-              <TagBadge label={herb.category} variant={categoryColors[herb.category] || 'purple'} />
-            )}
             {herb.effects?.length > 0 && <span>{herb.effects.join(', ')}</span>}
             {herb.affiliateLink ? (
               <a

--- a/src/components/TagDistribution.tsx
+++ b/src/components/TagDistribution.tsx
@@ -62,9 +62,6 @@ export default function TagDistribution({
 
   const max = React.useMemo(() => Math.max(1, ...groups.map(g => g.count)), [groups])
   const [showAll, setShowAll] = React.useState(false)
-  const [mode, setMode] = React.useState<'grouped' | 'raw'>('grouped')
-
-  React.useEffect(() => setShowAll(false), [mode])
 
   const selectedSet = React.useMemo(() => new Set(selected.map(canonicalTag)), [selected])
 
@@ -155,79 +152,32 @@ export default function TagDistribution({
     )
   }
 
-  const RawList = () => {
-    const list = showAll
-      ? entries
-      : entries.filter(([, count]) => count >= MIN_COUNT)
-    return (
-      <div className='grid grid-cols-1 gap-x-4 gap-y-2 md:grid-cols-2'>
-        {list.map(([tag, count]) => (
-          <Row
-            key={tag}
-            tag={tag}
-            count={count}
-            color='from-purple-400 via-pink-500 to-fuchsia-500'
-          />
-        ))}
-      </div>
-    )
-  }
-
   const displayGroups = showAll
     ? groups
     : groups.filter(g => g.count >= MIN_COUNT)
-  const hasMore =
-    mode === 'grouped'
-      ? groups.some(g => g.count < MIN_COUNT)
-      : entries.some(([, c]) => c < MIN_COUNT)
+  const hasMore = groups.some(g => g.count < MIN_COUNT)
 
   return (
     <div className={`space-y-2 ${className}`}>
-      <div className='text-right'>
+      <div className='grid grid-cols-1 gap-x-4 gap-y-2 md:grid-cols-2'>
+        {displayGroups.map(g => (
+          <GroupRow
+            key={g.label}
+            label={g.label}
+            tags={g.tags}
+            count={g.count}
+            color={g.color}
+          />
+        ))}
+      </div>
+      {hasMore && (
         <button
           type='button'
-          className='tag-pill'
-          onClick={() => setMode(m => (m === 'grouped' ? 'raw' : 'grouped'))}
+          className='tag-pill mx-auto block'
+          onClick={() => setShowAll(s => !s)}
         >
-          {mode === 'grouped' ? 'Raw Tags' : 'Categories'}
+          {showAll ? 'Show Less' : 'Show More'}
         </button>
-      </div>
-      {mode === 'grouped' ? (
-        <>
-          <div className='grid grid-cols-1 gap-x-4 gap-y-2 md:grid-cols-2'>
-            {displayGroups.map(g => (
-              <GroupRow
-                key={g.label}
-                label={g.label}
-                tags={g.tags}
-                count={g.count}
-                color={g.color}
-              />
-            ))}
-          </div>
-          {hasMore && (
-            <button
-              type='button'
-              className='tag-pill mx-auto block'
-              onClick={() => setShowAll(s => !s)}
-            >
-              {showAll ? 'Show Less' : 'Show More'}
-            </button>
-          )}
-        </>
-      ) : (
-        <>
-          <RawList />
-          {hasMore && (
-            <button
-              type='button'
-              className='tag-pill mx-auto block'
-              onClick={() => setShowAll(s => !s)}
-            >
-              {showAll ? 'Show Less' : 'Show More'}
-            </button>
-          )}
-        </>
       )}
       {groups.length > 10 && <ScrollToTopButton />}
     </div>

--- a/src/data/herbs.ts
+++ b/src/data/herbs.ts
@@ -5,6 +5,27 @@ import { decodeTag } from '../utils/format'
 
 const RAW_PATTERN = /^(?:[\p{Emoji}\p{Extended_Pictographic}]|.*\b(?:tea|snuff|mood|flower)\b)/iu
 
+function normalizeCategories(cat: string): string[] {
+  return Array.from(
+    new Set(
+      cat
+        .split(/[\/;,]/)
+        .map(p => p.trim())
+        .filter(Boolean)
+        .filter(p => !/ritual/i.test(p))
+        .map(p => {
+          const c = p.toLowerCase()
+          if (/(empathogen|euphoriant)/.test(c)) return 'Empathogen'
+          if (/psychedelic|visionary/.test(c)) return 'Psychedelic'
+          if (/dissociative|sedative/.test(c)) return 'Dissociative'
+          if (/oneirogen|dream/.test(c)) return 'Oneirogen'
+          if (/stimulant/.test(c)) return 'Stimulant'
+          return 'Other'
+        })
+    )
+  ).slice(0, 3)
+}
+
 const cleaned = raw.replace(/NaN/g, 'null')
 const herbs = JSON.parse(cleaned) as Herb[]
 herbs.forEach(h => {
@@ -19,6 +40,7 @@ herbs.forEach(h => {
     filtered.forEach(t => map.set(canonicalTag(t), t))
     h.tags = Array.from(map.values())
   }
+  h.normalizedCategories = normalizeCategories(h.category)
   if (h.affiliateLink == null) h.affiliateLink = ''
 })
 

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -204,6 +204,8 @@ export default function Database() {
             </button>
           </motion.div>
 
+          <p className='text-xs text-moss mb-2'>Raw tags have been removed for clarity.</p>
+
           <div className={`mb-4 space-y-4 ${filtersOpen ? '' : 'hidden sm:block'}`}>
             <CategoryFilter selected={filteredCategories} onChange={setFilteredCategories} />
             <TagFilterBar tags={allTags} counts={tagCounts} onChange={setFilteredTags} />

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,11 @@ export interface Herb {
   legalStatus: string
   region: string
   tags: string[]
+  /**
+   * Normalized high-level categories derived from the raw category field.
+   * At most 3 values ordered by relevance.
+   */
+  normalizedCategories?: string[]
   mechanismOfAction?: string
   pharmacokinetics?: string
   therapeuticUses?: string


### PR DESCRIPTION
## Summary
- compute and expose `normalizedCategories` when loading herb data
- display up to 3 category badges under each herb name
- remove raw tag mode from TagDistribution chart
- show note that raw tags are removed
- adjust gradients and category color map

## Testing
- `npm test`
- `npm run validate-herbs`
- `npx vite build` *(fails: Cannot find module 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_687c4404ac348323ada7cf64c5c79d8e