### PR TITLE
Fix missing navigation and blend route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,18 +4,24 @@ import Home from './pages/Home';
 import About from './pages/About';
 import Database from './pages/Database';
 import Favorites from './pages/Favorites';
+import HerbBlender from './pages/HerbBlender';
 import NotFound from './pages/NotFound';
+import Navbar from './components/Navbar';
 // Import other pages as needed
 
 export default function App() {
   return (
-    <Routes>
-      <Route path="/" element={<Home />} />
-      <Route path="/about" element={<About />} />
-      <Route path="/database" element={<Database />} />
-      <Route path="/favorites" element={<Favorites />} />
-      {/* Add other routes here */}
-      <Route path="*" element={<NotFound />} />
-    </Routes>
+    <>
+      <Navbar />
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/about" element={<About />} />
+        <Route path="/database" element={<Database />} />
+        <Route path="/blend" element={<HerbBlender />} />
+        <Route path="/favorites" element={<Favorites />} />
+        {/* Add other routes here */}
+        <Route path="*" element={<NotFound />} />
+      </Routes>
+    </>
   );
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -7,6 +7,7 @@ export default function Navbar() {
       <ul>
         <li><Link to="/">Home</Link></li>
         <li><Link to="/database">Database</Link></li>
+        <li><Link to="/blend">Build a Blend</Link></li>
         <li><Link to="/favorites">Favorites</Link></li>
         <li><Link to="/about">About</Link></li>
         {/* Add more navigation links as needed */}


### PR DESCRIPTION
## Summary
- reintroduce the navbar and add a link to the blend builder
- mount the Navbar in `App.tsx`
- add `/blend` route for the HerbBlender page

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68858b6208988323be5b176162482cbe