### PR TITLE
Fix build by dropping prebuild step

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "preview": "vite preview",
     "deploy": "gh-pages -d dist",
     "test": "echo \"No tests specified\" && exit 0",
-    "validate-herbs": "node scripts/validateHerbs.js",
-    "prebuild": "node scripts/refreshHerbImports.js"
+    "validate-herbs": "node scripts/validateHerbs.js"
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.16",


### PR DESCRIPTION
## Summary
- remove failing prebuild script that overwrote imports
- build successfully without needing generated herb data

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68862688888c832380834bdd0a8751e4