### PR TITLE
Add compounds index page

### DIFF
--- a/src/components/CompoundCard.tsx
+++ b/src/components/CompoundCard.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import { motion } from 'framer-motion'
 import { Link } from 'react-router-dom'
-import type { CompoundEntry } from '../data/compounds'
+import type { Compound } from '../data/compoundsIndex'
 import TagBadge from './TagBadge'
 import { slugify } from '../utils/slugify'
 
-export default function CompoundCard({ compound }: { compound: CompoundEntry }) {
+export default function CompoundCard({ compound }: { compound: Compound }) {
   return (
     <motion.article
       whileHover={{ scale: 1.03 }}
@@ -14,11 +14,11 @@ export default function CompoundCard({ compound }: { compound: CompoundEntry }) 
       <h2 className='mb-1 text-lg font-bold text-white'>{compound.name}</h2>
       <div className='mb-2 flex flex-wrap gap-2'>
         <TagBadge label={compound.type} />
-        <TagBadge label={compound.psychoactivity} variant='blue' />
+        <TagBadge label={compound.effectClass} variant='blue' />
       </div>
-      <p className='mb-2 text-sm text-sand'>{compound.description}</p>
+      <p className='mb-2 text-sm text-sand'>{compound.mechanism}</p>
       <div className='mt-auto flex flex-wrap gap-1'>
-        {compound.foundIn.map(h => (
+        {compound.sourceHerbs.map(h => (
           <Link
             key={h}
             to={`/database#${slugify(h)}`}

--- a/src/data/compoundsIndex.ts
+++ b/src/data/compoundsIndex.ts
@@ -1,0 +1,68 @@
+export interface Compound {
+  name: string
+  type: string
+  sourceHerbs: string[]
+  effectClass: string
+  mechanism: string
+}
+
+export const compounds: Compound[] = [
+  {
+    name: 'Psilocybin',
+    type: 'Tryptamine',
+    sourceHerbs: ['Psilocybe cubensis', 'Psilocybe cyanescens'],
+    effectClass: 'Psychedelic',
+    mechanism: '5-HT2A receptor agonist causing altered perception and cognition.',
+  },
+  {
+    name: 'Thujone',
+    type: 'Monoterpene Ketone',
+    sourceHerbs: ['Wormwood', 'Sage'],
+    effectClass: 'Stimulant / Deliriant',
+    mechanism: 'GABA-A receptor antagonist causing CNS stimulation.',
+  },
+  {
+    name: 'DMT',
+    type: 'Tryptamine',
+    sourceHerbs: ['Acacia maidenii', 'Anadenanthera peregrina'],
+    effectClass: 'Psychedelic',
+    mechanism: 'Powerful serotonin 5-HT2A agonist producing intense visions.',
+  },
+  {
+    name: 'Harmine',
+    type: 'Beta-carboline',
+    sourceHerbs: ['Banisteriopsis caapi', 'Syrian Rue'],
+    effectClass: 'MAOI',
+    mechanism: 'Reversible MAO-A inhibitor that potentiates tryptamines.',
+  },
+  {
+    name: 'Mescaline',
+    type: 'Phenethylamine',
+    sourceHerbs: ['Peyote', 'San Pedro'],
+    effectClass: 'Psychedelic',
+    mechanism: '5-HT2A receptor agonist with empathogenic qualities.',
+  },
+  {
+    name: 'Muscimol',
+    type: 'Isoxazole',
+    sourceHerbs: ['Amanita muscaria'],
+    effectClass: 'Sedative / Deliriant',
+    mechanism: 'GABA_A receptor agonist causing dissociative, sedative effects.',
+  },
+  {
+    name: 'Caffeine',
+    type: 'Xanthine',
+    sourceHerbs: ['Camellia sinensis', 'Coffee'],
+    effectClass: 'Stimulant',
+    mechanism: 'Adenosine receptor antagonist increasing alertness.',
+  },
+  {
+    name: 'CBD',
+    type: 'Cannabinoid',
+    sourceHerbs: ['Cannabis sativa'],
+    effectClass: 'Modulator',
+    mechanism: 'Modulates the endocannabinoid system and serotonin 5-HT1A.',
+  },
+]
+
+export default compounds

--- a/src/pages/Compounds.tsx
+++ b/src/pages/Compounds.tsx
@@ -1,14 +1,19 @@
 import React, { useMemo, useState } from 'react'
 import { Helmet } from 'react-helmet-async'
-import { compounds, CompoundEntry } from '../data/compounds'
+import { compounds, Compound } from '../data/compoundsIndex'
 import CompoundCard from '../components/CompoundCard'
 
 export default function CompoundsPage() {
   const [search, setSearch] = useState('')
   const [typeFilter, setTypeFilter] = useState('')
+  const [classFilter, setClassFilter] = useState('')
 
   const types = useMemo(
     () => Array.from(new Set(compounds.map(c => c.type))).sort(),
+    []
+  )
+  const classes = useMemo(
+    () => Array.from(new Set(compounds.map(c => c.effectClass))).sort(),
     []
   )
 
@@ -18,11 +23,12 @@ export default function CompoundsPage() {
       const matchesSearch =
         !q ||
         c.name.toLowerCase().includes(q) ||
-        c.foundIn.some(h => h.toLowerCase().includes(q))
+        c.sourceHerbs.some(h => h.toLowerCase().includes(q))
       const matchesType = !typeFilter || c.type === typeFilter
-      return matchesSearch && matchesType
+      const matchesClass = !classFilter || c.effectClass === classFilter
+      return matchesSearch && matchesType && matchesClass
     })
-  }, [search, typeFilter])
+  }, [search, typeFilter, classFilter])
 
   return (
     <>
@@ -53,10 +59,22 @@ export default function CompoundsPage() {
                 </option>
               ))}
             </select>
+            <select
+              value={classFilter}
+              onChange={e => setClassFilter(e.target.value)}
+              className='w-full rounded-md bg-space-dark/70 px-3 py-2 text-white backdrop-blur-md focus:outline-none sm:w-56'
+            >
+              <option value=''>All Classes</option>
+              {classes.map(c => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
           </div>
           <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'>
             {filtered.map(c => (
-              <CompoundCard key={c.name} compound={c as CompoundEntry} />
+              <CompoundCard key={c.name} compound={c} />
             ))}
           </div>
         </div>


### PR DESCRIPTION
## Summary
- implement a new `compoundsIndex` dataset describing psychoactive compounds
- update `CompoundCard` to display effect class, mechanism and link to herbs
- build `/compounds` page using the new data with filters for type and class

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687fc206208c8323bfc4f6cad0f0b98d