### PR TITLE
Improve hero UI and add random herb card

### DIFF
--- a/src/components/FeaturedHerbTeaser.tsx
+++ b/src/components/FeaturedHerbTeaser.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion'
 import { Link } from 'react-router-dom'
 import { herbs } from '../../herbsfull'
 import type { Herb } from '../types'
+import TagBadge from './TagBadge'
 
 interface Props {
   fixedId?: string
@@ -39,6 +40,13 @@ export default function FeaturedHerbTeaser({ fixedId = '' }: Props) {
         />
       )}
       <h3 className='mt-3 font-herb text-2xl'>{herb.name}</h3>
+      {herb.tags && (
+        <div className='mt-1 flex flex-wrap justify-center gap-1'>
+          {herb.tags.slice(0, 2).map(tag => (
+            <TagBadge key={tag} label={tag} className='text-xs' />
+          ))}
+        </div>
+      )}
       {(() => {
         const effects = Array.isArray(herb.effects)
           ? herb.effects.slice(0, 3).join(', ')

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -18,32 +18,42 @@ export default function Hero() {
       <HeroBackground />
       <FloatingElements />
 
-      <div className='relative z-10 flex flex-1 flex-col items-center justify-center gap-4'>
-        <motion.div
-          className='mx-auto max-w-2xl space-y-1'
-          initial={{ opacity: 0, y: 20, scale: 0.95 }}
-          animate={{ opacity: 1, y: 0, scale: 1 }}
-          transition={{ duration: 1, delay: 0.2, ease: 'easeOut' }}
-        >
-          <h1 className='text-gradient font-display text-4xl sm:text-5xl md:text-6xl lg:text-7xl'>
-            The Hippie Scientist
-          </h1>
-          <p className='text-opal text-base sm:text-lg md:text-xl'>Psychedelic Botany &amp; Conscious Exploration</p>
-        </motion.div>
+      <div className='relative z-10 mx-auto mt-6 w-full max-w-xl rounded-xl border border-lime-400/30 bg-white/10 p-6 shadow-xl backdrop-blur soft-border-glow'>
+        <div className='flex flex-col items-center justify-center gap-4'>
+          <motion.div
+            className='mx-auto max-w-2xl space-y-1'
+            initial={{ opacity: 0, y: 20, scale: 0.95 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            transition={{ duration: 1, delay: 0.2, ease: 'easeOut' }}
+          >
+            <h1 className='text-gradient font-display text-4xl sm:text-5xl md:text-6xl lg:text-7xl'>
+              The Hippie Scientist
+            </h1>
+            <p className='text-opal text-base sm:text-lg md:text-xl'>Psychedelic Botany &amp; Conscious Exploration</p>
+          </motion.div>
 
-        <div className='mt-2'>
-          <RotatingHerbCard />
+          <div className='mt-2'>
+            <RotatingHerbCard />
+          </div>
         </div>
-      </div>
 
-      <div className='relative z-10 mb-4 flex flex-col items-center gap-4'>
-        <StatsCounters className='mt-0' />
-        <Link
-          to='/database'
-          className='hover-glow inline-block rounded-md bg-black/30 px-6 py-3 text-white backdrop-blur-md hover:rotate-1'
-        >
-          🌿 Browse Database
-        </Link>
+        <div className='mt-6 flex flex-col items-center gap-4'>
+          <StatsCounters className='mt-0' />
+          <div className='flex flex-wrap items-center justify-center gap-4'>
+            <Link
+              to='/database'
+              className='hover-glow rounded-md bg-black/30 px-6 py-3 text-white transition hover:shadow-glow backdrop-blur'
+            >
+              🌿 Browse Herbs
+            </Link>
+            <Link
+              to='/blend'
+              className='hover-glow rounded-md bg-black/30 px-6 py-3 text-white transition hover:shadow-glow backdrop-blur'
+            >
+              🧪 Build a Blend
+            </Link>
+          </div>
+        </div>
       </div>
     </motion.section>
   )

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,21 +2,19 @@ import React from 'react'
 import Hero from '../components/Hero'
 import StarfieldBackground from '../components/StarfieldBackground'
 import MouseTrail from '../components/MouseTrail'
-import FeaturedHerbCarousel from '../components/FeaturedHerbCarousel'
+import FeaturedHerbTeaser from '../components/FeaturedHerbTeaser'
 
 export default function Home() {
   return (
     <main
       id='home'
       aria-label='Site introduction'
-      className='relative min-h-screen overflow-hidden bg-white pt-16 text-black dark:bg-black dark:text-white'
+      className='relative min-h-screen overflow-hidden bg-gradient-to-br from-purple-950 via-blue-950 to-green-900 animate-gradient pt-16 text-black dark:text-white'
     >
       <StarfieldBackground />
       <MouseTrail />
       <Hero />
-      <div className='hidden md:block'>
-        <FeaturedHerbCarousel />
-      </div>
+      <FeaturedHerbTeaser />
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- add a glassy container inside the hero section
- style CTA buttons and include a link to the blend builder
- show a random featured herb on the home page
- apply an animated gradient background
- display herb tags in the featured herb teaser

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687eec758098832399da9381982e8802