### PR TITLE
Improve responsive layout and add animations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react-countup": "^6.5.3",
         "react-dom": "^18.2.0",
         "react-helmet-async": "^1.3.0",
+        "react-intersection-observer": "^9.14.3",
         "react-markdown": "^10.1.0",
         "react-router-dom": "^6.22.3",
         "react-tooltip": "^5.20.0",
@@ -7173,6 +7174,21 @@
       "peerDependencies": {
         "react": "^16.6.0 || ^17.0.0 || ^18.0.0",
         "react-dom": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "9.16.0",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-9.16.0.tgz",
+      "integrity": "sha512-w9nJSEp+DrW9KmQmeWHQyfaP6b03v+TdXynaoA964Wxt7mdR3An11z4NNCQgL4gKSK7y1ver2Fq+JKH6CWEzUA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "rehype-raw": "^7.0.0",
     "tailwindcss": "^3.4.3",
     "tsparticles": "^3.8.1",
-    "vite-plugin-pwa": "^1.0.1"
+    "vite-plugin-pwa": "^1.0.1",
+    "react-intersection-observer": "^9.14.3"
   },
   "devDependencies": {
     "@types/react": "^19.1.8",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import Footer from './components/Footer'
 import MouseTrail from './components/MouseTrail'
 import ScrollToTopButton from './components/ScrollToTopButton'
 import FogOverlay from './components/FogOverlay'
+import Container from './components/Container'
 const Home = React.lazy(() => import('./pages/Home'))
 const HerbCardPage = React.lazy(() => import('./pages/HerbCardPage'))
 const HerbDetailView = React.lazy(() => import('./pages/HerbDetailView'))
@@ -28,9 +29,10 @@ function App() {
       <Navbar />
       <MouseTrail />
       <FogOverlay />
-      <main className='space-y-24 pt-16'>
-        <Suspense fallback={<LoadingScreen />}>
-          <Routes>
+      <main className='pt-16'>
+        <Container className='space-y-24'>
+          <Suspense fallback={<LoadingScreen />}>
+            <Routes>
             <Route path="/herbs/:herbId" element={<HerbDetailPage />} />
             <Route path='/' element={<Home />} />
             <Route path='/about' element={<About />} />
@@ -46,8 +48,9 @@ function App() {
             <Route path='/downloads' element={<Downloads />} />
             <Route path='/blend' element={<HerbBlender />} />
             <Route path='*' element={<NotFound />} />
-          </Routes>
-        </Suspense>
+            </Routes>
+          </Suspense>
+        </Container>
       </main>
       <Footer />
       <ScrollToTopButton />

--- a/src/components/Container.tsx
+++ b/src/components/Container.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+interface Props extends React.HTMLAttributes<HTMLDivElement> {
+  children: React.ReactNode
+}
+
+const Container: React.FC<Props> = ({ children, className = '', ...rest }) => {
+  return (
+    <div
+      className={`mx-auto max-w-screen-xl px-4 sm:px-6 lg:px-8 ${className}`}
+      {...rest}
+    >
+      {children}
+    </div>
+  )
+}
+
+export default Container

--- a/src/components/FadeInSection.tsx
+++ b/src/components/FadeInSection.tsx
@@ -1,0 +1,30 @@
+import { motion, useAnimation } from 'framer-motion'
+import { useEffect } from 'react'
+import { useInView } from 'react-intersection-observer'
+
+interface Props {
+  children: React.ReactNode
+  className?: string
+}
+
+export default function FadeInSection({ children, className }: Props) {
+  const controls = useAnimation()
+  const [ref, inView] = useInView({ triggerOnce: true, threshold: 0.2 })
+
+  useEffect(() => {
+    if (inView) controls.start('visible')
+  }, [controls, inView])
+
+  return (
+    <motion.section
+      ref={ref}
+      initial='hidden'
+      animate={controls}
+      variants={{ hidden: { opacity: 0, y: 20 }, visible: { opacity: 1, y: 0 } }}
+      transition={{ duration: 0.6 }}
+      className={className}
+    >
+      {children}
+    </motion.section>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -182,7 +182,7 @@ a {
 
 /* Hero layout utilities */
 .hero-section {
-  @apply relative flex min-h-hero flex-col items-center justify-between overflow-hidden px-4 text-center;
+  @apply relative flex min-h-hero flex-col items-center justify-center overflow-hidden px-4 text-center;
 }
 
 .pb-safe {

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Helmet } from 'react-helmet-async'
 import { motion } from 'framer-motion'
+import Container from '../components/Container'
 
 export default function About() {
   return (
@@ -14,7 +15,7 @@ export default function About() {
       </Helmet>
 
       <div className='min-h-screen px-4 pt-20'>
-        <div className='mx-auto max-w-3xl space-y-8'>
+        <Container className='space-y-8'>
           <motion.h1
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
@@ -62,7 +63,7 @@ export default function About() {
             If you have suggestions or wish to collaborate, please reach out through our contact
             links.
           </motion.p>
-        </div>
+        </Container>
       </div>
     </>
   )

--- a/src/pages/Compounds.tsx
+++ b/src/pages/Compounds.tsx
@@ -6,6 +6,8 @@ import CompoundCard from '../components/CompoundCard'
 import CompoundTagFilter, { Option } from '../components/CompoundTagFilter'
 import { metaCategory } from '../hooks/useFilteredHerbs'
 import { AnimatePresence, motion } from 'framer-motion'
+import Container from '../components/Container'
+import FadeInSection from '../components/FadeInSection'
 
 export default function CompoundsPage() {
   const [search, setSearch] = useState('')
@@ -65,10 +67,10 @@ export default function CompoundsPage() {
         <title>Psychoactive Compounds Index - The Hippie Scientist</title>
       </Helmet>
       <div className='min-h-screen px-4 pb-12 pt-20'>
-        <div className='mx-auto max-w-5xl text-center'>
-          <h1 className='text-gradient mb-2 text-4xl font-bold'>Psychoactive Compounds Index</h1>
-          <p className='mb-6 text-sand'>Explore the active ingredients behind each herb’s effects</p>
-          <div className='mb-4 flex flex-col items-center gap-4'>
+        <Container className='text-center space-y-6'>
+          <h1 className='text-gradient text-4xl font-bold'>Psychoactive Compounds Index</h1>
+          <p className='text-sand'>Explore the active ingredients behind each herb’s effects</p>
+          <div className='flex flex-col items-center gap-4'>
             <input
               type='text'
               placeholder='Search compounds or herbs...'
@@ -78,22 +80,24 @@ export default function CompoundsPage() {
             />
             <CompoundTagFilter options={classOptions} onChange={setClassFilter} />
           </div>
-          <motion.div layout className='grid max-h-[70vh] grid-cols-1 gap-4 overflow-y-auto sm:grid-cols-2 lg:grid-cols-3'>
-            <AnimatePresence>
-              {filtered.map(c => (
-                <motion.div
-                  key={c.name}
-                  layout
-                  initial={{ opacity: 0, y: 20 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: -20 }}
-                >
-                  <CompoundCard compound={c} />
-                </motion.div>
-              ))}
-            </AnimatePresence>
-          </motion.div>
-        </div>
+          <FadeInSection>
+            <motion.div layout className='grid max-h-[70vh] grid-cols-1 gap-4 overflow-y-auto sm:grid-cols-2 lg:grid-cols-3'>
+              <AnimatePresence>
+                {filtered.map(c => (
+                  <motion.div
+                    key={c.name}
+                    layout
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -20 }}
+                  >
+                    <CompoundCard compound={c} />
+                  </motion.div>
+                ))}
+              </AnimatePresence>
+            </motion.div>
+          </FadeInSection>
+        </Container>
       </div>
     </>
   )

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -3,6 +3,8 @@
 import React from 'react'
 import { Helmet } from 'react-helmet-async'
 import { motion } from 'framer-motion'
+import Container from '../components/Container'
+import FadeInSection from '../components/FadeInSection'
 import HerbList from '../components/HerbList'
 import TagFilterBar from '../components/TagFilterBar'
 import CategoryAnalytics from '../components/CategoryAnalytics'
@@ -88,6 +90,7 @@ export default function Database() {
   const [filtersOpen, setFiltersOpen] = React.useState(false)
   const [showBar, setShowBar] = React.useState(true)
   const [viewMode, setViewMode] = React.useState<'grid' | 'list'>('grid')
+  const [showAnalytics, setShowAnalytics] = React.useState(false)
 
   React.useEffect(() => {
     let last = window.scrollY
@@ -143,18 +146,19 @@ export default function Database() {
 
       <div className='relative min-h-screen px-4 pt-20'>
         <StarfieldBackground />
-        <div className='relative mx-auto max-w-6xl'>
-          <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.8 }}
-            className='mb-8 text-center'
-          >
-            <h1 className='text-gradient mb-6 text-5xl font-bold'>Herb Database</h1>
-            <p className='mx-auto max-w-4xl text-xl text-sand'>
-              Explore our collection of herbs. Click any entry to see detailed information.
-            </p>
-          </motion.div>
+        <Container className='relative lg:flex lg:items-start lg:gap-8'>
+          <div className='flex-1'>
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.8 }}
+              className='mb-8 text-center'
+            >
+              <h1 className='text-gradient mb-6 text-5xl font-bold'>Herb Database</h1>
+              <p className='mx-auto max-w-4xl text-xl text-sand'>
+                Explore our collection of herbs. Click any entry to see detailed information.
+              </p>
+            </motion.div>
 
           <motion.div
             className='sticky top-2 z-20 mb-4 flex flex-wrap items-center gap-2'
@@ -230,13 +234,27 @@ export default function Database() {
               ))}
             </div>
           )}
-          <CategoryAnalytics />
-          <HerbList herbs={filtered} highlightQuery={query} view={viewMode} />
+          <button
+            type='button'
+            onClick={() => setShowAnalytics(a => !a)}
+            className='mb-4 rounded-md bg-space-dark/70 px-3 py-2 text-sm text-sand backdrop-blur-md hover:bg-white/10 lg:hidden'
+          >
+            {showAnalytics ? 'Hide Stats' : 'Show Stats'}
+          </button>
+          <FadeInSection>
+            <HerbList herbs={filtered} highlightQuery={query} view={viewMode} />
+          </FadeInSection>
           <footer className='mt-4 text-center text-sm text-moss'>
-            Total herbs: {summary.total} · Affiliate links: {summary.affiliates} · MOA documented:{' '}
+            Total herbs: {summary.total} · Affiliate links: {summary.affiliates} · MOA documented{' '}
             {summary.moaCount} · Updated: {new Date(__BUILD_TIME__).toLocaleDateString()}
           </footer>
         </div>
+        <aside
+          className={`mt-6 lg:mt-0 lg:w-72 lg:sticky lg:top-24 ${showAnalytics ? '' : 'hidden lg:block'}`}
+        >
+          <CategoryAnalytics />
+        </aside>
+        </Container>
       </div>
     </>
   )

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -3,13 +3,14 @@ import SEO from '../components/SEO'
 import Hero from '../components/Hero'
 import StarfieldBackground from '../components/StarfieldBackground'
 import NewsletterSignup from '../components/NewsletterSignup'
+import FadeInSection from '../components/FadeInSection'
 
 export default function Home() {
   return (
     <main
       id='home'
       aria-label='Site introduction'
-      className='bg-cosmic-forest animate-gradient relative min-h-screen overflow-hidden pt-16 text-midnight dark:bg-space-night dark:text-sand'
+      className='bg-cosmic-forest animate-gradient relative min-h-screen overflow-hidden pt-16 pb-20 text-midnight dark:bg-space-night dark:text-sand'
     >
       <SEO
         title='The Hippie Scientist - Psychedelic Botany'
@@ -18,7 +19,9 @@ export default function Home() {
       />
       <StarfieldBackground />
       <Hero />
-      <NewsletterSignup />
+      <FadeInSection>
+        <NewsletterSignup />
+      </FadeInSection>
     </main>
   )
 }


### PR DESCRIPTION
## Summary
- add reusable `Container` component for consistent width and padding
- add `FadeInSection` for scroll triggered fade animations
- center hero section vertically
- restructure Database page with sidebar and responsive container
- tweak Compounds, About and Home page layouts
- update dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688388b61310832387b49ac04c5b86db