### PR TITLE
Improve compound listings

### DIFF
--- a/src/components/CompoundCard.tsx
+++ b/src/components/CompoundCard.tsx
@@ -1,32 +1,51 @@
 import React from 'react'
 import { motion } from 'framer-motion'
 import { Link } from 'react-router-dom'
-import type { Compound } from '../data/compounds/compoundsIndex'
+import type { CompoundEntry } from '../data/compounds/compounds'
 import TagBadge from './TagBadge'
-import { slugify } from '../utils/slugify'
 
-export default function CompoundCard({ compound }: { compound: Compound }) {
+interface HerbRef {
+  name: string
+  slug?: string
+}
+
+export interface CompoundWithRefs extends CompoundEntry {
+  herbsFound: HerbRef[]
+  effectClass?: string
+}
+
+export default function CompoundCard({ compound }: { compound: CompoundWithRefs }) {
   return (
     <motion.article
       whileHover={{ scale: 1.03 }}
-      className='glass-card hover-glow flex flex-col rounded-lg p-4 text-left'
+      className='hover-glow flex flex-col rounded-lg border border-gray-200 bg-white p-4 text-left dark:border-gray-700 dark:bg-gray-900'
     >
-      <h2 className='mb-1 text-lg font-bold text-white'>{compound.name}</h2>
+      <h2 className='mb-1 text-lg font-bold text-gray-900 dark:text-gray-100'>{compound.name}</h2>
       <div className='mb-2 flex flex-wrap gap-2'>
         <TagBadge label={compound.type} />
-        <TagBadge label={compound.effectClass} variant='blue' />
+        {compound.effectClass && <TagBadge label={compound.effectClass} variant='blue' />}
       </div>
-      <p className='mb-2 text-sm text-sand'>{compound.mechanism}</p>
+      <p className='mb-2 text-sm text-sand'>{compound.description}</p>
+      <p className='mb-2 text-sm text-sand'>{compound.mechanismOfAction}</p>
       <div className='mt-auto flex flex-wrap gap-1'>
-        {compound.sourceHerbs.map(h => (
-          <Link
-            key={h}
-            to={`/database#${slugify(h)}`}
-            className='tag-pill bg-space-dark/70 text-sand hover-glow transition-colors duration-300 dark:bg-gray-800 dark:text-gray-200'
-          >
-            {h}
-          </Link>
-        ))}
+        {compound.herbsFound.map(h =>
+          h.slug ? (
+            <Link
+              key={h.name}
+              to={`/herbs/${h.slug}`}
+              className='tag-pill bg-space-dark/70 text-sand hover-glow transition-colors duration-300 dark:bg-gray-800 dark:text-gray-200'
+            >
+              {h.name}
+            </Link>
+          ) : (
+            <span
+              key={h.name}
+              className='tag-pill bg-space-dark/70 text-sand dark:bg-gray-800 dark:text-gray-200'
+            >
+              {h.name}
+            </span>
+          )
+        )}
       </div>
     </motion.article>
   )


### PR DESCRIPTION
## Summary
- link compounds to corresponding herbs
- implement compound class tag filter and animated grid
- restyle compound cards for light/dark mode and herb links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fed6c0ca8832399b1ca9d72f7a238