### PR TITLE
Skip invalid herbs during render

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,9 +1,14 @@
 import React from 'react'
 
+interface Props {
+  children: React.ReactNode
+  fallback?: React.ReactNode
+}
+
 interface State { hasError: boolean }
 
-export default class ErrorBoundary extends React.Component<React.PropsWithChildren, State> {
-  constructor(props: React.PropsWithChildren) {
+export default class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
     super(props)
     this.state = { hasError: false }
   }
@@ -18,6 +23,9 @@ export default class ErrorBoundary extends React.Component<React.PropsWithChildr
 
   render() {
     if (this.state.hasError) {
+      if (this.props.fallback) {
+        return <>{this.props.fallback}</>
+      }
       return (
         <div className='p-6 text-center'>
           <h1 className='mb-4 text-2xl font-bold text-red-400'>Something went wrong.</h1>

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -68,6 +68,8 @@ function HerbCardAccordionInner({ herb, highlight = '' }: Props) {
     name: herb.name || 'Unknown Herb',
     effects: Array.isArray(herb.effects) ? herb.effects : [],
     category: herb.category || 'Other',
+    tags: Array.isArray(herb.tags) ? herb.tags : [],
+    description: typeof herb.description === 'string' ? herb.description : '',
     slug: (herb as any).slug || slugify(herb.name),
   }
 

--- a/src/components/HerbCardError.tsx
+++ b/src/components/HerbCardError.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default function HerbCardError() {
+  return (
+    <div className='hover-glow card-contrast relative overflow-hidden rounded-2xl bg-gray-700/40 p-6 text-center text-sand backdrop-blur-md'>
+      ⚠️ This herb entry is incomplete
+    </div>
+  )
+}

--- a/src/components/HerbList.tsx
+++ b/src/components/HerbList.tsx
@@ -3,6 +3,8 @@ import { AnimatePresence, motion } from 'framer-motion'
 import type { Herb } from '../types'
 import HerbCardAccordion from './HerbCardAccordion'
 import ErrorBoundary from './ErrorBoundary'
+import HerbCardError from './HerbCardError'
+import { isValidHerb } from '../utils/isValidHerb'
 
 const containerVariants = {
   hidden: {},
@@ -22,16 +24,26 @@ interface Props {
 const HerbList: React.FC<Props> = ({ herbs, highlightQuery = '', batchSize = 24 }) => {
   const [visible, setVisible] = React.useState(batchSize)
 
-  const showMore = () => setVisible(v => Math.min(v + batchSize, herbs.length))
+  const validHerbs = React.useMemo(() => {
+    return herbs.filter((h, i) => {
+      const ok = isValidHerb(h)
+      if (!ok) {
+        console.warn('Skipping invalid herb:', h?.name ?? `index ${i}`)
+      }
+      return ok
+    })
+  }, [herbs])
 
-  if (herbs.length === 0) {
+  const showMore = () => setVisible(v => Math.min(v + batchSize, validHerbs.length))
+
+  if (validHerbs.length === 0) {
     return <p className='text-center text-sand/80'>No herbs match your search.</p>
   }
 
   return (
     <>
       <motion.div
-        key={herbs.map(h => h.id).join('-')}
+        key={validHerbs.map(h => h.id).join('-')}
         layout
         variants={containerVariants}
         initial='hidden'
@@ -39,16 +51,16 @@ const HerbList: React.FC<Props> = ({ herbs, highlightQuery = '', batchSize = 24 
         className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'
       >
         <AnimatePresence>
-          {herbs.slice(0, visible).map(h => (
-            <motion.div key={h.id || h.name} variants={itemVariants} layout>
-              <ErrorBoundary>
+          {validHerbs.slice(0, visible).map((h, idx) => (
+            <motion.div key={h.id || h.name || idx} variants={itemVariants} layout>
+              <ErrorBoundary fallback={<HerbCardError />}> 
                 <HerbCardAccordion herb={h} highlight={highlightQuery} />
               </ErrorBoundary>
             </motion.div>
           ))}
         </AnimatePresence>
       </motion.div>
-      {visible < herbs.length && (
+      {visible < validHerbs.length && (
         <div className='mt-6 text-center'>
           <button
             type='button'

--- a/src/utils/isValidHerb.ts
+++ b/src/utils/isValidHerb.ts
@@ -1,0 +1,12 @@
+import type { Herb } from '../types'
+
+export function isValidHerb(h: any): h is Herb {
+  return (
+    h &&
+    typeof h.name === 'string' &&
+    Array.isArray(h.effects) &&
+    typeof h.category === 'string' &&
+    typeof h.description === 'string' &&
+    Array.isArray(h.tags)
+  )
+}


### PR DESCRIPTION
## Summary
- catch errors with customizable `ErrorBoundary`
- sanitize herb props to avoid undefined fields
- filter out invalid herb entries before mapping
- show placeholder card when herb data is malformed
- add `isValidHerb` utility

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d22aa23a48323bef7348cf54ce575