### PR TITLE
Improve herb data safety handling

### DIFF
--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -281,7 +281,11 @@ function HerbCardAccordionInner({ herb, highlight = '' }: Props) {
                   const keys = [...fieldOrder, ...extras]
                   return keys.map(key => {
                     const raw = (h as any)[key]
-                    if (raw == null || raw === '' || raw === 'N/A') {
+                    const isArray = Array.isArray(raw)
+                    const safe = isArray
+                      ? (Array.isArray(raw) ? raw : [])
+                      : safeHerbField(raw, '')
+                    if (!isArray && safe === '') {
                       if (key === 'description') {
                         return (
                           <motion.div key={key} variants={itemVariants}>
@@ -307,7 +311,7 @@ function HerbCardAccordionInner({ herb, highlight = '' }: Props) {
                       }
                       return null
                     }
-                    const value = Array.isArray(raw) ? raw.join(', ') : String(raw)
+                    const value = isArray ? (safe as any[]).join(', ') : String(safe)
                     if (!value.trim()) return null
                     const display = (
                       <span className={expanded[key] || value.length < 200 ? '' : 'line-clamp-2'}>

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -104,6 +104,16 @@ export default function Database() {
     )
   }
 
+  if (!loading && safeHerbs.length === 0) {
+    console.warn('No herbs available or failed to load.')
+    return (
+      <div className='min-h-screen pt-20'>
+        <StarfieldBackground />
+        <p className='text-center text-sand'>Failed to load herb database.</p>
+      </div>
+    )
+  }
+
   const tagCounts = React.useMemo(() => {
     const counts: Record<string, number> = {}
     safeHerbs.forEach(h => {

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -111,13 +111,16 @@ function HerbDetailInner() {
             'toxicityLD50',
           ].map(key => {
             const raw = (h as any)[key]
-            if (!raw) return null
+            const isArray = Array.isArray(raw)
+            const safe = isArray ? (raw as any[]) : safeHerbField(raw, '')
+            if (!isArray && safe === '') return null
+            const value = isArray ? (safe as any[]).join(', ') : String(safe)
             return (
               <div key={key}>
                 <span className='font-semibold text-lime-300'>
                   {key.replace(/([A-Z])/g, ' $1')}:
                 </span>{' '}
-                {raw}
+                {value}
               </div>
             )
           })}

--- a/src/pages/HerbDetailView.tsx
+++ b/src/pages/HerbDetailView.tsx
@@ -32,6 +32,7 @@ export default function HerbDetailView() {
   }
 
   if (!herbRaw) {
+    console.warn('Herb not found or malformed:', id)
     return (
       <div className='p-6 text-center'>
         <p>Herb not found.</p>
@@ -63,9 +64,10 @@ export default function HerbDetailView() {
           </div>
         ) : null
       })()}
-      {h.region && (
+      {safeHerbField(h.region, '') && (
         <div>
-          <span className='font-semibold text-lime-300'>Region:</span> {h.region}
+          <span className='font-semibold text-lime-300'>Region:</span>{' '}
+          {safeHerbField(h.region, '')}
         </div>
       )}
       {(h as any).history && (
@@ -98,14 +100,16 @@ export default function HerbDetailView() {
           ))}
         </div>
       )}
-      {h.mechanismOfAction && (
+      {safeHerbField(h.mechanismOfAction, '') && (
         <div>
-          <span className='font-semibold text-lime-300'>Mechanism:</span> {h.mechanismOfAction}
+          <span className='font-semibold text-lime-300'>Mechanism:</span>{' '}
+          {safeHerbField(h.mechanismOfAction, '')}
         </div>
       )}
-      {h.toxicityLD50 && (
+      {safeHerbField(h.toxicityLD50, '') && (
         <div>
-          <span className='font-semibold text-lime-300'>LD50:</span> {h.toxicityLD50}
+          <span className='font-semibold text-lime-300'>LD50:</span>{' '}
+          {safeHerbField(h.toxicityLD50, '')}
         </div>
       )}
     </div>
@@ -113,19 +117,22 @@ export default function HerbDetailView() {
 
   const usage = (
     <div className='space-y-2'>
-      {h.preparation && (
+      {safeHerbField(h.preparation, '') && (
         <div>
-          <span className='font-semibold text-lime-300'>Prep:</span> {h.preparation}
+          <span className='font-semibold text-lime-300'>Prep:</span>{' '}
+          {safeHerbField(h.preparation, '')}
         </div>
       )}
-      {h.intensity && (
+      {safeHerbField(h.intensity, '') && (
         <div>
-          <span className='font-semibold text-lime-300'>Intensity:</span> {h.intensity}
+          <span className='font-semibold text-lime-300'>Intensity:</span>{' '}
+          {safeHerbField(h.intensity, '')}
         </div>
       )}
-      {h.dosage && (
+      {safeHerbField(h.dosage, '') && (
         <div>
-          <span className='font-semibold text-lime-300'>Dosage:</span> {h.dosage}
+          <span className='font-semibold text-lime-300'>Dosage:</span>{' '}
+          {safeHerbField(h.dosage, '')}
         </div>
       )}
       {h.affiliateLink && h.affiliateLink.startsWith('http') ? (

--- a/src/utils/safeHerbField.ts
+++ b/src/utils/safeHerbField.ts
@@ -1,9 +1,17 @@
 export function safeHerbField<T>(field: any, fallback: T): T {
-  if (field === undefined || field === null) return fallback as T;
-  if (typeof field === 'string') {
-    const trimmed = field.trim();
-    if (trimmed === '' || trimmed === 'N/A') return fallback as T;
-    return field as T;
+  // If value is missing or explicitly marked as N/A, use the fallback
+  if (field === undefined || field === null) return fallback as T
+
+  // Handle array fields by ensuring we always return an array
+  if (Array.isArray(fallback)) {
+    return (Array.isArray(field) ? field : []) as unknown as T
   }
-  return field as T;
+
+  if (typeof field === 'string') {
+    const trimmed = field.trim()
+    if (trimmed === '' || trimmed === 'N/A') return fallback as T
+    return field as T
+  }
+
+  return field as T
 }


### PR DESCRIPTION
## Summary
- enhance `safeHerbField` to cover arrays and N/A cases
- guard database page when no herbs load
- use `safeHerbField` when rendering herb fields in detail views
- sanitize dynamic field rendering in `HerbCardAccordion`
- log warning when herb id not found

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d4b7cca488323bc4df1384a329c46