### PR TITLE
Enhance hero herb carousel

### DIFF
--- a/codex-changelog.md
+++ b/codex-changelog.md
@@ -2,3 +2,4 @@
 This file documents all Codex-generated updates to the Hippie Scientist project.
 - 2025-07-23: Added 404 redirect page and sessionStorage-based SPA routing fix.
 - 2025-07-23: Reverted unified herb data integration
+- 2025-07-24: Enhanced RotatingHerbHero with sliding transitions and controls

--- a/src/components/RotatingHerbHero.tsx
+++ b/src/components/RotatingHerbHero.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { Link } from 'react-router-dom'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { herbs } from '../data/masterList'
 import { slugify } from '../utils/slugify'
 import type { Herb } from '../types'
@@ -16,17 +17,42 @@ function shuffle<T>(arr: T[]): T[] {
   return a
 }
 
+const variants = {
+  enter: (d: number) => ({ x: d > 0 ? 100 : -100, opacity: 0 }),
+  center: { x: 0, opacity: 1 },
+  exit: (d: number) => ({ x: d > 0 ? -100 : 100, opacity: 0 }),
+}
+
 export default function RotatingHerbHero() {
   const [items, setItems] = useState<Herb[]>([])
   const [index, setIndex] = useState(0)
   const [loading, setLoading] = useState(true)
+  const [direction, setDirection] = useState(1)
   const timerRef = useRef<NodeJS.Timeout | null>(null)
 
   const scheduleNext = () => {
     const delay = 6000 + Math.random() * 2000
     timerRef.current = setTimeout(() => {
+      setDirection(1)
       setIndex(i => (i + 1) % items.length)
     }, delay)
+  }
+
+  const resetTimer = () => {
+    if (timerRef.current) clearTimeout(timerRef.current)
+    scheduleNext()
+  }
+
+  const handlePrev = () => {
+    setDirection(-1)
+    setIndex(i => (i - 1 + items.length) % items.length)
+    resetTimer()
+  }
+
+  const handleNext = () => {
+    setDirection(1)
+    setIndex(i => (i + 1) % items.length)
+    resetTimer()
   }
 
   useEffect(() => {
@@ -36,7 +62,7 @@ export default function RotatingHerbHero() {
   useEffect(() => {
     if (!items.length) return
     if (loading) setLoading(false)
-    scheduleNext()
+    resetTimer()
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current)
     }
@@ -53,23 +79,57 @@ export default function RotatingHerbHero() {
 
   return (
     <div className='relative mx-auto mt-8 flex max-w-xs justify-center sm:max-w-sm'>
-      <AnimatePresence mode='wait'>
+      <button
+        aria-label='Previous herb'
+        onClick={handlePrev}
+        className='absolute left-0 top-1/2 z-10 -translate-y-1/2 rounded-full bg-black/30 p-2 text-white backdrop-blur-md hover:scale-110'
+      >
+        <ChevronLeft className='h-5 w-5' />
+      </button>
+      <button
+        aria-label='Next herb'
+        onClick={handleNext}
+        className='absolute right-0 top-1/2 z-10 -translate-y-1/2 rounded-full bg-black/30 p-2 text-white backdrop-blur-md hover:scale-110'
+      >
+        <ChevronRight className='h-5 w-5' />
+      </button>
+      <AnimatePresence custom={direction} mode='wait'>
         <motion.article
           key={herb.id}
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: -20 }}
-          transition={{ duration: 0.6 }}
-          className='bg-psychedelic-gradient/30 soft-border-glow relative overflow-hidden rounded-2xl p-4 text-center text-white shadow-lg backdrop-blur-md'
+          custom={direction}
+          variants={variants}
+          initial='enter'
+          animate='center'
+          exit='exit'
+          transition={{
+            x: { type: 'spring', stiffness: 120, damping: 20 },
+            opacity: { duration: 0.2 },
+          }}
+          className='relative overflow-hidden rounded-2xl border border-white/20 bg-white/10 p-4 text-center text-white backdrop-blur'
         >
+          <motion.div
+            className='absolute inset-0 -z-10 rounded-2xl bg-gradient-to-br from-fuchsia-600/20 via-emerald-600/10 to-sky-600/20 blur-2xl'
+            animate={{ opacity: [0.5, 0.8, 0.5], scale: [1, 1.05, 1] }}
+            transition={{ duration: 10, ease: 'easeInOut', repeat: Infinity }}
+          />
           {herb.image && (
             <img src={herb.image} alt={herb.name} className='h-32 w-full rounded-md object-cover' />
           )}
-          <h3 className='mt-3 font-herb text-2xl text-lime-300 drop-shadow-[0_0_6px_rgba(163,255,134,0.8)]'>
+          <motion.h3
+            className='mt-3 font-herb text-2xl text-lime-300 drop-shadow-[0_0_6px_rgba(163,255,134,0.8)]'
+            initial={{ y: 10, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{ delay: 0.2 }}
+          >
             {herb.name}
-          </h3>
+          </motion.h3>
           {tags.length > 0 && (
-            <div className='mt-1 flex flex-wrap justify-center gap-1'>
+            <motion.div
+              className='mt-1 flex flex-wrap justify-center gap-1'
+              initial={{ y: 10, opacity: 0 }}
+              animate={{ y: 0, opacity: 1 }}
+              transition={{ delay: 0.3 }}
+            >
               {tags.map(tag => (
                 <TagBadge
                   key={tag}
@@ -78,15 +138,24 @@ export default function RotatingHerbHero() {
                   className='text-xs'
                 />
               ))}
-            </div>
+            </motion.div>
           )}
           {(() => {
             const effects = Array.isArray(herb.effects)
               ? herb.effects.slice(0, 3).join(', ')
               : herb.effects || ''
-            return effects ? <p className='mt-1 text-sm text-sand'>{effects}</p> : null
+            return effects ? (
+              <motion.p
+                className='mt-1 text-sm text-sand'
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={{ delay: 0.4 }}
+              >
+                {effects}
+              </motion.p>
+            ) : null
           })()}
-          <motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
+          <motion.div whileHover={{ scale: 1.1 }} whileTap={{ scale: 0.95 }}>
             <Link
               to={`/herb/${herb.slug || herb.id || slugify(herb.name)}`}
               className='hover-glow mt-3 inline-block rounded-md bg-black/30 px-4 py-2 text-sand backdrop-blur-md hover:bg-black/40'
@@ -94,11 +163,6 @@ export default function RotatingHerbHero() {
               More Info
             </Link>
           </motion.div>
-          <motion.div
-            className='pointer-events-none absolute inset-0 rounded-2xl border-2 border-fuchsia-500/40'
-            animate={{ opacity: [0.6, 0.2, 0.6] }}
-            transition={{ duration: 2.5, repeat: Infinity }}
-          />
         </motion.article>
       </AnimatePresence>
     </div>


### PR DESCRIPTION
## Summary
- add slide transitions with Framer Motion and manual controls
- use lucide chevron icons for navigation
- animate card contents and button
- add glassmorphic card style with animated gradient
- document Codex update

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68819b212d78832380961ec2d679547a