### PR TITLE
Fix More Info links on homepage

### DIFF
--- a/src/components/FeaturedHerbCarousel.tsx
+++ b/src/components/FeaturedHerbCarousel.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { Link } from 'react-router-dom'
 import { herbs } from '../../herbsfull'
+import { slugify } from '../utils/slugify'
 
 function pickFeatured() {
   const psychedelic = herbs.filter(h => h.category.includes('Psychedelic'))
@@ -50,7 +51,7 @@ export default function FeaturedHerbCarousel() {
             to={
               herb.slug
                 ? `/herb/${herb.slug}`
-                : `/database#${herb.name.replace(/\s+/g, '-').toLowerCase()}`
+                : `/database#${slugify(herb.name)}`
             }
             className='hover-glow mt-3 inline-block rounded-md bg-black/30 px-4 py-2 text-sand backdrop-blur-md hover:rotate-1'
           >

--- a/src/components/FeaturedHerbTeaser.tsx
+++ b/src/components/FeaturedHerbTeaser.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 import { herbs } from '../../herbsfull'
 import type { Herb } from '../types'
 import TagBadge from './TagBadge'
+import { slugify } from '../utils/slugify'
 
 interface Props {
   fixedId?: string
@@ -57,7 +58,7 @@ export default function FeaturedHerbTeaser({ fixedId = '' }: Props) {
         to={
           herb.slug
             ? `/herb/${herb.slug}`
-            : `/database#${herb.name.replace(/\s+/g, '-').toLowerCase()}`
+            : `/database#${slugify(herb.name)}`
         }
         className='hover-glow mt-3 inline-block rounded-md bg-black/30 px-4 py-2 text-sand backdrop-blur-md hover:rotate-1'
       >

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -60,7 +60,7 @@ export default function HerbCardAccordion({ herb }: Props) {
           toggleExpanded()
         }
       }}
-      id={`herb-${herb.id}`}
+      id={slugify(herb.name)}
       role='button'
       tabIndex={0}
       aria-expanded={expanded}

--- a/src/components/RotatingHerbCard.tsx
+++ b/src/components/RotatingHerbCard.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState, useRef } from 'react'
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 import { Link } from 'react-router-dom'
 import { herbs } from '../../herbsfull'
+import { slugify } from '../utils/slugify'
 import type { Herb } from '../types'
 
 function shuffle<T>(arr: T[]): T[] {
@@ -82,7 +83,7 @@ export default function RotatingHerbCard() {
             to={
               herb.slug
                 ? `/herb/${herb.slug}`
-                : `/database#${herb.name.replace(/\s+/g, '-').toLowerCase()}`
+                : `/database#${slugify(herb.name)}`
             }
             className='hover-glow mt-3 inline-block rounded-md bg-black/30 px-4 py-2 text-sand backdrop-blur-md hover:rotate-1'
           >
@@ -150,7 +151,7 @@ export default function RotatingHerbCard() {
             to={
               herb.slug
                 ? `/herb/${herb.slug}`
-                : `/database#${herb.name.replace(/\s+/g, '-').toLowerCase()}`
+                : `/database#${slugify(herb.name)}`
             }
             className='hover-glow mt-3 inline-block rounded-md bg-black/30 px-4 py-2 text-sand backdrop-blur-md hover:rotate-1'
           >


### PR DESCRIPTION
## Summary
- use `slugify` when linking to herbs from homepage components
- anchor each herb accordion by slug to enable hash navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ef269194c8323ae748e7d191ef3cc