### PR TITLE
Fix GitHub Pages refresh and update Learn layout

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,18 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Page Not Found - The Hippie Scientist</title>
-  </head>
-  <body>
-    <div id="root"></div>
+    <title>Redirecting...</title>
     <script>
-      if (!window.location.hash) {
-        const path = window.location.pathname + window.location.search
-        window.location.replace('/#' + path)
-      }
+      (function () {
+        var path = window.location.pathname + window.location.search + window.location.hash;
+        var url = '/?redirect=' + encodeURIComponent(path);
+        window.location.replace(url);
+      })();
     </script>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+  </head>
+  <body></body>
 </html>

--- a/src/index.css
+++ b/src/index.css
@@ -176,11 +176,11 @@ html {
 
 /* Learn page typography */
 .learn-section {
-  @apply my-10 rounded-lg border border-comet/30 bg-white/60 p-8 shadow-glow backdrop-blur-md dark:bg-black/40;
+  @apply my-8 rounded-xl border border-comet/20 bg-white/70 p-6 shadow-glow backdrop-blur-md dark:border-comet/40 dark:bg-midnight-blue/60;
 }
 
 .learn-title {
-  @apply mb-6 flex items-center gap-2 text-left text-4xl font-bold tracking-tight drop-shadow-glow md:text-5xl;
+  @apply mb-6 flex items-center gap-3 text-left text-3xl font-bold tracking-tight text-gradient drop-shadow-glow md:text-4xl;
 }
 
 .learn-prose h3,
@@ -215,10 +215,10 @@ html {
 
 /* Accordion styling for Learn page */
 .learn-accordion summary {
-  @apply flex cursor-pointer items-center justify-between py-2 font-semibold focus:outline-none focus-visible:ring-2 focus-visible:ring-psychedelic-purple;
+  @apply flex cursor-pointer items-center justify-between rounded-md bg-white/40 px-4 py-3 font-semibold shadow transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-psychedelic-purple dark:bg-midnight-blue/40 dark:text-sand dark:shadow-md;
 }
 .learn-accordion[open] summary {
-  @apply text-psychedelic-purple;
+  @apply text-psychedelic-purple bg-white/60 dark:bg-midnight-blue/60;
 }
 .accordion-summary::after {
   content: '▾';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,19 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { HashRouter } from 'react-router-dom'
+import { BrowserRouter } from 'react-router-dom'
 import { HelmetProvider } from 'react-helmet-async'
 import App from './App'
 import { ThemeProvider } from './contexts/theme'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import './index.css'
 import { registerSW } from 'virtual:pwa-register'
+
+const params = new URLSearchParams(window.location.search)
+const redirect = params.get('redirect')
+if (redirect) {
+  const url = decodeURIComponent(redirect)
+  window.history.replaceState(null, '', url)
+}
 
 registerSW({ immediate: true })
 
@@ -15,9 +22,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <HelmetProvider>
       <ErrorBoundary>
         <ThemeProvider>
-          <HashRouter>
+          <BrowserRouter>
             <App />
-          </HashRouter>
+          </BrowserRouter>
         </ThemeProvider>
       </ErrorBoundary>
     </HelmetProvider>


### PR DESCRIPTION
## Summary
- handle GitHub Pages refresh by redirecting from `404.html`
- decode redirect param in `main.tsx` and switch to BrowserRouter
- polish Learn page styles for better readability

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68805ccc57908323a01353bd12108d99