### PR TITLE
feat(favorites): star and persist favorite herbs

### DIFF
--- a/src/components/DatabaseHerbCard.tsx
+++ b/src/components/DatabaseHerbCard.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 import type { Herb } from '../types'
 import { has, list, bullets, urlish } from '../lib/format'
+import { useFavorites } from '../lib/useFavorites'
 import { herbName, splitField } from '../utils/herb'
 
 interface Props {
@@ -16,11 +17,29 @@ export function DatabaseHerbCard({ herb }: Props) {
   const legalStatus = herb.legalstatus?.trim()
   const effectsList = splitField(herb.effects)
   const effectsText = list(effectsList)
+  const { favs, toggle, has } = useFavorites()
+  const isFavorite = has(herb.slug)
 
   return (
-    <article className='glassmorphic-card soft-border-glow relative flex h-full flex-col gap-2 p-4 text-sand'>
+    <article
+      className='glassmorphic-card soft-border-glow relative flex h-full flex-col gap-2 p-4 text-sand'
+      data-favorites-count={favs.length}
+    >
       <header>
-        <h2 className='text-xl font-semibold text-lime-300'>{title}</h2>
+        <div className='flex items-center'>
+          <h2 className='text-xl font-semibold text-lime-300'>{title}</h2>
+          <button
+            onClick={event => {
+              event.stopPropagation()
+              toggle(herb.slug)
+            }}
+            className={`ml-2 text-xl ${isFavorite ? 'text-yellow-400' : 'text-gray-400'}`}
+            title={isFavorite ? 'Remove from favorites' : 'Add to favorites'}
+            aria-pressed={isFavorite}
+          >
+            ★
+          </button>
+        </div>
         {has(scientific) && <p className='text-sm italic text-sand/70'>{scientific}</p>}
         {has(intensity) && (
           <p className='mt-1 inline-flex items-center rounded-full bg-white/10 px-2 py-1 text-xs uppercase tracking-wide text-sand/80'>

--- a/src/lib/useFavorites.ts
+++ b/src/lib/useFavorites.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+
+const KEY = "herb_favorites";
+
+export function useFavorites() {
+  const [favs, setFavs] = useState<string[]>([]);
+
+  useEffect(() => {
+    try {
+      const saved = JSON.parse(localStorage.getItem(KEY) || "[]");
+      if (Array.isArray(saved)) setFavs(saved);
+    } catch {}
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem(KEY, JSON.stringify(favs));
+  }, [favs]);
+
+  const toggle = (slug: string) =>
+    setFavs(prev =>
+      prev.includes(slug) ? prev.filter(s => s !== slug) : [...prev, slug]
+    );
+
+  const clear = () => setFavs([]);
+
+  return { favs, toggle, clear, has: (slug: string) => favs.includes(slug) };
+}

--- a/src/pages/Favorites.tsx
+++ b/src/pages/Favorites.tsx
@@ -1,46 +1,38 @@
-import React from 'react'
-import { Link } from 'react-router-dom'
-import HerbList from '../components/HerbList'
-import { useHerbs } from '../hooks/useHerbs'
-import { useHerbFavorites } from '../hooks/useHerbFavorites'
-import { motion } from 'framer-motion'
-import SEO from '../components/SEO'
+import { Link } from 'react-router-dom';
+import data from '../data/herbs/herbs.normalized.json';
+import { useFavorites } from '../lib/useFavorites';
 
 export default function Favorites() {
-  const herbs = useHerbs()
-  const { favorites } = useHerbFavorites()
-
-  const favoriteHerbs = React.useMemo(
-    () => herbs.filter(h => favorites.includes(h.id)),
-    [herbs, favorites]
-  )
+  const { favs, clear } = useFavorites();
+  const herbs = data.filter(h => favs.includes(h.slug));
 
   return (
-    <div className='relative min-h-screen px-4 pt-20'>
-      <SEO
-        title='Favorite Herbs | The Hippie Scientist'
-        description='Review the psychoactive herbs you have starred for quick reference.'
-        canonical='https://thehippiescientist.net/favorites'
-      />
-      <div className='mx-auto max-w-6xl'>
-        <div className='mb-4'>
-          <Link to='/database' className='text-comet underline'>
-            ← Back to All Herbs
-          </Link>
-        </div>
-        <h1 className='text-gradient mb-6 text-center text-5xl font-bold'>My Herbs</h1>
-        {favoriteHerbs.length ? (
-          <HerbList herbs={favoriteHerbs} />
-        ) : (
-          <motion.p
-            className='text-center text-sand text-xl'
-            animate={{ y: [0, -10, 0] }}
-            transition={{ repeat: Infinity, duration: 2 }}
-          >
-            🌱 No favorites yet!
-          </motion.p>
+    <main className='mx-auto max-w-5xl px-4 py-8'>
+      <div className='mb-4 flex items-center justify-between'>
+        <h1 className='text-2xl font-bold'>Favorites ({herbs.length})</h1>
+        {herbs.length > 0 && (
+          <button onClick={clear} className='rounded-md border px-3 py-1'>
+            Clear All
+          </button>
         )}
       </div>
-    </div>
-  )
+      {herbs.length === 0 ? (
+        <p className='opacity-70'>You haven’t starred any herbs yet.</p>
+      ) : (
+        <div className='grid gap-4 sm:grid-cols-2'>
+          {herbs.map(h => (
+            <Link
+              key={h.slug}
+              to={`/herb/${h.slug}`}
+              className='rounded-xl border p-4 hover:bg-gray-50 dark:hover:bg-gray-900'
+            >
+              <h2 className='text-lg font-semibold'>{h.common}</h2>
+              <p className='text-sm italic opacity-80'>{h.scientific}</p>
+              {h.effects && <p className='mt-2 text-sm'>{h.effects}</p>}
+            </Link>
+          ))}
+        </div>
+      )}
+    </main>
+  );
 }


### PR DESCRIPTION
## Summary
- add a reusable favorites hook that persists starred herbs to localStorage
- let users toggle favorites directly from the database cards via a star button
- provide a favorites page to review and clear starred herbs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e422a51b34832380b130274f46504e