### PR TITLE
Fix herb database crashes with sanitization

### DIFF
--- a/src/components/HerbList.tsx
+++ b/src/components/HerbList.tsx
@@ -4,7 +4,7 @@ import type { Herb } from '../types'
 import HerbCardAccordion from './HerbCardAccordion'
 import ErrorBoundary from './ErrorBoundary'
 import HerbCardError from './HerbCardError'
-import { isValidHerb } from '../utils/isValidHerb'
+import { sanitizeHerb } from '../utils/sanitizeHerb'
 
 const containerVariants = {
   hidden: {},
@@ -25,12 +25,13 @@ const HerbList: React.FC<Props> = ({ herbs, highlightQuery = '', batchSize = 24 
   const [visible, setVisible] = React.useState(batchSize)
 
   const safeHerbs = React.useMemo(() => {
-    return herbs.filter((h, i) => {
-      const ok = isValidHerb(h)
-      if (!ok) {
-        console.warn('Skipping invalid herb:', h?.name ?? `index ${i}`)
+    return herbs.map((h, i) => {
+      try {
+        return sanitizeHerb(h)
+      } catch (e) {
+        console.warn(`Bad herb at index ${i}:`, h)
+        return sanitizeHerb({})
       }
-      return ok
     })
   }, [herbs])
 
@@ -53,7 +54,7 @@ const HerbList: React.FC<Props> = ({ herbs, highlightQuery = '', batchSize = 24 
         <AnimatePresence>
           {safeHerbs.slice(0, visible).map((h, idx) => (
             <motion.div key={h.id || h.name || idx} variants={itemVariants} layout>
-              <ErrorBoundary fallback={<HerbCardError />}> 
+              <ErrorBoundary fallback={<HerbCardError />}>
                 <HerbCardAccordion herb={h} highlight={highlightQuery} />
               </ErrorBoundary>
             </motion.div>
@@ -65,7 +66,7 @@ const HerbList: React.FC<Props> = ({ herbs, highlightQuery = '', batchSize = 24 
           <button
             type='button'
             onClick={showMore}
-            className='rounded-md bg-black/30 px-4 py-2 text-sand hover:bg-white/10 backdrop-blur-md'
+            className='rounded-md bg-black/30 px-4 py-2 text-sand backdrop-blur-md hover:bg-white/10'
           >
             Show More
           </button>

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -3,6 +3,7 @@ import { useParams, Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import { Helmet } from 'react-helmet-async'
 import { herbs } from '../data/herbs'
+import { sanitizeHerb } from '../utils/sanitizeHerb'
 import { decodeTag, tagVariant } from '../utils/format'
 import TagBadge from '../components/TagBadge'
 import { slugify } from '../utils/slugify'
@@ -38,12 +39,13 @@ function findSimilar(current: any) {
 
 function HerbDetailInner() {
   const { id } = useParams<{ id: string }>()
-  const herb = herbs.find(h => h.id === id)
+  const herbRaw = herbs.find(h => h.id === id)
+  const herb = sanitizeHerb(herbRaw || {})
   const [notes, setNotes] = useLocalStorage(`notes-${id}`, '')
   const [showSimilar, setShowSimilar] = React.useState(false)
 
-  if (!herb || !herb.name || !herb.effects) {
-    console.warn('Skipping malformed herb:', herb)
+  if (!herbRaw) {
+    console.warn('Herb not found or malformed:', id)
     return (
       <div className='p-6 text-center'>
         <p>Herb not found.</p>
@@ -56,9 +58,6 @@ function HerbDetailInner() {
 
   const h = {
     ...herb,
-    name: herb.name || 'Unknown Herb',
-    effects: Array.isArray(herb.effects) ? herb.effects : [],
-    category: herb.category || 'Other',
     slug: (herb as any).slug || slugify(herb.name),
   }
 

--- a/src/pages/HerbDetailView.tsx
+++ b/src/pages/HerbDetailView.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion'
 import { Helmet } from 'react-helmet-async'
 import { herbs } from '../data/herbs'
 import TagBadge from '../components/TagBadge'
+import { sanitizeHerb } from '../utils/sanitizeHerb'
 import { decodeTag, tagVariant } from '../utils/format'
 import { slugify } from '../utils/slugify'
 import { useLocalStorage } from '../hooks/useLocalStorage'
@@ -11,11 +12,12 @@ import TabContainer from '../components/TabContainer'
 
 export default function HerbDetailView() {
   const { id } = useParams<{ id: string }>()
-  const herb = herbs.find(h => h.id === id)
+  const herbRaw = herbs.find(h => h.id === id)
+  const herb = sanitizeHerb(herbRaw || {})
   const [notes, setNotes] = useLocalStorage(`notes-${id}`, '')
   const [copied, setCopied] = React.useState(false)
 
-  if (!herb) {
+  if (!herbRaw) {
     return (
       <div className='p-6 text-center'>
         <p>Herb not found.</p>
@@ -40,26 +42,21 @@ export default function HerbDetailView() {
   const overview = (
     <div className='space-y-2'>
       {(() => {
-        const eff = Array.isArray(herb.effects)
-          ? herb.effects.join(', ')
-          : (herb.effects || '')
+        const eff = Array.isArray(herb.effects) ? herb.effects.join(', ') : herb.effects || ''
         return eff ? (
           <div>
-            <span className='font-semibold text-lime-300'>Effects:</span>{' '}
-            {eff}
+            <span className='font-semibold text-lime-300'>Effects:</span> {eff}
           </div>
         ) : null
       })()}
       {herb.region && (
         <div>
-          <span className='font-semibold text-lime-300'>Region:</span>{' '}
-          {herb.region}
+          <span className='font-semibold text-lime-300'>Region:</span> {herb.region}
         </div>
       )}
       {(herb as any).history && (
         <div>
-          <span className='font-semibold text-lime-300'>History:</span>{' '}
-          {(herb as any).history}
+          <span className='font-semibold text-lime-300'>History:</span> {(herb as any).history}
         </div>
       )}
       {herb.tags?.length > 0 && (
@@ -80,21 +77,21 @@ export default function HerbDetailView() {
           {herb.activeConstituents.map((c, i) => (
             <React.Fragment key={c.name}>
               {i > 0 && ', '}
-              <Link className='text-sky-300 underline' to={`/compounds#${slugify(c.name)}`}>{c.name}</Link>
+              <Link className='text-sky-300 underline' to={`/compounds#${slugify(c.name)}`}>
+                {c.name}
+              </Link>
             </React.Fragment>
           ))}
         </div>
       )}
       {herb.mechanismOfAction && (
         <div>
-          <span className='font-semibold text-lime-300'>Mechanism:</span>{' '}
-          {herb.mechanismOfAction}
+          <span className='font-semibold text-lime-300'>Mechanism:</span> {herb.mechanismOfAction}
         </div>
       )}
       {herb.toxicityLD50 && (
         <div>
-          <span className='font-semibold text-lime-300'>LD50:</span>{' '}
-          {herb.toxicityLD50}
+          <span className='font-semibold text-lime-300'>LD50:</span> {herb.toxicityLD50}
         </div>
       )}
     </div>
@@ -104,24 +101,26 @@ export default function HerbDetailView() {
     <div className='space-y-2'>
       {herb.preparation && (
         <div>
-          <span className='font-semibold text-lime-300'>Prep:</span>{' '}
-          {herb.preparation}
+          <span className='font-semibold text-lime-300'>Prep:</span> {herb.preparation}
         </div>
       )}
       {herb.intensity && (
         <div>
-          <span className='font-semibold text-lime-300'>Intensity:</span>{' '}
-          {herb.intensity}
+          <span className='font-semibold text-lime-300'>Intensity:</span> {herb.intensity}
         </div>
       )}
       {herb.dosage && (
         <div>
-          <span className='font-semibold text-lime-300'>Dosage:</span>{' '}
-          {herb.dosage}
+          <span className='font-semibold text-lime-300'>Dosage:</span> {herb.dosage}
         </div>
       )}
       {herb.affiliateLink && herb.affiliateLink.startsWith('http') ? (
-        <a href={herb.affiliateLink} target='_blank' rel='noopener noreferrer' className='text-sky-300 underline'>
+        <a
+          href={herb.affiliateLink}
+          target='_blank'
+          rel='noopener noreferrer'
+          className='text-sky-300 underline'
+        >
           Buy Online
         </a>
       ) : (
@@ -153,9 +152,7 @@ export default function HerbDetailView() {
     { id: 'usage', label: 'Usage', content: usage },
   ]
 
-  const effectsSummary = Array.isArray(herb.effects)
-    ? herb.effects.join(', ')
-    : (herb.effects || '')
+  const effectsSummary = Array.isArray(herb.effects) ? herb.effects.join(', ') : herb.effects || ''
   const summary = `${herb.name} is classified as ${herb.category}. Known effects include ${effectsSummary}.`
 
   return (
@@ -164,7 +161,11 @@ export default function HerbDetailView() {
         <title>{herb.name} - The Hippie Scientist</title>
         {herb.description && <meta name='description' content={herb.description} />}
       </Helmet>
-      <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className='mx-auto max-w-3xl space-y-6 px-6 py-12'>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        className='mx-auto max-w-3xl space-y-6 px-6 py-12'
+      >
         <Link to='/database' className='text-comet underline'>
           ← Back
         </Link>
@@ -173,7 +174,7 @@ export default function HerbDetailView() {
         <button
           type='button'
           onClick={copyLink}
-          className='rounded-md bg-black/30 px-3 py-2 text-sm text-sand hover:bg-white/10 backdrop-blur-md'
+          className='rounded-md bg-black/30 px-3 py-2 text-sm text-sand backdrop-blur-md hover:bg-white/10'
         >
           {copied ? '✅ Copied!' : 'Share \uD83D\uDD17'}
         </button>

--- a/src/utils/sanitizeHerb.ts
+++ b/src/utils/sanitizeHerb.ts
@@ -1,0 +1,25 @@
+export function sanitizeHerb(raw: any): import('../types').Herb {
+  return {
+    name: raw?.name || 'Unnamed Herb',
+    scientificName: raw?.scientificName || '',
+    category: raw?.category || 'Unknown',
+    effects: Array.isArray(raw?.effects) ? raw.effects : ['Unknown'],
+    tags: Array.isArray(raw?.tags) ? raw.tags : [],
+    description: raw?.description || 'No description provided.',
+    mechanismOfAction: raw?.mechanismOfAction || 'Unknown',
+    preparation: raw?.preparation || '',
+    therapeuticUses: raw?.therapeuticUses || '',
+    pharmacokinetics: raw?.pharmacokinetics || '',
+    sideEffects: raw?.sideEffects || '',
+    contraindications: raw?.contraindications || '',
+    drugInteractions: raw?.drugInteractions || '',
+    intensity: raw?.intensity || '',
+    onset: raw?.onset || '',
+    duration: raw?.duration || '',
+    legalStatus: raw?.legalStatus || '',
+    region: raw?.region || '',
+    toxicity: raw?.toxicity || '',
+    toxicityLD50: raw?.toxicityLD50 || '',
+    safetyRating: raw?.safetyRating ?? null,
+  } as import('../types').Herb
+}


### PR DESCRIPTION
## Summary
- add `sanitizeHerb` utility for defensive runtime defaults
- sanitize herbs in `HerbList`
- sanitize herbs on detail pages so malformed entries can't break UI

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d2e34551483238fae00d302a4abb5