### PR TITLE
fix(cards): resilient rendering + data coverage check

### DIFF
--- a/scripts/convert-herbs.mjs
+++ b/scripts/convert-herbs.mjs
@@ -247,8 +247,14 @@ merged.sort((a,b)=>String(a.common||a.scientific).localeCompare(String(b.common|
 
 console.log(`[dedupe] in: ${out.length} → out: ${merged.length}`);
 
-const coverage = (k) =>
-  merged.filter((r) => (Array.isArray(r[k]) ? r[k].length : !!r[k])).length;
+const coverage = (key) =>
+  merged.filter((r) => {
+    const v = r[key];
+    return Array.isArray(v)
+      ? v.filter(Boolean).length > 0
+      : !!String(v ?? "").trim();
+  }).length;
+
 console.log("[coverage] common:", coverage("common"), "scientific:", coverage("scientific"));
 console.log(
   "[coverage] mechanism:",
@@ -258,6 +264,22 @@ console.log(
   "interactions:",
   coverage("interactions")
 );
+console.log(
+  "[coverage] effects:",
+  coverage("effects"),
+  "description:",
+  coverage("description"),
+  "tags:",
+  coverage("tags"),
+  "compounds:",
+  coverage("compounds"),
+  "contra:",
+  coverage("contraindications")
+);
+
+if (merged.length >= 200 && coverage("effects") < 50 && coverage("description") < 50) {
+  throw new Error("Sanity check: too many empty key fields — mapping likely broke.");
+}
 
 if (merged.length < 200) {
   const firstRow = rows[0] || {};

--- a/src/components/DatabaseHerbCard.tsx
+++ b/src/components/DatabaseHerbCard.tsx
@@ -1,8 +1,8 @@
 import { Link } from 'react-router-dom'
 import type { Herb } from '../types'
-import { has, list, bullets, urlish } from '../lib/format'
+import { isNonEmpty, toArray, firstN, cleanText, urlish } from '../lib/normalize'
 import { useFavorites } from '../lib/useFavorites'
-import { herbName, splitField } from '../utils/herb'
+import { herbName } from '../utils/herb'
 
 interface Props {
   herb: Herb
@@ -15,14 +15,8 @@ export function DatabaseHerbCard({ herb }: Props) {
   const intensity = herb.intensity?.trim()
   const region = herb.region?.trim()
   const legalStatus = herb.legalstatus?.trim()
-  const effectsList = splitField(herb.effects)
-  const effectsText = list(effectsList)
   const { favs, toggle, has } = useFavorites()
   const isFavorite = has(herb.slug)
-  const sourcesList = bullets(herb.sources)
-    .map(source => source.trim().replace(/[.;,]\s*$/, ''))
-    .filter(Boolean)
-
   return (
     <article
       className='glassmorphic-card soft-border-glow relative flex h-full flex-col gap-2 p-4 text-sand'
@@ -43,28 +37,28 @@ export function DatabaseHerbCard({ herb }: Props) {
             ★
           </button>
         </div>
-        {has(scientific) && <p className='text-sm italic text-sand/70'>{scientific}</p>}
-        {has(intensity) && (
+        {isNonEmpty(scientific) && <p className='text-sm italic text-sand/70'>{cleanText(scientific)}</p>}
+        {isNonEmpty(intensity) && (
           <p className='mt-1 inline-flex items-center rounded-full bg-white/10 px-2 py-1 text-xs uppercase tracking-wide text-sand/80'>
-            Intensity: {intensity}
+            Intensity: {cleanText(intensity)}
           </p>
         )}
       </header>
 
-      {has(effectsList) && (
+      {isNonEmpty(herb.effects) && (
         <p className='text-sm text-sand/90'>
-          <strong>Effects:</strong> {effectsText}
+          <strong>Effects:</strong> {cleanText(herb.effects)}
         </p>
       )}
-      {has(herb.description) && (
+      {isNonEmpty(herb.description) && (
         <p className='text-sm text-sand/80'>
-          <strong>Description:</strong> {herb.description}
+          <strong>Description:</strong> {cleanText(herb.description)}
         </p>
       )}
 
-      {has(herb.tags) && (
+      {isNonEmpty(herb.tags) && (
         <div className='mt-1 flex flex-wrap gap-2'>
-          {(herb.tags || []).slice(0, 6).map(tag => (
+          {firstN(herb.tags, 6).map(tag => (
             <span key={tag} className='rounded-full bg-purple-700/40 px-2 py-1 text-xs'>
               {tag}
             </span>
@@ -72,25 +66,25 @@ export function DatabaseHerbCard({ herb }: Props) {
         </div>
       )}
 
-      {has(region) && <p className='mt-1 text-sm text-sand/80'>🌍 {region}</p>}
+      {isNonEmpty(region) && <p className='mt-1 text-sm text-sand/80'>🌍 {cleanText(region)}</p>}
 
-      {has(herb.compounds) && (
+      {isNonEmpty(herb.compounds) && (
         <p className='mt-1 text-sm text-sand/90'>
-          <strong>Active Compounds:</strong> {list(herb.compounds, 3)}
+          <strong>Active Compounds:</strong> {firstN(herb.compounds, 3).join(', ')}
         </p>
       )}
 
-      {has(herb.contraindications) && (
+      {isNonEmpty(herb.contraindications) && (
         <p className='mt-1 text-sm text-sand/90'>
-          <strong>Contraindications:</strong> {list(herb.contraindications)}
+          <strong>Contraindications:</strong> {toArray(herb.contraindications).join(', ')}
         </p>
       )}
 
-      {sourcesList.length > 0 && (
+      {isNonEmpty(herb.sources) && (
         <div className='mt-2 text-sm text-sand/90'>
           <strong>Sources:</strong>
           <ul className='mt-1 list-disc pl-5'>
-            {sourcesList.map((source, index) => (
+            {toArray(herb.sources).map((source, index) => (
               <li key={`${herb.slug}-source-${index}`}>
                 {urlish(source) ? (
                   <a className='underline' href={source} target='_blank' rel='noreferrer'>
@@ -106,7 +100,7 @@ export function DatabaseHerbCard({ herb }: Props) {
       )}
 
       <div className='mt-auto flex items-center justify-between pt-2 text-xs text-sand/60'>
-        {has(legalStatus) && <span>Legal: {legalStatus}</span>}
+        {isNonEmpty(legalStatus) && <span>Legal: {cleanText(legalStatus)}</span>}
         <Link to={detailHref} className='text-sky-300 underline'>
           View details
         </Link>

--- a/src/lib/normalize.ts
+++ b/src/lib/normalize.ts
@@ -1,0 +1,15 @@
+export const isNonEmpty = (v: any) =>
+  Array.isArray(v) ? v.filter(Boolean).length > 0 : !!String(v ?? '').trim()
+
+export const toArray = (v: any): string[] => {
+  if (Array.isArray(v)) return v.filter(Boolean).map(String)
+  const s = String(v ?? '').trim()
+  if (!s) return []
+  return s.split(/[,;|]/).map(x => x.trim()).filter(Boolean)
+}
+
+export const firstN = (arr: any, n: number) => toArray(arr).slice(0, n)
+
+export const cleanText = (v: any) => String(v ?? '').trim()
+
+export const urlish = (s: string) => /^https?:\/\//i.test(s)

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -282,6 +282,12 @@ export default function Database() {
           </div>
         </div>
 
+        {import.meta.env.MODE !== 'production' && (
+          <p className='mt-2 text-xs opacity-60'>
+            debug: items={herbs.length} visible={filtered.length}
+          </p>
+        )}
+
         <div className='mt-6 flex flex-wrap items-center justify-between gap-2 text-sm text-sand/70'>
           <p>
             Showing <span className='font-semibold text-sand'>{paginated.length}</span> of{' '}


### PR DESCRIPTION
## Summary
- add shared UI normalizers to consistently handle array/string fields and URL detection
- update database herb cards to show rich details only when populated and gracefully handle mixed data shapes
- surface a development-only database debug indicator and extend the converter script with coverage guards

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e425f660cc8323b794a3178f3571ca