### PR TITLE
Add dynamic tag filtering and favorites page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ const Store = React.lazy(() => import('./pages/Store'))
 const Research = React.lazy(() => import('./pages/Research'))
 const Compounds = React.lazy(() => import('./pages/Compounds'))
 const Downloads = React.lazy(() => import('./pages/Downloads'))
+const Favorites = React.lazy(() => import('./pages/Favorites'))
 function App() {
   return (
     <>
@@ -33,6 +34,7 @@ function App() {
             <Route path='/learn' element={<Learn />} />
             <Route path='/learn/:slug' element={<Lesson />} />
             <Route path='/database' element={<Database />} />
+            <Route path='/favorites' element={<Favorites />} />
             <Route path='/research' element={<Research />} />
             <Route path='/herbs/:herbId' element={<HerbCardPage />} />
             <Route path='/herb/:id' element={<HerbDetailView />} />

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -60,10 +60,11 @@ export default function HerbCardAccordion({ herb }: Props) {
           toggleExpanded()
         }
       }}
+      id={`herb-${herb.id}`}
       role='button'
       tabIndex={0}
       aria-expanded={expanded}
-      className='bg-psychedelic-gradient/30 relative cursor-pointer overflow-hidden rounded-2xl p-4 text-white shadow-lg backdrop-blur-md transition-all hover:shadow-intense'
+      className='bg-psychedelic-gradient/30 relative cursor-pointer overflow-hidden rounded-2xl p-4 text-white shadow-lg backdrop-blur-md transition-all hover:shadow-intense focus:outline-none focus-visible:ring-2 focus-visible:ring-fuchsia-500'
     >
       <motion.div
         className='pointer-events-none absolute inset-0 rounded-2xl border-2 border-fuchsia-500/40'

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
-import { Menu, X, Atom, Download } from 'lucide-react'
+import { Menu, X, Atom, Download, Star } from 'lucide-react'
 import ThemeToggle from './ThemeToggle'
 
 const Navbar: React.FC = () => {
@@ -14,6 +14,7 @@ const Navbar: React.FC = () => {
     { path: '/learn', label: 'Learn' },
     { path: '/database', label: 'Database' },
     { path: '/research', label: 'Research' },
+    { path: '/favorites', label: 'Favorites', icon: Star },
     { path: '/compounds', label: 'Explore Compounds' },
     { path: '/store', label: 'Store' },
     { path: '/downloads', label: 'Downloads', icon: Download },

--- a/src/components/TagFilterBar.tsx
+++ b/src/components/TagFilterBar.tsx
@@ -1,18 +1,30 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { motion } from 'framer-motion'
 import { decodeTag } from '../utils/format'
+import { canonicalTag } from '../utils/tagUtils'
+import { herbs } from '../../herbsfull'
 
 interface Props {
-  tags: string[]
+  /**
+   * Optional list of tags to display. If omitted the tags will
+   * be generated from the global herbs dataset.
+   */
+  tags?: string[]
   onChange?: (tags: string[]) => void
 }
 
 export default function TagFilterBar({ tags, onChange }: Props) {
-  const unique = Array.from(new Set(tags))
+  const unique = useMemo(() => {
+    if (tags && tags.length) return Array.from(new Set(tags))
+    const all = herbs.flatMap(h => h.tags ?? [])
+    return Array.from(new Set(all.map(canonicalTag)))
+  }, [tags])
   const [activeTags, setActiveTags] = useState<string[]>([])
 
   const toggle = (tag: string) => {
-    setActiveTags(prev => (prev.includes(tag) ? prev.filter(t => t !== tag) : [...prev, tag]))
+    setActiveTags(prev =>
+      prev.includes(tag) ? prev.filter(t => t !== tag) : [...prev, tag]
+    )
   }
 
   useEffect(() => {
@@ -20,7 +32,7 @@ export default function TagFilterBar({ tags, onChange }: Props) {
   }, [activeTags, onChange])
 
   return (
-    <div className='flex gap-2 overflow-x-auto py-2'>
+    <div className='flex gap-2 overflow-x-auto py-2 no-scrollbar'>
       {unique.map(tag => {
         const active = activeTags.includes(tag)
         return (
@@ -28,11 +40,11 @@ export default function TagFilterBar({ tags, onChange }: Props) {
             type='button'
             key={tag}
             onClick={() => toggle(tag)}
-            whileTap={{ scale: 0.95 }}
-            whileHover={{ scale: 1.05 }}
-            className={`whitespace-nowrap rounded-full border px-3 py-1 text-sm backdrop-blur-md ${
-              active ? 'bg-emerald-600/80 text-white shadow-lg' : 'bg-space-dark/70 text-sand'
-            }`}
+            whileTap={{ scale: 0.9 }}
+            whileHover={{ scale: 1.08 }}
+            animate={active ? { scale: [1, 1.15, 1], boxShadow: '0 0 8px rgba(16,185,129,0.8)' } : { scale: 1, boxShadow: 'none' }}
+            transition={{ type: 'spring', stiffness: 300 }}
+            className={`tag-pill whitespace-nowrap ${active ? 'bg-emerald-700/70 text-white ring-2 ring-emerald-400' : 'bg-space-dark/70 text-sand'}`}
           >
             {decodeTag(tag)}
           </motion.button>

--- a/src/index.css
+++ b/src/index.css
@@ -107,6 +107,14 @@ html {
   @apply transition-shadow hover:shadow-intense hover:ring-2 hover:ring-psychedelic-pink/60;
 }
 
+.no-scrollbar {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
 .card-contrast {
   @apply shadow-inner shadow-white/10;
 }

--- a/src/pages/Favorites.tsx
+++ b/src/pages/Favorites.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { Helmet } from 'react-helmet-async'
+import HerbList from '../components/HerbList'
+import { useHerbs } from '../hooks/useHerbs'
+import { useHerbFavorites } from '../hooks/useHerbFavorites'
+
+export default function Favorites() {
+  const herbs = useHerbs()
+  const { favorites } = useHerbFavorites()
+
+  const favoriteHerbs = React.useMemo(
+    () => herbs.filter(h => favorites.includes(h.id)),
+    [herbs, favorites]
+  )
+
+  return (
+    <div className='relative min-h-screen px-4 pt-20'>
+      <Helmet>
+        <title>My Herbs - The Hippie Scientist</title>
+        <meta
+          name='description'
+          content='View herbs you have starred as favorites.'
+        />
+      </Helmet>
+      <div className='mx-auto max-w-6xl'>
+        <h1 className='text-gradient mb-6 text-center text-5xl font-bold'>My Herbs</h1>
+        {favoriteHerbs.length ? (
+          <HerbList herbs={favoriteHerbs} />
+        ) : (
+          <p className='text-center text-sand'>No favorites yet.</p>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- support deriving unique tags from the dataset inside `TagFilterBar`
- polish active tag animations
- hide scrollbars for the tag bar
- make herb cards focus accessible and give them ids
- add a favorites page and route with nav link

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687ec2a15d7c8323a45afed44f79e14d