### PR TITLE
Improve learn section layout

### DIFF
--- a/src/components/LearnTabs.tsx
+++ b/src/components/LearnTabs.tsx
@@ -38,17 +38,20 @@ export default function LearnTabs({ sections }: Props) {
   }, [active, sections])
 
   const content = (
-    <motion.div
+    <motion.article
       key={sections[active].id}
       initial={{ opacity: 0, y: 10 }}
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, y: -10 }}
       transition={{ duration: 0.3 }}
       id={sections[active].id}
-      className='prose prose-lg max-w-[80ch]'
+      className='learn-section'
     >
-      <ReactMarkdown>{sections[active].content}</ReactMarkdown>
-    </motion.div>
+      <h2 className='learn-title'>{sections[active].title}</h2>
+      <div className='prose learn-prose prose-lg max-w-[80ch]'>
+        <ReactMarkdown>{sections[active].content}</ReactMarkdown>
+      </div>
+    </motion.article>
   )
 
   if (mobile) {
@@ -59,17 +62,21 @@ export default function LearnTabs({ sections }: Props) {
             key={s.id}
             open={i === active}
             onClick={() => setActive(i)}
-            className='rounded-md bg-black/20 p-2'
+            className='learn-section'
             id={s.id}
           >
-            <summary className='cursor-pointer font-semibold'>{s.title}</summary>
+            <summary className='cursor-pointer font-semibold'>
+              <span className='flex items-center gap-2 text-xl md:text-2xl'>
+                {s.title}
+              </span>
+            </summary>
             <motion.div
               initial={{ opacity: 0 }}
               animate={{ opacity: 1 }}
               transition={{ duration: 0.3 }}
-              className='mt-2'
+              className='mt-4'
             >
-              <ReactMarkdown className='prose prose-lg max-w-[80ch]'>
+              <ReactMarkdown className='prose learn-prose prose-base max-w-[80ch]'>
                 {s.content}
               </ReactMarkdown>
             </motion.div>

--- a/src/index.css
+++ b/src/index.css
@@ -167,3 +167,38 @@ html {
 .pb-safe {
   padding-bottom: env(safe-area-inset-bottom);
 }
+
+/* Learn page typography */
+.learn-section {
+  @apply my-8 rounded-lg border border-comet/20 bg-white/50 p-6 backdrop-blur-md dark:bg-black/30;
+}
+
+.learn-title {
+  @apply mb-6 flex items-center gap-2 text-3xl font-bold tracking-tight md:text-4xl;
+}
+
+.learn-prose h3,
+.learn-prose h4 {
+  @apply flex items-center gap-2;
+}
+
+.learn-prose h3 {
+  @apply text-2xl font-semibold md:text-3xl;
+}
+
+.learn-prose h4 {
+  @apply text-xl font-medium md:text-2xl;
+}
+
+.learn-prose p {
+  @apply text-sand/90 leading-relaxed md:text-lg;
+}
+
+.learn-prose ul,
+.learn-prose ol {
+  @apply my-4 list-disc space-y-1 pl-6;
+}
+
+.learn-prose li {
+  @apply leading-relaxed;
+}


### PR DESCRIPTION
## Summary
- add `learn-section`, `learn-title` and typography styles
- render each learn section with `<h2>` headings
- support responsive details view on mobile

## Testing
- `npm run validate-herbs`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68804fbdfce8832390998eeadd47b3d0