### PR TITLE
Fix herb name icons

### DIFF
--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -61,9 +61,6 @@ export default function HerbCardAccordion({ herb }: Props) {
         animate={expanded ? { opacity: 1, scale: 1.05 } : { opacity: 0 }}
         transition={{ duration: 0.6, ease: 'easeInOut' }}
       />
-      <div className='absolute left-3 top-3'>
-        <SafetyIcon level={rating} />
-      </div>
       <button
         type='button'
         onClick={e => {
@@ -75,7 +72,10 @@ export default function HerbCardAccordion({ herb }: Props) {
       >
         <Star className={`h-5 w-5 ${favorite ? 'fill-yellow-400 text-yellow-400' : ''}`} />
       </button>
-      <h2 className='text-xl font-bold text-lime-300'>{herb.name || 'Unknown Herb'}</h2>
+      <div className='flex items-center gap-2'>
+        <span className='text-xl font-bold text-lime-300'>{herb.name || 'Unknown Herb'}</span>
+        {herb.safetyRating && <SafetyIcon safety={String(herb.safetyRating)} />}
+      </div>
       <p className='text-sm italic text-sand'>{herb.scientificName || 'Unknown species'}</p>
 
       <div className='mt-2 text-sm text-white'>
@@ -166,7 +166,7 @@ export default function HerbCardAccordion({ herb }: Props) {
               variants={itemVariants}
               className='inline-flex items-center gap-1 rounded px-2 py-0.5'
             >
-              <SafetyIcon level={rating} />
+              <SafetyIcon safety={String(rating)} />
               <span>{rating || 'Unknown'}</span>
             </motion.p>
             {Array.isArray(herb.sources) && herb.sources.length > 0 && (

--- a/src/components/SafetyIcon.tsx
+++ b/src/components/SafetyIcon.tsx
@@ -1,41 +1,22 @@
-import React from 'react'
-import InfoTooltip from './InfoTooltip'
+import { FC } from 'react'
+import { Tooltip } from 'react-tooltip'
 
-interface Props {
-  level?: string | number
-  className?: string
+const iconMap: Record<string, string> = {
+  safe: '✅',
+  caution: '⚠️',
+  toxic: '☠️',
+  avoid: '❌',
 }
 
-export default function SafetyIcon({ level, className = '' }: Props) {
-  if (level == null || level === '') return null
-  const value = String(level).toLowerCase()
-
-  let icon = '❓'
-  let aria = 'Unknown safety'
-  let color = 'text-gray-300'
-  if (/(safe|high)/.test(value)) {
-    icon = '✅'
-    aria = 'Generally safe'
-    color = 'text-green-400'
-  } else if (/(caution|medium)/.test(value)) {
-    icon = '⚠️'
-    aria = 'Use caution'
-    color = 'text-yellow-300'
-  } else if (/(toxic|low)/.test(value)) {
-    icon = '☠️'
-    aria = 'Potentially toxic'
-    color = 'text-red-400'
-  } else if (/avoid/.test(value)) {
-    icon = '❌'
-    aria = 'Avoid use'
-    color = 'text-red-500'
-  }
-
-  return (
-    <InfoTooltip text={`Safety level: ${value}`}>
-      <span role='img' aria-label={aria} className={`${color} ${className}`}>
+const SafetyIcon: FC<{ safety: string }> = ({ safety }) => {
+  const icon = iconMap[safety] || ''
+  return icon ? (
+    <Tooltip content={`Safety: ${safety}`}>
+      <span aria-label={`Safety rating: ${safety}`} role='img'>
         {icon}
       </span>
-    </InfoTooltip>
-  )
+    </Tooltip>
+  ) : null
 }
+
+export default SafetyIcon

--- a/src/pages/HerbDetailView.tsx
+++ b/src/pages/HerbDetailView.tsx
@@ -169,8 +169,8 @@ export default function HerbDetailView() {
           ← Back
         </Link>
         <h1 className='text-gradient flex items-center gap-2 text-4xl font-bold'>
-          {herb.name}
-          <SafetyIcon level={herb.safetyRating} />
+          <span>{herb.name}</span>
+          {herb.safetyRating && <SafetyIcon safety={String(herb.safetyRating)} />}
         </h1>
         {herb.scientificName && <p className='italic'>{herb.scientificName}</p>}
         <button


### PR DESCRIPTION
## Summary
- add new SafetyIcon with tooltips
- display SafetyIcon alongside herb names in list and detail views

## Testing
- `npm run validate-herbs`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687ed0a0da9c832381fd77936645d27d