### PR TITLE
Fix herb name safety emoji

### DIFF
--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -7,6 +7,7 @@ import InfoTooltip from './InfoTooltip'
 import { decodeTag, tagVariant } from '../utils/format'
 import { useHerbFavorites } from '../hooks/useHerbFavorites'
 import { Star } from 'lucide-react'
+import SafetyIcon from './SafetyIcon'
 
 interface Props {
   herb: Herb
@@ -21,19 +22,7 @@ export default function HerbCardAccordion({ herb }: Props) {
   const safeEffects = Array.isArray(herb.effects) ? herb.effects : []
   const favorite = isFavorite(herb.id)
 
-  const rating = String(herb.safetyRating || 'unknown').toLowerCase()
-  let ratingColor = 'gray'
-  let ratingIcon = '❓'
-  if (rating.includes('high')) {
-    ratingColor = 'green'
-    ratingIcon = '✅'
-  } else if (rating.includes('low')) {
-    ratingColor = 'red'
-    ratingIcon = '☠️'
-  } else if (rating.includes('medium')) {
-    ratingColor = 'yellow'
-    ratingIcon = '⚠️'
-  }
+  const rating = herb.safetyRating
 
   const containerVariants = {
     open: { transition: { staggerChildren: 0.05, delayChildren: 0.1 } },
@@ -72,20 +61,16 @@ export default function HerbCardAccordion({ herb }: Props) {
         animate={expanded ? { opacity: 1, scale: 1.05 } : { opacity: 0 }}
         transition={{ duration: 0.6, ease: 'easeInOut' }}
       />
-      <InfoTooltip text={`Safety rating: ${rating}`}>
-        <span
-          className={`absolute left-3 top-3 text-${ratingColor}-300 text-lg drop-shadow dark:drop-shadow-lg`}
-        >
-          {ratingIcon}
-        </span>
-      </InfoTooltip>
+      <div className='absolute left-3 top-3'>
+        <SafetyIcon level={rating} />
+      </div>
       <button
         type='button'
         onClick={e => {
           e.stopPropagation()
           toggle(herb.id)
         }}
-        className='absolute right-3 top-3 rounded-full bg-black/40 p-1 text-sand hover-glow backdrop-blur-md hover:bg-white/10'
+        className='hover-glow absolute right-3 top-3 rounded-full bg-black/40 p-1 text-sand backdrop-blur-md hover:bg-white/10'
         aria-label='Toggle favorite'
       >
         <Star className={`h-5 w-5 ${favorite ? 'fill-yellow-400 text-yellow-400' : ''}`} />
@@ -179,9 +164,9 @@ export default function HerbCardAccordion({ herb }: Props) {
             )}
             <motion.p
               variants={itemVariants}
-              className={`inline-flex items-center gap-1 rounded px-2 py-0.5 text-${ratingColor}-300`}
+              className='inline-flex items-center gap-1 rounded px-2 py-0.5'
             >
-              <span>{ratingIcon}</span>
+              <SafetyIcon level={rating} />
               <span>{rating || 'Unknown'}</span>
             </motion.p>
             {Array.isArray(herb.sources) && herb.sources.length > 0 && (

--- a/src/components/SafetyIcon.tsx
+++ b/src/components/SafetyIcon.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import InfoTooltip from './InfoTooltip'
+
+interface Props {
+  level?: string | number
+  className?: string
+}
+
+export default function SafetyIcon({ level, className = '' }: Props) {
+  if (level == null || level === '') return null
+  const value = String(level).toLowerCase()
+
+  let icon = '❓'
+  let aria = 'Unknown safety'
+  let color = 'text-gray-300'
+  if (/(safe|high)/.test(value)) {
+    icon = '✅'
+    aria = 'Generally safe'
+    color = 'text-green-400'
+  } else if (/(caution|medium)/.test(value)) {
+    icon = '⚠️'
+    aria = 'Use caution'
+    color = 'text-yellow-300'
+  } else if (/(toxic|low)/.test(value)) {
+    icon = '☠️'
+    aria = 'Potentially toxic'
+    color = 'text-red-400'
+  } else if (/avoid/.test(value)) {
+    icon = '❌'
+    aria = 'Avoid use'
+    color = 'text-red-500'
+  }
+
+  return (
+    <InfoTooltip text={`Safety level: ${value}`}>
+      <span role='img' aria-label={aria} className={`${color} ${className}`}>
+        {icon}
+      </span>
+    </InfoTooltip>
+  )
+}

--- a/src/pages/HerbDetailView.tsx
+++ b/src/pages/HerbDetailView.tsx
@@ -8,7 +8,7 @@ import { decodeTag, tagVariant } from '../utils/format'
 import { slugify } from '../utils/slugify'
 import { useLocalStorage } from '../hooks/useLocalStorage'
 import TabContainer from '../components/TabContainer'
-import InfoTooltip from '../components/InfoTooltip'
+import SafetyIcon from '../components/SafetyIcon'
 
 export default function HerbDetailView() {
   const { id } = useParams<{ id: string }>()
@@ -41,26 +41,21 @@ export default function HerbDetailView() {
   const overview = (
     <div className='space-y-2'>
       {(() => {
-        const eff = Array.isArray(herb.effects)
-          ? herb.effects.join(', ')
-          : (herb.effects || '')
+        const eff = Array.isArray(herb.effects) ? herb.effects.join(', ') : herb.effects || ''
         return eff ? (
           <div>
-            <span className='font-semibold text-lime-300'>Effects:</span>{' '}
-            {eff}
+            <span className='font-semibold text-lime-300'>Effects:</span> {eff}
           </div>
         ) : null
       })()}
       {herb.region && (
         <div>
-          <span className='font-semibold text-lime-300'>Region:</span>{' '}
-          {herb.region}
+          <span className='font-semibold text-lime-300'>Region:</span> {herb.region}
         </div>
       )}
       {(herb as any).history && (
         <div>
-          <span className='font-semibold text-lime-300'>History:</span>{' '}
-          {(herb as any).history}
+          <span className='font-semibold text-lime-300'>History:</span> {(herb as any).history}
         </div>
       )}
       {Array.isArray(herb.tags) && herb.tags.length > 0 && (
@@ -81,21 +76,21 @@ export default function HerbDetailView() {
           {herb.activeConstituents.map((c, i) => (
             <React.Fragment key={c.name}>
               {i > 0 && ', '}
-              <Link className='text-sky-300 underline' to={`/compounds#${slugify(c.name)}`}>{c.name}</Link>
+              <Link className='text-sky-300 underline' to={`/compounds#${slugify(c.name)}`}>
+                {c.name}
+              </Link>
             </React.Fragment>
           ))}
         </div>
       )}
       {herb.mechanismOfAction && (
         <div>
-          <span className='font-semibold text-lime-300'>Mechanism:</span>{' '}
-          {herb.mechanismOfAction}
+          <span className='font-semibold text-lime-300'>Mechanism:</span> {herb.mechanismOfAction}
         </div>
       )}
       {herb.toxicityLD50 && (
         <div>
-          <span className='font-semibold text-lime-300'>LD50:</span>{' '}
-          {herb.toxicityLD50}
+          <span className='font-semibold text-lime-300'>LD50:</span> {herb.toxicityLD50}
         </div>
       )}
     </div>
@@ -105,24 +100,26 @@ export default function HerbDetailView() {
     <div className='space-y-2'>
       {herb.preparation && (
         <div>
-          <span className='font-semibold text-lime-300'>Prep:</span>{' '}
-          {herb.preparation}
+          <span className='font-semibold text-lime-300'>Prep:</span> {herb.preparation}
         </div>
       )}
       {herb.intensity && (
         <div>
-          <span className='font-semibold text-lime-300'>Intensity:</span>{' '}
-          {herb.intensity}
+          <span className='font-semibold text-lime-300'>Intensity:</span> {herb.intensity}
         </div>
       )}
       {herb.dosage && (
         <div>
-          <span className='font-semibold text-lime-300'>Dosage:</span>{' '}
-          {herb.dosage}
+          <span className='font-semibold text-lime-300'>Dosage:</span> {herb.dosage}
         </div>
       )}
       {herb.affiliateLink && herb.affiliateLink.startsWith('http') ? (
-        <a href={herb.affiliateLink} target='_blank' rel='noopener noreferrer' className='text-sky-300 underline'>
+        <a
+          href={herb.affiliateLink}
+          target='_blank'
+          rel='noopener noreferrer'
+          className='text-sky-300 underline'
+        >
           Buy Online
         </a>
       ) : (
@@ -154,9 +151,7 @@ export default function HerbDetailView() {
     { id: 'usage', label: 'Usage', content: usage },
   ]
 
-  const effectsSummary = Array.isArray(herb.effects)
-    ? herb.effects.join(', ')
-    : (herb.effects || '')
+  const effectsSummary = Array.isArray(herb.effects) ? herb.effects.join(', ') : herb.effects || ''
   const summary = `${herb.name} is classified as ${herb.category}. Known effects include ${effectsSummary}.`
 
   return (
@@ -165,38 +160,23 @@ export default function HerbDetailView() {
         <title>{herb.name} - The Hippie Scientist</title>
         {herb.description && <meta name='description' content={herb.description} />}
       </Helmet>
-      <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className='mx-auto max-w-3xl space-y-6 px-6 py-12'>
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        className='mx-auto max-w-3xl space-y-6 px-6 py-12'
+      >
         <Link to='/database' className='text-comet underline'>
           ← Back
         </Link>
-        <h1 className='text-gradient text-4xl font-bold flex items-center gap-2'>
+        <h1 className='text-gradient flex items-center gap-2 text-4xl font-bold'>
           {herb.name}
-          {(() => {
-            const r = String(herb.safetyRating || '').toLowerCase()
-            let icon = '❓'
-            let color = 'gray'
-            if (r.includes('high')) {
-              icon = '✅'
-              color = 'green'
-            } else if (r.includes('low')) {
-              icon = '☣️'
-              color = 'red'
-            } else if (r.includes('medium')) {
-              icon = '⚠️'
-              color = 'yellow'
-            }
-            return (
-              <InfoTooltip text={`Safety rating: ${r || 'unknown'}`}>
-                <span className={`text-${color}-300`}>{icon}</span>
-              </InfoTooltip>
-            )
-          })()}
+          <SafetyIcon level={herb.safetyRating} />
         </h1>
         {herb.scientificName && <p className='italic'>{herb.scientificName}</p>}
         <button
           type='button'
           onClick={copyLink}
-          className='rounded-md bg-black/30 px-3 py-2 text-sm text-sand hover:bg-white/10 backdrop-blur-md'
+          className='rounded-md bg-black/30 px-3 py-2 text-sm text-sand backdrop-blur-md hover:bg-white/10'
         >
           {copied ? '✅ Copied!' : 'Share \uD83D\uDD17'}
         </button>


### PR DESCRIPTION
## Summary
- add `SafetyIcon` component for accessible safety indicators
- use `SafetyIcon` in `HerbCardAccordion` and `HerbDetailView`
- remove prior inline safety emoji logic

## Testing
- `npm run build`
- `npm run validate-herbs`


------
https://chatgpt.com/codex/tasks/task_e_687ece14b9a08323921f9452566b7ea2