### PR TITLE
fix(cards): resilient field mapping — details restored

### DIFF
--- a/src/lib/fields.ts
+++ b/src/lib/fields.ts
@@ -1,0 +1,40 @@
+export const isNonEmpty = (v: any) =>
+  Array.isArray(v) ? v.filter(Boolean).length > 0 : !!String(v ?? '').trim()
+
+export const toArray = (v: any): string[] => {
+  if (Array.isArray(v)) return v.filter(Boolean).map(String)
+  const s = String(v ?? '').trim()
+  if (!s) return []
+  return s.split(/[,;|]/).map(x => x.trim()).filter(Boolean)
+}
+
+export function getText(obj: any, primary: string, aliases: string[] = []) {
+  const all = [primary, ...aliases]
+  const map: Record<string, string> = {}
+  for (const k of Object.keys(obj || {})) map[k.toLowerCase()] = k
+  for (const a of all) {
+    const hit = map[a.toLowerCase()]
+    if (hit) {
+      const val = String(obj[hit] ?? '').trim()
+      if (val) return val
+    }
+  }
+  return ''
+}
+
+export function getList(obj: any, primary: string, aliases: string[] = []) {
+  const all = [primary, ...aliases]
+  const map: Record<string, string> = {}
+  for (const k of Object.keys(obj || {})) map[k.toLowerCase()] = k
+  for (const a of all) {
+    const hit = map[a.toLowerCase()]
+    if (hit) {
+      const v = obj[hit]
+      const arr = toArray(v)
+      if (arr.length) return arr
+    }
+  }
+  return []
+}
+
+export const urlish = (s: string) => /^https?:\/\//i.test(s)

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -311,7 +311,7 @@ export default function Database() {
 
         {paginated.length > 0 ? (
           <div className='mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'>
-            {paginated.map(herb => (
+            {paginated.map((herb, index) => (
               <div key={herb.id} className='space-y-2'>
                 <div className='flex justify-end'>
                   <label className='flex items-center gap-2 text-xs text-sand/80'>
@@ -323,7 +323,7 @@ export default function Database() {
                     Compare
                   </label>
                 </div>
-                <DatabaseHerbCard herb={herb} />
+                <DatabaseHerbCard herb={herb} index={index} />
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- add alias-aware field helpers for resolving text and list data at render time
- update database herb card to use resilient lookups and surface restored details while logging first item shape in dev
- pass the list index when rendering cards so the dev guard can report key drift

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e42830c9bc832382d89cfe45b23307