### PR TITLE
feat(spa): minimal GA4 + Herb Index

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,9 +8,13 @@ import HerbBlender from './pages/HerbBlender';
 import NotFound from './pages/NotFound';
 import Navbar from './components/Navbar';
 import { RedirectHandler } from './RedirectHandler';
+import { useGA } from './lib/useGA';
+import HerbIndex from './pages/HerbIndex';
+import HerbDetail from './pages/HerbDetail';
 // Import other pages as needed
 
 export default function App() {
+  useGA();
   return (
     <>
       <RedirectHandler />
@@ -22,6 +26,8 @@ export default function App() {
         <Route path="/blend" element={<HerbBlender />} />
         <Route path="/favorites" element={<Favorites />} />
         {/* Add other routes here */}
+        <Route path="/herb-index" element={<HerbIndex />} />
+        <Route path="/herb/:slug" element={<HerbDetail />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </>

--- a/src/data/seedHerbs.ts
+++ b/src/data/seedHerbs.ts
@@ -1,0 +1,30 @@
+export type Herb = {
+  commonName: string;
+  latinName: string;
+  imageUrl?: string;
+  mechanism?: string;
+  compounds?: string[];
+  traditionalUses?: string;
+  safety?: string;
+  legal?: string;
+};
+export const SEED_HERBS: Herb[] = [
+  {
+    commonName: "Kanna",
+    latinName: "Sceletium tortuosum",
+    mechanism: "SERT modulation / PDE4 inhibition (literature).",
+    compounds: ["Mesembrine", "Mesembrenone"],
+    traditionalUses: "Traditional South African mood aid.",
+    safety: "Educational only; avoid with serotonergic drugs.",
+    legal: "Generally available; check local laws."
+  },
+  {
+    commonName: "Blue Lotus",
+    latinName: "Nymphaea caerulea",
+    mechanism: "Aporphine-like alkaloids; relaxing (anecdotal).",
+    compounds: ["Nuciferine", "Aporphine (trace)"],
+    traditionalUses: "Historic infusions/teas.",
+    safety: "May cause drowsiness; avoid sedatives.",
+    legal: "Availability varies by region."
+  }
+];

--- a/src/lib/slug.ts
+++ b/src/lib/slug.ts
@@ -1,0 +1,3 @@
+export function slugify(s: string) {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}

--- a/src/lib/useGA.ts
+++ b/src/lib/useGA.ts
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+declare global { interface Window { gtag?: (...args:any[]) => void } }
+export function useGA() {
+  const { pathname, search } = useLocation();
+  useEffect(() => {
+    if (typeof window !== "undefined" && typeof window.gtag === "function") {
+      window.gtag("event", "page_view", {
+        page_location: window.location.href,
+        page_path: pathname + search,
+        page_title: document.title,
+      });
+    }
+  }, [pathname, search]);
+}

--- a/src/pages/HerbIndex.tsx
+++ b/src/pages/HerbIndex.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { SEED_HERBS } from "../data/seedHerbs";
+import { slugify } from "../lib/slug";
+export default function HerbIndex() {
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-8">
+      <h1 className="text-2xl font-bold">Herb Index</h1>
+      <ul className="mt-6 list-disc pl-5">
+        {SEED_HERBS.map(h => (
+          <li key={h.commonName}>
+            <Link className="underline" to={`/herb/${slugify(h.commonName)}`}>
+              {h.commonName} <span className="opacity-70 italic">({h.latinName})</span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add GA4 page_view tracking hook that fires on client-side route changes
- create lightweight herb index/detail views backed by a two-item seed list

## Testing
- navigate between /herb-index and /herb/kanna while watching GA4 Realtime for the page_view events

------
https://chatgpt.com/codex/tasks/task_e_68e2da9794f48323bb8d61f85fe9aac2