### PR TITLE
Fix SPA routing on GitHub Pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,27 +1,10 @@
-<!doctype html>
-<html lang="en">
+<!DOCTYPE html>
+<html>
   <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" href="/favicon.ico" />
-    <link rel="manifest" href="/manifest.json" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Explore psychedelic botanicals, cognitive enhancers, and consciousness tools at The Hippie Scientist." />
-    <meta property="og:title" content="The Hippie Scientist" />
-    <meta property="og:description" content="Psychedelic Botany &amp; Conscious Exploration" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://thehippiescientist.net" />
-    <meta property="og:image" content="/icon-512x512.png" />
-    <title>The Hippie Scientist</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Comfortaa:wght@400;700&family=Inter:wght@400;700&family=Orbitron:wght@400;700&family=Righteous&family=Syne:wght@400;700&display=swap"
-      rel="stylesheet"
-    />
+    <meta http-equiv="refresh" content="0; url=/" />
+    <script>
+      const redirectTo = sessionStorage.redirectTo || '/';
+      window.location.replace(redirectTo);
+    </script>
   </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
 </html>

--- a/codex-changelog.md
+++ b/codex-changelog.md
@@ -1,2 +1,3 @@
 # Codex Update Log
 This file documents all Codex-generated updates to the Hippie Scientist project.
+- 2025-07-23: Added 404 redirect page and sessionStorage-based SPA routing fix.

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -17,6 +17,11 @@ if (redirect) {
 
 registerSW({ immediate: true })
 
+// Store the current path so 404.html can redirect after refresh
+window.addEventListener('beforeunload', () => {
+  sessionStorage.redirectTo = window.location.pathname
+})
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <HelmetProvider>


### PR DESCRIPTION
## Summary
- create minimal `404.html` that forwards back to saved route
- store last path in `sessionStorage` on unload
- log the change

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688065dfeee883239fcd2f664c3a907f