### PR TITLE
Limit category bar and simplify hero

### DIFF
--- a/src/components/CategoryAnalytics.tsx
+++ b/src/components/CategoryAnalytics.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
+import { motion } from 'framer-motion'
 import { herbs } from '../data/herbs/herbsfull'
 
-const MIN_COUNT = 5
+const TOP_N = 5
 
 export default function CategoryAnalytics() {
   const counts = React.useMemo(() => {
@@ -13,49 +14,43 @@ export default function CategoryAnalytics() {
     return c
   }, [])
 
-  const entries = React.useMemo(
-    () => Object.entries(counts).sort((a, b) => b[1] - a[1]),
-    [counts]
-  )
+  const entries = React.useMemo(() => Object.entries(counts).sort((a, b) => b[1] - a[1]), [counts])
 
-  const [showAll, setShowAll] = React.useState(false)
+  const [expanded, setExpanded] = React.useState(false)
 
   const display = React.useMemo(
-    () =>
-      showAll ? entries : entries.filter(([, count]) => count >= MIN_COUNT),
-    [entries, showAll]
+    () => (expanded ? entries : entries.slice(0, TOP_N)),
+    [entries, expanded]
   )
 
-  const hasMore = React.useMemo(
-    () => entries.some(([, count]) => count < MIN_COUNT),
-    [entries]
-  )
+  const hasMore = entries.length > TOP_N
 
   const max = Math.max(...entries.map(([, c]) => c))
 
   return (
-    <div
-      className='relative space-y-2'
-      onMouseEnter={() => setShowAll(true)}
-      onMouseLeave={() => setShowAll(false)}
-    >
+    <motion.div layout className='space-y-2'>
       {display.map(([cat, count]) => (
-        <div key={cat} className='flex items-center gap-2'>
+        <motion.div key={cat} layout className='flex items-center gap-2'>
           <span className='w-40 text-sm'>{cat}</span>
-          <div className='flex-1 h-2 rounded bg-gray-200 dark:bg-gray-700 transition-colors duration-300'>
+          <div className='h-2 flex-1 rounded bg-gray-200 transition-colors duration-300 dark:bg-gray-700'>
             <div
-              className='h-2 rounded bg-pink-500 dark:bg-pink-400 transition-colors duration-300'
+              className='h-2 rounded bg-pink-500 transition-colors duration-300 dark:bg-pink-400'
               style={{ width: `${(count / max) * 100}%` }}
             />
           </div>
           <span className='text-sm'>{count}</span>
-        </div>
+        </motion.div>
       ))}
-      {hasMore && !showAll && (
-        <div className='pointer-events-none text-center text-xs text-moss'>
-          Hover to show more
-        </div>
+      {hasMore && (
+        <motion.button
+          layout
+          type='button'
+          onClick={() => setExpanded(e => !e)}
+          className='mx-auto block text-xs text-moss hover:underline'
+        >
+          {expanded ? 'Show Less' : 'Show More'}
+        </motion.button>
       )}
-    </div>
+    </motion.div>
   )
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,14 +2,13 @@ import React from 'react'
 import { Helmet } from 'react-helmet-async'
 import Hero from '../components/Hero'
 import StarfieldBackground from '../components/StarfieldBackground'
-import FeaturedHerbTeaser from '../components/FeaturedHerbTeaser'
 
 export default function Home() {
   return (
     <main
       id='home'
       aria-label='Site introduction'
-      className='relative min-h-screen overflow-hidden bg-cosmic-forest animate-gradient pt-16 text-midnight dark:bg-space-night dark:text-sand'
+      className='bg-cosmic-forest animate-gradient relative min-h-screen overflow-hidden pt-16 text-midnight dark:bg-space-night dark:text-sand'
     >
       <Helmet>
         <title>The Hippie Scientist - Psychedelic Botany</title>
@@ -20,14 +19,6 @@ export default function Home() {
       </Helmet>
       <StarfieldBackground />
       <Hero />
-      <section className='mx-auto mt-10 max-w-2xl space-y-4 rounded-xl bg-white/20 p-6 text-center backdrop-blur-md dark:bg-black/30'>
-        <p>
-          Welcome to The Hippie Scientist, a hub for psychedelic botany and conscious exploration.
-          Browse our herb database, read up on the latest research and craft your own herbal blends.
-        </p>
-        <p className='text-sm text-sand/90'>Information provided is for educational purposes only.</p>
-      </section>
-      <FeaturedHerbTeaser />
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- trim intro section and extra featured card on the homepage hero
- show only the top 5 categories in the bar chart with a toggle for more
- animate category chart expand/collapse with Framer Motion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68830703e8c483238d6c6801cb5389cd