### PR TITLE
Fix drop-shadow-glow utility

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -28,9 +28,10 @@ html {
 }
 
 /* Custom utility classes */
-.text-gradient {
-  @apply bg-gradient-to-r from-sky-400 via-fuchsia-500 to-purple-600 bg-clip-text text-transparent;
-}
+@layer utilities {
+  .text-gradient {
+    @apply bg-gradient-to-r from-sky-400 via-fuchsia-500 to-purple-600 bg-clip-text text-transparent;
+  }
 
 .glass-card {
   @apply border border-black/10 bg-gradient-to-br from-white/40 via-white/60 to-white/80 text-black shadow-lg backdrop-blur-xl transition-shadow duration-300 hover:ring-2 hover:ring-fuchsia-500/50 dark:border-white/10 dark:from-white/10 dark:via-space-dark/50 dark:to-space-dark/80 dark:text-sand;
@@ -150,13 +151,18 @@ html {
   display: none;
 }
 
-.card-contrast {
-  @apply shadow-inner shadow-white/10;
-}
+  .card-contrast {
+    @apply shadow-inner shadow-white/10;
+  }
 
-/* Improve text legibility */
-.text-shadow {
-  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+  /* Improve text legibility */
+  .text-shadow {
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+  }
+
+  .drop-shadow-glow {
+    filter: drop-shadow(0 0 10px rgba(255, 255, 255, 0.4));
+  }
 }
 
 /* Hero layout utilities */

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -30,6 +30,9 @@ export default {
         glow: '0 0 12px rgba(136, 192, 87, 0.5)',
         intense: '0 0 24px rgba(79, 193, 233, 0.4)',
       },
+      dropShadow: {
+        glow: '0 0 10px rgba(255, 255, 255, 0.4)',
+      },
       fontFamily: {
         display: ['"Syne"', '"Righteous"', 'cursive'],
         sans: ['"Inter"', 'sans-serif'],


### PR DESCRIPTION
## Summary
- expose `drop-shadow-glow` utility in Tailwind config
- move custom utilities into `@layer utilities` block and define `drop-shadow-glow` in CSS

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68805b1d24688323b84494af9e89e5f7