### PR TITLE
feat(seo): Helmet metadata, JSON-LD, and RSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,12 +11,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <!-- End Google Tag Manager -->
     <link rel="icon" href="/favicon.ico" />
     <link rel="manifest" href="/manifest.json" />
-    <link
-      rel="alternate"
-      type="application/rss+xml"
-      title="The Hippie Scientist RSS"
-      href="/feed.xml"
-    />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta
       name="description"
@@ -29,19 +23,6 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://thehippiescientist.net" />
     <meta property="og:image" content="/icon-512x512.png" />
-    <script type="application/ld+json">
-      {
-        "@context": "https://schema.org",
-        "@type": "WebSite",
-        "name": "The Hippie Scientist",
-        "url": "https://thehippiescientist.net",
-        "potentialAction": {
-          "@type": "SearchAction",
-          "target": "https://thehippiescientist.net/search?q={search_term_string}",
-          "query-input": "required name=search_term_string"
-        }
-      }
-    </script>
     <title>The Hippie Scientist</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -77,6 +58,28 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       gtag('config', 'G-7DFJL2FC6F', { debug_mode: true, send_page_view: true });
       gtag('event', 'page_view', { page_location: location.href, page_title: document.title });
     </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "name": "The Hippie Scientist",
+        "url": "https://thehippiescientist.net"
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "The Hippie Scientist",
+        "url": "https://thehippiescientist.net",
+        "potentialAction": {
+          "@type": "SearchAction",
+          "target": "https://thehippiescientist.net/?q={search_term_string}",
+          "query-input": "required name=search_term_string"
+        }
+      }
+    </script>
+    <link rel="alternate" type="application/rss+xml" title="The Hippie Scientist RSS" href="/feed.xml" />
   </head>
   <body>
     <!-- Google Tag Manager (noscript) -->

--- a/public/feed.xml
+++ b/public/feed.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>The Hippie Scientist</title>
+    <link>https://thehippiescientist.net/</link>
+    <description>Independent research on psychoactive herbs, entheogens, and natural neurochemistry.</description>
+    <language>en</language>
+    <lastBuildDate><!-- updated by deploy -->Mon, 06 Oct 2025 00:00:00 +0000</lastBuildDate>
+    <item>
+      <title>What Is a Psychoactive Herb?</title>
+      <link>https://thehippiescientist.net/blog/what-is-a-psychoactive-herb</link>
+      <guid>https://thehippiescientist.net/blog/what-is-a-psychoactive-herb</guid>
+      <pubDate>Mon, 06 Oct 2025 00:00:00 +0000</pubDate>
+      <description>Definitions, mechanisms, and cultural context.</description>
+    </item>
+    <item>
+      <title>How to Read Herbal Research</title>
+      <link>https://thehippiescientist.net/blog/how-to-read-herbal-research</link>
+      <guid>https://thehippiescientist.net/blog/how-to-read-herbal-research</guid>
+      <pubDate>Mon, 06 Oct 2025 00:00:00 +0000</pubDate>
+      <description>Practical checks for interpreting studies.</description>
+    </item>
+  </channel>
+</rss>

--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -1,23 +1,24 @@
 import React from 'react'
 import { Helmet } from 'react-helmet-async'
 
-interface SEOProps {
+type Props = {
   title: string
-  description: string
-  keywords?: string[]
-  jsonLd?: Record<string, unknown>
+  description?: string
+  canonical?: string
+  ogImage?: string
 }
 
-/**
- * Reusable component for injecting SEO meta tags and structured data.
- */
-export default function SEO({ title, description, keywords = [], jsonLd }: SEOProps) {
+export default function SEO({ title, description, canonical, ogImage = '/ogimage.jpg' }: Props) {
   return (
     <Helmet>
       <title>{title}</title>
-      <meta name='description' content={description} />
-      {keywords.length > 0 && <meta name='keywords' content={keywords.join(', ')} />}
-      {jsonLd && <script type='application/ld+json'>{JSON.stringify(jsonLd)}</script>}
+      {description && <meta name='description' content={description} />}
+      {canonical && <link rel='canonical' href={canonical} />}
+      <meta property='og:title' content={title} />
+      {description && <meta property='og:description' content={description} />}
+      <meta property='og:type' content='website' />
+      {canonical && <meta property='og:url' content={canonical} />}
+      <meta property='og:image' content={ogImage} />
     </Helmet>
   )
 }

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,18 +1,15 @@
 import React from 'react'
-import { Helmet } from 'react-helmet-async'
+import SEO from '../components/SEO'
 import { motion } from 'framer-motion'
 
 export default function About() {
   return (
     <>
-      <Helmet>
-        <title>About - The Hippie Scientist</title>
-        <meta
-          name='description'
-          content='Learn more about the mission behind The Hippie Scientist.'
-        />
-      </Helmet>
-
+      <SEO
+        title='About | The Hippie Scientist'
+        description='Independent site exploring psychoactive herbs with scientific rigor and cultural context.'
+        canonical='https://thehippiescientist.net/about'
+      />
       <div className='min-h-screen px-4 pt-20'>
         <div className='mx-auto max-w-3xl space-y-8'>
           <motion.h1

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -1,7 +1,7 @@
 // src/pages/Database.tsx
 
 import React from 'react'
-import { Helmet } from 'react-helmet-async'
+import SEO from '../components/SEO'
 import { motion } from 'framer-motion'
 import HerbList from '../components/HerbList'
 import TagFilterBar from '../components/TagFilterBar'
@@ -140,14 +140,11 @@ export default function Database() {
   return (
     <ErrorBoundary>
       <>
-        <Helmet>
-          <title>Database - The Hippie Scientist</title>
-          <meta
-            name='description'
-            content='Browse herbal entries and expand each to learn more about their effects and usage.'
-          />
-        </Helmet>
-
+        <SEO
+          title='Herb Database | The Hippie Scientist'
+          description='Browse psychoactive herb profiles with scientific and cultural context.'
+          canonical='https://thehippiescientist.net/database'
+        />
         <div className='relative min-h-screen px-4 pt-20'>
           <StarfieldBackground />
           <div className='relative mx-auto max-w-6xl'>

--- a/src/pages/Favorites.tsx
+++ b/src/pages/Favorites.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import { Helmet } from 'react-helmet-async'
 import { Link } from 'react-router-dom'
 import HerbList from '../components/HerbList'
 import { useHerbs } from '../hooks/useHerbs'
 import { useHerbFavorites } from '../hooks/useHerbFavorites'
 import { motion } from 'framer-motion'
+import SEO from '../components/SEO'
 
 export default function Favorites() {
   const herbs = useHerbs()
@@ -17,13 +17,11 @@ export default function Favorites() {
 
   return (
     <div className='relative min-h-screen px-4 pt-20'>
-      <Helmet>
-        <title>My Herbs - The Hippie Scientist</title>
-        <meta
-          name='description'
-          content='View herbs you have starred as favorites.'
-        />
-      </Helmet>
+      <SEO
+        title='Favorite Herbs | The Hippie Scientist'
+        description='Review the psychoactive herbs you have starred for quick reference.'
+        canonical='https://thehippiescientist.net/favorites'
+      />
       <div className='mx-auto max-w-6xl'>
         <div className='mb-4'>
           <Link to='/database' className='text-comet underline'>

--- a/src/pages/HerbBlender.tsx
+++ b/src/pages/HerbBlender.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Helmet } from 'react-helmet-async'
 import { motion, AnimatePresence } from 'framer-motion'
 import BlendSummaryCard from '../components/BlendSummaryCard'
 import HerbCardAccordion from '../components/HerbCardAccordion'
@@ -7,6 +6,7 @@ import TagBadge from '../components/TagBadge'
 import { useHerbs } from '../hooks/useHerbs'
 import { useLocalStorage } from '../hooks/useLocalStorage'
 import { herbName, splitField } from '../utils/herb'
+import SEO from '../components/SEO'
 
 export default function HerbBlender() {
   const herbs = useHerbs()
@@ -70,10 +70,11 @@ export default function HerbBlender() {
 
   return (
     <div className='relative min-h-screen px-4 pt-20'>
-      <Helmet>
-        <title>Blend Builder - The Hippie Scientist</title>
-        <meta name='description' content='Create custom herbal blends.' />
-      </Helmet>
+      <SEO
+        title='Herb Blend Builder | The Hippie Scientist'
+        description='Combine herbs to explore synergies and craft mindful blends.'
+        canonical='https://thehippiescientist.net/blend'
+      />
       <div className='mx-auto max-w-6xl space-y-6'>
         <motion.h1
           className='text-gradient text-center text-5xl font-bold'

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -1,25 +1,100 @@
-import React, { useMemo } from "react";
-import { useParams, Link } from "react-router-dom";
-import { SEED_HERBS } from "../data/seedHerbs";
-import { slugify } from "../lib/slug";
+import React, { useMemo } from 'react'
+import { useParams, Link } from 'react-router-dom'
+import { SEED_HERBS } from '../data/seedHerbs'
+import { slugify } from '../lib/slug'
+import SEO from '../components/SEO'
+
 export default function HerbDetail() {
-  const { slug } = useParams();
-  const herb = useMemo(() => SEED_HERBS.find(h => slugify(h.commonName) === slug), [slug]);
-  if (!herb) return <main className="mx-auto max-w-3xl px-4 py-8"><h1>Not found</h1><p><Link className="underline" to="/herb-index">← Back</Link></p></main>;
+  const { slug } = useParams()
+  const herb = useMemo(() => SEED_HERBS.find(h => slugify(h.commonName) === slug), [slug])
+  const canonical = slug ? `https://thehippiescientist.net/herb/${slug}` : undefined
+
+  if (!herb) {
+    return (
+      <>
+        <SEO
+          title='Herb Not Found | The Hippie Scientist'
+          description='The requested herb profile could not be located.'
+          canonical={canonical}
+        />
+        <main className='mx-auto max-w-3xl px-4 py-8'>
+          <h1>Not found</h1>
+          <p>
+            <Link className='underline' to='/herb-index'>
+              ← Back
+            </Link>
+          </p>
+        </main>
+      </>
+    )
+  }
+
   return (
-    <main className="mx-auto max-w-3xl px-4 py-8">
-      <p><Link className="underline" to="/herb-index">← Back to Herb Index</Link></p>
-      <h1 className="mt-3 text-3xl font-bold">{herb.commonName} <span className="text-lg italic opacity-70">({herb.latinName})</span></h1>
-      {herb.mechanism && <section className="mt-6"><h2 className="text-xl font-semibold">Mechanism</h2><p className="mt-2">{herb.mechanism}</p></section>}
-      {herb.compounds && <section className="mt-6"><h2 className="text-xl font-semibold">Key Compounds</h2><ul className="list-disc pl-5 mt-2">{herb.compounds.map(c => <li key={c}>{c}</li>)}</ul></section>}
-      {herb.traditionalUses && <section className="mt-6"><h2 className="text-xl font-semibold">Traditional Uses</h2><p className="mt-2">{herb.traditionalUses}</p></section>}
-      {herb.safety && <section className="mt-6"><h2 className="text-xl font-semibold">Safety & Interactions</h2><p className="mt-2">{herb.safety}</p></section>}
-      {herb.legal && <section className="mt-6"><h2 className="text-xl font-semibold">Legal & Availability</h2><p className="mt-2">{herb.legal}</p></section>}
-      <section className="mt-6"><h2 className="text-xl font-semibold">Related</h2>
-        <p className="mt-2">
-          {herb.commonName === "Kanna" ? <Link className="underline" to="/herb/blue-lotus">Blue Lotus</Link> : <Link className="underline" to="/herb/kanna">Kanna</Link>}
+    <>
+      <SEO
+        title={`${herb.commonName} | The Hippie Scientist`}
+        description={`Learn about ${herb.commonName}, including key compounds, traditional uses, and safety insights.`}
+        canonical={canonical}
+      />
+      <main className='mx-auto max-w-3xl px-4 py-8'>
+        <p>
+          <Link className='underline' to='/herb-index'>
+            ← Back to Herb Index
+          </Link>
         </p>
-      </section>
-    </main>
-  );
+        <h1 className='mt-3 text-3xl font-bold'>
+          {herb.commonName}{' '}
+          <span className='text-lg italic opacity-70'>({herb.latinName})</span>
+        </h1>
+        {herb.mechanism && (
+          <section className='mt-6'>
+            <h2 className='text-xl font-semibold'>Mechanism</h2>
+            <p className='mt-2'>{herb.mechanism}</p>
+          </section>
+        )}
+        {herb.compounds && (
+          <section className='mt-6'>
+            <h2 className='text-xl font-semibold'>Key Compounds</h2>
+            <ul className='mt-2 list-disc pl-5'>
+              {herb.compounds.map(c => (
+                <li key={c}>{c}</li>
+              ))}
+            </ul>
+          </section>
+        )}
+        {herb.traditionalUses && (
+          <section className='mt-6'>
+            <h2 className='text-xl font-semibold'>Traditional Uses</h2>
+            <p className='mt-2'>{herb.traditionalUses}</p>
+          </section>
+        )}
+        {herb.safety && (
+          <section className='mt-6'>
+            <h2 className='text-xl font-semibold'>Safety &amp; Interactions</h2>
+            <p className='mt-2'>{herb.safety}</p>
+          </section>
+        )}
+        {herb.legal && (
+          <section className='mt-6'>
+            <h2 className='text-xl font-semibold'>Legal &amp; Availability</h2>
+            <p className='mt-2'>{herb.legal}</p>
+          </section>
+        )}
+        <section className='mt-6'>
+          <h2 className='text-xl font-semibold'>Related</h2>
+          <p className='mt-2'>
+            {herb.commonName === 'Kanna' ? (
+              <Link className='underline' to='/herb/blue-lotus'>
+                Blue Lotus
+              </Link>
+            ) : (
+              <Link className='underline' to='/herb/kanna'>
+                Kanna
+              </Link>
+            )}
+          </p>
+        </section>
+      </main>
+    </>
+  )
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -6,19 +6,21 @@ import NewsletterSignup from '../components/NewsletterSignup'
 
 export default function Home() {
   return (
-    <main
-      id='home'
-      aria-label='Site introduction'
-      className='bg-cosmic-forest animate-gradient relative min-h-screen overflow-hidden pt-16 text-midnight dark:bg-space-night dark:text-sand'
-    >
+    <>
       <SEO
-        title='The Hippie Scientist - Psychedelic Botany'
-        description='Explore visionary botanicals, cognitive enhancers and research insights.'
-        keywords={['psychedelics', 'herbs', 'consciousness']}
+        title='The Hippie Scientist — Mindful Exploration of Psychoactive Herbs'
+        description='Independent research on psychoactive herbs, entheogens, and natural neurochemistry.'
+        canonical='https://thehippiescientist.net/'
       />
-      <StarfieldBackground />
-      <Hero />
-      <NewsletterSignup />
-    </main>
+      <main
+        id='home'
+        aria-label='Site introduction'
+        className='bg-cosmic-forest animate-gradient relative min-h-screen overflow-hidden pt-16 text-midnight dark:bg-space-night dark:text-sand'
+      >
+        <StarfieldBackground />
+        <Hero />
+        <NewsletterSignup />
+      </main>
+    </>
   )
 }


### PR DESCRIPTION
## WHAT
- add react-helmet-async SEO helper and apply per-route titles/descriptions for key pages
- embed organization and website JSON-LD plus RSS link in the HTML shell
- publish a static RSS feed at `/feed.xml`

## WHY
- improves crawlability and sharing previews by providing descriptive metadata per route
- exposes structured data and a feed to help discoverability across search and reader services

## HOW TO VERIFY
- run `npm run build` and ensure the bundle succeeds
- open the SPA, navigate between routes, and inspect the head to confirm Helmet updates title/meta tags
- request `/feed.xml` and validate the XML with an RSS validator or reader
- run the Google Rich Results test against `index.html` to confirm JSON-LD is detected

------
https://chatgpt.com/codex/tasks/task_e_68e2dc492cf883239b15fd4d815b4df0