### PR TITLE
Add fog overlay and glow styling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Navbar from './components/Navbar'
 import Footer from './components/Footer'
 import MouseTrail from './components/MouseTrail'
 import ScrollToTopButton from './components/ScrollToTopButton'
+import FogOverlay from './components/FogOverlay'
 const Home = React.lazy(() => import('./pages/Home'))
 const HerbCardPage = React.lazy(() => import('./pages/HerbCardPage'))
 const HerbDetailView = React.lazy(() => import('./pages/HerbDetailView'))
@@ -26,6 +27,7 @@ function App() {
     <>
       <Navbar />
       <MouseTrail />
+      <FogOverlay />
       <main className='space-y-24 pt-16'>
         <Suspense fallback={<LoadingScreen />}>
           <Routes>

--- a/src/components/FogOverlay.tsx
+++ b/src/components/FogOverlay.tsx
@@ -1,0 +1,12 @@
+import { motion } from 'framer-motion'
+
+export default function FogOverlay() {
+  return (
+    <motion.div
+      className='pointer-events-none fixed inset-0 -z-20 fog-layer'
+      initial={{ opacity: 0.2 }}
+      animate={{ opacity: [0.2, 0.4, 0.2] }}
+      transition={{ duration: 25, repeat: Infinity, ease: 'easeInOut' }}
+    />
+  )
+}

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -67,7 +67,7 @@ export default function HerbCardAccordion({ herb }: Props) {
       role='button'
       tabIndex={0}
       aria-expanded={expanded}
-      className='neon-card group relative cursor-pointer overflow-hidden p-4 text-gray-800 dark:text-gray-100'
+      className='neon-card soft-border-glow group relative cursor-pointer overflow-hidden p-4 text-gray-800 dark:text-gray-100'
     >
       <motion.div
         className='pointer-events-none absolute inset-0 rounded-lg border-2 border-fuchsia-500/40 dark:rounded-2xl'

--- a/src/components/PanelWrapper.tsx
+++ b/src/components/PanelWrapper.tsx
@@ -11,7 +11,7 @@ const PanelWrapper: React.FC<Props> = ({ children, className }) => (
     initial={{ opacity: 0, y: 20 }}
     whileInView={{ opacity: 1, y: 0 }}
     viewport={{ once: true }}
-    className={`neon-card relative my-12 overflow-hidden rounded-xl p-6 ${className ?? ''}`}
+    className={`neon-card soft-border-glow relative my-12 overflow-hidden rounded-xl p-6 ${className ?? ''}`}
   >
     <div className='absolute inset-x-0 top-0 h-px animate-pulse bg-gradient-to-r from-transparent via-lichen/30 to-transparent' />
     {children}

--- a/src/index.css
+++ b/src/index.css
@@ -219,14 +219,14 @@ html {
 
 /* Accordion styling for Learn page */
 .learn-accordion summary {
-  @apply flex cursor-pointer items-center justify-between rounded-md bg-white/40 px-4 py-3 font-semibold shadow transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-psychedelic-purple dark:bg-midnight-blue/40 dark:text-sand dark:shadow-md;
+  @apply flex cursor-pointer items-center justify-between rounded-md bg-white/40 px-4 py-3 font-semibold shadow transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-psychedelic-purple dark:bg-midnight-blue/40 dark:text-sand dark:shadow-md soft-border-glow;
 }
 .learn-accordion[open] summary {
-  @apply text-psychedelic-purple bg-white/60 dark:bg-midnight-blue/60;
+  @apply text-psychedelic-purple bg-white/60 dark:bg-midnight-blue/60 soft-border-glow;
 }
 .accordion-summary::after {
   content: '▾';
-  @apply ml-2 transition-transform duration-300 ease-in-out;
+  @apply ml-2 text-psychedelic-pink drop-shadow-glow transition-transform duration-300 ease-in-out;
 }
 .learn-accordion[open] .accordion-summary::after {
   transform: rotate(-180deg);
@@ -268,4 +268,11 @@ body {
 }
 .bounce {
   animation: float-bounce 3s ease-in-out infinite;
+}
+
+/* Fog overlay */
+.fog-layer {
+  background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.15) 0%, rgba(255, 255, 255, 0) 70%);
+  backdrop-filter: blur(50px);
+  mix-blend-mode: overlay;
 }


### PR DESCRIPTION
## Summary
- implement new FogOverlay component for subtle animated fog
- include FogOverlay in app layout
- enhance PanelWrapper and HerbCardAccordion with soft-border glow
- polish Learn accordion styling and add animated chevron

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688069e8d8a4832399027c77a124eee5