### PR TITLE
Add Google Analytics tags to static pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,6 +2,15 @@
 <html>
   <head>
     <meta http-equiv="refresh" content="0; url=./" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-7DFJL2FC6F"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-7DFJL2FC6F', { debug_mode: true, send_page_view: true });
+      gtag('event', 'page_view', { page_location: location.href, page_title: document.title });
+    </script>
     <script>
       const target =
         sessionStorage.redirectTo ||

--- a/about/index.html
+++ b/about/index.html
@@ -3,6 +3,15 @@
 <title>About | The Hippie Scientist</title>
 <meta name="description" content="About | The Hippie Scientist">
 <link rel="canonical" href="https://thehippiescientist.net/about">
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-7DFJL2FC6F"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-7DFJL2FC6F', { debug_mode: true, send_page_view: true });
+  gtag('event', 'page_view', { page_location: location.href, page_title: document.title });
+</script>
 </head><body>
 <header><a href="/">Home</a></header>
 <main>

--- a/contact/index.html
+++ b/contact/index.html
@@ -3,6 +3,15 @@
 <title>Contact | The Hippie Scientist</title>
 <meta name="description" content="Contact | The Hippie Scientist">
 <link rel="canonical" href="https://thehippiescientist.net/contact">
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-7DFJL2FC6F"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-7DFJL2FC6F', { debug_mode: true, send_page_view: true });
+  gtag('event', 'page_view', { page_location: location.href, page_title: document.title });
+</script>
 </head><body>
 <header><a href="/">Home</a></header>
 <main>

--- a/disclaimer/index.html
+++ b/disclaimer/index.html
@@ -3,6 +3,15 @@
 <title>Disclaimer | The Hippie Scientist</title>
 <meta name="description" content="Disclaimer | The Hippie Scientist">
 <link rel="canonical" href="https://thehippiescientist.net/disclaimer">
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-7DFJL2FC6F"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-7DFJL2FC6F', { debug_mode: true, send_page_view: true });
+  gtag('event', 'page_view', { page_location: location.href, page_title: document.title });
+</script>
 </head><body>
 <header><a href="/">Home</a></header>
 <main>

--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -3,6 +3,15 @@
 <title>Privacy Policy | The Hippie Scientist</title>
 <meta name="description" content="Privacy Policy | The Hippie Scientist">
 <link rel="canonical" href="https://thehippiescientist.net/privacy-policy">
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-7DFJL2FC6F"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'G-7DFJL2FC6F', { debug_mode: true, send_page_view: true });
+  gtag('event', 'page_view', { page_location: location.href, page_title: document.title });
+</script>
 </head><body>
 <header><a href="/">Home</a></header>
 <main>

--- a/public/404.html
+++ b/public/404.html
@@ -2,6 +2,15 @@
 <html>
   <head>
     <meta http-equiv="refresh" content="0; url=./" />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-7DFJL2FC6F"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-7DFJL2FC6F', { debug_mode: true, send_page_view: true });
+      gtag('event', 'page_view', { page_location: location.href, page_title: document.title });
+    </script>
     <script>
       // Save the original path for the SPA
       const target =

--- a/public/offline.html
+++ b/public/offline.html
@@ -4,6 +4,15 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Offline - The Hippie Scientist</title>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-7DFJL2FC6F"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-7DFJL2FC6F', { debug_mode: true, send_page_view: true });
+      gtag('event', 'page_view', { page_location: location.href, page_title: document.title });
+    </script>
   </head>
   <body>
     <p style="padding:1rem;text-align:center;font-family:sans-serif;color:#ccc">You appear to be offline. Some content may be unavailable.</p>


### PR DESCRIPTION
## Summary
- include the GA4 gtag snippet on the static informational pages
- ensure redirect and offline documents also load the analytics configuration

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2c488c18c83238928eb6f1ff42b9d