### PR TITLE
fix(data+ui): richer herb fields + cleaner UI (no ‘Unknown’)

### DIFF
--- a/src/components/DatabaseHerbCard.tsx
+++ b/src/components/DatabaseHerbCard.tsx
@@ -1,0 +1,96 @@
+import { Link } from 'react-router-dom'
+import type { Herb } from '../types'
+import { has, list, bullets, urlish } from '../lib/format'
+import { herbName, splitField } from '../utils/herb'
+
+interface Props {
+  herb: Herb
+}
+
+export function DatabaseHerbCard({ herb }: Props) {
+  const title = herbName(herb)
+  const scientific = herb.scientific?.trim()
+  const detailHref = `/herb/${herb.slug}`
+  const intensity = herb.intensity?.trim()
+  const region = herb.region?.trim()
+  const legalStatus = herb.legalstatus?.trim()
+  const effectsList = splitField(herb.effects)
+  const effectsText = list(effectsList)
+
+  return (
+    <article className='glassmorphic-card soft-border-glow relative flex h-full flex-col gap-2 p-4 text-sand'>
+      <header>
+        <h2 className='text-xl font-semibold text-lime-300'>{title}</h2>
+        {has(scientific) && <p className='text-sm italic text-sand/70'>{scientific}</p>}
+        {has(intensity) && (
+          <p className='mt-1 inline-flex items-center rounded-full bg-white/10 px-2 py-1 text-xs uppercase tracking-wide text-sand/80'>
+            Intensity: {intensity}
+          </p>
+        )}
+      </header>
+
+      {has(effectsList) && (
+        <p className='text-sm text-sand/90'>
+          <strong>Effects:</strong> {effectsText}
+        </p>
+      )}
+      {has(herb.description) && (
+        <p className='text-sm text-sand/80'>
+          <strong>Description:</strong> {herb.description}
+        </p>
+      )}
+
+      {has(herb.tags) && (
+        <div className='mt-1 flex flex-wrap gap-2'>
+          {(herb.tags || []).slice(0, 6).map(tag => (
+            <span key={tag} className='rounded-full bg-purple-700/40 px-2 py-1 text-xs'>
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {has(region) && <p className='mt-1 text-sm text-sand/80'>🌍 {region}</p>}
+
+      {has(herb.compounds) && (
+        <p className='mt-1 text-sm text-sand/90'>
+          <strong>Active Compounds:</strong> {list(herb.compounds, 3)}
+        </p>
+      )}
+
+      {has(herb.contraindications) && (
+        <p className='mt-1 text-sm text-sand/90'>
+          <strong>Contraindications:</strong> {list(herb.contraindications)}
+        </p>
+      )}
+
+      {has(herb.sources) && (
+        <div className='mt-2 text-sm text-sand/90'>
+          <strong>Sources:</strong>
+          <ul className='mt-1 list-disc pl-5'>
+            {bullets(herb.sources).map((source, index) => (
+              <li key={`${herb.slug}-source-${index}`}>
+                {urlish(source) ? (
+                  <a className='underline' href={source} target='_blank' rel='noreferrer'>
+                    {source}
+                  </a>
+                ) : (
+                  source
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className='mt-auto flex items-center justify-between pt-2 text-xs text-sand/60'>
+        {has(legalStatus) && <span>Legal: {legalStatus}</span>}
+        <Link to={detailHref} className='text-sky-300 underline'>
+          View details
+        </Link>
+      </div>
+    </article>
+  )
+}
+
+export default DatabaseHerbCard

--- a/src/data/herbs/herbs.normalized.json
+++ b/src/data/herbs/herbs.normalized.json
@@ -5,13 +5,18 @@
     "common": "",
     "scientific": "Acacia confusa",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Strong",
     "region": "taiwan, philippines, pacific islands",
     "legalstatus": "DMT restricted in many countries",
+    "schedule": "",
     "description": "a taiwanese tree whose root bark is rich in dmt and related tryptamines. commonly used in diy ayahuasca analogs or 'anahuasca' brews.",
     "effects": "Visual distortion;mystical states;introspection",
     "mechanism": "DMT – 5-HT2A agonist; requires MAOI for oral activity",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "spiritual exploration, traditional cleansing (when combined with maoi)",
     "interactions": [
       "maois",
       "antidepressants — risky"
@@ -20,20 +25,23 @@
       "mental health conditions",
       "ssris/maois"
     ],
-    "dosage": "",
-    "therapeutic": "spiritual exploration, traditional cleansing (when combined with maoi)",
+    "sideeffects": [
+      "strong visuals",
+      "nausea",
+      "anxiety"
+    ],
     "safety": "",
-    "sideeffects": "strong visuals, nausea, anxiety",
     "toxicity": "Low physiological, high psychological risk",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ caution",
       "🌿 root bark",
       "🧪 dmt"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "acacia-maidenii",
@@ -41,15 +49,20 @@
     "common": "",
     "scientific": "Acacia maidenii",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Strong",
     "region": "native to eastern australia",
     "legalstatus": "DMT restricted in many countries",
+    "schedule": "",
     "description": "australian acacia tree whose bark is rich in dmt and sometimes used in ayahuasca analogues.",
     "effects": "strong visuals;mystical experience;euphoria",
     "mechanism": "Root bark contains DMT that acts as a 5‑HT2A agonist; requires MAOI inhibition for oral activity",
     "compounds": [
       "DMT"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used in entheogenic brews for introspection and spiritual healing",
     "interactions": [
       "dangerous with maois or serotonergic drugs"
     ],
@@ -57,24 +70,27 @@
       "mental illness",
       "maoi or ssri medication"
     ],
-    "dosage": "",
-    "therapeutic": "used in entheogenic brews for introspection and spiritual healing",
+    "sideeffects": [
+      "nausea",
+      "anxiety",
+      "profound alterations of perception"
+    ],
     "safety": "",
-    "sideeffects": "nausea, anxiety, profound alterations of perception",
     "toxicity": "Low physiological toxicity but intense psychological effects",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "australian",
       "dmt",
       "tree"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://erowid.org/plants/acacia_maidenii/",
       "PubMed ID: 21798319",
       "Trouts Notes – Acacia Alkaloid Profiles"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "achillea-millefolium",
@@ -82,40 +98,46 @@
     "common": "",
     "scientific": "Achillea millefolium",
     "category": "astringent / anti-inflammatory / wound care / traditional european",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "europe, north america, temperate asia",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "named after achilles, who used it to treat battlefield wounds, yarrow is a classic herb for bleeding, inflammation, and fevers. it's used internally for digestion and externally for cuts, bruises, and nosebleeds.",
     "effects": "Wound healing;Fever reduction;Digestive support;Circulatory modulation",
     "mechanism": "Rich in flavonoids, alkaloids, sesquiterpene lactones, and salicylic acid derivatives. Acts as an anti-inflammatory, astringent, and mild diaphoretic.",
     "compounds": [
       "Thujone"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for wounds, bleeding, fevers, gi discomfort, menstrual cramps, and varicose veins. traditionally applied as poultice or tea.",
     "interactions": [
       "mild interactions with anticoagulants or nsaids possible."
     ],
     "contraindications": [
       "avoid during pregnancy due to potential uterine stimulation. caution in ragweed-allergic individuals."
     ],
-    "dosage": "",
-    "therapeutic": "used for wounds, bleeding, fevers, gi discomfort, menstrual cramps, and varicose veins. traditionally applied as poultice or tea.",
+    "sideeffects": [
+      "mild allergic reactions possible in sensitive individuals. large internal doses may upset digestion."
+    ],
     "safety": "",
-    "sideeffects": "mild allergic reactions possible in sensitive individuals. large internal doses may upset digestion.",
     "toxicity": "Low",
     "toxicity_ld50": "Not well established (safe in traditional use)",
-    "is_controlled_substance": false,
     "tags": [
       "🩸 astringent",
       "🌿 wound care",
       "🔥 anti-inflammatory",
       "🧘 menstrual"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6331677/",
       "British Herbal Compendium",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "achillea-millefolium",
@@ -123,13 +145,18 @@
     "common": "",
     "scientific": "Achillea millefolium",
     "category": "sedative / analgesic",
+    "subcategory": "",
     "intensity": "",
     "region": "northern hemisphere",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "common meadow herb with mild soothing effects.",
     "effects": "relaxation;pain relief",
     "mechanism": "Sesquiterpene lactones like chamazulene reduce inflammation and may calm nerves",
     "compounds": [],
+    "preparations": [],
+    "dosage": "2-4 g dried herb",
+    "therapeutic": "digestive aid, wound healing, relaxation",
     "interactions": [
       "may enhance sedatives"
     ],
@@ -137,19 +164,20 @@
       "pregnancy",
       "asteraceae allergy"
     ],
-    "dosage": "2-4 g dried herb",
-    "therapeutic": "digestive aid, wound healing, relaxation",
+    "sideeffects": [
+      "allergic reactions in some"
+    ],
     "safety": "",
-    "sideeffects": "allergic reactions in some",
     "toxicity": "Low",
     "toxicity_ld50": "~1.3 g/kg (rats, extract)",
-    "is_controlled_substance": false,
     "tags": [
       "🌼 flower",
       "😊 mild"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "acmella-oleracea",
@@ -157,38 +185,46 @@
     "common": "",
     "scientific": "Acmella oleracea",
     "category": "analgesic / salivary stimulant / traditional amazonian",
+    "subcategory": "",
     "intensity": "Moderate–Strong (topical), Mild (systemic)",
     "region": "south america, widely cultivated",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "famous for its electric tingle, spilanthes is traditionally used for dental pain, infections, and immune stimulation. its 'buzz buttons' offer a unique sensory experience and are increasingly used in mixology and herbalism.",
     "effects": "Numbing;Tingling;Salivation;Immune support",
     "mechanism": "Spilanthol (an alkamide) activates TRPV1 channels, producing a tingling and numbing sensation. Also shown to enhance immune response and have antibacterial activity.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for toothache, sore throat, ulcers, immune support, dry mouth, and topical infections.",
     "interactions": [
       "may interact with blood pressure or cns-active drugs due to salivation and mucosal absorption."
     ],
     "contraindications": [
       "avoid in pregnancy and with hypotension. may increase absorption of co-administered compounds."
     ],
-    "dosage": "",
-    "therapeutic": "used for toothache, sore throat, ulcers, immune support, dry mouth, and topical infections.",
+    "sideeffects": [
+      "mouth tingling",
+      "temporary numbness",
+      "increased salivation. rare allergic reaction."
+    ],
     "safety": "",
-    "sideeffects": "mouth tingling, temporary numbness, increased salivation. rare allergic reaction.",
     "toxicity": "Low",
     "toxicity_ld50": "Not fully established; high traditional safety margin",
-    "is_controlled_substance": false,
     "tags": [
       "⚡ tingling",
       "🦷 tooth pain",
       "🧪 immune tonic",
       "💧 salivary"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3817685/",
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "acorus-americanus",
@@ -196,31 +232,35 @@
     "common": "",
     "scientific": "Acorus americanus",
     "category": "ethnobotanical",
+    "subcategory": "",
     "intensity": "",
     "region": "north america",
     "legalstatus": "",
+    "schedule": "",
     "description": "american sweet flag, native to north america, used by indigenous groups for its psychoactive and stimulant properties.",
     "effects": "alertness;mental clarity;mild euphoria",
     "mechanism": "Cholinergic + dopaminergic modulation",
     "compounds": [
       "Alpha-asarone"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "native medicine",
       "calamus species",
       "uplifting"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "acorus-calamus",
@@ -228,13 +268,18 @@
     "common": "",
     "scientific": "Acorus calamus",
     "category": "calming / dream",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "europe, asia, north america",
     "legalstatus": "Generally legal, though some preparations restricted",
+    "schedule": "",
     "description": "fragrant wetland herb known as sweet flag; historically used for relaxation and vivid dreams.",
     "effects": "calm;mild euphoria;dream enhancement",
     "mechanism": "Contains beta‑asarone which may modulate GABA and serotonin receptors",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditionally used for digestion, anxiety and divination",
     "interactions": [
       "potential additive effects with other sedatives"
     ],
@@ -243,25 +288,27 @@
       "high doses",
       "liver disease"
     ],
-    "dosage": "",
-    "therapeutic": "traditionally used for digestion, anxiety and divination",
+    "sideeffects": [
+      "nausea",
+      "vomiting at large doses"
+    ],
     "safety": "",
-    "sideeffects": "nausea, vomiting at large doses",
     "toxicity": "Beta‑asarone may be carcinogenic in high doses",
     "toxicity_ld50": "Exceeds 1 g/kg in rodents",
-    "is_controlled_substance": false,
     "tags": [
       "dream",
       "root",
       "sedative"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6383205/",
       "PubChem CID: 73568",
       "Botanical Safety Handbook",
       "2nd ed."
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "acorus-calamus-angustatus",
@@ -269,31 +316,35 @@
     "common": "",
     "scientific": "Acorus calamus var. angustatus",
     "category": "ethnobotanical",
+    "subcategory": "",
     "intensity": "",
     "region": "himalayas",
     "legalstatus": "",
+    "schedule": "",
     "description": "a rare calamus variant high in beta-asarone, used in tibetan medicine and ritual incense.",
     "effects": "trance;mental clarity;light hallucinations",
     "mechanism": "GABAergic + cholinergic",
     "compounds": [
       "Beta-asarone"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "ritual",
       "variant",
       "aromatic stimulant"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "adhatoda-vasica",
@@ -301,13 +352,18 @@
     "common": "",
     "scientific": "Justicia adhatoda",
     "category": "stimulant / bronchodilator",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "indian subcontinent",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "known as vasaka or malabar nut, this shrub’s leaves ease breathing and offer a subtle stimulating effect.",
     "effects": "clear breathing;mild stimulation;warming",
     "mechanism": "Alkaloids such as vasicine act as bronchodilators and respiratory stimulants",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "ayurvedic herb for asthma, coughs and general vitality",
     "interactions": [
       "may potentiate other bronchodilators"
     ],
@@ -315,25 +371,26 @@
       "pregnancy",
       "high doses may cause vomiting"
     ],
-    "dosage": "",
-    "therapeutic": "ayurvedic herb for asthma, coughs and general vitality",
+    "sideeffects": [
+      "digestive upset at large doses"
+    ],
     "safety": "",
-    "sideeffects": "digestive upset at large doses",
     "toxicity": "Generally safe at therapeutic doses",
     "toxicity_ld50": ">2 g/kg in rodents",
-    "is_controlled_substance": false,
     "tags": [
       "ayurveda",
       "respiratory",
       "vasaka"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3249957/",
       "Phytomedicine. 2000",
       "7(1):37-44.",
       "Ayurvedic Pharmacopoeia of India"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "aegle-marmelos",
@@ -341,39 +398,45 @@
     "common": "",
     "scientific": "Aegle marmelos",
     "category": "digestive / mild sedative",
+    "subcategory": "",
     "intensity": "",
     "region": "south asia",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "bael tree used in ayurvedic medicine for digestion and calm",
     "effects": "calm;digestive relief",
     "mechanism": "Coumarins like marmelosin exhibit mild sedative and GI effects",
     "compounds": [
       "Marmelosin"
     ],
+    "preparations": [],
+    "dosage": "5-10 g dried fruit",
+    "therapeutic": "digestive tonic",
     "interactions": [
       "none significant"
     ],
     "contraindications": [
       "severe gi obstruction"
     ],
-    "dosage": "5-10 g dried fruit",
-    "therapeutic": "digestive tonic",
+    "sideeffects": [
+      "constipation in high amounts"
+    ],
     "safety": "",
-    "sideeffects": "constipation in high amounts",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 ayurveda",
       "🍈 fruit"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4027290/",
       "Indian Journal of Traditional Knowledge",
       "2009",
       "Ayurvedic Pharmacopoeia of India"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "african-dream-root",
@@ -381,36 +444,42 @@
     "common": "",
     "scientific": "Silene capensis",
     "category": "oneirogen",
+    "subcategory": "",
     "intensity": "Mild to moderate",
     "region": "south africa",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "a sacred dream-enhancing root used by the xhosa people of south africa to induce powerful and meaningful dreams.",
     "effects": "Vivid dreams;lucidity;spiritual connection",
     "mechanism": "Likely saponins and triterpenoids affecting sleep cycles",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "dream recall, ancestral communication (traditional)",
     "interactions": [],
     "contraindications": [
       "none well established"
     ],
-    "dosage": "",
-    "therapeutic": "dream recall, ancestral communication (traditional)",
+    "sideeffects": [
+      "mild nausea or grogginess if overdosed"
+    ],
     "safety": "",
-    "sideeffects": "mild nausea or grogginess if overdosed",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌙 dream",
       "🧘 ancestral"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://erowid.org/plants/silene_capensis/",
       "Dreaming Plant Guide – Ratsch",
       "Journal of Ethnopharmacology",
       "2008"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "albizia-julibrissin",
@@ -418,13 +487,18 @@
     "common": "",
     "scientific": "Albizia julibrissin",
     "category": "calming / mood",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "native to asia, cultivated elsewhere",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "often called persian silk tree; valued in asian herbalism for its tranquil and mood-brightening properties.",
     "effects": "uplifted mood;relaxation;mild sedation",
     "mechanism": "Contains saponins and flavonoids thought to modulate serotonin and GABA",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditional chinese medicine uses the bark and flowers as a calming antidepressant",
     "interactions": [
       "may enhance other sedatives or antidepressants"
     ],
@@ -432,26 +506,27 @@
       "none known",
       "though caution with sedatives"
     ],
-    "dosage": "",
-    "therapeutic": "traditional chinese medicine uses the bark and flowers as a calming antidepressant",
+    "sideeffects": [
+      "rare drowsiness in sensitive individuals"
+    ],
     "safety": "",
-    "sideeffects": "rare drowsiness in sensitive individuals",
     "toxicity": "Low",
     "toxicity_ld50": "Not well established",
-    "is_controlled_substance": false,
     "tags": [
       "tcm",
       "anxiolytic",
       "flower"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6834330/",
       "Chinese Herbal Medicine: Materia Medica",
       "3rd ed.",
       "Journal of Ethnopharmacology",
       "2009"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "alchornea-castaneifolia",
@@ -459,38 +534,45 @@
     "common": "Iporuru",
     "scientific": "Alchornea castaneifolia",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "amazon basin",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "used in amazonian shamanic rituals for its spiritual and anti-inflammatory effects. often included in ayahuasca blends.",
     "effects": "Anti-inflammatory;spiritual clarity;energetic cleansing",
     "mechanism": "Unknown; may involve tannins and flavonoids",
     "compounds": [
       "Alchorneine"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "rheumatism, arthritis, spiritual cleansing",
     "interactions": [],
     "contraindications": [
       "pregnancy"
     ],
-    "dosage": "",
-    "therapeutic": "rheumatism, arthritis, spiritual cleansing",
+    "sideeffects": [
+      "minimal",
+      "bitter taste"
+    ],
     "safety": "",
-    "sideeffects": "minimal; bitter taste",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌿 amazon",
       "🧘 cleanse"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4127826/",
       "Rainforest Healing Herb Profiles",
       "Journal of Ethnopharmacology",
       "2007"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "aloysia-citrodora",
@@ -498,9 +580,11 @@
     "common": "",
     "scientific": "Aloysia citrodora",
     "category": "ethnobotanical",
+    "subcategory": "",
     "intensity": "",
     "region": "south america",
     "legalstatus": "",
+    "schedule": "",
     "description": "lemon verbena, a gentle herbal tea with calming and mood-lifting effects.",
     "effects": "calm;relaxation;light euphoria",
     "mechanism": "GABAergic + serotonergic",
@@ -508,22 +592,24 @@
       "Citral",
       "Verbascoside"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "tea",
       "folk remedy",
       "calming"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "alpinia-galanga",
@@ -531,13 +617,18 @@
     "common": "",
     "scientific": "Alpinia galanga",
     "category": "stimulant",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "indonesia, thailand, malaysia",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "a common culinary spice known as galangal that offers gentle stimulation and a warming effect.",
     "effects": "warm stimulation;mild euphoria;enhanced circulation",
     "mechanism": "Contains eugenol and cineole that increase circulation and mild CNS stimulation",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used in southeast asian medicine for digestion and fatigue",
     "interactions": [
       "may alter absorption of other stimulants or anticoagulants"
     ],
@@ -545,24 +636,25 @@
       "gastric ulcers",
       "anticoagulant medication"
     ],
-    "dosage": "",
-    "therapeutic": "used in southeast asian medicine for digestion and fatigue",
+    "sideeffects": [
+      "heartburn or mild agitation at high doses"
+    ],
     "safety": "",
-    "sideeffects": "heartburn or mild agitation at high doses",
     "toxicity": "Generally safe as a culinary spice",
     "toxicity_ld50": ">3 g/kg in rodents",
-    "is_controlled_substance": false,
     "tags": [
       "aromatic",
       "galangal",
       "spice"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://pubmed.ncbi.nlm.nih.gov/20428007/",
       "Phytomedicine. 2005",
       "Ayurvedic Materia Medica"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "althaea-officinalis",
@@ -570,38 +662,44 @@
     "common": "",
     "scientific": "Althaea officinalis",
     "category": "demulcent / soothing / respiratory",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "europe, middle east, north america",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a classic mucilaginous herb known for its thick, slippery root extract. marshmallow has been used for centuries to coat and soothe mucous membranes, especially in the respiratory and digestive tracts.",
     "effects": "Soothes throat;Eases cough;Reduces inflammation;Digestive calm",
     "mechanism": "High mucilage content coats inflamed tissues, reducing irritation and inflammation. Also mildly antibacterial and immunomodulatory.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for sore throat, dry cough, gerd, stomach ulcers, and irritated urinary tract. also applied externally to wounds.",
     "interactions": [
       "may delay absorption of oral drugs."
     ],
     "contraindications": [
       "take medications 1–2 hrs apart. avoid if allergic to other mucilaginous herbs."
     ],
-    "dosage": "",
-    "therapeutic": "used for sore throat, dry cough, gerd, stomach ulcers, and irritated urinary tract. also applied externally to wounds.",
+    "sideeffects": [
+      "very rare. may slow absorption of medications if taken simultaneously."
+    ],
     "safety": "",
-    "sideeffects": "very rare. may slow absorption of medications if taken simultaneously.",
     "toxicity": "Extremely low.",
     "toxicity_ld50": ">5000 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🫖 soothing",
       "🫁 throat",
       "🩹 demulcent",
       "🌿 digestive"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5452227/",
       "British Herbal Compendium",
       "Herbal Medicine – Mills & Bone"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "amanita-muscaria",
@@ -609,9 +707,11 @@
     "common": "",
     "scientific": "Amanita muscaria",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Moderate to strong",
     "region": "northern hemisphere, boreal forests",
     "legalstatus": "Legal in most countries",
+    "schedule": "",
     "description": "iconic red-capped mushroom used in siberian shamanism and folklore. psychoactive when properly prepared.",
     "effects": "Euphoria;dissociation;dreamlike state",
     "mechanism": "Ibotenic acid and muscimol act as GABA agonists and NMDA antagonists after decarboxylation.",
@@ -619,31 +719,37 @@
       "Muscimol",
       "Ibotenic Acid"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "shamanic ritual, historical analgesic and sedative use.",
     "interactions": [
       "potentiates sedatives and alcohol"
     ],
     "contraindications": [
       "avoid with sedatives or psychiatric conditions."
     ],
-    "dosage": "",
-    "therapeutic": "shamanic ritual, historical analgesic and sedative use.",
+    "sideeffects": [
+      "nausea",
+      "ataxia",
+      "delirium"
+    ],
     "safety": "",
-    "sideeffects": "nausea, ataxia, delirium",
     "toxicity": "Can cause nausea, delirium, or poisoning if dose is high or raw mushrooms consumed.",
     "toxicity_ld50": "LD50 ~38 mg/kg (muscimol, mice)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ caution",
       "🍄 mushroom"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC10454585/",
       "Erowid Amanita Vault",
       "Journal of Ethnopharmacology",
       "2008",
       "Toxicological Profile: Muscimol & Ibotenic Acid (NIH)"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "amanita-pantherina",
@@ -651,13 +757,18 @@
     "common": "",
     "scientific": "Amanita pantherina",
     "category": "deliriant / sedative",
+    "subcategory": "",
     "intensity": "Strong",
     "region": "northern hemisphere",
     "legalstatus": "Varies; unscheduled in many countries",
+    "schedule": "",
     "description": "",
     "effects": "sedation;confusion;dizziness",
     "mechanism": "Contains muscimol and ibotenic acid acting on GABA receptors",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditional siberian shamanic use; rarely employed medically",
     "interactions": [
       "enhances effects of alcohol and sedatives"
     ],
@@ -665,20 +776,23 @@
       "mental illness",
       "combining with other depressants"
     ],
-    "dosage": "",
-    "therapeutic": "traditional siberian shamanic use; rarely employed medically",
+    "sideeffects": [
+      "nausea",
+      "loss of coordination",
+      "delirium"
+    ],
     "safety": "",
-    "sideeffects": "nausea, loss of coordination, delirium",
     "toxicity": "Potentially toxic at high doses",
     "toxicity_ld50": "Not well established",
-    "is_controlled_substance": false,
     "tags": [
       "muscimol",
       "mushroom",
       "panther cap"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "panax-quinquefolius",
@@ -686,13 +800,18 @@
     "common": "",
     "scientific": "Panax quinquefolius",
     "category": "empathogen / euphoriant",
+    "subcategory": "",
     "intensity": "",
     "region": "north america",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "north american species prized for restorative effects.",
     "effects": "calm energy",
     "mechanism": "Similar ginsenosides modulate neurotransmitters",
     "compounds": [],
+    "preparations": [],
+    "dosage": "1–3 g dried root",
+    "therapeutic": "energy, stress relief",
     "interactions": [
       "stimulants",
       "anticoagulants"
@@ -700,19 +819,21 @@
     "contraindications": [
       "hypertension"
     ],
-    "dosage": "1–3 g dried root",
-    "therapeutic": "energy, stress relief",
+    "sideeffects": [
+      "headache",
+      "insomnia"
+    ],
     "safety": "",
-    "sideeffects": "headache, insomnia",
     "toxicity": "Low",
     "toxicity_ld50": ">2000 mg/kg (rats)",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 root",
       "💊 oral"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "amorpha-fruticosa",
@@ -720,31 +841,35 @@
     "common": "",
     "scientific": "Amorpha fruticosa",
     "category": "ethnobotanical",
+    "subcategory": "",
     "intensity": "",
     "region": "north america",
     "legalstatus": "",
+    "schedule": "",
     "description": "false indigo bush, native to north america, was historically smoked for relaxation and vision-induction.",
     "effects": "relaxation;mental softening;trance",
     "mechanism": "Likely GABAergic",
     "compounds": [
       "Amorphigenin"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "folk",
       "smokable",
       "visionary"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "anadenanthera-colubrina",
@@ -752,15 +877,20 @@
     "common": "",
     "scientific": "Anadenanthera colubrina",
     "category": "psychedelic / entheogen",
+    "subcategory": "",
     "intensity": "High",
     "region": "amazon basin, andean regions of peru, brazil, colombia, venezuela",
     "legalstatus": "Bufotenine is Schedule I in the USA. Tree/seeds legal in some regions.",
+    "schedule": "",
     "description": "a south american tree whose seeds are used to make yopo, a potent psychoactive snuff. used ritually by indigenous tribes for divination and healing.",
     "effects": "Visual hallucinations;Disorientation;Euphoria;Auditory shifts;Dissociation",
     "mechanism": "Contains bufotenine (5-HO-DMT), DMT, and 5-MeO-DMT. Acts as a serotonergic agonist (5-HT2A, 5-HT1A), with bufotenine producing strong visual and somatic effects when insufflated.",
     "compounds": [
       "Bufotenine"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used traditionally for cleansing, communication with spirits, and insight. no clinical approval.",
     "interactions": [
       "dangerous with maois. may cause serotonin overload when mixed with ssris or other psychedelics."
     ],
@@ -770,27 +900,32 @@
       "asthma",
       "or psychiatric disorders."
     ],
-    "dosage": "",
-    "therapeutic": "used traditionally for cleansing, communication with spirits, and insight. no clinical approval.",
+    "sideeffects": [
+      "strong bodily discomfort",
+      "intense visual distortions",
+      "nausea",
+      "cardiovascular strain",
+      "and panic are common."
+    ],
     "safety": "",
-    "sideeffects": "strong bodily discomfort, intense visual distortions, nausea, cardiovascular strain, and panic are common.",
     "toxicity": "High doses of bufotenine can cause respiratory distress. Seeds contain toxic compounds if improperly prepared.",
     "toxicity_ld50": "Bufotenine: ~200–300 mg/kg (mice, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 entheogen",
       "🌬️ snuff",
       "🌀 yopo",
       "⛔ maoi warning"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://erowid.org/plants/anadenanthera/",
       "PubMed ID: 12065154",
       "Journal of Ethnopharmacology",
       "1994",
       "TiHKAL by Alexander Shulgin"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "anadenanthera-colubrina",
@@ -798,15 +933,20 @@
     "common": "",
     "scientific": "Anadenanthera colubrina",
     "category": "psychedelic / entheogen",
+    "subcategory": "",
     "intensity": "High",
     "region": "amazon basin, andean regions of peru, brazil, colombia, venezuela",
     "legalstatus": "Bufotenine is Schedule I in the USA. Tree/seeds legal in some regions.",
+    "schedule": "",
     "description": "a south american tree whose seeds are used to make yopo, a potent psychoactive snuff. used ritually by indigenous tribes for divination and healing.",
     "effects": "Visual hallucinations;Disorientation;Euphoria;Auditory shifts;Dissociation",
     "mechanism": "Contains bufotenine (5-HO-DMT), DMT, and 5-MeO-DMT. Acts as a serotonergic agonist (5-HT2A, 5-HT1A), with bufotenine producing strong visual and somatic effects when insufflated.",
     "compounds": [
       "Bufotenine"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used traditionally for cleansing, communication with spirits, and insight. no clinical approval.",
     "interactions": [
       "dangerous with maois. may cause serotonin overload when mixed with ssris or other psychedelics."
     ],
@@ -816,27 +956,32 @@
       "asthma",
       "or psychiatric disorders."
     ],
-    "dosage": "",
-    "therapeutic": "used traditionally for cleansing, communication with spirits, and insight. no clinical approval.",
+    "sideeffects": [
+      "strong bodily discomfort",
+      "intense visual distortions",
+      "nausea",
+      "cardiovascular strain",
+      "and panic are common."
+    ],
     "safety": "",
-    "sideeffects": "strong bodily discomfort, intense visual distortions, nausea, cardiovascular strain, and panic are common.",
     "toxicity": "High doses of bufotenine can cause respiratory distress. Seeds contain toxic compounds if improperly prepared.",
     "toxicity_ld50": "Bufotenine: ~200–300 mg/kg (mice, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 entheogen",
       "🌬️ snuff",
       "🌀 yopo",
       "⛔ maoi warning"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://erowid.org/plants/anadenanthera/",
       "PubMed ID: 12065154",
       "Journal of Ethnopharmacology",
       "1994",
       "TiHKAL by Alexander Shulgin"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "anadenanthera-peregrina",
@@ -844,15 +989,20 @@
     "common": "",
     "scientific": "Anadenanthera peregrina",
     "category": "psychedelic / entheogen",
+    "subcategory": "",
     "intensity": "Very high",
     "region": "venezuela, brazil, caribbean, northern south america",
     "legalstatus": "Bufotenine is Schedule I in the U.S.; plant materials legal in some countries.",
+    "schedule": "",
     "description": "closely related to a. colubrina, this species is the primary source of cohoba snuff used by taino and other caribbean-amazonian tribes. extremely potent and short-acting.",
     "effects": "Intense visuals;Out-of-body experience;Altered time perception;Spiritual insight",
     "mechanism": "Bufotenine (5-HO-DMT) is the dominant active; acts on 5-HT2A and 5-HT1A receptors. May also contain trace DMT and 5-MeO-DMT. Insufflated use bypasses first-pass metabolism.",
     "compounds": [
       "Bufotenine"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditionally used for healing, communication with spirits, and divination. no modern clinical uses.",
     "interactions": [
       "unsafe with maois",
       "ssris",
@@ -863,26 +1013,30 @@
       "asthma",
       "or psychiatric disorders. not for individuals with seizure history."
     ],
-    "dosage": "",
-    "therapeutic": "traditionally used for healing, communication with spirits, and divination. no modern clinical uses.",
+    "sideeffects": [
+      "coughing",
+      "burning in nose/throat",
+      "vomiting",
+      "disorientation. can be frightening or overwhelming."
+    ],
     "safety": "",
-    "sideeffects": "coughing, burning in nose/throat, vomiting, disorientation. can be frightening or overwhelming.",
     "toxicity": "Potentially toxic in high doses; bufotenine linked to pulmonary effects and vasoconstriction.",
     "toxicity_ld50": "Bufotenine: 200–300 mg/kg (mice, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🌬️ snuff",
       "🌀 visionary",
       "🔥 roasted seed",
       "⛔ controlled"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://erowid.org/plants/anadenanthera_peregrina/",
       "Ratsch: The Encyclopedia of Psychoactive Plants",
       "Journal of Psychoactive Drugs",
       "1986"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "anadenanthera-peregrina",
@@ -890,15 +1044,20 @@
     "common": "",
     "scientific": "Anadenanthera peregrina",
     "category": "psychedelic / entheogen",
+    "subcategory": "",
     "intensity": "Very high",
     "region": "venezuela, brazil, caribbean, northern south america",
     "legalstatus": "Bufotenine is Schedule I in the U.S.; plant materials legal in some countries.",
+    "schedule": "",
     "description": "closely related to a. colubrina, this species is the primary source of cohoba snuff used by taino and other caribbean-amazonian tribes. extremely potent and short-acting.",
     "effects": "Intense visuals;Out-of-body experience;Altered time perception;Spiritual insight",
     "mechanism": "Bufotenine (5-HO-DMT) is the dominant active; acts on 5-HT2A and 5-HT1A receptors. May also contain trace DMT and 5-MeO-DMT. Insufflated use bypasses first-pass metabolism.",
     "compounds": [
       "Bufotenine"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditionally used for healing, communication with spirits, and divination. no modern clinical uses.",
     "interactions": [
       "unsafe with maois",
       "ssris",
@@ -909,26 +1068,30 @@
       "asthma",
       "or psychiatric disorders. not for individuals with seizure history."
     ],
-    "dosage": "",
-    "therapeutic": "traditionally used for healing, communication with spirits, and divination. no modern clinical uses.",
+    "sideeffects": [
+      "coughing",
+      "burning in nose/throat",
+      "vomiting",
+      "disorientation. can be frightening or overwhelming."
+    ],
     "safety": "",
-    "sideeffects": "coughing, burning in nose/throat, vomiting, disorientation. can be frightening or overwhelming.",
     "toxicity": "Potentially toxic in high doses; bufotenine linked to pulmonary effects and vasoconstriction.",
     "toxicity_ld50": "Bufotenine: 200–300 mg/kg (mice, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🌬️ snuff",
       "🌀 visionary",
       "🔥 roasted seed",
       "⛔ controlled"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://erowid.org/plants/anadenanthera_peregrina/",
       "Ratsch: The Encyclopedia of Psychoactive Plants",
       "Journal of Psychoactive Drugs",
       "1986"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "anemone-pulsatilla",
@@ -936,13 +1099,18 @@
     "common": "",
     "scientific": "Pulsatilla vulgaris",
     "category": "sedative / analgesic",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "europe and western asia",
     "legalstatus": "Legal but not widely sold",
+    "schedule": "",
     "description": "also called pasque flower; once used by herbalists for calming nerves and relieving pain.",
     "effects": "calm;pain relief;mild altered awareness",
     "mechanism": "Contains lactones derived from protoanemonin that depress the central nervous system",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "european folk remedy for anxiety, insomnia and menstrual pain",
     "interactions": [
       "may potentiate other sedatives or analgesics"
     ],
@@ -951,20 +1119,22 @@
       "open wounds",
       "large doses"
     ],
-    "dosage": "",
-    "therapeutic": "european folk remedy for anxiety, insomnia and menstrual pain",
+    "sideeffects": [
+      "nausea",
+      "stomach irritation if taken fresh"
+    ],
     "safety": "",
-    "sideeffects": "nausea, stomach irritation if taken fresh",
     "toxicity": "Fresh plant is irritant and toxic until dried",
     "toxicity_ld50": "Not well established",
-    "is_controlled_substance": false,
     "tags": [
       "anodyne",
       "folk",
       "sedative"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "aquilaria-malaccensis",
@@ -972,13 +1142,18 @@
     "common": "",
     "scientific": "Aquilaria malaccensis",
     "category": "calming / aromatic",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "southeast asia",
     "legalstatus": "Cultivation regulated due to overharvesting but use is legal",
+    "schedule": "",
     "description": "source of precious agarwood resin, producing a soothing aroma and subtle psychoactive calm when burned.",
     "effects": "tranquil mind;subtle euphoria;aromatic relaxation",
     "mechanism": "Resin rich in sesquiterpenes acts via GABAergic and dopaminergic pathways when inhaled",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used in traditional asian medicine and incense for calming and meditation",
     "interactions": [
       "unknown",
       "likely minimal"
@@ -986,20 +1161,21 @@
     "contraindications": [
       "respiratory issues when inhaled heavily"
     ],
-    "dosage": "",
-    "therapeutic": "used in traditional asian medicine and incense for calming and meditation",
+    "sideeffects": [
+      "mild headache if smoke inhaled in excess"
+    ],
     "safety": "",
-    "sideeffects": "mild headache if smoke inhaled in excess",
     "toxicity": "Considered safe in incense amounts",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "agarwood",
       "incense",
       "sedative"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "arctostaphylos-uva-ursi",
@@ -1007,13 +1183,18 @@
     "common": "",
     "scientific": "Arctostaphylos uva-ursi",
     "category": "urinary / antiseptic / astringent",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "northern hemisphere (cool climates)",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a low-growing evergreen shrub used traditionally for urinary tract infections and kidney health. its leaves contain arbutin, which converts to hydroquinone in the bladder and acts as a urinary antiseptic.",
     "effects": "Urinary tract support;Astringent;Anti-inflammatory;Antibacterial",
     "mechanism": "Arbutin is hydrolyzed into hydroquinone in the urinary tract, which exerts antimicrobial activity. Tannins also provide astringent effects to mucous membranes.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for cystitis, urethritis, bladder infections, and general urinary tract irritation. often used in short-term protocols.",
     "interactions": [
       "may interact with diuretics",
       "nsaids",
@@ -1024,25 +1205,26 @@
       "in children",
       "or for long-term use. not with kidney disease."
     ],
-    "dosage": "",
-    "therapeutic": "used for cystitis, urethritis, bladder infections, and general urinary tract irritation. often used in short-term protocols.",
+    "sideeffects": [
+      "mild nausea or gi discomfort. prolonged use may irritate the liver or kidneys due to hydroquinone."
+    ],
     "safety": "",
-    "sideeffects": "mild nausea or gi discomfort. prolonged use may irritate the liver or kidneys due to hydroquinone.",
     "toxicity": "Low to moderate. Hydroquinone may be toxic in high doses or long-term use.",
     "toxicity_ld50": "Hydroquinone ~300 mg/kg (rat, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🧴 antiseptic",
       "🧽 astringent",
       "🧠 urinary",
       "🌿 traditional"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6204622/",
       "Herbal Medicine – Mills & Bone",
       "ESCOP Monographs"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "argemone-mexicana",
@@ -1050,13 +1232,18 @@
     "common": "",
     "scientific": "Argemone mexicana",
     "category": "sedative / analgesic",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "native to tropical america; naturalized worldwide",
     "legalstatus": "Legal but sometimes regulated due to toxicity",
+    "schedule": "",
     "description": "spiny yellow poppy whose milky latex was historically used for pain relief and sedation.",
     "effects": "relaxation;analgesia;slight euphoria",
     "mechanism": "Isoquinoline alkaloids interact with opioid and dopamine receptors",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "mexican and ayurvedic traditions use it for pain, insomnia and mild narcotic effects",
     "interactions": [
       "avoid combining with alcohol or other depressants"
     ],
@@ -1065,20 +1252,23 @@
       "pregnancy",
       "high doses"
     ],
-    "dosage": "",
-    "therapeutic": "mexican and ayurvedic traditions use it for pain, insomnia and mild narcotic effects",
+    "sideeffects": [
+      "headache",
+      "stomach upset",
+      "potential liver damage"
+    ],
     "safety": "",
-    "sideeffects": "headache, stomach upset, potential liver damage",
     "toxicity": "Seeds and latex can be hepatotoxic in high doses",
     "toxicity_ld50": "Not well quantified",
-    "is_controlled_substance": false,
     "tags": [
       "alkaloid",
       "folk medicine",
       "poppy"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "argyreia-nervosa",
@@ -1086,15 +1276,20 @@
     "common": "Hawaiian baby woodrose",
     "scientific": "Argyreia nervosa",
     "category": "psychedelic / ergolines",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "india, hawaii, tropical regions",
     "legalstatus": "Legal to possess in most countries; LSA may be restricted.",
+    "schedule": "",
     "description": "a climbing vine native to india and widely cultivated in hawaii. its seeds contain lsa (lysergic acid amide), a naturally occurring psychedelic related to lsd.",
     "effects": "Euphoria;Time distortion;Closed-eye visuals;Body heaviness;Drowsiness",
     "mechanism": "LSA (ergine) is a serotonergic compound acting primarily as a partial agonist at 5-HT2A receptors, similar to LSD but with more sedative effects.",
     "compounds": [
       "LSA (lysergic acid amide)"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "historically used in ayurveda for nervine and aphrodisiac properties. psychedelic use is experimental only.",
     "interactions": [
       "avoid combining with stimulants",
       "maois",
@@ -1106,25 +1301,29 @@
       "liver",
       "or psychiatric conditions. avoid during pregnancy."
     ],
-    "dosage": "",
-    "therapeutic": "historically used in ayurveda for nervine and aphrodisiac properties. psychedelic use is experimental only.",
+    "sideeffects": [
+      "strong nausea",
+      "vasoconstriction",
+      "lethargy",
+      "and confusion are common. may cause dizziness and chills."
+    ],
     "safety": "",
-    "sideeffects": "strong nausea, vasoconstriction, lethargy, and confusion are common. may cause dizziness and chills.",
     "toxicity": "Mild to moderate; effects mostly unpleasant rather than dangerous. Improper preparation increases risk.",
     "toxicity_ld50": "Unknown (ergine considered relatively low in acute toxicity)",
-    "is_controlled_substance": false,
     "tags": [
       "🌱 seed",
       "🌀 lsa",
       "🌙 sedative-psychedelic"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://erowid.org/plants/hbw/",
       "TiHKAL by Alexander Shulgin",
       "Journal of Ethnopharmacology",
       "1996"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "argyreia-speciosa",
@@ -1132,13 +1331,18 @@
     "common": "",
     "scientific": "Argyreia speciosa",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Moderate to Strong",
     "region": "india and southeast asia",
     "legalstatus": "Seeds legal though extraction of LSA may be restricted",
+    "schedule": "",
     "description": "close relative of hawaiian baby woodrose with lsa‑containing seeds used in some indian traditions.",
     "effects": "closed-eye visuals;euphoria;enhanced introspection",
     "mechanism": "Seeds contain lysergic acid amide (LSA) acting on serotonin receptors",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "occasionally used in ayurveda as a tonic and for spiritual rituals",
     "interactions": [
       "avoid with other serotonergic agents"
     ],
@@ -1146,25 +1350,28 @@
       "pregnancy",
       "mental health disorders"
     ],
-    "dosage": "",
-    "therapeutic": "occasionally used in ayurveda as a tonic and for spiritual rituals",
+    "sideeffects": [
+      "nausea",
+      "vasoconstriction",
+      "drowsiness"
+    ],
     "safety": "",
-    "sideeffects": "nausea, vasoconstriction, drowsiness",
     "toxicity": "Nausea common; large doses may be hepatotoxic",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "indian morning glory",
       "lsa",
       "seeds"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3880486/",
       "Ayurvedic Pharmacopoeia of India",
       "Journal of Ethnopharmacology",
       "2001"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "artemisia-abrotanum",
@@ -1172,9 +1379,11 @@
     "common": "",
     "scientific": "Artemisia abrotanum",
     "category": "ethnobotanical",
+    "subcategory": "",
     "intensity": "",
     "region": "mediterranean, europe",
     "legalstatus": "",
+    "schedule": "",
     "description": "southernwood is a fragrant herb used traditionally as a stimulant, memory aid, and dream enhancer.",
     "effects": "mental clarity;dream enhancement;stimulant",
     "mechanism": "GABAergic + cholinergic modulation",
@@ -1182,22 +1391,24 @@
       "Camphor",
       "Thujone"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "aromatic",
       "folk remedy",
       "uplifting"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "artemisia-absinthium",
@@ -1205,15 +1416,20 @@
     "common": "Wormwood",
     "scientific": "Artemisia absinthium",
     "category": "deliriant / digestive bitter",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "europe, north africa, western asia",
     "legalstatus": "Thujone content regulated in beverages (e.g. EU and US); plant itself legal",
+    "schedule": "",
     "description": "a bitter herb best known as the flavoring in traditional absinthe. contains thujone, a gaba receptor antagonist that can cause excitatory and convulsive effects in high doses.",
     "effects": "Euphoria;Mild hallucinations;Stimulation;Appetite stimulant",
     "mechanism": "Thujone is a GABA-A antagonist, reducing inhibitory signaling in the brain. At high doses, this may induce seizures or hallucinations. Also contains bitter principles that stimulate digestion.",
     "compounds": [
       "Thujone"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used as a bitter tonic for digestion, appetite stimulation, and historically as an anthelmintic. occasionally explored for mood elevation in aromatherapy.",
     "interactions": [
       "may reduce effectiveness of anticonvulsants. dangerous with gabaergic drugs",
       "alcohol",
@@ -1225,27 +1441,31 @@
       "kidney disease",
       "and with cns stimulants. use caution with antidepressants or alcohol."
     ],
-    "dosage": "",
-    "therapeutic": "used as a bitter tonic for digestion, appetite stimulation, and historically as an anthelmintic. occasionally explored for mood elevation in aromatherapy.",
+    "sideeffects": [
+      "nausea",
+      "dizziness",
+      "vomiting",
+      "neurotoxicity at high doses. prolonged use may irritate kidneys and liver."
+    ],
     "safety": "",
-    "sideeffects": "nausea, dizziness, vomiting, neurotoxicity at high doses. prolonged use may irritate kidneys and liver.",
     "toxicity": "High doses or chronic use may lead to tremors, seizures, and neurotoxicity ('absinthism').",
     "toxicity_ld50": "Thujone: ~87.5 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🍸 absinthium",
       "⚠️ neurotoxic",
       "🌿 bitter tonic",
       "🧠 gaba-antagonist"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3265070/",
       "Herbal Medicine: Biomolecular and Clinical Aspects",
       "2nd ed.",
       "Journal of Ethnopharmacology",
       "2003"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "artemisia-absinthium",
@@ -1253,15 +1473,20 @@
     "common": "Wormwood",
     "scientific": "Artemisia absinthium",
     "category": "deliriant / digestive bitter",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "europe, north africa, western asia",
     "legalstatus": "Thujone content regulated in beverages (e.g. EU and US); plant itself legal",
+    "schedule": "",
     "description": "a bitter herb best known as the flavoring in traditional absinthe. contains thujone, a gaba receptor antagonist that can cause excitatory and convulsive effects in high doses.",
     "effects": "Euphoria;Mild hallucinations;Stimulation;Appetite stimulant",
     "mechanism": "Thujone is a GABA-A antagonist, reducing inhibitory signaling in the brain. At high doses, this may induce seizures or hallucinations. Also contains bitter principles that stimulate digestion.",
     "compounds": [
       "Thujone"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used as a bitter tonic for digestion, appetite stimulation, and historically as an anthelmintic. occasionally explored for mood elevation in aromatherapy.",
     "interactions": [
       "may reduce effectiveness of anticonvulsants. dangerous with gabaergic drugs",
       "alcohol",
@@ -1273,27 +1498,31 @@
       "kidney disease",
       "and with cns stimulants. use caution with antidepressants or alcohol."
     ],
-    "dosage": "",
-    "therapeutic": "used as a bitter tonic for digestion, appetite stimulation, and historically as an anthelmintic. occasionally explored for mood elevation in aromatherapy.",
+    "sideeffects": [
+      "nausea",
+      "dizziness",
+      "vomiting",
+      "neurotoxicity at high doses. prolonged use may irritate kidneys and liver."
+    ],
     "safety": "",
-    "sideeffects": "nausea, dizziness, vomiting, neurotoxicity at high doses. prolonged use may irritate kidneys and liver.",
     "toxicity": "High doses or chronic use may lead to tremors, seizures, and neurotoxicity ('absinthism').",
     "toxicity_ld50": "Thujone: ~87.5 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🍸 absinthium",
       "⚠️ neurotoxic",
       "🌿 bitter tonic",
       "🧠 gaba-antagonist"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3265070/",
       "Herbal Medicine: Biomolecular and Clinical Aspects",
       "2nd ed.",
       "Journal of Ethnopharmacology",
       "2003"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "artemisia-ludoviciana",
@@ -1301,9 +1530,11 @@
     "common": "",
     "scientific": "Artemisia ludoviciana",
     "category": "ethnobotanical",
+    "subcategory": "",
     "intensity": "",
     "region": "north america",
     "legalstatus": "",
+    "schedule": "",
     "description": "also known as white sagebrush, used by native american tribes for cleansing, dreams, and mild sedation.",
     "effects": "mild sedation;visionary;cleansing",
     "mechanism": "GABAergic + anticholinergic",
@@ -1311,22 +1542,24 @@
       "Thujone",
       "Camphor"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "ritual",
       "dream",
       "folk medicine"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "artemisia-vulgaris",
@@ -1334,13 +1567,18 @@
     "common": "",
     "scientific": "Artemisia vulgaris",
     "category": "dream herb / digestive / traditional witchcraft",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "europe, north america, asia",
     "legalstatus": "Legal worldwide (restricted in some for thujone)",
+    "schedule": "",
     "description": "a classic european herb of the witches and dreamers. mugwort is used for enhancing dreams, calming digestion, and connecting to inner visions. often burned or used in dream pillows or teas.",
     "effects": "Lucid dreaming;Menstrual regulation;Mild sedation;Bitter tonic",
     "mechanism": "Contains thujone, camphor, and cineole — which mildly affect GABA receptors and CNS function. Also acts as a bitter digestive and mild uterine tonic.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for dreamwork, menstruation regulation, cramping, bloating, and spiritual practices.",
     "interactions": [
       "may interact with sedatives",
       "antiepileptics",
@@ -1349,25 +1587,26 @@
     "contraindications": [
       "avoid during pregnancy. caution with epilepsy or thujone sensitivity."
     ],
-    "dosage": "",
-    "therapeutic": "used for dreamwork, menstruation regulation, cramping, bloating, and spiritual practices.",
+    "sideeffects": [
+      "may cause nausea or dizziness. thujone-related toxicity at high doses or in essential oil form."
+    ],
     "safety": "",
-    "sideeffects": "may cause nausea or dizziness. thujone-related toxicity at high doses or in essential oil form.",
     "toxicity": "Low at traditional use levels. Essential oil is toxic if ingested.",
     "toxicity_ld50": "~120 mg/kg (thujone, rats)",
-    "is_controlled_substance": false,
     "tags": [
       "🌙 dream herb",
       "🩸 menstrual",
       "🫖 bitter tonic",
       "🔥 ritual"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5313054/",
       "Plants of the Gods – Rätsch",
       "British Herbal Pharmacopoeia"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "arundo-donax",
@@ -1375,37 +1614,46 @@
     "common": "",
     "scientific": "Arundo donax",
     "category": "psychoactive (trace tryptamines)",
+    "subcategory": "",
     "intensity": "Minimal or none (unless potentiated with MAOIs)",
     "region": "mediterranean, asia, naturalized worldwide",
     "legalstatus": "Legal as an ornamental and biomass plant; some components (e.g., DMT) may be restricted in purified form.",
+    "schedule": "",
     "description": "a large reed grass native to asia and the mediterranean. it has been occasionally referenced as a possible tryptamine source, but psychoactive effects are not reliably established.",
     "effects": "Unverified hallucinations;Mild sedation;Traditionally visionary (claimed)",
     "mechanism": "Alkaloid content includes DMT, bufotenine, and gramine in trace amounts. Psychoactivity is speculative and likely inactive without MAOIs.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "none clinically confirmed. mentioned in some obscure entheogenic literature as a potential visionary aid.",
     "interactions": [
       "dangerous with maois or serotonergic drugs due to alkaloid unpredictability."
     ],
     "contraindications": [
       "avoid use due to gramine toxicity. not a recommended dmt source."
     ],
-    "dosage": "",
-    "therapeutic": "none clinically confirmed. mentioned in some obscure entheogenic literature as a potential visionary aid.",
+    "sideeffects": [
+      "gramine is toxic",
+      "may cause nausea",
+      "convulsions",
+      "or hypotension. no established safety profile."
+    ],
     "safety": "",
-    "sideeffects": "gramine is toxic; may cause nausea, convulsions, or hypotension. no established safety profile.",
     "toxicity": "Gramine is toxic and can affect neuromuscular function and blood pressure.",
     "toxicity_ld50": "Gramine: 45–60 mg/kg (mice, intraperitoneal)",
-    "is_controlled_substance": false,
     "tags": [
       "🌾 reed",
       "⚠️ gramine-toxicity",
       "🧪 experimental"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://erowid.org/plants/arundo_donax/",
       "Trout’s Notes on Some Other Ayahuasca Analog Plants",
       "PubChem CID: 442018 (gramine)"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "asarum-canadense",
@@ -1413,13 +1661,18 @@
     "common": "",
     "scientific": "Asarum canadense",
     "category": "medicinal / aromatic",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "eastern north america",
     "legalstatus": "Legal; use restricted in commercial food products due to safrole",
+    "schedule": "",
     "description": "a north american woodland herb known as wild ginger. while unrelated to true ginger, its rhizome has a pungent, spicy aroma and has been used traditionally by indigenous peoples as a digestive aid and warming tonic.",
     "effects": "Warming;Digestive stimulant;Mild sedation;Aromatic",
     "mechanism": "Contains volatile oils (e.g. methyl eugenol, safrole) that may stimulate digestive enzymes and act as mild CNS modulators. Safrole is a weak psychoactive and hepatotoxic compound.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditionally used for colds, coughs, indigestion, menstrual discomfort, and as an emetic in high doses.",
     "interactions": [
       "may interfere with liver-metabolized drugs (cyp450 pathway). avoid combining with hepatotoxic herbs or medications."
     ],
@@ -1428,25 +1681,28 @@
       "liver disease",
       "or prolonged use. not recommended for large or chronic dosing."
     ],
-    "dosage": "",
-    "therapeutic": "traditionally used for colds, coughs, indigestion, menstrual discomfort, and as an emetic in high doses.",
+    "sideeffects": [
+      "high doses may cause nausea",
+      "vomiting",
+      "or liver stress due to safrole content. some individuals may experience allergic reactions."
+    ],
     "safety": "",
-    "sideeffects": "high doses may cause nausea, vomiting, or liver stress due to safrole content. some individuals may experience allergic reactions.",
     "toxicity": "Contains safrole, a known hepatocarcinogen in high doses. Rarely toxic acutely, but long-term use may pose risk.",
     "toxicity_ld50": "Safrole: ~1950 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 rhizome",
       "🌶️ aromatic",
       "⚠️ safrole",
       "🧑‍⚕️ traditional medicine"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4428597/",
       "Herbal Medicine: Expanded Commission E Monographs",
       "PubChem CID: 8467 (safrole)"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "asclepias-syriaca",
@@ -1454,13 +1710,18 @@
     "common": "",
     "scientific": "Asclepias syriaca",
     "category": "medicinal / toxic",
+    "subcategory": "",
     "intensity": "Mild (subtoxic dose) to Dangerous",
     "region": "eastern and central north america",
     "legalstatus": "Legal (not scheduled); some states advise caution with ingestion",
+    "schedule": "",
     "description": "common milkweed is a native north american plant traditionally used by indigenous peoples for treating warts, respiratory issues, and digestive complaints. however, it contains toxic cardiac glycosides.",
     "effects": "Mild sedation;Cardiac influence;Anti-inflammatory",
     "mechanism": "Contains cardenolides (e.g., syriogenin) that affect cardiac muscle contractility by inhibiting Na+/K+-ATPase, similar to digoxin.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "historically used for lung and bronchial infections, warts, constipation, and as an emetic. very limited modern therapeutic use due to toxicity.",
     "interactions": [
       "may dangerously amplify effects of digoxin",
       "beta-blockers",
@@ -1471,25 +1732,30 @@
       "diuretics",
       "or digitalis compounds. toxic in excess."
     ],
-    "dosage": "",
-    "therapeutic": "historically used for lung and bronchial infections, warts, constipation, and as an emetic. very limited modern therapeutic use due to toxicity.",
+    "sideeffects": [
+      "nausea",
+      "vomiting",
+      "dizziness",
+      "bradycardia",
+      "or arrhythmia at high doses. skin irritation from sap."
+    ],
     "safety": "",
-    "sideeffects": "nausea, vomiting, dizziness, bradycardia, or arrhythmia at high doses. skin irritation from sap.",
     "toxicity": "Moderate to high; all parts of the plant can be toxic, especially latex sap and immature pods.",
     "toxicity_ld50": "Estimated 75–150 mg/kg (mice, cardiac glycosides)",
-    "is_controlled_substance": false,
     "tags": [
       "🌱 milkweed",
       "⚠️ cardiotoxic",
       "🧪 traditional use only"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4271739/",
       "North American Ethnobotany Database",
       "HerbalGram. 2004",
       "(63): 34–45."
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "withania-somnifera",
@@ -1497,13 +1763,18 @@
     "common": "",
     "scientific": "Withania somnifera",
     "category": "adaptogen / nervine / endocrine support",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "india, middle east, north africa",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "one of the most revered herbs in ayurveda, ashwagandha is a potent adaptogen used to reduce stress, improve sleep, and balance the nervous and endocrine systems. often called 'indian ginseng'.",
     "effects": "Stress reduction;Cortisol regulation;Sleep support;Cognitive enhancement",
     "mechanism": "Withanolides modulate the hypothalamic-pituitary-adrenal (HPA) axis, lower cortisol, reduce oxidative stress, and improve GABAergic signaling.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for anxiety, fatigue, insomnia, adrenal support, libido, thyroid balance, and immune modulation.",
     "interactions": [
       "may enhance effects of sedatives",
       "thyroid meds",
@@ -1514,26 +1785,27 @@
       "sedative medications",
       "or during pregnancy without supervision."
     ],
-    "dosage": "",
-    "therapeutic": "used for anxiety, fatigue, insomnia, adrenal support, libido, thyroid balance, and immune modulation.",
+    "sideeffects": [
+      "mild gi upset or drowsiness. rare headaches or allergic reactions."
+    ],
     "safety": "",
-    "sideeffects": "mild gi upset or drowsiness. rare headaches or allergic reactions.",
     "toxicity": "Very low. High doses may affect thyroid hormone levels.",
     "toxicity_ld50": ">5000 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🧘 adaptogen",
       "💤 sleep",
       "🧠 brain support",
       "🌿 ayurvedic"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6979308/",
       "Herbal Medicine – Mills & Bone",
       "Indian Journal of Psychological Medicine",
       "2012"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "panax-ginseng",
@@ -1541,13 +1813,18 @@
     "common": "",
     "scientific": "Panax ginseng",
     "category": "empathogen / euphoriant",
+    "subcategory": "",
     "intensity": "",
     "region": "asia",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "classic tonic herb for stamina and cognition.",
     "effects": "vitality;adaptogen",
     "mechanism": "Ginsenosides modulate HPA axis and nitric oxide pathways",
     "compounds": [],
+    "preparations": [],
+    "dosage": "1–2 g dried root",
+    "therapeutic": "energy, immune support",
     "interactions": [
       "stimulants",
       "anticoagulants"
@@ -1555,19 +1832,21 @@
     "contraindications": [
       "hypertension"
     ],
-    "dosage": "1–2 g dried root",
-    "therapeutic": "energy, immune support",
+    "sideeffects": [
+      "headache",
+      "insomnia"
+    ],
     "safety": "",
-    "sideeffects": "headache, insomnia",
     "toxicity": "Low",
     "toxicity_ld50": ">2000 mg/kg (rats)",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 root",
       "💊 oral"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "avena-sativa",
@@ -1575,38 +1854,44 @@
     "common": "",
     "scientific": "Avena sativa",
     "category": "nervine / tonic",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "temperate regions globally (native to europe and southwest asia)",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "common oats, when harvested as milky green tops or dried straw, are used as a gentle nervine tonic in western herbalism. renowned for its restorative effects on the nervous system and libido.",
     "effects": "Mild euphoria;Anxiolytic;Nourishing tonic;Cognitive support",
     "mechanism": "Contains avenanthramides (antioxidants), saponins, alkaloids, and B vitamins. May modulate GABAergic tone and reduce inflammation in the nervous system.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for fatigue, nervous exhaustion, stress, sexual debility, and neuroinflammation. traditionally seen as a long-term restorative.",
     "interactions": [
       "none significant reported. may synergize gently with other nervines or antidepressants."
     ],
     "contraindications": [
       "caution with gluten intolerance or autoimmune sensitivity to oats (though oats are naturally gluten-free)."
     ],
-    "dosage": "",
-    "therapeutic": "used for fatigue, nervous exhaustion, stress, sexual debility, and neuroinflammation. traditionally seen as a long-term restorative.",
+    "sideeffects": [
+      "very well tolerated. rare allergy to oat proteins in sensitive individuals."
+    ],
     "safety": "",
-    "sideeffects": "very well tolerated. rare allergy to oat proteins in sensitive individuals.",
     "toxicity": "Very low. Considered one of the safest tonic herbs.",
     "toxicity_ld50": "No known LD50 in humans or animals for oat preparations",
-    "is_controlled_substance": false,
     "tags": [
       "🌾 nervine",
       "🧠 cognitive support",
       "💚 restorative",
       "🫖 tonic"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5989095/",
       "Medical Herbalism – David Hoffmann",
       "The Earthwise Herbal – Matthew Wood"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "banisteriopsis-caapi",
@@ -1614,15 +1899,20 @@
     "common": "",
     "scientific": "Banisteriopsis caapi",
     "category": "maoi / entheogen",
+    "subcategory": "",
     "intensity": "Moderate to profound (when combined)",
     "region": "amazon basin: peru, brazil, colombia",
     "legalstatus": "Plant is legal in many countries; brews may be scheduled depending on DMT laws",
+    "schedule": "",
     "description": "the primary vine used in the sacred amazonian brew ayahuasca. contains harmala alkaloids that inhibit mao, enabling oral activation of dmt. revered as the 'vine of the soul' in indigenous ceremonies.",
     "effects": "MAOI potentiation;Euphoria;Emotional release;Dreamlike states",
     "mechanism": "Contains harmine, harmaline, and tetrahydroharmine — reversible MAO-A inhibitors that also modulate serotonin and dopamine activity.",
     "compounds": [
       "Harmine"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for trauma, addiction, depression, and spiritual exploration (in ceremonial or clinical settings). being studied for neurogenesis.",
     "interactions": [
       "major interaction risk with serotonergic agents. see maoi interaction lists."
     ],
@@ -1632,26 +1922,30 @@
       "antipsychotics",
       "or tyramine-rich foods."
     ],
-    "dosage": "",
-    "therapeutic": "used for trauma, addiction, depression, and spiritual exploration (in ceremonial or clinical settings). being studied for neurogenesis.",
+    "sideeffects": [
+      "nausea",
+      "vomiting (purge)",
+      "dizziness",
+      "emotional catharsis. rarely: serotonin syndrome if combined with contraindicated drugs."
+    ],
     "safety": "",
-    "sideeffects": "nausea, vomiting (purge), dizziness, emotional catharsis. rarely: serotonin syndrome if combined with contraindicated drugs.",
     "toxicity": "Low when used alone. Overdose with other drugs can be fatal.",
     "toxicity_ld50": "Harmine LD50: ~500–750 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 vine",
       "🧠 maoi",
       "🌀 entheogen",
       "⛔ ssri warning"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6082376/",
       "Journal of Ethnopharmacology",
       "2010",
       "MAPS Ayahuasca Research Summary"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "betel-nut",
@@ -1659,13 +1953,18 @@
     "common": "",
     "scientific": "Areca catechu",
     "category": "empathogen / euphoriant",
+    "subcategory": "",
     "intensity": "",
     "region": "south and southeast asia",
     "legalstatus": "",
+    "schedule": "",
     "description": "a widely used masticatory stimulant in asia and the pacific, often combined with lime and betel leaf.",
     "effects": "Stimulation;warmth;mild euphoria",
     "mechanism": "Arecoline acts as a muscarinic cholinergic agonist",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditional digestive stimulant",
     "interactions": [
       "stimulants",
       "parasympathomimetics"
@@ -1674,16 +1973,18 @@
       "pregnancy",
       "cardiovascular conditions"
     ],
-    "dosage": "",
-    "therapeutic": "traditional digestive stimulant",
+    "sideeffects": [
+      "addiction",
+      "oral cancer with chronic use"
+    ],
     "safety": "",
-    "sideeffects": "addiction, oral cancer with chronic use",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "betula-lenta",
@@ -1691,31 +1992,35 @@
     "common": "",
     "scientific": "Betula lenta",
     "category": "ethnobotanical",
+    "subcategory": "",
     "intensity": "",
     "region": "north america",
     "legalstatus": "",
+    "schedule": "",
     "description": "sweet birch, aromatic and uplifting; contains methyl salicylate, offering mild euphoria and clarity.",
     "effects": "uplifting;mental clarity;aromatic",
     "mechanism": "Anti-inflammatory + mild serotonergic",
     "compounds": [
       "Methyl salicylate"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "tea",
       "uplifting",
       "aromatic"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "blue-lotus",
@@ -1723,33 +2028,40 @@
     "common": "",
     "scientific": "Nymphaea caerulea",
     "category": "oneirogen",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "egypt, india",
     "legalstatus": "Legal in most countries",
+    "schedule": "",
     "description": "sacred egyptian flower associated with dream states and aphrodisiac properties. contains aporphine alkaloids.",
     "effects": "Mild euphoria;lucid dreaming;relaxation",
     "mechanism": "Aporphine acts as dopamine receptor agonist",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "anxiety, mild sedation, aphrodisiac",
     "interactions": [
       "avoid sedatives"
     ],
     "contraindications": [
       "pregnancy"
     ],
-    "dosage": "",
-    "therapeutic": "anxiety, mild sedation, aphrodisiac",
+    "sideeffects": [
+      "mild drowsiness",
+      "vivid dreams"
+    ],
     "safety": "",
-    "sideeffects": "mild drowsiness, vivid dreams",
     "toxicity": "Low",
     "toxicity_ld50": "Not known",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌸 calm",
       "😊 euphoria"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "nymphaea-caerulea",
@@ -1757,9 +2069,11 @@
     "common": "Blue Lotus",
     "scientific": "Nymphaea caerulea",
     "category": "euphoric / sedative / sacred",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "nile valley, india, southeast asia",
     "legalstatus": "Legal worldwide (restricted in some US states for sale)",
+    "schedule": "",
     "description": "a sacred egyptian flower revered for inducing relaxed, blissful states. often soaked in wine or tea, blue lotus produces a dreamy calm and has been symbolically associated with rebirth, the sun, and divine union.",
     "effects": "Euphoria;Tranquility;Mild visuals;Dream enhancement",
     "mechanism": "Contains aporphine alkaloids (especially nuciferine) which act as dopamine receptor agonists and serotonin receptor modulators. Also binds GABA receptors slightly.",
@@ -1767,6 +2081,9 @@
       "Aporphine",
       "Nuciferine"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used traditionally for anxiety, libido enhancement, meditation, lucid dreaming, and as a ceremonial aphrodisiac.",
     "interactions": [
       "potentiates sedatives",
       "alcohol",
@@ -1775,25 +2092,28 @@
     "contraindications": [
       "avoid with sedatives or psychiatric conditions. unknown effects in pregnancy."
     ],
-    "dosage": "",
-    "therapeutic": "used traditionally for anxiety, libido enhancement, meditation, lucid dreaming, and as a ceremonial aphrodisiac.",
+    "sideeffects": [
+      "mild dry mouth",
+      "drowsiness",
+      "nausea in high doses. can cause lethargy or vivid dreams."
+    ],
     "safety": "",
-    "sideeffects": "mild dry mouth, drowsiness, nausea in high doses. can cause lethargy or vivid dreams.",
     "toxicity": "Low in moderate doses. Safe historically but limited modern study.",
     "toxicity_ld50": "Not well established; assumed low",
-    "is_controlled_substance": false,
     "tags": [
       "🌸 sacred flower",
       "🧘 euphoria",
       "🌙 dreamwork",
       "🌿 aphrodisiac"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3504522/",
       "Plants of the Gods – Rätsch",
       "Journal of Psychoactive Herbs – 2009"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "bobinsana",
@@ -1801,13 +2121,18 @@
     "common": "",
     "scientific": "Calliandra angustifolia",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "amazon basin (peru, ecuador)",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "a flowering amazonian shrub used in master plant dieta and as an adjunct to ayahuasca ceremonies for emotional healing and dream clarity.",
     "effects": "Heart-opening;emotional clarity;mild euphoria",
     "mechanism": "Unknown; possibly serotonergic modulation or mild MAOI",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "emotional trauma healing, dream support",
     "interactions": [
       "unknown",
       "caution with serotonergics"
@@ -1816,20 +2141,22 @@
       "pregnancy",
       "psychiatric disorders"
     ],
-    "dosage": "",
-    "therapeutic": "emotional trauma healing, dream support",
+    "sideeffects": [
+      "drowsiness",
+      "mild emotional vulnerability"
+    ],
     "safety": "",
-    "sideeffects": "drowsiness, mild emotional vulnerability",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌿 herbal",
       "🧘 calm"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "echinopsis-lageniformis",
@@ -1837,31 +2164,37 @@
     "common": "",
     "scientific": "Echinopsis lageniformis",
     "category": "psychedelic",
+    "subcategory": "",
     "intensity": "",
     "region": "andes",
     "legalstatus": "Cactus legal; mescaline controlled",
+    "schedule": "",
     "description": "another mescaline-rich andean cactus.",
     "effects": "visions;clarity",
     "mechanism": "Mescaline as 5-HT2A agonist",
     "compounds": [],
+    "preparations": [],
+    "dosage": "20–40 cm fresh cactus",
+    "therapeutic": "visionary rituals",
     "interactions": [
       "maois"
     ],
     "contraindications": [
       "heart conditions"
     ],
-    "dosage": "20–40 cm fresh cactus",
-    "therapeutic": "visionary rituals",
+    "sideeffects": [
+      "nausea"
+    ],
     "safety": "",
-    "sideeffects": "nausea",
     "toxicity": "Low",
     "toxicity_ld50": ">1 g/kg (rats)",
-    "is_controlled_substance": false,
     "tags": [
       "🌵 cactus"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "brugmansia",
@@ -1869,13 +2202,18 @@
     "common": "",
     "scientific": "Brugmansia suaveolens",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "",
     "region": "south america",
     "legalstatus": "",
+    "schedule": "",
     "description": "powerful and dangerous deliriant used in south american shamanism. highly toxic and not recommended for casual use.",
     "effects": "Hallucinations;delirium;disorientation",
     "mechanism": "Tropane alkaloids (scopolamine, atropine)",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "historical use in asthma and pain (no modern safe use)",
     "interactions": [
       "anticholinergics",
       "cns depressants"
@@ -1883,16 +2221,19 @@
     "contraindications": [
       "all unsupervised use"
     ],
-    "dosage": "",
-    "therapeutic": "historical use in asthma and pain (no modern safe use)",
+    "sideeffects": [
+      "extreme confusion",
+      "memory loss",
+      "risk of death"
+    ],
     "safety": "",
-    "sideeffects": "extreme confusion, memory loss, risk of death",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "brugmansia-suaveolens",
@@ -1900,13 +2241,18 @@
     "common": "",
     "scientific": "Brugmansia suaveolens",
     "category": "deliriant / tropane alkaloid",
+    "subcategory": "",
     "intensity": "Severe / Overwhelming",
     "region": "south america; cultivated ornamentally worldwide",
     "legalstatus": "Legal in most countries; some restrictions due to risk",
+    "schedule": "",
     "description": "a powerful ornamental tree with large trumpet-shaped flowers. brugmansia is traditionally used in south american shamanism but is highly toxic. its alkaloids cause intense deliriant experiences often indistinguishable from waking reality.",
     "effects": "True hallucinations;Amnesia;Delirium;Sedation",
     "mechanism": "Contains tropane alkaloids: scopolamine, atropine, and hyoscyamine. These are anticholinergic, blocking muscarinic acetylcholine receptors.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "none officially sanctioned. occasionally explored for dream states or initiatory visions in traditional contexts.",
     "interactions": [
       "highly dangerous with sedatives",
       "stimulants",
@@ -1917,26 +2263,33 @@
       "neurological",
       "or psychiatric conditions."
     ],
-    "dosage": "",
-    "therapeutic": "none officially sanctioned. occasionally explored for dream states or initiatory visions in traditional contexts.",
+    "sideeffects": [
+      "severe confusion",
+      "overheating",
+      "dry mouth",
+      "mydriasis",
+      "hallucinations",
+      "inability to distinguish reality",
+      "long-term memory gaps."
+    ],
     "safety": "",
-    "sideeffects": "severe confusion, overheating, dry mouth, mydriasis, hallucinations, inability to distinguish reality, long-term memory gaps.",
     "toxicity": "Extremely toxic. Even a few flower petals can induce hospitalization. Death has occurred from unmeasured ingestion.",
     "toxicity_ld50": "Scopolamine: ~400 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🌸 tropane",
       "⚠️ toxic",
       "🌪 deliriant",
       "🧠 anticholinergic"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3887309/",
       "The Encyclopedia of Psychoactive Plants – Rätsch",
       "Journal of Ethnopharmacology",
       "2001"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "brunfelsia-grandiflora",
@@ -1944,13 +2297,18 @@
     "common": "",
     "scientific": "Brunfelsia grandiflora",
     "category": "shamanic / tropane-like",
+    "subcategory": "",
     "intensity": "Moderate–Strong",
     "region": "amazon (peru, ecuador, colombia)",
     "legalstatus": "Legal; not scheduled internationally",
+    "schedule": "",
     "description": "a powerful and rare plant used in amazonian diets and initiations. sometimes used in conjunction with ayahuasca. it contains alkaloids structurally similar to tropanes but with unique visionary effects.",
     "effects": "Altered perception;Hallucinations;Sedation;Purging",
     "mechanism": "Believed to contain scopoletin, brunfelsamidine, and possibly tropane-like alkaloids. Effects include CNS sedation and GABAergic modulation, with visionary experiences at high doses.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for energetic cleansing, dream incubation, and emotional healing in vegetalismo traditions. no clinical use.",
     "interactions": [
       "dangerous with deliriants or gabaergic drugs. may interfere with maois or ssris."
     ],
@@ -1959,26 +2317,31 @@
       "anticholinergics",
       "or in pregnancy. not for casual or recreational use."
     ],
-    "dosage": "",
-    "therapeutic": "used for energetic cleansing, dream incubation, and emotional healing in vegetalismo traditions. no clinical use.",
+    "sideeffects": [
+      "strong purge",
+      "nausea",
+      "confusion",
+      "tremors",
+      "and temporary disorientation. possibly neurotoxic at high doses."
+    ],
     "safety": "",
-    "sideeffects": "strong purge, nausea, confusion, tremors, and temporary disorientation. possibly neurotoxic at high doses.",
     "toxicity": "Potential neurotoxicity from tropane-like compounds. Improper use can lead to hospitalization.",
     "toxicity_ld50": "Not established; presumed low threshold for toxicity",
-    "is_controlled_substance": false,
     "tags": [
       "🌀 dreamwork",
       "⚠️ tropane risk",
       "🌳 ayahuasca dieta"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "Journal of Ethnopharmacology",
       "2007",
       "Plants of the Gods – Schultes",
       "Hofmann",
       "Ayahuasca.com: Chiric Sanango Field Reports"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "byrsonima-crassifolia",
@@ -1986,9 +2349,11 @@
     "common": "Nance",
     "scientific": "",
     "category": "sedative",
+    "subcategory": "",
     "intensity": "",
     "region": "central and south america",
     "legalstatus": "",
+    "schedule": "",
     "description": "",
     "effects": "mild sedative;calming;tonic",
     "mechanism": "Flavonoid antioxidant and neuroprotective action",
@@ -1996,22 +2361,24 @@
       "Catechins",
       "Quercetin"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "sedative",
       "folk",
       "antioxidant"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "caapi",
@@ -2019,13 +2386,18 @@
     "common": "",
     "scientific": "Banisteriopsis caapi",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "",
     "region": "amazon basin",
     "legalstatus": "",
+    "schedule": "",
     "description": "the vine of the soul used in ayahuasca. contains harmala alkaloids and facilitates dmt absorption in the brew.",
     "effects": "MAOI effects;spiritual opening;purging",
     "mechanism": "Reversible MAO-A inhibition (harmine, harmaline)",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "ayahuasca therapy for ptsd, depression",
     "interactions": [
       "all serotonergic substances"
     ],
@@ -2034,16 +2406,19 @@
       "maois",
       "pregnancy"
     ],
-    "dosage": "",
-    "therapeutic": "ayahuasca therapy for ptsd, depression",
+    "sideeffects": [
+      "nausea",
+      "purging",
+      "dizziness"
+    ],
     "safety": "",
-    "sideeffects": "nausea, purging, dizziness",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "caesalpinia-sepiaria",
@@ -2051,37 +2426,45 @@
     "common": "",
     "scientific": "Caesalpinia sepiaria",
     "category": "traditional / stimulant",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "thailand, india, southeast asia",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "a thorny climbing shrub used in traditional southeast asian medicine. found in certain thai herbal stimulant blends (yaa chud), though its active compounds are poorly characterized.",
     "effects": "Stimulation;Increased stamina;Traditional energizing",
     "mechanism": "Poorly studied. Likely contains alkaloids and tannins with mild CNS effects. May act as a peripheral stimulant and astringent.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for fatigue, fever, and vitality in traditional thai and ayurvedic systems. often combined with other herbs.",
     "interactions": [
       "avoid with strong stimulants or blood pressure medications."
     ],
     "contraindications": [
       "not recommended during pregnancy or with hypertension due to possible stimulant effects."
     ],
-    "dosage": "",
-    "therapeutic": "used for fatigue, fever, and vitality in traditional thai and ayurvedic systems. often combined with other herbs.",
+    "sideeffects": [
+      "not well documented. possible gi upset",
+      "dizziness",
+      "or overstimulation in high doses."
+    ],
     "safety": "",
-    "sideeffects": "not well documented. possible gi upset, dizziness, or overstimulation in high doses.",
     "toxicity": "Low to moderate. Long-term effects not well studied.",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "🪴 thai herbalism",
       "⚡ mild stimulant",
       "🌿 yaa chud"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://pubmed.ncbi.nlm.nih.gov/17009863/",
       "Thai Traditional Medicine Pharmacopoeia",
       "Herbal Remedies of Southeast Asia – WHO"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "calea-ternifolia",
@@ -2089,38 +2472,46 @@
     "common": "",
     "scientific": "Calea ternifolia",
     "category": "oneirogen / bitter tonic",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "mexico, central america",
     "legalstatus": "Generally legal",
+    "schedule": "",
     "description": "calea is a traditional mexican dream herb used by the chontal people to enhance dream clarity and lucidity. often consumed as a tea or smoked before sleep.",
     "effects": "Lucid dreaming;Vivid dreams;Mild sedation;Dream recall",
     "mechanism": "Contains calein and germacranolides that may influence GABAergic and cholinergic systems related to REM sleep modulation.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "dream induction and clarity",
     "interactions": [
       "may interact with cns depressants"
     ],
     "contraindications": [
       "avoid in pregnancy and with sedatives"
     ],
-    "dosage": "",
-    "therapeutic": "dream induction and clarity",
+    "sideeffects": [
+      "bitterness",
+      "mild nausea",
+      "vivid dreams"
+    ],
     "safety": "",
-    "sideeffects": "bitterness, mild nausea, vivid dreams",
     "toxicity": "Low to moderate",
     "toxicity_ld50": "Not well established",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 dream",
       "😴 sleep",
       "🧘 oneirogen"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3158962/",
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology",
       "1986"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "calea-zacatechichi",
@@ -2128,15 +2519,20 @@
     "common": "Dream Herb",
     "scientific": "Calea ternifolia (zacatechichi)",
     "category": "oneirogen",
+    "subcategory": "",
     "intensity": "Mild to moderate",
     "region": "mexico, central america",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "known as the 'dream herb' of the chontal people of mexico, calea is traditionally used to enhance dreams and mental clarity during sleep.",
     "effects": "Lucid dreaming;dream recall;hypnagogic imagery",
     "mechanism": "May modulate GABAergic or cholinergic pathways; unclear",
     "compounds": [
       "Germacranolides"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "sleep induction, dream work",
     "interactions": [
       "avoid sedatives",
       "alcohol"
@@ -2145,20 +2541,22 @@
       "pregnancy",
       "sedative use"
     ],
-    "dosage": "",
-    "therapeutic": "sleep induction, dream work",
+    "sideeffects": [
+      "bitterness",
+      "mild nausea"
+    ],
     "safety": "",
-    "sideeffects": "bitterness, mild nausea",
     "toxicity": "Low",
     "toxicity_ld50": "Not known",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌙 dream",
       "🧘 calm"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "calliandra-angustifolia",
@@ -2166,13 +2564,18 @@
     "common": "",
     "scientific": "Calliandra angustifolia",
     "category": "nervine / shamanic",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "amazon basin: peru, brazil, ecuador",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "bobinsana is a shrubby tree native to the amazon basin, used in traditional dieta practices for emotional healing and dreamwork. often referred to as a 'plant teacher' with gentle, uplifting effects.",
     "effects": "Heart-opening;Dreamlike calm;Energetic cleansing",
     "mechanism": "Contains flavonoids and alkaloids that may have GABAergic and adaptogenic effects. Precise pharmacology is not well studied.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for grief, heartbreak, fatigue, and as an energetic tonic. some modern practitioners use it as a mild antidepressant or empathogen.",
     "interactions": [
       "mild theoretical risk with sedatives or maois",
       "especially in ceremonial contexts."
@@ -2180,25 +2583,26 @@
     "contraindications": [
       "avoid during pregnancy. caution with antidepressants or other cns modulators."
     ],
-    "dosage": "",
-    "therapeutic": "used for grief, heartbreak, fatigue, and as an energetic tonic. some modern practitioners use it as a mild antidepressant or empathogen.",
+    "sideeffects": [
+      "generally well tolerated. some report increased emotional sensitivity or lightheadedness."
+    ],
     "safety": "",
-    "sideeffects": "generally well tolerated. some report increased emotional sensitivity or lightheadedness.",
     "toxicity": "Very low. Considered safe in traditional doses.",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 empathogen",
       "🧘 dream herb",
       "🌱 dieta"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://rainforest-database.org/plants/bobinsana",
       "Journal of Amazonian Ethnobotany",
       "2009",
       "Plants of the Gods – Schultes & Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "camellia-japonica",
@@ -2206,13 +2610,18 @@
     "common": "",
     "scientific": "Camellia japonica",
     "category": "medicinal / cosmetic",
+    "subcategory": "",
     "intensity": "",
     "region": "japan, korea, china; ornamental worldwide",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "a flowering plant native to east asia, best known for its oil-rich seeds. unlike camellia sinensis, it is not caffeinated, but valued for its emollient and skin-protective properties.",
     "effects": "Skin soothing;Antioxidant;Mild anti-inflammatory",
     "mechanism": "Rich in oleic acid, tocopherols (Vitamin E), and polyphenols. These compounds hydrate the skin and reduce oxidative damage.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used in traditional korean and japanese medicine for dry skin, burns, hair conditioning, and inflammation.",
     "interactions": [
       "none significant reported."
     ],
@@ -2220,25 +2629,26 @@
       "topical only",
       "not suitable for injection or open wounds. monitor for contact dermatitis."
     ],
-    "dosage": "",
-    "therapeutic": "used in traditional korean and japanese medicine for dry skin, burns, hair conditioning, and inflammation.",
+    "sideeffects": [
+      "rare. may cause mild allergic skin reactions in sensitive individuals."
+    ],
     "safety": "",
-    "sideeffects": "rare. may cause mild allergic skin reactions in sensitive individuals.",
     "toxicity": "Very low. Used widely in cosmetics and culinary oils.",
     "toxicity_ld50": "Not established; similar to olive oil in safety",
-    "is_controlled_substance": false,
     "tags": [
       "💧 emollient",
       "🌸 skincare",
       "🌿 traditional beauty"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3586833/",
       "Journal of Ethnopharmacology",
       "2014",
       "Asian Botanical Dermatology Manual"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "camellia-sinensis",
@@ -2246,15 +2656,20 @@
     "common": "",
     "scientific": "Camellia sinensis",
     "category": "stimulant / nootropic",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "china, india, worldwide cultivation",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "source of green and black tea; contains caffeine and theanine for balanced stimulation.",
     "effects": "Alertness;relaxed focus",
     "mechanism": "Caffeine antagonizes adenosine receptors; L-theanine modulates glutamate and GABA.",
     "compounds": [
       "Caffeine"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "improved cognition, antioxidant, metabolism boost.",
     "interactions": [
       "potentiates other stimulants",
       "may reduce sedative efficacy"
@@ -2263,24 +2678,27 @@
       "heart conditions",
       "pregnancy (high amounts)."
     ],
-    "dosage": "",
-    "therapeutic": "improved cognition, antioxidant, metabolism boost.",
+    "sideeffects": [
+      "jitters",
+      "insomnia",
+      "digestive upset"
+    ],
     "safety": "",
-    "sideeffects": "jitters, insomnia, digestive upset",
     "toxicity": "High intake can cause jitteriness or insomnia.",
     "toxicity_ld50": "Caffeine LD50 ~190 mg/kg (rats)",
-    "is_controlled_substance": false,
     "tags": [
       "☕ caffeine",
       "🍵 tea"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7086330/",
       "Tea and Health: Springer",
       "2013",
       "Theanine and Mental Performance – Nutritional Neuroscience"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "campsiandra-angustifolia",
@@ -2288,37 +2706,43 @@
     "common": "",
     "scientific": "Campsiandra angustifolia",
     "category": "shamanic / tonic / adaptogen",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "amazon basin (peru, brazil, colombia)",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "a powerful amazonian tree used as a general tonic and aphrodisiac. often added to ayahuasca brews for stamina, libido, and protection. bark decoctions are the primary preparation.",
     "effects": "Anti-inflammatory;Aphrodisiac;Tonic;Mild stimulation",
     "mechanism": "Contains triterpenes, alkaloids, and flavonoids with antioxidant and potential hormonal activity. Exact pharmacodynamics not fully mapped.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for arthritis, sexual debility, digestive issues, fatigue, and spiritual protection.",
     "interactions": [
       "theoretical interactions with hormone therapies or strong anti-inflammatories."
     ],
     "contraindications": [
       "caution in pregnancy or with autoimmune disorders. limited data on immunomodulatory effects."
     ],
-    "dosage": "",
-    "therapeutic": "used for arthritis, sexual debility, digestive issues, fatigue, and spiritual protection.",
+    "sideeffects": [
+      "mild nausea or overstimulation possible with high doses. rare allergic reactions."
+    ],
     "safety": "",
-    "sideeffects": "mild nausea or overstimulation possible with high doses. rare allergic reactions.",
     "toxicity": "Low in traditional dosing. Bark is the safest part; seeds unstudied.",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🌳 tonic tree",
       "💪 aphrodisiac",
       "🌿 ayahuasca admixture"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6603680/",
       "Plants of the Gods – Rätsch",
       "Rainforest Database: Chuchuhuasi Monograph"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "cananga-odorata",
@@ -2326,13 +2750,18 @@
     "common": "",
     "scientific": "Cananga odorata",
     "category": "aromatic / relaxant",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "philippines, indonesia, polynesia",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "a tropical flowering tree native to southeast asia. its flowers yield ylang-ylang essential oil, a sweet floral extract used in perfumery and aromatherapy to reduce stress and promote sensuality.",
     "effects": "Euphoria;Relaxation;Aphrodisiac;Mild sedation",
     "mechanism": "Contains linalool, germacrene, and benzyl acetate, which act on GABA and dopaminergic pathways to induce calming and mood-lifting effects.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used to ease anxiety, insomnia, high blood pressure, and as a romantic enhancer in aromatherapy.",
     "interactions": [
       "none significant",
       "but may mildly potentiate sedatives."
@@ -2340,25 +2769,26 @@
     "contraindications": [
       "avoid internal use. dilute before skin application. use with caution in pregnancy."
     ],
-    "dosage": "",
-    "therapeutic": "used to ease anxiety, insomnia, high blood pressure, and as a romantic enhancer in aromatherapy.",
+    "sideeffects": [
+      "may cause headaches or nausea in high concentrations. possible skin irritation if undiluted."
+    ],
     "safety": "",
-    "sideeffects": "may cause headaches or nausea in high concentrations. possible skin irritation if undiluted.",
     "toxicity": "Low. Generally regarded as safe (GRAS) when used correctly.",
     "toxicity_ld50": "Unknown (topical only)",
-    "is_controlled_substance": false,
     "tags": [
       "🌺 aromatherapy",
       "💆 relaxant",
       "💖 aphrodisiac"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6979302/",
       "Essential Oils in Therapy – Springer 2021",
       "Journal of Natural Products",
       "2006"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "cananga-odorata",
@@ -2366,13 +2796,18 @@
     "common": "",
     "scientific": "Cananga odorata",
     "category": "aromatic / relaxant",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "philippines, indonesia, polynesia",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "a tropical flowering tree native to southeast asia. its flowers yield ylang-ylang essential oil, a sweet floral extract used in perfumery and aromatherapy to reduce stress and promote sensuality.",
     "effects": "Euphoria;Relaxation;Aphrodisiac;Mild sedation",
     "mechanism": "Contains linalool, germacrene, and benzyl acetate, which act on GABA and dopaminergic pathways to induce calming and mood-lifting effects.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used to ease anxiety, insomnia, high blood pressure, and as a romantic enhancer in aromatherapy.",
     "interactions": [
       "none significant",
       "but may mildly potentiate sedatives."
@@ -2380,25 +2815,26 @@
     "contraindications": [
       "avoid internal use. dilute before skin application. use with caution in pregnancy."
     ],
-    "dosage": "",
-    "therapeutic": "used to ease anxiety, insomnia, high blood pressure, and as a romantic enhancer in aromatherapy.",
+    "sideeffects": [
+      "may cause headaches or nausea in high concentrations. possible skin irritation if undiluted."
+    ],
     "safety": "",
-    "sideeffects": "may cause headaches or nausea in high concentrations. possible skin irritation if undiluted.",
     "toxicity": "Low. Generally regarded as safe (GRAS) when used correctly.",
     "toxicity_ld50": "Unknown (topical only)",
-    "is_controlled_substance": false,
     "tags": [
       "🌺 aromatherapy",
       "💆 relaxant",
       "💖 aphrodisiac"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6979302/",
       "Essential Oils in Therapy – Springer 2021",
       "Journal of Natural Products",
       "2006"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "cannabis-sativa",
@@ -2406,9 +2842,11 @@
     "common": "",
     "scientific": "Cannabis sativa",
     "category": "psychedelic / relaxant",
+    "subcategory": "",
     "intensity": "Variable",
     "region": "cultivated worldwide",
     "legalstatus": "Varies by jurisdiction",
+    "schedule": "",
     "description": "",
     "effects": "euphoria;relaxation;altered perception",
     "mechanism": "THC acts on cannabinoid receptors CB1 and CB2",
@@ -2416,6 +2854,9 @@
       "THC",
       "CBD"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "pain relief, appetite stimulation, anxiety reduction",
     "interactions": [
       "may interact with cns depressants and alcohol"
     ],
@@ -2424,25 +2865,28 @@
       "heart conditions",
       "pregnancy"
     ],
-    "dosage": "",
-    "therapeutic": "pain relief, appetite stimulation, anxiety reduction",
+    "sideeffects": [
+      "dry mouth",
+      "short-term memory impairment",
+      "anxiety in high doses"
+    ],
     "safety": "",
-    "sideeffects": "dry mouth, short-term memory impairment, anxiety in high doses",
     "toxicity": "Low physiological toxicity",
     "toxicity_ld50": ">1 g/kg THC in animals",
-    "is_controlled_substance": false,
     "tags": [
       "cbd",
       "thc",
       "marijuana"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7747003/",
       "Cannabis and Cannabinoid Research",
       "2021",
       "The Health Effects of Cannabis and Cannabinoids – National Academies"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "capsicum-annuum",
@@ -2450,13 +2894,18 @@
     "common": "",
     "scientific": "Capsicum annuum",
     "category": "stimulant / analgesic",
+    "subcategory": "",
     "intensity": "Mild to Intense (Scoville Heat Units dependent)",
     "region": "mexico, central america; cultivated globally",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "the source of most culinary chili peppers, c. annuum is valued for both its heat and its therapeutic effects. capsaicin, the active compound, causes a burning sensation and triggers endorphin release.",
     "effects": "Stimulation;Endorphin release;Heat sensation;Pain modulation",
     "mechanism": "Capsaicin binds to TRPV1 receptors on sensory neurons, causing depolarization, heat/pain sensation, and eventual desensitization.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "topical creams for arthritis and nerve pain. internally used to boost metabolism, circulation, and digestion.",
     "interactions": [
       "may enhance blood-thinners",
       "irritate gi if combined with nsaids."
@@ -2466,25 +2915,29 @@
       "in ulcers",
       "or in sensitive individuals. caution with anticoagulants."
     ],
-    "dosage": "",
-    "therapeutic": "topical creams for arthritis and nerve pain. internally used to boost metabolism, circulation, and digestion.",
+    "sideeffects": [
+      "burning",
+      "irritation (skin or gi)",
+      "sweating",
+      "increased heart rate. can cause nausea if overconsumed."
+    ],
     "safety": "",
-    "sideeffects": "burning, irritation (skin or gi), sweating, increased heart rate. can cause nausea if overconsumed.",
     "toxicity": "Low. Overconsumption can cause GI distress. Pure capsaicin is toxic at high doses.",
     "toxicity_ld50": "Capsaicin: ~47.2 mg/kg (mice, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🌶️ capsaicin",
       "🔥 stimulant",
       "🧴 analgesic"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4477151/",
       "Journal of Pain Research",
       "2014",
       "Capsaicin Handbook – CRC Press"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "carica-papaya",
@@ -2492,38 +2945,44 @@
     "common": "",
     "scientific": "Carica papaya",
     "category": "digestive / antiparasitic",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "tropics worldwide",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "while best known for its fruit, papaya’s leaves and seeds are used medicinally for digestion, dengue fever recovery, and as a vermifuge. the seeds have a sharp flavor and act as mild natural dewormers.",
     "effects": "Digestive support;Antiparasitic;Anti-inflammatory;Immune modulation",
     "mechanism": "Papain (a proteolytic enzyme) aids digestion and reduces inflammation. Seeds contain benzyl isothiocyanate, which may have antiparasitic and antimicrobial effects.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for bloating, intestinal worms, liver detox, and increasing platelet count in dengue fever.",
     "interactions": [
       "caution with anticoagulants (may increase bleeding risk)."
     ],
     "contraindications": [
       "avoid in pregnancy (uterine stimulant). papain may interfere with blood thinners."
     ],
-    "dosage": "",
-    "therapeutic": "used for bloating, intestinal worms, liver detox, and increasing platelet count in dengue fever.",
+    "sideeffects": [
+      "possible nausea or allergic reactions. papain can irritate mucosa in excess. seeds are mildly toxic at high doses."
+    ],
     "safety": "",
-    "sideeffects": "possible nausea or allergic reactions. papain can irritate mucosa in excess. seeds are mildly toxic at high doses.",
     "toxicity": "Low to moderate. Seeds can cause toxicity in large doses (nausea, CNS symptoms in animals).",
     "toxicity_ld50": "Papaya seed extract LD50: ~1500 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🍃 digestive",
       "🦠 antiparasitic",
       "🍈 enzymatic"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6204662/",
       "Journal of Medicinal Plants",
       "2015",
       "Ethnobotany of Tropical Plants – CRC Press"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "gelsemium-sempervirens",
@@ -2531,13 +2990,18 @@
     "common": "",
     "scientific": "Gelsemium sempervirens",
     "category": "other",
+    "subcategory": "",
     "intensity": "",
     "region": "southern usa",
     "legalstatus": "Ornamental; toxic",
+    "schedule": "",
     "description": "fragrant vine with toxic yet calming alkaloids.",
     "effects": "relaxation;sedation",
     "mechanism": "Gelsemine acts on glycine and nicotinic receptors",
     "compounds": [],
+    "preparations": [],
+    "dosage": "5–10 drops tincture",
+    "therapeutic": "folk remedy for anxiety",
     "interactions": [
       "sedatives",
       "muscle relaxants"
@@ -2546,18 +3010,19 @@
       "pregnancy",
       "heart issues"
     ],
-    "dosage": "5–10 drops tincture",
-    "therapeutic": "folk remedy for anxiety",
+    "sideeffects": [
+      "respiratory depression in overdose"
+    ],
     "safety": "",
-    "sideeffects": "respiratory depression in overdose",
     "toxicity": "High",
     "toxicity_ld50": ">10 mg/kg (mice)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ caution"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "casimiroa-edulis",
@@ -2565,31 +3030,35 @@
     "common": "White Sapote",
     "scientific": "Casimiroa edulis",
     "category": "ethnobotanical",
+    "subcategory": "",
     "intensity": "",
     "region": "central america",
     "legalstatus": "",
+    "schedule": "",
     "description": "the fruit of the white sapote tree is used as a sedative in traditional mexican herbal medicine.",
     "effects": "sedative;sleep aid",
     "mechanism": "Possible GABAergic activity",
     "compounds": [
       "Zapotin"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "sedative",
       "fruit",
       "folk medicine"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "catha-edulis",
@@ -2597,13 +3066,18 @@
     "common": "",
     "scientific": "Catha edulis",
     "category": "stimulant / euphoric",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "yemen, ethiopia, kenya, somalia",
     "legalstatus": "Illegal in many countries (Schedule I in US, Class C in UK); legal in some East African nations",
+    "schedule": "",
     "description": "khat is a flowering shrub native to east africa and the arabian peninsula. chewed for centuries in social rituals, it contains cathinone, a natural amphetamine-like stimulant with short-lived euphoric effects.",
     "effects": "Euphoria;Increased alertness;Sociability;Appetite suppression",
     "mechanism": "Cathinone is a monoamine-releasing agent, increasing dopamine, norepinephrine, and serotonin. Structurally related to amphetamine.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditionally used to combat fatigue, hunger, and for social interaction. some studies explore antidepressant effects.",
     "interactions": [
       "dangerous with maois",
       "stimulants",
@@ -2615,27 +3089,33 @@
       "psychiatric conditions",
       "or during pregnancy."
     ],
-    "dosage": "",
-    "therapeutic": "traditionally used to combat fatigue, hunger, and for social interaction. some studies explore antidepressant effects.",
+    "sideeffects": [
+      "insomnia",
+      "dry mouth",
+      "hypertension",
+      "anxiety",
+      "irritability",
+      "rebound fatigue. chronic use may lead to dependence."
+    ],
     "safety": "",
-    "sideeffects": "insomnia, dry mouth, hypertension, anxiety, irritability, rebound fatigue. chronic use may lead to dependence.",
     "toxicity": "Moderate. Chronic use linked to cardiovascular, dental, and GI issues.",
     "toxicity_ld50": "Cathinone est. ~50–100 mg/kg (mice, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 euphoric",
       "⚡ cathinone",
       "🚫 legal risk",
       "🧠 stimulant"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4473630/",
       "Journal of Ethnopharmacology",
       "2010",
       "UNODC Khat Report",
       "2006"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "erythroxylum-catuaba",
@@ -2643,40 +3123,46 @@
     "common": "",
     "scientific": "Erythroxylum catuaba",
     "category": "aphrodisiac / nootropic",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "brazil, amazon, south america",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "a traditional brazilian aphrodisiac made from the bark of various erythroxylum species (mainly e. catuaba). catuaba is used to boost libido, mental clarity, and mood — both in traditional medicine and modern supplements.",
     "effects": "Stimulation;Enhanced libido;Mild euphoria;Cognitive enhancement",
     "mechanism": "Contains alkaloids, flavonoids, and possibly tropane-related compounds. Stimulates central nervous system and may increase nitric oxide availability.",
     "compounds": [
       "Catuabine"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used traditionally for sexual debility, fatigue, poor memory, and stress. often paired with muira puama.",
     "interactions": [
       "may mildly potentiate stimulants or maois. interacts with dopaminergic drugs."
     ],
     "contraindications": [
       "caution with anxiety disorders or insomnia. avoid in pregnancy due to insufficient data."
     ],
-    "dosage": "",
-    "therapeutic": "used traditionally for sexual debility, fatigue, poor memory, and stress. often paired with muira puama.",
+    "sideeffects": [
+      "rare. may cause mild overstimulation or insomnia in sensitive individuals."
+    ],
     "safety": "",
-    "sideeffects": "rare. may cause mild overstimulation or insomnia in sensitive individuals.",
     "toxicity": "Low. Considered very safe in traditional dosing.",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🔥 aphrodisiac",
       "🧠 nootropic",
       "🌿 amazon tonic"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5937011/",
       "Brazilian Journal of Pharmacognosy",
       "2005",
       "The Healing Power of Rainforest Herbs – Leslie Taylor"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "celastrus-paniculatus",
@@ -2684,9 +3170,11 @@
     "common": "Intellect Tree",
     "scientific": "Celastrus paniculatus",
     "category": "empathogen / euphoriant",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "india, sri lanka, southeast asia",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "often called the 'intellect tree', this ayurvedic plant is used to support memory, learning, and vivid dreams. contains sesquiterpenes that may stimulate cholinergic activity.",
     "effects": "Cognitive clarity;memory enhancement;dream vividness",
     "mechanism": "Cholinergic modulation; antioxidant and neuroprotective effects",
@@ -2694,31 +3182,35 @@
       "Celastrine",
       "Paniculatin"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "memory support, neuroprotection, dream recall",
     "interactions": [
       "none well documented"
     ],
     "contraindications": [
       "pregnancy"
     ],
-    "dosage": "",
-    "therapeutic": "memory support, neuroprotection, dream recall",
+    "sideeffects": [
+      "headache or stimulation at high doses"
+    ],
     "safety": "",
-    "sideeffects": "headache or stimulation at high doses",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌿 herbal",
       "🧠 nootropic"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3612440/",
       "Journal of Ayurveda and Integrative Medicine",
       "2011",
       "Indian Materia Medica – Nadkarni"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "celastrus-paniculatus",
@@ -2726,9 +3218,11 @@
     "common": "Intellect Tree",
     "scientific": "Celastrus paniculatus",
     "category": "empathogen / euphoriant",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "india, sri lanka, southeast asia",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "often called the 'intellect tree', this ayurvedic plant is used to support memory, learning, and vivid dreams. contains sesquiterpenes that may stimulate cholinergic activity.",
     "effects": "Cognitive clarity;memory enhancement;dream vividness",
     "mechanism": "Cholinergic modulation; antioxidant and neuroprotective effects",
@@ -2736,31 +3230,35 @@
       "Celastrine",
       "Paniculatin"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "memory support, neuroprotection, dream recall",
     "interactions": [
       "none well documented"
     ],
     "contraindications": [
       "pregnancy"
     ],
-    "dosage": "",
-    "therapeutic": "memory support, neuroprotection, dream recall",
+    "sideeffects": [
+      "headache or stimulation at high doses"
+    ],
     "safety": "",
-    "sideeffects": "headache or stimulation at high doses",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌿 herbal",
       "🧠 nootropic"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3612440/",
       "Journal of Ayurveda and Integrative Medicine",
       "2011",
       "Indian Materia Medica – Nadkarni"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "centella-asiatica",
@@ -2768,13 +3266,18 @@
     "common": "",
     "scientific": "Centella asiatica",
     "category": "cognitive",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "asia",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "known as gotu kola, used in ayurvedic medicine to aid cognition.",
     "effects": "Mental clarity;calm focus",
     "mechanism": "Triterpenoids may modulate GABA and promote neurogenesis",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "memory enhancement, anxiety relief",
     "interactions": [
       "may potentiate sedatives"
     ],
@@ -2782,25 +3285,26 @@
       "pregnancy",
       "liver issues"
     ],
-    "dosage": "",
-    "therapeutic": "memory enhancement, anxiety relief",
+    "sideeffects": [
+      "rare headache or nausea"
+    ],
     "safety": "",
-    "sideeffects": "rare headache or nausea",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌿 leaf",
       "🧠 cognitive"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6814248/",
       "Journal of Ethnopharmacology",
       "2013",
       "Ayurvedic Pharmacopoeia of India"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "cestrum-nocturnum",
@@ -2808,13 +3312,18 @@
     "common": "",
     "scientific": "Cestrum nocturnum",
     "category": "aromatic / toxic",
+    "subcategory": "",
     "intensity": "Mild–Moderate (olfactory)",
     "region": "india, southeast asia, caribbean, central america",
     "legalstatus": "Legal as ornamental; not for ingestion",
+    "schedule": "",
     "description": "a strongly fragrant flowering shrub known for its intoxicating nighttime aroma. traditionally used in folk remedies for anxiety and respiratory issues — but contains toxic alkaloids and should not be ingested.",
     "effects": "Sedation;Headache (aroma);Potential hallucinations (in folklore)",
     "mechanism": "Contains solanine-like glycoalkaloids and tropane-related compounds. The fragrance may act as a mild CNS modulator, but oral use is toxic.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "rarely used in formal medicine. aromatherapy use for insomnia and nervous agitation. some regional folklore suggests use in dream induction.",
     "interactions": [
       "none studied — avoid combining with sedatives or anticholinergics."
     ],
@@ -2823,26 +3332,31 @@
       "pets",
       "or in enclosed spaces with strong aroma."
     ],
-    "dosage": "",
-    "therapeutic": "rarely used in formal medicine. aromatherapy use for insomnia and nervous agitation. some regional folklore suggests use in dream induction.",
+    "sideeffects": [
+      "headache",
+      "nausea",
+      "dizziness from prolonged inhalation. ingestion may cause gi upset",
+      "delirium",
+      "or paralysis."
+    ],
     "safety": "",
-    "sideeffects": "headache, nausea, dizziness from prolonged inhalation. ingestion may cause gi upset, delirium, or paralysis.",
     "toxicity": "Moderate to high. Toxic alkaloids accumulate in leaves and berries.",
     "toxicity_ld50": "Solanine (analogue): ~590 mg/kg (mice, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🌙 aromatic",
       "⚠️ toxic",
       "🌸 night flower",
       "🛏️ sedative folklore"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3136076/",
       "Toxic Plants of North America – Burrows & Tyrl",
       "Flora of the Caribbean – Botanical Review",
       "2008"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "chacruna",
@@ -2850,13 +3364,18 @@
     "common": "",
     "scientific": "Psychotria viridis",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Strong",
     "region": "amazon basin (peru, brazil, colombia)",
     "legalstatus": "DMT is controlled in most countries",
+    "schedule": "",
     "description": "a key component of traditional ayahuasca brews, chacruna contains dmt and is often combined with maois like banisteriopsis caapi to make it orally active.",
     "effects": "Visionary states;spiritual insight;hallucinations",
     "mechanism": "DMT – 5-HT2A receptor agonist; requires MAOI to be active orally",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "spiritual healing, emotional release (as part of ayahuasca)",
     "interactions": [
       "dangerous with antidepressants or stimulants"
     ],
@@ -2865,20 +3384,23 @@
       "ssris",
       "maois"
     ],
-    "dosage": "",
-    "therapeutic": "spiritual healing, emotional release (as part of ayahuasca)",
+    "sideeffects": [
+      "intense visuals",
+      "vomiting",
+      "nausea"
+    ],
     "safety": "",
-    "sideeffects": "intense visuals, vomiting, nausea",
     "toxicity": "Low physical toxicity, high psychological risk",
     "toxicity_ld50": "Not established in humans",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ caution",
       "🧠 vision",
       "🧪 dmt"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "psychotria-viridis",
@@ -2886,13 +3408,18 @@
     "common": "",
     "scientific": "Psychotria viridis",
     "category": "entheogen / dmt source / shamanic",
+    "subcategory": "",
     "intensity": "Strong",
     "region": "amazon basin (peru, brazil, colombia)",
     "legalstatus": "Restricted in many countries due to DMT",
+    "schedule": "",
     "description": "a tropical shrub from the amazon traditionally used in ayahuasca brews. its leaves contain high concentrations of n,n-dmt, making it a primary admixture plant in visionary ceremonies.",
     "effects": "Psychedelic visions;Emotional processing;Spiritual insight;Sensory enhancement",
     "mechanism": "Contains N,N-DMT, a potent serotonergic psychedelic that acts as a 5-HT2A receptor agonist. Requires MAOI (such as harmala alkaloids) to be orally active.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used in traditional amazonian healing for soul retrieval, trauma, depression, and spiritual communion. western research suggests benefit in mental health and addiction therapy.",
     "interactions": [
       "dangerous with serotonergic drugs. do not combine with other psychedelics unless experienced."
     ],
@@ -2902,26 +3429,30 @@
       "antipsychotics",
       "or in those with severe psychiatric conditions."
     ],
-    "dosage": "",
-    "therapeutic": "used in traditional amazonian healing for soul retrieval, trauma, depression, and spiritual communion. western research suggests benefit in mental health and addiction therapy.",
+    "sideeffects": [
+      "nausea",
+      "vomiting (purging)",
+      "anxiety",
+      "dissociation. can be intense or destabilizing in unprepared individuals."
+    ],
     "safety": "",
-    "sideeffects": "nausea, vomiting (purging), anxiety, dissociation. can be intense or destabilizing in unprepared individuals.",
     "toxicity": "Low at standard doses. Risk increases with improper preparation or interaction.",
     "toxicity_ld50": "~110 mg/kg (DMT, rat IP)",
-    "is_controlled_substance": false,
     "tags": [
       "🌀 dmt source",
       "🌿 ayahuasca",
       "🌌 visionary",
       "⚠️ maoi required"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7343898/",
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology",
       "2010"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "diplopterys-cabrerana",
@@ -2929,13 +3460,18 @@
     "common": "",
     "scientific": "Diplopterys cabrerana",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "",
     "region": "amazon",
     "legalstatus": "DMT restricted in most regions",
+    "schedule": "",
     "description": "ayahuasca admixture leaf high in tryptamines.",
     "effects": "visions;introspection",
     "mechanism": "Leaves contain DMT and 5-MeO-DMT acting on serotonin receptors",
     "compounds": [],
+    "preparations": [],
+    "dosage": "25–50 g leaves",
+    "therapeutic": "shamanic healing",
     "interactions": [
       "maois",
       "ssris"
@@ -2943,19 +3479,21 @@
     "contraindications": [
       "mental health disorders"
     ],
-    "dosage": "25–50 g leaves",
-    "therapeutic": "shamanic healing",
+    "sideeffects": [
+      "nausea",
+      "intense visions"
+    ],
     "safety": "",
-    "sideeffects": "nausea, intense visions",
     "toxicity": "Low physiological",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ caution",
       "🧪 dmt"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "cichorium-intybus",
@@ -2963,13 +3501,18 @@
     "common": "",
     "scientific": "Cichorium intybus",
     "category": "digestive / prebiotic / tonic",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "europe, asia, north america",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a bitter blue-flowered herb widely used as a coffee substitute, digestive tonic, and prebiotic. its root is rich in inulin, supporting gut health and liver detoxification.",
     "effects": "Liver support;Mild stimulant (roasted);Prebiotic;Digestive aid",
     "mechanism": "Inulin acts as a prebiotic fiber, feeding gut flora. Bitter compounds stimulate bile secretion and improve digestion. Roasted root contains lactones that mildly stimulate the CNS.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for sluggish digestion, fatty liver, gallbladder issues, and gut flora restoration. roasted root used to reduce caffeine intake.",
     "interactions": [
       "may alter absorption of some drugs by modulating gut transit or flora."
     ],
@@ -2978,25 +3521,28 @@
       "bile duct obstruction",
       "or fructan intolerance."
     ],
-    "dosage": "",
-    "therapeutic": "used for sluggish digestion, fatty liver, gallbladder issues, and gut flora restoration. roasted root used to reduce caffeine intake.",
+    "sideeffects": [
+      "may cause gas",
+      "bloating",
+      "or diarrhea if inulin dose is too high. bitter taste may cause nausea."
+    ],
     "safety": "",
-    "sideeffects": "may cause gas, bloating, or diarrhea if inulin dose is too high. bitter taste may cause nausea.",
     "toxicity": "Very low. Widely used as food and medicine.",
     "toxicity_ld50": "Inulin: >10 g/kg (oral, rats)",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 prebiotic",
       "☕ coffee alternative",
       "💩 gut health"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6893434/",
       "Journal of Functional Foods",
       "2015",
       "Herbal Medicine Monographs – WHO"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "cissampelos-pareira",
@@ -3004,9 +3550,11 @@
     "common": "Velvetleaf",
     "scientific": "Cissampelos pareira",
     "category": "ayurvedic / antispasmodic / antimalarial",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "india, south america, southeast asia",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "a climbing herb used in ayurveda and traditional amazonian medicine. often called ‘laghu patha’ in sanskrit, it is prized for menstrual support, malaria treatment, and as an adjunct to ayahuasca.",
     "effects": "Uterine tonic;Muscle relaxant;Antimalarial;Mild sedative",
     "mechanism": "Contains alkaloids like pareirine and cissamine. These modulate smooth muscle tone, and may exert anti-inflammatory, uterotonic, and antimicrobial effects.",
@@ -3014,32 +3562,38 @@
       "Pareirine",
       "Cissamine"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for menstrual cramps, utis, inflammation, diarrhea, and malaria. in south america, used spiritually as a ‘feminine vine’ complementary to banisteriopsis caapi.",
     "interactions": [
       "potential interactions with antimalarials or muscle relaxants. may mildly lower blood pressure."
     ],
     "contraindications": [
       "avoid during early pregnancy due to uterine effects. use caution with blood pressure medications."
     ],
-    "dosage": "",
-    "therapeutic": "used for menstrual cramps, utis, inflammation, diarrhea, and malaria. in south america, used spiritually as a ‘feminine vine’ complementary to banisteriopsis caapi.",
+    "sideeffects": [
+      "well tolerated in moderate doses. large doses may cause dizziness",
+      "nausea",
+      "or mild hypotension."
+    ],
     "safety": "",
-    "sideeffects": "well tolerated in moderate doses. large doses may cause dizziness, nausea, or mild hypotension.",
     "toxicity": "Low to moderate depending on alkaloid concentration.",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 ayurvedic",
       "🌙 feminine vine",
       "🧪 antimalarial",
       "🩸 menstrual tonic"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3783799/",
       "Journal of Ethnopharmacology",
       "2011",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "claviceps-purpurea",
@@ -3047,15 +3601,20 @@
     "common": "",
     "scientific": "Claviceps purpurea",
     "category": "ergolines / toxic",
+    "subcategory": "",
     "intensity": "Strong",
     "region": "worldwide on cereal grains",
     "legalstatus": "Controlled in many countries",
+    "schedule": "",
     "description": "",
     "effects": "vasoconstriction;hallucinations;numbness",
     "mechanism": "Produces ergot alkaloids acting on serotonin and adrenergic receptors",
     "compounds": [
       "Ergotamine"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "historically used to induce labor and treat migraines",
     "interactions": [
       "potentiates triptans and other vasoconstrictors"
     ],
@@ -3063,26 +3622,29 @@
       "pregnancy",
       "vascular disease"
     ],
-    "dosage": "",
-    "therapeutic": "historically used to induce labor and treat migraines",
+    "sideeffects": [
+      "nausea",
+      "convulsions",
+      "gangrene in high doses"
+    ],
     "safety": "",
-    "sideeffects": "nausea, convulsions, gangrene in high doses",
     "toxicity": "High; risk of ergotism",
     "toxicity_ld50": "~5 mg/kg lysergic acid amide (mouse)",
-    "is_controlled_substance": false,
     "tags": [
       "ergot",
       "fungus",
       "vasoconstrictor"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2765184/",
       "Ergot and Ergotism – Medical Mycology Textbook",
       "The Road to Eleusis – Hoffman",
       "Wasson",
       "Ruck"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "clavo-huasca",
@@ -3090,13 +3652,18 @@
     "common": "",
     "scientific": "Tynanthus panurensis",
     "category": "empathogen / euphoriant",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "amazon basin",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "amazonian vine used in both physical and spiritual medicine. traditionally consumed as a libido enhancer and pre-ayahuasca preparation.",
     "effects": "Aphrodisiac;calming;digestive",
     "mechanism": "Alkaloids may modulate dopamine and serotonin; warming vasodilator",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "aphrodisiac, digestive aid in amazonian medicine",
     "interactions": [
       "avoid cns depressants",
       "alcohol"
@@ -3105,20 +3672,21 @@
       "pregnancy",
       "blood pressure meds"
     ],
-    "dosage": "",
-    "therapeutic": "aphrodisiac, digestive aid in amazonian medicine",
+    "sideeffects": [
+      "mild hypotension or fatigue"
+    ],
     "safety": "",
-    "sideeffects": "mild hypotension or fatigue",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌿 amazonian",
       "🔥 aphrodisiac"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "clitoria-ternatea",
@@ -3126,39 +3694,45 @@
     "common": "",
     "scientific": "Clitoria ternatea",
     "category": "nootropic / adaptogen / nervine",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "india, thailand, malaysia, tropics worldwide",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "a striking blue-flowered vine used in ayurvedic and southeast asian medicine. known for its nootropic, anti-anxiety, and anti-inflammatory effects. often brewed into vivid blue tea and used ceremonially in thailand and india.",
     "effects": "Cognitive enhancement;Anxiolytic;Neuroprotective;Mild sedation",
     "mechanism": "Contains anthocyanins (ternatins), flavonoids, and cyclotides. May modulate acetylcholine and GABA signaling, as well as BDNF expression in the brain.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditionally used to enhance memory, relieve stress, calm nerves, and as a visual eye tonic. topical extracts also used for hair and skin.",
     "interactions": [
       "may mildly potentiate sedatives or anxiolytics."
     ],
     "contraindications": [
       "caution with hypotensive drugs. avoid during pregnancy until more data is available."
     ],
-    "dosage": "",
-    "therapeutic": "traditionally used to enhance memory, relieve stress, calm nerves, and as a visual eye tonic. topical extracts also used for hair and skin.",
+    "sideeffects": [
+      "very few reported. some may experience mild drowsiness or hypotension."
+    ],
     "safety": "",
-    "sideeffects": "very few reported. some may experience mild drowsiness or hypotension.",
     "toxicity": "Very low. Consumed widely as food and medicine.",
     "toxicity_ld50": "No established human LD50; >2000 mg/kg (rats, oral, extract)",
-    "is_controlled_substance": false,
     "tags": [
       "🌸 blue tea",
       "🧠 brain tonic",
       "🧘 adaptogen",
       "💙 anthocyanins"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7510498/",
       "Journal of Ethnopharmacology",
       "2010",
       "Ayurvedic Pharmacopoeia of India"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "erythroxylum-coca",
@@ -3166,13 +3740,18 @@
     "common": "",
     "scientific": "Erythroxylum coca",
     "category": "stimulant",
+    "subcategory": "",
     "intensity": "",
     "region": "andes",
     "legalstatus": "Controlled in most countries",
+    "schedule": "",
     "description": "traditional andean stimulant leaf.",
     "effects": "euphoria;energy",
     "mechanism": "Cocaine inhibits monoamine reuptake",
     "compounds": [],
+    "preparations": [],
+    "dosage": "1–3 g dried leaves",
+    "therapeutic": "altitude sickness",
     "interactions": [
       "stimulants",
       "maois"
@@ -3181,19 +3760,21 @@
       "heart issues",
       "pregnancy"
     ],
-    "dosage": "1–3 g dried leaves",
-    "therapeutic": "altitude sickness",
+    "sideeffects": [
+      "elevated heart rate",
+      "insomnia"
+    ],
     "safety": "",
-    "sideeffects": "elevated heart rate, insomnia",
     "toxicity": "High in purified form",
     "toxicity_ld50": "95 mg/kg (mice)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ restricted",
       "🌿 leaf"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "coffea-arabica",
@@ -3201,13 +3782,18 @@
     "common": "",
     "scientific": "Coffea arabica",
     "category": "stimulant",
+    "subcategory": "",
     "intensity": "",
     "region": "worldwide",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "beloved beverage plant containing caffeine.",
     "effects": "alertness;energy",
     "mechanism": "Caffeine blocks adenosine receptors increasing neurotransmitter release",
     "compounds": [],
+    "preparations": [],
+    "dosage": "50–150 mg caffeine",
+    "therapeutic": "fatigue reduction",
     "interactions": [
       "stimulants",
       "maois"
@@ -3215,18 +3801,20 @@
     "contraindications": [
       "heart arrhythmia"
     ],
-    "dosage": "50–150 mg caffeine",
-    "therapeutic": "fatigue reduction",
+    "sideeffects": [
+      "jitters",
+      "insomnia"
+    ],
     "safety": "",
-    "sideeffects": "jitters, insomnia",
     "toxicity": "Low",
     "toxicity_ld50": "~192 mg/kg (rats)",
-    "is_controlled_substance": false,
     "tags": [
       "☕ brewable"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "cola-acuminata",
@@ -3234,13 +3822,18 @@
     "common": "",
     "scientific": "Cola acuminata",
     "category": "stimulant / cultural",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "west africa; cultivated globally",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "a caffeine-rich seed native to west africa, traditionally chewed in ceremonies and social settings. kola nut is a powerful natural stimulant, historically used in early coca-cola formulas and as a fatigue-fighting tonic.",
     "effects": "Stimulation;Increased alertness;Mood elevation;Appetite suppression",
     "mechanism": "Contains caffeine, theobromine, and kolanin. These stimulate the central nervous system via adenosine receptor antagonism and mild dopaminergic effects.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used to combat fatigue, enhance performance, support digestion, and as a social stimulant. also used in weight loss supplements.",
     "interactions": [
       "interacts with maois",
       "beta-blockers",
@@ -3251,25 +3844,29 @@
       "insomnia",
       "or in combination with strong stimulants."
     ],
-    "dosage": "",
-    "therapeutic": "used to combat fatigue, enhance performance, support digestion, and as a social stimulant. also used in weight loss supplements.",
+    "sideeffects": [
+      "insomnia",
+      "anxiety",
+      "jitteriness",
+      "increased heart rate. long-term overuse may affect adrenal function."
+    ],
     "safety": "",
-    "sideeffects": "insomnia, anxiety, jitteriness, increased heart rate. long-term overuse may affect adrenal function.",
     "toxicity": "Moderate at high doses (caffeine-related).",
     "toxicity_ld50": "Caffeine LD50: ~192 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "⚡ caffeine",
       "🥥 traditional stimulant",
       "🌍 afro-indigenous use"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4703266/",
       "Journal of Pharmacognosy",
       "2013",
       "The Cultural Uses of Cola – African Medicine Studies"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "cola-nitida",
@@ -3277,13 +3874,18 @@
     "common": "",
     "scientific": "Cola nitida",
     "category": "stimulant",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "africa",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "kola nut used in energy drinks and ceremonies.",
     "effects": "Alertness;reduced fatigue",
     "mechanism": "Caffeine and kolanin stimulate CNS",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditional energizer",
     "interactions": [
       "other stimulants"
     ],
@@ -3291,20 +3893,22 @@
       "heart conditions",
       "pregnancy"
     ],
-    "dosage": "",
-    "therapeutic": "traditional energizer",
+    "sideeffects": [
+      "insomnia",
+      "jitteriness"
+    ],
     "safety": "",
-    "sideeffects": "insomnia, jitteriness",
     "toxicity": "Moderate",
     "toxicity_ld50": "Caffeine LD50 ~192 mg/kg (rat)",
-    "is_controlled_substance": false,
     "tags": [
       "stimulant",
       "✅ safe",
       "🌿 seed"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "plectranthus-scutellarioides",
@@ -3312,31 +3916,38 @@
     "common": "",
     "scientific": "Plectranthus scutellarioides",
     "category": "psychedelic / ornamental",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "tropical asia",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "",
     "effects": "mild visuals;color enhancement;relaxation",
     "mechanism": "Unclear; may act on serotonergic pathways",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "rarely used; some folk use for divination",
     "interactions": [],
     "contraindications": [
       "none known"
     ],
-    "dosage": "",
-    "therapeutic": "rarely used; some folk use for divination",
+    "sideeffects": [
+      "headache",
+      "nausea at high doses"
+    ],
     "safety": "",
-    "sideeffects": "headache, nausea at high doses",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "lamiaceae",
       "painted nettle",
       "visionary"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "combretum-quadrangulare",
@@ -3344,9 +3955,11 @@
     "common": "Sakae Naa",
     "scientific": "Combretum quadrangulare",
     "category": "stimulant",
+    "subcategory": "",
     "intensity": "Mild to Moderate",
     "region": "laos, cambodia, thailand",
     "legalstatus": "Legal with little regulation",
+    "schedule": "",
     "description": "often marketed as “sakae naa,” this plant is used as a mild energizing substitute for kratom.",
     "effects": "heightened alertness;subtle euphoria;increased focus",
     "mechanism": "Leaves contain combretol and related alkaloids acting on adrenergic systems",
@@ -3354,6 +3967,9 @@
       "Combretol",
       "Combretin"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditional stimulant and tonic in laos and thailand",
     "interactions": [
       "may potentiate other stimulants"
     ],
@@ -3361,25 +3977,27 @@
       "hypertension",
       "heart conditions"
     ],
-    "dosage": "",
-    "therapeutic": "traditional stimulant and tonic in laos and thailand",
+    "sideeffects": [
+      "jitters",
+      "insomnia if overused"
+    ],
     "safety": "",
-    "sideeffects": "jitters, insomnia if overused",
     "toxicity": "Limited data but appears low at customary doses",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "sakae naa",
       "southeast asia",
       "energy"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://erowid.org/plants/sakae_naa/",
       "Thai Ethnobotany Compendium",
       "2015",
       "Ethnopharmacology of Southeast Asia – WHO Report"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "convolvulus-arvensis",
@@ -3387,31 +4005,35 @@
     "common": "",
     "scientific": "Convolvulus arvensis",
     "category": "ethnobotanical",
+    "subcategory": "",
     "intensity": "",
     "region": "europe, north america",
     "legalstatus": "",
+    "schedule": "",
     "description": "bindweed, a relative of morning glory, contains ergoline alkaloids and is under investigation for mild entheogenic potential.",
     "effects": "light euphoria;subtle visual shifts",
     "mechanism": "5-HT2A agonist (potential)",
     "compounds": [
       "Ergoline alkaloids (trace)"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "entheogen",
       "ergoline",
       "wild plant"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "convolvulus-pluricaulis",
@@ -3419,13 +4041,18 @@
     "common": "",
     "scientific": "Convolvulus pluricaulis",
     "category": "ayurvedic / nootropic / nervine",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "india, nepal, southeast asia",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "one of ayurveda’s most revered medhya rasayanas (brain tonics). shankhpushpi is used to enhance memory, reduce anxiety, and balance vata/pitta energies. often prescribed for insomnia, fatigue, and poor concentration.",
     "effects": "Memory enhancement;Stress reduction;Mental clarity;Mild sedation",
     "mechanism": "Contains alkaloids like convolvine and flavonoids that may modulate GABA and acetylcholine pathways. Also shows antioxidant and adaptogenic activity.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for cognitive decline, anxiety, adhd, insomnia, and as a rejuvenating adaptogen. may assist in ptsd and stress disorders.",
     "interactions": [
       "may mildly potentiate benzodiazepines",
       "barbiturates",
@@ -3434,25 +4061,26 @@
     "contraindications": [
       "none major. caution with sedatives or in hypotension."
     ],
-    "dosage": "",
-    "therapeutic": "used for cognitive decline, anxiety, adhd, insomnia, and as a rejuvenating adaptogen. may assist in ptsd and stress disorders.",
+    "sideeffects": [
+      "very mild. excessive use may cause drowsiness or lowered blood pressure."
+    ],
     "safety": "",
-    "sideeffects": "very mild. excessive use may cause drowsiness or lowered blood pressure.",
     "toxicity": "Very low. Widely used in Ayurvedic pediatric formulas.",
     "toxicity_ld50": ">2 g/kg (rats, oral, extract)",
-    "is_controlled_substance": false,
     "tags": [
       "🧠 medhya",
       "🌿 ayurvedic nootropic",
       "🧘 nervine tonic"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3459457/",
       "Ayurvedic Pharmacopoeia of India",
       "Journal of Ethnopharmacology",
       "2010"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "corydalis-yanhusuo",
@@ -3460,15 +4088,20 @@
     "common": "Yanhusuo",
     "scientific": "Corydalis yanhusuo",
     "category": "sedative / analgesic",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "china and east asia",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "tubers of this asian herb provide notable pain relief and a tranquil state when used as tea or pills.",
     "effects": "analgesia;relaxation;subtle dreaminess",
     "mechanism": "Alkaloids such as tetrahydropalmatine act on dopamine and GABA receptors",
     "compounds": [
       "Tetrahydropalmatine (THP)"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditional chinese remedy for pain and insomnia",
     "interactions": [
       "may potentiate sedatives or dopaminergic drugs"
     ],
@@ -3477,25 +4110,27 @@
       "liver disease",
       "large doses"
     ],
-    "dosage": "",
-    "therapeutic": "traditional chinese remedy for pain and insomnia",
+    "sideeffects": [
+      "drowsiness",
+      "dizziness"
+    ],
     "safety": "",
-    "sideeffects": "drowsiness, dizziness",
     "toxicity": "Overuse may cause liver stress",
     "toxicity_ld50": ">1 g/kg in rodents",
-    "is_controlled_substance": false,
     "tags": [
       "tcm",
       "dopamine",
       "pain relief"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4046635/",
       "Journal of Pain Research",
       "2013",
       "Pharmacopoeia of the People’s Republic of China"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "crataegus-monogyna",
@@ -3503,38 +4138,44 @@
     "common": "",
     "scientific": "Crataegus monogyna",
     "category": "cardiovascular / tonic / nervine",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "europe, north africa, west asia",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "a thorny shrub known for its small red berries and heart-boosting properties. used in european herbalism for centuries to support circulation, reduce anxiety, and tone the cardiovascular system.",
     "effects": "Heart tonic;Circulation support;Anxiolytic;Antioxidant",
     "mechanism": "Rich in flavonoids and proanthocyanidins. Improves coronary blood flow, reduces vascular resistance, and has mild ACE-inhibiting properties. Antioxidant effects may protect endothelial tissue.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for mild heart failure, high blood pressure, arrhythmia, anxiety, and fatigue. may improve exercise tolerance in cardiovascular conditions.",
     "interactions": [
       "may potentiate beta-blockers or ace inhibitors. avoid with nitrates without supervision."
     ],
     "contraindications": [
       "caution with digitalis drugs or other cardiac medications. monitor blood pressure closely."
     ],
-    "dosage": "",
-    "therapeutic": "used for mild heart failure, high blood pressure, arrhythmia, anxiety, and fatigue. may improve exercise tolerance in cardiovascular conditions.",
+    "sideeffects": [
+      "very rare. possible dizziness or nausea in high doses."
+    ],
     "safety": "",
-    "sideeffects": "very rare. possible dizziness or nausea in high doses.",
     "toxicity": "Very low. Considered safe in standard dosing.",
     "toxicity_ld50": ">3000 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "❤️ heart tonic",
       "🍒 berry",
       "🌿 nervine"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3249903/",
       "ESC Guidelines on Hawthorn",
       "2019",
       "Herbal Medicine Monographs – WHO"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "crocus-sativus",
@@ -3542,13 +4183,18 @@
     "common": "",
     "scientific": "Crocus sativus",
     "category": "nootropic / mood enhancer / culinary",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "iran, india (kashmir), greece, spain",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "the world’s most expensive spice, saffron has been used for thousands of years in cooking, medicine, and ritual. its stigma threads contain compounds that brighten mood, enhance cognition, and protect neural function.",
     "effects": "Euphoria;Antidepressant;Cognitive support;Visual clarity",
     "mechanism": "Contains crocin, safranal, and picrocrocin. These modulate serotonin, dopamine, and GABA signaling. Also antioxidant and anti-inflammatory.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for depression, pms, cognitive decline, and visual fatigue. studies show efficacy comparable to ssris at low doses.",
     "interactions": [
       "possible synergistic effects with ssris",
       "maois",
@@ -3557,26 +4203,29 @@
     "contraindications": [
       "avoid in pregnancy or with strong antidepressants unless supervised."
     ],
-    "dosage": "",
-    "therapeutic": "used for depression, pms, cognitive decline, and visual fatigue. studies show efficacy comparable to ssris at low doses.",
+    "sideeffects": [
+      "rare. high doses may cause nausea",
+      "dizziness",
+      "or uterine stimulation."
+    ],
     "safety": "",
-    "sideeffects": "rare. high doses may cause nausea, dizziness, or uterine stimulation.",
     "toxicity": "Low at standard doses; high doses (>5g) may be toxic.",
     "toxicity_ld50": "Crocetin LD50: ~2000 mg/kg (mice, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🌼 mood-lifting",
       "🧠 nootropic",
       "🧘 calm focus",
       "💊 ssri-like"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4431160/",
       "Phytotherapy Research",
       "2016",
       "Traditional Persian Medicine – Avicenna Canon"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "curcuma-longa",
@@ -3584,13 +4233,18 @@
     "common": "",
     "scientific": "Curcuma longa",
     "category": "anti-inflammatory / adaptogen / culinary",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "india, southeast asia",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a golden root revered in ayurveda and traditional chinese medicine. curcumin, its key compound, fights inflammation, supports liver health, and improves brain function. used widely in cooking, teas, and supplements.",
     "effects": "Anti-inflammatory;Antioxidant;Liver tonic;Joint pain relief",
     "mechanism": "Curcumin inhibits COX-2 and NF-κB, reduces pro-inflammatory cytokines, and modulates glutathione and serotonin levels. Bioavailability enhanced with black pepper (piperine).",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for arthritis, inflammation, liver detox, depression, cognitive decline, metabolic syndrome, and gut repair.",
     "interactions": [
       "interacts with anticoagulants",
       "nsaids",
@@ -3601,25 +4255,26 @@
       "bleeding disorders",
       "or blood thinners."
     ],
-    "dosage": "",
-    "therapeutic": "used for arthritis, inflammation, liver detox, depression, cognitive decline, metabolic syndrome, and gut repair.",
+    "sideeffects": [
+      "may cause stomach upset in high doses. risk of gallbladder contraction or bleeding at large doses."
+    ],
     "safety": "",
-    "sideeffects": "may cause stomach upset in high doses. risk of gallbladder contraction or bleeding at large doses.",
     "toxicity": "Very low. Doses up to 8g/day studied safely.",
     "toxicity_ld50": ">2000 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "💛 anti-inflammatory",
       "🧠 brain support",
       "🍛 culinary adaptogen"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5664031/",
       "Ayurvedic Pharmacopoeia of India",
       "Journal of Alternative and Complementary Medicine",
       "2015"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "cyperus-articulatus",
@@ -3627,29 +4282,36 @@
     "common": "",
     "scientific": "Cyperus articulatus",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "africa, caribbean, amazon",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "known as piripiri or guinea rush, this sedge is used in afro-caribbean and amazonian rituals for mild visionary states and spiritual grounding.",
     "effects": "Calm;focus;light trance",
     "mechanism": "Unknown; may involve sesquiterpenes",
     "compounds": [],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "spiritual clarity, dream work, digestion",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [
+      "rare",
+      "mild sedation"
+    ],
     "safety": "",
-    "sideeffects": "rare; mild sedation",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌿 piripiri",
       "🧘 ritual"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "cytisus-scoparius",
@@ -3657,13 +4319,18 @@
     "common": "",
     "scientific": "Cytisus scoparius",
     "category": "stimulant / toxic / cardiovascular",
+    "subcategory": "",
     "intensity": "Moderate to Strong (dose-dependent)",
     "region": "europe, north america (naturalized)",
     "legalstatus": "Legal in most countries but discouraged or regulated in herbal supplements",
+    "schedule": "",
     "description": "a yellow-flowered shrub traditionally used as a cardiac stimulant and diuretic. contains sparteine, a toxic alkaloid with stimulant and hallucinogenic potential in high doses. use with caution — pharmacologically active but potentially dangerous.",
     "effects": "Cardiac stimulation;Diuretic;Mood elevation;Mild hallucinations (high dose)",
     "mechanism": "Sparteine acts on cardiac sodium channels and can influence rhythm and contractility. Also modulates adrenergic and muscarinic pathways.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used historically for arrhythmias, edema, and as a uterine tonic. some traditional european accounts suggest mild trance-like states at high doses.",
     "interactions": [
       "may dangerously interact with antiarrhythmics",
       "maois",
@@ -3674,24 +4341,29 @@
       "in heart conditions",
       "or with maois or stimulants."
     ],
-    "dosage": "",
-    "therapeutic": "used historically for arrhythmias, edema, and as a uterine tonic. some traditional european accounts suggest mild trance-like states at high doses.",
+    "sideeffects": [
+      "tachycardia",
+      "nausea",
+      "dizziness",
+      "visual disturbances",
+      "and convulsions in overdose. narrow margin of safety."
+    ],
     "safety": "",
-    "sideeffects": "tachycardia, nausea, dizziness, visual disturbances, and convulsions in overdose. narrow margin of safety.",
     "toxicity": "High. Sparteine is cardiotoxic at moderate to high doses.",
     "toxicity_ld50": "Sparteine est. ~50 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ toxic",
       "❤️ heart-active",
       "🌾 witch lore"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3920503/",
       "Traditional Herbal Medicines in Europe – ESCOP",
       "Botanical Safety Handbook – 2nd Ed."
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "damiana",
@@ -3699,13 +4371,18 @@
     "common": "",
     "scientific": "Turnera diffusa",
     "category": "empathogen / euphoriant",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "mexico, texas, central america",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "used traditionally in mexico and central america for libido, relaxation, and mild stimulation. sometimes blended in herbal smoking mixes.",
     "effects": "Mood boost;aphrodisiac;relaxation",
     "mechanism": "May modulate serotonin and GABA; unclear primary target",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "libido, nervous system support, mild stimulant",
     "interactions": [
       "may interact with blood sugar meds"
     ],
@@ -3713,20 +4390,21 @@
       "pregnancy",
       "urinary tract conditions"
     ],
-    "dosage": "",
-    "therapeutic": "libido, nervous system support, mild stimulant",
+    "sideeffects": [
+      "mild headaches or gi discomfort"
+    ],
     "safety": "",
-    "sideeffects": "mild headaches or gi discomfort",
     "toxicity": "Low",
     "toxicity_ld50": "Not well established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🔥 aphrodisiac",
       "😊 mood"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "datura-inoxia",
@@ -3734,13 +4412,18 @@
     "common": "",
     "scientific": "Datura inoxia",
     "category": "deliriant / toxic / visionary",
+    "subcategory": "",
     "intensity": "Extreme",
     "region": "southwestern us, mexico, central america",
     "legalstatus": "Legal to grow ornamentally; restricted in some countries for psychoactive use",
+    "schedule": "",
     "description": "a night-blooming white-flowered species of datura, known for its powerful deliriant and anticholinergic properties. used in shamanic rituals in mesoamerica, but also responsible for many poisonings due to its unpredictability.",
     "effects": "Intense delirium;Anticholinergic trance;Hallucinations;Amnesia",
     "mechanism": "Contains tropane alkaloids (scopolamine, hyoscyamine, atropine) that block muscarinic acetylcholine receptors, leading to hallucinations, confusion, and autonomic dysfunction.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditionally used in extremely small doses for asthma, pain, or divination. modern use is rare and discouraged due to risk.",
     "interactions": [
       "severe interactions with antipsychotics",
       "antihistamines",
@@ -3750,26 +4433,33 @@
     "contraindications": [
       "unsafe in all doses without expert guidance. never combine with other cns depressants or anticholinergics."
     ],
-    "dosage": "",
-    "therapeutic": "traditionally used in extremely small doses for asthma, pain, or divination. modern use is rare and discouraged due to risk.",
+    "sideeffects": [
+      "severe dry mouth",
+      "vision loss",
+      "fever",
+      "urinary retention",
+      "paranoia",
+      "terrifying hallucinations",
+      "and death in overdose."
+    ],
     "safety": "",
-    "sideeffects": "severe dry mouth, vision loss, fever, urinary retention, paranoia, terrifying hallucinations, and death in overdose.",
     "toxicity": "Very high. One seed or leaf may be lethal.",
     "toxicity_ld50": "Scopolamine LD50: ~300 mg/kg (mice, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🌙 deliriant",
       "🌀 dangerous",
       "🌿 shamanic",
       "⚠️ visionary plant"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1318951/",
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology",
       "1994"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "datura-metel",
@@ -3777,9 +4467,11 @@
     "common": "Devil's Trumpet",
     "scientific": "",
     "category": "",
+    "subcategory": "",
     "intensity": "",
     "region": "asia, africa",
     "legalstatus": "",
+    "schedule": "",
     "description": "",
     "effects": "hallucinogenic;deliriant;anticholinergic",
     "mechanism": "Antagonist of muscarinic acetylcholine receptors",
@@ -3787,22 +4479,24 @@
       "Scopolamine",
       "Atropine"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "hallucinogen",
       "deliriant",
       "toxic"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "datura-metel",
@@ -3810,9 +4504,11 @@
     "common": "Devil's Trumpet",
     "scientific": "",
     "category": "",
+    "subcategory": "",
     "intensity": "",
     "region": "asia, africa",
     "legalstatus": "",
+    "schedule": "",
     "description": "",
     "effects": "hallucinogenic;deliriant;anticholinergic",
     "mechanism": "Antagonist of muscarinic acetylcholine receptors",
@@ -3820,22 +4516,24 @@
       "Scopolamine",
       "Atropine"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "hallucinogen",
       "deliriant",
       "toxic"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "derris-elliptica",
@@ -3843,38 +4541,47 @@
     "common": "",
     "scientific": "Derris elliptica",
     "category": "insecticide / ethnobotanical / toxic",
+    "subcategory": "",
     "intensity": "Severe (if ingested)",
     "region": "southeast asia, pacific islands",
     "legalstatus": "Restricted or banned in many regions",
+    "schedule": "",
     "description": "a tropical vine traditionally used as a natural fish poison. contains rotenone, a potent neurotoxin that disrupts mitochondrial respiration. used in agriculture but dangerous to humans in concentrated doses.",
     "effects": "Paralysis (insects/fish);Mild euphoria (folklore);Toxicity",
     "mechanism": "Rotenone inhibits NADH dehydrogenase in the electron transport chain, disrupting ATP production and causing cellular hypoxia.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "no modern internal medical uses. occasionally used externally in veterinary or agricultural settings.",
     "interactions": [
       "n/a – not used internally."
     ],
     "contraindications": [
       "unsafe for human consumption. do not ingest or inhale powdered forms."
     ],
-    "dosage": "",
-    "therapeutic": "no modern internal medical uses. occasionally used externally in veterinary or agricultural settings.",
+    "sideeffects": [
+      "nausea",
+      "vomiting",
+      "respiratory depression",
+      "muscle paralysis. long-term rotenone exposure linked to parkinson’s-like symptoms."
+    ],
     "safety": "",
-    "sideeffects": "nausea, vomiting, respiratory depression, muscle paralysis. long-term rotenone exposure linked to parkinson’s-like symptoms.",
     "toxicity": "Very high. Rotenone has been used in rodenticides and insecticides.",
     "toxicity_ld50": "Rotenone ~132 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ toxic",
       "🌊 ethnobotany",
       "🐟 fish poison",
       "🧬 mitochondrial disruptor"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1241859/",
       "WHO Pesticide Evaluation Report – Rotenone",
       "Traditional Plant Lore of Southeast Asia – 2010"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "desfontainia-spinosa",
@@ -3882,15 +4589,20 @@
     "common": "Chilean holly",
     "scientific": "Desfontainia spinosa",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Strong",
     "region": "chile, colombia, andes",
     "legalstatus": "Legal but obscure",
+    "schedule": "",
     "description": "a rare south american shrub used by the mapuche and other indigenous groups in chile and colombia as a ritual intoxicant. known for unpredictable and potent effects.",
     "effects": "Hallucinations;disorientation;dreamlike state",
     "mechanism": "Unknown; possibly tropane alkaloid activity or diterpenes",
     "compounds": [
       "Desfontainin"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditional visionary plant; not clinically established",
     "interactions": [
       "unknown",
       "avoid cns drugs"
@@ -3900,20 +4612,23 @@
       "cardiovascular risk",
       "pregnancy"
     ],
-    "dosage": "",
-    "therapeutic": "traditional visionary plant; not clinically established",
+    "sideeffects": [
+      "strong nausea",
+      "confusion",
+      "pupil dilation"
+    ],
     "safety": "",
-    "sideeffects": "strong nausea, confusion, pupil dilation",
     "toxicity": "Potentially high at ritual doses",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ rare",
       "🌿 andes",
       "🧠 vision"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "desfontainia-spinosa",
@@ -3921,15 +4636,20 @@
     "common": "Chilean holly",
     "scientific": "Desfontainia spinosa",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Strong",
     "region": "chile, colombia, andes",
     "legalstatus": "Legal but obscure",
+    "schedule": "",
     "description": "a rare south american shrub used by the mapuche and other indigenous groups in chile and colombia as a ritual intoxicant. known for unpredictable and potent effects.",
     "effects": "Hallucinations;disorientation;dreamlike state",
     "mechanism": "Unknown; possibly tropane alkaloid activity or diterpenes",
     "compounds": [
       "Desfontainin"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditional visionary plant; not clinically established",
     "interactions": [
       "unknown",
       "avoid cns drugs"
@@ -3939,20 +4659,23 @@
       "cardiovascular risk",
       "pregnancy"
     ],
-    "dosage": "",
-    "therapeutic": "traditional visionary plant; not clinically established",
+    "sideeffects": [
+      "strong nausea",
+      "confusion",
+      "pupil dilation"
+    ],
     "safety": "",
-    "sideeffects": "strong nausea, confusion, pupil dilation",
     "toxicity": "Potentially high at ritual doses",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ rare",
       "🌿 andes",
       "🧠 vision"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "desmanthus-illinoensis",
@@ -3960,13 +4683,18 @@
     "common": "",
     "scientific": "Desmanthus illinoensis",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Strong",
     "region": "central and southern united states",
     "legalstatus": "DMT restricted in many countries",
+    "schedule": "",
     "description": "also called illinois bundleflower; its root bark contains notable amounts of dmt.",
     "effects": "visual enhancements;introspection;altered perception",
     "mechanism": "Root bark contains DMT; usually combined with MAOIs to be active orally",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used in underground ayahuasca analogs for spiritual exploration",
     "interactions": [
       "dangerous with maois or serotonergic drugs"
     ],
@@ -3974,20 +4702,23 @@
       "mental health issues",
       "maoi or ssri medication"
     ],
-    "dosage": "",
-    "therapeutic": "used in underground ayahuasca analogs for spiritual exploration",
+    "sideeffects": [
+      "nausea",
+      "anxiety",
+      "powerful visions"
+    ],
     "safety": "",
-    "sideeffects": "nausea, anxiety, powerful visions",
     "toxicity": "Low physiological, high psychological risk",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "american",
       "dmt",
       "root"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "desmodium-adscendens",
@@ -3995,9 +4726,11 @@
     "common": "Desmodium",
     "scientific": "",
     "category": "",
+    "subcategory": "",
     "intensity": "",
     "region": "west africa, south america",
     "legalstatus": "",
+    "schedule": "",
     "description": "",
     "effects": "bronchodilator;liver support;anti-allergic",
     "mechanism": "Smooth muscle relaxation and anti-inflammatory flavonoid activity",
@@ -4005,22 +4738,24 @@
       "Desmodin",
       "Astragalin"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "bronchodilator",
       "folk",
       "detox"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "desmodium-gangeticum",
@@ -4028,39 +4763,45 @@
     "common": "",
     "scientific": "Desmodium gangeticum",
     "category": "ayurvedic / tonic / anti-inflammatory",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "india, nepal, sri lanka",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "an ayurvedic herb used in dashamoola and other classical formulas. known for its rejuvenating, nervine, and anti-inflammatory actions, salparni is often used for vata balancing and in convalescence.",
     "effects": "Nervine support;Anti-inflammatory;Rejuvenation;Mild sedation",
     "mechanism": "Contains alkaloids (gangetin), flavonoids, and isoflavones with CNS modulating and antioxidant properties. Shows immunomodulatory and anti-inflammatory effects.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for asthma, arthritis, fever, low immunity, fatigue, and neurological weakness. common in rasayana therapy.",
     "interactions": [
       "may mildly potentiate immune-modulators or anti-inflammatories."
     ],
     "contraindications": [
       "none known. traditionally safe even in pediatrics."
     ],
-    "dosage": "",
-    "therapeutic": "used for asthma, arthritis, fever, low immunity, fatigue, and neurological weakness. common in rasayana therapy.",
+    "sideeffects": [
+      "rare. mild gi discomfort in high doses."
+    ],
     "safety": "",
-    "sideeffects": "rare. mild gi discomfort in high doses.",
     "toxicity": "Very low.",
     "toxicity_ld50": ">2000 mg/kg (rats, oral extract)",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 rasayana",
       "🧘 nervine",
       "🔥 anti-inflammatory",
       "🪷 vata pacifying"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3470461/",
       "Ayurvedic Pharmacopoeia of India",
       "Journal of Ethnopharmacology",
       "2006"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "desmodium-gangeticum",
@@ -4068,39 +4809,45 @@
     "common": "",
     "scientific": "Desmodium gangeticum",
     "category": "ayurvedic / tonic / anti-inflammatory",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "india, nepal, sri lanka",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "an ayurvedic herb used in dashamoola and other classical formulas. known for its rejuvenating, nervine, and anti-inflammatory actions, salparni is often used for vata balancing and in convalescence.",
     "effects": "Nervine support;Anti-inflammatory;Rejuvenation;Mild sedation",
     "mechanism": "Contains alkaloids (gangetin), flavonoids, and isoflavones with CNS modulating and antioxidant properties. Shows immunomodulatory and anti-inflammatory effects.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for asthma, arthritis, fever, low immunity, fatigue, and neurological weakness. common in rasayana therapy.",
     "interactions": [
       "may mildly potentiate immune-modulators or anti-inflammatories."
     ],
     "contraindications": [
       "none known. traditionally safe even in pediatrics."
     ],
-    "dosage": "",
-    "therapeutic": "used for asthma, arthritis, fever, low immunity, fatigue, and neurological weakness. common in rasayana therapy.",
+    "sideeffects": [
+      "rare. mild gi discomfort in high doses."
+    ],
     "safety": "",
-    "sideeffects": "rare. mild gi discomfort in high doses.",
     "toxicity": "Very low.",
     "toxicity_ld50": ">2000 mg/kg (rats, oral extract)",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 rasayana",
       "🧘 nervine",
       "🔥 anti-inflammatory",
       "🪷 vata pacifying"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3470461/",
       "Ayurvedic Pharmacopoeia of India",
       "Journal of Ethnopharmacology",
       "2006"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "dioscorea-villosa",
@@ -4108,37 +4855,43 @@
     "common": "",
     "scientific": "Dioscorea villosa",
     "category": "hormonal / anti-inflammatory / women's health",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "north america",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "wild yam is a north american root long used to support women's reproductive health, digestion, and inflammation. its active compound, diosgenin, is a steroidal saponin used in pharmaceutical hormone synthesis.",
     "effects": "Hormone balance;Menstrual relief;Anti-inflammatory;Digestive support",
     "mechanism": "Contains diosgenin, which mimics precursors of progesterone. Modulates prostaglandin synthesis and may balance estrogenic effects.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for pms, menopausal symptoms, cramping, gallbladder support, and joint inflammation.",
     "interactions": [
       "may interact with hormone therapy or birth control. no major acute interactions."
     ],
     "contraindications": [
       "caution in hormone-sensitive cancers. not a replacement for prescribed hormone therapy."
     ],
-    "dosage": "",
-    "therapeutic": "used for pms, menopausal symptoms, cramping, gallbladder support, and joint inflammation.",
+    "sideeffects": [
+      "generally well tolerated. rare gi upset or skin sensitivity from creams."
+    ],
     "safety": "",
-    "sideeffects": "generally well tolerated. rare gi upset or skin sensitivity from creams.",
     "toxicity": "Low. Long-term use considered safe.",
     "toxicity_ld50": ">5000 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 women's health",
       "🔥 anti-inflammatory",
       "🌙 hormone support"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4717896/",
       "Botanical Safety Handbook – 2nd Ed.",
       "American Herbal Pharmacopoeia – Wild Yam Monograph"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "duboisia-hopwoodii",
@@ -4146,13 +4899,18 @@
     "common": "",
     "scientific": "Duboisia hopwoodii",
     "category": "stimulant / indigenous / nicotine analog",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "australia (central and northern deserts)",
     "legalstatus": "Legal in Australia (cultural protection); restricted elsewhere due to alkaloid content",
+    "schedule": "",
     "description": "an indigenous australian shrub whose dried leaves are used as a traditional stimulant. pituri contains nicotine and nor-nicotine alkaloids, and is chewed with ash for enhanced absorption.",
     "effects": "Stimulation;Alertness;Appetite suppression;Euphoria (mild)",
     "mechanism": "Alkaloids bind to nicotinic acetylcholine receptors, stimulating the CNS, suppressing hunger, and inducing focus.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditionally used by aboriginal groups for endurance, ritual, and social bonding. not commonly used in modern herbalism.",
     "interactions": [
       "may interact with stimulants",
       "maois",
@@ -4163,25 +4921,29 @@
       "pregnancy",
       "or with other stimulants or nicotine products."
     ],
-    "dosage": "",
-    "therapeutic": "traditionally used by aboriginal groups for endurance, ritual, and social bonding. not commonly used in modern herbalism.",
+    "sideeffects": [
+      "nausea",
+      "dizziness",
+      "hypertension",
+      "or toxicity at high doses. dependence may develop with regular use."
+    ],
     "safety": "",
-    "sideeffects": "nausea, dizziness, hypertension, or toxicity at high doses. dependence may develop with regular use.",
     "toxicity": "Moderate. Nor-nicotine more toxic than nicotine in some strains.",
     "toxicity_ld50": "Nicotine ~50 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "⚡ nicotine",
       "🧠 stimulant",
       "🔥 indigenous use",
       "🌿 pituri"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7104054/",
       "Aboriginal Pharmacopoeia Australia",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "dysphania-ambrosioides",
@@ -4189,9 +4951,11 @@
     "common": "",
     "scientific": "Dysphania ambrosioides",
     "category": "ethnobotanical",
+    "subcategory": "",
     "intensity": "",
     "region": "mexico",
     "legalstatus": "",
+    "schedule": "",
     "description": "also known as epazote, used in mesoamerican rituals. contains cns-stimulating compounds but is toxic at high doses.",
     "effects": "dreamlike;stimulant",
     "mechanism": "CNS excitation at high doses",
@@ -4199,22 +4963,24 @@
       "Ascaridole",
       "p-Cymene"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "ritual",
       "visionary",
       "potentially toxic"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "echinacea-purpurea",
@@ -4222,31 +4988,37 @@
     "common": "",
     "scientific": "Echinacea purpurea",
     "category": "immune / mild stimulant",
+    "subcategory": "",
     "intensity": "",
     "region": "north america",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "purple coneflower commonly used for colds",
     "effects": "immune boost;slight energy",
     "mechanism": "Phenolic compounds like echinacoside modulate immune response",
     "compounds": [],
+    "preparations": [],
+    "dosage": "1-2 g dried",
+    "therapeutic": "immune support",
     "interactions": [
       "immunosuppressants"
     ],
     "contraindications": [
       "autoimmune disorders"
     ],
-    "dosage": "1-2 g dried",
-    "therapeutic": "immune support",
+    "sideeffects": [
+      "rare allergic rash"
+    ],
     "safety": "",
-    "sideeffects": "rare allergic rash",
     "toxicity": "Low",
     "toxicity_ld50": ">2.5 g/kg (rats)",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 root"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "echinopsis-pachanoi",
@@ -4254,15 +5026,20 @@
     "common": "",
     "scientific": "Echinopsis pachanoi",
     "category": "psychedelic cactus",
+    "subcategory": "",
     "intensity": "Strong",
     "region": "andes, cultivated worldwide",
     "legalstatus": "Cactus legal in many areas; mescaline often controlled",
+    "schedule": "",
     "description": "",
     "effects": "visuals;euphoria;spiritual insight",
     "mechanism": "Contains mescaline, a 5‑HT2A agonist phenethylamine",
     "compounds": [
       "Mescaline"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "andean traditional medicine for divination and healing",
     "interactions": [
       "avoid combining with stimulants or maois"
     ],
@@ -4270,25 +5047,28 @@
       "heart issues",
       "mental disorders"
     ],
-    "dosage": "",
-    "therapeutic": "andean traditional medicine for divination and healing",
+    "sideeffects": [
+      "nausea",
+      "increased heart rate",
+      "anxiety"
+    ],
     "safety": "",
-    "sideeffects": "nausea, increased heart rate, anxiety",
     "toxicity": "Low physiological but intense psychological effects",
     "toxicity_ld50": "Not well established",
-    "is_controlled_substance": false,
     "tags": [
       "san pedro",
       "cactus",
       "mescaline"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC10433235/",
       "Plants of the Gods – Rätsch & Hofmann",
       "Shamanic Plant Medicine – San Pedro",
       "2019"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "elaeagnus-angustifolia",
@@ -4296,9 +5076,11 @@
     "common": "Russian Olive",
     "scientific": "",
     "category": "sedative",
+    "subcategory": "",
     "intensity": "",
     "region": "central asia, middle east, europe",
     "legalstatus": "",
+    "schedule": "",
     "description": "",
     "effects": "anxiolytic;sedative;pain-relieving",
     "mechanism": "GABAergic effects and antioxidant pathways",
@@ -4306,22 +5088,24 @@
       "Elaeagnin",
       "Flavonoids"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "sedative",
       "analgesic",
       "folk"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "eleutherococcus-senticosus",
@@ -4329,38 +5113,44 @@
     "common": "",
     "scientific": "Eleutherococcus senticosus",
     "category": "stimulant / adaptogen",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "siberia",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "also called siberian ginseng, popular adaptogen.",
     "effects": "Energy;stress resistance",
     "mechanism": "Eleutherosides modulate stress hormones",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "enhance stamina and immune function",
     "interactions": [
       "may interact with digoxin"
     ],
     "contraindications": [
       "hypertension"
     ],
-    "dosage": "",
-    "therapeutic": "enhance stamina and immune function",
+    "sideeffects": [
+      "insomnia in sensitive individuals"
+    ],
     "safety": "",
-    "sideeffects": "insomnia in sensitive individuals",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "stimulant",
       "✅ safe",
       "🌿 root"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3659614/",
       "Phytomedicine",
       "2010",
       "WHO Monographs on Selected Medicinal Plants"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "elsholtzia-ciliata",
@@ -4368,31 +5158,35 @@
     "common": "Vietnamese Balm",
     "scientific": "",
     "category": "stimulant",
+    "subcategory": "",
     "intensity": "",
     "region": "east and southeast asia",
     "legalstatus": "",
+    "schedule": "",
     "description": "",
     "effects": "uplifting;digestive aid;mental clarity",
     "mechanism": "Stimulates gastrointestinal and olfactory receptors",
     "compounds": [
       "Elsholtzia ketone"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "stimulant",
       "folk",
       "clarity"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "ephedra-sinica",
@@ -4400,13 +5194,18 @@
     "common": "",
     "scientific": "Ephedra sinica",
     "category": "stimulant / decongestant",
+    "subcategory": "",
     "intensity": "Strong",
     "region": "china and central asia",
     "legalstatus": "Regulated in many countries",
+    "schedule": "",
     "description": "shrubby plant known as ma huang; source of ephedrine used both medicinally and recreationally.",
     "effects": "Energy boost;bronchodilation",
     "mechanism": "Ephedrine and pseudoephedrine stimulate adrenergic receptors and release norepinephrine.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditional chinese medicine for asthma, colds, and as a stimulant.",
     "interactions": [
       "dangerous with other stimulants or maois"
     ],
@@ -4415,23 +5214,26 @@
       "hypertension",
       "maois."
     ],
-    "dosage": "",
-    "therapeutic": "traditional chinese medicine for asthma, colds, and as a stimulant.",
+    "sideeffects": [
+      "jitters",
+      "elevated heart rate",
+      "insomnia"
+    ],
     "safety": "",
-    "sideeffects": "jitters, elevated heart rate, insomnia",
     "toxicity": "High doses can raise blood pressure and cause cardiovascular stress.",
     "toxicity_ld50": "Ephedrine LD50 ~50 mg/kg (rats)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ potent",
       "🌿 ma huang"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3896985/",
       "FDA Ephedra Ban Report (2004)",
       "Pharmacopoeia of the People’s Republic of China"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "ephedra-sinica",
@@ -4439,13 +5241,18 @@
     "common": "",
     "scientific": "Ephedra sinica",
     "category": "stimulant / decongestant",
+    "subcategory": "",
     "intensity": "Strong",
     "region": "china and central asia",
     "legalstatus": "Regulated in many countries",
+    "schedule": "",
     "description": "shrubby plant known as ma huang; source of ephedrine used both medicinally and recreationally.",
     "effects": "Energy boost;bronchodilation",
     "mechanism": "Ephedrine and pseudoephedrine stimulate adrenergic receptors and release norepinephrine.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditional chinese medicine for asthma, colds, and as a stimulant.",
     "interactions": [
       "dangerous with other stimulants or maois"
     ],
@@ -4454,23 +5261,26 @@
       "hypertension",
       "maois."
     ],
-    "dosage": "",
-    "therapeutic": "traditional chinese medicine for asthma, colds, and as a stimulant.",
+    "sideeffects": [
+      "jitters",
+      "elevated heart rate",
+      "insomnia"
+    ],
     "safety": "",
-    "sideeffects": "jitters, elevated heart rate, insomnia",
     "toxicity": "High doses can raise blood pressure and cause cardiovascular stress.",
     "toxicity_ld50": "Ephedrine LD50 ~50 mg/kg (rats)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ potent",
       "🌿 ma huang"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3896985/",
       "FDA Ephedra Ban Report (2004)",
       "Pharmacopoeia of the People’s Republic of China"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "erythrina-americana",
@@ -4478,13 +5288,18 @@
     "common": "",
     "scientific": "Erythrina americana",
     "category": "sedative / anxiolytic",
+    "subcategory": "",
     "intensity": "Mild to Moderate",
     "region": "mexico",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "known locally as colorín; its red flowers are brewed into a soothing bedtime drink.",
     "effects": "relaxation;dreaminess;reduced anxiety",
     "mechanism": "Contains erythrinan alkaloids acting as GABAergic depressants",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "mexican folk remedy for insomnia and nervous tension",
     "interactions": [
       "may enhance effects of other sedatives"
     ],
@@ -4492,20 +5307,22 @@
       "pregnancy",
       "combining with cns depressants"
     ],
-    "dosage": "",
-    "therapeutic": "mexican folk remedy for insomnia and nervous tension",
+    "sideeffects": [
+      "drowsiness",
+      "dizziness"
+    ],
     "safety": "",
-    "sideeffects": "drowsiness, dizziness",
     "toxicity": "Low to moderate",
     "toxicity_ld50": "Not well established",
-    "is_controlled_substance": false,
     "tags": [
       "mexico",
       "flower",
       "sleep"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "erythrina-mulungu",
@@ -4513,13 +5330,18 @@
     "common": "",
     "scientific": "Erythrina mulungu",
     "category": "sedative / anxiolytic",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "brazil and neighboring countries",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "flowering tree whose bark is prized in brazilian folk medicine for calming nerves and promoting sleep.",
     "effects": "deep relaxation;anxiety relief;sleepiness",
     "mechanism": "Erythrinan alkaloids interact with GABA receptors causing CNS depression",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "south american remedy for insomnia and stress",
     "interactions": [
       "may potentiate other cns depressants"
     ],
@@ -4527,26 +5349,28 @@
       "pregnancy",
       "combining with strong sedatives"
     ],
-    "dosage": "",
-    "therapeutic": "south american remedy for insomnia and stress",
+    "sideeffects": [
+      "drowsiness",
+      "lowered blood pressure"
+    ],
     "safety": "",
-    "sideeffects": "drowsiness, lowered blood pressure",
     "toxicity": "Relatively safe at moderate doses",
     "toxicity_ld50": "Not well documented",
-    "is_controlled_substance": false,
     "tags": [
       "brazil",
       "root",
       "sleep"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4770635/",
       "Journal of Ethnopharmacology",
       "2007",
       "Rainforest Remedies – Taylor",
       "2003"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "erythroxylum-catuaba",
@@ -4554,31 +5378,37 @@
     "common": "",
     "scientific": "Erythroxylum catuaba",
     "category": "stimulant / aphrodisiac",
+    "subcategory": "",
     "intensity": "",
     "region": "brazil",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "amazonian tonic reputed to enhance vitality",
     "effects": "mild euphoria;libido boost",
     "mechanism": "Alkaloids like catuabine may modulate dopamine",
     "compounds": [],
+    "preparations": [],
+    "dosage": "1-2 g bark",
+    "therapeutic": "aphrodisiac, tonic",
     "interactions": [
       "stimulants"
     ],
     "contraindications": [
       "insomnia"
     ],
-    "dosage": "1-2 g bark",
-    "therapeutic": "aphrodisiac, tonic",
+    "sideeffects": [
+      "restlessness"
+    ],
     "safety": "",
-    "sideeffects": "restlessness",
     "toxicity": "Low",
     "toxicity_ld50": "Not well documented",
-    "is_controlled_substance": false,
     "tags": [
       "🌳 bark"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "erythroxylum-coca",
@@ -4586,13 +5416,18 @@
     "common": "",
     "scientific": "Erythroxylum coca",
     "category": "stimulant",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "andean south america",
     "legalstatus": "Cultivation regulated; cocaine controlled",
+    "schedule": "",
     "description": "",
     "effects": "alertness;reduced fatigue;mild euphoria",
     "mechanism": "Leaves contain cocaine acting as a dopamine and norepinephrine reuptake inhibitor",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "altitude sickness relief, energy boost, appetite suppression",
     "interactions": [
       "dangerous with maois or stimulants"
     ],
@@ -4601,20 +5436,23 @@
       "pregnancy",
       "hypertension"
     ],
-    "dosage": "",
-    "therapeutic": "altitude sickness relief, energy boost, appetite suppression",
+    "sideeffects": [
+      "increased heart rate",
+      "insomnia",
+      "potential dependence"
+    ],
     "safety": "",
-    "sideeffects": "increased heart rate, insomnia, potential dependence",
     "toxicity": "Low in leaf form; purified alkaloid is addictive",
     "toxicity_ld50": "~95 mg/kg (rat, cocaine)",
-    "is_controlled_substance": false,
     "tags": [
       "andes",
       "alkaloid",
       "coca leaf"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "eschscholzia-californica",
@@ -4622,38 +5460,44 @@
     "common": "",
     "scientific": "Eschscholzia californica",
     "category": "dissociative / sedative",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "north america",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "california poppy with gentle relaxing properties.",
     "effects": "Sedation;mild euphoria",
     "mechanism": "Protopine alkaloids interact with GABA receptors",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "anxiety and sleep support",
     "interactions": [
       "potentiates cns depressants"
     ],
     "contraindications": [
       "use caution with other sedatives"
     ],
-    "dosage": "",
-    "therapeutic": "anxiety and sleep support",
+    "sideeffects": [
+      "drowsiness"
+    ],
     "safety": "",
-    "sideeffects": "drowsiness",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌿 flower",
       "💤 sedation"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3358986/",
       "American Herbal Pharmacopoeia – Eschscholzia",
       "Journal of Natural Medicines",
       "2011"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "espeletia-grandiflora",
@@ -4661,13 +5505,18 @@
     "common": "",
     "scientific": "Espeletia grandiflora",
     "category": "respiratory / folk medicine / andean",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "colombia, ecuador, andean cloud forests",
     "legalstatus": "Legal (not widely commercialized)",
+    "schedule": "",
     "description": "a fuzzy-leaved plant from the páramo cloud forests of the andes. used in colombian and ecuadorian folk medicine for respiratory and throat ailments. its woolly foliage helps conserve water and reduce inflammation when brewed.",
     "effects": "Cough relief;Lung support;Anti-inflammatory;Moisture retention",
     "mechanism": "Contains sesquiterpenes and flavonoids with anti-inflammatory and soothing properties. Traditionally believed to aid mucosal healing.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used in herbal teas for bronchitis, sore throat, dry cough, and cold weather ailments. also respected as a spiritual guardian plant by andean communities.",
     "interactions": [
       "none documented",
       "likely safe with most respiratory herbs."
@@ -4675,26 +5524,27 @@
     "contraindications": [
       "avoid during pregnancy due to unknown effects. no known toxicities in folk doses."
     ],
-    "dosage": "",
-    "therapeutic": "used in herbal teas for bronchitis, sore throat, dry cough, and cold weather ailments. also respected as a spiritual guardian plant by andean communities.",
+    "sideeffects": [
+      "mild gi discomfort if taken in excess. limited formal studies."
+    ],
     "safety": "",
-    "sideeffects": "mild gi discomfort if taken in excess. limited formal studies.",
     "toxicity": "Very low. Long traditional use in small communities.",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🌫️ andean",
       "💨 lung tonic",
       "🍵 folk remedy",
       "❄️ cold medicine"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9872784/",
       "Páramo Herbalism Studies – Colombia National University",
       "Ethnobotany of the Andes",
       "2019"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "eurycoma-longifolia",
@@ -4702,13 +5552,18 @@
     "common": "",
     "scientific": "Eurycoma longifolia",
     "category": "aphrodisiac / adaptogen / hormonal",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "malaysia, indonesia, thailand",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a southeast asian root revered for enhancing libido, strength, and masculinity. traditionally used by men to improve vitality and hormonal health. now globally marketed as a natural testosterone booster.",
     "effects": "Testosterone boost;Energy;Stress resilience;Libido enhancement",
     "mechanism": "Contains quassinoids like eurycomanone that may increase free testosterone, reduce cortisol, and stimulate dopaminergic and androgenic pathways.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for erectile dysfunction, fatigue, depression, infertility, and athletic performance. studied for stress-induced cortisol reduction.",
     "interactions": [
       "may interact with hormone therapies",
       "ssris",
@@ -4717,26 +5572,29 @@
     "contraindications": [
       "avoid in hormone-sensitive conditions or with steroids. not for pregnant individuals."
     ],
-    "dosage": "",
-    "therapeutic": "used for erectile dysfunction, fatigue, depression, infertility, and athletic performance. studied for stress-induced cortisol reduction.",
+    "sideeffects": [
+      "mild restlessness",
+      "insomnia",
+      "or irritability in high doses. not typically sedating."
+    ],
     "safety": "",
-    "sideeffects": "mild restlessness, insomnia, or irritability in high doses. not typically sedating.",
     "toxicity": "Low in normal doses. High doses can overstimulate.",
     "toxicity_ld50": ">3000 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🔥 aphrodisiac",
       "🏋️ testosterone",
       "🌿 adaptogen",
       "🧬 hormonal"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3654340/",
       "Journal of the International Society of Sports Nutrition",
       "2013",
       "Malaysian Herbal Monographs"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "ficus-religiosa",
@@ -4744,9 +5602,11 @@
     "common": "Sacred Fig",
     "scientific": "",
     "category": "sedative",
+    "subcategory": "",
     "intensity": "",
     "region": "india, southeast asia",
     "legalstatus": "",
+    "schedule": "",
     "description": "",
     "effects": "calming;mood-balancing;mild sedative",
     "mechanism": "Neuroprotective antioxidant and serotonin modulation",
@@ -4754,22 +5614,24 @@
       "Furanocoumarins",
       "Tannins"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "spiritual",
       "sedative",
       "folk"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "gloriosa-superba",
@@ -4777,31 +5639,38 @@
     "common": "",
     "scientific": "Gloriosa superba",
     "category": "other",
+    "subcategory": "",
     "intensity": "",
     "region": "africa, asia",
     "legalstatus": "Ornamental; toxic",
+    "schedule": "",
     "description": "highly poisonous ornamental sometimes misused.",
     "effects": "intense nausea;weak delirium",
     "mechanism": "Contains colchicine disrupting microtubules",
     "compounds": [],
+    "preparations": [],
+    "dosage": "<5 seeds",
+    "therapeutic": "traditional poison and medicine",
     "interactions": [
       "none documented"
     ],
     "contraindications": [
       "any internal use"
     ],
-    "dosage": "<5 seeds",
-    "therapeutic": "traditional poison and medicine",
+    "sideeffects": [
+      "severe vomiting",
+      "organ failure"
+    ],
     "safety": "",
-    "sideeffects": "severe vomiting, organ failure",
     "toxicity": "Very high",
     "toxicity_ld50": "20 mg/kg (mice)",
-    "is_controlled_substance": false,
     "tags": [
       "☠️ toxic"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "foxglove",
@@ -4809,13 +5678,18 @@
     "common": "",
     "scientific": "Digitalis purpurea",
     "category": "other",
+    "subcategory": "",
     "intensity": "",
     "region": "europe",
     "legalstatus": "Regulated as medicinal",
+    "schedule": "",
     "description": "source of cardiac glycosides used for heart failure; overdose is fatal.",
     "effects": "cardiac stimulation",
     "mechanism": "Cardiac glycosides inhibit Na⁺/K⁺-ATPase",
     "compounds": [],
+    "preparations": [],
+    "dosage": "0.1 g dried leaf equivalent",
+    "therapeutic": "heart failure medication",
     "interactions": [
       "diuretics",
       "calcium channel blockers"
@@ -4823,19 +5697,21 @@
     "contraindications": [
       "existing heart disease without supervision"
     ],
-    "dosage": "0.1 g dried leaf equivalent",
-    "therapeutic": "heart failure medication",
+    "sideeffects": [
+      "arrhythmia",
+      "vision changes"
+    ],
     "safety": "",
-    "sideeffects": "arrhythmia, vision changes",
     "toxicity": "Very high",
     "toxicity_ld50": "3 mg/kg (digitoxin, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "☠️ toxic",
       "💊 oral"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "galbulimima-belgraveana",
@@ -4843,9 +5719,11 @@
     "common": "Galbulimima",
     "scientific": "Galbulimima belgraveana",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Moderate to Strong",
     "region": "papua new guinea and northern australia",
     "legalstatus": "Little formal regulation",
+    "schedule": "",
     "description": "rare rainforest tree providing psychoactive bark traditionally used in new guinea for visionary experiences.",
     "effects": "dreamlike visions;dizziness;altered consciousness",
     "mechanism": "Contains himbacine-type alkaloids with muscarinic antagonist activity",
@@ -4853,6 +5731,9 @@
       "Himbacine",
       "Galbulimimine"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used by papuan tribes for shamanic rituals and hunting magic",
     "interactions": [
       "avoid combining with other anticholinergics"
     ],
@@ -4860,20 +5741,23 @@
       "unknown",
       "caution due to potent effects"
     ],
-    "dosage": "",
-    "therapeutic": "used by papuan tribes for shamanic rituals and hunting magic",
+    "sideeffects": [
+      "nausea",
+      "vertigo",
+      "intense dreams"
+    ],
     "safety": "",
-    "sideeffects": "nausea, vertigo, intense dreams",
     "toxicity": "Reports of toxicity at high doses; data limited",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "papua new guinea",
       "hallucinogen",
       "tree"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "galphimia-glauca",
@@ -4881,40 +5765,46 @@
     "common": "",
     "scientific": "Galphimia glauca",
     "category": "anxiolytic / sedative / mexican traditional",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "mexico, central america",
     "legalstatus": "Legal (limited international awareness)",
+    "schedule": "",
     "description": "a mexican herb used to treat anxiety, phobias, and restlessness. clinical studies in mexico show it to be comparable to benzodiazepines in reducing anxiety — but without sedation or dependency.",
     "effects": "Anxiety relief;Tranquility;Sleep aid;Reduced reactivity",
     "mechanism": "Contains galphimine B, a nor-seco-triterpenoid that modulates GABAergic and dopaminergic systems, particularly by blocking dopaminergic overactivation in limbic areas.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for anxiety, panic attacks, emotional hyper-reactivity, and stress-related insomnia. studied in treatment of specific phobias and social anxiety.",
     "interactions": [
       "mild additive effects with sedatives or alcohol."
     ],
     "contraindications": [
       "avoid combining with benzodiazepines or strong cns depressants. insufficient data in pregnancy."
     ],
-    "dosage": "",
-    "therapeutic": "used for anxiety, panic attacks, emotional hyper-reactivity, and stress-related insomnia. studied in treatment of specific phobias and social anxiety.",
+    "sideeffects": [
+      "very few. rare reports of mild dizziness or gi upset. no withdrawal or dependence noted."
+    ],
     "safety": "",
-    "sideeffects": "very few. rare reports of mild dizziness or gi upset. no withdrawal or dependence noted.",
     "toxicity": "Low. No observed toxicity at clinical doses.",
     "toxicity_ld50": ">5000 mg/kg (rats, oral extract)",
-    "is_controlled_substance": false,
     "tags": [
       "🌼 anti-anxiety",
       "🧘 calm",
       "🌿 mexican folk medicine",
       "💤 sleep aid"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7614475/",
       "Revista Mexicana de Neurociencia",
       "2014",
       "Phytomedicine",
       "2012"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "gastrodia-elata",
@@ -4922,39 +5812,45 @@
     "common": "",
     "scientific": "Gastrodia elata",
     "category": "neuroprotective / anticonvulsant / traditional chinese",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "china, korea, taiwan, japan",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a prized root in traditional chinese medicine used to calm internal wind and treat dizziness, seizures, and nervous system disorders. it grows symbiotically with fungi in shaded forest floors.",
     "effects": "Calms the liver;Relieves tremors;Supports cognition;Anti-epileptic",
     "mechanism": "Contains gastrodin and vanillin derivatives that modulate GABA activity, reduce neuroinflammation, and support mitochondrial health. Protective against seizures and neurodegeneration.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for epilepsy, tremors, dizziness, stroke recovery, and tension headaches. also supports memory and is studied for alzheimer's and parkinson’s models.",
     "interactions": [
       "may potentiate antiepileptics or anxiolytics. monitor if used with neuroactive prescriptions."
     ],
     "contraindications": [
       "none significant. caution with cns depressants or seizure meds."
     ],
-    "dosage": "",
-    "therapeutic": "used for epilepsy, tremors, dizziness, stroke recovery, and tension headaches. also supports memory and is studied for alzheimer's and parkinson’s models.",
+    "sideeffects": [
+      "rare. occasionally mild sedation or dry mouth."
+    ],
     "safety": "",
-    "sideeffects": "rare. occasionally mild sedation or dry mouth.",
     "toxicity": "Low. Used safely in TCM for centuries.",
     "toxicity_ld50": ">5000 mg/kg (rats, oral extract)",
-    "is_controlled_substance": false,
     "tags": [
       "🧠 neuroprotective",
       "🌿 tcm",
       "💫 tremor relief",
       "⚡ anticonvulsant"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6856235/",
       "Phytomedicine",
       "2015",
       "Chinese Pharmacopoeia – Tian Ma Entry"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "gelsemium-sempervirens",
@@ -4962,13 +5858,18 @@
     "common": "",
     "scientific": "Gelsemium sempervirens",
     "category": "toxic / nervine / homeopathic",
+    "subcategory": "",
     "intensity": "Strong (toxic)",
     "region": "southeastern u.s., mexico",
     "legalstatus": "Legal but restricted in some areas",
+    "schedule": "",
     "description": "a beautiful yet highly poisonous vine native to the southeastern u.s. used in extremely low doses for anxiety, migraines, and spasms — but lethal in excess. homeopathy and some experimental medicine have explored it for nervous tension.",
     "effects": "Muscle relaxation;Nervous system inhibition;Pain relief;Delirium (toxic doses)",
     "mechanism": "Contains gelsemine and gelseminine, which act as glycine receptor agonists and inhibit spinal reflexes. High doses paralyze the respiratory center.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "historically used for neuralgia, migraines, fevers, and anxiety — but now mostly used homeopathically. still researched for neuropathic pain.",
     "interactions": [
       "fatal when mixed with depressants",
       "alcohol",
@@ -4978,26 +5879,31 @@
     "contraindications": [
       "do not self-administer. avoid entirely unless under trained guidance. toxic to children and animals."
     ],
-    "dosage": "",
-    "therapeutic": "historically used for neuralgia, migraines, fevers, and anxiety — but now mostly used homeopathically. still researched for neuropathic pain.",
+    "sideeffects": [
+      "dizziness",
+      "blurred vision",
+      "slurred speech",
+      "muscle weakness",
+      "respiratory depression. fatal in high doses."
+    ],
     "safety": "",
-    "sideeffects": "dizziness, blurred vision, slurred speech, muscle weakness, respiratory depression. fatal in high doses.",
     "toxicity": "Extremely high. One drop of extract may be fatal.",
     "toxicity_ld50": "Gelsemine ~10 mg/kg (mice, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ toxic",
       "🌼 southern herbalism",
       "🧠 nervine",
       "💀 respiratory depressant"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6288960/",
       "Toxic Plants of North America – 2nd Ed.",
       "American Journal of Therapeutics",
       "2012"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "genipa-americana",
@@ -5005,40 +5911,46 @@
     "common": "",
     "scientific": "Genipa americana",
     "category": "traditional / ritual / antimicrobial",
+    "subcategory": "",
     "intensity": "Mild (topical); moderate (oral folk prep)",
     "region": "amazon basin, central & south america",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "an amazonian fruit tree whose juice oxidizes into a black-blue dye. used for temporary body art, sun protection, insect repellent, and ritual purification. sometimes used in decoctions for fever or wounds.",
     "effects": "Skin staining;Mild antibacterial;Cooling sensation;Symbolic use",
     "mechanism": "Genipin (active compound) crosslinks with amino acids in skin keratin, forming a black pigment. Also displays mild antimicrobial and antioxidant properties.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "topical use for decoration, bug repellent, minor skin infection; internal folk uses for respiratory infections and inflammation.",
     "interactions": [
       "none known."
     ],
     "contraindications": [
       "not for use on open wounds or in pregnancy (internal use)."
     ],
-    "dosage": "",
-    "therapeutic": "topical use for decoration, bug repellent, minor skin infection; internal folk uses for respiratory infections and inflammation.",
+    "sideeffects": [
+      "none when used externally. large internal doses may cause gi upset or hypotension."
+    ],
     "safety": "",
-    "sideeffects": "none when used externally. large internal doses may cause gi upset or hypotension.",
     "toxicity": "Low topically. Caution with internal use due to limited data.",
     "toxicity_ld50": "Genipin LD50 >5000 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🌌 body paint",
       "🦟 insect repellent",
       "🌿 traditional",
       "🖤 jagua tattoo"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1127453/",
       "Journal of Ethnopharmacology",
       "2004",
       "Amazonian Plant Medicine – Taylor",
       "2002"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "arundo-donax",
@@ -5046,31 +5958,37 @@
     "common": "",
     "scientific": "Arundo donax",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "",
     "region": "mediterranean, americas",
     "legalstatus": "Invasive species control",
+    "schedule": "",
     "description": "invasive reed rumored to contain tryptamines.",
     "effects": "mild visions",
     "mechanism": "Root bark may contain DMT and bufotenine",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "experimental entheogen",
     "interactions": [
       "maois"
     ],
     "contraindications": [
       "limited data"
     ],
-    "dosage": "",
-    "therapeutic": "experimental entheogen",
+    "sideeffects": [
+      "nausea"
+    ],
     "safety": "",
-    "sideeffects": "nausea",
     "toxicity": "",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 root bark"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "zingiber-officinale",
@@ -5078,13 +5996,18 @@
     "common": "",
     "scientific": "Zingiber officinale",
     "category": "digestive / anti-inflammatory / stimulant",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "tropical asia, cultivated globally",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a pungent rhizome widely used for its warming, carminative, and anti-inflammatory effects. revered in ayurvedic and traditional chinese medicine for treating nausea, coldness, and sluggish digestion.",
     "effects": "Digestive support;Anti-nausea;Circulation boost;Mild stimulation",
     "mechanism": "Contains gingerols and shogaols that modulate prostaglandins, TRP ion channels, and serotonin receptors involved in nausea.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for nausea, morning sickness, motion sickness, colds, pain, and poor circulation. also a culinary spice and tea staple.",
     "interactions": [
       "may interact with blood thinners or diabetes meds. synergistic with anti-nausea agents."
     ],
@@ -5093,25 +6016,27 @@
       "gallstones",
       "or gastritis in high doses."
     ],
-    "dosage": "",
-    "therapeutic": "used for nausea, morning sickness, motion sickness, colds, pain, and poor circulation. also a culinary spice and tea staple.",
+    "sideeffects": [
+      "heartburn",
+      "stomach upset in large doses. rare allergic reactions."
+    ],
     "safety": "",
-    "sideeffects": "heartburn, stomach upset in large doses. rare allergic reactions.",
     "toxicity": "Very low",
     "toxicity_ld50": ">5000 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🌶️ warming",
       "🫖 anti-nausea",
       "🫁 circulation",
       "🌿 culinary"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3665023/",
       "Herbal Medicine – Mills & Bone",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "ginkgo-biloba",
@@ -5119,13 +6044,18 @@
     "common": "",
     "scientific": "Ginkgo biloba",
     "category": "nootropic / circulatory",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "china, cultivated worldwide",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "",
     "effects": "improved cognition;circulation boost;alertness",
     "mechanism": "Flavone glycosides and terpenoids enhance blood flow and modulate neurotransmission",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for memory loss, dementia, and circulatory issues",
     "interactions": [
       "potentiates blood thinners like warfarin"
     ],
@@ -5133,25 +6063,28 @@
       "bleeding disorders",
       "anticoagulant use"
     ],
-    "dosage": "",
-    "therapeutic": "used for memory loss, dementia, and circulatory issues",
+    "sideeffects": [
+      "headache",
+      "upset stomach",
+      "possible bleeding risk"
+    ],
     "safety": "",
-    "sideeffects": "headache, upset stomach, possible bleeding risk",
     "toxicity": "Low",
     "toxicity_ld50": ">5 g/kg in animals",
-    "is_controlled_substance": false,
     "tags": [
       "ancient",
       "blood flow",
       "memory"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6567113/",
       "Journal of Clinical Psychopharmacology",
       "2001",
       "ESCOP Monograph – Ginkgo"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "gliricidia-sepium",
@@ -5159,39 +6092,45 @@
     "common": "",
     "scientific": "Gliricidia sepium",
     "category": "antiparasitic / agricultural / ethnovet",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "central america, philippines, tropical zones",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "a fast-growing tropical tree used in traditional medicine and animal care. known for treating scabies, wounds, and skin infections. leaves contain natural insecticidal compounds.",
     "effects": "Topical antiparasitic;Wound healing;Insect repellent;Mild analgesic",
     "mechanism": "Rich in tannins and coumarins with insecticidal, antibacterial, and anti-inflammatory effects. Used externally to kill lice, fleas, and skin pathogens.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for skin diseases, minor wounds, and pest repellent in animals and humans. also used as a green manure and fencing material.",
     "interactions": [
       "none known topically."
     ],
     "contraindications": [
       "avoid ingestion unless properly prepared. not for internal use in humans."
     ],
-    "dosage": "",
-    "therapeutic": "used for skin diseases, minor wounds, and pest repellent in animals and humans. also used as a green manure and fencing material.",
+    "sideeffects": [
+      "topical irritation in sensitive skin. toxic to livestock if ingested raw in large quantities."
+    ],
     "safety": "",
-    "sideeffects": "topical irritation in sensitive skin. toxic to livestock if ingested raw in large quantities.",
     "toxicity": "Moderate (internal); safe topically in folk doses.",
     "toxicity_ld50": "Not well established",
-    "is_controlled_substance": false,
     "tags": [
       "🦠 antiparasitic",
       "🌿 ethnoveterinary",
       "🌾 agroforestry",
       "🐾 skin health"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8323025/",
       "Philippine Herbal Medicine Compendium",
       "Agroforestry & Ethnomedicine Reports",
       "2018"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "paullinia-cupana",
@@ -5199,13 +6138,18 @@
     "common": "",
     "scientific": "Paullinia cupana",
     "category": "stimulant / nootropic",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "amazon basin",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "climbing plant native to brazil; its seeds provide a potent caffeine kick and are popular in energy drinks.",
     "effects": "Energy;mental focus",
     "mechanism": "Seeds contain high caffeine content that blocks adenosine receptors.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "fatigue reduction, weight loss aid, traditional tonic.",
     "interactions": [
       "potentiates other stimulants",
       "may interfere with sedatives"
@@ -5215,19 +6159,21 @@
       "pregnancy",
       "sensitivity to caffeine."
     ],
-    "dosage": "",
-    "therapeutic": "fatigue reduction, weight loss aid, traditional tonic.",
+    "sideeffects": [
+      "jitteriness",
+      "stomach upset"
+    ],
     "safety": "",
-    "sideeffects": "jitteriness, stomach upset",
     "toxicity": "Overuse leads to restlessness, insomnia, or tachycardia.",
     "toxicity_ld50": "Caffeine LD50 ~190 mg/kg (rats)",
-    "is_controlled_substance": false,
     "tags": [
       "☕ high caffeine",
       "🍫 seed"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "guayusa",
@@ -5235,13 +6181,18 @@
     "common": "",
     "scientific": "Ilex guayusa",
     "category": "empathogen / euphoriant",
+    "subcategory": "",
     "intensity": "Mild to moderate",
     "region": "ecuador, peru, amazon",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "a caffeinated amazonian holly used in dream rituals and for morning alertness. known for smooth energy and calming clarity.",
     "effects": "Stimulation;mental clarity;lucid dreaming",
     "mechanism": "Caffeine and theobromine – adenosine antagonists",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "energy, focus, lucid dreaming support",
     "interactions": [
       "stimulants",
       "caffeine"
@@ -5251,20 +6202,22 @@
       "heart conditions",
       "anxiety"
     ],
-    "dosage": "",
-    "therapeutic": "energy, focus, lucid dreaming support",
+    "sideeffects": [
+      "restlessness",
+      "jitteriness in sensitive individuals"
+    ],
     "safety": "",
-    "sideeffects": "restlessness, jitteriness in sensitive individuals",
     "toxicity": "Low",
     "toxicity_ld50": "~190 mg/kg (caffeine)",
-    "is_controlled_substance": false,
     "tags": [
       "stimulant",
       "✅ safe",
       "🌿 herbal"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "ilex-guayusa",
@@ -5272,13 +6225,18 @@
     "common": "",
     "scientific": "Ilex guayusa",
     "category": "stimulant / amazonian / adaptogen",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "amazon (ecuador, peru, colombia)",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a caffeinated amazonian holly tree leaf used for lucid dreaming, focus, and ritual wakefulness. known as the 'dreaming tea' by the kichwa people. smoother than yerba mate and less jittery than coffee.",
     "effects": "Smooth stimulation;Vivid dreams;Antioxidant;Focus;Energy",
     "mechanism": "Contains caffeine, theobromine, and L-theanine. Stimulates CNS while providing a relaxing balance via L-theanine’s GABAergic modulation.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for morning energy, digestion, lucid dream preparation, and antioxidant support. traditionally used before hunting or dreaming ceremonies.",
     "interactions": [
       "mild interactions with stimulants or sedatives. may mask fatigue."
     ],
@@ -5287,26 +6245,27 @@
       "during pregnancy",
       "or with cardiac arrhythmia."
     ],
-    "dosage": "",
-    "therapeutic": "used for morning energy, digestion, lucid dream preparation, and antioxidant support. traditionally used before hunting or dreaming ceremonies.",
+    "sideeffects": [
+      "mild insomnia or jitters at high doses. gentler than most stimulants."
+    ],
     "safety": "",
-    "sideeffects": "mild insomnia or jitters at high doses. gentler than most stimulants.",
     "toxicity": "Low. Comparable to green tea.",
     "toxicity_ld50": "Caffeine LD50 ~192 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 dream tea",
       "⚡ stimulant",
       "🧘 smooth focus",
       "☕ l-theanine"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3682131/",
       "Journal of Ethnopharmacology",
       "2011",
       "Amazonian Shamanic Tea Practices – 2020"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "gymnema-sylvestre",
@@ -5314,38 +6273,44 @@
     "common": "",
     "scientific": "Gymnema sylvestre",
     "category": "metabolic / nootropic",
+    "subcategory": "",
     "intensity": "",
     "region": "india",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "ayurvedic herb that dulls sugar perception",
     "effects": "reduced sweet taste;focus",
     "mechanism": "Gymnemic acids block sweet receptors and modulate glucose absorption",
     "compounds": [
       "Gymnemic Acids"
     ],
+    "preparations": [],
+    "dosage": "0.5-1 g leaf",
+    "therapeutic": "diabetes support, appetite",
     "interactions": [
       "antidiabetic drugs"
     ],
     "contraindications": [
       "hypoglycemia"
     ],
-    "dosage": "0.5-1 g leaf",
-    "therapeutic": "diabetes support, appetite",
+    "sideeffects": [
+      "temporary loss of sweet taste"
+    ],
     "safety": "",
-    "sideeffects": "temporary loss of sweet taste",
     "toxicity": "Low",
     "toxicity_ld50": ">3 g/kg (rats)",
-    "is_controlled_substance": false,
     "tags": [
       "🍃 leaf"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2170951/",
       "Journal of Clinical Biochemistry",
       "2011",
       "Ayurvedic Pharmacopoeia of India"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "gynostemma-pentaphyllum",
@@ -5353,32 +6318,38 @@
     "common": "",
     "scientific": "Gynostemma pentaphyllum",
     "category": "other",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "china",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "called jiaogulan, reputed longevity herb.",
     "effects": "Adaptogenic;anti-inflammatory",
     "mechanism": "Gypenosides modulate nitric oxide and cortisol",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "stress resilience, metabolic support",
     "interactions": [
       "may enhance anticoagulants"
     ],
     "contraindications": [
       "none known"
     ],
-    "dosage": "",
-    "therapeutic": "stress resilience, metabolic support",
+    "sideeffects": [
+      "rare digestive upset"
+    ],
     "safety": "",
-    "sideeffects": "rare digestive upset",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌿 leaf"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "argyreia-nervosa",
@@ -5386,13 +6357,18 @@
     "common": "",
     "scientific": "Argyreia nervosa",
     "category": "psychedelic / lsa",
+    "subcategory": "",
     "intensity": "Strong",
     "region": "india, tropical regions",
     "legalstatus": "Seeds legal in many places; extraction may be controlled",
+    "schedule": "",
     "description": "climber with heart-shaped leaves; its seeds contain lsa and are used as a legal alternative to lsd experiences.",
     "effects": "Visual distortions;euphoria;introspection",
     "mechanism": "Seeds contain ergoline alkaloids (LSA) that act on serotonin receptors similarly to LSD but with milder potency.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "occasional spiritual or introspective use; historically as ornamental and traditional medicine.",
     "interactions": [
       "avoid with vasoconstrictors or other psychedelics"
     ],
@@ -5401,19 +6377,22 @@
       "liver issues",
       "maois."
     ],
-    "dosage": "",
-    "therapeutic": "occasional spiritual or introspective use; historically as ornamental and traditional medicine.",
+    "sideeffects": [
+      "nausea",
+      "vasoconstriction",
+      "sedation"
+    ],
     "safety": "",
-    "sideeffects": "nausea, vasoconstriction, sedation",
     "toxicity": "Seeds can cause severe nausea and vasoconstriction at high doses.",
     "toxicity_ld50": "Not well established for humans; animal data scarce",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ nausea",
       "🌱 seeds"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "heimia-myrtifolia",
@@ -5421,32 +6400,38 @@
     "common": "",
     "scientific": "Heimia myrtifolia",
     "category": "dissociative / sedative",
+    "subcategory": "",
     "intensity": "",
     "region": "mexico",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "relative of sinicuichi used similarly for mild trance",
     "effects": "auditory shift;relaxation",
     "mechanism": "Alkaloids like vertine may alter neurotransmission",
     "compounds": [],
+    "preparations": [],
+    "dosage": "1-2 g leaves",
+    "therapeutic": "folk auditory enhancement",
     "interactions": [
       "caution with cns depressants"
     ],
     "contraindications": [
       "pregnancy"
     ],
-    "dosage": "1-2 g leaves",
-    "therapeutic": "folk auditory enhancement",
+    "sideeffects": [
+      "dry mouth"
+    ],
     "safety": "",
-    "sideeffects": "dry mouth",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🌀 altered sound",
       "🌿 leaf"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "heimia-salicifolia",
@@ -5454,9 +6439,11 @@
     "common": "Sinicuichi",
     "scientific": "Heimia salicifolia",
     "category": "oneirogen / traditional / mildly psychoactive",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "mexico, central america",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a yellow-flowering shrub used by indigenous mexican peoples for vision quests and dream work. traditionally prepared via solar fermentation, sinicuichi is known for inducing auditory changes and memory recall.",
     "effects": "Dream enhancement;Auditory distortion;Relaxation;Trance-like state",
     "mechanism": "Contains cryogenine and lythrine, which may modulate acetylcholine and GABA receptors, inducing mild CNS depression and altered perception.",
@@ -5464,6 +6451,9 @@
       "Cryogenine",
       "Lyfoline"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used in folk medicine for muscle pain, fevers, and spiritual visions. anecdotally used for lucid dreaming and relaxation.",
     "interactions": [
       "may amplify effects of cns depressants."
     ],
@@ -5472,26 +6462,29 @@
       "during driving",
       "or pregnancy. limited modern research."
     ],
-    "dosage": "",
-    "therapeutic": "used in folk medicine for muscle pain, fevers, and spiritual visions. anecdotally used for lucid dreaming and relaxation.",
+    "sideeffects": [
+      "dry mouth",
+      "heavy limbs",
+      "auditory distortions. rare reports of ‘golden vision’ or slow-motion perception."
+    ],
     "safety": "",
-    "sideeffects": "dry mouth, heavy limbs, auditory distortions. rare reports of ‘golden vision’ or slow-motion perception.",
     "toxicity": "Low in traditional doses; some anecdotal toxicity in concentrated extracts.",
     "toxicity_ld50": "Not well established",
-    "is_controlled_substance": false,
     "tags": [
       "🌙 dream herb",
       "🧠 memory",
       "🔊 auditory shifts",
       "🌿 nahuatl medicine"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3654015/",
       "Journal of Ethnopharmacology",
       "1992",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "helichrysum-odoratissimum",
@@ -5499,9 +6492,11 @@
     "common": "",
     "scientific": "Helichrysum odoratissimum",
     "category": "calming / ritual",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "southern africa",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "",
     "effects": "relaxation;mild euphoria;dream enhancement",
     "mechanism": "Aromatic compounds interact with GABA and serotonin systems",
@@ -5509,24 +6504,28 @@
       "Essential oils",
       "Flavonoids"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used by south african healers for cleansing and ancestor communication",
     "interactions": [],
     "contraindications": [
       "asthma or respiratory issues when smoked"
     ],
-    "dosage": "",
-    "therapeutic": "used by south african healers for cleansing and ancestor communication",
+    "sideeffects": [
+      "mild headache from smoke inhalation"
+    ],
     "safety": "",
-    "sideeffects": "mild headache from smoke inhalation",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "south africa",
       "imphepho",
       "smoke"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "hericium-erinaceus",
@@ -5534,39 +6533,45 @@
     "common": "",
     "scientific": "Hericium erinaceus",
     "category": "nootropic / mushroom / neuroregenerative",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "china, japan, north america (temperate forests)",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a shaggy white mushroom revered for its ability to stimulate ngf (nerve growth factor) and support brain regeneration. used in both traditional chinese medicine and modern nootropic stacks.",
     "effects": "Nerve growth;Memory enhancement;Mood support;Cognitive clarity",
     "mechanism": "Contains hericenones and erinacines that cross the blood-brain barrier and promote neurogenesis by upregulating NGF. Also modulates inflammation and gut-brain axis.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for mild cognitive impairment, memory loss, anxiety, depression, and neurodegenerative conditions (alzheimer's, parkinson’s).",
     "interactions": [
       "may enhance neuroplasticity synergistically with other nootropics or antidepressants."
     ],
     "contraindications": [
       "none major. caution in mushroom allergies."
     ],
-    "dosage": "",
-    "therapeutic": "used for mild cognitive impairment, memory loss, anxiety, depression, and neurodegenerative conditions (alzheimer's, parkinson’s).",
+    "sideeffects": [
+      "very rare. may cause mild digestive upset or skin itching in sensitive individuals."
+    ],
     "safety": "",
-    "sideeffects": "very rare. may cause mild digestive upset or skin itching in sensitive individuals.",
     "toxicity": "Very low. Widely used as food and supplement.",
     "toxicity_ld50": ">5000 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🧠 brain growth",
       "🍄 mushroom",
       "🌿 nerve repair",
       "🧬 ngf booster"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5987239/",
       "International Journal of Molecular Sciences",
       "2017",
       "Chinese Herbal Materia Medica"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "hibiscus-sabdariffa",
@@ -5574,38 +6579,44 @@
     "common": "",
     "scientific": "Hibiscus sabdariffa",
     "category": "relaxant / beverage",
+    "subcategory": "",
     "intensity": "",
     "region": "tropics",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "roselle flowers used for tart refreshing tea",
     "effects": "mild calm;vitamin C",
     "mechanism": "Anthocyanins provide antioxidant and hypotensive actions",
     "compounds": [
       "Anthocyanins"
     ],
+    "preparations": [],
+    "dosage": "2-4 g dried",
+    "therapeutic": "cooling beverage, mild relaxation",
     "interactions": [
       "may potentiate antihypertensives"
     ],
     "contraindications": [
       "pregnancy large amounts"
     ],
-    "dosage": "2-4 g dried",
-    "therapeutic": "cooling beverage, mild relaxation",
+    "sideeffects": [
+      "acidic on stomach"
+    ],
     "safety": "",
-    "sideeffects": "acidic on stomach",
     "toxicity": "Low",
     "toxicity_ld50": ">5 g/kg (rats)",
-    "is_controlled_substance": false,
     "tags": [
       "🍵 tea"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC529416/",
       "Journal of Human Hypertension",
       "2008",
       "African Herbal Pharmacopoeia"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "huperzia-serrata",
@@ -5613,15 +6624,20 @@
     "common": "",
     "scientific": "Huperzia serrata",
     "category": "nootropic / cognitive",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "china, southeast asia",
     "legalstatus": "Legal in most countries",
+    "schedule": "",
     "description": "club moss used in traditional chinese medicine; source of huperzine a nootropic.",
     "effects": "Improved memory;alertness",
     "mechanism": "Provides huperzine A, a reversible acetylcholinesterase inhibitor.",
     "compounds": [
       "Huperzine A"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "memory enhancement, research for alzheimer’s disease.",
     "interactions": [
       "potentiates cholinergic drugs or acetylcholinesterase inhibitors"
     ],
@@ -5629,19 +6645,22 @@
       "bradycardia",
       "cholinergic medications."
     ],
-    "dosage": "",
-    "therapeutic": "memory enhancement, research for alzheimer’s disease.",
+    "sideeffects": [
+      "nausea",
+      "sweating",
+      "muscle twitching at high doses"
+    ],
     "safety": "",
-    "sideeffects": "nausea, sweating, muscle twitching at high doses",
     "toxicity": "Generally safe at low doses; high doses may cause cholinergic effects.",
     "toxicity_ld50": "LD50 >2 mg/kg (rats, huperzine A)",
-    "is_controlled_substance": false,
     "tags": [
       "⚗️ alkaloid",
       "🧠 memory"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "hyoscyamus-niger",
@@ -5649,13 +6668,18 @@
     "common": "",
     "scientific": "Hyoscyamus niger",
     "category": "deliriant / toxic / visionary",
+    "subcategory": "",
     "intensity": "Extreme",
     "region": "europe, north africa, asia",
     "legalstatus": "Legal in some countries, restricted elsewhere",
+    "schedule": "",
     "description": "a notorious nightshade plant used historically in european witchcraft, sedatives, and flying ointments. contains powerful tropane alkaloids that can induce delirium, amnesia, and visionary states.",
     "effects": "Hallucinations;Disorientation;Sedation;Dryness;Trance",
     "mechanism": "Scopolamine, hyoscyamine, and atropine block muscarinic acetylcholine receptors (anticholinergic), disrupting sensory and cognitive processing.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used in minute doses for pain, asthma, or surgery pre-medication. historically employed in magic and sedation.",
     "interactions": [
       "dangerous with cns depressants",
       "alcohol",
@@ -5665,25 +6689,31 @@
     "contraindications": [
       "unsafe in all non-clinical contexts. avoid with any psychiatric history or cardiovascular conditions."
     ],
-    "dosage": "",
-    "therapeutic": "used in minute doses for pain, asthma, or surgery pre-medication. historically employed in magic and sedation.",
+    "sideeffects": [
+      "extreme dry mouth",
+      "confusion",
+      "hallucinations",
+      "overheating",
+      "pupil dilation",
+      "urinary retention. risk of fatal respiratory failure."
+    ],
     "safety": "",
-    "sideeffects": "extreme dry mouth, confusion, hallucinations, overheating, pupil dilation, urinary retention. risk of fatal respiratory failure.",
     "toxicity": "Very high. Narrow therapeutic index.",
     "toxicity_ld50": "Scopolamine LD50 ~300 mg/kg (mice, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ deadly nightshade",
       "🌙 visionary",
       "💀 toxic",
       "🌿 witches’ herb"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1318951/",
       "Plants of the Gods – Rätsch",
       "Handbook of Medicinal Plants – CRC Press"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "hypericum-perforatum",
@@ -5691,13 +6721,18 @@
     "common": "",
     "scientific": "Hypericum perforatum",
     "category": "antidepressant / nootropic",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "europe, naturalized elsewhere",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "",
     "effects": "improved mood;reduced anxiety;light sedation",
     "mechanism": "Hyperforin and hypericin inhibit reuptake of serotonin, dopamine, and norepinephrine",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "mild to moderate depression, anxiety, sleep issues",
     "interactions": [
       "strong inducer of liver enzymes",
       "reduces efficacy of many medications"
@@ -5707,20 +6742,23 @@
       "pregnancy",
       "strong sunlight exposure"
     ],
-    "dosage": "",
-    "therapeutic": "mild to moderate depression, anxiety, sleep issues",
+    "sideeffects": [
+      "photosensitivity",
+      "dry mouth",
+      "gastrointestinal upset"
+    ],
     "safety": "",
-    "sideeffects": "photosensitivity, dry mouth, gastrointestinal upset",
     "toxicity": "Low to moderate",
     "toxicity_ld50": ">2 g/kg in rodents",
-    "is_controlled_substance": false,
     "tags": [
       "maoi",
       "st. john's wort",
       "mood"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "hyssopus-officinalis",
@@ -5728,13 +6766,18 @@
     "common": "",
     "scientific": "Hyssopus officinalis",
     "category": "stimulant / expectorant",
+    "subcategory": "",
     "intensity": "",
     "region": "mediterranean",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "traditional biblical herb used for colds and rituals",
     "effects": "respiratory relief;mild alertness",
     "mechanism": "Monoterpenes like pinocamphone stimulate circulation",
     "compounds": [],
+    "preparations": [],
+    "dosage": "1-2 g dried leaf",
+    "therapeutic": "coughs, focus",
     "interactions": [
       "other stimulants"
     ],
@@ -5742,19 +6785,20 @@
       "epilepsy",
       "pregnancy"
     ],
-    "dosage": "1-2 g dried leaf",
-    "therapeutic": "coughs, focus",
+    "sideeffects": [
+      "high doses may cause seizures"
+    ],
     "safety": "",
-    "sideeffects": "high doses may cause seizures",
     "toxicity": "Moderate",
     "toxicity_ld50": ">1 g/kg (oil)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ strong oil",
       "🍵 tea"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "ilex-paraguariensis",
@@ -5762,9 +6806,11 @@
     "common": "Yerba Mate",
     "scientific": "Ilex paraguariensis",
     "category": "stimulant / tonic / social",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "argentina, brazil, paraguay, uruguay",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a south american herbal infusion made from the dried leaves of the yerba mate plant. revered for its energizing and antioxidant effects, mate is consumed in communal rituals or daily focus routines.",
     "effects": "Mental alertness;Appetite control;Social energy;Metabolism boost",
     "mechanism": "Caffeine, theobromine, and chlorogenic acid act as CNS stimulants and antioxidants. Enhances focus while reducing fatigue.",
@@ -5773,6 +6819,9 @@
       "Theobromine",
       "Chlorogenic acid"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for fatigue, digestion, weight loss, cognitive enhancement, and mild depression.",
     "interactions": [
       "interacts with maois",
       "stimulants",
@@ -5783,26 +6832,29 @@
       "ulcers",
       "or caffeine sensitivity. avoid boiling hot consumption."
     ],
-    "dosage": "",
-    "therapeutic": "used for fatigue, digestion, weight loss, cognitive enhancement, and mild depression.",
+    "sideeffects": [
+      "insomnia",
+      "gi irritation",
+      "or agitation at high doses. possible link to esophageal cancer when consumed very hot frequently."
+    ],
     "safety": "",
-    "sideeffects": "insomnia, gi irritation, or agitation at high doses. possible link to esophageal cancer when consumed very hot frequently.",
     "toxicity": "Low–Moderate (caffeine-related).",
     "toxicity_ld50": "Caffeine LD50 ~192 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "☕ social",
       "🔥 thermogenic",
       "🌿 focus",
       "⚡ stimulant"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6926402/",
       "South American Herbal Pharmacopoeia",
       "Journal of Human Nutrition and Dietetics",
       "2008"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "yerba-mate",
@@ -5810,13 +6862,18 @@
     "common": "",
     "scientific": "Ilex paraguariensis",
     "category": "empathogen / euphoriant",
+    "subcategory": "",
     "intensity": "Mild to moderate",
     "region": "argentina, paraguay, brazil",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "south american herbal stimulant rich in caffeine, theobromine, and theophylline. traditionally shared as a communal energizing tea.",
     "effects": "Stimulation;focus;social energy",
     "mechanism": "Adenosine receptor antagonism (via caffeine/theobromine)",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "energy, mental clarity, digestion",
     "interactions": [
       "cns stimulants",
       "caffeine"
@@ -5826,20 +6883,23 @@
       "heart conditions",
       "ulcers"
     ],
-    "dosage": "",
-    "therapeutic": "energy, mental clarity, digestion",
+    "sideeffects": [
+      "jitteriness",
+      "insomnia",
+      "gi discomfort in sensitive individuals"
+    ],
     "safety": "",
-    "sideeffects": "jitteriness, insomnia, gi discomfort in sensitive individuals",
     "toxicity": "Low to moderate (long-term use linked to GI issues)",
     "toxicity_ld50": "~192 mg/kg (caffeine)",
-    "is_controlled_substance": false,
     "tags": [
       "stimulant",
       "🌿 social",
       "🔥 energy"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "ilex-vomitoria",
@@ -5847,13 +6907,18 @@
     "common": "",
     "scientific": "Ilex vomitoria",
     "category": "stimulant / ritual",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "southeastern united states",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "",
     "effects": "alertness;mild euphoria;cleansing",
     "mechanism": "Contains caffeine and theobromine acting as adenosine receptor antagonists",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "native american ceremonial drink for stimulation and purification",
     "interactions": [
       "additive with other stimulants"
     ],
@@ -5862,20 +6927,22 @@
       "pregnancy",
       "anxiety disorders"
     ],
-    "dosage": "",
-    "therapeutic": "native american ceremonial drink for stimulation and purification",
+    "sideeffects": [
+      "nausea in excess",
+      "insomnia"
+    ],
     "safety": "",
-    "sideeffects": "nausea in excess, insomnia",
     "toxicity": "Low",
     "toxicity_ld50": ">1 g/kg caffeine in animals",
-    "is_controlled_substance": false,
     "tags": [
       "north america",
       "caffeine",
       "yaupon"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "impatiens-balsamina",
@@ -5883,39 +6950,45 @@
     "common": "",
     "scientific": "Impatiens balsamina",
     "category": "anti-inflammatory / antifungal / traditional",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "south and east asia",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a colorful flowering plant native to asia, known for its soothing effects on skin infections, wounds, and fungal issues. used in traditional medicine systems of china, korea, and india.",
     "effects": "Wound healing;Antimicrobial;Anti-itch;Skin soothing",
     "mechanism": "Contains flavonoids, naphthoquinones, and essential oils with antifungal, antibacterial, and anti-inflammatory properties. Lawsone (also found in henna) contributes to antifungal effects.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used to treat ringworm, athlete’s foot, nail infections, eczema, and inflamed wounds. also applied to burns and bites.",
     "interactions": [
       "none known (topical use)."
     ],
     "contraindications": [
       "avoid internal use due to lack of safety data. caution on broken or hypersensitive skin."
     ],
-    "dosage": "",
-    "therapeutic": "used to treat ringworm, athlete’s foot, nail infections, eczema, and inflamed wounds. also applied to burns and bites.",
+    "sideeffects": [
+      "rare. mild skin irritation possible with overuse."
+    ],
     "safety": "",
-    "sideeffects": "rare. mild skin irritation possible with overuse.",
     "toxicity": "Low in external application. Some species mildly toxic if ingested.",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🌸 skin",
       "🦠 antifungal",
       "🌿 traditional",
       "💧 soothing"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4704765/",
       "Journal of Ethnopharmacology",
       "2005",
       "Korean Pharmacopoeia"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "nelumbo-nucifera",
@@ -5923,13 +6996,18 @@
     "common": "",
     "scientific": "Nelumbo nucifera",
     "category": "dissociative / sedative",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "india, southeast asia",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "sacred flower in buddhism and hinduism, with mild psychoactive and calming properties. often used in teas or tinctures.",
     "effects": "Calm;mild euphoria;dreaminess",
     "mechanism": "Likely GABAergic and dopaminergic effects (alkaloids: nuciferine, aporphine)",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "stress, anxiety, spiritual use",
     "interactions": [
       "sedatives",
       "cns depressants"
@@ -5938,20 +7016,22 @@
       "pregnancy (caution)",
       "hypotension"
     ],
-    "dosage": "",
-    "therapeutic": "stress, anxiety, spiritual use",
+    "sideeffects": [
+      "drowsiness",
+      "dizziness"
+    ],
     "safety": "",
-    "sideeffects": "drowsiness, dizziness",
     "toxicity": "Low",
     "toxicity_ld50": "Not known",
-    "is_controlled_substance": false,
     "tags": [
       "🌊 spiritual",
       "🌸 sacred",
       "🧘 calm"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "monotropa-uniflora",
@@ -5959,13 +7039,18 @@
     "common": "",
     "scientific": "Monotropa uniflora",
     "category": "dissociative / sedative",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "temperate forests of north america and asia",
     "legalstatus": "Legal (but rare and protected in places)",
+    "schedule": "",
     "description": "a ghostly white forest plant used in native american medicine for pain and spiritual insight. non-photosynthetic and mysterious.",
     "effects": "Analgesia;calm;emotional detachment",
     "mechanism": "Contains monotropin; acts possibly on NMDA or opioid systems (hypothetical)",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "pain relief, emotional trauma support (traditional)",
     "interactions": [
       "possibly cns depressants"
     ],
@@ -5973,20 +7058,22 @@
       "unknown",
       "limited modern use"
     ],
-    "dosage": "",
-    "therapeutic": "pain relief, emotional trauma support (traditional)",
+    "sideeffects": [
+      "unknown at pharmacological doses",
+      "rare usage"
+    ],
     "safety": "",
-    "sideeffects": "unknown at pharmacological doses; rare usage",
     "toxicity": "",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🌲 pain relief",
       "👻 ghost plant",
       "🧠 emotional"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "ipomoea-tricolor",
@@ -5994,13 +7081,18 @@
     "common": "",
     "scientific": "Ipomoea tricolor",
     "category": "psychedelic / traditional / visionary",
+    "subcategory": "",
     "intensity": "Moderate–Strong",
     "region": "mexico, central america",
     "legalstatus": "Legal to grow; seeds often labeled 'not for consumption'",
+    "schedule": "",
     "description": "this morning glory species contains lsa (lysergic acid amide), a natural psychedelic alkaloid structurally similar to lsd. used by aztec priests and modern psychonauts for altered states.",
     "effects": "Visual distortions;Dream-like state;Nausea;Time alteration",
     "mechanism": "LSA is a serotonin 5-HT2A partial agonist, producing dream-like hallucinations and euphoria. Less stimulating than LSD but longer-lasting.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditional ritual use for divination, reflection, and spiritual cleansing. some modern use in microdosing or introspective journeys.",
     "interactions": [
       "do not mix with maois",
       "ssris",
@@ -6012,26 +7104,30 @@
       "maois",
       "or psychiatric medications."
     ],
-    "dosage": "",
-    "therapeutic": "traditional ritual use for divination, reflection, and spiritual cleansing. some modern use in microdosing or introspective journeys.",
+    "sideeffects": [
+      "nausea",
+      "vasoconstriction",
+      "lethargy",
+      "disorientation. seeds sold commercially may be coated with toxins."
+    ],
     "safety": "",
-    "sideeffects": "nausea, vasoconstriction, lethargy, disorientation. seeds sold commercially may be coated with toxins.",
     "toxicity": "Low–moderate in raw form. Seed coatings can be toxic.",
     "toxicity_ld50": "LSA estimated LD50 >150 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🌸 psychedelic",
       "🌈 visionary",
       "⚠️ nausea-prone",
       "🌀 traditional use"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5003218/",
       "Plants of the Gods – Rätsch",
       "Journal of Psychoactive Drugs",
       "2006"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "datura-stramonium",
@@ -6039,13 +7135,18 @@
     "common": "",
     "scientific": "Datura stramonium",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "",
     "region": "worldwide",
     "legalstatus": "Unregulated but dangerous",
+    "schedule": "",
     "description": "common weed producing powerful delirium when misused.",
     "effects": "delirium;hallucinations",
     "mechanism": "Scopolamine and atropine block muscarinic receptors",
     "compounds": [],
+    "preparations": [],
+    "dosage": "5–15 seeds",
+    "therapeutic": "historically asthma treatment",
     "interactions": [
       "anticholinergics",
       "antihistamines"
@@ -6054,19 +7155,21 @@
       "heart conditions",
       "mental illness"
     ],
-    "dosage": "5–15 seeds",
-    "therapeutic": "historically asthma treatment",
+    "sideeffects": [
+      "severe confusion",
+      "elevated heart rate"
+    ],
     "safety": "",
-    "sideeffects": "severe confusion, elevated heart rate",
     "toxicity": "Very high",
     "toxicity_ld50": "~50 mg/kg (atropine)",
-    "is_controlled_substance": false,
     "tags": [
       "☠️ toxic",
       "⚠️ caution"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "justicia-adhatoda",
@@ -6074,9 +7177,11 @@
     "common": "",
     "scientific": "Justicia adhatoda",
     "category": "ethnobotanical",
+    "subcategory": "",
     "intensity": "",
     "region": "india, sri lanka",
     "legalstatus": "",
+    "schedule": "",
     "description": "also called malabar nut, this herb has traditional uses as a respiratory aid and mild sedative.",
     "effects": "calming;respiratory clearing;mild sedation",
     "mechanism": "Bronchodilation + GABAergic",
@@ -6084,22 +7189,24 @@
       "Vasicine",
       "Vasicinone"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "sedative",
       "respiratory",
       "ayurvedic"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "justicia-pectoralis",
@@ -6107,9 +7214,11 @@
     "common": "Tilo",
     "scientific": "Justicia pectoralis",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "amazon basin",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "aromatic herb called tilo, brewed or smoked for calming effects.",
     "effects": "Relaxation;light euphoria;spiritual dreams",
     "mechanism": "Likely GABAergic; coumarins may modulate CNS",
@@ -6117,6 +7226,9 @@
       "Coumarin",
       "Umelliferone"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "anxiety, insomnia, spiritual enhancement",
     "interactions": [
       "coumarin-sensitive meds (e.g.",
       "blood thinners)"
@@ -6125,25 +7237,26 @@
       "liver disorders",
       "pregnancy"
     ],
-    "dosage": "",
-    "therapeutic": "anxiety, insomnia, spiritual enhancement",
+    "sideeffects": [
+      "liver risk in excess due to coumarin"
+    ],
     "safety": "1",
-    "sideeffects": "liver risk in excess due to coumarin",
     "toxicity": "Low–moderate with excess",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ legal",
       "🌿 ayahuasca-additive",
       "🧘 calm"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7820446/",
       "Journal of Ethnopharmacology",
       "1999",
       "Shamanic Pharmacopoeia – Amazonian Plants"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "sceletium-tortuosum",
@@ -6151,13 +7264,18 @@
     "common": "",
     "scientific": "Sceletium tortuosum",
     "category": "empathogen / euphoriant",
+    "subcategory": "",
     "intensity": "Mild to moderate",
     "region": "southern africa",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "a south african succulent traditionally chewed or snuffed to reduce anxiety and induce euphoria.",
     "effects": "Mood lift;calm euphoria;focus",
     "mechanism": "Serotonin reuptake inhibition (mesembrine alkaloids)",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "anxiety, stress, social comfort",
     "interactions": [
       "antidepressants",
       "serotonergic agents"
@@ -6167,20 +7285,23 @@
       "maois",
       "bipolar disorder"
     ],
-    "dosage": "",
-    "therapeutic": "anxiety, stress, social comfort",
+    "sideeffects": [
+      "headache",
+      "nausea",
+      "serotonin syndrome (in excess or with ssris)"
+    ],
     "safety": "",
-    "sideeffects": "headache, nausea, serotonin syndrome (in excess or with ssris)",
     "toxicity": "Low",
     "toxicity_ld50": "Not established (safe in traditional use)",
-    "is_controlled_substance": false,
     "tags": [
       "🌼 euphoric",
       "🧘 calm",
       "🧬 natural ssri"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "sceletium-tortuosum",
@@ -6188,15 +7309,20 @@
     "common": "",
     "scientific": "Sceletium tortuosum",
     "category": "mood enhancer / traditional / ssri-like",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "south africa, namibia",
     "legalstatus": "Legal worldwide (except select EU countries)",
+    "schedule": "",
     "description": "a succulent plant native to south africa, kanna has been chewed, snuffed, and brewed for centuries by khoisan peoples to ease stress, elevate mood, and promote social connection. it’s now gaining modern popularity as a legal natural serotonin booster.",
     "effects": "Euphoria;Reduced anxiety;Social enhancement;Emotional softening",
     "mechanism": "Contains mesembrine alkaloids that act as selective serotonin reuptake inhibitors (SSRI), PDE4 inhibitors, and mild serotonin releasing agents (SRA). Also mildly acts on dopamine.",
     "compounds": [
       "Mesembrine"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for anxiety, mild depression, public speaking stress, trauma relief, and social disconnection. studied for antidepressant properties.",
     "interactions": [
       "potentially dangerous with other serotonergic substances (e.g.",
       "mdma",
@@ -6208,26 +7334,29 @@
       "maois",
       "or serotonergic drugs (risk of serotonin syndrome). avoid during pregnancy or with bipolar disorder."
     ],
-    "dosage": "",
-    "therapeutic": "used for anxiety, mild depression, public speaking stress, trauma relief, and social disconnection. studied for antidepressant properties.",
+    "sideeffects": [
+      "rare. may include dry mouth",
+      "slight sedation",
+      "or overstimulation if combined with caffeine. excessive doses may cause emotional blunting or nausea."
+    ],
     "safety": "",
-    "sideeffects": "rare. may include dry mouth, slight sedation, or overstimulation if combined with caffeine. excessive doses may cause emotional blunting or nausea.",
     "toxicity": "Low in traditional or moderate modern doses. No known fatalities or organ toxicity.",
     "toxicity_ld50": ">5000 mg/kg (rats, oral extract)",
-    "is_controlled_substance": false,
     "tags": [
       "🧠 serotonin",
       "🧘 mood booster",
       "💬 social",
       "🌿 traditional african"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5386632/",
       "Journal of Ethnopharmacology",
       "2013",
       "South African Herbal Compendium"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "kava",
@@ -6235,13 +7364,18 @@
     "common": "",
     "scientific": "Piper methysticum",
     "category": "dissociative / sedative",
+    "subcategory": "",
     "intensity": "Mild to moderate",
     "region": "polynesia, micronesia, melanesia",
     "legalstatus": "Legal; restricted in some EU countries",
+    "schedule": "",
     "description": "south pacific root brew known for its relaxing and anxiolytic effects.",
     "effects": "Relaxation;social ease;mild euphoria",
     "mechanism": "Kavalactones modulate GABA, block sodium and calcium channels",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "anxiety, stress, sleep aid",
     "interactions": [
       "cns depressants",
       "alcohol",
@@ -6252,20 +7386,22 @@
       "alcohol",
       "sedatives"
     ],
-    "dosage": "",
-    "therapeutic": "anxiety, stress, sleep aid",
+    "sideeffects": [
+      "liver strain (rare)",
+      "drowsiness"
+    ],
     "safety": "2",
-    "sideeffects": "liver strain (rare), drowsiness",
     "toxicity": "Low to moderate; caution with prolonged use",
     "toxicity_ld50": "~4.3 g/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 root",
       "🍵 social",
       "🧘 calm"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "catha-edulis",
@@ -6273,13 +7409,18 @@
     "common": "",
     "scientific": "Catha edulis",
     "category": "stimulant / euphoric",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "horn of africa, yemen",
     "legalstatus": "Illegal or controlled in many countries",
+    "schedule": "",
     "description": "evergreen shrub whose fresh leaves are chewed for stimulant and euphoric effects in social settings.",
     "effects": "Euphoria;alertness;appetite suppression",
     "mechanism": "Cathinone alkaloids release dopamine and norepinephrine.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "social stimulant chewed in east africa and the arabian peninsula.",
     "interactions": [
       "avoid with stimulants or maois"
     ],
@@ -6288,19 +7429,22 @@
       "pregnancy",
       "maois."
     ],
-    "dosage": "",
-    "therapeutic": "social stimulant chewed in east africa and the arabian peninsula.",
+    "sideeffects": [
+      "dry mouth",
+      "increased heart rate",
+      "insomnia"
+    ],
     "safety": "",
-    "sideeffects": "dry mouth, increased heart rate, insomnia",
     "toxicity": "Excess use leads to insomnia, hypertension, or dependency.",
     "toxicity_ld50": "Cathinone LD50 ~75 mg/kg (rats)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ controlled",
       "🌿 leaves"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "solandra-maxima",
@@ -6308,13 +7452,18 @@
     "common": "",
     "scientific": "Solandra maxima",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "",
     "region": "mexico",
     "legalstatus": "Unregulated",
+    "schedule": "",
     "description": "rarely used solanaceous vine with powerful effects.",
     "effects": "visions;disorientation",
     "mechanism": "Tropane alkaloids similar to datura",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "visionary rituals",
     "interactions": [
       "anticholinergics"
     ],
@@ -6322,18 +7471,20 @@
       "pregnancy",
       "heart issues"
     ],
-    "dosage": "",
-    "therapeutic": "visionary rituals",
+    "sideeffects": [
+      "severe confusion",
+      "amnesia"
+    ],
     "safety": "",
-    "sideeffects": "severe confusion, amnesia",
     "toxicity": "High",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "☠️ toxic"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "mitragyna-speciosa",
@@ -6341,13 +7492,18 @@
     "common": "",
     "scientific": "Mitragyna speciosa",
     "category": "stimulant",
+    "subcategory": "",
     "intensity": "",
     "region": "southeast asia",
     "legalstatus": "Varies by country",
+    "schedule": "",
     "description": "popular herbal stimulant and analgesic.",
     "effects": "euphoria;pain relief",
     "mechanism": "Mitragynine acts on opioid receptors",
     "compounds": [],
+    "preparations": [],
+    "dosage": "2–5 g leaf powder",
+    "therapeutic": "pain management, energy",
     "interactions": [
       "opioids",
       "depressants"
@@ -6355,19 +7511,21 @@
     "contraindications": [
       "opioid addiction recovery"
     ],
-    "dosage": "2–5 g leaf powder",
-    "therapeutic": "pain management, energy",
+    "sideeffects": [
+      "nausea",
+      "dependence"
+    ],
     "safety": "",
-    "sideeffects": "nausea, dependence",
     "toxicity": "Moderate",
     "toxicity_ld50": ">400 mg/kg (rats)",
-    "is_controlled_substance": false,
     "tags": [
       "🌀 euphoric",
       "💊 oral"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "mitragyna-speciosa",
@@ -6375,13 +7533,18 @@
     "common": "",
     "scientific": "Mitragyna speciosa",
     "category": "stimulant / opioid-like / traditional / controversial",
+    "subcategory": "",
     "intensity": "Mild–Strong (dose-dependent)",
     "region": "thailand, indonesia, malaysia",
     "legalstatus": "Legal in some regions; banned or restricted in others (e.g. Thailand, Australia, some U.S. states)",
+    "schedule": "",
     "description": "a tropical tree whose leaves are traditionally chewed for stamina and pain relief in southeast asia. kratom has gained global attention as both a potential therapeutic tool and a substance of concern due to its opioid-like effects.",
     "effects": "Energy;Euphoria;Pain relief;Calm focus",
     "mechanism": "Mitragynine and 7-hydroxymitragynine are partial mu-opioid agonists with stimulant properties at low doses and sedative effects at higher doses. Also interacts with adrenergic and serotonergic systems.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for pain management, anxiety, fatigue, opioid withdrawal, and mood enhancement. reported as helpful in tapering off prescription opioids.",
     "interactions": [
       "potentiates cns depressants. interacts with liver enzymes (cyp3a4",
       "cyp2d6)."
@@ -6392,27 +7555,32 @@
       "alcohol",
       "or in heart/liver conditions."
     ],
-    "dosage": "",
-    "therapeutic": "used for pain management, anxiety, fatigue, opioid withdrawal, and mood enhancement. reported as helpful in tapering off prescription opioids.",
+    "sideeffects": [
+      "constipation",
+      "dry mouth",
+      "nausea",
+      "dependency",
+      "withdrawal symptoms with chronic use. some cardiac risk at high doses."
+    ],
     "safety": "",
-    "sideeffects": "constipation, dry mouth, nausea, dependency, withdrawal symptoms with chronic use. some cardiac risk at high doses.",
     "toxicity": "Moderate at high doses or with poly-drug use. Risk of dependency.",
     "toxicity_ld50": "Mitragynine LD50 >500 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🍃 opioid-like",
       "⚖️ controversial",
       "🌿 traditional",
       "🩹 pain relief"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6534344/",
       "Journal of the American Osteopathic Association",
       "2020",
       "WHO Kratom Review Report",
       "2021"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "kratom-hybrids",
@@ -6420,13 +7588,18 @@
     "common": "",
     "scientific": "Mitragyna speciosa hybrids",
     "category": "stimulant / analgesic",
+    "subcategory": "",
     "intensity": "",
     "region": "cultivated southeast asia",
     "legalstatus": "Varies by region",
+    "schedule": "",
     "description": "selective breeding of kratom species for varied alkaloid ratios",
     "effects": "energy;pain relief",
     "mechanism": "Indole alkaloids act as partial mu-opioid agonists",
     "compounds": [],
+    "preparations": [],
+    "dosage": "2-5 g leaf",
+    "therapeutic": "pain relief, mood lift",
     "interactions": [
       "opioids and sedatives"
     ],
@@ -6434,19 +7607,21 @@
       "heart conditions",
       "maois"
     ],
-    "dosage": "2-5 g leaf",
-    "therapeutic": "pain relief, mood lift",
+    "sideeffects": [
+      "nausea",
+      "dependency"
+    ],
     "safety": "",
-    "sideeffects": "nausea, dependency",
     "toxicity": "Moderate",
     "toxicity_ld50": ">200 mg/kg (rats, mitragynine)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ use caution",
       "🍃 leaf"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "lactuca-canadensis",
@@ -6454,13 +7629,18 @@
     "common": "",
     "scientific": "Lactuca canadensis",
     "category": "dissociative / sedative",
+    "subcategory": "",
     "intensity": "Mild to moderate",
     "region": "north america",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "wild lettuce species containing lactucarium for gentle analgesia.",
     "effects": "Relaxation;pain relief;drowsiness",
     "mechanism": "Mild opioid-like action via lactucin/lactucopicrin",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "insomnia, pain, cough relief",
     "interactions": [
       "cns depressants",
       "alcohol"
@@ -6469,20 +7649,22 @@
       "sedatives",
       "pregnancy"
     ],
-    "dosage": "",
-    "therapeutic": "insomnia, pain, cough relief",
+    "sideeffects": [
+      "drowsiness",
+      "gi upset at high doses"
+    ],
     "safety": "1",
-    "sideeffects": "drowsiness, gi upset at high doses",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌿 opium lettuce",
       "😴 sedative"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "lactuca-virosa",
@@ -6490,9 +7672,11 @@
     "common": "Wild Lettuce",
     "scientific": "Lactuca virosa",
     "category": "sedative / analgesic / nervine",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "europe, north america, asia",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a tall, bitter plant sometimes called 'opium lettuce' due to its historical use for pain and sleep. it contains lactucopicrin and lactucin, compounds with mild sedative and analgesic properties. used in western herbalism since the 19th century.",
     "effects": "Pain relief;Mild euphoria;Sedation;Calming",
     "mechanism": "Lactucin and lactucopicrin are sesquiterpene lactones that interact with GABAergic systems and have antinociceptive properties.",
@@ -6500,6 +7684,9 @@
       "Lactucin",
       "Lactucopicrin"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for pain, insomnia, anxiety, coughing, and muscle tension. popular in herbal tinctures and teas.",
     "interactions": [
       "potentiates sedatives or alcohol."
     ],
@@ -6508,26 +7695,29 @@
       "glaucoma",
       "or with cns depressants. not for prolonged heavy use."
     ],
-    "dosage": "",
-    "therapeutic": "used for pain, insomnia, anxiety, coughing, and muscle tension. popular in herbal tinctures and teas.",
+    "sideeffects": [
+      "may cause dizziness",
+      "nausea",
+      "or mild hallucinations at high doses. bitter taste often deters excess use."
+    ],
     "safety": "",
-    "sideeffects": "may cause dizziness, nausea, or mild hallucinations at high doses. bitter taste often deters excess use.",
     "toxicity": "Low to moderate. High doses may cause CNS depression.",
     "toxicity_ld50": "Not well documented in humans; extracts assumed safe below 500 mg/kg",
-    "is_controlled_substance": false,
     "tags": [
       "💤 sedative",
       "🌿 analgesic",
       "🌙 calming",
       "🧪 bitter"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6232791/",
       "Herbal Medicines",
       "4th Ed. – Barnes et al.",
       "A Modern Herbal – Grieve"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "wild-lettuce",
@@ -6535,13 +7725,18 @@
     "common": "",
     "scientific": "Lactuca virosa",
     "category": "dissociative / sedative",
+    "subcategory": "",
     "intensity": "Mild to moderate",
     "region": "europe, north america",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "leafy plant exuding sedative latex historically called 'lettuce opium.'",
     "effects": "Sedation;pain relief;light euphoria",
     "mechanism": "Lactucin and lactucopicrin may act as acetylcholinesterase inhibitors",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "insomnia, pain relief, cough suppression",
     "interactions": [
       "avoid with sedatives",
       "opioids"
@@ -6550,20 +7745,22 @@
       "pregnancy",
       "cns depressants"
     ],
-    "dosage": "",
-    "therapeutic": "insomnia, pain relief, cough suppression",
+    "sideeffects": [
+      "drowsiness",
+      "nausea at high doses"
+    ],
     "safety": "1",
-    "sideeffects": "drowsiness, nausea at high doses",
     "toxicity": "Low in traditional doses",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌿 herbal",
       "😴 sedative"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "lagochilus-inebrians",
@@ -6571,33 +7768,39 @@
     "common": "",
     "scientific": "Lagochilus inebrians",
     "category": "sedative / euphoric",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "central asia",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "known as intoxicating mint; produces a pleasant calm and slight euphoria when brewed.",
     "effects": "relaxation;mild euphoria;reduced anxiety",
     "mechanism": "Contains lagochilin which depresses the CNS and may interact with GABA",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "folk remedy in uzbekistan and kazakhstan for tension and insomnia",
     "interactions": [
       "could potentiate other depressants"
     ],
     "contraindications": [
       "none documented but caution when operating machinery"
     ],
-    "dosage": "",
-    "therapeutic": "folk remedy in uzbekistan and kazakhstan for tension and insomnia",
+    "sideeffects": [
+      "drowsiness"
+    ],
     "safety": "",
-    "sideeffects": "drowsiness",
     "toxicity": "Little toxicity noted at customary doses",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "central asia",
       "calming",
       "intoxicating mint"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "lavandula-angustifolia",
@@ -6605,31 +7808,37 @@
     "common": "",
     "scientific": "Lavandula angustifolia",
     "category": "relaxant / aromatic",
+    "subcategory": "",
     "intensity": "",
     "region": "mediterranean",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "fragrant lavender widely used for relaxation",
     "effects": "calm;sleep aid",
     "mechanism": "Linalool and linalyl acetate modulate GABA",
     "compounds": [],
+    "preparations": [],
+    "dosage": "1-2 g dried or few drops oil",
+    "therapeutic": "anxiety, insomnia",
     "interactions": [
       "sedatives"
     ],
     "contraindications": [
       "pregnancy large amounts"
     ],
-    "dosage": "1-2 g dried or few drops oil",
-    "therapeutic": "anxiety, insomnia",
+    "sideeffects": [
+      "rare skin irritation"
+    ],
     "safety": "",
-    "sideeffects": "rare skin irritation",
     "toxicity": "Low",
     "toxicity_ld50": ">2 g/kg (rats, oil)",
-    "is_controlled_substance": false,
     "tags": [
       "🌸 aroma"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "leonotis-leonurus",
@@ -6637,38 +7846,44 @@
     "common": "",
     "scientific": "Leonotis leonurus",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "south africa",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "also called wild dagga, smoked for gentle euphoric effects.",
     "effects": "Mild euphoria;relaxation",
     "mechanism": "Leonurine may act on serotonin receptors",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditional relaxant and ritual smoke",
     "interactions": [
       "limited data"
     ],
     "contraindications": [
       "none known"
     ],
-    "dosage": "",
-    "therapeutic": "traditional relaxant and ritual smoke",
+    "sideeffects": [
+      "dizziness with heavy use"
+    ],
     "safety": "",
-    "sideeffects": "dizziness with heavy use",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌿 leaf",
       "🧪 alkaloid"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3887317/",
       "Journal of Ethnopharmacology",
       "2005",
       "African Herbal Medicine Compendium"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "leonotis-leonurus",
@@ -6676,38 +7891,44 @@
     "common": "",
     "scientific": "Leonotis leonurus",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "south africa",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "also called wild dagga, smoked for gentle euphoric effects.",
     "effects": "Mild euphoria;relaxation",
     "mechanism": "Leonurine may act on serotonin receptors",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditional relaxant and ritual smoke",
     "interactions": [
       "limited data"
     ],
     "contraindications": [
       "none known"
     ],
-    "dosage": "",
-    "therapeutic": "traditional relaxant and ritual smoke",
+    "sideeffects": [
+      "dizziness with heavy use"
+    ],
     "safety": "",
-    "sideeffects": "dizziness with heavy use",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌿 leaf",
       "🧪 alkaloid"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3887317/",
       "Journal of Ethnopharmacology",
       "2005",
       "African Herbal Medicine Compendium"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "leonurus-cardiaca",
@@ -6715,9 +7936,11 @@
     "common": "Motherwort",
     "scientific": "Leonurus cardiaca",
     "category": "cardiotonic / nervine / women’s health",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "europe, north america, asia",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a traditional european nervine used to ease tension, heart flutter, and menstrual discomfort. known as ‘mother’s herb’ for its supportive effects during emotional distress and hormonal fluctuations.",
     "effects": "Calms heart palpitations;Reduces anxiety;Uterine tonic;Regulates menstrual tension",
     "mechanism": "Alkaloids such as leonurine and stachydrine provide mild sedative, antispasmodic, and cardiotonic effects, possibly modulating GABA and muscarinic pathways.",
@@ -6725,31 +7948,36 @@
       "Leonurine",
       "Stachydrine"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for pms, menopause, anxiety, nervous heart conditions, and postpartum recovery. may support vagal tone and reduce sympathetic overdrive.",
     "interactions": [
       "caution with heart medications or sedatives."
     ],
     "contraindications": [
       "avoid in pregnancy (uterine stimulant). may slightly lower blood pressure."
     ],
-    "dosage": "",
-    "therapeutic": "used for pms, menopause, anxiety, nervous heart conditions, and postpartum recovery. may support vagal tone and reduce sympathetic overdrive.",
+    "sideeffects": [
+      "bitter taste",
+      "possible drowsiness or stomach upset in some. generally well tolerated."
+    ],
     "safety": "",
-    "sideeffects": "bitter taste, possible drowsiness or stomach upset in some. generally well tolerated.",
     "toxicity": "Low. Used widely in folk medicine.",
     "toxicity_ld50": "Not established in humans",
-    "is_controlled_substance": false,
     "tags": [
       "🫀 heart support",
       "🌸 women’s health",
       "🧘 nervine",
       "🌿 bitter tonic"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8762752/",
       "Herbal Medicine – Mills & Bone",
       "British Herbal Compendium"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "leonurus-sibiricus",
@@ -6757,35 +7985,41 @@
     "common": "",
     "scientific": "Leonurus sibiricus",
     "category": "calming / dream",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "native to asia, cultivated in the americas",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "sometimes called marihuanilla or siberian motherwort, providing gentle calming effects and subtle dreaminess.",
     "effects": "mild sedation;light euphoria;dream enhancement",
     "mechanism": "Contains leonurine and other alkaloids that depress CNS activity",
     "compounds": [
       "Leonurine"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used in latin american and asian folk medicine for relaxation and spiritual rituals",
     "interactions": [
       "may enhance effects of other sedatives"
     ],
     "contraindications": [
       "none known"
     ],
-    "dosage": "",
-    "therapeutic": "used in latin american and asian folk medicine for relaxation and spiritual rituals",
+    "sideeffects": [
+      "drowsiness at high doses"
+    ],
     "safety": "",
-    "sideeffects": "drowsiness at high doses",
     "toxicity": "Considered safe in moderate amounts",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "marihuanilla",
       "mint family",
       "sedative"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "lepidium-meyenii",
@@ -6793,39 +8027,47 @@
     "common": "",
     "scientific": "Lepidium meyenii",
     "category": "adaptogen / hormonal / nutritional",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "peru, andes mountains",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a peruvian root vegetable and superfood traditionally consumed to increase energy, stamina, fertility, and hormonal resilience. grown high in the andes, maca is revered as a nutritional tonic and endocrine modulator.",
     "effects": "Hormone balancing;Energy boost;Libido enhancement;Mood support",
     "mechanism": "Contains macamides, macaenes, and glucosinolates. These influence the hypothalamic-pituitary axis, modulate neurotransmitters, and support hormonal balance without introducing phytohormones.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for fatigue, low libido, pms, menopause, mood swings, and athletic endurance.",
     "interactions": [
       "may interact with hormone therapies. mild hypoglycemic synergy."
     ],
     "contraindications": [
       "caution in thyroid disorders due to goitrogens. not advised in hormonal cancers without consultation."
     ],
-    "dosage": "",
-    "therapeutic": "used for fatigue, low libido, pms, menopause, mood swings, and athletic endurance.",
+    "sideeffects": [
+      "may cause gas",
+      "thyroid suppression (in high doses/raw)",
+      "or overstimulation in some."
+    ],
     "safety": "",
-    "sideeffects": "may cause gas, thyroid suppression (in high doses/raw), or overstimulation in some.",
     "toxicity": "Low. Widely used as food.",
     "toxicity_ld50": ">15 g/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🏋️ energy",
       "🧬 endocrine",
       "🌿 adaptogen",
       "💞 libido"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3184420/",
       "Journal of Ethnopharmacology",
       "2009",
       "Peruvian Herbal Compendium"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "lions-mane",
@@ -6833,13 +8075,18 @@
     "common": "",
     "scientific": "Hericium erinaceus",
     "category": "other",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "🇨🇳 east asia",
     "legalstatus": "Legal / Unregulated",
+    "schedule": "",
     "description": "medicinal mushroom valued for promoting nerve growth and mental clarity.",
     "effects": "Neurotrophic support;cognitive enhancement",
     "mechanism": "Hericenones and erinacines stimulate nerve growth factor.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "memory, focus, nerve regeneration, mood support.",
     "interactions": [
       "no major interactions documented."
     ],
@@ -6847,20 +8094,22 @@
       "allergy to mushrooms",
       "pregnancy (limited data)."
     ],
-    "dosage": "",
-    "therapeutic": "memory, focus, nerve regeneration, mood support.",
+    "sideeffects": [
+      "rare allergic reactions",
+      "generally well-tolerated."
+    ],
     "safety": "1",
-    "sideeffects": "rare allergic reactions; generally well-tolerated.",
     "toxicity": "Low toxicity; consumed as food in many cultures.",
     "toxicity_ld50": "Not established; considered safe.",
-    "is_controlled_substance": false,
     "tags": [
       "\\ud83d\\udc8a oral",
       "\\ud83e\\udde0 cognitive",
       "\\u2705 safe"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "lobelia-inflata",
@@ -6868,13 +8117,18 @@
     "common": "",
     "scientific": "Lobelia inflata",
     "category": "respiratory / nervine / strong medicinal",
+    "subcategory": "",
     "intensity": "Moderate–Strong",
     "region": "north america",
     "legalstatus": "Legal with caution",
+    "schedule": "",
     "description": "a powerful respiratory herb used by native americans and western herbalists to aid breathing, reduce asthma spasms, and stimulate detoxification. sometimes called ‘the thinking herb’ for its clarity-inducing effects.",
     "effects": "Bronchodilation;Muscle relaxation;Emetic (high dose);Stimulates breath",
     "mechanism": "Contains lobeline, a nicotinic acetylcholine receptor partial agonist that stimulates respiration and clears airways. Also acts as a relaxant in low doses.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for asthma, bronchitis, whooping cough, tension, and as a smoke cessation aid. in high doses, historically used to induce vomiting in detox protocols.",
     "interactions": [
       "potentiates sedatives or respiratory stimulants."
     ],
@@ -6883,25 +8137,30 @@
       "with heart disease",
       "or alongside strong sedatives. use cautiously."
     ],
-    "dosage": "",
-    "therapeutic": "used for asthma, bronchitis, whooping cough, tension, and as a smoke cessation aid. in high doses, historically used to induce vomiting in detox protocols.",
+    "sideeffects": [
+      "nausea",
+      "vomiting",
+      "salivation",
+      "dizziness",
+      "or tingling. overdose may cause respiratory distress."
+    ],
     "safety": "",
-    "sideeffects": "nausea, vomiting, salivation, dizziness, or tingling. overdose may cause respiratory distress.",
     "toxicity": "Moderate to high in excess. Use under guidance.",
     "toxicity_ld50": "~0.6 g/kg lobeline in animals (est.)",
-    "is_controlled_substance": false,
     "tags": [
       "🌬️ respiratory",
       "🫁 bronchodilator",
       "⚠️ low dose only",
       "🌿 native american use"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4119142/",
       "American Herbal Pharmacopoeia – Lobelia",
       "Materia Medica – Eclectic School"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "lobelia-inflata",
@@ -6909,13 +8168,18 @@
     "common": "",
     "scientific": "Lobelia inflata",
     "category": "respiratory / nervine / strong medicinal",
+    "subcategory": "",
     "intensity": "Moderate–Strong",
     "region": "north america",
     "legalstatus": "Legal with caution",
+    "schedule": "",
     "description": "a powerful respiratory herb used by native americans and western herbalists to aid breathing, reduce asthma spasms, and stimulate detoxification. sometimes called ‘the thinking herb’ for its clarity-inducing effects.",
     "effects": "Bronchodilation;Muscle relaxation;Emetic (high dose);Stimulates breath",
     "mechanism": "Contains lobeline, a nicotinic acetylcholine receptor partial agonist that stimulates respiration and clears airways. Also acts as a relaxant in low doses.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for asthma, bronchitis, whooping cough, tension, and as a smoke cessation aid. in high doses, historically used to induce vomiting in detox protocols.",
     "interactions": [
       "potentiates sedatives or respiratory stimulants."
     ],
@@ -6924,25 +8188,30 @@
       "with heart disease",
       "or alongside strong sedatives. use cautiously."
     ],
-    "dosage": "",
-    "therapeutic": "used for asthma, bronchitis, whooping cough, tension, and as a smoke cessation aid. in high doses, historically used to induce vomiting in detox protocols.",
+    "sideeffects": [
+      "nausea",
+      "vomiting",
+      "salivation",
+      "dizziness",
+      "or tingling. overdose may cause respiratory distress."
+    ],
     "safety": "",
-    "sideeffects": "nausea, vomiting, salivation, dizziness, or tingling. overdose may cause respiratory distress.",
     "toxicity": "Moderate to high in excess. Use under guidance.",
     "toxicity_ld50": "~0.6 g/kg lobeline in animals (est.)",
-    "is_controlled_substance": false,
     "tags": [
       "🌬️ respiratory",
       "🫁 bronchodilator",
       "⚠️ low dose only",
       "🌿 native american use"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4119142/",
       "American Herbal Pharmacopoeia – Lobelia",
       "Materia Medica – Eclectic School"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "lophophora-williamsii",
@@ -6950,15 +8219,20 @@
     "common": "",
     "scientific": "Lophophora williamsii",
     "category": "psychedelic / entheogen / sacred",
+    "subcategory": "",
     "intensity": "Strong",
     "region": "southwestern u.s., mexico",
     "legalstatus": "Illegal in many countries; ceremonial exemption in U.S. (NAC)",
+    "schedule": "",
     "description": "a small cactus revered for centuries in native american and mesoamerican spiritual traditions. contains mescaline, a potent psychedelic that induces visionary, heart-centered, and introspective states. still legally protected for ceremonial use in some indigenous groups.",
     "effects": "Visuals;Emotional opening;Ego dissolution;Sacred insight",
     "mechanism": "Mescaline is a serotonin 5-HT2A agonist and also modulates dopamine and norepinephrine. Alters perception, emotion, and time sense.",
     "compounds": [
       "Mescaline"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for ptsd, addiction, grief, personal transformation, and connection to spirit. studied for antidepressant and anti-addictive properties.",
     "interactions": [
       "do not combine with antidepressants",
       "stimulants",
@@ -6970,26 +8244,30 @@
       "heart conditions",
       "or psychosis history. not for casual or unsupervised use."
     ],
-    "dosage": "",
-    "therapeutic": "used for ptsd, addiction, grief, personal transformation, and connection to spirit. studied for antidepressant and anti-addictive properties.",
+    "sideeffects": [
+      "nausea",
+      "vomiting (especially in raw cactus)",
+      "emotional overload",
+      "overstimulation. physically safe but requires emotional preparedness."
+    ],
     "safety": "",
-    "sideeffects": "nausea, vomiting (especially in raw cactus), emotional overload, overstimulation. physically safe but requires emotional preparedness.",
     "toxicity": "Low physiological toxicity. High psychological intensity.",
     "toxicity_ld50": "Mescaline LD50 ~880 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🌵 psychedelic",
       "🌀 visionary",
       "💖 sacred plant",
       "🌈 mescaline"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7188374/",
       "Plants of the Gods – Rätsch",
       "Journal of Psychoactive Drugs",
       "2013"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "lsd",
@@ -6997,13 +8275,18 @@
     "common": "",
     "scientific": "Lysergic acid diethylamide",
     "category": "psychedelic",
+    "subcategory": "",
     "intensity": "High",
     "region": "🌎 synthetic",
     "legalstatus": "Controlled / Illegal in many regions",
+    "schedule": "",
     "description": "semi-synthetic ergoline discovered in 1938; among the most potent psychedelics.",
     "effects": "Intense visuals;ego dissolution;synesthesia",
     "mechanism": "Potent 5-HT2A receptor agonist affecting serotonin and dopamine systems.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "investigated for cluster headaches, anxiety, and addiction therapy.",
     "interactions": [
       "ssris may blunt effects",
       "maois potentiate."
@@ -7012,20 +8295,23 @@
       "psychosis",
       "severe cardiovascular disease."
     ],
-    "dosage": "",
-    "therapeutic": "investigated for cluster headaches, anxiety, and addiction therapy.",
+    "sideeffects": [
+      "anxiety",
+      "confusion",
+      "possible flashbacks at high doses."
+    ],
     "safety": "2",
-    "sideeffects": "anxiety, confusion, possible flashbacks at high doses.",
     "toxicity": "Very low physiological toxicity but strong psychological effects.",
     "toxicity_ld50": ">14 mg/kg (mice, intravenous)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ restricted",
       "🌀 visionary",
       "💊 oral"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "lycopodium-clavatum",
@@ -7033,13 +8319,18 @@
     "common": "",
     "scientific": "Lycopodium clavatum",
     "category": "homeopathic / traditional / anticholinergic (spores)",
+    "subcategory": "",
     "intensity": "Very mild",
     "region": "europe, north america, eurasia",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a moss-like vascular plant traditionally used in european folk and homeopathic medicine. its yellow spores were used in rituals and historically as flash powder due to their flammability. internally, it has been used for digestive and urinary complaints.",
     "effects": "Cognitive stimulation (mild);Digestive tonic;Symbolic use;Spore dispersal agent",
     "mechanism": "Spores are inert unless extracted. Extracts may act mildly as cholinergic modulators or anti-inflammatory agents. In homeopathy, extremely diluted preparations are used for liver, bladder, and memory issues.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used in homeopathy for digestive bloating, urinary retention, liver stress, and memory loss. folk use includes treating gout, kidney stones, and fevers.",
     "interactions": [
       "none documented at low doses."
     ],
@@ -7048,26 +8339,27 @@
       "asthma",
       "or lung sensitivity (spores may irritate). not for use in pregnancy."
     ],
-    "dosage": "",
-    "therapeutic": "used in homeopathy for digestive bloating, urinary retention, liver stress, and memory loss. folk use includes treating gout, kidney stones, and fevers.",
+    "sideeffects": [
+      "rare. may cause irritation if spores inhaled or applied to wounds. avoid raw use in respiratory conditions."
+    ],
     "safety": "",
-    "sideeffects": "rare. may cause irritation if spores inhaled or applied to wounds. avoid raw use in respiratory conditions.",
     "toxicity": "Low externally; internal extracts used with caution.",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 moss",
       "⚗️ homeopathy",
       "🔥 ritual powder",
       "🧠 memory"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1070629/",
       "Homeopathic Materia Medica – Boericke",
       "Phytotherapy Research",
       "2002"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "mandragora-officinarum",
@@ -7075,13 +8367,18 @@
     "common": "",
     "scientific": "Mandragora officinarum",
     "category": "deliriant / hallucinogenic / historical magic",
+    "subcategory": "",
     "intensity": "Extreme",
     "region": "mediterranean, europe, near east",
     "legalstatus": "Restricted or regulated in some countries",
+    "schedule": "",
     "description": "a legendary plant of myth and medicine, mandrake has deep roots in european witchcraft, alchemy, and ancient anesthetic practices. the humanoid root contains potent tropane alkaloids similar to deadly nightshades.",
     "effects": "Hallucinations;Sedation;Amnesia;Pain relief (historical)",
     "mechanism": "Scopolamine, hyoscyamine, and atropine act as central anticholinergics, disrupting memory, balance, perception, and consciousness. Mimics effects of belladonna and henbane.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "historically used for surgery anesthesia, pain, sleep, and aphrodisiac purposes. modern use is rare and dangerous.",
     "interactions": [
       "fatal with other anticholinergics",
       "sedatives",
@@ -7091,25 +8388,31 @@
     "contraindications": [
       "unsafe in almost all settings. avoid with any cns-active substances or psychiatric history."
     ],
-    "dosage": "",
-    "therapeutic": "historically used for surgery anesthesia, pain, sleep, and aphrodisiac purposes. modern use is rare and dangerous.",
+    "sideeffects": [
+      "confusion",
+      "visual hallucinations",
+      "overheating",
+      "dry mouth",
+      "tachycardia",
+      "respiratory distress. easily overdosed."
+    ],
     "safety": "",
-    "sideeffects": "confusion, visual hallucinations, overheating, dry mouth, tachycardia, respiratory distress. easily overdosed.",
     "toxicity": "Very high. Even small doses can be toxic or fatal.",
     "toxicity_ld50": "Atropine ~453 mg/kg (rats, oral); scopolamine lower",
-    "is_controlled_substance": false,
     "tags": [
       "💀 toxic",
       "🌙 magical",
       "🌿 solanaceae",
       "🌀 deliriant"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6367476/",
       "Plants of the Gods – Rätsch",
       "Toxicology in Herbal Medicine – 2020"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "mandrake",
@@ -7117,13 +8420,18 @@
     "common": "",
     "scientific": "Mandragora officinarum",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "",
     "region": "mediterranean",
     "legalstatus": "Cultivation legal in most regions",
+    "schedule": "",
     "description": "legendary root used in magic rituals; highly toxic.",
     "effects": "hallucinations;sedation",
     "mechanism": "Tropane alkaloids block muscarinic acetylcholine receptors",
     "compounds": [],
+    "preparations": [],
+    "dosage": "0.1–0.3 g dried root",
+    "therapeutic": "historical anesthetic",
     "interactions": [
       "anticholinergic medications"
     ],
@@ -7131,19 +8439,22 @@
       "heart conditions",
       "pregnancy"
     ],
-    "dosage": "0.1–0.3 g dried root",
-    "therapeutic": "historical anesthetic",
+    "sideeffects": [
+      "confusion",
+      "dry mouth",
+      "delirium"
+    ],
     "safety": "",
-    "sideeffects": "confusion, dry mouth, delirium",
     "toxicity": "High",
     "toxicity_ld50": "~50 mg/kg (mice, scopolamine)",
-    "is_controlled_substance": false,
     "tags": [
       "☠️ toxic",
       "🌿 root"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "marrubium-vulgare",
@@ -7151,37 +8462,43 @@
     "common": "",
     "scientific": "Marrubium vulgare",
     "category": "expectorant / bitter",
+    "subcategory": "",
     "intensity": "",
     "region": "europe, north africa",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "also known as horehound, used in cough drops",
     "effects": "digestive stimulation;clear lungs",
     "mechanism": "Diterpene lactone marrubiin stimulates mucus production",
     "compounds": [
       "Marrubiin"
     ],
+    "preparations": [],
+    "dosage": "1-2 g dried",
+    "therapeutic": "coughs, digestion",
     "interactions": [
       "none noted"
     ],
     "contraindications": [
       "pregnancy high doses"
     ],
-    "dosage": "1-2 g dried",
-    "therapeutic": "coughs, digestion",
+    "sideeffects": [
+      "bitter taste"
+    ],
     "safety": "",
-    "sideeffects": "bitter taste",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🍬 candy"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6494426/",
       "ESCOP Monograph – Marrubium",
       "American Herbal Pharmacopoeia – Horehound"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "matricaria-chamomilla",
@@ -7189,13 +8506,18 @@
     "common": "",
     "scientific": "Matricaria chamomilla",
     "category": "nervine / digestive / anti-inflammatory",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "europe, north africa, western asia (now global)",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a gentle daisy-like flower used worldwide for calming nerves, reducing inflammation, and aiding digestion. chamomile tea is one of the most common herbal remedies for stress and insomnia.",
     "effects": "Calming;Sleep aid;Soothes digestion;Mild pain relief",
     "mechanism": "Contains apigenin, a flavonoid that binds to benzodiazepine receptors. Also anti-inflammatory through COX-2 inhibition and spasmolytic via smooth muscle relaxation.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for anxiety, insomnia, gi discomfort, colic, pms, and skin inflammation. also common in baby teas and skin creams.",
     "interactions": [
       "mild interaction with blood thinners",
       "sedatives."
@@ -7205,25 +8527,26 @@
       "pregnancy (in very large doses)",
       "or severe allergies to asteraceae."
     ],
-    "dosage": "",
-    "therapeutic": "used for anxiety, insomnia, gi discomfort, colic, pms, and skin inflammation. also common in baby teas and skin creams.",
+    "sideeffects": [
+      "rare. may cause allergic reaction in ragweed-sensitive individuals. mild sedation."
+    ],
     "safety": "",
-    "sideeffects": "rare. may cause allergic reaction in ragweed-sensitive individuals. mild sedation.",
     "toxicity": "Very low. Commonly consumed as food/tea.",
     "toxicity_ld50": ">5 g/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🧘 calm",
       "🌼 sleep",
       "🫖 tea",
       "🌿 gut soothing"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2995283/",
       "ESCOP Monograph – Chamomilla",
       "The Complete German Commission E Monographs"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "melissa-officinalis",
@@ -7231,39 +8554,45 @@
     "common": "",
     "scientific": "Melissa officinalis",
     "category": "nervine / antiviral / cognitive",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "mediterranean, now global",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a fragrant member of the mint family, lemon balm has been used for centuries to calm the nervous system, lift the mood, and improve memory. its subtle citrus aroma makes it popular in teas and tinctures.",
     "effects": "Anti-anxiety;Cognitive clarity;Mood boost;Antiviral",
     "mechanism": "GABA-T inhibition and acetylcholine modulation. Rich in rosmarinic acid and flavonoids, which contribute to anxiolytic and nootropic effects.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for stress, overthinking, anxiety, herpes simplex outbreaks, restlessness, and cognitive focus.",
     "interactions": [
       "may potentiate sedatives or thyroid medications."
     ],
     "contraindications": [
       "avoid large doses in hypothyroidism (may suppress tsh)."
     ],
-    "dosage": "",
-    "therapeutic": "used for stress, overthinking, anxiety, herpes simplex outbreaks, restlessness, and cognitive focus.",
+    "sideeffects": [
+      "rare. may cause drowsiness or lowered alertness in some. mild gi upset if taken in excess."
+    ],
     "safety": "",
-    "sideeffects": "rare. may cause drowsiness or lowered alertness in some. mild gi upset if taken in excess.",
     "toxicity": "Very low.",
     "toxicity_ld50": ">5 g/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🍋 uplifting",
       "🧘 nootropic",
       "🌿 antiviral",
       "🫖 nervine"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5871149/",
       "Journal of Ethnopharmacology",
       "2004",
       "Herbal Medicine – Mills & Bone"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "mentha-piperita",
@@ -7271,13 +8600,18 @@
     "common": "",
     "scientific": "Mentha piperita",
     "category": "digestive / stimulant / antispasmodic",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "global cultivation",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a cooling, aromatic herb widely used for digestive and nervous system support. common in teas, extracts, and aromatherapy. historically used in european, middle eastern, and asian herbalism.",
     "effects": "Soothes digestion;Stimulates focus;Relieves cramps;Cools",
     "mechanism": "Menthol and other essential oils act as calcium channel blockers in smooth muscle and desensitize cold receptors (TRPM8), producing cooling and antispasmodic effects.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for ibs, nausea, headache, muscle cramps, and focus. may be used topically for tension or inhaled for alertness.",
     "interactions": [
       "may interact with antacids",
       "cyclosporine",
@@ -7288,25 +8622,26 @@
       "gallstones",
       "or infants (risk of respiratory spasm)."
     ],
-    "dosage": "",
-    "therapeutic": "used for ibs, nausea, headache, muscle cramps, and focus. may be used topically for tension or inhaled for alertness.",
+    "sideeffects": [
+      "may cause heartburn or skin sensitivity. excess can cause nausea."
+    ],
     "safety": "",
-    "sideeffects": "may cause heartburn or skin sensitivity. excess can cause nausea.",
     "toxicity": "Low. Essential oil can be toxic in large doses.",
     "toxicity_ld50": "Menthol LD50 ~3300 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🌱 digestive",
       "❄️ cooling",
       "🧠 focus",
       "🪻 aromatic"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4103722/",
       "ESCOP Monographs",
       "Herbal Medicine – New Oxford Textbook"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "mescaline",
@@ -7314,13 +8649,18 @@
     "common": "",
     "scientific": "3,4,5-trimethoxyphenethylamine",
     "category": "psychedelic",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "🌎 americas",
     "legalstatus": "Controlled in many regions",
+    "schedule": "",
     "description": "classic phenethylamine psychedelic from peyote and san pedro cacti.",
     "effects": "Color enhancement;empathy;spiritual visions",
     "mechanism": "Phenethylamine psychedelic acting on 5-HT2A and dopamine receptors.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditional sacrament; studied for alcoholism and psychotherapy.",
     "interactions": [
       "maois and sympathomimetics may potentiate."
     ],
@@ -7328,20 +8668,23 @@
       "heart disease",
       "pregnancy."
     ],
-    "dosage": "",
-    "therapeutic": "traditional sacrament; studied for alcoholism and psychotherapy.",
+    "sideeffects": [
+      "nausea",
+      "increased heart rate",
+      "dilated pupils."
+    ],
     "safety": "2",
-    "sideeffects": "nausea, increased heart rate, dilated pupils.",
     "toxicity": "Low physiological toxicity; psychological effects strong.",
     "toxicity_ld50": ">1,000 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ restricted",
       "🌀 visionary",
       "💊 oral"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "mimosa-hostilis",
@@ -7349,13 +8692,18 @@
     "common": "",
     "scientific": "Mimosa tenuiflora",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Strong",
     "region": "brazil, central america",
     "legalstatus": "DMT controlled in many countries",
+    "schedule": "",
     "description": "highly sought after for its dmt-rich root bark. used in anahuasca brews as a substitute for chacruna or yopo.",
     "effects": "Visionary states;purging;emotional release",
     "mechanism": "DMT – 5-HT2A agonist (requires MAOI orally)",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "spiritual healing, insight, skin regeneration (topical)",
     "interactions": [
       "maois",
       "antidepressants"
@@ -7365,25 +8713,28 @@
       "maois",
       "ssris"
     ],
-    "dosage": "",
-    "therapeutic": "spiritual healing, insight, skin regeneration (topical)",
+    "sideeffects": [
+      "intense purging",
+      "nausea",
+      "anxiety"
+    ],
     "safety": "",
-    "sideeffects": "intense purging, nausea, anxiety",
     "toxicity": "Low physiological, high psychological",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ visionary",
       "🌿 anahuasca",
       "🧪 dmt"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6334226/",
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology",
       "1993"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "mimosa-pudica",
@@ -7391,39 +8742,47 @@
     "common": "",
     "scientific": "Mimosa pudica",
     "category": "nervine / anti-parasitic / mysterious plant movement",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "south america, southeast asia, india",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "known for its rapid leaf-closing reflex, this tropical creeping plant is used in ayurvedic and modern herbal medicine for gut detox, parasite cleansing, and calming the nerves.",
     "effects": "Intestinal cleanse;Antiparasitic;Calming;Unique tactile motion",
     "mechanism": "Contains mimosine, alkaloids, and tannins. Antiparasitic action through mechanical mucilage binding and gut wall modulation. Also mildly acts on serotonin and GABA pathways.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for intestinal worms, heavy metal detox, gi inflammation, gut-brain axis repair, and nervous tension.",
     "interactions": [
       "may bind to medications and reduce absorption. space doses accordingly."
     ],
     "contraindications": [
       "avoid in pregnancy. use caution in constipation or with gi disorders unless guided."
     ],
-    "dosage": "",
-    "therapeutic": "used for intestinal worms, heavy metal detox, gi inflammation, gut-brain axis repair, and nervous tension.",
+    "sideeffects": [
+      "possible constipation",
+      "fatigue",
+      "or gut discomfort in first few days. rare allergic response."
+    ],
     "safety": "",
-    "sideeffects": "possible constipation, fatigue, or gut discomfort in first few days. rare allergic response.",
     "toxicity": "Low–Moderate. Use within appropriate dose ranges.",
     "toxicity_ld50": ">2000 mg/kg (rats, oral extract)",
-    "is_controlled_substance": false,
     "tags": [
       "🧬 gut health",
       "🪱 parasite cleanse",
       "🌿 ayurvedic",
       "🖐️ reactive plant"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4027290/",
       "Ayurvedic Pharmacopeia – India",
       "Journal of Parasitology Research",
       "2017"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "mitchella-repens",
@@ -7431,9 +8790,11 @@
     "common": "",
     "scientific": "Mitchella repens",
     "category": "ethnobotanical",
+    "subcategory": "",
     "intensity": "",
     "region": "north america",
     "legalstatus": "",
+    "schedule": "",
     "description": "known as partridgeberry, used as a uterine tonic and mild relaxing agent in north american herbalism.",
     "effects": "relaxation;nervine",
     "mechanism": "Smooth muscle relaxant",
@@ -7441,22 +8802,24 @@
       "Saponins",
       "Iridoids"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "calming",
       "uterine",
       "folk remedy"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "mitragyna-hirsuta",
@@ -7464,13 +8827,18 @@
     "common": "",
     "scientific": "Mitragyna hirsuta",
     "category": "stimulant / relaxant / kratom alternative",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "thailand, southeast asia",
     "legalstatus": "Legal in most regions",
+    "schedule": "",
     "description": "a close relative of mitragyna speciosa (kratom), this thai tree is used as a legal alternative with gentler psychoactive effects. traditionally chewed by laborers for stamina and focus.",
     "effects": "Mild euphoria;Calm stimulation;Analgesia;Energy boost",
     "mechanism": "Contains mitraphylline and isomitraphylline — alkaloids that act on opioid receptors (mu, delta) and possibly serotonin/dopamine pathways, though weaker than kratom.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for mood lift, fatigue reduction, mild pain relief, and kratom tapering.",
     "interactions": [
       "similar caution as with kratom — potential additive effect with sedatives."
     ],
@@ -7479,26 +8847,29 @@
       "depressants",
       "or alcohol. safety in pregnancy unknown."
     ],
-    "dosage": "",
-    "therapeutic": "used for mood lift, fatigue reduction, mild pain relief, and kratom tapering.",
+    "sideeffects": [
+      "mild nausea",
+      "dry mouth",
+      "light sedation. fewer side effects than kratom. little to no dependency reported."
+    ],
     "safety": "",
-    "sideeffects": "mild nausea, dry mouth, light sedation. fewer side effects than kratom. little to no dependency reported.",
     "toxicity": "Low to moderate. No confirmed toxicity in traditional doses.",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🍃 kratom-like",
       "⚡ energy",
       "🧘 calm",
       "🩹 mild analgesic"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6571610/",
       "Journal of Ethnopharmacology",
       "2016",
       "Thai Botanical Index – 2014"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "mitragyna-hirsuta",
@@ -7506,13 +8877,18 @@
     "common": "",
     "scientific": "Mitragyna hirsuta",
     "category": "stimulant / relaxant / kratom alternative",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "thailand, southeast asia",
     "legalstatus": "Legal in most regions",
+    "schedule": "",
     "description": "a close relative of mitragyna speciosa (kratom), this thai tree is used as a legal alternative with gentler psychoactive effects. traditionally chewed by laborers for stamina and focus.",
     "effects": "Mild euphoria;Calm stimulation;Analgesia;Energy boost",
     "mechanism": "Contains mitraphylline and isomitraphylline — alkaloids that act on opioid receptors (mu, delta) and possibly serotonin/dopamine pathways, though weaker than kratom.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for mood lift, fatigue reduction, mild pain relief, and kratom tapering.",
     "interactions": [
       "similar caution as with kratom — potential additive effect with sedatives."
     ],
@@ -7521,26 +8897,29 @@
       "depressants",
       "or alcohol. safety in pregnancy unknown."
     ],
-    "dosage": "",
-    "therapeutic": "used for mood lift, fatigue reduction, mild pain relief, and kratom tapering.",
+    "sideeffects": [
+      "mild nausea",
+      "dry mouth",
+      "light sedation. fewer side effects than kratom. little to no dependency reported."
+    ],
     "safety": "",
-    "sideeffects": "mild nausea, dry mouth, light sedation. fewer side effects than kratom. little to no dependency reported.",
     "toxicity": "Low to moderate. No confirmed toxicity in traditional doses.",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🍃 kratom-like",
       "⚡ energy",
       "🧘 calm",
       "🩹 mild analgesic"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6571610/",
       "Journal of Ethnopharmacology",
       "2016",
       "Thai Botanical Index – 2014"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "ephedra-nevadensis",
@@ -7548,13 +8927,18 @@
     "common": "",
     "scientific": "Ephedra nevadensis",
     "category": "stimulant",
+    "subcategory": "",
     "intensity": "",
     "region": "north america",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "mild stimulant desert shrub without strong ephedra content.",
     "effects": "mild stimulation",
     "mechanism": "Contains ephedrine-like alkaloids releasing norepinephrine",
     "compounds": [],
+    "preparations": [],
+    "dosage": "5–10 g dried stems",
+    "therapeutic": "decongestant",
     "interactions": [
       "stimulants",
       "decongestants"
@@ -7562,18 +8946,19 @@
     "contraindications": [
       "hypertension"
     ],
-    "dosage": "5–10 g dried stems",
-    "therapeutic": "decongestant",
+    "sideeffects": [
+      "increased heart rate"
+    ],
     "safety": "",
-    "sideeffects": "increased heart rate",
     "toxicity": "Low",
     "toxicity_ld50": ">500 mg/kg (mice)",
-    "is_controlled_substance": false,
     "tags": [
       "☕ brewable"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "mucuna-pruriens",
@@ -7581,13 +8966,18 @@
     "common": "",
     "scientific": "Mucuna pruriens",
     "category": "stimulant / nootropic",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "tropical asia and africa",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "also called velvet bean; boosts dopamine and serves as a traditional tonic in ayurvedic practice.",
     "effects": "increased motivation;energy;elevated mood",
     "mechanism": "Seeds contain L‑DOPA which increases brain dopamine levels",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used in ayurveda for parkinson's disease, mood disorders and vitality",
     "interactions": [
       "avoid with maois or dopamine medications"
     ],
@@ -7595,25 +8985,26 @@
       "psychosis",
       "concurrent l‑dopa medication"
     ],
-    "dosage": "",
-    "therapeutic": "used in ayurveda for parkinson's disease, mood disorders and vitality",
+    "sideeffects": [
+      "nausea or headache with excessive intake"
+    ],
     "safety": "",
-    "sideeffects": "nausea or headache with excessive intake",
     "toxicity": "Generally safe at typical doses; high doses may cause nausea",
     "toxicity_ld50": ">6 g/kg in rodents",
-    "is_controlled_substance": false,
     "tags": [
       "ayurveda",
       "dopamine",
       "velvet bean"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4213965/",
       "Journal of Traditional and Complementary Medicine",
       "2015",
       "Ayurvedic Materia Medica"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "mucuna-pruriens",
@@ -7621,13 +9012,18 @@
     "common": "",
     "scientific": "Mucuna pruriens",
     "category": "stimulant / nootropic",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "tropical asia and africa",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "also called velvet bean; boosts dopamine and serves as a traditional tonic in ayurvedic practice.",
     "effects": "increased motivation;energy;elevated mood",
     "mechanism": "Seeds contain L‑DOPA which increases brain dopamine levels",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used in ayurveda for parkinson's disease, mood disorders and vitality",
     "interactions": [
       "avoid with maois or dopamine medications"
     ],
@@ -7635,25 +9031,26 @@
       "psychosis",
       "concurrent l‑dopa medication"
     ],
-    "dosage": "",
-    "therapeutic": "used in ayurveda for parkinson's disease, mood disorders and vitality",
+    "sideeffects": [
+      "nausea or headache with excessive intake"
+    ],
     "safety": "",
-    "sideeffects": "nausea or headache with excessive intake",
     "toxicity": "Generally safe at typical doses; high doses may cause nausea",
     "toxicity_ld50": ">6 g/kg in rodents",
-    "is_controlled_substance": false,
     "tags": [
       "ayurveda",
       "dopamine",
       "velvet bean"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4213965/",
       "Journal of Traditional and Complementary Medicine",
       "2015",
       "Ayurvedic Materia Medica"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "myristica-fragrans",
@@ -7661,9 +9058,11 @@
     "common": "Nutmeg",
     "scientific": "Myristica fragrans",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Strong",
     "region": "indonesia",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "nutmeg seeds can be psychoactive in large amounts.",
     "effects": "Deliriant states;nausea",
     "mechanism": "Myristicin metabolizes to MMDA-like compounds",
@@ -7671,6 +9070,9 @@
       "Myristicin",
       "Elemicin"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "rarely used therapeutically",
     "interactions": [
       "potential maoi interaction"
     ],
@@ -7678,24 +9080,27 @@
       "pregnancy",
       "psychiatric conditions"
     ],
-    "dosage": "",
-    "therapeutic": "rarely used therapeutically",
+    "sideeffects": [
+      "nausea",
+      "dehydration",
+      "delirium"
+    ],
     "safety": "",
-    "sideeffects": "nausea, dehydration, delirium",
     "toxicity": "High at large doses",
     "toxicity_ld50": "Myristicin LD50 ~400 mg/kg (mouse)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ caution",
       "🌿 seed",
       "🧪 phenethylamine"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3457357/",
       "Plants of the Gods – Rätsch",
       "Toxicology of Spices – 2012"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "myristica-fragrans",
@@ -7703,9 +9108,11 @@
     "common": "Nutmeg",
     "scientific": "Myristica fragrans",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Strong",
     "region": "indonesia",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "nutmeg seeds can be psychoactive in large amounts.",
     "effects": "Deliriant states;nausea",
     "mechanism": "Myristicin metabolizes to MMDA-like compounds",
@@ -7713,6 +9120,9 @@
       "Myristicin",
       "Elemicin"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "rarely used therapeutically",
     "interactions": [
       "potential maoi interaction"
     ],
@@ -7720,24 +9130,27 @@
       "pregnancy",
       "psychiatric conditions"
     ],
-    "dosage": "",
-    "therapeutic": "rarely used therapeutically",
+    "sideeffects": [
+      "nausea",
+      "dehydration",
+      "delirium"
+    ],
     "safety": "",
-    "sideeffects": "nausea, dehydration, delirium",
     "toxicity": "High at large doses",
     "toxicity_ld50": "Myristicin LD50 ~400 mg/kg (mouse)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ caution",
       "🌿 seed",
       "🧪 phenethylamine"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3457357/",
       "Plants of the Gods – Rätsch",
       "Toxicology of Spices – 2012"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "nelumbo-lutea",
@@ -7745,38 +9158,46 @@
     "common": "",
     "scientific": "Nelumbo lutea",
     "category": "nervine / sacred / hormonal",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "north america",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a north american relative of the sacred lotus, nelumbo lutea has similar calming, euphoric properties. it has been used by native american groups for its edible seeds and roots, and possibly ceremonial effects when brewed from the flower.",
     "effects": "Tranquility;Heart-opening;Sensual awareness;Lucid dreaming",
     "mechanism": "Contains alkaloids such as nuciferine and neferine, modulating dopamine and serotonin receptors. Mildly sedative and possibly aphrodisiac.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used traditionally for calming the mind, balancing hormones, dreamwork, and as a meditative herb.",
     "interactions": [
       "may potentiate sedatives or antihypertensives."
     ],
     "contraindications": [
       "avoid with sedatives or hypotension. safety during pregnancy not well studied."
     ],
-    "dosage": "",
-    "therapeutic": "used traditionally for calming the mind, balancing hormones, dreamwork, and as a meditative herb.",
+    "sideeffects": [
+      "drowsiness",
+      "lowered blood pressure",
+      "dry mouth in sensitive users."
+    ],
     "safety": "",
-    "sideeffects": "drowsiness, lowered blood pressure, dry mouth in sensitive users.",
     "toxicity": "Low at traditional doses.",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🪷 sacred",
       "🌿 native american",
       "🌙 dream",
       "💖 hormonal"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3991026/",
       "Ethnobotany of North American Indians – 1993",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "nelumbo-nucifera",
@@ -7784,9 +9205,11 @@
     "common": "Sacred Lotus",
     "scientific": "Nelumbo nucifera",
     "category": "oneirogen",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "india, china, southeast asia",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "sacred lotus revered for tranquil, mildly euphoric properties.",
     "effects": "Relaxation;dream enhancement;calm euphoria",
     "mechanism": "Dopamine receptor agonism (aporphine alkaloids)",
@@ -7794,6 +9217,9 @@
       "Nuciferine",
       "Neferine"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "calm, aphrodisiac, meditation support",
     "interactions": [
       "avoid cns depressants"
     ],
@@ -7801,24 +9227,26 @@
       "sedatives",
       "pregnancy"
     ],
-    "dosage": "",
-    "therapeutic": "calm, aphrodisiac, meditation support",
+    "sideeffects": [
+      "sedation",
+      "mild dizziness"
+    ],
     "safety": "1",
-    "sideeffects": "sedation, mild dizziness",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌸 calm",
       "🧘 meditation"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7442399/",
       "Ayurvedic Herbal Compendium",
       "Chinese Pharmacopoeia"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "nepeta-cataria",
@@ -7826,40 +9254,46 @@
     "common": "Catnip",
     "scientific": "Nepeta cataria",
     "category": "nervine / mild sedative / folk remedy",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "europe, north america",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "best known for its effects on cats, catnip is also a gentle human nervine herb traditionally used for digestion, colds, and sleep. it has a subtle calming effect and is often included in herbal teas.",
     "effects": "Relaxation;Mild euphoria;Digestive aid;Sleep support",
     "mechanism": "Nepetalactone interacts with GABAergic and opioid pathways in humans. Also antispasmodic and diaphoretic.",
     "compounds": [
       "Nepetalactone"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for anxiety, insomnia, indigestion, fever, and colic. also a mild menstrual relaxant.",
     "interactions": [
       "may interact with sedatives or barbiturates."
     ],
     "contraindications": [
       "avoid during pregnancy (stimulates uterus). not recommended before operating machinery."
     ],
-    "dosage": "",
-    "therapeutic": "used for anxiety, insomnia, indigestion, fever, and colic. also a mild menstrual relaxant.",
+    "sideeffects": [
+      "mild drowsiness or stomach upset. rare allergic reaction."
+    ],
     "safety": "",
-    "sideeffects": "mild drowsiness or stomach upset. rare allergic reaction.",
     "toxicity": "Very low. Safe in tea form at moderate doses.",
     "toxicity_ld50": ">3000 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🐱 cat herb",
       "🧘 calm",
       "🫖 tea",
       "🌿 folk medicine"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3612440/",
       "Herbal Medicine – Mills & Bone",
       "Materia Medica – David Hoffman"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "nicotiana-rustica",
@@ -7867,9 +9301,11 @@
     "common": "Aztec Tobacco",
     "scientific": "Nicotiana rustica",
     "category": "stimulant / ritual",
+    "subcategory": "",
     "intensity": "Strong",
     "region": "south america and worldwide cultivation",
     "legalstatus": "Legal but regulated like tobacco",
+    "schedule": "",
     "description": "potent tobacco species used ceremonially in the amazon, far stronger than common n. tabacum.",
     "effects": "alertness;intense buzz;clearing of thoughts",
     "mechanism": "High nicotine plus MAO‑inhibiting beta‑carbolines stimulate nicotinic receptors and inhibit MAO",
@@ -7877,6 +9313,9 @@
       "Nicotine",
       "Harmala alkaloids"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used by amazonian shamans for cleansing and focus",
     "interactions": [
       "strongly potentiated by maois",
       "interacts with many medications"
@@ -7886,20 +9325,23 @@
       "pregnancy",
       "hypertension"
     ],
-    "dosage": "",
-    "therapeutic": "used by amazonian shamans for cleansing and focus",
+    "sideeffects": [
+      "nausea",
+      "increased heart rate",
+      "dizziness"
+    ],
     "safety": "",
-    "sideeffects": "nausea, increased heart rate, dizziness",
     "toxicity": "High nicotine content can be poisonous in large amounts",
     "toxicity_ld50": "Nicotine LD50 ~50 mg/kg (mouse)",
-    "is_controlled_substance": false,
     "tags": [
       "mapacho",
       "nicotine",
       "tobacco"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "nicotiana-rustica",
@@ -7907,9 +9349,11 @@
     "common": "Aztec Tobacco",
     "scientific": "Nicotiana rustica",
     "category": "stimulant / ritual",
+    "subcategory": "",
     "intensity": "Strong",
     "region": "south america and worldwide cultivation",
     "legalstatus": "Legal but regulated like tobacco",
+    "schedule": "",
     "description": "potent tobacco species used ceremonially in the amazon, far stronger than common n. tabacum.",
     "effects": "alertness;intense buzz;clearing of thoughts",
     "mechanism": "High nicotine plus MAO‑inhibiting beta‑carbolines stimulate nicotinic receptors and inhibit MAO",
@@ -7917,6 +9361,9 @@
       "Nicotine",
       "Harmala alkaloids"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used by amazonian shamans for cleansing and focus",
     "interactions": [
       "strongly potentiated by maois",
       "interacts with many medications"
@@ -7926,20 +9373,23 @@
       "pregnancy",
       "hypertension"
     ],
-    "dosage": "",
-    "therapeutic": "used by amazonian shamans for cleansing and focus",
+    "sideeffects": [
+      "nausea",
+      "increased heart rate",
+      "dizziness"
+    ],
     "safety": "",
-    "sideeffects": "nausea, increased heart rate, dizziness",
     "toxicity": "High nicotine content can be poisonous in large amounts",
     "toxicity_ld50": "Nicotine LD50 ~50 mg/kg (mouse)",
-    "is_controlled_substance": false,
     "tags": [
       "mapacho",
       "nicotine",
       "tobacco"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "nicotiana-tabacum",
@@ -7947,13 +9397,18 @@
     "common": "",
     "scientific": "Nicotiana tabacum",
     "category": "stimulant",
+    "subcategory": "",
     "intensity": "",
     "region": "worldwide",
     "legalstatus": "Regulated",
+    "schedule": "",
     "description": "common tobacco plant widely used recreationally",
     "effects": "alertness;mild euphoria",
     "mechanism": "Nicotine stimulates nicotinic acetylcholine receptors releasing dopamine",
     "compounds": [],
+    "preparations": [],
+    "dosage": "1-2 cigarettes equivalent",
+    "therapeutic": "traditional ceremonies, appetite suppression",
     "interactions": [
       "additive with stimulants"
     ],
@@ -7961,19 +9416,21 @@
       "heart disease",
       "pregnancy"
     ],
-    "dosage": "1-2 cigarettes equivalent",
-    "therapeutic": "traditional ceremonies, appetite suppression",
+    "sideeffects": [
+      "addiction",
+      "cardiovascular strain"
+    ],
     "safety": "",
-    "sideeffects": "addiction, cardiovascular strain",
     "toxicity": "Moderate",
     "toxicity_ld50": "50 mg/kg (rats)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ addictive",
       "🚬 smoke"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "nymphaea-lotus",
@@ -7981,33 +9438,39 @@
     "common": "",
     "scientific": "Nymphaea lotus",
     "category": "calming / dream",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "africa and southeast asia",
     "legalstatus": "Generally legal",
+    "schedule": "",
     "description": "also called the egyptian white lotus, historically revered for its gentle calming and dreamlike qualities.",
     "effects": "relaxation;dream enhancement;mild euphoria",
     "mechanism": "Contains aporphine alkaloids that act on dopamine and serotonin receptors",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used in ancient egypt for sedation and ritual ceremonies",
     "interactions": [
       "may add to effects of other sedatives"
     ],
     "contraindications": [
       "none known but caution with sedatives"
     ],
-    "dosage": "",
-    "therapeutic": "used in ancient egypt for sedation and ritual ceremonies",
+    "sideeffects": [
+      "drowsiness at high doses"
+    ],
     "safety": "",
-    "sideeffects": "drowsiness at high doses",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "egyptian lotus",
       "sedative",
       "water lily"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "nymphaea-nouchali",
@@ -8015,38 +9478,46 @@
     "common": "",
     "scientific": "Nymphaea nouchali",
     "category": "sacred / calming / dream herb",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "india, sri lanka, southeast asia",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a revered flower across south and southeast asia, often confused with blue lotus. it holds symbolic significance in buddhism and ayurveda. the flowers are known for inducing a soft, euphoric state when steeped or smoked.",
     "effects": "Calm euphoria;Sensual clarity;Dream enhancement;Mild sedation",
     "mechanism": "Contains aporphine and related alkaloids that affect dopamine and serotonin receptors. Mildly sedative and introspective.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditionally used for anxiety, libido, meditation, and emotional calm. may enhance clarity in dreams.",
     "interactions": [
       "may potentiate cns depressants and interact with ssris or maois."
     ],
     "contraindications": [
       "avoid with other sedatives or during pregnancy unless guided by a practitioner."
     ],
-    "dosage": "",
-    "therapeutic": "traditionally used for anxiety, libido, meditation, and emotional calm. may enhance clarity in dreams.",
+    "sideeffects": [
+      "mild lethargy",
+      "dry mouth",
+      "or dizziness in high doses."
+    ],
     "safety": "",
-    "sideeffects": "mild lethargy, dry mouth, or dizziness in high doses.",
     "toxicity": "Low at traditional use levels.",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🌺 sacred",
       "🧘 relaxant",
       "🌙 dream herb",
       "💫 aphrodisiac"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3708387/",
       "Ayurvedic Pharmacopeia of India",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "nymphaea-rubra",
@@ -8054,31 +9525,37 @@
     "common": "",
     "scientific": "Nymphaea rubra",
     "category": "sedative / euphoric",
+    "subcategory": "",
     "intensity": "",
     "region": "south asia",
     "legalstatus": "Varies",
+    "schedule": "",
     "description": "red lotus used similarly to blue lotus for relaxation",
     "effects": "calming;dreamy state",
     "mechanism": "Alkaloids like apomorphine interact with dopamine receptors",
     "compounds": [],
+    "preparations": [],
+    "dosage": "3-5 g petals",
+    "therapeutic": "mild euphoria, aphrodisiac",
     "interactions": [
       "sedatives"
     ],
     "contraindications": [
       "pregnancy"
     ],
-    "dosage": "3-5 g petals",
-    "therapeutic": "mild euphoria, aphrodisiac",
+    "sideeffects": [
+      "drowsiness"
+    ],
     "safety": "",
-    "sideeffects": "drowsiness",
     "toxicity": "Low",
     "toxicity_ld50": "Not well studied",
-    "is_controlled_substance": false,
     "tags": [
       "🌸 flower"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "ocimum-sanctum",
@@ -8086,13 +9563,18 @@
     "common": "",
     "scientific": "Ocimum sanctum",
     "category": "adaptogen / nervine / immune",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "india, southeast asia",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a sacred ayurvedic herb used for spiritual purification, resilience, and vitality. known as 'tulsi' in india, it’s revered for its uplifting, adaptogenic, and rejuvenating properties.",
     "effects": "Stress reduction;Mental clarity;Immune modulation;Anti-inflammatory",
     "mechanism": "Rich in eugenol, ursolic acid, and flavonoids. Acts as an adaptogen through HPA axis modulation, antioxidant pathways, and mild cortisol-lowering activity.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for adrenal fatigue, anxiety, cognitive enhancement, colds, blood sugar balance, and spiritual rituals.",
     "interactions": [
       "may enhance effects of insulin",
       "anxiolytics",
@@ -8101,25 +9583,26 @@
     "contraindications": [
       "avoid in pregnancy without supervision. may lower blood sugar."
     ],
-    "dosage": "",
-    "therapeutic": "used for adrenal fatigue, anxiety, cognitive enhancement, colds, blood sugar balance, and spiritual rituals.",
+    "sideeffects": [
+      "rare. mild nausea or drowsiness in sensitive individuals."
+    ],
     "safety": "",
-    "sideeffects": "rare. mild nausea or drowsiness in sensitive individuals.",
     "toxicity": "Very low. Widely consumed in tea form.",
     "toxicity_ld50": ">5000 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 adaptogen",
       "🧘 calm",
       "🛡️ immune",
       "🕉️ sacred"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5376420/",
       "Ayurvedic Materia Medica",
       "Journal of Ayurveda and Integrative Medicine"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "papaver-somniferum",
@@ -8127,13 +9610,18 @@
     "common": "",
     "scientific": "Papaver somniferum",
     "category": "other",
+    "subcategory": "",
     "intensity": "",
     "region": "worldwide",
     "legalstatus": "Highly controlled",
+    "schedule": "",
     "description": "primary source of medicinal opiates.",
     "effects": "analgesia;euphoria",
     "mechanism": "Morphine alkaloids activate mu-opioid receptors",
     "compounds": [],
+    "preparations": [],
+    "dosage": "50–200 mg opium",
+    "therapeutic": "pain relief",
     "interactions": [
       "cns depressants",
       "alcohol"
@@ -8142,19 +9630,21 @@
       "respiratory issues",
       "pregnancy"
     ],
-    "dosage": "50–200 mg opium",
-    "therapeutic": "pain relief",
+    "sideeffects": [
+      "respiratory depression",
+      "addiction"
+    ],
     "safety": "",
-    "sideeffects": "respiratory depression, addiction",
     "toxicity": "High",
     "toxicity_ld50": "~150 mg/kg (morphine, rats)",
-    "is_controlled_substance": false,
     "tags": [
       "☠️ addictive",
       "💊 oral"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "passiflora-incarnata",
@@ -8162,13 +9652,18 @@
     "common": "",
     "scientific": "Passiflora incarnata",
     "category": "nervine / anxiolytic / sleep",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "north america, central america",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a beautiful climbing flower used to calm restlessness, anxiety, and insomnia. native to the southeastern u.s., passionflower is valued for its non-habit-forming, gently sedative qualities.",
     "effects": "Anxiety relief;Mild sedation;Muscle relaxation;Sleep support",
     "mechanism": "Rich in flavonoids like chrysin and vitexin that modulate GABA-A receptors. Also may inhibit MAO and reduce neuronal excitability.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for anxiety, sleep difficulty, muscle spasms, withdrawal symptoms, and nervous gi issues.",
     "interactions": [
       "may potentiate benzodiazepines",
       "opioids",
@@ -8179,25 +9674,28 @@
       "barbiturates",
       "or pregnancy (uterine relaxant)."
     ],
-    "dosage": "",
-    "therapeutic": "used for anxiety, sleep difficulty, muscle spasms, withdrawal symptoms, and nervous gi issues.",
+    "sideeffects": [
+      "drowsiness",
+      "vivid dreams",
+      "or mild nausea. rare allergic reactions."
+    ],
     "safety": "",
-    "sideeffects": "drowsiness, vivid dreams, or mild nausea. rare allergic reactions.",
     "toxicity": "Very low. Safe in therapeutic range.",
     "toxicity_ld50": ">3000 mg/kg (mice, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🛌 sleep",
       "🧘 anti-anxiety",
       "🌸 sedative",
       "🌿 nervine"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4271694/",
       "ESCOP Monograph – Passiflora",
       "Herbal Medicine – Mills & Bone"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "passionflower",
@@ -8205,13 +9703,18 @@
     "common": "",
     "scientific": "Passiflora incarnata",
     "category": "dissociative / sedative",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "southeastern u.s., latin america",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "climbing vine traditionally brewed for anxiety relief and restful sleep.",
     "effects": "Relaxation;mild sedation;anxiolytic",
     "mechanism": "GABAergic (modulation of GABA_A receptors), mild MAOI",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "anxiety, insomnia, nervous restlessness",
     "interactions": [
       "cns depressants",
       "maois"
@@ -8220,20 +9723,22 @@
       "pregnancy",
       "cns depressants"
     ],
-    "dosage": "",
-    "therapeutic": "anxiety, insomnia, nervous restlessness",
+    "sideeffects": [
+      "drowsiness",
+      "dizziness"
+    ],
     "safety": "1",
-    "sideeffects": "drowsiness, dizziness",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌿 sedative",
       "🧘 calm"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "paullinia-cupana",
@@ -8241,13 +9746,18 @@
     "common": "",
     "scientific": "Paullinia cupana",
     "category": "stimulant / nootropic / metabolic",
+    "subcategory": "",
     "intensity": "Moderate–Strong",
     "region": "brazil, amazon rainforest",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a highly caffeinated amazonian seed used traditionally for endurance, alertness, and ritual vigor. now a common additive in energy drinks, guaraná offers a longer-lasting stimulation than coffee due to slow-release alkaloids and tannins.",
     "effects": "Energy;Focus;Mood boost;Appetite suppression",
     "mechanism": "High caffeine content (~2–6% by weight) acts as an adenosine receptor antagonist. Also contains theobromine and catechins for extended alertness.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for fatigue, cognitive performance, mild depression, sexual energy, and metabolism enhancement.",
     "interactions": [
       "synergistic with other stimulants",
       "avoid with maois",
@@ -8260,27 +9770,31 @@
       "pregnancy",
       "or with other stimulants."
     ],
-    "dosage": "",
-    "therapeutic": "used for fatigue, cognitive performance, mild depression, sexual energy, and metabolism enhancement.",
+    "sideeffects": [
+      "restlessness",
+      "insomnia",
+      "irritability",
+      "or digestive upset in sensitive individuals."
+    ],
     "safety": "",
-    "sideeffects": "restlessness, insomnia, irritability, or digestive upset in sensitive individuals.",
     "toxicity": "Moderate at high doses. Caffeine overdose is possible.",
     "toxicity_ld50": "Caffeine LD50 ~192 mg/kg (humans)",
-    "is_controlled_substance": false,
     "tags": [
       "⚡ stimulant",
       "🧠 focus",
       "🌿 amazonian",
       "🔥 metabolic"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4334453/",
       "Journal of Ethnopharmacology",
       "2001",
       "Phytochemistry Reviews",
       "2008"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "paullinia-yoco",
@@ -8288,13 +9802,18 @@
     "common": "",
     "scientific": "Paullinia yoco",
     "category": "stimulant / ritual",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "amazon rainforest",
     "legalstatus": "Generally legal",
+    "schedule": "",
     "description": "liana used by several amazonian tribes; the bark yields a potent caffeinated beverage for energy.",
     "effects": "alertness;energy;reduced fatigue",
     "mechanism": "Bark rich in caffeine acts as an adenosine receptor antagonist",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used by indigenous amazonian peoples for stamina on hunts",
     "interactions": [
       "potentiates other stimulants and certain medications"
     ],
@@ -8303,20 +9822,23 @@
       "insomnia",
       "sensitivity to caffeine"
     ],
-    "dosage": "",
-    "therapeutic": "used by indigenous amazonian peoples for stamina on hunts",
+    "sideeffects": [
+      "jitters",
+      "rapid heartbeat",
+      "sleeplessness"
+    ],
     "safety": "",
-    "sideeffects": "jitters, rapid heartbeat, sleeplessness",
     "toxicity": "Comparable to other caffeinated products",
     "toxicity_ld50": "Caffeine LD50 ~192 mg/kg in rats",
-    "is_controlled_substance": false,
     "tags": [
       "amazon",
       "caffeine",
       "vine"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "pausinystalia-johimbe",
@@ -8324,13 +9846,18 @@
     "common": "",
     "scientific": "Pausinystalia johimbe",
     "category": "stimulant / aphrodisiac / vasodilator",
+    "subcategory": "",
     "intensity": "Moderate–Strong",
     "region": "west africa (cameroon, nigeria, gabon)",
     "legalstatus": "Regulated in some countries; available OTC or by prescription in others",
+    "schedule": "",
     "description": "an african tree bark used as a traditional male aphrodisiac and stimulant. contains yohimbine, an alkaloid used in pharmaceuticals for erectile dysfunction and athletic performance.",
     "effects": "Increased libido;Stimulation;Increased blood flow;Alertness",
     "mechanism": "Yohimbine is an alpha-2 adrenergic receptor antagonist, increasing norepinephrine release and blood flow. Also affects serotonin and dopamine.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for sexual dysfunction, athletic enhancement, weight loss, and sometimes as a stimulant. traditional use includes ceremonial energizing purposes.",
     "interactions": [
       "dangerous with ssris",
       "maois",
@@ -8343,26 +9870,31 @@
       "schizophrenia",
       "or with stimulants. not for use in pregnancy."
     ],
-    "dosage": "",
-    "therapeutic": "used for sexual dysfunction, athletic enhancement, weight loss, and sometimes as a stimulant. traditional use includes ceremonial energizing purposes.",
+    "sideeffects": [
+      "anxiety",
+      "increased heart rate",
+      "elevated blood pressure",
+      "tremors",
+      "irritability. high doses can cause panic or heart issues."
+    ],
     "safety": "",
-    "sideeffects": "anxiety, increased heart rate, elevated blood pressure, tremors, irritability. high doses can cause panic or heart issues.",
     "toxicity": "Moderate to high. Narrow therapeutic index.",
     "toxicity_ld50": "~50 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🔥 aphrodisiac",
       "⚠️ stimulant",
       "🫀 blood flow",
       "🌿 traditional african"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3777290/",
       "Plants of the Gods – Rätsch",
       "International Journal of Impotence Research",
       "2002"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "pausinystalia-johimbe",
@@ -8370,13 +9902,18 @@
     "common": "",
     "scientific": "Pausinystalia johimbe",
     "category": "stimulant / aphrodisiac",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "west africa",
     "legalstatus": "Restricted or prescription in some countries",
+    "schedule": "",
     "description": "west african tree bark rich in yohimbine, historically used as an aphrodisiac and stimulant.",
     "effects": "Stimulation;increased libido;elevated heart rate",
     "mechanism": "Yohimbine blocks alpha-2 adrenergic receptors leading to increased norepinephrine release.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for erectile dysfunction and as a stimulant.",
     "interactions": [
       "interacts with stimulants and antihypertensives"
     ],
@@ -8385,19 +9922,22 @@
       "anxiety disorders",
       "maois."
     ],
-    "dosage": "",
-    "therapeutic": "used for erectile dysfunction and as a stimulant.",
+    "sideeffects": [
+      "increased blood pressure",
+      "jitteriness",
+      "insomnia"
+    ],
     "safety": "",
-    "sideeffects": "increased blood pressure, jitteriness, insomnia",
     "toxicity": "High doses cause anxiety, hypertension, or hallucinations.",
     "toxicity_ld50": "LD50 ~50 mg/kg (rats, yohimbine)",
-    "is_controlled_substance": false,
     "tags": [
       "🌳 bark",
       "🔥 libido"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "pausinystalia-yohimbe",
@@ -8405,13 +9945,18 @@
     "common": "",
     "scientific": "Pausinystalia yohimbe",
     "category": "stimulant",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "africa",
     "legalstatus": "Regulated in some regions",
+    "schedule": "",
     "description": "potent bark traditionally used as an aphrodisiac.",
     "effects": "Aphrodisiac;stimulant",
     "mechanism": "Yohimbine is an adrenergic receptor antagonist",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "erectile dysfunction treatment",
     "interactions": [
       "maois",
       "stimulants"
@@ -8420,20 +9965,22 @@
       "heart disease",
       "anxiety disorders"
     ],
-    "dosage": "",
-    "therapeutic": "erectile dysfunction treatment",
+    "sideeffects": [
+      "anxiety",
+      "hypertension"
+    ],
     "safety": "",
-    "sideeffects": "anxiety, hypertension",
     "toxicity": "Moderate",
     "toxicity_ld50": "Yohimbine LD50 ~50 mg/kg (mouse)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ caution",
       "🌿 bark",
       "🔥 intensity"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "peganum-harmala",
@@ -8441,15 +9988,20 @@
     "common": "",
     "scientific": "Peganum harmala",
     "category": "maoi / entheogen / traditional medicine",
+    "subcategory": "",
     "intensity": "Moderate–Strong",
     "region": "middle east, north africa, central asia",
     "legalstatus": "Legal in most countries; restricted in some due to MAOI activity",
+    "schedule": "",
     "description": "a desert shrub revered in persian, middle eastern, and central asian traditions. its seeds contain harmala alkaloids (harmine, harmaline, tetrahydroharmine) that act as reversible mao-a inhibitors and are used both spiritually and medicinally.",
     "effects": "MAO inhibition;Dream enhancement;Entheogenic potentiation;Altered perception",
     "mechanism": "Reversible inhibition of monoamine oxidase A (MAO-A), increasing serotonin, dopamine, and other monoamines. Also mild SSRI and hallucinogenic potentiator.",
     "compounds": [
       "Harmine"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditionally used for depression, spiritual ritual, antiparasitic cleansing, and as a potentiator of dmt-containing plants.",
     "interactions": [
       "strong interaction with serotonergic drugs. serotonin syndrome risk."
     ],
@@ -8461,26 +10013,31 @@
       "psychiatric meds",
       "pregnancy."
     ],
-    "dosage": "",
-    "therapeutic": "traditionally used for depression, spiritual ritual, antiparasitic cleansing, and as a potentiator of dmt-containing plants.",
+    "sideeffects": [
+      "nausea",
+      "vomiting",
+      "dizziness",
+      "tremors",
+      "anxiety. strong purgative effect possible. tyramine reaction risk."
+    ],
     "safety": "",
-    "sideeffects": "nausea, vomiting, dizziness, tremors, anxiety. strong purgative effect possible. tyramine reaction risk.",
     "toxicity": "Moderate–High. Purified alkaloids more dangerous than seed prep.",
     "toxicity_ld50": "~370 mg/kg (harmaline, mice, IP)",
-    "is_controlled_substance": false,
     "tags": [
       "🧠 maoi",
       "🌌 entheogen",
       "🌿 traditional",
       "🌙 dreams"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4621295/",
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology",
       "1997"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "peganum-harmala",
@@ -8488,13 +10045,18 @@
     "common": "",
     "scientific": "Peganum harmala",
     "category": "ritual / maoi",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "middle east, central asia",
     "legalstatus": "Restricted in some countries",
+    "schedule": "",
     "description": "potent maoi seed used traditionally for protection and divination.",
     "effects": "MAOI effects;mild hallucinations;dream enhancement",
     "mechanism": "Harmala alkaloids reversibly inhibit MAO-A and MAO-B.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used in middle eastern rituals; sometimes combined with dmt for oral activity.",
     "interactions": [
       "dangerous with other maois or serotonergic drugs"
     ],
@@ -8503,19 +10065,22 @@
       "stimulants",
       "or liver disease."
     ],
-    "dosage": "",
-    "therapeutic": "used in middle eastern rituals; sometimes combined with dmt for oral activity.",
+    "sideeffects": [
+      "nausea",
+      "vomiting",
+      "weakness"
+    ],
     "safety": "",
-    "sideeffects": "nausea, vomiting, weakness",
     "toxicity": "High doses cause nausea, tremors, or hallucinations.",
     "toxicity_ld50": "LD50 ~150 mg/kg (harmaline, mice)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ maoi",
       "🌿 seeds"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "perilla-frutescens",
@@ -8523,9 +10088,11 @@
     "common": "",
     "scientific": "Perilla frutescens",
     "category": "ethnobotanical",
+    "subcategory": "",
     "intensity": "",
     "region": "east asia",
     "legalstatus": "",
+    "schedule": "",
     "description": "used in east asian cuisine and medicine, this leaf contains mild mood-elevating and cognitive enhancing properties.",
     "effects": "uplifting;calm clarity",
     "mechanism": "Cholinergic + antioxidant effects",
@@ -8533,22 +10100,24 @@
       "Perillaldehyde",
       "Rosmarinic Acid"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "mild nootropic",
       "culinary",
       "relaxing"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "echinopsis-peruviana",
@@ -8556,13 +10125,18 @@
     "common": "",
     "scientific": "Echinopsis peruviana",
     "category": "psychedelic",
+    "subcategory": "",
     "intensity": "",
     "region": "andes",
     "legalstatus": "Cactus legal; mescaline controlled",
+    "schedule": "",
     "description": "cactus rich in mescaline similar to san pedro.",
     "effects": "visions;empathy",
     "mechanism": "Mescaline acts as a 5-HT2A agonist",
     "compounds": [],
+    "preparations": [],
+    "dosage": "20–30 cm fresh cactus",
+    "therapeutic": "spiritual insight",
     "interactions": [
       "maois",
       "stimulants"
@@ -8571,19 +10145,21 @@
       "heart issues",
       "pregnancy"
     ],
-    "dosage": "20–30 cm fresh cactus",
-    "therapeutic": "spiritual insight",
+    "sideeffects": [
+      "nausea",
+      "dilated pupils"
+    ],
     "safety": "",
-    "sideeffects": "nausea, dilated pupils",
     "toxicity": "Low",
     "toxicity_ld50": ">1 g/kg (rats)",
-    "is_controlled_substance": false,
     "tags": [
       "🌀 visionary",
       "🌵 cactus"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "petasites-hybridus",
@@ -8591,9 +10167,11 @@
     "common": "Butterbur",
     "scientific": "Petasites hybridus",
     "category": "dissociative / sedative",
+    "subcategory": "",
     "intensity": "Mild to moderate",
     "region": "europe, asia",
     "legalstatus": "Legal with restrictions (PA-free only)",
+    "schedule": "",
     "description": "also known as butterbur, this european root was historically used as a remedy for migraines and spasms. contains pyrrolizidine alkaloids, so safe extracts must be purified.",
     "effects": "Relaxation;muscle relief;headache reduction",
     "mechanism": "Antispasmodic and anti-inflammatory effects; calcium channel modulation",
@@ -8601,6 +10179,9 @@
       "Petasin",
       "Isopetasin"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "migraine prevention, allergies, anxiety",
     "interactions": [
       "avoid hepatotoxic meds"
     ],
@@ -8609,20 +10190,21 @@
       "pregnancy",
       "raw extract use"
     ],
-    "dosage": "",
-    "therapeutic": "migraine prevention, allergies, anxiety",
+    "sideeffects": [
+      "liver toxicity risk from unpurified products"
+    ],
     "safety": "",
-    "sideeffects": "liver toxicity risk from unpurified products",
     "toxicity": "Moderate to high (raw plant)",
     "toxicity_ld50": "~950 mg/kg (mouse, oral, unpurified)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ pa toxins",
       "🌿 herbal",
       "🧠 headache"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "peumus-boldus",
@@ -8630,9 +10212,11 @@
     "common": "",
     "scientific": "Peumus boldus",
     "category": "ethnobotanical",
+    "subcategory": "",
     "intensity": "",
     "region": "chile",
     "legalstatus": "",
+    "schedule": "",
     "description": "boldo is a south american medicinal herb with liver-supportive and mild hypnotic properties.",
     "effects": "calming;digestive aid;dreamy",
     "mechanism": "Cholinergic + serotonergic",
@@ -8640,22 +10224,24 @@
       "Boldine",
       "Ascaridole"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "digestive",
       "sleep aid",
       "folk medicine"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "pimenta-dioica",
@@ -8663,9 +10249,11 @@
     "common": "Allspice",
     "scientific": "Pimenta dioica",
     "category": "ethnobotanical",
+    "subcategory": "",
     "intensity": "",
     "region": "caribbean, central america",
     "legalstatus": "",
+    "schedule": "",
     "description": "also known as allspice, this caribbean plant has mild uplifting and warming effects, sometimes used in ritual incense.",
     "effects": "stimulant;aromatic euphoria;warming",
     "mechanism": "GABAergic + serotonergic",
@@ -8673,22 +10261,24 @@
       "Eugenol",
       "Quercetin"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "aromatic",
       "ritual",
       "mild stimulant"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "piper-auritum",
@@ -8696,41 +10286,48 @@
     "common": "",
     "scientific": "Piper auritum",
     "category": "culinary / mild relaxant / traditional mesoamerican",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "mexico, central america",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a large-leaved herb with a root beer aroma, used in traditional mexican cuisine and healing rituals. also called 'hoja santa', it is believed to gently support digestion, lungs, and emotional balance.",
     "effects": "Digestive aid;Calming;Flavor enhancer;Mild euphoria (traditional use)",
     "mechanism": "Contains safrole and other aromatic compounds that may mildly modulate GABA and dopamine activity. Primary use is culinary, with subtle psychoactivity in large doses.",
     "compounds": [
       "Safrole"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for indigestion, respiratory soothing, menstrual support, and mild calming. culturally linked to rituals and purification.",
     "interactions": [
       "may inhibit cyp enzymes. avoid combining with hepatotoxic substances."
     ],
     "contraindications": [
       "avoid chronic high-dose consumption. not for pregnant users or liver conditions."
     ],
-    "dosage": "",
-    "therapeutic": "used for indigestion, respiratory soothing, menstrual support, and mild calming. culturally linked to rituals and purification.",
+    "sideeffects": [
+      "in large doses: nausea",
+      "drowsiness. safrole is a known liver carcinogen at high doses in animals."
+    ],
     "safety": "",
-    "sideeffects": "in large doses: nausea, drowsiness. safrole is a known liver carcinogen at high doses in animals.",
     "toxicity": "Low at culinary doses. Chronic use of concentrated extract not advised.",
     "toxicity_ld50": "Safrole ~1950 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 digestive",
       "🌮 culinary",
       "🫖 soothing",
       "🌀 mild relaxant"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8757553/",
       "Journal of Ethnopharmacology",
       "2005",
       "Ethnobotany of Mexico – 2012"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "piper-methysticum",
@@ -8738,13 +10335,18 @@
     "common": "",
     "scientific": "Piper methysticum",
     "category": "dissociative / sedative",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "pacific islands",
     "legalstatus": "Regulated in some countries",
+    "schedule": "",
     "description": "kava root beverage with calming properties.",
     "effects": "Anxiolytic;sedation",
     "mechanism": "Kavalactones modulate GABA receptors",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "anxiety relief, social relaxation",
     "interactions": [
       "potentiates sedatives and alcohol"
     ],
@@ -8752,25 +10354,27 @@
       "liver disease",
       "heavy alcohol use"
     ],
-    "dosage": "",
-    "therapeutic": "anxiety relief, social relaxation",
+    "sideeffects": [
+      "drowsiness",
+      "potential hepatotoxicity"
+    ],
     "safety": "",
-    "sideeffects": "drowsiness, potential hepatotoxicity",
     "toxicity": "Moderate",
     "toxicity_ld50": "Kavain LD50 ~920 mg/kg (mouse)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ caution",
       "🌿 root",
       "💤 sedation"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4385482/",
       "ESCOP Monograph – Kava",
       "Journal of Clinical Psychopharmacology",
       "2013"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "pogostemon-cablin",
@@ -8778,9 +10382,11 @@
     "common": "",
     "scientific": "Pogostemon cablin",
     "category": "ethnobotanical",
+    "subcategory": "",
     "intensity": "",
     "region": "asia",
     "legalstatus": "",
+    "schedule": "",
     "description": "patchouli, while mainly aromatic, has mild psychoactive effects in traditional incense rituals.",
     "effects": "sensory enhancement;calm focus;uplifted mood",
     "mechanism": "Aromatherapeutic + serotonergic",
@@ -8788,22 +10394,24 @@
       "Patchoulol",
       "Alpha-bulnesene"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "aromatic",
       "ritual",
       "uplifting"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "polygala-tenuifolia",
@@ -8811,31 +10419,37 @@
     "common": "",
     "scientific": "Polygala tenuifolia",
     "category": "nootropic / adaptogen",
+    "subcategory": "",
     "intensity": "",
     "region": "east asia",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "called yuan zhi in tcm; promotes mental clarity",
     "effects": "focus;mood lift",
     "mechanism": "Tenuigenin saponins modulate neurochemistry and neurotrophic factors",
     "compounds": [],
+    "preparations": [],
+    "dosage": "1-2 g root",
+    "therapeutic": "memory, stress",
     "interactions": [
       "none known"
     ],
     "contraindications": [
       "severe gastritis"
     ],
-    "dosage": "1-2 g root",
-    "therapeutic": "memory, stress",
+    "sideeffects": [
+      "gi upset"
+    ],
     "safety": "",
-    "sideeffects": "gi upset",
     "toxicity": "Low",
     "toxicity_ld50": ">3 g/kg (rats)",
-    "is_controlled_substance": false,
     "tags": [
       "🧠 focus"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "psilocybin",
@@ -8843,13 +10457,18 @@
     "common": "",
     "scientific": "Psilocybin",
     "category": "psychedelic",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "🌎 global",
     "legalstatus": "Controlled in many countries",
+    "schedule": "",
     "description": "active compound in psychedelic mushrooms producing profound perceptual changes.",
     "effects": "Visual patterns;mystical insight;emotional release",
     "mechanism": "Converted to psilocin which acts as 5-HT2A agonist.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "promising treatment for depression, addiction, and end-of-life anxiety.",
     "interactions": [
       "ssris may reduce effects",
       "avoid maois."
@@ -8858,20 +10477,23 @@
       "psychosis",
       "uncontrolled hypertension."
     ],
-    "dosage": "",
-    "therapeutic": "promising treatment for depression, addiction, and end-of-life anxiety.",
+    "sideeffects": [
+      "nausea",
+      "anxiety",
+      "transient increase in heart rate."
+    ],
     "safety": "2",
-    "sideeffects": "nausea, anxiety, transient increase in heart rate.",
     "toxicity": "Low toxicity; wide margin of safety.",
     "toxicity_ld50": "285 mg/kg (rats, oral) for psilocybin",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ restricted",
       "🌀 visionary",
       "💊 oral"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "psychotria-carthagenensis",
@@ -8879,13 +10501,18 @@
     "common": "",
     "scientific": "Psychotria carthagenensis",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Strong",
     "region": "amazon basin",
     "legalstatus": "DMT restricted in many countries",
+    "schedule": "",
     "description": "amazonian shrub also known as chaliponga; its dmt-rich leaves are valued in shamanic ceremonies.",
     "effects": "visual effects;introspection;spiritual insight",
     "mechanism": "Leaves contain N,N-dimethyltryptamine acting as a serotonin agonist; requires MAO inhibition orally",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used in ayahuasca analogues for visionary experiences",
     "interactions": [
       "dangerous with serotonergic drugs or other maois"
     ],
@@ -8893,20 +10520,23 @@
       "mental health conditions",
       "maoi or ssri medication"
     ],
-    "dosage": "",
-    "therapeutic": "used in ayahuasca analogues for visionary experiences",
+    "sideeffects": [
+      "nausea",
+      "intense visions",
+      "possible anxiety"
+    ],
     "safety": "",
-    "sideeffects": "nausea, intense visions, possible anxiety",
     "toxicity": "Low physiological but intense psychological effects",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "amazon",
       "dmt",
       "chaliponga"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "psychotria-carthaginensis",
@@ -8914,13 +10544,18 @@
     "common": "",
     "scientific": "Psychotria carthaginensis",
     "category": "psychedelic",
+    "subcategory": "",
     "intensity": "",
     "region": "south america",
     "legalstatus": "Often legal; DMT controlled",
+    "schedule": "",
     "description": "chacruna relative sometimes used as admixture in brews",
     "effects": "visions;euphoria",
     "mechanism": "Leaves contain DMT acting on 5-HT2A when combined with MAOI",
     "compounds": [],
+    "preparations": [],
+    "dosage": "50-100 g fresh leaves",
+    "therapeutic": "visionary states",
     "interactions": [
       "maois",
       "ssris"
@@ -8928,19 +10563,20 @@
     "contraindications": [
       "mental health disorders"
     ],
-    "dosage": "50-100 g fresh leaves",
-    "therapeutic": "visionary states",
+    "sideeffects": [
+      "nausea with maoi"
+    ],
     "safety": "",
-    "sideeffects": "nausea with maoi",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 ayahuasca",
       "🍃 leaf"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "ptychopetalum-olacoides",
@@ -8948,33 +10584,39 @@
     "common": "",
     "scientific": "Ptychopetalum olacoides",
     "category": "stimulant",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "amazon",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "known as muira puama, used for vitality and libido.",
     "effects": "Libido boost;mild stimulation",
     "mechanism": "Alkaloids may act on dopamine pathways",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "aphrodisiac and tonic",
     "interactions": [
       "none known"
     ],
     "contraindications": [
       "pregnancy"
     ],
-    "dosage": "",
-    "therapeutic": "aphrodisiac and tonic",
+    "sideeffects": [
+      "rare insomnia"
+    ],
     "safety": "",
-    "sideeffects": "rare insomnia",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "stimulant",
       "✅ safe",
       "🌿 bark"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "reishi-mushroom",
@@ -8982,13 +10624,18 @@
     "common": "",
     "scientific": "Ganoderma lucidum",
     "category": "other",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "🇨🇳 east asia",
     "legalstatus": "Legal / Unregulated",
+    "schedule": "",
     "description": "tonic fungus revered in asia for boosting immunity and easing stress.",
     "effects": "Immune support;calm focus",
     "mechanism": "Triterpenoids and beta-glucans modulate immune response.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "immune enhancement, stress resilience, antioxidant.",
     "interactions": [
       "anticoagulants",
       "immunosuppressants."
@@ -8997,20 +10644,21 @@
       "bleeding disorders",
       "surgery."
     ],
-    "dosage": "",
-    "therapeutic": "immune enhancement, stress resilience, antioxidant.",
+    "sideeffects": [
+      "rare digestive upset or rash."
+    ],
     "safety": "1",
-    "sideeffects": "rare digestive upset or rash.",
     "toxicity": "Very low toxicity; widely consumed as tonic.",
     "toxicity_ld50": "Not established; safe in traditional use.",
-    "is_controlled_substance": false,
     "tags": [
       "\\u2615 brewable",
       "\\ud83e\\udde0 cognitive",
       "\\u2705 safe"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "rhododendron-anthopogon",
@@ -9018,9 +10666,11 @@
     "common": "Anthopogon",
     "scientific": "",
     "category": "",
+    "subcategory": "",
     "intensity": "",
     "region": "himalayas",
     "legalstatus": "",
+    "schedule": "",
     "description": "",
     "effects": "uplifting;clarity;spiritual aid",
     "mechanism": "Aromatherapeutic and cognitive modulation via essential oils",
@@ -9028,22 +10678,24 @@
       "Flavonoids",
       "Volatile oils"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "uplifting",
       "ritual",
       "clarity"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "rubus-idaeus",
@@ -9051,9 +10703,11 @@
     "common": "Red Raspberry Leaf",
     "scientific": "",
     "category": "tonic",
+    "subcategory": "",
     "intensity": "",
     "region": "europe, north america",
     "legalstatus": "",
+    "schedule": "",
     "description": "",
     "effects": "uterine tonic;calming;digestive support",
     "mechanism": "Smooth muscle modulation and antioxidant action",
@@ -9061,22 +10715,24 @@
       "Fragarine",
       "Tiliroside"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "folk",
       "uterine",
       "tonic"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "ruta-graveolens",
@@ -9084,9 +10740,11 @@
     "common": "Rue",
     "scientific": "Ruta graveolens",
     "category": "ethnobotanical",
+    "subcategory": "",
     "intensity": "",
     "region": "mediterranean",
     "legalstatus": "",
+    "schedule": "",
     "description": "common rue, used historically as a sedative, an abortifacient, and for spiritual protection.",
     "effects": "relaxation;hypnotic;mystical",
     "mechanism": "GABA-A modulation, alkaloid effects",
@@ -9094,22 +10752,24 @@
       "Rutarin",
       "Graveoline"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "ritual",
       "bitter",
       "traditional medicine"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "salvia-apiana",
@@ -9117,9 +10777,11 @@
     "common": "White Sage",
     "scientific": "Salvia apiana",
     "category": "ritual / aromatic",
+    "subcategory": "",
     "intensity": "",
     "region": "southwestern us",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "white sage revered for cleansing ceremonies",
     "effects": "calm;clarity",
     "mechanism": "Essential oils like cineole and thujone provide mild GABA modulation",
@@ -9127,25 +10789,29 @@
       "Cineole",
       "Rosmarinic acid"
     ],
+    "preparations": [],
+    "dosage": "Smoke small bundle or 1 g in tea",
+    "therapeutic": "purification rites, relaxation",
     "interactions": [
       "none known"
     ],
     "contraindications": [
       "pregnancy high doses"
     ],
-    "dosage": "Smoke small bundle or 1 g in tea",
-    "therapeutic": "purification rites, relaxation",
+    "sideeffects": [
+      "rare allergic cough"
+    ],
     "safety": "",
-    "sideeffects": "rare allergic cough",
     "toxicity": "Low",
     "toxicity_ld50": "Not well studied",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 ritual",
       "🪔 incense"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "salvia-sclarea",
@@ -9153,9 +10819,11 @@
     "common": "",
     "scientific": "Salvia sclarea",
     "category": "ethnobotanical",
+    "subcategory": "",
     "intensity": "",
     "region": "mediterranean",
     "legalstatus": "",
+    "schedule": "",
     "description": "clary sage, used aromatically and medicinally for mild euphoria, hormonal balancing, and clarity.",
     "effects": "clarity;relief;uplifting",
     "mechanism": "GABA-A modulation, estrogenic activity",
@@ -9163,22 +10831,24 @@
       "Linalyl acetate",
       "Sclareol"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "aromatic",
       "elevating",
       "folk remedy"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "tabernaemontana-sananho",
@@ -9186,31 +10856,37 @@
     "common": "",
     "scientific": "Tabernaemontana sananho",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "",
     "region": "amazon",
     "legalstatus": "Unregulated",
+    "schedule": "",
     "description": "shamanic plant sometimes added to ayahuasca.",
     "effects": "dream enhancement;mild stimulation",
     "mechanism": "Iboga-type alkaloids act on NMDA and serotonin receptors",
     "compounds": [],
+    "preparations": [],
+    "dosage": "10–20 g root",
+    "therapeutic": "traditional spiritual healer",
     "interactions": [
       "maois"
     ],
     "contraindications": [
       "heart conditions"
     ],
-    "dosage": "10–20 g root",
-    "therapeutic": "traditional spiritual healer",
+    "sideeffects": [
+      "nausea"
+    ],
     "safety": "",
-    "sideeffects": "nausea",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 root"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "sassafras-albidum",
@@ -9218,13 +10894,18 @@
     "common": "",
     "scientific": "Sassafras albidum",
     "category": "stimulant / traditional",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "eastern north america",
     "legalstatus": "Restricted as food additive in the U.S.",
+    "schedule": "",
     "description": "fragrant tree whose root bark and oil were once common flavorings; contains safrole with mild psychoactive properties.",
     "effects": "Mild euphoria;warmth",
     "mechanism": "Safrole may modulate dopamine release and acts as a mild hallucinogen at high doses.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "historically used as spring tonic, aromatic beverage, and folk medicine.",
     "interactions": [
       "may interact with maois or increase hepatotoxic drugs"
     ],
@@ -9232,19 +10913,21 @@
       "liver disease",
       "pregnancy."
     ],
-    "dosage": "",
-    "therapeutic": "historically used as spring tonic, aromatic beverage, and folk medicine.",
+    "sideeffects": [
+      "nausea",
+      "possible hepatotoxicity"
+    ],
     "safety": "",
-    "sideeffects": "nausea, possible hepatotoxicity",
     "toxicity": "Safrole is hepatotoxic and potentially carcinogenic in high amounts.",
     "toxicity_ld50": "Safrole LD50 ~1.95 g/kg (rats)",
-    "is_controlled_substance": false,
     "tags": [
       "🌳 root bark",
       "🌿 tea"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "scutellaria-lateriflora",
@@ -9252,9 +10935,11 @@
     "common": "Blue Skullcap",
     "scientific": "Scutellaria lateriflora",
     "category": "dissociative / sedative",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "north america",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "commonly known as skullcap, this north american herb has a long history in western herbalism for treating nervous tension and insomnia.",
     "effects": "Mild sedation;anxiety relief;mental clarity",
     "mechanism": "GABA_A receptor modulation (baicalin and other flavonoids)",
@@ -9262,6 +10947,9 @@
       "Baicalin",
       "Scutellarin"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "anxiety, stress, insomnia, pms",
     "interactions": [
       "cns depressants",
       "alcohol",
@@ -9271,20 +10959,22 @@
       "pregnancy",
       "cns depressants"
     ],
-    "dosage": "",
-    "therapeutic": "anxiety, stress, insomnia, pms",
+    "sideeffects": [
+      "drowsiness",
+      "dizziness at high doses"
+    ],
     "safety": "",
-    "sideeffects": "drowsiness, dizziness at high doses",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌿 herbal",
       "😴 sedative"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "sida-acuta",
@@ -9292,32 +10982,38 @@
     "common": "",
     "scientific": "Sida acuta",
     "category": "stimulant / nootropic",
+    "subcategory": "",
     "intensity": "",
     "region": "tropical regions",
     "legalstatus": "Varies",
+    "schedule": "",
     "description": "weedy plant sometimes used as a mild stimulant",
     "effects": "energy;focus",
     "mechanism": "Contains ephedrine-like alkaloids stimulating adrenergic receptors",
     "compounds": [],
+    "preparations": [],
+    "dosage": "1-3 g dried leaf",
+    "therapeutic": "traditional fever remedy",
     "interactions": [
       "stimulants"
     ],
     "contraindications": [
       "hypertension"
     ],
-    "dosage": "1-3 g dried leaf",
-    "therapeutic": "traditional fever remedy",
+    "sideeffects": [
+      "increased heart rate"
+    ],
     "safety": "",
-    "sideeffects": "increased heart rate",
     "toxicity": "Moderate",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "stimulant",
       "🍃 leaf"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "silene-capensis",
@@ -9325,38 +11021,44 @@
     "common": "",
     "scientific": "Silene capensis",
     "category": "oneirogen",
+    "subcategory": "",
     "intensity": "Mild to moderate",
     "region": "south africa",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "known as 'xhosa dream root', silene capensis is a sacred plant used by the xhosa people of south africa for initiating vivid and prophetic dreams.",
     "effects": "Lucid dreaming;enhanced dream recall;vivid visions",
     "mechanism": "Likely acts on cholinergic and serotonergic systems; exact mechanism unknown",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "dream enhancement, ancestral communication",
     "interactions": [
       "none well documented"
     ],
     "contraindications": [
       "pregnancy"
     ],
-    "dosage": "",
-    "therapeutic": "dream enhancement, ancestral communication",
+    "sideeffects": [
+      "mild nausea if taken in excess"
+    ],
     "safety": "",
-    "sideeffects": "mild nausea if taken in excess",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌙 dream",
       "🧠 vision"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4308394/",
       "Plants of the Gods – Rätsch",
       "African Ethnobotany in the Americas",
       "2014"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "silene-undulata",
@@ -9364,31 +11066,35 @@
     "common": "African Dream Root",
     "scientific": "",
     "category": "",
+    "subcategory": "",
     "intensity": "",
     "region": "south africa",
     "legalstatus": "",
+    "schedule": "",
     "description": "",
     "effects": "lucid dreaming;dream recall;mild sedation",
     "mechanism": "Unknown; may influence cholinergic systems during sleep cycles.",
     "compounds": [
       "Triterpenoid saponins"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "dream",
       "visionary",
       "african"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "silene-undulata",
@@ -9396,31 +11102,35 @@
     "common": "African Dream Root",
     "scientific": "",
     "category": "",
+    "subcategory": "",
     "intensity": "",
     "region": "south africa",
     "legalstatus": "",
+    "schedule": "",
     "description": "",
     "effects": "lucid dreaming;dream recall;mild sedation",
     "mechanism": "Unknown; may influence cholinergic systems during sleep cycles.",
     "compounds": [
       "Triterpenoid saponins"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "dream",
       "visionary",
       "african"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "silybum-marianum",
@@ -9428,32 +11138,38 @@
     "common": "",
     "scientific": "Silybum marianum",
     "category": "other",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "mediterranean",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "milk thistle seeds support liver function.",
     "effects": "Liver protection",
     "mechanism": "Silymarin acts as antioxidant and hepatoprotective",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "liver detox support",
     "interactions": [
       "may affect drug metabolism"
     ],
     "contraindications": [
       "allergy to asteraceae"
     ],
-    "dosage": "",
-    "therapeutic": "liver detox support",
+    "sideeffects": [
+      "digestive upset"
+    ],
     "safety": "",
-    "sideeffects": "digestive upset",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌿 seed"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "sinicuichi",
@@ -9461,13 +11177,18 @@
     "common": "",
     "scientific": "Heimia salicifolia",
     "category": "oneirogen",
+    "subcategory": "",
     "intensity": "Mild to moderate",
     "region": "mexico, central america",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "used traditionally in central america as a 'sun opener,' believed to enhance memory and auditory perception. alters sound and memory in dreamlike ways.",
     "effects": "Auditory distortion;dreamy state;euphoria",
     "mechanism": "Alkaloids may modulate GABA and acetylcholine systems",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "folk use for memory and dream recall",
     "interactions": [
       "avoid cns depressants or alcohol"
     ],
@@ -9475,20 +11196,23 @@
       "pregnancy",
       "driving"
     ],
-    "dosage": "",
-    "therapeutic": "folk use for memory and dream recall",
+    "sideeffects": [
+      "dry mouth",
+      "yellow vision",
+      "dizziness"
+    ],
     "safety": "",
-    "sideeffects": "dry mouth, yellow vision, dizziness",
     "toxicity": "Low to moderate; not well studied",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🌞 sun",
       "🎧 auditory",
       "🧠 dream"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "sophora-secundiflora",
@@ -9496,31 +11220,35 @@
     "common": "",
     "scientific": "Sophora secundiflora",
     "category": "ethnobotanical",
+    "subcategory": "",
     "intensity": "",
     "region": "southwestern us, mexico",
     "legalstatus": "",
+    "schedule": "",
     "description": "mescal bean, used ceremonially by native american tribes. highly toxic, formerly used as an ordeal poison.",
     "effects": "delirium;visions;dizziness",
     "mechanism": "Nicotinic receptor agonist",
     "compounds": [
       "Cytisine"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "ceremonial",
       "toxic",
       "visionary"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "spigelia-marilandica",
@@ -9528,13 +11256,18 @@
     "common": "",
     "scientific": "Spigelia marilandica",
     "category": "anthelmintic / nervine / traditional native american",
+    "subcategory": "",
     "intensity": "Moderate–Strong (dose-dependent)",
     "region": "southeastern united states",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a striking woodland plant native to the southeastern u.s., traditionally used for expelling intestinal parasites. it has mild nervine and sedative effects, but can cause strong reactions in high doses.",
     "effects": "Parasitic cleanse;Mild sedation;Vision changes (in excess);Calming",
     "mechanism": "Alkaloids (spigeline and others) are toxic to parasitic worms and may also affect the central nervous system. In high doses, can produce dizziness and visual distortion.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "historically used for intestinal worms, especially in children, and as a calming nervine in small doses.",
     "interactions": [
       "may interact with sedatives",
       "anti-parasitics",
@@ -9543,25 +11276,29 @@
     "contraindications": [
       "avoid in pregnancy or with seizure disorders. dose carefully due to narrow safety margin."
     ],
-    "dosage": "",
-    "therapeutic": "historically used for intestinal worms, especially in children, and as a calming nervine in small doses.",
+    "sideeffects": [
+      "high doses may cause headache",
+      "visual disturbances",
+      "nausea",
+      "or even convulsions."
+    ],
     "safety": "",
-    "sideeffects": "high doses may cause headache, visual disturbances, nausea, or even convulsions.",
     "toxicity": "Moderate. Therapeutic window is narrow.",
     "toxicity_ld50": "Not well established; potentially toxic at high doses",
-    "is_controlled_substance": false,
     "tags": [
       "🪱 antiparasitic",
       "🌿 native american",
       "🧠 nervine",
       "⚠️ toxic in excess"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6492244/",
       "Native American Ethnobotany – Moerman",
       "Herbal Medicine – Mills & Bone"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "tabernaemontana-undulata",
@@ -9569,15 +11306,20 @@
     "common": "Bechette",
     "scientific": "Tabernaemontana undulata",
     "category": "analgesic / visionary",
+    "subcategory": "",
     "intensity": "Moderate to Strong",
     "region": "western amazon",
     "legalstatus": "Mostly legal but little researched",
+    "schedule": "",
     "description": "also called uchu sanango; this rare shrub contains iboga-like compounds and is used in shamanic practices.",
     "effects": "tingling sensation;dream enhancement;altered perception",
     "mechanism": "Contains iboga-type alkaloids affecting serotonin and NMDA receptors",
     "compounds": [
       "Voacangine"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "amazonian tribes use the bark for hunting preparation and pain",
     "interactions": [
       "avoid with other serotonergic or stimulant substances"
     ],
@@ -9586,20 +11328,23 @@
       "pregnancy",
       "mental illness"
     ],
-    "dosage": "",
-    "therapeutic": "amazonian tribes use the bark for hunting preparation and pain",
+    "sideeffects": [
+      "nausea",
+      "numbness",
+      "dizziness"
+    ],
     "safety": "",
-    "sideeffects": "nausea, numbness, dizziness",
     "toxicity": "High doses may be neurotoxic or cardiotoxic",
     "toxicity_ld50": "Not well known",
-    "is_controlled_substance": false,
     "tags": [
       "amazon",
       "uchu sanango",
       "iboga alkaloids"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "tabernanthe-iboga",
@@ -9607,15 +11352,20 @@
     "common": "",
     "scientific": "Tabernanthe iboga",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Very strong",
     "region": "central africa",
     "legalstatus": "Controlled or prescription in many countries",
+    "schedule": "",
     "description": "sacred shrub central to bwiti ceremonies; contains ibogaine producing intense visionary states and potential addiction therapy.",
     "effects": "Powerful visions;spiritual insight;stimulation",
     "mechanism": "Ibogaine acts on NMDA, kappa-opioid, and serotonin systems while promoting neurotrophic factors.",
     "compounds": [
       "Ibogaine"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditional bwiti initiation; studied for addiction interruption.",
     "interactions": [
       "dangerous with other stimulants or opioids"
     ],
@@ -9624,24 +11374,27 @@
       "psychiatric disorders",
       "maois."
     ],
-    "dosage": "",
-    "therapeutic": "traditional bwiti initiation; studied for addiction interruption.",
+    "sideeffects": [
+      "nausea",
+      "ataxia",
+      "prolonged recovery"
+    ],
     "safety": "",
-    "sideeffects": "nausea, ataxia, prolonged recovery",
     "toxicity": "Cardiotoxic and neurotoxic at high doses; medical supervision required.",
     "toxicity_ld50": "Ibogaine LD50 ~50 mg/kg (mice)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ intense",
       "🌿 root bark"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4218771/",
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology",
       "2014"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "tagetes-lucida",
@@ -9649,39 +11402,45 @@
     "common": "",
     "scientific": "Tagetes lucida",
     "category": "oneirogen / digestive / traditional mesoamerican",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "mexico, central america",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "used by the aztecs and modern curanderos, this aromatic herb has both culinary and psychoactive properties. smoked or brewed, it can enhance dreams and alter perception gently.",
     "effects": "Mild euphoria;Vision enhancement;Lucid dreaming;Digestive aid",
     "mechanism": "Contains estragole, ocimene, and anethole, which may mildly modulate GABA and serotonergic pathways. Psychoactive effects are subtle and dose-dependent.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for digestive issues, anxiety, and ceremonial purposes. also employed for lucid dreaming and spirit communication in traditional rituals.",
     "interactions": [
       "minimal in traditional doses. theoretical synergy with other calming or dream herbs."
     ],
     "contraindications": [
       "avoid in pregnancy or with hormone-sensitive conditions. not for chronic high-dose use."
     ],
-    "dosage": "",
-    "therapeutic": "used for digestive issues, anxiety, and ceremonial purposes. also employed for lucid dreaming and spirit communication in traditional rituals.",
+    "sideeffects": [
+      "mild nausea or dizziness in excess. estragole is a potential carcinogen at high doses in animals."
+    ],
     "safety": "",
-    "sideeffects": "mild nausea or dizziness in excess. estragole is a potential carcinogen at high doses in animals.",
     "toxicity": "Low at ceremonial/culinary doses. Estragole raises caution at high concentrations.",
     "toxicity_ld50": "Estragole: ~1500 mg/kg (rat, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🌼 floral",
       "🌙 dream herb",
       "🫖 digestive",
       "🌀 mesoamerican"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5372953/",
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology",
       "2005"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "tamarindus-indica",
@@ -9689,9 +11448,11 @@
     "common": "Tamarind",
     "scientific": "",
     "category": "",
+    "subcategory": "",
     "intensity": "",
     "region": "africa, south asia",
     "legalstatus": "",
+    "schedule": "",
     "description": "",
     "effects": "laxative;digestive aid;cooling",
     "mechanism": "Promotes gastrointestinal motility and antioxidant action",
@@ -9699,22 +11460,24 @@
       "Tartaric acid",
       "Lupeol"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "digestive",
       "folk",
       "cooling"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "tetradenia-riparia",
@@ -9722,13 +11485,18 @@
     "common": "",
     "scientific": "Tetradenia riparia",
     "category": "calming / analgesic",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "eastern and southern africa",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "fragrant african shrub sometimes called iboza; provides a relaxing effect and mild pain relief.",
     "effects": "relaxation;pain relief;lightheadedness",
     "mechanism": "Aromatic diterpenes may modulate GABA and opioid receptors",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used in african folk medicine for headaches and anxiety",
     "interactions": [
       "may enhance sedatives or blood pressure medications"
     ],
@@ -9736,20 +11504,22 @@
       "pregnancy",
       "caution with hypotensive drugs"
     ],
-    "dosage": "",
-    "therapeutic": "used in african folk medicine for headaches and anxiety",
+    "sideeffects": [
+      "dizziness",
+      "low blood pressure"
+    ],
     "safety": "",
-    "sideeffects": "dizziness, low blood pressure",
     "toxicity": "Limited research; appears safe in small amounts",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "african",
       "iboza",
       "aromatic"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "thymus-vulgaris",
@@ -9757,33 +11527,39 @@
     "common": "",
     "scientific": "Thymus vulgaris",
     "category": "aromatic / antimicrobial",
+    "subcategory": "",
     "intensity": "",
     "region": "mediterranean",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "common thyme used medicinally and as spice",
     "effects": "alertness;respiratory relief",
     "mechanism": "Essential oil rich in thymol acts as antimicrobial and mild stimulant",
     "compounds": [
       "Thymol"
     ],
+    "preparations": [],
+    "dosage": "1 g dried leaf",
+    "therapeutic": "coughs, focus",
     "interactions": [
       "anticoagulants"
     ],
     "contraindications": [
       "pregnancy large doses"
     ],
-    "dosage": "1 g dried leaf",
-    "therapeutic": "coughs, focus",
+    "sideeffects": [
+      "gi upset high doses"
+    ],
     "safety": "",
-    "sideeffects": "gi upset high doses",
     "toxicity": "Low",
     "toxicity_ld50": "880 mg/kg (rats, thymol)",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 culinary"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "tilia-cordata",
@@ -9791,38 +11567,44 @@
     "common": "",
     "scientific": "Tilia cordata",
     "category": "nervine / sedative / cardiovascular",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "europe, temperate asia",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "linden flowers, from the lime tree (not citrus), are a gentle remedy for stress, insomnia, and tension-related heart symptoms. often used in relaxing teas and rituals.",
     "effects": "Calming;Antispasmodic;Cardiovascular support;Mild hypnotic",
     "mechanism": "Flavonoids (quercetin), volatile oils, and mucilage reduce anxiety, soothe the digestive tract, and support vasodilation. GABA modulation contributes to calming effect.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for anxiety, palpitations, high blood pressure, colds, insomnia, and mild headaches.",
     "interactions": [
       "may mildly potentiate sedatives or antihypertensives."
     ],
     "contraindications": [
       "none major. monitor in heart medications due to blood pressure effects."
     ],
-    "dosage": "",
-    "therapeutic": "used for anxiety, palpitations, high blood pressure, colds, insomnia, and mild headaches.",
+    "sideeffects": [
+      "very well tolerated. rare allergic reactions possible in pollen-sensitive individuals."
+    ],
     "safety": "",
-    "sideeffects": "very well tolerated. rare allergic reactions possible in pollen-sensitive individuals.",
     "toxicity": "Very low",
     "toxicity_ld50": "Not established; traditionally safe",
-    "is_controlled_substance": false,
     "tags": [
       "🌸 floral",
       "💤 sedative",
       "🧘 heart-calming",
       "🌿 relaxant"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6626440/",
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "tilia-europaea",
@@ -9830,9 +11612,11 @@
     "common": "Linden",
     "scientific": "Tilia europaea",
     "category": "nervine / anxiolytic / antispasmodic",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "europe, western asia, north america (ornamental)",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "linden flowers are fragrant and soothing, traditionally used in europe as a gentle sedative and nerve tonic. often brewed into calming teas to relieve stress, tension, and digestive upset.",
     "effects": "Calm;Stress relief;Muscle relaxation;Sleep support",
     "mechanism": "Contains flavonoids (e.g., quercetin, kaempferol) and volatile oils that act as mild GABA modulators and muscle relaxants.",
@@ -9840,31 +11624,36 @@
       "Farnesol",
       "Kaempferol"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for anxiety, tension headaches, high blood pressure, insomnia, and muscle cramps. also supports digestion and reduces inflammation.",
     "interactions": [
       "minimal. may slightly enhance effects of sedatives or diuretics."
     ],
     "contraindications": [
       "none significant. use with caution if allergic to pollen or linden trees."
     ],
-    "dosage": "",
-    "therapeutic": "used for anxiety, tension headaches, high blood pressure, insomnia, and muscle cramps. also supports digestion and reduces inflammation.",
+    "sideeffects": [
+      "very rare",
+      "occasional mild drowsiness or allergic reaction."
+    ],
     "safety": "",
-    "sideeffects": "very rare; occasional mild drowsiness or allergic reaction.",
     "toxicity": "Very low",
     "toxicity_ld50": "Not established (very safe at therapeutic levels)",
-    "is_controlled_substance": false,
     "tags": [
       "🧘 calm",
       "💤 sleep",
       "🌼 floral",
       "🌿 traditional european"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6597275/",
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "tilia-tomentosa",
@@ -9872,9 +11661,11 @@
     "common": "",
     "scientific": "Tilia tomentosa",
     "category": "ethnobotanical",
+    "subcategory": "",
     "intensity": "",
     "region": "europe",
     "legalstatus": "",
+    "schedule": "",
     "description": "silver linden, used as a calming tea in europe. shows sedative and anti-anxiety effects.",
     "effects": "calming;sleep aid;nervine",
     "mechanism": "GABAergic, anti-inflammatory",
@@ -9882,22 +11673,24 @@
       "Quercetin",
       "Volatile oils"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "relaxing",
       "tea",
       "folk medicine"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "toloache",
@@ -9905,33 +11698,41 @@
     "common": "",
     "scientific": "Datura spp.",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Extremely strong",
     "region": "americas, mediterranean",
     "legalstatus": "Legal but restricted in many countries",
+    "schedule": "",
     "description": "a powerful and dangerous tropane alkaloid plant traditionally used in witchcraft and shamanic rituals. highly toxic.",
     "effects": "Delirium;hallucinations;disorientation",
     "mechanism": "Anticholinergic – blocks acetylcholine via scopolamine, atropine",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "rarely used medically; historically for pain/spiritual rites",
     "interactions": [
       "all cns-affecting meds"
     ],
     "contraindications": [
       "everything — extremely risky"
     ],
-    "dosage": "",
-    "therapeutic": "rarely used medically; historically for pain/spiritual rites",
+    "sideeffects": [
+      "severe hallucinations",
+      "amnesia",
+      "potential death"
+    ],
     "safety": "",
-    "sideeffects": "severe hallucinations, amnesia, potential death",
     "toxicity": "Very high",
     "toxicity_ld50": "~50 mg/kg (atropine/scopolamine)",
-    "is_controlled_substance": false,
     "tags": [
       "☠️ toxic",
       "⚠️ caution",
       "🧠 vision"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "tropaeolum-majus",
@@ -9939,31 +11740,35 @@
     "common": "Nasturtium",
     "scientific": "",
     "category": "stimulant",
+    "subcategory": "",
     "intensity": "",
     "region": "south america (peru, andes)",
     "legalstatus": "",
+    "schedule": "",
     "description": "",
     "effects": "mild stimulant;respiratory enhancer",
     "mechanism": "Antimicrobial and expectorant, may enhance breathing clarity.",
     "compounds": [
       "Benzyl isothiocyanate"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "stimulant",
       "respiratory",
       "folk"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "turnera-diffusa",
@@ -9971,15 +11776,20 @@
     "common": "Damiana",
     "scientific": "Turnera diffusa",
     "category": "empathogen / euphoriant",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "texas, mexico, central america",
     "legalstatus": "Legal / Unregulated",
+    "schedule": "",
     "description": "fragrant shrub known as damiana, smoked or brewed as aphrodisiac and relaxant.",
     "effects": "aphrodisiac;mood-enhancing;anxiolytic",
     "mechanism": "Likely modulates serotonin, dopamine, and GABA neurotransmission via flavonoids and tannins [8, 6].",
     "compounds": [
       "Damianin"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "aphrodisiac, mood enhancement, stress relief [8, 6].",
     "interactions": [
       "serotonergic medications."
     ],
@@ -9987,25 +11797,28 @@
       "pregnancy",
       "maoi coadministration."
     ],
-    "dosage": "",
-    "therapeutic": "aphrodisiac, mood enhancement, stress relief [8, 6].",
+    "sideeffects": [
+      "mild headache",
+      "insomnia at high doses [8",
+      "6]."
+    ],
     "safety": "1",
-    "sideeffects": "mild headache, insomnia at high doses [8, 6].",
     "toxicity": "Low in traditional doses.",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "☕ brewable",
       "✅ safe",
       "🌬️ smokable",
       "💫 euphoria"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3210006/",
       "Plants of Love – Christian Rätsch",
       "Herbal Medicine – Mills & Bone"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "turnera-diffusa-aphrodisiaca",
@@ -10013,9 +11826,11 @@
     "common": "",
     "scientific": "Turnera diffusa var. aphrodisiaca",
     "category": "ethnobotanical",
+    "subcategory": "",
     "intensity": "",
     "region": "mexico",
     "legalstatus": "",
+    "schedule": "",
     "description": "a variant of damiana known for its aphrodisiac and mood-brightening properties. traditionally used as a tonic.",
     "effects": "aphrodisiac;mood enhancer",
     "mechanism": "Dopaminergic and GABAergic synergy",
@@ -10023,22 +11838,24 @@
       "Damianin",
       "Flavonoids"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "aphrodisiac",
       "tonic",
       "euphoric"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "turnera-ulmifolia",
@@ -10046,36 +11863,42 @@
     "common": "",
     "scientific": "Turnera ulmifolia",
     "category": "empathogen / euphoriant",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "central and south america",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "closely related to damiana (turnera diffusa), this species is also used traditionally in folk medicine for reproductive health and mood.",
     "effects": "Relaxation;mood elevation;aphrodisiac",
     "mechanism": "Unknown; may modulate GABA or serotonin",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "libido, menstrual cramps, anxiety",
     "interactions": [],
     "contraindications": [
       "pregnancy"
     ],
-    "dosage": "",
-    "therapeutic": "libido, menstrual cramps, anxiety",
+    "sideeffects": [
+      "mild sedation"
+    ],
     "safety": "",
-    "sideeffects": "mild sedation",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌺 aphrodisiac",
       "😊 mood"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7087816/",
       "Journal of Ethnopharmacology",
       "2013",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "tussilago-farfara",
@@ -10083,13 +11906,18 @@
     "common": "",
     "scientific": "Tussilago farfara",
     "category": "respiratory / expectorant / traditional european",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "europe, western asia, north america",
     "legalstatus": "Regulated or banned in some countries for internal use",
+    "schedule": "",
     "description": "a yellow-flowered plant long revered in european herbalism for its effects on the respiratory tract. coltsfoot is soothing to irritated lungs and commonly used in herbal cough formulas.",
     "effects": "Cough suppression;Lung soothing;Mild sedation;Anti-inflammatory",
     "mechanism": "Contains mucilage, flavonoids, and alkaloids. Mucilage soothes mucous membranes; pyrrolizidine alkaloids (PAs) pose some risk to the liver.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for coughs, bronchitis, asthma, sore throats, and hoarseness. traditionally smoked or brewed.",
     "interactions": [
       "potential hepatotoxicity if combined with other liver-sensitive drugs."
     ],
@@ -10098,25 +11926,26 @@
       "liver disease",
       "or prolonged use. use pa-free extracts if possible."
     ],
-    "dosage": "",
-    "therapeutic": "used for coughs, bronchitis, asthma, sore throats, and hoarseness. traditionally smoked or brewed.",
+    "sideeffects": [
+      "generally mild. long-term use linked to potential liver toxicity from pas."
+    ],
     "safety": "",
-    "sideeffects": "generally mild. long-term use linked to potential liver toxicity from pas.",
     "toxicity": "Moderate (due to PAs); safe short-term with proper prep.",
     "toxicity_ld50": "PAs vary; cumulative risk more relevant than acute dose",
-    "is_controlled_substance": false,
     "tags": [
       "🌬️ respiratory",
       "🫁 expectorant",
       "🫖 lung tea",
       "⚠️ pa caution"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7092813/",
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "tylophora-indica",
@@ -10124,13 +11953,18 @@
     "common": "",
     "scientific": "Tylophora indica",
     "category": "respiratory / immunomodulator / ayurvedic",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "india, sri lanka, southeast asia",
     "legalstatus": "Legal in India; regulated in some countries due to emetic effects",
+    "schedule": "",
     "description": "an ayurvedic herb used for bronchial conditions, immune regulation, and allergic responses. known as indian ipecac for its traditional role in treating asthma and respiratory issues.",
     "effects": "Asthma relief;Anti-allergy;Immunoregulation;Expectorant",
     "mechanism": "Contains tylophorine alkaloids with immunosuppressive, anti-inflammatory, and antiallergic properties. Reduces histamine release and cytokine activity.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for asthma, allergies, bronchitis, autoimmune flare-ups, and inflammation. sometimes used topically for skin disorders.",
     "interactions": [
       "may interfere with immune therapies",
       "steroids",
@@ -10141,26 +11975,27 @@
       "with immunosuppressants",
       "or in emaciated individuals. not for long-term high-dose use."
     ],
-    "dosage": "",
-    "therapeutic": "used for asthma, allergies, bronchitis, autoimmune flare-ups, and inflammation. sometimes used topically for skin disorders.",
+    "sideeffects": [
+      "nausea and vomiting in higher doses. gi discomfort is common early in treatment."
+    ],
     "safety": "",
-    "sideeffects": "nausea and vomiting in higher doses. gi discomfort is common early in treatment.",
     "toxicity": "Moderate in high doses. Emetic effects limit overuse.",
     "toxicity_ld50": "~100 mg/kg (mice, oral) – estimated",
-    "is_controlled_substance": false,
     "tags": [
       "🫁 respiratory",
       "🌿 ayurvedic",
       "⚠️ emetic",
       "🤧 anti-allergy"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3887322/",
       "Ayurvedic Pharmacopoeia of India",
       "Journal of Ethnopharmacology",
       "2004"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "tynanthus-panurensis",
@@ -10168,9 +12003,11 @@
     "common": "Clavo Huasca",
     "scientific": "",
     "category": "",
+    "subcategory": "",
     "intensity": "",
     "region": "amazon rainforest",
     "legalstatus": "",
+    "schedule": "",
     "description": "",
     "effects": "aphrodisiac;warming;digestive aid",
     "mechanism": "TRPV1 activation, increases circulation and warmth",
@@ -10178,22 +12015,24 @@
       "Eugenol",
       "Tynanthin"
     ],
-    "interactions": [],
-    "contraindications": [],
+    "preparations": [],
     "dosage": "",
     "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "sideeffects": "",
     "toxicity": "",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "aphrodisiac",
       "folk",
       "warming"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "ulex-europaeus",
@@ -10201,38 +12040,45 @@
     "common": "",
     "scientific": "Ulex europaeus",
     "category": "mood / flower essence / traditional european",
+    "subcategory": "",
     "intensity": "Mild (emotional)",
     "region": "western europe, naturalized elsewhere",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a bright yellow-flowered shrub associated with resilience and hope in celtic and bach flower traditions. while not widely used internally, its flowers have gentle nervine and uplifting properties.",
     "effects": "Mood elevation;Hope restoration;Mild nervous system support",
     "mechanism": "Primarily used in energetic and flower essence systems. Contains flavonoids and trace alkaloids which may mildly affect neurotransmission.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used to combat despair, mental fatigue, and chronic discouragement. often chosen in flower therapy blends.",
     "interactions": [
       "none known."
     ],
     "contraindications": [
       "avoid large internal doses. primarily for emotional support or ritual use."
     ],
-    "dosage": "",
-    "therapeutic": "used to combat despair, mental fatigue, and chronic discouragement. often chosen in flower therapy blends.",
+    "sideeffects": [
+      "rare. in high doses",
+      "possible gi discomfort."
+    ],
     "safety": "",
-    "sideeffects": "rare. in high doses, possible gi discomfort.",
     "toxicity": "Low",
     "toxicity_ld50": "Not well documented; external use traditionally preferred",
-    "is_controlled_substance": false,
     "tags": [
       "🌼 flower essence",
       "🌞 mood uplift",
       "🌿 hope tonic",
       "🧘 gentle"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://pubmed.ncbi.nlm.nih.gov/21768182/",
       "Plants of the Gods – Rätsch",
       "Bach Flower Remedies"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "uncaria-rhynchophylla",
@@ -10240,33 +12086,39 @@
     "common": "",
     "scientific": "Uncaria rhynchophylla",
     "category": "dissociative / sedative",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "china",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "known as gou teng in chinese medicine.",
     "effects": "Calming;anticonvulsant",
     "mechanism": "Rhynchophylline blocks NMDA receptors",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditional treatment for tremors and agitation",
     "interactions": [
       "may potentiate sedatives"
     ],
     "contraindications": [
       "none documented"
     ],
-    "dosage": "",
-    "therapeutic": "traditional treatment for tremors and agitation",
+    "sideeffects": [
+      "drowsiness"
+    ],
     "safety": "",
-    "sideeffects": "drowsiness",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌿 vine",
       "💤 sedation"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "uncaria-tomentosa",
@@ -10274,38 +12126,44 @@
     "common": "",
     "scientific": "Uncaria tomentosa",
     "category": "other",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "amazon",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "known as cat's claw, used in peruvian medicine.",
     "effects": "Immune modulation",
     "mechanism": "Oxindole alkaloids stimulate immune function",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "anti-inflammatory, immune support",
     "interactions": [
       "may interact with immunosuppressants"
     ],
     "contraindications": [
       "autoimmune conditions caution"
     ],
-    "dosage": "",
-    "therapeutic": "anti-inflammatory, immune support",
+    "sideeffects": [
+      "stomach upset in some"
+    ],
     "safety": "",
-    "sideeffects": "stomach upset in some",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌿 bark",
       "🛡️ immune"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5372954/",
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology",
       "2001"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "urtica-dioica",
@@ -10313,13 +12171,18 @@
     "common": "",
     "scientific": "Urtica dioica",
     "category": "dissociative / sedative",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "europe, north america, asia",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "known as stinging nettle, this european herb has been used for centuries to relieve joint pain, allergies, and fatigue. its psychoactivity is subtle, mostly somatic.",
     "effects": "Stimulation;anti-inflammatory;tonic",
     "mechanism": "Histamine release and anti-inflammatory cytokine modulation",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "allergies, joint pain, urinary tract support",
     "interactions": [
       "diuretics",
       "anticoagulants"
@@ -10328,24 +12191,26 @@
       "pregnancy",
       "blood thinners"
     ],
-    "dosage": "",
-    "therapeutic": "allergies, joint pain, urinary tract support",
+    "sideeffects": [
+      "mild stomach upset",
+      "skin irritation"
+    ],
     "safety": "",
-    "sideeffects": "mild stomach upset, skin irritation",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌿 anti-inflammatory",
       "🧘 mild"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4843967/",
       "Herbal Medicine – Mills & Bone",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "urtica-urens",
@@ -10353,38 +12218,44 @@
     "common": "",
     "scientific": "Urtica urens",
     "category": "nutritive / skin & immune / homeopathic–traditional",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "europe, north america",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a close relative of urtica dioica, this smaller species is used for similar purposes, especially in homeopathy and traditional european herbalism. known for calming itchy skin and boosting the blood.",
     "effects": "Skin soothing;Detox support;Mineral boost;Allergy modulation",
     "mechanism": "Similar to stinging nettle: silica, flavonoids, and histamine-like compounds that support immunity, reduce inflammation, and supply trace minerals.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for hives, eczema, gout, allergies, and fatigue. often included in mineral-building tonics and allergy blends.",
     "interactions": [
       "may enhance effect of antihistamines or diuretics."
     ],
     "contraindications": [
       "caution in pregnancy or kidney disorders. may lower blood pressure slightly."
     ],
-    "dosage": "",
-    "therapeutic": "used for hives, eczema, gout, allergies, and fatigue. often included in mineral-building tonics and allergy blends.",
+    "sideeffects": [
+      "stinging hairs can irritate skin raw. mild diuretic effect or digestive upset possible."
+    ],
     "safety": "",
-    "sideeffects": "stinging hairs can irritate skin raw. mild diuretic effect or digestive upset possible.",
     "toxicity": "Low",
     "toxicity_ld50": "Not established; widely used in folk and clinical practice",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 nutritive",
       "🌱 allergy mod",
       "🩹 skin",
       "🍵 gentle tonic"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3671822/",
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "vachellia-farnesiana",
@@ -10392,38 +12263,44 @@
     "common": "",
     "scientific": "Vachellia farnesiana",
     "category": "aromatic / nervine / traditional perfume & medicine",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "tropical americas, asia, australia",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a fragrant, thorny shrub with yellow puffball flowers, historically used in perfumery and herbal medicine. its flowers and pods have soothing, mildly euphoric properties and are used in aromatic and topical blends.",
     "effects": "Relaxation;Calming;Uplifting mood;Aromatic euphoria",
     "mechanism": "Volatile oils such as benzyl acetate, linalool, and coumarins provide gentle aromatic CNS modulation and possible GABAergic effects.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditionally used as a sedative, aphrodisiac, digestive aid, and mood enhancer. also used in fragrance and sacred incense.",
     "interactions": [
       "none well documented."
     ],
     "contraindications": [
       "none significant. caution with allergies to fabaceae plants."
     ],
-    "dosage": "",
-    "therapeutic": "traditionally used as a sedative, aphrodisiac, digestive aid, and mood enhancer. also used in fragrance and sacred incense.",
+    "sideeffects": [
+      "none common in traditional doses. high aromatic concentrations may cause nausea."
+    ],
     "safety": "",
-    "sideeffects": "none common in traditional doses. high aromatic concentrations may cause nausea.",
     "toxicity": "Low",
     "toxicity_ld50": "Not established; used widely in perfumery and teas",
-    "is_controlled_substance": false,
     "tags": [
       "🌸 fragrant",
       "🧘 aromatic",
       "🌿 sedative",
       "💐 aphrodisiac"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4494854/",
       "Plants of the Gods – Rätsch",
       "Indian Journal of Pharmacognosy"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "vachellia-nilotica",
@@ -10431,38 +12308,44 @@
     "common": "",
     "scientific": "Vachellia nilotica",
     "category": "astringent / antimicrobial / traditional african–indian",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "africa, middle east, indian subcontinent",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a widely used tree in african and indian traditional medicine. its bark, pods, and gum are rich in tannins and have potent astringent and antiseptic properties.",
     "effects": "Wound healing;Oral health;Diarrhea relief;Antimicrobial",
     "mechanism": "Tannins, flavonoids, and saponins exert antimicrobial, anti-inflammatory, and astringent effects. Helps constrict tissues and protect mucosa.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for dysentery, gum disease, wounds, sore throats, and as a contraceptive in traditional systems. bark decoction or powder is common.",
     "interactions": [
       "may reduce absorption of minerals or medications when taken orally."
     ],
     "contraindications": [
       "caution with chronic constipation or iron absorption issues."
     ],
-    "dosage": "",
-    "therapeutic": "used for dysentery, gum disease, wounds, sore throats, and as a contraceptive in traditional systems. bark decoction or powder is common.",
+    "sideeffects": [
+      "mild gi irritation if overused. may cause constipation in high doses due to tannins."
+    ],
     "safety": "",
-    "sideeffects": "mild gi irritation if overused. may cause constipation in high doses due to tannins.",
     "toxicity": "Low–moderate",
     "toxicity_ld50": "Not well documented; used safely in traditional medicine",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 astringent",
       "🦷 oral health",
       "🛡️ antimicrobial",
       "🌍 african–ayurvedic"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4285565/",
       "Journal of Ethnopharmacology",
       "Indian Journal of Traditional Knowledge"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "valerian",
@@ -10470,13 +12353,18 @@
     "common": "",
     "scientific": "Valeriana officinalis",
     "category": "dissociative / sedative",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "🇧🇪 europe",
     "legalstatus": "Legal / Unregulated",
+    "schedule": "",
     "description": "pungent root used as a natural sleep aid and mild tranquilizer.",
     "effects": "Relaxation;sleep support",
     "mechanism": "Valerenic acid modulates GABA receptors and inhibits breakdown.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "insomnia, anxiety, muscle tension.",
     "interactions": [
       "sedatives",
       "alcohol."
@@ -10485,20 +12373,23 @@
       "pregnancy",
       "heavy alcohol use."
     ],
-    "dosage": "",
-    "therapeutic": "insomnia, anxiety, muscle tension.",
+    "sideeffects": [
+      "grogginess",
+      "vivid dreams",
+      "headache."
+    ],
     "safety": "1",
-    "sideeffects": "grogginess, vivid dreams, headache.",
     "toxicity": "Generally safe; high doses may cause dizziness.",
     "toxicity_ld50": "LD50 > 3 g/kg (rat).",
-    "is_controlled_substance": false,
     "tags": [
       "\\u2615 brewable",
       "\\ud83e\\uddd8 sedation",
       "\\u2705 safe"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "valeriana-officinalis",
@@ -10506,13 +12397,18 @@
     "common": "",
     "scientific": "Valeriana officinalis",
     "category": "sedative / sleep aid / nervine",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "europe, western asia, north america (cultivated)",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a strong-smelling root long used as a natural sedative and anxiety aid. valerian is commonly included in sleep teas, tinctures, and stress blends.",
     "effects": "Sleep induction;Calm;Anxiety reduction;Muscle relaxation",
     "mechanism": "Acts on GABA-A receptors via valerenic acid and other sesquiterpenes. May inhibit GABA breakdown and modulate serotonin and adenosine.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for insomnia, nervousness, anxiety, muscle tension, and restlessness. may reduce time to fall asleep and improve sleep quality.",
     "interactions": [
       "additive with cns depressants",
       "benzodiazepines",
@@ -10524,25 +12420,29 @@
       "sedatives",
       "or heavy machinery. not advised during pregnancy without guidance."
     ],
-    "dosage": "",
-    "therapeutic": "used for insomnia, nervousness, anxiety, muscle tension, and restlessness. may reduce time to fall asleep and improve sleep quality.",
+    "sideeffects": [
+      "drowsiness",
+      "vivid dreams",
+      "headache",
+      "gi upset. rare paradoxical stimulation."
+    ],
     "safety": "",
-    "sideeffects": "drowsiness, vivid dreams, headache, gi upset. rare paradoxical stimulation.",
     "toxicity": "Low. Well tolerated in most users.",
     "toxicity_ld50": ">3000 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "💤 sedative",
       "🧘 nervine",
       "🌿 sleep aid",
       "🛌 relaxation"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4394901/",
       "Herbal Medicine – Mills & Bone",
       "British Herbal Pharmacopoeia"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "valeriana-officinalis",
@@ -10550,32 +12450,39 @@
     "common": "",
     "scientific": "Valeriana officinalis",
     "category": "sedative / anxiolytic",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "europe, north america",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "traditional european herb valued for calming and sleep-promoting properties.",
     "effects": "Relaxation;improved sleep;mild anxiolysis",
     "mechanism": "Valerenic acid modulates GABA receptors and may inhibit GABA breakdown.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "insomnia, anxiety, muscle tension.",
     "interactions": [
       "additive with benzodiazepines or alcohol"
     ],
     "contraindications": [
       "avoid with other sedatives or during pregnancy."
     ],
-    "dosage": "",
-    "therapeutic": "insomnia, anxiety, muscle tension.",
+    "sideeffects": [
+      "drowsiness",
+      "vivid dreams"
+    ],
     "safety": "",
-    "sideeffects": "drowsiness, vivid dreams",
     "toxicity": "Generally safe; high doses may cause headaches or dizziness.",
     "toxicity_ld50": "LD50 >3 g/kg (mouse, extract)",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 root",
       "😴 sleep"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "valeriana-jatamansi",
@@ -10583,37 +12490,43 @@
     "common": "",
     "scientific": "Valeriana jatamansi",
     "category": "sedative / anxiolytic",
+    "subcategory": "",
     "intensity": "",
     "region": "india",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "indian valerian used similarly to v. officinalis",
     "effects": "calming;sleep",
     "mechanism": "Sesquiterpenes like valeranon interact with GABA",
     "compounds": [
       "Valeranon"
     ],
+    "preparations": [],
+    "dosage": "1-3 g root",
+    "therapeutic": "insomnia, anxiety",
     "interactions": [
       "sedatives"
     ],
     "contraindications": [
       "pregnancy"
     ],
-    "dosage": "1-3 g root",
-    "therapeutic": "insomnia, anxiety",
+    "sideeffects": [
+      "drowsiness"
+    ],
     "safety": "",
-    "sideeffects": "drowsiness",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 root"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4046171/",
       "Ayurvedic Pharmacopoeia of India",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "valeriana-wallichii",
@@ -10621,13 +12534,18 @@
     "common": "",
     "scientific": "Valeriana wallichii",
     "category": "sedative / nervine / ayurvedic",
+    "subcategory": "",
     "intensity": "Moderate–Strong",
     "region": "himalayas, nepal, india",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a potent aromatic root used in ayurveda as a tranquilizing agent. it has a similar but stronger scent and effect profile compared to european valerian. known locally as tagar ganthoda.",
     "effects": "Sleep aid;Mental calm;Muscle relaxant;Tranquilizer",
     "mechanism": "Valerenic acid and valepotriates modulate GABA-A receptors, decreasing nervous excitability. Sedative effects supported by sesquiterpenes and lignans.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for insomnia, epilepsy, anxiety, muscle spasms, and stress-induced hypertension.",
     "interactions": [
       "potentiates sedatives",
       "hypnotics",
@@ -10636,25 +12554,28 @@
     "contraindications": [
       "avoid with cns depressants or alcohol. caution in pregnancy and hypotension."
     ],
-    "dosage": "",
-    "therapeutic": "used for insomnia, epilepsy, anxiety, muscle spasms, and stress-induced hypertension.",
+    "sideeffects": [
+      "drowsiness",
+      "grogginess",
+      "or gi upset. possible paradoxical excitement."
+    ],
     "safety": "",
-    "sideeffects": "drowsiness, grogginess, or gi upset. possible paradoxical excitement.",
     "toxicity": "Low–Moderate",
     "toxicity_ld50": "Not well documented",
-    "is_controlled_substance": false,
     "tags": [
       "🛏️ sedative",
       "🧘 calm",
       "🌿 ayurvedic",
       "🪵 root"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3679533/",
       "Indian Journal of Pharmacognosy",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "verbascum-thapsus",
@@ -10662,38 +12583,45 @@
     "common": "",
     "scientific": "Verbascum thapsus",
     "category": "respiratory / demulcent / anti-inflammatory",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "europe, naturalized in americas and asia",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a tall, fuzzy-leaved plant with bright yellow flowers, mullein is a classic remedy for respiratory complaints. its soft leaves and flowers are demulcent, soothing inflamed tissues and promoting gentle expectoration.",
     "effects": "Lung soothing;Cough relief;Anti-inflammatory;Mucus clearing",
     "mechanism": "Saponins and mucilage coat and soothe mucous membranes, while flavonoids and iridoids reduce inflammation and stimulate immune response.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for dry cough, bronchitis, sore throat, asthma, earaches (flower oil), and inflammation of lungs and throat.",
     "interactions": [
       "none known."
     ],
     "contraindications": [
       "none significant. avoid inhaling loose hairs."
     ],
-    "dosage": "",
-    "therapeutic": "used for dry cough, bronchitis, sore throat, asthma, earaches (flower oil), and inflammation of lungs and throat.",
+    "sideeffects": [
+      "very mild",
+      "possible gi upset if taken in large quantities. fuzzy hairs may irritate throat if not properly strained."
+    ],
     "safety": "",
-    "sideeffects": "very mild; possible gi upset if taken in large quantities. fuzzy hairs may irritate throat if not properly strained.",
     "toxicity": "Very low",
     "toxicity_ld50": "Not established; widely regarded as safe",
-    "is_controlled_substance": false,
     "tags": [
       "🫁 lung herb",
       "🩹 soothing",
       "🌼 flower remedy",
       "🍵 tea"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8010964/",
       "Plants of the Gods – Rätsch",
       "British Herbal Compendium"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "verbena-hastata",
@@ -10701,38 +12629,44 @@
     "common": "",
     "scientific": "Verbena hastata",
     "category": "nervine / relaxant / digestive–emotional",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "north america",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a native north american vervain with bitter, calming properties. traditionally used by indigenous and eclectic physicians for tension, insomnia, and digestive sluggishness tied to anxiety.",
     "effects": "Stress relief;Mood regulation;Tension release;Digestive stimulation",
     "mechanism": "Iridoid glycosides (verbenalin) and bitter principles act as mild GABA modulators and cholagogues, relaxing the nervous system while aiding digestion.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for nervous tension, stress headaches, insomnia, grief, indigestion, and menstrual discomfort. especially useful for 'overthinkers'.",
     "interactions": [
       "may enhance effects of sedatives or antispasmodics."
     ],
     "contraindications": [
       "avoid during pregnancy due to potential uterine stimulation."
     ],
-    "dosage": "",
-    "therapeutic": "used for nervous tension, stress headaches, insomnia, grief, indigestion, and menstrual discomfort. especially useful for 'overthinkers'.",
+    "sideeffects": [
+      "possible nausea due to bitterness. rare allergic reaction."
+    ],
     "safety": "",
-    "sideeffects": "possible nausea due to bitterness. rare allergic reaction.",
     "toxicity": "Low",
     "toxicity_ld50": "Not well established; widely regarded as safe",
-    "is_controlled_substance": false,
     "tags": [
       "🧘 nervine",
       "🌿 bitter",
       "💤 sedative",
       "🌾 native american"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8052706/",
       "Eclectic Materia Medica – Felter",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "verbena-officinalis",
@@ -10740,37 +12674,43 @@
     "common": "Vervain",
     "scientific": "Verbena officinalis",
     "category": "mild sedative",
+    "subcategory": "",
     "intensity": "",
     "region": "europe",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "common vervain valued for gentle calming",
     "effects": "relaxation;digestive aid",
     "mechanism": "Iridoid glycosides like verbenalin may influence GABA",
     "compounds": [
       "Verbenalin"
     ],
+    "preparations": [],
+    "dosage": "2-3 g dried",
+    "therapeutic": "tension, digestion",
     "interactions": [
       "none known"
     ],
     "contraindications": [
       "pregnancy"
     ],
-    "dosage": "2-3 g dried",
-    "therapeutic": "tension, digestion",
+    "sideeffects": [
+      "rare gi upset"
+    ],
     "safety": "",
-    "sideeffects": "rare gi upset",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 tea"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6520897/",
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "viburnum-opulus",
@@ -10778,38 +12718,44 @@
     "common": "",
     "scientific": "Viburnum opulus",
     "category": "antispasmodic / uterine tonic / nervine",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "europe, north america",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a classic herbal remedy used for centuries to relieve muscular and menstrual cramping. cramp bark calms smooth muscles, especially in the uterus and digestive tract.",
     "effects": "Muscle relaxation;Menstrual relief;Sedative;Uterine support",
     "mechanism": "Contains viburnin, salicin, and valerenic acid-like compounds that act as antispasmodics and mild sedatives, likely via GABA modulation and smooth muscle relaxation.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for dysmenorrhea, muscle spasms, back pain, nervous tension, and sometimes asthma-related tension.",
     "interactions": [
       "may enhance effects of muscle relaxants or sedatives."
     ],
     "contraindications": [
       "avoid during pregnancy unless directed by a practitioner. may cause hypotension in sensitive individuals."
     ],
-    "dosage": "",
-    "therapeutic": "used for dysmenorrhea, muscle spasms, back pain, nervous tension, and sometimes asthma-related tension.",
+    "sideeffects": [
+      "mild drowsiness or gi upset. rare allergic responses."
+    ],
     "safety": "",
-    "sideeffects": "mild drowsiness or gi upset. rare allergic responses.",
     "toxicity": "Low",
     "toxicity_ld50": "Not well established; safe in traditional doses",
-    "is_controlled_substance": false,
     "tags": [
       "🩸 menstrual",
       "🧘 nervine",
       "🪵 bark remedy",
       "💤 sedative"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5487595/",
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "vinca-minor",
@@ -10817,13 +12763,18 @@
     "common": "",
     "scientific": "Vinca minor",
     "category": "cognitive / circulatory / alkaloid-based",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "europe, cultivated globally",
     "legalstatus": "Regulated or restricted in some regions due to alkaloid content",
+    "schedule": "",
     "description": "a low-growing evergreen plant whose alkaloid-rich leaves are used for memory, focus, and circulatory enhancement. related to the nootropic vinpocetine.",
     "effects": "Cognitive enhancement;Vasodilation;Memory support;Cerebral blood flow",
     "mechanism": "Contains vincamine, a vasodilatory alkaloid that improves cerebral blood flow. Vinpocetine, a semi-synthetic derivative, is used in neuroprotection studies.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for cognitive decline, tinnitus, dizziness, poor peripheral circulation, and memory support.",
     "interactions": [
       "may interact with blood thinners",
       "vasodilators",
@@ -10834,25 +12785,28 @@
       "pregnancy",
       "or with anticoagulants."
     ],
-    "dosage": "",
-    "therapeutic": "used for cognitive decline, tinnitus, dizziness, poor peripheral circulation, and memory support.",
+    "sideeffects": [
+      "low blood pressure",
+      "headache",
+      "or gi upset possible. excess may cause hypotension or bradycardia."
+    ],
     "safety": "",
-    "sideeffects": "low blood pressure, headache, or gi upset possible. excess may cause hypotension or bradycardia.",
     "toxicity": "Moderate (dose-dependent)",
     "toxicity_ld50": "~75 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🧠 cognitive",
       "💉 circulatory",
       "🌿 nootropic",
       "⚠️ alkaloid-based"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3966305/",
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "viola-odorata",
@@ -10860,9 +12814,11 @@
     "common": "Sweet Violet",
     "scientific": "Viola odorata",
     "category": "respiratory / nervine / floral sedative",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "europe, western asia, north africa",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a fragrant violet flower traditionally used for respiratory and emotional conditions. offers calming, anti-inflammatory, and mucilaginous support, often in teas or syrups.",
     "effects": "Soothing;Anti-inflammatory;Sleep support;Cough relief",
     "mechanism": "Contains salicylic acid derivatives, mucilage, and volatile oils. Gently modulates GABA and prostaglandins. Mild expectorant and anti-inflammatory activity.",
@@ -10870,31 +12826,36 @@
       "Violine",
       "Methyl salicylate"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for sore throats, coughs, grief, insomnia, and skin irritation. can be taken internally or applied topically.",
     "interactions": [
       "mild anticoagulant effects. may enhance other sedatives slightly."
     ],
     "contraindications": [
       "none known in normal doses. use caution in salicylate-sensitive individuals."
     ],
-    "dosage": "",
-    "therapeutic": "used for sore throats, coughs, grief, insomnia, and skin irritation. can be taken internally or applied topically.",
+    "sideeffects": [
+      "mild",
+      "possible skin reaction or gi upset with large doses."
+    ],
     "safety": "",
-    "sideeffects": "mild; possible skin reaction or gi upset with large doses.",
     "toxicity": "Very low",
     "toxicity_ld50": "Not established (safe in folk medicine)",
-    "is_controlled_substance": false,
     "tags": [
       "🌸 floral",
       "🧘 nervine",
       "🫁 respiratory",
       "💤 calming"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7533724/",
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "viola-tricolor",
@@ -10902,13 +12863,18 @@
     "common": "",
     "scientific": "Viola tricolor",
     "category": "nervine / skin support / respiratory",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "europe, naturalized elsewhere",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a small wildflower with colorful petals, known traditionally for emotional soothing ('heartsease'), as well as support for skin issues, respiratory inflammation, and mild nervous conditions.",
     "effects": "Calming;Anti-inflammatory;Expectorant;Skin soothing",
     "mechanism": "Contains flavonoids, salicylates, and mucilage. Modulates inflammatory mediators and has demulcent, expectorant, and nervine effects.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for eczema, cradle cap, dry cough, mild anxiety, and urinary inflammation. often included in spring tonics.",
     "interactions": [
       "minimal",
       "theoretical additive effect with anti-inflammatory or sedative herbs."
@@ -10916,25 +12882,27 @@
     "contraindications": [
       "none known. considered very gentle."
     ],
-    "dosage": "",
-    "therapeutic": "used for eczema, cradle cap, dry cough, mild anxiety, and urinary inflammation. often included in spring tonics.",
+    "sideeffects": [
+      "very mild",
+      "large doses may cause stomach upset or diarrhea."
+    ],
     "safety": "",
-    "sideeffects": "very mild; large doses may cause stomach upset or diarrhea.",
     "toxicity": "Very low",
     "toxicity_ld50": "Not established; widely used in children",
-    "is_controlled_substance": false,
     "tags": [
       "🌸 calming",
       "🩹 skin support",
       "🫁 expectorant",
       "🧘 gentle"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7318715/",
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "virola-theiodora",
@@ -10942,9 +12910,11 @@
     "common": "Epena",
     "scientific": "Virola theiodora",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Very strong",
     "region": "amazon (brazil, venezuela)",
     "legalstatus": "DMT controlled in most countries",
+    "schedule": "",
     "description": "a snuff plant from the amazon containing dmt and 5-meo-dmt. used by yanomami and other tribes for potent visionary rituals.",
     "effects": "Strong visuals;spiritual experiences;disorientation",
     "mechanism": "DMT and 5-MeO-DMT – 5-HT2A agonists",
@@ -10952,6 +12922,9 @@
       "DMT",
       "5-MeO-DMT"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "shamanic ritual; purging and vision work",
     "interactions": [
       "maois",
       "antidepressants"
@@ -10960,20 +12933,23 @@
       "maois",
       "mental health issues"
     ],
-    "dosage": "",
-    "therapeutic": "shamanic ritual; purging and vision work",
+    "sideeffects": [
+      "nausea",
+      "tremors",
+      "vomiting"
+    ],
     "safety": "",
-    "sideeffects": "nausea, tremors, vomiting",
     "toxicity": "High psychological, moderate physical",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ vision",
       "🌬️ snuff",
       "🧠 dmt"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "virola-theiodora",
@@ -10981,9 +12957,11 @@
     "common": "Epena",
     "scientific": "Virola theiodora",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Very strong",
     "region": "amazon (brazil, venezuela)",
     "legalstatus": "DMT controlled in most countries",
+    "schedule": "",
     "description": "a snuff plant from the amazon containing dmt and 5-meo-dmt. used by yanomami and other tribes for potent visionary rituals.",
     "effects": "Strong visuals;spiritual experiences;disorientation",
     "mechanism": "DMT and 5-MeO-DMT – 5-HT2A agonists",
@@ -10991,6 +12969,9 @@
       "DMT",
       "5-MeO-DMT"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "shamanic ritual; purging and vision work",
     "interactions": [
       "maois",
       "antidepressants"
@@ -10999,20 +12980,23 @@
       "maois",
       "mental health issues"
     ],
-    "dosage": "",
-    "therapeutic": "shamanic ritual; purging and vision work",
+    "sideeffects": [
+      "nausea",
+      "tremors",
+      "vomiting"
+    ],
     "safety": "",
-    "sideeffects": "nausea, tremors, vomiting",
     "toxicity": "High psychological, moderate physical",
     "toxicity_ld50": "",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ vision",
       "🌬️ snuff",
       "🧠 dmt"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "viscum-album",
@@ -11020,13 +13004,18 @@
     "common": "",
     "scientific": "Viscum album",
     "category": "immunomodulator / nervine / traditional european",
+    "subcategory": "",
     "intensity": "Moderate",
     "region": "europe, western asia",
     "legalstatus": "Legal but regulated in some countries",
+    "schedule": "",
     "description": "a sacred plant in ancient druidic and european traditions, mistletoe has been used both ritually and medicinally for nervous disorders, cancer support, and hypertension. often associated with peace and protection.",
     "effects": "Immune regulation;Sedation;Nervous system balance;Blood pressure modulation",
     "mechanism": "Contains viscotoxins, lectins, and alkaloids that affect immune cells, induce apoptosis, and modulate autonomic nervous system activity. Used in anthroposophic cancer therapy.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for anxiety, epilepsy, hypertension, and integrative cancer care. noted for its calming and immune-balancing effects.",
     "interactions": [
       "may interfere with immunosuppressants or chemotherapeutics."
     ],
@@ -11035,25 +13024,28 @@
       "active infection",
       "or autoimmune conditions without supervision. toxic at high doses."
     ],
-    "dosage": "",
-    "therapeutic": "used for anxiety, epilepsy, hypertension, and integrative cancer care. noted for its calming and immune-balancing effects.",
+    "sideeffects": [
+      "injection-site inflammation",
+      "allergic reactions",
+      "or flu-like symptoms possible. oral use milder but requires caution."
+    ],
     "safety": "",
-    "sideeffects": "injection-site inflammation, allergic reactions, or flu-like symptoms possible. oral use milder but requires caution.",
     "toxicity": "Moderate–high (dose-dependent)",
     "toxicity_ld50": "~2.5 mg/kg (IV, mice – viscotoxins)",
-    "is_controlled_substance": false,
     "tags": [
       "🎄 nervine",
       "🛡️ immune",
       "🌿 cancer therapy",
       "⚠️ toxic dose window"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3201634/",
       "European Medicines Agency",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "vitex-agnus-castus",
@@ -11061,13 +13053,18 @@
     "common": "",
     "scientific": "Vitex agnus-castus",
     "category": "endocrine / hormonal / reproductive",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "mediterranean, western asia",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a mediterranean shrub used traditionally to balance female hormones, regulate menstrual cycles, and support fertility. also known as monk’s pepper due to its historical use in suppressing libido.",
     "effects": "Hormone regulation;Menstrual cycle balancing;Mood support;Fertility enhancement",
     "mechanism": "Acts on dopamine D2 receptors to modulate pituitary prolactin levels. Indirectly balances estrogen and progesterone.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for pms, breast tenderness, irregular menstruation, pcos, fertility support, and mild hormonal acne.",
     "interactions": [
       "may interact with dopamine-related medications or hormone therapies."
     ],
@@ -11076,25 +13073,28 @@
       "breastfeeding",
       "or with hormone-sensitive conditions unless guided by a practitioner."
     ],
-    "dosage": "",
-    "therapeutic": "used for pms, breast tenderness, irregular menstruation, pcos, fertility support, and mild hormonal acne.",
+    "sideeffects": [
+      "mild gi upset",
+      "headache",
+      "or rash. may alter menstrual cycle timing."
+    ],
     "safety": "",
-    "sideeffects": "mild gi upset, headache, or rash. may alter menstrual cycle timing.",
     "toxicity": "Low",
     "toxicity_ld50": "Not well established; traditionally safe",
-    "is_controlled_substance": false,
     "tags": [
       "🩸 hormone balance",
       "♀️ reproductive",
       "🌿 fertility",
       "🧘 pms relief"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6275797/",
       "British Herbal Compendium",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "vitex-negundo",
@@ -11102,38 +13102,44 @@
     "common": "",
     "scientific": "Vitex negundo",
     "category": "anti-inflammatory / respiratory / analgesic",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "india, southeast asia",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a traditional ayurvedic and siddha herb used for joint pain, respiratory disorders, and menstrual issues. though related to vitex agnus-castus, its actions differ and it is widely used in south and southeast asia.",
     "effects": "Pain relief;Anti-inflammatory;Respiratory support;Menstrual regulation",
     "mechanism": "Flavonoids, alkaloids, and iridoid glycosides modulate prostaglandins, inhibit COX enzymes, and relax bronchial muscles. Some dopaminergic modulation noted.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for rheumatism, asthma, cough, sinusitis, fever, and gynecological conditions. also used topically for wounds and inflammation.",
     "interactions": [
       "may interact with nsaids or dopaminergic agents."
     ],
     "contraindications": [
       "avoid during pregnancy unless prescribed. caution in liver conditions."
     ],
-    "dosage": "",
-    "therapeutic": "used for rheumatism, asthma, cough, sinusitis, fever, and gynecological conditions. also used topically for wounds and inflammation.",
+    "sideeffects": [
+      "well tolerated. high doses may cause mild stomach upset or dizziness."
+    ],
     "safety": "",
-    "sideeffects": "well tolerated. high doses may cause mild stomach upset or dizziness.",
     "toxicity": "Low",
     "toxicity_ld50": "Not well established; considered safe in traditional doses",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 ayurvedic",
       "🔥 anti-inflammatory",
       "🫁 respiratory",
       "🧘 analgesic"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6267229/",
       "Indian Journal of Traditional Knowledge",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "vitis-vinifera",
@@ -11141,38 +13147,46 @@
     "common": "",
     "scientific": "Vitis vinifera (seed)",
     "category": "antioxidant / cardiovascular / nootropic adjunct",
+    "subcategory": "",
     "intensity": "Mild–Moderate (non-psychoactive)",
     "region": "mediterranean, global cultivation",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "extracted from the seeds of red grapes, this compound is rich in oligomeric proanthocyanidins (opcs) — potent antioxidants shown to support circulation, reduce inflammation, and protect cellular integrity.",
     "effects": "Vascular support;Free radical scavenging;Skin protection;Cognitive enhancement (adjunct)",
     "mechanism": "OPCs reduce oxidative stress, inhibit inflammatory enzymes (like COX-2), and strengthen collagen and capillaries. Also modulates nitric oxide and enhances endothelial function.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for varicose veins, cardiovascular protection, cognitive longevity, eye health, and skin aging. may help mitigate nootropic stimulant stress.",
     "interactions": [
       "may enhance effect of blood thinners or antihypertensives."
     ],
     "contraindications": [
       "caution in bleeding disorders or with anticoagulants."
     ],
-    "dosage": "",
-    "therapeutic": "used for varicose veins, cardiovascular protection, cognitive longevity, eye health, and skin aging. may help mitigate nootropic stimulant stress.",
+    "sideeffects": [
+      "mild gi upset",
+      "headache",
+      "or dizziness possible. rare allergic responses."
+    ],
     "safety": "",
-    "sideeffects": "mild gi upset, headache, or dizziness possible. rare allergic responses.",
     "toxicity": "Low",
     "toxicity_ld50": "~5000 mg/kg (rats, oral)",
-    "is_controlled_substance": false,
     "tags": [
       "🍇 antioxidant",
       "🩸 circulation",
       "🧠 brain support",
       "🌿 nootropic ally"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6164840/",
       "Journal of Medicinal Food",
       "European Medicines Agency"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "voacanga-africana",
@@ -11180,13 +13194,18 @@
     "common": "",
     "scientific": "Voacanga africana",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Strong",
     "region": "west africa",
     "legalstatus": "Unscheduled; may be regulated for alkaloids",
+    "schedule": "",
     "description": "a powerful african plant containing voacangine and iboga alkaloids. used traditionally in ritual contexts and studied as a potential ibogaine precursor.",
     "effects": "Stimulation;psychedelic effects;cardiovascular activation",
     "mechanism": "Voacangine is a prodrug to ibogaine (NMDA antagonist, serotonin transporter blocker)",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "experimental use in addiction therapy (via ibogaine synthesis)",
     "interactions": [
       "avoid all stimulants",
       "antidepressants",
@@ -11196,25 +13215,28 @@
       "heart conditions",
       "psychiatric disorders"
     ],
-    "dosage": "",
-    "therapeutic": "experimental use in addiction therapy (via ibogaine synthesis)",
+    "sideeffects": [
+      "vomiting",
+      "overstimulation",
+      "visual distortions"
+    ],
     "safety": "",
-    "sideeffects": "vomiting, overstimulation, visual distortions",
     "toxicity": "High in overdose; cardiotoxic potential",
     "toxicity_ld50": "~90–120 mg/kg (est. voacangine)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ caution",
       "🌍 african",
       "🧠 vision"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4181566/",
       "Plants of the Gods – Rätsch",
       "Voacanga africana: Ethnobotany and Chemistry – J Ethnopharmacol",
       "2014"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "voacanga-africana",
@@ -11222,13 +13244,18 @@
     "common": "",
     "scientific": "Voacanga africana",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Strong",
     "region": "west africa",
     "legalstatus": "Unscheduled; may be regulated for alkaloids",
+    "schedule": "",
     "description": "a powerful african plant containing voacangine and iboga alkaloids. used traditionally in ritual contexts and studied as a potential ibogaine precursor.",
     "effects": "Stimulation;psychedelic effects;cardiovascular activation",
     "mechanism": "Voacangine is a prodrug to ibogaine (NMDA antagonist, serotonin transporter blocker)",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "experimental use in addiction therapy (via ibogaine synthesis)",
     "interactions": [
       "avoid all stimulants",
       "antidepressants",
@@ -11238,25 +13265,28 @@
       "heart conditions",
       "psychiatric disorders"
     ],
-    "dosage": "",
-    "therapeutic": "experimental use in addiction therapy (via ibogaine synthesis)",
+    "sideeffects": [
+      "vomiting",
+      "overstimulation",
+      "visual distortions"
+    ],
     "safety": "",
-    "sideeffects": "vomiting, overstimulation, visual distortions",
     "toxicity": "High in overdose; cardiotoxic potential",
     "toxicity_ld50": "~90–120 mg/kg (est. voacangine)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ caution",
       "🌍 african",
       "🧠 vision"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4181566/",
       "Plants of the Gods – Rätsch",
       "Voacanga africana: Ethnobotany and Chemistry – J Ethnopharmacol",
       "2014"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "white-lily",
@@ -11264,33 +13294,40 @@
     "common": "",
     "scientific": "Nymphaea ampla",
     "category": "oneirogen",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "mexico, central america",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "related to blue lotus, this sacred flower from mesoamerican traditions is used to promote meditation and lucid dreaming.",
     "effects": "Calm;light sedation;dream potentiation",
     "mechanism": "Contains aporphine alkaloids (dopamine agonist)",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "relaxation, aphrodisiac, dream enhancement",
     "interactions": [
       "avoid cns depressants"
     ],
     "contraindications": [
       "pregnancy"
     ],
-    "dosage": "",
-    "therapeutic": "relaxation, aphrodisiac, dream enhancement",
+    "sideeffects": [
+      "drowsiness",
+      "vivid dreams"
+    ],
     "safety": "",
-    "sideeffects": "drowsiness, vivid dreams",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "✅ safe",
       "🌸 calm",
       "🌿 sedative"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "leonotis-leonurus",
@@ -11298,32 +13335,39 @@
     "common": "",
     "scientific": "Leonotis leonurus",
     "category": "relaxant / euphoric",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "southern africa",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "orange-flowered shrub also called lion’s tail; smoked traditionally for mild cannabis-like effects.",
     "effects": "Mild euphoria;relaxation",
     "mechanism": "Contains leonurine; may act on serotonin and cannabinoid receptors.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "folk remedy for coughs, fever and as a mild psychoactive when smoked.",
     "interactions": [
       "may potentiate other sedatives"
     ],
     "contraindications": [
       "avoid during pregnancy or with heart conditions."
     ],
-    "dosage": "",
-    "therapeutic": "folk remedy for coughs, fever and as a mild psychoactive when smoked.",
+    "sideeffects": [
+      "dry mouth",
+      "slight dizziness"
+    ],
     "safety": "",
-    "sideeffects": "dry mouth, slight dizziness",
     "toxicity": "Low; high doses may cause dizziness or nausea.",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 smoke",
       "🦁 dagga"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "wormwood",
@@ -11331,13 +13375,18 @@
     "common": "",
     "scientific": "Artemisia absinthium",
     "category": "oneirogen",
+    "subcategory": "",
     "intensity": "Mild to moderate",
     "region": "europe, asia, north america",
     "legalstatus": "Restricted in high-thujone formulations",
+    "schedule": "",
     "description": "key ingredient in absinthe. contains thujone, which is a gaba_a antagonist and neurostimulant in high doses. historically used for dreaming, digestion, and ritual.",
     "effects": "Lucid dreams;stimulating;mental clarity",
     "mechanism": "Thujone – GABA_A receptor antagonist",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "digestive tonic, dream work, antiparasitic",
     "interactions": [
       "avoid alcohol",
       "cns drugs"
@@ -11347,20 +13396,23 @@
       "epilepsy",
       "high doses"
     ],
-    "dosage": "",
-    "therapeutic": "digestive tonic, dream work, antiparasitic",
+    "sideeffects": [
+      "headache",
+      "nausea",
+      "tremors at high doses"
+    ],
     "safety": "",
-    "sideeffects": "headache, nausea, tremors at high doses",
     "toxicity": "Neurotoxic in large doses",
     "toxicity_ld50": "~30 mg/kg (thujone)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ caution",
       "🌙 dream",
       "🌿 bitter"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "xylopia-aethiopica",
@@ -11368,38 +13420,44 @@
     "common": "",
     "scientific": "Xylopia aethiopica",
     "category": "spice / respiratory / afro-caribbean traditional",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "west africa, caribbean",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a spicy fruit used in west african and caribbean cuisine and medicine. traditionally employed to treat respiratory and digestive issues, and as a warming tonic for colds and fatigue.",
     "effects": "Warming;Decongestant;Digestive aid;Mild stimulant",
     "mechanism": "Contains volatile oils (e.g. eugenol, β-pinene) that have antimicrobial, warming, and stimulant actions. May stimulate mucous clearance and circulation.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for coughs, bronchitis, gas, malaria prevention, postpartum recovery, and flavoring food and medicine.",
     "interactions": [
       "minimal. may interact with stimulants or other warming agents."
     ],
     "contraindications": [
       "avoid in pregnancy unless under traditional guidance due to uterine stimulant effect."
     ],
-    "dosage": "",
-    "therapeutic": "used for coughs, bronchitis, gas, malaria prevention, postpartum recovery, and flavoring food and medicine.",
+    "sideeffects": [
+      "in large doses may cause stomach irritation or overstimulation."
+    ],
     "safety": "",
-    "sideeffects": "in large doses may cause stomach irritation or overstimulation.",
     "toxicity": "Low at culinary or traditional doses",
     "toxicity_ld50": "Not well documented",
-    "is_controlled_substance": false,
     "tags": [
       "🌶️ spice",
       "🌬️ decongestant",
       "🌿 afro-caribbean",
       "🫖 traditional tonic"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8736103/",
       "Journal of Ethnopharmacology",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "glaucium-flavum",
@@ -11407,32 +13465,39 @@
     "common": "",
     "scientific": "Glaucium flavum",
     "category": "other",
+    "subcategory": "",
     "intensity": "",
     "region": "mediterranean",
     "legalstatus": "Varies",
+    "schedule": "",
     "description": "coastal poppy used occasionally for its glaucine content.",
     "effects": "mild euphoria;sedation",
     "mechanism": "Contains glaucine, a bronchodilator acting on dopamine receptors",
     "compounds": [],
+    "preparations": [],
+    "dosage": "10–20 mg glaucine",
+    "therapeutic": "cough suppressant",
     "interactions": [
       "cns depressants"
     ],
     "contraindications": [
       "pregnancy"
     ],
-    "dosage": "10–20 mg glaucine",
-    "therapeutic": "cough suppressant",
+    "sideeffects": [
+      "dizziness",
+      "nausea"
+    ],
     "safety": "",
-    "sideeffects": "dizziness, nausea",
     "toxicity": "Moderate",
     "toxicity_ld50": ">300 mg/kg (mice)",
-    "is_controlled_substance": false,
     "tags": [
       "🌀 visionary",
       "💊 oral"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "yopo",
@@ -11440,13 +13505,18 @@
     "common": "",
     "scientific": "Anadenanthera peregrina",
     "category": "ritual / visionary",
+    "subcategory": "",
     "intensity": "Very strong",
     "region": "south america (orinoco, amazon basin)",
     "legalstatus": "Controlled in many countries due to DMT content",
+    "schedule": "",
     "description": "used in amazonian rituals, yopo seeds are ground and insufflated to induce powerful entheogenic experiences. contains bufotenine, dmt, and 5-meo-dmt.",
     "effects": "Intense visions;altered time perception;spiritual insight",
     "mechanism": "5-HT2A receptor agonist (bufotenine, DMT, 5-MeO-DMT)",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "shamanic healing, insight rituals",
     "interactions": [
       "avoid with antidepressants or maois"
     ],
@@ -11455,20 +13525,23 @@
       "mental health disorders",
       "maois"
     ],
-    "dosage": "",
-    "therapeutic": "shamanic healing, insight rituals",
+    "sideeffects": [
+      "intense nausea",
+      "disorientation",
+      "respiratory irritation"
+    ],
     "safety": "",
-    "sideeffects": "intense nausea, disorientation, respiratory irritation",
     "toxicity": "High risk with improper use; bufotenine toxic at high dose",
     "toxicity_ld50": "50–80 mg/kg (bufotenine, mice)",
-    "is_controlled_substance": false,
     "tags": [
       "⚠️ caution",
       "🌬️ snuff",
       "🧠 vision"
     ],
-    "sources": [],
-    "image": ""
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "zanthoxylum-americanum",
@@ -11476,38 +13549,44 @@
     "common": "",
     "scientific": "Zanthoxylum americanum",
     "category": "analgesic / circulatory stimulant / traditional native american",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "north america (northern u.s., canada)",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "northern relative of zanthoxylum clava-herculis, this species was widely used by native americans for toothaches, cold limbs, and digestion. like its southern cousin, it produces a numbing and buzzing sensation when chewed.",
     "effects": "Tingling;Local analgesia;Salivation;Circulation boost",
     "mechanism": "Sanshools (alkylamides) modulate TRPV1 and TRPA1 channels on nerve endings, producing a buzzing, tingling analgesic effect. Also stimulates saliva and gastric secretions.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used topically or chewed for oral pain, indigestion, sluggish circulation, or nerve support. historically used in decoctions or salves.",
     "interactions": [
       "minimal. theoretical interaction with oral analgesics or vasodilators."
     ],
     "contraindications": [
       "avoid in broken oral tissue or wounds. caution with hot spices or ulcers."
     ],
-    "dosage": "",
-    "therapeutic": "used topically or chewed for oral pain, indigestion, sluggish circulation, or nerve support. historically used in decoctions or salves.",
+    "sideeffects": [
+      "local irritation or tingling. mild drooling or numbing. rare allergic reactions."
+    ],
     "safety": "",
-    "sideeffects": "local irritation or tingling. mild drooling or numbing. rare allergic reactions.",
     "toxicity": "Low in traditional use",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🦷 oral care",
       "🌿 native american",
       "🫦 tingling",
       "🔥 circulatory"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7144794/",
       "Native American Ethnobotany – Moerman",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "zanthoxylum-bungeanum",
@@ -11515,38 +13594,44 @@
     "common": "",
     "scientific": "Zanthoxylum bungeanum",
     "category": "digestive / circulatory / sensory-modulating",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "china, east asia",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "used in chinese cuisine and medicine, sichuan pepper causes a tingling numbness and has been traditionally used to support digestion and stimulate circulation. its unique effect is due to hydroxy-alpha-sanshool.",
     "effects": "Tingling sensation;Digestive stimulant;Mild analgesia;Circulation support",
     "mechanism": "Sanshools activate somatosensory ion channels (TRPA1, TRPV1) leading to a buzzing/tingling anesthetic effect. Also improves gastric secretions and peripheral blood flow.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used to improve digestion, relieve stomach cramps, stimulate salivation, reduce cold extremities, and in topical pain blends.",
     "interactions": [
       "may alter absorption of other herbs or drugs via gi stimulation."
     ],
     "contraindications": [
       "avoid in mucosal lesions or in large doses during pregnancy."
     ],
-    "dosage": "",
-    "therapeutic": "used to improve digestion, relieve stomach cramps, stimulate salivation, reduce cold extremities, and in topical pain blends.",
+    "sideeffects": [
+      "can cause intense tingling. overuse may irritate gi tract or cause local numbness."
+    ],
     "safety": "",
-    "sideeffects": "can cause intense tingling. overuse may irritate gi tract or cause local numbness.",
     "toxicity": "Low",
     "toxicity_ld50": "Not fully established; safe in culinary and moderate medicinal use",
-    "is_controlled_substance": false,
     "tags": [
       "🌶️ tingling",
       "🍽️ digestive",
       "🩸 circulatory",
       "🌿 culinary-medical"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6452023/",
       "Chinese Herbal Materia Medica",
       "Journal of Ethnopharmacology"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "zanthoxylum-clava-herculis",
@@ -11554,9 +13639,11 @@
     "common": "Toothache Tree",
     "scientific": "Zanthoxylum clava-herculis",
     "category": "analgesic / stimulant",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "southeastern united states",
     "legalstatus": "Legal",
+    "schedule": "",
     "description": "also called the toothache tree; its bark creates a tingling numbness and light stimulation when chewed.",
     "effects": "mouth numbness;mild stimulation;pain relief",
     "mechanism": "Bark contains sanshools that cause paresthesia and stimulate trigeminal nerves",
@@ -11564,30 +13651,36 @@
       "Pellitorine",
       "Sanshools"
     ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "native american remedy for toothaches and sore throats; also used as a tonic",
     "interactions": [
       "may interact with other numbing agents"
     ],
     "contraindications": [
       "mouth ulcers or sensitive gums"
     ],
-    "dosage": "",
-    "therapeutic": "native american remedy for toothaches and sore throats; also used as a tonic",
+    "sideeffects": [
+      "tingling",
+      "salivation",
+      "mild stomach upset"
+    ],
     "safety": "",
-    "sideeffects": "tingling, salivation, mild stomach upset",
     "toxicity": "Low in customary doses",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "north america",
       "tingling",
       "toothache tree"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5656514/",
       "Native American Ethnobotany – Moerman",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "zea-mays-stigma",
@@ -11595,39 +13688,45 @@
     "common": "",
     "scientific": "Zea mays (stigma)",
     "category": "diuretic / urinary tract / soothing",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "worldwide (where corn is cultivated)",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "the long threads of corn (called silk) are a gentle herbal remedy for urinary tract issues, swelling, and kidney function. used in teas for centuries in both native american and chinese traditions.",
     "effects": "Urine flow increase;Soothing;Kidney support;Anti-inflammatory",
     "mechanism": "Contains flavonoids, saponins, and potassium that increase urine output, reduce inflammation, and soothe irritated tissues.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for utis, bladder inflammation, bedwetting, kidney stones, and fluid retention. also mildly calming.",
     "interactions": [
       "may enhance diuretics or alter potassium levels. mild blood pressure effects."
     ],
     "contraindications": [
       "avoid with diuretic medications or in cases of severe kidney disease unless supervised."
     ],
-    "dosage": "",
-    "therapeutic": "used for utis, bladder inflammation, bedwetting, kidney stones, and fluid retention. also mildly calming.",
+    "sideeffects": [
+      "rare. may cause mild electrolyte loss or allergic reaction in corn-sensitive individuals."
+    ],
     "safety": "",
-    "sideeffects": "rare. may cause mild electrolyte loss or allergic reaction in corn-sensitive individuals.",
     "toxicity": "Very low",
     "toxicity_ld50": "Not established; extremely safe at traditional doses",
-    "is_controlled_substance": false,
     "tags": [
       "🌾 kidney support",
       "💧 diuretic",
       "🫖 soothing",
       "🌿 folk remedy"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7121893/",
       "Plants of the Gods – Rätsch",
       "Journal of Medicinal Plants Research",
       "2011"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "zingiber-zerumbet",
@@ -11635,38 +13734,44 @@
     "common": "",
     "scientific": "Zingiber zerumbet",
     "category": "anti-inflammatory / aromatic / dermatological",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "hawaii, southeast asia, pacific islands",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a tropical ginger species prized for its aromatic rhizomes and milky juice-filled cones used in traditional polynesian medicine and hair care. mildly relaxing and soothing, both internally and externally.",
     "effects": "Skin and hair care;Topical anti-inflammatory;Digestive aid;Aromatic relaxant",
     "mechanism": "Zerumbone and essential oils contribute to anti-inflammatory, antioxidant, and antimicrobial effects. Soothes skin, modulates TRP channels, and supports digestion.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used topically for hair conditioning, inflammation, burns, and fungal issues. internally for nausea, digestive support, and respiratory infections.",
     "interactions": [
       "may mildly enhance absorption or circulation of co-administered compounds."
     ],
     "contraindications": [
       "caution during pregnancy. not for chronic high-dose ingestion."
     ],
-    "dosage": "",
-    "therapeutic": "used topically for hair conditioning, inflammation, burns, and fungal issues. internally for nausea, digestive support, and respiratory infections.",
+    "sideeffects": [
+      "rare. may cause skin sensitivity in some. avoid in large oral doses without preparation."
+    ],
     "safety": "",
-    "sideeffects": "rare. may cause skin sensitivity in some. avoid in large oral doses without preparation.",
     "toxicity": "Low",
     "toxicity_ld50": "Not well established; traditionally regarded as safe",
-    "is_controlled_substance": false,
     "tags": [
       "🫧 hair care",
       "🌿 soothing",
       "🔥 anti-inflammatory",
       "🌺 polynesian use"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8751302/",
       "Hawaiian Ethnobotany – Beatrice Krauss",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "ziziphus-jujuba",
@@ -11674,38 +13779,45 @@
     "common": "",
     "scientific": "Ziziphus jujuba",
     "category": "sedative / adaptogen / digestive",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "china, middle east, mediterranean",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "a traditional fruit in chinese and middle eastern medicine, jujube is used as a tonic, sleep aid, and digestive harmonizer. rich in antioxidants and calming saponins.",
     "effects": "Sleep support;Stress reduction;Digestive regulation;Immune modulation",
     "mechanism": "Jujubosides interact with GABA-A receptors and modulate cortisol. Flavonoids and triterpenes provide antioxidant and anti-inflammatory effects.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for insomnia, anxiety, poor appetite, fatigue, and gastrointestinal upset. often included in tcm formulas like suan zao ren tang.",
     "interactions": [
       "may enhance sedative or anxiolytic medications."
     ],
     "contraindications": [
       "none major. caution in hypotensive patients due to mild sedative effects."
     ],
-    "dosage": "",
-    "therapeutic": "used for insomnia, anxiety, poor appetite, fatigue, and gastrointestinal upset. often included in tcm formulas like suan zao ren tang.",
+    "sideeffects": [
+      "rare",
+      "well tolerated. mild drowsiness or loose stool at high doses."
+    ],
     "safety": "",
-    "sideeffects": "rare; well tolerated. mild drowsiness or loose stool at high doses.",
     "toxicity": "Low",
     "toxicity_ld50": "Not well documented; safe in dietary and medicinal use",
-    "is_controlled_substance": false,
     "tags": [
       "🍎 tcm",
       "💤 sleep",
       "🛡️ immune",
       "🌿 mild adaptogen"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6267325/",
       "Journal of Ethnopharmacology",
       "Chinese Herbal Medicine – Bensky & Gamble"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "ziziphus-spinosa",
@@ -11713,13 +13825,18 @@
     "common": "",
     "scientific": "Ziziphus spinosa",
     "category": "sedative / anxiolytic / traditional chinese medicine",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "china, korea, japan",
     "legalstatus": "Legal worldwide",
+    "schedule": "",
     "description": "the seeds of this wild jujube are used in traditional chinese medicine (tcm) for calming the spirit and nourishing the heart. a key herb in formulas for insomnia and anxiety, including suan zao ren tang.",
     "effects": "Sleep promotion;Anxiety relief;Dream regulation;Heart-calming",
     "mechanism": "Jujubosides and flavonoids interact with GABA receptors and modulate neurotransmitters like serotonin and dopamine. Mildly hypnotic and anxiolytic.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for insomnia, restlessness, palpitations, excessive dreaming, and mental fatigue.",
     "interactions": [
       "may enhance effects of sedatives",
       "hypnotics",
@@ -11728,25 +13845,26 @@
     "contraindications": [
       "caution in hypotension or concurrent sedative use."
     ],
-    "dosage": "",
-    "therapeutic": "used for insomnia, restlessness, palpitations, excessive dreaming, and mental fatigue.",
+    "sideeffects": [
+      "rare. large doses may cause mild gi upset or daytime drowsiness."
+    ],
     "safety": "",
-    "sideeffects": "rare. large doses may cause mild gi upset or daytime drowsiness.",
     "toxicity": "Low",
     "toxicity_ld50": "Not well documented; safe in traditional use",
-    "is_controlled_substance": false,
     "tags": [
       "💤 sleep",
       "🧘 calm",
       "🌿 tcm",
       "🌙 dream"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6163148/",
       "Chinese Herbal Medicine – Bensky",
       "Plants of the Gods – Rätsch"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "zornia-diphylla",
@@ -11754,38 +13872,44 @@
     "common": "",
     "scientific": "Zornia diphylla",
     "category": "calming / respiratory / psychoactive adjunct",
+    "subcategory": "",
     "intensity": "Mild",
     "region": "south america, caribbean",
     "legalstatus": "Legal in most regions",
+    "schedule": "",
     "description": "a lesser-known south american herb with calming, slightly psychoactive properties. sometimes used similarly to zornia latifolia in herbal smoking blends and indigenous rituals.",
     "effects": "Relaxation;Mild psychoactive;Cough soothing;Mood lifting",
     "mechanism": "Likely contains flavonoids and volatile oils with CNS-depressant and bronchodilatory effects. Specific constituents under-studied.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for calming anxiety, promoting mild euphoria, relieving cough or bronchial irritation, and enhancing relaxation in blend formulas.",
     "interactions": [
       "may enhance effects of other cns depressants or respiratory herbs."
     ],
     "contraindications": [
       "avoid use with strong sedatives or during pregnancy. limited safety data."
     ],
-    "dosage": "",
-    "therapeutic": "used for calming anxiety, promoting mild euphoria, relieving cough or bronchial irritation, and enhancing relaxation in blend formulas.",
+    "sideeffects": [
+      "very mild. may cause sedation or lightheadedness in large amounts."
+    ],
     "safety": "",
-    "sideeffects": "very mild. may cause sedation or lightheadedness in large amounts.",
     "toxicity": "Unknown but presumed low based on traditional use",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🌀 psychoactive-adjunct",
       "🛌 calm",
       "🫁 respiratory",
       "🌿 ethnobotanical"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://erowid.org/herbs/zornia_diphylla/",
       "Plants of the Gods – Rätsch",
       "Amazonian Ethnobotany Archives"
-    ],
-    "image": ""
+    ]
   },
   {
     "id": "zornia-latifolia",
@@ -11793,37 +13917,44 @@
     "common": "",
     "scientific": "Zornia latifolia",
     "category": "psychoactive / calming / south american traditional",
+    "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "brazil, paraguay, south america",
     "legalstatus": "Legal in most regions",
+    "schedule": "",
     "description": "known as 'false marijuana' in brazil, this south american herb produces a relaxing, slightly euphoric state when smoked or brewed. used traditionally in rituals and to aid sleep or meditation.",
     "effects": "Mild euphoria;Mental calm;Lucid dreaming;Cannabinoid mimicry",
     "mechanism": "Flavonoids and potential endocannabinoid-modulating compounds interact with CB1/CB2 receptors, though exact active constituents remain under-researched.",
     "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for anxiety, insomnia, meditation enhancement, and as a legal cannabis substitute in some herbal blends.",
     "interactions": [
       "theoretical synergy with gabaergic or cannabinoid-active compounds."
     ],
     "contraindications": [
       "avoid mixing with alcohol or sedatives. not for use in pregnancy."
     ],
-    "dosage": "",
-    "therapeutic": "used for anxiety, insomnia, meditation enhancement, and as a legal cannabis substitute in some herbal blends.",
+    "sideeffects": [
+      "very mild",
+      "potential sedation or grogginess. high doses may cause dizziness."
+    ],
     "safety": "",
-    "sideeffects": "very mild; potential sedation or grogginess. high doses may cause dizziness.",
     "toxicity": "Low",
     "toxicity_ld50": "Not established",
-    "is_controlled_substance": false,
     "tags": [
       "🌿 psychoactive",
       "🛌 dream herb",
       "🧘 relaxing",
       "🌀 cannabis-like"
     ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
     "sources": [
       "https://erowid.org/herbs/zornia_latifolia/",
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology"
-    ],
-    "image": ""
+    ]
   }
 ]

--- a/src/data/herbs/herbsfull.ts
+++ b/src/data/herbs/herbsfull.ts
@@ -16,18 +16,14 @@ function toStringArray(value: unknown): string[] {
   return []
 }
 
-function boolFrom(value: unknown): boolean {
-  if (typeof value === 'boolean') return value
-  if (typeof value === 'string') return value.toLowerCase() === 'true'
-  if (typeof value === 'number') return value !== 0
-  return false
-}
-
 const normalized: Herb[] = (rawHerbs as any[]).map(raw => {
   const compounds = toStringArray(raw.compounds)
   const tags = toStringArray(raw.tags)
   const interactions = toStringArray(raw.interactions)
   const contraindications = toStringArray(raw.contraindications)
+  const sideeffects = toStringArray(raw.sideeffects)
+  const preparations = toStringArray(raw.preparations)
+  const regiontags = toStringArray(raw.regiontags)
   const sources = toStringArray(raw.sources)
 
   const common = typeof raw.common === 'string' ? raw.common : ''
@@ -44,7 +40,10 @@ const normalized: Herb[] = (rawHerbs as any[]).map(raw => {
 
   const legalstatus = typeof raw.legalstatus === 'string' ? raw.legalstatus : ''
   const therapeutic = typeof raw.therapeutic === 'string' ? raw.therapeutic : ''
-  const sideeffects = typeof raw.sideeffects === 'string' ? raw.sideeffects : ''
+  const safety = typeof raw.safety === 'string' ? raw.safety : ''
+  const legalnotes = typeof raw.legalnotes === 'string' ? raw.legalnotes : ''
+  const schedule = typeof raw.schedule === 'string' ? raw.schedule : ''
+  const subcategory = typeof raw.subcategory === 'string' ? raw.subcategory : ''
 
   const herb: Herb = {
     id,
@@ -52,6 +51,7 @@ const normalized: Herb[] = (rawHerbs as any[]).map(raw => {
     common,
     scientific,
     category: typeof raw.category === 'string' ? raw.category : '',
+    subcategory,
     category_label:
       typeof raw.category_label === 'string' && raw.category_label
         ? raw.category_label
@@ -67,20 +67,23 @@ const normalized: Herb[] = (rawHerbs as any[]).map(raw => {
           : '',
     region: typeof raw.region === 'string' ? raw.region : '',
     legalstatus,
+    schedule,
     description: typeof raw.description === 'string' ? raw.description : '',
     effects: typeof raw.effects === 'string' ? raw.effects : '',
     mechanism,
     compounds,
+    preparations,
     interactions,
     contraindications,
     dosage: typeof raw.dosage === 'string' ? raw.dosage : '',
     therapeutic,
-    safety: typeof raw.safety === 'string' ? raw.safety : '',
+    safety,
     sideeffects,
     toxicity: typeof raw.toxicity === 'string' ? raw.toxicity : '',
     toxicity_ld50: typeof raw.toxicity_ld50 === 'string' ? raw.toxicity_ld50 : '',
-    is_controlled_substance: boolFrom(raw.is_controlled_substance),
     tags,
+    regiontags,
+    legalnotes,
     sources,
     image: typeof raw.image === 'string' ? raw.image : '',
     name:
@@ -100,7 +103,8 @@ const normalized: Herb[] = (rawHerbs as any[]).map(raw => {
     legalStatus: typeof raw.legalStatus === 'string' ? raw.legalStatus : legalstatus,
     therapeuticUses:
       typeof raw.therapeuticUses === 'string' ? raw.therapeuticUses : therapeutic,
-    sideEffects: typeof raw.sideEffects === 'string' ? raw.sideEffects : sideeffects,
+    sideEffects:
+      typeof raw.sideEffects === 'string' ? raw.sideEffects : sideeffects.join('; '),
     drugInteractions:
       typeof raw.drugInteractions === 'string' && raw.drugInteractions
         ? raw.drugInteractions
@@ -122,6 +126,10 @@ const normalized: Herb[] = (rawHerbs as any[]).map(raw => {
       typeof raw.interactionsText === 'string' && raw.interactionsText
         ? raw.interactionsText
         : interactions.join('; '),
+    preparationsText:
+      typeof raw.preparationsText === 'string' && raw.preparationsText
+        ? raw.preparationsText
+        : preparations.join('; '),
     tagsRaw: typeof raw.tagsRaw === 'string' && raw.tagsRaw ? raw.tagsRaw : tags.join('; '),
     duration: (raw.duration ?? null) as string | null,
     onset: (raw.onset ?? null) as string | null,

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,6 @@
+export const has = (v: any) => (Array.isArray(v) ? v.length > 0 : !!v);
+export const list = (arr?: string[], max?: number) =>
+  Array.isArray(arr) ? (max ? arr.slice(0, max) : arr).join(", ") : "";
+export const bullets = (arr?: string[]) =>
+  Array.isArray(arr) ? arr.filter(Boolean) : [];
+export const urlish = (s: string) => /^https?:\/\//i.test(s);

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react'
 import Fuse from 'fuse.js'
 import SEO from '../components/SEO'
 import StarfieldBackground from '../components/StarfieldBackground'
-import HerbCardAccordion from '../components/HerbCardAccordion'
+import DatabaseHerbCard from '../components/DatabaseHerbCard'
 import ErrorBoundary from '../components/ErrorBoundary'
 import type { Herb } from '../types'
 import herbsData from '../data/herbs/herbs.normalized.json'
@@ -243,7 +243,7 @@ export default function Database() {
                     Compare
                   </label>
                 </div>
-                <HerbCardAccordion herb={herb} />
+                <DatabaseHerbCard herb={herb} />
               </div>
             ))}
           </div>

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -3,6 +3,7 @@ import { useParams, Link } from 'react-router-dom'
 import SEO from '../components/SEO'
 import { herbs } from '../data/herbs/herbsfull'
 import { herbName, splitField } from '../utils/herb'
+import { has, bullets, urlish } from '../lib/format'
 
 const DISCLAIMER_TEXT =
   'The information on this site is for educational purposes only. It is not medical advice and should not be used to diagnose, treat, cure, or prevent any disease. Always consult a qualified healthcare professional before using any herbal products or supplements.'
@@ -47,30 +48,42 @@ export default function HerbDetail() {
   }
 
   const imageSrc = herb.image || `/images/herbs/${herb.slug}.jpg`
-  const compounds = (Array.isArray(herb.compounds) ? herb.compounds : splitField(herb.compounds)).filter(Boolean)
-  const interactions = (Array.isArray(herb.interactions)
-    ? herb.interactions
-    : splitField(herb.interactions)
-  ).filter(Boolean)
-  const contraindications = (Array.isArray(herb.contraindications)
-    ? herb.contraindications
-    : splitField(herb.contraindications)
-  ).filter(Boolean)
-  const sources = (Array.isArray(herb.sources) ? herb.sources : splitField(herb.sources)).filter(Boolean)
+  const compounds = bullets(splitField(herb.compounds))
+  const preparations = bullets(splitField(herb.preparations))
+  const interactions = bullets(splitField(herb.interactions))
+  const contraindications = bullets(splitField(herb.contraindications))
+  const sideEffects = bullets(splitField(herb.sideeffects))
+  const sources = bullets(splitField(herb.sources))
 
-  const mechanismText = (herb.mechanism || herb.mechanismofaction || '').trim()
-  const therapeuticText = (herb.therapeutic || '').trim()
-  const safetyText = (herb.safety || '').trim()
-  const sideEffectsText = (herb.sideeffects || '').trim()
+  const descriptionText = herb.description?.trim() || ''
+  const categoryText = herb.category?.trim() || ''
+  const subcategoryText = herb.subcategory?.trim() || ''
+  const intensityText = herb.intensity?.trim() || ''
+  const regionText = herb.region?.trim() || ''
+  const effectsText = herb.effects?.trim() || ''
+  const mechanismText = herb.mechanism?.trim() || ''
+  const therapeuticText = herb.therapeutic?.trim() || ''
+  const dosageText = herb.dosage?.trim() || ''
+  const safetyText = herb.safety?.trim() || ''
+  const legalStatusText = herb.legalstatus?.trim() || ''
+  const scheduleText = herb.schedule?.trim() || ''
+  const legalNotesText = herb.legalnotes?.trim() || ''
+  const toxicityLD50 = herb.toxicity_ld50?.trim() || ''
 
-  const hasMechanism = Boolean(mechanismText)
-  const hasSafety = Boolean(therapeuticText || safetyText || sideEffectsText)
-  const hasCompounds = compounds.length > 0
-  const hasInteractions = interactions.length > 0
-  const hasContraindications = contraindications.length > 0
-  const hasSources = sources.length > 0
   const hasExtraSections =
-    hasMechanism || hasCompounds || hasInteractions || hasContraindications || hasSafety || hasSources
+    has(effectsText) ||
+    has(mechanismText) ||
+    has(compounds) ||
+    has(preparations) ||
+    has(dosageText) ||
+    has(therapeuticText) ||
+    has(interactions) ||
+    has(contraindications) ||
+    has(sideEffects) ||
+    has(safetyText) ||
+    has(legalStatusText) ||
+    has(scheduleText) ||
+    has(sources)
 
   return (
     <>
@@ -95,42 +108,54 @@ export default function HerbDetail() {
             {herb.scientific && (
               <p className='mt-1 text-lg italic text-sand/80'>{herb.scientific}</p>
             )}
-            {herb.description && <p className='mt-4 text-sand/90'>{herb.description}</p>}
+            {has(descriptionText) && <p className='mt-4 text-sand/90'>{descriptionText}</p>}
             <dl className='mt-4 grid gap-3 text-sm text-sand/80 sm:grid-cols-2'>
-              {herb.category && (
+              {has(categoryText) && (
                 <div>
                   <dt className='font-semibold uppercase tracking-wide text-xs text-sand/60'>Category</dt>
                   <dd>{herb.category_label ? herb.category_label : herb.category}</dd>
                 </div>
               )}
-              {herb.intensity && (
+              {has(subcategoryText) && (
+                <div>
+                  <dt className='font-semibold uppercase tracking-wide text-xs text-sand/60'>Subcategory</dt>
+                  <dd>{herb.subcategory}</dd>
+                </div>
+              )}
+              {has(intensityText) && (
                 <div>
                   <dt className='font-semibold uppercase tracking-wide text-xs text-sand/60'>Intensity</dt>
                   <dd>{herb.intensity_label ? herb.intensity_label : herb.intensity}</dd>
                 </div>
               )}
-              {herb.legalstatus && (
+              {has(legalStatusText) && (
                 <div>
                   <dt className='font-semibold uppercase tracking-wide text-xs text-sand/60'>Legal Status</dt>
-                  <dd>{herb.legalstatus}</dd>
+                  <dd>{legalStatusText}</dd>
                 </div>
               )}
-              {herb.region && (
+              {has(scheduleText) && (
+                <div>
+                  <dt className='font-semibold uppercase tracking-wide text-xs text-sand/60'>Schedule</dt>
+                  <dd>{scheduleText}</dd>
+                </div>
+              )}
+              {has(regionText) && (
                 <div>
                   <dt className='font-semibold uppercase tracking-wide text-xs text-sand/60'>Region</dt>
                   <dd>{herb.region}</dd>
                 </div>
               )}
-              {herb.dosage && (
+              {has(dosageText) && (
                 <div>
                   <dt className='font-semibold uppercase tracking-wide text-xs text-sand/60'>Dosage</dt>
-                  <dd>{herb.dosage}</dd>
+                  <dd>{dosageText}</dd>
                 </div>
               )}
-              {herb.toxicity_ld50 && (
+              {has(toxicityLD50) && (
                 <div>
                   <dt className='font-semibold uppercase tracking-wide text-xs text-sand/60'>LD50</dt>
-                  <dd>{herb.toxicity_ld50}</dd>
+                  <dd>{toxicityLD50}</dd>
                 </div>
               )}
             </dl>
@@ -150,14 +175,21 @@ export default function HerbDetail() {
           </div>
         </header>
 
-        {hasMechanism && (
+        {has(effectsText) && (
+          <section className='mt-10 rounded-2xl bg-white/5 p-6 shadow-lg backdrop-blur'>
+            <h2 className='text-2xl font-semibold text-lime-300'>Effects</h2>
+            <p className='mt-3 text-sand/90'>{effectsText}</p>
+          </section>
+        )}
+
+        {has(mechanismText) && (
           <section className='mt-10 rounded-2xl bg-white/5 p-6 shadow-lg backdrop-blur'>
             <h2 className='text-2xl font-semibold text-lime-300'>Mechanism</h2>
             <p className='mt-3 text-sand/90'>{mechanismText}</p>
           </section>
         )}
 
-        {hasCompounds && (
+        {has(compounds) && (
           <section className='mt-10 rounded-2xl bg-white/5 p-6 shadow-lg backdrop-blur'>
             <h2 className='text-2xl font-semibold text-lime-300'>Key Compounds</h2>
             <ul className='mt-3 list-disc space-y-2 pl-6 text-sand/90'>
@@ -168,62 +200,89 @@ export default function HerbDetail() {
           </section>
         )}
 
-        {(hasInteractions || hasContraindications) && (
+        {has(preparations) && (
           <section className='mt-10 rounded-2xl bg-white/5 p-6 shadow-lg backdrop-blur'>
-            <h2 className='text-2xl font-semibold text-lime-300'>Interactions &amp; Contraindications</h2>
-            {hasInteractions && (
-              <div className='mt-3'>
-                <h3 className='text-lg font-semibold text-sand'>Interactions</h3>
-                <ul className='mt-2 list-disc space-y-2 pl-6 text-sand/90'>
-                  {interactions.map(item => (
-                    <li key={`interaction-${item}`}>{item}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
-            {hasContraindications && (
-              <div className='mt-4'>
-                <h3 className='text-lg font-semibold text-sand'>Contraindications</h3>
-                <ul className='mt-2 list-disc space-y-2 pl-6 text-sand/90'>
-                  {contraindications.map(item => (
-                    <li key={`contra-${item}`}>{item}</li>
-                  ))}
-                </ul>
-              </div>
-            )}
+            <h2 className='text-2xl font-semibold text-lime-300'>Preparations</h2>
+            <ul className='mt-3 list-disc space-y-2 pl-6 text-sand/90'>
+              {preparations.map(item => (
+                <li key={`prep-${item}`}>{item}</li>
+              ))}
+            </ul>
           </section>
         )}
 
-        {hasSafety && (
+        {has(dosageText) && (
           <section className='mt-10 rounded-2xl bg-white/5 p-6 shadow-lg backdrop-blur'>
-            <h2 className='text-2xl font-semibold text-lime-300'>Therapeutic &amp; Safety Notes</h2>
-            <div className='mt-3 space-y-3 text-sand/90'>
-              {therapeuticText && (
-                <p>
-                  <strong className='text-sand'>Therapeutic Use:</strong> {therapeuticText}
-                </p>
-              )}
-              {safetyText && (
-                <p>
-                  <strong className='text-sand'>Safety:</strong> {safetyText}
-                </p>
-              )}
-              {sideEffectsText && (
-                <p>
-                  <strong className='text-sand'>Side Effects:</strong> {sideEffectsText}
-                </p>
-              )}
+            <h2 className='text-2xl font-semibold text-lime-300'>Dosage</h2>
+            <p className='mt-3 text-sand/90'>{dosageText}</p>
+          </section>
+        )}
+
+        {has(therapeuticText) && (
+          <section className='mt-10 rounded-2xl bg-white/5 p-6 shadow-lg backdrop-blur'>
+            <h2 className='text-2xl font-semibold text-lime-300'>Therapeutic Uses</h2>
+            <p className='mt-3 text-sand/90'>{therapeuticText}</p>
+          </section>
+        )}
+
+        {has(interactions) && (
+          <section className='mt-10 rounded-2xl bg-white/5 p-6 shadow-lg backdrop-blur'>
+            <h2 className='text-2xl font-semibold text-lime-300'>Interactions</h2>
+            <ul className='mt-3 list-disc space-y-2 pl-6 text-sand/90'>
+              {interactions.map(item => (
+                <li key={`interaction-${item}`}>{item}</li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {has(contraindications) && (
+          <section className='mt-10 rounded-2xl bg-white/5 p-6 shadow-lg backdrop-blur'>
+            <h2 className='text-2xl font-semibold text-lime-300'>Contraindications</h2>
+            <ul className='mt-3 list-disc space-y-2 pl-6 text-sand/90'>
+              {contraindications.map(item => (
+                <li key={`contra-${item}`}>{item}</li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {has(sideEffects) && (
+          <section className='mt-10 rounded-2xl bg-white/5 p-6 shadow-lg backdrop-blur'>
+            <h2 className='text-2xl font-semibold text-lime-300'>Side Effects</h2>
+            <ul className='mt-3 list-disc space-y-2 pl-6 text-sand/90'>
+              {sideEffects.map(item => (
+                <li key={`side-${item}`}>{item}</li>
+              ))}
+            </ul>
+          </section>
+        )}
+
+        {has(safetyText) && (
+          <section className='mt-10 rounded-2xl bg-white/5 p-6 shadow-lg backdrop-blur'>
+            <h2 className='text-2xl font-semibold text-lime-300'>Safety</h2>
+            <p className='mt-3 text-sand/90'>{safetyText}</p>
+          </section>
+        )}
+
+        {(has(legalStatusText) || has(scheduleText) || has(legalNotesText)) && (
+          <section className='mt-10 rounded-2xl bg-white/5 p-6 shadow-lg backdrop-blur'>
+            <h2 className='text-2xl font-semibold text-lime-300'>Legal Notes</h2>
+            <div className='mt-3 space-y-2 text-sand/90'>
+              {has(legalStatusText) && <p><strong>Legal Status:</strong> {legalStatusText}</p>}
+              {has(scheduleText) && <p><strong>Schedule:</strong> {scheduleText}</p>}
+              {has(legalNotesText) && <p><strong>Notes:</strong> {legalNotesText}</p>}
             </div>
           </section>
         )}
 
-        {hasSources && (
+        {has(sources) && (
           <section className='mt-10 rounded-2xl bg-white/5 p-6 shadow-lg backdrop-blur'>
             <h2 className='text-2xl font-semibold text-lime-300'>Sources &amp; References</h2>
             <ul className='mt-3 list-disc space-y-2 pl-6 text-sand/90'>
               {sources.map(src => (
                 <li key={src}>
-                  {/^https?:\/\//i.test(src) ? (
+                  {urlish(src) ? (
                     <a href={src} target='_blank' rel='noopener noreferrer' className='text-sky-300 underline'>
                       {src}
                     </a>

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,25 +4,29 @@ export interface Herb {
   common: string
   scientific: string
   category: string
+  subcategory: string
   category_label?: string
   intensity: string
   intensity_label?: string
   region: string
   legalstatus: string
+  schedule: string
   description: string
   effects: string
   mechanism: string
   compounds: string[]
+  preparations: string[]
   interactions: string[]
   contraindications: string[]
   dosage: string
   therapeutic: string
+  sideeffects: string[]
   safety: string
-  sideeffects: string
   toxicity: string
   toxicity_ld50: string
-  is_controlled_substance: boolean
   tags: string[]
+  regiontags: string[]
+  legalnotes: string
   sources: string[]
   image: string
   // Derived/legacy compatibility fields
@@ -43,6 +47,7 @@ export interface Herb {
   activeConstituents?: { name: string }[]
   contraindicationsText?: string
   interactionsText?: string
+  preparationsText?: string
   tagsRaw?: string
   duration?: string | null
   onset?: string | null


### PR DESCRIPTION
## Summary
- expand the herb conversion script to normalize more metadata fields, derive fallback categories, and report coverage during builds
- add reusable formatting helpers and a richer database card so cards surface effects, tags, regions, compounds, contraindications, and sources without showing “Unknown”
- enhance the herb detail page to conditionally render the expanded dataset (effects, preparations, safety, legal notes, etc.) while hiding empty sections

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4150d1b7083238013eefd98b55469