### PR TITLE
Enhance database filtering and compounds page

### DIFF
--- a/src/components/CompoundCard.tsx
+++ b/src/components/CompoundCard.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import { motion } from 'framer-motion'
+import { Link } from 'react-router-dom'
+import InfoTooltip from './InfoTooltip'
+import TagBadge from './TagBadge'
+import { Compound } from '../data/compounds'
+
+const classColors: Record<string, string> = {
+  alkaloid: 'purple',
+  terpene: 'green',
+  glycoside: 'yellow',
+  phenethylamine: 'pink',
+  tryptamine: 'blue',
+}
+
+export default function CompoundCard({ compound }: { compound: Compound }) {
+  const colorKey = Object.keys(classColors).find(k =>
+    compound.class.toLowerCase().includes(k)
+  )
+  const variant = colorKey ? classColors[colorKey] : 'purple'
+  return (
+    <motion.article
+      whileHover={{ scale: 1.05 }}
+      whileTap={{ scale: 0.98 }}
+      tabIndex={0}
+      className='glass-card hover-glow rounded-xl p-4 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-psychedelic-pink'
+    >
+      <h2 className='text-xl font-bold text-white'>{compound.name}</h2>
+      <p className='text-sm text-moss'>
+        <TagBadge label={compound.class} variant={variant} className='mr-2' />
+      </p>
+      {compound.effects.length > 0 && (
+        <p className='mt-1 text-sm text-sand'>Effects: {compound.effects.join(', ')}</p>
+      )}
+      {compound.notes && <p className='mt-1 text-xs italic text-sand'>{compound.notes}</p>}
+      {compound.toxicityWarning && (
+        <InfoTooltip text={compound.toxicityWarning}>
+          <span className='mt-1 inline-flex items-center text-red-400'>☣️</span>
+        </InfoTooltip>
+      )}
+      {compound.sourceHerbs.length > 0 && (
+        <p className='mt-2 text-xs text-sand'>
+          Herbs:
+          {compound.sourceHerbs.map((h, i) => (
+            <React.Fragment key={h}>
+              {i > 0 && ', '}
+              <Link to={`/herbs/${h}`} className='underline'>
+                {h.replace(/-/g, ' ')}
+              </Link>
+            </React.Fragment>
+          ))}
+        </p>
+      )}
+      <Link
+        to={`/database?herbs=${compound.sourceHerbs.join(',')}`}
+        className='tag-pill mt-2 inline-block'
+      >
+        Source Herbs
+      </Link>
+    </motion.article>
+  )
+}

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -71,6 +71,13 @@ export default function HerbCardAccordion({ herb }: Props) {
         animate={expanded ? { opacity: 1, scale: 1.05 } : { opacity: 0 }}
         transition={{ duration: 0.6, ease: 'easeInOut' }}
       />
+      <InfoTooltip text={`Safety rating: ${rating}`}>
+        <span
+          className={`absolute left-3 top-3 text-${ratingColor}-300 text-lg`}
+        >
+          {ratingIcon}
+        </span>
+      </InfoTooltip>
       <button
         type='button'
         onClick={e => {

--- a/src/components/TagFilterBar.tsx
+++ b/src/components/TagFilterBar.tsx
@@ -50,6 +50,17 @@ export default function TagFilterBar({ tags, onChange }: Props) {
           </motion.button>
         )
       })}
+      {activeTags.length > 0 && (
+        <motion.button
+          type='button'
+          onClick={() => setActiveTags([])}
+          whileTap={{ scale: 0.9 }}
+          whileHover={{ scale: 1.08 }}
+          className='tag-pill whitespace-nowrap bg-rose-700/70 text-white'
+        >
+          Clear Filters
+        </motion.button>
+      )}
     </div>
   )
 }

--- a/src/data/compounds.ts
+++ b/src/data/compounds.ts
@@ -1,0 +1,46 @@
+export interface Compound {
+  name: string
+  class: string
+  effects: string[]
+  sourceHerbs: string[]
+  toxicityWarning?: string
+  notes?: string
+}
+
+export const compounds: Compound[] = [
+  {
+    name: 'Mescaline',
+    class: 'phenethylamine',
+    effects: ['psychedelic', 'empathogenic'],
+    sourceHerbs: ['lophophora-williamsii'],
+    toxicityWarning: 'High doses may cause nausea and anxiety',
+  },
+  {
+    name: 'Psilocybin',
+    class: 'tryptamine',
+    effects: ['psychedelic'],
+    sourceHerbs: ['psilocybe-cubensis'],
+    notes: 'Converted to psilocin in the body',
+  },
+  {
+    name: 'Mitragynine',
+    class: 'indole alkaloid',
+    effects: ['stimulant', 'analgesic'],
+    sourceHerbs: ['kratom-hybrids'],
+  },
+  {
+    name: 'Harmine',
+    class: 'beta-carboline',
+    effects: ['MAOI', 'psychedelic potentiator'],
+    sourceHerbs: ['banisteriopsis-caapi'],
+  },
+  {
+    name: 'Thujone',
+    class: 'monoterpene',
+    effects: ['GABA antagonist'],
+    sourceHerbs: ['salvia-apiana', 'achillea-millefolium'],
+    toxicityWarning: 'Convulsant at high doses',
+  },
+]
+
+export default compounds

--- a/src/pages/Compounds.tsx
+++ b/src/pages/Compounds.tsx
@@ -1,116 +1,35 @@
 import React from 'react'
 import { Helmet } from 'react-helmet-async'
-import { motion } from 'framer-motion'
-import { herbs } from '../../herbsfull'
-import baseCompounds, { CompoundInfo } from '../data/compoundData'
-import { FlaskConical, Leaf, Gem, Droplet } from 'lucide-react'
-import { Link } from 'react-router-dom'
-import { slugify } from '../utils/slugify'
-
-interface Compound extends CompoundInfo {
-  sources: { id: string; name: string }[]
-}
-
-function typeIcon(type: string) {
-  const t = type.toLowerCase()
-  if (t.includes('alkaloid')) return <FlaskConical className='mr-1 inline h-4 w-4' />
-  if (t.includes('terpene')) return <Leaf className='mr-1 inline h-4 w-4' />
-  if (t.includes('glycoside')) return <Gem className='mr-1 inline h-4 w-4' />
-  if (t.includes('phenolic') || t.includes('coumarin'))
-    return <Droplet className='mr-1 inline h-4 w-4' />
-  return null
-}
+import { compounds } from '../data/compounds'
+import CompoundCard from '../components/CompoundCard'
+import TagFilterBar from '../components/TagFilterBar'
 
 export default function Compounds() {
-  const compounds = React.useMemo(() => {
-    const map = new Map<string, Compound>()
-    baseCompounds.forEach(c => {
-      map.set(c.name, { ...c, sources: [] })
-    })
-    herbs.forEach(h => {
-      h.activeConstituents?.forEach(c => {
-        const key = c.name
-        if (!map.has(key)) {
-          map.set(key, {
-            name: c.name,
-            type: c.type,
-            mechanism: '',
-            affiliateLink: undefined,
-            sources: [{ id: h.id, name: h.name }],
-          })
-        } else {
-          const entry = map.get(key)!
-          if (!entry.sources.find(s => s.id === h.id)) {
-            entry.sources.push({ id: h.id, name: h.name })
-          }
-        }
-      })
-    })
-    return Array.from(map.values())
-  }, [])
+  const classes = React.useMemo(
+    () => Array.from(new Set(compounds.map(c => c.class.toLowerCase()))),
+    []
+  )
+  const [selected, setSelected] = React.useState<string[]>([])
+  const filtered = React.useMemo(() => {
+    if (selected.length === 0) return compounds
+    return compounds.filter(c =>
+      selected.every(s => c.class.toLowerCase().includes(s.toLowerCase()))
+    )
+  }, [selected])
 
   return (
     <>
       <Helmet>
         <title>Psychoactive Compounds - The Hippie Scientist</title>
-        <meta
-          name='description'
-          content='Browse active constituents found in herbs and learn their mechanisms.'
-        />
       </Helmet>
       <div className='min-h-screen px-4 pb-12 pt-20'>
         <div className='mx-auto max-w-4xl text-center'>
           <h1 className='text-gradient mb-6 text-5xl font-bold'>Psychoactive Compounds</h1>
-          <p className='mb-8 text-sand'>
-            Prototype view of active constituents found in the herb database.
-          </p>
-          <div className='space-y-4'>
-            {compounds.map(c => (
-              <motion.article
-                key={c.name}
-                whileHover={{ scale: 1.05, boxShadow: '0 0 20px rgba(34,197,94,0.5)' }}
-                whileTap={{ scale: 0.98 }}
-                whileFocus={{ scale: 1.05 }}
-                tabIndex={0}
-                className='glass-card hover-glow rounded-xl p-3 text-left transition-shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-psychedelic-pink sm:p-6'
-              >
-                <h2 className='max-w-xs truncate text-xl font-bold text-white'>{c.name}</h2>
-                <p className='text-sm text-moss'>
-                  {typeIcon(c.type)}
-                  {c.type}
-                </p>
-                {c.mechanism && <p className='text-xs text-sand'>MOA: {c.mechanism}</p>}
-                {c.notes && <p className='text-xs italic text-sand'>{c.notes}</p>}
-                <p className='text-xs text-sand'>
-                  Herbs:
-                  {c.sources.map((s, i) => (
-                    <React.Fragment key={s.id}>
-                      {i > 0 && ', '}
-                      <Link to={`/herbs/${s.id}`} className='underline'>
-                        {s.name}
-                      </Link>
-                    </React.Fragment>
-                  ))}
-                </p>
-                {c.sources.length > 0 && (
-                  <Link
-                    to={`/database?herbs=${c.sources.map(s => s.id).join(',')}`}
-                    className='tag-pill mt-2 inline-block'
-                  >
-                    Source Herbs
-                  </Link>
-                )}
-                {c.affiliateLink && (
-                  <a
-                    href={c.affiliateLink}
-                    target='_blank'
-                    rel='noopener noreferrer'
-                    className='mt-1 inline-block text-sm text-sky-300 underline'
-                  >
-                    Buy Online
-                  </a>
-                )}
-              </motion.article>
+          <p className='mb-8 text-sand'>List of notable active constituents and their source herbs.</p>
+          <TagFilterBar tags={classes} onChange={setSelected} />
+          <div className='mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2'>
+            {filtered.map(c => (
+              <CompoundCard key={c.name} compound={c} />
             ))}
           </div>
         </div>

--- a/src/pages/Favorites.tsx
+++ b/src/pages/Favorites.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Helmet } from 'react-helmet-async'
+import { Link } from 'react-router-dom'
 import HerbList from '../components/HerbList'
 import { useHerbs } from '../hooks/useHerbs'
 import { useHerbFavorites } from '../hooks/useHerbFavorites'
@@ -23,6 +24,11 @@ export default function Favorites() {
         />
       </Helmet>
       <div className='mx-auto max-w-6xl'>
+        <div className='mb-4'>
+          <Link to='/database' className='text-comet underline'>
+            ← Back to All Herbs
+          </Link>
+        </div>
         <h1 className='text-gradient mb-6 text-center text-5xl font-bold'>My Herbs</h1>
         {favoriteHerbs.length ? (
           <HerbList herbs={favoriteHerbs} />

--- a/src/pages/HerbDetailView.tsx
+++ b/src/pages/HerbDetailView.tsx
@@ -8,6 +8,7 @@ import { decodeTag, tagVariant } from '../utils/format'
 import { slugify } from '../utils/slugify'
 import { useLocalStorage } from '../hooks/useLocalStorage'
 import TabContainer from '../components/TabContainer'
+import InfoTooltip from '../components/InfoTooltip'
 
 export default function HerbDetailView() {
   const { id } = useParams<{ id: string }>()
@@ -168,7 +169,29 @@ export default function HerbDetailView() {
         <Link to='/database' className='text-comet underline'>
           ← Back
         </Link>
-        <h1 className='text-gradient text-4xl font-bold'>{herb.name}</h1>
+        <h1 className='text-gradient text-4xl font-bold flex items-center gap-2'>
+          {herb.name}
+          {(() => {
+            const r = String(herb.safetyRating || '').toLowerCase()
+            let icon = '❓'
+            let color = 'gray'
+            if (r.includes('high')) {
+              icon = '✅'
+              color = 'green'
+            } else if (r.includes('low')) {
+              icon = '☣️'
+              color = 'red'
+            } else if (r.includes('medium')) {
+              icon = '⚠️'
+              color = 'yellow'
+            }
+            return (
+              <InfoTooltip text={`Safety rating: ${r || 'unknown'}`}>
+                <span className={`text-${color}-300`}>{icon}</span>
+              </InfoTooltip>
+            )
+          })()}
+        </h1>
         {herb.scientificName && <p className='italic'>{herb.scientificName}</p>}
         <button
           type='button'


### PR DESCRIPTION
## Summary
- add dataset for psychoactive compounds
- create `CompoundCard` component
- redesign `/compounds` page using new dataset and tag filtering
- show safety icons in herb cards and detail view
- add clear button to `TagFilterBar`
- enhance favorites page with link back to all herbs

## Testing
- `npm run validate-herbs`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687ec92c1be4832390a2bb43d9c22f70