### PR TITLE
Fix More Info link on herb slideshow

### DIFF
--- a/src/components/FeaturedHerbCarousel.tsx
+++ b/src/components/FeaturedHerbCarousel.tsx
@@ -47,10 +47,14 @@ export default function FeaturedHerbCarousel() {
             <p className='mt-1 line-clamp-2 text-sm text-sand'>{herb.description}</p>
           )}
           <Link
-            to={`/herbs/${herb.id}`}
+            to={
+              herb.slug
+                ? `/herb/${herb.slug}`
+                : `/database#${herb.name.replace(/\s+/g, '-').toLowerCase()}`
+            }
             className='hover-glow mt-3 inline-block rounded-md bg-black/30 px-4 py-2 text-sand backdrop-blur-md hover:rotate-1'
           >
-            Learn More
+            More Info
           </Link>
         </motion.div>
       </AnimatePresence>

--- a/src/components/FeaturedHerbTeaser.tsx
+++ b/src/components/FeaturedHerbTeaser.tsx
@@ -46,10 +46,14 @@ export default function FeaturedHerbTeaser({ fixedId = '' }: Props) {
         return effects ? <p className='mt-1 text-sm text-sand'>{effects}</p> : null
       })()}
       <Link
-        to={`/herbs/${herb.id}`}
+        to={
+          herb.slug
+            ? `/herb/${herb.slug}`
+            : `/database#${herb.name.replace(/\s+/g, '-').toLowerCase()}`
+        }
         className='hover-glow mt-3 inline-block rounded-md bg-black/30 px-4 py-2 text-sand backdrop-blur-md hover:rotate-1'
       >
-        Learn More
+        More Info
       </Link>
     </motion.div>
   )

--- a/src/components/RotatingHerbCard.tsx
+++ b/src/components/RotatingHerbCard.tsx
@@ -79,10 +79,14 @@ export default function RotatingHerbCard() {
             ) : null
           })()}
           <Link
-            to={`/herbs/${herb.id}`}
+            to={
+              herb.slug
+                ? `/herb/${herb.slug}`
+                : `/database#${herb.name.replace(/\s+/g, '-').toLowerCase()}`
+            }
             className='hover-glow mt-3 inline-block rounded-md bg-black/30 px-4 py-2 text-sand backdrop-blur-md hover:rotate-1'
           >
-            Learn More
+            More Info
           </Link>
         </div>
       </div>
@@ -143,10 +147,14 @@ export default function RotatingHerbCard() {
             ) : null
           })()}
           <Link
-            to={`/herbs/${herb.id}`}
+            to={
+              herb.slug
+                ? `/herb/${herb.slug}`
+                : `/database#${herb.name.replace(/\s+/g, '-').toLowerCase()}`
+            }
             className='hover-glow mt-3 inline-block rounded-md bg-black/30 px-4 py-2 text-sand backdrop-blur-md hover:rotate-1'
           >
-            Learn More
+            More Info
           </Link>
           <motion.div
             className='pointer-events-none absolute inset-0 rounded-xl ring-2 ring-psychedelic-pink/40 drop-shadow-[0_0_8px_#ff00ff]'


### PR DESCRIPTION
## Summary
- link the "More Info" button in herb slideshow components to actual herb details
- fall back to the herb database section when slug is missing

## Testing
- `npm test`
- `npm run validate-herbs`


------
https://chatgpt.com/codex/tasks/task_e_687ee88d2b448323b36eb3e12e9abcca