### PR TITLE
Fix build by converting ESM imports

### DIFF
--- a/scripts/cleanHerbData.ts
+++ b/scripts/cleanHerbData.ts
@@ -1,5 +1,5 @@
-import fs from 'fs'
-import path from 'path'
+const fs = require('fs')
+const path = require('path')
 
 interface Herb {
   name?: string


### PR DESCRIPTION
## Summary
- use `require` syntax in `scripts/cleanHerbData.ts`

## Testing
- `npm run clean-herbs && npm run validate-herbs`

------
https://chatgpt.com/codex/tasks/task_e_687cdf4d83948323822472f88720afa6