### PR TITLE
Enhance herb search and compound explorer

### DIFF
--- a/src/components/CompoundCard.tsx
+++ b/src/components/CompoundCard.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 import InfoTooltip from './InfoTooltip'
 import TagBadge from './TagBadge'
 import { Compound } from '../data/compounds'
+import { slugify } from '../utils/slugify'
 
 const classColors: Record<string, string> = {
   alkaloid: 'purple',
@@ -21,6 +22,7 @@ export default function CompoundCard({ compound }: { compound: Compound }) {
   const variant = colorKey ? classColors[colorKey] : 'purple'
   return (
     <motion.article
+      id={slugify(compound.name)}
       layout
       onClick={() => setExpanded(e => !e)}
       whileHover={{ scale: 1.05 }}
@@ -36,6 +38,19 @@ export default function CompoundCard({ compound }: { compound: Compound }) {
         <p className='mt-1 text-sm text-sand'>Effects: {compound.effects.join(', ')}</p>
       )}
       {compound.notes && <p className='mt-1 text-xs italic text-sand'>{compound.notes}</p>}
+      {compound.sourceHerbs.length > 0 && !expanded && (
+        <p className='mt-1 text-sm text-sand'>
+          Source:{' '}
+          {compound.sourceHerbs.map((h, i) => (
+            <React.Fragment key={h}>
+              {i > 0 && ', '}
+              <Link to={`/herbs/${h}`} className='underline'>
+                {h.replace(/-/g, ' ')}
+              </Link>
+            </React.Fragment>
+          ))}
+        </p>
+      )}
       {compound.toxicityWarning && (
         <InfoTooltip text={compound.toxicityWarning}>
           <span className='mt-1 inline-flex items-center text-red-400'>☣️</span>

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -7,6 +7,7 @@ import InfoTooltip from './InfoTooltip'
 import { decodeTag, tagVariant } from '../utils/format'
 import { useHerbFavorites } from '../hooks/useHerbFavorites'
 import { Star } from 'lucide-react'
+import { slugify } from '../utils/slugify'
 
 interface Props {
   herb: Herb
@@ -82,7 +83,11 @@ export default function HerbCardAccordion({ herb }: Props) {
         <Star className={`h-5 w-5 ${favorite ? 'fill-yellow-400 text-yellow-400' : ''}`} />
       </button>
       <div className='flex items-center gap-2'>
-        <span className='text-xl font-bold text-lime-300'>{herb.name || 'Unknown Herb'}</span>
+        <span
+          className='text-xl font-bold text-lime-300 transition group-hover:drop-shadow-[0_0_6px_rgba(163,255,134,0.8)] group-hover:text-lime-200'
+        >
+          {herb.name || 'Unknown Herb'}
+        </span>
       </div>
       <p className='text-sm italic text-sand'>{herb.scientificName || 'Unknown species'}</p>
 
@@ -168,6 +173,19 @@ export default function HerbCardAccordion({ herb }: Props) {
             {herb.intensity && (
               <motion.p variants={itemVariants} className='whitespace-pre-wrap break-words'>
                 <strong>Intensity:</strong> {herb.intensity}
+              </motion.p>
+            )}
+            {Array.isArray(herb.activeConstituents) && herb.activeConstituents.length > 0 && (
+              <motion.p variants={itemVariants} className='whitespace-pre-wrap break-words'>
+                <strong>Active Compounds:</strong>{' '}
+                {herb.activeConstituents.map((c, i) => (
+                  <React.Fragment key={c.name}>
+                    {i > 0 && ', '}
+                    <Link to={`/compounds#${slugify(c.name)}`} className='underline'>
+                      {c.name}
+                    </Link>
+                  </React.Fragment>
+                ))}
               </motion.p>
             )}
             {Array.isArray(herb.sources) && herb.sources.length > 0 && (

--- a/src/components/TagBadge.tsx
+++ b/src/components/TagBadge.tsx
@@ -30,7 +30,7 @@ export default function TagBadge({ label, variant = 'purple', className }: Props
       whileTap={{ scale: 0.95 }}
       tabIndex={0}
       className={clsx(
-        'hover-glow text-shadow inline-flex items-center whitespace-pre-wrap break-words rounded-full bg-gradient-to-br px-2 py-0.5 text-xs font-medium text-white/90 shadow ring-1 ring-white/40 backdrop-blur-sm dark:ring-black/40',
+        'hover-glow soft-border-glow text-shadow inline-flex items-center whitespace-pre-wrap break-words rounded-full bg-gradient-to-br px-2 py-0.5 text-xs font-medium text-white/90 shadow ring-1 ring-white/40 backdrop-blur-sm dark:ring-black/40',
         colorMap[variant],
         className
       )}

--- a/src/hooks/useFilteredHerbs.ts
+++ b/src/hooks/useFilteredHerbs.ts
@@ -25,6 +25,13 @@ export function useFilteredHerbs(herbs: Herb[], options: Options = {}) {
   const [categories, setCategories] = React.useState<string[]>([])
   const [sort, setSort] = React.useState('')
 
+  const blendScore = React.useCallback((h: Herb) => {
+    const inDesc = h.description?.toLowerCase().includes('blend') || false
+    const inPrep = h.preparation?.toLowerCase().includes('blend') || false
+    const inTags = h.tags?.some(t => t.toLowerCase().includes('blend')) || false
+    return [inDesc, inPrep, inTags].filter(Boolean).length
+  }, [])
+
   const fuse = React.useMemo(
     () =>
       new Fuse(herbs, {
@@ -62,6 +69,12 @@ export function useFilteredHerbs(herbs: Herb[], options: Options = {}) {
     }
     if (sort === 'name') {
       res = [...res].sort((a, b) => a.name.localeCompare(b.name))
+    } else if (sort === 'category') {
+      res = [...res].sort((a, b) => a.category.localeCompare(b.category))
+    } else if (sort === 'intensity') {
+      res = [...res].sort((a, b) => (a.intensity || '').localeCompare(b.intensity || ''))
+    } else if (sort === 'blend') {
+      res = [...res].sort((a, b) => blendScore(b) - blendScore(a))
     }
     return res
   }, [herbs, query, tags, categories, favoritesOnly, favorites, sort, fuse, matchAll])

--- a/src/pages/Compounds.tsx
+++ b/src/pages/Compounds.tsx
@@ -31,6 +31,14 @@ export default function Compounds() {
 
   const [selectedClasses, setSelectedClasses] = React.useState<string[]>([])
   const [selectedHerbs, setSelectedHerbs] = React.useState<string[]>([])
+  const types = React.useMemo(
+    () =>
+      Array.from(
+        new Set(compoundList.flatMap(c => c.effects.map(e => e.toLowerCase())))
+      ),
+    [compoundList]
+  )
+  const [selectedTypes, setSelectedTypes] = React.useState<string[]>([])
 
   const filtered = React.useMemo(() => {
     let res = compoundList
@@ -38,12 +46,16 @@ export default function Compounds() {
       res = res.filter(c =>
         selectedClasses.every(s => c.class.toLowerCase().includes(s.toLowerCase())),
       )
+    if (selectedTypes.length)
+      res = res.filter(c =>
+        selectedTypes.every(t => c.effects.map(e => e.toLowerCase()).includes(t))
+      )
     if (selectedHerbs.length)
       res = res.filter(c =>
         selectedHerbs.every(h => c.sourceHerbs.includes(h) || c.foundInHerbs?.includes(h)),
       )
     return res
-  }, [compoundList, selectedClasses, selectedHerbs])
+  }, [compoundList, selectedClasses, selectedHerbs, selectedTypes])
 
   return (
     <>
@@ -55,6 +67,7 @@ export default function Compounds() {
           <h1 className='text-gradient mb-6 text-5xl font-bold'>Psychoactive Compounds</h1>
           <p className='mb-8 text-sand'>List of notable active constituents and their source herbs.</p>
           <TagFilterBar tags={classes} onChange={setSelectedClasses} />
+          <TagFilterBar tags={types} onChange={setSelectedTypes} />
           <CompoundTagFilter
             options={herbOptions}
             onChange={vals => setSelectedHerbs(vals)}

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -33,6 +33,8 @@ export default function Database() {
     setCategories: setFilteredCategories,
     favoritesOnly,
     setFavoritesOnly,
+    sort,
+    setSort,
     fuse,
   } = useFilteredHerbs(herbs, { favorites })
 
@@ -167,6 +169,17 @@ export default function Database() {
             >
               {matchAll ? 'Match ALL' : 'Match ANY'}
             </button>
+            <select
+              value={sort}
+              onChange={e => setSort(e.target.value)}
+              className='rounded-md bg-space-dark/70 px-3 py-2 text-sm text-sand backdrop-blur-md hover:bg-white/10'
+            >
+              <option value=''>Sort By...</option>
+              <option value='name'>Alphabetical (A–Z)</option>
+              <option value='category'>Category</option>
+              <option value='intensity'>Psychoactive Intensity</option>
+              <option value='blend'>Blend-Friendliness</option>
+            </select>
             <Link
               to='/downloads'
               className='rounded-md bg-space-dark/70 p-2 text-sand backdrop-blur-md hover:bg-white/10'


### PR DESCRIPTION
## Summary
- support multiple sort modes including blend detection
- polish TagBadge with soft-border-glow
- glow herb titles on hover and list active compounds in index accordion
- link source herbs in compound cards and allow anchors
- add filtering by compound effects
- expose sort controls in database page

## Testing
- `npm run validate-herbs`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687edd04e09083239a32f8ea63621ab0