### PR TITLE
Fix herb list validation

### DIFF
--- a/src/components/CategoryAnalytics.tsx
+++ b/src/components/CategoryAnalytics.tsx
@@ -7,7 +7,7 @@ export default function CategoryAnalytics() {
   const counts = React.useMemo(() => {
     const c: Record<string, number> = {}
     herbs.forEach(h => {
-      const main = h.category.split('/')[0].trim()
+      const main = (h.category ?? '').split('/')[0].trim()
       c[main] = (c[main] || 0) + 1
     })
     return c

--- a/src/hooks/useHerbs.ts
+++ b/src/hooks/useHerbs.ts
@@ -1,6 +1,7 @@
 import React from 'react'
 import type { Herb } from '../types'
 import herbsData from '../data/herbs'
+import { validateHerb } from '../utils/validateHerb'
 
 interface Result {
   herbs: Herb[]
@@ -18,13 +19,19 @@ export function useHerbs(): Result {
       .then((data: Herb[]) => {
         if (!mounted) return
         const parsed = Array.isArray(data) ? data : []
-        const filtered = parsed.filter(h => h && h.name)
-        filtered.sort((a, b) => a.name.localeCompare(b.name))
-        setHerbs(filtered)
+        const validated = parsed
+          .map(validateHerb)
+          .filter((h): h is Herb => h !== null)
+        validated.sort((a, b) => a.name.localeCompare(b.name))
+        setHerbs(validated)
       })
       .catch(err => {
         console.error('Failed loading herbs', err)
-        setHerbs(herbsData)
+        const validated = herbsData
+          .map(validateHerb)
+          .filter((h): h is Herb => h !== null)
+        validated.sort((a, b) => a.name.localeCompare(b.name))
+        setHerbs(validated)
       })
       .finally(() => mounted && setLoading(false))
     return () => {

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -66,7 +66,7 @@ export default function Database() {
   }, [])
 
   const allTags = React.useMemo(() => {
-    const t = herbs.reduce<string[]>((acc, h) => acc.concat(h.tags), [])
+    const t = herbs.reduce<string[]>((acc, h) => acc.concat(h.tags ?? []), [])
     return Array.from(new Set(t.map(canonicalTag)))
   }, [herbs])
 
@@ -90,7 +90,7 @@ export default function Database() {
   const tagCounts = React.useMemo(() => {
     const counts: Record<string, number> = {}
     herbs.forEach(h => {
-      h.tags.forEach(t => {
+      ;(h.tags ?? []).forEach(t => {
         const canon = canonicalTag(t)
         counts[canon] = (counts[canon] || 0) + 1
       })
@@ -128,8 +128,12 @@ export default function Database() {
     if (filteredTags.length === 0) return [] as string[]
     const counts: Record<string, number> = {}
     herbs.forEach(h => {
-      if (filteredTags.every(t => h.tags.some(ht => canonicalTag(ht) === canonicalTag(t)))) {
-        h.tags.forEach(t => {
+      if (
+        filteredTags.every(t =>
+          (h.tags ?? []).some(ht => canonicalTag(ht) === canonicalTag(t))
+        )
+      ) {
+        ;(h.tags ?? []).forEach(t => {
           const canon = canonicalTag(t)
           if (!filteredTags.some(ft => canonicalTag(ft) === canon)) {
             counts[canon] = (counts[canon] || 0) + 1

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -13,9 +13,9 @@ function findSimilar(current: any) {
   const scores = herbs.map(h => {
     if (h.id === current.id) return { h, score: -1 }
     let score = 0
-    const tags = new Set(h.tags)
+    const tags = new Set(h.tags ?? [])
     const effects = new Set(h.effects || [])
-    current.tags.forEach((t: string) => {
+    ;(current.tags ?? []).forEach((t: string) => {
       if (tags.has(t)) score += 2
     })
     ;(current.effects || []).forEach((e: string) => {
@@ -136,7 +136,7 @@ function HerbDetailInner() {
             </a>
           )}
           <div className='flex flex-wrap gap-2 pt-2'>
-            {h.tags.map(tag => (
+            {h.tags?.map(tag => (
               <TagBadge key={tag} label={decodeTag(tag)} variant={tagVariant(tag)} />
             ))}
           </div>

--- a/src/pages/HerbDetailView.tsx
+++ b/src/pages/HerbDetailView.tsx
@@ -62,9 +62,9 @@ export default function HerbDetailView() {
           {(herb as any).history}
         </div>
       )}
-      {herb.tags.length > 0 && (
+      {herb.tags?.length > 0 && (
         <div className='flex flex-wrap gap-2 pt-2'>
-          {herb.tags.map(tag => (
+          {herb.tags?.map(tag => (
             <TagBadge key={tag} label={decodeTag(tag)} variant={tagVariant(tag)} />
           ))}
         </div>

--- a/src/utils/validateHerb.ts
+++ b/src/utils/validateHerb.ts
@@ -1,0 +1,98 @@
+import type { Herb } from '../types'
+import { slugify } from './slugify'
+
+/**
+ * Validate and normalize a potential Herb object.
+ * Returns a sanitized Herb or null if the entry is unusable.
+ */
+export function validateHerb(raw: any): Herb | null {
+  if (!raw || typeof raw !== 'object') return null
+
+  if (typeof raw.name !== 'string' || !raw.name.trim()) {
+    console.warn('Skipping herb with invalid name', raw)
+    return null
+  }
+
+  const tags = Array.isArray(raw.tags)
+    ? raw.tags.filter((t: any) => typeof t === 'string' && t.trim())
+    : []
+  if (!Array.isArray(raw.tags)) {
+    console.warn(`Herb ${raw.name} missing tags array`)
+  }
+
+  const effects = Array.isArray(raw.effects)
+    ? raw.effects.filter((e: any) => typeof e === 'string' && e.trim())
+    : []
+
+  const herb: Herb = {
+    id:
+      typeof raw.id === 'string' && raw.id.trim()
+        ? raw.id
+        : slugify(raw.name),
+    name: raw.name.trim(),
+    category:
+      typeof raw.category === 'string' && raw.category.trim()
+        ? raw.category
+        : 'Other',
+    effects,
+    preparation:
+      typeof raw.preparation === 'string' ? raw.preparation : '',
+    intensity:
+      typeof raw.intensity === 'string' && raw.intensity.trim()
+        ? raw.intensity
+        : 'Unknown',
+    onset: typeof raw.onset === 'string' ? raw.onset : '',
+    duration: typeof raw.duration === 'string' ? raw.duration : undefined,
+    legalStatus:
+      typeof raw.legalStatus === 'string' ? raw.legalStatus : '',
+    region: typeof raw.region === 'string' ? raw.region : '',
+    tags,
+    normalizedCategories: Array.isArray(raw.normalizedCategories)
+      ? raw.normalizedCategories.filter((t: any) => typeof t === 'string')
+      : undefined,
+    scientificName:
+      typeof raw.scientificName === 'string' ? raw.scientificName : undefined,
+    mechanismOfAction:
+      typeof raw.mechanismOfAction === 'string'
+        ? raw.mechanismOfAction
+        : undefined,
+    pharmacokinetics:
+      typeof raw.pharmacokinetics === 'string'
+        ? raw.pharmacokinetics
+        : undefined,
+    therapeuticUses:
+      typeof raw.therapeuticUses === 'string'
+        ? raw.therapeuticUses
+        : undefined,
+    sideEffects:
+      typeof raw.sideEffects === 'string' ? raw.sideEffects : undefined,
+    contraindications:
+      typeof raw.contraindications === 'string'
+        ? raw.contraindications
+        : undefined,
+    drugInteractions:
+      typeof raw.drugInteractions === 'string' ? raw.drugInteractions : undefined,
+    toxicity: typeof raw.toxicity === 'string' ? raw.toxicity : undefined,
+    toxicityLD50:
+      typeof raw.toxicityLD50 === 'string' ? raw.toxicityLD50 : undefined,
+    description:
+      typeof raw.description === 'string' ? raw.description : undefined,
+    safetyRating:
+      raw.safetyRating != null && !isNaN(Number(raw.safetyRating))
+        ? Number(raw.safetyRating)
+        : undefined,
+    sourceRefs: Array.isArray(raw.sourceRefs)
+      ? raw.sourceRefs.filter((r: any) => typeof r === 'string')
+      : undefined,
+    image: typeof raw.image === 'string' ? raw.image : undefined,
+    activeConstituents: Array.isArray(raw.activeConstituents)
+      ? raw.activeConstituents.filter(
+          (c: any) => c && typeof c.name === 'string'
+        )
+      : undefined,
+    affiliateLink:
+      typeof raw.affiliateLink === 'string' ? raw.affiliateLink : '',
+  }
+
+  return herb
+}


### PR DESCRIPTION
## Summary
- validate herb data when loading herbs
- warn and skip invalid herbs
- avoid crashes if herb tags or category are missing
- show tags and categories safely in herb views

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d1de67f04832386dba3c5fc0963df