### PR TITLE
Improve herb data resilience

### DIFF
--- a/src/components/FeaturedHerbCarousel.tsx
+++ b/src/components/FeaturedHerbCarousel.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { Link } from 'react-router-dom'
 import herbs from '../data/herbs'
+import { safeHerbField } from '../utils/safeHerbField'
 
 function pickFeatured() {
   const psychedelic = herbs.filter(h => h.category.includes('Psychedelic'))
@@ -21,6 +22,8 @@ export default function FeaturedHerbCarousel() {
   }, [])
 
   const herb = featured[index]
+  const name = safeHerbField(herb.name, 'Unnamed Herb')
+  const desc = safeHerbField(herb.description, '')
 
   return (
     <motion.div
@@ -40,11 +43,11 @@ export default function FeaturedHerbCarousel() {
           whileHover={{ scale: 1.03, rotate: 0.5 }}
         >
           {herb.image && (
-            <img src={herb.image} alt={herb.name} className='h-40 w-full rounded-md object-cover' />
+            <img src={herb.image} alt={name} className='h-40 w-full rounded-md object-cover' />
           )}
-          <h3 className='mt-3 font-herb text-2xl'>{herb.name}</h3>
-          {herb.description && (
-            <p className='mt-1 line-clamp-2 text-sm text-sand'>{herb.description}</p>
+          <h3 className='mt-3 font-herb text-2xl'>{name}</h3>
+          {desc && (
+            <p className='mt-1 line-clamp-2 text-sm text-sand'>{desc}</p>
           )}
           <Link
             to={`/herbs/${herb.id}`}

--- a/src/components/FeaturedHerbTeaser.tsx
+++ b/src/components/FeaturedHerbTeaser.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion'
 import { Link } from 'react-router-dom'
 import herbs from '../data/herbs'
 import type { Herb } from '../types'
+import { safeHerbField } from '../utils/safeHerbField'
 
 interface Props {
   fixedId?: string
@@ -24,6 +25,9 @@ export default function FeaturedHerbTeaser({ fixedId = '' }: Props) {
 
   if (!herb) return null
 
+  const name = safeHerbField(herb.name, 'Unnamed Herb')
+  const effects = Array.isArray(herb.effects) ? herb.effects : []
+
   return (
     <motion.div
       id='featured-herb'
@@ -34,16 +38,14 @@ export default function FeaturedHerbTeaser({ fixedId = '' }: Props) {
       {herb.image && (
         <img
           src={herb.image}
-          alt={herb.name}
+          alt={name}
           className='h-32 w-full rounded-md object-cover'
         />
       )}
-      <h3 className='mt-3 font-herb text-2xl'>{herb.name}</h3>
+      <h3 className='mt-3 font-herb text-2xl'>{name}</h3>
       {(() => {
-        const effects = Array.isArray(herb.effects)
-          ? herb.effects.slice(0, 3).join(', ')
-          : (herb.effects || '')
-        return effects ? <p className='mt-1 text-sm text-sand'>{effects}</p> : null
+        const text = effects.slice(0, 3).join(', ')
+        return text ? <p className='mt-1 text-sm text-sand'>{text}</p> : null
       })()}
       <Link
         to={`/herbs/${herb.id}`}

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -10,6 +10,7 @@ import TagBadge from './TagBadge'
 import { useHerbFavorites } from '../hooks/useHerbFavorites'
 import InfoTooltip from './InfoTooltip'
 import { slugify } from '../utils/slugify'
+import { safeHerbField } from '../utils/safeHerbField'
 import ErrorBoundary from './ErrorBoundary'
 import HerbCardError from './HerbCardError'
 
@@ -67,12 +68,12 @@ function HerbCardAccordionInner({ herb, highlight = '' }: Props) {
 
   const h = {
     ...herb,
-    name: herb.name || 'Unknown Herb',
+    name: safeHerbField(herb.name, 'Unknown Herb'),
     effects: Array.isArray(herb.effects) ? herb.effects : [],
-    category: herb.category || 'Other',
+    category: safeHerbField(herb.category, 'Other'),
     tags: Array.isArray(herb.tags) ? herb.tags : [],
-    description: typeof herb.description === 'string' ? herb.description : '',
-    slug: (herb as any).slug || slugify(herb.name),
+    description: safeHerbField(herb.description, ''),
+    slug: (herb as any).slug || slugify(safeHerbField(herb.name, '')),
   }
 
   const [open, setOpen] = useState(false)

--- a/src/components/RotatingHerbCard.tsx
+++ b/src/components/RotatingHerbCard.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import { Link } from 'react-router-dom'
 import herbs from '../data/herbs'
 import type { Herb } from '../types'
+import { safeHerbField } from '../utils/safeHerbField'
 
 function shuffle<T>(arr: T[]): T[] {
   const a = [...arr]
@@ -37,6 +38,9 @@ export default function RotatingHerbCard() {
   const herb = items[index]
   if (!herb) return null
 
+  const name = safeHerbField(herb.name, 'Unnamed Herb')
+  const effects = Array.isArray(herb.effects) ? herb.effects : []
+
   const handleAdvance = () => {
     const statsRaw = localStorage.getItem('herbTapCounts')
     const stats = statsRaw ? JSON.parse(statsRaw) : {}
@@ -61,21 +65,23 @@ export default function RotatingHerbCard() {
           style={{ position: 'absolute', top: 0, left: 0 }}
         >
           {herb.image && (
-            <img src={herb.image} alt={herb.name} className='h-32 w-full rounded-md object-cover' />
+            <img
+              src={herb.image}
+              alt={name}
+              className='h-32 w-full rounded-md object-cover'
+            />
           )}
           <h3
             className={`mt-3 font-herb ${
-              herb.name.length > 20 ? 'text-lg sm:text-xl' : 'text-xl sm:text-2xl'
+              name.length > 20 ? 'text-lg sm:text-xl' : 'text-xl sm:text-2xl'
             }`}
           >
-            {herb.name}
+            {name}
           </h3>
           {(() => {
-            const effects = Array.isArray(herb.effects)
-              ? herb.effects.slice(0, 3).join(', ')
-              : (herb.effects || '')
-            return effects ? (
-              <p className='mt-1 text-sm text-sand'>{effects}</p>
+            const text = effects.slice(0, 3).join(', ')
+            return text ? (
+              <p className='mt-1 text-sm text-sand'>{text}</p>
             ) : null
           })()}
           <Link
@@ -109,10 +115,8 @@ export default function RotatingHerbCard() {
       <AnimatePresence exitBeforeEnter>
         <motion.div
           key={herb.id}
-          aria-label={`Herb preview: ${herb.name}${(() => {
-            const eff = Array.isArray(herb.effects)
-              ? herb.effects.slice(0, 2).join(', ')
-              : (herb.effects || '')
+          aria-label={`Herb preview: ${name}${(() => {
+            const eff = effects.slice(0, 2).join(', ')
             return eff ? ` – ${eff}` : ''
           })()}`}
           className='glass-card hover-glow inset-0 flex w-full flex-col justify-center rounded-xl p-4 text-center shadow-lg'
@@ -125,21 +129,23 @@ export default function RotatingHerbCard() {
           whileTap={{ scale: 0.98 }}
         >
           {herb.image && (
-            <img src={herb.image} alt={herb.name} className='h-32 w-full rounded-md object-cover' />
+            <img
+              src={herb.image}
+              alt={name}
+              className='h-32 w-full rounded-md object-cover'
+            />
           )}
           <h3
             className={`mt-3 font-herb ${
-              herb.name.length > 20 ? 'text-lg sm:text-xl' : 'text-xl sm:text-2xl'
+              name.length > 20 ? 'text-lg sm:text-xl' : 'text-xl sm:text-2xl'
             }`}
           >
-            {herb.name}
+            {name}
           </h3>
           {(() => {
-            const effects = Array.isArray(herb.effects)
-              ? herb.effects.slice(0, 3).join(', ')
-              : (herb.effects || '')
-            return effects ? (
-              <p className='mt-1 text-sm text-sand'>{effects}</p>
+            const text = effects.slice(0, 3).join(', ')
+            return text ? (
+              <p className='mt-1 text-sm text-sand'>{text}</p>
             ) : null
           })()}
           <Link

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion'
 import { Helmet } from 'react-helmet-async'
 import { herbs } from '../data/herbs'
 import { safeRenderHerb } from '../utils/safeRenderHerb'
+import { safeHerbField } from '../utils/safeHerbField'
 import { decodeTag, tagVariant } from '../utils/format'
 import TagBadge from '../components/TagBadge'
 import { slugify } from '../utils/slugify'
@@ -58,7 +59,12 @@ function HerbDetailInner() {
 
   const h = {
     ...herb,
-    slug: (herb as any).slug || slugify(herb.name),
+    name: safeHerbField(herb.name, 'Unnamed Herb'),
+    description: safeHerbField(herb.description, ''),
+    category: safeHerbField(herb.category, 'Other'),
+    tags: Array.isArray(herb.tags) ? herb.tags : [],
+    effects: Array.isArray(herb.effects) ? herb.effects : [],
+    slug: (herb as any).slug || slugify(safeHerbField(herb.name, '')),
   }
 
   if (!herbRaw?.name || !herbRaw?.description) {

--- a/src/pages/HerbDetailView.tsx
+++ b/src/pages/HerbDetailView.tsx
@@ -5,6 +5,7 @@ import { Helmet } from 'react-helmet-async'
 import { herbs } from '../data/herbs'
 import TagBadge from '../components/TagBadge'
 import { safeRenderHerb } from '../utils/safeRenderHerb'
+import { safeHerbField } from '../utils/safeHerbField'
 import { decodeTag, tagVariant } from '../utils/format'
 import { slugify } from '../utils/slugify'
 import { useLocalStorage } from '../hooks/useLocalStorage'
@@ -14,6 +15,15 @@ export default function HerbDetailView() {
   const { id } = useParams<{ id: string }>()
   const herbRaw = herbs.find(h => h.id === id)
   const herb = safeRenderHerb(herbRaw || {})
+  const h = {
+    ...herb,
+    name: safeHerbField(herb.name, 'Unnamed Herb'),
+    description: safeHerbField(herb.description, ''),
+    category: safeHerbField(herb.category, 'Other'),
+    tags: Array.isArray(herb.tags) ? herb.tags : [],
+    effects: Array.isArray(herb.effects) ? herb.effects : [],
+    slug: (herb as any).slug || slugify(safeHerbField(herb.name, '')),
+  }
   const [notes, setNotes] = useLocalStorage(`notes-${id}`, '')
   const [copied, setCopied] = React.useState(false)
 
@@ -32,7 +42,7 @@ export default function HerbDetailView() {
     )
   }
 
-  const shareUrl = `https://thehippiescientist.net/#/herb/${herb.id}`
+  const shareUrl = `https://thehippiescientist.net/#/herb/${h.id}`
   const copyLink = async () => {
     try {
       await navigator.clipboard.writeText(shareUrl)
@@ -46,26 +56,26 @@ export default function HerbDetailView() {
   const overview = (
     <div className='space-y-2'>
       {(() => {
-        const eff = Array.isArray(herb.effects) ? herb.effects.join(', ') : herb.effects || ''
+        const eff = Array.isArray(h.effects) ? h.effects.join(', ') : h.effects || ''
         return eff ? (
           <div>
             <span className='font-semibold text-lime-300'>Effects:</span> {eff}
           </div>
         ) : null
       })()}
-      {herb.region && (
+      {h.region && (
         <div>
-          <span className='font-semibold text-lime-300'>Region:</span> {herb.region}
+          <span className='font-semibold text-lime-300'>Region:</span> {h.region}
         </div>
       )}
-      {(herb as any).history && (
+      {(h as any).history && (
         <div>
-          <span className='font-semibold text-lime-300'>History:</span> {(herb as any).history}
+          <span className='font-semibold text-lime-300'>History:</span> {(h as any).history}
         </div>
       )}
-      {herb.tags?.length > 0 && (
+      {h.tags?.length > 0 && (
         <div className='flex flex-wrap gap-2 pt-2'>
-          {herb.tags?.map(tag => (
+          {h.tags?.map(tag => (
             <TagBadge key={tag} label={decodeTag(tag)} variant={tagVariant(tag)} />
           ))}
         </div>
@@ -75,10 +85,10 @@ export default function HerbDetailView() {
 
   const chemistry = (
     <div className='space-y-2'>
-      {herb.activeConstituents?.length > 0 && (
+      {h.activeConstituents?.length > 0 && (
         <div>
           <span className='font-semibold text-lime-300'>Compounds:</span>{' '}
-          {herb.activeConstituents.map((c, i) => (
+          {h.activeConstituents.map((c, i) => (
             <React.Fragment key={c.name}>
               {i > 0 && ', '}
               <Link className='text-sky-300 underline' to={`/compounds#${slugify(c.name)}`}>
@@ -88,14 +98,14 @@ export default function HerbDetailView() {
           ))}
         </div>
       )}
-      {herb.mechanismOfAction && (
+      {h.mechanismOfAction && (
         <div>
-          <span className='font-semibold text-lime-300'>Mechanism:</span> {herb.mechanismOfAction}
+          <span className='font-semibold text-lime-300'>Mechanism:</span> {h.mechanismOfAction}
         </div>
       )}
-      {herb.toxicityLD50 && (
+      {h.toxicityLD50 && (
         <div>
-          <span className='font-semibold text-lime-300'>LD50:</span> {herb.toxicityLD50}
+          <span className='font-semibold text-lime-300'>LD50:</span> {h.toxicityLD50}
         </div>
       )}
     </div>
@@ -103,24 +113,24 @@ export default function HerbDetailView() {
 
   const usage = (
     <div className='space-y-2'>
-      {herb.preparation && (
+      {h.preparation && (
         <div>
-          <span className='font-semibold text-lime-300'>Prep:</span> {herb.preparation}
+          <span className='font-semibold text-lime-300'>Prep:</span> {h.preparation}
         </div>
       )}
-      {herb.intensity && (
+      {h.intensity && (
         <div>
-          <span className='font-semibold text-lime-300'>Intensity:</span> {herb.intensity}
+          <span className='font-semibold text-lime-300'>Intensity:</span> {h.intensity}
         </div>
       )}
-      {herb.dosage && (
+      {h.dosage && (
         <div>
-          <span className='font-semibold text-lime-300'>Dosage:</span> {herb.dosage}
+          <span className='font-semibold text-lime-300'>Dosage:</span> {h.dosage}
         </div>
       )}
-      {herb.affiliateLink && herb.affiliateLink.startsWith('http') ? (
+      {h.affiliateLink && h.affiliateLink.startsWith('http') ? (
         <a
-          href={herb.affiliateLink}
+          href={h.affiliateLink}
           target='_blank'
           rel='noopener noreferrer'
           className='text-sky-300 underline'
@@ -156,14 +166,14 @@ export default function HerbDetailView() {
     { id: 'usage', label: 'Usage', content: usage },
   ]
 
-  const effectsSummary = Array.isArray(herb.effects) ? herb.effects.join(', ') : herb.effects || ''
-  const summary = `${herb.name} is classified as ${herb.category}. Known effects include ${effectsSummary}.`
+  const effectsSummary = Array.isArray(h.effects) ? h.effects.join(', ') : h.effects || ''
+  const summary = `${h.name} is classified as ${h.category}. Known effects include ${effectsSummary}.`
 
   return (
     <>
       <Helmet>
-        <title>{herb.name} - The Hippie Scientist</title>
-        {herb.description && <meta name='description' content={herb.description} />}
+        <title>{h.name} - The Hippie Scientist</title>
+        {h.description && <meta name='description' content={h.description} />}
       </Helmet>
       <motion.div
         initial={{ opacity: 0 }}
@@ -173,8 +183,8 @@ export default function HerbDetailView() {
         <Link to='/database' className='text-comet underline'>
           ← Back
         </Link>
-        <h1 className='text-gradient text-4xl font-bold'>{herb.name}</h1>
-        {herb.scientificName && <p className='italic'>{herb.scientificName}</p>}
+        <h1 className='text-gradient text-4xl font-bold'>{h.name}</h1>
+        {h.scientificName && <p className='italic'>{h.scientificName}</p>}
         <button
           type='button'
           onClick={copyLink}

--- a/src/utils/safeHerbField.ts
+++ b/src/utils/safeHerbField.ts
@@ -1,0 +1,9 @@
+export function safeHerbField<T>(field: any, fallback: T): T {
+  if (field === undefined || field === null) return fallback as T;
+  if (typeof field === 'string') {
+    const trimmed = field.trim();
+    if (trimmed === '' || trimmed === 'N/A') return fallback as T;
+    return field as T;
+  }
+  return field as T;
+}

--- a/src/utils/sanitizeHerb.ts
+++ b/src/utils/sanitizeHerb.ts
@@ -1,7 +1,7 @@
+import { safeHerbField } from './safeHerbField'
+
 function cleanStr(value: any, fallback = ''): string {
-  if (typeof value !== 'string') return fallback
-  if (value === 'N/A' || value === 'Unknown') return fallback
-  return value
+  return safeHerbField(value, fallback)
 }
 
 export function sanitizeHerb(herb: any): import('../types').Herb {


### PR DESCRIPTION
## Summary
- implement `safeHerbField` helper
- guard detail pages and herb cards against malformed data
- sanitize herb fields during render and in helper utilities
- harden featured herb components and rotating card

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d43a47b208323a92d96c69b6d8d2f