### PR TITLE
Improve herb page error handling

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,7 +1,8 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
 
 interface Props {
-  children: ReactNode;
+  children: ReactNode
+  fallback?: ReactNode
 }
 
 interface State {
@@ -26,13 +27,15 @@ class ErrorBoundary extends Component<Props, State> {
   render() {
     if (this.state.hasError) {
       return (
-        <div className='flex min-h-screen items-center justify-center p-6'>
-          <h1 className='text-2xl font-bold'>Something went wrong.</h1>
-        </div>
+        this.props.fallback ?? (
+          <div className='flex min-h-screen items-center justify-center p-6'>
+            <h1 className='text-2xl font-bold'>Something went wrong.</h1>
+          </div>
+        )
       )
     }
 
-    return this.props.children;
+    return this.props.children
   }
 }
 

--- a/src/pages/HerbCardPage.tsx
+++ b/src/pages/HerbCardPage.tsx
@@ -2,30 +2,41 @@ import React from 'react'
 import { useParams, Link } from 'react-router-dom'
 import herbs from '../data/herbs'
 import HerbCardAccordion from '../components/HerbCardAccordion'
+import ErrorBoundary from '../components/ErrorBoundary'
 import { slugify } from '../utils/slugify'
 
 export default function HerbCardPage() {
   const { herbId } = useParams<{ herbId?: string }>();
   const id = herbId?.toLowerCase() || '';
   const herb = React.useMemo(() => {
-    return herbs.find(
-      h =>
+    return herbs.find(h => {
+      const nameSlug = h.name?.toLowerCase().replaceAll(' ', '-')
+      const slug = (h as any).slug?.toLowerCase()
+      return (
         h.id?.toLowerCase() === id ||
-        slugify(h.name).toLowerCase() === id ||
-        h.name?.toLowerCase() === id
-    )
+        slug === id ||
+        nameSlug === id ||
+        slugify(h.name).toLowerCase() === id
+      )
+    })
   }, [id])
+
+  const notFound = (
+    <div className='rounded-md border border-red-500/40 bg-red-500/10 p-6 text-center'>
+      <h1 className='text-2xl font-bold text-red-300'>404 – Herb Not Found</h1>
+      <Link to='/database' className='text-comet underline'>
+        Back to database
+      </Link>
+    </div>
+  )
 
   const content =
     herb && typeof herb === 'object' && herb.name ? (
-      <HerbCardAccordion herb={herb} />
+      <ErrorBoundary fallback={notFound}>
+        <HerbCardAccordion herb={herb} />
+      </ErrorBoundary>
     ) : (
-      <div className='rounded-md border border-red-500/40 bg-red-500/10 p-6 text-center'>
-        <h1 className='text-2xl font-bold text-red-300'>404 – Herb Not Found</h1>
-        <Link to='/database' className='text-comet underline'>
-          Back to database
-        </Link>
-      </div>
+      notFound
     )
 
   return <div className='mx-auto max-w-3xl px-4 py-8'>{content}</div>


### PR DESCRIPTION
## Summary
- allow `ErrorBoundary` to render custom fallback content
- look up herbs by slug or normalized name
- show in-page 404 and wrap HerbCardAccordion with ErrorBoundary

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d94f491188323aa8c10ec4a321f18