### PR TITLE
Fix database loading errors with defensive checks

### DIFF
--- a/public/database.json
+++ b/public/database.json
@@ -1,0 +1,1908 @@
+[
+  {
+    "name": "Entada rheedii",
+    "scientificName": "Entada rheedii",
+    "category": "Oneirogen",
+    "effects": [
+      "Dream enhancement",
+      "trance"
+    ],
+    "preparation": "Seed powder or chew",
+    "intensity": "Moderate",
+    "onset": "30-60 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🇲🇽 Latin America",
+    "tags": [
+      "\\ud83d\\udc8a Oral",
+      "\\ud83e\\udde0 Dream",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Tryptamine alkaloids may interact with serotonin receptors.",
+    "pharmacokinetics": "Traditionally consumed as cold water infusion; onset ~1–2 h; effects last ~6–8 h [0, 11].",
+    "therapeuticUses": "Dream enhancement, lucid dreaming, traditional remedy for diarrhea and stomach aches [0, 6, 0, 11].",
+    "sideEffects": "Mild GI upset, drowsiness; rare nausea [0, 6].",
+    "contraindications": "Pregnancy, lactation, hypersensitivity [0, 6].",
+    "drugInteractions": "May potentiate CNS depressants; caution with anticholinergics [0, 6].",
+    "toxicity": "Low; no severe toxicity reported in traditional use [0, 6].",
+    "toxicityLD50": "Unknown",
+    "id": "entada-rheedii",
+    "description": "Seed from a tropical vine used in African traditions to induce vivid dreams.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Kava",
+    "scientificName": "Piper methysticum",
+    "category": "Dissociative / Sedative",
+    "effects": [
+      "Relaxation",
+      "anxiolytic",
+      "mild euphoria"
+    ],
+    "preparation": "Traditional root tea or capsule",
+    "intensity": "Moderate",
+    "onset": "10-20 min",
+    "legalStatus": "Regulated / Varies",
+    "region": "🌎 Pacific Islands",
+    "tags": [
+      "\\ud83d\\udc8a Oral",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Kavalactones modulate GABA receptors and inhibit norepinephrine reuptake.",
+    "pharmacokinetics": "Oral onset 10–20 min; duration 2–3 h.",
+    "therapeuticUses": "Anxiety relief, muscle relaxation, social ease.",
+    "sideEffects": "Drowsiness, impaired coordination, rare hepatotoxicity.",
+    "contraindications": "Liver disease, pregnancy, use with CNS depressants.",
+    "drugInteractions": "Potentiates sedatives, alcohol, hepatotoxic drugs.",
+    "toxicity": "High doses linked to liver toxicity in extracts.",
+    "toxicityLD50": "No clear LD50; chronic heavy use may be harmful.",
+    "id": "kava",
+    "description": "South Pacific root brew known for its relaxing and anxiolytic effects.",
+    "safetyRating": 2,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Lion's Mane",
+    "scientificName": "Hericium erinaceus",
+    "category": "Other",
+    "effects": [
+      "Neurotrophic support",
+      "cognitive enhancement"
+    ],
+    "preparation": "Cooked, tea, or capsule",
+    "intensity": "Mild",
+    "onset": "Days to weeks",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🇨🇳 East Asia",
+    "tags": [
+      "\\ud83d\\udc8a Oral",
+      "\\ud83e\\udde0 Cognitive",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Hericenones and erinacines stimulate nerve growth factor.",
+    "pharmacokinetics": "Benefits accumulate with regular use over weeks.",
+    "therapeuticUses": "Memory, focus, nerve regeneration, mood support.",
+    "sideEffects": "Rare allergic reactions; generally well-tolerated.",
+    "contraindications": "Allergy to mushrooms, pregnancy (limited data).",
+    "drugInteractions": "No major interactions documented.",
+    "toxicity": "Low toxicity; consumed as food in many cultures.",
+    "toxicityLD50": "Not established; considered safe.",
+    "id": "lions-mane",
+    "description": "Medicinal mushroom valued for promoting nerve growth and mental clarity.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Passionflower",
+    "scientificName": "Passiflora incarnata",
+    "category": "Dissociative / Sedative",
+    "effects": [
+      "Anxiolytic",
+      "mild hypnotic"
+    ],
+    "preparation": "Tea, tincture, or smoke",
+    "intensity": "Mild",
+    "onset": "20-40 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌎 North America",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\u2615 Brewable",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Flavonoids and harmala alkaloids modulate GABA and MAO activity.",
+    "pharmacokinetics": "Oral onset 20–40 min; duration 1–2 h.",
+    "therapeuticUses": "Insomnia, anxiety relief, muscle relaxation.",
+    "sideEffects": "Drowsiness, dizziness at high doses.",
+    "contraindications": "Pregnancy, use with CNS depressants.",
+    "drugInteractions": "May enhance sedatives and MAOIs.",
+    "toxicity": "Generally safe at recommended doses.",
+    "toxicityLD50": "Not well established; high safety margin.",
+    "id": "passionflower",
+    "description": "Climbing vine traditionally brewed for anxiety relief and restful sleep.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Reishi Mushroom",
+    "scientificName": "Ganoderma lucidum",
+    "category": "Other",
+    "effects": [
+      "Immune support",
+      "calm focus"
+    ],
+    "preparation": "Dried fruiting body tea or extract",
+    "intensity": "Mild",
+    "onset": "30-60 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🇨🇳 East Asia",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83e\\udde0 Cognitive",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Triterpenoids and beta-glucans modulate immune response.",
+    "pharmacokinetics": "Oral; benefits build over weeks of use.",
+    "therapeuticUses": "Immune enhancement, stress resilience, antioxidant.",
+    "sideEffects": "Rare digestive upset or rash.",
+    "contraindications": "Bleeding disorders, surgery.",
+    "drugInteractions": "Anticoagulants, immunosuppressants.",
+    "toxicity": "Very low toxicity; widely consumed as tonic.",
+    "toxicityLD50": "Not established; safe in traditional use.",
+    "id": "reishi-mushroom",
+    "description": "Tonic fungus revered in Asia for boosting immunity and easing stress.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Valerian",
+    "scientificName": "Valeriana officinalis",
+    "category": "Dissociative / Sedative",
+    "effects": [
+      "Relaxation",
+      "sleep support"
+    ],
+    "preparation": "Root tea or capsule",
+    "intensity": "Mild",
+    "onset": "30-60 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🇧🇪 Europe",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Valerenic acid modulates GABA receptors and inhibits breakdown.",
+    "pharmacokinetics": "Oral onset 30–60 min; effects last 2–4 h.",
+    "therapeuticUses": "Insomnia, anxiety, muscle tension.",
+    "sideEffects": "Grogginess, vivid dreams, headache.",
+    "contraindications": "Pregnancy, heavy alcohol use.",
+    "drugInteractions": "Sedatives, alcohol.",
+    "toxicity": "Generally safe; high doses may cause dizziness.",
+    "toxicityLD50": "LD50 > 3 g/kg (rat).",
+    "id": "valerian",
+    "description": "Pungent root used as a natural sleep aid and mild tranquilizer.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Mugwort",
+    "scientificName": "",
+    "category": "Oneirogen",
+    "effects": [
+      "Lucid dreams",
+      "astral travel"
+    ],
+    "preparation": "Tea, smoke, or pillow herb",
+    "intensity": "Mild",
+    "onset": "1-5 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🇪🇺 Europe",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\u2615 Brewable",
+      "\\ud83e\\udde0 Dream",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Contains thujone, a GABAA antagonist; may also modulate cholinergic systems [9, 9].",
+    "pharmacokinetics": "Smoked or tea; onset 20–40 min; duration ~1–2 h [9, 9].",
+    "therapeuticUses": "Lucid dreaming, digestive support, menstrual aid [9, 9].",
+    "sideEffects": "Headache, nausea, dizziness; risk in pregnancy and seizure disorders [9, 9].",
+    "contraindications": "Pregnancy, allergies to ragweed, epilepsy [9, 9].",
+    "drugInteractions": "Avoid with CNS depressants and anticonvulsants [9, 9].",
+    "toxicity": "Contains thujone and other essential oils that are toxic in high doses.",
+    "toxicityLD50": "Thujone LD50 ~87–120 mg/kg in mice; caution advised at high doses or chronic use.",
+    "id": "mugwort",
+    "description": "Aromatic herb smoked or sipped to enhance dreaming and soothe digestion.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Heimia salicifolia (Sinicuichi)",
+    "scientificName": "",
+    "category": "Dissociative / Sedative",
+    "effects": [
+      "Auditory hallucinations",
+      "slowed time"
+    ],
+    "preparation": "Fermented sun tea",
+    "intensity": "Moderate",
+    "onset": "15-45 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83e\\uddea Fermented",
+      "\\ud83c\\udf00 Dissociation",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Alkaloids may affect auditory processing and blood flow, potentially modulating neurotransmission [9, 4].",
+    "pharmacokinetics": "Traditionally fermented sun tea; slow onset 15–45 min; duration ~2–3 h [9, 4].",
+    "therapeuticUses": "Divination, auditory changes, euphoria in folk practices [9, 4].",
+    "sideEffects": "Dry mouth, muscle relaxation, altered hearing [9, 4].",
+    "contraindications": "Avoid with alcohol or CNS depressants, pregnancy [9, 4].",
+    "drugInteractions": "None known; caution with psychiatric medications [9, 4].",
+    "toxicity": "Low toxicity; high doses may cause mild sedation or nausea [9, 4].",
+    "toxicityLD50": "Not well established; no fatal doses reported in traditional use.",
+    "id": "heimia-salicifolia-sinicuichi",
+    "description": "Mexican shrub whose fermented leaves produce mild auditory shifts.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Sceletium tortuosum (Kanna)",
+    "scientificName": "",
+    "category": "Empathogen / Euphoriant",
+    "effects": [
+      "Mood lift",
+      "empathy",
+      "sociability"
+    ],
+    "preparation": "Chew, snuff, extract",
+    "intensity": "Moderate",
+    "onset": "30-60 min",
+    "legalStatus": "Legal, sometimes restricted",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\ud83d\\udc8a Oral",
+      "\\ud83d\\udcab Euphoria",
+      "\\u26a0\\ufe0f Restricted"
+    ],
+    "mechanismOfAction": "Selective serotonin reuptake inhibition (SSRI) and phosphodiesterase-4 (PDE4) inhibition [9, 4].",
+    "pharmacokinetics": "Oral onset 20–60 min; duration 2–4 h [9, 4].",
+    "therapeuticUses": "Mood enhancement, anti-anxiety, social facilitation [9, 4].",
+    "sideEffects": "Headache, nausea, mild sedation [9, 4].",
+    "contraindications": "Do not combine with other serotonergic substances; pregnancy [9, 4].",
+    "drugInteractions": "SSRIs, MAOIs, stimulants [9, 4].",
+    "toxicity": "Low toxicity at traditional doses [9, 4].",
+    "toxicityLD50": "Not established in humans; high safety margin observed in animal studies.",
+    "id": "sceletium-tortuosum-kanna",
+    "description": "South African succulent chewed to elevate mood and decrease tension.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Blue Lotus (Nymphaea caerulea)",
+    "scientificName": "",
+    "category": "Other",
+    "effects": [
+      "Euphoria",
+      "aphrodisiac",
+      "dreamy calm"
+    ],
+    "preparation": "Wine soak, smoke, tea",
+    "intensity": "Mild",
+    "onset": "1-5 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\u2615 Brewable",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Contains aporphine and nuciferine; dopamine receptor modulation and mild sedative effect.",
+    "pharmacokinetics": "Smoked or soaked in wine; onset rapid (5–20 min); duration ~1–3 hrs.",
+    "therapeuticUses": "Mild euphoria, anxiety relief, and aphrodisiac in traditional use.",
+    "sideEffects": "Drowsiness, mild dizziness at high doses.",
+    "contraindications": "Pregnancy, avoid with dopaminergic drugs.",
+    "drugInteractions": "Potential additive effects with CNS depressants.",
+    "toxicity": "Low toxicity; no serious effects reported from traditional use.",
+    "toxicityLD50": "Not established; no reported lethal doses.",
+    "id": "blue-lotus-nymphaea-caerulea",
+    "description": "Sacred water lily delivering gentle euphoria and relaxation.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Salvia divinorum",
+    "scientificName": "",
+    "category": "Dissociative / Sedative",
+    "effects": [
+      "Total dissociation",
+      "entity contact"
+    ],
+    "preparation": "Smoked, intense, short duration",
+    "intensity": "High",
+    "onset": "1-5 min",
+    "legalStatus": "Restricted in many regions",
+    "region": "🇲🇽 Latin America",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\u26a0\\ufe0f Restricted"
+    ],
+    "mechanismOfAction": "Unknown",
+    "pharmacokinetics": "Absorbed via oral mucosa, smoking or vaporization; rapid onset (seconds–minutes), short duration (~15–30 min), quickly metabolized to inactive salvinorin B [3, 1].",
+    "therapeuticUses": "Visionary experiences in traditional Mazatec rituals; investigated for analgesic and anti-inflammatory properties [3, 0].",
+    "sideEffects": "Tiredness, dizziness, amnesia, potential for transient psychosis in vulnerable individuals [3, 2].",
+    "contraindications": "Psychiatric disorders, cardiovascular instability; avoid in those at risk for psychosis [3, 2].",
+    "drugInteractions": "CNS depressants may potentiate sedative effects; caution when coadministered [3, 3].",
+    "toxicity": "Low toxicity; animal studies show minimal organ damage even at high doses [3, 3].",
+    "toxicityLD50": "LD50 not established; salvinorin A active at microgram levels with no evidence of physical toxicity.",
+    "id": "salvia-divinorum",
+    "description": "Mazatec entheogen with powerful, short-lived visionary effects.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Wild Lettuce",
+    "scientificName": "",
+    "category": "Dissociative / Sedative",
+    "effects": [
+      "Opium-like body high",
+      "sedation"
+    ],
+    "preparation": "Smoke or extract",
+    "intensity": "Moderate",
+    "onset": "1-5 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Lactucin and lactucopicrin act as acetylcholinesterase inhibitors and may bind opioid receptors, producing sedative and analgesic effects [0, 50].",
+    "pharmacokinetics": "Oral ingestion (tea or tincture); onset 30–60 min; duration ~4 h; metabolites excreted renally [0, 2].",
+    "therapeuticUses": "Mild analgesic, sedative, sleep aid [0, 7].",
+    "sideEffects": "Mydriasis, photophobia, dizziness, diaphoresis, auditory hallucinations, cardiovascular and respiratory distress at high doses [0, 2].",
+    "contraindications": "Pregnancy, concurrent sedative use, latex allergy.",
+    "drugInteractions": "Additive sedation with CNS depressants and alcohol.",
+    "toxicity": "Dose-dependent toxicity; hospitalizations reported but full recovery common [0, 2].",
+    "toxicityLD50": "Unknown",
+    "id": "wild-lettuce",
+    "description": "Leafy plant exuding sedative latex historically called 'lettuce opium.'",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Chiric Sanango",
+    "scientificName": "",
+    "category": "Dissociative / Sedative",
+    "effects": [
+      "Shadow work",
+      "spiritual clearing"
+    ],
+    "preparation": "Amazonian brew; not casual use",
+    "intensity": "High",
+    "onset": "15-45 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Contains β-carboline alkaloids (harmine, harmaline) and coumarins (scopoletin) that may inhibit monoamine oxidase and modulate serotonergic/cholinergic systems [0, 11, 0, 1].",
+    "pharmacokinetics": "Traditionally infused or added to ayahuasca; alkaloids absorbed orally; onset ~30–60 min; duration several hours [0, 10].",
+    "therapeuticUses": "Potentiates ayahuasca, used in Amazonian rituals for introspection and mild hallucinations [0, 4].",
+    "sideEffects": "Dizziness, nausea, muscle tremors, delirium at high doses [0, 11].",
+    "contraindications": "Pregnancy, cardiovascular conditions.",
+    "drugInteractions": "Other serotonergic or cholinergic agents.",
+    "toxicity": "Toxic in high doses; caution advised.",
+    "toxicityLD50": "LD50 not established; considered mildly toxic in large doses due to cholinergic effects.",
+    "id": "chiric-sanango",
+    "description": "Amazonian shrub added to ayahuasca for introspection and cleansing.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Mapacho",
+    "scientificName": "",
+    "category": "Ritual / Visionary",
+    "effects": [
+      "Sacred tobacco",
+      "heavy grounding"
+    ],
+    "preparation": "Smoked ceremonially (very strong)",
+    "intensity": "High",
+    "onset": "1-5 min",
+    "legalStatus": "Restricted (due to nicotine content)",
+    "region": "🇲🇽 Latin America",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\ud83d\\udd2e Ritual",
+      "\\u26a0\\ufe0f Restricted"
+    ],
+    "mechanismOfAction": "Nicotine agonizes nicotinic acetylcholine receptors; contains β-carbolines (harmala alkaloids) acting as reversible MAO inhibitors [1, 0, 1, 9].",
+    "pharmacokinetics": "Smoked or insufflated; rapid absorption via lungs or mucosa; peak plasma nicotine within minutes; half-life ~2 hours [1, 0].",
+    "therapeuticUses": "Shamanic entheogen in rapé blends for sensory enhancement and ritual purification [1, 0].",
+    "sideEffects": "Nausea, tachycardia, vomiting, dizziness at high doses [1, 0].",
+    "contraindications": "Cardiovascular disease, pregnancy.",
+    "drugInteractions": "Other nicotinic agonists and MAO inhibitors.",
+    "toxicity": "High risk of nicotine overdose; very toxic.",
+    "toxicityLD50": "LD50 (nicotine) ~0.5–1.0 mg/kg in humans (oral); overdose via smoke is rare but possible.",
+    "id": "mapacho",
+    "description": "Potent Nicotiana rustica tobacco burned in ritual for focus and protection.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Tagetes lucida (Mexican Tarragon)",
+    "scientificName": "",
+    "category": "Other",
+    "effects": [
+      "Visionary dreams",
+      "clarity"
+    ],
+    "preparation": "Tea, incense, or smoke",
+    "intensity": "Mild",
+    "onset": "1-5 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🇲🇽 Latin America",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\u2615 Brewable",
+      "\\ud83d\\udd6f\\ufe0f Ritual",
+      "\\ud83e\\udde0 Cognitive",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Coumarins (dimethylfraxetin, herniarin) and essential oils (methyl eugenol, estragole) interact with GABAₐ and 5-HT₁ₐ receptors, producing anxiolytic and sedative effects [2, 2, 2, 10].",
+    "pharmacokinetics": "Consumed as tea or tincture; onset ~20–30 min; duration ~2–4 hours [2, 2].",
+    "therapeuticUses": "Anxiolytic, digestive aid, ritual incense for purification [2, 10].",
+    "sideEffects": "Mild GI upset, potential photosensitivity [2, 3].",
+    "contraindications": "Pregnancy, concurrent sedatives.",
+    "drugInteractions": "Benzodiazepines and serotonergic drugs.",
+    "toxicity": "Low; traditional use generally safe.",
+    "toxicityLD50": "Unknown",
+    "id": "tagetes-lucida-mexican-tarragon",
+    "description": "Sweet marigold used as tea or incense for clear dreams and calm.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Turnera diffusa",
+    "scientificName": "Turnera diffusa",
+    "category": "Empathogen / Euphoriant",
+    "effects": [
+      "aphrodisiac",
+      "mood-enhancing",
+      "anxiolytic"
+    ],
+    "preparation": "Tea or smoke",
+    "intensity": "Mild",
+    "onset": "1-5 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "Texas, Mexico, Central America",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\u2615 Brewable",
+      "\\ud83d\\udcab Euphoria",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Likely modulates serotonin, dopamine, and GABA neurotransmission via flavonoids and tannins [8, 6].",
+    "pharmacokinetics": "Tea or smoked; onset ~30–45 min; duration ~2–4 hours [8, 6].",
+    "therapeuticUses": "Aphrodisiac, mood enhancement, stress relief [8, 6].",
+    "sideEffects": "Mild headache, insomnia at high doses [8, 6].",
+    "contraindications": "Pregnancy, MAOI coadministration.",
+    "drugInteractions": "Serotonergic medications.",
+    "toxicity": "Low in traditional doses.",
+    "toxicityLD50": "Unknown",
+    "id": "turnera-diffusa",
+    "description": "Fragrant shrub known as damiana, smoked or brewed as aphrodisiac and relaxant.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Kra Thum Na / Kok",
+    "scientificName": "",
+    "category": "Empathogen / Euphoriant",
+    "effects": [
+      "Stimulation",
+      "kratom-like body feel"
+    ],
+    "preparation": "Capsule or tea",
+    "intensity": "Moderate",
+    "onset": "15-45 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83d\\udc8a Oral",
+      "\\ud83d\\udcab Euphoria",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Unknown",
+    "pharmacokinetics": "Not well documented",
+    "therapeuticUses": "Not well documented",
+    "sideEffects": "Not well documented",
+    "contraindications": "Not well documented",
+    "drugInteractions": "Not well documented",
+    "toxicity": "Unknown",
+    "toxicityLD50": "Unknown",
+    "id": "kra-thum-na--kok",
+    "description": "Southeast Asian tree related to kratom with stimulating leaves.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Sakae Naa",
+    "scientificName": "",
+    "category": "Empathogen / Euphoriant",
+    "effects": [
+      "Mild stimulant",
+      "mood separation"
+    ],
+    "preparation": "Tea or capsule",
+    "intensity": "Mild",
+    "onset": "15-45 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83d\\udc8a Oral",
+      "\\ud83d\\udcab Euphoria",
+      "\\u26a1 Stimulant",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Mitragynine-like alkaloids; mild adrenergic and dopaminergic stimulation.",
+    "pharmacokinetics": "Oral (tea/capsule); onset 20–40 min; effects last ~3–4 hrs.",
+    "therapeuticUses": "Used as stimulant, mood enhancer, and mild analgesic.",
+    "sideEffects": "Mild stimulation, jitteriness, GI upset at high doses.",
+    "contraindications": "Avoid with stimulants or heart issues.",
+    "drugInteractions": "May interact with MAOIs, stimulants, and certain SSRIs.",
+    "toxicity": "Low, but less studied than kratom.",
+    "toxicityLD50": "Not established; no fatalities reported in isolated use.",
+    "id": "sakae-naa",
+    "description": "Thai herb with mitragynine-like alkaloids providing mild stimulation.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Nelumbo nucifera",
+    "scientificName": "",
+    "category": "Empathogen / Euphoriant",
+    "effects": [
+      "Mild dissociation",
+      "calm euphoria"
+    ],
+    "preparation": "Tea, smoke",
+    "intensity": "Mild",
+    "onset": "1-5 min",
+    "legalStatus": "Legal, low concern",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\u2615 Brewable",
+      "\\ud83d\\udcab Euphoria",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Contains nuciferine (dopamine receptor modulator) and aporphine alkaloids.",
+    "pharmacokinetics": "Smoked or tea; onset rapid (5–15 min); duration ~2–3 hrs.",
+    "therapeuticUses": "Mild euphoria, stress reduction, dream enhancement.",
+    "sideEffects": "Mild dizziness or nausea if overused.",
+    "contraindications": "Pregnancy, hypotension.",
+    "drugInteractions": "Possible additive effects with MAOIs and dopamine agents.",
+    "toxicity": "Low toxicity in traditional doses.",
+    "toxicityLD50": "Not well-established; estimated to be >500 mg/kg (safe range).",
+    "id": "nelumbo-nucifera",
+    "description": "Sacred lotus revered for tranquil, mildly euphoric properties.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Scullcap (Scutellaria)",
+    "scientificName": "",
+    "category": "Dissociative / Sedative",
+    "effects": [
+      "Relaxing",
+      "anxiety-reducing",
+      "dream support"
+    ],
+    "preparation": "Tea or tincture",
+    "intensity": "Mild",
+    "onset": "15-45 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Flavonoids and baicalin modulate GABA-A receptors and inhibit inflammation.",
+    "pharmacokinetics": "Taken orally; onset ~30 min; effects last ~2–4 hrs.",
+    "therapeuticUses": "Calming, anticonvulsant, neuroprotective.",
+    "sideEffects": "Rarely causes liver enzyme elevation or drowsiness.",
+    "contraindications": "Liver issues; consult provider before long-term use.",
+    "drugInteractions": "Additive effects with sedatives or anxiolytics.",
+    "toxicity": "Generally safe, though adulterants in supplements have caused concern.",
+    "toxicityLD50": "No standard LD50 data; high therapeutic margin.",
+    "id": "scullcap-scutellaria",
+    "description": "Calming mint-family herb rich in baicalin used as nerve tonic.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "California Poppy",
+    "scientificName": "",
+    "category": "Dissociative / Sedative",
+    "effects": [
+      "Gentle sedative",
+      "dreamlike calm"
+    ],
+    "preparation": "Tea, tincture, or extract",
+    "intensity": "Mild",
+    "onset": "15-45 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Mild GABAergic activity and opioid receptor affinity (non-narcotic).",
+    "pharmacokinetics": "Oral (tea or tincture); onset ~30 min; lasts 2–3 hrs.",
+    "therapeuticUses": "Used for anxiety, insomnia, and pain management.",
+    "sideEffects": "Drowsiness, vivid dreams, dizziness.",
+    "contraindications": "Not for use in pregnancy or with other CNS depressants.",
+    "drugInteractions": "May amplify effects of benzodiazepines and alcohol.",
+    "toxicity": "Low toxicity; non-habit-forming.",
+    "toxicityLD50": "No known LD50 in humans; safe at standard doses.",
+    "id": "california-poppy",
+    "description": "California's state flower containing non-addictive sedative alkaloids.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Hop Flowers",
+    "scientificName": "",
+    "category": "Dissociative / Sedative",
+    "effects": [
+      "Relaxation",
+      "dream enhancement"
+    ],
+    "preparation": "Tea or herbal pillow",
+    "intensity": "Mild",
+    "onset": "15-45 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Binds to GABA-A receptors, promoting sedation and relaxation.",
+    "pharmacokinetics": "Oral or inhaled; onset ~20–40 min; duration ~2–4 hrs.",
+    "therapeuticUses": "Used as a mild sleep aid, anxiety reducer, and dream enhancer.",
+    "sideEffects": "Drowsiness, mild headache, possible hormonal effects in large doses.",
+    "contraindications": "Pregnancy, estrogen-sensitive conditions (e.g. breast cancer).",
+    "drugInteractions": "May enhance sedatives, alcohol, and hypnotics.",
+    "toxicity": "Very low toxicity; generally regarded as safe.",
+    "toxicityLD50": "No human LD50; high safety margin reported in herbal use.",
+    "id": "hop-flowers",
+    "description": "Bitter cones of Humulus lupulus used for relaxation and sleep.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Copal",
+    "scientificName": "",
+    "category": "Ritual / Visionary",
+    "effects": [
+      "Purifying",
+      "sacred aroma",
+      "trance enhancement"
+    ],
+    "preparation": "Burned as incense",
+    "intensity": "Mild",
+    "onset": "5-20 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌐 Global / Ritual",
+    "tags": [
+      "\\ud83d\\udd6f\\ufe0f Ritual",
+      "\\ud83d\\udd2e Ritual",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Unknown",
+    "pharmacokinetics": "Not well documented",
+    "therapeuticUses": "Not well documented",
+    "sideEffects": "Not well documented",
+    "contraindications": "Not well documented",
+    "drugInteractions": "Not well documented",
+    "toxicity": "Unknown",
+    "toxicityLD50": "Unknown",
+    "id": "copal",
+    "description": "Resin from Bursera trees burned ceremonially to purify and induce trance.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Sweetgrass",
+    "scientificName": "",
+    "category": "Ritual / Visionary",
+    "effects": [
+      "Positive energy",
+      "spiritual invocation"
+    ],
+    "preparation": "Burned or braided for ceremonies",
+    "intensity": "Mild",
+    "onset": "Varies",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌐 Global / Ritual",
+    "tags": [
+      "\\ud83d\\udd2e Ritual",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Unknown",
+    "pharmacokinetics": "Not well documented",
+    "therapeuticUses": "Not well documented",
+    "sideEffects": "Not well documented",
+    "contraindications": "Not well documented",
+    "drugInteractions": "Not well documented",
+    "toxicity": "Unknown",
+    "toxicityLD50": "Unknown",
+    "id": "sweetgrass",
+    "description": "Vanilla-scented grass braided and burned to invite positive spirits.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "White Sage",
+    "scientificName": "",
+    "category": "Ritual / Visionary",
+    "effects": [
+      "Clarity",
+      "purification",
+      "spiritual reset"
+    ],
+    "preparation": "Burned as incense",
+    "intensity": "Mild",
+    "onset": "5-20 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌐 Global / Ritual",
+    "tags": [
+      "\\ud83d\\udd6f\\ufe0f Ritual",
+      "\\ud83d\\udd2e Ritual",
+      "\\ud83e\\udde0 Cognitive",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "1,8-Cineole and α-thujone inhibit pro-inflammatory cytokines (TNFα, IL-1β) and arachidonic acid metabolism; antimicrobial and antiviral effects via NF-κB inhibition [0, 19, 0, 4].",
+    "pharmacokinetics": "Inhaled or topical; rapid local absorption; systemic exposure minimal; metabolites excreted renally [0, 4].",
+    "therapeuticUses": "Smudging rituals for purification, antimicrobial, respiratory support, mental clarity [0, 19].",
+    "sideEffects": "Respiratory irritation, asthmatic exacerbation, headaches at high exposure [0, 19].",
+    "contraindications": "Asthma, pregnancy, respiratory disorders.",
+    "drugInteractions": "None significant documented.",
+    "toxicity": "Very low; excessive inhalation may cause dizziness or nausea [0, 4].",
+    "toxicityLD50": "Unknown",
+    "id": "white-sage",
+    "description": "Aromatic sage revered for cleansing rituals and mental clarity.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Frankincense (Boswellia)",
+    "scientificName": "",
+    "category": "Other",
+    "effects": [
+      "Trance",
+      "meditative awareness"
+    ],
+    "preparation": "Resin burned",
+    "intensity": "Mild",
+    "onset": "Varies",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌐 Global / Ritual",
+    "tags": [
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Unknown",
+    "pharmacokinetics": "Not well documented",
+    "therapeuticUses": "Not well documented",
+    "sideEffects": "Not well documented",
+    "contraindications": "Not well documented",
+    "drugInteractions": "Not well documented",
+    "toxicity": "Unknown",
+    "toxicityLD50": "Unknown",
+    "id": "frankincense-boswellia",
+    "description": "Resin incense with boswellic acids studied for anti-inflammatory effects.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Henbane",
+    "scientificName": "",
+    "category": "Deliriant / Toxic",
+    "effects": [
+      "Delirium",
+      "hallucinations",
+      "anticholinergic"
+    ],
+    "preparation": "Historically ritual; dangerous/toxic",
+    "intensity": "High",
+    "onset": "Varies",
+    "legalStatus": "Controlled / Toxic",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\ud83d\\udd6f\\ufe0f Ritual",
+      "\\u2620\\ufe0f Toxic"
+    ],
+    "mechanismOfAction": "Unknown",
+    "pharmacokinetics": "Not well documented",
+    "therapeuticUses": "Not well documented",
+    "sideEffects": "Not well documented",
+    "contraindications": "Not well documented",
+    "drugInteractions": "Not well documented",
+    "toxicity": "Unknown",
+    "toxicityLD50": "Unknown",
+    "id": "henbane",
+    "description": "Nightshade containing tropane alkaloids causing powerful delirium.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Belladonna",
+    "scientificName": "",
+    "category": "Deliriant / Toxic",
+    "effects": [
+      "Hallucinations",
+      "dreamlike confusion"
+    ],
+    "preparation": "Highly toxic – not for casual use",
+    "intensity": "High",
+    "onset": "Varies",
+    "legalStatus": "Controlled / Toxic",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\u2620\\ufe0f Toxic"
+    ],
+    "mechanismOfAction": "Tropane alkaloids block acetylcholine; causes anticholinergic delirium.",
+    "pharmacokinetics": "Oral or topical; onset ~30–90 mins; effects last 4–12 hrs.",
+    "therapeuticUses": "Historically used for pain, muscle spasms, and cosmetic dilation.",
+    "sideEffects": "Dry mouth, hallucinations, delirium, elevated pulse.",
+    "contraindications": "Cardiovascular disease, glaucoma, pregnancy.",
+    "drugInteractions": "CNS depressants, anticholinergic drugs.",
+    "toxicity": "Highly toxic; accidental ingestion can be fatal.",
+    "toxicityLD50": "Atropine LD50 (rat, oral): ~453 mg/kg.",
+    "id": "belladonna",
+    "description": "Deadly nightshade once used for trance and as a cosmetic poison.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Mandrake Root",
+    "scientificName": "",
+    "category": "Deliriant / Toxic",
+    "effects": [
+      "Narcotic",
+      "visionary trance"
+    ],
+    "preparation": "Traditional ceremonial use only",
+    "intensity": "High",
+    "onset": "Varies",
+    "legalStatus": "Controlled / Toxic",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\u2620\\ufe0f Toxic"
+    ],
+    "mechanismOfAction": "Contains tropane alkaloids (scopolamine, atropine); anticholinergic deliriant.",
+    "pharmacokinetics": "Oral or transdermal; slow absorption; long-lasting (6–12 hrs).",
+    "therapeuticUses": "Historically used as anesthetic, antispasmodic, and in witchcraft.",
+    "sideEffects": "Dry mouth, confusion, hallucinations, elevated heart rate.",
+    "contraindications": "Pregnancy, glaucoma, heart conditions.",
+    "drugInteractions": "Potentiates other anticholinergics, CNS depressants.",
+    "toxicity": "Highly toxic in moderate doses.",
+    "toxicityLD50": "Scopolamine LD50 (rat, oral): ~310 mg/kg.",
+    "id": "mandrake-root",
+    "description": "Mythic Mediterranean root with hallucinogenic tropane alkaloids.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Anadenanthera colubrina (Cebíl)",
+    "scientificName": "",
+    "category": "Ethnobotanical / Rare",
+    "effects": [
+      "Entheogenic snuff",
+      "alternate reality feel"
+    ],
+    "preparation": "South American use",
+    "intensity": "High",
+    "onset": "Varies",
+    "legalStatus": "Restricted in many regions",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\u26a0\\ufe0f Restricted"
+    ],
+    "mechanismOfAction": "Bufotenin acts as a potent and non-selective serotonin receptor agonist at 5-HT₁A, 5-HT₂A, 5-HT₂C, and 5-HT₃ receptors, and serves as a specific serotonin releasing agent [1, 0].",
+    "pharmacokinetics": "When insufflated, bufotenin is rapidly absorbed nasally with onset in 5–15 min and duration around 1–2 h [1, 1].",
+    "therapeuticUses": "Traditionally used as a snuff for visionary and divinatory rituals in South American cultures [1, 1].",
+    "sideEffects": "Prominent cardiovascular changes, nausea, vomiting, and dizziness [1, 0, 1, 1].",
+    "contraindications": "Cardiovascular disorders, psychiatric conditions, and pregnancy.",
+    "drugInteractions": "Concomitant use with SSRIs or MAOIs may risk serotonin syndrome [1, 0].",
+    "toxicity": "No documented human LD50; rodent LD50 approximately 200–300 mg/kg (intraperitoneal) [1, 0].",
+    "toxicityLD50": "No documented human LD50; rodent LD50 approximately 200–300 mg/kg (intraperitoneal) [1, 0].",
+    "id": "anadenanthera-colubrina-cebl",
+    "description": "South American tree whose snuffable seeds contain bufotenin.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Virola spp.",
+    "scientificName": "",
+    "category": "Ethnobotanical / Rare",
+    "effects": [
+      "DMT-containing tree resin"
+    ],
+    "preparation": "Used in Amazonian snuffs",
+    "intensity": "High",
+    "onset": "1-3 min",
+    "legalStatus": "Restricted / Controlled",
+    "region": "🇲🇽 Latin America",
+    "tags": [
+      "\\u26a0\\ufe0f Restricted"
+    ],
+    "mechanismOfAction": "Contains DMT, 5-MeO-DMT, and beta-carbolines; classic tryptamine entheogen profile.",
+    "pharmacokinetics": "Insufflated or oral with MAOIs; fast onset if smoked or snuffed.",
+    "therapeuticUses": "Used in Amazonian shamanic healing rituals; possible antidepressant potential.",
+    "sideEffects": "Nausea, intense hallucinations, elevated heart rate.",
+    "contraindications": "Mental health disorders, heart issues, MAOI interactions.",
+    "drugInteractions": "Dangerous with SSRIs, MAOIs, and other serotonergic substances.",
+    "toxicity": "Can be overwhelming; physical toxicity low but psychological risks high.",
+    "toxicityLD50": "No established LD50 for DMT in humans; low systemic toxicity at typical doses.",
+    "id": "virola-spp",
+    "description": "Amazonian trees producing DMT-rich resins for shamanic snuffs.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Acorus gramineus",
+    "scientificName": "",
+    "category": "Ethnobotanical / Rare",
+    "effects": [
+      "Cognitive clarity",
+      "trippy effects (debated)"
+    ],
+    "preparation": "Tea or chewed",
+    "intensity": "Mild",
+    "onset": "15-45 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🇨🇳 East Asia",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83d\\udc8a Oral",
+      "\\ud83e\\udde0 Cognitive",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Contains β-asarone; may modulate acetylcholine and GABA pathways; traditional use for cognition.",
+    "pharmacokinetics": "Oral tea or tincture; slow onset (~1 hr); mild duration (2–3 hrs).",
+    "therapeuticUses": "Cognitive enhancement, anxiety, neuroprotective potential.",
+    "sideEffects": "Nausea at high doses, possible carcinogenic risk with long-term β-asarone exposure.",
+    "contraindications": "Pregnancy, long-term use caution due to β-asarone.",
+    "drugInteractions": "May enhance CNS depressants.",
+    "toxicity": "Concerns over β-asarone carcinogenicity in some studies.",
+    "toxicityLD50": "β-asarone LD50 (rat, oral): ~310 mg/kg.",
+    "id": "acorus-gramineus",
+    "description": "Asian sweet flag containing β-asarone, sometimes taken for cognition.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Celastrus paniculatus (Intellect Tree)",
+    "scientificName": "",
+    "category": "Other",
+    "effects": [
+      "Lucid dreaming",
+      "cognitive enhancer"
+    ],
+    "preparation": "Oil or seeds consumed",
+    "intensity": "Mild",
+    "onset": "Varies",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\ud83e\\udde0 Cognitive",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Unknown",
+    "pharmacokinetics": "Not well documented",
+    "therapeuticUses": "Not well documented",
+    "sideEffects": "Not well documented",
+    "contraindications": "Not well documented",
+    "drugInteractions": "Not well documented",
+    "toxicity": "Unknown",
+    "toxicityLD50": "Unknown",
+    "id": "celastrus-paniculatus-intellect-tree",
+    "description": "Indian vine whose oil is consumed to sharpen memory and dream vividly.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Silphium (extinct)",
+    "scientificName": "",
+    "category": "Other",
+    "effects": [
+      "Ancient psychoactive/contraceptive herb"
+    ],
+    "preparation": "No longer available but worth note",
+    "intensity": "Mild",
+    "onset": "Varies",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Unknown",
+    "pharmacokinetics": "Not well documented",
+    "therapeuticUses": "Not well documented",
+    "sideEffects": "Not well documented",
+    "contraindications": "Not well documented",
+    "drugInteractions": "Not well documented",
+    "toxicity": "Unknown",
+    "toxicityLD50": "Unknown",
+    "id": "silphium-extinct",
+    "description": "Famed classical herb believed to have contraceptive and psychoactive resins.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Nymphaea ampla",
+    "scientificName": "",
+    "category": "Empathogen / Euphoriant",
+    "effects": [
+      "Sedative",
+      "euphoric",
+      "dreamlike states"
+    ],
+    "preparation": "Tea or smoke",
+    "intensity": "Mild",
+    "onset": "15-45 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\u2615 Brewable",
+      "\\ud83d\\udcab Euphoria",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Unknown",
+    "pharmacokinetics": "Not well documented",
+    "therapeuticUses": "Not well documented",
+    "sideEffects": "Not well documented",
+    "contraindications": "Not well documented",
+    "drugInteractions": "Not well documented",
+    "toxicity": "Unknown",
+    "toxicityLD50": "Unknown",
+    "id": "nymphaea-ampla",
+    "description": "Central American water lily providing mild euphoria and sedation.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Pedicularis densiflora (Indian warrior)",
+    "scientificName": "",
+    "category": "Dissociative / Sedative",
+    "effects": [
+      "Muscle relaxation",
+      "mild body high"
+    ],
+    "preparation": "Smoked or tea",
+    "intensity": "Moderate",
+    "onset": "5-15 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌍 Africa, 🇮🇳 India",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\u2615 Brewable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Muscle relaxant potential via GABAergic modulation [2, 0].",
+    "pharmacokinetics": "Smoked or tea; onset rapid (minutes); duration ~2–3 h [2, 0].",
+    "therapeuticUses": "Muscle tension, pain relief, sleep aid applications [2, 0].",
+    "sideEffects": "Drowsiness, dizziness [2, 0].",
+    "contraindications": "Pregnancy, use with other sedatives [2, 0].",
+    "drugInteractions": "Additive effects with CNS depressants [2, 0].",
+    "toxicity": "Low; limited data on long-term use [2, 0].",
+    "toxicityLD50": "Unknown",
+    "id": "pedicularis-densiflora-indian-warrior",
+    "description": "North American wildflower smoked for muscle relaxation.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Pedicularis groenlandica",
+    "scientificName": "",
+    "category": "Dissociative / Sedative",
+    "effects": [
+      "Stronger relaxation",
+      "tension relief"
+    ],
+    "preparation": "Smoked or tea",
+    "intensity": "Moderate",
+    "onset": "5-15 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌍 Africa",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\u2615 Brewable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Unknown",
+    "pharmacokinetics": "Oral infusion onset ~30 min; duration ~4 h; metabolites excreted renally [0, 7].",
+    "therapeuticUses": "Muscle relaxant, antioxidant, antimicrobial, traditional remedy for pain and inflammation [0, 7].",
+    "sideEffects": "Rare; possible GI upset [0, 7].",
+    "contraindications": "Pregnancy, lactation [0, 7].",
+    "drugInteractions": "Additive with CNS depressants [0, 7].",
+    "toxicity": "Low; no significant toxicity reported [0, 7].",
+    "toxicityLD50": "Unknown",
+    "id": "pedicularis-groenlandica",
+    "description": "High-elevation lousewort prized for soothing tense muscles.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Lactuca canadensis",
+    "scientificName": "",
+    "category": "Dissociative / Sedative",
+    "effects": [
+      "Wild lettuce relative",
+      "opium-like calm"
+    ],
+    "preparation": "Tea or smoke",
+    "intensity": "Mild",
+    "onset": "15-45 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\u2615 Brewable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Contains lactucopicrin and lactucin; thought to act as mild opioid receptor agonists.",
+    "pharmacokinetics": "Oral ingestion onset 30–60 min; duration ~4 h; metabolites excreted renally [0, 6].",
+    "therapeuticUses": "Sedative, analgesic, sleep aid, antitussive [0, 6].",
+    "sideEffects": "Mydriasis, dizziness, GI upset at high doses [0, 6].",
+    "contraindications": "Pregnancy, concurrent opioid use [0, 6].",
+    "drugInteractions": "CNS depressants [0, 6].",
+    "toxicity": "Low; hospitalizations reported but recovery common [0, 6].",
+    "toxicityLD50": "Not established; presumed low. No acute toxicity reported in human use.",
+    "id": "lactuca-canadensis",
+    "description": "Wild lettuce species containing lactucarium for gentle analgesia.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Artemisia vulgaris (Mugwort)",
+    "scientificName": "",
+    "category": "Oneirogen",
+    "effects": [
+      "Lucid dreaming",
+      "light hallucinations"
+    ],
+    "preparation": "Smoke, tea, or ritual incense",
+    "intensity": "Mild",
+    "onset": "5-15 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🇪🇺 Europe",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\u2615 Brewable",
+      "\\ud83d\\udd6f\\ufe0f Ritual",
+      "\\ud83e\\udde0 Dream",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Unknown",
+    "pharmacokinetics": "Not well documented",
+    "therapeuticUses": "Not well documented",
+    "sideEffects": "Not well documented",
+    "contraindications": "Not well documented",
+    "drugInteractions": "Not well documented",
+    "toxicity": "Unknown",
+    "toxicityLD50": "Unknown",
+    "id": "artemisia-vulgaris-mugwort",
+    "description": "Common European mugwort used in dream pillows and as bitter tonic.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Justicia pectoralis",
+    "scientificName": "",
+    "category": "Empathogen / Euphoriant",
+    "effects": [
+      "Aromatic",
+      "mild euphoria",
+      "anti-anxiety"
+    ],
+    "preparation": "Smoked or brewed",
+    "intensity": "Mild",
+    "onset": "15-30 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\u2615 Brewable",
+      "\\ud83d\\udcab Euphoria",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Contains coumarin and umbelliferone; mild monoamine modulation; relaxant properties.",
+    "pharmacokinetics": "Oral infusion onset 30–60 min; metabolites via hepatic pathways; urinary excretion [0, 10].",
+    "therapeuticUses": "Gastroprotective, anti-inflammatory, antispasmodic, anxiolytic; used as snuff admixture [0, 2, 0, 10].",
+    "sideEffects": "Rare; possible sedation, GI discomfort [0, 10].",
+    "contraindications": "Pregnancy; MAOI coadministration [0, 18].",
+    "drugInteractions": "MAO inhibitors, sedatives [0, 18].",
+    "toxicity": "Low; safe at traditional doses [0, 10].",
+    "toxicityLD50": "Low; no established LD50, but considered safe in traditional use.",
+    "id": "justicia-pectoralis",
+    "description": "Aromatic herb called tilo, brewed or smoked for calming effects.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Viola odorata (Sweet violet)",
+    "scientificName": "",
+    "category": "Dissociative / Sedative",
+    "effects": [
+      "Mild sedative",
+      "calming",
+      "gentle dreaminess"
+    ],
+    "preparation": "Tea or syrup",
+    "intensity": "Mild",
+    "onset": "15-30 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🇪🇺 Europe",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Mild central sedative via salicylates and alkaloids; may influence serotonin and prostaglandin pathways.",
+    "pharmacokinetics": "Taken as tea or syrup; onset ~30 min; short duration.",
+    "therapeuticUses": "Cough suppressant, mild anxiolytic, anti-inflammatory, gentle sleep aid.",
+    "sideEffects": "Very rare; may include mild drowsiness or nausea.",
+    "contraindications": "None known in normal amounts; avoid if allergic.",
+    "drugInteractions": "Minimal; theoretically additive with CNS depressants.",
+    "toxicity": "Regarded as very safe in traditional herbalism.",
+    "toxicityLD50": "No human LD50 data; extremely low toxicity reported.",
+    "id": "viola-odorata-sweet-violet",
+    "description": "Fragrant violet whose flowers are a mild sedative and expectorant.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Piper auritum (Root beer plant)",
+    "scientificName": "",
+    "category": "Empathogen / Euphoriant",
+    "effects": [
+      "Calming",
+      "warming",
+      "euphoric"
+    ],
+    "preparation": "Tea or culinary use",
+    "intensity": "Mild",
+    "onset": "15-30 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83d\\udcab Euphoria",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Contains safrole and other volatile oils; possible mild dopaminergic stimulation and GI modulation.",
+    "pharmacokinetics": "Oral infusion or extract onset 30–60 min; hepatic metabolism; renal excretion [0, 11].",
+    "therapeuticUses": "Digestive aid, anti-inflammatory, antimutagen, diuretic, antipyretic [0, 11].",
+    "sideEffects": "High doses may cause GI upset; safrole is a potential carcinogen [1, 11].",
+    "contraindications": "Pregnancy; safrole-containing extracts discouraged [1, 11].",
+    "drugInteractions": "CYP450 substrates; caution with anticoagulants [0, 19].",
+    "toxicity": "Safrole hepatotoxic; use sparingly [1, 11].",
+    "toxicityLD50": "LD50 (rats, oral) safrole ~1,950 mg/kg; safrole is hepatotoxic at high doses.",
+    "id": "piper-auritum-root-beer-plant",
+    "description": "Sassafras-scented leaf from Mexico used culinary and for mild mood lift.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Eschscholzia californica (California poppy)",
+    "scientificName": "",
+    "category": "Dissociative / Sedative",
+    "effects": [
+      "Sleep aid",
+      "mild dreamlike calm"
+    ],
+    "preparation": "Tea, tincture",
+    "intensity": "Mild",
+    "onset": "15-45 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Unknown",
+    "pharmacokinetics": "Oral (tea, extract); onset 30–60 min; duration ~4 h; bioavailability of key alkaloids moderate [2, 3].",
+    "therapeuticUses": "Anxiety reduction, insomnia aid, mild analgesic, vasomotor headache relief [2, 3, 2, 7].",
+    "sideEffects": "High doses may cause residual sedation (\"hangover\"), nausea, dizziness; avoid operating machinery [2, 8, 2, 9].",
+    "contraindications": "Glaucoma, MAOI therapy, pregnancy, lactation [2, 9].",
+    "drugInteractions": "Additive CNS depression with sedatives, barbiturates; caution with blood thinners and antihypertensives [2, 8].",
+    "toxicity": "Low; no significant toxicity at therapeutic doses [2, 9].",
+    "toxicityLD50": "Unknown",
+    "id": "eschscholzia-californica-california-poppy",
+    "description": "Gentle sedative flower used for anxiety and sleep support.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Rivea corymbosa",
+    "scientificName": "",
+    "category": "Ethnobotanical / Rare",
+    "effects": [
+      "Dreamy visuals",
+      "nausea",
+      "traditional Mazatec use"
+    ],
+    "preparation": "Seeds ground and cold infused",
+    "intensity": "High",
+    "onset": "30-90 min",
+    "legalStatus": "Restricted in some countries",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\u26a0\\ufe0f Restricted"
+    ],
+    "mechanismOfAction": "Unknown",
+    "pharmacokinetics": "Insufflated or ingested; onset 20–60 min; duration 4–8 h; hepatic metabolism [0, 12].",
+    "therapeuticUses": "Entheogenic snuff (ololiuqui) in Mesoamerican rituals [0, 4].",
+    "sideEffects": "Nausea, vasoconstriction, dizziness [0, 4].",
+    "contraindications": "Cardiovascular disease, pregnancy [0, 4].",
+    "drugInteractions": "Serotonergic medications [0, 12].",
+    "toxicity": "Low; moderate overdose risk [0, 12].",
+    "toxicityLD50": "Unknown",
+    "id": "rivea-corymbosa",
+    "description": "Morning glory species with LSA seeds used in ancient Mexican rituals.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Ipomoea tricolor (Heavenly Blue)",
+    "scientificName": "",
+    "category": "Ethnobotanical / Rare",
+    "effects": [
+      "LSD-like visuals",
+      "spiritual confusion"
+    ],
+    "preparation": "Seeds ground and cold infused",
+    "intensity": "High",
+    "onset": "30-90 min",
+    "legalStatus": "Restricted in some countries",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\u26a0\\ufe0f Restricted"
+    ],
+    "mechanismOfAction": "Unknown",
+    "pharmacokinetics": "Oral ingestion onset 45–120 min; duration 4–10 h; hepatic metabolism [0, 5].",
+    "therapeuticUses": "Visionary experiences, ethnobotanical use [0, 5].",
+    "sideEffects": "Nausea, vasoconstriction, headache [0, 5].",
+    "contraindications": "Cardiovascular disorders, psychiatric conditions [0, 5].",
+    "drugInteractions": "SSRIs/MAOIs [0, 5].",
+    "toxicity": "Low; rodent LD50 ~200–300 mg/kg [0, 5].",
+    "toxicityLD50": "Unknown",
+    "id": "ipomoea-tricolor-heavenly-blue",
+    "description": "Ornamental morning glory whose seeds induce LSD-like visions.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Tilia europaea (Linden flower)",
+    "scientificName": "",
+    "category": "Dissociative / Sedative",
+    "effects": [
+      "Calming",
+      "relaxing",
+      "mild dream aid"
+    ],
+    "preparation": "Tea",
+    "intensity": "Mild",
+    "onset": "15-30 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🇪🇺 Europe",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Unknown",
+    "pharmacokinetics": "Not well documented",
+    "therapeuticUses": "Not well documented",
+    "sideEffects": "Not well documented",
+    "contraindications": "Not well documented",
+    "drugInteractions": "Not well documented",
+    "toxicity": "Unknown",
+    "toxicityLD50": "Unknown",
+    "id": "tilia-europaea-linden-flower",
+    "description": "Soothing tree blossoms steeped as tea for relaxation and cold relief.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Melissa officinalis (Lemon balm)",
+    "scientificName": "",
+    "category": "Dissociative / Sedative",
+    "effects": [
+      "Anxiolytic",
+      "cognitive calming"
+    ],
+    "preparation": "Tea, tincture, or smoke",
+    "intensity": "Mild",
+    "onset": "15-30 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f Smokable",
+      "\\u2615 Brewable",
+      "\\ud83c\\udf00 Dissociation",
+      "\\ud83e\\udde0 Cognitive",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Unknown",
+    "pharmacokinetics": "Oral onset 30–60 min; active compounds absorbed in GI tract; hepatic metabolism; renal excretion [0, 0].",
+    "therapeuticUses": "Anxiety, insomnia, nervous tension, digestive aid [0, 8].",
+    "sideEffects": "Drowsiness; possible allergic reactions; GI upset at high doses [0, 0].",
+    "contraindications": "Pregnancy, known Asteraceae allergy [0, 16].",
+    "drugInteractions": "May potentiate sedatives, anticoagulants; caution with CNS depressants [0, 16].",
+    "toxicity": "Low; safe at therapeutic doses [0, 0].",
+    "toxicityLD50": "Unknown",
+    "id": "melissa-officinalis-lemon-balm",
+    "description": "Lemony herb easing anxiety and digestive upset while calming the mind.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Ocimum sanctum (Holy Basil / Tulsi)",
+    "scientificName": "",
+    "category": "Empathogen / Euphoriant",
+    "effects": [
+      "Mood lift",
+      "sacred calm",
+      "spiritual focus"
+    ],
+    "preparation": "Tea or incense",
+    "intensity": "Mild",
+    "onset": "15-30 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🇮🇳 India",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83d\\udd6f\\ufe0f Ritual",
+      "\\ud83d\\udcab Euphoria",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Modulates cortisol, inflammation, and neurotransmitters; contains eugenol, ursolic acid, and apigenin.",
+    "pharmacokinetics": "Rapid absorption via oral tea/tincture; hepatic metabolism.",
+    "therapeuticUses": "Adaptogen, anxiety, spiritual focus, blood sugar balance.",
+    "sideEffects": "May lower blood sugar, mild sedation, mild nausea.",
+    "contraindications": "Pregnancy, diabetes medication.",
+    "drugInteractions": "May potentiate anti-diabetic, anticoagulant, or sedative drugs.",
+    "toxicity": "Pending",
+    "toxicityLD50": "Pending",
+    "id": "ocimum-sanctum-holy-basil--tulsi",
+    "description": "Sacred basil revered in Ayurveda for uplifting and adaptogenic qualities.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Rhodiola rosea",
+    "scientificName": "",
+    "category": "Empathogen / Euphoriant",
+    "effects": [
+      "Focus",
+      "reduced fatigue",
+      "mind clarity"
+    ],
+    "preparation": "Capsule, tincture",
+    "intensity": "Mild",
+    "onset": "30-60 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🌎 Unknown / Global",
+    "tags": [
+      "\\ud83d\\udc8a Oral",
+      "\\ud83d\\udcab Euphoria",
+      "\\ud83e\\udde0 Cognitive",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Influences serotonin, norepinephrine, dopamine; modulates HPA axis and stress adaptation via rosavins and salidroside.",
+    "pharmacokinetics": "Absorbed orally; peak plasma ~1-2 hours; active compounds metabolized in liver, excreted renally.",
+    "therapeuticUses": "Fatigue, stress resilience, cognitive enhancement, mild depression.",
+    "sideEffects": "Irritability, dry mouth, dizziness (rare, dose-dependent).",
+    "contraindications": "Bipolar disorder, stimulants, pregnancy.",
+    "drugInteractions": "May affect antidepressants, stimulants, or MAOIs.",
+    "toxicity": "Mild toxicity; high doses may cause irritability or insomnia.",
+    "toxicityLD50": "LD50 (rats, oral) >28,000 mg/kg; very low toxicity.",
+    "id": "rhodiola-rosea",
+    "description": "Hardy root enhancing endurance and stress tolerance via adaptogens.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Withania somnifera (Ashwagandha)",
+    "scientificName": "",
+    "category": "Dissociative / Sedative",
+    "effects": [
+      "Grounded calm",
+      "dream support"
+    ],
+    "preparation": "Tea or capsule",
+    "intensity": "Mild",
+    "onset": "30-60 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🇮🇳 India",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83d\\udc8a Oral",
+      "\\ud83c\\udf00 Dissociation",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Modulates GABAergic and serotonergic activity; reduces cortisol; withanolides are primary active compounds.",
+    "pharmacokinetics": "Oral onset 30–60 min; withanolides bioavailable; hepatic metabolism; renal excretion [0, 17].",
+    "therapeuticUses": "Adaptogen, anti-stress, anxiolytic, neuroprotective, anti-inflammatory, immune support [0, 1, 0, 17].",
+    "sideEffects": "GI upset, drowsiness, rare thyroid hormone changes [0, 9].",
+    "contraindications": "Pregnancy, hyperthyroidism, autoimmune diseases [0, 1].",
+    "drugInteractions": "Immunosuppressants, sedatives, thyroid medications [0, 24].",
+    "toxicity": "Low; well-tolerated in clinical studies [0, 1].",
+    "toxicityLD50": "LD50 (rats, oral) ~4650 mg/kg; relatively low acute toxicity.",
+    "id": "withania-somnifera-ashwagandha",
+    "description": "Indian nightshade root that reduces stress hormones and promotes sleep.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Bacopa monnieri",
+    "scientificName": "",
+    "category": "Empathogen / Euphoriant",
+    "effects": [
+      "Memory enhancer",
+      "mild calming"
+    ],
+    "preparation": "Tea, capsule",
+    "intensity": "Mild",
+    "onset": "30-60 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🇮🇳 India",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83d\\udc8a Oral",
+      "\\ud83d\\udcab Euphoria",
+      "\\ud83e\\uddd8 Sedation",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Contains bacosides A and B which enhance cholinergic transmission, antioxidant defenses, and modulate neurotransmitter levels (serotonin, dopamine) [0, 0, 0, 2].",
+    "pharmacokinetics": "Oral preparations (extracts or powder); onset 30–60 min; requires chronic dosing for peak cognitive benefits [0, 5].",
+    "therapeuticUses": "Cognitive enhancement (memory, learning), anxiety reduction, ADHD management [0, 1, 0, 6].",
+    "sideEffects": "Gastrointestinal upset (nausea, increased motility), fatigue, dry mouth [0, 5].",
+    "contraindications": "Pregnancy, lactation, hypersensitivity to any component [0, 5].",
+    "drugInteractions": "No major interactions documented; caution with sedatives [0, 5].",
+    "toxicity": "Generally non-toxic; no serious adverse effects at recommended doses; rodent LD50 not well established [0, 6].",
+    "toxicityLD50": "Generally non-toxic; no serious adverse effects at recommended doses; rodent LD50 not well established [0, 6].",
+    "id": "bacopa-monnieri",
+    "description": "Aquatic herb taken long-term to improve memory and concentration.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Eleutherococcus senticosus (Siberian Ginseng)",
+    "scientificName": "",
+    "category": "Empathogen / Euphoriant",
+    "effects": [
+      "Balanced energy",
+      "mood resilience"
+    ],
+    "preparation": "Tea or extract",
+    "intensity": "Mild",
+    "onset": "30-60 min",
+    "legalStatus": "Legal / Unregulated",
+    "region": "🇨🇳 East Asia",
+    "tags": [
+      "\\u2615 Brewable",
+      "\\ud83d\\udcab Euphoria",
+      "\\u2705 Safe"
+    ],
+    "mechanismOfAction": "Adaptogenic modulation of HPA axis and immune response; contains eleutherosides influencing stress resilience.",
+    "pharmacokinetics": "Oral onset in 30–60 minutes; active glycosides metabolized hepatically.",
+    "therapeuticUses": "Fatigue, immune support, cognitive performance under stress.",
+    "sideEffects": "Mild insomnia, irritability, nervousness in high doses.",
+    "contraindications": "Hypertension, pregnancy, hormone-sensitive conditions.",
+    "drugInteractions": "May interact with stimulants, immunosuppressants, and anticoagulants.",
+    "toxicity": "Generally considered safe when used short-term. Long-term effects less studied.",
+    "toxicityLD50": "No established LD50; high doses in animals show minimal acute toxicity.",
+    "id": "eleutherococcus-senticosus-siberian-ginseng",
+    "description": "Adaptogenic root boosting stamina and immune function.",
+    "safetyRating": 1,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "LSD",
+    "scientificName": "Lysergic acid diethylamide",
+    "category": "Psychedelic",
+    "effects": [
+      "Intense visuals",
+      "ego dissolution",
+      "synesthesia"
+    ],
+    "preparation": "Oral blotter or liquid",
+    "intensity": "High",
+    "onset": "30-90 min",
+    "legalStatus": "Controlled / Illegal in many regions",
+    "region": "🌎 Synthetic",
+    "tags": [
+      "💊 Oral",
+      "⚠️ Restricted",
+      "🌀 Visionary"
+    ],
+    "mechanismOfAction": "Potent 5-HT2A receptor agonist affecting serotonin and dopamine systems.",
+    "pharmacokinetics": "Oral administration with effects lasting 8-12 h; hepatic metabolism to inactive metabolites.",
+    "therapeuticUses": "Investigated for cluster headaches, anxiety, and addiction therapy.",
+    "sideEffects": "Anxiety, confusion, possible flashbacks at high doses.",
+    "contraindications": "Psychosis, severe cardiovascular disease.",
+    "drugInteractions": "SSRIs may blunt effects; MAOIs potentiate.",
+    "toxicity": "Very low physiological toxicity but strong psychological effects.",
+    "toxicityLD50": ">14 mg/kg (mice, intravenous)",
+    "id": "lsd",
+    "description": "Semi-synthetic ergoline discovered in 1938; among the most potent psychedelics.",
+    "safetyRating": 2,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Psilocybin",
+    "scientificName": "Psilocybin",
+    "category": "Psychedelic",
+    "effects": [
+      "Visual patterns",
+      "mystical insight",
+      "emotional release"
+    ],
+    "preparation": "Consumed as dried mushrooms or extract",
+    "intensity": "Moderate",
+    "onset": "20-60 min",
+    "legalStatus": "Controlled in many countries",
+    "region": "🌎 Global",
+    "tags": [
+      "💊 Oral",
+      "🌀 Visionary",
+      "⚠️ Restricted"
+    ],
+    "mechanismOfAction": "Converted to psilocin which acts as 5-HT2A agonist.",
+    "pharmacokinetics": "Oral onset ~30 min; duration 4-6 h; metabolized hepatically.",
+    "therapeuticUses": "Promising treatment for depression, addiction, and end-of-life anxiety.",
+    "sideEffects": "Nausea, anxiety, transient increase in heart rate.",
+    "contraindications": "Psychosis, uncontrolled hypertension.",
+    "drugInteractions": "SSRIs may reduce effects; avoid MAOIs.",
+    "toxicity": "Low toxicity; wide margin of safety.",
+    "toxicityLD50": "285 mg/kg (rats, oral) for psilocybin",
+    "id": "psilocybin",
+    "description": "Active compound in psychedelic mushrooms producing profound perceptual changes.",
+    "safetyRating": 2,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  },
+  {
+    "name": "Mescaline",
+    "scientificName": "3,4,5-trimethoxyphenethylamine",
+    "category": "Psychedelic",
+    "effects": [
+      "Color enhancement",
+      "empathy",
+      "spiritual visions"
+    ],
+    "preparation": "Ingested cactus buttons or purified sulfate",
+    "intensity": "Moderate",
+    "onset": "45-120 min",
+    "legalStatus": "Controlled in many regions",
+    "region": "🌎 Americas",
+    "tags": [
+      "💊 Oral",
+      "🌀 Visionary",
+      "⚠️ Restricted"
+    ],
+    "mechanismOfAction": "Phenethylamine psychedelic acting on 5-HT2A and dopamine receptors.",
+    "pharmacokinetics": "Oral absorption with peak at 2 h; duration 8-12 h; renal excretion.",
+    "therapeuticUses": "Traditional sacrament; studied for alcoholism and psychotherapy.",
+    "sideEffects": "Nausea, increased heart rate, dilated pupils.",
+    "contraindications": "Heart disease, pregnancy.",
+    "drugInteractions": "MAOIs and sympathomimetics may potentiate.",
+    "toxicity": "Low physiological toxicity; psychological effects strong.",
+    "toxicityLD50": ">1,000 mg/kg (rats, oral)",
+    "id": "mescaline",
+    "description": "Classic phenethylamine psychedelic from peyote and San Pedro cacti.",
+    "safetyRating": 2,
+    "affiliateLink": "N/A",
+    "activeConstituents": [
+      "Unknown"
+    ]
+  }
+]
+

--- a/src/components/BlendSummaryCard.tsx
+++ b/src/components/BlendSummaryCard.tsx
@@ -9,8 +9,10 @@ interface Props {
 
 function generateName(herbs: Herb[]): string {
   if (herbs.length === 0) return 'Your Custom Blend'
-  const parts = herbs.map(h => h.name.split(' ')[0])
-  return parts.join(' ') + ' Fusion'
+  const parts = herbs
+    .map(h => (h.name || '').split(' ')[0])
+    .filter(Boolean)
+  return parts.length ? parts.join(' ') + ' Fusion' : 'Your Custom Blend'
 }
 
 function generateSummary(herbs: Herb[]): string {

--- a/src/components/CategoryAnalytics.tsx
+++ b/src/components/CategoryAnalytics.tsx
@@ -7,7 +7,8 @@ export default function CategoryAnalytics() {
   const counts = React.useMemo(() => {
     const c: Record<string, number> = {}
     herbs.forEach(h => {
-      const main = h.category.split('/')[0].trim()
+      const raw = typeof h.category === 'string' ? h.category : 'Unknown'
+      const main = raw.split('/')[0].trim()
       c[main] = (c[main] || 0) + 1
     })
     return c

--- a/src/hooks/useFilteredHerbs.ts
+++ b/src/hooks/useFilteredHerbs.ts
@@ -7,7 +7,8 @@ interface Options {
   favorites?: string[]
 }
 
-export function metaCategory(cat: string): string {
+export function metaCategory(cat?: string): string {
+  if (typeof cat !== 'string') return 'Other'
   const c = cat.toLowerCase()
   if (/(empathogen|euphoriant)/.test(c)) return 'Empathogen'
   if (/(psychedelic|visionary)/.test(c)) return 'Psychedelic'

--- a/src/hooks/useHerbs.ts
+++ b/src/hooks/useHerbs.ts
@@ -1,20 +1,49 @@
 import React from 'react'
 import type { Herb } from '../types'
-import { herbs } from '../data/herbs/herbsfull'
+import { herbs as fallback } from '../data/herbs/herbsfull'
 
-export function useHerbs(): Herb[] {
-  const [herbList] = React.useState<Herb[]>(() => {
-    const map = new Map<string, Herb>()
-    herbs.forEach(h => {
-      if (!map.has(h.id)) map.set(h.id, h)
-    })
-    return Array.from(map.values())
-  })
+export function useHerbs(): {
+  herbs: Herb[]
+  loading: boolean
+  error: string | null
+} {
+  const [herbList, setHerbList] = React.useState<Herb[]>([])
+  const [loading, setLoading] = React.useState(true)
+  const [error, setError] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/database.json')
+        if (!res.ok) throw new Error(`status ${res.status}`)
+        const data = await res.json()
+        if (!Array.isArray(data)) throw new Error('invalid format')
+        const map = new Map<string, Herb>()
+        data
+          .filter((h: any) => h && typeof h.name === 'string')
+          .forEach((h: Herb) => {
+            if (h.id && !map.has(h.id)) map.set(h.id, h)
+          })
+        setHerbList(Array.from(map.values()))
+      } catch (err) {
+        console.error('Failed to fetch database', err)
+        setError((err as Error).message)
+        const map = new Map<string, Herb>()
+        fallback.forEach(h => {
+          if (!map.has(h.id)) map.set(h.id, h)
+        })
+        setHerbList(Array.from(map.values()))
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [])
 
   React.useEffect(() => {
     if (!import.meta.env.DEV) return
 
-    herbs.forEach(h => {
+    herbList.forEach(h => {
       const missing: string[] = []
       if (!h.affiliateLink) missing.push('affiliateLink')
       if (!h.activeConstituents?.length) missing.push('activeConstituents')
@@ -23,7 +52,7 @@ export function useHerbs(): Herb[] {
         console.warn(`${h.name} missing: ${missing.join(', ')}`)
       }
     })
-  }, [])
+  }, [herbList])
 
-  return herbList
+  return { herbs: herbList, loading, error }
 }

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -17,9 +17,17 @@ import { Download } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { useFilteredHerbs } from '../hooks/useFilteredHerbs'
 import { getLocal, setLocal } from '../utils/localStorage'
+import { LoadingScreen } from '../components/LoadingScreen'
 
 export default function Database() {
-  const herbs = useHerbs()
+  const { herbs, loading, error } = useHerbs()
+  if (loading) return <LoadingScreen />
+  if (error)
+    return (
+      <div className='min-h-screen px-4 pt-20 text-center'>
+        <p className='text-red-500'>Failed to load herb data.</p>
+      </div>
+    )
   const safeHerbs = React.useMemo(() => {
     const isValid = (h: any) =>
       h &&

--- a/src/pages/Favorites.tsx
+++ b/src/pages/Favorites.tsx
@@ -3,12 +3,21 @@ import { Helmet } from 'react-helmet-async'
 import { Link } from 'react-router-dom'
 import HerbList from '../components/HerbList'
 import { useHerbs } from '../hooks/useHerbs'
+import { LoadingScreen } from '../components/LoadingScreen'
 import { useHerbFavorites } from '../hooks/useHerbFavorites'
 import { motion } from 'framer-motion'
 
 export default function Favorites() {
-  const herbs = useHerbs()
+  const { herbs, loading, error } = useHerbs()
   const { favorites } = useHerbFavorites()
+
+  if (loading) return <LoadingScreen />
+  if (error)
+    return (
+      <div className='min-h-screen px-4 pt-20 text-center'>
+        <p className='text-red-500'>Failed to load herb data.</p>
+      </div>
+    )
 
   const favoriteHerbs = React.useMemo(
     () => herbs.filter(h => favorites.includes(h.id)),

--- a/src/pages/HerbBlender.tsx
+++ b/src/pages/HerbBlender.tsx
@@ -6,12 +6,21 @@ import HerbCardAccordion from '../components/HerbCardAccordion'
 import TagBadge from '../components/TagBadge'
 import { useHerbs } from '../hooks/useHerbs'
 import { useLocalStorage } from '../hooks/useLocalStorage'
+import { LoadingScreen } from '../components/LoadingScreen'
 
 export default function HerbBlender() {
-  const herbs = useHerbs()
+  const { herbs, loading, error } = useHerbs()
   const [input, setInput] = React.useState('')
   const [selected, setSelected] = React.useState<string[]>([])
   const [saved, setSaved] = useLocalStorage<string[][]>('savedBlends', [])
+
+  if (loading) return <LoadingScreen />
+  if (error)
+    return (
+      <div className='min-h-screen px-4 pt-20 text-center'>
+        <p className='text-red-500'>Failed to load herb data.</p>
+      </div>
+    )
 
   const addHerb = () => {
     const h = herbs.find(

--- a/src/utils/tagUtils.ts
+++ b/src/utils/tagUtils.ts
@@ -34,7 +34,8 @@ export const tagAliasMap: Record<string, string> = {
   nootropic: 'stimulant',
 }
 
-export function canonicalTag(tag: string): string {
+export function canonicalTag(tag?: string): string {
+  if (typeof tag !== 'string') return ''
   const decoded = decodeTag(tag).toLowerCase().trim()
   return tagAliasMap[decoded] || decoded
 }


### PR DESCRIPTION
## Summary
- fetch herb data from `public/database.json`
- handle errors and invalid data in `useHerbs`
- guard against undefined category or tags when filtering
- prevent crashes in CategoryAnalytics and BlendSummaryCard
- show fallback UI when data fails to load
- ship database file for fetch requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882bf47d0508323bdce545e244a2905