### PR TITLE
Add animated tag filter bar

### DIFF
--- a/src/components/TagFilterBar.tsx
+++ b/src/components/TagFilterBar.tsx
@@ -1,39 +1,34 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React from 'react'
 import { motion } from 'framer-motion'
 import { decodeTag } from '../utils/format'
-import { canonicalTag } from '../utils/tagUtils'
-import { herbs } from '../../herbsfull'
 
 interface Props {
   /**
-   * Optional list of tags to display. If omitted the tags will
-   * be generated from the global herbs dataset.
+   * List of all unique tags available for filtering.
    */
-  tags?: string[]
-  onChange?: (tags: string[]) => void
+  allTags: string[]
+  /**
+   * Currently active tags used for filtering.
+   */
+  activeTags: string[]
+  /**
+   * Toggle a tag on/off in the parent state.
+   */
+  onToggleTag: (tag: string) => void
 }
 
-export default function TagFilterBar({ tags, onChange }: Props) {
-  const unique = useMemo(() => {
-    if (tags && tags.length) return Array.from(new Set(tags))
-    const all = herbs.flatMap(h => h.tags ?? [])
-    return Array.from(new Set(all.map(canonicalTag)))
-  }, [tags])
-  const [activeTags, setActiveTags] = useState<string[]>([])
-
+export default function TagFilterBar({ allTags, activeTags, onToggleTag }: Props) {
   const toggle = (tag: string) => {
-    setActiveTags(prev =>
-      prev.includes(tag) ? prev.filter(t => t !== tag) : [...prev, tag]
-    )
+    onToggleTag(tag)
   }
 
-  useEffect(() => {
-    onChange?.(activeTags)
-  }, [activeTags, onChange])
+  const clearAll = () => {
+    activeTags.forEach(t => onToggleTag(t))
+  }
 
   return (
-    <div className='flex gap-2 overflow-x-auto py-2 no-scrollbar'>
-      {unique.map(tag => {
+    <div className='no-scrollbar flex gap-2 overflow-x-auto py-2'>
+      {allTags.map(tag => {
         const active = activeTags.includes(tag)
         return (
           <motion.button
@@ -48,7 +43,7 @@ export default function TagFilterBar({ tags, onChange }: Props) {
                 : { scale: 1, boxShadow: 'none' }
             }
             transition={{ type: 'spring', stiffness: 220, damping: 12 }}
-            className={`tag-pill whitespace-nowrap hover-glow ${active ? 'bg-emerald-700/70 text-white ring-2 ring-emerald-400' : 'bg-space-dark/70 text-sand'}`}
+            className={`tag-pill hover-glow whitespace-nowrap ${active ? 'bg-emerald-700/70 text-white ring-2 ring-emerald-400' : 'bg-space-dark/70 text-sand'}`}
           >
             {decodeTag(tag)}
           </motion.button>
@@ -57,11 +52,11 @@ export default function TagFilterBar({ tags, onChange }: Props) {
       {activeTags.length > 0 && (
         <motion.button
           type='button'
-          onClick={() => setActiveTags([])}
+          onClick={clearAll}
           whileTap={{ scale: 0.9 }}
           whileHover={{ scale: 1.08 }}
           transition={{ type: 'spring', stiffness: 220, damping: 12 }}
-          className='tag-pill whitespace-nowrap hover-glow bg-rose-700/70 text-white'
+          className='tag-pill hover-glow whitespace-nowrap bg-rose-700/70 text-white'
         >
           Clear Filters
         </motion.button>

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -79,6 +79,12 @@ export default function Database() {
     return { total: herbs.length, affiliates, moaCount }
   }, [herbs])
 
+  const toggleTag = React.useCallback(
+    (tag: string) =>
+      setFilteredTags(prev => (prev.includes(tag) ? prev.filter(t => t !== tag) : [...prev, tag])),
+    [setFilteredTags]
+  )
+
   const [filtersOpen, setFiltersOpen] = React.useState(false)
   const [showBar, setShowBar] = React.useState(true)
 
@@ -198,7 +204,7 @@ export default function Database() {
 
           <div className={`mb-4 space-y-4 ${filtersOpen ? '' : 'hidden sm:block'}`}>
             <CategoryFilter selected={filteredCategories} onChange={setFilteredCategories} />
-            <TagFilterBar tags={allTags} onChange={setFilteredTags} />
+            <TagFilterBar allTags={allTags} activeTags={filteredTags} onToggleTag={toggleTag} />
           </div>
           {relatedTags.length > 0 && (
             <div className='mb-4 flex flex-wrap items-center gap-2'>


### PR DESCRIPTION
## Summary
- implement animated `TagFilterBar` with controlled state
- allow Database page to toggle tags via the new component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fb02958a48323b181c7b3850f765c