### PR TITLE
Add error boundary for reliability

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,35 +1,30 @@
-import { Component, ErrorInfo, ReactNode } from 'react';
+import React from 'react'
 
-interface Props {
-  children: ReactNode;
-}
+interface State { hasError: boolean }
 
-interface State {
-  hasError: boolean;
-}
-
-class ErrorBoundary extends Component<Props, State> {
-  constructor(props: Props) {
-    super(props);
-    this.state = { hasError: false };
+export default class ErrorBoundary extends React.Component<React.PropsWithChildren, State> {
+  constructor(props: React.PropsWithChildren) {
+    super(props)
+    this.state = { hasError: false }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  static getDerivedStateFromError(_error: Error): State {
-    return { hasError: true };
+  static getDerivedStateFromError() {
+    return { hasError: true }
   }
 
-  componentDidCatch(error: Error, info: ErrorInfo) {
-    console.error('Uncaught error:', error, info);
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('ErrorBoundary caught an error', error, info)
   }
 
   render() {
     if (this.state.hasError) {
-      return <h1>Something went wrong.</h1>;
+      return (
+        <div className='p-6 text-center'>
+          <h1 className='mb-4 text-2xl font-bold text-red-400'>Something went wrong.</h1>
+          <p className='text-sand'>Please try refreshing the page.</p>
+        </div>
+      )
     }
-
-    return this.props.children;
+    return this.props.children
   }
 }
-
-export default ErrorBoundary;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { HashRouter } from 'react-router-dom';
 import { HelmetProvider } from 'react-helmet-async';
 import App from './App';
 import { ThemeProvider } from './contexts/theme';
+import ErrorBoundary from './components/ErrorBoundary';
 import './index.css';
 import { registerSW } from 'virtual:pwa-register';
 
@@ -15,7 +16,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <HelmetProvider>
       <ThemeProvider>
         <HashRouter>
-          <App />
+          <ErrorBoundary>
+            <App />
+          </ErrorBoundary>
         </HashRouter>
       </ThemeProvider>
     </HelmetProvider>


### PR DESCRIPTION
## Summary
- update ErrorBoundary to show a user-friendly message
- wrap the app with ErrorBoundary so runtime errors don't produce blank pages

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ce7c8b0a483239d80796ae62e7759