### PR TITLE
Gracefully handle invalid herb route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,7 +7,7 @@ import Footer from './components/Footer'
 import MouseTrail from './components/MouseTrail'
 import ScrollToTopButton from './components/ScrollToTopButton'
 const Home = React.lazy(() => import('./pages/Home'))
-const HerbDetail = React.lazy(() => import('./pages/HerbDetail'))
+const HerbCardPage = React.lazy(() => import('./pages/HerbCardPage'))
 const HerbDetailView = React.lazy(() => import('./pages/HerbDetailView'))
 const NotFound = React.lazy(() => import('./pages/NotFound'))
 const Learn = React.lazy(() => import('./pages/Learn'))
@@ -33,7 +33,7 @@ function App() {
             <Route path='/learn/:slug' element={<Lesson />} />
             <Route path='/database' element={<Database />} />
             <Route path='/research' element={<Research />} />
-            <Route path='/herbs/:id' element={<HerbDetail />} />
+            <Route path='/herbs/:herbId' element={<HerbCardPage />} />
             <Route path='/herb/:id' element={<HerbDetailView />} />
             <Route path='/compounds' element={<Compounds />} />
             <Route path='/store' element={<Store />} />

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -20,12 +20,16 @@ class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
-    console.error('Uncaught error:', error, info);
+    console.error('Uncaught error:', error, info)
   }
 
   render() {
     if (this.state.hasError) {
-      return <h1>Something went wrong.</h1>;
+      return (
+        <div className='flex min-h-screen items-center justify-center p-6'>
+          <h1 className='text-2xl font-bold'>Something went wrong.</h1>
+        </div>
+      )
     }
 
     return this.props.children;

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -78,8 +78,11 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
   }
 
   const sortedTags = React.useMemo(() => {
-    const active = new Set(herb.activeConstituents?.map(c => canonicalTag(c.name)) || [])
-    return [...herb.tags].sort((a, b) => {
+    const tags = Array.isArray(herb.tags) ? herb.tags : []
+    const active = new Set(
+      herb.activeConstituents?.map(c => canonicalTag(c.name)) || []
+    )
+    return [...tags].sort((a, b) => {
       const aActive = active.has(canonicalTag(a))
       const bActive = active.has(canonicalTag(b))
       return aActive === bActive ? 0 : aActive ? -1 : 1
@@ -286,7 +289,7 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
                 )
               })}
 
-              {herb.activeConstituents?.length > 0 && (
+              {Array.isArray(herb.activeConstituents) && herb.activeConstituents.length > 0 && (
                 <motion.div variants={itemVariants}>
                   <span className='font-semibold text-lime-300'>Active Compounds:</span>{' '}
                   {herb.activeConstituents.map((c, i) => (
@@ -304,7 +307,7 @@ export default function HerbCardAccordion({ herb, highlight = '' }: Props) {
                 </motion.div>
               )}
 
-              {herb.tags?.length > 0 && (
+              {Array.isArray(herb.tags) && herb.tags.length > 0 && (
                 <motion.div
                   variants={itemVariants}
                   className='flex max-h-24 flex-wrap gap-2 overflow-y-auto pt-2 sm:max-h-32'

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { HashRouter } from 'react-router-dom';
 import { HelmetProvider } from 'react-helmet-async';
 import App from './App';
 import { ThemeProvider } from './contexts/theme';
+import ErrorBoundary from './components/ErrorBoundary';
 import './index.css';
 import { registerSW } from 'virtual:pwa-register';
 
@@ -13,11 +14,13 @@ registerSW({ immediate: true });
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <HelmetProvider>
-      <ThemeProvider>
-        <HashRouter>
-          <App />
-        </HashRouter>
-      </ThemeProvider>
+      <ErrorBoundary>
+        <ThemeProvider>
+          <HashRouter>
+            <App />
+          </HashRouter>
+        </ThemeProvider>
+      </ErrorBoundary>
     </HelmetProvider>
   </React.StrictMode>
 );

--- a/src/pages/HerbCardPage.tsx
+++ b/src/pages/HerbCardPage.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { useParams, Link } from 'react-router-dom';
+import herbs from '../data/herbs';
+import HerbCardAccordion from '../components/HerbCardAccordion';
+import { slugify } from '../utils/slugify';
+
+export default function HerbCardPage() {
+  const { herbId } = useParams<{ herbId?: string }>();
+  const id = herbId?.toLowerCase() || '';
+  const herb = React.useMemo(() => {
+    return herbs.find(
+      h =>
+        h.id?.toLowerCase() === id ||
+        slugify(h.name).toLowerCase() === id ||
+        h.name?.toLowerCase() === id
+    );
+  }, [id]);
+
+  if (!herb || typeof herb !== 'object' || !herb.name) {
+    return (
+      <div className='flex min-h-screen items-center justify-center p-6'>
+        <div className='space-y-4 text-center'>
+          <h1 className='text-4xl font-bold'>404 – Herb Not Found</h1>
+          <Link to='/database' className='text-comet underline'>Back to database</Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className='mx-auto max-w-3xl px-4 py-8'>
+      <HerbCardAccordion herb={herb} />
+    </div>
+  );
+}

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -101,7 +101,7 @@ export default function HerbDetail() {
               </div>
             )
           })}
-          {herb.activeConstituents?.length > 0 && (
+          {Array.isArray(herb.activeConstituents) && herb.activeConstituents.length > 0 && (
             <div>
               <span className='font-semibold text-lime-300'>Active Compounds:</span>{' '}
               {herb.activeConstituents.map((c, i) => (
@@ -124,11 +124,13 @@ export default function HerbDetail() {
               Buy Online
             </a>
           )}
-          <div className='flex flex-wrap gap-2 pt-2'>
-            {herb.tags.map(tag => (
-              <TagBadge key={tag} label={decodeTag(tag)} variant={tagVariant(tag)} />
-            ))}
-          </div>
+          {Array.isArray(herb.tags) && (
+            <div className='flex flex-wrap gap-2 pt-2'>
+              {herb.tags.map(tag => (
+                <TagBadge key={tag} label={decodeTag(tag)} variant={tagVariant(tag)} />
+              ))}
+            </div>
+          )}
         </div>
         <button
           type='button'

--- a/src/pages/HerbDetailView.tsx
+++ b/src/pages/HerbDetailView.tsx
@@ -62,7 +62,7 @@ export default function HerbDetailView() {
           {(herb as any).history}
         </div>
       )}
-      {herb.tags.length > 0 && (
+      {Array.isArray(herb.tags) && herb.tags.length > 0 && (
         <div className='flex flex-wrap gap-2 pt-2'>
           {herb.tags.map(tag => (
             <TagBadge key={tag} label={decodeTag(tag)} variant={tagVariant(tag)} />
@@ -74,7 +74,7 @@ export default function HerbDetailView() {
 
   const chemistry = (
     <div className='space-y-2'>
-      {herb.activeConstituents?.length > 0 && (
+      {Array.isArray(herb.activeConstituents) && herb.activeConstituents.length > 0 && (
         <div>
           <span className='font-semibold text-lime-300'>Compounds:</span>{' '}
           {herb.activeConstituents.map((c, i) => (


### PR DESCRIPTION
## Summary
- add `HerbCardPage` for `/herbs/:herbId`
- show 404 message when an invalid herb is requested
- wrap app in `ErrorBoundary` to catch runtime errors
- guard herb field access in `HerbCardAccordion`, `HerbDetail`, and `HerbDetailView`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d909d60ec83238ea2baae759d2200