### PR TITLE
feat(compare): side-by-side herb comparison

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { RedirectHandler } from './RedirectHandler';
 import { useGA } from './lib/useGA';
 import HerbIndex from './pages/HerbIndex';
 import HerbDetail from './pages/HerbDetail';
+import Compare from './pages/Compare';
 // Import other pages as needed
 
 export default function App() {
@@ -28,6 +29,7 @@ export default function App() {
         {/* Add other routes here */}
         <Route path="/herb-index" element={<HerbIndex />} />
         <Route path="/herb/:slug" element={<HerbDetail />} />
+        <Route path="/compare" element={<Compare />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </>

--- a/src/pages/Compare.tsx
+++ b/src/pages/Compare.tsx
@@ -1,0 +1,77 @@
+import React, { useMemo } from "react";
+import { useSearchParams, Link } from "react-router-dom";
+import data from "../data/herbs/herbs.normalized.json";
+
+type Herb = typeof data[number];
+
+function pick(slug: string): Herb | undefined {
+  return (data as Herb[]).find(h => h.slug === slug);
+}
+
+const FIELDS: Array<[keyof Herb, string]> = [
+  ["common", "Common Name"],
+  ["scientific", "Scientific Name"],
+  ["category", "Category"],
+  ["intensity", "Intensity"],
+  ["region", "Region"],
+  ["legalstatus", "Legal Status"],
+  ["mechanism", "Mechanism"],
+  ["compounds", "Key Compounds"],
+  ["interactions", "Interactions"],
+  ["contraindications", "Contraindications"],
+  ["safety", "Safety"],
+  ["sideeffects", "Side Effects"],
+  ["toxicity", "Toxicity"],
+  ["sources", "Sources"]
+];
+
+export default function Compare() {
+  const [sp] = useSearchParams();
+  const ids = (sp.get("ids") || "").split(",").map(s => s.trim()).filter(Boolean).slice(0,3);
+  const herbs = useMemo(() => ids.map(pick).filter(Boolean) as Herb[], [ids]);
+
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-8">
+      <div className="flex flex-wrap items-baseline justify-between gap-4">
+        <h1 className="text-2xl font-bold">Compare Herbs</h1>
+        <Link className="underline" to="/database">← Back to Database</Link>
+      </div>
+
+      {herbs.length === 0 ? (
+        <p className="mt-4">No herbs selected. Choose up to three from the database and click Compare.</p>
+      ) : (
+        <div className="mt-6 overflow-x-auto">
+          <table className="w-full border-collapse">
+            <thead>
+              <tr>
+                <th className="border-b p-2 text-left">Field</th>
+                {herbs.map(h => (
+                  <th key={h.slug} className="border-b p-2 text-left">
+                    <div className="font-semibold">{h.common || h.scientific}</div>
+                    <div className="text-sm opacity-70">{h.scientific}</div>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {FIELDS.map(([key,label]) => (
+                <tr key={String(key)}>
+                  <td className="border-b p-2 align-top font-medium">{label}</td>
+                  {herbs.map(h => {
+                    const v = (h as any)[key];
+                    const text = Array.isArray(v) ? v.join(", ") : (v ?? "");
+                    return <td key={h.slug + String(key)} className="border-b p-2 align-top whitespace-pre-wrap">{text}</td>;
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <p className="mt-6 text-sm opacity-70">
+        Educational content only, not medical advice. Verify legal status locally. Individual responses vary.
+      </p>
+    </main>
+  );
+}

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -19,6 +19,16 @@ export default function Database() {
   const [category, setCategory] = useState('')
   const [legal, setLegal] = useState('')
   const [page, setPage] = useState(1)
+  const [selected, setSelected] = useState<string[]>([])
+  function toggleSelect(slug: string) {
+    setSelected(prev => {
+      const exists = prev.includes(slug)
+      if (exists) return prev.filter(s => s !== slug)
+      if (prev.length >= 3) return prev
+      return [...prev, slug]
+    })
+  }
+  const compareHref = selected.length ? `/compare?ids=${selected.join(',')}` : ''
   const pageSize = 30
 
   const categories = useMemo(
@@ -166,6 +176,30 @@ export default function Database() {
               </option>
             ))}
           </select>
+          <div className='flex items-center gap-2'>
+            <button
+              type='button'
+              disabled={!selected.length}
+              onClick={() => {
+                if (compareHref) {
+                  window.location.href = compareHref
+                }
+              }}
+              className={`rounded-md px-3 py-1 ${selected.length ? 'bg-gray-900 text-white' : 'cursor-not-allowed bg-gray-300 text-gray-600'}`}
+              title='Select up to 3 and compare'
+            >
+              Compare ({selected.length}/3)
+            </button>
+            {selected.length > 0 && (
+              <button
+                type='button'
+                onClick={() => setSelected([])}
+                className='rounded-md border px-2 py-1'
+              >
+                Clear
+              </button>
+            )}
+          </div>
         </div>
 
         <div className='mt-6 flex flex-wrap items-center justify-between gap-2 text-sm text-sand/70'>
@@ -192,7 +226,19 @@ export default function Database() {
         {paginated.length > 0 ? (
           <div className='mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'>
             {paginated.map(herb => (
-              <HerbCardAccordion key={herb.id} herb={herb} />
+              <div key={herb.id} className='space-y-2'>
+                <div className='flex justify-end'>
+                  <label className='flex items-center gap-2 text-xs text-sand/80'>
+                    <input
+                      type='checkbox'
+                      checked={selected.includes(herb.slug)}
+                      onChange={() => toggleSelect(herb.slug)}
+                    />
+                    Compare
+                  </label>
+                </div>
+                <HerbCardAccordion herb={herb} />
+              </div>
             ))}
           </div>
         ) : (


### PR DESCRIPTION
## Summary
- add /compare page to show selected herb attributes side by side and support shareable URLs
- enable selecting up to three herbs on the database page with compare and clear controls
- wire the new compare route into the app router

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3f8a1a62083239c75ded5610eaeb1