### PR TITLE
Add cleanHerb sanitizer and improve Database loading

### DIFF
--- a/codex-changelog.md
+++ b/codex-changelog.md
@@ -1,2 +1,3 @@
 # Codex Update Log
 This file documents all Codex-generated updates to the Hippie Scientist project.
+- Added cleanHerb utility and integrated into database rendering

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -420,7 +420,7 @@ function HerbCardAccordionInner({ herb, highlight = '' }: Props) {
 }
 
 export default function HerbCardAccordion({ herb, highlight }: Props) {
-  if (!herb || !(herb as any).name) return null
+  if (!herb || typeof herb !== 'object') return null
   return (
     <ErrorBoundary>
       <HerbCardAccordionInner herb={herb} highlight={highlight} />

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -18,22 +18,19 @@ import { Download } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { useFilteredHerbs } from '../hooks/useFilteredHerbs'
 import { getLocal, setLocal } from '../utils/localStorage'
-import { sanitizeHerb } from '../utils/sanitizeHerb'
+import { cleanHerb } from '../utils/cleanHerb'
 import { isValidHerb } from '../utils/herbValidator'
 
 export default function Database() {
   const { herbs, loading } = useHerbs()
   const safeHerbs = React.useMemo(
     () =>
-      (herbs || [])
-        .filter(h => {
-          const ok = isValidHerb(h)
-          if (!ok && import.meta.env.DEV) {
-            console.warn('Invalid herb skipped:', h)
-          }
-          return ok
-        })
-        .map(h => sanitizeHerb(h)) as import('../types').Herb[],
+      (herbs || []).map(h => {
+        if (!isValidHerb(h) && import.meta.env.DEV) {
+          console.warn('Malformed herb entry:', h)
+        }
+        return cleanHerb(h)
+      }) as import('../types').Herb[],
     [herbs]
   )
   const { favorites } = useHerbFavorites()

--- a/src/utils/cleanHerb.ts
+++ b/src/utils/cleanHerb.ts
@@ -1,0 +1,24 @@
+export function cleanHerb(herb: any): import('../types').Herb {
+  return {
+    name: herb?.name || 'Unnamed Herb',
+    scientificName: herb?.scientificName || '',
+    category: herb?.category || 'Other',
+    effects: Array.isArray(herb?.effects) ? herb.effects : [],
+    preparation: herb?.preparation || 'N/A',
+    intensity: herb?.intensity || 'Unknown',
+    onset: herb?.onset || 'Unknown',
+    legalStatus: herb?.legalStatus || 'Varies',
+    region: herb?.region || 'Unknown',
+    tags: Array.isArray(herb?.tags) ? herb.tags : [],
+    mechanismOfAction: herb?.mechanismOfAction || 'Unclear',
+    therapeuticUses: herb?.therapeuticUses || '',
+    sideEffects: herb?.sideEffects || '',
+    contraindications: herb?.contraindications || '',
+    drugInteractions: herb?.drugInteractions || '',
+    pharmacokinetics: herb?.pharmacokinetics || '',
+    duration: herb?.duration || '',
+    toxicity: herb?.toxicity || '',
+    toxicityLD50: herb?.toxicityLD50 || '',
+    safetyRating: herb?.safetyRating ?? 'Unknown',
+  } as import('../types').Herb
+}


### PR DESCRIPTION
## Summary
- prevent malformed herbs from crashing Database page
- create new utility `cleanHerb`
- use `cleanHerb` when loading herb data
- guard against invalid props in `HerbCardAccordion`
- document the update

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d398d6d688323bbb75bd7f5b725a8