### PR TITLE
Improve herb viewer 404 handling

### DIFF
--- a/src/pages/HerbCardPage.tsx
+++ b/src/pages/HerbCardPage.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { useParams, Link } from 'react-router-dom';
-import herbs from '../data/herbs';
-import HerbCardAccordion from '../components/HerbCardAccordion';
-import { slugify } from '../utils/slugify';
+import React from 'react'
+import { useParams, Link } from 'react-router-dom'
+import herbs from '../data/herbs'
+import HerbCardAccordion from '../components/HerbCardAccordion'
+import { slugify } from '../utils/slugify'
 
 export default function HerbCardPage() {
   const { herbId } = useParams<{ herbId?: string }>();
@@ -13,23 +13,20 @@ export default function HerbCardPage() {
         h.id?.toLowerCase() === id ||
         slugify(h.name).toLowerCase() === id ||
         h.name?.toLowerCase() === id
-    );
-  }, [id]);
+    )
+  }, [id])
 
-  if (!herb || typeof herb !== 'object' || !herb.name) {
-    return (
-      <div className='flex min-h-screen items-center justify-center p-6'>
-        <div className='space-y-4 text-center'>
-          <h1 className='text-4xl font-bold'>404 – Herb Not Found</h1>
-          <Link to='/database' className='text-comet underline'>Back to database</Link>
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className='mx-auto max-w-3xl px-4 py-8'>
+  const content =
+    herb && typeof herb === 'object' && herb.name ? (
       <HerbCardAccordion herb={herb} />
-    </div>
-  );
+    ) : (
+      <div className='rounded-md border border-red-500/40 bg-red-500/10 p-6 text-center'>
+        <h1 className='text-2xl font-bold text-red-300'>404 – Herb Not Found</h1>
+        <Link to='/database' className='text-comet underline'>
+          Back to database
+        </Link>
+      </div>
+    )
+
+  return <div className='mx-auto max-w-3xl px-4 py-8'>{content}</div>
 }


### PR DESCRIPTION
## Summary
- show a 404 message within the standard page layout when an invalid herb slug is requested
- avoid redirecting and only render `HerbCardAccordion` if a valid herb exists

## Testing
- `npm test`
- `npm run validate-herbs`


------
https://chatgpt.com/codex/tasks/task_e_687d92ad0f9c8323ba60b472dfbf53d1