### PR TITLE
Improve light mode herb card styling

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,6 @@
 export default function Footer() {
   return (
-    <footer className='relative py-6 text-center text-sm text-gray-600 dark:text-sand'>
+  <footer className='relative py-6 text-center text-sm text-gray-800 dark:text-sand'>
       <div
         className='absolute inset-0 mx-auto my-0 h-full w-11/12 rounded-full border border-comet/40 blur-sm'
         aria-hidden='true'

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -67,10 +67,10 @@ export default function HerbCardAccordion({ herb }: Props) {
       role='button'
       tabIndex={0}
       aria-expanded={expanded}
-      className='bg-psychedelic-gradient/30 soft-border-glow group relative cursor-pointer overflow-hidden rounded-2xl p-4 text-white shadow-lg backdrop-blur-md transition-all hover:shadow-intense focus:outline-none'
+      className='group relative cursor-pointer overflow-hidden rounded-lg border border-gray-200 bg-white p-4 text-gray-800 shadow-sm transition-all hover:border-lime-400 hover:shadow-md focus:outline-none dark:bg-psychedelic-gradient/30 dark:text-white dark:soft-border-glow dark:shadow-lg dark:hover:shadow-intense'
     >
       <motion.div
-        className='pointer-events-none absolute inset-0 rounded-2xl border-2 border-fuchsia-500/40'
+        className='pointer-events-none absolute inset-0 rounded-lg border-2 border-fuchsia-500/40 dark:rounded-2xl'
         animate={expanded ? { opacity: 1, scale: 1.05 } : { opacity: 0 }}
         transition={{ duration: 0.4, ease: 'easeInOut' }}
       />
@@ -86,22 +86,24 @@ export default function HerbCardAccordion({ herb }: Props) {
         <Star className={`h-5 w-5 ${favorite ? 'fill-yellow-400 text-yellow-400' : ''}`} />
       </button>
       <div className='flex items-center gap-2'>
-        <span className='text-xl font-bold text-lime-300 transition group-hover:text-lime-200 group-hover:drop-shadow-[0_0_6px_rgba(163,255,134,0.8)]'>
+        <span className='text-xl font-bold text-lime-600 transition group-hover:text-lime-700 group-hover:drop-shadow-[0_0_6px_rgba(163,255,134,0.8)] dark:text-lime-300 dark:group-hover:text-lime-200'>
           {herb.name || 'Unknown Herb'}
         </span>
       </div>
       <p className='text-sm italic text-sand'>{herb.scientificName || 'Unknown species'}</p>
       {!expanded && herbBlurbs[herb.name] && (
-        <p className='mt-1 text-sm italic text-gray-300'>{herbBlurbs[herb.name]}</p>
+        <p className='mt-1 text-sm italic text-gray-800 dark:text-gray-300'>
+          {herbBlurbs[herb.name]}
+        </p>
       )}
 
       {expanded && (
         <>
-          <div className='mt-2 text-sm text-white'>
+          <div className='mt-2 text-sm text-gray-800 dark:text-white'>
             <strong>Effects:</strong> {safeEffects.length > 0 ? safeEffects.join(', ') : 'Unknown'}
           </div>
 
-          <div className='mt-2 text-sm text-white'>
+          <div className='mt-2 text-sm text-gray-800 dark:text-white'>
             <strong>Description:</strong> {herb.description || herbBlurbs[herb.name] || ''}
           </div>
         </>

--- a/src/components/TagBadge.tsx
+++ b/src/components/TagBadge.tsx
@@ -18,6 +18,15 @@ const colorMap = {
   red: 'from-rose-600 via-red-500 to-rose-600 shadow-red-500/40',
 }
 
+const textColorMap = {
+  pink: 'text-white',
+  blue: 'text-white',
+  purple: 'text-white',
+  green: 'text-white',
+  yellow: 'text-black',
+  red: 'text-white',
+} as const
+
 export default function TagBadge({ label, variant = 'purple', className }: Props) {
   const cleaned = label.replace(/☠️/g, '').trim()
   const alias = tagAliasMap[cleaned.toLowerCase()]
@@ -30,8 +39,10 @@ export default function TagBadge({ label, variant = 'purple', className }: Props
       whileTap={{ scale: 0.95 }}
       tabIndex={0}
       className={clsx(
-        'hover-glow soft-border-glow text-shadow inline-flex items-center whitespace-pre-wrap break-words rounded-full bg-gradient-to-br px-2 py-0.5 text-xs font-medium text-white/90 shadow ring-1 ring-white/40 backdrop-blur-sm dark:ring-black/40',
+        'hover-glow soft-border-glow text-shadow inline-flex items-center whitespace-pre-wrap break-words rounded-full bg-gradient-to-br px-2 py-0.5 text-xs font-medium shadow ring-1 ring-white/40 backdrop-blur-sm dark:ring-black/40',
         colorMap[variant],
+        textColorMap[variant],
+        'dark:text-white',
         className
       )}
     >

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -97,7 +97,7 @@ export default function HerbDetail() {
             if (!raw) return null
             return (
               <div key={key}>
-                <span className='font-semibold text-lime-300'>
+                <span className='font-semibold text-lime-600 dark:text-lime-300'>
                   {key.replace(/([A-Z])/g, ' $1')}:
                 </span>{' '}
                 {raw}
@@ -106,7 +106,7 @@ export default function HerbDetail() {
           })}
           {safeCompounds.length > 0 && (
             <div className='flex flex-wrap items-center gap-1'>
-              <span className='font-semibold text-lime-300 w-full'>Active Compounds:</span>
+              <span className='font-semibold text-lime-600 dark:text-lime-300 w-full'>Active Compounds:</span>
               {safeCompounds.map(c => (
                 <CompoundBadge key={c} name={c} />
               ))}

--- a/src/pages/HerbDetailView.tsx
+++ b/src/pages/HerbDetailView.tsx
@@ -43,18 +43,18 @@ export default function HerbDetailView() {
         const eff = Array.isArray(herb.effects) ? herb.effects.join(', ') : herb.effects || ''
         return eff ? (
           <div>
-            <span className='font-semibold text-lime-300'>Effects:</span> {eff}
+            <span className='font-semibold text-lime-600 dark:text-lime-300'>Effects:</span> {eff}
           </div>
         ) : null
       })()}
       {herb.region && (
         <div>
-          <span className='font-semibold text-lime-300'>Region:</span> {herb.region}
+            <span className='font-semibold text-lime-600 dark:text-lime-300'>Region:</span> {herb.region}
         </div>
       )}
       {(herb as any).history && (
         <div>
-          <span className='font-semibold text-lime-300'>History:</span> {(herb as any).history}
+            <span className='font-semibold text-lime-600 dark:text-lime-300'>History:</span> {(herb as any).history}
         </div>
       )}
       {Array.isArray(herb.tags) && herb.tags.length > 0 && (
@@ -71,7 +71,7 @@ export default function HerbDetailView() {
     <div className='space-y-2'>
       {Array.isArray(herb.activeConstituents) && herb.activeConstituents.length > 0 && (
         <div>
-          <span className='font-semibold text-lime-300'>Compounds:</span>{' '}
+            <span className='font-semibold text-lime-600 dark:text-lime-300'>Compounds:</span>{' '}
           {herb.activeConstituents.map((c, i) => (
             <React.Fragment key={c.name}>
               {i > 0 && ', '}
@@ -84,12 +84,12 @@ export default function HerbDetailView() {
       )}
       {herb.mechanismOfAction && (
         <div>
-          <span className='font-semibold text-lime-300'>Mechanism:</span> {herb.mechanismOfAction}
+            <span className='font-semibold text-lime-600 dark:text-lime-300'>Mechanism:</span> {herb.mechanismOfAction}
         </div>
       )}
       {herb.toxicityLD50 && (
         <div>
-          <span className='font-semibold text-lime-300'>LD50:</span> {herb.toxicityLD50}
+            <span className='font-semibold text-lime-600 dark:text-lime-300'>LD50:</span> {herb.toxicityLD50}
         </div>
       )}
     </div>
@@ -99,17 +99,17 @@ export default function HerbDetailView() {
     <div className='space-y-2'>
       {herb.preparation && (
         <div>
-          <span className='font-semibold text-lime-300'>Prep:</span> {herb.preparation}
+            <span className='font-semibold text-lime-600 dark:text-lime-300'>Prep:</span> {herb.preparation}
         </div>
       )}
       {herb.intensity && (
         <div>
-          <span className='font-semibold text-lime-300'>Intensity:</span> {herb.intensity}
+            <span className='font-semibold text-lime-600 dark:text-lime-300'>Intensity:</span> {herb.intensity}
         </div>
       )}
       {herb.dosage && (
         <div>
-          <span className='font-semibold text-lime-300'>Dosage:</span> {herb.dosage}
+            <span className='font-semibold text-lime-600 dark:text-lime-300'>Dosage:</span> {herb.dosage}
         </div>
       )}
       {herb.affiliateLink && herb.affiliateLink.startsWith('http') ? (


### PR DESCRIPTION
## Summary
- adjust border, background, and hover effects for herb cards in light mode
- darken light-mode headings and blurbs
- ensure TagBadge variants pick readable text colors
- tweak footer color
- update herb detail pages for lime text contrast

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687fcb0146008323bcb592fc883186d2