### PR TITLE
Polish light mode visuals

### DIFF
--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -67,7 +67,7 @@ export default function HerbCardAccordion({ herb }: Props) {
       role='button'
       tabIndex={0}
       aria-expanded={expanded}
-      className='group relative cursor-pointer overflow-hidden rounded-lg border border-gray-200 bg-white p-4 text-gray-800 shadow-sm transition-all hover:border-lime-400 hover:shadow-md focus:outline-none dark:bg-psychedelic-gradient/30 dark:text-white dark:soft-border-glow dark:shadow-lg dark:hover:shadow-intense'
+        className='group relative cursor-pointer overflow-hidden rounded-lg border border-gray-200 bg-white p-4 text-gray-800 shadow-sm transition-all duration-150 hover:border-lime-400 hover:shadow-md focus:outline-none dark:bg-psychedelic-gradient/30 dark:text-white dark:soft-border-glow dark:shadow-lg dark:hover:shadow-intense'
     >
       <motion.div
         className='pointer-events-none absolute inset-0 rounded-lg border-2 border-fuchsia-500/40 dark:rounded-2xl'
@@ -90,7 +90,7 @@ export default function HerbCardAccordion({ herb }: Props) {
           {herb.name || 'Unknown Herb'}
         </span>
       </div>
-      <p className='text-sm italic text-sand'>{herb.scientificName || 'Unknown species'}</p>
+      <p className='text-sm italic text-gray-600'>{herb.scientificName || 'Unknown species'}</p>
       {!expanded && herbBlurbs[herb.name] && (
         <p className='mt-1 text-sm italic text-gray-800 dark:text-gray-300'>
           {herbBlurbs[herb.name]}

--- a/src/components/RotatingHerbCard.tsx
+++ b/src/components/RotatingHerbCard.tsx
@@ -163,13 +163,15 @@ export default function RotatingHerbCard() {
             animate={{ filter: ['hue-rotate(0deg)', 'hue-rotate(360deg)'] }}
             transition={{ duration: 8, repeat: Infinity, ease: 'linear' }}
           />
-          <motion.div
-            key={index}
-            className='absolute bottom-0 left-0 h-1 w-full bg-forest-green/40'
-            initial={{ width: 0 }}
-            animate={{ width: '100%' }}
-            transition={{ duration: INTERVAL / 1000, ease: 'linear' }}
-          />
+          <div className='absolute bottom-2 left-2 right-2 h-2 rounded-full bg-gray-300'>
+            <motion.div
+              key={index}
+              className='h-full rounded-full bg-purple-500'
+              initial={{ width: 0 }}
+              animate={{ width: '100%' }}
+              transition={{ duration: INTERVAL / 1000, ease: 'linear' }}
+            />
+          </div>
         </motion.div>
       </AnimatePresence>
     </div>

--- a/src/components/TagBadge.tsx
+++ b/src/components/TagBadge.tsx
@@ -39,7 +39,7 @@ export default function TagBadge({ label, variant = 'purple', className }: Props
       whileTap={{ scale: 0.95 }}
       tabIndex={0}
       className={clsx(
-        'hover-glow soft-border-glow text-shadow inline-flex items-center whitespace-pre-wrap break-words rounded-full bg-gradient-to-br px-2 py-0.5 text-xs font-medium shadow ring-1 ring-white/40 backdrop-blur-sm dark:ring-black/40',
+        'hover-glow soft-border-glow text-shadow inline-flex items-center whitespace-pre-wrap break-words rounded-full bg-gradient-to-br px-2 py-1 text-xs font-medium shadow ring-1 ring-white/40 backdrop-blur-sm dark:ring-black/40',
         colorMap[variant],
         textColorMap[variant],
         'dark:text-white',

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -73,7 +73,9 @@ export default function HerbDetail() {
           ← Back
         </Link>
         <h1 className='text-gradient text-4xl font-bold'>{herb.name}</h1>
-        {herb.scientificName && <p className='italic'>{herb.scientificName}</p>}
+        {herb.scientificName && (
+          <p className='italic text-gray-600'>{herb.scientificName}</p>
+        )}
         <div className='space-y-2'>
           {[
             'description',

--- a/src/pages/HerbDetailView.tsx
+++ b/src/pages/HerbDetailView.tsx
@@ -170,7 +170,9 @@ export default function HerbDetailView() {
         <h1 className='text-gradient flex items-center gap-2 text-4xl font-bold'>
           <span>{herb.name}</span>
         </h1>
-        {herb.scientificName && <p className='italic'>{herb.scientificName}</p>}
+        {herb.scientificName && (
+          <p className='italic text-gray-600'>{herb.scientificName}</p>
+        )}
         <button
           type='button'
           onClick={copyLink}


### PR DESCRIPTION
## Summary
- improve tag badge padding for clarity
- style rotating herb progress bar
- tweak herb card readability in light mode
- add styling to scientific names on herb detail pages

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687fd9c15b04832393569aa94f45069a