### PR TITLE
Improve dark mode styling for herb database

### DIFF
--- a/src/components/CategoryAnalytics.tsx
+++ b/src/components/CategoryAnalytics.tsx
@@ -42,9 +42,9 @@ export default function CategoryAnalytics() {
       {display.map(([cat, count]) => (
         <div key={cat} className='flex items-center gap-2'>
           <span className='w-40 text-sm'>{cat}</span>
-          <div className='flex-1 bg-slate-700/50 h-2 rounded'>
+          <div className='flex-1 h-2 rounded bg-gray-200 dark:bg-gray-700 transition-colors duration-300'>
             <div
-              className='h-2 rounded bg-fuchsia-500'
+              className='h-2 rounded bg-pink-500 dark:bg-pink-400 transition-colors duration-300'
               style={{ width: `${(count / max) * 100}%` }}
             />
           </div>

--- a/src/components/CategoryFilter.tsx
+++ b/src/components/CategoryFilter.tsx
@@ -31,7 +31,7 @@ export default function CategoryFilter({ selected, onChange }: Props) {
             key={cat}
             type='button'
             onClick={() => toggle(cat)}
-            className={`tag-pill ${selected.includes(cat) ? 'ring-2 ring-emerald-400' : ''}`}
+            className={`tag-pill transition-colors duration-300 ${selected.includes(cat) ? 'ring-2 ring-emerald-400 bg-emerald-700/70 text-white dark:bg-emerald-800' : 'bg-space-dark/70 text-sand dark:bg-gray-800 dark:text-gray-200'}`}
           >
             {cat} ({count})
           </button>

--- a/src/components/CompoundCard.tsx
+++ b/src/components/CompoundCard.tsx
@@ -22,7 +22,7 @@ export default function CompoundCard({ compound }: { compound: Compound }) {
           <Link
             key={h}
             to={`/database#${slugify(h)}`}
-            className='tag-pill bg-space-dark/70 text-sand hover-glow'
+            className='tag-pill bg-space-dark/70 text-sand hover-glow transition-colors duration-300 dark:bg-gray-800 dark:text-gray-200'
           >
             {h}
           </Link>

--- a/src/components/CompoundTagFilter.tsx
+++ b/src/components/CompoundTagFilter.tsx
@@ -30,7 +30,7 @@ export default function CompoundTagFilter({ options, onChange }: { options: Opti
             whileHover={{ scale: 1.08 }}
             animate={act ? { scale: [1, 1.15, 1], boxShadow: '0 0 8px rgba(16,185,129,0.8)' } : { scale: 1, boxShadow: 'none' }}
             transition={{ type: 'spring', stiffness: 220, damping: 12 }}
-            className={`tag-pill whitespace-nowrap hover-glow ${act ? 'bg-emerald-700/70 text-white ring-2 ring-emerald-400' : 'bg-space-dark/70 text-sand'}`}
+            className={`tag-pill whitespace-nowrap hover-glow transition-colors duration-300 ${act ? 'bg-emerald-700/70 text-white ring-2 ring-emerald-400 dark:bg-emerald-800' : 'bg-space-dark/70 text-sand dark:bg-gray-800 dark:text-gray-200'}`}
           >
             {opt.label}
           </motion.button>
@@ -43,7 +43,7 @@ export default function CompoundTagFilter({ options, onChange }: { options: Opti
           whileTap={{ scale: 0.9 }}
           whileHover={{ scale: 1.08 }}
           transition={{ type: 'spring', stiffness: 220, damping: 12 }}
-          className='tag-pill whitespace-nowrap hover-glow bg-rose-700/70 text-white'
+          className='tag-pill whitespace-nowrap hover-glow bg-rose-700/70 text-white dark:bg-rose-800 transition-colors duration-300'
         >
           Clear
         </motion.button>

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -67,7 +67,7 @@ export default function HerbCardAccordion({ herb }: Props) {
       role='button'
       tabIndex={0}
       aria-expanded={expanded}
-        className='group relative cursor-pointer overflow-hidden rounded-lg border border-gray-200 bg-white p-4 text-gray-800 shadow-sm transition-all duration-150 hover:border-lime-400 hover:shadow-md focus:outline-none dark:bg-psychedelic-gradient/30 dark:text-white dark:soft-border-glow dark:shadow-lg dark:hover:shadow-intense'
+      className='group relative cursor-pointer overflow-hidden rounded-lg border border-gray-200 bg-white p-4 text-gray-800 shadow-sm transition-colors duration-300 hover:border-lime-400 hover:shadow-md focus:outline-none dark:border-gray-800 dark:bg-gray-900 dark:text-gray-100'
     >
       <motion.div
         className='pointer-events-none absolute inset-0 rounded-lg border-2 border-fuchsia-500/40 dark:rounded-2xl'
@@ -90,9 +90,9 @@ export default function HerbCardAccordion({ herb }: Props) {
           {herb.name || 'Unknown Herb'}
         </span>
       </div>
-      <p className='text-sm italic text-gray-600'>{herb.scientificName || 'Unknown species'}</p>
+      <p className='text-sm italic text-gray-700 dark:text-gray-300 transition-colors duration-300'>{herb.scientificName || 'Unknown species'}</p>
       {!expanded && herbBlurbs[herb.name] && (
-        <p className='mt-1 text-sm italic text-gray-800 dark:text-gray-300'>
+        <p className='mt-1 text-sm italic text-gray-800 dark:text-gray-100 transition-colors duration-300'>
           {herbBlurbs[herb.name]}
         </p>
       )}
@@ -103,7 +103,7 @@ export default function HerbCardAccordion({ herb }: Props) {
             <strong>Effects:</strong> {safeEffects.length > 0 ? safeEffects.join(', ') : 'Unknown'}
           </div>
 
-          <div className='mt-2 text-sm text-gray-800 dark:text-white'>
+          <div className='mt-2 text-sm text-gray-700 dark:text-gray-300 transition-colors duration-300'>
             <strong>Description:</strong> {herb.description || herbBlurbs[herb.name] || ''}
           </div>
         </>

--- a/src/components/SearchFilter.tsx
+++ b/src/components/SearchFilter.tsx
@@ -89,7 +89,7 @@ const SearchFilter: React.FC<SearchFilterProps> = ({ herbs, onFilter }) => {
       />
       <div className='flex flex-wrap items-center gap-2 gap-y-2'>
         {selectedTags.map(tag => (
-          <button type='button' key={tag} onClick={() => removeTag(tag)} className='tag-pill'>
+          <button type='button' key={tag} onClick={() => removeTag(tag)} className='tag-pill transition-colors duration-300 dark:bg-gray-800 dark:text-gray-200'>
             {decodeTag(tag)}
           </button>
         ))}

--- a/src/components/TagBadge.tsx
+++ b/src/components/TagBadge.tsx
@@ -10,12 +10,12 @@ interface Props {
 }
 
 const colorMap = {
-  pink: 'from-pink-600 via-fuchsia-500 to-pink-600 shadow-pink-500/40',
-  blue: 'from-sky-600 via-cyan-500 to-sky-600 shadow-cyan-500/40',
-  purple: 'from-purple-700 via-violet-600 to-purple-700 shadow-violet-600/40',
-  green: 'from-lime-600 via-emerald-500 to-lime-600 shadow-emerald-500/40',
-  yellow: 'from-amber-600 via-yellow-500 to-amber-600 shadow-amber-500/40',
-  red: 'from-rose-600 via-red-500 to-rose-600 shadow-red-500/40',
+  pink: 'from-pink-600 via-fuchsia-500 to-pink-600 shadow-pink-500/40 dark:bg-pink-800',
+  blue: 'from-sky-600 via-cyan-500 to-sky-600 shadow-cyan-500/40 dark:bg-sky-800',
+  purple: 'from-purple-700 via-violet-600 to-purple-700 shadow-violet-600/40 dark:bg-purple-800',
+  green: 'from-lime-600 via-emerald-500 to-lime-600 shadow-emerald-500/40 dark:bg-green-800',
+  yellow: 'from-amber-600 via-yellow-500 to-amber-600 shadow-amber-500/40 dark:bg-yellow-700',
+  red: 'from-rose-600 via-red-500 to-rose-600 shadow-red-500/40 dark:bg-red-800',
 }
 
 const textColorMap = {
@@ -23,7 +23,7 @@ const textColorMap = {
   blue: 'text-white',
   purple: 'text-white',
   green: 'text-white',
-  yellow: 'text-black',
+  yellow: 'text-black dark:text-white',
   red: 'text-white',
 } as const
 
@@ -39,7 +39,7 @@ export default function TagBadge({ label, variant = 'purple', className }: Props
       whileTap={{ scale: 0.95 }}
       tabIndex={0}
       className={clsx(
-        'hover-glow soft-border-glow text-shadow inline-flex items-center whitespace-pre-wrap break-words rounded-full bg-gradient-to-br px-2 py-1 text-xs font-medium shadow ring-1 ring-white/40 backdrop-blur-sm dark:ring-black/40',
+        'hover-glow soft-border-glow text-shadow inline-flex items-center whitespace-pre-wrap break-words rounded-full bg-gradient-to-br px-2 py-1 text-xs font-medium shadow ring-1 ring-white/40 backdrop-blur-sm dark:ring-black/40 transition-colors duration-300',
         colorMap[variant],
         textColorMap[variant],
         'dark:text-white',

--- a/src/components/TagFilterBar.tsx
+++ b/src/components/TagFilterBar.tsx
@@ -43,7 +43,7 @@ export default function TagFilterBar({ allTags, activeTags, onToggleTag }: Props
                 : { scale: 1, boxShadow: 'none' }
             }
             transition={{ type: 'spring', stiffness: 220, damping: 12 }}
-            className={`tag-pill hover-glow whitespace-nowrap ${active ? 'bg-emerald-700/70 text-white ring-2 ring-emerald-400' : 'bg-space-dark/70 text-sand'}`}
+            className={`tag-pill hover-glow whitespace-nowrap transition-colors duration-300 ${active ? 'bg-emerald-700/70 text-white ring-2 ring-emerald-400 dark:bg-emerald-800' : 'bg-space-dark/70 text-sand dark:bg-gray-800 dark:text-gray-200'}`}
           >
             {decodeTag(tag)}
           </motion.button>
@@ -56,7 +56,7 @@ export default function TagFilterBar({ allTags, activeTags, onToggleTag }: Props
           whileTap={{ scale: 0.9 }}
           whileHover={{ scale: 1.08 }}
           transition={{ type: 'spring', stiffness: 220, damping: 12 }}
-          className='tag-pill hover-glow whitespace-nowrap bg-rose-700/70 text-white'
+          className='tag-pill hover-glow whitespace-nowrap bg-rose-700/70 text-white dark:bg-rose-800 transition-colors duration-300'
         >
           Clear Filters
         </motion.button>

--- a/src/hooks/useHerbs.ts
+++ b/src/hooks/useHerbs.ts
@@ -3,7 +3,13 @@ import type { Herb } from '../types'
 import { herbs } from '../data/herbsfull'
 
 export function useHerbs(): Herb[] {
-  const [herbList] = React.useState<Herb[]>(herbs)
+  const [herbList] = React.useState<Herb[]>(() => {
+    const map = new Map<string, Herb>()
+    herbs.forEach(h => {
+      if (!map.has(h.id)) map.set(h.id, h)
+    })
+    return Array.from(map.values())
+  })
 
   React.useEffect(() => {
     if (!import.meta.env.DEV) return

--- a/src/index.css
+++ b/src/index.css
@@ -52,7 +52,7 @@ html {
 }
 /* Animations and extra utilities */
 .tag-pill {
-  @apply text-shadow inline-flex items-center gap-1 rounded-full bg-black/10 px-2 py-0.5 text-xs shadow ring-1 ring-white/20 backdrop-blur-sm hover:bg-black/20 dark:bg-white/10 dark:ring-black/30 dark:hover:bg-white/20;
+  @apply text-shadow inline-flex items-center gap-1 rounded-full bg-black/10 px-2 py-0.5 text-xs shadow ring-1 ring-white/20 backdrop-blur-sm hover:bg-black/20 border border-gray-200 dark:bg-white/10 dark:ring-black/30 dark:hover:bg-white/20 dark:border-gray-800 transition-colors duration-300;
 }
 
 @keyframes gradient-shift {


### PR DESCRIPTION
## Summary
- deduplicate herbs list in `useHerbs`
- restyle herb cards for dark mode using Tailwind `dark:` variants
- update tag pill styling and filters for consistent colors
- fix progress bars in analytics component
- tweak index CSS utilities for borders and transitions

## Testing
- `npm install`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fe466e4d48323ba80e666cea73b17