### PR TITLE
Refactor cleanHerbData script to JS

### DIFF
--- a/scripts/cleanHerbData.js
+++ b/scripts/cleanHerbData.js
@@ -1,7 +1,6 @@
 const fs = require('fs')
 const path = require('path')
 
-
 const dataDir = 'data'
 const originalPath = path.join(dataDir, 'herbs.original.json')
 const cleanedPath = path.join(dataDir, 'herbs.cleaned.json')


### PR DESCRIPTION
## Summary
- cleanHerbData script uses Node.js CommonJS
- tidy formatting for cleanHerbData.js

## Testing
- `npm run clean-herbs`
- `npm run validate-herbs` *(fails: Cannot find module './validateHerbData.ts')*
- `npm run build` *(fails: Cannot find module './validateHerbData.ts')*

------
https://chatgpt.com/codex/tasks/task_e_687ced375a1c8323b81547b4cc5c2901