### PR TITLE
feat(database): dedupe, sorting, and sticky filters

### DIFF
--- a/src/components/DatabaseHerbCard.tsx
+++ b/src/components/DatabaseHerbCard.tsx
@@ -19,6 +19,9 @@ export function DatabaseHerbCard({ herb }: Props) {
   const effectsText = list(effectsList)
   const { favs, toggle, has } = useFavorites()
   const isFavorite = has(herb.slug)
+  const sourcesList = bullets(herb.sources)
+    .map(source => source.trim().replace(/[.;,]\s*$/, ''))
+    .filter(Boolean)
 
   return (
     <article
@@ -83,11 +86,11 @@ export function DatabaseHerbCard({ herb }: Props) {
         </p>
       )}
 
-      {has(herb.sources) && (
+      {sourcesList.length > 0 && (
         <div className='mt-2 text-sm text-sand/90'>
           <strong>Sources:</strong>
           <ul className='mt-1 list-disc pl-5'>
-            {bullets(herb.sources).map((source, index) => (
+            {sourcesList.map((source, index) => (
               <li key={`${herb.slug}-source-${index}`}>
                 {urlish(source) ? (
                   <a className='underline' href={source} target='_blank' rel='noreferrer'>

--- a/src/data/herbs/herbs.normalized.json
+++ b/src/data/herbs/herbs.normalized.json
@@ -1,5 +1,48 @@
 [
   {
+    "id": "mescaline",
+    "slug": "3-4-5-trimethoxyphenethylamine",
+    "common": "",
+    "scientific": "3,4,5-trimethoxyphenethylamine",
+    "category": "psychedelic",
+    "subcategory": "",
+    "intensity": "Moderate",
+    "region": "🌎 americas",
+    "legalstatus": "Controlled in many regions",
+    "schedule": "",
+    "description": "classic phenethylamine psychedelic from peyote and san pedro cacti.",
+    "effects": "Color enhancement;empathy;spiritual visions",
+    "mechanism": "Phenethylamine psychedelic acting on 5-HT2A and dopamine receptors.",
+    "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditional sacrament; studied for alcoholism and psychotherapy.",
+    "interactions": [
+      "maois and sympathomimetics may potentiate."
+    ],
+    "contraindications": [
+      "heart disease",
+      "pregnancy."
+    ],
+    "sideeffects": [
+      "nausea",
+      "increased heart rate",
+      "dilated pupils."
+    ],
+    "safety": "2",
+    "toxicity": "Low physiological toxicity; psychological effects strong.",
+    "toxicity_ld50": ">1,000 mg/kg (rats, oral)",
+    "tags": [
+      "⚠️ restricted",
+      "🌀 visionary",
+      "💊 oral"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
+  },
+  {
     "id": "acacia-confusa",
     "slug": "acacia-confusa",
     "common": "",
@@ -110,16 +153,20 @@
       "Thujone"
     ],
     "preparations": [],
-    "dosage": "",
+    "dosage": "2-4 g dried herb",
     "therapeutic": "used for wounds, bleeding, fevers, gi discomfort, menstrual cramps, and varicose veins. traditionally applied as poultice or tea.",
     "interactions": [
-      "mild interactions with anticoagulants or nsaids possible."
+      "mild interactions with anticoagulants or nsaids possible.",
+      "may enhance sedatives"
     ],
     "contraindications": [
-      "avoid during pregnancy due to potential uterine stimulation. caution in ragweed-allergic individuals."
+      "avoid during pregnancy due to potential uterine stimulation. caution in ragweed-allergic individuals.",
+      "pregnancy",
+      "asteraceae allergy"
     ],
     "sideeffects": [
-      "mild allergic reactions possible in sensitive individuals. large internal doses may upset digestion."
+      "mild allergic reactions possible in sensitive individuals. large internal doses may upset digestion.",
+      "allergic reactions in some"
     ],
     "safety": "",
     "toxicity": "Low",
@@ -128,7 +175,9 @@
       "🩸 astringent",
       "🌿 wound care",
       "🔥 anti-inflammatory",
-      "🧘 menstrual"
+      "🧘 menstrual",
+      "🌼 flower",
+      "😊 mild"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -138,46 +187,6 @@
       "British Herbal Compendium",
       "Plants of the Gods – Rätsch"
     ]
-  },
-  {
-    "id": "achillea-millefolium",
-    "slug": "achillea-millefolium",
-    "common": "",
-    "scientific": "Achillea millefolium",
-    "category": "sedative / analgesic",
-    "subcategory": "",
-    "intensity": "",
-    "region": "northern hemisphere",
-    "legalstatus": "Legal",
-    "schedule": "",
-    "description": "common meadow herb with mild soothing effects.",
-    "effects": "relaxation;pain relief",
-    "mechanism": "Sesquiterpene lactones like chamazulene reduce inflammation and may calm nerves",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "2-4 g dried herb",
-    "therapeutic": "digestive aid, wound healing, relaxation",
-    "interactions": [
-      "may enhance sedatives"
-    ],
-    "contraindications": [
-      "pregnancy",
-      "asteraceae allergy"
-    ],
-    "sideeffects": [
-      "allergic reactions in some"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "~1.3 g/kg (rats, extract)",
-    "tags": [
-      "🌼 flower",
-      "😊 mild"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
   },
   {
     "id": "acmella-oleracea",
@@ -347,52 +356,6 @@
     "sources": []
   },
   {
-    "id": "adhatoda-vasica",
-    "slug": "justicia-adhatoda",
-    "common": "",
-    "scientific": "Justicia adhatoda",
-    "category": "stimulant / bronchodilator",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "indian subcontinent",
-    "legalstatus": "Legal",
-    "schedule": "",
-    "description": "known as vasaka or malabar nut, this shrub’s leaves ease breathing and offer a subtle stimulating effect.",
-    "effects": "clear breathing;mild stimulation;warming",
-    "mechanism": "Alkaloids such as vasicine act as bronchodilators and respiratory stimulants",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "ayurvedic herb for asthma, coughs and general vitality",
-    "interactions": [
-      "may potentiate other bronchodilators"
-    ],
-    "contraindications": [
-      "pregnancy",
-      "high doses may cause vomiting"
-    ],
-    "sideeffects": [
-      "digestive upset at large doses"
-    ],
-    "safety": "",
-    "toxicity": "Generally safe at therapeutic doses",
-    "toxicity_ld50": ">2 g/kg in rodents",
-    "tags": [
-      "ayurveda",
-      "respiratory",
-      "vasaka"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3249957/",
-      "Phytomedicine. 2000",
-      "7(1):37-44.",
-      "Ayurvedic Pharmacopoeia of India"
-    ]
-  },
-  {
     "id": "aegle-marmelos",
     "slug": "aegle-marmelos",
     "common": "",
@@ -439,47 +402,40 @@
     ]
   },
   {
-    "id": "african-dream-root",
-    "slug": "silene-capensis",
-    "common": "",
-    "scientific": "Silene capensis",
-    "category": "oneirogen",
+    "id": "silene-undulata",
+    "slug": "african-dream-root",
+    "common": "African Dream Root",
+    "scientific": "",
+    "category": "",
     "subcategory": "",
-    "intensity": "Mild to moderate",
+    "intensity": "",
     "region": "south africa",
-    "legalstatus": "Legal",
+    "legalstatus": "",
     "schedule": "",
-    "description": "a sacred dream-enhancing root used by the xhosa people of south africa to induce powerful and meaningful dreams.",
-    "effects": "Vivid dreams;lucidity;spiritual connection",
-    "mechanism": "Likely saponins and triterpenoids affecting sleep cycles",
-    "compounds": [],
+    "description": "",
+    "effects": "lucid dreaming;dream recall;mild sedation",
+    "mechanism": "Unknown; may influence cholinergic systems during sleep cycles.",
+    "compounds": [
+      "Triterpenoid saponins"
+    ],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "dream recall, ancestral communication (traditional)",
+    "therapeutic": "",
     "interactions": [],
-    "contraindications": [
-      "none well established"
-    ],
-    "sideeffects": [
-      "mild nausea or grogginess if overdosed"
-    ],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "toxicity": "",
+    "toxicity_ld50": "",
     "tags": [
-      "✅ safe",
-      "🌙 dream",
-      "🧘 ancestral"
+      "dream",
+      "visionary",
+      "african"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
-    "sources": [
-      "https://erowid.org/plants/silene_capensis/",
-      "Dreaming Plant Guide – Ratsch",
-      "Journal of Ethnopharmacology",
-      "2008"
-    ]
+    "sources": []
   },
   {
     "id": "albizia-julibrissin",
@@ -529,50 +485,41 @@
     ]
   },
   {
-    "id": "alchornea-castaneifolia",
-    "slug": "iporuru",
-    "common": "Iporuru",
-    "scientific": "Alchornea castaneifolia",
-    "category": "ritual / visionary",
+    "id": "pimenta-dioica",
+    "slug": "allspice",
+    "common": "Allspice",
+    "scientific": "Pimenta dioica",
+    "category": "ethnobotanical",
     "subcategory": "",
-    "intensity": "Mild",
-    "region": "amazon basin",
-    "legalstatus": "Legal",
+    "intensity": "",
+    "region": "caribbean, central america",
+    "legalstatus": "",
     "schedule": "",
-    "description": "used in amazonian shamanic rituals for its spiritual and anti-inflammatory effects. often included in ayahuasca blends.",
-    "effects": "Anti-inflammatory;spiritual clarity;energetic cleansing",
-    "mechanism": "Unknown; may involve tannins and flavonoids",
+    "description": "also known as allspice, this caribbean plant has mild uplifting and warming effects, sometimes used in ritual incense.",
+    "effects": "stimulant;aromatic euphoria;warming",
+    "mechanism": "GABAergic + serotonergic",
     "compounds": [
-      "Alchorneine"
+      "Eugenol",
+      "Quercetin"
     ],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "rheumatism, arthritis, spiritual cleansing",
+    "therapeutic": "",
     "interactions": [],
-    "contraindications": [
-      "pregnancy"
-    ],
-    "sideeffects": [
-      "minimal",
-      "bitter taste"
-    ],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "toxicity": "",
+    "toxicity_ld50": "",
     "tags": [
-      "✅ safe",
-      "🌿 amazon",
-      "🧘 cleanse"
+      "aromatic",
+      "ritual",
+      "mild stimulant"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4127826/",
-      "Rainforest Healing Herb Profiles",
-      "Journal of Ethnopharmacology",
-      "2007"
-    ]
+    "sources": []
   },
   {
     "id": "aloysia-citrodora",
@@ -795,47 +742,6 @@
     "sources": []
   },
   {
-    "id": "panax-quinquefolius",
-    "slug": "panax-quinquefolius",
-    "common": "",
-    "scientific": "Panax quinquefolius",
-    "category": "empathogen / euphoriant",
-    "subcategory": "",
-    "intensity": "",
-    "region": "north america",
-    "legalstatus": "Legal",
-    "schedule": "",
-    "description": "north american species prized for restorative effects.",
-    "effects": "calm energy",
-    "mechanism": "Similar ginsenosides modulate neurotransmitters",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "1–3 g dried root",
-    "therapeutic": "energy, stress relief",
-    "interactions": [
-      "stimulants",
-      "anticoagulants"
-    ],
-    "contraindications": [
-      "hypertension"
-    ],
-    "sideeffects": [
-      "headache",
-      "insomnia"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": ">2000 mg/kg (rats)",
-    "tags": [
-      "🌿 root",
-      "💊 oral"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
     "id": "amorpha-fruticosa",
     "slug": "amorpha-fruticosa",
     "common": "",
@@ -928,69 +834,13 @@
     ]
   },
   {
-    "id": "anadenanthera-colubrina",
-    "slug": "anadenanthera-colubrina",
-    "common": "",
-    "scientific": "Anadenanthera colubrina",
-    "category": "psychedelic / entheogen",
-    "subcategory": "",
-    "intensity": "High",
-    "region": "amazon basin, andean regions of peru, brazil, colombia, venezuela",
-    "legalstatus": "Bufotenine is Schedule I in the USA. Tree/seeds legal in some regions.",
-    "schedule": "",
-    "description": "a south american tree whose seeds are used to make yopo, a potent psychoactive snuff. used ritually by indigenous tribes for divination and healing.",
-    "effects": "Visual hallucinations;Disorientation;Euphoria;Auditory shifts;Dissociation",
-    "mechanism": "Contains bufotenine (5-HO-DMT), DMT, and 5-MeO-DMT. Acts as a serotonergic agonist (5-HT2A, 5-HT1A), with bufotenine producing strong visual and somatic effects when insufflated.",
-    "compounds": [
-      "Bufotenine"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used traditionally for cleansing, communication with spirits, and insight. no clinical approval.",
-    "interactions": [
-      "dangerous with maois. may cause serotonin overload when mixed with ssris or other psychedelics."
-    ],
-    "contraindications": [
-      "avoid if prone to heart issues",
-      "anxiety",
-      "asthma",
-      "or psychiatric disorders."
-    ],
-    "sideeffects": [
-      "strong bodily discomfort",
-      "intense visual distortions",
-      "nausea",
-      "cardiovascular strain",
-      "and panic are common."
-    ],
-    "safety": "",
-    "toxicity": "High doses of bufotenine can cause respiratory distress. Seeds contain toxic compounds if improperly prepared.",
-    "toxicity_ld50": "Bufotenine: ~200–300 mg/kg (mice, oral)",
-    "tags": [
-      "🌿 entheogen",
-      "🌬️ snuff",
-      "🌀 yopo",
-      "⛔ maoi warning"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://erowid.org/plants/anadenanthera/",
-      "PubMed ID: 12065154",
-      "Journal of Ethnopharmacology",
-      "1994",
-      "TiHKAL by Alexander Shulgin"
-    ]
-  },
-  {
     "id": "anadenanthera-peregrina",
     "slug": "anadenanthera-peregrina",
     "common": "",
     "scientific": "Anadenanthera peregrina",
     "category": "psychedelic / entheogen",
     "subcategory": "",
-    "intensity": "Very high",
+    "intensity": "Very strong",
     "region": "venezuela, brazil, caribbean, northern south america",
     "legalstatus": "Bufotenine is Schedule I in the U.S.; plant materials legal in some countries.",
     "schedule": "",
@@ -1006,18 +856,24 @@
     "interactions": [
       "unsafe with maois",
       "ssris",
-      "or other tryptamines. potential for serotonin syndrome."
+      "or other tryptamines. potential for serotonin syndrome.",
+      "avoid with antidepressants or maois"
     ],
     "contraindications": [
       "avoid with heart conditions",
       "asthma",
-      "or psychiatric disorders. not for individuals with seizure history."
+      "or psychiatric disorders. not for individuals with seizure history.",
+      "mental health disorders",
+      "maois"
     ],
     "sideeffects": [
       "coughing",
       "burning in nose/throat",
       "vomiting",
-      "disorientation. can be frightening or overwhelming."
+      "disorientation. can be frightening or overwhelming.",
+      "intense nausea",
+      "disorientation",
+      "respiratory irritation"
     ],
     "safety": "",
     "toxicity": "Potentially toxic in high doses; bufotenine linked to pulmonary effects and vasoconstriction.",
@@ -1026,7 +882,9 @@
       "🌬️ snuff",
       "🌀 visionary",
       "🔥 roasted seed",
-      "⛔ controlled"
+      "⛔ controlled",
+      "⚠️ caution",
+      "🧠 vision"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -1039,97 +897,36 @@
     ]
   },
   {
-    "id": "anadenanthera-peregrina",
-    "slug": "anadenanthera-peregrina",
-    "common": "",
-    "scientific": "Anadenanthera peregrina",
-    "category": "psychedelic / entheogen",
+    "id": "rhododendron-anthopogon",
+    "slug": "anthopogon",
+    "common": "Anthopogon",
+    "scientific": "",
+    "category": "",
     "subcategory": "",
-    "intensity": "Very high",
-    "region": "venezuela, brazil, caribbean, northern south america",
-    "legalstatus": "Bufotenine is Schedule I in the U.S.; plant materials legal in some countries.",
+    "intensity": "",
+    "region": "himalayas",
+    "legalstatus": "",
     "schedule": "",
-    "description": "closely related to a. colubrina, this species is the primary source of cohoba snuff used by taino and other caribbean-amazonian tribes. extremely potent and short-acting.",
-    "effects": "Intense visuals;Out-of-body experience;Altered time perception;Spiritual insight",
-    "mechanism": "Bufotenine (5-HO-DMT) is the dominant active; acts on 5-HT2A and 5-HT1A receptors. May also contain trace DMT and 5-MeO-DMT. Insufflated use bypasses first-pass metabolism.",
+    "description": "",
+    "effects": "uplifting;clarity;spiritual aid",
+    "mechanism": "Aromatherapeutic and cognitive modulation via essential oils",
     "compounds": [
-      "Bufotenine"
+      "Flavonoids",
+      "Volatile oils"
     ],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "traditionally used for healing, communication with spirits, and divination. no modern clinical uses.",
-    "interactions": [
-      "unsafe with maois",
-      "ssris",
-      "or other tryptamines. potential for serotonin syndrome."
-    ],
-    "contraindications": [
-      "avoid with heart conditions",
-      "asthma",
-      "or psychiatric disorders. not for individuals with seizure history."
-    ],
-    "sideeffects": [
-      "coughing",
-      "burning in nose/throat",
-      "vomiting",
-      "disorientation. can be frightening or overwhelming."
-    ],
+    "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "toxicity": "Potentially toxic in high doses; bufotenine linked to pulmonary effects and vasoconstriction.",
-    "toxicity_ld50": "Bufotenine: 200–300 mg/kg (mice, oral)",
+    "toxicity": "",
+    "toxicity_ld50": "",
     "tags": [
-      "🌬️ snuff",
-      "🌀 visionary",
-      "🔥 roasted seed",
-      "⛔ controlled"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://erowid.org/plants/anadenanthera_peregrina/",
-      "Ratsch: The Encyclopedia of Psychoactive Plants",
-      "Journal of Psychoactive Drugs",
-      "1986"
-    ]
-  },
-  {
-    "id": "anemone-pulsatilla",
-    "slug": "pulsatilla-vulgaris",
-    "common": "",
-    "scientific": "Pulsatilla vulgaris",
-    "category": "sedative / analgesic",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "europe and western asia",
-    "legalstatus": "Legal but not widely sold",
-    "schedule": "",
-    "description": "also called pasque flower; once used by herbalists for calming nerves and relieving pain.",
-    "effects": "calm;pain relief;mild altered awareness",
-    "mechanism": "Contains lactones derived from protoanemonin that depress the central nervous system",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "european folk remedy for anxiety, insomnia and menstrual pain",
-    "interactions": [
-      "may potentiate other sedatives or analgesics"
-    ],
-    "contraindications": [
-      "pregnancy",
-      "open wounds",
-      "large doses"
-    ],
-    "sideeffects": [
-      "nausea",
-      "stomach irritation if taken fresh"
-    ],
-    "safety": "",
-    "toxicity": "Fresh plant is irritant and toxic until dried",
-    "toxicity_ld50": "Not well established",
-    "tags": [
-      "anodyne",
-      "folk",
-      "sedative"
+      "uplifting",
+      "ritual",
+      "clarity"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -1227,6 +1024,45 @@
     ]
   },
   {
+    "id": "betel-nut",
+    "slug": "areca-catechu",
+    "common": "",
+    "scientific": "Areca catechu",
+    "category": "empathogen / euphoriant",
+    "subcategory": "",
+    "intensity": "",
+    "region": "south and southeast asia",
+    "legalstatus": "",
+    "schedule": "",
+    "description": "a widely used masticatory stimulant in asia and the pacific, often combined with lime and betel leaf.",
+    "effects": "Stimulation;warmth;mild euphoria",
+    "mechanism": "Arecoline acts as a muscarinic cholinergic agonist",
+    "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditional digestive stimulant",
+    "interactions": [
+      "stimulants",
+      "parasympathomimetics"
+    ],
+    "contraindications": [
+      "pregnancy",
+      "cardiovascular conditions"
+    ],
+    "sideeffects": [
+      "addiction",
+      "oral cancer with chronic use"
+    ],
+    "safety": "",
+    "toxicity": "",
+    "toxicity_ld50": "",
+    "tags": [],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
+  },
+  {
     "id": "argemone-mexicana",
     "slug": "argemone-mexicana",
     "common": "",
@@ -1269,61 +1105,6 @@
     "legalnotes": "",
     "image": "",
     "sources": []
-  },
-  {
-    "id": "argyreia-nervosa",
-    "slug": "hawaiian-baby-woodrose",
-    "common": "Hawaiian baby woodrose",
-    "scientific": "Argyreia nervosa",
-    "category": "psychedelic / ergolines",
-    "subcategory": "",
-    "intensity": "Moderate",
-    "region": "india, hawaii, tropical regions",
-    "legalstatus": "Legal to possess in most countries; LSA may be restricted.",
-    "schedule": "",
-    "description": "a climbing vine native to india and widely cultivated in hawaii. its seeds contain lsa (lysergic acid amide), a naturally occurring psychedelic related to lsd.",
-    "effects": "Euphoria;Time distortion;Closed-eye visuals;Body heaviness;Drowsiness",
-    "mechanism": "LSA (ergine) is a serotonergic compound acting primarily as a partial agonist at 5-HT2A receptors, similar to LSD but with more sedative effects.",
-    "compounds": [
-      "LSA (lysergic acid amide)"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "historically used in ayurveda for nervine and aphrodisiac properties. psychedelic use is experimental only.",
-    "interactions": [
-      "avoid combining with stimulants",
-      "maois",
-      "ssris",
-      "or vasoconstrictive drugs."
-    ],
-    "contraindications": [
-      "not recommended for people with cardiovascular",
-      "liver",
-      "or psychiatric conditions. avoid during pregnancy."
-    ],
-    "sideeffects": [
-      "strong nausea",
-      "vasoconstriction",
-      "lethargy",
-      "and confusion are common. may cause dizziness and chills."
-    ],
-    "safety": "",
-    "toxicity": "Mild to moderate; effects mostly unpleasant rather than dangerous. Improper preparation increases risk.",
-    "toxicity_ld50": "Unknown (ergine considered relatively low in acute toxicity)",
-    "tags": [
-      "🌱 seed",
-      "🌀 lsa",
-      "🌙 sedative-psychedelic"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://erowid.org/plants/hbw/",
-      "TiHKAL by Alexander Shulgin",
-      "Journal of Ethnopharmacology",
-      "1996"
-    ]
   },
   {
     "id": "argyreia-speciosa",
@@ -1409,120 +1190,6 @@
     "legalnotes": "",
     "image": "",
     "sources": []
-  },
-  {
-    "id": "artemisia-absinthium",
-    "slug": "wormwood",
-    "common": "Wormwood",
-    "scientific": "Artemisia absinthium",
-    "category": "deliriant / digestive bitter",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "europe, north africa, western asia",
-    "legalstatus": "Thujone content regulated in beverages (e.g. EU and US); plant itself legal",
-    "schedule": "",
-    "description": "a bitter herb best known as the flavoring in traditional absinthe. contains thujone, a gaba receptor antagonist that can cause excitatory and convulsive effects in high doses.",
-    "effects": "Euphoria;Mild hallucinations;Stimulation;Appetite stimulant",
-    "mechanism": "Thujone is a GABA-A antagonist, reducing inhibitory signaling in the brain. At high doses, this may induce seizures or hallucinations. Also contains bitter principles that stimulate digestion.",
-    "compounds": [
-      "Thujone"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used as a bitter tonic for digestion, appetite stimulation, and historically as an anthelmintic. occasionally explored for mood elevation in aromatherapy.",
-    "interactions": [
-      "may reduce effectiveness of anticonvulsants. dangerous with gabaergic drugs",
-      "alcohol",
-      "or stimulants."
-    ],
-    "contraindications": [
-      "avoid in epilepsy",
-      "pregnancy",
-      "kidney disease",
-      "and with cns stimulants. use caution with antidepressants or alcohol."
-    ],
-    "sideeffects": [
-      "nausea",
-      "dizziness",
-      "vomiting",
-      "neurotoxicity at high doses. prolonged use may irritate kidneys and liver."
-    ],
-    "safety": "",
-    "toxicity": "High doses or chronic use may lead to tremors, seizures, and neurotoxicity ('absinthism').",
-    "toxicity_ld50": "Thujone: ~87.5 mg/kg (rats, oral)",
-    "tags": [
-      "🍸 absinthium",
-      "⚠️ neurotoxic",
-      "🌿 bitter tonic",
-      "🧠 gaba-antagonist"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3265070/",
-      "Herbal Medicine: Biomolecular and Clinical Aspects",
-      "2nd ed.",
-      "Journal of Ethnopharmacology",
-      "2003"
-    ]
-  },
-  {
-    "id": "artemisia-absinthium",
-    "slug": "wormwood",
-    "common": "Wormwood",
-    "scientific": "Artemisia absinthium",
-    "category": "deliriant / digestive bitter",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "europe, north africa, western asia",
-    "legalstatus": "Thujone content regulated in beverages (e.g. EU and US); plant itself legal",
-    "schedule": "",
-    "description": "a bitter herb best known as the flavoring in traditional absinthe. contains thujone, a gaba receptor antagonist that can cause excitatory and convulsive effects in high doses.",
-    "effects": "Euphoria;Mild hallucinations;Stimulation;Appetite stimulant",
-    "mechanism": "Thujone is a GABA-A antagonist, reducing inhibitory signaling in the brain. At high doses, this may induce seizures or hallucinations. Also contains bitter principles that stimulate digestion.",
-    "compounds": [
-      "Thujone"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used as a bitter tonic for digestion, appetite stimulation, and historically as an anthelmintic. occasionally explored for mood elevation in aromatherapy.",
-    "interactions": [
-      "may reduce effectiveness of anticonvulsants. dangerous with gabaergic drugs",
-      "alcohol",
-      "or stimulants."
-    ],
-    "contraindications": [
-      "avoid in epilepsy",
-      "pregnancy",
-      "kidney disease",
-      "and with cns stimulants. use caution with antidepressants or alcohol."
-    ],
-    "sideeffects": [
-      "nausea",
-      "dizziness",
-      "vomiting",
-      "neurotoxicity at high doses. prolonged use may irritate kidneys and liver."
-    ],
-    "safety": "",
-    "toxicity": "High doses or chronic use may lead to tremors, seizures, and neurotoxicity ('absinthism').",
-    "toxicity_ld50": "Thujone: ~87.5 mg/kg (rats, oral)",
-    "tags": [
-      "🍸 absinthium",
-      "⚠️ neurotoxic",
-      "🌿 bitter tonic",
-      "🧠 gaba-antagonist"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3265070/",
-      "Herbal Medicine: Biomolecular and Clinical Aspects",
-      "2nd ed.",
-      "Journal of Ethnopharmacology",
-      "2003"
-    ]
   },
   {
     "id": "artemisia-ludoviciana",
@@ -1627,16 +1294,19 @@
     "dosage": "",
     "therapeutic": "none clinically confirmed. mentioned in some obscure entheogenic literature as a potential visionary aid.",
     "interactions": [
-      "dangerous with maois or serotonergic drugs due to alkaloid unpredictability."
+      "dangerous with maois or serotonergic drugs due to alkaloid unpredictability.",
+      "maois"
     ],
     "contraindications": [
-      "avoid use due to gramine toxicity. not a recommended dmt source."
+      "avoid use due to gramine toxicity. not a recommended dmt source.",
+      "limited data"
     ],
     "sideeffects": [
       "gramine is toxic",
       "may cause nausea",
       "convulsions",
-      "or hypotension. no established safety profile."
+      "or hypotension. no established safety profile.",
+      "nausea"
     ],
     "safety": "",
     "toxicity": "Gramine is toxic and can affect neuromuscular function and blood pressure.",
@@ -1644,7 +1314,8 @@
     "tags": [
       "🌾 reed",
       "⚠️ gramine-toxicity",
-      "🧪 experimental"
+      "🧪 experimental",
+      "🌿 root bark"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -1758,97 +1429,6 @@
     ]
   },
   {
-    "id": "withania-somnifera",
-    "slug": "withania-somnifera",
-    "common": "",
-    "scientific": "Withania somnifera",
-    "category": "adaptogen / nervine / endocrine support",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "india, middle east, north africa",
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "description": "one of the most revered herbs in ayurveda, ashwagandha is a potent adaptogen used to reduce stress, improve sleep, and balance the nervous and endocrine systems. often called 'indian ginseng'.",
-    "effects": "Stress reduction;Cortisol regulation;Sleep support;Cognitive enhancement",
-    "mechanism": "Withanolides modulate the hypothalamic-pituitary-adrenal (HPA) axis, lower cortisol, reduce oxidative stress, and improve GABAergic signaling.",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for anxiety, fatigue, insomnia, adrenal support, libido, thyroid balance, and immune modulation.",
-    "interactions": [
-      "may enhance effects of sedatives",
-      "thyroid meds",
-      "or immunosuppressants."
-    ],
-    "contraindications": [
-      "avoid with hyperthyroidism",
-      "sedative medications",
-      "or during pregnancy without supervision."
-    ],
-    "sideeffects": [
-      "mild gi upset or drowsiness. rare headaches or allergic reactions."
-    ],
-    "safety": "",
-    "toxicity": "Very low. High doses may affect thyroid hormone levels.",
-    "toxicity_ld50": ">5000 mg/kg (rats, oral)",
-    "tags": [
-      "🧘 adaptogen",
-      "💤 sleep",
-      "🧠 brain support",
-      "🌿 ayurvedic"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6979308/",
-      "Herbal Medicine – Mills & Bone",
-      "Indian Journal of Psychological Medicine",
-      "2012"
-    ]
-  },
-  {
-    "id": "panax-ginseng",
-    "slug": "panax-ginseng",
-    "common": "",
-    "scientific": "Panax ginseng",
-    "category": "empathogen / euphoriant",
-    "subcategory": "",
-    "intensity": "",
-    "region": "asia",
-    "legalstatus": "Legal",
-    "schedule": "",
-    "description": "classic tonic herb for stamina and cognition.",
-    "effects": "vitality;adaptogen",
-    "mechanism": "Ginsenosides modulate HPA axis and nitric oxide pathways",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "1–2 g dried root",
-    "therapeutic": "energy, immune support",
-    "interactions": [
-      "stimulants",
-      "anticoagulants"
-    ],
-    "contraindications": [
-      "hypertension"
-    ],
-    "sideeffects": [
-      "headache",
-      "insomnia"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": ">2000 mg/kg (rats)",
-    "tags": [
-      "🌿 root",
-      "💊 oral"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
     "id": "avena-sativa",
     "slug": "avena-sativa",
     "common": "",
@@ -1894,11 +1474,59 @@
     ]
   },
   {
+    "id": "nicotiana-rustica",
+    "slug": "aztec-tobacco",
+    "common": "Aztec Tobacco",
+    "scientific": "Nicotiana rustica",
+    "category": "stimulant / ritual",
+    "subcategory": "",
+    "intensity": "Strong",
+    "region": "south america and worldwide cultivation",
+    "legalstatus": "Legal but regulated like tobacco",
+    "schedule": "",
+    "description": "potent tobacco species used ceremonially in the amazon, far stronger than common n. tabacum.",
+    "effects": "alertness;intense buzz;clearing of thoughts",
+    "mechanism": "High nicotine plus MAO‑inhibiting beta‑carbolines stimulate nicotinic receptors and inhibit MAO",
+    "compounds": [
+      "Nicotine",
+      "Harmala alkaloids"
+    ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used by amazonian shamans for cleansing and focus",
+    "interactions": [
+      "strongly potentiated by maois",
+      "interacts with many medications"
+    ],
+    "contraindications": [
+      "heart disease",
+      "pregnancy",
+      "hypertension"
+    ],
+    "sideeffects": [
+      "nausea",
+      "increased heart rate",
+      "dizziness"
+    ],
+    "safety": "",
+    "toxicity": "High nicotine content can be poisonous in large amounts",
+    "toxicity_ld50": "Nicotine LD50 ~50 mg/kg (mouse)",
+    "tags": [
+      "mapacho",
+      "nicotine",
+      "tobacco"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
+  },
+  {
     "id": "banisteriopsis-caapi",
     "slug": "banisteriopsis-caapi",
     "common": "",
     "scientific": "Banisteriopsis caapi",
-    "category": "maoi / entheogen",
+    "category": "ritual / visionary",
     "subcategory": "",
     "intensity": "Moderate to profound (when combined)",
     "region": "amazon basin: peru, brazil, colombia",
@@ -1914,19 +1542,24 @@
     "dosage": "",
     "therapeutic": "used for trauma, addiction, depression, and spiritual exploration (in ceremonial or clinical settings). being studied for neurogenesis.",
     "interactions": [
-      "major interaction risk with serotonergic agents. see maoi interaction lists."
+      "major interaction risk with serotonergic agents. see maoi interaction lists.",
+      "all serotonergic substances"
     ],
     "contraindications": [
       "do not combine with ssris",
       "stimulants",
       "antipsychotics",
-      "or tyramine-rich foods."
+      "or tyramine-rich foods.",
+      "ssris",
+      "maois",
+      "pregnancy"
     ],
     "sideeffects": [
       "nausea",
       "vomiting (purge)",
       "dizziness",
-      "emotional catharsis. rarely: serotonin syndrome if combined with contraindicated drugs."
+      "emotional catharsis. rarely: serotonin syndrome if combined with contraindicated drugs.",
+      "purging"
     ],
     "safety": "",
     "toxicity": "Low when used alone. Overdose with other drugs can be fatal.",
@@ -1948,39 +1581,46 @@
     ]
   },
   {
-    "id": "betel-nut",
-    "slug": "areca-catechu",
-    "common": "",
-    "scientific": "Areca catechu",
-    "category": "empathogen / euphoriant",
+    "id": "tabernaemontana-undulata",
+    "slug": "bechette",
+    "common": "Bechette",
+    "scientific": "Tabernaemontana undulata",
+    "category": "analgesic / visionary",
     "subcategory": "",
-    "intensity": "",
-    "region": "south and southeast asia",
-    "legalstatus": "",
+    "intensity": "Moderate to Strong",
+    "region": "western amazon",
+    "legalstatus": "Mostly legal but little researched",
     "schedule": "",
-    "description": "a widely used masticatory stimulant in asia and the pacific, often combined with lime and betel leaf.",
-    "effects": "Stimulation;warmth;mild euphoria",
-    "mechanism": "Arecoline acts as a muscarinic cholinergic agonist",
-    "compounds": [],
+    "description": "also called uchu sanango; this rare shrub contains iboga-like compounds and is used in shamanic practices.",
+    "effects": "tingling sensation;dream enhancement;altered perception",
+    "mechanism": "Contains iboga-type alkaloids affecting serotonin and NMDA receptors",
+    "compounds": [
+      "Voacangine"
+    ],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "traditional digestive stimulant",
+    "therapeutic": "amazonian tribes use the bark for hunting preparation and pain",
     "interactions": [
-      "stimulants",
-      "parasympathomimetics"
+      "avoid with other serotonergic or stimulant substances"
     ],
     "contraindications": [
+      "heart problems",
       "pregnancy",
-      "cardiovascular conditions"
+      "mental illness"
     ],
     "sideeffects": [
-      "addiction",
-      "oral cancer with chronic use"
+      "nausea",
+      "numbness",
+      "dizziness"
     ],
     "safety": "",
-    "toxicity": "",
-    "toxicity_ld50": "",
-    "tags": [],
+    "toxicity": "High doses may be neurotoxic or cardiotoxic",
+    "toxicity_ld50": "Not well known",
+    "tags": [
+      "amazon",
+      "uchu sanango",
+      "iboga alkaloids"
+    ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
@@ -2025,47 +1665,6 @@
   {
     "id": "blue-lotus",
     "slug": "nymphaea-caerulea",
-    "common": "",
-    "scientific": "Nymphaea caerulea",
-    "category": "oneirogen",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "egypt, india",
-    "legalstatus": "Legal in most countries",
-    "schedule": "",
-    "description": "sacred egyptian flower associated with dream states and aphrodisiac properties. contains aporphine alkaloids.",
-    "effects": "Mild euphoria;lucid dreaming;relaxation",
-    "mechanism": "Aporphine acts as dopamine receptor agonist",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "anxiety, mild sedation, aphrodisiac",
-    "interactions": [
-      "avoid sedatives"
-    ],
-    "contraindications": [
-      "pregnancy"
-    ],
-    "sideeffects": [
-      "mild drowsiness",
-      "vivid dreams"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not known",
-    "tags": [
-      "✅ safe",
-      "🌸 calm",
-      "😊 euphoria"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "nymphaea-caerulea",
-    "slug": "blue-lotus",
     "common": "Blue Lotus",
     "scientific": "Nymphaea caerulea",
     "category": "euphoric / sedative / sacred",
@@ -2085,14 +1684,18 @@
     "dosage": "",
     "therapeutic": "used traditionally for anxiety, libido enhancement, meditation, lucid dreaming, and as a ceremonial aphrodisiac.",
     "interactions": [
+      "avoid sedatives",
       "potentiates sedatives",
       "alcohol",
       "and maois. caution advised with ssris."
     ],
     "contraindications": [
+      "pregnancy",
       "avoid with sedatives or psychiatric conditions. unknown effects in pregnancy."
     ],
     "sideeffects": [
+      "mild drowsiness",
+      "vivid dreams",
       "mild dry mouth",
       "drowsiness",
       "nausea in high doses. can cause lethargy or vivid dreams."
@@ -2101,6 +1704,9 @@
     "toxicity": "Low in moderate doses. Safe historically but limited modern study.",
     "toxicity_ld50": "Not well established; assumed low",
     "tags": [
+      "✅ safe",
+      "🌸 calm",
+      "😊 euphoria",
       "🌸 sacred flower",
       "🧘 euphoria",
       "🌙 dreamwork",
@@ -2116,34 +1722,38 @@
     ]
   },
   {
-    "id": "bobinsana",
-    "slug": "calliandra-angustifolia",
-    "common": "",
-    "scientific": "Calliandra angustifolia",
-    "category": "ritual / visionary",
+    "id": "scutellaria-lateriflora",
+    "slug": "blue-skullcap",
+    "common": "Blue Skullcap",
+    "scientific": "Scutellaria lateriflora",
+    "category": "dissociative / sedative",
     "subcategory": "",
     "intensity": "Mild",
-    "region": "amazon basin (peru, ecuador)",
+    "region": "north america",
     "legalstatus": "Legal",
     "schedule": "",
-    "description": "a flowering amazonian shrub used in master plant dieta and as an adjunct to ayahuasca ceremonies for emotional healing and dream clarity.",
-    "effects": "Heart-opening;emotional clarity;mild euphoria",
-    "mechanism": "Unknown; possibly serotonergic modulation or mild MAOI",
-    "compounds": [],
+    "description": "commonly known as skullcap, this north american herb has a long history in western herbalism for treating nervous tension and insomnia.",
+    "effects": "Mild sedation;anxiety relief;mental clarity",
+    "mechanism": "GABA_A receptor modulation (baicalin and other flavonoids)",
+    "compounds": [
+      "Baicalin",
+      "Scutellarin"
+    ],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "emotional trauma healing, dream support",
+    "therapeutic": "anxiety, stress, insomnia, pms",
     "interactions": [
-      "unknown",
-      "caution with serotonergics"
+      "cns depressants",
+      "alcohol",
+      "benzodiazepines"
     ],
     "contraindications": [
       "pregnancy",
-      "psychiatric disorders"
+      "cns depressants"
     ],
     "sideeffects": [
       "drowsiness",
-      "mild emotional vulnerability"
+      "dizziness at high doses"
     ],
     "safety": "",
     "toxicity": "Low",
@@ -2151,45 +1761,7 @@
     "tags": [
       "✅ safe",
       "🌿 herbal",
-      "🧘 calm"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "echinopsis-lageniformis",
-    "slug": "echinopsis-lageniformis",
-    "common": "",
-    "scientific": "Echinopsis lageniformis",
-    "category": "psychedelic",
-    "subcategory": "",
-    "intensity": "",
-    "region": "andes",
-    "legalstatus": "Cactus legal; mescaline controlled",
-    "schedule": "",
-    "description": "another mescaline-rich andean cactus.",
-    "effects": "visions;clarity",
-    "mechanism": "Mescaline as 5-HT2A agonist",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "20–40 cm fresh cactus",
-    "therapeutic": "visionary rituals",
-    "interactions": [
-      "maois"
-    ],
-    "contraindications": [
-      "heart conditions"
-    ],
-    "sideeffects": [
-      "nausea"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": ">1 g/kg (rats)",
-    "tags": [
-      "🌵 cactus"
+      "😴 sedative"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -2198,45 +1770,6 @@
   },
   {
     "id": "brugmansia",
-    "slug": "brugmansia-suaveolens",
-    "common": "",
-    "scientific": "Brugmansia suaveolens",
-    "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "",
-    "region": "south america",
-    "legalstatus": "",
-    "schedule": "",
-    "description": "powerful and dangerous deliriant used in south american shamanism. highly toxic and not recommended for casual use.",
-    "effects": "Hallucinations;delirium;disorientation",
-    "mechanism": "Tropane alkaloids (scopolamine, atropine)",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "historical use in asthma and pain (no modern safe use)",
-    "interactions": [
-      "anticholinergics",
-      "cns depressants"
-    ],
-    "contraindications": [
-      "all unsupervised use"
-    ],
-    "sideeffects": [
-      "extreme confusion",
-      "memory loss",
-      "risk of death"
-    ],
-    "safety": "",
-    "toxicity": "",
-    "toxicity_ld50": "",
-    "tags": [],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "brugmansia-suaveolens",
     "slug": "brugmansia-suaveolens",
     "common": "",
     "scientific": "Brugmansia suaveolens",
@@ -2254,16 +1787,22 @@
     "dosage": "",
     "therapeutic": "none officially sanctioned. occasionally explored for dream states or initiatory visions in traditional contexts.",
     "interactions": [
+      "anticholinergics",
+      "cns depressants",
       "highly dangerous with sedatives",
       "stimulants",
       "or other anticholinergics."
     ],
     "contraindications": [
+      "all unsupervised use",
       "never safe recreationally. dangerous for anyone with cardiovascular",
       "neurological",
       "or psychiatric conditions."
     ],
     "sideeffects": [
+      "extreme confusion",
+      "memory loss",
+      "risk of death",
       "severe confusion",
       "overheating",
       "dry mouth",
@@ -2344,77 +1883,45 @@
     ]
   },
   {
-    "id": "byrsonima-crassifolia",
-    "slug": "nance",
-    "common": "Nance",
-    "scientific": "",
-    "category": "sedative",
+    "id": "petasites-hybridus",
+    "slug": "butterbur",
+    "common": "Butterbur",
+    "scientific": "Petasites hybridus",
+    "category": "dissociative / sedative",
     "subcategory": "",
-    "intensity": "",
-    "region": "central and south america",
-    "legalstatus": "",
+    "intensity": "Mild to moderate",
+    "region": "europe, asia",
+    "legalstatus": "Legal with restrictions (PA-free only)",
     "schedule": "",
-    "description": "",
-    "effects": "mild sedative;calming;tonic",
-    "mechanism": "Flavonoid antioxidant and neuroprotective action",
+    "description": "also known as butterbur, this european root was historically used as a remedy for migraines and spasms. contains pyrrolizidine alkaloids, so safe extracts must be purified.",
+    "effects": "Relaxation;muscle relief;headache reduction",
+    "mechanism": "Antispasmodic and anti-inflammatory effects; calcium channel modulation",
     "compounds": [
-      "Catechins",
-      "Quercetin"
+      "Petasin",
+      "Isopetasin"
     ],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
-    "toxicity_ld50": "",
-    "tags": [
-      "sedative",
-      "folk",
-      "antioxidant"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "caapi",
-    "slug": "banisteriopsis-caapi",
-    "common": "",
-    "scientific": "Banisteriopsis caapi",
-    "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "",
-    "region": "amazon basin",
-    "legalstatus": "",
-    "schedule": "",
-    "description": "the vine of the soul used in ayahuasca. contains harmala alkaloids and facilitates dmt absorption in the brew.",
-    "effects": "MAOI effects;spiritual opening;purging",
-    "mechanism": "Reversible MAO-A inhibition (harmine, harmaline)",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "ayahuasca therapy for ptsd, depression",
+    "therapeutic": "migraine prevention, allergies, anxiety",
     "interactions": [
-      "all serotonergic substances"
+      "avoid hepatotoxic meds"
     ],
     "contraindications": [
-      "ssris",
-      "maois",
-      "pregnancy"
+      "liver conditions",
+      "pregnancy",
+      "raw extract use"
     ],
     "sideeffects": [
-      "nausea",
-      "purging",
-      "dizziness"
+      "liver toxicity risk from unpurified products"
     ],
     "safety": "",
-    "toxicity": "",
-    "toxicity_ld50": "",
-    "tags": [],
+    "toxicity": "Moderate to high (raw plant)",
+    "toxicity_ld50": "~950 mg/kg (mouse, oral, unpurified)",
+    "tags": [
+      "⚠️ pa toxins",
+      "🌿 herbal",
+      "🧠 headache"
+    ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
@@ -2514,56 +2021,11 @@
     ]
   },
   {
-    "id": "calea-zacatechichi",
-    "slug": "dream-herb",
-    "common": "Dream Herb",
-    "scientific": "Calea ternifolia (zacatechichi)",
-    "category": "oneirogen",
-    "subcategory": "",
-    "intensity": "Mild to moderate",
-    "region": "mexico, central america",
-    "legalstatus": "Legal",
-    "schedule": "",
-    "description": "known as the 'dream herb' of the chontal people of mexico, calea is traditionally used to enhance dreams and mental clarity during sleep.",
-    "effects": "Lucid dreaming;dream recall;hypnagogic imagery",
-    "mechanism": "May modulate GABAergic or cholinergic pathways; unclear",
-    "compounds": [
-      "Germacranolides"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "sleep induction, dream work",
-    "interactions": [
-      "avoid sedatives",
-      "alcohol"
-    ],
-    "contraindications": [
-      "pregnancy",
-      "sedative use"
-    ],
-    "sideeffects": [
-      "bitterness",
-      "mild nausea"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not known",
-    "tags": [
-      "✅ safe",
-      "🌙 dream",
-      "🧘 calm"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "calliandra-angustifolia",
+    "id": "bobinsana",
     "slug": "calliandra-angustifolia",
     "common": "",
     "scientific": "Calliandra angustifolia",
-    "category": "nervine / shamanic",
+    "category": "ritual / visionary",
     "subcategory": "",
     "intensity": "Mild",
     "region": "amazon basin: peru, brazil, ecuador",
@@ -2577,19 +2039,28 @@
     "dosage": "",
     "therapeutic": "used for grief, heartbreak, fatigue, and as an energetic tonic. some modern practitioners use it as a mild antidepressant or empathogen.",
     "interactions": [
+      "unknown",
+      "caution with serotonergics",
       "mild theoretical risk with sedatives or maois",
       "especially in ceremonial contexts."
     ],
     "contraindications": [
+      "pregnancy",
+      "psychiatric disorders",
       "avoid during pregnancy. caution with antidepressants or other cns modulators."
     ],
     "sideeffects": [
+      "drowsiness",
+      "mild emotional vulnerability",
       "generally well tolerated. some report increased emotional sensitivity or lightheadedness."
     ],
     "safety": "",
     "toxicity": "Very low. Considered safe in traditional doses.",
     "toxicity_ld50": "Not established",
     "tags": [
+      "✅ safe",
+      "🌿 herbal",
+      "🧘 calm",
       "🌿 empathogen",
       "🧘 dream herb",
       "🌱 dieta"
@@ -2791,52 +2262,6 @@
     ]
   },
   {
-    "id": "cananga-odorata",
-    "slug": "cananga-odorata",
-    "common": "",
-    "scientific": "Cananga odorata",
-    "category": "aromatic / relaxant",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "philippines, indonesia, polynesia",
-    "legalstatus": "Legal",
-    "schedule": "",
-    "description": "a tropical flowering tree native to southeast asia. its flowers yield ylang-ylang essential oil, a sweet floral extract used in perfumery and aromatherapy to reduce stress and promote sensuality.",
-    "effects": "Euphoria;Relaxation;Aphrodisiac;Mild sedation",
-    "mechanism": "Contains linalool, germacrene, and benzyl acetate, which act on GABA and dopaminergic pathways to induce calming and mood-lifting effects.",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used to ease anxiety, insomnia, high blood pressure, and as a romantic enhancer in aromatherapy.",
-    "interactions": [
-      "none significant",
-      "but may mildly potentiate sedatives."
-    ],
-    "contraindications": [
-      "avoid internal use. dilute before skin application. use with caution in pregnancy."
-    ],
-    "sideeffects": [
-      "may cause headaches or nausea in high concentrations. possible skin irritation if undiluted."
-    ],
-    "safety": "",
-    "toxicity": "Low. Generally regarded as safe (GRAS) when used correctly.",
-    "toxicity_ld50": "Unknown (topical only)",
-    "tags": [
-      "🌺 aromatherapy",
-      "💆 relaxant",
-      "💖 aphrodisiac"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6979302/",
-      "Essential Oils in Therapy – Springer 2021",
-      "Journal of Natural Products",
-      "2006"
-    ]
-  },
-  {
     "id": "cannabis-sativa",
     "slug": "cannabis-sativa",
     "common": "",
@@ -2985,82 +2410,6 @@
     ]
   },
   {
-    "id": "gelsemium-sempervirens",
-    "slug": "gelsemium-sempervirens",
-    "common": "",
-    "scientific": "Gelsemium sempervirens",
-    "category": "other",
-    "subcategory": "",
-    "intensity": "",
-    "region": "southern usa",
-    "legalstatus": "Ornamental; toxic",
-    "schedule": "",
-    "description": "fragrant vine with toxic yet calming alkaloids.",
-    "effects": "relaxation;sedation",
-    "mechanism": "Gelsemine acts on glycine and nicotinic receptors",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "5–10 drops tincture",
-    "therapeutic": "folk remedy for anxiety",
-    "interactions": [
-      "sedatives",
-      "muscle relaxants"
-    ],
-    "contraindications": [
-      "pregnancy",
-      "heart issues"
-    ],
-    "sideeffects": [
-      "respiratory depression in overdose"
-    ],
-    "safety": "",
-    "toxicity": "High",
-    "toxicity_ld50": ">10 mg/kg (mice)",
-    "tags": [
-      "⚠️ caution"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "casimiroa-edulis",
-    "slug": "white-sapote",
-    "common": "White Sapote",
-    "scientific": "Casimiroa edulis",
-    "category": "ethnobotanical",
-    "subcategory": "",
-    "intensity": "",
-    "region": "central america",
-    "legalstatus": "",
-    "schedule": "",
-    "description": "the fruit of the white sapote tree is used as a sedative in traditional mexican herbal medicine.",
-    "effects": "sedative;sleep aid",
-    "mechanism": "Possible GABAergic activity",
-    "compounds": [
-      "Zapotin"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
-    "toxicity_ld50": "",
-    "tags": [
-      "sedative",
-      "fruit",
-      "folk medicine"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
     "id": "catha-edulis",
     "slug": "catha-edulis",
     "common": "",
@@ -3081,13 +2430,17 @@
     "interactions": [
       "dangerous with maois",
       "stimulants",
-      "or antidepressants. increases blood pressure and heart rate."
+      "or antidepressants. increases blood pressure and heart rate.",
+      "avoid with stimulants or maois"
     ],
     "contraindications": [
       "avoid in heart disease",
       "high blood pressure",
       "psychiatric conditions",
-      "or during pregnancy."
+      "or during pregnancy.",
+      "heart issues",
+      "pregnancy",
+      "maois."
     ],
     "sideeffects": [
       "insomnia",
@@ -3095,7 +2448,8 @@
       "hypertension",
       "anxiety",
       "irritability",
-      "rebound fatigue. chronic use may lead to dependence."
+      "rebound fatigue. chronic use may lead to dependence.",
+      "increased heart rate"
     ],
     "safety": "",
     "toxicity": "Moderate. Chronic use linked to cardiovascular, dental, and GI issues.",
@@ -3104,7 +2458,9 @@
       "🌿 euphoric",
       "⚡ cathinone",
       "🚫 legal risk",
-      "🧠 stimulant"
+      "🧠 stimulant",
+      "⚠️ controlled",
+      "🌿 leaves"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -3118,146 +2474,50 @@
     ]
   },
   {
-    "id": "erythroxylum-catuaba",
-    "slug": "erythroxylum-catuaba",
-    "common": "",
-    "scientific": "Erythroxylum catuaba",
-    "category": "aphrodisiac / nootropic",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "brazil, amazon, south america",
-    "legalstatus": "Legal",
-    "schedule": "",
-    "description": "a traditional brazilian aphrodisiac made from the bark of various erythroxylum species (mainly e. catuaba). catuaba is used to boost libido, mental clarity, and mood — both in traditional medicine and modern supplements.",
-    "effects": "Stimulation;Enhanced libido;Mild euphoria;Cognitive enhancement",
-    "mechanism": "Contains alkaloids, flavonoids, and possibly tropane-related compounds. Stimulates central nervous system and may increase nitric oxide availability.",
-    "compounds": [
-      "Catuabine"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used traditionally for sexual debility, fatigue, poor memory, and stress. often paired with muira puama.",
-    "interactions": [
-      "may mildly potentiate stimulants or maois. interacts with dopaminergic drugs."
-    ],
-    "contraindications": [
-      "caution with anxiety disorders or insomnia. avoid in pregnancy due to insufficient data."
-    ],
-    "sideeffects": [
-      "rare. may cause mild overstimulation or insomnia in sensitive individuals."
-    ],
-    "safety": "",
-    "toxicity": "Low. Considered very safe in traditional dosing.",
-    "toxicity_ld50": "Not established",
-    "tags": [
-      "🔥 aphrodisiac",
-      "🧠 nootropic",
-      "🌿 amazon tonic"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5937011/",
-      "Brazilian Journal of Pharmacognosy",
-      "2005",
-      "The Healing Power of Rainforest Herbs – Leslie Taylor"
-    ]
-  },
-  {
-    "id": "celastrus-paniculatus",
-    "slug": "intellect-tree",
-    "common": "Intellect Tree",
-    "scientific": "Celastrus paniculatus",
-    "category": "empathogen / euphoriant",
+    "id": "nepeta-cataria",
+    "slug": "catnip",
+    "common": "Catnip",
+    "scientific": "Nepeta cataria",
+    "category": "nervine / mild sedative / folk remedy",
     "subcategory": "",
     "intensity": "Mild",
-    "region": "india, sri lanka, southeast asia",
-    "legalstatus": "Legal",
+    "region": "europe, north america",
+    "legalstatus": "Legal worldwide",
     "schedule": "",
-    "description": "often called the 'intellect tree', this ayurvedic plant is used to support memory, learning, and vivid dreams. contains sesquiterpenes that may stimulate cholinergic activity.",
-    "effects": "Cognitive clarity;memory enhancement;dream vividness",
-    "mechanism": "Cholinergic modulation; antioxidant and neuroprotective effects",
+    "description": "best known for its effects on cats, catnip is also a gentle human nervine herb traditionally used for digestion, colds, and sleep. it has a subtle calming effect and is often included in herbal teas.",
+    "effects": "Relaxation;Mild euphoria;Digestive aid;Sleep support",
+    "mechanism": "Nepetalactone interacts with GABAergic and opioid pathways in humans. Also antispasmodic and diaphoretic.",
     "compounds": [
-      "Celastrine",
-      "Paniculatin"
+      "Nepetalactone"
     ],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "memory support, neuroprotection, dream recall",
+    "therapeutic": "used for anxiety, insomnia, indigestion, fever, and colic. also a mild menstrual relaxant.",
     "interactions": [
-      "none well documented"
+      "may interact with sedatives or barbiturates."
     ],
     "contraindications": [
-      "pregnancy"
+      "avoid during pregnancy (stimulates uterus). not recommended before operating machinery."
     ],
     "sideeffects": [
-      "headache or stimulation at high doses"
+      "mild drowsiness or stomach upset. rare allergic reaction."
     ],
     "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "toxicity": "Very low. Safe in tea form at moderate doses.",
+    "toxicity_ld50": ">3000 mg/kg (rats, oral)",
     "tags": [
-      "✅ safe",
-      "🌿 herbal",
-      "🧠 nootropic"
+      "🐱 cat herb",
+      "🧘 calm",
+      "🫖 tea",
+      "🌿 folk medicine"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3612440/",
-      "Journal of Ayurveda and Integrative Medicine",
-      "2011",
-      "Indian Materia Medica – Nadkarni"
-    ]
-  },
-  {
-    "id": "celastrus-paniculatus",
-    "slug": "intellect-tree",
-    "common": "Intellect Tree",
-    "scientific": "Celastrus paniculatus",
-    "category": "empathogen / euphoriant",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "india, sri lanka, southeast asia",
-    "legalstatus": "Legal",
-    "schedule": "",
-    "description": "often called the 'intellect tree', this ayurvedic plant is used to support memory, learning, and vivid dreams. contains sesquiterpenes that may stimulate cholinergic activity.",
-    "effects": "Cognitive clarity;memory enhancement;dream vividness",
-    "mechanism": "Cholinergic modulation; antioxidant and neuroprotective effects",
-    "compounds": [
-      "Celastrine",
-      "Paniculatin"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "memory support, neuroprotection, dream recall",
-    "interactions": [
-      "none well documented"
-    ],
-    "contraindications": [
-      "pregnancy"
-    ],
-    "sideeffects": [
-      "headache or stimulation at high doses"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
-    "tags": [
-      "✅ safe",
-      "🌿 herbal",
-      "🧠 nootropic"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3612440/",
-      "Journal of Ayurveda and Integrative Medicine",
-      "2011",
-      "Indian Materia Medica – Nadkarni"
+      "Herbal Medicine – Mills & Bone",
+      "Materia Medica – David Hoffman"
     ]
   },
   {
@@ -3359,136 +2619,46 @@
     ]
   },
   {
-    "id": "chacruna",
-    "slug": "psychotria-viridis",
-    "common": "",
-    "scientific": "Psychotria viridis",
+    "id": "desfontainia-spinosa",
+    "slug": "chilean-holly",
+    "common": "Chilean holly",
+    "scientific": "Desfontainia spinosa",
     "category": "ritual / visionary",
     "subcategory": "",
     "intensity": "Strong",
-    "region": "amazon basin (peru, brazil, colombia)",
-    "legalstatus": "DMT is controlled in most countries",
+    "region": "chile, colombia, andes",
+    "legalstatus": "Legal but obscure",
     "schedule": "",
-    "description": "a key component of traditional ayahuasca brews, chacruna contains dmt and is often combined with maois like banisteriopsis caapi to make it orally active.",
-    "effects": "Visionary states;spiritual insight;hallucinations",
-    "mechanism": "DMT – 5-HT2A receptor agonist; requires MAOI to be active orally",
-    "compounds": [],
+    "description": "a rare south american shrub used by the mapuche and other indigenous groups in chile and colombia as a ritual intoxicant. known for unpredictable and potent effects.",
+    "effects": "Hallucinations;disorientation;dreamlike state",
+    "mechanism": "Unknown; possibly tropane alkaloid activity or diterpenes",
+    "compounds": [
+      "Desfontainin"
+    ],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "spiritual healing, emotional release (as part of ayahuasca)",
+    "therapeutic": "traditional visionary plant; not clinically established",
     "interactions": [
-      "dangerous with antidepressants or stimulants"
+      "unknown",
+      "avoid cns drugs"
     ],
     "contraindications": [
-      "mental health disorders",
-      "ssris",
-      "maois"
+      "mental illness",
+      "cardiovascular risk",
+      "pregnancy"
     ],
     "sideeffects": [
-      "intense visuals",
-      "vomiting",
-      "nausea"
+      "strong nausea",
+      "confusion",
+      "pupil dilation"
     ],
     "safety": "",
-    "toxicity": "Low physical toxicity, high psychological risk",
-    "toxicity_ld50": "Not established in humans",
-    "tags": [
-      "⚠️ caution",
-      "🧠 vision",
-      "🧪 dmt"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "psychotria-viridis",
-    "slug": "psychotria-viridis",
-    "common": "",
-    "scientific": "Psychotria viridis",
-    "category": "entheogen / dmt source / shamanic",
-    "subcategory": "",
-    "intensity": "Strong",
-    "region": "amazon basin (peru, brazil, colombia)",
-    "legalstatus": "Restricted in many countries due to DMT",
-    "schedule": "",
-    "description": "a tropical shrub from the amazon traditionally used in ayahuasca brews. its leaves contain high concentrations of n,n-dmt, making it a primary admixture plant in visionary ceremonies.",
-    "effects": "Psychedelic visions;Emotional processing;Spiritual insight;Sensory enhancement",
-    "mechanism": "Contains N,N-DMT, a potent serotonergic psychedelic that acts as a 5-HT2A receptor agonist. Requires MAOI (such as harmala alkaloids) to be orally active.",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used in traditional amazonian healing for soul retrieval, trauma, depression, and spiritual communion. western research suggests benefit in mental health and addiction therapy.",
-    "interactions": [
-      "dangerous with serotonergic drugs. do not combine with other psychedelics unless experienced."
-    ],
-    "contraindications": [
-      "avoid with ssris",
-      "maois",
-      "antipsychotics",
-      "or in those with severe psychiatric conditions."
-    ],
-    "sideeffects": [
-      "nausea",
-      "vomiting (purging)",
-      "anxiety",
-      "dissociation. can be intense or destabilizing in unprepared individuals."
-    ],
-    "safety": "",
-    "toxicity": "Low at standard doses. Risk increases with improper preparation or interaction.",
-    "toxicity_ld50": "~110 mg/kg (DMT, rat IP)",
-    "tags": [
-      "🌀 dmt source",
-      "🌿 ayahuasca",
-      "🌌 visionary",
-      "⚠️ maoi required"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7343898/",
-      "Plants of the Gods – Rätsch",
-      "Journal of Ethnopharmacology",
-      "2010"
-    ]
-  },
-  {
-    "id": "diplopterys-cabrerana",
-    "slug": "diplopterys-cabrerana",
-    "common": "",
-    "scientific": "Diplopterys cabrerana",
-    "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "",
-    "region": "amazon",
-    "legalstatus": "DMT restricted in most regions",
-    "schedule": "",
-    "description": "ayahuasca admixture leaf high in tryptamines.",
-    "effects": "visions;introspection",
-    "mechanism": "Leaves contain DMT and 5-MeO-DMT acting on serotonin receptors",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "25–50 g leaves",
-    "therapeutic": "shamanic healing",
-    "interactions": [
-      "maois",
-      "ssris"
-    ],
-    "contraindications": [
-      "mental health disorders"
-    ],
-    "sideeffects": [
-      "nausea",
-      "intense visions"
-    ],
-    "safety": "",
-    "toxicity": "Low physiological",
+    "toxicity": "Potentially high at ritual doses",
     "toxicity_ld50": "Not established",
     "tags": [
-      "⚠️ caution",
-      "🧪 dmt"
+      "⚠️ rare",
+      "🌿 andes",
+      "🧠 vision"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -3545,57 +2715,6 @@
     ]
   },
   {
-    "id": "cissampelos-pareira",
-    "slug": "velvetleaf",
-    "common": "Velvetleaf",
-    "scientific": "Cissampelos pareira",
-    "category": "ayurvedic / antispasmodic / antimalarial",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "india, south america, southeast asia",
-    "legalstatus": "Legal",
-    "schedule": "",
-    "description": "a climbing herb used in ayurveda and traditional amazonian medicine. often called ‘laghu patha’ in sanskrit, it is prized for menstrual support, malaria treatment, and as an adjunct to ayahuasca.",
-    "effects": "Uterine tonic;Muscle relaxant;Antimalarial;Mild sedative",
-    "mechanism": "Contains alkaloids like pareirine and cissamine. These modulate smooth muscle tone, and may exert anti-inflammatory, uterotonic, and antimicrobial effects.",
-    "compounds": [
-      "Pareirine",
-      "Cissamine"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for menstrual cramps, utis, inflammation, diarrhea, and malaria. in south america, used spiritually as a ‘feminine vine’ complementary to banisteriopsis caapi.",
-    "interactions": [
-      "potential interactions with antimalarials or muscle relaxants. may mildly lower blood pressure."
-    ],
-    "contraindications": [
-      "avoid during early pregnancy due to uterine effects. use caution with blood pressure medications."
-    ],
-    "sideeffects": [
-      "well tolerated in moderate doses. large doses may cause dizziness",
-      "nausea",
-      "or mild hypotension."
-    ],
-    "safety": "",
-    "toxicity": "Low to moderate depending on alkaloid concentration.",
-    "toxicity_ld50": "Not established",
-    "tags": [
-      "🌿 ayurvedic",
-      "🌙 feminine vine",
-      "🧪 antimalarial",
-      "🩸 menstrual tonic"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3783799/",
-      "Journal of Ethnopharmacology",
-      "2011",
-      "Plants of the Gods – Rätsch"
-    ]
-  },
-  {
     "id": "claviceps-purpurea",
     "slug": "claviceps-purpurea",
     "common": "",
@@ -3647,41 +2766,36 @@
     ]
   },
   {
-    "id": "clavo-huasca",
-    "slug": "tynanthus-panurensis",
-    "common": "",
-    "scientific": "Tynanthus panurensis",
-    "category": "empathogen / euphoriant",
+    "id": "tynanthus-panurensis",
+    "slug": "clavo-huasca",
+    "common": "Clavo Huasca",
+    "scientific": "",
+    "category": "",
     "subcategory": "",
-    "intensity": "Mild",
-    "region": "amazon basin",
-    "legalstatus": "Legal",
+    "intensity": "",
+    "region": "amazon rainforest",
+    "legalstatus": "",
     "schedule": "",
-    "description": "amazonian vine used in both physical and spiritual medicine. traditionally consumed as a libido enhancer and pre-ayahuasca preparation.",
-    "effects": "Aphrodisiac;calming;digestive",
-    "mechanism": "Alkaloids may modulate dopamine and serotonin; warming vasodilator",
-    "compounds": [],
+    "description": "",
+    "effects": "aphrodisiac;warming;digestive aid",
+    "mechanism": "TRPV1 activation, increases circulation and warmth",
+    "compounds": [
+      "Eugenol",
+      "Tynanthin"
+    ],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "aphrodisiac, digestive aid in amazonian medicine",
-    "interactions": [
-      "avoid cns depressants",
-      "alcohol"
-    ],
-    "contraindications": [
-      "pregnancy",
-      "blood pressure meds"
-    ],
-    "sideeffects": [
-      "mild hypotension or fatigue"
-    ],
+    "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "toxicity": "",
+    "toxicity_ld50": "",
     "tags": [
-      "✅ safe",
-      "🌿 amazonian",
-      "🔥 aphrodisiac"
+      "aphrodisiac",
+      "folk",
+      "warming"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -3733,48 +2847,6 @@
       "2010",
       "Ayurvedic Pharmacopoeia of India"
     ]
-  },
-  {
-    "id": "erythroxylum-coca",
-    "slug": "erythroxylum-coca",
-    "common": "",
-    "scientific": "Erythroxylum coca",
-    "category": "stimulant",
-    "subcategory": "",
-    "intensity": "",
-    "region": "andes",
-    "legalstatus": "Controlled in most countries",
-    "schedule": "",
-    "description": "traditional andean stimulant leaf.",
-    "effects": "euphoria;energy",
-    "mechanism": "Cocaine inhibits monoamine reuptake",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "1–3 g dried leaves",
-    "therapeutic": "altitude sickness",
-    "interactions": [
-      "stimulants",
-      "maois"
-    ],
-    "contraindications": [
-      "heart issues",
-      "pregnancy"
-    ],
-    "sideeffects": [
-      "elevated heart rate",
-      "insomnia"
-    ],
-    "safety": "",
-    "toxicity": "High in purified form",
-    "toxicity_ld50": "95 mg/kg (mice)",
-    "tags": [
-      "⚠️ restricted",
-      "🌿 leaf"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
   },
   {
     "id": "coffea-arabica",
@@ -3911,95 +2983,6 @@
     "sources": []
   },
   {
-    "id": "plectranthus-scutellarioides",
-    "slug": "plectranthus-scutellarioides",
-    "common": "",
-    "scientific": "Plectranthus scutellarioides",
-    "category": "psychedelic / ornamental",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "tropical asia",
-    "legalstatus": "Legal",
-    "schedule": "",
-    "description": "",
-    "effects": "mild visuals;color enhancement;relaxation",
-    "mechanism": "Unclear; may act on serotonergic pathways",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "rarely used; some folk use for divination",
-    "interactions": [],
-    "contraindications": [
-      "none known"
-    ],
-    "sideeffects": [
-      "headache",
-      "nausea at high doses"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
-    "tags": [
-      "lamiaceae",
-      "painted nettle",
-      "visionary"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "combretum-quadrangulare",
-    "slug": "sakae-naa",
-    "common": "Sakae Naa",
-    "scientific": "Combretum quadrangulare",
-    "category": "stimulant",
-    "subcategory": "",
-    "intensity": "Mild to Moderate",
-    "region": "laos, cambodia, thailand",
-    "legalstatus": "Legal with little regulation",
-    "schedule": "",
-    "description": "often marketed as “sakae naa,” this plant is used as a mild energizing substitute for kratom.",
-    "effects": "heightened alertness;subtle euphoria;increased focus",
-    "mechanism": "Leaves contain combretol and related alkaloids acting on adrenergic systems",
-    "compounds": [
-      "Combretol",
-      "Combretin"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditional stimulant and tonic in laos and thailand",
-    "interactions": [
-      "may potentiate other stimulants"
-    ],
-    "contraindications": [
-      "hypertension",
-      "heart conditions"
-    ],
-    "sideeffects": [
-      "jitters",
-      "insomnia if overused"
-    ],
-    "safety": "",
-    "toxicity": "Limited data but appears low at customary doses",
-    "toxicity_ld50": "Not established",
-    "tags": [
-      "sakae naa",
-      "southeast asia",
-      "energy"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://erowid.org/plants/sakae_naa/",
-      "Thai Ethnobotany Compendium",
-      "2015",
-      "Ethnopharmacology of Southeast Asia – WHO Report"
-    ]
-  },
-  {
     "id": "convolvulus-arvensis",
     "slug": "convolvulus-arvensis",
     "common": "",
@@ -4080,56 +3063,6 @@
       "Ayurvedic Pharmacopoeia of India",
       "Journal of Ethnopharmacology",
       "2010"
-    ]
-  },
-  {
-    "id": "corydalis-yanhusuo",
-    "slug": "yanhusuo",
-    "common": "Yanhusuo",
-    "scientific": "Corydalis yanhusuo",
-    "category": "sedative / analgesic",
-    "subcategory": "",
-    "intensity": "Moderate",
-    "region": "china and east asia",
-    "legalstatus": "Legal",
-    "schedule": "",
-    "description": "tubers of this asian herb provide notable pain relief and a tranquil state when used as tea or pills.",
-    "effects": "analgesia;relaxation;subtle dreaminess",
-    "mechanism": "Alkaloids such as tetrahydropalmatine act on dopamine and GABA receptors",
-    "compounds": [
-      "Tetrahydropalmatine (THP)"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditional chinese remedy for pain and insomnia",
-    "interactions": [
-      "may potentiate sedatives or dopaminergic drugs"
-    ],
-    "contraindications": [
-      "pregnancy",
-      "liver disease",
-      "large doses"
-    ],
-    "sideeffects": [
-      "drowsiness",
-      "dizziness"
-    ],
-    "safety": "",
-    "toxicity": "Overuse may cause liver stress",
-    "toxicity_ld50": ">1 g/kg in rodents",
-    "tags": [
-      "tcm",
-      "dopamine",
-      "pain relief"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4046635/",
-      "Journal of Pain Research",
-      "2013",
-      "Pharmacopoeia of the People’s Republic of China"
     ]
   },
   {
@@ -4368,43 +3301,57 @@
   {
     "id": "damiana",
     "slug": "turnera-diffusa",
-    "common": "",
+    "common": "Damiana",
     "scientific": "Turnera diffusa",
     "category": "empathogen / euphoriant",
     "subcategory": "",
     "intensity": "Mild",
     "region": "mexico, texas, central america",
-    "legalstatus": "Legal",
+    "legalstatus": "Legal / Unregulated",
     "schedule": "",
     "description": "used traditionally in mexico and central america for libido, relaxation, and mild stimulation. sometimes blended in herbal smoking mixes.",
-    "effects": "Mood boost;aphrodisiac;relaxation",
-    "mechanism": "May modulate serotonin and GABA; unclear primary target",
-    "compounds": [],
+    "effects": "aphrodisiac;mood-enhancing;anxiolytic",
+    "mechanism": "Likely modulates serotonin, dopamine, and GABA neurotransmission via flavonoids and tannins [8, 6].",
+    "compounds": [
+      "Damianin"
+    ],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "libido, nervous system support, mild stimulant",
+    "therapeutic": "aphrodisiac, mood enhancement, stress relief [8, 6].",
     "interactions": [
-      "may interact with blood sugar meds"
+      "may interact with blood sugar meds",
+      "serotonergic medications."
     ],
     "contraindications": [
       "pregnancy",
-      "urinary tract conditions"
+      "urinary tract conditions",
+      "maoi coadministration."
     ],
     "sideeffects": [
-      "mild headaches or gi discomfort"
+      "mild headaches or gi discomfort",
+      "mild headache",
+      "insomnia at high doses [8",
+      "6]."
     ],
-    "safety": "",
-    "toxicity": "Low",
+    "safety": "1",
+    "toxicity": "Low in traditional doses.",
     "toxicity_ld50": "Not well established",
     "tags": [
       "✅ safe",
       "🔥 aphrodisiac",
-      "😊 mood"
+      "😊 mood",
+      "☕ brewable",
+      "🌬️ smokable",
+      "💫 euphoria"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
-    "sources": []
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3210006/",
+      "Plants of Love – Christian Rätsch",
+      "Herbal Medicine – Mills & Bone"
+    ]
   },
   {
     "id": "datura-inoxia",
@@ -4462,36 +3409,41 @@
     ]
   },
   {
-    "id": "datura-metel",
-    "slug": "devil-s-trumpet",
-    "common": "Devil's Trumpet",
-    "scientific": "",
-    "category": "",
+    "id": "toloache",
+    "slug": "datura-spp",
+    "common": "",
+    "scientific": "Datura spp.",
+    "category": "ritual / visionary",
     "subcategory": "",
-    "intensity": "",
-    "region": "asia, africa",
-    "legalstatus": "",
+    "intensity": "Extremely strong",
+    "region": "americas, mediterranean",
+    "legalstatus": "Legal but restricted in many countries",
     "schedule": "",
-    "description": "",
-    "effects": "hallucinogenic;deliriant;anticholinergic",
-    "mechanism": "Antagonist of muscarinic acetylcholine receptors",
-    "compounds": [
-      "Scopolamine",
-      "Atropine"
-    ],
+    "description": "a powerful and dangerous tropane alkaloid plant traditionally used in witchcraft and shamanic rituals. highly toxic.",
+    "effects": "Delirium;hallucinations;disorientation",
+    "mechanism": "Anticholinergic – blocks acetylcholine via scopolamine, atropine",
+    "compounds": [],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
+    "therapeutic": "rarely used medically; historically for pain/spiritual rites",
+    "interactions": [
+      "all cns-affecting meds"
+    ],
+    "contraindications": [
+      "everything — extremely risky"
+    ],
+    "sideeffects": [
+      "severe hallucinations",
+      "amnesia",
+      "potential death"
+    ],
     "safety": "",
-    "toxicity": "",
-    "toxicity_ld50": "",
+    "toxicity": "Very high",
+    "toxicity_ld50": "~50 mg/kg (atropine/scopolamine)",
     "tags": [
-      "hallucinogen",
-      "deliriant",
-      "toxic"
+      "☠️ toxic",
+      "⚠️ caution",
+      "🧠 vision"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -4499,36 +3451,41 @@
     "sources": []
   },
   {
-    "id": "datura-metel",
-    "slug": "devil-s-trumpet",
-    "common": "Devil's Trumpet",
-    "scientific": "",
-    "category": "",
+    "id": "datura-stramonium",
+    "slug": "datura-stramonium",
+    "common": "",
+    "scientific": "Datura stramonium",
+    "category": "ritual / visionary",
     "subcategory": "",
     "intensity": "",
-    "region": "asia, africa",
-    "legalstatus": "",
+    "region": "worldwide",
+    "legalstatus": "Unregulated but dangerous",
     "schedule": "",
-    "description": "",
-    "effects": "hallucinogenic;deliriant;anticholinergic",
-    "mechanism": "Antagonist of muscarinic acetylcholine receptors",
-    "compounds": [
-      "Scopolamine",
-      "Atropine"
-    ],
+    "description": "common weed producing powerful delirium when misused.",
+    "effects": "delirium;hallucinations",
+    "mechanism": "Scopolamine and atropine block muscarinic receptors",
+    "compounds": [],
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
+    "dosage": "5–15 seeds",
+    "therapeutic": "historically asthma treatment",
+    "interactions": [
+      "anticholinergics",
+      "antihistamines"
+    ],
+    "contraindications": [
+      "heart conditions",
+      "mental illness"
+    ],
+    "sideeffects": [
+      "severe confusion",
+      "elevated heart rate"
+    ],
     "safety": "",
-    "toxicity": "",
-    "toxicity_ld50": "",
+    "toxicity": "Very high",
+    "toxicity_ld50": "~50 mg/kg (atropine)",
     "tags": [
-      "hallucinogen",
-      "deliriant",
-      "toxic"
+      "☠️ toxic",
+      "⚠️ caution"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -4582,100 +3539,6 @@
       "WHO Pesticide Evaluation Report – Rotenone",
       "Traditional Plant Lore of Southeast Asia – 2010"
     ]
-  },
-  {
-    "id": "desfontainia-spinosa",
-    "slug": "chilean-holly",
-    "common": "Chilean holly",
-    "scientific": "Desfontainia spinosa",
-    "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Strong",
-    "region": "chile, colombia, andes",
-    "legalstatus": "Legal but obscure",
-    "schedule": "",
-    "description": "a rare south american shrub used by the mapuche and other indigenous groups in chile and colombia as a ritual intoxicant. known for unpredictable and potent effects.",
-    "effects": "Hallucinations;disorientation;dreamlike state",
-    "mechanism": "Unknown; possibly tropane alkaloid activity or diterpenes",
-    "compounds": [
-      "Desfontainin"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditional visionary plant; not clinically established",
-    "interactions": [
-      "unknown",
-      "avoid cns drugs"
-    ],
-    "contraindications": [
-      "mental illness",
-      "cardiovascular risk",
-      "pregnancy"
-    ],
-    "sideeffects": [
-      "strong nausea",
-      "confusion",
-      "pupil dilation"
-    ],
-    "safety": "",
-    "toxicity": "Potentially high at ritual doses",
-    "toxicity_ld50": "Not established",
-    "tags": [
-      "⚠️ rare",
-      "🌿 andes",
-      "🧠 vision"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "desfontainia-spinosa",
-    "slug": "chilean-holly",
-    "common": "Chilean holly",
-    "scientific": "Desfontainia spinosa",
-    "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Strong",
-    "region": "chile, colombia, andes",
-    "legalstatus": "Legal but obscure",
-    "schedule": "",
-    "description": "a rare south american shrub used by the mapuche and other indigenous groups in chile and colombia as a ritual intoxicant. known for unpredictable and potent effects.",
-    "effects": "Hallucinations;disorientation;dreamlike state",
-    "mechanism": "Unknown; possibly tropane alkaloid activity or diterpenes",
-    "compounds": [
-      "Desfontainin"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditional visionary plant; not clinically established",
-    "interactions": [
-      "unknown",
-      "avoid cns drugs"
-    ],
-    "contraindications": [
-      "mental illness",
-      "cardiovascular risk",
-      "pregnancy"
-    ],
-    "sideeffects": [
-      "strong nausea",
-      "confusion",
-      "pupil dilation"
-    ],
-    "safety": "",
-    "toxicity": "Potentially high at ritual doses",
-    "toxicity_ld50": "Not established",
-    "tags": [
-      "⚠️ rare",
-      "🌿 andes",
-      "🧠 vision"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
   },
   {
     "id": "desmanthus-illinoensis",
@@ -4804,50 +3667,82 @@
     ]
   },
   {
-    "id": "desmodium-gangeticum",
-    "slug": "desmodium-gangeticum",
-    "common": "",
-    "scientific": "Desmodium gangeticum",
-    "category": "ayurvedic / tonic / anti-inflammatory",
+    "id": "datura-metel",
+    "slug": "devil-s-trumpet",
+    "common": "Devil's Trumpet",
+    "scientific": "",
+    "category": "",
     "subcategory": "",
-    "intensity": "Mild",
-    "region": "india, nepal, sri lanka",
-    "legalstatus": "Legal worldwide",
+    "intensity": "",
+    "region": "asia, africa",
+    "legalstatus": "",
     "schedule": "",
-    "description": "an ayurvedic herb used in dashamoola and other classical formulas. known for its rejuvenating, nervine, and anti-inflammatory actions, salparni is often used for vata balancing and in convalescence.",
-    "effects": "Nervine support;Anti-inflammatory;Rejuvenation;Mild sedation",
-    "mechanism": "Contains alkaloids (gangetin), flavonoids, and isoflavones with CNS modulating and antioxidant properties. Shows immunomodulatory and anti-inflammatory effects.",
-    "compounds": [],
+    "description": "",
+    "effects": "hallucinogenic;deliriant;anticholinergic",
+    "mechanism": "Antagonist of muscarinic acetylcholine receptors",
+    "compounds": [
+      "Scopolamine",
+      "Atropine"
+    ],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "used for asthma, arthritis, fever, low immunity, fatigue, and neurological weakness. common in rasayana therapy.",
-    "interactions": [
-      "may mildly potentiate immune-modulators or anti-inflammatories."
-    ],
-    "contraindications": [
-      "none known. traditionally safe even in pediatrics."
-    ],
-    "sideeffects": [
-      "rare. mild gi discomfort in high doses."
-    ],
+    "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "toxicity": "Very low.",
-    "toxicity_ld50": ">2000 mg/kg (rats, oral extract)",
+    "toxicity": "",
+    "toxicity_ld50": "",
     "tags": [
-      "🌿 rasayana",
-      "🧘 nervine",
-      "🔥 anti-inflammatory",
-      "🪷 vata pacifying"
+      "hallucinogen",
+      "deliriant",
+      "toxic"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3470461/",
-      "Ayurvedic Pharmacopoeia of India",
-      "Journal of Ethnopharmacology",
-      "2006"
-    ]
+    "sources": []
+  },
+  {
+    "id": "foxglove",
+    "slug": "digitalis-purpurea",
+    "common": "",
+    "scientific": "Digitalis purpurea",
+    "category": "other",
+    "subcategory": "",
+    "intensity": "",
+    "region": "europe",
+    "legalstatus": "Regulated as medicinal",
+    "schedule": "",
+    "description": "source of cardiac glycosides used for heart failure; overdose is fatal.",
+    "effects": "cardiac stimulation",
+    "mechanism": "Cardiac glycosides inhibit Na⁺/K⁺-ATPase",
+    "compounds": [],
+    "preparations": [],
+    "dosage": "0.1 g dried leaf equivalent",
+    "therapeutic": "heart failure medication",
+    "interactions": [
+      "diuretics",
+      "calcium channel blockers"
+    ],
+    "contraindications": [
+      "existing heart disease without supervision"
+    ],
+    "sideeffects": [
+      "arrhythmia",
+      "vision changes"
+    ],
+    "safety": "",
+    "toxicity": "Very high",
+    "toxicity_ld50": "3 mg/kg (digitoxin, oral)",
+    "tags": [
+      "☠️ toxic",
+      "💊 oral"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "dioscorea-villosa",
@@ -4892,6 +3787,92 @@
       "Botanical Safety Handbook – 2nd Ed.",
       "American Herbal Pharmacopoeia – Wild Yam Monograph"
     ]
+  },
+  {
+    "id": "diplopterys-cabrerana",
+    "slug": "diplopterys-cabrerana",
+    "common": "",
+    "scientific": "Diplopterys cabrerana",
+    "category": "ritual / visionary",
+    "subcategory": "",
+    "intensity": "",
+    "region": "amazon",
+    "legalstatus": "DMT restricted in most regions",
+    "schedule": "",
+    "description": "ayahuasca admixture leaf high in tryptamines.",
+    "effects": "visions;introspection",
+    "mechanism": "Leaves contain DMT and 5-MeO-DMT acting on serotonin receptors",
+    "compounds": [],
+    "preparations": [],
+    "dosage": "25–50 g leaves",
+    "therapeutic": "shamanic healing",
+    "interactions": [
+      "maois",
+      "ssris"
+    ],
+    "contraindications": [
+      "mental health disorders"
+    ],
+    "sideeffects": [
+      "nausea",
+      "intense visions"
+    ],
+    "safety": "",
+    "toxicity": "Low physiological",
+    "toxicity_ld50": "Not established",
+    "tags": [
+      "⚠️ caution",
+      "🧪 dmt"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
+  },
+  {
+    "id": "calea-zacatechichi",
+    "slug": "dream-herb",
+    "common": "Dream Herb",
+    "scientific": "Calea ternifolia (zacatechichi)",
+    "category": "oneirogen",
+    "subcategory": "",
+    "intensity": "Mild to moderate",
+    "region": "mexico, central america",
+    "legalstatus": "Legal",
+    "schedule": "",
+    "description": "known as the 'dream herb' of the chontal people of mexico, calea is traditionally used to enhance dreams and mental clarity during sleep.",
+    "effects": "Lucid dreaming;dream recall;hypnagogic imagery",
+    "mechanism": "May modulate GABAergic or cholinergic pathways; unclear",
+    "compounds": [
+      "Germacranolides"
+    ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "sleep induction, dream work",
+    "interactions": [
+      "avoid sedatives",
+      "alcohol"
+    ],
+    "contraindications": [
+      "pregnancy",
+      "sedative use"
+    ],
+    "sideeffects": [
+      "bitterness",
+      "mild nausea"
+    ],
+    "safety": "",
+    "toxicity": "Low",
+    "toxicity_ld50": "Not known",
+    "tags": [
+      "✅ safe",
+      "🌙 dream",
+      "🧘 calm"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "duboisia-hopwoodii",
@@ -5021,6 +4002,44 @@
     "sources": []
   },
   {
+    "id": "echinopsis-lageniformis",
+    "slug": "echinopsis-lageniformis",
+    "common": "",
+    "scientific": "Echinopsis lageniformis",
+    "category": "psychedelic",
+    "subcategory": "",
+    "intensity": "",
+    "region": "andes",
+    "legalstatus": "Cactus legal; mescaline controlled",
+    "schedule": "",
+    "description": "another mescaline-rich andean cactus.",
+    "effects": "visions;clarity",
+    "mechanism": "Mescaline as 5-HT2A agonist",
+    "compounds": [],
+    "preparations": [],
+    "dosage": "20–40 cm fresh cactus",
+    "therapeutic": "visionary rituals",
+    "interactions": [
+      "maois"
+    ],
+    "contraindications": [
+      "heart conditions"
+    ],
+    "sideeffects": [
+      "nausea"
+    ],
+    "safety": "",
+    "toxicity": "Low",
+    "toxicity_ld50": ">1 g/kg (rats)",
+    "tags": [
+      "🌵 cactus"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
+  },
+  {
     "id": "echinopsis-pachanoi",
     "slug": "echinopsis-pachanoi",
     "common": "",
@@ -5071,36 +4090,41 @@
     ]
   },
   {
-    "id": "elaeagnus-angustifolia",
-    "slug": "russian-olive",
-    "common": "Russian Olive",
-    "scientific": "",
-    "category": "sedative",
+    "id": "echinopsis-peruviana",
+    "slug": "echinopsis-peruviana",
+    "common": "",
+    "scientific": "Echinopsis peruviana",
+    "category": "psychedelic",
     "subcategory": "",
     "intensity": "",
-    "region": "central asia, middle east, europe",
-    "legalstatus": "",
+    "region": "andes",
+    "legalstatus": "Cactus legal; mescaline controlled",
     "schedule": "",
-    "description": "",
-    "effects": "anxiolytic;sedative;pain-relieving",
-    "mechanism": "GABAergic effects and antioxidant pathways",
-    "compounds": [
-      "Elaeagnin",
-      "Flavonoids"
-    ],
+    "description": "cactus rich in mescaline similar to san pedro.",
+    "effects": "visions;empathy",
+    "mechanism": "Mescaline acts as a 5-HT2A agonist",
+    "compounds": [],
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
+    "dosage": "20–30 cm fresh cactus",
+    "therapeutic": "spiritual insight",
+    "interactions": [
+      "maois",
+      "stimulants"
+    ],
+    "contraindications": [
+      "heart issues",
+      "pregnancy"
+    ],
+    "sideeffects": [
+      "nausea",
+      "dilated pupils"
+    ],
     "safety": "",
-    "toxicity": "",
-    "toxicity_ld50": "",
+    "toxicity": "Low",
+    "toxicity_ld50": ">1 g/kg (rats)",
     "tags": [
-      "sedative",
-      "analgesic",
-      "folk"
+      "🌀 visionary",
+      "🌵 cactus"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -5153,35 +4177,46 @@
     ]
   },
   {
-    "id": "elsholtzia-ciliata",
-    "slug": "vietnamese-balm",
-    "common": "Vietnamese Balm",
-    "scientific": "",
-    "category": "stimulant",
+    "id": "virola-theiodora",
+    "slug": "epena",
+    "common": "Epena",
+    "scientific": "Virola theiodora",
+    "category": "ritual / visionary",
     "subcategory": "",
-    "intensity": "",
-    "region": "east and southeast asia",
-    "legalstatus": "",
+    "intensity": "Very strong",
+    "region": "amazon (brazil, venezuela)",
+    "legalstatus": "DMT controlled in most countries",
     "schedule": "",
-    "description": "",
-    "effects": "uplifting;digestive aid;mental clarity",
-    "mechanism": "Stimulates gastrointestinal and olfactory receptors",
+    "description": "a snuff plant from the amazon containing dmt and 5-meo-dmt. used by yanomami and other tribes for potent visionary rituals.",
+    "effects": "Strong visuals;spiritual experiences;disorientation",
+    "mechanism": "DMT and 5-MeO-DMT – 5-HT2A agonists",
     "compounds": [
-      "Elsholtzia ketone"
+      "DMT",
+      "5-MeO-DMT"
     ],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
+    "therapeutic": "shamanic ritual; purging and vision work",
+    "interactions": [
+      "maois",
+      "antidepressants"
+    ],
+    "contraindications": [
+      "maois",
+      "mental health issues"
+    ],
+    "sideeffects": [
+      "nausea",
+      "tremors",
+      "vomiting"
+    ],
     "safety": "",
-    "toxicity": "",
+    "toxicity": "High psychological, moderate physical",
     "toxicity_ld50": "",
     "tags": [
-      "stimulant",
-      "folk",
-      "clarity"
+      "⚠️ vision",
+      "🌬️ snuff",
+      "🧠 dmt"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -5189,51 +4224,43 @@
     "sources": []
   },
   {
-    "id": "ephedra-sinica",
-    "slug": "ephedra-sinica",
+    "id": "ephedra-nevadensis",
+    "slug": "ephedra-nevadensis",
     "common": "",
-    "scientific": "Ephedra sinica",
-    "category": "stimulant / decongestant",
+    "scientific": "Ephedra nevadensis",
+    "category": "stimulant",
     "subcategory": "",
-    "intensity": "Strong",
-    "region": "china and central asia",
-    "legalstatus": "Regulated in many countries",
+    "intensity": "",
+    "region": "north america",
+    "legalstatus": "Legal",
     "schedule": "",
-    "description": "shrubby plant known as ma huang; source of ephedrine used both medicinally and recreationally.",
-    "effects": "Energy boost;bronchodilation",
-    "mechanism": "Ephedrine and pseudoephedrine stimulate adrenergic receptors and release norepinephrine.",
+    "description": "mild stimulant desert shrub without strong ephedra content.",
+    "effects": "mild stimulation",
+    "mechanism": "Contains ephedrine-like alkaloids releasing norepinephrine",
     "compounds": [],
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditional chinese medicine for asthma, colds, and as a stimulant.",
+    "dosage": "5–10 g dried stems",
+    "therapeutic": "decongestant",
     "interactions": [
-      "dangerous with other stimulants or maois"
+      "stimulants",
+      "decongestants"
     ],
     "contraindications": [
-      "heart disease",
-      "hypertension",
-      "maois."
+      "hypertension"
     ],
     "sideeffects": [
-      "jitters",
-      "elevated heart rate",
-      "insomnia"
+      "increased heart rate"
     ],
     "safety": "",
-    "toxicity": "High doses can raise blood pressure and cause cardiovascular stress.",
-    "toxicity_ld50": "Ephedrine LD50 ~50 mg/kg (rats)",
+    "toxicity": "Low",
+    "toxicity_ld50": ">500 mg/kg (mice)",
     "tags": [
-      "⚠️ potent",
-      "🌿 ma huang"
+      "☕ brewable"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3896985/",
-      "FDA Ephedra Ban Report (2004)",
-      "Pharmacopoeia of the People’s Republic of China"
-    ]
+    "sources": []
   },
   {
     "id": "ephedra-sinica",
@@ -5377,38 +4404,51 @@
     "slug": "erythroxylum-catuaba",
     "common": "",
     "scientific": "Erythroxylum catuaba",
-    "category": "stimulant / aphrodisiac",
+    "category": "aphrodisiac / nootropic",
     "subcategory": "",
-    "intensity": "",
-    "region": "brazil",
+    "intensity": "Mild–Moderate",
+    "region": "brazil, amazon, south america",
     "legalstatus": "Legal",
     "schedule": "",
-    "description": "amazonian tonic reputed to enhance vitality",
-    "effects": "mild euphoria;libido boost",
-    "mechanism": "Alkaloids like catuabine may modulate dopamine",
-    "compounds": [],
+    "description": "a traditional brazilian aphrodisiac made from the bark of various erythroxylum species (mainly e. catuaba). catuaba is used to boost libido, mental clarity, and mood — both in traditional medicine and modern supplements.",
+    "effects": "Stimulation;Enhanced libido;Mild euphoria;Cognitive enhancement",
+    "mechanism": "Contains alkaloids, flavonoids, and possibly tropane-related compounds. Stimulates central nervous system and may increase nitric oxide availability.",
+    "compounds": [
+      "Catuabine"
+    ],
     "preparations": [],
     "dosage": "1-2 g bark",
-    "therapeutic": "aphrodisiac, tonic",
+    "therapeutic": "used traditionally for sexual debility, fatigue, poor memory, and stress. often paired with muira puama.",
     "interactions": [
+      "may mildly potentiate stimulants or maois. interacts with dopaminergic drugs.",
       "stimulants"
     ],
     "contraindications": [
+      "caution with anxiety disorders or insomnia. avoid in pregnancy due to insufficient data.",
       "insomnia"
     ],
     "sideeffects": [
+      "rare. may cause mild overstimulation or insomnia in sensitive individuals.",
       "restlessness"
     ],
     "safety": "",
-    "toxicity": "Low",
+    "toxicity": "Low. Considered very safe in traditional dosing.",
     "toxicity_ld50": "Not well documented",
     "tags": [
+      "🔥 aphrodisiac",
+      "🧠 nootropic",
+      "🌿 amazon tonic",
       "🌳 bark"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
-    "sources": []
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5937011/",
+      "Brazilian Journal of Pharmacognosy",
+      "2005",
+      "The Healing Power of Rainforest Herbs – Leslie Taylor"
+    ]
   },
   {
     "id": "erythroxylum-coca",
@@ -5421,30 +4461,36 @@
     "region": "andean south america",
     "legalstatus": "Cultivation regulated; cocaine controlled",
     "schedule": "",
-    "description": "",
+    "description": "traditional andean stimulant leaf.",
     "effects": "alertness;reduced fatigue;mild euphoria",
     "mechanism": "Leaves contain cocaine acting as a dopamine and norepinephrine reuptake inhibitor",
     "compounds": [],
     "preparations": [],
-    "dosage": "",
+    "dosage": "1–3 g dried leaves",
     "therapeutic": "altitude sickness relief, energy boost, appetite suppression",
     "interactions": [
+      "stimulants",
+      "maois",
       "dangerous with maois or stimulants"
     ],
     "contraindications": [
-      "heart disease",
+      "heart issues",
       "pregnancy",
+      "heart disease",
       "hypertension"
     ],
     "sideeffects": [
-      "increased heart rate",
+      "elevated heart rate",
       "insomnia",
+      "increased heart rate",
       "potential dependence"
     ],
     "safety": "",
     "toxicity": "Low in leaf form; purified alkaloid is addictive",
     "toxicity_ld50": "~95 mg/kg (rat, cocaine)",
     "tags": [
+      "⚠️ restricted",
+      "🌿 leaf",
       "andes",
       "alkaloid",
       "coca leaf"
@@ -5597,123 +4643,6 @@
     ]
   },
   {
-    "id": "ficus-religiosa",
-    "slug": "sacred-fig",
-    "common": "Sacred Fig",
-    "scientific": "",
-    "category": "sedative",
-    "subcategory": "",
-    "intensity": "",
-    "region": "india, southeast asia",
-    "legalstatus": "",
-    "schedule": "",
-    "description": "",
-    "effects": "calming;mood-balancing;mild sedative",
-    "mechanism": "Neuroprotective antioxidant and serotonin modulation",
-    "compounds": [
-      "Furanocoumarins",
-      "Tannins"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
-    "toxicity_ld50": "",
-    "tags": [
-      "spiritual",
-      "sedative",
-      "folk"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "gloriosa-superba",
-    "slug": "gloriosa-superba",
-    "common": "",
-    "scientific": "Gloriosa superba",
-    "category": "other",
-    "subcategory": "",
-    "intensity": "",
-    "region": "africa, asia",
-    "legalstatus": "Ornamental; toxic",
-    "schedule": "",
-    "description": "highly poisonous ornamental sometimes misused.",
-    "effects": "intense nausea;weak delirium",
-    "mechanism": "Contains colchicine disrupting microtubules",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "<5 seeds",
-    "therapeutic": "traditional poison and medicine",
-    "interactions": [
-      "none documented"
-    ],
-    "contraindications": [
-      "any internal use"
-    ],
-    "sideeffects": [
-      "severe vomiting",
-      "organ failure"
-    ],
-    "safety": "",
-    "toxicity": "Very high",
-    "toxicity_ld50": "20 mg/kg (mice)",
-    "tags": [
-      "☠️ toxic"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "foxglove",
-    "slug": "digitalis-purpurea",
-    "common": "",
-    "scientific": "Digitalis purpurea",
-    "category": "other",
-    "subcategory": "",
-    "intensity": "",
-    "region": "europe",
-    "legalstatus": "Regulated as medicinal",
-    "schedule": "",
-    "description": "source of cardiac glycosides used for heart failure; overdose is fatal.",
-    "effects": "cardiac stimulation",
-    "mechanism": "Cardiac glycosides inhibit Na⁺/K⁺-ATPase",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "0.1 g dried leaf equivalent",
-    "therapeutic": "heart failure medication",
-    "interactions": [
-      "diuretics",
-      "calcium channel blockers"
-    ],
-    "contraindications": [
-      "existing heart disease without supervision"
-    ],
-    "sideeffects": [
-      "arrhythmia",
-      "vision changes"
-    ],
-    "safety": "",
-    "toxicity": "Very high",
-    "toxicity_ld50": "3 mg/kg (digitoxin, oral)",
-    "tags": [
-      "☠️ toxic",
-      "💊 oral"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
     "id": "galbulimima-belgraveana",
     "slug": "galbulimima",
     "common": "Galbulimima",
@@ -5807,6 +4736,48 @@
     ]
   },
   {
+    "id": "reishi-mushroom",
+    "slug": "ganoderma-lucidum",
+    "common": "",
+    "scientific": "Ganoderma lucidum",
+    "category": "other",
+    "subcategory": "",
+    "intensity": "Mild",
+    "region": "🇨🇳 east asia",
+    "legalstatus": "Legal / Unregulated",
+    "schedule": "",
+    "description": "tonic fungus revered in asia for boosting immunity and easing stress.",
+    "effects": "Immune support;calm focus",
+    "mechanism": "Triterpenoids and beta-glucans modulate immune response.",
+    "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "immune enhancement, stress resilience, antioxidant.",
+    "interactions": [
+      "anticoagulants",
+      "immunosuppressants."
+    ],
+    "contraindications": [
+      "bleeding disorders",
+      "surgery."
+    ],
+    "sideeffects": [
+      "rare digestive upset or rash."
+    ],
+    "safety": "1",
+    "toxicity": "Very low toxicity; widely consumed as tonic.",
+    "toxicity_ld50": "Not established; safe in traditional use.",
+    "tags": [
+      "\\u2615 brewable",
+      "\\ud83e\\udde0 cognitive",
+      "\\u2705 safe"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
+  },
+  {
     "id": "gastrodia-elata",
     "slug": "gastrodia-elata",
     "common": "",
@@ -5868,18 +4839,23 @@
     "mechanism": "Contains gelsemine and gelseminine, which act as glycine receptor agonists and inhibit spinal reflexes. High doses paralyze the respiratory center.",
     "compounds": [],
     "preparations": [],
-    "dosage": "",
+    "dosage": "5–10 drops tincture",
     "therapeutic": "historically used for neuralgia, migraines, fevers, and anxiety — but now mostly used homeopathically. still researched for neuropathic pain.",
     "interactions": [
+      "sedatives",
+      "muscle relaxants",
       "fatal when mixed with depressants",
       "alcohol",
       "opioids",
       "or sedatives."
     ],
     "contraindications": [
+      "pregnancy",
+      "heart issues",
       "do not self-administer. avoid entirely unless under trained guidance. toxic to children and animals."
     ],
     "sideeffects": [
+      "respiratory depression in overdose",
       "dizziness",
       "blurred vision",
       "slurred speech",
@@ -5890,6 +4866,7 @@
     "toxicity": "Extremely high. One drop of extract may be fatal.",
     "toxicity_ld50": "Gelsemine ~10 mg/kg (mice, oral)",
     "tags": [
+      "⚠️ caution",
       "⚠️ toxic",
       "🌼 southern herbalism",
       "🧠 nervine",
@@ -5953,92 +4930,6 @@
     ]
   },
   {
-    "id": "arundo-donax",
-    "slug": "arundo-donax",
-    "common": "",
-    "scientific": "Arundo donax",
-    "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "",
-    "region": "mediterranean, americas",
-    "legalstatus": "Invasive species control",
-    "schedule": "",
-    "description": "invasive reed rumored to contain tryptamines.",
-    "effects": "mild visions",
-    "mechanism": "Root bark may contain DMT and bufotenine",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "experimental entheogen",
-    "interactions": [
-      "maois"
-    ],
-    "contraindications": [
-      "limited data"
-    ],
-    "sideeffects": [
-      "nausea"
-    ],
-    "safety": "",
-    "toxicity": "",
-    "toxicity_ld50": "Not established",
-    "tags": [
-      "🌿 root bark"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "zingiber-officinale",
-    "slug": "zingiber-officinale",
-    "common": "",
-    "scientific": "Zingiber officinale",
-    "category": "digestive / anti-inflammatory / stimulant",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "tropical asia, cultivated globally",
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "description": "a pungent rhizome widely used for its warming, carminative, and anti-inflammatory effects. revered in ayurvedic and traditional chinese medicine for treating nausea, coldness, and sluggish digestion.",
-    "effects": "Digestive support;Anti-nausea;Circulation boost;Mild stimulation",
-    "mechanism": "Contains gingerols and shogaols that modulate prostaglandins, TRP ion channels, and serotonin receptors involved in nausea.",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for nausea, morning sickness, motion sickness, colds, pain, and poor circulation. also a culinary spice and tea staple.",
-    "interactions": [
-      "may interact with blood thinners or diabetes meds. synergistic with anti-nausea agents."
-    ],
-    "contraindications": [
-      "caution with anticoagulants",
-      "gallstones",
-      "or gastritis in high doses."
-    ],
-    "sideeffects": [
-      "heartburn",
-      "stomach upset in large doses. rare allergic reactions."
-    ],
-    "safety": "",
-    "toxicity": "Very low",
-    "toxicity_ld50": ">5000 mg/kg (rats, oral)",
-    "tags": [
-      "🌶️ warming",
-      "🫖 anti-nausea",
-      "🫁 circulation",
-      "🌿 culinary"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3665023/",
-      "Herbal Medicine – Mills & Bone",
-      "Plants of the Gods – Rätsch"
-    ]
-  },
-  {
     "id": "ginkgo-biloba",
     "slug": "ginkgo-biloba",
     "common": "",
@@ -6087,6 +4978,46 @@
     ]
   },
   {
+    "id": "glaucium-flavum",
+    "slug": "glaucium-flavum",
+    "common": "",
+    "scientific": "Glaucium flavum",
+    "category": "other",
+    "subcategory": "",
+    "intensity": "",
+    "region": "mediterranean",
+    "legalstatus": "Varies",
+    "schedule": "",
+    "description": "coastal poppy used occasionally for its glaucine content.",
+    "effects": "mild euphoria;sedation",
+    "mechanism": "Contains glaucine, a bronchodilator acting on dopamine receptors",
+    "compounds": [],
+    "preparations": [],
+    "dosage": "10–20 mg glaucine",
+    "therapeutic": "cough suppressant",
+    "interactions": [
+      "cns depressants"
+    ],
+    "contraindications": [
+      "pregnancy"
+    ],
+    "sideeffects": [
+      "dizziness",
+      "nausea"
+    ],
+    "safety": "",
+    "toxicity": "Moderate",
+    "toxicity_ld50": ">300 mg/kg (mice)",
+    "tags": [
+      "🌀 visionary",
+      "💊 oral"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
+  },
+  {
     "id": "gliricidia-sepium",
     "slug": "gliricidia-sepium",
     "common": "",
@@ -6133,139 +5064,43 @@
     ]
   },
   {
-    "id": "paullinia-cupana",
-    "slug": "paullinia-cupana",
+    "id": "gloriosa-superba",
+    "slug": "gloriosa-superba",
     "common": "",
-    "scientific": "Paullinia cupana",
-    "category": "stimulant / nootropic",
+    "scientific": "Gloriosa superba",
+    "category": "other",
     "subcategory": "",
-    "intensity": "Moderate",
-    "region": "amazon basin",
-    "legalstatus": "Legal",
+    "intensity": "",
+    "region": "africa, asia",
+    "legalstatus": "Ornamental; toxic",
     "schedule": "",
-    "description": "climbing plant native to brazil; its seeds provide a potent caffeine kick and are popular in energy drinks.",
-    "effects": "Energy;mental focus",
-    "mechanism": "Seeds contain high caffeine content that blocks adenosine receptors.",
+    "description": "highly poisonous ornamental sometimes misused.",
+    "effects": "intense nausea;weak delirium",
+    "mechanism": "Contains colchicine disrupting microtubules",
     "compounds": [],
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "fatigue reduction, weight loss aid, traditional tonic.",
+    "dosage": "<5 seeds",
+    "therapeutic": "traditional poison and medicine",
     "interactions": [
-      "potentiates other stimulants",
-      "may interfere with sedatives"
+      "none documented"
     ],
     "contraindications": [
-      "heart problems",
-      "pregnancy",
-      "sensitivity to caffeine."
+      "any internal use"
     ],
     "sideeffects": [
-      "jitteriness",
-      "stomach upset"
+      "severe vomiting",
+      "organ failure"
     ],
     "safety": "",
-    "toxicity": "Overuse leads to restlessness, insomnia, or tachycardia.",
-    "toxicity_ld50": "Caffeine LD50 ~190 mg/kg (rats)",
+    "toxicity": "Very high",
+    "toxicity_ld50": "20 mg/kg (mice)",
     "tags": [
-      "☕ high caffeine",
-      "🍫 seed"
+      "☠️ toxic"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
     "sources": []
-  },
-  {
-    "id": "guayusa",
-    "slug": "ilex-guayusa",
-    "common": "",
-    "scientific": "Ilex guayusa",
-    "category": "empathogen / euphoriant",
-    "subcategory": "",
-    "intensity": "Mild to moderate",
-    "region": "ecuador, peru, amazon",
-    "legalstatus": "Legal",
-    "schedule": "",
-    "description": "a caffeinated amazonian holly used in dream rituals and for morning alertness. known for smooth energy and calming clarity.",
-    "effects": "Stimulation;mental clarity;lucid dreaming",
-    "mechanism": "Caffeine and theobromine – adenosine antagonists",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "energy, focus, lucid dreaming support",
-    "interactions": [
-      "stimulants",
-      "caffeine"
-    ],
-    "contraindications": [
-      "pregnancy",
-      "heart conditions",
-      "anxiety"
-    ],
-    "sideeffects": [
-      "restlessness",
-      "jitteriness in sensitive individuals"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "~190 mg/kg (caffeine)",
-    "tags": [
-      "stimulant",
-      "✅ safe",
-      "🌿 herbal"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "ilex-guayusa",
-    "slug": "ilex-guayusa",
-    "common": "",
-    "scientific": "Ilex guayusa",
-    "category": "stimulant / amazonian / adaptogen",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "amazon (ecuador, peru, colombia)",
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "description": "a caffeinated amazonian holly tree leaf used for lucid dreaming, focus, and ritual wakefulness. known as the 'dreaming tea' by the kichwa people. smoother than yerba mate and less jittery than coffee.",
-    "effects": "Smooth stimulation;Vivid dreams;Antioxidant;Focus;Energy",
-    "mechanism": "Contains caffeine, theobromine, and L-theanine. Stimulates CNS while providing a relaxing balance via L-theanine’s GABAergic modulation.",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for morning energy, digestion, lucid dream preparation, and antioxidant support. traditionally used before hunting or dreaming ceremonies.",
-    "interactions": [
-      "mild interactions with stimulants or sedatives. may mask fatigue."
-    ],
-    "contraindications": [
-      "avoid with caffeine sensitivity",
-      "during pregnancy",
-      "or with cardiac arrhythmia."
-    ],
-    "sideeffects": [
-      "mild insomnia or jitters at high doses. gentler than most stimulants."
-    ],
-    "safety": "",
-    "toxicity": "Low. Comparable to green tea.",
-    "toxicity_ld50": "Caffeine LD50 ~192 mg/kg (rats, oral)",
-    "tags": [
-      "🌿 dream tea",
-      "⚡ stimulant",
-      "🧘 smooth focus",
-      "☕ l-theanine"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3682131/",
-      "Journal of Ethnopharmacology",
-      "2011",
-      "Amazonian Shamanic Tea Practices – 2020"
-    ]
   },
   {
     "id": "gymnema-sylvestre",
@@ -6353,46 +5188,66 @@
   },
   {
     "id": "argyreia-nervosa",
-    "slug": "argyreia-nervosa",
-    "common": "",
+    "slug": "hawaiian-baby-woodrose",
+    "common": "Hawaiian baby woodrose",
     "scientific": "Argyreia nervosa",
-    "category": "psychedelic / lsa",
+    "category": "psychedelic / ergolines",
     "subcategory": "",
-    "intensity": "Strong",
-    "region": "india, tropical regions",
-    "legalstatus": "Seeds legal in many places; extraction may be controlled",
+    "intensity": "Moderate",
+    "region": "india, hawaii, tropical regions",
+    "legalstatus": "Legal to possess in most countries; LSA may be restricted.",
     "schedule": "",
-    "description": "climber with heart-shaped leaves; its seeds contain lsa and are used as a legal alternative to lsd experiences.",
-    "effects": "Visual distortions;euphoria;introspection",
-    "mechanism": "Seeds contain ergoline alkaloids (LSA) that act on serotonin receptors similarly to LSD but with milder potency.",
-    "compounds": [],
+    "description": "a climbing vine native to india and widely cultivated in hawaii. its seeds contain lsa (lysergic acid amide), a naturally occurring psychedelic related to lsd.",
+    "effects": "Euphoria;Time distortion;Closed-eye visuals;Body heaviness;Drowsiness",
+    "mechanism": "LSA (ergine) is a serotonergic compound acting primarily as a partial agonist at 5-HT2A receptors, similar to LSD but with more sedative effects.",
+    "compounds": [
+      "LSA (lysergic acid amide)"
+    ],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "occasional spiritual or introspective use; historically as ornamental and traditional medicine.",
+    "therapeutic": "historically used in ayurveda for nervine and aphrodisiac properties. psychedelic use is experimental only.",
     "interactions": [
+      "avoid combining with stimulants",
+      "maois",
+      "ssris",
+      "or vasoconstrictive drugs.",
       "avoid with vasoconstrictors or other psychedelics"
     ],
     "contraindications": [
+      "not recommended for people with cardiovascular",
+      "liver",
+      "or psychiatric conditions. avoid during pregnancy.",
       "pregnancy",
       "liver issues",
       "maois."
     ],
     "sideeffects": [
-      "nausea",
+      "strong nausea",
       "vasoconstriction",
+      "lethargy",
+      "and confusion are common. may cause dizziness and chills.",
+      "nausea",
       "sedation"
     ],
     "safety": "",
-    "toxicity": "Seeds can cause severe nausea and vasoconstriction at high doses.",
-    "toxicity_ld50": "Not well established for humans; animal data scarce",
+    "toxicity": "Mild to moderate; effects mostly unpleasant rather than dangerous. Improper preparation increases risk.",
+    "toxicity_ld50": "Unknown (ergine considered relatively low in acute toxicity)",
     "tags": [
+      "🌱 seed",
+      "🌀 lsa",
+      "🌙 sedative-psychedelic",
       "⚠️ nausea",
       "🌱 seeds"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
-    "sources": []
+    "sources": [
+      "https://erowid.org/plants/hbw/",
+      "TiHKAL by Alexander Shulgin",
+      "Journal of Ethnopharmacology",
+      "1996"
+    ]
   },
   {
     "id": "heimia-myrtifolia",
@@ -6432,59 +5287,6 @@
     "legalnotes": "",
     "image": "",
     "sources": []
-  },
-  {
-    "id": "heimia-salicifolia",
-    "slug": "sinicuichi",
-    "common": "Sinicuichi",
-    "scientific": "Heimia salicifolia",
-    "category": "oneirogen / traditional / mildly psychoactive",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "mexico, central america",
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "description": "a yellow-flowering shrub used by indigenous mexican peoples for vision quests and dream work. traditionally prepared via solar fermentation, sinicuichi is known for inducing auditory changes and memory recall.",
-    "effects": "Dream enhancement;Auditory distortion;Relaxation;Trance-like state",
-    "mechanism": "Contains cryogenine and lythrine, which may modulate acetylcholine and GABA receptors, inducing mild CNS depression and altered perception.",
-    "compounds": [
-      "Cryogenine",
-      "Lyfoline"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used in folk medicine for muscle pain, fevers, and spiritual visions. anecdotally used for lucid dreaming and relaxation.",
-    "interactions": [
-      "may amplify effects of cns depressants."
-    ],
-    "contraindications": [
-      "avoid with sedatives",
-      "during driving",
-      "or pregnancy. limited modern research."
-    ],
-    "sideeffects": [
-      "dry mouth",
-      "heavy limbs",
-      "auditory distortions. rare reports of ‘golden vision’ or slow-motion perception."
-    ],
-    "safety": "",
-    "toxicity": "Low in traditional doses; some anecdotal toxicity in concentrated extracts.",
-    "toxicity_ld50": "Not well established",
-    "tags": [
-      "🌙 dream herb",
-      "🧠 memory",
-      "🔊 auditory shifts",
-      "🌿 nahuatl medicine"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3654015/",
-      "Journal of Ethnopharmacology",
-      "1992",
-      "Plants of the Gods – Rätsch"
-    ]
   },
   {
     "id": "helichrysum-odoratissimum",
@@ -6536,7 +5338,7 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "china, japan, north america (temperate forests)",
-    "legalstatus": "Legal worldwide",
+    "legalstatus": "Legal / Unregulated",
     "schedule": "",
     "description": "a shaggy white mushroom revered for its ability to stimulate ngf (nerve growth factor) and support brain regeneration. used in both traditional chinese medicine and modern nootropic stacks.",
     "effects": "Nerve growth;Memory enhancement;Mood support;Cognitive clarity",
@@ -6546,22 +5348,30 @@
     "dosage": "",
     "therapeutic": "used for mild cognitive impairment, memory loss, anxiety, depression, and neurodegenerative conditions (alzheimer's, parkinson’s).",
     "interactions": [
-      "may enhance neuroplasticity synergistically with other nootropics or antidepressants."
+      "may enhance neuroplasticity synergistically with other nootropics or antidepressants.",
+      "no major interactions documented."
     ],
     "contraindications": [
-      "none major. caution in mushroom allergies."
+      "none major. caution in mushroom allergies.",
+      "allergy to mushrooms",
+      "pregnancy (limited data)."
     ],
     "sideeffects": [
-      "very rare. may cause mild digestive upset or skin itching in sensitive individuals."
+      "very rare. may cause mild digestive upset or skin itching in sensitive individuals.",
+      "rare allergic reactions",
+      "generally well-tolerated."
     ],
-    "safety": "",
-    "toxicity": "Very low. Widely used as food and supplement.",
-    "toxicity_ld50": ">5000 mg/kg (rats, oral)",
+    "safety": "1",
+    "toxicity": "Low toxicity; consumed as food in many cultures.",
+    "toxicity_ld50": "Not established; considered safe.",
     "tags": [
       "🧠 brain growth",
       "🍄 mushroom",
       "🌿 nerve repair",
-      "🧬 ngf booster"
+      "🧬 ngf booster",
+      "\\ud83d\\udc8a oral",
+      "\\ud83e\\udde0 cognitive",
+      "\\u2705 safe"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -6801,105 +5611,62 @@
     "sources": []
   },
   {
-    "id": "ilex-paraguariensis",
-    "slug": "yerba-mate",
-    "common": "Yerba Mate",
-    "scientific": "Ilex paraguariensis",
-    "category": "stimulant / tonic / social",
+    "id": "guayusa",
+    "slug": "ilex-guayusa",
+    "common": "",
+    "scientific": "Ilex guayusa",
+    "category": "stimulant / amazonian / adaptogen",
     "subcategory": "",
-    "intensity": "Moderate",
-    "region": "argentina, brazil, paraguay, uruguay",
+    "intensity": "Mild to moderate",
+    "region": "amazon (ecuador, peru, colombia)",
     "legalstatus": "Legal worldwide",
     "schedule": "",
-    "description": "a south american herbal infusion made from the dried leaves of the yerba mate plant. revered for its energizing and antioxidant effects, mate is consumed in communal rituals or daily focus routines.",
-    "effects": "Mental alertness;Appetite control;Social energy;Metabolism boost",
-    "mechanism": "Caffeine, theobromine, and chlorogenic acid act as CNS stimulants and antioxidants. Enhances focus while reducing fatigue.",
-    "compounds": [
-      "Caffeine",
-      "Theobromine",
-      "Chlorogenic acid"
-    ],
+    "description": "a caffeinated amazonian holly tree leaf used for lucid dreaming, focus, and ritual wakefulness. known as the 'dreaming tea' by the kichwa people. smoother than yerba mate and less jittery than coffee.",
+    "effects": "Smooth stimulation;Vivid dreams;Antioxidant;Focus;Energy",
+    "mechanism": "Contains caffeine, theobromine, and L-theanine. Stimulates CNS while providing a relaxing balance via L-theanine’s GABAergic modulation.",
+    "compounds": [],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "used for fatigue, digestion, weight loss, cognitive enhancement, and mild depression.",
+    "therapeutic": "used for morning energy, digestion, lucid dream preparation, and antioxidant support. traditionally used before hunting or dreaming ceremonies.",
     "interactions": [
-      "interacts with maois",
       "stimulants",
-      "or blood pressure meds. may influence cyp enzymes."
+      "caffeine",
+      "mild interactions with stimulants or sedatives. may mask fatigue."
     ],
     "contraindications": [
-      "caution in hypertension",
-      "ulcers",
-      "or caffeine sensitivity. avoid boiling hot consumption."
+      "pregnancy",
+      "heart conditions",
+      "anxiety",
+      "avoid with caffeine sensitivity",
+      "during pregnancy",
+      "or with cardiac arrhythmia."
     ],
     "sideeffects": [
-      "insomnia",
-      "gi irritation",
-      "or agitation at high doses. possible link to esophageal cancer when consumed very hot frequently."
+      "restlessness",
+      "jitteriness in sensitive individuals",
+      "mild insomnia or jitters at high doses. gentler than most stimulants."
     ],
     "safety": "",
-    "toxicity": "Low–Moderate (caffeine-related).",
+    "toxicity": "Low. Comparable to green tea.",
     "toxicity_ld50": "Caffeine LD50 ~192 mg/kg (rats, oral)",
     "tags": [
-      "☕ social",
-      "🔥 thermogenic",
-      "🌿 focus",
-      "⚡ stimulant"
+      "stimulant",
+      "✅ safe",
+      "🌿 herbal",
+      "🌿 dream tea",
+      "⚡ stimulant",
+      "🧘 smooth focus",
+      "☕ l-theanine"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
     "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6926402/",
-      "South American Herbal Pharmacopoeia",
-      "Journal of Human Nutrition and Dietetics",
-      "2008"
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3682131/",
+      "Journal of Ethnopharmacology",
+      "2011",
+      "Amazonian Shamanic Tea Practices – 2020"
     ]
-  },
-  {
-    "id": "yerba-mate",
-    "slug": "ilex-paraguariensis",
-    "common": "",
-    "scientific": "Ilex paraguariensis",
-    "category": "empathogen / euphoriant",
-    "subcategory": "",
-    "intensity": "Mild to moderate",
-    "region": "argentina, paraguay, brazil",
-    "legalstatus": "Legal",
-    "schedule": "",
-    "description": "south american herbal stimulant rich in caffeine, theobromine, and theophylline. traditionally shared as a communal energizing tea.",
-    "effects": "Stimulation;focus;social energy",
-    "mechanism": "Adenosine receptor antagonism (via caffeine/theobromine)",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "energy, mental clarity, digestion",
-    "interactions": [
-      "cns stimulants",
-      "caffeine"
-    ],
-    "contraindications": [
-      "anxiety",
-      "heart conditions",
-      "ulcers"
-    ],
-    "sideeffects": [
-      "jitteriness",
-      "insomnia",
-      "gi discomfort in sensitive individuals"
-    ],
-    "safety": "",
-    "toxicity": "Low to moderate (long-term use linked to GI issues)",
-    "toxicity_ld50": "~192 mg/kg (caffeine)",
-    "tags": [
-      "stimulant",
-      "🌿 social",
-      "🔥 energy"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
   },
   {
     "id": "ilex-vomitoria",
@@ -6991,89 +5758,52 @@
     ]
   },
   {
-    "id": "nelumbo-nucifera",
-    "slug": "nelumbo-nucifera",
-    "common": "",
-    "scientific": "Nelumbo nucifera",
-    "category": "dissociative / sedative",
+    "id": "celastrus-paniculatus",
+    "slug": "intellect-tree",
+    "common": "Intellect Tree",
+    "scientific": "Celastrus paniculatus",
+    "category": "empathogen / euphoriant",
     "subcategory": "",
     "intensity": "Mild",
-    "region": "india, southeast asia",
+    "region": "india, sri lanka, southeast asia",
     "legalstatus": "Legal",
     "schedule": "",
-    "description": "sacred flower in buddhism and hinduism, with mild psychoactive and calming properties. often used in teas or tinctures.",
-    "effects": "Calm;mild euphoria;dreaminess",
-    "mechanism": "Likely GABAergic and dopaminergic effects (alkaloids: nuciferine, aporphine)",
-    "compounds": [],
+    "description": "often called the 'intellect tree', this ayurvedic plant is used to support memory, learning, and vivid dreams. contains sesquiterpenes that may stimulate cholinergic activity.",
+    "effects": "Cognitive clarity;memory enhancement;dream vividness",
+    "mechanism": "Cholinergic modulation; antioxidant and neuroprotective effects",
+    "compounds": [
+      "Celastrine",
+      "Paniculatin"
+    ],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "stress, anxiety, spiritual use",
+    "therapeutic": "memory support, neuroprotection, dream recall",
     "interactions": [
-      "sedatives",
-      "cns depressants"
+      "none well documented"
     ],
     "contraindications": [
-      "pregnancy (caution)",
-      "hypotension"
+      "pregnancy"
     ],
     "sideeffects": [
-      "drowsiness",
-      "dizziness"
+      "headache or stimulation at high doses"
     ],
     "safety": "",
     "toxicity": "Low",
-    "toxicity_ld50": "Not known",
-    "tags": [
-      "🌊 spiritual",
-      "🌸 sacred",
-      "🧘 calm"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "monotropa-uniflora",
-    "slug": "monotropa-uniflora",
-    "common": "",
-    "scientific": "Monotropa uniflora",
-    "category": "dissociative / sedative",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "temperate forests of north america and asia",
-    "legalstatus": "Legal (but rare and protected in places)",
-    "schedule": "",
-    "description": "a ghostly white forest plant used in native american medicine for pain and spiritual insight. non-photosynthetic and mysterious.",
-    "effects": "Analgesia;calm;emotional detachment",
-    "mechanism": "Contains monotropin; acts possibly on NMDA or opioid systems (hypothetical)",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "pain relief, emotional trauma support (traditional)",
-    "interactions": [
-      "possibly cns depressants"
-    ],
-    "contraindications": [
-      "unknown",
-      "limited modern use"
-    ],
-    "sideeffects": [
-      "unknown at pharmacological doses",
-      "rare usage"
-    ],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "Not established",
     "tags": [
-      "🌲 pain relief",
-      "👻 ghost plant",
-      "🧠 emotional"
+      "✅ safe",
+      "🌿 herbal",
+      "🧠 nootropic"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
-    "sources": []
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3612440/",
+      "Journal of Ayurveda and Integrative Medicine",
+      "2011",
+      "Indian Materia Medica – Nadkarni"
+    ]
   },
   {
     "id": "ipomoea-tricolor",
@@ -7130,498 +5860,101 @@
     ]
   },
   {
-    "id": "datura-stramonium",
-    "slug": "datura-stramonium",
-    "common": "",
-    "scientific": "Datura stramonium",
-    "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "",
-    "region": "worldwide",
-    "legalstatus": "Unregulated but dangerous",
-    "schedule": "",
-    "description": "common weed producing powerful delirium when misused.",
-    "effects": "delirium;hallucinations",
-    "mechanism": "Scopolamine and atropine block muscarinic receptors",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "5–15 seeds",
-    "therapeutic": "historically asthma treatment",
-    "interactions": [
-      "anticholinergics",
-      "antihistamines"
-    ],
-    "contraindications": [
-      "heart conditions",
-      "mental illness"
-    ],
-    "sideeffects": [
-      "severe confusion",
-      "elevated heart rate"
-    ],
-    "safety": "",
-    "toxicity": "Very high",
-    "toxicity_ld50": "~50 mg/kg (atropine)",
-    "tags": [
-      "☠️ toxic",
-      "⚠️ caution"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "justicia-adhatoda",
-    "slug": "justicia-adhatoda",
-    "common": "",
-    "scientific": "Justicia adhatoda",
-    "category": "ethnobotanical",
-    "subcategory": "",
-    "intensity": "",
-    "region": "india, sri lanka",
-    "legalstatus": "",
-    "schedule": "",
-    "description": "also called malabar nut, this herb has traditional uses as a respiratory aid and mild sedative.",
-    "effects": "calming;respiratory clearing;mild sedation",
-    "mechanism": "Bronchodilation + GABAergic",
-    "compounds": [
-      "Vasicine",
-      "Vasicinone"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
-    "toxicity_ld50": "",
-    "tags": [
-      "sedative",
-      "respiratory",
-      "ayurvedic"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "justicia-pectoralis",
-    "slug": "tilo",
-    "common": "Tilo",
-    "scientific": "Justicia pectoralis",
+    "id": "alchornea-castaneifolia",
+    "slug": "iporuru",
+    "common": "Iporuru",
+    "scientific": "Alchornea castaneifolia",
     "category": "ritual / visionary",
     "subcategory": "",
     "intensity": "Mild",
     "region": "amazon basin",
     "legalstatus": "Legal",
     "schedule": "",
-    "description": "aromatic herb called tilo, brewed or smoked for calming effects.",
-    "effects": "Relaxation;light euphoria;spiritual dreams",
-    "mechanism": "Likely GABAergic; coumarins may modulate CNS",
+    "description": "used in amazonian shamanic rituals for its spiritual and anti-inflammatory effects. often included in ayahuasca blends.",
+    "effects": "Anti-inflammatory;spiritual clarity;energetic cleansing",
+    "mechanism": "Unknown; may involve tannins and flavonoids",
     "compounds": [
-      "Coumarin",
-      "Umelliferone"
+      "Alchorneine"
     ],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "anxiety, insomnia, spiritual enhancement",
-    "interactions": [
-      "coumarin-sensitive meds (e.g.",
-      "blood thinners)"
-    ],
+    "therapeutic": "rheumatism, arthritis, spiritual cleansing",
+    "interactions": [],
     "contraindications": [
-      "liver disorders",
       "pregnancy"
     ],
     "sideeffects": [
-      "liver risk in excess due to coumarin"
-    ],
-    "safety": "1",
-    "toxicity": "Low–moderate with excess",
-    "toxicity_ld50": "Not established",
-    "tags": [
-      "✅ legal",
-      "🌿 ayahuasca-additive",
-      "🧘 calm"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7820446/",
-      "Journal of Ethnopharmacology",
-      "1999",
-      "Shamanic Pharmacopoeia – Amazonian Plants"
-    ]
-  },
-  {
-    "id": "sceletium-tortuosum",
-    "slug": "sceletium-tortuosum",
-    "common": "",
-    "scientific": "Sceletium tortuosum",
-    "category": "empathogen / euphoriant",
-    "subcategory": "",
-    "intensity": "Mild to moderate",
-    "region": "southern africa",
-    "legalstatus": "Legal",
-    "schedule": "",
-    "description": "a south african succulent traditionally chewed or snuffed to reduce anxiety and induce euphoria.",
-    "effects": "Mood lift;calm euphoria;focus",
-    "mechanism": "Serotonin reuptake inhibition (mesembrine alkaloids)",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "anxiety, stress, social comfort",
-    "interactions": [
-      "antidepressants",
-      "serotonergic agents"
-    ],
-    "contraindications": [
-      "ssris",
-      "maois",
-      "bipolar disorder"
-    ],
-    "sideeffects": [
-      "headache",
-      "nausea",
-      "serotonin syndrome (in excess or with ssris)"
+      "minimal",
+      "bitter taste"
     ],
     "safety": "",
     "toxicity": "Low",
-    "toxicity_ld50": "Not established (safe in traditional use)",
+    "toxicity_ld50": "Not established",
     "tags": [
-      "🌼 euphoric",
-      "🧘 calm",
-      "🧬 natural ssri"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "sceletium-tortuosum",
-    "slug": "sceletium-tortuosum",
-    "common": "",
-    "scientific": "Sceletium tortuosum",
-    "category": "mood enhancer / traditional / ssri-like",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "south africa, namibia",
-    "legalstatus": "Legal worldwide (except select EU countries)",
-    "schedule": "",
-    "description": "a succulent plant native to south africa, kanna has been chewed, snuffed, and brewed for centuries by khoisan peoples to ease stress, elevate mood, and promote social connection. it’s now gaining modern popularity as a legal natural serotonin booster.",
-    "effects": "Euphoria;Reduced anxiety;Social enhancement;Emotional softening",
-    "mechanism": "Contains mesembrine alkaloids that act as selective serotonin reuptake inhibitors (SSRI), PDE4 inhibitors, and mild serotonin releasing agents (SRA). Also mildly acts on dopamine.",
-    "compounds": [
-      "Mesembrine"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for anxiety, mild depression, public speaking stress, trauma relief, and social disconnection. studied for antidepressant properties.",
-    "interactions": [
-      "potentially dangerous with other serotonergic substances (e.g.",
-      "mdma",
-      "ssris",
-      "st. john's wort)."
-    ],
-    "contraindications": [
-      "do not combine with ssris",
-      "maois",
-      "or serotonergic drugs (risk of serotonin syndrome). avoid during pregnancy or with bipolar disorder."
-    ],
-    "sideeffects": [
-      "rare. may include dry mouth",
-      "slight sedation",
-      "or overstimulation if combined with caffeine. excessive doses may cause emotional blunting or nausea."
-    ],
-    "safety": "",
-    "toxicity": "Low in traditional or moderate modern doses. No known fatalities or organ toxicity.",
-    "toxicity_ld50": ">5000 mg/kg (rats, oral extract)",
-    "tags": [
-      "🧠 serotonin",
-      "🧘 mood booster",
-      "💬 social",
-      "🌿 traditional african"
+      "✅ safe",
+      "🌿 amazon",
+      "🧘 cleanse"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
     "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5386632/",
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4127826/",
+      "Rainforest Healing Herb Profiles",
       "Journal of Ethnopharmacology",
-      "2013",
-      "South African Herbal Compendium"
+      "2007"
     ]
   },
   {
-    "id": "kava",
-    "slug": "piper-methysticum",
+    "id": "adhatoda-vasica",
+    "slug": "justicia-adhatoda",
     "common": "",
-    "scientific": "Piper methysticum",
-    "category": "dissociative / sedative",
+    "scientific": "Justicia adhatoda",
+    "category": "stimulant / bronchodilator",
     "subcategory": "",
-    "intensity": "Mild to moderate",
-    "region": "polynesia, micronesia, melanesia",
-    "legalstatus": "Legal; restricted in some EU countries",
+    "intensity": "Mild",
+    "region": "indian subcontinent",
+    "legalstatus": "Legal",
     "schedule": "",
-    "description": "south pacific root brew known for its relaxing and anxiolytic effects.",
-    "effects": "Relaxation;social ease;mild euphoria",
-    "mechanism": "Kavalactones modulate GABA, block sodium and calcium channels",
-    "compounds": [],
+    "description": "known as vasaka or malabar nut, this shrub’s leaves ease breathing and offer a subtle stimulating effect.",
+    "effects": "calming;respiratory clearing;mild sedation",
+    "mechanism": "Alkaloids such as vasicine act as bronchodilators and respiratory stimulants",
+    "compounds": [
+      "Vasicine",
+      "Vasicinone"
+    ],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "anxiety, stress, sleep aid",
+    "therapeutic": "ayurvedic herb for asthma, coughs and general vitality",
     "interactions": [
-      "cns depressants",
-      "alcohol",
-      "liver-metabolized drugs"
-    ],
-    "contraindications": [
-      "liver conditions",
-      "alcohol",
-      "sedatives"
-    ],
-    "sideeffects": [
-      "liver strain (rare)",
-      "drowsiness"
-    ],
-    "safety": "2",
-    "toxicity": "Low to moderate; caution with prolonged use",
-    "toxicity_ld50": "~4.3 g/kg (rats, oral)",
-    "tags": [
-      "🌿 root",
-      "🍵 social",
-      "🧘 calm"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "catha-edulis",
-    "slug": "catha-edulis",
-    "common": "",
-    "scientific": "Catha edulis",
-    "category": "stimulant / euphoric",
-    "subcategory": "",
-    "intensity": "Moderate",
-    "region": "horn of africa, yemen",
-    "legalstatus": "Illegal or controlled in many countries",
-    "schedule": "",
-    "description": "evergreen shrub whose fresh leaves are chewed for stimulant and euphoric effects in social settings.",
-    "effects": "Euphoria;alertness;appetite suppression",
-    "mechanism": "Cathinone alkaloids release dopamine and norepinephrine.",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "social stimulant chewed in east africa and the arabian peninsula.",
-    "interactions": [
-      "avoid with stimulants or maois"
-    ],
-    "contraindications": [
-      "heart issues",
-      "pregnancy",
-      "maois."
-    ],
-    "sideeffects": [
-      "dry mouth",
-      "increased heart rate",
-      "insomnia"
-    ],
-    "safety": "",
-    "toxicity": "Excess use leads to insomnia, hypertension, or dependency.",
-    "toxicity_ld50": "Cathinone LD50 ~75 mg/kg (rats)",
-    "tags": [
-      "⚠️ controlled",
-      "🌿 leaves"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "solandra-maxima",
-    "slug": "solandra-maxima",
-    "common": "",
-    "scientific": "Solandra maxima",
-    "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "",
-    "region": "mexico",
-    "legalstatus": "Unregulated",
-    "schedule": "",
-    "description": "rarely used solanaceous vine with powerful effects.",
-    "effects": "visions;disorientation",
-    "mechanism": "Tropane alkaloids similar to datura",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "visionary rituals",
-    "interactions": [
-      "anticholinergics"
+      "may potentiate other bronchodilators"
     ],
     "contraindications": [
       "pregnancy",
-      "heart issues"
+      "high doses may cause vomiting"
     ],
     "sideeffects": [
-      "severe confusion",
-      "amnesia"
+      "digestive upset at large doses"
     ],
     "safety": "",
-    "toxicity": "High",
-    "toxicity_ld50": "",
+    "toxicity": "Generally safe at therapeutic doses",
+    "toxicity_ld50": ">2 g/kg in rodents",
     "tags": [
-      "☠️ toxic"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "mitragyna-speciosa",
-    "slug": "mitragyna-speciosa",
-    "common": "",
-    "scientific": "Mitragyna speciosa",
-    "category": "stimulant",
-    "subcategory": "",
-    "intensity": "",
-    "region": "southeast asia",
-    "legalstatus": "Varies by country",
-    "schedule": "",
-    "description": "popular herbal stimulant and analgesic.",
-    "effects": "euphoria;pain relief",
-    "mechanism": "Mitragynine acts on opioid receptors",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "2–5 g leaf powder",
-    "therapeutic": "pain management, energy",
-    "interactions": [
-      "opioids",
-      "depressants"
-    ],
-    "contraindications": [
-      "opioid addiction recovery"
-    ],
-    "sideeffects": [
-      "nausea",
-      "dependence"
-    ],
-    "safety": "",
-    "toxicity": "Moderate",
-    "toxicity_ld50": ">400 mg/kg (rats)",
-    "tags": [
-      "🌀 euphoric",
-      "💊 oral"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "mitragyna-speciosa",
-    "slug": "mitragyna-speciosa",
-    "common": "",
-    "scientific": "Mitragyna speciosa",
-    "category": "stimulant / opioid-like / traditional / controversial",
-    "subcategory": "",
-    "intensity": "Mild–Strong (dose-dependent)",
-    "region": "thailand, indonesia, malaysia",
-    "legalstatus": "Legal in some regions; banned or restricted in others (e.g. Thailand, Australia, some U.S. states)",
-    "schedule": "",
-    "description": "a tropical tree whose leaves are traditionally chewed for stamina and pain relief in southeast asia. kratom has gained global attention as both a potential therapeutic tool and a substance of concern due to its opioid-like effects.",
-    "effects": "Energy;Euphoria;Pain relief;Calm focus",
-    "mechanism": "Mitragynine and 7-hydroxymitragynine are partial mu-opioid agonists with stimulant properties at low doses and sedative effects at higher doses. Also interacts with adrenergic and serotonergic systems.",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for pain management, anxiety, fatigue, opioid withdrawal, and mood enhancement. reported as helpful in tapering off prescription opioids.",
-    "interactions": [
-      "potentiates cns depressants. interacts with liver enzymes (cyp3a4",
-      "cyp2d6)."
-    ],
-    "contraindications": [
-      "avoid with other opioids",
-      "benzodiazepines",
-      "alcohol",
-      "or in heart/liver conditions."
-    ],
-    "sideeffects": [
-      "constipation",
-      "dry mouth",
-      "nausea",
-      "dependency",
-      "withdrawal symptoms with chronic use. some cardiac risk at high doses."
-    ],
-    "safety": "",
-    "toxicity": "Moderate at high doses or with poly-drug use. Risk of dependency.",
-    "toxicity_ld50": "Mitragynine LD50 >500 mg/kg (rats, oral)",
-    "tags": [
-      "🍃 opioid-like",
-      "⚖️ controversial",
-      "🌿 traditional",
-      "🩹 pain relief"
+      "ayurveda",
+      "respiratory",
+      "vasaka",
+      "sedative",
+      "ayurvedic"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
     "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6534344/",
-      "Journal of the American Osteopathic Association",
-      "2020",
-      "WHO Kratom Review Report",
-      "2021"
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3249957/",
+      "Phytomedicine. 2000",
+      "7(1):37-44.",
+      "Ayurvedic Pharmacopoeia of India"
     ]
-  },
-  {
-    "id": "kratom-hybrids",
-    "slug": "mitragyna-speciosa-hybrids",
-    "common": "",
-    "scientific": "Mitragyna speciosa hybrids",
-    "category": "stimulant / analgesic",
-    "subcategory": "",
-    "intensity": "",
-    "region": "cultivated southeast asia",
-    "legalstatus": "Varies by region",
-    "schedule": "",
-    "description": "selective breeding of kratom species for varied alkaloid ratios",
-    "effects": "energy;pain relief",
-    "mechanism": "Indole alkaloids act as partial mu-opioid agonists",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "2-5 g leaf",
-    "therapeutic": "pain relief, mood lift",
-    "interactions": [
-      "opioids and sedatives"
-    ],
-    "contraindications": [
-      "heart conditions",
-      "maois"
-    ],
-    "sideeffects": [
-      "nausea",
-      "dependency"
-    ],
-    "safety": "",
-    "toxicity": "Moderate",
-    "toxicity_ld50": ">200 mg/kg (rats, mitragynine)",
-    "tags": [
-      "⚠️ use caution",
-      "🍃 leaf"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
   },
   {
     "id": "lactuca-canadensis",
@@ -7659,102 +5992,6 @@
     "tags": [
       "✅ safe",
       "🌿 opium lettuce",
-      "😴 sedative"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "lactuca-virosa",
-    "slug": "wild-lettuce",
-    "common": "Wild Lettuce",
-    "scientific": "Lactuca virosa",
-    "category": "sedative / analgesic / nervine",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "europe, north america, asia",
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "description": "a tall, bitter plant sometimes called 'opium lettuce' due to its historical use for pain and sleep. it contains lactucopicrin and lactucin, compounds with mild sedative and analgesic properties. used in western herbalism since the 19th century.",
-    "effects": "Pain relief;Mild euphoria;Sedation;Calming",
-    "mechanism": "Lactucin and lactucopicrin are sesquiterpene lactones that interact with GABAergic systems and have antinociceptive properties.",
-    "compounds": [
-      "Lactucin",
-      "Lactucopicrin"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for pain, insomnia, anxiety, coughing, and muscle tension. popular in herbal tinctures and teas.",
-    "interactions": [
-      "potentiates sedatives or alcohol."
-    ],
-    "contraindications": [
-      "avoid in pregnancy",
-      "glaucoma",
-      "or with cns depressants. not for prolonged heavy use."
-    ],
-    "sideeffects": [
-      "may cause dizziness",
-      "nausea",
-      "or mild hallucinations at high doses. bitter taste often deters excess use."
-    ],
-    "safety": "",
-    "toxicity": "Low to moderate. High doses may cause CNS depression.",
-    "toxicity_ld50": "Not well documented in humans; extracts assumed safe below 500 mg/kg",
-    "tags": [
-      "💤 sedative",
-      "🌿 analgesic",
-      "🌙 calming",
-      "🧪 bitter"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6232791/",
-      "Herbal Medicines",
-      "4th Ed. – Barnes et al.",
-      "A Modern Herbal – Grieve"
-    ]
-  },
-  {
-    "id": "wild-lettuce",
-    "slug": "lactuca-virosa",
-    "common": "",
-    "scientific": "Lactuca virosa",
-    "category": "dissociative / sedative",
-    "subcategory": "",
-    "intensity": "Mild to moderate",
-    "region": "europe, north america",
-    "legalstatus": "Legal",
-    "schedule": "",
-    "description": "leafy plant exuding sedative latex historically called 'lettuce opium.'",
-    "effects": "Sedation;pain relief;light euphoria",
-    "mechanism": "Lactucin and lactucopicrin may act as acetylcholinesterase inhibitors",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "insomnia, pain relief, cough suppression",
-    "interactions": [
-      "avoid with sedatives",
-      "opioids"
-    ],
-    "contraindications": [
-      "pregnancy",
-      "cns depressants"
-    ],
-    "sideeffects": [
-      "drowsiness",
-      "nausea at high doses"
-    ],
-    "safety": "1",
-    "toxicity": "Low in traditional doses",
-    "toxicity_ld50": "Not established",
-    "tags": [
-      "✅ safe",
-      "🌿 herbal",
       "😴 sedative"
     ],
     "regiontags": [],
@@ -7845,35 +6082,41 @@
     "slug": "leonotis-leonurus",
     "common": "",
     "scientific": "Leonotis leonurus",
-    "category": "ritual / visionary",
+    "category": "relaxant / euphoric",
     "subcategory": "",
     "intensity": "Mild",
-    "region": "south africa",
+    "region": "southern africa",
     "legalstatus": "Legal",
     "schedule": "",
-    "description": "also called wild dagga, smoked for gentle euphoric effects.",
+    "description": "orange-flowered shrub also called lion’s tail; smoked traditionally for mild cannabis-like effects.",
     "effects": "Mild euphoria;relaxation",
-    "mechanism": "Leonurine may act on serotonin receptors",
+    "mechanism": "Contains leonurine; may act on serotonin and cannabinoid receptors.",
     "compounds": [],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "traditional relaxant and ritual smoke",
+    "therapeutic": "folk remedy for coughs, fever and as a mild psychoactive when smoked.",
     "interactions": [
-      "limited data"
+      "limited data",
+      "may potentiate other sedatives"
     ],
     "contraindications": [
-      "none known"
+      "none known",
+      "avoid during pregnancy or with heart conditions."
     ],
     "sideeffects": [
-      "dizziness with heavy use"
+      "dizziness with heavy use",
+      "dry mouth",
+      "slight dizziness"
     ],
     "safety": "",
-    "toxicity": "Low",
+    "toxicity": "Low; high doses may cause dizziness or nausea.",
     "toxicity_ld50": "Not established",
     "tags": [
       "✅ safe",
       "🌿 leaf",
-      "🧪 alkaloid"
+      "🧪 alkaloid",
+      "🌿 smoke",
+      "🦁 dagga"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -7883,100 +6126,6 @@
       "Journal of Ethnopharmacology",
       "2005",
       "African Herbal Medicine Compendium"
-    ]
-  },
-  {
-    "id": "leonotis-leonurus",
-    "slug": "leonotis-leonurus",
-    "common": "",
-    "scientific": "Leonotis leonurus",
-    "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "south africa",
-    "legalstatus": "Legal",
-    "schedule": "",
-    "description": "also called wild dagga, smoked for gentle euphoric effects.",
-    "effects": "Mild euphoria;relaxation",
-    "mechanism": "Leonurine may act on serotonin receptors",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditional relaxant and ritual smoke",
-    "interactions": [
-      "limited data"
-    ],
-    "contraindications": [
-      "none known"
-    ],
-    "sideeffects": [
-      "dizziness with heavy use"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
-    "tags": [
-      "✅ safe",
-      "🌿 leaf",
-      "🧪 alkaloid"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3887317/",
-      "Journal of Ethnopharmacology",
-      "2005",
-      "African Herbal Medicine Compendium"
-    ]
-  },
-  {
-    "id": "leonurus-cardiaca",
-    "slug": "motherwort",
-    "common": "Motherwort",
-    "scientific": "Leonurus cardiaca",
-    "category": "cardiotonic / nervine / women’s health",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "europe, north america, asia",
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "description": "a traditional european nervine used to ease tension, heart flutter, and menstrual discomfort. known as ‘mother’s herb’ for its supportive effects during emotional distress and hormonal fluctuations.",
-    "effects": "Calms heart palpitations;Reduces anxiety;Uterine tonic;Regulates menstrual tension",
-    "mechanism": "Alkaloids such as leonurine and stachydrine provide mild sedative, antispasmodic, and cardiotonic effects, possibly modulating GABA and muscarinic pathways.",
-    "compounds": [
-      "Leonurine",
-      "Stachydrine"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for pms, menopause, anxiety, nervous heart conditions, and postpartum recovery. may support vagal tone and reduce sympathetic overdrive.",
-    "interactions": [
-      "caution with heart medications or sedatives."
-    ],
-    "contraindications": [
-      "avoid in pregnancy (uterine stimulant). may slightly lower blood pressure."
-    ],
-    "sideeffects": [
-      "bitter taste",
-      "possible drowsiness or stomach upset in some. generally well tolerated."
-    ],
-    "safety": "",
-    "toxicity": "Low. Used widely in folk medicine.",
-    "toxicity_ld50": "Not established in humans",
-    "tags": [
-      "🫀 heart support",
-      "🌸 women’s health",
-      "🧘 nervine",
-      "🌿 bitter tonic"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8762752/",
-      "Herbal Medicine – Mills & Bone",
-      "British Herbal Compendium"
     ]
   },
   {
@@ -8070,96 +6219,52 @@
     ]
   },
   {
-    "id": "lions-mane",
-    "slug": "hericium-erinaceus",
-    "common": "",
-    "scientific": "Hericium erinaceus",
-    "category": "other",
+    "id": "tilia-europaea",
+    "slug": "linden",
+    "common": "Linden",
+    "scientific": "Tilia europaea",
+    "category": "nervine / anxiolytic / antispasmodic",
     "subcategory": "",
     "intensity": "Mild",
-    "region": "🇨🇳 east asia",
-    "legalstatus": "Legal / Unregulated",
+    "region": "europe, western asia, north america (ornamental)",
+    "legalstatus": "Legal worldwide",
     "schedule": "",
-    "description": "medicinal mushroom valued for promoting nerve growth and mental clarity.",
-    "effects": "Neurotrophic support;cognitive enhancement",
-    "mechanism": "Hericenones and erinacines stimulate nerve growth factor.",
-    "compounds": [],
+    "description": "linden flowers are fragrant and soothing, traditionally used in europe as a gentle sedative and nerve tonic. often brewed into calming teas to relieve stress, tension, and digestive upset.",
+    "effects": "Calm;Stress relief;Muscle relaxation;Sleep support",
+    "mechanism": "Contains flavonoids (e.g., quercetin, kaempferol) and volatile oils that act as mild GABA modulators and muscle relaxants.",
+    "compounds": [
+      "Farnesol",
+      "Kaempferol"
+    ],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "memory, focus, nerve regeneration, mood support.",
+    "therapeutic": "used for anxiety, tension headaches, high blood pressure, insomnia, and muscle cramps. also supports digestion and reduces inflammation.",
     "interactions": [
-      "no major interactions documented."
+      "minimal. may slightly enhance effects of sedatives or diuretics."
     ],
     "contraindications": [
-      "allergy to mushrooms",
-      "pregnancy (limited data)."
+      "none significant. use with caution if allergic to pollen or linden trees."
     ],
     "sideeffects": [
-      "rare allergic reactions",
-      "generally well-tolerated."
-    ],
-    "safety": "1",
-    "toxicity": "Low toxicity; consumed as food in many cultures.",
-    "toxicity_ld50": "Not established; considered safe.",
-    "tags": [
-      "\\ud83d\\udc8a oral",
-      "\\ud83e\\udde0 cognitive",
-      "\\u2705 safe"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "lobelia-inflata",
-    "slug": "lobelia-inflata",
-    "common": "",
-    "scientific": "Lobelia inflata",
-    "category": "respiratory / nervine / strong medicinal",
-    "subcategory": "",
-    "intensity": "Moderate–Strong",
-    "region": "north america",
-    "legalstatus": "Legal with caution",
-    "schedule": "",
-    "description": "a powerful respiratory herb used by native americans and western herbalists to aid breathing, reduce asthma spasms, and stimulate detoxification. sometimes called ‘the thinking herb’ for its clarity-inducing effects.",
-    "effects": "Bronchodilation;Muscle relaxation;Emetic (high dose);Stimulates breath",
-    "mechanism": "Contains lobeline, a nicotinic acetylcholine receptor partial agonist that stimulates respiration and clears airways. Also acts as a relaxant in low doses.",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for asthma, bronchitis, whooping cough, tension, and as a smoke cessation aid. in high doses, historically used to induce vomiting in detox protocols.",
-    "interactions": [
-      "potentiates sedatives or respiratory stimulants."
-    ],
-    "contraindications": [
-      "avoid in pregnancy",
-      "with heart disease",
-      "or alongside strong sedatives. use cautiously."
-    ],
-    "sideeffects": [
-      "nausea",
-      "vomiting",
-      "salivation",
-      "dizziness",
-      "or tingling. overdose may cause respiratory distress."
+      "very rare",
+      "occasional mild drowsiness or allergic reaction."
     ],
     "safety": "",
-    "toxicity": "Moderate to high in excess. Use under guidance.",
-    "toxicity_ld50": "~0.6 g/kg lobeline in animals (est.)",
+    "toxicity": "Very low",
+    "toxicity_ld50": "Not established (very safe at therapeutic levels)",
     "tags": [
-      "🌬️ respiratory",
-      "🫁 bronchodilator",
-      "⚠️ low dose only",
-      "🌿 native american use"
+      "🧘 calm",
+      "💤 sleep",
+      "🌼 floral",
+      "🌿 traditional european"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
     "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4119142/",
-      "American Herbal Pharmacopoeia – Lobelia",
-      "Materia Medica – Eclectic School"
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6597275/",
+      "British Herbal Pharmacopoeia",
+      "Plants of the Gods – Rätsch"
     ]
   },
   {
@@ -8270,50 +6375,6 @@
     ]
   },
   {
-    "id": "lsd",
-    "slug": "lysergic-acid-diethylamide",
-    "common": "",
-    "scientific": "Lysergic acid diethylamide",
-    "category": "psychedelic",
-    "subcategory": "",
-    "intensity": "High",
-    "region": "🌎 synthetic",
-    "legalstatus": "Controlled / Illegal in many regions",
-    "schedule": "",
-    "description": "semi-synthetic ergoline discovered in 1938; among the most potent psychedelics.",
-    "effects": "Intense visuals;ego dissolution;synesthesia",
-    "mechanism": "Potent 5-HT2A receptor agonist affecting serotonin and dopamine systems.",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "investigated for cluster headaches, anxiety, and addiction therapy.",
-    "interactions": [
-      "ssris may blunt effects",
-      "maois potentiate."
-    ],
-    "contraindications": [
-      "psychosis",
-      "severe cardiovascular disease."
-    ],
-    "sideeffects": [
-      "anxiety",
-      "confusion",
-      "possible flashbacks at high doses."
-    ],
-    "safety": "2",
-    "toxicity": "Very low physiological toxicity but strong psychological effects.",
-    "toxicity_ld50": ">14 mg/kg (mice, intravenous)",
-    "tags": [
-      "⚠️ restricted",
-      "🌀 visionary",
-      "💊 oral"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
     "id": "lycopodium-clavatum",
     "slug": "lycopodium-clavatum",
     "common": "",
@@ -8362,6 +6423,50 @@
     ]
   },
   {
+    "id": "lsd",
+    "slug": "lysergic-acid-diethylamide",
+    "common": "",
+    "scientific": "Lysergic acid diethylamide",
+    "category": "psychedelic",
+    "subcategory": "",
+    "intensity": "High",
+    "region": "🌎 synthetic",
+    "legalstatus": "Controlled / Illegal in many regions",
+    "schedule": "",
+    "description": "semi-synthetic ergoline discovered in 1938; among the most potent psychedelics.",
+    "effects": "Intense visuals;ego dissolution;synesthesia",
+    "mechanism": "Potent 5-HT2A receptor agonist affecting serotonin and dopamine systems.",
+    "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "investigated for cluster headaches, anxiety, and addiction therapy.",
+    "interactions": [
+      "ssris may blunt effects",
+      "maois potentiate."
+    ],
+    "contraindications": [
+      "psychosis",
+      "severe cardiovascular disease."
+    ],
+    "sideeffects": [
+      "anxiety",
+      "confusion",
+      "possible flashbacks at high doses."
+    ],
+    "safety": "2",
+    "toxicity": "Very low physiological toxicity but strong psychological effects.",
+    "toxicity_ld50": ">14 mg/kg (mice, intravenous)",
+    "tags": [
+      "⚠️ restricted",
+      "🌀 visionary",
+      "💊 oral"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
+  },
+  {
     "id": "mandragora-officinarum",
     "slug": "mandragora-officinarum",
     "common": "",
@@ -8377,16 +6482,19 @@
     "mechanism": "Scopolamine, hyoscyamine, and atropine act as central anticholinergics, disrupting memory, balance, perception, and consciousness. Mimics effects of belladonna and henbane.",
     "compounds": [],
     "preparations": [],
-    "dosage": "",
+    "dosage": "0.1–0.3 g dried root",
     "therapeutic": "historically used for surgery anesthesia, pain, sleep, and aphrodisiac purposes. modern use is rare and dangerous.",
     "interactions": [
       "fatal with other anticholinergics",
       "sedatives",
       "maois",
-      "or alcohol."
+      "or alcohol.",
+      "anticholinergic medications"
     ],
     "contraindications": [
-      "unsafe in almost all settings. avoid with any cns-active substances or psychiatric history."
+      "unsafe in almost all settings. avoid with any cns-active substances or psychiatric history.",
+      "heart conditions",
+      "pregnancy"
     ],
     "sideeffects": [
       "confusion",
@@ -8394,7 +6502,8 @@
       "overheating",
       "dry mouth",
       "tachycardia",
-      "respiratory distress. easily overdosed."
+      "respiratory distress. easily overdosed.",
+      "delirium"
     ],
     "safety": "",
     "toxicity": "Very high. Even small doses can be toxic or fatal.",
@@ -8403,7 +6512,9 @@
       "💀 toxic",
       "🌙 magical",
       "🌿 solanaceae",
-      "🌀 deliriant"
+      "🌀 deliriant",
+      "☠️ toxic",
+      "🌿 root"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -8413,48 +6524,6 @@
       "Plants of the Gods – Rätsch",
       "Toxicology in Herbal Medicine – 2020"
     ]
-  },
-  {
-    "id": "mandrake",
-    "slug": "mandragora-officinarum",
-    "common": "",
-    "scientific": "Mandragora officinarum",
-    "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "",
-    "region": "mediterranean",
-    "legalstatus": "Cultivation legal in most regions",
-    "schedule": "",
-    "description": "legendary root used in magic rituals; highly toxic.",
-    "effects": "hallucinations;sedation",
-    "mechanism": "Tropane alkaloids block muscarinic acetylcholine receptors",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "0.1–0.3 g dried root",
-    "therapeutic": "historical anesthetic",
-    "interactions": [
-      "anticholinergic medications"
-    ],
-    "contraindications": [
-      "heart conditions",
-      "pregnancy"
-    ],
-    "sideeffects": [
-      "confusion",
-      "dry mouth",
-      "delirium"
-    ],
-    "safety": "",
-    "toxicity": "High",
-    "toxicity_ld50": "~50 mg/kg (mice, scopolamine)",
-    "tags": [
-      "☠️ toxic",
-      "🌿 root"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
   },
   {
     "id": "marrubium-vulgare",
@@ -8644,47 +6713,52 @@
     ]
   },
   {
-    "id": "mescaline",
-    "slug": "3-4-5-trimethoxyphenethylamine",
+    "id": "mimosa-pudica",
+    "slug": "mimosa-pudica",
     "common": "",
-    "scientific": "3,4,5-trimethoxyphenethylamine",
-    "category": "psychedelic",
+    "scientific": "Mimosa pudica",
+    "category": "nervine / anti-parasitic / mysterious plant movement",
     "subcategory": "",
-    "intensity": "Moderate",
-    "region": "🌎 americas",
-    "legalstatus": "Controlled in many regions",
+    "intensity": "Mild–Moderate",
+    "region": "south america, southeast asia, india",
+    "legalstatus": "Legal worldwide",
     "schedule": "",
-    "description": "classic phenethylamine psychedelic from peyote and san pedro cacti.",
-    "effects": "Color enhancement;empathy;spiritual visions",
-    "mechanism": "Phenethylamine psychedelic acting on 5-HT2A and dopamine receptors.",
+    "description": "known for its rapid leaf-closing reflex, this tropical creeping plant is used in ayurvedic and modern herbal medicine for gut detox, parasite cleansing, and calming the nerves.",
+    "effects": "Intestinal cleanse;Antiparasitic;Calming;Unique tactile motion",
+    "mechanism": "Contains mimosine, alkaloids, and tannins. Antiparasitic action through mechanical mucilage binding and gut wall modulation. Also mildly acts on serotonin and GABA pathways.",
     "compounds": [],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "traditional sacrament; studied for alcoholism and psychotherapy.",
+    "therapeutic": "used for intestinal worms, heavy metal detox, gi inflammation, gut-brain axis repair, and nervous tension.",
     "interactions": [
-      "maois and sympathomimetics may potentiate."
+      "may bind to medications and reduce absorption. space doses accordingly."
     ],
     "contraindications": [
-      "heart disease",
-      "pregnancy."
+      "avoid in pregnancy. use caution in constipation or with gi disorders unless guided."
     ],
     "sideeffects": [
-      "nausea",
-      "increased heart rate",
-      "dilated pupils."
+      "possible constipation",
+      "fatigue",
+      "or gut discomfort in first few days. rare allergic response."
     ],
-    "safety": "2",
-    "toxicity": "Low physiological toxicity; psychological effects strong.",
-    "toxicity_ld50": ">1,000 mg/kg (rats, oral)",
+    "safety": "",
+    "toxicity": "Low–Moderate. Use within appropriate dose ranges.",
+    "toxicity_ld50": ">2000 mg/kg (rats, oral extract)",
     "tags": [
-      "⚠️ restricted",
-      "🌀 visionary",
-      "💊 oral"
+      "🧬 gut health",
+      "🪱 parasite cleanse",
+      "🌿 ayurvedic",
+      "🖐️ reactive plant"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
-    "sources": []
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4027290/",
+      "Ayurvedic Pharmacopeia – India",
+      "Journal of Parasitology Research",
+      "2017"
+    ]
   },
   {
     "id": "mimosa-hostilis",
@@ -8734,54 +6808,6 @@
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology",
       "1993"
-    ]
-  },
-  {
-    "id": "mimosa-pudica",
-    "slug": "mimosa-pudica",
-    "common": "",
-    "scientific": "Mimosa pudica",
-    "category": "nervine / anti-parasitic / mysterious plant movement",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "south america, southeast asia, india",
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "description": "known for its rapid leaf-closing reflex, this tropical creeping plant is used in ayurvedic and modern herbal medicine for gut detox, parasite cleansing, and calming the nerves.",
-    "effects": "Intestinal cleanse;Antiparasitic;Calming;Unique tactile motion",
-    "mechanism": "Contains mimosine, alkaloids, and tannins. Antiparasitic action through mechanical mucilage binding and gut wall modulation. Also mildly acts on serotonin and GABA pathways.",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for intestinal worms, heavy metal detox, gi inflammation, gut-brain axis repair, and nervous tension.",
-    "interactions": [
-      "may bind to medications and reduce absorption. space doses accordingly."
-    ],
-    "contraindications": [
-      "avoid in pregnancy. use caution in constipation or with gi disorders unless guided."
-    ],
-    "sideeffects": [
-      "possible constipation",
-      "fatigue",
-      "or gut discomfort in first few days. rare allergic response."
-    ],
-    "safety": "",
-    "toxicity": "Low–Moderate. Use within appropriate dose ranges.",
-    "toxicity_ld50": ">2000 mg/kg (rats, oral extract)",
-    "tags": [
-      "🧬 gut health",
-      "🪱 parasite cleanse",
-      "🌿 ayurvedic",
-      "🖐️ reactive plant"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4027290/",
-      "Ayurvedic Pharmacopeia – India",
-      "Journal of Parasitology Research",
-      "2017"
     ]
   },
   {
@@ -8872,88 +6898,101 @@
     ]
   },
   {
-    "id": "mitragyna-hirsuta",
-    "slug": "mitragyna-hirsuta",
+    "id": "mitragyna-speciosa",
+    "slug": "mitragyna-speciosa",
     "common": "",
-    "scientific": "Mitragyna hirsuta",
-    "category": "stimulant / relaxant / kratom alternative",
+    "scientific": "Mitragyna speciosa",
+    "category": "stimulant / opioid-like / traditional / controversial",
     "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "thailand, southeast asia",
-    "legalstatus": "Legal in most regions",
+    "intensity": "Mild–Strong (dose-dependent)",
+    "region": "thailand, indonesia, malaysia",
+    "legalstatus": "Legal in some regions; banned or restricted in others (e.g. Thailand, Australia, some U.S. states)",
     "schedule": "",
-    "description": "a close relative of mitragyna speciosa (kratom), this thai tree is used as a legal alternative with gentler psychoactive effects. traditionally chewed by laborers for stamina and focus.",
-    "effects": "Mild euphoria;Calm stimulation;Analgesia;Energy boost",
-    "mechanism": "Contains mitraphylline and isomitraphylline — alkaloids that act on opioid receptors (mu, delta) and possibly serotonin/dopamine pathways, though weaker than kratom.",
+    "description": "a tropical tree whose leaves are traditionally chewed for stamina and pain relief in southeast asia. kratom has gained global attention as both a potential therapeutic tool and a substance of concern due to its opioid-like effects.",
+    "effects": "Energy;Euphoria;Pain relief;Calm focus",
+    "mechanism": "Mitragynine and 7-hydroxymitragynine are partial mu-opioid agonists with stimulant properties at low doses and sedative effects at higher doses. Also interacts with adrenergic and serotonergic systems.",
     "compounds": [],
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for mood lift, fatigue reduction, mild pain relief, and kratom tapering.",
+    "dosage": "2–5 g leaf powder",
+    "therapeutic": "used for pain management, anxiety, fatigue, opioid withdrawal, and mood enhancement. reported as helpful in tapering off prescription opioids.",
     "interactions": [
-      "similar caution as with kratom — potential additive effect with sedatives."
+      "opioids",
+      "depressants",
+      "potentiates cns depressants. interacts with liver enzymes (cyp3a4",
+      "cyp2d6)."
     ],
     "contraindications": [
-      "avoid combining with opioids",
-      "depressants",
-      "or alcohol. safety in pregnancy unknown."
+      "opioid addiction recovery",
+      "avoid with other opioids",
+      "benzodiazepines",
+      "alcohol",
+      "or in heart/liver conditions."
     ],
     "sideeffects": [
-      "mild nausea",
+      "nausea",
+      "dependence",
+      "constipation",
       "dry mouth",
-      "light sedation. fewer side effects than kratom. little to no dependency reported."
+      "dependency",
+      "withdrawal symptoms with chronic use. some cardiac risk at high doses."
     ],
     "safety": "",
-    "toxicity": "Low to moderate. No confirmed toxicity in traditional doses.",
-    "toxicity_ld50": "Not established",
+    "toxicity": "Moderate at high doses or with poly-drug use. Risk of dependency.",
+    "toxicity_ld50": "Mitragynine LD50 >500 mg/kg (rats, oral)",
     "tags": [
-      "🍃 kratom-like",
-      "⚡ energy",
-      "🧘 calm",
-      "🩹 mild analgesic"
+      "🌀 euphoric",
+      "💊 oral",
+      "🍃 opioid-like",
+      "⚖️ controversial",
+      "🌿 traditional",
+      "🩹 pain relief"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
     "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6571610/",
-      "Journal of Ethnopharmacology",
-      "2016",
-      "Thai Botanical Index – 2014"
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6534344/",
+      "Journal of the American Osteopathic Association",
+      "2020",
+      "WHO Kratom Review Report",
+      "2021"
     ]
   },
   {
-    "id": "ephedra-nevadensis",
-    "slug": "ephedra-nevadensis",
+    "id": "kratom-hybrids",
+    "slug": "mitragyna-speciosa-hybrids",
     "common": "",
-    "scientific": "Ephedra nevadensis",
-    "category": "stimulant",
+    "scientific": "Mitragyna speciosa hybrids",
+    "category": "stimulant / analgesic",
     "subcategory": "",
     "intensity": "",
-    "region": "north america",
-    "legalstatus": "Legal",
+    "region": "cultivated southeast asia",
+    "legalstatus": "Varies by region",
     "schedule": "",
-    "description": "mild stimulant desert shrub without strong ephedra content.",
-    "effects": "mild stimulation",
-    "mechanism": "Contains ephedrine-like alkaloids releasing norepinephrine",
+    "description": "selective breeding of kratom species for varied alkaloid ratios",
+    "effects": "energy;pain relief",
+    "mechanism": "Indole alkaloids act as partial mu-opioid agonists",
     "compounds": [],
     "preparations": [],
-    "dosage": "5–10 g dried stems",
-    "therapeutic": "decongestant",
+    "dosage": "2-5 g leaf",
+    "therapeutic": "pain relief, mood lift",
     "interactions": [
-      "stimulants",
-      "decongestants"
+      "opioids and sedatives"
     ],
     "contraindications": [
-      "hypertension"
+      "heart conditions",
+      "maois"
     ],
     "sideeffects": [
-      "increased heart rate"
+      "nausea",
+      "dependency"
     ],
     "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": ">500 mg/kg (mice)",
+    "toxicity": "Moderate",
+    "toxicity_ld50": ">200 mg/kg (rats, mitragynine)",
     "tags": [
-      "☕ brewable"
+      "⚠️ use caution",
+      "🍃 leaf"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -8961,6 +7000,97 @@
     "sources": []
   },
   {
+    "id": "monotropa-uniflora",
+    "slug": "monotropa-uniflora",
+    "common": "",
+    "scientific": "Monotropa uniflora",
+    "category": "dissociative / sedative",
+    "subcategory": "",
+    "intensity": "Mild",
+    "region": "temperate forests of north america and asia",
+    "legalstatus": "Legal (but rare and protected in places)",
+    "schedule": "",
+    "description": "a ghostly white forest plant used in native american medicine for pain and spiritual insight. non-photosynthetic and mysterious.",
+    "effects": "Analgesia;calm;emotional detachment",
+    "mechanism": "Contains monotropin; acts possibly on NMDA or opioid systems (hypothetical)",
+    "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "pain relief, emotional trauma support (traditional)",
+    "interactions": [
+      "possibly cns depressants"
+    ],
+    "contraindications": [
+      "unknown",
+      "limited modern use"
+    ],
+    "sideeffects": [
+      "unknown at pharmacological doses",
+      "rare usage"
+    ],
+    "safety": "",
+    "toxicity": "",
+    "toxicity_ld50": "Not established",
+    "tags": [
+      "🌲 pain relief",
+      "👻 ghost plant",
+      "🧠 emotional"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
+  },
+  {
+    "id": "leonurus-cardiaca",
+    "slug": "motherwort",
+    "common": "Motherwort",
+    "scientific": "Leonurus cardiaca",
+    "category": "cardiotonic / nervine / women’s health",
+    "subcategory": "",
+    "intensity": "Mild",
+    "region": "europe, north america, asia",
+    "legalstatus": "Legal worldwide",
+    "schedule": "",
+    "description": "a traditional european nervine used to ease tension, heart flutter, and menstrual discomfort. known as ‘mother’s herb’ for its supportive effects during emotional distress and hormonal fluctuations.",
+    "effects": "Calms heart palpitations;Reduces anxiety;Uterine tonic;Regulates menstrual tension",
+    "mechanism": "Alkaloids such as leonurine and stachydrine provide mild sedative, antispasmodic, and cardiotonic effects, possibly modulating GABA and muscarinic pathways.",
+    "compounds": [
+      "Leonurine",
+      "Stachydrine"
+    ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for pms, menopause, anxiety, nervous heart conditions, and postpartum recovery. may support vagal tone and reduce sympathetic overdrive.",
+    "interactions": [
+      "caution with heart medications or sedatives."
+    ],
+    "contraindications": [
+      "avoid in pregnancy (uterine stimulant). may slightly lower blood pressure."
+    ],
+    "sideeffects": [
+      "bitter taste",
+      "possible drowsiness or stomach upset in some. generally well tolerated."
+    ],
+    "safety": "",
+    "toxicity": "Low. Used widely in folk medicine.",
+    "toxicity_ld50": "Not established in humans",
+    "tags": [
+      "🫀 heart support",
+      "🌸 women’s health",
+      "🧘 nervine",
+      "🌿 bitter tonic"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8762752/",
+      "Herbal Medicine – Mills & Bone",
+      "British Herbal Compendium"
+    ]
+  },
+  {
     "id": "mucuna-pruriens",
     "slug": "mucuna-pruriens",
     "common": "",
@@ -9007,150 +7137,77 @@
     ]
   },
   {
-    "id": "mucuna-pruriens",
-    "slug": "mucuna-pruriens",
-    "common": "",
-    "scientific": "Mucuna pruriens",
-    "category": "stimulant / nootropic",
+    "id": "byrsonima-crassifolia",
+    "slug": "nance",
+    "common": "Nance",
+    "scientific": "",
+    "category": "sedative",
     "subcategory": "",
-    "intensity": "Moderate",
-    "region": "tropical asia and africa",
-    "legalstatus": "Legal",
+    "intensity": "",
+    "region": "central and south america",
+    "legalstatus": "",
     "schedule": "",
-    "description": "also called velvet bean; boosts dopamine and serves as a traditional tonic in ayurvedic practice.",
-    "effects": "increased motivation;energy;elevated mood",
-    "mechanism": "Seeds contain L‑DOPA which increases brain dopamine levels",
-    "compounds": [],
+    "description": "",
+    "effects": "mild sedative;calming;tonic",
+    "mechanism": "Flavonoid antioxidant and neuroprotective action",
+    "compounds": [
+      "Catechins",
+      "Quercetin"
+    ],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "used in ayurveda for parkinson's disease, mood disorders and vitality",
-    "interactions": [
-      "avoid with maois or dopamine medications"
-    ],
-    "contraindications": [
-      "psychosis",
-      "concurrent l‑dopa medication"
-    ],
-    "sideeffects": [
-      "nausea or headache with excessive intake"
-    ],
+    "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "toxicity": "Generally safe at typical doses; high doses may cause nausea",
-    "toxicity_ld50": ">6 g/kg in rodents",
+    "toxicity": "",
+    "toxicity_ld50": "",
     "tags": [
-      "ayurveda",
-      "dopamine",
-      "velvet bean"
+      "sedative",
+      "folk",
+      "antioxidant"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4213965/",
-      "Journal of Traditional and Complementary Medicine",
-      "2015",
-      "Ayurvedic Materia Medica"
-    ]
+    "sources": []
   },
   {
-    "id": "myristica-fragrans",
-    "slug": "nutmeg",
-    "common": "Nutmeg",
-    "scientific": "Myristica fragrans",
-    "category": "ritual / visionary",
+    "id": "tropaeolum-majus",
+    "slug": "nasturtium",
+    "common": "Nasturtium",
+    "scientific": "",
+    "category": "stimulant",
     "subcategory": "",
-    "intensity": "Strong",
-    "region": "indonesia",
-    "legalstatus": "Legal",
+    "intensity": "",
+    "region": "south america (peru, andes)",
+    "legalstatus": "",
     "schedule": "",
-    "description": "nutmeg seeds can be psychoactive in large amounts.",
-    "effects": "Deliriant states;nausea",
-    "mechanism": "Myristicin metabolizes to MMDA-like compounds",
+    "description": "",
+    "effects": "mild stimulant;respiratory enhancer",
+    "mechanism": "Antimicrobial and expectorant, may enhance breathing clarity.",
     "compounds": [
-      "Myristicin",
-      "Elemicin"
+      "Benzyl isothiocyanate"
     ],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "rarely used therapeutically",
-    "interactions": [
-      "potential maoi interaction"
-    ],
-    "contraindications": [
-      "pregnancy",
-      "psychiatric conditions"
-    ],
-    "sideeffects": [
-      "nausea",
-      "dehydration",
-      "delirium"
-    ],
+    "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "toxicity": "High at large doses",
-    "toxicity_ld50": "Myristicin LD50 ~400 mg/kg (mouse)",
+    "toxicity": "",
+    "toxicity_ld50": "",
     "tags": [
-      "⚠️ caution",
-      "🌿 seed",
-      "🧪 phenethylamine"
+      "stimulant",
+      "respiratory",
+      "folk"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3457357/",
-      "Plants of the Gods – Rätsch",
-      "Toxicology of Spices – 2012"
-    ]
-  },
-  {
-    "id": "myristica-fragrans",
-    "slug": "nutmeg",
-    "common": "Nutmeg",
-    "scientific": "Myristica fragrans",
-    "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Strong",
-    "region": "indonesia",
-    "legalstatus": "Legal",
-    "schedule": "",
-    "description": "nutmeg seeds can be psychoactive in large amounts.",
-    "effects": "Deliriant states;nausea",
-    "mechanism": "Myristicin metabolizes to MMDA-like compounds",
-    "compounds": [
-      "Myristicin",
-      "Elemicin"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "rarely used therapeutically",
-    "interactions": [
-      "potential maoi interaction"
-    ],
-    "contraindications": [
-      "pregnancy",
-      "psychiatric conditions"
-    ],
-    "sideeffects": [
-      "nausea",
-      "dehydration",
-      "delirium"
-    ],
-    "safety": "",
-    "toxicity": "High at large doses",
-    "toxicity_ld50": "Myristicin LD50 ~400 mg/kg (mouse)",
-    "tags": [
-      "⚠️ caution",
-      "🌿 seed",
-      "🧪 phenethylamine"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3457357/",
-      "Plants of the Gods – Rätsch",
-      "Toxicology of Spices – 2012"
-    ]
+    "sources": []
   },
   {
     "id": "nelumbo-lutea",
@@ -9200,198 +7257,6 @@
     ]
   },
   {
-    "id": "nelumbo-nucifera",
-    "slug": "sacred-lotus",
-    "common": "Sacred Lotus",
-    "scientific": "Nelumbo nucifera",
-    "category": "oneirogen",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "india, china, southeast asia",
-    "legalstatus": "Legal",
-    "schedule": "",
-    "description": "sacred lotus revered for tranquil, mildly euphoric properties.",
-    "effects": "Relaxation;dream enhancement;calm euphoria",
-    "mechanism": "Dopamine receptor agonism (aporphine alkaloids)",
-    "compounds": [
-      "Nuciferine",
-      "Neferine"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "calm, aphrodisiac, meditation support",
-    "interactions": [
-      "avoid cns depressants"
-    ],
-    "contraindications": [
-      "sedatives",
-      "pregnancy"
-    ],
-    "sideeffects": [
-      "sedation",
-      "mild dizziness"
-    ],
-    "safety": "1",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
-    "tags": [
-      "✅ safe",
-      "🌸 calm",
-      "🧘 meditation"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7442399/",
-      "Ayurvedic Herbal Compendium",
-      "Chinese Pharmacopoeia"
-    ]
-  },
-  {
-    "id": "nepeta-cataria",
-    "slug": "catnip",
-    "common": "Catnip",
-    "scientific": "Nepeta cataria",
-    "category": "nervine / mild sedative / folk remedy",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "europe, north america",
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "description": "best known for its effects on cats, catnip is also a gentle human nervine herb traditionally used for digestion, colds, and sleep. it has a subtle calming effect and is often included in herbal teas.",
-    "effects": "Relaxation;Mild euphoria;Digestive aid;Sleep support",
-    "mechanism": "Nepetalactone interacts with GABAergic and opioid pathways in humans. Also antispasmodic and diaphoretic.",
-    "compounds": [
-      "Nepetalactone"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for anxiety, insomnia, indigestion, fever, and colic. also a mild menstrual relaxant.",
-    "interactions": [
-      "may interact with sedatives or barbiturates."
-    ],
-    "contraindications": [
-      "avoid during pregnancy (stimulates uterus). not recommended before operating machinery."
-    ],
-    "sideeffects": [
-      "mild drowsiness or stomach upset. rare allergic reaction."
-    ],
-    "safety": "",
-    "toxicity": "Very low. Safe in tea form at moderate doses.",
-    "toxicity_ld50": ">3000 mg/kg (rats, oral)",
-    "tags": [
-      "🐱 cat herb",
-      "🧘 calm",
-      "🫖 tea",
-      "🌿 folk medicine"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3612440/",
-      "Herbal Medicine – Mills & Bone",
-      "Materia Medica – David Hoffman"
-    ]
-  },
-  {
-    "id": "nicotiana-rustica",
-    "slug": "aztec-tobacco",
-    "common": "Aztec Tobacco",
-    "scientific": "Nicotiana rustica",
-    "category": "stimulant / ritual",
-    "subcategory": "",
-    "intensity": "Strong",
-    "region": "south america and worldwide cultivation",
-    "legalstatus": "Legal but regulated like tobacco",
-    "schedule": "",
-    "description": "potent tobacco species used ceremonially in the amazon, far stronger than common n. tabacum.",
-    "effects": "alertness;intense buzz;clearing of thoughts",
-    "mechanism": "High nicotine plus MAO‑inhibiting beta‑carbolines stimulate nicotinic receptors and inhibit MAO",
-    "compounds": [
-      "Nicotine",
-      "Harmala alkaloids"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used by amazonian shamans for cleansing and focus",
-    "interactions": [
-      "strongly potentiated by maois",
-      "interacts with many medications"
-    ],
-    "contraindications": [
-      "heart disease",
-      "pregnancy",
-      "hypertension"
-    ],
-    "sideeffects": [
-      "nausea",
-      "increased heart rate",
-      "dizziness"
-    ],
-    "safety": "",
-    "toxicity": "High nicotine content can be poisonous in large amounts",
-    "toxicity_ld50": "Nicotine LD50 ~50 mg/kg (mouse)",
-    "tags": [
-      "mapacho",
-      "nicotine",
-      "tobacco"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "nicotiana-rustica",
-    "slug": "aztec-tobacco",
-    "common": "Aztec Tobacco",
-    "scientific": "Nicotiana rustica",
-    "category": "stimulant / ritual",
-    "subcategory": "",
-    "intensity": "Strong",
-    "region": "south america and worldwide cultivation",
-    "legalstatus": "Legal but regulated like tobacco",
-    "schedule": "",
-    "description": "potent tobacco species used ceremonially in the amazon, far stronger than common n. tabacum.",
-    "effects": "alertness;intense buzz;clearing of thoughts",
-    "mechanism": "High nicotine plus MAO‑inhibiting beta‑carbolines stimulate nicotinic receptors and inhibit MAO",
-    "compounds": [
-      "Nicotine",
-      "Harmala alkaloids"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used by amazonian shamans for cleansing and focus",
-    "interactions": [
-      "strongly potentiated by maois",
-      "interacts with many medications"
-    ],
-    "contraindications": [
-      "heart disease",
-      "pregnancy",
-      "hypertension"
-    ],
-    "sideeffects": [
-      "nausea",
-      "increased heart rate",
-      "dizziness"
-    ],
-    "safety": "",
-    "toxicity": "High nicotine content can be poisonous in large amounts",
-    "toxicity_ld50": "Nicotine LD50 ~50 mg/kg (mouse)",
-    "tags": [
-      "mapacho",
-      "nicotine",
-      "tobacco"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
     "id": "nicotiana-tabacum",
     "slug": "nicotiana-tabacum",
     "common": "",
@@ -9426,6 +7291,97 @@
     "tags": [
       "⚠️ addictive",
       "🚬 smoke"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
+  },
+  {
+    "id": "myristica-fragrans",
+    "slug": "nutmeg",
+    "common": "Nutmeg",
+    "scientific": "Myristica fragrans",
+    "category": "ritual / visionary",
+    "subcategory": "",
+    "intensity": "Strong",
+    "region": "indonesia",
+    "legalstatus": "Legal",
+    "schedule": "",
+    "description": "nutmeg seeds can be psychoactive in large amounts.",
+    "effects": "Deliriant states;nausea",
+    "mechanism": "Myristicin metabolizes to MMDA-like compounds",
+    "compounds": [
+      "Myristicin",
+      "Elemicin"
+    ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "rarely used therapeutically",
+    "interactions": [
+      "potential maoi interaction"
+    ],
+    "contraindications": [
+      "pregnancy",
+      "psychiatric conditions"
+    ],
+    "sideeffects": [
+      "nausea",
+      "dehydration",
+      "delirium"
+    ],
+    "safety": "",
+    "toxicity": "High at large doses",
+    "toxicity_ld50": "Myristicin LD50 ~400 mg/kg (mouse)",
+    "tags": [
+      "⚠️ caution",
+      "🌿 seed",
+      "🧪 phenethylamine"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3457357/",
+      "Plants of the Gods – Rätsch",
+      "Toxicology of Spices – 2012"
+    ]
+  },
+  {
+    "id": "white-lily",
+    "slug": "nymphaea-ampla",
+    "common": "",
+    "scientific": "Nymphaea ampla",
+    "category": "oneirogen",
+    "subcategory": "",
+    "intensity": "Mild",
+    "region": "mexico, central america",
+    "legalstatus": "Legal",
+    "schedule": "",
+    "description": "related to blue lotus, this sacred flower from mesoamerican traditions is used to promote meditation and lucid dreaming.",
+    "effects": "Calm;light sedation;dream potentiation",
+    "mechanism": "Contains aporphine alkaloids (dopamine agonist)",
+    "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "relaxation, aphrodisiac, dream enhancement",
+    "interactions": [
+      "avoid cns depressants"
+    ],
+    "contraindications": [
+      "pregnancy"
+    ],
+    "sideeffects": [
+      "drowsiness",
+      "vivid dreams"
+    ],
+    "safety": "",
+    "toxicity": "Low",
+    "toxicity_ld50": "Not established",
+    "tags": [
+      "✅ safe",
+      "🌸 calm",
+      "🌿 sedative"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -9605,6 +7561,88 @@
     ]
   },
   {
+    "id": "panax-ginseng",
+    "slug": "panax-ginseng",
+    "common": "",
+    "scientific": "Panax ginseng",
+    "category": "empathogen / euphoriant",
+    "subcategory": "",
+    "intensity": "",
+    "region": "asia",
+    "legalstatus": "Legal",
+    "schedule": "",
+    "description": "classic tonic herb for stamina and cognition.",
+    "effects": "vitality;adaptogen",
+    "mechanism": "Ginsenosides modulate HPA axis and nitric oxide pathways",
+    "compounds": [],
+    "preparations": [],
+    "dosage": "1–2 g dried root",
+    "therapeutic": "energy, immune support",
+    "interactions": [
+      "stimulants",
+      "anticoagulants"
+    ],
+    "contraindications": [
+      "hypertension"
+    ],
+    "sideeffects": [
+      "headache",
+      "insomnia"
+    ],
+    "safety": "",
+    "toxicity": "Low",
+    "toxicity_ld50": ">2000 mg/kg (rats)",
+    "tags": [
+      "🌿 root",
+      "💊 oral"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
+  },
+  {
+    "id": "panax-quinquefolius",
+    "slug": "panax-quinquefolius",
+    "common": "",
+    "scientific": "Panax quinquefolius",
+    "category": "empathogen / euphoriant",
+    "subcategory": "",
+    "intensity": "",
+    "region": "north america",
+    "legalstatus": "Legal",
+    "schedule": "",
+    "description": "north american species prized for restorative effects.",
+    "effects": "calm energy",
+    "mechanism": "Similar ginsenosides modulate neurotransmitters",
+    "compounds": [],
+    "preparations": [],
+    "dosage": "1–3 g dried root",
+    "therapeutic": "energy, stress relief",
+    "interactions": [
+      "stimulants",
+      "anticoagulants"
+    ],
+    "contraindications": [
+      "hypertension"
+    ],
+    "sideeffects": [
+      "headache",
+      "insomnia"
+    ],
+    "safety": "",
+    "toxicity": "Low",
+    "toxicity_ld50": ">2000 mg/kg (rats)",
+    "tags": [
+      "🌿 root",
+      "💊 oral"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
+  },
+  {
     "id": "papaver-somniferum",
     "slug": "papaver-somniferum",
     "common": "",
@@ -9654,7 +7692,7 @@
     "category": "nervine / anxiolytic / sleep",
     "subcategory": "",
     "intensity": "Mild–Moderate",
-    "region": "north america, central america",
+    "region": "southeastern u.s., latin america",
     "legalstatus": "Legal worldwide",
     "schedule": "",
     "description": "a beautiful climbing flower used to calm restlessness, anxiety, and insomnia. native to the southeastern u.s., passionflower is valued for its non-habit-forming, gently sedative qualities.",
@@ -9667,26 +7705,34 @@
     "interactions": [
       "may potentiate benzodiazepines",
       "opioids",
-      "and alcohol."
+      "and alcohol.",
+      "cns depressants",
+      "maois"
     ],
     "contraindications": [
       "avoid with strong sedatives",
       "barbiturates",
-      "or pregnancy (uterine relaxant)."
+      "or pregnancy (uterine relaxant).",
+      "pregnancy",
+      "cns depressants"
     ],
     "sideeffects": [
       "drowsiness",
       "vivid dreams",
-      "or mild nausea. rare allergic reactions."
+      "or mild nausea. rare allergic reactions.",
+      "dizziness"
     ],
-    "safety": "",
+    "safety": "1",
     "toxicity": "Very low. Safe in therapeutic range.",
     "toxicity_ld50": ">3000 mg/kg (mice, oral)",
     "tags": [
       "🛌 sleep",
       "🧘 anti-anxiety",
       "🌸 sedative",
-      "🌿 nervine"
+      "🌿 nervine",
+      "✅ safe",
+      "🌿 sedative",
+      "🧘 calm"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -9696,49 +7742,6 @@
       "ESCOP Monograph – Passiflora",
       "Herbal Medicine – Mills & Bone"
     ]
-  },
-  {
-    "id": "passionflower",
-    "slug": "passiflora-incarnata",
-    "common": "",
-    "scientific": "Passiflora incarnata",
-    "category": "dissociative / sedative",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "southeastern u.s., latin america",
-    "legalstatus": "Legal",
-    "schedule": "",
-    "description": "climbing vine traditionally brewed for anxiety relief and restful sleep.",
-    "effects": "Relaxation;mild sedation;anxiolytic",
-    "mechanism": "GABAergic (modulation of GABA_A receptors), mild MAOI",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "anxiety, insomnia, nervous restlessness",
-    "interactions": [
-      "cns depressants",
-      "maois"
-    ],
-    "contraindications": [
-      "pregnancy",
-      "cns depressants"
-    ],
-    "sideeffects": [
-      "drowsiness",
-      "dizziness"
-    ],
-    "safety": "1",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
-    "tags": [
-      "✅ safe",
-      "🌿 sedative",
-      "🧘 calm"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
   },
   {
     "id": "paullinia-cupana",
@@ -9759,27 +7762,35 @@
     "dosage": "",
     "therapeutic": "used for fatigue, cognitive performance, mild depression, sexual energy, and metabolism enhancement.",
     "interactions": [
+      "potentiates other stimulants",
+      "may interfere with sedatives",
       "synergistic with other stimulants",
       "avoid with maois",
       "ssris",
       "or cardiac drugs."
     ],
     "contraindications": [
+      "heart problems",
+      "pregnancy",
+      "sensitivity to caffeine.",
       "avoid in anxiety",
       "hypertension",
-      "pregnancy",
       "or with other stimulants."
     ],
     "sideeffects": [
+      "jitteriness",
+      "stomach upset",
       "restlessness",
       "insomnia",
       "irritability",
       "or digestive upset in sensitive individuals."
     ],
     "safety": "",
-    "toxicity": "Moderate at high doses. Caffeine overdose is possible.",
+    "toxicity": "Overuse leads to restlessness, insomnia, or tachycardia.",
     "toxicity_ld50": "Caffeine LD50 ~192 mg/kg (humans)",
     "tags": [
+      "☕ high caffeine",
+      "🍫 seed",
       "⚡ stimulant",
       "🧠 focus",
       "🌿 amazonian",
@@ -9862,29 +7873,38 @@
       "dangerous with ssris",
       "maois",
       "stimulants",
-      "or antihypertensives."
+      "or antihypertensives.",
+      "interacts with stimulants and antihypertensives"
     ],
     "contraindications": [
       "avoid in heart conditions",
       "anxiety",
       "schizophrenia",
-      "or with stimulants. not for use in pregnancy."
+      "or with stimulants. not for use in pregnancy.",
+      "heart disease",
+      "anxiety disorders",
+      "maois."
     ],
     "sideeffects": [
       "anxiety",
       "increased heart rate",
       "elevated blood pressure",
       "tremors",
-      "irritability. high doses can cause panic or heart issues."
+      "irritability. high doses can cause panic or heart issues.",
+      "increased blood pressure",
+      "jitteriness",
+      "insomnia"
     ],
     "safety": "",
-    "toxicity": "Moderate to high. Narrow therapeutic index.",
-    "toxicity_ld50": "~50 mg/kg (rats, oral)",
+    "toxicity": "High doses cause anxiety, hypertension, or hallucinations.",
+    "toxicity_ld50": "LD50 ~50 mg/kg (rats, yohimbine)",
     "tags": [
       "🔥 aphrodisiac",
       "⚠️ stimulant",
       "🫀 blood flow",
-      "🌿 traditional african"
+      "🌿 traditional african",
+      "🌳 bark",
+      "🔥 libido"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -9895,49 +7915,6 @@
       "International Journal of Impotence Research",
       "2002"
     ]
-  },
-  {
-    "id": "pausinystalia-johimbe",
-    "slug": "pausinystalia-johimbe",
-    "common": "",
-    "scientific": "Pausinystalia johimbe",
-    "category": "stimulant / aphrodisiac",
-    "subcategory": "",
-    "intensity": "Moderate",
-    "region": "west africa",
-    "legalstatus": "Restricted or prescription in some countries",
-    "schedule": "",
-    "description": "west african tree bark rich in yohimbine, historically used as an aphrodisiac and stimulant.",
-    "effects": "Stimulation;increased libido;elevated heart rate",
-    "mechanism": "Yohimbine blocks alpha-2 adrenergic receptors leading to increased norepinephrine release.",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for erectile dysfunction and as a stimulant.",
-    "interactions": [
-      "interacts with stimulants and antihypertensives"
-    ],
-    "contraindications": [
-      "heart disease",
-      "anxiety disorders",
-      "maois."
-    ],
-    "sideeffects": [
-      "increased blood pressure",
-      "jitteriness",
-      "insomnia"
-    ],
-    "safety": "",
-    "toxicity": "High doses cause anxiety, hypertension, or hallucinations.",
-    "toxicity_ld50": "LD50 ~50 mg/kg (rats, yohimbine)",
-    "tags": [
-      "🌳 bark",
-      "🔥 libido"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
   },
   {
     "id": "pausinystalia-yohimbe",
@@ -10003,7 +7980,8 @@
     "dosage": "",
     "therapeutic": "traditionally used for depression, spiritual ritual, antiparasitic cleansing, and as a potentiator of dmt-containing plants.",
     "interactions": [
-      "strong interaction with serotonergic drugs. serotonin syndrome risk."
+      "strong interaction with serotonergic drugs. serotonin syndrome risk.",
+      "dangerous with other maois or serotonergic drugs"
     ],
     "contraindications": [
       "avoid with ssris",
@@ -10011,23 +7989,27 @@
       "stimulants",
       "tyramine-rich foods",
       "psychiatric meds",
-      "pregnancy."
+      "pregnancy.",
+      "or liver disease."
     ],
     "sideeffects": [
       "nausea",
       "vomiting",
       "dizziness",
       "tremors",
-      "anxiety. strong purgative effect possible. tyramine reaction risk."
+      "anxiety. strong purgative effect possible. tyramine reaction risk.",
+      "weakness"
     ],
     "safety": "",
     "toxicity": "Moderate–High. Purified alkaloids more dangerous than seed prep.",
-    "toxicity_ld50": "~370 mg/kg (harmaline, mice, IP)",
+    "toxicity_ld50": "LD50 ~150 mg/kg (harmaline, mice)",
     "tags": [
       "🧠 maoi",
       "🌌 entheogen",
       "🌿 traditional",
-      "🌙 dreams"
+      "🌙 dreams",
+      "⚠️ maoi",
+      "🌿 seeds"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -10038,49 +8020,6 @@
       "Journal of Ethnopharmacology",
       "1997"
     ]
-  },
-  {
-    "id": "peganum-harmala",
-    "slug": "peganum-harmala",
-    "common": "",
-    "scientific": "Peganum harmala",
-    "category": "ritual / maoi",
-    "subcategory": "",
-    "intensity": "Moderate",
-    "region": "middle east, central asia",
-    "legalstatus": "Restricted in some countries",
-    "schedule": "",
-    "description": "potent maoi seed used traditionally for protection and divination.",
-    "effects": "MAOI effects;mild hallucinations;dream enhancement",
-    "mechanism": "Harmala alkaloids reversibly inhibit MAO-A and MAO-B.",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used in middle eastern rituals; sometimes combined with dmt for oral activity.",
-    "interactions": [
-      "dangerous with other maois or serotonergic drugs"
-    ],
-    "contraindications": [
-      "avoid with ssris",
-      "stimulants",
-      "or liver disease."
-    ],
-    "sideeffects": [
-      "nausea",
-      "vomiting",
-      "weakness"
-    ],
-    "safety": "",
-    "toxicity": "High doses cause nausea, tremors, or hallucinations.",
-    "toxicity_ld50": "LD50 ~150 mg/kg (harmaline, mice)",
-    "tags": [
-      "⚠️ maoi",
-      "🌿 seeds"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
   },
   {
     "id": "perilla-frutescens",
@@ -10120,93 +8059,6 @@
     "sources": []
   },
   {
-    "id": "echinopsis-peruviana",
-    "slug": "echinopsis-peruviana",
-    "common": "",
-    "scientific": "Echinopsis peruviana",
-    "category": "psychedelic",
-    "subcategory": "",
-    "intensity": "",
-    "region": "andes",
-    "legalstatus": "Cactus legal; mescaline controlled",
-    "schedule": "",
-    "description": "cactus rich in mescaline similar to san pedro.",
-    "effects": "visions;empathy",
-    "mechanism": "Mescaline acts as a 5-HT2A agonist",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "20–30 cm fresh cactus",
-    "therapeutic": "spiritual insight",
-    "interactions": [
-      "maois",
-      "stimulants"
-    ],
-    "contraindications": [
-      "heart issues",
-      "pregnancy"
-    ],
-    "sideeffects": [
-      "nausea",
-      "dilated pupils"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": ">1 g/kg (rats)",
-    "tags": [
-      "🌀 visionary",
-      "🌵 cactus"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "petasites-hybridus",
-    "slug": "butterbur",
-    "common": "Butterbur",
-    "scientific": "Petasites hybridus",
-    "category": "dissociative / sedative",
-    "subcategory": "",
-    "intensity": "Mild to moderate",
-    "region": "europe, asia",
-    "legalstatus": "Legal with restrictions (PA-free only)",
-    "schedule": "",
-    "description": "also known as butterbur, this european root was historically used as a remedy for migraines and spasms. contains pyrrolizidine alkaloids, so safe extracts must be purified.",
-    "effects": "Relaxation;muscle relief;headache reduction",
-    "mechanism": "Antispasmodic and anti-inflammatory effects; calcium channel modulation",
-    "compounds": [
-      "Petasin",
-      "Isopetasin"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "migraine prevention, allergies, anxiety",
-    "interactions": [
-      "avoid hepatotoxic meds"
-    ],
-    "contraindications": [
-      "liver conditions",
-      "pregnancy",
-      "raw extract use"
-    ],
-    "sideeffects": [
-      "liver toxicity risk from unpurified products"
-    ],
-    "safety": "",
-    "toxicity": "Moderate to high (raw plant)",
-    "toxicity_ld50": "~950 mg/kg (mouse, oral, unpurified)",
-    "tags": [
-      "⚠️ pa toxins",
-      "🌿 herbal",
-      "🧠 headache"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
     "id": "peumus-boldus",
     "slug": "peumus-boldus",
     "common": "",
@@ -10237,43 +8089,6 @@
       "digestive",
       "sleep aid",
       "folk medicine"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "pimenta-dioica",
-    "slug": "allspice",
-    "common": "Allspice",
-    "scientific": "Pimenta dioica",
-    "category": "ethnobotanical",
-    "subcategory": "",
-    "intensity": "",
-    "region": "caribbean, central america",
-    "legalstatus": "",
-    "schedule": "",
-    "description": "also known as allspice, this caribbean plant has mild uplifting and warming effects, sometimes used in ritual incense.",
-    "effects": "stimulant;aromatic euphoria;warming",
-    "mechanism": "GABAergic + serotonergic",
-    "compounds": [
-      "Eugenol",
-      "Quercetin"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
-    "toxicity_ld50": "",
-    "tags": [
-      "aromatic",
-      "ritual",
-      "mild stimulant"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -10330,40 +8145,49 @@
     ]
   },
   {
-    "id": "piper-methysticum",
+    "id": "kava",
     "slug": "piper-methysticum",
     "common": "",
     "scientific": "Piper methysticum",
     "category": "dissociative / sedative",
     "subcategory": "",
-    "intensity": "Moderate",
-    "region": "pacific islands",
-    "legalstatus": "Regulated in some countries",
+    "intensity": "Mild to moderate",
+    "region": "polynesia, micronesia, melanesia",
+    "legalstatus": "Legal; restricted in some EU countries",
     "schedule": "",
-    "description": "kava root beverage with calming properties.",
-    "effects": "Anxiolytic;sedation",
-    "mechanism": "Kavalactones modulate GABA receptors",
+    "description": "south pacific root brew known for its relaxing and anxiolytic effects.",
+    "effects": "Relaxation;social ease;mild euphoria",
+    "mechanism": "Kavalactones modulate GABA, block sodium and calcium channels",
     "compounds": [],
     "preparations": [],
     "dosage": "",
     "therapeutic": "anxiety relief, social relaxation",
     "interactions": [
+      "cns depressants",
+      "alcohol",
+      "liver-metabolized drugs",
       "potentiates sedatives and alcohol"
     ],
     "contraindications": [
+      "liver conditions",
+      "alcohol",
+      "sedatives",
       "liver disease",
       "heavy alcohol use"
     ],
     "sideeffects": [
+      "liver strain (rare)",
       "drowsiness",
       "potential hepatotoxicity"
     ],
-    "safety": "",
-    "toxicity": "Moderate",
+    "safety": "2",
+    "toxicity": "Low to moderate; caution with prolonged use",
     "toxicity_ld50": "Kavain LD50 ~920 mg/kg (mouse)",
     "tags": [
-      "⚠️ caution",
       "🌿 root",
+      "🍵 social",
+      "🧘 calm",
+      "⚠️ caution",
       "💤 sedation"
     ],
     "regiontags": [],
@@ -10375,6 +8199,45 @@
       "Journal of Clinical Psychopharmacology",
       "2013"
     ]
+  },
+  {
+    "id": "plectranthus-scutellarioides",
+    "slug": "plectranthus-scutellarioides",
+    "common": "",
+    "scientific": "Plectranthus scutellarioides",
+    "category": "psychedelic / ornamental",
+    "subcategory": "",
+    "intensity": "Mild",
+    "region": "tropical asia",
+    "legalstatus": "Legal",
+    "schedule": "",
+    "description": "",
+    "effects": "mild visuals;color enhancement;relaxation",
+    "mechanism": "Unclear; may act on serotonergic pathways",
+    "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "rarely used; some folk use for divination",
+    "interactions": [],
+    "contraindications": [
+      "none known"
+    ],
+    "sideeffects": [
+      "headache",
+      "nausea at high doses"
+    ],
+    "safety": "",
+    "toxicity": "Low",
+    "toxicity_ld50": "Not established",
+    "tags": [
+      "lamiaceae",
+      "painted nettle",
+      "visionary"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
   },
   {
     "id": "pogostemon-cablin",
@@ -10579,6 +8442,66 @@
     "sources": []
   },
   {
+    "id": "chacruna",
+    "slug": "psychotria-viridis",
+    "common": "",
+    "scientific": "Psychotria viridis",
+    "category": "entheogen / dmt source / shamanic",
+    "subcategory": "",
+    "intensity": "Strong",
+    "region": "amazon basin (peru, brazil, colombia)",
+    "legalstatus": "Restricted in many countries due to DMT",
+    "schedule": "",
+    "description": "a tropical shrub from the amazon traditionally used in ayahuasca brews. its leaves contain high concentrations of n,n-dmt, making it a primary admixture plant in visionary ceremonies.",
+    "effects": "Psychedelic visions;Emotional processing;Spiritual insight;Sensory enhancement",
+    "mechanism": "Contains N,N-DMT, a potent serotonergic psychedelic that acts as a 5-HT2A receptor agonist. Requires MAOI (such as harmala alkaloids) to be orally active.",
+    "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used in traditional amazonian healing for soul retrieval, trauma, depression, and spiritual communion. western research suggests benefit in mental health and addiction therapy.",
+    "interactions": [
+      "dangerous with antidepressants or stimulants",
+      "dangerous with serotonergic drugs. do not combine with other psychedelics unless experienced."
+    ],
+    "contraindications": [
+      "mental health disorders",
+      "ssris",
+      "maois",
+      "avoid with ssris",
+      "antipsychotics",
+      "or in those with severe psychiatric conditions."
+    ],
+    "sideeffects": [
+      "intense visuals",
+      "vomiting",
+      "nausea",
+      "vomiting (purging)",
+      "anxiety",
+      "dissociation. can be intense or destabilizing in unprepared individuals."
+    ],
+    "safety": "",
+    "toxicity": "Low at standard doses. Risk increases with improper preparation or interaction.",
+    "toxicity_ld50": "Not established in humans",
+    "tags": [
+      "⚠️ caution",
+      "🧠 vision",
+      "🧪 dmt",
+      "🌀 dmt source",
+      "🌿 ayahuasca",
+      "🌌 visionary",
+      "⚠️ maoi required"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7343898/",
+      "Plants of the Gods – Rätsch",
+      "Journal of Ethnopharmacology",
+      "2010"
+    ]
+  },
+  {
     "id": "ptychopetalum-olacoides",
     "slug": "ptychopetalum-olacoides",
     "common": "",
@@ -10619,78 +8542,42 @@
     "sources": []
   },
   {
-    "id": "reishi-mushroom",
-    "slug": "ganoderma-lucidum",
+    "id": "anemone-pulsatilla",
+    "slug": "pulsatilla-vulgaris",
     "common": "",
-    "scientific": "Ganoderma lucidum",
-    "category": "other",
+    "scientific": "Pulsatilla vulgaris",
+    "category": "sedative / analgesic",
     "subcategory": "",
     "intensity": "Mild",
-    "region": "🇨🇳 east asia",
-    "legalstatus": "Legal / Unregulated",
+    "region": "europe and western asia",
+    "legalstatus": "Legal but not widely sold",
     "schedule": "",
-    "description": "tonic fungus revered in asia for boosting immunity and easing stress.",
-    "effects": "Immune support;calm focus",
-    "mechanism": "Triterpenoids and beta-glucans modulate immune response.",
+    "description": "also called pasque flower; once used by herbalists for calming nerves and relieving pain.",
+    "effects": "calm;pain relief;mild altered awareness",
+    "mechanism": "Contains lactones derived from protoanemonin that depress the central nervous system",
     "compounds": [],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "immune enhancement, stress resilience, antioxidant.",
+    "therapeutic": "european folk remedy for anxiety, insomnia and menstrual pain",
     "interactions": [
-      "anticoagulants",
-      "immunosuppressants."
+      "may potentiate other sedatives or analgesics"
     ],
     "contraindications": [
-      "bleeding disorders",
-      "surgery."
+      "pregnancy",
+      "open wounds",
+      "large doses"
     ],
     "sideeffects": [
-      "rare digestive upset or rash."
+      "nausea",
+      "stomach irritation if taken fresh"
     ],
-    "safety": "1",
-    "toxicity": "Very low toxicity; widely consumed as tonic.",
-    "toxicity_ld50": "Not established; safe in traditional use.",
-    "tags": [
-      "\\u2615 brewable",
-      "\\ud83e\\udde0 cognitive",
-      "\\u2705 safe"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "rhododendron-anthopogon",
-    "slug": "anthopogon",
-    "common": "Anthopogon",
-    "scientific": "",
-    "category": "",
-    "subcategory": "",
-    "intensity": "",
-    "region": "himalayas",
-    "legalstatus": "",
-    "schedule": "",
-    "description": "",
-    "effects": "uplifting;clarity;spiritual aid",
-    "mechanism": "Aromatherapeutic and cognitive modulation via essential oils",
-    "compounds": [
-      "Flavonoids",
-      "Volatile oils"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
     "safety": "",
-    "toxicity": "",
-    "toxicity_ld50": "",
+    "toxicity": "Fresh plant is irritant and toxic until dried",
+    "toxicity_ld50": "Not well established",
     "tags": [
-      "uplifting",
-      "ritual",
-      "clarity"
+      "anodyne",
+      "folk",
+      "sedative"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -10772,46 +8659,186 @@
     "sources": []
   },
   {
-    "id": "salvia-apiana",
-    "slug": "white-sage",
-    "common": "White Sage",
-    "scientific": "Salvia apiana",
-    "category": "ritual / aromatic",
+    "id": "elaeagnus-angustifolia",
+    "slug": "russian-olive",
+    "common": "Russian Olive",
+    "scientific": "",
+    "category": "sedative",
     "subcategory": "",
     "intensity": "",
-    "region": "southwestern us",
-    "legalstatus": "Legal",
+    "region": "central asia, middle east, europe",
+    "legalstatus": "",
     "schedule": "",
-    "description": "white sage revered for cleansing ceremonies",
-    "effects": "calm;clarity",
-    "mechanism": "Essential oils like cineole and thujone provide mild GABA modulation",
+    "description": "",
+    "effects": "anxiolytic;sedative;pain-relieving",
+    "mechanism": "GABAergic effects and antioxidant pathways",
     "compounds": [
-      "Cineole",
-      "Rosmarinic acid"
+      "Elaeagnin",
+      "Flavonoids"
     ],
     "preparations": [],
-    "dosage": "Smoke small bundle or 1 g in tea",
-    "therapeutic": "purification rites, relaxation",
-    "interactions": [
-      "none known"
-    ],
-    "contraindications": [
-      "pregnancy high doses"
-    ],
-    "sideeffects": [
-      "rare allergic cough"
-    ],
+    "dosage": "",
+    "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
     "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not well studied",
+    "toxicity": "",
+    "toxicity_ld50": "",
     "tags": [
-      "🌿 ritual",
-      "🪔 incense"
+      "sedative",
+      "analgesic",
+      "folk"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
     "sources": []
+  },
+  {
+    "id": "ficus-religiosa",
+    "slug": "sacred-fig",
+    "common": "Sacred Fig",
+    "scientific": "",
+    "category": "sedative",
+    "subcategory": "",
+    "intensity": "",
+    "region": "india, southeast asia",
+    "legalstatus": "",
+    "schedule": "",
+    "description": "",
+    "effects": "calming;mood-balancing;mild sedative",
+    "mechanism": "Neuroprotective antioxidant and serotonin modulation",
+    "compounds": [
+      "Furanocoumarins",
+      "Tannins"
+    ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
+    "safety": "",
+    "toxicity": "",
+    "toxicity_ld50": "",
+    "tags": [
+      "spiritual",
+      "sedative",
+      "folk"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
+  },
+  {
+    "id": "nelumbo-nucifera",
+    "slug": "nelumbo-nucifera",
+    "common": "Sacred Lotus",
+    "scientific": "Nelumbo nucifera",
+    "category": "dissociative / sedative",
+    "subcategory": "",
+    "intensity": "Mild",
+    "region": "india, china, southeast asia",
+    "legalstatus": "Legal",
+    "schedule": "",
+    "description": "sacred flower in buddhism and hinduism, with mild psychoactive and calming properties. often used in teas or tinctures.",
+    "effects": "Relaxation;dream enhancement;calm euphoria",
+    "mechanism": "Likely GABAergic and dopaminergic effects (alkaloids: nuciferine, aporphine)",
+    "compounds": [
+      "Nuciferine",
+      "Neferine"
+    ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "calm, aphrodisiac, meditation support",
+    "interactions": [
+      "sedatives",
+      "cns depressants",
+      "avoid cns depressants"
+    ],
+    "contraindications": [
+      "pregnancy (caution)",
+      "hypotension",
+      "sedatives",
+      "pregnancy"
+    ],
+    "sideeffects": [
+      "drowsiness",
+      "dizziness",
+      "sedation",
+      "mild dizziness"
+    ],
+    "safety": "1",
+    "toxicity": "Low",
+    "toxicity_ld50": "Not established",
+    "tags": [
+      "🌊 spiritual",
+      "🌸 sacred",
+      "🧘 calm",
+      "✅ safe",
+      "🌸 calm",
+      "🧘 meditation"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7442399/",
+      "Ayurvedic Herbal Compendium",
+      "Chinese Pharmacopoeia"
+    ]
+  },
+  {
+    "id": "combretum-quadrangulare",
+    "slug": "sakae-naa",
+    "common": "Sakae Naa",
+    "scientific": "Combretum quadrangulare",
+    "category": "stimulant",
+    "subcategory": "",
+    "intensity": "Mild to Moderate",
+    "region": "laos, cambodia, thailand",
+    "legalstatus": "Legal with little regulation",
+    "schedule": "",
+    "description": "often marketed as “sakae naa,” this plant is used as a mild energizing substitute for kratom.",
+    "effects": "heightened alertness;subtle euphoria;increased focus",
+    "mechanism": "Leaves contain combretol and related alkaloids acting on adrenergic systems",
+    "compounds": [
+      "Combretol",
+      "Combretin"
+    ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "traditional stimulant and tonic in laos and thailand",
+    "interactions": [
+      "may potentiate other stimulants"
+    ],
+    "contraindications": [
+      "hypertension",
+      "heart conditions"
+    ],
+    "sideeffects": [
+      "jitters",
+      "insomnia if overused"
+    ],
+    "safety": "",
+    "toxicity": "Limited data but appears low at customary doses",
+    "toxicity_ld50": "Not established",
+    "tags": [
+      "sakae naa",
+      "southeast asia",
+      "energy"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": [
+      "https://erowid.org/plants/sakae_naa/",
+      "Thai Ethnobotany Compendium",
+      "2015",
+      "Ethnopharmacology of Southeast Asia – WHO Report"
+    ]
   },
   {
     "id": "salvia-sclarea",
@@ -10844,44 +8871,6 @@
       "aromatic",
       "elevating",
       "folk remedy"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "tabernaemontana-sananho",
-    "slug": "tabernaemontana-sananho",
-    "common": "",
-    "scientific": "Tabernaemontana sananho",
-    "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "",
-    "region": "amazon",
-    "legalstatus": "Unregulated",
-    "schedule": "",
-    "description": "shamanic plant sometimes added to ayahuasca.",
-    "effects": "dream enhancement;mild stimulation",
-    "mechanism": "Iboga-type alkaloids act on NMDA and serotonin receptors",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "10–20 g root",
-    "therapeutic": "traditional spiritual healer",
-    "interactions": [
-      "maois"
-    ],
-    "contraindications": [
-      "heart conditions"
-    ],
-    "sideeffects": [
-      "nausea"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
-    "tags": [
-      "🌿 root"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -10930,51 +8919,69 @@
     "sources": []
   },
   {
-    "id": "scutellaria-lateriflora",
-    "slug": "blue-skullcap",
-    "common": "Blue Skullcap",
-    "scientific": "Scutellaria lateriflora",
-    "category": "dissociative / sedative",
+    "id": "sceletium-tortuosum",
+    "slug": "sceletium-tortuosum",
+    "common": "",
+    "scientific": "Sceletium tortuosum",
+    "category": "mood enhancer / traditional / ssri-like",
     "subcategory": "",
-    "intensity": "Mild",
-    "region": "north america",
-    "legalstatus": "Legal",
+    "intensity": "Mild to moderate",
+    "region": "south africa, namibia",
+    "legalstatus": "Legal worldwide (except select EU countries)",
     "schedule": "",
-    "description": "commonly known as skullcap, this north american herb has a long history in western herbalism for treating nervous tension and insomnia.",
-    "effects": "Mild sedation;anxiety relief;mental clarity",
-    "mechanism": "GABA_A receptor modulation (baicalin and other flavonoids)",
+    "description": "a succulent plant native to south africa, kanna has been chewed, snuffed, and brewed for centuries by khoisan peoples to ease stress, elevate mood, and promote social connection. it’s now gaining modern popularity as a legal natural serotonin booster.",
+    "effects": "Euphoria;Reduced anxiety;Social enhancement;Emotional softening",
+    "mechanism": "Contains mesembrine alkaloids that act as selective serotonin reuptake inhibitors (SSRI), PDE4 inhibitors, and mild serotonin releasing agents (SRA). Also mildly acts on dopamine.",
     "compounds": [
-      "Baicalin",
-      "Scutellarin"
+      "Mesembrine"
     ],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "anxiety, stress, insomnia, pms",
+    "therapeutic": "used for anxiety, mild depression, public speaking stress, trauma relief, and social disconnection. studied for antidepressant properties.",
     "interactions": [
-      "cns depressants",
-      "alcohol",
-      "benzodiazepines"
+      "antidepressants",
+      "serotonergic agents",
+      "potentially dangerous with other serotonergic substances (e.g.",
+      "mdma",
+      "ssris",
+      "st. john's wort)."
     ],
     "contraindications": [
-      "pregnancy",
-      "cns depressants"
+      "ssris",
+      "maois",
+      "bipolar disorder",
+      "do not combine with ssris",
+      "or serotonergic drugs (risk of serotonin syndrome). avoid during pregnancy or with bipolar disorder."
     ],
     "sideeffects": [
-      "drowsiness",
-      "dizziness at high doses"
+      "headache",
+      "nausea",
+      "serotonin syndrome (in excess or with ssris)",
+      "rare. may include dry mouth",
+      "slight sedation",
+      "or overstimulation if combined with caffeine. excessive doses may cause emotional blunting or nausea."
     ],
     "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "toxicity": "Low in traditional or moderate modern doses. No known fatalities or organ toxicity.",
+    "toxicity_ld50": "Not established (safe in traditional use)",
     "tags": [
-      "✅ safe",
-      "🌿 herbal",
-      "😴 sedative"
+      "🌼 euphoric",
+      "🧘 calm",
+      "🧬 natural ssri",
+      "🧠 serotonin",
+      "🧘 mood booster",
+      "💬 social",
+      "🌿 traditional african"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
-    "sources": []
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5386632/",
+      "Journal of Ethnopharmacology",
+      "2013",
+      "South African Herbal Compendium"
+    ]
   },
   {
     "id": "sida-acuta",
@@ -11016,7 +9023,7 @@
     "sources": []
   },
   {
-    "id": "silene-capensis",
+    "id": "african-dream-root",
     "slug": "silene-capensis",
     "common": "",
     "scientific": "Silene capensis",
@@ -11032,14 +9039,16 @@
     "compounds": [],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "dream enhancement, ancestral communication",
+    "therapeutic": "dream recall, ancestral communication (traditional)",
     "interactions": [
       "none well documented"
     ],
     "contraindications": [
+      "none well established",
       "pregnancy"
     ],
     "sideeffects": [
+      "mild nausea or grogginess if overdosed",
       "mild nausea if taken in excess"
     ],
     "safety": "",
@@ -11048,89 +9057,22 @@
     "tags": [
       "✅ safe",
       "🌙 dream",
+      "🧘 ancestral",
       "🧠 vision"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
     "sources": [
+      "https://erowid.org/plants/silene_capensis/",
+      "Dreaming Plant Guide – Ratsch",
+      "Journal of Ethnopharmacology",
+      "2008",
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4308394/",
       "Plants of the Gods – Rätsch",
       "African Ethnobotany in the Americas",
       "2014"
     ]
-  },
-  {
-    "id": "silene-undulata",
-    "slug": "african-dream-root",
-    "common": "African Dream Root",
-    "scientific": "",
-    "category": "",
-    "subcategory": "",
-    "intensity": "",
-    "region": "south africa",
-    "legalstatus": "",
-    "schedule": "",
-    "description": "",
-    "effects": "lucid dreaming;dream recall;mild sedation",
-    "mechanism": "Unknown; may influence cholinergic systems during sleep cycles.",
-    "compounds": [
-      "Triterpenoid saponins"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
-    "toxicity_ld50": "",
-    "tags": [
-      "dream",
-      "visionary",
-      "african"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "silene-undulata",
-    "slug": "african-dream-root",
-    "common": "African Dream Root",
-    "scientific": "",
-    "category": "",
-    "subcategory": "",
-    "intensity": "",
-    "region": "south africa",
-    "legalstatus": "",
-    "schedule": "",
-    "description": "",
-    "effects": "lucid dreaming;dream recall;mild sedation",
-    "mechanism": "Unknown; may influence cholinergic systems during sleep cycles.",
-    "compounds": [
-      "Triterpenoid saponins"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
-    "toxicity_ld50": "",
-    "tags": [
-      "dream",
-      "visionary",
-      "african"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
   },
   {
     "id": "silybum-marianum",
@@ -11172,42 +9114,100 @@
     "sources": []
   },
   {
-    "id": "sinicuichi",
-    "slug": "heimia-salicifolia",
-    "common": "",
+    "id": "heimia-salicifolia",
+    "slug": "sinicuichi",
+    "common": "Sinicuichi",
     "scientific": "Heimia salicifolia",
-    "category": "oneirogen",
+    "category": "oneirogen / traditional / mildly psychoactive",
     "subcategory": "",
     "intensity": "Mild to moderate",
     "region": "mexico, central america",
-    "legalstatus": "Legal",
+    "legalstatus": "Legal worldwide",
     "schedule": "",
-    "description": "used traditionally in central america as a 'sun opener,' believed to enhance memory and auditory perception. alters sound and memory in dreamlike ways.",
-    "effects": "Auditory distortion;dreamy state;euphoria",
-    "mechanism": "Alkaloids may modulate GABA and acetylcholine systems",
-    "compounds": [],
+    "description": "a yellow-flowering shrub used by indigenous mexican peoples for vision quests and dream work. traditionally prepared via solar fermentation, sinicuichi is known for inducing auditory changes and memory recall.",
+    "effects": "Dream enhancement;Auditory distortion;Relaxation;Trance-like state",
+    "mechanism": "Contains cryogenine and lythrine, which may modulate acetylcholine and GABA receptors, inducing mild CNS depression and altered perception.",
+    "compounds": [
+      "Cryogenine",
+      "Lyfoline"
+    ],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "folk use for memory and dream recall",
+    "therapeutic": "used in folk medicine for muscle pain, fevers, and spiritual visions. anecdotally used for lucid dreaming and relaxation.",
     "interactions": [
+      "may amplify effects of cns depressants.",
       "avoid cns depressants or alcohol"
     ],
     "contraindications": [
+      "avoid with sedatives",
+      "during driving",
+      "or pregnancy. limited modern research.",
       "pregnancy",
       "driving"
     ],
     "sideeffects": [
       "dry mouth",
+      "heavy limbs",
+      "auditory distortions. rare reports of ‘golden vision’ or slow-motion perception.",
       "yellow vision",
       "dizziness"
     ],
     "safety": "",
-    "toxicity": "Low to moderate; not well studied",
-    "toxicity_ld50": "Not established",
+    "toxicity": "Low in traditional doses; some anecdotal toxicity in concentrated extracts.",
+    "toxicity_ld50": "Not well established",
     "tags": [
+      "🌙 dream herb",
+      "🧠 memory",
+      "🔊 auditory shifts",
+      "🌿 nahuatl medicine",
       "🌞 sun",
       "🎧 auditory",
       "🧠 dream"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3654015/",
+      "Journal of Ethnopharmacology",
+      "1992",
+      "Plants of the Gods – Rätsch"
+    ]
+  },
+  {
+    "id": "solandra-maxima",
+    "slug": "solandra-maxima",
+    "common": "",
+    "scientific": "Solandra maxima",
+    "category": "ritual / visionary",
+    "subcategory": "",
+    "intensity": "",
+    "region": "mexico",
+    "legalstatus": "Unregulated",
+    "schedule": "",
+    "description": "rarely used solanaceous vine with powerful effects.",
+    "effects": "visions;disorientation",
+    "mechanism": "Tropane alkaloids similar to datura",
+    "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "visionary rituals",
+    "interactions": [
+      "anticholinergics"
+    ],
+    "contraindications": [
+      "pregnancy",
+      "heart issues"
+    ],
+    "sideeffects": [
+      "severe confusion",
+      "amnesia"
+    ],
+    "safety": "",
+    "toxicity": "High",
+    "toxicity_ld50": "",
+    "tags": [
+      "☠️ toxic"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -11301,45 +9301,86 @@
     ]
   },
   {
-    "id": "tabernaemontana-undulata",
-    "slug": "bechette",
-    "common": "Bechette",
-    "scientific": "Tabernaemontana undulata",
-    "category": "analgesic / visionary",
+    "id": "viola-odorata",
+    "slug": "sweet-violet",
+    "common": "Sweet Violet",
+    "scientific": "Viola odorata",
+    "category": "respiratory / nervine / floral sedative",
     "subcategory": "",
-    "intensity": "Moderate to Strong",
-    "region": "western amazon",
-    "legalstatus": "Mostly legal but little researched",
+    "intensity": "Mild",
+    "region": "europe, western asia, north africa",
+    "legalstatus": "Legal worldwide",
     "schedule": "",
-    "description": "also called uchu sanango; this rare shrub contains iboga-like compounds and is used in shamanic practices.",
-    "effects": "tingling sensation;dream enhancement;altered perception",
-    "mechanism": "Contains iboga-type alkaloids affecting serotonin and NMDA receptors",
+    "description": "a fragrant violet flower traditionally used for respiratory and emotional conditions. offers calming, anti-inflammatory, and mucilaginous support, often in teas or syrups.",
+    "effects": "Soothing;Anti-inflammatory;Sleep support;Cough relief",
+    "mechanism": "Contains salicylic acid derivatives, mucilage, and volatile oils. Gently modulates GABA and prostaglandins. Mild expectorant and anti-inflammatory activity.",
     "compounds": [
-      "Voacangine"
+      "Violine",
+      "Methyl salicylate"
     ],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "amazonian tribes use the bark for hunting preparation and pain",
+    "therapeutic": "used for sore throats, coughs, grief, insomnia, and skin irritation. can be taken internally or applied topically.",
     "interactions": [
-      "avoid with other serotonergic or stimulant substances"
+      "mild anticoagulant effects. may enhance other sedatives slightly."
     ],
     "contraindications": [
-      "heart problems",
-      "pregnancy",
-      "mental illness"
+      "none known in normal doses. use caution in salicylate-sensitive individuals."
     ],
     "sideeffects": [
-      "nausea",
-      "numbness",
-      "dizziness"
+      "mild",
+      "possible skin reaction or gi upset with large doses."
     ],
     "safety": "",
-    "toxicity": "High doses may be neurotoxic or cardiotoxic",
-    "toxicity_ld50": "Not well known",
+    "toxicity": "Very low",
+    "toxicity_ld50": "Not established (safe in folk medicine)",
     "tags": [
-      "amazon",
-      "uchu sanango",
-      "iboga alkaloids"
+      "🌸 floral",
+      "🧘 nervine",
+      "🫁 respiratory",
+      "💤 calming"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7533724/",
+      "British Herbal Pharmacopoeia",
+      "Plants of the Gods – Rätsch"
+    ]
+  },
+  {
+    "id": "tabernaemontana-sananho",
+    "slug": "tabernaemontana-sananho",
+    "common": "",
+    "scientific": "Tabernaemontana sananho",
+    "category": "ritual / visionary",
+    "subcategory": "",
+    "intensity": "",
+    "region": "amazon",
+    "legalstatus": "Unregulated",
+    "schedule": "",
+    "description": "shamanic plant sometimes added to ayahuasca.",
+    "effects": "dream enhancement;mild stimulation",
+    "mechanism": "Iboga-type alkaloids act on NMDA and serotonin receptors",
+    "compounds": [],
+    "preparations": [],
+    "dosage": "10–20 g root",
+    "therapeutic": "traditional spiritual healer",
+    "interactions": [
+      "maois"
+    ],
+    "contraindications": [
+      "heart conditions"
+    ],
+    "sideeffects": [
+      "nausea"
+    ],
+    "safety": "",
+    "toxicity": "Low",
+    "toxicity_ld50": "Not established",
+    "tags": [
+      "🌿 root"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -11607,55 +9648,6 @@
     ]
   },
   {
-    "id": "tilia-europaea",
-    "slug": "linden",
-    "common": "Linden",
-    "scientific": "Tilia europaea",
-    "category": "nervine / anxiolytic / antispasmodic",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "europe, western asia, north america (ornamental)",
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "description": "linden flowers are fragrant and soothing, traditionally used in europe as a gentle sedative and nerve tonic. often brewed into calming teas to relieve stress, tension, and digestive upset.",
-    "effects": "Calm;Stress relief;Muscle relaxation;Sleep support",
-    "mechanism": "Contains flavonoids (e.g., quercetin, kaempferol) and volatile oils that act as mild GABA modulators and muscle relaxants.",
-    "compounds": [
-      "Farnesol",
-      "Kaempferol"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for anxiety, tension headaches, high blood pressure, insomnia, and muscle cramps. also supports digestion and reduces inflammation.",
-    "interactions": [
-      "minimal. may slightly enhance effects of sedatives or diuretics."
-    ],
-    "contraindications": [
-      "none significant. use with caution if allergic to pollen or linden trees."
-    ],
-    "sideeffects": [
-      "very rare",
-      "occasional mild drowsiness or allergic reaction."
-    ],
-    "safety": "",
-    "toxicity": "Very low",
-    "toxicity_ld50": "Not established (very safe at therapeutic levels)",
-    "tags": [
-      "🧘 calm",
-      "💤 sleep",
-      "🌼 floral",
-      "🌿 traditional european"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6597275/",
-      "British Herbal Pharmacopoeia",
-      "Plants of the Gods – Rätsch"
-    ]
-  },
-  {
     "id": "tilia-tomentosa",
     "slug": "tilia-tomentosa",
     "common": "",
@@ -11693,131 +9685,102 @@
     "sources": []
   },
   {
-    "id": "toloache",
-    "slug": "datura-spp",
-    "common": "",
-    "scientific": "Datura spp.",
+    "id": "justicia-pectoralis",
+    "slug": "tilo",
+    "common": "Tilo",
+    "scientific": "Justicia pectoralis",
     "category": "ritual / visionary",
     "subcategory": "",
-    "intensity": "Extremely strong",
-    "region": "americas, mediterranean",
-    "legalstatus": "Legal but restricted in many countries",
-    "schedule": "",
-    "description": "a powerful and dangerous tropane alkaloid plant traditionally used in witchcraft and shamanic rituals. highly toxic.",
-    "effects": "Delirium;hallucinations;disorientation",
-    "mechanism": "Anticholinergic – blocks acetylcholine via scopolamine, atropine",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "rarely used medically; historically for pain/spiritual rites",
-    "interactions": [
-      "all cns-affecting meds"
-    ],
-    "contraindications": [
-      "everything — extremely risky"
-    ],
-    "sideeffects": [
-      "severe hallucinations",
-      "amnesia",
-      "potential death"
-    ],
-    "safety": "",
-    "toxicity": "Very high",
-    "toxicity_ld50": "~50 mg/kg (atropine/scopolamine)",
-    "tags": [
-      "☠️ toxic",
-      "⚠️ caution",
-      "🧠 vision"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "tropaeolum-majus",
-    "slug": "nasturtium",
-    "common": "Nasturtium",
-    "scientific": "",
-    "category": "stimulant",
-    "subcategory": "",
-    "intensity": "",
-    "region": "south america (peru, andes)",
-    "legalstatus": "",
-    "schedule": "",
-    "description": "",
-    "effects": "mild stimulant;respiratory enhancer",
-    "mechanism": "Antimicrobial and expectorant, may enhance breathing clarity.",
-    "compounds": [
-      "Benzyl isothiocyanate"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
-    "toxicity_ld50": "",
-    "tags": [
-      "stimulant",
-      "respiratory",
-      "folk"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "turnera-diffusa",
-    "slug": "damiana",
-    "common": "Damiana",
-    "scientific": "Turnera diffusa",
-    "category": "empathogen / euphoriant",
-    "subcategory": "",
     "intensity": "Mild",
-    "region": "texas, mexico, central america",
-    "legalstatus": "Legal / Unregulated",
+    "region": "amazon basin",
+    "legalstatus": "Legal",
     "schedule": "",
-    "description": "fragrant shrub known as damiana, smoked or brewed as aphrodisiac and relaxant.",
-    "effects": "aphrodisiac;mood-enhancing;anxiolytic",
-    "mechanism": "Likely modulates serotonin, dopamine, and GABA neurotransmission via flavonoids and tannins [8, 6].",
+    "description": "aromatic herb called tilo, brewed or smoked for calming effects.",
+    "effects": "Relaxation;light euphoria;spiritual dreams",
+    "mechanism": "Likely GABAergic; coumarins may modulate CNS",
     "compounds": [
-      "Damianin"
+      "Coumarin",
+      "Umelliferone"
     ],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "aphrodisiac, mood enhancement, stress relief [8, 6].",
+    "therapeutic": "anxiety, insomnia, spiritual enhancement",
     "interactions": [
-      "serotonergic medications."
+      "coumarin-sensitive meds (e.g.",
+      "blood thinners)"
     ],
     "contraindications": [
-      "pregnancy",
-      "maoi coadministration."
+      "liver disorders",
+      "pregnancy"
     ],
     "sideeffects": [
-      "mild headache",
-      "insomnia at high doses [8",
-      "6]."
+      "liver risk in excess due to coumarin"
     ],
     "safety": "1",
-    "toxicity": "Low in traditional doses.",
-    "toxicity_ld50": "",
+    "toxicity": "Low–moderate with excess",
+    "toxicity_ld50": "Not established",
     "tags": [
-      "☕ brewable",
-      "✅ safe",
-      "🌬️ smokable",
-      "💫 euphoria"
+      "✅ legal",
+      "🌿 ayahuasca-additive",
+      "🧘 calm"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
     "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3210006/",
-      "Plants of Love – Christian Rätsch",
-      "Herbal Medicine – Mills & Bone"
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7820446/",
+      "Journal of Ethnopharmacology",
+      "1999",
+      "Shamanic Pharmacopoeia – Amazonian Plants"
+    ]
+  },
+  {
+    "id": "zanthoxylum-clava-herculis",
+    "slug": "toothache-tree",
+    "common": "Toothache Tree",
+    "scientific": "Zanthoxylum clava-herculis",
+    "category": "analgesic / stimulant",
+    "subcategory": "",
+    "intensity": "Mild",
+    "region": "southeastern united states",
+    "legalstatus": "Legal",
+    "schedule": "",
+    "description": "also called the toothache tree; its bark creates a tingling numbness and light stimulation when chewed.",
+    "effects": "mouth numbness;mild stimulation;pain relief",
+    "mechanism": "Bark contains sanshools that cause paresthesia and stimulate trigeminal nerves",
+    "compounds": [
+      "Pellitorine",
+      "Sanshools"
+    ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "native american remedy for toothaches and sore throats; also used as a tonic",
+    "interactions": [
+      "may interact with other numbing agents"
+    ],
+    "contraindications": [
+      "mouth ulcers or sensitive gums"
+    ],
+    "sideeffects": [
+      "tingling",
+      "salivation",
+      "mild stomach upset"
+    ],
+    "safety": "",
+    "toxicity": "Low in customary doses",
+    "toxicity_ld50": "Not established",
+    "tags": [
+      "north america",
+      "tingling",
+      "toothache tree"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5656514/",
+      "Native American Ethnobotany – Moerman",
+      "Plants of the Gods – Rätsch"
     ]
   },
   {
@@ -11998,36 +9961,41 @@
     ]
   },
   {
-    "id": "tynanthus-panurensis",
-    "slug": "clavo-huasca",
-    "common": "Clavo Huasca",
-    "scientific": "",
-    "category": "",
+    "id": "clavo-huasca",
+    "slug": "tynanthus-panurensis",
+    "common": "",
+    "scientific": "Tynanthus panurensis",
+    "category": "empathogen / euphoriant",
     "subcategory": "",
-    "intensity": "",
-    "region": "amazon rainforest",
-    "legalstatus": "",
+    "intensity": "Mild",
+    "region": "amazon basin",
+    "legalstatus": "Legal",
     "schedule": "",
-    "description": "",
-    "effects": "aphrodisiac;warming;digestive aid",
-    "mechanism": "TRPV1 activation, increases circulation and warmth",
-    "compounds": [
-      "Eugenol",
-      "Tynanthin"
-    ],
+    "description": "amazonian vine used in both physical and spiritual medicine. traditionally consumed as a libido enhancer and pre-ayahuasca preparation.",
+    "effects": "Aphrodisiac;calming;digestive",
+    "mechanism": "Alkaloids may modulate dopamine and serotonin; warming vasodilator",
+    "compounds": [],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
+    "therapeutic": "aphrodisiac, digestive aid in amazonian medicine",
+    "interactions": [
+      "avoid cns depressants",
+      "alcohol"
+    ],
+    "contraindications": [
+      "pregnancy",
+      "blood pressure meds"
+    ],
+    "sideeffects": [
+      "mild hypotension or fatigue"
+    ],
     "safety": "",
-    "toxicity": "",
-    "toxicity_ld50": "",
+    "toxicity": "Low",
+    "toxicity_ld50": "Not established",
     "tags": [
-      "aphrodisiac",
-      "folk",
-      "warming"
+      "✅ safe",
+      "🌿 amazonian",
+      "🔥 aphrodisiac"
     ],
     "regiontags": [],
     "legalnotes": "",
@@ -12348,143 +10316,6 @@
     ]
   },
   {
-    "id": "valerian",
-    "slug": "valeriana-officinalis",
-    "common": "",
-    "scientific": "Valeriana officinalis",
-    "category": "dissociative / sedative",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "🇧🇪 europe",
-    "legalstatus": "Legal / Unregulated",
-    "schedule": "",
-    "description": "pungent root used as a natural sleep aid and mild tranquilizer.",
-    "effects": "Relaxation;sleep support",
-    "mechanism": "Valerenic acid modulates GABA receptors and inhibits breakdown.",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "insomnia, anxiety, muscle tension.",
-    "interactions": [
-      "sedatives",
-      "alcohol."
-    ],
-    "contraindications": [
-      "pregnancy",
-      "heavy alcohol use."
-    ],
-    "sideeffects": [
-      "grogginess",
-      "vivid dreams",
-      "headache."
-    ],
-    "safety": "1",
-    "toxicity": "Generally safe; high doses may cause dizziness.",
-    "toxicity_ld50": "LD50 > 3 g/kg (rat).",
-    "tags": [
-      "\\u2615 brewable",
-      "\\ud83e\\uddd8 sedation",
-      "\\u2705 safe"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "valeriana-officinalis",
-    "slug": "valeriana-officinalis",
-    "common": "",
-    "scientific": "Valeriana officinalis",
-    "category": "sedative / sleep aid / nervine",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "europe, western asia, north america (cultivated)",
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "description": "a strong-smelling root long used as a natural sedative and anxiety aid. valerian is commonly included in sleep teas, tinctures, and stress blends.",
-    "effects": "Sleep induction;Calm;Anxiety reduction;Muscle relaxation",
-    "mechanism": "Acts on GABA-A receptors via valerenic acid and other sesquiterpenes. May inhibit GABA breakdown and modulate serotonin and adenosine.",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for insomnia, nervousness, anxiety, muscle tension, and restlessness. may reduce time to fall asleep and improve sleep quality.",
-    "interactions": [
-      "additive with cns depressants",
-      "benzodiazepines",
-      "barbiturates",
-      "and alcohol."
-    ],
-    "contraindications": [
-      "avoid mixing with alcohol",
-      "sedatives",
-      "or heavy machinery. not advised during pregnancy without guidance."
-    ],
-    "sideeffects": [
-      "drowsiness",
-      "vivid dreams",
-      "headache",
-      "gi upset. rare paradoxical stimulation."
-    ],
-    "safety": "",
-    "toxicity": "Low. Well tolerated in most users.",
-    "toxicity_ld50": ">3000 mg/kg (rats, oral)",
-    "tags": [
-      "💤 sedative",
-      "🧘 nervine",
-      "🌿 sleep aid",
-      "🛌 relaxation"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4394901/",
-      "Herbal Medicine – Mills & Bone",
-      "British Herbal Pharmacopoeia"
-    ]
-  },
-  {
-    "id": "valeriana-officinalis",
-    "slug": "valeriana-officinalis",
-    "common": "",
-    "scientific": "Valeriana officinalis",
-    "category": "sedative / anxiolytic",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "europe, north america",
-    "legalstatus": "Legal",
-    "schedule": "",
-    "description": "traditional european herb valued for calming and sleep-promoting properties.",
-    "effects": "Relaxation;improved sleep;mild anxiolysis",
-    "mechanism": "Valerenic acid modulates GABA receptors and may inhibit GABA breakdown.",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "insomnia, anxiety, muscle tension.",
-    "interactions": [
-      "additive with benzodiazepines or alcohol"
-    ],
-    "contraindications": [
-      "avoid with other sedatives or during pregnancy."
-    ],
-    "sideeffects": [
-      "drowsiness",
-      "vivid dreams"
-    ],
-    "safety": "",
-    "toxicity": "Generally safe; high doses may cause headaches or dizziness.",
-    "toxicity_ld50": "LD50 >3 g/kg (mouse, extract)",
-    "tags": [
-      "🌿 root",
-      "😴 sleep"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
     "id": "valeriana-jatamansi",
     "slug": "valeriana-jatamansi",
     "common": "",
@@ -12526,6 +10357,72 @@
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4046171/",
       "Ayurvedic Pharmacopoeia of India",
       "Plants of the Gods – Rätsch"
+    ]
+  },
+  {
+    "id": "valerian",
+    "slug": "valeriana-officinalis",
+    "common": "",
+    "scientific": "Valeriana officinalis",
+    "category": "sedative / sleep aid / nervine",
+    "subcategory": "",
+    "intensity": "Mild–Moderate",
+    "region": "europe, western asia, north america (cultivated)",
+    "legalstatus": "Legal / Unregulated",
+    "schedule": "",
+    "description": "a strong-smelling root long used as a natural sedative and anxiety aid. valerian is commonly included in sleep teas, tinctures, and stress blends.",
+    "effects": "Sleep induction;Calm;Anxiety reduction;Muscle relaxation",
+    "mechanism": "Acts on GABA-A receptors via valerenic acid and other sesquiterpenes. May inhibit GABA breakdown and modulate serotonin and adenosine.",
+    "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for insomnia, nervousness, anxiety, muscle tension, and restlessness. may reduce time to fall asleep and improve sleep quality.",
+    "interactions": [
+      "sedatives",
+      "alcohol.",
+      "additive with cns depressants",
+      "benzodiazepines",
+      "barbiturates",
+      "and alcohol.",
+      "additive with benzodiazepines or alcohol"
+    ],
+    "contraindications": [
+      "pregnancy",
+      "heavy alcohol use.",
+      "avoid mixing with alcohol",
+      "sedatives",
+      "or heavy machinery. not advised during pregnancy without guidance.",
+      "avoid with other sedatives or during pregnancy."
+    ],
+    "sideeffects": [
+      "grogginess",
+      "vivid dreams",
+      "headache.",
+      "drowsiness",
+      "headache",
+      "gi upset. rare paradoxical stimulation."
+    ],
+    "safety": "1",
+    "toxicity": "Generally safe; high doses may cause headaches or dizziness.",
+    "toxicity_ld50": "LD50 >3 g/kg (mouse, extract)",
+    "tags": [
+      "\\u2615 brewable",
+      "\\ud83e\\uddd8 sedation",
+      "\\u2705 safe",
+      "💤 sedative",
+      "🧘 nervine",
+      "🌿 sleep aid",
+      "🛌 relaxation",
+      "🌿 root",
+      "😴 sleep"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4394901/",
+      "Herbal Medicine – Mills & Bone",
+      "British Herbal Pharmacopoeia"
     ]
   },
   {
@@ -12574,6 +10471,57 @@
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3679533/",
       "Indian Journal of Pharmacognosy",
+      "Plants of the Gods – Rätsch"
+    ]
+  },
+  {
+    "id": "cissampelos-pareira",
+    "slug": "velvetleaf",
+    "common": "Velvetleaf",
+    "scientific": "Cissampelos pareira",
+    "category": "ayurvedic / antispasmodic / antimalarial",
+    "subcategory": "",
+    "intensity": "Mild–Moderate",
+    "region": "india, south america, southeast asia",
+    "legalstatus": "Legal",
+    "schedule": "",
+    "description": "a climbing herb used in ayurveda and traditional amazonian medicine. often called ‘laghu patha’ in sanskrit, it is prized for menstrual support, malaria treatment, and as an adjunct to ayahuasca.",
+    "effects": "Uterine tonic;Muscle relaxant;Antimalarial;Mild sedative",
+    "mechanism": "Contains alkaloids like pareirine and cissamine. These modulate smooth muscle tone, and may exert anti-inflammatory, uterotonic, and antimicrobial effects.",
+    "compounds": [
+      "Pareirine",
+      "Cissamine"
+    ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for menstrual cramps, utis, inflammation, diarrhea, and malaria. in south america, used spiritually as a ‘feminine vine’ complementary to banisteriopsis caapi.",
+    "interactions": [
+      "potential interactions with antimalarials or muscle relaxants. may mildly lower blood pressure."
+    ],
+    "contraindications": [
+      "avoid during early pregnancy due to uterine effects. use caution with blood pressure medications."
+    ],
+    "sideeffects": [
+      "well tolerated in moderate doses. large doses may cause dizziness",
+      "nausea",
+      "or mild hypotension."
+    ],
+    "safety": "",
+    "toxicity": "Low to moderate depending on alkaloid concentration.",
+    "toxicity_ld50": "Not established",
+    "tags": [
+      "🌿 ayurvedic",
+      "🌙 feminine vine",
+      "🧪 antimalarial",
+      "🩸 menstrual tonic"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3783799/",
+      "Journal of Ethnopharmacology",
+      "2011",
       "Plants of the Gods – Rätsch"
     ]
   },
@@ -12758,6 +10706,42 @@
     ]
   },
   {
+    "id": "elsholtzia-ciliata",
+    "slug": "vietnamese-balm",
+    "common": "Vietnamese Balm",
+    "scientific": "",
+    "category": "stimulant",
+    "subcategory": "",
+    "intensity": "",
+    "region": "east and southeast asia",
+    "legalstatus": "",
+    "schedule": "",
+    "description": "",
+    "effects": "uplifting;digestive aid;mental clarity",
+    "mechanism": "Stimulates gastrointestinal and olfactory receptors",
+    "compounds": [
+      "Elsholtzia ketone"
+    ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
+    "safety": "",
+    "toxicity": "",
+    "toxicity_ld50": "",
+    "tags": [
+      "stimulant",
+      "folk",
+      "clarity"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
+  },
+  {
     "id": "vinca-minor",
     "slug": "vinca-minor",
     "common": "",
@@ -12809,55 +10793,6 @@
     ]
   },
   {
-    "id": "viola-odorata",
-    "slug": "sweet-violet",
-    "common": "Sweet Violet",
-    "scientific": "Viola odorata",
-    "category": "respiratory / nervine / floral sedative",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "europe, western asia, north africa",
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "description": "a fragrant violet flower traditionally used for respiratory and emotional conditions. offers calming, anti-inflammatory, and mucilaginous support, often in teas or syrups.",
-    "effects": "Soothing;Anti-inflammatory;Sleep support;Cough relief",
-    "mechanism": "Contains salicylic acid derivatives, mucilage, and volatile oils. Gently modulates GABA and prostaglandins. Mild expectorant and anti-inflammatory activity.",
-    "compounds": [
-      "Violine",
-      "Methyl salicylate"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for sore throats, coughs, grief, insomnia, and skin irritation. can be taken internally or applied topically.",
-    "interactions": [
-      "mild anticoagulant effects. may enhance other sedatives slightly."
-    ],
-    "contraindications": [
-      "none known in normal doses. use caution in salicylate-sensitive individuals."
-    ],
-    "sideeffects": [
-      "mild",
-      "possible skin reaction or gi upset with large doses."
-    ],
-    "safety": "",
-    "toxicity": "Very low",
-    "toxicity_ld50": "Not established (safe in folk medicine)",
-    "tags": [
-      "🌸 floral",
-      "🧘 nervine",
-      "🫁 respiratory",
-      "💤 calming"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7533724/",
-      "British Herbal Pharmacopoeia",
-      "Plants of the Gods – Rätsch"
-    ]
-  },
-  {
     "id": "viola-tricolor",
     "slug": "viola-tricolor",
     "common": "",
@@ -12903,100 +10838,6 @@
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
     ]
-  },
-  {
-    "id": "virola-theiodora",
-    "slug": "epena",
-    "common": "Epena",
-    "scientific": "Virola theiodora",
-    "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Very strong",
-    "region": "amazon (brazil, venezuela)",
-    "legalstatus": "DMT controlled in most countries",
-    "schedule": "",
-    "description": "a snuff plant from the amazon containing dmt and 5-meo-dmt. used by yanomami and other tribes for potent visionary rituals.",
-    "effects": "Strong visuals;spiritual experiences;disorientation",
-    "mechanism": "DMT and 5-MeO-DMT – 5-HT2A agonists",
-    "compounds": [
-      "DMT",
-      "5-MeO-DMT"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "shamanic ritual; purging and vision work",
-    "interactions": [
-      "maois",
-      "antidepressants"
-    ],
-    "contraindications": [
-      "maois",
-      "mental health issues"
-    ],
-    "sideeffects": [
-      "nausea",
-      "tremors",
-      "vomiting"
-    ],
-    "safety": "",
-    "toxicity": "High psychological, moderate physical",
-    "toxicity_ld50": "",
-    "tags": [
-      "⚠️ vision",
-      "🌬️ snuff",
-      "🧠 dmt"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "virola-theiodora",
-    "slug": "epena",
-    "common": "Epena",
-    "scientific": "Virola theiodora",
-    "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Very strong",
-    "region": "amazon (brazil, venezuela)",
-    "legalstatus": "DMT controlled in most countries",
-    "schedule": "",
-    "description": "a snuff plant from the amazon containing dmt and 5-meo-dmt. used by yanomami and other tribes for potent visionary rituals.",
-    "effects": "Strong visuals;spiritual experiences;disorientation",
-    "mechanism": "DMT and 5-MeO-DMT – 5-HT2A agonists",
-    "compounds": [
-      "DMT",
-      "5-MeO-DMT"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "shamanic ritual; purging and vision work",
-    "interactions": [
-      "maois",
-      "antidepressants"
-    ],
-    "contraindications": [
-      "maois",
-      "mental health issues"
-    ],
-    "sideeffects": [
-      "nausea",
-      "tremors",
-      "vomiting"
-    ],
-    "safety": "",
-    "toxicity": "High psychological, moderate physical",
-    "toxicity_ld50": "",
-    "tags": [
-      "⚠️ vision",
-      "🌬️ snuff",
-      "🧠 dmt"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
   },
   {
     "id": "viscum-album",
@@ -13239,172 +11080,246 @@
     ]
   },
   {
-    "id": "voacanga-africana",
-    "slug": "voacanga-africana",
-    "common": "",
-    "scientific": "Voacanga africana",
-    "category": "ritual / visionary",
+    "id": "salvia-apiana",
+    "slug": "white-sage",
+    "common": "White Sage",
+    "scientific": "Salvia apiana",
+    "category": "ritual / aromatic",
     "subcategory": "",
-    "intensity": "Strong",
-    "region": "west africa",
-    "legalstatus": "Unscheduled; may be regulated for alkaloids",
+    "intensity": "",
+    "region": "southwestern us",
+    "legalstatus": "Legal",
     "schedule": "",
-    "description": "a powerful african plant containing voacangine and iboga alkaloids. used traditionally in ritual contexts and studied as a potential ibogaine precursor.",
-    "effects": "Stimulation;psychedelic effects;cardiovascular activation",
-    "mechanism": "Voacangine is a prodrug to ibogaine (NMDA antagonist, serotonin transporter blocker)",
-    "compounds": [],
+    "description": "white sage revered for cleansing ceremonies",
+    "effects": "calm;clarity",
+    "mechanism": "Essential oils like cineole and thujone provide mild GABA modulation",
+    "compounds": [
+      "Cineole",
+      "Rosmarinic acid"
+    ],
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "experimental use in addiction therapy (via ibogaine synthesis)",
+    "dosage": "Smoke small bundle or 1 g in tea",
+    "therapeutic": "purification rites, relaxation",
     "interactions": [
-      "avoid all stimulants",
-      "antidepressants",
-      "maois"
+      "none known"
     ],
     "contraindications": [
-      "heart conditions",
-      "psychiatric disorders"
+      "pregnancy high doses"
     ],
     "sideeffects": [
-      "vomiting",
-      "overstimulation",
-      "visual distortions"
+      "rare allergic cough"
     ],
     "safety": "",
-    "toxicity": "High in overdose; cardiotoxic potential",
-    "toxicity_ld50": "~90–120 mg/kg (est. voacangine)",
+    "toxicity": "Low",
+    "toxicity_ld50": "Not well studied",
     "tags": [
-      "⚠️ caution",
-      "🌍 african",
-      "🧠 vision"
+      "🌿 ritual",
+      "🪔 incense"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
+  },
+  {
+    "id": "casimiroa-edulis",
+    "slug": "white-sapote",
+    "common": "White Sapote",
+    "scientific": "Casimiroa edulis",
+    "category": "ethnobotanical",
+    "subcategory": "",
+    "intensity": "",
+    "region": "central america",
+    "legalstatus": "",
+    "schedule": "",
+    "description": "the fruit of the white sapote tree is used as a sedative in traditional mexican herbal medicine.",
+    "effects": "sedative;sleep aid",
+    "mechanism": "Possible GABAergic activity",
+    "compounds": [
+      "Zapotin"
+    ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "",
+    "interactions": [],
+    "contraindications": [],
+    "sideeffects": [],
+    "safety": "",
+    "toxicity": "",
+    "toxicity_ld50": "",
+    "tags": [
+      "sedative",
+      "fruit",
+      "folk medicine"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": []
+  },
+  {
+    "id": "lactuca-virosa",
+    "slug": "wild-lettuce",
+    "common": "Wild Lettuce",
+    "scientific": "Lactuca virosa",
+    "category": "sedative / analgesic / nervine",
+    "subcategory": "",
+    "intensity": "Mild to moderate",
+    "region": "europe, north america, asia",
+    "legalstatus": "Legal worldwide",
+    "schedule": "",
+    "description": "a tall, bitter plant sometimes called 'opium lettuce' due to its historical use for pain and sleep. it contains lactucopicrin and lactucin, compounds with mild sedative and analgesic properties. used in western herbalism since the 19th century.",
+    "effects": "Pain relief;Mild euphoria;Sedation;Calming",
+    "mechanism": "Lactucin and lactucopicrin are sesquiterpene lactones that interact with GABAergic systems and have antinociceptive properties.",
+    "compounds": [
+      "Lactucin",
+      "Lactucopicrin"
+    ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for pain, insomnia, anxiety, coughing, and muscle tension. popular in herbal tinctures and teas.",
+    "interactions": [
+      "potentiates sedatives or alcohol.",
+      "avoid with sedatives",
+      "opioids"
+    ],
+    "contraindications": [
+      "avoid in pregnancy",
+      "glaucoma",
+      "or with cns depressants. not for prolonged heavy use.",
+      "pregnancy",
+      "cns depressants"
+    ],
+    "sideeffects": [
+      "may cause dizziness",
+      "nausea",
+      "or mild hallucinations at high doses. bitter taste often deters excess use.",
+      "drowsiness",
+      "nausea at high doses"
+    ],
+    "safety": "1",
+    "toxicity": "Low to moderate. High doses may cause CNS depression.",
+    "toxicity_ld50": "Not well documented in humans; extracts assumed safe below 500 mg/kg",
+    "tags": [
+      "💤 sedative",
+      "🌿 analgesic",
+      "🌙 calming",
+      "🧪 bitter",
+      "✅ safe",
+      "🌿 herbal",
+      "😴 sedative"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
     "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4181566/",
-      "Plants of the Gods – Rätsch",
-      "Voacanga africana: Ethnobotany and Chemistry – J Ethnopharmacol",
-      "2014"
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6232791/",
+      "Herbal Medicines",
+      "4th Ed. – Barnes et al.",
+      "A Modern Herbal – Grieve"
     ]
   },
   {
-    "id": "white-lily",
-    "slug": "nymphaea-ampla",
+    "id": "withania-somnifera",
+    "slug": "withania-somnifera",
     "common": "",
-    "scientific": "Nymphaea ampla",
-    "category": "oneirogen",
+    "scientific": "Withania somnifera",
+    "category": "adaptogen / nervine / endocrine support",
     "subcategory": "",
-    "intensity": "Mild",
-    "region": "mexico, central america",
-    "legalstatus": "Legal",
+    "intensity": "Mild–Moderate",
+    "region": "india, middle east, north africa",
+    "legalstatus": "Legal worldwide",
     "schedule": "",
-    "description": "related to blue lotus, this sacred flower from mesoamerican traditions is used to promote meditation and lucid dreaming.",
-    "effects": "Calm;light sedation;dream potentiation",
-    "mechanism": "Contains aporphine alkaloids (dopamine agonist)",
+    "description": "one of the most revered herbs in ayurveda, ashwagandha is a potent adaptogen used to reduce stress, improve sleep, and balance the nervous and endocrine systems. often called 'indian ginseng'.",
+    "effects": "Stress reduction;Cortisol regulation;Sleep support;Cognitive enhancement",
+    "mechanism": "Withanolides modulate the hypothalamic-pituitary-adrenal (HPA) axis, lower cortisol, reduce oxidative stress, and improve GABAergic signaling.",
     "compounds": [],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "relaxation, aphrodisiac, dream enhancement",
+    "therapeutic": "used for anxiety, fatigue, insomnia, adrenal support, libido, thyroid balance, and immune modulation.",
     "interactions": [
-      "avoid cns depressants"
+      "may enhance effects of sedatives",
+      "thyroid meds",
+      "or immunosuppressants."
     ],
     "contraindications": [
-      "pregnancy"
+      "avoid with hyperthyroidism",
+      "sedative medications",
+      "or during pregnancy without supervision."
     ],
     "sideeffects": [
-      "drowsiness",
-      "vivid dreams"
+      "mild gi upset or drowsiness. rare headaches or allergic reactions."
     ],
     "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "toxicity": "Very low. High doses may affect thyroid hormone levels.",
+    "toxicity_ld50": ">5000 mg/kg (rats, oral)",
     "tags": [
-      "✅ safe",
-      "🌸 calm",
-      "🌿 sedative"
+      "🧘 adaptogen",
+      "💤 sleep",
+      "🧠 brain support",
+      "🌿 ayurvedic"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
-    "sources": []
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6979308/",
+      "Herbal Medicine – Mills & Bone",
+      "Indian Journal of Psychological Medicine",
+      "2012"
+    ]
   },
   {
-    "id": "leonotis-leonurus",
-    "slug": "leonotis-leonurus",
-    "common": "",
-    "scientific": "Leonotis leonurus",
-    "category": "relaxant / euphoric",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "southern africa",
-    "legalstatus": "Legal",
-    "schedule": "",
-    "description": "orange-flowered shrub also called lion’s tail; smoked traditionally for mild cannabis-like effects.",
-    "effects": "Mild euphoria;relaxation",
-    "mechanism": "Contains leonurine; may act on serotonin and cannabinoid receptors.",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "folk remedy for coughs, fever and as a mild psychoactive when smoked.",
-    "interactions": [
-      "may potentiate other sedatives"
-    ],
-    "contraindications": [
-      "avoid during pregnancy or with heart conditions."
-    ],
-    "sideeffects": [
-      "dry mouth",
-      "slight dizziness"
-    ],
-    "safety": "",
-    "toxicity": "Low; high doses may cause dizziness or nausea.",
-    "toxicity_ld50": "Not established",
-    "tags": [
-      "🌿 smoke",
-      "🦁 dagga"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "wormwood",
-    "slug": "artemisia-absinthium",
-    "common": "",
+    "id": "artemisia-absinthium",
+    "slug": "wormwood",
+    "common": "Wormwood",
     "scientific": "Artemisia absinthium",
-    "category": "oneirogen",
+    "category": "deliriant / digestive bitter",
     "subcategory": "",
     "intensity": "Mild to moderate",
-    "region": "europe, asia, north america",
-    "legalstatus": "Restricted in high-thujone formulations",
+    "region": "europe, north africa, western asia",
+    "legalstatus": "Thujone content regulated in beverages (e.g. EU and US); plant itself legal",
     "schedule": "",
-    "description": "key ingredient in absinthe. contains thujone, which is a gaba_a antagonist and neurostimulant in high doses. historically used for dreaming, digestion, and ritual.",
-    "effects": "Lucid dreams;stimulating;mental clarity",
-    "mechanism": "Thujone – GABA_A receptor antagonist",
-    "compounds": [],
+    "description": "a bitter herb best known as the flavoring in traditional absinthe. contains thujone, a gaba receptor antagonist that can cause excitatory and convulsive effects in high doses.",
+    "effects": "Euphoria;Mild hallucinations;Stimulation;Appetite stimulant",
+    "mechanism": "Thujone is a GABA-A antagonist, reducing inhibitory signaling in the brain. At high doses, this may induce seizures or hallucinations. Also contains bitter principles that stimulate digestion.",
+    "compounds": [
+      "Thujone"
+    ],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "digestive tonic, dream work, antiparasitic",
+    "therapeutic": "used as a bitter tonic for digestion, appetite stimulation, and historically as an anthelmintic. occasionally explored for mood elevation in aromatherapy.",
     "interactions": [
+      "may reduce effectiveness of anticonvulsants. dangerous with gabaergic drugs",
+      "alcohol",
+      "or stimulants.",
       "avoid alcohol",
       "cns drugs"
     ],
     "contraindications": [
+      "avoid in epilepsy",
       "pregnancy",
+      "kidney disease",
+      "and with cns stimulants. use caution with antidepressants or alcohol.",
       "epilepsy",
       "high doses"
     ],
     "sideeffects": [
-      "headache",
       "nausea",
+      "dizziness",
+      "vomiting",
+      "neurotoxicity at high doses. prolonged use may irritate kidneys and liver.",
+      "headache",
       "tremors at high doses"
     ],
     "safety": "",
-    "toxicity": "Neurotoxic in large doses",
-    "toxicity_ld50": "~30 mg/kg (thujone)",
+    "toxicity": "High doses or chronic use may lead to tremors, seizures, and neurotoxicity ('absinthism').",
+    "toxicity_ld50": "Thujone: ~87.5 mg/kg (rats, oral)",
     "tags": [
+      "🍸 absinthium",
+      "⚠️ neurotoxic",
+      "🌿 bitter tonic",
+      "🧠 gaba-antagonist",
       "⚠️ caution",
       "🌙 dream",
       "🌿 bitter"
@@ -13412,7 +11327,13 @@
     "regiontags": [],
     "legalnotes": "",
     "image": "",
-    "sources": []
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3265070/",
+      "Herbal Medicine: Biomolecular and Clinical Aspects",
+      "2nd ed.",
+      "Journal of Ethnopharmacology",
+      "2003"
+    ]
   },
   {
     "id": "xylopia-aethiopica",
@@ -13460,88 +11381,119 @@
     ]
   },
   {
-    "id": "glaucium-flavum",
-    "slug": "glaucium-flavum",
-    "common": "",
-    "scientific": "Glaucium flavum",
-    "category": "other",
+    "id": "corydalis-yanhusuo",
+    "slug": "yanhusuo",
+    "common": "Yanhusuo",
+    "scientific": "Corydalis yanhusuo",
+    "category": "sedative / analgesic",
     "subcategory": "",
-    "intensity": "",
-    "region": "mediterranean",
-    "legalstatus": "Varies",
+    "intensity": "Moderate",
+    "region": "china and east asia",
+    "legalstatus": "Legal",
     "schedule": "",
-    "description": "coastal poppy used occasionally for its glaucine content.",
-    "effects": "mild euphoria;sedation",
-    "mechanism": "Contains glaucine, a bronchodilator acting on dopamine receptors",
-    "compounds": [],
-    "preparations": [],
-    "dosage": "10–20 mg glaucine",
-    "therapeutic": "cough suppressant",
-    "interactions": [
-      "cns depressants"
+    "description": "tubers of this asian herb provide notable pain relief and a tranquil state when used as tea or pills.",
+    "effects": "analgesia;relaxation;subtle dreaminess",
+    "mechanism": "Alkaloids such as tetrahydropalmatine act on dopamine and GABA receptors",
+    "compounds": [
+      "Tetrahydropalmatine (THP)"
     ],
-    "contraindications": [
-      "pregnancy"
-    ],
-    "sideeffects": [
-      "dizziness",
-      "nausea"
-    ],
-    "safety": "",
-    "toxicity": "Moderate",
-    "toxicity_ld50": ">300 mg/kg (mice)",
-    "tags": [
-      "🌀 visionary",
-      "💊 oral"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
-  },
-  {
-    "id": "yopo",
-    "slug": "anadenanthera-peregrina",
-    "common": "",
-    "scientific": "Anadenanthera peregrina",
-    "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Very strong",
-    "region": "south america (orinoco, amazon basin)",
-    "legalstatus": "Controlled in many countries due to DMT content",
-    "schedule": "",
-    "description": "used in amazonian rituals, yopo seeds are ground and insufflated to induce powerful entheogenic experiences. contains bufotenine, dmt, and 5-meo-dmt.",
-    "effects": "Intense visions;altered time perception;spiritual insight",
-    "mechanism": "5-HT2A receptor agonist (bufotenine, DMT, 5-MeO-DMT)",
-    "compounds": [],
     "preparations": [],
     "dosage": "",
-    "therapeutic": "shamanic healing, insight rituals",
+    "therapeutic": "traditional chinese remedy for pain and insomnia",
     "interactions": [
-      "avoid with antidepressants or maois"
+      "may potentiate sedatives or dopaminergic drugs"
     ],
     "contraindications": [
-      "asthma",
-      "mental health disorders",
-      "maois"
+      "pregnancy",
+      "liver disease",
+      "large doses"
     ],
     "sideeffects": [
-      "intense nausea",
-      "disorientation",
-      "respiratory irritation"
+      "drowsiness",
+      "dizziness"
     ],
     "safety": "",
-    "toxicity": "High risk with improper use; bufotenine toxic at high dose",
-    "toxicity_ld50": "50–80 mg/kg (bufotenine, mice)",
+    "toxicity": "Overuse may cause liver stress",
+    "toxicity_ld50": ">1 g/kg in rodents",
     "tags": [
-      "⚠️ caution",
-      "🌬️ snuff",
-      "🧠 vision"
+      "tcm",
+      "dopamine",
+      "pain relief"
     ],
     "regiontags": [],
     "legalnotes": "",
     "image": "",
-    "sources": []
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4046635/",
+      "Journal of Pain Research",
+      "2013",
+      "Pharmacopoeia of the People’s Republic of China"
+    ]
+  },
+  {
+    "id": "ilex-paraguariensis",
+    "slug": "yerba-mate",
+    "common": "Yerba Mate",
+    "scientific": "Ilex paraguariensis",
+    "category": "stimulant / tonic / social",
+    "subcategory": "",
+    "intensity": "Mild to moderate",
+    "region": "argentina, brazil, paraguay, uruguay",
+    "legalstatus": "Legal worldwide",
+    "schedule": "",
+    "description": "a south american herbal infusion made from the dried leaves of the yerba mate plant. revered for its energizing and antioxidant effects, mate is consumed in communal rituals or daily focus routines.",
+    "effects": "Mental alertness;Appetite control;Social energy;Metabolism boost",
+    "mechanism": "Caffeine, theobromine, and chlorogenic acid act as CNS stimulants and antioxidants. Enhances focus while reducing fatigue.",
+    "compounds": [
+      "Caffeine",
+      "Theobromine",
+      "Chlorogenic acid"
+    ],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for fatigue, digestion, weight loss, cognitive enhancement, and mild depression.",
+    "interactions": [
+      "interacts with maois",
+      "stimulants",
+      "or blood pressure meds. may influence cyp enzymes.",
+      "cns stimulants",
+      "caffeine"
+    ],
+    "contraindications": [
+      "caution in hypertension",
+      "ulcers",
+      "or caffeine sensitivity. avoid boiling hot consumption.",
+      "anxiety",
+      "heart conditions"
+    ],
+    "sideeffects": [
+      "insomnia",
+      "gi irritation",
+      "or agitation at high doses. possible link to esophageal cancer when consumed very hot frequently.",
+      "jitteriness",
+      "gi discomfort in sensitive individuals"
+    ],
+    "safety": "",
+    "toxicity": "Low to moderate (long-term use linked to GI issues)",
+    "toxicity_ld50": "Caffeine LD50 ~192 mg/kg (rats, oral)",
+    "tags": [
+      "☕ social",
+      "🔥 thermogenic",
+      "🌿 focus",
+      "⚡ stimulant",
+      "stimulant",
+      "🌿 social",
+      "🔥 energy"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6926402/",
+      "South American Herbal Pharmacopoeia",
+      "Journal of Human Nutrition and Dietetics",
+      "2008"
+    ]
   },
   {
     "id": "zanthoxylum-americanum",
@@ -13634,55 +11586,6 @@
     ]
   },
   {
-    "id": "zanthoxylum-clava-herculis",
-    "slug": "toothache-tree",
-    "common": "Toothache Tree",
-    "scientific": "Zanthoxylum clava-herculis",
-    "category": "analgesic / stimulant",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "southeastern united states",
-    "legalstatus": "Legal",
-    "schedule": "",
-    "description": "also called the toothache tree; its bark creates a tingling numbness and light stimulation when chewed.",
-    "effects": "mouth numbness;mild stimulation;pain relief",
-    "mechanism": "Bark contains sanshools that cause paresthesia and stimulate trigeminal nerves",
-    "compounds": [
-      "Pellitorine",
-      "Sanshools"
-    ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "native american remedy for toothaches and sore throats; also used as a tonic",
-    "interactions": [
-      "may interact with other numbing agents"
-    ],
-    "contraindications": [
-      "mouth ulcers or sensitive gums"
-    ],
-    "sideeffects": [
-      "tingling",
-      "salivation",
-      "mild stomach upset"
-    ],
-    "safety": "",
-    "toxicity": "Low in customary doses",
-    "toxicity_ld50": "Not established",
-    "tags": [
-      "north america",
-      "tingling",
-      "toothache tree"
-    ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": [
-      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5656514/",
-      "Native American Ethnobotany – Moerman",
-      "Plants of the Gods – Rätsch"
-    ]
-  },
-  {
     "id": "zea-mays-stigma",
     "slug": "zea-mays-stigma",
     "common": "",
@@ -13726,6 +11629,54 @@
       "Plants of the Gods – Rätsch",
       "Journal of Medicinal Plants Research",
       "2011"
+    ]
+  },
+  {
+    "id": "zingiber-officinale",
+    "slug": "zingiber-officinale",
+    "common": "",
+    "scientific": "Zingiber officinale",
+    "category": "digestive / anti-inflammatory / stimulant",
+    "subcategory": "",
+    "intensity": "Mild–Moderate",
+    "region": "tropical asia, cultivated globally",
+    "legalstatus": "Legal worldwide",
+    "schedule": "",
+    "description": "a pungent rhizome widely used for its warming, carminative, and anti-inflammatory effects. revered in ayurvedic and traditional chinese medicine for treating nausea, coldness, and sluggish digestion.",
+    "effects": "Digestive support;Anti-nausea;Circulation boost;Mild stimulation",
+    "mechanism": "Contains gingerols and shogaols that modulate prostaglandins, TRP ion channels, and serotonin receptors involved in nausea.",
+    "compounds": [],
+    "preparations": [],
+    "dosage": "",
+    "therapeutic": "used for nausea, morning sickness, motion sickness, colds, pain, and poor circulation. also a culinary spice and tea staple.",
+    "interactions": [
+      "may interact with blood thinners or diabetes meds. synergistic with anti-nausea agents."
+    ],
+    "contraindications": [
+      "caution with anticoagulants",
+      "gallstones",
+      "or gastritis in high doses."
+    ],
+    "sideeffects": [
+      "heartburn",
+      "stomach upset in large doses. rare allergic reactions."
+    ],
+    "safety": "",
+    "toxicity": "Very low",
+    "toxicity_ld50": ">5000 mg/kg (rats, oral)",
+    "tags": [
+      "🌶️ warming",
+      "🫖 anti-nausea",
+      "🫁 circulation",
+      "🌿 culinary"
+    ],
+    "regiontags": [],
+    "legalnotes": "",
+    "image": "",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3665023/",
+      "Herbal Medicine – Mills & Bone",
+      "Plants of the Gods – Rätsch"
     ]
   },
   {


### PR DESCRIPTION
## Summary
- de-duplicate and merge herb rows by scientific name during CSV conversion and log coverage
- persist database filters/sorting in URL search params and add name/intensity/region sort options
- clean up herb card source lists by trimming punctuation and removing blanks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4242575008323a928fb4ad8e108c3