### PR TITLE
Compound page enhancements and UI polish

### DIFF
--- a/src/components/CompoundCard.tsx
+++ b/src/components/CompoundCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { motion } from 'framer-motion'
 import { Link } from 'react-router-dom'
 import InfoTooltip from './InfoTooltip'
@@ -14,16 +14,19 @@ const classColors: Record<string, string> = {
 }
 
 export default function CompoundCard({ compound }: { compound: Compound }) {
+  const [expanded, setExpanded] = useState(false)
   const colorKey = Object.keys(classColors).find(k =>
     compound.class.toLowerCase().includes(k)
   )
   const variant = colorKey ? classColors[colorKey] : 'purple'
   return (
     <motion.article
+      layout
+      onClick={() => setExpanded(e => !e)}
       whileHover={{ scale: 1.05 }}
       whileTap={{ scale: 0.98 }}
       tabIndex={0}
-      className='glass-card hover-glow rounded-xl p-4 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-psychedelic-pink'
+      className='glass-card hover-glow cursor-pointer rounded-xl p-4 text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-psychedelic-pink'
     >
       <h2 className='text-xl font-bold text-white'>{compound.name}</h2>
       <p className='text-sm text-moss'>
@@ -38,24 +41,44 @@ export default function CompoundCard({ compound }: { compound: Compound }) {
           <span className='mt-1 inline-flex items-center text-red-400'>☣️</span>
         </InfoTooltip>
       )}
-      {compound.sourceHerbs.length > 0 && (
-        <p className='mt-2 text-xs text-sand'>
-          Herbs:
-          {compound.sourceHerbs.map((h, i) => (
-            <React.Fragment key={h}>
-              {i > 0 && ', '}
-              <Link to={`/herbs/${h}`} className='underline'>
-                {h.replace(/-/g, ' ')}
-              </Link>
-            </React.Fragment>
-          ))}
-        </p>
+      {expanded && (
+        <motion.div
+          layout
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ type: 'spring', stiffness: 80, damping: 16 }}
+          className='mt-2 space-y-1 text-sm text-sand'
+        >
+          {compound.mechanismOfAction && (
+            <p>
+              <strong>Mechanism:</strong> {compound.mechanismOfAction}
+            </p>
+          )}
+          {compound.psychoactiveEffects?.length && (
+            <p>
+              <strong>Effects:</strong> {compound.psychoactiveEffects.join(', ')}
+            </p>
+          )}
+          {(compound.foundInHerbs ?? compound.sourceHerbs).length > 0 && (
+            <p>
+              <strong>Found In:</strong>{' '}
+              {(compound.foundInHerbs ?? compound.sourceHerbs).map((h, i) => (
+                <React.Fragment key={h}>
+                  {i > 0 && ', '}
+                  <Link to={`/herbs/${h}`} className='underline'>
+                    {h.replace(/-/g, ' ')}
+                  </Link>
+                </React.Fragment>
+              ))}
+            </p>
+          )}
+        </motion.div>
       )}
       <Link
         to={`/database?herbs=${compound.sourceHerbs.join(',')}`}
         className='tag-pill mt-2 inline-block'
       >
-        Source Herbs
+        🧬 Source Herb
       </Link>
     </motion.article>
   )

--- a/src/components/CompoundTagFilter.tsx
+++ b/src/components/CompoundTagFilter.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react'
+import { motion } from 'framer-motion'
+
+export interface Option {
+  label: string
+  value: string
+}
+
+export default function CompoundTagFilter({ options, onChange }: { options: Option[]; onChange?: (v: string[]) => void }) {
+  const [active, setActive] = useState<string[]>([])
+
+  const toggle = (val: string) => {
+    setActive(prev => (prev.includes(val) ? prev.filter(v => v !== val) : [...prev, val]))
+  }
+
+  useEffect(() => {
+    onChange?.(active)
+  }, [active, onChange])
+
+  return (
+    <div className='flex gap-2 overflow-x-auto py-2 no-scrollbar'>
+      {options.map(opt => {
+        const act = active.includes(opt.value)
+        return (
+          <motion.button
+            key={opt.value}
+            type='button'
+            onClick={() => toggle(opt.value)}
+            whileTap={{ scale: 0.9 }}
+            whileHover={{ scale: 1.08 }}
+            animate={act ? { scale: [1, 1.15, 1], boxShadow: '0 0 8px rgba(16,185,129,0.8)' } : { scale: 1, boxShadow: 'none' }}
+            transition={{ type: 'spring', stiffness: 220, damping: 12 }}
+            className={`tag-pill whitespace-nowrap hover-glow ${act ? 'bg-emerald-700/70 text-white ring-2 ring-emerald-400' : 'bg-space-dark/70 text-sand'}`}
+          >
+            {opt.label}
+          </motion.button>
+        )
+      })}
+      {active.length > 0 && (
+        <motion.button
+          type='button'
+          onClick={() => setActive([])}
+          whileTap={{ scale: 0.9 }}
+          whileHover={{ scale: 1.08 }}
+          transition={{ type: 'spring', stiffness: 220, damping: 12 }}
+          className='tag-pill whitespace-nowrap hover-glow bg-rose-700/70 text-white'
+        >
+          Clear
+        </motion.button>
+      )}
+    </div>
+  )
+}

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -48,6 +48,7 @@ export default function HerbCardAccordion({ herb }: Props) {
   return (
     <motion.article
       layout
+      layoutTransition={{ type: 'spring', stiffness: 120, damping: 14 }}
       initial={{ opacity: 0, scale: 0.95 }}
       animate={{ opacity: 1, scale: 1 }}
       exit={{ opacity: 0, scale: 0.95 }}
@@ -73,7 +74,7 @@ export default function HerbCardAccordion({ herb }: Props) {
       />
       <InfoTooltip text={`Safety rating: ${rating}`}>
         <span
-          className={`absolute left-3 top-3 text-${ratingColor}-300 text-lg`}
+          className={`absolute left-3 top-3 text-${ratingColor}-300 text-lg drop-shadow dark:drop-shadow-lg`}
         >
           {ratingIcon}
         </span>
@@ -84,7 +85,7 @@ export default function HerbCardAccordion({ herb }: Props) {
           e.stopPropagation()
           toggle(herb.id)
         }}
-        className='absolute right-3 top-3 rounded-full bg-black/40 p-1 text-sand backdrop-blur-md hover:bg-white/10'
+        className='absolute right-3 top-3 rounded-full bg-black/40 p-1 text-sand hover-glow backdrop-blur-md hover:bg-white/10'
         aria-label='Toggle favorite'
       >
         <Star className={`h-5 w-5 ${favorite ? 'fill-yellow-400 text-yellow-400' : ''}`} />
@@ -114,7 +115,7 @@ export default function HerbCardAccordion({ herb }: Props) {
             initial='collapsed'
             animate='open'
             exit='collapsed'
-            transition={{ type: 'spring', stiffness: 70, damping: 20 }}
+            transition={{ type: 'spring', stiffness: 120, damping: 14 }}
             className='mt-4 space-y-2 text-sm text-sand'
           >
             <motion.p variants={itemVariants} className='whitespace-pre-wrap break-words'>

--- a/src/components/TagFilterBar.tsx
+++ b/src/components/TagFilterBar.tsx
@@ -42,9 +42,13 @@ export default function TagFilterBar({ tags, onChange }: Props) {
             onClick={() => toggle(tag)}
             whileTap={{ scale: 0.9 }}
             whileHover={{ scale: 1.08 }}
-            animate={active ? { scale: [1, 1.15, 1], boxShadow: '0 0 8px rgba(16,185,129,0.8)' } : { scale: 1, boxShadow: 'none' }}
-            transition={{ type: 'spring', stiffness: 300 }}
-            className={`tag-pill whitespace-nowrap ${active ? 'bg-emerald-700/70 text-white ring-2 ring-emerald-400' : 'bg-space-dark/70 text-sand'}`}
+            animate={
+              active
+                ? { scale: [1, 1.15, 1], boxShadow: '0 0 8px rgba(16,185,129,0.8)' }
+                : { scale: 1, boxShadow: 'none' }
+            }
+            transition={{ type: 'spring', stiffness: 220, damping: 12 }}
+            className={`tag-pill whitespace-nowrap hover-glow ${active ? 'bg-emerald-700/70 text-white ring-2 ring-emerald-400' : 'bg-space-dark/70 text-sand'}`}
           >
             {decodeTag(tag)}
           </motion.button>
@@ -56,7 +60,8 @@ export default function TagFilterBar({ tags, onChange }: Props) {
           onClick={() => setActiveTags([])}
           whileTap={{ scale: 0.9 }}
           whileHover={{ scale: 1.08 }}
-          className='tag-pill whitespace-nowrap bg-rose-700/70 text-white'
+          transition={{ type: 'spring', stiffness: 220, damping: 12 }}
+          className='tag-pill whitespace-nowrap hover-glow bg-rose-700/70 text-white'
         >
           Clear Filters
         </motion.button>

--- a/src/data/compounds.ts
+++ b/src/data/compounds.ts
@@ -2,7 +2,12 @@ export interface Compound {
   name: string
   class: string
   effects: string[]
+  /** Herbs that contain this compound */
   sourceHerbs: string[]
+  /** Optional extra fields for detailed view */
+  mechanismOfAction?: string
+  psychoactiveEffects?: string[]
+  foundInHerbs?: string[]
   toxicityWarning?: string
   notes?: string
 }
@@ -13,6 +18,9 @@ export const compounds: Compound[] = [
     class: 'phenethylamine',
     effects: ['psychedelic', 'empathogenic'],
     sourceHerbs: ['lophophora-williamsii'],
+    mechanismOfAction: '5-HT2A agonist',
+    psychoactiveEffects: ['visual enhancement', 'emotional openness'],
+    foundInHerbs: ['lophophora-williamsii'],
     toxicityWarning: 'High doses may cause nausea and anxiety',
   },
   {
@@ -21,24 +29,36 @@ export const compounds: Compound[] = [
     effects: ['psychedelic'],
     sourceHerbs: ['psilocybe-cubensis'],
     notes: 'Converted to psilocin in the body',
+    mechanismOfAction: 'Converted to psilocin; 5-HT2A agonist',
+    psychoactiveEffects: ['visual distortion', 'mystical states'],
+    foundInHerbs: ['psilocybe-cubensis'],
   },
   {
     name: 'Mitragynine',
     class: 'indole alkaloid',
     effects: ['stimulant', 'analgesic'],
     sourceHerbs: ['kratom-hybrids'],
+    mechanismOfAction: 'Partial μ-opioid agonist',
+    psychoactiveEffects: ['energy boost', 'pain relief'],
+    foundInHerbs: ['kratom-hybrids'],
   },
   {
     name: 'Harmine',
     class: 'beta-carboline',
     effects: ['MAOI', 'psychedelic potentiator'],
     sourceHerbs: ['banisteriopsis-caapi'],
+    mechanismOfAction: 'Reversible MAO-A inhibitor',
+    psychoactiveEffects: ['potentiates DMT'],
+    foundInHerbs: ['banisteriopsis-caapi'],
   },
   {
     name: 'Thujone',
     class: 'monoterpene',
     effects: ['GABA antagonist'],
     sourceHerbs: ['salvia-apiana', 'achillea-millefolium'],
+    mechanismOfAction: 'GABA_A receptor antagonist',
+    psychoactiveEffects: ['stimulant', 'convulsant at high dose'],
+    foundInHerbs: ['salvia-apiana', 'achillea-millefolium'],
     toxicityWarning: 'Convulsant at high doses',
   },
 ]

--- a/src/hooks/useCompounds.ts
+++ b/src/hooks/useCompounds.ts
@@ -1,0 +1,28 @@
+import React from 'react'
+import { compounds, Compound } from '../data/compounds'
+import { herbs } from '../../herbsfull'
+
+export function useCompounds(): Compound[] {
+  const [list] = React.useState<Compound[]>(compounds)
+
+  React.useEffect(() => {
+    list.forEach(c => {
+      const refs = c.foundInHerbs ?? c.sourceHerbs
+      refs.forEach(h => {
+        if (!herbs.find(x => x.id === h)) {
+          console.warn(`Compound ${c.name} references missing herb: ${h}`)
+        }
+      })
+    })
+
+    herbs.forEach(h => {
+      h.activeConstituents?.forEach(cn => {
+        if (!list.find(c => c.name.toLowerCase() === cn.name.toLowerCase())) {
+          console.warn(`Herb ${h.name} lists unknown compound: ${cn.name}`)
+        }
+      })
+    })
+  }, [list])
+
+  return list
+}

--- a/src/pages/Compounds.tsx
+++ b/src/pages/Compounds.tsx
@@ -1,21 +1,49 @@
 import React from 'react'
 import { Helmet } from 'react-helmet-async'
-import { compounds } from '../data/compounds'
+import { useCompounds } from '../hooks/useCompounds'
+import { useHerbs } from '../hooks/useHerbs'
 import CompoundCard from '../components/CompoundCard'
 import TagFilterBar from '../components/TagFilterBar'
+import CompoundTagFilter from '../components/CompoundTagFilter'
 
 export default function Compounds() {
+  const compoundList = useCompounds()
+  const herbs = useHerbs()
   const classes = React.useMemo(
-    () => Array.from(new Set(compounds.map(c => c.class.toLowerCase()))),
-    []
+    () => Array.from(new Set(compoundList.map(c => c.class.toLowerCase()))),
+    [compoundList]
   )
-  const [selected, setSelected] = React.useState<string[]>([])
+  const herbMap = React.useMemo(() => {
+    const map: Record<string, string> = {}
+    herbs.forEach(h => {
+      map[h.id] = h.name
+    })
+    return map
+  }, [herbs])
+  const herbOptions = React.useMemo(
+    () =>
+      Array.from(new Set(compoundList.flatMap(c => c.sourceHerbs))).map(h => ({
+        value: h,
+        label: herbMap[h] || h.replace(/-/g, ' '),
+      })),
+    [compoundList, herbMap]
+  )
+
+  const [selectedClasses, setSelectedClasses] = React.useState<string[]>([])
+  const [selectedHerbs, setSelectedHerbs] = React.useState<string[]>([])
+
   const filtered = React.useMemo(() => {
-    if (selected.length === 0) return compounds
-    return compounds.filter(c =>
-      selected.every(s => c.class.toLowerCase().includes(s.toLowerCase()))
-    )
-  }, [selected])
+    let res = compoundList
+    if (selectedClasses.length)
+      res = res.filter(c =>
+        selectedClasses.every(s => c.class.toLowerCase().includes(s.toLowerCase())),
+      )
+    if (selectedHerbs.length)
+      res = res.filter(c =>
+        selectedHerbs.every(h => c.sourceHerbs.includes(h) || c.foundInHerbs?.includes(h)),
+      )
+    return res
+  }, [compoundList, selectedClasses, selectedHerbs])
 
   return (
     <>
@@ -26,7 +54,11 @@ export default function Compounds() {
         <div className='mx-auto max-w-4xl text-center'>
           <h1 className='text-gradient mb-6 text-5xl font-bold'>Psychoactive Compounds</h1>
           <p className='mb-8 text-sand'>List of notable active constituents and their source herbs.</p>
-          <TagFilterBar tags={classes} onChange={setSelected} />
+          <TagFilterBar tags={classes} onChange={setSelectedClasses} />
+          <CompoundTagFilter
+            options={herbOptions}
+            onChange={vals => setSelectedHerbs(vals)}
+          />
           <div className='mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2'>
             {filtered.map(c => (
               <CompoundCard key={c.name} compound={c} />

--- a/src/pages/Favorites.tsx
+++ b/src/pages/Favorites.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 import HerbList from '../components/HerbList'
 import { useHerbs } from '../hooks/useHerbs'
 import { useHerbFavorites } from '../hooks/useHerbFavorites'
+import { motion } from 'framer-motion'
 
 export default function Favorites() {
   const herbs = useHerbs()
@@ -33,7 +34,13 @@ export default function Favorites() {
         {favoriteHerbs.length ? (
           <HerbList herbs={favoriteHerbs} />
         ) : (
-          <p className='text-center text-sand'>No favorites yet.</p>
+          <motion.p
+            className='text-center text-sand text-xl'
+            animate={{ y: [0, -10, 0] }}
+            transition={{ repeat: Infinity, duration: 2 }}
+          >
+            🌱 No favorites yet!
+          </motion.p>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- smooth spring motion for HerbCardAccordion and TagFilterBar
- add hover glow and improved dark-mode icon styling
- animated empty state on Favorites page
- expandable CompoundCard with detailed info and source herb links
- compound filtering by class and herb with new hooks and UI
- warnings for inconsistent compound/herb links
- backup created at `backups/hippie-scientist-v2.0-compounds-polished.zip`

## Testing
- `npm run build`
- `npm run validate-herbs`


------
https://chatgpt.com/codex/tasks/task_e_687ecbab3f148323a78bf395432c0d83