### PR TITLE
Fix herb list crashes

### DIFF
--- a/src/components/HerbList.tsx
+++ b/src/components/HerbList.tsx
@@ -5,6 +5,7 @@ import HerbCardAccordion from './HerbCardAccordion'
 import ErrorBoundary from './ErrorBoundary'
 import HerbCardError from './HerbCardError'
 import { sanitizeHerb } from '../utils/sanitizeHerb'
+import { isValidHerb } from '../utils/herbValidator'
 
 const containerVariants = {
   hidden: {},
@@ -25,11 +26,13 @@ const HerbList: React.FC<Props> = ({ herbs, highlightQuery = '', batchSize = 24 
   const [visible, setVisible] = React.useState(batchSize)
 
   const safeHerbs = React.useMemo(() => {
-    return herbs.map((h, i) => {
+    return herbs.filter(isValidHerb).map((h, i) => {
       try {
         return sanitizeHerb(h)
       } catch (e) {
-        console.warn(`Bad herb at index ${i}:`, h)
+        if (import.meta.env.DEV) {
+          console.warn(`Bad herb at index ${i}:`, h)
+        }
         return sanitizeHerb({})
       }
     })

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -19,21 +19,21 @@ import { Link } from 'react-router-dom'
 import { useFilteredHerbs } from '../hooks/useFilteredHerbs'
 import { getLocal, setLocal } from '../utils/localStorage'
 import { sanitizeHerb } from '../utils/sanitizeHerb'
+import { isValidHerb } from '../utils/herbValidator'
 
 export default function Database() {
   const { herbs, loading } = useHerbs()
   const safeHerbs = React.useMemo(
     () =>
       (herbs || [])
-        .map((h, i) => {
-          try {
-            return sanitizeHerb(h)
-          } catch (err) {
+        .filter(h => {
+          const ok = isValidHerb(h)
+          if (!ok && import.meta.env.DEV) {
             console.warn('Invalid herb skipped:', h)
-            return null
           }
+          return ok
         })
-        .filter(Boolean) as import('../types').Herb[],
+        .map(h => sanitizeHerb(h)) as import('../types').Herb[],
     [herbs]
   )
   const { favorites } = useHerbFavorites()

--- a/src/utils/herbValidator.ts
+++ b/src/utils/herbValidator.ts
@@ -1,0 +1,8 @@
+export function isValidHerb(herb: any): boolean {
+  if (!herb || typeof herb !== 'object') return false
+  if (!herb.name || typeof herb.name !== 'string') return false
+  if (!Array.isArray(herb.effects)) herb.effects = []
+  if (!Array.isArray(herb.tags)) herb.tags = []
+  if (!herb.category) herb.category = 'Other'
+  return true
+}


### PR DESCRIPTION
## Summary
- validate herbs before sanitizing them
- filter invalid herbs and warn only while developing
- add a simple `herbValidator`

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d359709388323807caa6341f3530e