### PR TITLE
Improve /learn responsive layout

### DIFF
--- a/src/components/LearnTabs.tsx
+++ b/src/components/LearnTabs.tsx
@@ -27,7 +27,7 @@ export default function LearnTabs({ sections }: Props) {
   // handle deep linking on mount
   React.useEffect(() => {
     const hash = window.location.hash.slice(1)
-    const index = sections.findIndex((s) => s.id === hash)
+    const index = sections.findIndex(s => s.id === hash)
     if (index >= 0) setActive(index)
   }, [sections])
 
@@ -41,15 +41,16 @@ export default function LearnTabs({ sections }: Props) {
   const content = (
     <motion.article
       key={sections[active].id}
-      initial={{ opacity: 0, y: 10 }}
-      animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: -10 }}
-      transition={{ duration: 0.3 }}
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -20 }}
+      viewport={{ once: true, amount: 0.2 }}
+      transition={{ duration: 0.4 }}
       id={sections[active].id}
-      className='learn-section'
+      className='learn-section mx-auto'
     >
       <h2 className='learn-title'>{sections[active].title}</h2>
-      <div className='prose learn-prose prose-lg max-w-[80ch]'>
+      <div className='learn-prose prose prose-lg max-w-none'>
         <ReactMarkdown rehypePlugins={[rehypeRaw]}>{sections[active].content}</ReactMarkdown>
       </div>
     </motion.article>
@@ -63,13 +64,11 @@ export default function LearnTabs({ sections }: Props) {
             key={s.id}
             open={i === active}
             onClick={() => setActive(i)}
-            className='learn-section'
+            className='learn-section learn-accordion mx-auto'
             id={s.id}
           >
-            <summary className='cursor-pointer font-semibold'>
-              <span className='flex items-center gap-2 text-xl md:text-2xl'>
-                {s.title}
-              </span>
+            <summary className='accordion-summary'>
+              <span className='flex items-center gap-2 text-xl md:text-2xl'>{s.title}</span>
             </summary>
             <motion.div
               initial={{ opacity: 0 }}
@@ -77,7 +76,10 @@ export default function LearnTabs({ sections }: Props) {
               transition={{ duration: 0.3 }}
               className='mt-4'
             >
-              <ReactMarkdown className='prose learn-prose prose-base max-w-[80ch]' rehypePlugins={[rehypeRaw]}>
+              <ReactMarkdown
+                className='learn-prose prose prose-base max-w-none'
+                rehypePlugins={[rehypeRaw]}
+              >
                 {s.content}
               </ReactMarkdown>
             </motion.div>

--- a/src/index.css
+++ b/src/index.css
@@ -67,7 +67,7 @@ html {
 }
 /* Animations and extra utilities */
 .tag-pill {
-  @apply text-shadow inline-flex items-center gap-1 rounded-full bg-black/10 px-2 py-0.5 text-xs shadow ring-1 ring-white/20 backdrop-blur-sm hover:bg-black/20 border border-gray-200 dark:bg-white/10 dark:ring-black/30 dark:hover:bg-white/20 dark:border-gray-800 transition-colors duration-300;
+  @apply text-shadow inline-flex items-center gap-1 rounded-full border border-gray-200 bg-black/10 px-2 py-0.5 text-xs shadow ring-1 ring-white/20 backdrop-blur-sm transition-colors duration-300 hover:bg-black/20 dark:border-gray-800 dark:bg-white/10 dark:ring-black/30 dark:hover:bg-white/20;
 }
 
 @keyframes gradient-shift {
@@ -191,7 +191,7 @@ html {
 }
 
 .learn-prose p {
-  @apply text-sand/90 leading-relaxed md:text-lg;
+  @apply leading-relaxed text-sand/90 md:text-lg;
 }
 
 .learn-prose ul,
@@ -201,4 +201,19 @@ html {
 
 .learn-prose li {
   @apply leading-relaxed;
+}
+
+/* Accordion styling for Learn page */
+.learn-accordion summary {
+  @apply flex cursor-pointer items-center justify-between py-2 font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-psychedelic-purple;
+}
+.learn-accordion[open] summary {
+  @apply text-psychedelic-purple;
+}
+.accordion-summary::after {
+  content: '▾';
+  @apply ml-2 transition-transform duration-300 ease-in-out;
+}
+.learn-accordion[open] .accordion-summary::after {
+  transform: rotate(-180deg);
 }

--- a/src/pages/Learn.tsx
+++ b/src/pages/Learn.tsx
@@ -8,22 +8,31 @@ import { learnSections } from '../data/learnContent.enrichedXL'
 export default function Learn() {
   return (
     <div className='min-h-screen px-4 pt-20'>
-      <Helmet>
-        <title>Learn - The Hippie Scientist</title>
-        <meta name='description' content='Educational resources on psychoactive herbs and practices.' />
-      </Helmet>
-      <motion.div
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.8 }}
-        className='mb-12 text-center'
-      >
-        <h1 className='text-gradient mb-4 text-5xl font-bold md:text-6xl'>🌿 The Hippie Scientist Codex</h1>
-        <p className='mx-auto max-w-3xl text-xl text-sand'>Welcome! Explore each topic below to deepen your understanding.</p>
-      </motion.div>
-      <PanelWrapper>
-        <LearnTabs sections={learnSections} />
-      </PanelWrapper>
+      <div className='mx-auto max-w-5xl'>
+        <Helmet>
+          <title>Learn - The Hippie Scientist</title>
+          <meta
+            name='description'
+            content='Educational resources on psychoactive herbs and practices.'
+          />
+        </Helmet>
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.8 }}
+          className='mb-12 text-center'
+        >
+          <h1 className='text-gradient mb-4 text-5xl font-bold md:text-6xl'>
+            🌿 The Hippie Scientist Codex
+          </h1>
+          <p className='mx-auto max-w-3xl text-xl text-sand'>
+            Welcome! Explore each topic below to deepen your understanding.
+          </p>
+        </motion.div>
+        <PanelWrapper className='mx-auto max-w-5xl'>
+          <LearnTabs sections={learnSections} />
+        </PanelWrapper>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- adjust Learn page container width
- animate sections in LearnTabs and improve markdown rendering
- style accordion details and summary arrow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68805639e18c83238ce5408b2d1735b8