### PR TITLE
fix(analytics): make GA4 visible (debug + page_view)

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,7 +42,8 @@
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-7DFJL2FC6F');
+      gtag('config', 'G-7DFJL2FC6F', { debug_mode: true, send_page_view: true });
+      gtag('event', 'page_view', { page_location: location.href, page_title: document.title });
     </script>
   </head>
   <body>


### PR DESCRIPTION
## Why
- Ensure GA4 activity is visible immediately via debug data

## What
- Set GA4 config to enable debug_mode and immediate send_page_view
- Trigger an explicit page_view event with the current location and title

## How to verify
- Check GA4 Realtime and DebugView dashboards

------
https://chatgpt.com/codex/tasks/task_e_68e2bc586db8832399bcf68424ab80bc