### PR TITLE
Use HashRouter for routing

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { BrowserRouter } from 'react-router-dom'
+import { HashRouter } from 'react-router-dom'
 import { HelmetProvider } from 'react-helmet-async'
 import App from './App'
 import { ThemeProvider } from './contexts/theme'
@@ -27,9 +27,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <HelmetProvider>
       <ErrorBoundary>
         <ThemeProvider>
-          <BrowserRouter>
+          <HashRouter>
             <App />
-          </BrowserRouter>
+          </HashRouter>
         </ThemeProvider>
       </ErrorBoundary>
     </HelmetProvider>


### PR DESCRIPTION
## Summary
- swap BrowserRouter for HashRouter to simplify routing setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688562c78fe88323a1362c70d2aa182f