### PR TITLE
Add Google Tag Manager to static pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,6 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-K9MGMJZS');</script>
+    <!-- End Google Tag Manager -->
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Page Not Found | The Hippie Scientist</title>
@@ -68,6 +75,10 @@
     </script>
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K9MGMJZS"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <main>
       <h1>Lost in the Psychedelic Wilderness</h1>
       <p>

--- a/about/index.html
+++ b/about/index.html
@@ -1,31 +1,47 @@
-<!doctype html><html lang="en"><head>
-<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title>About | The Hippie Scientist</title>
-<meta name="description" content="About | The Hippie Scientist">
-<link rel="canonical" href="https://thehippiescientist.net/about">
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-7DFJL2FC6F"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-7DFJL2FC6F', { debug_mode: true, send_page_view: true });
-  gtag('event', 'page_view', { page_location: location.href, page_title: document.title });
-</script>
-</head><body>
-<header><a href="/">Home</a></header>
-<main>
-<h1>About</h1>
-<p><strong>The Hippie Scientist</strong> explores psychoactive herbs with scientific rigor and cultural context. 
-This site is independent and not affiliated with any podcast of a similar name.</p>
-</main>
-<footer>
-  <nav>
-    <a href="/about">About</a> ·
-    <a href="/disclaimer">Disclaimer</a> ·
-    <a href="/privacy-policy">Privacy</a> ·
-    <a href="/contact">Contact</a>
-  </nav>
-  <small>© 2025 The Hippie Scientist</small>
-</footer>
-</body></html>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>About | The Hippie Scientist</title>
+    <meta name="description" content="About | The Hippie Scientist" />
+    <link rel="canonical" href="https://thehippiescientist.net/about" />
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-K9MGMJZS');</script>
+    <!-- End Google Tag Manager -->
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-7DFJL2FC6F"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-7DFJL2FC6F', { debug_mode: true, send_page_view: true });
+      gtag('event', 'page_view', { page_location: location.href, page_title: document.title });
+    </script>
+  </head>
+  <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K9MGMJZS"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    <header><a href="/">Home</a></header>
+    <main>
+      <h1>About</h1>
+      <p><strong>The Hippie Scientist</strong> explores psychoactive herbs with scientific rigor and cultural context.
+      This site is independent and not affiliated with any podcast of a similar name.</p>
+    </main>
+    <footer>
+      <nav>
+        <a href="/about">About</a> ·
+        <a href="/disclaimer">Disclaimer</a> ·
+        <a href="/privacy-policy">Privacy</a> ·
+        <a href="/contact">Contact</a>
+      </nav>
+      <small>© 2025 The Hippie Scientist</small>
+    </footer>
+  </body>
+</html>

--- a/blog/how-to-read-herbal-research/index.html
+++ b/blog/how-to-read-herbal-research/index.html
@@ -1,6 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-K9MGMJZS');</script>
+    <!-- End Google Tag Manager -->
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>How to Read Herbal Research | The Hippie Scientist</title>
@@ -112,6 +119,10 @@
     </script>
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K9MGMJZS"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <main>
       <article>
         <p><a href="/blog/">← Back to Blog</a></p>

--- a/blog/index.html
+++ b/blog/index.html
@@ -1,6 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-K9MGMJZS');</script>
+    <!-- End Google Tag Manager -->
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Blog | The Hippie Scientist</title>
@@ -92,6 +99,10 @@
     </script>
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K9MGMJZS"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <main>
       <header>
         <p><a href="/">← Home</a></p>

--- a/blog/what-is-a-psychoactive-herb/index.html
+++ b/blog/what-is-a-psychoactive-herb/index.html
@@ -1,6 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-K9MGMJZS');</script>
+    <!-- End Google Tag Manager -->
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>What Is a Psychoactive Herb? | The Hippie Scientist</title>
@@ -113,6 +120,10 @@
     </script>
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K9MGMJZS"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <main>
       <article>
         <p><a href="/blog/">← Back to Blog</a></p>

--- a/contact/index.html
+++ b/contact/index.html
@@ -1,30 +1,46 @@
-<!doctype html><html lang="en"><head>
-<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Contact | The Hippie Scientist</title>
-<meta name="description" content="Contact | The Hippie Scientist">
-<link rel="canonical" href="https://thehippiescientist.net/contact">
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-7DFJL2FC6F"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'G-7DFJL2FC6F', { debug_mode: true, send_page_view: true });
-  gtag('event', 'page_view', { page_location: location.href, page_title: document.title });
-</script>
-</head><body>
-<header><a href="/">Home</a></header>
-<main>
-<h1>Contact</h1>
-<p>Email: <a href="mailto:hello@thehippiescientist.net">hello@thehippiescientist.net</a></p>
-</main>
-<footer>
-  <nav>
-    <a href="/about">About</a> ·
-    <a href="/disclaimer">Disclaimer</a> ·
-    <a href="/privacy-policy">Privacy</a> ·
-    <a href="/contact">Contact</a>
-  </nav>
-  <small>© 2025 The Hippie Scientist</small>
-</footer>
-</body></html>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Contact | The Hippie Scientist</title>
+    <meta name="description" content="Contact | The Hippie Scientist" />
+    <link rel="canonical" href="https://thehippiescientist.net/contact" />
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-K9MGMJZS');</script>
+    <!-- End Google Tag Manager -->
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-7DFJL2FC6F"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-7DFJL2FC6F', { debug_mode: true, send_page_view: true });
+      gtag('event', 'page_view', { page_location: location.href, page_title: document.title });
+    </script>
+  </head>
+  <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K9MGMJZS"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    <header><a href="/">Home</a></header>
+    <main>
+      <h1>Contact</h1>
+      <p>Email: <a href="mailto:hello@thehippiescientist.net">hello@thehippiescientist.net</a></p>
+    </main>
+    <footer>
+      <nav>
+        <a href="/about">About</a> ·
+        <a href="/disclaimer">Disclaimer</a> ·
+        <a href="/privacy-policy">Privacy</a> ·
+        <a href="/contact">Contact</a>
+      </nav>
+      <small>© 2025 The Hippie Scientist</small>
+    </footer>
+  </body>
+</html>

--- a/disclaimer/index.html
+++ b/disclaimer/index.html
@@ -1,4 +1,11 @@
 <!doctype html><html lang="en"><head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-K9MGMJZS');</script>
+    <!-- End Google Tag Manager -->
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Disclaimer | The Hippie Scientist</title>
 <meta name="description" content="Disclaimer | The Hippie Scientist">
@@ -13,6 +20,10 @@
   gtag('event', 'page_view', { page_location: location.href, page_title: document.title });
 </script>
 </head><body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K9MGMJZS"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
 <header><a href="/">Home</a></header>
 <main>
 <h1>Disclaimer</h1>

--- a/herb-index/index.html
+++ b/herb-index/index.html
@@ -1,6 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-K9MGMJZS');</script>
+    <!-- End Google Tag Manager -->
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Herb Index | The Hippie Scientist</title>
@@ -102,6 +109,10 @@
     </script>
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K9MGMJZS"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <main>
       <header>
         <p><a href="/">← Home</a></p>

--- a/herbs/blue-lotus/index.html
+++ b/herbs/blue-lotus/index.html
@@ -1,6 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-K9MGMJZS');</script>
+    <!-- End Google Tag Manager -->
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Blue Lotus (Nymphaea caerulea) Guide | The Hippie Scientist</title>
@@ -95,6 +102,10 @@
     </script>
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K9MGMJZS"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <main>
       <header>
         <p><a href="/herb-index">← Back to Herb Index</a></p>

--- a/herbs/kanna/index.html
+++ b/herbs/kanna/index.html
@@ -1,6 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-K9MGMJZS');</script>
+    <!-- End Google Tag Manager -->
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Kanna (Sceletium tortuosum) Guide | The Hippie Scientist</title>
@@ -95,6 +102,10 @@
     </script>
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K9MGMJZS"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <main>
       <header>
         <p><a href="/herb-index">← Back to Herb Index</a></p>

--- a/index.html
+++ b/index.html
@@ -2,6 +2,13 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-K9MGMJZS');</script>
+    <!-- End Google Tag Manager -->
     <link rel="icon" href="/favicon.ico" />
     <link rel="manifest" href="/manifest.json" />
     <link
@@ -72,6 +79,10 @@
     </script>
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K9MGMJZS"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <div id="root"></div>
     <footer class="site-entry-nav">
       <nav>

--- a/privacy-policy/index.html
+++ b/privacy-policy/index.html
@@ -1,4 +1,11 @@
 <!doctype html><html lang="en"><head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-K9MGMJZS');</script>
+    <!-- End Google Tag Manager -->
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Privacy Policy | The Hippie Scientist</title>
 <meta name="description" content="Privacy Policy | The Hippie Scientist">
@@ -13,6 +20,10 @@
   gtag('event', 'page_view', { page_location: location.href, page_title: document.title });
 </script>
 </head><body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K9MGMJZS"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
 <header><a href="/">Home</a></header>
 <main>
 <h1>Privacy Policy</h1>

--- a/public/404.html
+++ b/public/404.html
@@ -1,6 +1,13 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-K9MGMJZS');</script>
+    <!-- End Google Tag Manager -->
     <meta http-equiv="refresh" content="0; url=./" />
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-7DFJL2FC6F"></script>
@@ -21,6 +28,10 @@
     </script>
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K9MGMJZS"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <h1>Redirecting...</h1>
   </body>
 </html>

--- a/public/offline.html
+++ b/public/offline.html
@@ -1,6 +1,13 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-K9MGMJZS');</script>
+    <!-- End Google Tag Manager -->
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Offline - The Hippie Scientist</title>
@@ -15,6 +22,10 @@
     </script>
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K9MGMJZS"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <p style="padding:1rem;text-align:center;font-family:sans-serif;color:#ccc">You appear to be offline. Some content may be unavailable.</p>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add the Google Tag Manager loader snippet to the head of every static HTML page
- insert the corresponding noscript fallback immediately after each body tag so GTM loads when JavaScript is disabled

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2d424c7988323bb455f8831ba5c6a