### PR TITLE
Remove no-link badge from cards

### DIFF
--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -348,7 +348,7 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
                 >
                   View full page
                 </Link>
-                {herb.affiliateLink ? (
+                {herb.affiliateLink && (
                   <a
                     href={herb.affiliateLink}
                     target='_blank'
@@ -358,8 +358,6 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
                   >
                     🌐 Buy Online
                   </a>
-                ) : (
-                  <span className='ml-4 text-sm text-sand/50'>⚠️ Buy Online</span>
                 )}
               </motion.div>
             </motion.div>


### PR DESCRIPTION
## Summary
- remove the placeholder warning shown when herbs are missing an affiliate link

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c5e3f792c8323a42bcf3f6aeea9f6