### PR TITLE
feat(analytics): add GA4 (G-7DFJL2FC6F) + privacy update

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,14 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Manrope:wght@400;700&family=Unbounded:wght@400;700&family=Major+Mono+Display&display=swap"
       rel="stylesheet"
     />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-7DFJL2FC6F"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-7DFJL2FC6F');
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -8,6 +8,7 @@
 <main>
 <h1>Privacy Policy</h1>
 <p>We collect minimal data necessary to operate this site (e.g., analytics). If Google Analytics is enabled, it may use cookies and anonymized IP. You can block cookies in your browser.</p>
+<p>This site uses Google Analytics (GA4) to collect anonymous traffic data. No personally identifying information is stored.</p>
 <p>Contact: <a href="/contact">/contact</a>. Last updated: Oct 05, 2025.</p>
 </main>
 <footer>


### PR DESCRIPTION
## What
- Injects GA4 snippet into the main HTML head and updates Privacy Policy to note anonymous analytics.

## Why
- Establish baseline traffic/behavior metrics for SEO and content strategy.

## Scope
- Only modifies the single HTML head entry and /privacy-policy/index.html.

## Test
- Build locally and load site; verify Realtime users in GA4. Confirm no duplicate GA tags.

------
https://chatgpt.com/codex/tasks/task_e_68e2b73d36088323b11e60a4a28ddef7