### PR TITLE
fix(seo): analytics + discoverability follow-ups

### DIFF
--- a/404.html
+++ b/404.html
@@ -58,6 +58,14 @@
         text-decoration: none;
       }
     </style>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-7DFJL2FC6F"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-7DFJL2FC6F');
+    </script>
   </head>
   <body>
     <main>

--- a/blog/how-to-read-herbal-research/index.html
+++ b/blog/how-to-read-herbal-research/index.html
@@ -102,6 +102,14 @@
         text-decoration: none;
       }
     </style>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-7DFJL2FC6F"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-7DFJL2FC6F');
+    </script>
   </head>
   <body>
     <main>

--- a/blog/index.html
+++ b/blog/index.html
@@ -82,6 +82,14 @@
         text-decoration: none;
       }
     </style>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-7DFJL2FC6F"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-7DFJL2FC6F');
+    </script>
   </head>
   <body>
     <main>

--- a/blog/what-is-a-psychoactive-herb/index.html
+++ b/blog/what-is-a-psychoactive-herb/index.html
@@ -103,6 +103,14 @@
         text-decoration: none;
       }
     </style>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-7DFJL2FC6F"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-7DFJL2FC6F');
+    </script>
   </head>
   <body>
     <main>

--- a/herb-index/index.html
+++ b/herb-index/index.html
@@ -92,6 +92,14 @@
         text-decoration: none;
       }
     </style>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-7DFJL2FC6F"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-7DFJL2FC6F');
+    </script>
   </head>
   <body>
     <main>

--- a/herbs/blue-lotus/index.html
+++ b/herbs/blue-lotus/index.html
@@ -85,6 +85,14 @@
         text-decoration: none;
       }
     </style>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-7DFJL2FC6F"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-7DFJL2FC6F');
+    </script>
   </head>
   <body>
     <main>

--- a/herbs/kanna/index.html
+++ b/herbs/kanna/index.html
@@ -85,6 +85,14 @@
         text-decoration: none;
       }
     </style>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-7DFJL2FC6F"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-7DFJL2FC6F');
+    </script>
   </head>
   <body>
     <main>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <link rel="manifest" href="/manifest.json" />
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title="The Hippie Scientist RSS"
+      href="/feed.xml"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
@@ -36,6 +42,25 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Manrope:wght@400;700&family=Unbounded:wght@400;700&family=Major+Mono+Display&display=swap"
       rel="stylesheet"
     />
+    <style>
+      .site-entry-nav {
+        text-align: center;
+        margin: 2rem auto;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        font-size: 0.95rem;
+        color: #202020;
+      }
+      .site-entry-nav nav {
+        margin-bottom: 0.5rem;
+      }
+      .site-entry-nav a {
+        color: inherit;
+        text-decoration: none;
+      }
+      .site-entry-nav a:hover {
+        text-decoration: underline;
+      }
+    </style>
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-7DFJL2FC6F"></script>
     <script>
@@ -48,6 +73,17 @@
   </head>
   <body>
     <div id="root"></div>
+    <footer class="site-entry-nav">
+      <nav>
+        <a href="/herb-index">Herb Index</a> ·
+        <a href="/blog/">Blog</a> ·
+        <a href="/about">About</a> ·
+        <a href="/disclaimer">Disclaimer</a> ·
+        <a href="/privacy-policy">Privacy</a> ·
+        <a href="/contact">Contact</a>
+      </nav>
+      <small>© 2025 The Hippie Scientist</small>
+    </footer>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Add the GA4 measurement snippet to the herb index, herb detail, blog listing, article pages, and 404 page so every static surface reports into the same property.
- Add an RSS discovery link and a static footer navigation block on the homepage to surface the herb index, blog, and key policy pages.

## Verification
- Realtime in GA4 should show `page_view` events when loading the herb index, herb detail pages, blog listing, article pages, and the 404 page.
- Visit `/feed.xml` to confirm the RSS feed is discoverable from the homepage metadata.
- Confirm the homepage footer renders links to Herb Index, Blog, About, Disclaimer, Privacy, and Contact.
- Check that `sitemap.xml` contains the herb index, herb detail, blog, and 404 URLs.

------
https://chatgpt.com/codex/tasks/task_e_68e2d1e63f648323a59e0a160b673e48