### PR TITLE
feat(schema+ui): canonical mapping and richer herb details

### DIFF
--- a/scripts/convert-herbs.mjs
+++ b/scripts/convert-herbs.mjs
@@ -5,290 +5,218 @@ import Papa from "papaparse";
 const SRC = "src/data/herbs/deep_audited_subset_updated_v1.28.csv";
 const OUT = "src/data/herbs/herbs.normalized.json";
 
-function slugify(s) {
-  return String(s || "")
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
-
-const NULLY = new Set([
-  "",
-  "na",
-  "n/a",
-  "none",
-  "null",
-  "undefined",
-  "unknown",
-  "unk",
-  "?",
-  "-",
-]);
-
-function norm(v) {
-  if (v == null) return "";
-  const s = String(v).trim();
-  return NULLY.has(s.toLowerCase()) ? "" : s;
-}
-
-function splitList(v) {
-  if (v == null) return [];
-  return String(v)
-    .split(/[,;|]/)
-    .map((s) => s.trim())
-    .filter(Boolean);
-}
-
-function pick(row, aliases) {
-  const lower = Object.fromEntries(
-    Object.keys(row).map((k) => [k.toLowerCase(), k])
-  );
-  for (const key of aliases) {
-    const hit = lower[key.toLowerCase()];
-    if (hit) return norm(row[hit]);
-  }
-  return "";
-}
-
-const csv = fs.readFileSync(SRC, "utf-8");
-const parsed = Papa.parse(csv, {
-  header: true,
-  skipEmptyLines: "greedy",
-  dynamicTyping: false,
-});
-
-if (parsed.errors?.length) {
-  console.error("CSV parse errors (first 3):", parsed.errors.slice(0, 3));
-}
-
-const rows = (parsed.data || []).filter((r) => Object.keys(r).length);
-const out = rows
-  .map((r) => {
-    const common = pick(r, ["common", "commonname", "name"]);
-    const scientific = pick(r, [
-      "scientific",
-      "scientificname",
-      "latin",
-      "latinname",
-      "binomial",
-    ]);
-    const slug = slugify(common || scientific);
-
-    const category = pick(r, [
-      "category",
-      "categoryprimary",
-      "primarycategory",
-      "group",
-    ]);
-    const subcategory = pick(r, ["subcategory", "secondarycategory"]);
-    const intensity = pick(r, ["intensity", "potency", "strength"]);
-    const region = pick(r, ["region", "origin", "geography", "distribution"]);
-    const legalstatus = pick(r, ["legalstatus", "legal_status", "status"]);
-    const schedule = pick(r, ["schedule", "controlled_schedule"]);
-    const description = pick(r, ["description", "summary", "overview"]);
-    const effects = pick(r, ["effects", "effect"]);
-    const mechanism = pick(r, [
-      "mechanismofaction",
-      "mechanism",
-      "moa",
-      "mechanism_of_action",
-      "action",
-    ]);
-
-    const compounds = splitList(
-      pick(r, ["compound", "compounds", "keycompounds", "actives", "constituents"])
-    );
-    const preparations = splitList(
-      pick(r, [
-        "preparations",
-        "preparation",
-        "method",
-        "forms",
-        "formulations",
-      ])
-    );
-    const dosage = pick(r, [
-      "dosage",
-      "dose",
-      "dosing",
-      "dosage_and_administration",
-      "administration",
-    ]);
-    const therapeutic = pick(r, [
-      "therapeutic",
-      "uses",
-      "applications",
-      "benefits",
-      "traditional_uses",
-    ]);
-    const interactions = splitList(
-      pick(r, ["interactions", "drug_interactions", "mixing"])
-    );
-    const contraind = splitList(
-      pick(r, ["contraindications", "contradictions", "cautions"])
-    );
-    const sideeffects = splitList(
-      pick(r, [
-        "sideeffects",
-        "side_effects",
-        "adverse_effects",
-        "unwanted_effects",
-      ])
-    );
-    const safety = pick(r, [
-      "safety",
-      "warnings",
-      "precautions",
-      "risk_profile",
-    ]);
-    const toxicity = pick(r, ["toxicity", "tox_profile"]);
-    const toxicityLD50 = pick(r, ["toxicity_ld50", "toxicityld50", "ld50"]);
-
-    const tags = splitList(pick(r, ["tags", "labels", "keywords"]));
-    const regiontags = splitList(pick(r, ["region_tags", "regions"]));
-    const legalnotes = pick(r, ["legalnotes", "legal_notes"]);
-    const image = pick(r, ["image", "imageurl", "img", "photo"]);
-    const sourcesStr = pick(r, ["sources", "refs", "references"]);
-    const sources = splitList(sourcesStr);
-
-    const catFromTags =
-      tags.find((t) =>
-        /stimulant|sedative|nootropic|adaptogen|entheogen|tonic|anxiolytic|analgesic/i.test(
-          t
-        )
-      ) || "";
-    const finalCategory = category || catFromTags;
-
-    return {
-      id: pick(r, ["id", "uuid"]) || slug,
-      slug,
-      common,
-      scientific,
-      category: finalCategory,
-      subcategory,
-      intensity,
-      region,
-      legalstatus,
-      schedule,
-      description,
-      effects,
-      mechanism,
-      compounds,
-      preparations,
-      dosage,
-      therapeutic,
-      interactions,
-      contraindications: contraind,
-      sideeffects,
-      safety,
-      toxicity,
-      toxicity_ld50: toxicityLD50,
-      tags,
-      regiontags,
-      legalnotes,
-      image,
-      sources,
+async function main() {
+  let ALIASES;
+  try {
+    ({ ALIASES } = await import("../src/data/schema.ts"));
+  } catch (err) {
+    console.warn("[convert-herbs] Falling back to local aliases map", err?.message);
+    ALIASES = {
+      common: ["common", "commonname", "name"],
+      scientific: ["scientific", "scientificname", "latin", "latinname", "binomial"],
+      slug: ["slug"],
+      category: ["category", "categoryprimary", "primarycategory", "group"],
+      subcategory: ["subcategory", "secondarycategory"],
+      intensity: ["intensity", "potency", "strength"],
+      region: ["region", "origin", "geography", "distribution"],
+      regiontags: ["region_tags", "regions"],
+      legalstatus: ["legalstatus", "legal_status", "status"],
+      schedule: ["schedule", "controlled_schedule"],
+      legalnotes: ["legalnotes", "legal_notes"],
+      description: ["description", "summary", "overview", "desc"],
+      effects: ["effects", "effect"],
+      mechanism: ["mechanismofaction", "mechanism", "moa", "mechanism_of_action", "action"],
+      compounds: ["compounds", "compound", "keycompounds", "actives", "constituents"],
+      preparations: ["preparations", "preparation", "method", "forms", "formulations"],
+      dosage: ["dosage", "dose", "dosing", "dosage_and_administration", "administration"],
+      therapeutic: ["therapeutic", "uses", "applications", "benefits", "traditional_uses"],
+      interactions: ["interactions", "drug_interactions", "mixing"],
+      contraindications: ["contraindications", "contradictions", "cautions"],
+      sideeffects: ["sideeffects", "side_effects", "adverse_effects", "unwanted_effects"],
+      safety: ["safety", "warnings", "precautions", "risk_profile"],
+      toxicity: ["toxicity", "tox_profile"],
+      toxicity_ld50: ["toxicity_ld50", "toxicityld50", "ld50"],
+      tags: ["tags", "labels", "keywords"],
+      sources: ["sources", "refs", "references"],
+      image: ["image", "imageurl", "img", "photo"],
     };
-  })
-  .filter((x) => x.slug);
+  }
 
-function canonSci(s){ return String(s||"").toLowerCase().replace(/\s+/g," ").trim(); }
-function mergeArrays(a,b){
-  const set = new Set([...(a||[]), ...(b||[])] .map(v=>String(v).trim()).filter(Boolean));
-  return Array.from(set);
-}
-function prefer(a,b){
-  const A = (a??"").trim(), B=(b??"").trim();
-  if (A && !B) return A;
-  if (!A && B) return B;
-  return A.length >= B.length ? A : B;
-}
-const byKey = new Map();
-for (const r of out){
-  const key = canonSci(r.scientific) || r.slug;
-  if (!byKey.has(key)){ byKey.set(key, r); continue; }
-  const prev = byKey.get(key);
-  byKey.set(key, {
-    ...prev,
-    id: prev.id || r.id,
-    slug: prev.slug, // keep first slug stable
-    common: prefer(prev.common, r.common),
-    scientific: prefer(prev.scientific, r.scientific),
-    category: prefer(prev.category, r.category),
-    subcategory: prefer(prev.subcategory, r.subcategory),
-    intensity: prefer(prev.intensity, r.intensity),
-    region: prefer(prev.region, r.region),
-    legalstatus: prefer(prev.legalstatus, r.legalstatus),
-    schedule: prefer(prev.schedule, r.schedule),
-    description: prefer(prev.description, r.description),
-    effects: prefer(prev.effects, r.effects),
-    mechanism: prefer(prev.mechanism, r.mechanism),
-    dosage: prefer(prev.dosage, r.dosage),
-    therapeutic: prefer(prev.therapeutic, r.therapeutic),
-    safety: prefer(prev.safety, r.safety),
-    toxicity: prefer(prev.toxicity, r.toxicity),
-    toxicity_ld50: prefer(prev.toxicity_ld50, r.toxicity_ld50),
-    legalnotes: prefer(prev.legalnotes, r.legalnotes),
-    image: prefer(prev.image, r.image),
-    compounds: mergeArrays(prev.compounds, r.compounds),
-    preparations: mergeArrays(prev.preparations, r.preparations),
-    interactions: mergeArrays(prev.interactions, r.interactions),
-    contraindications: mergeArrays(prev.contraindications, r.contraindications),
-    sideeffects: mergeArrays(prev.sideeffects, r.sideeffects),
-    tags: mergeArrays(prev.tags, r.tags),
-    regiontags: mergeArrays(prev.regiontags, r.regiontags),
-    sources: mergeArrays(prev.sources, r.sources),
+  const NULLY = new Set(["", "na", "n/a", "none", "null", "undefined", "unknown", "unk", "?", "-"]);
+  const text = (v) => {
+    const s = String(v ?? "").trim();
+    return NULLY.has(s.toLowerCase()) ? "" : s;
+  };
+  const list = (v) => {
+    if (Array.isArray(v)) return v.map(String).map((s) => s.trim()).filter(Boolean);
+    const s = text(v);
+    if (!s) return [];
+    return s.split(/[,;|]/).map((x) => x.trim()).filter(Boolean);
+  };
+  const pick = (row, keys) => {
+    const map = Object.fromEntries(Object.keys(row).map((k) => [k.toLowerCase(), k]));
+    for (const key of keys) {
+      const hit = map[key.toLowerCase()];
+      if (hit) return text(row[hit]);
+    }
+    return "";
+  };
+  const pickList = (row, keys) => list(pick(row, keys));
+  const slugify = (s) =>
+    String(s || "")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+
+  const csv = fs.readFileSync(SRC, "utf-8");
+  const parsed = Papa.parse(csv, {
+    header: true,
+    skipEmptyLines: "greedy",
+    dynamicTyping: false,
   });
-}
-const merged = Array.from(byKey.values());
 
-// optional: sort merged by common name for stable output
-merged.sort((a,b)=>String(a.common||a.scientific).localeCompare(String(b.common||b.scientific)));
+  if (parsed.errors?.length) {
+    console.error("CSV parse errors (first 3):", parsed.errors.slice(0, 3));
+  }
 
-console.log(`[dedupe] in: ${out.length} → out: ${merged.length}`);
+  const rows = (parsed.data || []).filter((r) => Object.keys(r).length);
+  let out = rows
+    .map((r) => {
+      const common = pick(r, ALIASES.common);
+      const scientific = pick(r, ALIASES.scientific);
+      const slug = slugify(common || scientific);
 
-const coverage = (key) =>
-  merged.filter((r) => {
-    const v = r[key];
-    return Array.isArray(v)
-      ? v.filter(Boolean).length > 0
-      : !!String(v ?? "").trim();
-  }).length;
+      const obj = {
+        id: pick(r, ["id", "uuid"]) || slug,
+        slug,
+        common,
+        scientific,
+        category: pick(r, ALIASES.category),
+        subcategory: pick(r, ALIASES.subcategory),
+        intensity: pick(r, ALIASES.intensity),
+        region: pick(r, ALIASES.region),
+        regiontags: pickList(r, ALIASES.regiontags),
+        legalstatus: pick(r, ALIASES.legalstatus),
+        schedule: pick(r, ALIASES.schedule),
+        legalnotes: pick(r, ALIASES.legalnotes),
+        description: pick(r, ALIASES.description),
+        effects: pick(r, ALIASES.effects),
+        mechanism: pick(r, ALIASES.mechanism),
+        compounds: pickList(r, ALIASES.compounds),
+        preparations: pickList(r, ALIASES.preparations),
+        dosage: pick(r, ALIASES.dosage),
+        therapeutic: pick(r, ALIASES.therapeutic),
+        interactions: pickList(r, ALIASES.interactions),
+        contraindications: pickList(r, ALIASES.contraindications),
+        sideeffects: pickList(r, ALIASES.sideeffects),
+        safety: pick(r, ALIASES.safety),
+        toxicity: pick(r, ALIASES.toxicity),
+        toxicity_ld50: pick(r, ALIASES.toxicity_ld50),
+        tags: pickList(r, ALIASES.tags),
+        sources: pickList(r, ALIASES.sources),
+        image: pick(r, ALIASES.image),
+      };
 
-console.log("[coverage] common:", coverage("common"), "scientific:", coverage("scientific"));
-console.log(
-  "[coverage] mechanism:",
-  coverage("mechanism"),
-  "compounds:",
-  coverage("compounds"),
-  "interactions:",
-  coverage("interactions")
-);
-console.log(
-  "[coverage] effects:",
-  coverage("effects"),
-  "description:",
-  coverage("description"),
-  "tags:",
-  coverage("tags"),
-  "compounds:",
-  coverage("compounds"),
-  "contra:",
-  coverage("contraindications")
-);
+      // derive category from tags if empty
+      if (!obj.category) {
+        const t = obj.tags.find((t) =>
+          /stimulant|sedative|nootropic|adaptogen|entheogen|tonic|anxiolytic|analgesic/i.test(t)
+        );
+        if (t) obj.category = t;
+      }
+      return obj;
+    })
+    .filter((x) => x.slug);
 
-if (merged.length >= 200 && coverage("effects") < 50 && coverage("description") < 50) {
-  throw new Error("Sanity check: too many empty key fields — mapping likely broke.");
-}
+  function canonSci(s) {
+    return String(s || "").toLowerCase().replace(/\s+/g, " ").trim();
+  }
+  function mergeArrays(a, b) {
+    const set = new Set([...(a || []), ...(b || [])].map((v) => String(v).trim()).filter(Boolean));
+    return Array.from(set);
+  }
+  function prefer(a, b) {
+    const A = (a ?? "").trim();
+    const B = (b ?? "").trim();
+    if (A && !B) return A;
+    if (!A && B) return B;
+    return A.length >= B.length ? A : B;
+  }
+  const byKey = new Map();
+  for (const r of out) {
+    const key = canonSci(r.scientific) || r.slug;
+    if (!byKey.has(key)) {
+      byKey.set(key, r);
+      continue;
+    }
+    const prev = byKey.get(key);
+    byKey.set(key, {
+      ...prev,
+      id: prev.id || r.id,
+      slug: prev.slug, // keep first slug stable
+      common: prefer(prev.common, r.common),
+      scientific: prefer(prev.scientific, r.scientific),
+      category: prefer(prev.category, r.category),
+      subcategory: prefer(prev.subcategory, r.subcategory),
+      intensity: prefer(prev.intensity, r.intensity),
+      region: prefer(prev.region, r.region),
+      regiontags: mergeArrays(prev.regiontags, r.regiontags),
+      legalstatus: prefer(prev.legalstatus, r.legalstatus),
+      schedule: prefer(prev.schedule, r.schedule),
+      legalnotes: prefer(prev.legalnotes, r.legalnotes),
+      description: prefer(prev.description, r.description),
+      effects: prefer(prev.effects, r.effects),
+      mechanism: prefer(prev.mechanism, r.mechanism),
+      compounds: mergeArrays(prev.compounds, r.compounds),
+      preparations: mergeArrays(prev.preparations, r.preparations),
+      dosage: prefer(prev.dosage, r.dosage),
+      therapeutic: prefer(prev.therapeutic, r.therapeutic),
+      interactions: mergeArrays(prev.interactions, r.interactions),
+      contraindications: mergeArrays(prev.contraindications, r.contraindications),
+      sideeffects: mergeArrays(prev.sideeffects, r.sideeffects),
+      safety: prefer(prev.safety, r.safety),
+      toxicity: prefer(prev.toxicity, r.toxicity),
+      toxicity_ld50: prefer(prev.toxicity_ld50, r.toxicity_ld50),
+      tags: mergeArrays(prev.tags, r.tags),
+      sources: mergeArrays(prev.sources, r.sources),
+      image: prefer(prev.image, r.image),
+    });
+  }
+  out = Array.from(byKey.values());
 
-if (merged.length < 200) {
-  const firstRow = rows[0] || {};
-  console.error("Column keys (sample row):", Object.keys(firstRow));
-  throw new Error(
-    `Converter sanity check failed: only ${merged.length} rows emitted. Check column names/CSV formatting.`
+  // optional: sort merged by common name for stable output
+  out.sort((a, b) =>
+    String(a.common || a.scientific).localeCompare(String(b.common || b.scientific))
   );
+
+  console.log(`[dedupe] in: ${rows.length} → out: ${out.length}`);
+
+  fs.mkdirSync(path.dirname(OUT), { recursive: true });
+  fs.writeFileSync(OUT, JSON.stringify(out, null, 2), "utf-8");
+  console.log(`Wrote ${OUT} (${out.length} rows)`);
+
+  const coverage = (k) =>
+    out.filter((r) => (Array.isArray(r[k]) ? r[k].length : !!String(r[k] || "").trim())).length;
+  console.log(
+    "[coverage] effects:",
+    coverage("effects"),
+    "mechanism:",
+    coverage("mechanism"),
+    "dosage:",
+    coverage("dosage"),
+    "therapeutic:",
+    coverage("therapeutic"),
+    "preparations:",
+    coverage("preparations"),
+    "sideeffects:",
+    coverage("sideeffects"),
+    "safety:",
+    coverage("safety")
+  );
+  if (out.length < 200) throw new Error("Sanity: too few rows");
 }
 
-fs.mkdirSync(path.dirname(OUT), { recursive: true });
-fs.writeFileSync(OUT, JSON.stringify(merged, null, 2), "utf-8");
-console.log(`Wrote ${OUT} (${merged.length} rows)`);
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/src/components/DatabaseHerbCard.tsx
+++ b/src/components/DatabaseHerbCard.tsx
@@ -16,6 +16,7 @@ export function DatabaseHerbCard({ herb, index = 0 }: Props) {
   const intensity = getText(herb, 'intensity', ['potency', 'strength'])
   const region = getText(herb, 'region', ['regions', 'origin', 'geography'])
   const legalStatus = getText(herb, 'legalstatus', ['legal_status', 'status'])
+  const showLegal = isNonEmpty(legalStatus) && !/^legal$/i.test(legalStatus)
   const { favs, toggle, has } = useFavorites()
   const isFavorite = has(herb.slug)
 
@@ -114,7 +115,7 @@ export function DatabaseHerbCard({ herb, index = 0 }: Props) {
       )}
 
       <div className='mt-auto flex items-center justify-between pt-2 text-xs text-sand/60'>
-        {isNonEmpty(legalStatus) && <span>Legal: {legalStatus}</span>}
+        {showLegal && <span>Legal: {legalStatus}</span>}
         <Link to={detailHref} className='text-sky-300 underline'>
           View details
         </Link>

--- a/src/data/herbs/herbs.normalized.json
+++ b/src/data/herbs/herbs.normalized.json
@@ -8,8 +8,10 @@
     "subcategory": "",
     "intensity": "Moderate",
     "region": "🌎 americas",
+    "regiontags": [],
     "legalstatus": "Controlled in many regions",
     "schedule": "",
+    "legalnotes": "",
     "description": "classic phenethylamine psychedelic from peyote and san pedro cacti.",
     "effects": "Color enhancement;empathy;spiritual visions",
     "mechanism": "Phenethylamine psychedelic acting on 5-HT2A and dopamine receptors.",
@@ -37,10 +39,8 @@
       "🌀 visionary",
       "💊 oral"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "acacia-confusa",
@@ -51,8 +51,10 @@
     "subcategory": "",
     "intensity": "Strong",
     "region": "taiwan, philippines, pacific islands",
+    "regiontags": [],
     "legalstatus": "DMT restricted in many countries",
     "schedule": "",
+    "legalnotes": "",
     "description": "a taiwanese tree whose root bark is rich in dmt and related tryptamines. commonly used in diy ayahuasca analogs or 'anahuasca' brews.",
     "effects": "Visual distortion;mystical states;introspection",
     "mechanism": "DMT – 5-HT2A agonist; requires MAOI for oral activity",
@@ -81,10 +83,8 @@
       "🌿 root bark",
       "🧪 dmt"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "acacia-maidenii",
@@ -95,8 +95,10 @@
     "subcategory": "",
     "intensity": "Strong",
     "region": "native to eastern australia",
+    "regiontags": [],
     "legalstatus": "DMT restricted in many countries",
     "schedule": "",
+    "legalnotes": "",
     "description": "australian acacia tree whose bark is rich in dmt and sometimes used in ayahuasca analogues.",
     "effects": "strong visuals;mystical experience;euphoria",
     "mechanism": "Root bark contains DMT that acts as a 5‑HT2A agonist; requires MAOI inhibition for oral activity",
@@ -126,14 +128,12 @@
       "dmt",
       "tree"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://erowid.org/plants/acacia_maidenii/",
       "PubMed ID: 21798319",
       "Trouts Notes – Acacia Alkaloid Profiles"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "achillea-millefolium",
@@ -144,8 +144,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "europe, north america, temperate asia",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "named after achilles, who used it to treat battlefield wounds, yarrow is a classic herb for bleeding, inflammation, and fevers. it's used internally for digestion and externally for cuts, bruises, and nosebleeds.",
     "effects": "Wound healing;Fever reduction;Digestive support;Circulatory modulation",
     "mechanism": "Rich in flavonoids, alkaloids, sesquiterpene lactones, and salicylic acid derivatives. Acts as an anti-inflammatory, astringent, and mild diaphoretic.",
@@ -179,14 +181,12 @@
       "🌼 flower",
       "😊 mild"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6331677/",
       "British Herbal Compendium",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "acmella-oleracea",
@@ -197,8 +197,10 @@
     "subcategory": "",
     "intensity": "Moderate–Strong (topical), Mild (systemic)",
     "region": "south america, widely cultivated",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "famous for its electric tingle, spilanthes is traditionally used for dental pain, infections, and immune stimulation. its 'buzz buttons' offer a unique sensory experience and are increasingly used in mixology and herbalism.",
     "effects": "Numbing;Tingling;Salivation;Immune support",
     "mechanism": "Spilanthol (an alkamide) activates TRPV1 channels, producing a tingling and numbing sensation. Also shown to enhance immune response and have antibacterial activity.",
@@ -226,14 +228,12 @@
       "🧪 immune tonic",
       "💧 salivary"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3817685/",
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "acorus-americanus",
@@ -244,8 +244,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "north america",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "american sweet flag, native to north america, used by indigenous groups for its psychoactive and stimulant properties.",
     "effects": "alertness;mental clarity;mild euphoria",
     "mechanism": "Cholinergic + dopaminergic modulation",
@@ -266,10 +268,8 @@
       "calamus species",
       "uplifting"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "acorus-calamus",
@@ -280,8 +280,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "europe, asia, north america",
+    "regiontags": [],
     "legalstatus": "Generally legal, though some preparations restricted",
     "schedule": "",
+    "legalnotes": "",
     "description": "fragrant wetland herb known as sweet flag; historically used for relaxation and vivid dreams.",
     "effects": "calm;mild euphoria;dream enhancement",
     "mechanism": "Contains beta‑asarone which may modulate GABA and serotonin receptors",
@@ -309,15 +311,13 @@
       "root",
       "sedative"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6383205/",
       "PubChem CID: 73568",
       "Botanical Safety Handbook",
       "2nd ed."
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "acorus-calamus-angustatus",
@@ -328,8 +328,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "himalayas",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "a rare calamus variant high in beta-asarone, used in tibetan medicine and ritual incense.",
     "effects": "trance;mental clarity;light hallucinations",
     "mechanism": "GABAergic + cholinergic",
@@ -350,10 +352,8 @@
       "variant",
       "aromatic stimulant"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "aegle-marmelos",
@@ -364,8 +364,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "south asia",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "bael tree used in ayurvedic medicine for digestion and calm",
     "effects": "calm;digestive relief",
     "mechanism": "Coumarins like marmelosin exhibit mild sedative and GI effects",
@@ -391,15 +393,13 @@
       "🌿 ayurveda",
       "🍈 fruit"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4027290/",
       "Indian Journal of Traditional Knowledge",
       "2009",
       "Ayurvedic Pharmacopoeia of India"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "silene-undulata",
@@ -410,8 +410,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "south africa",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "",
     "effects": "lucid dreaming;dream recall;mild sedation",
     "mechanism": "Unknown; may influence cholinergic systems during sleep cycles.",
@@ -432,10 +434,8 @@
       "visionary",
       "african"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "albizia-julibrissin",
@@ -446,8 +446,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "native to asia, cultivated elsewhere",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "often called persian silk tree; valued in asian herbalism for its tranquil and mood-brightening properties.",
     "effects": "uplifted mood;relaxation;mild sedation",
     "mechanism": "Contains saponins and flavonoids thought to modulate serotonin and GABA",
@@ -473,16 +475,14 @@
       "anxiolytic",
       "flower"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6834330/",
       "Chinese Herbal Medicine: Materia Medica",
       "3rd ed.",
       "Journal of Ethnopharmacology",
       "2009"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "pimenta-dioica",
@@ -493,8 +493,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "caribbean, central america",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "also known as allspice, this caribbean plant has mild uplifting and warming effects, sometimes used in ritual incense.",
     "effects": "stimulant;aromatic euphoria;warming",
     "mechanism": "GABAergic + serotonergic",
@@ -516,10 +518,8 @@
       "ritual",
       "mild stimulant"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "aloysia-citrodora",
@@ -530,8 +530,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "south america",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "lemon verbena, a gentle herbal tea with calming and mood-lifting effects.",
     "effects": "calm;relaxation;light euphoria",
     "mechanism": "GABAergic + serotonergic",
@@ -553,10 +555,8 @@
       "folk remedy",
       "calming"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "alpinia-galanga",
@@ -567,8 +567,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "indonesia, thailand, malaysia",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "a common culinary spice known as galangal that offers gentle stimulation and a warming effect.",
     "effects": "warm stimulation;mild euphoria;enhanced circulation",
     "mechanism": "Contains eugenol and cineole that increase circulation and mild CNS stimulation",
@@ -594,14 +596,12 @@
       "galangal",
       "spice"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://pubmed.ncbi.nlm.nih.gov/20428007/",
       "Phytomedicine. 2005",
       "Ayurvedic Materia Medica"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "althaea-officinalis",
@@ -612,8 +612,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "europe, middle east, north america",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a classic mucilaginous herb known for its thick, slippery root extract. marshmallow has been used for centuries to coat and soothe mucous membranes, especially in the respiratory and digestive tracts.",
     "effects": "Soothes throat;Eases cough;Reduces inflammation;Digestive calm",
     "mechanism": "High mucilage content coats inflamed tissues, reducing irritation and inflammation. Also mildly antibacterial and immunomodulatory.",
@@ -639,14 +641,12 @@
       "🩹 demulcent",
       "🌿 digestive"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5452227/",
       "British Herbal Compendium",
       "Herbal Medicine – Mills & Bone"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "amanita-muscaria",
@@ -657,8 +657,10 @@
     "subcategory": "",
     "intensity": "Moderate to strong",
     "region": "northern hemisphere, boreal forests",
+    "regiontags": [],
     "legalstatus": "Legal in most countries",
     "schedule": "",
+    "legalnotes": "",
     "description": "iconic red-capped mushroom used in siberian shamanism and folklore. psychoactive when properly prepared.",
     "effects": "Euphoria;dissociation;dreamlike state",
     "mechanism": "Ibotenic acid and muscimol act as GABA agonists and NMDA antagonists after decarboxylation.",
@@ -687,16 +689,14 @@
       "⚠️ caution",
       "🍄 mushroom"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC10454585/",
       "Erowid Amanita Vault",
       "Journal of Ethnopharmacology",
       "2008",
       "Toxicological Profile: Muscimol & Ibotenic Acid (NIH)"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "amanita-pantherina",
@@ -707,8 +707,10 @@
     "subcategory": "",
     "intensity": "Strong",
     "region": "northern hemisphere",
+    "regiontags": [],
     "legalstatus": "Varies; unscheduled in many countries",
     "schedule": "",
+    "legalnotes": "",
     "description": "",
     "effects": "sedation;confusion;dizziness",
     "mechanism": "Contains muscimol and ibotenic acid acting on GABA receptors",
@@ -736,10 +738,8 @@
       "mushroom",
       "panther cap"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "amorpha-fruticosa",
@@ -750,8 +750,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "north america",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "false indigo bush, native to north america, was historically smoked for relaxation and vision-induction.",
     "effects": "relaxation;mental softening;trance",
     "mechanism": "Likely GABAergic",
@@ -772,10 +774,8 @@
       "smokable",
       "visionary"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "anadenanthera-colubrina",
@@ -786,8 +786,10 @@
     "subcategory": "",
     "intensity": "High",
     "region": "amazon basin, andean regions of peru, brazil, colombia, venezuela",
+    "regiontags": [],
     "legalstatus": "Bufotenine is Schedule I in the USA. Tree/seeds legal in some regions.",
     "schedule": "",
+    "legalnotes": "",
     "description": "a south american tree whose seeds are used to make yopo, a potent psychoactive snuff. used ritually by indigenous tribes for divination and healing.",
     "effects": "Visual hallucinations;Disorientation;Euphoria;Auditory shifts;Dissociation",
     "mechanism": "Contains bufotenine (5-HO-DMT), DMT, and 5-MeO-DMT. Acts as a serotonergic agonist (5-HT2A, 5-HT1A), with bufotenine producing strong visual and somatic effects when insufflated.",
@@ -822,16 +824,14 @@
       "🌀 yopo",
       "⛔ maoi warning"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://erowid.org/plants/anadenanthera/",
       "PubMed ID: 12065154",
       "Journal of Ethnopharmacology",
       "1994",
       "TiHKAL by Alexander Shulgin"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "anadenanthera-peregrina",
@@ -842,8 +842,10 @@
     "subcategory": "",
     "intensity": "Very strong",
     "region": "venezuela, brazil, caribbean, northern south america",
+    "regiontags": [],
     "legalstatus": "Bufotenine is Schedule I in the U.S.; plant materials legal in some countries.",
     "schedule": "",
+    "legalnotes": "",
     "description": "closely related to a. colubrina, this species is the primary source of cohoba snuff used by taino and other caribbean-amazonian tribes. extremely potent and short-acting.",
     "effects": "Intense visuals;Out-of-body experience;Altered time perception;Spiritual insight",
     "mechanism": "Bufotenine (5-HO-DMT) is the dominant active; acts on 5-HT2A and 5-HT1A receptors. May also contain trace DMT and 5-MeO-DMT. Insufflated use bypasses first-pass metabolism.",
@@ -886,15 +888,13 @@
       "⚠️ caution",
       "🧠 vision"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://erowid.org/plants/anadenanthera_peregrina/",
       "Ratsch: The Encyclopedia of Psychoactive Plants",
       "Journal of Psychoactive Drugs",
       "1986"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "rhododendron-anthopogon",
@@ -905,8 +905,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "himalayas",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "",
     "effects": "uplifting;clarity;spiritual aid",
     "mechanism": "Aromatherapeutic and cognitive modulation via essential oils",
@@ -928,10 +930,8 @@
       "ritual",
       "clarity"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "aquilaria-malaccensis",
@@ -942,8 +942,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "southeast asia",
+    "regiontags": [],
     "legalstatus": "Cultivation regulated due to overharvesting but use is legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "source of precious agarwood resin, producing a soothing aroma and subtle psychoactive calm when burned.",
     "effects": "tranquil mind;subtle euphoria;aromatic relaxation",
     "mechanism": "Resin rich in sesquiterpenes acts via GABAergic and dopaminergic pathways when inhaled",
@@ -969,10 +971,8 @@
       "incense",
       "sedative"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "arctostaphylos-uva-ursi",
@@ -983,8 +983,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "northern hemisphere (cool climates)",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a low-growing evergreen shrub used traditionally for urinary tract infections and kidney health. its leaves contain arbutin, which converts to hydroquinone in the bladder and acts as a urinary antiseptic.",
     "effects": "Urinary tract support;Astringent;Anti-inflammatory;Antibacterial",
     "mechanism": "Arbutin is hydrolyzed into hydroquinone in the urinary tract, which exerts antimicrobial activity. Tannins also provide astringent effects to mucous membranes.",
@@ -1014,14 +1016,12 @@
       "🧠 urinary",
       "🌿 traditional"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6204622/",
       "Herbal Medicine – Mills & Bone",
       "ESCOP Monographs"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "betel-nut",
@@ -1032,8 +1032,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "south and southeast asia",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "a widely used masticatory stimulant in asia and the pacific, often combined with lime and betel leaf.",
     "effects": "Stimulation;warmth;mild euphoria",
     "mechanism": "Arecoline acts as a muscarinic cholinergic agonist",
@@ -1057,10 +1059,8 @@
     "toxicity": "",
     "toxicity_ld50": "",
     "tags": [],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "argemone-mexicana",
@@ -1071,8 +1071,10 @@
     "subcategory": "",
     "intensity": "Moderate",
     "region": "native to tropical america; naturalized worldwide",
+    "regiontags": [],
     "legalstatus": "Legal but sometimes regulated due to toxicity",
     "schedule": "",
+    "legalnotes": "",
     "description": "spiny yellow poppy whose milky latex was historically used for pain relief and sedation.",
     "effects": "relaxation;analgesia;slight euphoria",
     "mechanism": "Isoquinoline alkaloids interact with opioid and dopamine receptors",
@@ -1101,10 +1103,8 @@
       "folk medicine",
       "poppy"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "argyreia-speciosa",
@@ -1115,8 +1115,10 @@
     "subcategory": "",
     "intensity": "Moderate to Strong",
     "region": "india and southeast asia",
+    "regiontags": [],
     "legalstatus": "Seeds legal though extraction of LSA may be restricted",
     "schedule": "",
+    "legalnotes": "",
     "description": "close relative of hawaiian baby woodrose with lsa‑containing seeds used in some indian traditions.",
     "effects": "closed-eye visuals;euphoria;enhanced introspection",
     "mechanism": "Seeds contain lysergic acid amide (LSA) acting on serotonin receptors",
@@ -1144,15 +1146,13 @@
       "lsa",
       "seeds"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3880486/",
       "Ayurvedic Pharmacopoeia of India",
       "Journal of Ethnopharmacology",
       "2001"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "artemisia-abrotanum",
@@ -1163,8 +1163,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "mediterranean, europe",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "southernwood is a fragrant herb used traditionally as a stimulant, memory aid, and dream enhancer.",
     "effects": "mental clarity;dream enhancement;stimulant",
     "mechanism": "GABAergic + cholinergic modulation",
@@ -1186,10 +1188,8 @@
       "folk remedy",
       "uplifting"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "artemisia-ludoviciana",
@@ -1200,8 +1200,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "north america",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "also known as white sagebrush, used by native american tribes for cleansing, dreams, and mild sedation.",
     "effects": "mild sedation;visionary;cleansing",
     "mechanism": "GABAergic + anticholinergic",
@@ -1223,10 +1225,8 @@
       "dream",
       "folk medicine"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "artemisia-vulgaris",
@@ -1237,8 +1237,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "europe, north america, asia",
+    "regiontags": [],
     "legalstatus": "Legal worldwide (restricted in some for thujone)",
     "schedule": "",
+    "legalnotes": "",
     "description": "a classic european herb of the witches and dreamers. mugwort is used for enhancing dreams, calming digestion, and connecting to inner visions. often burned or used in dream pillows or teas.",
     "effects": "Lucid dreaming;Menstrual regulation;Mild sedation;Bitter tonic",
     "mechanism": "Contains thujone, camphor, and cineole — which mildly affect GABA receptors and CNS function. Also acts as a bitter digestive and mild uterine tonic.",
@@ -1266,14 +1268,12 @@
       "🫖 bitter tonic",
       "🔥 ritual"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5313054/",
       "Plants of the Gods – Rätsch",
       "British Herbal Pharmacopoeia"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "arundo-donax",
@@ -1284,8 +1284,10 @@
     "subcategory": "",
     "intensity": "Minimal or none (unless potentiated with MAOIs)",
     "region": "mediterranean, asia, naturalized worldwide",
+    "regiontags": [],
     "legalstatus": "Legal as an ornamental and biomass plant; some components (e.g., DMT) may be restricted in purified form.",
     "schedule": "",
+    "legalnotes": "",
     "description": "a large reed grass native to asia and the mediterranean. it has been occasionally referenced as a possible tryptamine source, but psychoactive effects are not reliably established.",
     "effects": "Unverified hallucinations;Mild sedation;Traditionally visionary (claimed)",
     "mechanism": "Alkaloid content includes DMT, bufotenine, and gramine in trace amounts. Psychoactivity is speculative and likely inactive without MAOIs.",
@@ -1317,14 +1319,12 @@
       "🧪 experimental",
       "🌿 root bark"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://erowid.org/plants/arundo_donax/",
       "Trout’s Notes on Some Other Ayahuasca Analog Plants",
       "PubChem CID: 442018 (gramine)"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "asarum-canadense",
@@ -1335,8 +1335,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "eastern north america",
+    "regiontags": [],
     "legalstatus": "Legal; use restricted in commercial food products due to safrole",
     "schedule": "",
+    "legalnotes": "",
     "description": "a north american woodland herb known as wild ginger. while unrelated to true ginger, its rhizome has a pungent, spicy aroma and has been used traditionally by indigenous peoples as a digestive aid and warming tonic.",
     "effects": "Warming;Digestive stimulant;Mild sedation;Aromatic",
     "mechanism": "Contains volatile oils (e.g. methyl eugenol, safrole) that may stimulate digestive enzymes and act as mild CNS modulators. Safrole is a weak psychoactive and hepatotoxic compound.",
@@ -1366,14 +1368,12 @@
       "⚠️ safrole",
       "🧑‍⚕️ traditional medicine"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4428597/",
       "Herbal Medicine: Expanded Commission E Monographs",
       "PubChem CID: 8467 (safrole)"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "asclepias-syriaca",
@@ -1384,8 +1384,10 @@
     "subcategory": "",
     "intensity": "Mild (subtoxic dose) to Dangerous",
     "region": "eastern and central north america",
+    "regiontags": [],
     "legalstatus": "Legal (not scheduled); some states advise caution with ingestion",
     "schedule": "",
+    "legalnotes": "",
     "description": "common milkweed is a native north american plant traditionally used by indigenous peoples for treating warts, respiratory issues, and digestive complaints. however, it contains toxic cardiac glycosides.",
     "effects": "Mild sedation;Cardiac influence;Anti-inflammatory",
     "mechanism": "Contains cardenolides (e.g., syriogenin) that affect cardiac muscle contractility by inhibiting Na+/K+-ATPase, similar to digoxin.",
@@ -1418,15 +1420,13 @@
       "⚠️ cardiotoxic",
       "🧪 traditional use only"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4271739/",
       "North American Ethnobotany Database",
       "HerbalGram. 2004",
       "(63): 34–45."
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "avena-sativa",
@@ -1437,8 +1437,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "temperate regions globally (native to europe and southwest asia)",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "common oats, when harvested as milky green tops or dried straw, are used as a gentle nervine tonic in western herbalism. renowned for its restorative effects on the nervous system and libido.",
     "effects": "Mild euphoria;Anxiolytic;Nourishing tonic;Cognitive support",
     "mechanism": "Contains avenanthramides (antioxidants), saponins, alkaloids, and B vitamins. May modulate GABAergic tone and reduce inflammation in the nervous system.",
@@ -1464,14 +1466,12 @@
       "💚 restorative",
       "🫖 tonic"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5989095/",
       "Medical Herbalism – David Hoffmann",
       "The Earthwise Herbal – Matthew Wood"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "nicotiana-rustica",
@@ -1482,8 +1482,10 @@
     "subcategory": "",
     "intensity": "Strong",
     "region": "south america and worldwide cultivation",
+    "regiontags": [],
     "legalstatus": "Legal but regulated like tobacco",
     "schedule": "",
+    "legalnotes": "",
     "description": "potent tobacco species used ceremonially in the amazon, far stronger than common n. tabacum.",
     "effects": "alertness;intense buzz;clearing of thoughts",
     "mechanism": "High nicotine plus MAO‑inhibiting beta‑carbolines stimulate nicotinic receptors and inhibit MAO",
@@ -1516,10 +1518,8 @@
       "nicotine",
       "tobacco"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "banisteriopsis-caapi",
@@ -1530,8 +1530,10 @@
     "subcategory": "",
     "intensity": "Moderate to profound (when combined)",
     "region": "amazon basin: peru, brazil, colombia",
+    "regiontags": [],
     "legalstatus": "Plant is legal in many countries; brews may be scheduled depending on DMT laws",
     "schedule": "",
+    "legalnotes": "",
     "description": "the primary vine used in the sacred amazonian brew ayahuasca. contains harmala alkaloids that inhibit mao, enabling oral activation of dmt. revered as the 'vine of the soul' in indigenous ceremonies.",
     "effects": "MAOI potentiation;Euphoria;Emotional release;Dreamlike states",
     "mechanism": "Contains harmine, harmaline, and tetrahydroharmine — reversible MAO-A inhibitors that also modulate serotonin and dopamine activity.",
@@ -1570,15 +1572,13 @@
       "🌀 entheogen",
       "⛔ ssri warning"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6082376/",
       "Journal of Ethnopharmacology",
       "2010",
       "MAPS Ayahuasca Research Summary"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "tabernaemontana-undulata",
@@ -1589,8 +1589,10 @@
     "subcategory": "",
     "intensity": "Moderate to Strong",
     "region": "western amazon",
+    "regiontags": [],
     "legalstatus": "Mostly legal but little researched",
     "schedule": "",
+    "legalnotes": "",
     "description": "also called uchu sanango; this rare shrub contains iboga-like compounds and is used in shamanic practices.",
     "effects": "tingling sensation;dream enhancement;altered perception",
     "mechanism": "Contains iboga-type alkaloids affecting serotonin and NMDA receptors",
@@ -1621,10 +1623,8 @@
       "uchu sanango",
       "iboga alkaloids"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "betula-lenta",
@@ -1635,8 +1635,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "north america",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "sweet birch, aromatic and uplifting; contains methyl salicylate, offering mild euphoria and clarity.",
     "effects": "uplifting;mental clarity;aromatic",
     "mechanism": "Anti-inflammatory + mild serotonergic",
@@ -1657,10 +1659,8 @@
       "uplifting",
       "aromatic"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "blue-lotus",
@@ -1671,8 +1671,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "nile valley, india, southeast asia",
+    "regiontags": [],
     "legalstatus": "Legal worldwide (restricted in some US states for sale)",
     "schedule": "",
+    "legalnotes": "",
     "description": "a sacred egyptian flower revered for inducing relaxed, blissful states. often soaked in wine or tea, blue lotus produces a dreamy calm and has been symbolically associated with rebirth, the sun, and divine union.",
     "effects": "Euphoria;Tranquility;Mild visuals;Dream enhancement",
     "mechanism": "Contains aporphine alkaloids (especially nuciferine) which act as dopamine receptor agonists and serotonin receptor modulators. Also binds GABA receptors slightly.",
@@ -1712,14 +1714,12 @@
       "🌙 dreamwork",
       "🌿 aphrodisiac"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3504522/",
       "Plants of the Gods – Rätsch",
       "Journal of Psychoactive Herbs – 2009"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "scutellaria-lateriflora",
@@ -1730,8 +1730,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "north america",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "commonly known as skullcap, this north american herb has a long history in western herbalism for treating nervous tension and insomnia.",
     "effects": "Mild sedation;anxiety relief;mental clarity",
     "mechanism": "GABA_A receptor modulation (baicalin and other flavonoids)",
@@ -1763,10 +1765,8 @@
       "🌿 herbal",
       "😴 sedative"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "brugmansia",
@@ -1777,8 +1777,10 @@
     "subcategory": "",
     "intensity": "Severe / Overwhelming",
     "region": "south america; cultivated ornamentally worldwide",
+    "regiontags": [],
     "legalstatus": "Legal in most countries; some restrictions due to risk",
     "schedule": "",
+    "legalnotes": "",
     "description": "a powerful ornamental tree with large trumpet-shaped flowers. brugmansia is traditionally used in south american shamanism but is highly toxic. its alkaloids cause intense deliriant experiences often indistinguishable from waking reality.",
     "effects": "True hallucinations;Amnesia;Delirium;Sedation",
     "mechanism": "Contains tropane alkaloids: scopolamine, atropine, and hyoscyamine. These are anticholinergic, blocking muscarinic acetylcholine receptors.",
@@ -1820,15 +1822,13 @@
       "🌪 deliriant",
       "🧠 anticholinergic"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3887309/",
       "The Encyclopedia of Psychoactive Plants – Rätsch",
       "Journal of Ethnopharmacology",
       "2001"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "brunfelsia-grandiflora",
@@ -1839,8 +1839,10 @@
     "subcategory": "",
     "intensity": "Moderate–Strong",
     "region": "amazon (peru, ecuador, colombia)",
+    "regiontags": [],
     "legalstatus": "Legal; not scheduled internationally",
     "schedule": "",
+    "legalnotes": "",
     "description": "a powerful and rare plant used in amazonian diets and initiations. sometimes used in conjunction with ayahuasca. it contains alkaloids structurally similar to tropanes but with unique visionary effects.",
     "effects": "Altered perception;Hallucinations;Sedation;Purging",
     "mechanism": "Believed to contain scopoletin, brunfelsamidine, and possibly tropane-like alkaloids. Effects include CNS sedation and GABAergic modulation, with visionary experiences at high doses.",
@@ -1871,16 +1873,14 @@
       "⚠️ tropane risk",
       "🌳 ayahuasca dieta"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "Journal of Ethnopharmacology",
       "2007",
       "Plants of the Gods – Schultes",
       "Hofmann",
       "Ayahuasca.com: Chiric Sanango Field Reports"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "petasites-hybridus",
@@ -1891,8 +1891,10 @@
     "subcategory": "",
     "intensity": "Mild to moderate",
     "region": "europe, asia",
+    "regiontags": [],
     "legalstatus": "Legal with restrictions (PA-free only)",
     "schedule": "",
+    "legalnotes": "",
     "description": "also known as butterbur, this european root was historically used as a remedy for migraines and spasms. contains pyrrolizidine alkaloids, so safe extracts must be purified.",
     "effects": "Relaxation;muscle relief;headache reduction",
     "mechanism": "Antispasmodic and anti-inflammatory effects; calcium channel modulation",
@@ -1922,10 +1924,8 @@
       "🌿 herbal",
       "🧠 headache"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "caesalpinia-sepiaria",
@@ -1936,8 +1936,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "thailand, india, southeast asia",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "a thorny climbing shrub used in traditional southeast asian medicine. found in certain thai herbal stimulant blends (yaa chud), though its active compounds are poorly characterized.",
     "effects": "Stimulation;Increased stamina;Traditional energizing",
     "mechanism": "Poorly studied. Likely contains alkaloids and tannins with mild CNS effects. May act as a peripheral stimulant and astringent.",
@@ -1964,14 +1966,12 @@
       "⚡ mild stimulant",
       "🌿 yaa chud"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://pubmed.ncbi.nlm.nih.gov/17009863/",
       "Thai Traditional Medicine Pharmacopoeia",
       "Herbal Remedies of Southeast Asia – WHO"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "calea-ternifolia",
@@ -1982,8 +1982,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "mexico, central america",
+    "regiontags": [],
     "legalstatus": "Generally legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "calea is a traditional mexican dream herb used by the chontal people to enhance dream clarity and lucidity. often consumed as a tea or smoked before sleep.",
     "effects": "Lucid dreaming;Vivid dreams;Mild sedation;Dream recall",
     "mechanism": "Contains calein and germacranolides that may influence GABAergic and cholinergic systems related to REM sleep modulation.",
@@ -2010,15 +2012,13 @@
       "😴 sleep",
       "🧘 oneirogen"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3158962/",
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology",
       "1986"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "bobinsana",
@@ -2029,8 +2029,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "amazon basin: peru, brazil, ecuador",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "bobinsana is a shrubby tree native to the amazon basin, used in traditional dieta practices for emotional healing and dreamwork. often referred to as a 'plant teacher' with gentle, uplifting effects.",
     "effects": "Heart-opening;Dreamlike calm;Energetic cleansing",
     "mechanism": "Contains flavonoids and alkaloids that may have GABAergic and adaptogenic effects. Precise pharmacology is not well studied.",
@@ -2065,15 +2067,13 @@
       "🧘 dream herb",
       "🌱 dieta"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://rainforest-database.org/plants/bobinsana",
       "Journal of Amazonian Ethnobotany",
       "2009",
       "Plants of the Gods – Schultes & Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "camellia-japonica",
@@ -2084,8 +2084,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "japan, korea, china; ornamental worldwide",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "a flowering plant native to east asia, best known for its oil-rich seeds. unlike camellia sinensis, it is not caffeinated, but valued for its emollient and skin-protective properties.",
     "effects": "Skin soothing;Antioxidant;Mild anti-inflammatory",
     "mechanism": "Rich in oleic acid, tocopherols (Vitamin E), and polyphenols. These compounds hydrate the skin and reduce oxidative damage.",
@@ -2111,15 +2113,13 @@
       "🌸 skincare",
       "🌿 traditional beauty"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3586833/",
       "Journal of Ethnopharmacology",
       "2014",
       "Asian Botanical Dermatology Manual"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "camellia-sinensis",
@@ -2130,8 +2130,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "china, india, worldwide cultivation",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "source of green and black tea; contains caffeine and theanine for balanced stimulation.",
     "effects": "Alertness;relaxed focus",
     "mechanism": "Caffeine antagonizes adenosine receptors; L-theanine modulates glutamate and GABA.",
@@ -2161,15 +2163,13 @@
       "☕ caffeine",
       "🍵 tea"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7086330/",
       "Tea and Health: Springer",
       "2013",
       "Theanine and Mental Performance – Nutritional Neuroscience"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "campsiandra-angustifolia",
@@ -2180,8 +2180,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "amazon basin (peru, brazil, colombia)",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "a powerful amazonian tree used as a general tonic and aphrodisiac. often added to ayahuasca brews for stamina, libido, and protection. bark decoctions are the primary preparation.",
     "effects": "Anti-inflammatory;Aphrodisiac;Tonic;Mild stimulation",
     "mechanism": "Contains triterpenes, alkaloids, and flavonoids with antioxidant and potential hormonal activity. Exact pharmacodynamics not fully mapped.",
@@ -2206,14 +2208,12 @@
       "💪 aphrodisiac",
       "🌿 ayahuasca admixture"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6603680/",
       "Plants of the Gods – Rätsch",
       "Rainforest Database: Chuchuhuasi Monograph"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "cananga-odorata",
@@ -2224,8 +2224,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "philippines, indonesia, polynesia",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "a tropical flowering tree native to southeast asia. its flowers yield ylang-ylang essential oil, a sweet floral extract used in perfumery and aromatherapy to reduce stress and promote sensuality.",
     "effects": "Euphoria;Relaxation;Aphrodisiac;Mild sedation",
     "mechanism": "Contains linalool, germacrene, and benzyl acetate, which act on GABA and dopaminergic pathways to induce calming and mood-lifting effects.",
@@ -2251,15 +2253,13 @@
       "💆 relaxant",
       "💖 aphrodisiac"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6979302/",
       "Essential Oils in Therapy – Springer 2021",
       "Journal of Natural Products",
       "2006"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "cannabis-sativa",
@@ -2270,8 +2270,10 @@
     "subcategory": "",
     "intensity": "Variable",
     "region": "cultivated worldwide",
+    "regiontags": [],
     "legalstatus": "Varies by jurisdiction",
     "schedule": "",
+    "legalnotes": "",
     "description": "",
     "effects": "euphoria;relaxation;altered perception",
     "mechanism": "THC acts on cannabinoid receptors CB1 and CB2",
@@ -2303,15 +2305,13 @@
       "thc",
       "marijuana"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7747003/",
       "Cannabis and Cannabinoid Research",
       "2021",
       "The Health Effects of Cannabis and Cannabinoids – National Academies"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "capsicum-annuum",
@@ -2322,8 +2322,10 @@
     "subcategory": "",
     "intensity": "Mild to Intense (Scoville Heat Units dependent)",
     "region": "mexico, central america; cultivated globally",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "the source of most culinary chili peppers, c. annuum is valued for both its heat and its therapeutic effects. capsaicin, the active compound, causes a burning sensation and triggers endorphin release.",
     "effects": "Stimulation;Endorphin release;Heat sensation;Pain modulation",
     "mechanism": "Capsaicin binds to TRPV1 receptors on sensory neurons, causing depolarization, heat/pain sensation, and eventual desensitization.",
@@ -2354,15 +2356,13 @@
       "🔥 stimulant",
       "🧴 analgesic"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4477151/",
       "Journal of Pain Research",
       "2014",
       "Capsaicin Handbook – CRC Press"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "carica-papaya",
@@ -2373,8 +2373,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "tropics worldwide",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "while best known for its fruit, papaya’s leaves and seeds are used medicinally for digestion, dengue fever recovery, and as a vermifuge. the seeds have a sharp flavor and act as mild natural dewormers.",
     "effects": "Digestive support;Antiparasitic;Anti-inflammatory;Immune modulation",
     "mechanism": "Papain (a proteolytic enzyme) aids digestion and reduces inflammation. Seeds contain benzyl isothiocyanate, which may have antiparasitic and antimicrobial effects.",
@@ -2399,15 +2401,13 @@
       "🦠 antiparasitic",
       "🍈 enzymatic"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6204662/",
       "Journal of Medicinal Plants",
       "2015",
       "Ethnobotany of Tropical Plants – CRC Press"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "catha-edulis",
@@ -2418,8 +2418,10 @@
     "subcategory": "",
     "intensity": "Moderate",
     "region": "yemen, ethiopia, kenya, somalia",
+    "regiontags": [],
     "legalstatus": "Illegal in many countries (Schedule I in US, Class C in UK); legal in some East African nations",
     "schedule": "",
+    "legalnotes": "",
     "description": "khat is a flowering shrub native to east africa and the arabian peninsula. chewed for centuries in social rituals, it contains cathinone, a natural amphetamine-like stimulant with short-lived euphoric effects.",
     "effects": "Euphoria;Increased alertness;Sociability;Appetite suppression",
     "mechanism": "Cathinone is a monoamine-releasing agent, increasing dopamine, norepinephrine, and serotonin. Structurally related to amphetamine.",
@@ -2462,16 +2464,14 @@
       "⚠️ controlled",
       "🌿 leaves"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4473630/",
       "Journal of Ethnopharmacology",
       "2010",
       "UNODC Khat Report",
       "2006"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "nepeta-cataria",
@@ -2482,8 +2482,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "europe, north america",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "best known for its effects on cats, catnip is also a gentle human nervine herb traditionally used for digestion, colds, and sleep. it has a subtle calming effect and is often included in herbal teas.",
     "effects": "Relaxation;Mild euphoria;Digestive aid;Sleep support",
     "mechanism": "Nepetalactone interacts with GABAergic and opioid pathways in humans. Also antispasmodic and diaphoretic.",
@@ -2511,14 +2513,12 @@
       "🫖 tea",
       "🌿 folk medicine"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3612440/",
       "Herbal Medicine – Mills & Bone",
       "Materia Medica – David Hoffman"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "centella-asiatica",
@@ -2529,8 +2529,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "asia",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "known as gotu kola, used in ayurvedic medicine to aid cognition.",
     "effects": "Mental clarity;calm focus",
     "mechanism": "Triterpenoids may modulate GABA and promote neurogenesis",
@@ -2556,15 +2558,13 @@
       "🌿 leaf",
       "🧠 cognitive"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6814248/",
       "Journal of Ethnopharmacology",
       "2013",
       "Ayurvedic Pharmacopoeia of India"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "cestrum-nocturnum",
@@ -2575,8 +2575,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate (olfactory)",
     "region": "india, southeast asia, caribbean, central america",
+    "regiontags": [],
     "legalstatus": "Legal as ornamental; not for ingestion",
     "schedule": "",
+    "legalnotes": "",
     "description": "a strongly fragrant flowering shrub known for its intoxicating nighttime aroma. traditionally used in folk remedies for anxiety and respiratory issues — but contains toxic alkaloids and should not be ingested.",
     "effects": "Sedation;Headache (aroma);Potential hallucinations (in folklore)",
     "mechanism": "Contains solanine-like glycoalkaloids and tropane-related compounds. The fragrance may act as a mild CNS modulator, but oral use is toxic.",
@@ -2608,15 +2610,13 @@
       "🌸 night flower",
       "🛏️ sedative folklore"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3136076/",
       "Toxic Plants of North America – Burrows & Tyrl",
       "Flora of the Caribbean – Botanical Review",
       "2008"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "desfontainia-spinosa",
@@ -2627,8 +2627,10 @@
     "subcategory": "",
     "intensity": "Strong",
     "region": "chile, colombia, andes",
+    "regiontags": [],
     "legalstatus": "Legal but obscure",
     "schedule": "",
+    "legalnotes": "",
     "description": "a rare south american shrub used by the mapuche and other indigenous groups in chile and colombia as a ritual intoxicant. known for unpredictable and potent effects.",
     "effects": "Hallucinations;disorientation;dreamlike state",
     "mechanism": "Unknown; possibly tropane alkaloid activity or diterpenes",
@@ -2660,10 +2662,8 @@
       "🌿 andes",
       "🧠 vision"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "cichorium-intybus",
@@ -2674,8 +2674,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "europe, asia, north america",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a bitter blue-flowered herb widely used as a coffee substitute, digestive tonic, and prebiotic. its root is rich in inulin, supporting gut health and liver detoxification.",
     "effects": "Liver support;Mild stimulant (roasted);Prebiotic;Digestive aid",
     "mechanism": "Inulin acts as a prebiotic fiber, feeding gut flora. Bitter compounds stimulate bile secretion and improve digestion. Roasted root contains lactones that mildly stimulate the CNS.",
@@ -2704,15 +2706,13 @@
       "☕ coffee alternative",
       "💩 gut health"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6893434/",
       "Journal of Functional Foods",
       "2015",
       "Herbal Medicine Monographs – WHO"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "claviceps-purpurea",
@@ -2723,8 +2723,10 @@
     "subcategory": "",
     "intensity": "Strong",
     "region": "worldwide on cereal grains",
+    "regiontags": [],
     "legalstatus": "Controlled in many countries",
     "schedule": "",
+    "legalnotes": "",
     "description": "",
     "effects": "vasoconstriction;hallucinations;numbness",
     "mechanism": "Produces ergot alkaloids acting on serotonin and adrenergic receptors",
@@ -2754,16 +2756,14 @@
       "fungus",
       "vasoconstrictor"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2765184/",
       "Ergot and Ergotism – Medical Mycology Textbook",
       "The Road to Eleusis – Hoffman",
       "Wasson",
       "Ruck"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "tynanthus-panurensis",
@@ -2774,8 +2774,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "amazon rainforest",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "",
     "effects": "aphrodisiac;warming;digestive aid",
     "mechanism": "TRPV1 activation, increases circulation and warmth",
@@ -2797,10 +2799,8 @@
       "folk",
       "warming"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "clitoria-ternatea",
@@ -2811,8 +2811,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "india, thailand, malaysia, tropics worldwide",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "a striking blue-flowered vine used in ayurvedic and southeast asian medicine. known for its nootropic, anti-anxiety, and anti-inflammatory effects. often brewed into vivid blue tea and used ceremonially in thailand and india.",
     "effects": "Cognitive enhancement;Anxiolytic;Neuroprotective;Mild sedation",
     "mechanism": "Contains anthocyanins (ternatins), flavonoids, and cyclotides. May modulate acetylcholine and GABA signaling, as well as BDNF expression in the brain.",
@@ -2838,15 +2840,13 @@
       "🧘 adaptogen",
       "💙 anthocyanins"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7510498/",
       "Journal of Ethnopharmacology",
       "2010",
       "Ayurvedic Pharmacopoeia of India"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "coffea-arabica",
@@ -2857,8 +2857,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "worldwide",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "beloved beverage plant containing caffeine.",
     "effects": "alertness;energy",
     "mechanism": "Caffeine blocks adenosine receptors increasing neurotransmitter release",
@@ -2883,10 +2885,8 @@
     "tags": [
       "☕ brewable"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "cola-acuminata",
@@ -2897,8 +2897,10 @@
     "subcategory": "",
     "intensity": "Moderate",
     "region": "west africa; cultivated globally",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "a caffeine-rich seed native to west africa, traditionally chewed in ceremonies and social settings. kola nut is a powerful natural stimulant, historically used in early coca-cola formulas and as a fatigue-fighting tonic.",
     "effects": "Stimulation;Increased alertness;Mood elevation;Appetite suppression",
     "mechanism": "Contains caffeine, theobromine, and kolanin. These stimulate the central nervous system via adenosine receptor antagonism and mild dopaminergic effects.",
@@ -2930,15 +2932,13 @@
       "🥥 traditional stimulant",
       "🌍 afro-indigenous use"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4703266/",
       "Journal of Pharmacognosy",
       "2013",
       "The Cultural Uses of Cola – African Medicine Studies"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "cola-nitida",
@@ -2949,8 +2949,10 @@
     "subcategory": "",
     "intensity": "Moderate",
     "region": "africa",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "kola nut used in energy drinks and ceremonies.",
     "effects": "Alertness;reduced fatigue",
     "mechanism": "Caffeine and kolanin stimulate CNS",
@@ -2977,10 +2979,8 @@
       "✅ safe",
       "🌿 seed"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "convolvulus-arvensis",
@@ -2991,8 +2991,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "europe, north america",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "bindweed, a relative of morning glory, contains ergoline alkaloids and is under investigation for mild entheogenic potential.",
     "effects": "light euphoria;subtle visual shifts",
     "mechanism": "5-HT2A agonist (potential)",
@@ -3013,10 +3015,8 @@
       "ergoline",
       "wild plant"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "convolvulus-pluricaulis",
@@ -3027,8 +3027,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "india, nepal, southeast asia",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "one of ayurveda’s most revered medhya rasayanas (brain tonics). shankhpushpi is used to enhance memory, reduce anxiety, and balance vata/pitta energies. often prescribed for insomnia, fatigue, and poor concentration.",
     "effects": "Memory enhancement;Stress reduction;Mental clarity;Mild sedation",
     "mechanism": "Contains alkaloids like convolvine and flavonoids that may modulate GABA and acetylcholine pathways. Also shows antioxidant and adaptogenic activity.",
@@ -3055,15 +3057,13 @@
       "🌿 ayurvedic nootropic",
       "🧘 nervine tonic"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3459457/",
       "Ayurvedic Pharmacopoeia of India",
       "Journal of Ethnopharmacology",
       "2010"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "crataegus-monogyna",
@@ -3074,8 +3074,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "europe, north africa, west asia",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "a thorny shrub known for its small red berries and heart-boosting properties. used in european herbalism for centuries to support circulation, reduce anxiety, and tone the cardiovascular system.",
     "effects": "Heart tonic;Circulation support;Anxiolytic;Antioxidant",
     "mechanism": "Rich in flavonoids and proanthocyanidins. Improves coronary blood flow, reduces vascular resistance, and has mild ACE-inhibiting properties. Antioxidant effects may protect endothelial tissue.",
@@ -3100,15 +3102,13 @@
       "🍒 berry",
       "🌿 nervine"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3249903/",
       "ESC Guidelines on Hawthorn",
       "2019",
       "Herbal Medicine Monographs – WHO"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "crocus-sativus",
@@ -3119,8 +3119,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "iran, india (kashmir), greece, spain",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "the world’s most expensive spice, saffron has been used for thousands of years in cooking, medicine, and ritual. its stigma threads contain compounds that brighten mood, enhance cognition, and protect neural function.",
     "effects": "Euphoria;Antidepressant;Cognitive support;Visual clarity",
     "mechanism": "Contains crocin, safranal, and picrocrocin. These modulate serotonin, dopamine, and GABA signaling. Also antioxidant and anti-inflammatory.",
@@ -3150,15 +3152,13 @@
       "🧘 calm focus",
       "💊 ssri-like"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4431160/",
       "Phytotherapy Research",
       "2016",
       "Traditional Persian Medicine – Avicenna Canon"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "curcuma-longa",
@@ -3169,8 +3169,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "india, southeast asia",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a golden root revered in ayurveda and traditional chinese medicine. curcumin, its key compound, fights inflammation, supports liver health, and improves brain function. used widely in cooking, teas, and supplements.",
     "effects": "Anti-inflammatory;Antioxidant;Liver tonic;Joint pain relief",
     "mechanism": "Curcumin inhibits COX-2 and NF-κB, reduces pro-inflammatory cytokines, and modulates glutathione and serotonin levels. Bioavailability enhanced with black pepper (piperine).",
@@ -3199,15 +3201,13 @@
       "🧠 brain support",
       "🍛 culinary adaptogen"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5664031/",
       "Ayurvedic Pharmacopoeia of India",
       "Journal of Alternative and Complementary Medicine",
       "2015"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "cyperus-articulatus",
@@ -3218,8 +3218,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "africa, caribbean, amazon",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "known as piripiri or guinea rush, this sedge is used in afro-caribbean and amazonian rituals for mild visionary states and spiritual grounding.",
     "effects": "Calm;focus;light trance",
     "mechanism": "Unknown; may involve sesquiterpenes",
@@ -3241,10 +3243,8 @@
       "🌿 piripiri",
       "🧘 ritual"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "cytisus-scoparius",
@@ -3255,8 +3255,10 @@
     "subcategory": "",
     "intensity": "Moderate to Strong (dose-dependent)",
     "region": "europe, north america (naturalized)",
+    "regiontags": [],
     "legalstatus": "Legal in most countries but discouraged or regulated in herbal supplements",
     "schedule": "",
+    "legalnotes": "",
     "description": "a yellow-flowered shrub traditionally used as a cardiac stimulant and diuretic. contains sparteine, a toxic alkaloid with stimulant and hallucinogenic potential in high doses. use with caution — pharmacologically active but potentially dangerous.",
     "effects": "Cardiac stimulation;Diuretic;Mood elevation;Mild hallucinations (high dose)",
     "mechanism": "Sparteine acts on cardiac sodium channels and can influence rhythm and contractility. Also modulates adrenergic and muscarinic pathways.",
@@ -3289,14 +3291,12 @@
       "❤️ heart-active",
       "🌾 witch lore"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3920503/",
       "Traditional Herbal Medicines in Europe – ESCOP",
       "Botanical Safety Handbook – 2nd Ed."
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "damiana",
@@ -3307,8 +3307,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "mexico, texas, central america",
+    "regiontags": [],
     "legalstatus": "Legal / Unregulated",
     "schedule": "",
+    "legalnotes": "",
     "description": "used traditionally in mexico and central america for libido, relaxation, and mild stimulation. sometimes blended in herbal smoking mixes.",
     "effects": "aphrodisiac;mood-enhancing;anxiolytic",
     "mechanism": "Likely modulates serotonin, dopamine, and GABA neurotransmission via flavonoids and tannins [8, 6].",
@@ -3344,14 +3346,12 @@
       "🌬️ smokable",
       "💫 euphoria"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3210006/",
       "Plants of Love – Christian Rätsch",
       "Herbal Medicine – Mills & Bone"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "datura-inoxia",
@@ -3362,8 +3362,10 @@
     "subcategory": "",
     "intensity": "Extreme",
     "region": "southwestern us, mexico, central america",
+    "regiontags": [],
     "legalstatus": "Legal to grow ornamentally; restricted in some countries for psychoactive use",
     "schedule": "",
+    "legalnotes": "",
     "description": "a night-blooming white-flowered species of datura, known for its powerful deliriant and anticholinergic properties. used in shamanic rituals in mesoamerica, but also responsible for many poisonings due to its unpredictability.",
     "effects": "Intense delirium;Anticholinergic trance;Hallucinations;Amnesia",
     "mechanism": "Contains tropane alkaloids (scopolamine, hyoscyamine, atropine) that block muscarinic acetylcholine receptors, leading to hallucinations, confusion, and autonomic dysfunction.",
@@ -3398,15 +3400,13 @@
       "🌿 shamanic",
       "⚠️ visionary plant"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1318951/",
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology",
       "1994"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "toloache",
@@ -3417,8 +3417,10 @@
     "subcategory": "",
     "intensity": "Extremely strong",
     "region": "americas, mediterranean",
+    "regiontags": [],
     "legalstatus": "Legal but restricted in many countries",
     "schedule": "",
+    "legalnotes": "",
     "description": "a powerful and dangerous tropane alkaloid plant traditionally used in witchcraft and shamanic rituals. highly toxic.",
     "effects": "Delirium;hallucinations;disorientation",
     "mechanism": "Anticholinergic – blocks acetylcholine via scopolamine, atropine",
@@ -3445,10 +3447,8 @@
       "⚠️ caution",
       "🧠 vision"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "datura-stramonium",
@@ -3459,8 +3459,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "worldwide",
+    "regiontags": [],
     "legalstatus": "Unregulated but dangerous",
     "schedule": "",
+    "legalnotes": "",
     "description": "common weed producing powerful delirium when misused.",
     "effects": "delirium;hallucinations",
     "mechanism": "Scopolamine and atropine block muscarinic receptors",
@@ -3487,10 +3489,8 @@
       "☠️ toxic",
       "⚠️ caution"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "derris-elliptica",
@@ -3501,8 +3501,10 @@
     "subcategory": "",
     "intensity": "Severe (if ingested)",
     "region": "southeast asia, pacific islands",
+    "regiontags": [],
     "legalstatus": "Restricted or banned in many regions",
     "schedule": "",
+    "legalnotes": "",
     "description": "a tropical vine traditionally used as a natural fish poison. contains rotenone, a potent neurotoxin that disrupts mitochondrial respiration. used in agriculture but dangerous to humans in concentrated doses.",
     "effects": "Paralysis (insects/fish);Mild euphoria (folklore);Toxicity",
     "mechanism": "Rotenone inhibits NADH dehydrogenase in the electron transport chain, disrupting ATP production and causing cellular hypoxia.",
@@ -3531,14 +3533,12 @@
       "🐟 fish poison",
       "🧬 mitochondrial disruptor"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1241859/",
       "WHO Pesticide Evaluation Report – Rotenone",
       "Traditional Plant Lore of Southeast Asia – 2010"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "desmanthus-illinoensis",
@@ -3549,8 +3549,10 @@
     "subcategory": "",
     "intensity": "Strong",
     "region": "central and southern united states",
+    "regiontags": [],
     "legalstatus": "DMT restricted in many countries",
     "schedule": "",
+    "legalnotes": "",
     "description": "also called illinois bundleflower; its root bark contains notable amounts of dmt.",
     "effects": "visual enhancements;introspection;altered perception",
     "mechanism": "Root bark contains DMT; usually combined with MAOIs to be active orally",
@@ -3578,10 +3580,8 @@
       "dmt",
       "root"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "desmodium-adscendens",
@@ -3592,8 +3592,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "west africa, south america",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "",
     "effects": "bronchodilator;liver support;anti-allergic",
     "mechanism": "Smooth muscle relaxation and anti-inflammatory flavonoid activity",
@@ -3615,10 +3617,8 @@
       "folk",
       "detox"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "desmodium-gangeticum",
@@ -3629,8 +3629,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "india, nepal, sri lanka",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "an ayurvedic herb used in dashamoola and other classical formulas. known for its rejuvenating, nervine, and anti-inflammatory actions, salparni is often used for vata balancing and in convalescence.",
     "effects": "Nervine support;Anti-inflammatory;Rejuvenation;Mild sedation",
     "mechanism": "Contains alkaloids (gangetin), flavonoids, and isoflavones with CNS modulating and antioxidant properties. Shows immunomodulatory and anti-inflammatory effects.",
@@ -3656,15 +3658,13 @@
       "🔥 anti-inflammatory",
       "🪷 vata pacifying"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3470461/",
       "Ayurvedic Pharmacopoeia of India",
       "Journal of Ethnopharmacology",
       "2006"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "datura-metel",
@@ -3675,8 +3675,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "asia, africa",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "",
     "effects": "hallucinogenic;deliriant;anticholinergic",
     "mechanism": "Antagonist of muscarinic acetylcholine receptors",
@@ -3698,10 +3700,8 @@
       "deliriant",
       "toxic"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "foxglove",
@@ -3712,8 +3712,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "europe",
+    "regiontags": [],
     "legalstatus": "Regulated as medicinal",
     "schedule": "",
+    "legalnotes": "",
     "description": "source of cardiac glycosides used for heart failure; overdose is fatal.",
     "effects": "cardiac stimulation",
     "mechanism": "Cardiac glycosides inhibit Na⁺/K⁺-ATPase",
@@ -3739,10 +3741,8 @@
       "☠️ toxic",
       "💊 oral"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "dioscorea-villosa",
@@ -3753,8 +3753,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "north america",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "wild yam is a north american root long used to support women's reproductive health, digestion, and inflammation. its active compound, diosgenin, is a steroidal saponin used in pharmaceutical hormone synthesis.",
     "effects": "Hormone balance;Menstrual relief;Anti-inflammatory;Digestive support",
     "mechanism": "Contains diosgenin, which mimics precursors of progesterone. Modulates prostaglandin synthesis and may balance estrogenic effects.",
@@ -3779,14 +3781,12 @@
       "🔥 anti-inflammatory",
       "🌙 hormone support"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4717896/",
       "Botanical Safety Handbook – 2nd Ed.",
       "American Herbal Pharmacopoeia – Wild Yam Monograph"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "diplopterys-cabrerana",
@@ -3797,8 +3797,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "amazon",
+    "regiontags": [],
     "legalstatus": "DMT restricted in most regions",
     "schedule": "",
+    "legalnotes": "",
     "description": "ayahuasca admixture leaf high in tryptamines.",
     "effects": "visions;introspection",
     "mechanism": "Leaves contain DMT and 5-MeO-DMT acting on serotonin receptors",
@@ -3824,10 +3826,8 @@
       "⚠️ caution",
       "🧪 dmt"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "calea-zacatechichi",
@@ -3838,8 +3838,10 @@
     "subcategory": "",
     "intensity": "Mild to moderate",
     "region": "mexico, central america",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "known as the 'dream herb' of the chontal people of mexico, calea is traditionally used to enhance dreams and mental clarity during sleep.",
     "effects": "Lucid dreaming;dream recall;hypnagogic imagery",
     "mechanism": "May modulate GABAergic or cholinergic pathways; unclear",
@@ -3869,10 +3871,8 @@
       "🌙 dream",
       "🧘 calm"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "duboisia-hopwoodii",
@@ -3883,8 +3883,10 @@
     "subcategory": "",
     "intensity": "Moderate",
     "region": "australia (central and northern deserts)",
+    "regiontags": [],
     "legalstatus": "Legal in Australia (cultural protection); restricted elsewhere due to alkaloid content",
     "schedule": "",
+    "legalnotes": "",
     "description": "an indigenous australian shrub whose dried leaves are used as a traditional stimulant. pituri contains nicotine and nor-nicotine alkaloids, and is chewed with ash for enhanced absorption.",
     "effects": "Stimulation;Alertness;Appetite suppression;Euphoria (mild)",
     "mechanism": "Alkaloids bind to nicotinic acetylcholine receptors, stimulating the CNS, suppressing hunger, and inducing focus.",
@@ -3917,14 +3919,12 @@
       "🔥 indigenous use",
       "🌿 pituri"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7104054/",
       "Aboriginal Pharmacopoeia Australia",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "dysphania-ambrosioides",
@@ -3935,8 +3935,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "mexico",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "also known as epazote, used in mesoamerican rituals. contains cns-stimulating compounds but is toxic at high doses.",
     "effects": "dreamlike;stimulant",
     "mechanism": "CNS excitation at high doses",
@@ -3958,10 +3960,8 @@
       "visionary",
       "potentially toxic"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "echinacea-purpurea",
@@ -3972,8 +3972,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "north america",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "purple coneflower commonly used for colds",
     "effects": "immune boost;slight energy",
     "mechanism": "Phenolic compounds like echinacoside modulate immune response",
@@ -3996,10 +3998,8 @@
     "tags": [
       "🌿 root"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "echinopsis-lageniformis",
@@ -4010,8 +4010,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "andes",
+    "regiontags": [],
     "legalstatus": "Cactus legal; mescaline controlled",
     "schedule": "",
+    "legalnotes": "",
     "description": "another mescaline-rich andean cactus.",
     "effects": "visions;clarity",
     "mechanism": "Mescaline as 5-HT2A agonist",
@@ -4034,10 +4036,8 @@
     "tags": [
       "🌵 cactus"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "echinopsis-pachanoi",
@@ -4048,8 +4048,10 @@
     "subcategory": "",
     "intensity": "Strong",
     "region": "andes, cultivated worldwide",
+    "regiontags": [],
     "legalstatus": "Cactus legal in many areas; mescaline often controlled",
     "schedule": "",
+    "legalnotes": "",
     "description": "",
     "effects": "visuals;euphoria;spiritual insight",
     "mechanism": "Contains mescaline, a 5‑HT2A agonist phenethylamine",
@@ -4079,15 +4081,13 @@
       "cactus",
       "mescaline"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC10433235/",
       "Plants of the Gods – Rätsch & Hofmann",
       "Shamanic Plant Medicine – San Pedro",
       "2019"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "echinopsis-peruviana",
@@ -4098,8 +4098,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "andes",
+    "regiontags": [],
     "legalstatus": "Cactus legal; mescaline controlled",
     "schedule": "",
+    "legalnotes": "",
     "description": "cactus rich in mescaline similar to san pedro.",
     "effects": "visions;empathy",
     "mechanism": "Mescaline acts as a 5-HT2A agonist",
@@ -4126,10 +4128,8 @@
       "🌀 visionary",
       "🌵 cactus"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "eleutherococcus-senticosus",
@@ -4140,8 +4140,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "siberia",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "also called siberian ginseng, popular adaptogen.",
     "effects": "Energy;stress resistance",
     "mechanism": "Eleutherosides modulate stress hormones",
@@ -4166,15 +4168,13 @@
       "✅ safe",
       "🌿 root"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3659614/",
       "Phytomedicine",
       "2010",
       "WHO Monographs on Selected Medicinal Plants"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "virola-theiodora",
@@ -4185,8 +4185,10 @@
     "subcategory": "",
     "intensity": "Very strong",
     "region": "amazon (brazil, venezuela)",
+    "regiontags": [],
     "legalstatus": "DMT controlled in most countries",
     "schedule": "",
+    "legalnotes": "",
     "description": "a snuff plant from the amazon containing dmt and 5-meo-dmt. used by yanomami and other tribes for potent visionary rituals.",
     "effects": "Strong visuals;spiritual experiences;disorientation",
     "mechanism": "DMT and 5-MeO-DMT – 5-HT2A agonists",
@@ -4218,10 +4220,8 @@
       "🌬️ snuff",
       "🧠 dmt"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "ephedra-nevadensis",
@@ -4232,8 +4232,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "north america",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "mild stimulant desert shrub without strong ephedra content.",
     "effects": "mild stimulation",
     "mechanism": "Contains ephedrine-like alkaloids releasing norepinephrine",
@@ -4257,10 +4259,8 @@
     "tags": [
       "☕ brewable"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "ephedra-sinica",
@@ -4271,8 +4271,10 @@
     "subcategory": "",
     "intensity": "Strong",
     "region": "china and central asia",
+    "regiontags": [],
     "legalstatus": "Regulated in many countries",
     "schedule": "",
+    "legalnotes": "",
     "description": "shrubby plant known as ma huang; source of ephedrine used both medicinally and recreationally.",
     "effects": "Energy boost;bronchodilation",
     "mechanism": "Ephedrine and pseudoephedrine stimulate adrenergic receptors and release norepinephrine.",
@@ -4300,14 +4302,12 @@
       "⚠️ potent",
       "🌿 ma huang"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3896985/",
       "FDA Ephedra Ban Report (2004)",
       "Pharmacopoeia of the People’s Republic of China"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "erythrina-americana",
@@ -4318,8 +4318,10 @@
     "subcategory": "",
     "intensity": "Mild to Moderate",
     "region": "mexico",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "known locally as colorín; its red flowers are brewed into a soothing bedtime drink.",
     "effects": "relaxation;dreaminess;reduced anxiety",
     "mechanism": "Contains erythrinan alkaloids acting as GABAergic depressants",
@@ -4346,10 +4348,8 @@
       "flower",
       "sleep"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "erythrina-mulungu",
@@ -4360,8 +4360,10 @@
     "subcategory": "",
     "intensity": "Moderate",
     "region": "brazil and neighboring countries",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "flowering tree whose bark is prized in brazilian folk medicine for calming nerves and promoting sleep.",
     "effects": "deep relaxation;anxiety relief;sleepiness",
     "mechanism": "Erythrinan alkaloids interact with GABA receptors causing CNS depression",
@@ -4388,16 +4390,14 @@
       "root",
       "sleep"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4770635/",
       "Journal of Ethnopharmacology",
       "2007",
       "Rainforest Remedies – Taylor",
       "2003"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "erythroxylum-catuaba",
@@ -4408,8 +4408,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "brazil, amazon, south america",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "a traditional brazilian aphrodisiac made from the bark of various erythroxylum species (mainly e. catuaba). catuaba is used to boost libido, mental clarity, and mood — both in traditional medicine and modern supplements.",
     "effects": "Stimulation;Enhanced libido;Mild euphoria;Cognitive enhancement",
     "mechanism": "Contains alkaloids, flavonoids, and possibly tropane-related compounds. Stimulates central nervous system and may increase nitric oxide availability.",
@@ -4440,15 +4442,13 @@
       "🌿 amazon tonic",
       "🌳 bark"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5937011/",
       "Brazilian Journal of Pharmacognosy",
       "2005",
       "The Healing Power of Rainforest Herbs – Leslie Taylor"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "erythroxylum-coca",
@@ -4459,8 +4459,10 @@
     "subcategory": "",
     "intensity": "Moderate",
     "region": "andean south america",
+    "regiontags": [],
     "legalstatus": "Cultivation regulated; cocaine controlled",
     "schedule": "",
+    "legalnotes": "",
     "description": "traditional andean stimulant leaf.",
     "effects": "alertness;reduced fatigue;mild euphoria",
     "mechanism": "Leaves contain cocaine acting as a dopamine and norepinephrine reuptake inhibitor",
@@ -4495,10 +4497,8 @@
       "alkaloid",
       "coca leaf"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "eschscholzia-californica",
@@ -4509,8 +4509,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "north america",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "california poppy with gentle relaxing properties.",
     "effects": "Sedation;mild euphoria",
     "mechanism": "Protopine alkaloids interact with GABA receptors",
@@ -4535,15 +4537,13 @@
       "🌿 flower",
       "💤 sedation"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3358986/",
       "American Herbal Pharmacopoeia – Eschscholzia",
       "Journal of Natural Medicines",
       "2011"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "espeletia-grandiflora",
@@ -4554,8 +4554,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "colombia, ecuador, andean cloud forests",
+    "regiontags": [],
     "legalstatus": "Legal (not widely commercialized)",
     "schedule": "",
+    "legalnotes": "",
     "description": "a fuzzy-leaved plant from the páramo cloud forests of the andes. used in colombian and ecuadorian folk medicine for respiratory and throat ailments. its woolly foliage helps conserve water and reduce inflammation when brewed.",
     "effects": "Cough relief;Lung support;Anti-inflammatory;Moisture retention",
     "mechanism": "Contains sesquiterpenes and flavonoids with anti-inflammatory and soothing properties. Traditionally believed to aid mucosal healing.",
@@ -4582,15 +4584,13 @@
       "🍵 folk remedy",
       "❄️ cold medicine"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC9872784/",
       "Páramo Herbalism Studies – Colombia National University",
       "Ethnobotany of the Andes",
       "2019"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "eurycoma-longifolia",
@@ -4601,8 +4601,10 @@
     "subcategory": "",
     "intensity": "Moderate",
     "region": "malaysia, indonesia, thailand",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a southeast asian root revered for enhancing libido, strength, and masculinity. traditionally used by men to improve vitality and hormonal health. now globally marketed as a natural testosterone booster.",
     "effects": "Testosterone boost;Energy;Stress resilience;Libido enhancement",
     "mechanism": "Contains quassinoids like eurycomanone that may increase free testosterone, reduce cortisol, and stimulate dopaminergic and androgenic pathways.",
@@ -4632,15 +4634,13 @@
       "🌿 adaptogen",
       "🧬 hormonal"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3654340/",
       "Journal of the International Society of Sports Nutrition",
       "2013",
       "Malaysian Herbal Monographs"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "galbulimima-belgraveana",
@@ -4651,8 +4651,10 @@
     "subcategory": "",
     "intensity": "Moderate to Strong",
     "region": "papua new guinea and northern australia",
+    "regiontags": [],
     "legalstatus": "Little formal regulation",
     "schedule": "",
+    "legalnotes": "",
     "description": "rare rainforest tree providing psychoactive bark traditionally used in new guinea for visionary experiences.",
     "effects": "dreamlike visions;dizziness;altered consciousness",
     "mechanism": "Contains himbacine-type alkaloids with muscarinic antagonist activity",
@@ -4683,10 +4685,8 @@
       "hallucinogen",
       "tree"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "galphimia-glauca",
@@ -4697,8 +4697,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "mexico, central america",
+    "regiontags": [],
     "legalstatus": "Legal (limited international awareness)",
     "schedule": "",
+    "legalnotes": "",
     "description": "a mexican herb used to treat anxiety, phobias, and restlessness. clinical studies in mexico show it to be comparable to benzodiazepines in reducing anxiety — but without sedation or dependency.",
     "effects": "Anxiety relief;Tranquility;Sleep aid;Reduced reactivity",
     "mechanism": "Contains galphimine B, a nor-seco-triterpenoid that modulates GABAergic and dopaminergic systems, particularly by blocking dopaminergic overactivation in limbic areas.",
@@ -4724,16 +4726,14 @@
       "🌿 mexican folk medicine",
       "💤 sleep aid"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7614475/",
       "Revista Mexicana de Neurociencia",
       "2014",
       "Phytomedicine",
       "2012"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "reishi-mushroom",
@@ -4744,8 +4744,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "🇨🇳 east asia",
+    "regiontags": [],
     "legalstatus": "Legal / Unregulated",
     "schedule": "",
+    "legalnotes": "",
     "description": "tonic fungus revered in asia for boosting immunity and easing stress.",
     "effects": "Immune support;calm focus",
     "mechanism": "Triterpenoids and beta-glucans modulate immune response.",
@@ -4772,10 +4774,8 @@
       "\\ud83e\\udde0 cognitive",
       "\\u2705 safe"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "gastrodia-elata",
@@ -4786,8 +4786,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "china, korea, taiwan, japan",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a prized root in traditional chinese medicine used to calm internal wind and treat dizziness, seizures, and nervous system disorders. it grows symbiotically with fungi in shaded forest floors.",
     "effects": "Calms the liver;Relieves tremors;Supports cognition;Anti-epileptic",
     "mechanism": "Contains gastrodin and vanillin derivatives that modulate GABA activity, reduce neuroinflammation, and support mitochondrial health. Protective against seizures and neurodegeneration.",
@@ -4813,15 +4815,13 @@
       "💫 tremor relief",
       "⚡ anticonvulsant"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6856235/",
       "Phytomedicine",
       "2015",
       "Chinese Pharmacopoeia – Tian Ma Entry"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "gelsemium-sempervirens",
@@ -4832,8 +4832,10 @@
     "subcategory": "",
     "intensity": "Strong (toxic)",
     "region": "southeastern u.s., mexico",
+    "regiontags": [],
     "legalstatus": "Legal but restricted in some areas",
     "schedule": "",
+    "legalnotes": "",
     "description": "a beautiful yet highly poisonous vine native to the southeastern u.s. used in extremely low doses for anxiety, migraines, and spasms — but lethal in excess. homeopathy and some experimental medicine have explored it for nervous tension.",
     "effects": "Muscle relaxation;Nervous system inhibition;Pain relief;Delirium (toxic doses)",
     "mechanism": "Contains gelsemine and gelseminine, which act as glycine receptor agonists and inhibit spinal reflexes. High doses paralyze the respiratory center.",
@@ -4872,15 +4874,13 @@
       "🧠 nervine",
       "💀 respiratory depressant"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6288960/",
       "Toxic Plants of North America – 2nd Ed.",
       "American Journal of Therapeutics",
       "2012"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "genipa-americana",
@@ -4891,8 +4891,10 @@
     "subcategory": "",
     "intensity": "Mild (topical); moderate (oral folk prep)",
     "region": "amazon basin, central & south america",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "an amazonian fruit tree whose juice oxidizes into a black-blue dye. used for temporary body art, sun protection, insect repellent, and ritual purification. sometimes used in decoctions for fever or wounds.",
     "effects": "Skin staining;Mild antibacterial;Cooling sensation;Symbolic use",
     "mechanism": "Genipin (active compound) crosslinks with amino acids in skin keratin, forming a black pigment. Also displays mild antimicrobial and antioxidant properties.",
@@ -4918,16 +4920,14 @@
       "🌿 traditional",
       "🖤 jagua tattoo"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1127453/",
       "Journal of Ethnopharmacology",
       "2004",
       "Amazonian Plant Medicine – Taylor",
       "2002"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "ginkgo-biloba",
@@ -4938,8 +4938,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "china, cultivated worldwide",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "",
     "effects": "improved cognition;circulation boost;alertness",
     "mechanism": "Flavone glycosides and terpenoids enhance blood flow and modulate neurotransmission",
@@ -4967,15 +4969,13 @@
       "blood flow",
       "memory"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6567113/",
       "Journal of Clinical Psychopharmacology",
       "2001",
       "ESCOP Monograph – Ginkgo"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "glaucium-flavum",
@@ -4986,8 +4986,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "mediterranean",
+    "regiontags": [],
     "legalstatus": "Varies",
     "schedule": "",
+    "legalnotes": "",
     "description": "coastal poppy used occasionally for its glaucine content.",
     "effects": "mild euphoria;sedation",
     "mechanism": "Contains glaucine, a bronchodilator acting on dopamine receptors",
@@ -5012,10 +5014,8 @@
       "🌀 visionary",
       "💊 oral"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "gliricidia-sepium",
@@ -5026,8 +5026,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "central america, philippines, tropical zones",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "a fast-growing tropical tree used in traditional medicine and animal care. known for treating scabies, wounds, and skin infections. leaves contain natural insecticidal compounds.",
     "effects": "Topical antiparasitic;Wound healing;Insect repellent;Mild analgesic",
     "mechanism": "Rich in tannins and coumarins with insecticidal, antibacterial, and anti-inflammatory effects. Used externally to kill lice, fleas, and skin pathogens.",
@@ -5053,15 +5055,13 @@
       "🌾 agroforestry",
       "🐾 skin health"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8323025/",
       "Philippine Herbal Medicine Compendium",
       "Agroforestry & Ethnomedicine Reports",
       "2018"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "gloriosa-superba",
@@ -5072,8 +5072,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "africa, asia",
+    "regiontags": [],
     "legalstatus": "Ornamental; toxic",
     "schedule": "",
+    "legalnotes": "",
     "description": "highly poisonous ornamental sometimes misused.",
     "effects": "intense nausea;weak delirium",
     "mechanism": "Contains colchicine disrupting microtubules",
@@ -5097,10 +5099,8 @@
     "tags": [
       "☠️ toxic"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "gymnema-sylvestre",
@@ -5111,8 +5111,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "india",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "ayurvedic herb that dulls sugar perception",
     "effects": "reduced sweet taste;focus",
     "mechanism": "Gymnemic acids block sweet receptors and modulate glucose absorption",
@@ -5137,15 +5139,13 @@
     "tags": [
       "🍃 leaf"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2170951/",
       "Journal of Clinical Biochemistry",
       "2011",
       "Ayurvedic Pharmacopoeia of India"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "gynostemma-pentaphyllum",
@@ -5156,8 +5156,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "china",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "called jiaogulan, reputed longevity herb.",
     "effects": "Adaptogenic;anti-inflammatory",
     "mechanism": "Gypenosides modulate nitric oxide and cortisol",
@@ -5181,10 +5183,8 @@
       "✅ safe",
       "🌿 leaf"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "argyreia-nervosa",
@@ -5195,8 +5195,10 @@
     "subcategory": "",
     "intensity": "Moderate",
     "region": "india, hawaii, tropical regions",
+    "regiontags": [],
     "legalstatus": "Legal to possess in most countries; LSA may be restricted.",
     "schedule": "",
+    "legalnotes": "",
     "description": "a climbing vine native to india and widely cultivated in hawaii. its seeds contain lsa (lysergic acid amide), a naturally occurring psychedelic related to lsd.",
     "effects": "Euphoria;Time distortion;Closed-eye visuals;Body heaviness;Drowsiness",
     "mechanism": "LSA (ergine) is a serotonergic compound acting primarily as a partial agonist at 5-HT2A receptors, similar to LSD but with more sedative effects.",
@@ -5239,15 +5241,13 @@
       "⚠️ nausea",
       "🌱 seeds"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://erowid.org/plants/hbw/",
       "TiHKAL by Alexander Shulgin",
       "Journal of Ethnopharmacology",
       "1996"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "heimia-myrtifolia",
@@ -5258,8 +5258,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "mexico",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "relative of sinicuichi used similarly for mild trance",
     "effects": "auditory shift;relaxation",
     "mechanism": "Alkaloids like vertine may alter neurotransmission",
@@ -5283,10 +5285,8 @@
       "🌀 altered sound",
       "🌿 leaf"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "helichrysum-odoratissimum",
@@ -5297,8 +5297,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "southern africa",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "",
     "effects": "relaxation;mild euphoria;dream enhancement",
     "mechanism": "Aromatic compounds interact with GABA and serotonin systems",
@@ -5324,10 +5326,8 @@
       "imphepho",
       "smoke"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "hericium-erinaceus",
@@ -5338,8 +5338,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "china, japan, north america (temperate forests)",
+    "regiontags": [],
     "legalstatus": "Legal / Unregulated",
     "schedule": "",
+    "legalnotes": "",
     "description": "a shaggy white mushroom revered for its ability to stimulate ngf (nerve growth factor) and support brain regeneration. used in both traditional chinese medicine and modern nootropic stacks.",
     "effects": "Nerve growth;Memory enhancement;Mood support;Cognitive clarity",
     "mechanism": "Contains hericenones and erinacines that cross the blood-brain barrier and promote neurogenesis by upregulating NGF. Also modulates inflammation and gut-brain axis.",
@@ -5373,15 +5375,13 @@
       "\\ud83e\\udde0 cognitive",
       "\\u2705 safe"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5987239/",
       "International Journal of Molecular Sciences",
       "2017",
       "Chinese Herbal Materia Medica"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "hibiscus-sabdariffa",
@@ -5392,8 +5392,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "tropics",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "roselle flowers used for tart refreshing tea",
     "effects": "mild calm;vitamin C",
     "mechanism": "Anthocyanins provide antioxidant and hypotensive actions",
@@ -5418,15 +5420,13 @@
     "tags": [
       "🍵 tea"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC529416/",
       "Journal of Human Hypertension",
       "2008",
       "African Herbal Pharmacopoeia"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "huperzia-serrata",
@@ -5437,8 +5437,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "china, southeast asia",
+    "regiontags": [],
     "legalstatus": "Legal in most countries",
     "schedule": "",
+    "legalnotes": "",
     "description": "club moss used in traditional chinese medicine; source of huperzine a nootropic.",
     "effects": "Improved memory;alertness",
     "mechanism": "Provides huperzine A, a reversible acetylcholinesterase inhibitor.",
@@ -5467,10 +5469,8 @@
       "⚗️ alkaloid",
       "🧠 memory"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "hyoscyamus-niger",
@@ -5481,8 +5481,10 @@
     "subcategory": "",
     "intensity": "Extreme",
     "region": "europe, north africa, asia",
+    "regiontags": [],
     "legalstatus": "Legal in some countries, restricted elsewhere",
     "schedule": "",
+    "legalnotes": "",
     "description": "a notorious nightshade plant used historically in european witchcraft, sedatives, and flying ointments. contains powerful tropane alkaloids that can induce delirium, amnesia, and visionary states.",
     "effects": "Hallucinations;Disorientation;Sedation;Dryness;Trance",
     "mechanism": "Scopolamine, hyoscyamine, and atropine block muscarinic acetylcholine receptors (anticholinergic), disrupting sensory and cognitive processing.",
@@ -5516,14 +5518,12 @@
       "💀 toxic",
       "🌿 witches’ herb"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1318951/",
       "Plants of the Gods – Rätsch",
       "Handbook of Medicinal Plants – CRC Press"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "hypericum-perforatum",
@@ -5534,8 +5534,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "europe, naturalized elsewhere",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "",
     "effects": "improved mood;reduced anxiety;light sedation",
     "mechanism": "Hyperforin and hypericin inhibit reuptake of serotonin, dopamine, and norepinephrine",
@@ -5565,10 +5567,8 @@
       "st. john's wort",
       "mood"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "hyssopus-officinalis",
@@ -5579,8 +5579,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "mediterranean",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "traditional biblical herb used for colds and rituals",
     "effects": "respiratory relief;mild alertness",
     "mechanism": "Monoterpenes like pinocamphone stimulate circulation",
@@ -5605,10 +5607,8 @@
       "⚠️ strong oil",
       "🍵 tea"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "guayusa",
@@ -5619,8 +5619,10 @@
     "subcategory": "",
     "intensity": "Mild to moderate",
     "region": "amazon (ecuador, peru, colombia)",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a caffeinated amazonian holly tree leaf used for lucid dreaming, focus, and ritual wakefulness. known as the 'dreaming tea' by the kichwa people. smoother than yerba mate and less jittery than coffee.",
     "effects": "Smooth stimulation;Vivid dreams;Antioxidant;Focus;Energy",
     "mechanism": "Contains caffeine, theobromine, and L-theanine. Stimulates CNS while providing a relaxing balance via L-theanine’s GABAergic modulation.",
@@ -5658,15 +5660,13 @@
       "🧘 smooth focus",
       "☕ l-theanine"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3682131/",
       "Journal of Ethnopharmacology",
       "2011",
       "Amazonian Shamanic Tea Practices – 2020"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "ilex-vomitoria",
@@ -5677,8 +5677,10 @@
     "subcategory": "",
     "intensity": "Moderate",
     "region": "southeastern united states",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "",
     "effects": "alertness;mild euphoria;cleansing",
     "mechanism": "Contains caffeine and theobromine acting as adenosine receptor antagonists",
@@ -5706,10 +5708,8 @@
       "caffeine",
       "yaupon"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "impatiens-balsamina",
@@ -5720,8 +5720,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "south and east asia",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a colorful flowering plant native to asia, known for its soothing effects on skin infections, wounds, and fungal issues. used in traditional medicine systems of china, korea, and india.",
     "effects": "Wound healing;Antimicrobial;Anti-itch;Skin soothing",
     "mechanism": "Contains flavonoids, naphthoquinones, and essential oils with antifungal, antibacterial, and anti-inflammatory properties. Lawsone (also found in henna) contributes to antifungal effects.",
@@ -5747,15 +5749,13 @@
       "🌿 traditional",
       "💧 soothing"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4704765/",
       "Journal of Ethnopharmacology",
       "2005",
       "Korean Pharmacopoeia"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "celastrus-paniculatus",
@@ -5766,8 +5766,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "india, sri lanka, southeast asia",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "often called the 'intellect tree', this ayurvedic plant is used to support memory, learning, and vivid dreams. contains sesquiterpenes that may stimulate cholinergic activity.",
     "effects": "Cognitive clarity;memory enhancement;dream vividness",
     "mechanism": "Cholinergic modulation; antioxidant and neuroprotective effects",
@@ -5795,15 +5797,13 @@
       "🌿 herbal",
       "🧠 nootropic"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3612440/",
       "Journal of Ayurveda and Integrative Medicine",
       "2011",
       "Indian Materia Medica – Nadkarni"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "ipomoea-tricolor",
@@ -5814,8 +5814,10 @@
     "subcategory": "",
     "intensity": "Moderate–Strong",
     "region": "mexico, central america",
+    "regiontags": [],
     "legalstatus": "Legal to grow; seeds often labeled 'not for consumption'",
     "schedule": "",
+    "legalnotes": "",
     "description": "this morning glory species contains lsa (lysergic acid amide), a natural psychedelic alkaloid structurally similar to lsd. used by aztec priests and modern psychonauts for altered states.",
     "effects": "Visual distortions;Dream-like state;Nausea;Time alteration",
     "mechanism": "LSA is a serotonin 5-HT2A partial agonist, producing dream-like hallucinations and euphoria. Less stimulating than LSD but longer-lasting.",
@@ -5849,15 +5851,13 @@
       "⚠️ nausea-prone",
       "🌀 traditional use"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5003218/",
       "Plants of the Gods – Rätsch",
       "Journal of Psychoactive Drugs",
       "2006"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "alchornea-castaneifolia",
@@ -5868,8 +5868,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "amazon basin",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "used in amazonian shamanic rituals for its spiritual and anti-inflammatory effects. often included in ayahuasca blends.",
     "effects": "Anti-inflammatory;spiritual clarity;energetic cleansing",
     "mechanism": "Unknown; may involve tannins and flavonoids",
@@ -5895,15 +5897,13 @@
       "🌿 amazon",
       "🧘 cleanse"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4127826/",
       "Rainforest Healing Herb Profiles",
       "Journal of Ethnopharmacology",
       "2007"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "adhatoda-vasica",
@@ -5914,8 +5914,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "indian subcontinent",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "known as vasaka or malabar nut, this shrub’s leaves ease breathing and offer a subtle stimulating effect.",
     "effects": "calming;respiratory clearing;mild sedation",
     "mechanism": "Alkaloids such as vasicine act as bronchodilators and respiratory stimulants",
@@ -5946,15 +5948,13 @@
       "sedative",
       "ayurvedic"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3249957/",
       "Phytomedicine. 2000",
       "7(1):37-44.",
       "Ayurvedic Pharmacopoeia of India"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "lactuca-canadensis",
@@ -5965,8 +5965,10 @@
     "subcategory": "",
     "intensity": "Mild to moderate",
     "region": "north america",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "wild lettuce species containing lactucarium for gentle analgesia.",
     "effects": "Relaxation;pain relief;drowsiness",
     "mechanism": "Mild opioid-like action via lactucin/lactucopicrin",
@@ -5994,10 +5996,8 @@
       "🌿 opium lettuce",
       "😴 sedative"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "lagochilus-inebrians",
@@ -6008,8 +6008,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "central asia",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "known as intoxicating mint; produces a pleasant calm and slight euphoria when brewed.",
     "effects": "relaxation;mild euphoria;reduced anxiety",
     "mechanism": "Contains lagochilin which depresses the CNS and may interact with GABA",
@@ -6034,10 +6036,8 @@
       "calming",
       "intoxicating mint"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "lavandula-angustifolia",
@@ -6048,8 +6048,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "mediterranean",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "fragrant lavender widely used for relaxation",
     "effects": "calm;sleep aid",
     "mechanism": "Linalool and linalyl acetate modulate GABA",
@@ -6072,10 +6074,8 @@
     "tags": [
       "🌸 aroma"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "leonotis-leonurus",
@@ -6086,8 +6086,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "southern africa",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "orange-flowered shrub also called lion’s tail; smoked traditionally for mild cannabis-like effects.",
     "effects": "Mild euphoria;relaxation",
     "mechanism": "Contains leonurine; may act on serotonin and cannabinoid receptors.",
@@ -6118,15 +6120,13 @@
       "🌿 smoke",
       "🦁 dagga"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3887317/",
       "Journal of Ethnopharmacology",
       "2005",
       "African Herbal Medicine Compendium"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "leonurus-sibiricus",
@@ -6137,8 +6137,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "native to asia, cultivated in the americas",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "sometimes called marihuanilla or siberian motherwort, providing gentle calming effects and subtle dreaminess.",
     "effects": "mild sedation;light euphoria;dream enhancement",
     "mechanism": "Contains leonurine and other alkaloids that depress CNS activity",
@@ -6165,10 +6167,8 @@
       "mint family",
       "sedative"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "lepidium-meyenii",
@@ -6179,8 +6179,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "peru, andes mountains",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a peruvian root vegetable and superfood traditionally consumed to increase energy, stamina, fertility, and hormonal resilience. grown high in the andes, maca is revered as a nutritional tonic and endocrine modulator.",
     "effects": "Hormone balancing;Energy boost;Libido enhancement;Mood support",
     "mechanism": "Contains macamides, macaenes, and glucosinolates. These influence the hypothalamic-pituitary axis, modulate neurotransmitters, and support hormonal balance without introducing phytohormones.",
@@ -6208,15 +6210,13 @@
       "🌿 adaptogen",
       "💞 libido"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3184420/",
       "Journal of Ethnopharmacology",
       "2009",
       "Peruvian Herbal Compendium"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "tilia-europaea",
@@ -6227,8 +6227,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "europe, western asia, north america (ornamental)",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "linden flowers are fragrant and soothing, traditionally used in europe as a gentle sedative and nerve tonic. often brewed into calming teas to relieve stress, tension, and digestive upset.",
     "effects": "Calm;Stress relief;Muscle relaxation;Sleep support",
     "mechanism": "Contains flavonoids (e.g., quercetin, kaempferol) and volatile oils that act as mild GABA modulators and muscle relaxants.",
@@ -6258,14 +6260,12 @@
       "🌼 floral",
       "🌿 traditional european"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6597275/",
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "lobelia-inflata",
@@ -6276,8 +6276,10 @@
     "subcategory": "",
     "intensity": "Moderate–Strong",
     "region": "north america",
+    "regiontags": [],
     "legalstatus": "Legal with caution",
     "schedule": "",
+    "legalnotes": "",
     "description": "a powerful respiratory herb used by native americans and western herbalists to aid breathing, reduce asthma spasms, and stimulate detoxification. sometimes called ‘the thinking herb’ for its clarity-inducing effects.",
     "effects": "Bronchodilation;Muscle relaxation;Emetic (high dose);Stimulates breath",
     "mechanism": "Contains lobeline, a nicotinic acetylcholine receptor partial agonist that stimulates respiration and clears airways. Also acts as a relaxant in low doses.",
@@ -6309,14 +6311,12 @@
       "⚠️ low dose only",
       "🌿 native american use"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4119142/",
       "American Herbal Pharmacopoeia – Lobelia",
       "Materia Medica – Eclectic School"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "lophophora-williamsii",
@@ -6327,8 +6327,10 @@
     "subcategory": "",
     "intensity": "Strong",
     "region": "southwestern u.s., mexico",
+    "regiontags": [],
     "legalstatus": "Illegal in many countries; ceremonial exemption in U.S. (NAC)",
     "schedule": "",
+    "legalnotes": "",
     "description": "a small cactus revered for centuries in native american and mesoamerican spiritual traditions. contains mescaline, a potent psychedelic that induces visionary, heart-centered, and introspective states. still legally protected for ceremonial use in some indigenous groups.",
     "effects": "Visuals;Emotional opening;Ego dissolution;Sacred insight",
     "mechanism": "Mescaline is a serotonin 5-HT2A agonist and also modulates dopamine and norepinephrine. Alters perception, emotion, and time sense.",
@@ -6364,15 +6366,13 @@
       "💖 sacred plant",
       "🌈 mescaline"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7188374/",
       "Plants of the Gods – Rätsch",
       "Journal of Psychoactive Drugs",
       "2013"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "lycopodium-clavatum",
@@ -6383,8 +6383,10 @@
     "subcategory": "",
     "intensity": "Very mild",
     "region": "europe, north america, eurasia",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a moss-like vascular plant traditionally used in european folk and homeopathic medicine. its yellow spores were used in rituals and historically as flash powder due to their flammability. internally, it has been used for digestive and urinary complaints.",
     "effects": "Cognitive stimulation (mild);Digestive tonic;Symbolic use;Spore dispersal agent",
     "mechanism": "Spores are inert unless extracted. Extracts may act mildly as cholinergic modulators or anti-inflammatory agents. In homeopathy, extremely diluted preparations are used for liver, bladder, and memory issues.",
@@ -6412,15 +6414,13 @@
       "🔥 ritual powder",
       "🧠 memory"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1070629/",
       "Homeopathic Materia Medica – Boericke",
       "Phytotherapy Research",
       "2002"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "lsd",
@@ -6431,8 +6431,10 @@
     "subcategory": "",
     "intensity": "High",
     "region": "🌎 synthetic",
+    "regiontags": [],
     "legalstatus": "Controlled / Illegal in many regions",
     "schedule": "",
+    "legalnotes": "",
     "description": "semi-synthetic ergoline discovered in 1938; among the most potent psychedelics.",
     "effects": "Intense visuals;ego dissolution;synesthesia",
     "mechanism": "Potent 5-HT2A receptor agonist affecting serotonin and dopamine systems.",
@@ -6461,10 +6463,8 @@
       "🌀 visionary",
       "💊 oral"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "mandragora-officinarum",
@@ -6475,8 +6475,10 @@
     "subcategory": "",
     "intensity": "Extreme",
     "region": "mediterranean, europe, near east",
+    "regiontags": [],
     "legalstatus": "Restricted or regulated in some countries",
     "schedule": "",
+    "legalnotes": "",
     "description": "a legendary plant of myth and medicine, mandrake has deep roots in european witchcraft, alchemy, and ancient anesthetic practices. the humanoid root contains potent tropane alkaloids similar to deadly nightshades.",
     "effects": "Hallucinations;Sedation;Amnesia;Pain relief (historical)",
     "mechanism": "Scopolamine, hyoscyamine, and atropine act as central anticholinergics, disrupting memory, balance, perception, and consciousness. Mimics effects of belladonna and henbane.",
@@ -6516,14 +6518,12 @@
       "☠️ toxic",
       "🌿 root"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6367476/",
       "Plants of the Gods – Rätsch",
       "Toxicology in Herbal Medicine – 2020"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "marrubium-vulgare",
@@ -6534,8 +6534,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "europe, north africa",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "also known as horehound, used in cough drops",
     "effects": "digestive stimulation;clear lungs",
     "mechanism": "Diterpene lactone marrubiin stimulates mucus production",
@@ -6560,14 +6562,12 @@
     "tags": [
       "🍬 candy"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6494426/",
       "ESCOP Monograph – Marrubium",
       "American Herbal Pharmacopoeia – Horehound"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "matricaria-chamomilla",
@@ -6578,8 +6578,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "europe, north africa, western asia (now global)",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a gentle daisy-like flower used worldwide for calming nerves, reducing inflammation, and aiding digestion. chamomile tea is one of the most common herbal remedies for stress and insomnia.",
     "effects": "Calming;Sleep aid;Soothes digestion;Mild pain relief",
     "mechanism": "Contains apigenin, a flavonoid that binds to benzodiazepine receptors. Also anti-inflammatory through COX-2 inhibition and spasmolytic via smooth muscle relaxation.",
@@ -6608,14 +6610,12 @@
       "🫖 tea",
       "🌿 gut soothing"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2995283/",
       "ESCOP Monograph – Chamomilla",
       "The Complete German Commission E Monographs"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "melissa-officinalis",
@@ -6626,8 +6626,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "mediterranean, now global",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a fragrant member of the mint family, lemon balm has been used for centuries to calm the nervous system, lift the mood, and improve memory. its subtle citrus aroma makes it popular in teas and tinctures.",
     "effects": "Anti-anxiety;Cognitive clarity;Mood boost;Antiviral",
     "mechanism": "GABA-T inhibition and acetylcholine modulation. Rich in rosmarinic acid and flavonoids, which contribute to anxiolytic and nootropic effects.",
@@ -6653,15 +6655,13 @@
       "🌿 antiviral",
       "🫖 nervine"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5871149/",
       "Journal of Ethnopharmacology",
       "2004",
       "Herbal Medicine – Mills & Bone"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "mentha-piperita",
@@ -6672,8 +6672,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "global cultivation",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a cooling, aromatic herb widely used for digestive and nervous system support. common in teas, extracts, and aromatherapy. historically used in european, middle eastern, and asian herbalism.",
     "effects": "Soothes digestion;Stimulates focus;Relieves cramps;Cools",
     "mechanism": "Menthol and other essential oils act as calcium channel blockers in smooth muscle and desensitize cold receptors (TRPM8), producing cooling and antispasmodic effects.",
@@ -6703,14 +6705,12 @@
       "🧠 focus",
       "🪻 aromatic"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4103722/",
       "ESCOP Monographs",
       "Herbal Medicine – New Oxford Textbook"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "mimosa-pudica",
@@ -6721,8 +6721,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "south america, southeast asia, india",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "known for its rapid leaf-closing reflex, this tropical creeping plant is used in ayurvedic and modern herbal medicine for gut detox, parasite cleansing, and calming the nerves.",
     "effects": "Intestinal cleanse;Antiparasitic;Calming;Unique tactile motion",
     "mechanism": "Contains mimosine, alkaloids, and tannins. Antiparasitic action through mechanical mucilage binding and gut wall modulation. Also mildly acts on serotonin and GABA pathways.",
@@ -6750,15 +6752,13 @@
       "🌿 ayurvedic",
       "🖐️ reactive plant"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4027290/",
       "Ayurvedic Pharmacopeia – India",
       "Journal of Parasitology Research",
       "2017"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "mimosa-hostilis",
@@ -6769,8 +6769,10 @@
     "subcategory": "",
     "intensity": "Strong",
     "region": "brazil, central america",
+    "regiontags": [],
     "legalstatus": "DMT controlled in many countries",
     "schedule": "",
+    "legalnotes": "",
     "description": "highly sought after for its dmt-rich root bark. used in anahuasca brews as a substitute for chacruna or yopo.",
     "effects": "Visionary states;purging;emotional release",
     "mechanism": "DMT – 5-HT2A agonist (requires MAOI orally)",
@@ -6800,15 +6802,13 @@
       "🌿 anahuasca",
       "🧪 dmt"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6334226/",
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology",
       "1993"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "mitchella-repens",
@@ -6819,8 +6819,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "north america",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "known as partridgeberry, used as a uterine tonic and mild relaxing agent in north american herbalism.",
     "effects": "relaxation;nervine",
     "mechanism": "Smooth muscle relaxant",
@@ -6842,10 +6844,8 @@
       "uterine",
       "folk remedy"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "mitragyna-hirsuta",
@@ -6856,8 +6856,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "thailand, southeast asia",
+    "regiontags": [],
     "legalstatus": "Legal in most regions",
     "schedule": "",
+    "legalnotes": "",
     "description": "a close relative of mitragyna speciosa (kratom), this thai tree is used as a legal alternative with gentler psychoactive effects. traditionally chewed by laborers for stamina and focus.",
     "effects": "Mild euphoria;Calm stimulation;Analgesia;Energy boost",
     "mechanism": "Contains mitraphylline and isomitraphylline — alkaloids that act on opioid receptors (mu, delta) and possibly serotonin/dopamine pathways, though weaker than kratom.",
@@ -6887,15 +6889,13 @@
       "🧘 calm",
       "🩹 mild analgesic"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6571610/",
       "Journal of Ethnopharmacology",
       "2016",
       "Thai Botanical Index – 2014"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "mitragyna-speciosa",
@@ -6906,8 +6906,10 @@
     "subcategory": "",
     "intensity": "Mild–Strong (dose-dependent)",
     "region": "thailand, indonesia, malaysia",
+    "regiontags": [],
     "legalstatus": "Legal in some regions; banned or restricted in others (e.g. Thailand, Australia, some U.S. states)",
     "schedule": "",
+    "legalnotes": "",
     "description": "a tropical tree whose leaves are traditionally chewed for stamina and pain relief in southeast asia. kratom has gained global attention as both a potential therapeutic tool and a substance of concern due to its opioid-like effects.",
     "effects": "Energy;Euphoria;Pain relief;Calm focus",
     "mechanism": "Mitragynine and 7-hydroxymitragynine are partial mu-opioid agonists with stimulant properties at low doses and sedative effects at higher doses. Also interacts with adrenergic and serotonergic systems.",
@@ -6947,16 +6949,14 @@
       "🌿 traditional",
       "🩹 pain relief"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6534344/",
       "Journal of the American Osteopathic Association",
       "2020",
       "WHO Kratom Review Report",
       "2021"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "kratom-hybrids",
@@ -6967,8 +6967,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "cultivated southeast asia",
+    "regiontags": [],
     "legalstatus": "Varies by region",
     "schedule": "",
+    "legalnotes": "",
     "description": "selective breeding of kratom species for varied alkaloid ratios",
     "effects": "energy;pain relief",
     "mechanism": "Indole alkaloids act as partial mu-opioid agonists",
@@ -6994,10 +6996,8 @@
       "⚠️ use caution",
       "🍃 leaf"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "monotropa-uniflora",
@@ -7008,8 +7008,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "temperate forests of north america and asia",
+    "regiontags": [],
     "legalstatus": "Legal (but rare and protected in places)",
     "schedule": "",
+    "legalnotes": "",
     "description": "a ghostly white forest plant used in native american medicine for pain and spiritual insight. non-photosynthetic and mysterious.",
     "effects": "Analgesia;calm;emotional detachment",
     "mechanism": "Contains monotropin; acts possibly on NMDA or opioid systems (hypothetical)",
@@ -7036,10 +7038,8 @@
       "👻 ghost plant",
       "🧠 emotional"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "leonurus-cardiaca",
@@ -7050,8 +7050,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "europe, north america, asia",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a traditional european nervine used to ease tension, heart flutter, and menstrual discomfort. known as ‘mother’s herb’ for its supportive effects during emotional distress and hormonal fluctuations.",
     "effects": "Calms heart palpitations;Reduces anxiety;Uterine tonic;Regulates menstrual tension",
     "mechanism": "Alkaloids such as leonurine and stachydrine provide mild sedative, antispasmodic, and cardiotonic effects, possibly modulating GABA and muscarinic pathways.",
@@ -7081,14 +7083,12 @@
       "🧘 nervine",
       "🌿 bitter tonic"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8762752/",
       "Herbal Medicine – Mills & Bone",
       "British Herbal Compendium"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "mucuna-pruriens",
@@ -7099,8 +7099,10 @@
     "subcategory": "",
     "intensity": "Moderate",
     "region": "tropical asia and africa",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "also called velvet bean; boosts dopamine and serves as a traditional tonic in ayurvedic practice.",
     "effects": "increased motivation;energy;elevated mood",
     "mechanism": "Seeds contain L‑DOPA which increases brain dopamine levels",
@@ -7126,15 +7128,13 @@
       "dopamine",
       "velvet bean"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4213965/",
       "Journal of Traditional and Complementary Medicine",
       "2015",
       "Ayurvedic Materia Medica"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "byrsonima-crassifolia",
@@ -7145,8 +7145,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "central and south america",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "",
     "effects": "mild sedative;calming;tonic",
     "mechanism": "Flavonoid antioxidant and neuroprotective action",
@@ -7168,10 +7170,8 @@
       "folk",
       "antioxidant"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "tropaeolum-majus",
@@ -7182,8 +7182,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "south america (peru, andes)",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "",
     "effects": "mild stimulant;respiratory enhancer",
     "mechanism": "Antimicrobial and expectorant, may enhance breathing clarity.",
@@ -7204,10 +7206,8 @@
       "respiratory",
       "folk"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "nelumbo-lutea",
@@ -7218,8 +7218,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "north america",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a north american relative of the sacred lotus, nelumbo lutea has similar calming, euphoric properties. it has been used by native american groups for its edible seeds and roots, and possibly ceremonial effects when brewed from the flower.",
     "effects": "Tranquility;Heart-opening;Sensual awareness;Lucid dreaming",
     "mechanism": "Contains alkaloids such as nuciferine and neferine, modulating dopamine and serotonin receptors. Mildly sedative and possibly aphrodisiac.",
@@ -7247,14 +7249,12 @@
       "🌙 dream",
       "💖 hormonal"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3991026/",
       "Ethnobotany of North American Indians – 1993",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "nicotiana-tabacum",
@@ -7265,8 +7265,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "worldwide",
+    "regiontags": [],
     "legalstatus": "Regulated",
     "schedule": "",
+    "legalnotes": "",
     "description": "common tobacco plant widely used recreationally",
     "effects": "alertness;mild euphoria",
     "mechanism": "Nicotine stimulates nicotinic acetylcholine receptors releasing dopamine",
@@ -7292,10 +7294,8 @@
       "⚠️ addictive",
       "🚬 smoke"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "myristica-fragrans",
@@ -7306,8 +7306,10 @@
     "subcategory": "",
     "intensity": "Strong",
     "region": "indonesia",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "nutmeg seeds can be psychoactive in large amounts.",
     "effects": "Deliriant states;nausea",
     "mechanism": "Myristicin metabolizes to MMDA-like compounds",
@@ -7338,14 +7340,12 @@
       "🌿 seed",
       "🧪 phenethylamine"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3457357/",
       "Plants of the Gods – Rätsch",
       "Toxicology of Spices – 2012"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "white-lily",
@@ -7356,8 +7356,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "mexico, central america",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "related to blue lotus, this sacred flower from mesoamerican traditions is used to promote meditation and lucid dreaming.",
     "effects": "Calm;light sedation;dream potentiation",
     "mechanism": "Contains aporphine alkaloids (dopamine agonist)",
@@ -7383,10 +7385,8 @@
       "🌸 calm",
       "🌿 sedative"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "nymphaea-lotus",
@@ -7397,8 +7397,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "africa and southeast asia",
+    "regiontags": [],
     "legalstatus": "Generally legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "also called the egyptian white lotus, historically revered for its gentle calming and dreamlike qualities.",
     "effects": "relaxation;dream enhancement;mild euphoria",
     "mechanism": "Contains aporphine alkaloids that act on dopamine and serotonin receptors",
@@ -7423,10 +7425,8 @@
       "sedative",
       "water lily"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "nymphaea-nouchali",
@@ -7437,8 +7437,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "india, sri lanka, southeast asia",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a revered flower across south and southeast asia, often confused with blue lotus. it holds symbolic significance in buddhism and ayurveda. the flowers are known for inducing a soft, euphoric state when steeped or smoked.",
     "effects": "Calm euphoria;Sensual clarity;Dream enhancement;Mild sedation",
     "mechanism": "Contains aporphine and related alkaloids that affect dopamine and serotonin receptors. Mildly sedative and introspective.",
@@ -7466,14 +7468,12 @@
       "🌙 dream herb",
       "💫 aphrodisiac"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3708387/",
       "Ayurvedic Pharmacopeia of India",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "nymphaea-rubra",
@@ -7484,8 +7484,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "south asia",
+    "regiontags": [],
     "legalstatus": "Varies",
     "schedule": "",
+    "legalnotes": "",
     "description": "red lotus used similarly to blue lotus for relaxation",
     "effects": "calming;dreamy state",
     "mechanism": "Alkaloids like apomorphine interact with dopamine receptors",
@@ -7508,10 +7510,8 @@
     "tags": [
       "🌸 flower"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "ocimum-sanctum",
@@ -7522,8 +7522,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "india, southeast asia",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a sacred ayurvedic herb used for spiritual purification, resilience, and vitality. known as 'tulsi' in india, it’s revered for its uplifting, adaptogenic, and rejuvenating properties.",
     "effects": "Stress reduction;Mental clarity;Immune modulation;Anti-inflammatory",
     "mechanism": "Rich in eugenol, ursolic acid, and flavonoids. Acts as an adaptogen through HPA axis modulation, antioxidant pathways, and mild cortisol-lowering activity.",
@@ -7551,14 +7553,12 @@
       "🛡️ immune",
       "🕉️ sacred"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5376420/",
       "Ayurvedic Materia Medica",
       "Journal of Ayurveda and Integrative Medicine"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "panax-ginseng",
@@ -7569,8 +7569,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "asia",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "classic tonic herb for stamina and cognition.",
     "effects": "vitality;adaptogen",
     "mechanism": "Ginsenosides modulate HPA axis and nitric oxide pathways",
@@ -7596,10 +7598,8 @@
       "🌿 root",
       "💊 oral"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "panax-quinquefolius",
@@ -7610,8 +7610,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "north america",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "north american species prized for restorative effects.",
     "effects": "calm energy",
     "mechanism": "Similar ginsenosides modulate neurotransmitters",
@@ -7637,10 +7639,8 @@
       "🌿 root",
       "💊 oral"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "papaver-somniferum",
@@ -7651,8 +7651,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "worldwide",
+    "regiontags": [],
     "legalstatus": "Highly controlled",
     "schedule": "",
+    "legalnotes": "",
     "description": "primary source of medicinal opiates.",
     "effects": "analgesia;euphoria",
     "mechanism": "Morphine alkaloids activate mu-opioid receptors",
@@ -7679,10 +7681,8 @@
       "☠️ addictive",
       "💊 oral"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "passiflora-incarnata",
@@ -7693,8 +7693,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "southeastern u.s., latin america",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a beautiful climbing flower used to calm restlessness, anxiety, and insomnia. native to the southeastern u.s., passionflower is valued for its non-habit-forming, gently sedative qualities.",
     "effects": "Anxiety relief;Mild sedation;Muscle relaxation;Sleep support",
     "mechanism": "Rich in flavonoids like chrysin and vitexin that modulate GABA-A receptors. Also may inhibit MAO and reduce neuronal excitability.",
@@ -7734,14 +7736,12 @@
       "🌿 sedative",
       "🧘 calm"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4271694/",
       "ESCOP Monograph – Passiflora",
       "Herbal Medicine – Mills & Bone"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "paullinia-cupana",
@@ -7752,8 +7752,10 @@
     "subcategory": "",
     "intensity": "Moderate–Strong",
     "region": "brazil, amazon rainforest",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a highly caffeinated amazonian seed used traditionally for endurance, alertness, and ritual vigor. now a common additive in energy drinks, guaraná offers a longer-lasting stimulation than coffee due to slow-release alkaloids and tannins.",
     "effects": "Energy;Focus;Mood boost;Appetite suppression",
     "mechanism": "High caffeine content (~2–6% by weight) acts as an adenosine receptor antagonist. Also contains theobromine and catechins for extended alertness.",
@@ -7796,16 +7798,14 @@
       "🌿 amazonian",
       "🔥 metabolic"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4334453/",
       "Journal of Ethnopharmacology",
       "2001",
       "Phytochemistry Reviews",
       "2008"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "paullinia-yoco",
@@ -7816,8 +7816,10 @@
     "subcategory": "",
     "intensity": "Moderate",
     "region": "amazon rainforest",
+    "regiontags": [],
     "legalstatus": "Generally legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "liana used by several amazonian tribes; the bark yields a potent caffeinated beverage for energy.",
     "effects": "alertness;energy;reduced fatigue",
     "mechanism": "Bark rich in caffeine acts as an adenosine receptor antagonist",
@@ -7846,10 +7848,8 @@
       "caffeine",
       "vine"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "pausinystalia-johimbe",
@@ -7860,8 +7860,10 @@
     "subcategory": "",
     "intensity": "Moderate–Strong",
     "region": "west africa (cameroon, nigeria, gabon)",
+    "regiontags": [],
     "legalstatus": "Regulated in some countries; available OTC or by prescription in others",
     "schedule": "",
+    "legalnotes": "",
     "description": "an african tree bark used as a traditional male aphrodisiac and stimulant. contains yohimbine, an alkaloid used in pharmaceuticals for erectile dysfunction and athletic performance.",
     "effects": "Increased libido;Stimulation;Increased blood flow;Alertness",
     "mechanism": "Yohimbine is an alpha-2 adrenergic receptor antagonist, increasing norepinephrine release and blood flow. Also affects serotonin and dopamine.",
@@ -7906,15 +7908,13 @@
       "🌳 bark",
       "🔥 libido"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3777290/",
       "Plants of the Gods – Rätsch",
       "International Journal of Impotence Research",
       "2002"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "pausinystalia-yohimbe",
@@ -7925,8 +7925,10 @@
     "subcategory": "",
     "intensity": "Moderate",
     "region": "africa",
+    "regiontags": [],
     "legalstatus": "Regulated in some regions",
     "schedule": "",
+    "legalnotes": "",
     "description": "potent bark traditionally used as an aphrodisiac.",
     "effects": "Aphrodisiac;stimulant",
     "mechanism": "Yohimbine is an adrenergic receptor antagonist",
@@ -7954,10 +7956,8 @@
       "🌿 bark",
       "🔥 intensity"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "peganum-harmala",
@@ -7968,8 +7968,10 @@
     "subcategory": "",
     "intensity": "Moderate–Strong",
     "region": "middle east, north africa, central asia",
+    "regiontags": [],
     "legalstatus": "Legal in most countries; restricted in some due to MAOI activity",
     "schedule": "",
+    "legalnotes": "",
     "description": "a desert shrub revered in persian, middle eastern, and central asian traditions. its seeds contain harmala alkaloids (harmine, harmaline, tetrahydroharmine) that act as reversible mao-a inhibitors and are used both spiritually and medicinally.",
     "effects": "MAO inhibition;Dream enhancement;Entheogenic potentiation;Altered perception",
     "mechanism": "Reversible inhibition of monoamine oxidase A (MAO-A), increasing serotonin, dopamine, and other monoamines. Also mild SSRI and hallucinogenic potentiator.",
@@ -8011,15 +8013,13 @@
       "⚠️ maoi",
       "🌿 seeds"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4621295/",
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology",
       "1997"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "perilla-frutescens",
@@ -8030,8 +8030,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "east asia",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "used in east asian cuisine and medicine, this leaf contains mild mood-elevating and cognitive enhancing properties.",
     "effects": "uplifting;calm clarity",
     "mechanism": "Cholinergic + antioxidant effects",
@@ -8053,10 +8055,8 @@
       "culinary",
       "relaxing"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "peumus-boldus",
@@ -8067,8 +8067,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "chile",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "boldo is a south american medicinal herb with liver-supportive and mild hypnotic properties.",
     "effects": "calming;digestive aid;dreamy",
     "mechanism": "Cholinergic + serotonergic",
@@ -8090,10 +8092,8 @@
       "sleep aid",
       "folk medicine"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "piper-auritum",
@@ -8104,8 +8104,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "mexico, central america",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a large-leaved herb with a root beer aroma, used in traditional mexican cuisine and healing rituals. also called 'hoja santa', it is believed to gently support digestion, lungs, and emotional balance.",
     "effects": "Digestive aid;Calming;Flavor enhancer;Mild euphoria (traditional use)",
     "mechanism": "Contains safrole and other aromatic compounds that may mildly modulate GABA and dopamine activity. Primary use is culinary, with subtle psychoactivity in large doses.",
@@ -8134,15 +8136,13 @@
       "🫖 soothing",
       "🌀 mild relaxant"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8757553/",
       "Journal of Ethnopharmacology",
       "2005",
       "Ethnobotany of Mexico – 2012"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "kava",
@@ -8153,8 +8153,10 @@
     "subcategory": "",
     "intensity": "Mild to moderate",
     "region": "polynesia, micronesia, melanesia",
+    "regiontags": [],
     "legalstatus": "Legal; restricted in some EU countries",
     "schedule": "",
+    "legalnotes": "",
     "description": "south pacific root brew known for its relaxing and anxiolytic effects.",
     "effects": "Relaxation;social ease;mild euphoria",
     "mechanism": "Kavalactones modulate GABA, block sodium and calcium channels",
@@ -8190,15 +8192,13 @@
       "⚠️ caution",
       "💤 sedation"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4385482/",
       "ESCOP Monograph – Kava",
       "Journal of Clinical Psychopharmacology",
       "2013"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "plectranthus-scutellarioides",
@@ -8209,8 +8209,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "tropical asia",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "",
     "effects": "mild visuals;color enhancement;relaxation",
     "mechanism": "Unclear; may act on serotonergic pathways",
@@ -8234,10 +8236,8 @@
       "painted nettle",
       "visionary"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "pogostemon-cablin",
@@ -8248,8 +8248,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "asia",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "patchouli, while mainly aromatic, has mild psychoactive effects in traditional incense rituals.",
     "effects": "sensory enhancement;calm focus;uplifted mood",
     "mechanism": "Aromatherapeutic + serotonergic",
@@ -8271,10 +8273,8 @@
       "ritual",
       "uplifting"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "polygala-tenuifolia",
@@ -8285,8 +8285,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "east asia",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "called yuan zhi in tcm; promotes mental clarity",
     "effects": "focus;mood lift",
     "mechanism": "Tenuigenin saponins modulate neurochemistry and neurotrophic factors",
@@ -8309,10 +8311,8 @@
     "tags": [
       "🧠 focus"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "psilocybin",
@@ -8323,8 +8323,10 @@
     "subcategory": "",
     "intensity": "Moderate",
     "region": "🌎 global",
+    "regiontags": [],
     "legalstatus": "Controlled in many countries",
     "schedule": "",
+    "legalnotes": "",
     "description": "active compound in psychedelic mushrooms producing profound perceptual changes.",
     "effects": "Visual patterns;mystical insight;emotional release",
     "mechanism": "Converted to psilocin which acts as 5-HT2A agonist.",
@@ -8353,10 +8355,8 @@
       "🌀 visionary",
       "💊 oral"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "psychotria-carthagenensis",
@@ -8367,8 +8367,10 @@
     "subcategory": "",
     "intensity": "Strong",
     "region": "amazon basin",
+    "regiontags": [],
     "legalstatus": "DMT restricted in many countries",
     "schedule": "",
+    "legalnotes": "",
     "description": "amazonian shrub also known as chaliponga; its dmt-rich leaves are valued in shamanic ceremonies.",
     "effects": "visual effects;introspection;spiritual insight",
     "mechanism": "Leaves contain N,N-dimethyltryptamine acting as a serotonin agonist; requires MAO inhibition orally",
@@ -8396,10 +8398,8 @@
       "dmt",
       "chaliponga"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "psychotria-carthaginensis",
@@ -8410,8 +8410,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "south america",
+    "regiontags": [],
     "legalstatus": "Often legal; DMT controlled",
     "schedule": "",
+    "legalnotes": "",
     "description": "chacruna relative sometimes used as admixture in brews",
     "effects": "visions;euphoria",
     "mechanism": "Leaves contain DMT acting on 5-HT2A when combined with MAOI",
@@ -8436,10 +8438,8 @@
       "🌿 ayahuasca",
       "🍃 leaf"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "chacruna",
@@ -8450,8 +8450,10 @@
     "subcategory": "",
     "intensity": "Strong",
     "region": "amazon basin (peru, brazil, colombia)",
+    "regiontags": [],
     "legalstatus": "Restricted in many countries due to DMT",
     "schedule": "",
+    "legalnotes": "",
     "description": "a tropical shrub from the amazon traditionally used in ayahuasca brews. its leaves contain high concentrations of n,n-dmt, making it a primary admixture plant in visionary ceremonies.",
     "effects": "Psychedelic visions;Emotional processing;Spiritual insight;Sensory enhancement",
     "mechanism": "Contains N,N-DMT, a potent serotonergic psychedelic that acts as a 5-HT2A receptor agonist. Requires MAOI (such as harmala alkaloids) to be orally active.",
@@ -8491,15 +8493,13 @@
       "🌌 visionary",
       "⚠️ maoi required"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7343898/",
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology",
       "2010"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "ptychopetalum-olacoides",
@@ -8510,8 +8510,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "amazon",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "known as muira puama, used for vitality and libido.",
     "effects": "Libido boost;mild stimulation",
     "mechanism": "Alkaloids may act on dopamine pathways",
@@ -8536,10 +8538,8 @@
       "✅ safe",
       "🌿 bark"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "anemone-pulsatilla",
@@ -8550,8 +8550,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "europe and western asia",
+    "regiontags": [],
     "legalstatus": "Legal but not widely sold",
     "schedule": "",
+    "legalnotes": "",
     "description": "also called pasque flower; once used by herbalists for calming nerves and relieving pain.",
     "effects": "calm;pain relief;mild altered awareness",
     "mechanism": "Contains lactones derived from protoanemonin that depress the central nervous system",
@@ -8579,10 +8581,8 @@
       "folk",
       "sedative"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "rubus-idaeus",
@@ -8593,8 +8593,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "europe, north america",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "",
     "effects": "uterine tonic;calming;digestive support",
     "mechanism": "Smooth muscle modulation and antioxidant action",
@@ -8616,10 +8618,8 @@
       "uterine",
       "tonic"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "ruta-graveolens",
@@ -8630,8 +8630,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "mediterranean",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "common rue, used historically as a sedative, an abortifacient, and for spiritual protection.",
     "effects": "relaxation;hypnotic;mystical",
     "mechanism": "GABA-A modulation, alkaloid effects",
@@ -8653,10 +8655,8 @@
       "bitter",
       "traditional medicine"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "elaeagnus-angustifolia",
@@ -8667,8 +8667,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "central asia, middle east, europe",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "",
     "effects": "anxiolytic;sedative;pain-relieving",
     "mechanism": "GABAergic effects and antioxidant pathways",
@@ -8690,10 +8692,8 @@
       "analgesic",
       "folk"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "ficus-religiosa",
@@ -8704,8 +8704,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "india, southeast asia",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "",
     "effects": "calming;mood-balancing;mild sedative",
     "mechanism": "Neuroprotective antioxidant and serotonin modulation",
@@ -8727,10 +8729,8 @@
       "sedative",
       "folk"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "nelumbo-nucifera",
@@ -8741,8 +8741,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "india, china, southeast asia",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "sacred flower in buddhism and hinduism, with mild psychoactive and calming properties. often used in teas or tinctures.",
     "effects": "Relaxation;dream enhancement;calm euphoria",
     "mechanism": "Likely GABAergic and dopaminergic effects (alkaloids: nuciferine, aporphine)",
@@ -8781,14 +8783,12 @@
       "🌸 calm",
       "🧘 meditation"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7442399/",
       "Ayurvedic Herbal Compendium",
       "Chinese Pharmacopoeia"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "combretum-quadrangulare",
@@ -8799,8 +8799,10 @@
     "subcategory": "",
     "intensity": "Mild to Moderate",
     "region": "laos, cambodia, thailand",
+    "regiontags": [],
     "legalstatus": "Legal with little regulation",
     "schedule": "",
+    "legalnotes": "",
     "description": "often marketed as “sakae naa,” this plant is used as a mild energizing substitute for kratom.",
     "effects": "heightened alertness;subtle euphoria;increased focus",
     "mechanism": "Leaves contain combretol and related alkaloids acting on adrenergic systems",
@@ -8830,15 +8832,13 @@
       "southeast asia",
       "energy"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://erowid.org/plants/sakae_naa/",
       "Thai Ethnobotany Compendium",
       "2015",
       "Ethnopharmacology of Southeast Asia – WHO Report"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "salvia-sclarea",
@@ -8849,8 +8849,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "mediterranean",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "clary sage, used aromatically and medicinally for mild euphoria, hormonal balancing, and clarity.",
     "effects": "clarity;relief;uplifting",
     "mechanism": "GABA-A modulation, estrogenic activity",
@@ -8872,10 +8874,8 @@
       "elevating",
       "folk remedy"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "sassafras-albidum",
@@ -8886,8 +8886,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "eastern north america",
+    "regiontags": [],
     "legalstatus": "Restricted as food additive in the U.S.",
     "schedule": "",
+    "legalnotes": "",
     "description": "fragrant tree whose root bark and oil were once common flavorings; contains safrole with mild psychoactive properties.",
     "effects": "Mild euphoria;warmth",
     "mechanism": "Safrole may modulate dopamine release and acts as a mild hallucinogen at high doses.",
@@ -8913,10 +8915,8 @@
       "🌳 root bark",
       "🌿 tea"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "sceletium-tortuosum",
@@ -8927,8 +8927,10 @@
     "subcategory": "",
     "intensity": "Mild to moderate",
     "region": "south africa, namibia",
+    "regiontags": [],
     "legalstatus": "Legal worldwide (except select EU countries)",
     "schedule": "",
+    "legalnotes": "",
     "description": "a succulent plant native to south africa, kanna has been chewed, snuffed, and brewed for centuries by khoisan peoples to ease stress, elevate mood, and promote social connection. it’s now gaining modern popularity as a legal natural serotonin booster.",
     "effects": "Euphoria;Reduced anxiety;Social enhancement;Emotional softening",
     "mechanism": "Contains mesembrine alkaloids that act as selective serotonin reuptake inhibitors (SSRI), PDE4 inhibitors, and mild serotonin releasing agents (SRA). Also mildly acts on dopamine.",
@@ -8973,15 +8975,13 @@
       "💬 social",
       "🌿 traditional african"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5386632/",
       "Journal of Ethnopharmacology",
       "2013",
       "South African Herbal Compendium"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "sida-acuta",
@@ -8992,8 +8992,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "tropical regions",
+    "regiontags": [],
     "legalstatus": "Varies",
     "schedule": "",
+    "legalnotes": "",
     "description": "weedy plant sometimes used as a mild stimulant",
     "effects": "energy;focus",
     "mechanism": "Contains ephedrine-like alkaloids stimulating adrenergic receptors",
@@ -9017,10 +9019,8 @@
       "stimulant",
       "🍃 leaf"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "african-dream-root",
@@ -9031,8 +9031,10 @@
     "subcategory": "",
     "intensity": "Mild to moderate",
     "region": "south africa",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "known as 'xhosa dream root', silene capensis is a sacred plant used by the xhosa people of south africa for initiating vivid and prophetic dreams.",
     "effects": "Lucid dreaming;enhanced dream recall;vivid visions",
     "mechanism": "Likely acts on cholinergic and serotonergic systems; exact mechanism unknown",
@@ -9060,9 +9062,6 @@
       "🧘 ancestral",
       "🧠 vision"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://erowid.org/plants/silene_capensis/",
       "Dreaming Plant Guide – Ratsch",
@@ -9072,7 +9071,8 @@
       "Plants of the Gods – Rätsch",
       "African Ethnobotany in the Americas",
       "2014"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "silybum-marianum",
@@ -9083,8 +9083,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "mediterranean",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "milk thistle seeds support liver function.",
     "effects": "Liver protection",
     "mechanism": "Silymarin acts as antioxidant and hepatoprotective",
@@ -9108,10 +9110,8 @@
       "✅ safe",
       "🌿 seed"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "heimia-salicifolia",
@@ -9122,8 +9122,10 @@
     "subcategory": "",
     "intensity": "Mild to moderate",
     "region": "mexico, central america",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a yellow-flowering shrub used by indigenous mexican peoples for vision quests and dream work. traditionally prepared via solar fermentation, sinicuichi is known for inducing auditory changes and memory recall.",
     "effects": "Dream enhancement;Auditory distortion;Relaxation;Trance-like state",
     "mechanism": "Contains cryogenine and lythrine, which may modulate acetylcholine and GABA receptors, inducing mild CNS depression and altered perception.",
@@ -9164,15 +9166,13 @@
       "🎧 auditory",
       "🧠 dream"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3654015/",
       "Journal of Ethnopharmacology",
       "1992",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "solandra-maxima",
@@ -9183,8 +9183,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "mexico",
+    "regiontags": [],
     "legalstatus": "Unregulated",
     "schedule": "",
+    "legalnotes": "",
     "description": "rarely used solanaceous vine with powerful effects.",
     "effects": "visions;disorientation",
     "mechanism": "Tropane alkaloids similar to datura",
@@ -9209,10 +9211,8 @@
     "tags": [
       "☠️ toxic"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "sophora-secundiflora",
@@ -9223,8 +9223,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "southwestern us, mexico",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "mescal bean, used ceremonially by native american tribes. highly toxic, formerly used as an ordeal poison.",
     "effects": "delirium;visions;dizziness",
     "mechanism": "Nicotinic receptor agonist",
@@ -9245,10 +9247,8 @@
       "toxic",
       "visionary"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "spigelia-marilandica",
@@ -9259,8 +9259,10 @@
     "subcategory": "",
     "intensity": "Moderate–Strong (dose-dependent)",
     "region": "southeastern united states",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a striking woodland plant native to the southeastern u.s., traditionally used for expelling intestinal parasites. it has mild nervine and sedative effects, but can cause strong reactions in high doses.",
     "effects": "Parasitic cleanse;Mild sedation;Vision changes (in excess);Calming",
     "mechanism": "Alkaloids (spigeline and others) are toxic to parasitic worms and may also affect the central nervous system. In high doses, can produce dizziness and visual distortion.",
@@ -9291,14 +9293,12 @@
       "🧠 nervine",
       "⚠️ toxic in excess"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6492244/",
       "Native American Ethnobotany – Moerman",
       "Herbal Medicine – Mills & Bone"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "viola-odorata",
@@ -9309,8 +9309,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "europe, western asia, north africa",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a fragrant violet flower traditionally used for respiratory and emotional conditions. offers calming, anti-inflammatory, and mucilaginous support, often in teas or syrups.",
     "effects": "Soothing;Anti-inflammatory;Sleep support;Cough relief",
     "mechanism": "Contains salicylic acid derivatives, mucilage, and volatile oils. Gently modulates GABA and prostaglandins. Mild expectorant and anti-inflammatory activity.",
@@ -9340,14 +9342,12 @@
       "🫁 respiratory",
       "💤 calming"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7533724/",
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "tabernaemontana-sananho",
@@ -9358,8 +9358,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "amazon",
+    "regiontags": [],
     "legalstatus": "Unregulated",
     "schedule": "",
+    "legalnotes": "",
     "description": "shamanic plant sometimes added to ayahuasca.",
     "effects": "dream enhancement;mild stimulation",
     "mechanism": "Iboga-type alkaloids act on NMDA and serotonin receptors",
@@ -9382,10 +9384,8 @@
     "tags": [
       "🌿 root"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "tabernanthe-iboga",
@@ -9396,8 +9396,10 @@
     "subcategory": "",
     "intensity": "Very strong",
     "region": "central africa",
+    "regiontags": [],
     "legalstatus": "Controlled or prescription in many countries",
     "schedule": "",
+    "legalnotes": "",
     "description": "sacred shrub central to bwiti ceremonies; contains ibogaine producing intense visionary states and potential addiction therapy.",
     "effects": "Powerful visions;spiritual insight;stimulation",
     "mechanism": "Ibogaine acts on NMDA, kappa-opioid, and serotonin systems while promoting neurotrophic factors.",
@@ -9427,15 +9429,13 @@
       "⚠️ intense",
       "🌿 root bark"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4218771/",
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology",
       "2014"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "tagetes-lucida",
@@ -9446,8 +9446,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "mexico, central america",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "used by the aztecs and modern curanderos, this aromatic herb has both culinary and psychoactive properties. smoked or brewed, it can enhance dreams and alter perception gently.",
     "effects": "Mild euphoria;Vision enhancement;Lucid dreaming;Digestive aid",
     "mechanism": "Contains estragole, ocimene, and anethole, which may mildly modulate GABA and serotonergic pathways. Psychoactive effects are subtle and dose-dependent.",
@@ -9473,15 +9475,13 @@
       "🫖 digestive",
       "🌀 mesoamerican"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5372953/",
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology",
       "2005"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "tamarindus-indica",
@@ -9492,8 +9492,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "africa, south asia",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "",
     "effects": "laxative;digestive aid;cooling",
     "mechanism": "Promotes gastrointestinal motility and antioxidant action",
@@ -9515,10 +9517,8 @@
       "folk",
       "cooling"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "tetradenia-riparia",
@@ -9529,8 +9529,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "eastern and southern africa",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "fragrant african shrub sometimes called iboza; provides a relaxing effect and mild pain relief.",
     "effects": "relaxation;pain relief;lightheadedness",
     "mechanism": "Aromatic diterpenes may modulate GABA and opioid receptors",
@@ -9557,10 +9559,8 @@
       "iboza",
       "aromatic"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "thymus-vulgaris",
@@ -9571,8 +9571,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "mediterranean",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "common thyme used medicinally and as spice",
     "effects": "alertness;respiratory relief",
     "mechanism": "Essential oil rich in thymol acts as antimicrobial and mild stimulant",
@@ -9597,10 +9599,8 @@
     "tags": [
       "🌿 culinary"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "tilia-cordata",
@@ -9611,8 +9611,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "europe, temperate asia",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "linden flowers, from the lime tree (not citrus), are a gentle remedy for stress, insomnia, and tension-related heart symptoms. often used in relaxing teas and rituals.",
     "effects": "Calming;Antispasmodic;Cardiovascular support;Mild hypnotic",
     "mechanism": "Flavonoids (quercetin), volatile oils, and mucilage reduce anxiety, soothe the digestive tract, and support vasodilation. GABA modulation contributes to calming effect.",
@@ -9638,14 +9640,12 @@
       "🧘 heart-calming",
       "🌿 relaxant"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6626440/",
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "tilia-tomentosa",
@@ -9656,8 +9656,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "europe",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "silver linden, used as a calming tea in europe. shows sedative and anti-anxiety effects.",
     "effects": "calming;sleep aid;nervine",
     "mechanism": "GABAergic, anti-inflammatory",
@@ -9679,10 +9681,8 @@
       "tea",
       "folk medicine"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "justicia-pectoralis",
@@ -9693,8 +9693,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "amazon basin",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "aromatic herb called tilo, brewed or smoked for calming effects.",
     "effects": "Relaxation;light euphoria;spiritual dreams",
     "mechanism": "Likely GABAergic; coumarins may modulate CNS",
@@ -9724,15 +9726,13 @@
       "🌿 ayahuasca-additive",
       "🧘 calm"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7820446/",
       "Journal of Ethnopharmacology",
       "1999",
       "Shamanic Pharmacopoeia – Amazonian Plants"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "zanthoxylum-clava-herculis",
@@ -9743,8 +9743,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "southeastern united states",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "also called the toothache tree; its bark creates a tingling numbness and light stimulation when chewed.",
     "effects": "mouth numbness;mild stimulation;pain relief",
     "mechanism": "Bark contains sanshools that cause paresthesia and stimulate trigeminal nerves",
@@ -9774,14 +9776,12 @@
       "tingling",
       "toothache tree"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5656514/",
       "Native American Ethnobotany – Moerman",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "turnera-diffusa-aphrodisiaca",
@@ -9792,8 +9792,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "mexico",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "a variant of damiana known for its aphrodisiac and mood-brightening properties. traditionally used as a tonic.",
     "effects": "aphrodisiac;mood enhancer",
     "mechanism": "Dopaminergic and GABAergic synergy",
@@ -9815,10 +9817,8 @@
       "tonic",
       "euphoric"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "turnera-ulmifolia",
@@ -9829,8 +9829,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "central and south america",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "closely related to damiana (turnera diffusa), this species is also used traditionally in folk medicine for reproductive health and mood.",
     "effects": "Relaxation;mood elevation;aphrodisiac",
     "mechanism": "Unknown; may modulate GABA or serotonin",
@@ -9853,15 +9855,13 @@
       "🌺 aphrodisiac",
       "😊 mood"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7087816/",
       "Journal of Ethnopharmacology",
       "2013",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "tussilago-farfara",
@@ -9872,8 +9872,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "europe, western asia, north america",
+    "regiontags": [],
     "legalstatus": "Regulated or banned in some countries for internal use",
     "schedule": "",
+    "legalnotes": "",
     "description": "a yellow-flowered plant long revered in european herbalism for its effects on the respiratory tract. coltsfoot is soothing to irritated lungs and commonly used in herbal cough formulas.",
     "effects": "Cough suppression;Lung soothing;Mild sedation;Anti-inflammatory",
     "mechanism": "Contains mucilage, flavonoids, and alkaloids. Mucilage soothes mucous membranes; pyrrolizidine alkaloids (PAs) pose some risk to the liver.",
@@ -9901,14 +9903,12 @@
       "🫖 lung tea",
       "⚠️ pa caution"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7092813/",
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "tylophora-indica",
@@ -9919,8 +9919,10 @@
     "subcategory": "",
     "intensity": "Moderate",
     "region": "india, sri lanka, southeast asia",
+    "regiontags": [],
     "legalstatus": "Legal in India; regulated in some countries due to emetic effects",
     "schedule": "",
+    "legalnotes": "",
     "description": "an ayurvedic herb used for bronchial conditions, immune regulation, and allergic responses. known as indian ipecac for its traditional role in treating asthma and respiratory issues.",
     "effects": "Asthma relief;Anti-allergy;Immunoregulation;Expectorant",
     "mechanism": "Contains tylophorine alkaloids with immunosuppressive, anti-inflammatory, and antiallergic properties. Reduces histamine release and cytokine activity.",
@@ -9950,15 +9952,13 @@
       "⚠️ emetic",
       "🤧 anti-allergy"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3887322/",
       "Ayurvedic Pharmacopoeia of India",
       "Journal of Ethnopharmacology",
       "2004"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "clavo-huasca",
@@ -9969,8 +9969,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "amazon basin",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "amazonian vine used in both physical and spiritual medicine. traditionally consumed as a libido enhancer and pre-ayahuasca preparation.",
     "effects": "Aphrodisiac;calming;digestive",
     "mechanism": "Alkaloids may modulate dopamine and serotonin; warming vasodilator",
@@ -9997,10 +9999,8 @@
       "🌿 amazonian",
       "🔥 aphrodisiac"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "ulex-europaeus",
@@ -10011,8 +10011,10 @@
     "subcategory": "",
     "intensity": "Mild (emotional)",
     "region": "western europe, naturalized elsewhere",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a bright yellow-flowered shrub associated with resilience and hope in celtic and bach flower traditions. while not widely used internally, its flowers have gentle nervine and uplifting properties.",
     "effects": "Mood elevation;Hope restoration;Mild nervous system support",
     "mechanism": "Primarily used in energetic and flower essence systems. Contains flavonoids and trace alkaloids which may mildly affect neurotransmission.",
@@ -10039,14 +10041,12 @@
       "🌿 hope tonic",
       "🧘 gentle"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://pubmed.ncbi.nlm.nih.gov/21768182/",
       "Plants of the Gods – Rätsch",
       "Bach Flower Remedies"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "uncaria-rhynchophylla",
@@ -10057,8 +10057,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "china",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "known as gou teng in chinese medicine.",
     "effects": "Calming;anticonvulsant",
     "mechanism": "Rhynchophylline blocks NMDA receptors",
@@ -10083,10 +10085,8 @@
       "🌿 vine",
       "💤 sedation"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "uncaria-tomentosa",
@@ -10097,8 +10097,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "amazon",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "known as cat's claw, used in peruvian medicine.",
     "effects": "Immune modulation",
     "mechanism": "Oxindole alkaloids stimulate immune function",
@@ -10123,15 +10125,13 @@
       "🌿 bark",
       "🛡️ immune"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5372954/",
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology",
       "2001"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "urtica-dioica",
@@ -10142,8 +10142,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "europe, north america, asia",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "known as stinging nettle, this european herb has been used for centuries to relieve joint pain, allergies, and fatigue. its psychoactivity is subtle, mostly somatic.",
     "effects": "Stimulation;anti-inflammatory;tonic",
     "mechanism": "Histamine release and anti-inflammatory cytokine modulation",
@@ -10171,14 +10173,12 @@
       "🌿 anti-inflammatory",
       "🧘 mild"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4843967/",
       "Herbal Medicine – Mills & Bone",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "urtica-urens",
@@ -10189,8 +10189,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "europe, north america",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a close relative of urtica dioica, this smaller species is used for similar purposes, especially in homeopathy and traditional european herbalism. known for calming itchy skin and boosting the blood.",
     "effects": "Skin soothing;Detox support;Mineral boost;Allergy modulation",
     "mechanism": "Similar to stinging nettle: silica, flavonoids, and histamine-like compounds that support immunity, reduce inflammation, and supply trace minerals.",
@@ -10216,14 +10218,12 @@
       "🩹 skin",
       "🍵 gentle tonic"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3671822/",
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "vachellia-farnesiana",
@@ -10234,8 +10234,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "tropical americas, asia, australia",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a fragrant, thorny shrub with yellow puffball flowers, historically used in perfumery and herbal medicine. its flowers and pods have soothing, mildly euphoric properties and are used in aromatic and topical blends.",
     "effects": "Relaxation;Calming;Uplifting mood;Aromatic euphoria",
     "mechanism": "Volatile oils such as benzyl acetate, linalool, and coumarins provide gentle aromatic CNS modulation and possible GABAergic effects.",
@@ -10261,14 +10263,12 @@
       "🌿 sedative",
       "💐 aphrodisiac"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4494854/",
       "Plants of the Gods – Rätsch",
       "Indian Journal of Pharmacognosy"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "vachellia-nilotica",
@@ -10279,8 +10279,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "africa, middle east, indian subcontinent",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a widely used tree in african and indian traditional medicine. its bark, pods, and gum are rich in tannins and have potent astringent and antiseptic properties.",
     "effects": "Wound healing;Oral health;Diarrhea relief;Antimicrobial",
     "mechanism": "Tannins, flavonoids, and saponins exert antimicrobial, anti-inflammatory, and astringent effects. Helps constrict tissues and protect mucosa.",
@@ -10306,14 +10308,12 @@
       "🛡️ antimicrobial",
       "🌍 african–ayurvedic"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4285565/",
       "Journal of Ethnopharmacology",
       "Indian Journal of Traditional Knowledge"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "valeriana-jatamansi",
@@ -10324,8 +10324,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "india",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "indian valerian used similarly to v. officinalis",
     "effects": "calming;sleep",
     "mechanism": "Sesquiterpenes like valeranon interact with GABA",
@@ -10350,14 +10352,12 @@
     "tags": [
       "🌿 root"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4046171/",
       "Ayurvedic Pharmacopoeia of India",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "valerian",
@@ -10368,8 +10368,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "europe, western asia, north america (cultivated)",
+    "regiontags": [],
     "legalstatus": "Legal / Unregulated",
     "schedule": "",
+    "legalnotes": "",
     "description": "a strong-smelling root long used as a natural sedative and anxiety aid. valerian is commonly included in sleep teas, tinctures, and stress blends.",
     "effects": "Sleep induction;Calm;Anxiety reduction;Muscle relaxation",
     "mechanism": "Acts on GABA-A receptors via valerenic acid and other sesquiterpenes. May inhibit GABA breakdown and modulate serotonin and adenosine.",
@@ -10416,14 +10418,12 @@
       "🌿 root",
       "😴 sleep"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4394901/",
       "Herbal Medicine – Mills & Bone",
       "British Herbal Pharmacopoeia"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "valeriana-wallichii",
@@ -10434,8 +10434,10 @@
     "subcategory": "",
     "intensity": "Moderate–Strong",
     "region": "himalayas, nepal, india",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a potent aromatic root used in ayurveda as a tranquilizing agent. it has a similar but stronger scent and effect profile compared to european valerian. known locally as tagar ganthoda.",
     "effects": "Sleep aid;Mental calm;Muscle relaxant;Tranquilizer",
     "mechanism": "Valerenic acid and valepotriates modulate GABA-A receptors, decreasing nervous excitability. Sedative effects supported by sesquiterpenes and lignans.",
@@ -10465,14 +10467,12 @@
       "🌿 ayurvedic",
       "🪵 root"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3679533/",
       "Indian Journal of Pharmacognosy",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "cissampelos-pareira",
@@ -10483,8 +10483,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "india, south america, southeast asia",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "a climbing herb used in ayurveda and traditional amazonian medicine. often called ‘laghu patha’ in sanskrit, it is prized for menstrual support, malaria treatment, and as an adjunct to ayahuasca.",
     "effects": "Uterine tonic;Muscle relaxant;Antimalarial;Mild sedative",
     "mechanism": "Contains alkaloids like pareirine and cissamine. These modulate smooth muscle tone, and may exert anti-inflammatory, uterotonic, and antimicrobial effects.",
@@ -10515,15 +10517,13 @@
       "🧪 antimalarial",
       "🩸 menstrual tonic"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3783799/",
       "Journal of Ethnopharmacology",
       "2011",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "verbascum-thapsus",
@@ -10534,8 +10534,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "europe, naturalized in americas and asia",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a tall, fuzzy-leaved plant with bright yellow flowers, mullein is a classic remedy for respiratory complaints. its soft leaves and flowers are demulcent, soothing inflamed tissues and promoting gentle expectoration.",
     "effects": "Lung soothing;Cough relief;Anti-inflammatory;Mucus clearing",
     "mechanism": "Saponins and mucilage coat and soothe mucous membranes, while flavonoids and iridoids reduce inflammation and stimulate immune response.",
@@ -10562,14 +10564,12 @@
       "🌼 flower remedy",
       "🍵 tea"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8010964/",
       "Plants of the Gods – Rätsch",
       "British Herbal Compendium"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "verbena-hastata",
@@ -10580,8 +10580,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "north america",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a native north american vervain with bitter, calming properties. traditionally used by indigenous and eclectic physicians for tension, insomnia, and digestive sluggishness tied to anxiety.",
     "effects": "Stress relief;Mood regulation;Tension release;Digestive stimulation",
     "mechanism": "Iridoid glycosides (verbenalin) and bitter principles act as mild GABA modulators and cholagogues, relaxing the nervous system while aiding digestion.",
@@ -10607,14 +10609,12 @@
       "💤 sedative",
       "🌾 native american"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8052706/",
       "Eclectic Materia Medica – Felter",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "verbena-officinalis",
@@ -10625,8 +10625,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "europe",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "common vervain valued for gentle calming",
     "effects": "relaxation;digestive aid",
     "mechanism": "Iridoid glycosides like verbenalin may influence GABA",
@@ -10651,14 +10653,12 @@
     "tags": [
       "🌿 tea"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6520897/",
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "viburnum-opulus",
@@ -10669,8 +10669,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "europe, north america",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a classic herbal remedy used for centuries to relieve muscular and menstrual cramping. cramp bark calms smooth muscles, especially in the uterus and digestive tract.",
     "effects": "Muscle relaxation;Menstrual relief;Sedative;Uterine support",
     "mechanism": "Contains viburnin, salicin, and valerenic acid-like compounds that act as antispasmodics and mild sedatives, likely via GABA modulation and smooth muscle relaxation.",
@@ -10696,14 +10698,12 @@
       "🪵 bark remedy",
       "💤 sedative"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5487595/",
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "elsholtzia-ciliata",
@@ -10714,8 +10714,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "east and southeast asia",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "",
     "effects": "uplifting;digestive aid;mental clarity",
     "mechanism": "Stimulates gastrointestinal and olfactory receptors",
@@ -10736,10 +10738,8 @@
       "folk",
       "clarity"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "vinca-minor",
@@ -10750,8 +10750,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "europe, cultivated globally",
+    "regiontags": [],
     "legalstatus": "Regulated or restricted in some regions due to alkaloid content",
     "schedule": "",
+    "legalnotes": "",
     "description": "a low-growing evergreen plant whose alkaloid-rich leaves are used for memory, focus, and circulatory enhancement. related to the nootropic vinpocetine.",
     "effects": "Cognitive enhancement;Vasodilation;Memory support;Cerebral blood flow",
     "mechanism": "Contains vincamine, a vasodilatory alkaloid that improves cerebral blood flow. Vinpocetine, a semi-synthetic derivative, is used in neuroprotection studies.",
@@ -10783,14 +10785,12 @@
       "🌿 nootropic",
       "⚠️ alkaloid-based"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3966305/",
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "viola-tricolor",
@@ -10801,8 +10801,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "europe, naturalized elsewhere",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a small wildflower with colorful petals, known traditionally for emotional soothing ('heartsease'), as well as support for skin issues, respiratory inflammation, and mild nervous conditions.",
     "effects": "Calming;Anti-inflammatory;Expectorant;Skin soothing",
     "mechanism": "Contains flavonoids, salicylates, and mucilage. Modulates inflammatory mediators and has demulcent, expectorant, and nervine effects.",
@@ -10830,14 +10832,12 @@
       "🫁 expectorant",
       "🧘 gentle"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7318715/",
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "viscum-album",
@@ -10848,8 +10848,10 @@
     "subcategory": "",
     "intensity": "Moderate",
     "region": "europe, western asia",
+    "regiontags": [],
     "legalstatus": "Legal but regulated in some countries",
     "schedule": "",
+    "legalnotes": "",
     "description": "a sacred plant in ancient druidic and european traditions, mistletoe has been used both ritually and medicinally for nervous disorders, cancer support, and hypertension. often associated with peace and protection.",
     "effects": "Immune regulation;Sedation;Nervous system balance;Blood pressure modulation",
     "mechanism": "Contains viscotoxins, lectins, and alkaloids that affect immune cells, induce apoptosis, and modulate autonomic nervous system activity. Used in anthroposophic cancer therapy.",
@@ -10879,14 +10881,12 @@
       "🌿 cancer therapy",
       "⚠️ toxic dose window"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3201634/",
       "European Medicines Agency",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "vitex-agnus-castus",
@@ -10897,8 +10897,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "mediterranean, western asia",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a mediterranean shrub used traditionally to balance female hormones, regulate menstrual cycles, and support fertility. also known as monk’s pepper due to its historical use in suppressing libido.",
     "effects": "Hormone regulation;Menstrual cycle balancing;Mood support;Fertility enhancement",
     "mechanism": "Acts on dopamine D2 receptors to modulate pituitary prolactin levels. Indirectly balances estrogen and progesterone.",
@@ -10928,14 +10930,12 @@
       "🌿 fertility",
       "🧘 pms relief"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6275797/",
       "British Herbal Compendium",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "vitex-negundo",
@@ -10946,8 +10946,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "india, southeast asia",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a traditional ayurvedic and siddha herb used for joint pain, respiratory disorders, and menstrual issues. though related to vitex agnus-castus, its actions differ and it is widely used in south and southeast asia.",
     "effects": "Pain relief;Anti-inflammatory;Respiratory support;Menstrual regulation",
     "mechanism": "Flavonoids, alkaloids, and iridoid glycosides modulate prostaglandins, inhibit COX enzymes, and relax bronchial muscles. Some dopaminergic modulation noted.",
@@ -10973,14 +10975,12 @@
       "🫁 respiratory",
       "🧘 analgesic"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6267229/",
       "Indian Journal of Traditional Knowledge",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "vitis-vinifera",
@@ -10991,8 +10991,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate (non-psychoactive)",
     "region": "mediterranean, global cultivation",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "extracted from the seeds of red grapes, this compound is rich in oligomeric proanthocyanidins (opcs) — potent antioxidants shown to support circulation, reduce inflammation, and protect cellular integrity.",
     "effects": "Vascular support;Free radical scavenging;Skin protection;Cognitive enhancement (adjunct)",
     "mechanism": "OPCs reduce oxidative stress, inhibit inflammatory enzymes (like COX-2), and strengthen collagen and capillaries. Also modulates nitric oxide and enhances endothelial function.",
@@ -11020,14 +11022,12 @@
       "🧠 brain support",
       "🌿 nootropic ally"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6164840/",
       "Journal of Medicinal Food",
       "European Medicines Agency"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "voacanga-africana",
@@ -11038,8 +11038,10 @@
     "subcategory": "",
     "intensity": "Strong",
     "region": "west africa",
+    "regiontags": [],
     "legalstatus": "Unscheduled; may be regulated for alkaloids",
     "schedule": "",
+    "legalnotes": "",
     "description": "a powerful african plant containing voacangine and iboga alkaloids. used traditionally in ritual contexts and studied as a potential ibogaine precursor.",
     "effects": "Stimulation;psychedelic effects;cardiovascular activation",
     "mechanism": "Voacangine is a prodrug to ibogaine (NMDA antagonist, serotonin transporter blocker)",
@@ -11069,15 +11071,13 @@
       "🌍 african",
       "🧠 vision"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4181566/",
       "Plants of the Gods – Rätsch",
       "Voacanga africana: Ethnobotany and Chemistry – J Ethnopharmacol",
       "2014"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "salvia-apiana",
@@ -11088,8 +11088,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "southwestern us",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "white sage revered for cleansing ceremonies",
     "effects": "calm;clarity",
     "mechanism": "Essential oils like cineole and thujone provide mild GABA modulation",
@@ -11116,10 +11118,8 @@
       "🌿 ritual",
       "🪔 incense"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "casimiroa-edulis",
@@ -11130,8 +11130,10 @@
     "subcategory": "",
     "intensity": "",
     "region": "central america",
+    "regiontags": [],
     "legalstatus": "",
     "schedule": "",
+    "legalnotes": "",
     "description": "the fruit of the white sapote tree is used as a sedative in traditional mexican herbal medicine.",
     "effects": "sedative;sleep aid",
     "mechanism": "Possible GABAergic activity",
@@ -11152,10 +11154,8 @@
       "fruit",
       "folk medicine"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
-    "sources": []
+    "sources": [],
+    "image": ""
   },
   {
     "id": "lactuca-virosa",
@@ -11166,8 +11166,10 @@
     "subcategory": "",
     "intensity": "Mild to moderate",
     "region": "europe, north america, asia",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a tall, bitter plant sometimes called 'opium lettuce' due to its historical use for pain and sleep. it contains lactucopicrin and lactucin, compounds with mild sedative and analgesic properties. used in western herbalism since the 19th century.",
     "effects": "Pain relief;Mild euphoria;Sedation;Calming",
     "mechanism": "Lactucin and lactucopicrin are sesquiterpene lactones that interact with GABAergic systems and have antinociceptive properties.",
@@ -11209,15 +11211,13 @@
       "🌿 herbal",
       "😴 sedative"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6232791/",
       "Herbal Medicines",
       "4th Ed. – Barnes et al.",
       "A Modern Herbal – Grieve"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "withania-somnifera",
@@ -11228,8 +11228,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "india, middle east, north africa",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "one of the most revered herbs in ayurveda, ashwagandha is a potent adaptogen used to reduce stress, improve sleep, and balance the nervous and endocrine systems. often called 'indian ginseng'.",
     "effects": "Stress reduction;Cortisol regulation;Sleep support;Cognitive enhancement",
     "mechanism": "Withanolides modulate the hypothalamic-pituitary-adrenal (HPA) axis, lower cortisol, reduce oxidative stress, and improve GABAergic signaling.",
@@ -11259,15 +11261,13 @@
       "🧠 brain support",
       "🌿 ayurvedic"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6979308/",
       "Herbal Medicine – Mills & Bone",
       "Indian Journal of Psychological Medicine",
       "2012"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "artemisia-absinthium",
@@ -11278,8 +11278,10 @@
     "subcategory": "",
     "intensity": "Mild to moderate",
     "region": "europe, north africa, western asia",
+    "regiontags": [],
     "legalstatus": "Thujone content regulated in beverages (e.g. EU and US); plant itself legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "a bitter herb best known as the flavoring in traditional absinthe. contains thujone, a gaba receptor antagonist that can cause excitatory and convulsive effects in high doses.",
     "effects": "Euphoria;Mild hallucinations;Stimulation;Appetite stimulant",
     "mechanism": "Thujone is a GABA-A antagonist, reducing inhibitory signaling in the brain. At high doses, this may induce seizures or hallucinations. Also contains bitter principles that stimulate digestion.",
@@ -11324,16 +11326,14 @@
       "🌙 dream",
       "🌿 bitter"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3265070/",
       "Herbal Medicine: Biomolecular and Clinical Aspects",
       "2nd ed.",
       "Journal of Ethnopharmacology",
       "2003"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "xylopia-aethiopica",
@@ -11344,8 +11344,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "west africa, caribbean",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a spicy fruit used in west african and caribbean cuisine and medicine. traditionally employed to treat respiratory and digestive issues, and as a warming tonic for colds and fatigue.",
     "effects": "Warming;Decongestant;Digestive aid;Mild stimulant",
     "mechanism": "Contains volatile oils (e.g. eugenol, β-pinene) that have antimicrobial, warming, and stimulant actions. May stimulate mucous clearance and circulation.",
@@ -11371,14 +11373,12 @@
       "🌿 afro-caribbean",
       "🫖 traditional tonic"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8736103/",
       "Journal of Ethnopharmacology",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "corydalis-yanhusuo",
@@ -11389,8 +11389,10 @@
     "subcategory": "",
     "intensity": "Moderate",
     "region": "china and east asia",
+    "regiontags": [],
     "legalstatus": "Legal",
     "schedule": "",
+    "legalnotes": "",
     "description": "tubers of this asian herb provide notable pain relief and a tranquil state when used as tea or pills.",
     "effects": "analgesia;relaxation;subtle dreaminess",
     "mechanism": "Alkaloids such as tetrahydropalmatine act on dopamine and GABA receptors",
@@ -11420,15 +11422,13 @@
       "dopamine",
       "pain relief"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4046635/",
       "Journal of Pain Research",
       "2013",
       "Pharmacopoeia of the People’s Republic of China"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "ilex-paraguariensis",
@@ -11439,8 +11439,10 @@
     "subcategory": "",
     "intensity": "Mild to moderate",
     "region": "argentina, brazil, paraguay, uruguay",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a south american herbal infusion made from the dried leaves of the yerba mate plant. revered for its energizing and antioxidant effects, mate is consumed in communal rituals or daily focus routines.",
     "effects": "Mental alertness;Appetite control;Social energy;Metabolism boost",
     "mechanism": "Caffeine, theobromine, and chlorogenic acid act as CNS stimulants and antioxidants. Enhances focus while reducing fatigue.",
@@ -11485,15 +11487,13 @@
       "🌿 social",
       "🔥 energy"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6926402/",
       "South American Herbal Pharmacopoeia",
       "Journal of Human Nutrition and Dietetics",
       "2008"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "zanthoxylum-americanum",
@@ -11504,8 +11504,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "north america (northern u.s., canada)",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "northern relative of zanthoxylum clava-herculis, this species was widely used by native americans for toothaches, cold limbs, and digestion. like its southern cousin, it produces a numbing and buzzing sensation when chewed.",
     "effects": "Tingling;Local analgesia;Salivation;Circulation boost",
     "mechanism": "Sanshools (alkylamides) modulate TRPV1 and TRPA1 channels on nerve endings, producing a buzzing, tingling analgesic effect. Also stimulates saliva and gastric secretions.",
@@ -11531,14 +11533,12 @@
       "🫦 tingling",
       "🔥 circulatory"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7144794/",
       "Native American Ethnobotany – Moerman",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "zanthoxylum-bungeanum",
@@ -11549,8 +11549,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "china, east asia",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "used in chinese cuisine and medicine, sichuan pepper causes a tingling numbness and has been traditionally used to support digestion and stimulate circulation. its unique effect is due to hydroxy-alpha-sanshool.",
     "effects": "Tingling sensation;Digestive stimulant;Mild analgesia;Circulation support",
     "mechanism": "Sanshools activate somatosensory ion channels (TRPA1, TRPV1) leading to a buzzing/tingling anesthetic effect. Also improves gastric secretions and peripheral blood flow.",
@@ -11576,14 +11578,12 @@
       "🩸 circulatory",
       "🌿 culinary-medical"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6452023/",
       "Chinese Herbal Materia Medica",
       "Journal of Ethnopharmacology"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "zea-mays-stigma",
@@ -11594,8 +11594,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "worldwide (where corn is cultivated)",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "the long threads of corn (called silk) are a gentle herbal remedy for urinary tract issues, swelling, and kidney function. used in teas for centuries in both native american and chinese traditions.",
     "effects": "Urine flow increase;Soothing;Kidney support;Anti-inflammatory",
     "mechanism": "Contains flavonoids, saponins, and potassium that increase urine output, reduce inflammation, and soothe irritated tissues.",
@@ -11621,15 +11623,13 @@
       "🫖 soothing",
       "🌿 folk remedy"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC7121893/",
       "Plants of the Gods – Rätsch",
       "Journal of Medicinal Plants Research",
       "2011"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "zingiber-officinale",
@@ -11640,8 +11640,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "tropical asia, cultivated globally",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a pungent rhizome widely used for its warming, carminative, and anti-inflammatory effects. revered in ayurvedic and traditional chinese medicine for treating nausea, coldness, and sluggish digestion.",
     "effects": "Digestive support;Anti-nausea;Circulation boost;Mild stimulation",
     "mechanism": "Contains gingerols and shogaols that modulate prostaglandins, TRP ion channels, and serotonin receptors involved in nausea.",
@@ -11670,14 +11672,12 @@
       "🫁 circulation",
       "🌿 culinary"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3665023/",
       "Herbal Medicine – Mills & Bone",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "zingiber-zerumbet",
@@ -11688,8 +11688,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "hawaii, southeast asia, pacific islands",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a tropical ginger species prized for its aromatic rhizomes and milky juice-filled cones used in traditional polynesian medicine and hair care. mildly relaxing and soothing, both internally and externally.",
     "effects": "Skin and hair care;Topical anti-inflammatory;Digestive aid;Aromatic relaxant",
     "mechanism": "Zerumbone and essential oils contribute to anti-inflammatory, antioxidant, and antimicrobial effects. Soothes skin, modulates TRP channels, and supports digestion.",
@@ -11715,14 +11717,12 @@
       "🔥 anti-inflammatory",
       "🌺 polynesian use"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8751302/",
       "Hawaiian Ethnobotany – Beatrice Krauss",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "ziziphus-jujuba",
@@ -11733,8 +11733,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "china, middle east, mediterranean",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "a traditional fruit in chinese and middle eastern medicine, jujube is used as a tonic, sleep aid, and digestive harmonizer. rich in antioxidants and calming saponins.",
     "effects": "Sleep support;Stress reduction;Digestive regulation;Immune modulation",
     "mechanism": "Jujubosides interact with GABA-A receptors and modulate cortisol. Flavonoids and triterpenes provide antioxidant and anti-inflammatory effects.",
@@ -11761,14 +11763,12 @@
       "🛡️ immune",
       "🌿 mild adaptogen"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6267325/",
       "Journal of Ethnopharmacology",
       "Chinese Herbal Medicine – Bensky & Gamble"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "ziziphus-spinosa",
@@ -11779,8 +11779,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "china, korea, japan",
+    "regiontags": [],
     "legalstatus": "Legal worldwide",
     "schedule": "",
+    "legalnotes": "",
     "description": "the seeds of this wild jujube are used in traditional chinese medicine (tcm) for calming the spirit and nourishing the heart. a key herb in formulas for insomnia and anxiety, including suan zao ren tang.",
     "effects": "Sleep promotion;Anxiety relief;Dream regulation;Heart-calming",
     "mechanism": "Jujubosides and flavonoids interact with GABA receptors and modulate neurotransmitters like serotonin and dopamine. Mildly hypnotic and anxiolytic.",
@@ -11808,14 +11810,12 @@
       "🌿 tcm",
       "🌙 dream"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6163148/",
       "Chinese Herbal Medicine – Bensky",
       "Plants of the Gods – Rätsch"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "zornia-diphylla",
@@ -11826,8 +11826,10 @@
     "subcategory": "",
     "intensity": "Mild",
     "region": "south america, caribbean",
+    "regiontags": [],
     "legalstatus": "Legal in most regions",
     "schedule": "",
+    "legalnotes": "",
     "description": "a lesser-known south american herb with calming, slightly psychoactive properties. sometimes used similarly to zornia latifolia in herbal smoking blends and indigenous rituals.",
     "effects": "Relaxation;Mild psychoactive;Cough soothing;Mood lifting",
     "mechanism": "Likely contains flavonoids and volatile oils with CNS-depressant and bronchodilatory effects. Specific constituents under-studied.",
@@ -11853,14 +11855,12 @@
       "🫁 respiratory",
       "🌿 ethnobotanical"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://erowid.org/herbs/zornia_diphylla/",
       "Plants of the Gods – Rätsch",
       "Amazonian Ethnobotany Archives"
-    ]
+    ],
+    "image": ""
   },
   {
     "id": "zornia-latifolia",
@@ -11871,8 +11871,10 @@
     "subcategory": "",
     "intensity": "Mild–Moderate",
     "region": "brazil, paraguay, south america",
+    "regiontags": [],
     "legalstatus": "Legal in most regions",
     "schedule": "",
+    "legalnotes": "",
     "description": "known as 'false marijuana' in brazil, this south american herb produces a relaxing, slightly euphoric state when smoked or brewed. used traditionally in rituals and to aid sleep or meditation.",
     "effects": "Mild euphoria;Mental calm;Lucid dreaming;Cannabinoid mimicry",
     "mechanism": "Flavonoids and potential endocannabinoid-modulating compounds interact with CB1/CB2 receptors, though exact active constituents remain under-researched.",
@@ -11899,13 +11901,11 @@
       "🧘 relaxing",
       "🌀 cannabis-like"
     ],
-    "regiontags": [],
-    "legalnotes": "",
-    "image": "",
     "sources": [
       "https://erowid.org/herbs/zornia_latifolia/",
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology"
-    ]
+    ],
+    "image": ""
   }
 ]

--- a/src/data/schema.ts
+++ b/src/data/schema.ts
@@ -1,0 +1,39 @@
+export type Canon =
+  | "common" | "scientific" | "slug"
+  | "category" | "subcategory" | "intensity" | "region" | "regiontags"
+  | "legalstatus" | "schedule" | "legalnotes"
+  | "description" | "effects" | "mechanism"
+  | "compounds" | "preparations" | "dosage" | "therapeutic"
+  | "interactions" | "contraindications" | "sideeffects" | "safety"
+  | "toxicity" | "toxicity_ld50"
+  | "tags" | "sources" | "image";
+
+export const ALIASES: Record<Canon, string[]> = {
+  common: ["common","commonname","name"],
+  scientific: ["scientific","scientificname","latin","latinname","binomial"],
+  slug: ["slug"],
+  category: ["category","categoryprimary","primarycategory","group"],
+  subcategory: ["subcategory","secondarycategory"],
+  intensity: ["intensity","potency","strength"],
+  region: ["region","origin","geography","distribution"],
+  regiontags: ["region_tags","regions"],
+  legalstatus: ["legalstatus","legal_status","status"],
+  schedule: ["schedule","controlled_schedule"],
+  legalnotes: ["legalnotes","legal_notes"],
+  description: ["description","summary","overview","desc"],
+  effects: ["effects","effect"],
+  mechanism: ["mechanismofaction","mechanism","moa","mechanism_of_action","action"],
+  compounds: ["compounds","compound","keycompounds","actives","constituents"],
+  preparations: ["preparations","preparation","method","forms","formulations"],
+  dosage: ["dosage","dose","dosing","dosage_and_administration","administration"],
+  therapeutic: ["therapeutic","uses","applications","benefits","traditional_uses"],
+  interactions: ["interactions","drug_interactions","mixing"],
+  contraindications: ["contraindications","contradictions","cautions"],
+  sideeffects: ["sideeffects","side_effects","adverse_effects","unwanted_effects"],
+  safety: ["safety","warnings","precautions","risk_profile"],
+  toxicity: ["toxicity","tox_profile"],
+  toxicity_ld50: ["toxicity_ld50","toxicityld50","ld50"],
+  tags: ["tags","labels","keywords"],
+  sources: ["sources","refs","references"],
+  image: ["image","imageurl","img","photo"],
+};

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -64,7 +64,7 @@ export default function Database() {
         new Set(
           herbs
             .map(herb => herb.legalstatus?.trim())
-            .filter((value): value is string => Boolean(value))
+            .filter((value): value is string => Boolean(value) && !/^legal$/i.test(value))
         )
       ).sort((a, b) => formatLabel(a).localeCompare(formatLabel(b))),
     [herbs]
@@ -200,9 +200,12 @@ export default function Database() {
                   {herb.category && (
                     <p className='mt-2 text-sm text-sand/80'>Category: {formatLabel(herb.category)}</p>
                   )}
-                  {herb.legalstatus && (
-                    <p className='text-sm text-sand/80'>Legal: {formatLabel(herb.legalstatus)}</p>
-                  )}
+                  {(() => {
+                    const legal = formatLabel((herb.legalstatus || '').trim())
+                    return legal && !/^legal$/i.test(legal) ? (
+                      <p className='text-sm text-sand/80'>Legal: {legal}</p>
+                    ) : null
+                  })()}
                 </div>
                 )
               })}

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -2,8 +2,10 @@ import React, { useMemo } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import SEO from '../components/SEO'
 import { herbs } from '../data/herbs/herbsfull'
-import { herbName, splitField } from '../utils/herb'
+import { herbName } from '../utils/herb'
 import { has, bullets, urlish } from '../lib/format'
+import { getList, getText } from '../lib/fields'
+import { ALIASES } from '../data/schema'
 
 const DISCLAIMER_TEXT =
   'The information on this site is for educational purposes only. It is not medical advice and should not be used to diagnose, treat, cure, or prevent any disease. Always consult a qualified healthcare professional before using any herbal products or supplements.'
@@ -48,27 +50,30 @@ export default function HerbDetail() {
   }
 
   const imageSrc = herb.image || `/images/herbs/${herb.slug}.jpg`
-  const compounds = bullets(splitField(herb.compounds))
-  const preparations = bullets(splitField(herb.preparations))
-  const interactions = bullets(splitField(herb.interactions))
-  const contraindications = bullets(splitField(herb.contraindications))
-  const sideEffects = bullets(splitField(herb.sideeffects))
-  const sources = bullets(splitField(herb.sources))
+  const compounds = bullets(getList(herb, 'compounds', ALIASES.compounds))
+  const preparations = bullets(getList(herb, 'preparations', ALIASES.preparations))
+  const interactions = bullets(getList(herb, 'interactions', ALIASES.interactions))
+  const contraindications = bullets(getList(herb, 'contraindications', ALIASES.contraindications))
+  const sideEffects = bullets(getList(herb, 'sideeffects', ALIASES.sideeffects))
+  const sources = bullets(getList(herb, 'sources', ALIASES.sources))
 
-  const descriptionText = herb.description?.trim() || ''
-  const categoryText = herb.category?.trim() || ''
-  const subcategoryText = herb.subcategory?.trim() || ''
-  const intensityText = herb.intensity?.trim() || ''
-  const regionText = herb.region?.trim() || ''
-  const effectsText = herb.effects?.trim() || ''
-  const mechanismText = herb.mechanism?.trim() || ''
-  const therapeuticText = herb.therapeutic?.trim() || ''
-  const dosageText = herb.dosage?.trim() || ''
-  const safetyText = herb.safety?.trim() || ''
-  const legalStatusText = herb.legalstatus?.trim() || ''
-  const scheduleText = herb.schedule?.trim() || ''
-  const legalNotesText = herb.legalnotes?.trim() || ''
-  const toxicityLD50 = herb.toxicity_ld50?.trim() || ''
+  const descriptionText = getText(herb, 'description', ALIASES.description)
+  const categoryText = getText(herb, 'category', ALIASES.category)
+  const subcategoryText = getText(herb, 'subcategory', ALIASES.subcategory)
+  const intensityText = getText(herb, 'intensity', ALIASES.intensity)
+  const regionText = getText(herb, 'region', ALIASES.region)
+  const effectsText = getText(herb, 'effects', ALIASES.effects)
+  const mechanismText = getText(herb, 'mechanism', ALIASES.mechanism)
+  const therapeuticText = getText(herb, 'therapeutic', ALIASES.therapeutic)
+  const dosageText = getText(herb, 'dosage', ALIASES.dosage)
+  const safetyText = getText(herb, 'safety', ALIASES.safety)
+  const toxicityText = getText(herb, 'toxicity', ALIASES.toxicity)
+  const toxicityLD50 = getText(herb, 'toxicity_ld50', ALIASES.toxicity_ld50)
+  const legalStatusText = getText(herb, 'legalstatus', ALIASES.legalstatus)
+  const scheduleText = getText(herb, 'schedule', ALIASES.schedule)
+  const legalNotesText = getText(herb, 'legalnotes', ALIASES.legalnotes)
+
+  const legalStatusClean = /^legal$/i.test(legalStatusText) ? '' : legalStatusText
 
   const hasExtraSections =
     has(effectsText) ||
@@ -81,8 +86,11 @@ export default function HerbDetail() {
     has(contraindications) ||
     has(sideEffects) ||
     has(safetyText) ||
-    has(legalStatusText) ||
+    has(toxicityText) ||
+    has(toxicityLD50) ||
+    has(legalStatusClean) ||
     has(scheduleText) ||
+    has(legalNotesText) ||
     has(sources)
 
   return (
@@ -128,10 +136,10 @@ export default function HerbDetail() {
                   <dd>{herb.intensity_label ? herb.intensity_label : herb.intensity}</dd>
                 </div>
               )}
-              {has(legalStatusText) && (
+              {has(legalStatusClean) && (
                 <div>
                   <dt className='font-semibold uppercase tracking-wide text-xs text-sand/60'>Legal Status</dt>
-                  <dd>{legalStatusText}</dd>
+                  <dd>{legalStatusClean}</dd>
                 </div>
               )}
               {has(scheduleText) && (
@@ -150,6 +158,12 @@ export default function HerbDetail() {
                 <div>
                   <dt className='font-semibold uppercase tracking-wide text-xs text-sand/60'>Dosage</dt>
                   <dd>{dosageText}</dd>
+                </div>
+              )}
+              {has(toxicityText) && (
+                <div>
+                  <dt className='font-semibold uppercase tracking-wide text-xs text-sand/60'>Toxicity</dt>
+                  <dd>{toxicityText}</dd>
                 </div>
               )}
               {has(toxicityLD50) && (
@@ -215,16 +229,16 @@ export default function HerbDetail() {
         )}
 
         {has(mechanismText) && (
-          <section className='mt-6'>
-            <h2 className='text-lg font-semibold'>Mechanism of Action</h2>
-            <p className='text-sm'>{mechanismText}</p>
+          <section className='mt-6 rounded-2xl bg-white/5 p-6 shadow-lg backdrop-blur'>
+            <h2 className='text-2xl font-semibold text-lime-300'>Mechanism of Action</h2>
+            <p className='mt-3 text-sand/90'>{mechanismText}</p>
           </section>
         )}
 
         {preparations.length > 0 && (
-          <section className='mt-6'>
-            <h2 className='text-lg font-semibold'>Common Preparations</h2>
-            <ul className='list-disc pl-5 text-sm'>
+          <section className='mt-6 rounded-2xl bg-white/5 p-6 shadow-lg backdrop-blur'>
+            <h2 className='text-2xl font-semibold text-lime-300'>Common Preparations</h2>
+            <ul className='mt-3 list-disc space-y-2 pl-6 text-sand/90'>
               {preparations.map(item => (
                 <li key={item}>{item}</li>
               ))}
@@ -233,23 +247,23 @@ export default function HerbDetail() {
         )}
 
         {has(dosageText) && (
-          <section className='mt-6'>
-            <h2 className='text-lg font-semibold'>Dosage / Administration</h2>
-            <p className='text-sm'>{dosageText}</p>
+          <section className='mt-6 rounded-2xl bg-white/5 p-6 shadow-lg backdrop-blur'>
+            <h2 className='text-2xl font-semibold text-lime-300'>Dosage / Administration</h2>
+            <p className='mt-3 text-sand/90'>{dosageText}</p>
           </section>
         )}
 
         {has(therapeuticText) && (
-          <section className='mt-6'>
-            <h2 className='text-lg font-semibold'>Therapeutic / Traditional Uses</h2>
-            <p className='text-sm'>{therapeuticText}</p>
+          <section className='mt-6 rounded-2xl bg-white/5 p-6 shadow-lg backdrop-blur'>
+            <h2 className='text-2xl font-semibold text-lime-300'>Therapeutic / Traditional Uses</h2>
+            <p className='mt-3 text-sand/90'>{therapeuticText}</p>
           </section>
         )}
 
         {sideEffects.length > 0 && (
-          <section className='mt-6'>
-            <h2 className='text-lg font-semibold'>Side Effects</h2>
-            <ul className='list-disc pl-5 text-sm'>
+          <section className='mt-6 rounded-2xl bg-white/5 p-6 shadow-lg backdrop-blur'>
+            <h2 className='text-2xl font-semibold text-lime-300'>Side Effects</h2>
+            <ul className='mt-3 list-disc space-y-2 pl-6 text-sand/90'>
               {sideEffects.map(item => (
                 <li key={item}>{item}</li>
               ))}
@@ -258,17 +272,24 @@ export default function HerbDetail() {
         )}
 
         {has(safetyText) && (
-          <section className='mt-6'>
-            <h2 className='text-lg font-semibold'>Safety Notes</h2>
-            <p className='text-sm'>{safetyText}</p>
+          <section className='mt-6 rounded-2xl bg-white/5 p-6 shadow-lg backdrop-blur'>
+            <h2 className='text-2xl font-semibold text-lime-300'>Safety Notes</h2>
+            <p className='mt-3 text-sand/90'>{safetyText}</p>
           </section>
         )}
 
-        {(has(legalStatusText) || has(scheduleText) || has(legalNotesText)) && (
+        {has(toxicityText) && (
+          <section className='mt-6 rounded-2xl bg-white/5 p-6 shadow-lg backdrop-blur'>
+            <h2 className='text-2xl font-semibold text-lime-300'>Toxicity</h2>
+            <p className='mt-3 text-sand/90'>{toxicityText}</p>
+          </section>
+        )}
+
+        {(has(legalStatusClean) || has(scheduleText) || has(legalNotesText)) && (
           <section className='mt-10 rounded-2xl bg-white/5 p-6 shadow-lg backdrop-blur'>
             <h2 className='text-2xl font-semibold text-lime-300'>Legal Notes</h2>
             <div className='mt-3 space-y-2 text-sand/90'>
-              {has(legalStatusText) && <p><strong>Legal Status:</strong> {legalStatusText}</p>}
+              {has(legalStatusClean) && <p><strong>Legal Status:</strong> {legalStatusClean}</p>}
               {has(scheduleText) && <p><strong>Schedule:</strong> {scheduleText}</p>}
               {has(legalNotesText) && <p><strong>Notes:</strong> {legalNotesText}</p>}
             </div>


### PR DESCRIPTION
## Summary
- add a canonical herb schema definition with shared alias mappings
- update the herb conversion script to normalize using the canonical schema and report field coverage
- expand database card/detail rendering with the new fields while hiding trivial legal statuses

## Testing
- `node scripts/convert-herbs.mjs`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e4573e6f9483239929dc5a04e0711c