### PR TITLE
Psychedelic style revamp

### DIFF
--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -67,7 +67,7 @@ export default function HerbCardAccordion({ herb }: Props) {
       role='button'
       tabIndex={0}
       aria-expanded={expanded}
-      className='group relative cursor-pointer overflow-hidden rounded-lg border border-gray-200 bg-white p-4 text-gray-800 shadow-sm transition-colors duration-300 hover:border-lime-400 hover:shadow-md focus:outline-none dark:border-gray-800 dark:bg-gray-900 dark:text-gray-100'
+      className='neon-card group relative cursor-pointer overflow-hidden p-4 text-gray-800 dark:text-gray-100'
     >
       <motion.div
         className='pointer-events-none absolute inset-0 rounded-lg border-2 border-fuchsia-500/40 dark:rounded-2xl'

--- a/src/components/LearnTabs.tsx
+++ b/src/components/LearnTabs.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
+import { ChevronDown } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import rehypeRaw from 'rehype-raw'
 
@@ -67,8 +68,15 @@ export default function LearnTabs({ sections }: Props) {
             className='learn-section learn-accordion mx-auto'
             id={s.id}
           >
-            <summary className='accordion-summary'>
+            <summary className='accordion-summary flex items-center justify-between'>
               <span className='flex items-center gap-2 text-xl md:text-2xl'>{s.title}</span>
+              <motion.span
+                initial={false}
+                animate={{ rotate: i === active ? 180 : 0 }}
+                className='ml-2 text-psychedelic-purple'
+              >
+                <ChevronDown size={20} />
+              </motion.span>
             </summary>
             <motion.div
               initial={{ height: 0, opacity: 0 }}

--- a/src/components/PanelWrapper.tsx
+++ b/src/components/PanelWrapper.tsx
@@ -11,7 +11,7 @@ const PanelWrapper: React.FC<Props> = ({ children, className }) => (
     initial={{ opacity: 0, y: 20 }}
     whileInView={{ opacity: 1, y: 0 }}
     viewport={{ once: true }}
-    className={`relative my-12 overflow-hidden rounded-xl border border-gray-300 bg-white/60 p-6 shadow-glow backdrop-blur-lg dark:border-bark dark:bg-bark/60 ${className ?? ''}`}
+    className={`neon-card relative my-12 overflow-hidden rounded-xl p-6 ${className ?? ''}`}
   >
     <div className='absolute inset-x-0 top-0 h-px animate-pulse bg-gradient-to-r from-transparent via-lichen/30 to-transparent' />
     {children}

--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -16,7 +16,7 @@ export default function ScrollToTopButton() {
       onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
       initial={{ opacity: 0 }}
       animate={{ opacity: visible ? 1 : 0 }}
-      className='fixed bottom-6 right-6 z-40 rounded-full bg-psychedelic-purple p-3 text-white shadow-lg hover:scale-105'
+      className='bounce fixed bottom-6 right-6 z-40 rounded-full bg-psychedelic-purple p-3 text-white shadow-lg hover:scale-105'
       aria-label='Scroll to top'
     >
       <ArrowUp />

--- a/src/components/TagFilterBar.tsx
+++ b/src/components/TagFilterBar.tsx
@@ -26,12 +26,28 @@ export default function TagFilterBar({ allTags, activeTags, onToggleTag }: Props
     activeTags.forEach(t => onToggleTag(t))
   }
 
+  const containerVariants = {
+    hidden: {},
+    visible: { transition: { staggerChildren: 0.05 } },
+  }
+
+  const itemVariants = {
+    hidden: { opacity: 0, y: 10 },
+    visible: { opacity: 1, y: 0 },
+  }
+
   return (
-    <div className='no-scrollbar flex gap-2 overflow-x-auto py-2'>
+    <motion.div
+      variants={containerVariants}
+      initial='hidden'
+      animate='visible'
+      className='no-scrollbar flex gap-2 overflow-x-auto py-2'
+    >
       {allTags.map(tag => {
         const active = activeTags.includes(tag)
         return (
           <motion.button
+            variants={itemVariants}
             type='button'
             key={tag}
             onClick={() => toggle(tag)}
@@ -61,6 +77,6 @@ export default function TagFilterBar({ allTags, activeTags, onToggleTag }: Props
           Clear Filters
         </motion.button>
       )}
-    </div>
+    </motion.div>
   )
 }

--- a/src/contexts/theme.tsx
+++ b/src/contexts/theme.tsx
@@ -25,12 +25,19 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
   })
 
+  // apply theme immediately on mount
+  useEffect(() => {
+    applyTheme(theme)
+  }, [])
+
   // Function to apply theme class
   const applyTheme = useCallback((theme: Theme) => {
     document.documentElement.classList.remove('light', 'dark')
     document.body.classList.remove('light', 'dark')
     document.documentElement.classList.add(theme)
     document.body.classList.add(theme)
+    // ensure psychedelic gradient background is always applied
+    document.body.classList.add('psychedelic-bg')
   }, [])
 
   // Update DOM and localStorage on theme change

--- a/src/index.css
+++ b/src/index.css
@@ -52,6 +52,10 @@ html {
   @apply border border-comet/30 px-2 py-1;
 }
 
+.table-card {
+  @apply overflow-x-auto rounded-lg border border-comet/30 bg-white/60 shadow-glow backdrop-blur-md dark:bg-midnight-blue/50;
+}
+
 .ring-comet {
   @apply ring-1 ring-comet/50;
 }
@@ -230,4 +234,38 @@ html {
 
 .accordion-content {
   @apply overflow-hidden transition-all duration-500;
+}
+/* Psychedelic background and scrollbars */
+.psychedelic-bg {
+  @apply bg-gradient-to-br from-deep-indigo via-space-dark to-black bg-fixed;
+}
+
+body {
+  scrollbar-color: theme('colors.psychedelic-purple') transparent;
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+::-webkit-scrollbar-thumb {
+  background: linear-gradient(135deg, theme('colors.psychedelic-pink'), theme('colors.psychedelic-purple'));
+  border-radius: 4px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+/* Neon glass card */
+.neon-card {
+  @apply glass-card ring-1 ring-psychedelic-purple/30 hover:ring-psychedelic-pink/60 backdrop-blur-lg;
+}
+
+/* Bounce animation */
+@keyframes float-bounce {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-8px); }
+}
+.bounce {
+  animation: float-bounce 3s ease-in-out infinite;
 }

--- a/src/pages/Learn.tsx
+++ b/src/pages/Learn.tsx
@@ -3,11 +3,15 @@ import { Helmet } from 'react-helmet-async'
 import { motion } from 'framer-motion'
 import PanelWrapper from '../components/PanelWrapper'
 import LearnTabs from '../components/LearnTabs'
+import StarfieldBackground from '../components/StarfieldBackground'
+import FloatingParticles from '../components/FloatingParticles'
 import { learnSections } from '../data/learnContent.enrichedXL'
 
 export default function Learn() {
   return (
-    <div className='min-h-screen px-4 pt-20'>
+    <div className='relative min-h-screen px-4 pt-20'>
+      <StarfieldBackground />
+      <FloatingParticles />
       <div className='mx-auto max-w-5xl'>
         <Helmet>
           <title>Learn - The Hippie Scientist</title>


### PR DESCRIPTION
## Summary
- add psychedelic gradient background and scrollbar styles
- enhance panel and herb cards with new neon glass effect
- animate Learn page accordion chevrons
- stagger TagFilterBar items and bounce scroll-to-top button
- overlay starfields on Learn page and ensure theme applies gradient background

## Testing
- `npm test`
- `npm run validate-herbs`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68806787aa88832394275caf930aebbc