### PR TITLE
Fix GitHub Pages routing and ErrorBoundary export

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { HelmetProvider } from 'react-helmet-async';
 import App from './App';
 import { ThemeProvider } from './contexts/theme';
 import ErrorBoundary from './components/ErrorBoundary';
+import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/src/pages/HerbCardPage.tsx
+++ b/src/pages/HerbCardPage.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { herbs } from '../data/herbs/herbsfull'
 import HerbCardAccordion from '../components/HerbCardAccordion'
-import { ErrorBoundary } from '../components/ErrorBoundary'
+import ErrorBoundary from '../components/ErrorBoundary'
 import { slugify } from '../utils/slugify'
 
 export default function HerbCardPage() {

--- a/src/pages/HerbDetailPage.tsx
+++ b/src/pages/HerbDetailPage.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { useParams } from 'react-router-dom';
 import { herbs } from '../data/herbs/herbsfull'; // Adjust path if needed
 import HerbCardAccordion from '../components/HerbCardAccordion';
-import { ErrorBoundary } from '../components/ErrorBoundary';
+import ErrorBoundary from '../components/ErrorBoundary';
 
 export default function HerbDetailPage() {
   const { herbId } = useParams();


### PR DESCRIPTION
## Summary
- import CSS in `main.tsx`
- fix default `ErrorBoundary` imports in herb pages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688588a04bd483239da249f122449276