### PR TITLE
Improve herb loading safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ Additional scripts are available:
 
 Source files live in `src/`. Pages are under `src/pages` and reusable components are in `src/components`. Production assets are generated into `dist/` during the build process.
 
+## Data Source
+
+Herb entries are loaded from `public/database.json`. When running under Vite or
+Create React App this file is served statically from the `public` folder. If you
+deploy the front‑end behind a custom backend make sure this JSON file is served
+at the site root (`/database.json`).
+
 ## Features
 
 - **Database** – interactive herbal index with tag filtering


### PR DESCRIPTION
## Summary
- keep a stable empty array in `useHerbs` and fallback to built‑in data when the fetch fails
- handle invalid or missing herb arrays in `HerbList`
- document where `/database.json` must live

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882c23603d48323bd4e54f12a3fffa2