### PR TITLE
Fix homepage featured herb card

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 import HeroBackground from './HeroBackground'
 import ParticlesBackground from './ParticlesBackground'
 import FloatingElements from './FloatingElements'
-import RotatingHerbCard from './RotatingHerbCard'
+import HeroFeaturedHerb from './HeroFeaturedHerb'
 import StatsCounters from './StatsCounters'
 
 export default function Hero() {
@@ -33,7 +33,7 @@ export default function Hero() {
           </motion.div>
 
           <div className='mt-2'>
-            <RotatingHerbCard />
+            <HeroFeaturedHerb />
           </div>
         </div>
 

--- a/src/components/HeroFeaturedHerb.tsx
+++ b/src/components/HeroFeaturedHerb.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from 'react'
+import { motion } from 'framer-motion'
+import { Link } from 'react-router-dom'
+import { herbs } from '../../herbsfull'
+import type { Herb } from '../types'
+import TagBadge from './TagBadge'
+import { slugify } from '../utils/slugify'
+import { decodeTag, tagVariant } from '../utils/format'
+
+interface Props {
+  fixedId?: string
+}
+
+export default function HeroFeaturedHerb({ fixedId = '' }: Props) {
+  const [herb, setHerb] = useState<Herb | null>(null)
+
+  useEffect(() => {
+    if (fixedId) {
+      const selected = herbs.find(h => h.id === fixedId || h.name === fixedId)
+      setHerb(selected ?? herbs[0])
+      return
+    }
+    const psychedelic = herbs.filter(h => h.category.includes('Psychedelic'))
+    const pool = psychedelic.length > 0 ? psychedelic : herbs
+    setHerb(pool[Math.floor(Math.random() * pool.length)])
+  }, [fixedId])
+
+  if (!herb) return null
+
+  const tags = Array.isArray(herb.tags) ? herb.tags.slice(0, 3) : []
+
+  return (
+    <motion.div
+      id='hero-featured-herb'
+      className='mx-auto mt-8 max-w-xs sm:max-w-sm'
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+    >
+      <motion.article
+        className='bg-psychedelic-gradient/30 soft-border-glow relative overflow-hidden rounded-2xl p-4 text-center text-white shadow-lg backdrop-blur-md'
+      >
+        {herb.image && (
+          <img src={herb.image} alt={herb.name} className='h-32 w-full rounded-md object-cover' />
+        )}
+        <h3 className='mt-3 font-herb text-2xl text-lime-300'>{herb.name}</h3>
+        {tags.length > 0 && (
+          <div className='mt-1 flex flex-wrap justify-center gap-1'>
+            {tags.map(tag => (
+              <TagBadge
+                key={tag}
+                label={decodeTag(tag)}
+                variant={tagVariant(tag)}
+                className='text-xs'
+              />
+            ))}
+          </div>
+        )}
+        {(() => {
+          const effects = Array.isArray(herb.effects)
+            ? herb.effects.slice(0, 3).join(', ')
+            : herb.effects || ''
+          return effects ? <p className='mt-1 text-sm text-sand'>{effects}</p> : null
+        })()}
+        <Link
+          to={`/herb/${herb.slug || herb.id || slugify(herb.name)}`}
+          className='hover-glow mt-3 inline-block rounded-md bg-black/30 px-4 py-2 text-sand backdrop-blur-md hover:bg-black/40'
+        >
+          More Info
+        </Link>
+        <motion.div
+          className='pointer-events-none absolute inset-0 rounded-2xl border-2 border-fuchsia-500/40'
+          animate={{ opacity: [0.6, 0.2, 0.6] }}
+          transition={{ duration: 2.5, repeat: Infinity }}
+        />
+      </motion.article>
+    </motion.div>
+  )
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import Hero from '../components/Hero'
 import StarfieldBackground from '../components/StarfieldBackground'
 import MouseTrail from '../components/MouseTrail'
-import FeaturedHerbTeaser from '../components/FeaturedHerbTeaser'
 
 export default function Home() {
   return (
@@ -14,7 +13,6 @@ export default function Home() {
       <StarfieldBackground />
       <MouseTrail />
       <Hero />
-      <FeaturedHerbTeaser />
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- introduce `HeroFeaturedHerb` to show a single random featured herb
- swap out `RotatingHerbCard` for new component in `Hero`
- clean up `Home` page to use the hero section only

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687ef5e581348323a52cc70861dc81b2