### PR TITLE
Add compound badges to herb cards

### DIFF
--- a/src/components/CompoundBadge.tsx
+++ b/src/components/CompoundBadge.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+import TagBadge from './TagBadge'
+import InfoTooltip from './InfoTooltip'
+import { slugify } from '../utils/slugify'
+import { compounds as compoundList } from '../data/compounds'
+
+export default function CompoundBadge({ name }: { name: string }) {
+  const info = compoundList.find(
+    c => c.name.toLowerCase() === name.toLowerCase()
+  )
+  const badge = (
+    <Link to={`/compound/${slugify(name)}`} className='inline-block'>
+      <TagBadge label={name} variant='green' />
+    </Link>
+  )
+  return info ? <InfoTooltip text={info.type}>{badge}</InfoTooltip> : badge
+}

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 import { Herb } from '../types/Herb'
 import TagBadge from './TagBadge'
 import InfoTooltip from './InfoTooltip'
+import CompoundBadge from './CompoundBadge'
 import { decodeTag, tagVariant } from '../utils/format'
 import { useHerbFavorites } from '../hooks/useHerbFavorites'
 import { Star } from 'lucide-react'
@@ -31,6 +32,9 @@ export default function HerbCardAccordion({ herb }: Props) {
   }, [expanded])
   const safeTags = Array.isArray(herb.tags) ? herb.tags : []
   const safeEffects = Array.isArray(herb.effects) ? herb.effects : []
+  const safeCompounds = Array.isArray((herb as any).compounds)
+    ? (herb as any).compounds
+    : []
   const favorite = isFavorite(herb.id)
 
   const containerVariants = {
@@ -175,18 +179,16 @@ export default function HerbCardAccordion({ herb }: Props) {
                 <strong>Intensity:</strong> {herb.intensity}
               </motion.p>
             )}
-            {Array.isArray(herb.activeConstituents) && herb.activeConstituents.length > 0 && (
-              <motion.p variants={itemVariants} className='whitespace-pre-wrap break-words'>
-                <strong>Active Compounds:</strong>{' '}
-                {herb.activeConstituents.map((c, i) => (
-                  <React.Fragment key={c.name}>
-                    {i > 0 && ', '}
-                    <Link to={`/compounds#${slugify(c.name)}`} className='underline'>
-                      {c.name}
-                    </Link>
-                  </React.Fragment>
+            {safeCompounds.length > 0 && (
+              <motion.div
+                variants={itemVariants}
+                className='flex flex-wrap items-center gap-1'
+              >
+                <strong className='mr-1'>Active Compounds:</strong>
+                {safeCompounds.map(c => (
+                  <CompoundBadge key={c} name={c} />
                 ))}
-              </motion.p>
+              </motion.div>
             )}
             {Array.isArray(herb.sources) && herb.sources.length > 0 && (
               <motion.div variants={itemVariants}>

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -5,6 +5,7 @@ import { Helmet } from 'react-helmet-async'
 import { herbs } from '../../herbsfull'
 import { decodeTag, tagVariant } from '../utils/format'
 import TagBadge from '../components/TagBadge'
+import CompoundBadge from '../components/CompoundBadge'
 import { slugify } from '../utils/slugify'
 import { useLocalStorage } from '../hooks/useLocalStorage'
 
@@ -40,6 +41,9 @@ export default function HerbDetail() {
   const herb = herbs.find(h => h.id === id)
   const [notes, setNotes] = useLocalStorage(`notes-${id}`, '')
   const [showSimilar, setShowSimilar] = React.useState(false)
+  const safeCompounds = Array.isArray((herb as any)?.compounds)
+    ? ((herb as any).compounds as string[])
+    : []
   if (!herb) {
     return (
       <div className='p-6 text-center'>
@@ -100,16 +104,11 @@ export default function HerbDetail() {
               </div>
             )
           })}
-          {Array.isArray(herb.activeConstituents) && herb.activeConstituents.length > 0 && (
-            <div>
-              <span className='font-semibold text-lime-300'>Active Compounds:</span>{' '}
-              {herb.activeConstituents.map((c, i) => (
-                <React.Fragment key={c.name}>
-                  {i > 0 && ', '}
-                  <Link className='text-sky-300 underline' to={`/compounds#${slugify(c.name)}`}>
-                    {c.name}
-                  </Link>
-                </React.Fragment>
+          {safeCompounds.length > 0 && (
+            <div className='flex flex-wrap items-center gap-1'>
+              <span className='font-semibold text-lime-300 w-full'>Active Compounds:</span>
+              {safeCompounds.map(c => (
+                <CompoundBadge key={c} name={c} />
               ))}
             </div>
           )}

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,8 @@ export interface Herb {
   duration?: string
   legalStatus?: string
   region?: string
+  /** Array of active psychoactive compounds present in the herb */
+  compounds?: string[]
   tags?: string[]
   sources?: string[]
   needsReview?: boolean


### PR DESCRIPTION
## Summary
- create `CompoundBadge` component
- display active compound tags in `HerbCardAccordion`
- show active compounds in `HerbDetail` page
- type update for herbs to include `compounds`

## Testing
- `npm test`
- `npm run validate-herbs`
- `npx tsc -p tsconfig.json` *(fails: numerous existing TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f032b0d148323a103331cf96c8b8a