### PR TITLE
Homepage interactive polish

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,14 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="scroll-smooth">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Explore psychedelic botanicals, cognitive enhancers, and consciousness tools at The Hippie Scientist." />
+    <meta
+      name="description"
+      content="Explore psychedelic botanicals, cognitive enhancers, and consciousness tools at The Hippie Scientist."
+    />
     <meta property="og:title" content="The Hippie Scientist" />
     <meta property="og:description" content="Psychedelic Botany &amp; Conscious Exploration" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />

--- a/src/components/HerbCardAccordion.tsx
+++ b/src/components/HerbCardAccordion.tsx
@@ -67,7 +67,7 @@ export default function HerbCardAccordion({ herb }: Props) {
       role='button'
       tabIndex={0}
       aria-expanded={expanded}
-      className='neon-card soft-border-glow group relative cursor-pointer overflow-hidden p-4 text-gray-800 dark:text-gray-100'
+      className='neon-card soft-border-glow group relative cursor-pointer overflow-hidden p-4 text-gray-800 hover:shadow-glow dark:text-gray-100'
     >
       <motion.div
         className='pointer-events-none absolute inset-0 rounded-lg border-2 border-fuchsia-500/40 dark:rounded-2xl'
@@ -90,9 +90,11 @@ export default function HerbCardAccordion({ herb }: Props) {
           {herb.name || 'Unknown Herb'}
         </span>
       </div>
-      <p className='text-sm italic text-gray-700 dark:text-gray-300 transition-colors duration-300'>{herb.scientificName || 'Unknown species'}</p>
+      <p className='text-sm italic text-gray-700 transition-colors duration-300 dark:text-gray-300'>
+        {herb.scientificName || 'Unknown species'}
+      </p>
       {!expanded && herbBlurbs[herb.name] && (
-        <p className='mt-1 text-sm italic text-gray-800 dark:text-gray-100 transition-colors duration-300'>
+        <p className='mt-1 text-sm italic text-gray-800 transition-colors duration-300 dark:text-gray-100'>
           {herbBlurbs[herb.name]}
         </p>
       )}
@@ -103,7 +105,7 @@ export default function HerbCardAccordion({ herb }: Props) {
             <strong>Effects:</strong> {safeEffects.length > 0 ? safeEffects.join(', ') : 'Unknown'}
           </div>
 
-          <div className='mt-2 text-sm text-gray-700 dark:text-gray-300 transition-colors duration-300'>
+          <div className='mt-2 text-sm text-gray-700 transition-colors duration-300 dark:text-gray-300'>
             <strong>Description:</strong> {herb.description || herbBlurbs[herb.name] || ''}
           </div>
         </>
@@ -124,7 +126,7 @@ export default function HerbCardAccordion({ herb }: Props) {
             animate='open'
             exit='collapsed'
             transition={{ type: 'spring', stiffness: 200, damping: 24 }}
-            className='mt-4 space-y-2 text-sm text-sand'
+            className='mt-4 space-y-2 rounded-md bg-black/30 p-3 text-sm text-sand backdrop-blur-md'
           >
             <motion.p variants={itemVariants} className='whitespace-pre-wrap break-words'>
               <span role='img' aria-label='Mechanism'>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -18,7 +18,7 @@ export default function Hero() {
       <HeroBackground />
       <FloatingElements />
 
-      <div className='relative z-10 mx-auto mt-6 w-full max-w-xl rounded-xl border border-lime-400/30 bg-white/10 p-6 shadow-xl backdrop-blur soft-border-glow'>
+      <div className='soft-border-glow relative z-10 mx-auto mt-6 w-full max-w-xl rounded-xl border border-lime-400/30 bg-white/10 p-6 shadow-xl backdrop-blur'>
         <div className='flex flex-col items-center justify-center gap-4'>
           <motion.div
             className='mx-auto max-w-2xl space-y-1'
@@ -26,10 +26,15 @@ export default function Hero() {
             animate={{ opacity: 1, y: 0, scale: 1 }}
             transition={{ duration: 1, delay: 0.2, ease: 'easeOut' }}
           >
-            <h1 className='text-gradient font-display text-4xl sm:text-5xl md:text-6xl lg:text-7xl'>
+            <h1
+              id='site-title'
+              className='text-gradient font-display text-4xl sm:text-5xl md:text-6xl lg:text-7xl'
+            >
               The Hippie Scientist
             </h1>
-            <p className='text-opal text-base sm:text-lg md:text-xl'>Psychedelic Botany &amp; Conscious Exploration</p>
+            <p className='text-base text-opal sm:text-lg md:text-xl'>
+              Psychedelic Botany &amp; Conscious Exploration
+            </p>
           </motion.div>
 
           <div className='mt-2 flex justify-center'>
@@ -42,13 +47,13 @@ export default function Hero() {
           <div className='flex flex-wrap items-center justify-center gap-4'>
             <Link
               to='/database'
-              className='hover-glow rounded-md bg-black/30 px-6 py-3 text-white transition hover:shadow-glow backdrop-blur'
+              className='hover-glow rounded-md bg-black/30 px-6 py-3 text-white backdrop-blur transition hover:shadow-glow'
             >
               🌿 Browse Herbs
             </Link>
             <Link
               to='/blend'
-              className='hover-glow rounded-md bg-black/30 px-6 py-3 text-white transition hover:shadow-glow backdrop-blur'
+              className='hover-glow rounded-md bg-black/30 px-6 py-3 text-white backdrop-blur transition hover:shadow-glow'
             >
               🧪 Build a Blend
             </Link>

--- a/src/components/RotatingHerbHero.tsx
+++ b/src/components/RotatingHerbHero.tsx
@@ -20,12 +20,15 @@ export default function RotatingHerbHero() {
   const [items, setItems] = useState<Herb[]>([])
   const [index, setIndex] = useState(0)
   const [loading, setLoading] = useState(true)
+  const [paused, setPaused] = useState(false)
   const timerRef = useRef<NodeJS.Timeout | null>(null)
 
   const scheduleNext = () => {
-    const delay = 6000 + Math.random() * 2000
+    const delay = 5000 + Math.random() * 5000
     timerRef.current = setTimeout(() => {
-      setIndex(i => (i + 1) % items.length)
+      if (!paused) {
+        setIndex(i => (i + 1) % items.length)
+      }
     }, delay)
   }
 
@@ -40,19 +43,24 @@ export default function RotatingHerbHero() {
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current)
     }
-  }, [items, index])
+  }, [items, index, paused])
 
   if (loading) {
-    return (
-      <div className='mx-auto mt-8 text-center text-sand'>Loading featured herb...</div>
-    )
+    return <div className='mx-auto mt-8 text-center text-sand'>Loading featured herb...</div>
   }
 
   const herb = items[index]
   const tags = Array.isArray(herb.tags) ? herb.tags.slice(0, 3) : []
 
   return (
-    <div className='relative mx-auto mt-8 flex max-w-xs justify-center sm:max-w-sm'>
+    <div
+      className='relative mx-auto mt-8 flex max-w-xs justify-center sm:max-w-sm'
+      onMouseEnter={() => setPaused(true)}
+      onMouseLeave={() => {
+        setPaused(false)
+        scheduleNext()
+      }}
+    >
       <AnimatePresence mode='wait'>
         <motion.article
           key={herb.id}
@@ -60,7 +68,8 @@ export default function RotatingHerbHero() {
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: -20 }}
           transition={{ duration: 0.6 }}
-          className='bg-psychedelic-gradient/30 soft-border-glow relative overflow-hidden rounded-2xl p-4 text-center text-white shadow-lg backdrop-blur-md'
+          whileHover={{ rotateX: -3, rotateY: 3 }}
+          className='bg-psychedelic-gradient/30 soft-border-glow group relative overflow-hidden rounded-2xl p-4 text-center text-white shadow-lg backdrop-blur-md'
         >
           {herb.image && (
             <img src={herb.image} alt={herb.name} className='h-32 w-full rounded-md object-cover' />
@@ -86,17 +95,22 @@ export default function RotatingHerbHero() {
               : herb.effects || ''
             return effects ? <p className='mt-1 text-sm text-sand'>{effects}</p> : null
           })()}
-          <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
-            <Link
-              to={`/herb/${herb.slug || herb.id || slugify(herb.name)}`}
-              className='hover-glow mt-3 inline-block rounded-md bg-black/30 px-4 py-2 text-sand backdrop-blur-md hover:bg-black/40'
-            >
-              More Info
-            </Link>
-          </motion.div>
+          <div className='mt-3 opacity-0 transition-opacity group-hover:opacity-100'>
+            <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+              <Link
+                to={`/herb/${herb.slug || herb.id || slugify(herb.name)}`}
+                className='hover-glow inline-block rounded-md bg-black/30 px-4 py-2 text-sand backdrop-blur-md hover:bg-black/40'
+              >
+                More Info
+              </Link>
+            </motion.div>
+          </div>
           <motion.div
             className='pointer-events-none absolute inset-0 rounded-2xl border-2 border-fuchsia-500/40'
-            animate={{ opacity: [0.6, 0.2, 0.6] }}
+            animate={{
+              opacity: [0.6, 0.2, 0.6],
+              boxShadow: ['0 0 8px #e879f9', '0 0 16px #e879f9', '0 0 8px #e879f9'],
+            }}
             transition={{ duration: 2.5, repeat: Infinity }}
           />
         </motion.article>

--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -11,9 +11,20 @@ export default function ScrollToTopButton() {
     return () => window.removeEventListener('scroll', onScroll)
   }, [])
 
+  const handleClick = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+    const title = document.getElementById('site-title')
+    if (title) {
+      title.animate(
+        [{ transform: 'scale(1)' }, { transform: 'scale(1.1)' }, { transform: 'scale(1)' }],
+        { duration: 600, easing: 'ease-out' }
+      )
+    }
+  }
+
   return (
     <motion.button
-      onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+      onClick={handleClick}
       initial={{ opacity: 0 }}
       animate={{ opacity: visible ? 1 : 0 }}
       className='bounce fixed bottom-6 right-6 z-40 rounded-full bg-psychedelic-purple p-3 text-white shadow-lg hover:scale-105'

--- a/src/components/TagFilterBar.tsx
+++ b/src/components/TagFilterBar.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { motion } from 'framer-motion'
+import { spring, fadeInUp } from '../utils/motionConfig'
 import { decodeTag } from '../utils/format'
 
 interface Props {
@@ -27,22 +28,22 @@ export default function TagFilterBar({ allTags, activeTags, onToggleTag }: Props
   }
 
   const containerVariants = {
-    hidden: {},
-    visible: { transition: { staggerChildren: 0.05 } },
+    hidden: { opacity: 0, y: 10 },
+    visible: { opacity: 1, y: 0, transition: { staggerChildren: 0.05 } },
   }
 
-  const itemVariants = {
-    hidden: { opacity: 0, y: 10 },
-    visible: { opacity: 1, y: 0 },
-  }
+  const itemVariants = fadeInUp
 
   return (
     <motion.div
       variants={containerVariants}
       initial='hidden'
       animate='visible'
-      className='no-scrollbar flex gap-2 overflow-x-auto py-2'
+      className='no-scrollbar flex items-center gap-2 overflow-x-auto py-2'
     >
+      <span className='pl-1 pr-2 text-xs font-semibold text-opal'>
+        {activeTags.length > 0 ? `Filtered (${activeTags.length})` : 'Filter Tags'}
+      </span>
       {allTags.map(tag => {
         const active = activeTags.includes(tag)
         return (
@@ -50,15 +51,25 @@ export default function TagFilterBar({ allTags, activeTags, onToggleTag }: Props
             variants={itemVariants}
             type='button'
             key={tag}
+            aria-pressed={active}
+            aria-label={`${active ? 'Remove' : 'Add'} filter ${decodeTag(tag)}`}
             onClick={() => toggle(tag)}
             whileTap={{ scale: 0.9 }}
             whileHover={{ scale: 1.08 }}
             animate={
               active
-                ? { scale: [1, 1.15, 1], boxShadow: '0 0 8px rgba(16,185,129,0.8)' }
+                ? {
+                    scale: [1, 1.15, 1],
+                    boxShadow: '0 0 8px rgba(16,185,129,0.8)',
+                  }
                 : { scale: 1, boxShadow: 'none' }
             }
-            transition={{ type: 'spring', stiffness: 220, damping: 12 }}
+            transition={{
+              ...spring,
+              repeat: active ? Infinity : 0,
+              repeatType: 'mirror',
+              duration: 1.2,
+            }}
             className={`tag-pill hover-glow whitespace-nowrap transition-colors duration-300 ${active ? 'bg-emerald-700/70 text-white ring-2 ring-emerald-400 dark:bg-emerald-800' : 'bg-space-dark/70 text-sand dark:bg-gray-800 dark:text-gray-200'}`}
           >
             {decodeTag(tag)}
@@ -68,11 +79,12 @@ export default function TagFilterBar({ allTags, activeTags, onToggleTag }: Props
       {activeTags.length > 0 && (
         <motion.button
           type='button'
+          aria-label='Clear all filters'
           onClick={clearAll}
           whileTap={{ scale: 0.9 }}
           whileHover={{ scale: 1.08 }}
-          transition={{ type: 'spring', stiffness: 220, damping: 12 }}
-          className='tag-pill hover-glow whitespace-nowrap bg-rose-700/70 text-white dark:bg-rose-800 transition-colors duration-300'
+          transition={spring}
+          className='tag-pill hover-glow whitespace-nowrap bg-rose-700/70 text-white transition-colors duration-300 dark:bg-rose-800'
         >
           Clear Filters
         </motion.button>

--- a/src/utils/motionConfig.ts
+++ b/src/utils/motionConfig.ts
@@ -1,0 +1,10 @@
+export const spring = {
+  type: 'spring',
+  stiffness: 220,
+  damping: 20,
+}
+
+export const fadeInUp = {
+  hidden: { opacity: 0, y: 20 },
+  visible: { opacity: 1, y: 0 },
+}

--- a/src/utils/themeUtils.ts
+++ b/src/utils/themeUtils.ts
@@ -1,0 +1,3 @@
+export function cardBg(dark: boolean) {
+  return dark ? 'bg-gray-800/70 text-gray-100' : 'bg-white/70 text-gray-800'
+}


### PR DESCRIPTION
## Summary
- animate tag filter bar entry and active state
- polish rotating herb hero with hover pause and shimmer
- add hover glow and blur to herb cards
- animate site title when scrolling to top
- enable smooth scrolling

## Testing
- `npm test`
- `npm run build`
- `npm run validate-herbs`


------
https://chatgpt.com/codex/tasks/task_e_68806e8ac1608323b355dff3a935f26e