### PR TITLE
Fix herb page crashes

### DIFF
--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -11,6 +11,7 @@ import { useHerbFavorites } from '../hooks/useHerbFavorites'
 import InfoTooltip from './InfoTooltip'
 import { slugify } from '../utils/slugify'
 import ErrorBoundary from './ErrorBoundary'
+import HerbCardError from './HerbCardError'
 
 interface Props {
   herb: Herb
@@ -58,10 +59,11 @@ function gradientForCategory(cat: string): string {
 }
 
 function HerbCardAccordionInner({ herb, highlight = '' }: Props) {
-  if (!herb || !herb.name) {
-    console.warn('Skipping malformed herb:', herb)
-    return null
-  }
+  try {
+    if (!herb || !herb.name) {
+      console.warn('Skipping malformed herb:', herb)
+      return <HerbCardError />
+    }
 
   const h = {
     ...herb,
@@ -279,6 +281,14 @@ function HerbCardAccordionInner({ herb, highlight = '' }: Props) {
                   return keys.map(key => {
                     const raw = (h as any)[key]
                     if (raw == null || raw === '' || raw === 'N/A') {
+                      if (key === 'description') {
+                        return (
+                          <motion.div key={key} variants={itemVariants}>
+                            <span className='font-semibold text-lime-300'>Description:</span>{' '}
+                            {NOT_WELL_DOCUMENTED}
+                          </motion.div>
+                        )
+                      }
                       if (
                         key === 'mechanismOfAction' ||
                         key === 'toxicity' ||
@@ -402,6 +412,10 @@ function HerbCardAccordionInner({ herb, highlight = '' }: Props) {
       </AnimatePresence>
     </motion.article>
   )
+  } catch (err) {
+    console.warn('Render herb card failed', herb?.name, err)
+    return <HerbCardError />
+  }
 }
 
 export default function HerbCardAccordion({ herb, highlight }: Props) {

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -26,10 +26,15 @@ export default function Database() {
   const safeHerbs = React.useMemo(
     () =>
       (herbs || []).map(h => {
-        if (!isValidHerb(h) && import.meta.env.DEV) {
-          console.warn('Malformed herb entry:', h)
+        try {
+          if (!isValidHerb(h) && import.meta.env.DEV) {
+            console.warn('Malformed herb entry:', h)
+          }
+          return cleanHerb(h)
+        } catch (err) {
+          console.warn('Failed cleaning herb', h?.name, err)
+          return cleanHerb({})
         }
-        return cleanHerb(h)
       }) as import('../types').Herb[],
     [herbs]
   )

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -61,6 +61,10 @@ function HerbDetailInner() {
     slug: (herb as any).slug || slugify(herb.name),
   }
 
+  if (!herbRaw?.name || !herbRaw?.description) {
+    console.warn('Incomplete herb data', id, herbRaw)
+  }
+
   const similar = React.useMemo(() => findSimilar(h), [h])
   const summary = `${h.name} is classified as ${h.category}. Known effects include ${h.effects.join(', ')}.`
 

--- a/src/pages/HerbDetailView.tsx
+++ b/src/pages/HerbDetailView.tsx
@@ -17,6 +17,10 @@ export default function HerbDetailView() {
   const [notes, setNotes] = useLocalStorage(`notes-${id}`, '')
   const [copied, setCopied] = React.useState(false)
 
+  if (!herbRaw?.name || !herbRaw?.description) {
+    console.warn('Incomplete herb data', id, herbRaw)
+  }
+
   if (!herbRaw) {
     return (
       <div className='p-6 text-center'>

--- a/src/utils/safeRenderHerb.ts
+++ b/src/utils/safeRenderHerb.ts
@@ -8,7 +8,10 @@ import type { Herb } from '../types'
 export function safeRenderHerb(herb: any): Herb {
   try {
     return sanitizeHerb(herb)
-  } catch {
+  } catch (err) {
+    if (import.meta.env.DEV) {
+      console.warn('Failed to sanitize herb', herb?.name, err)
+    }
     return sanitizeHerb({})
   }
 }

--- a/src/utils/sanitizeHerb.ts
+++ b/src/utils/sanitizeHerb.ts
@@ -1,25 +1,34 @@
+function cleanStr(value: any, fallback = ''): string {
+  if (typeof value !== 'string') return fallback
+  if (value === 'N/A' || value === 'Unknown') return fallback
+  return value
+}
+
 export function sanitizeHerb(herb: any): import('../types').Herb {
   return {
-    name: typeof herb?.name === 'string' ? herb.name : 'Unnamed Herb',
-    scientificName: herb?.scientificName || '',
-    category: herb?.category || 'Other',
+    name: cleanStr(herb?.name, 'Unnamed Herb'),
+    scientificName: cleanStr(herb?.scientificName),
+    category: cleanStr(herb?.category, 'Other'),
     effects: Array.isArray(herb?.effects) ? herb.effects : [],
     tags: Array.isArray(herb?.tags) ? herb.tags : [],
-    description: herb?.description || '',
-    mechanismOfAction: herb?.mechanismOfAction || '',
-    preparation: herb?.preparation || '',
-    therapeuticUses: herb?.therapeuticUses || '',
-    pharmacokinetics: herb?.pharmacokinetics || '',
-    sideEffects: herb?.sideEffects || '',
-    contraindications: herb?.contraindications || '',
-    drugInteractions: herb?.drugInteractions || '',
-    intensity: herb?.intensity || '',
-    onset: herb?.onset || '',
-    duration: herb?.duration || '',
-    legalStatus: herb?.legalStatus || '',
-    region: herb?.region || '',
-    toxicity: herb?.toxicity || '',
-    toxicityLD50: herb?.toxicityLD50 || '',
-    safetyRating: herb?.safetyRating ?? null,
+    description: cleanStr(herb?.description),
+    mechanismOfAction: cleanStr(herb?.mechanismOfAction),
+    preparation: cleanStr(herb?.preparation),
+    therapeuticUses: cleanStr(herb?.therapeuticUses),
+    pharmacokinetics: cleanStr(herb?.pharmacokinetics),
+    sideEffects: cleanStr(herb?.sideEffects),
+    contraindications: cleanStr(herb?.contraindications),
+    drugInteractions: cleanStr(herb?.drugInteractions),
+    intensity: cleanStr(herb?.intensity),
+    onset: cleanStr(herb?.onset),
+    duration: cleanStr(herb?.duration),
+    legalStatus: cleanStr(herb?.legalStatus),
+    region: cleanStr(herb?.region),
+    toxicity: cleanStr(herb?.toxicity),
+    toxicityLD50: cleanStr(herb?.toxicityLD50),
+    safetyRating:
+      herb?.safetyRating === 'N/A' || herb?.safetyRating === 'Unknown'
+        ? null
+        : (herb?.safetyRating as any) ?? null,
   } as import('../types').Herb
 }


### PR DESCRIPTION
## Summary
- sanitize herb data for "N/A" and other invalid values
- warn and gracefully handle incomplete herb cards
- add defensive logging when loading herb data
- improve error resilience in details pages

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d40e40bb08323ab211d317c305742