### PR TITLE
Implement dynamic tag filtering component

### DIFF
--- a/src/components/TagFilterBar.tsx
+++ b/src/components/TagFilterBar.tsx
@@ -1,30 +1,46 @@
 import React from 'react'
 import { motion } from 'framer-motion'
+import HerbList from './HerbList'
+import { useLocalStorage } from '../hooks/useLocalStorage'
 import { decodeTag } from '../utils/format'
+import { canonicalTag } from '../utils/tagUtils'
+import type { Herb } from '../types'
 
 interface Props {
-  /**
-   * List of all unique tags available for filtering.
-   */
-  allTags: string[]
-  /**
-   * Currently active tags used for filtering.
-   */
-  activeTags: string[]
-  /**
-   * Toggle a tag on/off in the parent state.
-   */
-  onToggleTag: (tag: string) => void
+  /** Full list of herbs to filter */
+  herbs: Herb[]
 }
 
-export default function TagFilterBar({ allTags, activeTags, onToggleTag }: Props) {
+/**
+ * TagFilterBar renders a row of tag buttons that can be toggled on/off.
+ * Selected tags are saved to localStorage so the filter persists across page reloads.
+ * The component also renders the filtered list of herb entries below the tag bar.
+ */
+export default function TagFilterBar({ herbs }: Props) {
+  const [activeTags, setActiveTags] = useLocalStorage<string[]>(
+    'hs-active-tags',
+    []
+  )
+
+  const allTags = React.useMemo(() => {
+    const t = herbs.reduce<string[]>((acc, h) => acc.concat(h.tags || []), [])
+    return Array.from(new Set(t.map(canonicalTag)))
+  }, [herbs])
+
   const toggle = (tag: string) => {
-    onToggleTag(tag)
+    setActiveTags(prev =>
+      prev.includes(tag) ? prev.filter(t => t !== tag) : [...prev, tag]
+    )
   }
 
-  const clearAll = () => {
-    activeTags.forEach(t => onToggleTag(t))
-  }
+  const clearAll = () => setActiveTags([])
+
+  const filteredHerbs = React.useMemo(() => {
+    if (activeTags.length === 0) return herbs
+    return herbs.filter(h =>
+      h.tags?.some(t => activeTags.includes(canonicalTag(t)))
+    )
+  }, [herbs, activeTags])
 
   const containerVariants = {
     hidden: {},
@@ -37,46 +53,49 @@ export default function TagFilterBar({ allTags, activeTags, onToggleTag }: Props
   }
 
   return (
-    <motion.div
-      variants={containerVariants}
-      initial='hidden'
-      animate='visible'
-      className='no-scrollbar flex gap-2 overflow-x-auto py-2'
-    >
-      {allTags.map(tag => {
-        const active = activeTags.includes(tag)
-        return (
+    <>
+      <motion.div
+        variants={containerVariants}
+        initial='hidden'
+        animate='visible'
+        className='no-scrollbar flex gap-2 overflow-x-auto py-2'
+      >
+        {allTags.map(tag => {
+          const active = activeTags.includes(tag)
+          return (
+            <motion.button
+              variants={itemVariants}
+              type='button'
+              key={tag}
+              onClick={() => toggle(tag)}
+              whileTap={{ scale: 0.9 }}
+              whileHover={{ scale: 1.08 }}
+              animate={
+                active
+                  ? { scale: [1, 1.15, 1], boxShadow: '0 0 8px rgba(16,185,129,0.8)' }
+                  : { scale: 1, boxShadow: 'none' }
+              }
+              transition={{ type: 'spring', stiffness: 220, damping: 12 }}
+              className={`tag-pill hover-glow whitespace-nowrap transition-colors duration-300 ${active ? 'bg-emerald-700/70 text-white ring-2 ring-emerald-400 dark:bg-emerald-800' : 'bg-space-dark/70 text-sand dark:bg-gray-800 dark:text-gray-200'}`}
+            >
+              {decodeTag(tag)}
+            </motion.button>
+          )
+        })}
+        {activeTags.length > 0 && (
           <motion.button
-            variants={itemVariants}
             type='button'
-            key={tag}
-            onClick={() => toggle(tag)}
+            onClick={clearAll}
             whileTap={{ scale: 0.9 }}
             whileHover={{ scale: 1.08 }}
-            animate={
-              active
-                ? { scale: [1, 1.15, 1], boxShadow: '0 0 8px rgba(16,185,129,0.8)' }
-                : { scale: 1, boxShadow: 'none' }
-            }
             transition={{ type: 'spring', stiffness: 220, damping: 12 }}
-            className={`tag-pill hover-glow whitespace-nowrap transition-colors duration-300 ${active ? 'bg-emerald-700/70 text-white ring-2 ring-emerald-400 dark:bg-emerald-800' : 'bg-space-dark/70 text-sand dark:bg-gray-800 dark:text-gray-200'}`}
+            className='tag-pill hover-glow whitespace-nowrap bg-rose-700/70 text-white dark:bg-rose-800 transition-colors duration-300'
           >
-            {decodeTag(tag)}
+            Clear All
           </motion.button>
-        )
-      })}
-      {activeTags.length > 0 && (
-        <motion.button
-          type='button'
-          onClick={clearAll}
-          whileTap={{ scale: 0.9 }}
-          whileHover={{ scale: 1.08 }}
-          transition={{ type: 'spring', stiffness: 220, damping: 12 }}
-          className='tag-pill hover-glow whitespace-nowrap bg-rose-700/70 text-white dark:bg-rose-800 transition-colors duration-300'
-        >
-          Clear Filters
-        </motion.button>
-      )}
-    </motion.div>
+        )}
+      </motion.div>
+      <HerbList herbs={filteredHerbs} />
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- add a stateful `TagFilterBar` component
- persist selected tags to localStorage
- filter herbs in-place and render the filtered `HerbList`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688199d97f6c8323ba23bca2d75d04a0