### PR TITLE
fix(schema): unify herb index v1.28 columns

### DIFF
--- a/src/data/herbs/herbs.normalized.json
+++ b/src/data/herbs/herbs.normalized.json
@@ -1,45 +1,3714 @@
 [
   {
+    "id": "acorus-gramineus",
+    "slug": "acorus-gramineus",
+    "common": "",
+    "scientific": "",
+    "category": "ethnobotanical / rare",
+    "description": "asian sweet flag containing β-asarone, sometimes taken for cognition.",
+    "effects": "Cognitive clarity;trippy effects (debated)",
+    "intensity": "Mild",
+    "region": "🇨🇳 east asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "Contains β-asarone; may modulate acetylcholine and GABA pathways; traditional use for cognition.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "β-asarone LD50 (rat, oral): ~310 mg/kg.",
+    "safety": "1",
+    "sideeffects": [
+      "nausea at high doses",
+      "possible carcinogenic risk with long-term β-asarone exposure."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "long-term use caution due to β-asarone."
+    ],
+    "therapeutic": "cognitive enhancement, anxiety, neuroprotective potential.",
+    "tags": [
+      "☕ brewable",
+      "✅ safe",
+      "💊 oral",
+      "🧠 cognitive"
+    ],
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3545267/",
+      "Botanical Safety Handbook",
+      "Journal of Ethnopharmacology",
+      "2012"
+    ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may enhance cns depressants."
+    ],
+    "toxicity": "Concerns over β-asarone carcinogenicity in some studies.",
+    "image": ""
+  },
+  {
+    "id": "anadenanthera-colubrina-cebl",
+    "slug": "anadenanthera-colubrina-cebl",
+    "common": "",
+    "scientific": "",
+    "category": "ethnobotanical / rare",
+    "description": "south american tree whose snuffable seeds contain bufotenin.",
+    "effects": "Entheogenic snuff;alternate reality feel",
+    "intensity": "High",
+    "region": "🌎 unknown / global",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Restricted in many regions",
+    "mechanism": "Bufotenin acts as a potent and non-selective serotonin receptor agonist at 5-HT₁A, 5-HT₂A, 5-HT₂C, and 5-HT₃ receptors, and serves as a specific serotonin releasing agent [1, 0].",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "No documented human LD50; rodent LD50 approximately 200–300 mg/kg (intraperitoneal) [1, 0].",
+    "safety": "1",
+    "sideeffects": [
+      "prominent cardiovascular changes",
+      "nausea",
+      "vomiting",
+      "and dizziness [1",
+      "0",
+      "1",
+      "1]."
+    ],
+    "contraindications": [
+      "cardiovascular disorders",
+      "psychiatric conditions",
+      "and pregnancy."
+    ],
+    "therapeutic": "traditionally used as a snuff for visionary and divinatory rituals in south american cultures [1, 1].",
+    "tags": [
+      "\\u26a0\\ufe0f restricted",
+      "⚠️ restricted"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "concomitant use with ssris or maois may risk serotonin syndrome [1",
+      "0]."
+    ],
+    "toxicity": "No documented human LD50; rodent LD50 approximately 200–300 mg/kg (intraperitoneal) [1, 0].",
+    "image": ""
+  },
+  {
+    "id": "mugwort",
+    "slug": "mugwort",
+    "common": "",
+    "scientific": "",
+    "category": "oneirogen",
+    "description": "aromatic herb smoked or sipped to enhance dreaming and soothe digestion.",
+    "effects": "Lucid dreams;astral travel",
+    "intensity": "Mild",
+    "region": "🇪🇺 europe",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "GABA modulation; possible cholinergic effects.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Low toxicity; thujone content can be harmful in excess.",
+    "safety": "1",
+    "sideeffects": [
+      "allergic reactions",
+      "nausea."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "ragweed allergy."
+    ],
+    "therapeutic": "dream vividness, digestion, menstrual support.",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f smokable",
+      "\\u2615 brewable",
+      "\\ud83e\\udde0 dream",
+      "\\u2705 safe"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "sedatives",
+      "anticoagulants."
+    ],
+    "toxicity": "Contains thujone and other essential oils that are toxic in high doses.",
+    "image": ""
+  },
+  {
+    "id": "artemisia-vulgaris-mugwort",
+    "slug": "artemisia-vulgaris-mugwort",
+    "common": "",
+    "scientific": "",
+    "category": "oneirogen",
+    "description": "common european mugwort used in dream pillows and as bitter tonic.",
+    "effects": "Lucid dreaming;light hallucinations",
+    "intensity": "Mild",
+    "region": "🇪🇺 europe",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "",
+    "safety": "1",
+    "sideeffects": [
+      "not well documented"
+    ],
+    "contraindications": [
+      "not well documented"
+    ],
+    "therapeutic": "not well documented",
+    "tags": [
+      "☕ brewable",
+      "✅ safe",
+      "🌬️ smokable",
+      "🕯️ ritual",
+      "🧠 dream"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "not well documented"
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "ashwagandha",
+    "slug": "ashwagandha",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Modulates cortisol, GABAergic and serotonergic systems.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "LD50 >2 g/kg (rats).",
+    "safety": "",
+    "sideeffects": [
+      "gi upset",
+      "drowsiness."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "thyroid issues."
+    ],
+    "therapeutic": "stress, anxiety, strength, sleep support.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "sedatives",
+      "thyroid meds."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "ayahuasca",
+    "slug": "ayahuasca",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "MAOIs + DMT activate serotonergic and hallucinogenic pathways.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Varies; psychological risks high.",
+    "safety": "",
+    "sideeffects": [
+      "nausea",
+      "intense hallucinations."
+    ],
+    "contraindications": [
+      "ssris",
+      "bipolar disorder."
+    ],
+    "therapeutic": "psychedelic therapy, depression, trauma.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "maois",
+      "antidepressants."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "bacopa",
+    "slug": "bacopa",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Enhances cholinergic transmission; antioxidant and neuroprotective.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "LD50 >2000 mg/kg (rats).",
+    "safety": "",
+    "sideeffects": [
+      "gi discomfort",
+      "fatigue (rare)."
+    ],
+    "contraindications": [
+      "ulcers",
+      "thyroid conditions."
+    ],
+    "therapeutic": "memory, anxiety reduction, learning.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "thyroid meds",
+      "sedatives."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "bacopa-monnieri",
+    "slug": "bacopa-monnieri",
+    "common": "",
+    "scientific": "",
+    "category": "empathogen / euphoriant",
+    "description": "aquatic herb taken long-term to improve memory and concentration.",
+    "effects": "Memory enhancer;mild calming",
+    "intensity": "Mild",
+    "region": "🇮🇳 india",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "Contains bacosides A and B which enhance cholinergic transmission, antioxidant defenses, and modulate neurotransmitter levels (serotonin, dopamine) [0, 0, 0, 2].",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [
+      "Bacosides A and B"
+    ],
+    "toxicity_ld50": "Generally non-toxic; no serious adverse effects at recommended doses; rodent LD50 not well established [0, 6].",
+    "safety": "1",
+    "sideeffects": [
+      "gastrointestinal upset (nausea",
+      "increased motility)",
+      "fatigue",
+      "dry mouth [0",
+      "5]."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "lactation",
+      "hypersensitivity to any component [0",
+      "5]."
+    ],
+    "therapeutic": "cognitive enhancement (memory, learning), anxiety reduction, adhd management [0, 1, 0, 6].",
+    "tags": [
+      "☕ brewable",
+      "✅ safe",
+      "💊 oral",
+      "💫 euphoria",
+      "🧘 sedation"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "no major interactions documented",
+      "caution with sedatives [0",
+      "5]."
+    ],
+    "toxicity": "Generally non-toxic; no serious adverse effects at recommended doses; rodent LD50 not well established [0, 6].",
+    "image": ""
+  },
+  {
+    "id": "baybean",
+    "slug": "baybean",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Contains alkaloids with mild psychoactive potential; unclear exact MOA.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Very limited data; considered safe traditionally.",
+    "safety": "",
+    "sideeffects": [
+      "rare",
+      "may cause mild nausea or dizziness."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "limited safety data."
+    ],
+    "therapeutic": "traditional smoking blend; relaxation.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "unknown due to lack of research."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "belladonna",
+    "slug": "belladonna",
+    "common": "",
+    "scientific": "",
+    "category": "deliriant / toxic",
+    "description": "deadly nightshade once used for trance and as a cosmetic poison.",
+    "effects": "Hallucinations;dreamlike confusion",
+    "intensity": "High",
+    "region": "🌎 unknown / global",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Controlled / Toxic",
+    "mechanism": "Tropane alkaloids block acetylcholine; causes anticholinergic delirium.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Atropine LD50 (rat, oral): ~453 mg/kg.",
+    "safety": "1",
+    "sideeffects": [
+      "dry mouth",
+      "hallucinations",
+      "delirium",
+      "elevated pulse."
+    ],
+    "contraindications": [
+      "cardiovascular disease",
+      "glaucoma",
+      "pregnancy."
+    ],
+    "therapeutic": "historically used for pain, muscle spasms, and cosmetic dilation.",
+    "tags": [
+      "☠️ toxic"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "cns depressants",
+      "anticholinergic drugs."
+    ],
+    "toxicity": "Highly toxic; accidental ingestion can be fatal.",
+    "image": ""
+  },
+  {
+    "id": "blue-lotus-nymphaea-caerulea",
+    "slug": "blue-lotus-nymphaea-caerulea",
+    "common": "",
+    "scientific": "",
+    "category": "other",
+    "description": "sacred water lily delivering gentle euphoria and relaxation.",
+    "effects": "Euphoria;aphrodisiac;dreamy calm",
+    "intensity": "Mild",
+    "region": "🌎 unknown / global",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "Contains aporphine and nuciferine; dopamine receptor modulation and mild sedative effect.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Not established; no reported lethal doses.",
+    "safety": "1",
+    "sideeffects": [
+      "drowsiness",
+      "mild dizziness at high doses."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "avoid with dopaminergic drugs."
+    ],
+    "therapeutic": "mild euphoria, anxiety relief, and aphrodisiac in traditional use.",
+    "tags": [
+      "☕ brewable",
+      "✅ safe",
+      "🌬️ smokable",
+      "🧘 sedation"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "potential additive effects with cns depressants."
+    ],
+    "toxicity": "Low toxicity; no serious effects reported from traditional use.",
+    "image": ""
+  },
+  {
+    "id": "boldo",
+    "slug": "boldo",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Contains boldine; acts as antioxidant and cholagogue.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Boldine LD50 ~500 mg/kg (rat, oral).",
+    "safety": "",
+    "sideeffects": [
+      "nausea",
+      "allergic reactions."
+    ],
+    "contraindications": [
+      "bile duct obstruction",
+      "pregnancy."
+    ],
+    "therapeutic": "digestive support, liver detoxification, mild sedative.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "anticoagulants",
+      "hepatotoxic drugs."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "calamus",
+    "slug": "calamus",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Contains β-asarone; possible GABAergic and serotonergic effects.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Animal studies show carcinogenicity at high doses.",
+    "safety": "",
+    "sideeffects": [
+      "nausea",
+      "potential carcinogenicity (β-asarone)."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "cancer risk",
+      "seizures."
+    ],
+    "therapeutic": "mental clarity, digestion, mild psychoactivity.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "cns depressants",
+      "anticoagulants."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "california-poppy",
+    "slug": "california-poppy",
+    "common": "",
+    "scientific": "",
+    "category": "dissociative / sedative",
+    "description": "california's state flower containing non-addictive sedative alkaloids.",
+    "effects": "Gentle sedative;dreamlike calm",
+    "intensity": "Mild",
+    "region": "🌎 unknown / global",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "Mild GABAergic activity and opioid receptor affinity (non-narcotic).",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "No known LD50 in humans; safe at standard doses.",
+    "safety": "1",
+    "sideeffects": [
+      "drowsiness",
+      "vivid dreams",
+      "dizziness."
+    ],
+    "contraindications": [
+      "not for use in pregnancy or with other cns depressants."
+    ],
+    "therapeutic": "used for anxiety, insomnia, and pain management.",
+    "tags": [
+      "☕ brewable",
+      "✅ safe",
+      "🌀 dissociation",
+      "🧘 sedation"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may amplify effects of benzodiazepines and alcohol."
+    ],
+    "toxicity": "Low toxicity; non-habit-forming.",
+    "image": ""
+  },
+  {
+    "id": "cbd",
+    "slug": "cbd",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Interacts with endocannabinoid system (CB1/CB2); anti-inflammatory and anxiolytic.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "CBD LD50 >200 mg/kg (oral, rats).",
+    "safety": "",
+    "sideeffects": [
+      "fatigue",
+      "diarrhea",
+      "appetite changes."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "liver conditions."
+    ],
+    "therapeutic": "anxiety, epilepsy, pain relief, inflammation.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "antiepileptics",
+      "sedatives",
+      "blood thinners."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "celastrus-paniculatus-intellect-tree",
+    "slug": "celastrus-paniculatus-intellect-tree",
+    "common": "",
+    "scientific": "",
+    "category": "other",
+    "description": "indian vine whose oil is consumed to sharpen memory and dream vividly.",
+    "effects": "Lucid dreaming;cognitive enhancer",
+    "intensity": "Mild",
+    "region": "🌎 unknown / global",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "",
+    "safety": "1",
+    "sideeffects": [
+      "not well documented"
+    ],
+    "contraindications": [
+      "not well documented"
+    ],
+    "therapeutic": "not well documented",
+    "tags": [
+      "✅ safe",
+      "🧠 cognitive"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "not well documented"
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "chiric-sanango",
+    "slug": "chiric-sanango",
+    "common": "",
+    "scientific": "",
+    "category": "dissociative / sedative",
+    "description": "amazonian shrub added to ayahuasca for introspection and cleansing.",
+    "effects": "Shadow work;spiritual clearing",
+    "intensity": "High",
+    "region": "🌎 unknown / global",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "Contains β-carboline alkaloids (harmine, harmaline) and coumarins (scopoletin) that may inhibit monoamine oxidase and modulate serotonergic/cholinergic systems [0, 11, 0, 1].",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "LD50 not established; considered mildly toxic in large doses due to cholinergic effects.",
+    "safety": "1",
+    "sideeffects": [
+      "dizziness",
+      "nausea",
+      "muscle tremors",
+      "delirium at high doses [0",
+      "11]."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "cardiovascular conditions."
+    ],
+    "therapeutic": "potentiates ayahuasca, used in amazonian rituals for introspection and mild hallucinations [0, 4].",
+    "tags": [
+      "☕ brewable",
+      "✅ safe",
+      "🌀 dissociation"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "other serotonergic or cholinergic agents."
+    ],
+    "toxicity": "Toxic in high doses; caution advised.",
+    "image": ""
+  },
+  {
+    "id": "coca-leaf",
+    "slug": "coca-leaf",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Cocaine alkaloids inhibit dopamine, norepinephrine, and serotonin reuptake.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Cocaine LD50 ~95 mg/kg (oral, rats).",
+    "safety": "",
+    "sideeffects": [
+      "euphoria",
+      "increased heart rate",
+      "dependency (with concentrated extracts)."
+    ],
+    "contraindications": [
+      "cardiovascular disease",
+      "pregnancy."
+    ],
+    "therapeutic": "altitude sickness, energy boost, appetite suppression (traditional use).",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "stimulants",
+      "maois",
+      "beta-blockers."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "shankhpushpi",
+    "slug": "shankhpushpi",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Enhances cholinergic activity; acts as a nootropic and neuroprotective agent.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Low; used safely in Ayurveda.",
+    "safety": "",
+    "sideeffects": [
+      "mild sedation",
+      "gi discomfort (rare)."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "hypotension."
+    ],
+    "therapeutic": "memory enhancement, anxiety reduction, cognitive support.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "sedatives",
+      "anticholinergics."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "copal",
+    "slug": "copal",
+    "common": "",
+    "scientific": "",
+    "category": "ritual / visionary",
+    "description": "resin from bursera trees burned ceremonially to purify and induce trance.",
+    "effects": "Purifying;sacred aroma;trance enhancement",
+    "intensity": "Mild",
+    "region": "🌐 global / ritual",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "",
+    "safety": "1",
+    "sideeffects": [
+      "not well documented"
+    ],
+    "contraindications": [
+      "not well documented"
+    ],
+    "therapeutic": "not well documented",
+    "tags": [
+      "✅ safe",
+      "🔮 ritual",
+      "🕯️ ritual"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "not well documented"
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "turmeric",
+    "slug": "turmeric",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Curcumin inhibits COX-2, NF-κB; anti-inflammatory and antioxidant.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Curcumin LD50 ~2 g/kg (mice).",
+    "safety": "",
+    "sideeffects": [
+      "gi issues (rare)."
+    ],
+    "contraindications": [
+      "gallstones",
+      "bleeding disorders."
+    ],
+    "therapeutic": "inflammation, pain, digestion.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "nsaids",
+      "anticoagulants."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "dream-herb",
+    "slug": "dream-herb",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Modulates acetylcholine and sleep-phase pathways.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Low; traditional use supports safety.",
+    "safety": "",
+    "sideeffects": [
+      "grogginess",
+      "dry mouth."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "epilepsy."
+    ],
+    "therapeutic": "lucid dreaming, dream recall.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "sedatives",
+      "anticholinergics."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "eleutherococcus-senticosus-siberian-ginseng",
+    "slug": "eleutherococcus-senticosus-siberian-ginseng",
+    "common": "",
+    "scientific": "",
+    "category": "empathogen / euphoriant",
+    "description": "adaptogenic root boosting stamina and immune function.",
+    "effects": "Balanced energy;mood resilience",
+    "intensity": "Mild",
+    "region": "🇨🇳 east asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "Adaptogenic modulation of HPA axis and immune response; contains eleutherosides influencing stress resilience.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "No established LD50; high doses in animals show minimal acute toxicity.",
+    "safety": "1",
+    "sideeffects": [
+      "mild insomnia",
+      "irritability",
+      "nervousness in high doses."
+    ],
+    "contraindications": [
+      "hypertension",
+      "pregnancy",
+      "hormone-sensitive conditions."
+    ],
+    "therapeutic": "fatigue, immune support, cognitive performance under stress.",
+    "tags": [
+      "☕ brewable",
+      "✅ safe",
+      "💫 euphoria"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interact with stimulants",
+      "immunosuppressants",
+      "and anticoagulants."
+    ],
+    "toxicity": "Generally considered safe when used short-term. Long-term effects less studied.",
+    "image": ""
+  },
+  {
+    "id": "entada-rheedii",
+    "slug": "entada-rheedii",
+    "common": "",
+    "scientific": "",
+    "category": "oneirogen",
+    "description": "seed from a tropical vine used in african traditions to induce vivid dreams.",
+    "effects": "Dream enhancement;trance",
+    "intensity": "Moderate",
+    "region": "🇲🇽 latin america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [
+      "Saponins"
+    ],
+    "toxicity_ld50": "",
+    "safety": "1",
+    "sideeffects": [
+      "mild gi upset",
+      "drowsiness",
+      "rare nausea [0",
+      "6]."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "lactation",
+      "hypersensitivity [0",
+      "6]."
+    ],
+    "therapeutic": "dream enhancement, lucid dreaming, traditional remedy for diarrhea and stomach aches [0, 6, 0, 11].",
+    "tags": [
+      "✅ safe",
+      "💊 oral",
+      "🧠 dream"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may potentiate cns depressants",
+      "caution with anticholinergics [0",
+      "6]."
+    ],
+    "toxicity": "Low; no severe toxicity reported in traditional use [0, 6].",
+    "image": ""
+  },
+  {
+    "id": "ephedra",
+    "slug": "ephedra",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Ephedrine stimulates alpha and beta adrenergic receptors; raises heart rate and CNS activity.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Ephedrine LD50 ~50 mg/kg (oral, mice).",
+    "safety": "",
+    "sideeffects": [
+      "palpitations",
+      "anxiety",
+      "hypertension."
+    ],
+    "contraindications": [
+      "heart conditions",
+      "hypertension",
+      "pregnancy."
+    ],
+    "therapeutic": "decongestant, stimulant, fat loss aid.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "stimulants",
+      "beta-blockers",
+      "maois."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "tongkat-ali",
+    "slug": "tongkat-ali",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Boosts free testosterone; reduces cortisol.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "LD50 >2 g/kg (rats).",
+    "safety": "",
+    "sideeffects": [
+      "irritability",
+      "insomnia."
+    ],
+    "contraindications": [
+      "heart disease",
+      "hormone-sensitive conditions."
+    ],
+    "therapeutic": "libido, muscle mass, energy.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "stimulants",
+      "steroids."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "frankincense-boswellia",
+    "slug": "frankincense-boswellia",
+    "common": "",
+    "scientific": "",
+    "category": "other",
+    "description": "resin incense with boswellic acids studied for anti-inflammatory effects.",
+    "effects": "Trance;meditative awareness",
+    "intensity": "Mild",
+    "region": "🌐 global / ritual",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "",
+    "safety": "1",
+    "sideeffects": [
+      "not well documented"
+    ],
+    "contraindications": [
+      "not well documented"
+    ],
+    "therapeutic": "not well documented",
+    "tags": [
+      "✅ safe"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "not well documented"
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "ginger",
+    "slug": "ginger",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Modulates prostaglandins and serotonin receptors; antiemetic and anti-inflammatory.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Ginger extract LD50 >5 g/kg (rats).",
+    "safety": "",
+    "sideeffects": [
+      "heartburn",
+      "bloating (rare)."
+    ],
+    "contraindications": [
+      "gallstones",
+      "bleeding disorders."
+    ],
+    "therapeutic": "nausea relief, inflammation, digestive aid.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "anticoagulants",
+      "antidiabetics."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "gotu-kola",
+    "slug": "gotu-kola",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Boosts collagen synthesis, modulates GABA and blood flow.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "LD50 ~4.9 g/kg (rats).",
+    "safety": "",
+    "sideeffects": [
+      "drowsiness",
+      "skin rash."
+    ],
+    "contraindications": [
+      "liver conditions",
+      "pregnancy."
+    ],
+    "therapeutic": "cognition, wound healing, anxiety.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "sedatives",
+      "hepatotoxic drugs."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "heimia",
+    "slug": "heimia",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "May affect auditory processing and memory; unknown alkaloid MOA.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Low; traditionally used safely.",
+    "safety": "",
+    "sideeffects": [
+      "drowsiness",
+      "dizziness."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "psychiatric disorders."
+    ],
+    "therapeutic": "auditory shifts, relaxation, dream recall.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "cns depressants",
+      "alcohol."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "heimia-salicifolia-sinicuichi",
+    "slug": "heimia-salicifolia-sinicuichi",
+    "common": "",
+    "scientific": "",
+    "category": "dissociative / sedative",
+    "description": "mexican shrub whose fermented leaves produce mild auditory shifts.",
+    "effects": "Auditory hallucinations;slowed time",
+    "intensity": "Moderate",
+    "region": "🌎 unknown / global",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "Alkaloids may affect auditory processing and blood flow, potentially modulating neurotransmission [9, 4].",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Not well established; no fatal doses reported in traditional use.",
+    "safety": "1",
+    "sideeffects": [
+      "dry mouth",
+      "muscle relaxation",
+      "altered hearing [9",
+      "4]."
+    ],
+    "contraindications": [
+      "avoid with alcohol or cns depressants",
+      "pregnancy [9",
+      "4]."
+    ],
+    "therapeutic": "divination, auditory changes, euphoria in folk practices [9, 4].",
+    "tags": [
+      "☕ brewable",
+      "✅ safe",
+      "🌀 dissociation",
+      "🧪 fermented"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "none known",
+      "caution with psychiatric medications [9",
+      "4]."
+    ],
+    "toxicity": "Low toxicity; high doses may cause mild sedation or nausea [9, 4].",
+    "image": ""
+  },
+  {
+    "id": "henbane",
+    "slug": "henbane",
+    "common": "",
+    "scientific": "",
+    "category": "deliriant / toxic",
+    "description": "nightshade containing tropane alkaloids causing powerful delirium.",
+    "effects": "Delirium;hallucinations;anticholinergic",
+    "intensity": "High",
+    "region": "🌎 unknown / global",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Controlled / Toxic",
+    "mechanism": "",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "",
+    "safety": "1",
+    "sideeffects": [
+      "not well documented"
+    ],
+    "contraindications": [
+      "not well documented"
+    ],
+    "therapeutic": "not well documented",
+    "tags": [
+      "☠️ toxic",
+      "🕯️ ritual"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "0.05–0.1 g dried leaf",
+    "interactions": [
+      "not well documented"
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "hop-flowers",
+    "slug": "hop-flowers",
+    "common": "",
+    "scientific": "",
+    "category": "dissociative / sedative",
+    "description": "bitter cones of humulus lupulus used for relaxation and sleep.",
+    "effects": "Relaxation;dream enhancement",
+    "intensity": "Mild",
+    "region": "🌎 unknown / global",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "Binds to GABA-A receptors, promoting sedation and relaxation.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "No human LD50; high safety margin reported in herbal use.",
+    "safety": "1",
+    "sideeffects": [
+      "drowsiness",
+      "mild headache",
+      "possible hormonal effects in large doses."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "estrogen-sensitive conditions (e.g. breast cancer)."
+    ],
+    "therapeutic": "used as a mild sleep aid, anxiety reducer, and dream enhancer.",
+    "tags": [
+      "☕ brewable",
+      "✅ safe",
+      "🌀 dissociation"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may enhance sedatives",
+      "alcohol",
+      "and hypnotics."
+    ],
+    "toxicity": "Very low toxicity; generally regarded as safe.",
+    "image": ""
+  },
+  {
+    "id": "hops",
+    "slug": "hops",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "GABA-A receptor modulation and sedative flavonoids.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Low; very safe in typical doses.",
+    "safety": "",
+    "sideeffects": [
+      "drowsiness",
+      "hormonal effects."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "hormone-sensitive conditions."
+    ],
+    "therapeutic": "insomnia, anxiety, menopausal symptoms.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "sedatives",
+      "cns depressants."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "horny-goat-weed",
+    "slug": "horny-goat-weed",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Icariin inhibits PDE5 and boosts nitric oxide; mimics testosterone effects.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Icariin LD50 ~2 g/kg (rats, oral).",
+    "safety": "",
+    "sideeffects": [
+      "dizziness",
+      "rapid heartbeat",
+      "dry mouth."
+    ],
+    "contraindications": [
+      "heart conditions",
+      "hormone-sensitive disorders."
+    ],
+    "therapeutic": "libido enhancement, erectile dysfunction, fatigue reduction.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "nitrates",
+      "antihypertensives",
+      "stimulants."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "iboga",
+    "slug": "iboga",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Ibogaine affects NMDA, opioid, and serotonergic receptors.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "LD50 ~263 mg/kg (mice, oral).",
+    "safety": "",
+    "sideeffects": [
+      "nausea",
+      "heart arrhythmia",
+      "hallucinations."
+    ],
+    "contraindications": [
+      "heart disease",
+      "psychiatric disorders."
+    ],
+    "therapeutic": "addiction treatment, introspection.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "opioids",
+      "antidepressants."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "indian-warrior",
+    "slug": "indian-warrior",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "May act on GABA receptors; muscle relaxant and sedative properties.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Limited data; traditionally used safely.",
+    "safety": "",
+    "sideeffects": [
+      "drowsiness",
+      "dry mouth."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "cns depression."
+    ],
+    "therapeutic": "muscle relaxation, sleep support, mild pain relief.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "sedatives",
+      "depressants."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "ipomoea-tricolor-heavenly-blue",
+    "slug": "ipomoea-tricolor-heavenly-blue",
+    "common": "",
+    "scientific": "",
+    "category": "ethnobotanical / rare",
+    "description": "ornamental morning glory whose seeds induce lsd-like visions.",
+    "effects": "LSD-like visuals;spiritual confusion",
+    "intensity": "High",
+    "region": "🌎 unknown / global",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Restricted in some countries",
+    "mechanism": "",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "",
+    "safety": "1",
+    "sideeffects": [
+      "nausea",
+      "vasoconstriction",
+      "headache [0",
+      "5]."
+    ],
+    "contraindications": [
+      "cardiovascular disorders",
+      "psychiatric conditions [0",
+      "5]."
+    ],
+    "therapeutic": "visionary experiences, ethnobotanical use [0, 5].",
+    "tags": [
+      "⚠️ restricted"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "ssris/maois [0",
+      "5]."
+    ],
+    "toxicity": "Low; rodent LD50 ~200–300 mg/kg [0, 5].",
+    "image": ""
+  },
+  {
+    "id": "kana",
+    "slug": "kana",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Inhibits PDE4, increases serotonin; mild SSRI-like effect.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Low; safe in moderate doses.",
+    "safety": "",
+    "sideeffects": [
+      "mild nausea",
+      "sedation."
+    ],
+    "contraindications": [
+      "ssris",
+      "maois."
+    ],
+    "therapeutic": "mood enhancement, anxiety.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "antidepressants",
+      "alcohol."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "klip-dagga",
+    "slug": "klip-dagga",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Similar to Wild Dagga; interacts with cannabinoid receptors.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Low; traditionally used safely.",
+    "safety": "",
+    "sideeffects": [
+      "sedation",
+      "dry mouth."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "psychiatric disorders."
+    ],
+    "therapeutic": "relaxation, mild euphoria, traditional pain relief.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "cannabis",
+      "cns depressants."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "kra-thum-na--kok",
+    "slug": "kra-thum-na-kok",
+    "common": "",
+    "scientific": "",
+    "category": "empathogen / euphoriant",
+    "description": "southeast asian tree related to kratom with stimulating leaves.",
+    "effects": "Stimulation;kratom-like body feel",
+    "intensity": "Moderate",
+    "region": "🌎 unknown / global",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "",
+    "safety": "1",
+    "sideeffects": [
+      "not well documented"
+    ],
+    "contraindications": [
+      "not well documented"
+    ],
+    "therapeutic": "not well documented",
+    "tags": [
+      "☕ brewable",
+      "✅ safe",
+      "💊 oral",
+      "💫 euphoria",
+      "\\u2615 brewable",
+      "\\ud83d\\udc8a oral",
+      "\\ud83d\\udcab euphoria",
+      "\\u2705 safe"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "not well documented"
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "lavender",
+    "slug": "lavender",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Linalool modulates GABA and serotonin pathways; anxiolytic and sedative.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Linalool LD50 ~2790 mg/kg (oral, rats).",
+    "safety": "",
+    "sideeffects": [
+      "drowsiness",
+      "allergic reactions."
+    ],
+    "contraindications": [
+      "pregnancy (high doses)",
+      "hormone-sensitive conditions."
+    ],
+    "therapeutic": "anxiety relief, sleep aid, calming effects.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "sedatives",
+      "antidepressants."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "lion-s-tail",
+    "slug": "lion-s-tail",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Acts on cannabinoid receptors; may offer sedative and euphoric effects.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Low; safe in traditional use.",
+    "safety": "",
+    "sideeffects": [
+      "dry mouth",
+      "sedation."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "psychiatric conditions."
+    ],
+    "therapeutic": "anxiety relief, mood boost, mild pain relief.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "cannabis",
+      "cns depressants."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "peyote",
+    "slug": "peyote",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Mescaline agonizes 5-HT2A receptors; psychedelic effects.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Mescaline LD50 ~212 mg/kg (rat).",
+    "safety": "",
+    "sideeffects": [
+      "nausea",
+      "hallucinations."
+    ],
+    "contraindications": [
+      "psychosis",
+      "pregnancy."
+    ],
+    "therapeutic": "spiritual experiences, ptsd research.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "ssris",
+      "maois",
+      "stimulants."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "maca-root",
+    "slug": "maca-root",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Alkaloids modulate endocrine function and energy metabolism.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Very low; high tolerance in humans.",
+    "safety": "",
+    "sideeffects": [
+      "gi upset",
+      "jitteriness (rare)."
+    ],
+    "contraindications": [
+      "hormone-sensitive conditions."
+    ],
+    "therapeutic": "energy, fertility, libido.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "hormonal therapies."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "mandrake-root",
+    "slug": "mandrake-root",
+    "common": "",
+    "scientific": "",
+    "category": "deliriant / toxic",
+    "description": "mythic mediterranean root with hallucinogenic tropane alkaloids.",
+    "effects": "Narcotic;visionary trance",
+    "intensity": "High",
+    "region": "🌎 unknown / global",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Controlled / Toxic",
+    "mechanism": "Contains tropane alkaloids (scopolamine, atropine); anticholinergic deliriant.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Scopolamine LD50 (rat, oral): ~310 mg/kg.",
+    "safety": "1",
+    "sideeffects": [
+      "dry mouth",
+      "confusion",
+      "hallucinations",
+      "elevated heart rate."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "glaucoma",
+      "heart conditions."
+    ],
+    "therapeutic": "historically used as anesthetic, antispasmodic, and in witchcraft.",
+    "tags": [
+      "☠️ toxic"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "potentiates other anticholinergics",
+      "cns depressants."
+    ],
+    "toxicity": "Highly toxic in moderate doses.",
+    "image": ""
+  },
+  {
+    "id": "mapacho",
+    "slug": "mapacho",
+    "common": "",
+    "scientific": "",
+    "category": "ritual / visionary",
+    "description": "potent nicotiana rustica tobacco burned in ritual for focus and protection.",
+    "effects": "Sacred tobacco;heavy grounding",
+    "intensity": "High",
+    "region": "🇲🇽 latin america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Restricted (due to nicotine content)",
+    "mechanism": "Nicotine agonizes nicotinic acetylcholine receptors; contains β-carbolines (harmala alkaloids) acting as reversible MAO inhibitors [1, 0, 1, 9].",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "LD50 (nicotine) ~0.5–1.0 mg/kg in humans (oral); overdose via smoke is rare but possible.",
+    "safety": "1",
+    "sideeffects": [
+      "nausea",
+      "tachycardia",
+      "vomiting",
+      "dizziness at high doses [1",
+      "0]."
+    ],
+    "contraindications": [
+      "cardiovascular disease",
+      "pregnancy."
+    ],
+    "therapeutic": "shamanic entheogen in rapé blends for sensory enhancement and ritual purification [1, 0].",
+    "tags": [
+      "\\ud83c\\udf2c\\ufe0f smokable",
+      "\\ud83d\\udd2e ritual",
+      "\\u26a0\\ufe0f restricted"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "other nicotinic agonists and mao inhibitors."
+    ],
+    "toxicity": "High risk of nicotine overdose; very toxic.",
+    "image": ""
+  },
+  {
+    "id": "melissa-officinalis-lemon-balm",
+    "slug": "melissa-officinalis-lemon-balm",
+    "common": "",
+    "scientific": "",
+    "category": "dissociative / sedative",
+    "description": "lemony herb easing anxiety and digestive upset while calming the mind.",
+    "effects": "Anxiolytic;cognitive calming",
+    "intensity": "Mild",
+    "region": "🌎 unknown / global",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "",
+    "safety": "1",
+    "sideeffects": [
+      "drowsiness",
+      "possible allergic reactions",
+      "gi upset at high doses [0",
+      "0]."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "known asteraceae allergy [0",
+      "16]."
+    ],
+    "therapeutic": "anxiety, insomnia, nervous tension, digestive aid [0, 8].",
+    "tags": [
+      "☕ brewable",
+      "✅ safe",
+      "🌀 dissociation",
+      "🌬️ smokable",
+      "🧘 sedation",
+      "🧠 cognitive"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may potentiate sedatives",
+      "anticoagulants",
+      "caution with cns depressants [0",
+      "16]."
+    ],
+    "toxicity": "Low; safe at therapeutic doses [0, 0].",
+    "image": ""
+  },
+  {
+    "id": "muira-puama",
+    "slug": "muira-puama",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "May enhance dopamine activity and increase blood flow; adaptogenic.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Low; traditionally used safely.",
+    "safety": "",
+    "sideeffects": [
+      "headache",
+      "insomnia (high doses)."
+    ],
+    "contraindications": [
+      "hypertension",
+      "pregnancy."
+    ],
+    "therapeutic": "libido enhancement, cognitive function, stress relief.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "stimulants",
+      "antidepressants."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "mulungu",
+    "slug": "mulungu",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Sedative alkaloids may bind GABA and serotonin receptors.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Low toxicity reported.",
+    "safety": "",
+    "sideeffects": [
+      "drowsiness",
+      "hypotension."
+    ],
+    "contraindications": [
+      "low blood pressure",
+      "sedative use."
+    ],
+    "therapeutic": "anxiety, stress, insomnia.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "antihypertensives",
+      "depressants."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "nymphaea-ampla",
+    "slug": "nymphaea-ampla",
+    "common": "",
+    "scientific": "",
+    "category": "empathogen / euphoriant",
+    "description": "central american water lily providing mild euphoria and sedation.",
+    "effects": "Sedative;euphoric;dreamlike states",
+    "intensity": "Mild",
+    "region": "🌎 unknown / global",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "",
+    "safety": "1",
+    "sideeffects": [
+      "not well documented"
+    ],
+    "contraindications": [
+      "not well documented"
+    ],
+    "therapeutic": "not well documented",
+    "tags": [
+      "☕ brewable",
+      "✅ safe",
+      "🌬️ smokable",
+      "💫 euphoria"
+    ],
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6331724/",
+      "Plants of the Gods – Rätsch",
+      "Journal of Ethnopharmacology",
+      "2012"
+    ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "not well documented"
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "ocimum-sanctum-holy-basil--tulsi",
+    "slug": "ocimum-sanctum-holy-basil-tulsi",
+    "common": "",
+    "scientific": "",
+    "category": "empathogen / euphoriant",
+    "description": "sacred basil revered in ayurveda for uplifting and adaptogenic qualities.",
+    "effects": "Mood lift;sacred calm;spiritual focus",
+    "intensity": "Mild",
+    "region": "🇮🇳 india",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "Modulates cortisol, inflammation, and neurotransmitters; contains eugenol, ursolic acid, and apigenin.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Pending",
+    "safety": "1",
+    "sideeffects": [
+      "may lower blood sugar",
+      "mild sedation",
+      "mild nausea."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "diabetes medication."
+    ],
+    "therapeutic": "adaptogen, anxiety, spiritual focus, blood sugar balance.",
+    "tags": [
+      "☕ brewable",
+      "✅ safe",
+      "💫 euphoria",
+      "🕯️ ritual",
+      "🧘 sedation",
+      "\\u2615 brewable",
+      "\\ud83d\\udd6f\\ufe0f ritual",
+      "\\ud83d\\udcab euphoria",
+      "\\ud83e\\uddd8 sedation",
+      "\\u2705 safe"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may potentiate anti-diabetic",
+      "anticoagulant",
+      "or sedative drugs."
+    ],
+    "toxicity": "Pending",
+    "image": ""
+  },
+  {
+    "id": "pedicularis-densiflora-indian-warrior",
+    "slug": "pedicularis-densiflora-indian-warrior",
+    "common": "",
+    "scientific": "",
+    "category": "dissociative / sedative",
+    "description": "north american wildflower smoked for muscle relaxation.",
+    "effects": "Muscle relaxation;mild body high",
+    "intensity": "Moderate",
+    "region": "🌍 africa, 🇮🇳 india",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "Muscle relaxant potential via GABAergic modulation [2, 0].",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "",
+    "safety": "1",
+    "sideeffects": [
+      "drowsiness",
+      "dizziness [2",
+      "0]."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "use with other sedatives [2",
+      "0]."
+    ],
+    "therapeutic": "muscle tension, pain relief, sleep aid applications [2, 0].",
+    "tags": [
+      "☕ brewable",
+      "✅ safe",
+      "🌀 dissociation",
+      "🌬️ smokable"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "additive effects with cns depressants [2",
+      "0]."
+    ],
+    "toxicity": "Low; limited data on long-term use [2, 0].",
+    "image": ""
+  },
+  {
+    "id": "pedicularis-groenlandica",
+    "slug": "pedicularis-groenlandica",
+    "common": "",
+    "scientific": "",
+    "category": "dissociative / sedative",
+    "description": "high-elevation lousewort prized for soothing tense muscles.",
+    "effects": "Stronger relaxation;tension relief",
+    "intensity": "Moderate",
+    "region": "🌍 africa",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "",
+    "safety": "1",
+    "sideeffects": [
+      "rare",
+      "possible gi upset [0",
+      "7]."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "lactation [0",
+      "7]."
+    ],
+    "therapeutic": "muscle relaxant, antioxidant, antimicrobial, traditional remedy for pain and inflammation [0, 7].",
+    "tags": [
+      "☕ brewable",
+      "✅ safe",
+      "🌀 dissociation",
+      "🌬️ smokable"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "additive with cns depressants [0",
+      "7]."
+    ],
+    "toxicity": "Low; no significant toxicity reported [0, 7].",
+    "image": ""
+  },
+  {
+    "id": "piper-auritum-root-beer-plant",
+    "slug": "piper-auritum-root-beer-plant",
+    "common": "",
+    "scientific": "",
+    "category": "empathogen / euphoriant",
+    "description": "sassafras-scented leaf from mexico used culinary and for mild mood lift.",
+    "effects": "Calming;warming;euphoric",
+    "intensity": "Mild",
+    "region": "🌎 unknown / global",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "Contains safrole and other volatile oils; possible mild dopaminergic stimulation and GI modulation.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "LD50 (rats, oral) safrole ~1,950 mg/kg; safrole is hepatotoxic at high doses.",
+    "safety": "1",
+    "sideeffects": [
+      "high doses may cause gi upset",
+      "safrole is a potential carcinogen [1",
+      "11]."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "safrole-containing extracts discouraged [1",
+      "11]."
+    ],
+    "therapeutic": "digestive aid, anti-inflammatory, antimutagen, diuretic, antipyretic [0, 11].",
+    "tags": [
+      "☕ brewable",
+      "✅ safe",
+      "💫 euphoria",
+      "🧘 sedation"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "cyp450 substrates",
+      "caution with anticoagulants [0",
+      "19]."
+    ],
+    "toxicity": "Safrole hepatotoxic; use sparingly [1, 11].",
+    "image": ""
+  },
+  {
+    "id": "rhodiola",
+    "slug": "rhodiola",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Inhibits monoamine oxidase; modulates cortisol and neurotransmitters.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Low; high safety margin in studies.",
+    "safety": "",
+    "sideeffects": [
+      "irritability",
+      "dry mouth."
+    ],
+    "contraindications": [
+      "bipolar disorder",
+      "pregnancy."
+    ],
+    "therapeutic": "fatigue, depression, cognitive support.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "ssris",
+      "maois",
+      "stimulants."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "rhodiola-rosea",
+    "slug": "rhodiola-rosea",
+    "common": "",
+    "scientific": "",
+    "category": "empathogen / euphoriant",
+    "description": "hardy root enhancing endurance and stress tolerance via adaptogens.",
+    "effects": "Focus;reduced fatigue;mind clarity",
+    "intensity": "Mild",
+    "region": "🌎 unknown / global",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "Influences serotonin, norepinephrine, dopamine; modulates HPA axis and stress adaptation via rosavins and salidroside.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "LD50 (rats, oral) >28,000 mg/kg; very low toxicity.",
+    "safety": "1",
+    "sideeffects": [
+      "irritability",
+      "dry mouth",
+      "dizziness (rare",
+      "dose-dependent)."
+    ],
+    "contraindications": [
+      "bipolar disorder",
+      "stimulants",
+      "pregnancy."
+    ],
+    "therapeutic": "fatigue, stress resilience, cognitive enhancement, mild depression.",
+    "tags": [
+      "✅ safe",
+      "💊 oral",
+      "💫 euphoria",
+      "🧠 cognitive"
+    ],
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6279142/",
+      "Herbal Medicine – Mills & Bone",
+      "Plants of the Gods – Rätsch"
+    ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may affect antidepressants",
+      "stimulants",
+      "or maois."
+    ],
+    "toxicity": "Mild toxicity; high doses may cause irritability or insomnia.",
+    "image": ""
+  },
+  {
+    "id": "rivea-corymbosa",
+    "slug": "rivea-corymbosa",
+    "common": "",
+    "scientific": "",
+    "category": "ethnobotanical / rare",
+    "description": "morning glory species with lsa seeds used in ancient mexican rituals.",
+    "effects": "Dreamy visuals;nausea;traditional Mazatec use",
+    "intensity": "High",
+    "region": "🌎 unknown / global",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Restricted in some countries",
+    "mechanism": "",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "",
+    "safety": "1",
+    "sideeffects": [
+      "nausea",
+      "vasoconstriction",
+      "dizziness [0",
+      "4]."
+    ],
+    "contraindications": [
+      "cardiovascular disease",
+      "pregnancy [0",
+      "4]."
+    ],
+    "therapeutic": "entheogenic snuff (ololiuqui) in mesoamerican rituals [0, 4].",
+    "tags": [
+      "⚠️ restricted"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "serotonergic medications [0",
+      "12]."
+    ],
+    "toxicity": "Low; moderate overdose risk [0, 12].",
+    "image": ""
+  },
+  {
+    "id": "sacred-basil",
+    "slug": "sacred-basil",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Modulates cortisol, dopamine, and serotonin; adaptogenic and anxiolytic.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Low toxicity; very safe traditionally.",
+    "safety": "",
+    "sideeffects": [
+      "dry mouth",
+      "mild sedation."
+    ],
+    "contraindications": [
+      "pregnancy (high doses)",
+      "thyroid issues."
+    ],
+    "therapeutic": "stress relief, mood balance, cognitive clarity.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "sedatives",
+      "anticoagulants."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "sakae-naa",
+    "slug": "sakae-naa",
+    "common": "",
+    "scientific": "",
+    "category": "empathogen / euphoriant",
+    "description": "thai herb with mitragynine-like alkaloids providing mild stimulation.",
+    "effects": "Mild stimulant;mood separation",
+    "intensity": "Mild",
+    "region": "🌎 unknown / global",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "Stimulates dopamine receptors; alkaloids may mimic stimulant activity.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Low; limited toxicity data.",
+    "safety": "1",
+    "sideeffects": [
+      "restlessness",
+      "jitteriness",
+      "insomnia."
+    ],
+    "contraindications": [
+      "hypertension",
+      "anxiety disorders."
+    ],
+    "therapeutic": "stimulation, alertness, mild euphoria.",
+    "tags": [
+      "\\u2615 brewable",
+      "\\ud83d\\udc8a oral",
+      "\\ud83d\\udcab euphoria",
+      "\\u26a1 stimulant",
+      "\\u2705 safe"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "stimulants",
+      "maois."
+    ],
+    "toxicity": "Low, but less studied than kratom.",
+    "image": ""
+  },
+  {
+    "id": "salvia",
+    "slug": "salvia",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Salvinorin A is a kappa-opioid agonist; dissociative hallucinogen.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Very low; psychological risk high.",
+    "safety": "",
+    "sideeffects": [
+      "dysphoria",
+      "confusion."
+    ],
+    "contraindications": [
+      "mental health disorders."
+    ],
+    "therapeutic": "shamanic rituals, research on consciousness.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "opioids",
+      "depressants."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "salvia-divinorum",
+    "slug": "salvia-divinorum",
+    "common": "",
+    "scientific": "",
+    "category": "dissociative / sedative",
+    "description": "mazatec entheogen with powerful, short-lived visionary effects.",
+    "effects": "Total dissociation;entity contact",
+    "intensity": "High",
+    "region": "🇲🇽 latin america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Restricted in many regions",
+    "mechanism": "",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "LD50 not established; salvinorin A active at microgram levels with no evidence of physical toxicity.",
+    "safety": "1",
+    "sideeffects": [
+      "tiredness",
+      "dizziness",
+      "amnesia",
+      "potential for transient psychosis in vulnerable individuals [3",
+      "2]."
+    ],
+    "contraindications": [
+      "psychiatric disorders",
+      "cardiovascular instability",
+      "avoid in those at risk for psychosis [3",
+      "2]."
+    ],
+    "therapeutic": "visionary experiences in traditional mazatec rituals; investigated for analgesic and anti-inflammatory properties [3, 0].",
+    "tags": [
+      "⚠️ restricted",
+      "🌀 dissociation",
+      "🌬️ smokable"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "cns depressants may potentiate sedative effects",
+      "caution when coadministered [3",
+      "3]."
+    ],
+    "toxicity": "Low toxicity; animal studies show minimal organ damage even at high doses [3, 3].",
+    "image": ""
+  },
+  {
+    "id": "san-pedro",
+    "slug": "san-pedro",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Contains mescaline; affects serotonin 5-HT2A receptors.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Mescaline LD50 ~212 mg/kg (rat).",
+    "safety": "",
+    "sideeffects": [
+      "gi upset",
+      "hallucinations."
+    ],
+    "contraindications": [
+      "mental illness",
+      "pregnancy."
+    ],
+    "therapeutic": "visionary states, emotional healing.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "psychedelics",
+      "maois."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "sananga",
+    "slug": "sananga",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Contains alkaloids that affect vision and inflammation.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Unknown; traditional use considered safe.",
+    "safety": "",
+    "sideeffects": [
+      "burning eyes",
+      "temporary vision blur."
+    ],
+    "contraindications": [
+      "eye infections",
+      "sensitivity."
+    ],
+    "therapeutic": "vision clarity, spiritual rituals.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "limited research."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "sceletium-tortuosum-kanna",
+    "slug": "sceletium-tortuosum-kanna",
+    "common": "",
+    "scientific": "",
+    "category": "empathogen / euphoriant",
+    "description": "south african succulent chewed to elevate mood and decrease tension.",
+    "effects": "Mood lift;empathy;sociability",
+    "intensity": "Moderate",
+    "region": "🌎 unknown / global",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal, sometimes restricted",
+    "mechanism": "Selective serotonin reuptake inhibition (SSRI) and phosphodiesterase-4 (PDE4) inhibition [9, 4].",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Not established in humans; high safety margin observed in animal studies.",
+    "safety": "1",
+    "sideeffects": [
+      "headache",
+      "nausea",
+      "mild sedation [9",
+      "4]."
+    ],
+    "contraindications": [
+      "do not combine with other serotonergic substances",
+      "pregnancy [9",
+      "4]."
+    ],
+    "therapeutic": "mood enhancement, anti-anxiety, social facilitation [9, 4].",
+    "tags": [
+      "⚠️ restricted",
+      "💊 oral",
+      "💫 euphoria"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "ssris",
+      "maois",
+      "stimulants [9",
+      "4]."
+    ],
+    "toxicity": "Low toxicity at traditional doses [9, 4].",
+    "image": ""
+  },
+  {
+    "id": "scullcap-scutellaria",
+    "slug": "scullcap-scutellaria",
+    "common": "",
+    "scientific": "",
+    "category": "dissociative / sedative",
+    "description": "calming mint-family herb rich in baicalin used as nerve tonic.",
+    "effects": "Relaxing;anxiety-reducing;dream support",
+    "intensity": "Mild",
+    "region": "🌎 unknown / global",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "Flavonoids and baicalin modulate GABA-A receptors and inhibit inflammation.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "No standard LD50 data; high therapeutic margin.",
+    "safety": "1",
+    "sideeffects": [
+      "rarely causes liver enzyme elevation or drowsiness."
+    ],
+    "contraindications": [
+      "liver issues",
+      "consult provider before long-term use."
+    ],
+    "therapeutic": "calming, anticonvulsant, neuroprotective.",
+    "tags": [
+      "☕ brewable",
+      "✅ safe",
+      "🌀 dissociation"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "additive effects with sedatives or anxiolytics."
+    ],
+    "toxicity": "Generally safe, though adulterants in supplements have caused concern.",
+    "image": ""
+  },
+  {
+    "id": "siberian-motherwort",
+    "slug": "siberian-motherwort",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Contains leonurine; acts as a mild GABA modulator and muscle relaxant.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Low; traditional use suggests safe profile.",
+    "safety": "",
+    "sideeffects": [
+      "mild sedation",
+      "low blood pressure."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "hypotension."
+    ],
+    "therapeutic": "anxiety relief, heart health, muscle relaxation.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "sedatives",
+      "antihypertensives."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "silphium-extinct",
+    "slug": "silphium-extinct",
+    "common": "",
+    "scientific": "",
+    "category": "other",
+    "description": "famed classical herb believed to have contraceptive and psychoactive resins.",
+    "effects": "Ancient psychoactive/contraceptive herb",
+    "intensity": "Mild",
+    "region": "🌎 unknown / global",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "",
+    "safety": "1",
+    "sideeffects": [
+      "not well documented"
+    ],
+    "contraindications": [
+      "not well documented"
+    ],
+    "therapeutic": "not well documented",
+    "tags": [
+      "✅ safe"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "not well documented"
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "skullcap",
+    "slug": "skullcap",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Flavonoids modulate GABA receptors; offers calming and anxiolytic effects.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Low; traditionally used safely.",
+    "safety": "",
+    "sideeffects": [
+      "drowsiness",
+      "mild gi upset."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "sedative sensitivity."
+    ],
+    "therapeutic": "anxiety, sleep support, muscle tension.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "cns depressants",
+      "alcohol."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "sweet-flag",
+    "slug": "sweet-flag",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Possible GABAergic and dopaminergic effects; unclear active compound mechanism.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "High doses toxic in rodents; human safety debated.",
+    "safety": "",
+    "sideeffects": [
+      "nausea",
+      "headache",
+      "potential carcinogenicity."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "cancer risk (β-asarone in some strains)."
+    ],
+    "therapeutic": "cognition, digestion, mild hallucination (in high doses).",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "cns depressants",
+      "antiarrhythmics."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "sweetgrass",
+    "slug": "sweetgrass",
+    "common": "",
+    "scientific": "",
+    "category": "ritual / visionary",
+    "description": "vanilla-scented grass braided and burned to invite positive spirits.",
+    "effects": "Positive energy;spiritual invocation",
+    "intensity": "Mild",
+    "region": "🌐 global / ritual",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "",
+    "safety": "1",
+    "sideeffects": [
+      "not well documented"
+    ],
+    "contraindications": [
+      "not well documented"
+    ],
+    "therapeutic": "not well documented",
+    "tags": [
+      "✅ safe",
+      "🔮 ritual"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "not well documented"
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "tagetes-lucida-mexican-tarragon",
+    "slug": "tagetes-lucida-mexican-tarragon",
+    "common": "",
+    "scientific": "",
+    "category": "other",
+    "description": "sweet marigold used as tea or incense for clear dreams and calm.",
+    "effects": "Visionary dreams;clarity",
+    "intensity": "Mild",
+    "region": "🇲🇽 latin america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "Coumarins (dimethylfraxetin, herniarin) and essential oils (methyl eugenol, estragole) interact with GABAₐ and 5-HT₁ₐ receptors, producing anxiolytic and sedative effects [2, 2, 2, 10].",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "",
+    "safety": "1",
+    "sideeffects": [
+      "mild gi upset",
+      "potential photosensitivity [2",
+      "3]."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "concurrent sedatives."
+    ],
+    "therapeutic": "anxiolytic, digestive aid, ritual incense for purification [2, 10].",
+    "tags": [
+      "☕ brewable",
+      "✅ safe",
+      "🌬️ smokable",
+      "🕯️ ritual",
+      "🧠 cognitive"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "benzodiazepines and serotonergic drugs."
+    ],
+    "toxicity": "Low; traditional use generally safe.",
+    "image": ""
+  },
+  {
+    "id": "thc",
+    "slug": "thc",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Agonist at CB1 receptors; modulates dopamine and GABA release.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Estimated ~800–1900 mg/kg (rats).",
+    "safety": "",
+    "sideeffects": [
+      "euphoria",
+      "anxiety",
+      "dry mouth",
+      "impaired cognition."
+    ],
+    "contraindications": [
+      "psychosis",
+      "pregnancy",
+      "heart disease."
+    ],
+    "therapeutic": "pain, appetite stimulation, nausea, anxiety relief (low doses).",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "cns depressants",
+      "alcohol",
+      "ssris."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "tilia-europaea-linden-flower",
+    "slug": "tilia-europaea-linden-flower",
+    "common": "",
+    "scientific": "",
+    "category": "dissociative / sedative",
+    "description": "soothing tree blossoms steeped as tea for relaxation and cold relief.",
+    "effects": "Calming;relaxing;mild dream aid",
+    "intensity": "Mild",
+    "region": "🇪🇺 europe",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "",
+    "safety": "1",
+    "sideeffects": [
+      "not well documented"
+    ],
+    "contraindications": [
+      "not well documented"
+    ],
+    "therapeutic": "not well documented",
+    "tags": [
+      "☕ brewable",
+      "✅ safe",
+      "🌀 dissociation",
+      "🧘 sedation"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "not well documented"
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "tonga-root",
+    "slug": "tonga-root",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Possibly androgenic and adaptogenic; exact MOA unclear.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Low; safety profile not fully established.",
+    "safety": "",
+    "sideeffects": [
+      "mild gi upset (rare)."
+    ],
+    "contraindications": [
+      "hormone-sensitive conditions."
+    ],
+    "therapeutic": "libido, stamina, traditional tonic.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "hormonal medications",
+      "stimulants."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "tulsi",
+    "slug": "tulsi",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Acts as an adaptogen; modulates cortisol and inflammatory pathways.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Low; well tolerated in traditional medicine.",
+    "safety": "",
+    "sideeffects": [
+      "rare nausea",
+      "drowsiness."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "anticoagulant use."
+    ],
+    "therapeutic": "stress relief, immune support, cognitive clarity.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "blood thinners",
+      "sedatives."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
+    "id": "viola-odorata-sweet-violet",
+    "slug": "viola-odorata-sweet-violet",
+    "common": "",
+    "scientific": "",
+    "category": "dissociative / sedative",
+    "description": "fragrant violet whose flowers are a mild sedative and expectorant.",
+    "effects": "Mild sedative;calming;gentle dreaminess",
+    "intensity": "Mild",
+    "region": "🇪🇺 europe",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "Mild central sedative via salicylates and alkaloids; may influence serotonin and prostaglandin pathways.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "No human LD50 data; extremely low toxicity reported.",
+    "safety": "1",
+    "sideeffects": [
+      "very rare",
+      "may include mild drowsiness or nausea."
+    ],
+    "contraindications": [
+      "none known in normal amounts",
+      "avoid if allergic."
+    ],
+    "therapeutic": "cough suppressant, mild anxiolytic, anti-inflammatory, gentle sleep aid.",
+    "tags": [
+      "☕ brewable",
+      "✅ safe",
+      "🌀 dissociation",
+      "🧘 sedation"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "minimal",
+      "theoretically additive with cns depressants."
+    ],
+    "toxicity": "Regarded as very safe in traditional herbalism.",
+    "image": ""
+  },
+  {
+    "id": "virola-spp",
+    "slug": "virola-spp",
+    "common": "",
+    "scientific": "",
+    "category": "ethnobotanical / rare",
+    "description": "amazonian trees producing dmt-rich resins for shamanic snuffs.",
+    "effects": "DMT-containing tree resin",
+    "intensity": "High",
+    "region": "🇲🇽 latin america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Restricted / Controlled",
+    "mechanism": "Contains DMT, 5-MeO-DMT, and beta-carbolines; classic tryptamine entheogen profile.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "No established LD50 for DMT in humans; low systemic toxicity at typical doses.",
+    "safety": "1",
+    "sideeffects": [
+      "nausea",
+      "intense hallucinations",
+      "elevated heart rate."
+    ],
+    "contraindications": [
+      "mental health disorders",
+      "heart issues",
+      "maoi interactions."
+    ],
+    "therapeutic": "used in amazonian shamanic healing rituals; possible antidepressant potential.",
+    "tags": [
+      "\\u26a0\\ufe0f restricted",
+      "⚠️ restricted"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "dangerous with ssris",
+      "maois",
+      "and other serotonergic substances."
+    ],
+    "toxicity": "Can be overwhelming; physical toxicity low but psychological risks high.",
+    "image": ""
+  },
+  {
+    "id": "white-sage",
+    "slug": "white-sage",
+    "common": "",
+    "scientific": "",
+    "category": "ritual / visionary",
+    "description": "aromatic sage revered for cleansing rituals and mental clarity.",
+    "effects": "Clarity;purification;spiritual reset",
+    "intensity": "Mild",
+    "region": "🌐 global / ritual",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "1,8-Cineole and α-thujone inhibit pro-inflammatory cytokines (TNFα, IL-1β) and arachidonic acid metabolism; antimicrobial and antiviral effects via NF-κB inhibition [0, 19, 0, 4].",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "",
+    "safety": "1",
+    "sideeffects": [
+      "respiratory irritation",
+      "asthmatic exacerbation",
+      "headaches at high exposure [0",
+      "19]."
+    ],
+    "contraindications": [
+      "asthma",
+      "pregnancy",
+      "respiratory disorders."
+    ],
+    "therapeutic": "smudging rituals for purification, antimicrobial, respiratory support, mental clarity [0, 19].",
+    "tags": [
+      "✅ safe",
+      "🔮 ritual",
+      "🕯️ ritual",
+      "🧠 cognitive"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "none significant documented."
+    ],
+    "toxicity": "Very low; excessive inhalation may cause dizziness or nausea [0, 4].",
+    "image": ""
+  },
+  {
+    "id": "withania-somnifera-ashwagandha",
+    "slug": "withania-somnifera-ashwagandha",
+    "common": "",
+    "scientific": "",
+    "category": "dissociative / sedative",
+    "description": "indian nightshade root that reduces stress hormones and promotes sleep.",
+    "effects": "Grounded calm;dream support",
+    "intensity": "Mild",
+    "region": "🇮🇳 india",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
+    "mechanism": "Modulates GABAergic and serotonergic activity; reduces cortisol; withanolides are primary active compounds.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "LD50 (rats, oral) ~4650 mg/kg; relatively low acute toxicity.",
+    "safety": "1",
+    "sideeffects": [
+      "gi upset",
+      "drowsiness",
+      "rare thyroid hormone changes [0",
+      "9]."
+    ],
+    "contraindications": [
+      "pregnancy",
+      "hyperthyroidism",
+      "autoimmune diseases [0",
+      "1]."
+    ],
+    "therapeutic": "adaptogen, anti-stress, anxiolytic, neuroprotective, anti-inflammatory, immune support [0, 1, 0, 17].",
+    "tags": [
+      "☕ brewable",
+      "✅ safe",
+      "🌀 dissociation",
+      "💊 oral",
+      "🧘 sedation"
+    ],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "immunosuppressants",
+      "sedatives",
+      "thyroid medications [0",
+      "24]."
+    ],
+    "toxicity": "Low; well-tolerated in clinical studies [0, 1].",
+    "image": ""
+  },
+  {
+    "id": "yerba-mat",
+    "slug": "yerba-mat",
+    "common": "",
+    "scientific": "",
+    "category": "",
+    "description": "",
+    "effects": "",
+    "intensity": "",
+    "region": "",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
+    "mechanism": "Contains caffeine, theobromine; acts as CNS stimulant by blocking adenosine receptors.",
+    "pharmacology": "",
+    "preparations": [],
+    "compounds": [],
+    "toxicity_ld50": "Caffeine LD50 ~190 mg/kg (human est.).",
+    "safety": "",
+    "sideeffects": [
+      "insomnia",
+      "jitteriness",
+      "increased heart rate."
+    ],
+    "contraindications": [
+      "heart conditions",
+      "anxiety",
+      "pregnancy (high doses)."
+    ],
+    "therapeutic": "mental alertness, energy, antioxidant support.",
+    "tags": [],
+    "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "stimulants",
+      "maois",
+      "beta-blockers."
+    ],
+    "toxicity": "",
+    "image": ""
+  },
+  {
     "id": "mescaline",
     "slug": "3-4-5-trimethoxyphenethylamine",
     "common": "",
     "scientific": "3,4,5-trimethoxyphenethylamine",
     "category": "psychedelic",
-    "subcategory": "",
-    "intensity": "Moderate",
-    "region": "🌎 americas",
-    "regiontags": [],
-    "legalstatus": "Controlled in many regions",
-    "schedule": "",
-    "legalnotes": "",
     "description": "classic phenethylamine psychedelic from peyote and san pedro cacti.",
     "effects": "Color enhancement;empathy;spiritual visions",
+    "intensity": "Moderate",
+    "region": "🌎 americas",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Controlled in many regions",
     "mechanism": "Phenethylamine psychedelic acting on 5-HT2A and dopamine receptors.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditional sacrament; studied for alcoholism and psychotherapy.",
-    "interactions": [
-      "maois and sympathomimetics may potentiate."
-    ],
-    "contraindications": [
-      "heart disease",
-      "pregnancy."
-    ],
+    "compounds": [],
+    "toxicity_ld50": ">1,000 mg/kg (rats, oral)",
+    "safety": "2",
     "sideeffects": [
       "nausea",
       "increased heart rate",
       "dilated pupils."
     ],
-    "safety": "2",
-    "toxicity": "Low physiological toxicity; psychological effects strong.",
-    "toxicity_ld50": ">1,000 mg/kg (rats, oral)",
+    "contraindications": [
+      "heart disease",
+      "pregnancy."
+    ],
+    "therapeutic": "traditional sacrament; studied for alcoholism and psychotherapy.",
     "tags": [
       "⚠️ restricted",
       "🌀 visionary",
       "💊 oral"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "maois and sympathomimetics may potentiate."
+    ],
+    "toxicity": "Low physiological toxicity; psychological effects strong.",
     "image": ""
   },
   {
@@ -48,42 +3717,45 @@
     "common": "",
     "scientific": "Acacia confusa",
     "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Strong",
-    "region": "taiwan, philippines, pacific islands",
-    "regiontags": [],
-    "legalstatus": "DMT restricted in many countries",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a taiwanese tree whose root bark is rich in dmt and related tryptamines. commonly used in diy ayahuasca analogs or 'anahuasca' brews.",
     "effects": "Visual distortion;mystical states;introspection",
+    "intensity": "Strong",
+    "region": "taiwan, philippines, pacific islands",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "DMT restricted in many countries",
     "mechanism": "DMT – 5-HT2A agonist; requires MAOI for oral activity",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "spiritual exploration, traditional cleansing (when combined with maoi)",
-    "interactions": [
-      "maois",
-      "antidepressants — risky"
-    ],
-    "contraindications": [
-      "mental health conditions",
-      "ssris/maois"
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
     "sideeffects": [
       "strong visuals",
       "nausea",
       "anxiety"
     ],
-    "safety": "",
-    "toxicity": "Low physiological, high psychological risk",
-    "toxicity_ld50": "Not established",
+    "contraindications": [
+      "mental health conditions",
+      "ssris/maois"
+    ],
+    "therapeutic": "spiritual exploration, traditional cleansing (when combined with maoi)",
     "tags": [
       "⚠️ caution",
       "🌿 root bark",
       "🧪 dmt"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "maois",
+      "antidepressants — risky"
+    ],
+    "toxicity": "Low physiological, high psychological risk",
     "image": ""
   },
   {
@@ -92,37 +3764,31 @@
     "common": "",
     "scientific": "Acacia maidenii",
     "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Strong",
-    "region": "native to eastern australia",
-    "regiontags": [],
-    "legalstatus": "DMT restricted in many countries",
-    "schedule": "",
-    "legalnotes": "",
     "description": "australian acacia tree whose bark is rich in dmt and sometimes used in ayahuasca analogues.",
     "effects": "strong visuals;mystical experience;euphoria",
+    "intensity": "Strong",
+    "region": "native to eastern australia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "DMT restricted in many countries",
     "mechanism": "Root bark contains DMT that acts as a 5‑HT2A agonist; requires MAOI inhibition for oral activity",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "DMT"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used in entheogenic brews for introspection and spiritual healing",
-    "interactions": [
-      "dangerous with maois or serotonergic drugs"
-    ],
-    "contraindications": [
-      "mental illness",
-      "maoi or ssri medication"
-    ],
+    "toxicity_ld50": "Not established",
+    "safety": "",
     "sideeffects": [
       "nausea",
       "anxiety",
       "profound alterations of perception"
     ],
-    "safety": "",
-    "toxicity": "Low physiological toxicity but intense psychological effects",
-    "toxicity_ld50": "Not established",
+    "contraindications": [
+      "mental illness",
+      "maoi or ssri medication"
+    ],
+    "therapeutic": "used in entheogenic brews for introspection and spiritual healing",
     "tags": [
       "australian",
       "dmt",
@@ -133,6 +3799,15 @@
       "PubMed ID: 21798319",
       "Trouts Notes – Acacia Alkaloid Profiles"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "dangerous with maois or serotonergic drugs"
+    ],
+    "toxicity": "Low physiological toxicity but intense psychological effects",
     "image": ""
   },
   {
@@ -141,38 +3816,31 @@
     "common": "",
     "scientific": "Achillea millefolium",
     "category": "astringent / anti-inflammatory / wound care / traditional european",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "europe, north america, temperate asia",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "named after achilles, who used it to treat battlefield wounds, yarrow is a classic herb for bleeding, inflammation, and fevers. it's used internally for digestion and externally for cuts, bruises, and nosebleeds.",
     "effects": "Wound healing;Fever reduction;Digestive support;Circulatory modulation",
+    "intensity": "Mild–Moderate",
+    "region": "europe, north america, temperate asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Rich in flavonoids, alkaloids, sesquiterpene lactones, and salicylic acid derivatives. Acts as an anti-inflammatory, astringent, and mild diaphoretic.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Thujone"
     ],
-    "preparations": [],
-    "dosage": "2-4 g dried herb",
-    "therapeutic": "used for wounds, bleeding, fevers, gi discomfort, menstrual cramps, and varicose veins. traditionally applied as poultice or tea.",
-    "interactions": [
-      "mild interactions with anticoagulants or nsaids possible.",
-      "may enhance sedatives"
+    "toxicity_ld50": "Not well established (safe in traditional use)",
+    "safety": "",
+    "sideeffects": [
+      "mild allergic reactions possible in sensitive individuals. large internal doses may upset digestion.",
+      "allergic reactions in some"
     ],
     "contraindications": [
       "avoid during pregnancy due to potential uterine stimulation. caution in ragweed-allergic individuals.",
       "pregnancy",
       "asteraceae allergy"
     ],
-    "sideeffects": [
-      "mild allergic reactions possible in sensitive individuals. large internal doses may upset digestion.",
-      "allergic reactions in some"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not well established (safe in traditional use)",
+    "therapeutic": "used for wounds, bleeding, fevers, gi discomfort, menstrual cramps, and varicose veins. traditionally applied as poultice or tea.",
     "tags": [
       "🩸 astringent",
       "🌿 wound care",
@@ -186,6 +3854,16 @@
       "British Herbal Compendium",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "2-4 g dried herb",
+    "interactions": [
+      "mild interactions with anticoagulants or nsaids possible.",
+      "may enhance sedatives"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -194,34 +3872,28 @@
     "common": "",
     "scientific": "Acmella oleracea",
     "category": "analgesic / salivary stimulant / traditional amazonian",
-    "subcategory": "",
-    "intensity": "Moderate–Strong (topical), Mild (systemic)",
-    "region": "south america, widely cultivated",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "famous for its electric tingle, spilanthes is traditionally used for dental pain, infections, and immune stimulation. its 'buzz buttons' offer a unique sensory experience and are increasingly used in mixology and herbalism.",
     "effects": "Numbing;Tingling;Salivation;Immune support",
+    "intensity": "Moderate–Strong (topical), Mild (systemic)",
+    "region": "south america, widely cultivated",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Spilanthol (an alkamide) activates TRPV1 channels, producing a tingling and numbing sensation. Also shown to enhance immune response and have antibacterial activity.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for toothache, sore throat, ulcers, immune support, dry mouth, and topical infections.",
-    "interactions": [
-      "may interact with blood pressure or cns-active drugs due to salivation and mucosal absorption."
-    ],
-    "contraindications": [
-      "avoid in pregnancy and with hypotension. may increase absorption of co-administered compounds."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Not fully established; high traditional safety margin",
+    "safety": "",
     "sideeffects": [
       "mouth tingling",
       "temporary numbness",
       "increased salivation. rare allergic reaction."
     ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not fully established; high traditional safety margin",
+    "contraindications": [
+      "avoid in pregnancy and with hypotension. may increase absorption of co-administered compounds."
+    ],
+    "therapeutic": "used for toothache, sore throat, ulcers, immune support, dry mouth, and topical infections.",
     "tags": [
       "⚡ tingling",
       "🦷 tooth pain",
@@ -233,6 +3905,15 @@
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interact with blood pressure or cns-active drugs due to salivation and mucosal absorption."
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -241,34 +3922,37 @@
     "common": "",
     "scientific": "Acorus americanus",
     "category": "ethnobotanical",
-    "subcategory": "",
-    "intensity": "",
-    "region": "north america",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "american sweet flag, native to north america, used by indigenous groups for its psychoactive and stimulant properties.",
     "effects": "alertness;mental clarity;mild euphoria",
+    "intensity": "",
+    "region": "north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "Cholinergic + dopaminergic modulation",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Alpha-asarone"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "native medicine",
       "calamus species",
       "uplifting"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -277,35 +3961,29 @@
     "common": "",
     "scientific": "Acorus calamus",
     "category": "calming / dream",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "europe, asia, north america",
-    "regiontags": [],
-    "legalstatus": "Generally legal, though some preparations restricted",
-    "schedule": "",
-    "legalnotes": "",
     "description": "fragrant wetland herb known as sweet flag; historically used for relaxation and vivid dreams.",
     "effects": "calm;mild euphoria;dream enhancement",
+    "intensity": "Mild",
+    "region": "europe, asia, north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Generally legal, though some preparations restricted",
     "mechanism": "Contains beta‑asarone which may modulate GABA and serotonin receptors",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditionally used for digestion, anxiety and divination",
-    "interactions": [
-      "potential additive effects with other sedatives"
+    "compounds": [],
+    "toxicity_ld50": "Exceeds 1 g/kg in rodents",
+    "safety": "",
+    "sideeffects": [
+      "nausea",
+      "vomiting at large doses"
     ],
     "contraindications": [
       "pregnancy",
       "high doses",
       "liver disease"
     ],
-    "sideeffects": [
-      "nausea",
-      "vomiting at large doses"
-    ],
-    "safety": "",
-    "toxicity": "Beta‑asarone may be carcinogenic in high doses",
-    "toxicity_ld50": "Exceeds 1 g/kg in rodents",
+    "therapeutic": "traditionally used for digestion, anxiety and divination",
     "tags": [
       "dream",
       "root",
@@ -317,6 +3995,15 @@
       "Botanical Safety Handbook",
       "2nd ed."
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "potential additive effects with other sedatives"
+    ],
+    "toxicity": "Beta‑asarone may be carcinogenic in high doses",
     "image": ""
   },
   {
@@ -325,34 +4012,37 @@
     "common": "",
     "scientific": "Acorus calamus var. angustatus",
     "category": "ethnobotanical",
-    "subcategory": "",
-    "intensity": "",
-    "region": "himalayas",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a rare calamus variant high in beta-asarone, used in tibetan medicine and ritual incense.",
     "effects": "trance;mental clarity;light hallucinations",
+    "intensity": "",
+    "region": "himalayas",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "GABAergic + cholinergic",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Beta-asarone"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "ritual",
       "variant",
       "aromatic stimulant"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -361,34 +4051,28 @@
     "common": "",
     "scientific": "Aegle marmelos",
     "category": "digestive / mild sedative",
-    "subcategory": "",
-    "intensity": "",
-    "region": "south asia",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "bael tree used in ayurvedic medicine for digestion and calm",
     "effects": "calm;digestive relief",
+    "intensity": "",
+    "region": "south asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Coumarins like marmelosin exhibit mild sedative and GI effects",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Marmelosin"
     ],
-    "preparations": [],
-    "dosage": "5-10 g dried fruit",
-    "therapeutic": "digestive tonic",
-    "interactions": [
-      "none significant"
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "constipation in high amounts"
     ],
     "contraindications": [
       "severe gi obstruction"
     ],
-    "sideeffects": [
-      "constipation in high amounts"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "digestive tonic",
     "tags": [
       "🌿 ayurveda",
       "🍈 fruit"
@@ -399,6 +4083,15 @@
       "2009",
       "Ayurvedic Pharmacopoeia of India"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "5-10 g dried fruit",
+    "interactions": [
+      "none significant"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -407,34 +4100,37 @@
     "common": "African Dream Root",
     "scientific": "",
     "category": "",
-    "subcategory": "",
-    "intensity": "",
-    "region": "south africa",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "",
     "effects": "lucid dreaming;dream recall;mild sedation",
+    "intensity": "",
+    "region": "south africa",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "Unknown; may influence cholinergic systems during sleep cycles.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Triterpenoid saponins"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "dream",
       "visionary",
       "african"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -443,33 +4139,27 @@
     "common": "",
     "scientific": "Albizia julibrissin",
     "category": "calming / mood",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "native to asia, cultivated elsewhere",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "often called persian silk tree; valued in asian herbalism for its tranquil and mood-brightening properties.",
     "effects": "uplifted mood;relaxation;mild sedation",
+    "intensity": "Mild",
+    "region": "native to asia, cultivated elsewhere",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Contains saponins and flavonoids thought to modulate serotonin and GABA",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditional chinese medicine uses the bark and flowers as a calming antidepressant",
-    "interactions": [
-      "may enhance other sedatives or antidepressants"
+    "compounds": [],
+    "toxicity_ld50": "Not well established",
+    "safety": "",
+    "sideeffects": [
+      "rare drowsiness in sensitive individuals"
     ],
     "contraindications": [
       "none known",
       "though caution with sedatives"
     ],
-    "sideeffects": [
-      "rare drowsiness in sensitive individuals"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not well established",
+    "therapeutic": "traditional chinese medicine uses the bark and flowers as a calming antidepressant",
     "tags": [
       "tcm",
       "anxiolytic",
@@ -482,6 +4172,15 @@
       "Journal of Ethnopharmacology",
       "2009"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may enhance other sedatives or antidepressants"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -490,35 +4189,38 @@
     "common": "Allspice",
     "scientific": "Pimenta dioica",
     "category": "ethnobotanical",
-    "subcategory": "",
-    "intensity": "",
-    "region": "caribbean, central america",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "also known as allspice, this caribbean plant has mild uplifting and warming effects, sometimes used in ritual incense.",
     "effects": "stimulant;aromatic euphoria;warming",
+    "intensity": "",
+    "region": "caribbean, central america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "GABAergic + serotonergic",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Eugenol",
       "Quercetin"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "aromatic",
       "ritual",
       "mild stimulant"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -527,35 +4229,38 @@
     "common": "",
     "scientific": "Aloysia citrodora",
     "category": "ethnobotanical",
-    "subcategory": "",
-    "intensity": "",
-    "region": "south america",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "lemon verbena, a gentle herbal tea with calming and mood-lifting effects.",
     "effects": "calm;relaxation;light euphoria",
+    "intensity": "",
+    "region": "south america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "GABAergic + serotonergic",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Citral",
       "Verbascoside"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "tea",
       "folk remedy",
       "calming"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -564,33 +4269,27 @@
     "common": "",
     "scientific": "Alpinia galanga",
     "category": "stimulant",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "indonesia, thailand, malaysia",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a common culinary spice known as galangal that offers gentle stimulation and a warming effect.",
     "effects": "warm stimulation;mild euphoria;enhanced circulation",
+    "intensity": "Mild",
+    "region": "indonesia, thailand, malaysia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Contains eugenol and cineole that increase circulation and mild CNS stimulation",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used in southeast asian medicine for digestion and fatigue",
-    "interactions": [
-      "may alter absorption of other stimulants or anticoagulants"
+    "compounds": [],
+    "toxicity_ld50": ">3 g/kg in rodents",
+    "safety": "",
+    "sideeffects": [
+      "heartburn or mild agitation at high doses"
     ],
     "contraindications": [
       "gastric ulcers",
       "anticoagulant medication"
     ],
-    "sideeffects": [
-      "heartburn or mild agitation at high doses"
-    ],
-    "safety": "",
-    "toxicity": "Generally safe as a culinary spice",
-    "toxicity_ld50": ">3 g/kg in rodents",
+    "therapeutic": "used in southeast asian medicine for digestion and fatigue",
     "tags": [
       "aromatic",
       "galangal",
@@ -601,6 +4300,15 @@
       "Phytomedicine. 2005",
       "Ayurvedic Materia Medica"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may alter absorption of other stimulants or anticoagulants"
+    ],
+    "toxicity": "Generally safe as a culinary spice",
     "image": ""
   },
   {
@@ -609,32 +4317,26 @@
     "common": "",
     "scientific": "Althaea officinalis",
     "category": "demulcent / soothing / respiratory",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "europe, middle east, north america",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a classic mucilaginous herb known for its thick, slippery root extract. marshmallow has been used for centuries to coat and soothe mucous membranes, especially in the respiratory and digestive tracts.",
     "effects": "Soothes throat;Eases cough;Reduces inflammation;Digestive calm",
+    "intensity": "Mild",
+    "region": "europe, middle east, north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "High mucilage content coats inflamed tissues, reducing irritation and inflammation. Also mildly antibacterial and immunomodulatory.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for sore throat, dry cough, gerd, stomach ulcers, and irritated urinary tract. also applied externally to wounds.",
-    "interactions": [
-      "may delay absorption of oral drugs."
+    "compounds": [],
+    "toxicity_ld50": ">5000 mg/kg (rats, oral)",
+    "safety": "",
+    "sideeffects": [
+      "very rare. may slow absorption of medications if taken simultaneously."
     ],
     "contraindications": [
       "take medications 1–2 hrs apart. avoid if allergic to other mucilaginous herbs."
     ],
-    "sideeffects": [
-      "very rare. may slow absorption of medications if taken simultaneously."
-    ],
-    "safety": "",
-    "toxicity": "Extremely low.",
-    "toxicity_ld50": ">5000 mg/kg (rats, oral)",
+    "therapeutic": "used for sore throat, dry cough, gerd, stomach ulcers, and irritated urinary tract. also applied externally to wounds.",
     "tags": [
       "🫖 soothing",
       "🫁 throat",
@@ -646,6 +4348,15 @@
       "British Herbal Compendium",
       "Herbal Medicine – Mills & Bone"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may delay absorption of oral drugs."
+    ],
+    "toxicity": "Extremely low.",
     "image": ""
   },
   {
@@ -654,37 +4365,31 @@
     "common": "",
     "scientific": "Amanita muscaria",
     "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Moderate to strong",
-    "region": "northern hemisphere, boreal forests",
-    "regiontags": [],
-    "legalstatus": "Legal in most countries",
-    "schedule": "",
-    "legalnotes": "",
     "description": "iconic red-capped mushroom used in siberian shamanism and folklore. psychoactive when properly prepared.",
     "effects": "Euphoria;dissociation;dreamlike state",
+    "intensity": "Moderate to strong",
+    "region": "northern hemisphere, boreal forests",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal in most countries",
     "mechanism": "Ibotenic acid and muscimol act as GABA agonists and NMDA antagonists after decarboxylation.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Muscimol",
       "Ibotenic Acid"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "shamanic ritual, historical analgesic and sedative use.",
-    "interactions": [
-      "potentiates sedatives and alcohol"
-    ],
-    "contraindications": [
-      "avoid with sedatives or psychiatric conditions."
-    ],
+    "toxicity_ld50": "LD50 ~38 mg/kg (muscimol, mice)",
+    "safety": "",
     "sideeffects": [
       "nausea",
       "ataxia",
       "delirium"
     ],
-    "safety": "",
-    "toxicity": "Can cause nausea, delirium, or poisoning if dose is high or raw mushrooms consumed.",
-    "toxicity_ld50": "LD50 ~38 mg/kg (muscimol, mice)",
+    "contraindications": [
+      "avoid with sedatives or psychiatric conditions."
+    ],
+    "therapeutic": "shamanic ritual, historical analgesic and sedative use.",
     "tags": [
       "⚠️ caution",
       "🍄 mushroom"
@@ -696,6 +4401,15 @@
       "2008",
       "Toxicological Profile: Muscimol & Ibotenic Acid (NIH)"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "potentiates sedatives and alcohol"
+    ],
+    "toxicity": "Can cause nausea, delirium, or poisoning if dose is high or raw mushrooms consumed.",
     "image": ""
   },
   {
@@ -704,41 +4418,44 @@
     "common": "",
     "scientific": "Amanita pantherina",
     "category": "deliriant / sedative",
-    "subcategory": "",
-    "intensity": "Strong",
-    "region": "northern hemisphere",
-    "regiontags": [],
-    "legalstatus": "Varies; unscheduled in many countries",
-    "schedule": "",
-    "legalnotes": "",
     "description": "",
     "effects": "sedation;confusion;dizziness",
+    "intensity": "Strong",
+    "region": "northern hemisphere",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Varies; unscheduled in many countries",
     "mechanism": "Contains muscimol and ibotenic acid acting on GABA receptors",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditional siberian shamanic use; rarely employed medically",
-    "interactions": [
-      "enhances effects of alcohol and sedatives"
-    ],
-    "contraindications": [
-      "mental illness",
-      "combining with other depressants"
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Not well established",
+    "safety": "",
     "sideeffects": [
       "nausea",
       "loss of coordination",
       "delirium"
     ],
-    "safety": "",
-    "toxicity": "Potentially toxic at high doses",
-    "toxicity_ld50": "Not well established",
+    "contraindications": [
+      "mental illness",
+      "combining with other depressants"
+    ],
+    "therapeutic": "traditional siberian shamanic use; rarely employed medically",
     "tags": [
       "muscimol",
       "mushroom",
       "panther cap"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "enhances effects of alcohol and sedatives"
+    ],
+    "toxicity": "Potentially toxic at high doses",
     "image": ""
   },
   {
@@ -747,34 +4464,37 @@
     "common": "",
     "scientific": "Amorpha fruticosa",
     "category": "ethnobotanical",
-    "subcategory": "",
-    "intensity": "",
-    "region": "north america",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "false indigo bush, native to north america, was historically smoked for relaxation and vision-induction.",
     "effects": "relaxation;mental softening;trance",
+    "intensity": "",
+    "region": "north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "Likely GABAergic",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Amorphigenin"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "folk",
       "smokable",
       "visionary"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -783,31 +4503,21 @@
     "common": "",
     "scientific": "Anadenanthera colubrina",
     "category": "psychedelic / entheogen",
-    "subcategory": "",
-    "intensity": "High",
-    "region": "amazon basin, andean regions of peru, brazil, colombia, venezuela",
-    "regiontags": [],
-    "legalstatus": "Bufotenine is Schedule I in the USA. Tree/seeds legal in some regions.",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a south american tree whose seeds are used to make yopo, a potent psychoactive snuff. used ritually by indigenous tribes for divination and healing.",
     "effects": "Visual hallucinations;Disorientation;Euphoria;Auditory shifts;Dissociation",
+    "intensity": "High",
+    "region": "amazon basin, andean regions of peru, brazil, colombia, venezuela",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Bufotenine is Schedule I in the USA. Tree/seeds legal in some regions.",
     "mechanism": "Contains bufotenine (5-HO-DMT), DMT, and 5-MeO-DMT. Acts as a serotonergic agonist (5-HT2A, 5-HT1A), with bufotenine producing strong visual and somatic effects when insufflated.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Bufotenine"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used traditionally for cleansing, communication with spirits, and insight. no clinical approval.",
-    "interactions": [
-      "dangerous with maois. may cause serotonin overload when mixed with ssris or other psychedelics."
-    ],
-    "contraindications": [
-      "avoid if prone to heart issues",
-      "anxiety",
-      "asthma",
-      "or psychiatric disorders."
-    ],
+    "toxicity_ld50": "Bufotenine: ~200–300 mg/kg (mice, oral)",
+    "safety": "",
     "sideeffects": [
       "strong bodily discomfort",
       "intense visual distortions",
@@ -815,9 +4525,13 @@
       "cardiovascular strain",
       "and panic are common."
     ],
-    "safety": "",
-    "toxicity": "High doses of bufotenine can cause respiratory distress. Seeds contain toxic compounds if improperly prepared.",
-    "toxicity_ld50": "Bufotenine: ~200–300 mg/kg (mice, oral)",
+    "contraindications": [
+      "avoid if prone to heart issues",
+      "anxiety",
+      "asthma",
+      "or psychiatric disorders."
+    ],
+    "therapeutic": "used traditionally for cleansing, communication with spirits, and insight. no clinical approval.",
     "tags": [
       "🌿 entheogen",
       "🌬️ snuff",
@@ -831,6 +4545,15 @@
       "1994",
       "TiHKAL by Alexander Shulgin"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "dangerous with maois. may cause serotonin overload when mixed with ssris or other psychedelics."
+    ],
+    "toxicity": "High doses of bufotenine can cause respiratory distress. Seeds contain toxic compounds if improperly prepared.",
     "image": ""
   },
   {
@@ -839,35 +4562,21 @@
     "common": "",
     "scientific": "Anadenanthera peregrina",
     "category": "psychedelic / entheogen",
-    "subcategory": "",
-    "intensity": "Very strong",
-    "region": "venezuela, brazil, caribbean, northern south america",
-    "regiontags": [],
-    "legalstatus": "Bufotenine is Schedule I in the U.S.; plant materials legal in some countries.",
-    "schedule": "",
-    "legalnotes": "",
     "description": "closely related to a. colubrina, this species is the primary source of cohoba snuff used by taino and other caribbean-amazonian tribes. extremely potent and short-acting.",
     "effects": "Intense visuals;Out-of-body experience;Altered time perception;Spiritual insight",
+    "intensity": "Very strong",
+    "region": "venezuela, brazil, caribbean, northern south america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Bufotenine is Schedule I in the U.S.; plant materials legal in some countries.",
     "mechanism": "Bufotenine (5-HO-DMT) is the dominant active; acts on 5-HT2A and 5-HT1A receptors. May also contain trace DMT and 5-MeO-DMT. Insufflated use bypasses first-pass metabolism.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Bufotenine"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditionally used for healing, communication with spirits, and divination. no modern clinical uses.",
-    "interactions": [
-      "unsafe with maois",
-      "ssris",
-      "or other tryptamines. potential for serotonin syndrome.",
-      "avoid with antidepressants or maois"
-    ],
-    "contraindications": [
-      "avoid with heart conditions",
-      "asthma",
-      "or psychiatric disorders. not for individuals with seizure history.",
-      "mental health disorders",
-      "maois"
-    ],
+    "toxicity_ld50": "Bufotenine: 200–300 mg/kg (mice, oral)",
+    "safety": "",
     "sideeffects": [
       "coughing",
       "burning in nose/throat",
@@ -877,9 +4586,14 @@
       "disorientation",
       "respiratory irritation"
     ],
-    "safety": "",
-    "toxicity": "Potentially toxic in high doses; bufotenine linked to pulmonary effects and vasoconstriction.",
-    "toxicity_ld50": "Bufotenine: 200–300 mg/kg (mice, oral)",
+    "contraindications": [
+      "avoid with heart conditions",
+      "asthma",
+      "or psychiatric disorders. not for individuals with seizure history.",
+      "mental health disorders",
+      "maois"
+    ],
+    "therapeutic": "traditionally used for healing, communication with spirits, and divination. no modern clinical uses.",
     "tags": [
       "🌬️ snuff",
       "🌀 visionary",
@@ -894,6 +4608,18 @@
       "Journal of Psychoactive Drugs",
       "1986"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "unsafe with maois",
+      "ssris",
+      "or other tryptamines. potential for serotonin syndrome.",
+      "avoid with antidepressants or maois"
+    ],
+    "toxicity": "Potentially toxic in high doses; bufotenine linked to pulmonary effects and vasoconstriction.",
     "image": ""
   },
   {
@@ -902,35 +4628,38 @@
     "common": "Anthopogon",
     "scientific": "",
     "category": "",
-    "subcategory": "",
-    "intensity": "",
-    "region": "himalayas",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "",
     "effects": "uplifting;clarity;spiritual aid",
+    "intensity": "",
+    "region": "himalayas",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "Aromatherapeutic and cognitive modulation via essential oils",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Flavonoids",
       "Volatile oils"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "uplifting",
       "ritual",
       "clarity"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -939,39 +4668,41 @@
     "common": "",
     "scientific": "Aquilaria malaccensis",
     "category": "calming / aromatic",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "southeast asia",
-    "regiontags": [],
-    "legalstatus": "Cultivation regulated due to overharvesting but use is legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "source of precious agarwood resin, producing a soothing aroma and subtle psychoactive calm when burned.",
     "effects": "tranquil mind;subtle euphoria;aromatic relaxation",
+    "intensity": "Mild",
+    "region": "southeast asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Cultivation regulated due to overharvesting but use is legal",
     "mechanism": "Resin rich in sesquiterpenes acts via GABAergic and dopaminergic pathways when inhaled",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used in traditional asian medicine and incense for calming and meditation",
-    "interactions": [
-      "unknown",
-      "likely minimal"
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "mild headache if smoke inhaled in excess"
     ],
     "contraindications": [
       "respiratory issues when inhaled heavily"
     ],
-    "sideeffects": [
-      "mild headache if smoke inhaled in excess"
-    ],
-    "safety": "",
-    "toxicity": "Considered safe in incense amounts",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "used in traditional asian medicine and incense for calming and meditation",
     "tags": [
       "agarwood",
       "incense",
       "sedative"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "likely minimal"
+    ],
+    "toxicity": "Considered safe in incense amounts",
     "image": ""
   },
   {
@@ -980,36 +4711,28 @@
     "common": "",
     "scientific": "Arctostaphylos uva-ursi",
     "category": "urinary / antiseptic / astringent",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "northern hemisphere (cool climates)",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a low-growing evergreen shrub used traditionally for urinary tract infections and kidney health. its leaves contain arbutin, which converts to hydroquinone in the bladder and acts as a urinary antiseptic.",
     "effects": "Urinary tract support;Astringent;Anti-inflammatory;Antibacterial",
+    "intensity": "Mild–Moderate",
+    "region": "northern hemisphere (cool climates)",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Arbutin is hydrolyzed into hydroquinone in the urinary tract, which exerts antimicrobial activity. Tannins also provide astringent effects to mucous membranes.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for cystitis, urethritis, bladder infections, and general urinary tract irritation. often used in short-term protocols.",
-    "interactions": [
-      "may interact with diuretics",
-      "nsaids",
-      "or acidic drugs. requires alkaline urine for efficacy."
+    "compounds": [],
+    "toxicity_ld50": "Hydroquinone ~300 mg/kg (rat, oral)",
+    "safety": "",
+    "sideeffects": [
+      "mild nausea or gi discomfort. prolonged use may irritate the liver or kidneys due to hydroquinone."
     ],
     "contraindications": [
       "avoid during pregnancy",
       "in children",
       "or for long-term use. not with kidney disease."
     ],
-    "sideeffects": [
-      "mild nausea or gi discomfort. prolonged use may irritate the liver or kidneys due to hydroquinone."
-    ],
-    "safety": "",
-    "toxicity": "Low to moderate. Hydroquinone may be toxic in high doses or long-term use.",
-    "toxicity_ld50": "Hydroquinone ~300 mg/kg (rat, oral)",
+    "therapeutic": "used for cystitis, urethritis, bladder infections, and general urinary tract irritation. often used in short-term protocols.",
     "tags": [
       "🧴 antiseptic",
       "🧽 astringent",
@@ -1021,6 +4744,17 @@
       "Herbal Medicine – Mills & Bone",
       "ESCOP Monographs"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interact with diuretics",
+      "nsaids",
+      "or acidic drugs. requires alkaline urine for efficacy."
+    ],
+    "toxicity": "Low to moderate. Hydroquinone may be toxic in high doses or long-term use.",
     "image": ""
   },
   {
@@ -1029,37 +4763,40 @@
     "common": "",
     "scientific": "Areca catechu",
     "category": "empathogen / euphoriant",
-    "subcategory": "",
-    "intensity": "",
-    "region": "south and southeast asia",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a widely used masticatory stimulant in asia and the pacific, often combined with lime and betel leaf.",
     "effects": "Stimulation;warmth;mild euphoria",
+    "intensity": "",
+    "region": "south and southeast asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "Arecoline acts as a muscarinic cholinergic agonist",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditional digestive stimulant",
-    "interactions": [
-      "stimulants",
-      "parasympathomimetics"
+    "compounds": [],
+    "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [
+      "addiction",
+      "oral cancer with chronic use"
     ],
     "contraindications": [
       "pregnancy",
       "cardiovascular conditions"
     ],
-    "sideeffects": [
-      "addiction",
-      "oral cancer with chronic use"
-    ],
-    "safety": "",
-    "toxicity": "",
-    "toxicity_ld50": "",
+    "therapeutic": "traditional digestive stimulant",
     "tags": [],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "stimulants",
+      "parasympathomimetics"
+    ],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -1068,42 +4805,45 @@
     "common": "",
     "scientific": "Argemone mexicana",
     "category": "sedative / analgesic",
-    "subcategory": "",
-    "intensity": "Moderate",
-    "region": "native to tropical america; naturalized worldwide",
-    "regiontags": [],
-    "legalstatus": "Legal but sometimes regulated due to toxicity",
-    "schedule": "",
-    "legalnotes": "",
     "description": "spiny yellow poppy whose milky latex was historically used for pain relief and sedation.",
     "effects": "relaxation;analgesia;slight euphoria",
+    "intensity": "Moderate",
+    "region": "native to tropical america; naturalized worldwide",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal but sometimes regulated due to toxicity",
     "mechanism": "Isoquinoline alkaloids interact with opioid and dopamine receptors",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "mexican and ayurvedic traditions use it for pain, insomnia and mild narcotic effects",
-    "interactions": [
-      "avoid combining with alcohol or other depressants"
+    "compounds": [],
+    "toxicity_ld50": "Not well quantified",
+    "safety": "",
+    "sideeffects": [
+      "headache",
+      "stomach upset",
+      "potential liver damage"
     ],
     "contraindications": [
       "liver disorders",
       "pregnancy",
       "high doses"
     ],
-    "sideeffects": [
-      "headache",
-      "stomach upset",
-      "potential liver damage"
-    ],
-    "safety": "",
-    "toxicity": "Seeds and latex can be hepatotoxic in high doses",
-    "toxicity_ld50": "Not well quantified",
+    "therapeutic": "mexican and ayurvedic traditions use it for pain, insomnia and mild narcotic effects",
     "tags": [
       "alkaloid",
       "folk medicine",
       "poppy"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "avoid combining with alcohol or other depressants"
+    ],
+    "toxicity": "Seeds and latex can be hepatotoxic in high doses",
     "image": ""
   },
   {
@@ -1112,35 +4852,29 @@
     "common": "",
     "scientific": "Argyreia speciosa",
     "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Moderate to Strong",
-    "region": "india and southeast asia",
-    "regiontags": [],
-    "legalstatus": "Seeds legal though extraction of LSA may be restricted",
-    "schedule": "",
-    "legalnotes": "",
     "description": "close relative of hawaiian baby woodrose with lsa‑containing seeds used in some indian traditions.",
     "effects": "closed-eye visuals;euphoria;enhanced introspection",
+    "intensity": "Moderate to Strong",
+    "region": "india and southeast asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Seeds legal though extraction of LSA may be restricted",
     "mechanism": "Seeds contain lysergic acid amide (LSA) acting on serotonin receptors",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "occasionally used in ayurveda as a tonic and for spiritual rituals",
-    "interactions": [
-      "avoid with other serotonergic agents"
-    ],
-    "contraindications": [
-      "pregnancy",
-      "mental health disorders"
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
     "sideeffects": [
       "nausea",
       "vasoconstriction",
       "drowsiness"
     ],
-    "safety": "",
-    "toxicity": "Nausea common; large doses may be hepatotoxic",
-    "toxicity_ld50": "Not established",
+    "contraindications": [
+      "pregnancy",
+      "mental health disorders"
+    ],
+    "therapeutic": "occasionally used in ayurveda as a tonic and for spiritual rituals",
     "tags": [
       "indian morning glory",
       "lsa",
@@ -1152,6 +4886,15 @@
       "Journal of Ethnopharmacology",
       "2001"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "avoid with other serotonergic agents"
+    ],
+    "toxicity": "Nausea common; large doses may be hepatotoxic",
     "image": ""
   },
   {
@@ -1160,35 +4903,38 @@
     "common": "",
     "scientific": "Artemisia abrotanum",
     "category": "ethnobotanical",
-    "subcategory": "",
-    "intensity": "",
-    "region": "mediterranean, europe",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "southernwood is a fragrant herb used traditionally as a stimulant, memory aid, and dream enhancer.",
     "effects": "mental clarity;dream enhancement;stimulant",
+    "intensity": "",
+    "region": "mediterranean, europe",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "GABAergic + cholinergic modulation",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Camphor",
       "Thujone"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "aromatic",
       "folk remedy",
       "uplifting"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -1197,35 +4943,38 @@
     "common": "",
     "scientific": "Artemisia ludoviciana",
     "category": "ethnobotanical",
-    "subcategory": "",
-    "intensity": "",
-    "region": "north america",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "also known as white sagebrush, used by native american tribes for cleansing, dreams, and mild sedation.",
     "effects": "mild sedation;visionary;cleansing",
+    "intensity": "",
+    "region": "north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "GABAergic + anticholinergic",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Thujone",
       "Camphor"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "ritual",
       "dream",
       "folk medicine"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -1234,34 +4983,26 @@
     "common": "",
     "scientific": "Artemisia vulgaris",
     "category": "dream herb / digestive / traditional witchcraft",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "europe, north america, asia",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide (restricted in some for thujone)",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a classic european herb of the witches and dreamers. mugwort is used for enhancing dreams, calming digestion, and connecting to inner visions. often burned or used in dream pillows or teas.",
     "effects": "Lucid dreaming;Menstrual regulation;Mild sedation;Bitter tonic",
+    "intensity": "Mild–Moderate",
+    "region": "europe, north america, asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide (restricted in some for thujone)",
     "mechanism": "Contains thujone, camphor, and cineole — which mildly affect GABA receptors and CNS function. Also acts as a bitter digestive and mild uterine tonic.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for dreamwork, menstruation regulation, cramping, bloating, and spiritual practices.",
-    "interactions": [
-      "may interact with sedatives",
-      "antiepileptics",
-      "or other bitter herbs."
+    "compounds": [],
+    "toxicity_ld50": "~120 mg/kg (thujone, rats)",
+    "safety": "",
+    "sideeffects": [
+      "may cause nausea or dizziness. thujone-related toxicity at high doses or in essential oil form."
     ],
     "contraindications": [
       "avoid during pregnancy. caution with epilepsy or thujone sensitivity."
     ],
-    "sideeffects": [
-      "may cause nausea or dizziness. thujone-related toxicity at high doses or in essential oil form."
-    ],
-    "safety": "",
-    "toxicity": "Low at traditional use levels. Essential oil is toxic if ingested.",
-    "toxicity_ld50": "~120 mg/kg (thujone, rats)",
+    "therapeutic": "used for dreamwork, menstruation regulation, cramping, bloating, and spiritual practices.",
     "tags": [
       "🌙 dream herb",
       "🩸 menstrual",
@@ -1273,6 +5014,17 @@
       "Plants of the Gods – Rätsch",
       "British Herbal Pharmacopoeia"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interact with sedatives",
+      "antiepileptics",
+      "or other bitter herbs."
+    ],
+    "toxicity": "Low at traditional use levels. Essential oil is toxic if ingested.",
     "image": ""
   },
   {
@@ -1281,28 +5033,19 @@
     "common": "",
     "scientific": "Arundo donax",
     "category": "psychoactive (trace tryptamines)",
-    "subcategory": "",
-    "intensity": "Minimal or none (unless potentiated with MAOIs)",
-    "region": "mediterranean, asia, naturalized worldwide",
-    "regiontags": [],
-    "legalstatus": "Legal as an ornamental and biomass plant; some components (e.g., DMT) may be restricted in purified form.",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a large reed grass native to asia and the mediterranean. it has been occasionally referenced as a possible tryptamine source, but psychoactive effects are not reliably established.",
     "effects": "Unverified hallucinations;Mild sedation;Traditionally visionary (claimed)",
+    "intensity": "Minimal or none (unless potentiated with MAOIs)",
+    "region": "mediterranean, asia, naturalized worldwide",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal as an ornamental and biomass plant; some components (e.g., DMT) may be restricted in purified form.",
     "mechanism": "Alkaloid content includes DMT, bufotenine, and gramine in trace amounts. Psychoactivity is speculative and likely inactive without MAOIs.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "none clinically confirmed. mentioned in some obscure entheogenic literature as a potential visionary aid.",
-    "interactions": [
-      "dangerous with maois or serotonergic drugs due to alkaloid unpredictability.",
-      "maois"
-    ],
-    "contraindications": [
-      "avoid use due to gramine toxicity. not a recommended dmt source.",
-      "limited data"
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Gramine: 45–60 mg/kg (mice, intraperitoneal)",
+    "safety": "",
     "sideeffects": [
       "gramine is toxic",
       "may cause nausea",
@@ -1310,9 +5053,11 @@
       "or hypotension. no established safety profile.",
       "nausea"
     ],
-    "safety": "",
-    "toxicity": "Gramine is toxic and can affect neuromuscular function and blood pressure.",
-    "toxicity_ld50": "Gramine: 45–60 mg/kg (mice, intraperitoneal)",
+    "contraindications": [
+      "avoid use due to gramine toxicity. not a recommended dmt source.",
+      "limited data"
+    ],
+    "therapeutic": "none clinically confirmed. mentioned in some obscure entheogenic literature as a potential visionary aid.",
     "tags": [
       "🌾 reed",
       "⚠️ gramine-toxicity",
@@ -1324,6 +5069,16 @@
       "Trout’s Notes on Some Other Ayahuasca Analog Plants",
       "PubChem CID: 442018 (gramine)"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "dangerous with maois or serotonergic drugs due to alkaloid unpredictability.",
+      "maois"
+    ],
+    "toxicity": "Gramine is toxic and can affect neuromuscular function and blood pressure.",
     "image": ""
   },
   {
@@ -1332,36 +5087,30 @@
     "common": "",
     "scientific": "Asarum canadense",
     "category": "medicinal / aromatic",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "eastern north america",
-    "regiontags": [],
-    "legalstatus": "Legal; use restricted in commercial food products due to safrole",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a north american woodland herb known as wild ginger. while unrelated to true ginger, its rhizome has a pungent, spicy aroma and has been used traditionally by indigenous peoples as a digestive aid and warming tonic.",
     "effects": "Warming;Digestive stimulant;Mild sedation;Aromatic",
+    "intensity": "Mild",
+    "region": "eastern north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal; use restricted in commercial food products due to safrole",
     "mechanism": "Contains volatile oils (e.g. methyl eugenol, safrole) that may stimulate digestive enzymes and act as mild CNS modulators. Safrole is a weak psychoactive and hepatotoxic compound.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditionally used for colds, coughs, indigestion, menstrual discomfort, and as an emetic in high doses.",
-    "interactions": [
-      "may interfere with liver-metabolized drugs (cyp450 pathway). avoid combining with hepatotoxic herbs or medications."
+    "compounds": [],
+    "toxicity_ld50": "Safrole: ~1950 mg/kg (rats, oral)",
+    "safety": "",
+    "sideeffects": [
+      "high doses may cause nausea",
+      "vomiting",
+      "or liver stress due to safrole content. some individuals may experience allergic reactions."
     ],
     "contraindications": [
       "avoid during pregnancy",
       "liver disease",
       "or prolonged use. not recommended for large or chronic dosing."
     ],
-    "sideeffects": [
-      "high doses may cause nausea",
-      "vomiting",
-      "or liver stress due to safrole content. some individuals may experience allergic reactions."
-    ],
-    "safety": "",
-    "toxicity": "Contains safrole, a known hepatocarcinogen in high doses. Rarely toxic acutely, but long-term use may pose risk.",
-    "toxicity_ld50": "Safrole: ~1950 mg/kg (rats, oral)",
+    "therapeutic": "traditionally used for colds, coughs, indigestion, menstrual discomfort, and as an emetic in high doses.",
     "tags": [
       "🌿 rhizome",
       "🌶️ aromatic",
@@ -1373,6 +5122,15 @@
       "Herbal Medicine: Expanded Commission E Monographs",
       "PubChem CID: 8467 (safrole)"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interfere with liver-metabolized drugs (cyp450 pathway). avoid combining with hepatotoxic herbs or medications."
+    ],
+    "toxicity": "Contains safrole, a known hepatocarcinogen in high doses. Rarely toxic acutely, but long-term use may pose risk.",
     "image": ""
   },
   {
@@ -1381,30 +5139,19 @@
     "common": "",
     "scientific": "Asclepias syriaca",
     "category": "medicinal / toxic",
-    "subcategory": "",
-    "intensity": "Mild (subtoxic dose) to Dangerous",
-    "region": "eastern and central north america",
-    "regiontags": [],
-    "legalstatus": "Legal (not scheduled); some states advise caution with ingestion",
-    "schedule": "",
-    "legalnotes": "",
     "description": "common milkweed is a native north american plant traditionally used by indigenous peoples for treating warts, respiratory issues, and digestive complaints. however, it contains toxic cardiac glycosides.",
     "effects": "Mild sedation;Cardiac influence;Anti-inflammatory",
+    "intensity": "Mild (subtoxic dose) to Dangerous",
+    "region": "eastern and central north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal (not scheduled); some states advise caution with ingestion",
     "mechanism": "Contains cardenolides (e.g., syriogenin) that affect cardiac muscle contractility by inhibiting Na+/K+-ATPase, similar to digoxin.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "historically used for lung and bronchial infections, warts, constipation, and as an emetic. very limited modern therapeutic use due to toxicity.",
-    "interactions": [
-      "may dangerously amplify effects of digoxin",
-      "beta-blockers",
-      "or diuretics."
-    ],
-    "contraindications": [
-      "should not be used with heart disease",
-      "diuretics",
-      "or digitalis compounds. toxic in excess."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Estimated 75–150 mg/kg (mice, cardiac glycosides)",
+    "safety": "",
     "sideeffects": [
       "nausea",
       "vomiting",
@@ -1412,9 +5159,12 @@
       "bradycardia",
       "or arrhythmia at high doses. skin irritation from sap."
     ],
-    "safety": "",
-    "toxicity": "Moderate to high; all parts of the plant can be toxic, especially latex sap and immature pods.",
-    "toxicity_ld50": "Estimated 75–150 mg/kg (mice, cardiac glycosides)",
+    "contraindications": [
+      "should not be used with heart disease",
+      "diuretics",
+      "or digitalis compounds. toxic in excess."
+    ],
+    "therapeutic": "historically used for lung and bronchial infections, warts, constipation, and as an emetic. very limited modern therapeutic use due to toxicity.",
     "tags": [
       "🌱 milkweed",
       "⚠️ cardiotoxic",
@@ -1426,6 +5176,17 @@
       "HerbalGram. 2004",
       "(63): 34–45."
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may dangerously amplify effects of digoxin",
+      "beta-blockers",
+      "or diuretics."
+    ],
+    "toxicity": "Moderate to high; all parts of the plant can be toxic, especially latex sap and immature pods.",
     "image": ""
   },
   {
@@ -1434,32 +5195,26 @@
     "common": "",
     "scientific": "Avena sativa",
     "category": "nervine / tonic",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "temperate regions globally (native to europe and southwest asia)",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "common oats, when harvested as milky green tops or dried straw, are used as a gentle nervine tonic in western herbalism. renowned for its restorative effects on the nervous system and libido.",
     "effects": "Mild euphoria;Anxiolytic;Nourishing tonic;Cognitive support",
+    "intensity": "Mild",
+    "region": "temperate regions globally (native to europe and southwest asia)",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Contains avenanthramides (antioxidants), saponins, alkaloids, and B vitamins. May modulate GABAergic tone and reduce inflammation in the nervous system.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for fatigue, nervous exhaustion, stress, sexual debility, and neuroinflammation. traditionally seen as a long-term restorative.",
-    "interactions": [
-      "none significant reported. may synergize gently with other nervines or antidepressants."
+    "compounds": [],
+    "toxicity_ld50": "No known LD50 in humans or animals for oat preparations",
+    "safety": "",
+    "sideeffects": [
+      "very well tolerated. rare allergy to oat proteins in sensitive individuals."
     ],
     "contraindications": [
       "caution with gluten intolerance or autoimmune sensitivity to oats (though oats are naturally gluten-free)."
     ],
-    "sideeffects": [
-      "very well tolerated. rare allergy to oat proteins in sensitive individuals."
-    ],
-    "safety": "",
-    "toxicity": "Very low. Considered one of the safest tonic herbs.",
-    "toxicity_ld50": "No known LD50 in humans or animals for oat preparations",
+    "therapeutic": "used for fatigue, nervous exhaustion, stress, sexual debility, and neuroinflammation. traditionally seen as a long-term restorative.",
     "tags": [
       "🌾 nervine",
       "🧠 cognitive support",
@@ -1471,6 +5226,15 @@
       "Medical Herbalism – David Hoffmann",
       "The Earthwise Herbal – Matthew Wood"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "none significant reported. may synergize gently with other nervines or antidepressants."
+    ],
+    "toxicity": "Very low. Considered one of the safest tonic herbs.",
     "image": ""
   },
   {
@@ -1479,46 +5243,49 @@
     "common": "Aztec Tobacco",
     "scientific": "Nicotiana rustica",
     "category": "stimulant / ritual",
-    "subcategory": "",
-    "intensity": "Strong",
-    "region": "south america and worldwide cultivation",
-    "regiontags": [],
-    "legalstatus": "Legal but regulated like tobacco",
-    "schedule": "",
-    "legalnotes": "",
     "description": "potent tobacco species used ceremonially in the amazon, far stronger than common n. tabacum.",
     "effects": "alertness;intense buzz;clearing of thoughts",
+    "intensity": "Strong",
+    "region": "south america and worldwide cultivation",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal but regulated like tobacco",
     "mechanism": "High nicotine plus MAO‑inhibiting beta‑carbolines stimulate nicotinic receptors and inhibit MAO",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Nicotine",
       "Harmala alkaloids"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used by amazonian shamans for cleansing and focus",
-    "interactions": [
-      "strongly potentiated by maois",
-      "interacts with many medications"
+    "toxicity_ld50": "Nicotine LD50 ~50 mg/kg (mouse)",
+    "safety": "",
+    "sideeffects": [
+      "nausea",
+      "increased heart rate",
+      "dizziness"
     ],
     "contraindications": [
       "heart disease",
       "pregnancy",
       "hypertension"
     ],
-    "sideeffects": [
-      "nausea",
-      "increased heart rate",
-      "dizziness"
-    ],
-    "safety": "",
-    "toxicity": "High nicotine content can be poisonous in large amounts",
-    "toxicity_ld50": "Nicotine LD50 ~50 mg/kg (mouse)",
+    "therapeutic": "used by amazonian shamans for cleansing and focus",
     "tags": [
       "mapacho",
       "nicotine",
       "tobacco"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "strongly potentiated by maois",
+      "interacts with many medications"
+    ],
+    "toxicity": "High nicotine content can be poisonous in large amounts",
     "image": ""
   },
   {
@@ -1527,25 +5294,27 @@
     "common": "",
     "scientific": "Banisteriopsis caapi",
     "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Moderate to profound (when combined)",
-    "region": "amazon basin: peru, brazil, colombia",
-    "regiontags": [],
-    "legalstatus": "Plant is legal in many countries; brews may be scheduled depending on DMT laws",
-    "schedule": "",
-    "legalnotes": "",
     "description": "the primary vine used in the sacred amazonian brew ayahuasca. contains harmala alkaloids that inhibit mao, enabling oral activation of dmt. revered as the 'vine of the soul' in indigenous ceremonies.",
     "effects": "MAOI potentiation;Euphoria;Emotional release;Dreamlike states",
+    "intensity": "Moderate to profound (when combined)",
+    "region": "amazon basin: peru, brazil, colombia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Plant is legal in many countries; brews may be scheduled depending on DMT laws",
     "mechanism": "Contains harmine, harmaline, and tetrahydroharmine — reversible MAO-A inhibitors that also modulate serotonin and dopamine activity.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Harmine"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for trauma, addiction, depression, and spiritual exploration (in ceremonial or clinical settings). being studied for neurogenesis.",
-    "interactions": [
-      "major interaction risk with serotonergic agents. see maoi interaction lists.",
-      "all serotonergic substances"
+    "toxicity_ld50": "Harmine LD50: ~500–750 mg/kg (rats, oral)",
+    "safety": "",
+    "sideeffects": [
+      "nausea",
+      "vomiting (purge)",
+      "dizziness",
+      "emotional catharsis. rarely: serotonin syndrome if combined with contraindicated drugs.",
+      "purging"
     ],
     "contraindications": [
       "do not combine with ssris",
@@ -1556,16 +5325,7 @@
       "maois",
       "pregnancy"
     ],
-    "sideeffects": [
-      "nausea",
-      "vomiting (purge)",
-      "dizziness",
-      "emotional catharsis. rarely: serotonin syndrome if combined with contraindicated drugs.",
-      "purging"
-    ],
-    "safety": "",
-    "toxicity": "Low when used alone. Overdose with other drugs can be fatal.",
-    "toxicity_ld50": "Harmine LD50: ~500–750 mg/kg (rats, oral)",
+    "therapeutic": "used for trauma, addiction, depression, and spiritual exploration (in ceremonial or clinical settings). being studied for neurogenesis.",
     "tags": [
       "🌿 vine",
       "🧠 maoi",
@@ -1578,6 +5338,16 @@
       "2010",
       "MAPS Ayahuasca Research Summary"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "major interaction risk with serotonergic agents. see maoi interaction lists.",
+      "all serotonergic substances"
+    ],
+    "toxicity": "Low when used alone. Overdose with other drugs can be fatal.",
     "image": ""
   },
   {
@@ -1586,44 +5356,47 @@
     "common": "Bechette",
     "scientific": "Tabernaemontana undulata",
     "category": "analgesic / visionary",
-    "subcategory": "",
-    "intensity": "Moderate to Strong",
-    "region": "western amazon",
-    "regiontags": [],
-    "legalstatus": "Mostly legal but little researched",
-    "schedule": "",
-    "legalnotes": "",
     "description": "also called uchu sanango; this rare shrub contains iboga-like compounds and is used in shamanic practices.",
     "effects": "tingling sensation;dream enhancement;altered perception",
+    "intensity": "Moderate to Strong",
+    "region": "western amazon",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Mostly legal but little researched",
     "mechanism": "Contains iboga-type alkaloids affecting serotonin and NMDA receptors",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Voacangine"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "amazonian tribes use the bark for hunting preparation and pain",
-    "interactions": [
-      "avoid with other serotonergic or stimulant substances"
+    "toxicity_ld50": "Not well known",
+    "safety": "",
+    "sideeffects": [
+      "nausea",
+      "numbness",
+      "dizziness"
     ],
     "contraindications": [
       "heart problems",
       "pregnancy",
       "mental illness"
     ],
-    "sideeffects": [
-      "nausea",
-      "numbness",
-      "dizziness"
-    ],
-    "safety": "",
-    "toxicity": "High doses may be neurotoxic or cardiotoxic",
-    "toxicity_ld50": "Not well known",
+    "therapeutic": "amazonian tribes use the bark for hunting preparation and pain",
     "tags": [
       "amazon",
       "uchu sanango",
       "iboga alkaloids"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "avoid with other serotonergic or stimulant substances"
+    ],
+    "toxicity": "High doses may be neurotoxic or cardiotoxic",
     "image": ""
   },
   {
@@ -1632,34 +5405,37 @@
     "common": "",
     "scientific": "Betula lenta",
     "category": "ethnobotanical",
-    "subcategory": "",
-    "intensity": "",
-    "region": "north america",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "sweet birch, aromatic and uplifting; contains methyl salicylate, offering mild euphoria and clarity.",
     "effects": "uplifting;mental clarity;aromatic",
+    "intensity": "",
+    "region": "north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "Anti-inflammatory + mild serotonergic",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Methyl salicylate"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "tea",
       "uplifting",
       "aromatic"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -1668,33 +5444,22 @@
     "common": "Blue Lotus",
     "scientific": "Nymphaea caerulea",
     "category": "euphoric / sedative / sacred",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "nile valley, india, southeast asia",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide (restricted in some US states for sale)",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a sacred egyptian flower revered for inducing relaxed, blissful states. often soaked in wine or tea, blue lotus produces a dreamy calm and has been symbolically associated with rebirth, the sun, and divine union.",
     "effects": "Euphoria;Tranquility;Mild visuals;Dream enhancement",
+    "intensity": "Mild–Moderate",
+    "region": "nile valley, india, southeast asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide (restricted in some US states for sale)",
     "mechanism": "Contains aporphine alkaloids (especially nuciferine) which act as dopamine receptor agonists and serotonin receptor modulators. Also binds GABA receptors slightly.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Aporphine",
       "Nuciferine"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used traditionally for anxiety, libido enhancement, meditation, lucid dreaming, and as a ceremonial aphrodisiac.",
-    "interactions": [
-      "avoid sedatives",
-      "potentiates sedatives",
-      "alcohol",
-      "and maois. caution advised with ssris."
-    ],
-    "contraindications": [
-      "pregnancy",
-      "avoid with sedatives or psychiatric conditions. unknown effects in pregnancy."
-    ],
+    "toxicity_ld50": "Not well established; assumed low",
+    "safety": "",
     "sideeffects": [
       "mild drowsiness",
       "vivid dreams",
@@ -1702,9 +5467,11 @@
       "drowsiness",
       "nausea in high doses. can cause lethargy or vivid dreams."
     ],
-    "safety": "",
-    "toxicity": "Low in moderate doses. Safe historically but limited modern study.",
-    "toxicity_ld50": "Not well established; assumed low",
+    "contraindications": [
+      "pregnancy",
+      "avoid with sedatives or psychiatric conditions. unknown effects in pregnancy."
+    ],
+    "therapeutic": "used traditionally for anxiety, libido enhancement, meditation, lucid dreaming, and as a ceremonial aphrodisiac.",
     "tags": [
       "✅ safe",
       "🌸 calm",
@@ -1719,6 +5486,18 @@
       "Plants of the Gods – Rätsch",
       "Journal of Psychoactive Herbs – 2009"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "avoid sedatives",
+      "potentiates sedatives",
+      "alcohol",
+      "and maois. caution advised with ssris."
+    ],
+    "toxicity": "Low in moderate doses. Safe historically but limited modern study.",
     "image": ""
   },
   {
@@ -1727,45 +5506,48 @@
     "common": "Blue Skullcap",
     "scientific": "Scutellaria lateriflora",
     "category": "dissociative / sedative",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "north america",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "commonly known as skullcap, this north american herb has a long history in western herbalism for treating nervous tension and insomnia.",
     "effects": "Mild sedation;anxiety relief;mental clarity",
+    "intensity": "Mild",
+    "region": "north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "GABA_A receptor modulation (baicalin and other flavonoids)",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Baicalin",
       "Scutellarin"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "anxiety, stress, insomnia, pms",
-    "interactions": [
-      "cns depressants",
-      "alcohol",
-      "benzodiazepines"
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "drowsiness",
+      "dizziness at high doses"
     ],
     "contraindications": [
       "pregnancy",
       "cns depressants"
     ],
-    "sideeffects": [
-      "drowsiness",
-      "dizziness at high doses"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "anxiety, stress, insomnia, pms",
     "tags": [
       "✅ safe",
       "🌿 herbal",
       "😴 sedative"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "cns depressants",
+      "alcohol",
+      "benzodiazepines"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -1774,33 +5556,19 @@
     "common": "",
     "scientific": "Brugmansia suaveolens",
     "category": "deliriant / tropane alkaloid",
-    "subcategory": "",
-    "intensity": "Severe / Overwhelming",
-    "region": "south america; cultivated ornamentally worldwide",
-    "regiontags": [],
-    "legalstatus": "Legal in most countries; some restrictions due to risk",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a powerful ornamental tree with large trumpet-shaped flowers. brugmansia is traditionally used in south american shamanism but is highly toxic. its alkaloids cause intense deliriant experiences often indistinguishable from waking reality.",
     "effects": "True hallucinations;Amnesia;Delirium;Sedation",
+    "intensity": "Severe / Overwhelming",
+    "region": "south america; cultivated ornamentally worldwide",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal in most countries; some restrictions due to risk",
     "mechanism": "Contains tropane alkaloids: scopolamine, atropine, and hyoscyamine. These are anticholinergic, blocking muscarinic acetylcholine receptors.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "none officially sanctioned. occasionally explored for dream states or initiatory visions in traditional contexts.",
-    "interactions": [
-      "anticholinergics",
-      "cns depressants",
-      "highly dangerous with sedatives",
-      "stimulants",
-      "or other anticholinergics."
-    ],
-    "contraindications": [
-      "all unsupervised use",
-      "never safe recreationally. dangerous for anyone with cardiovascular",
-      "neurological",
-      "or psychiatric conditions."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Scopolamine: ~400 mg/kg (rats, oral)",
+    "safety": "",
     "sideeffects": [
       "extreme confusion",
       "memory loss",
@@ -1813,9 +5581,13 @@
       "inability to distinguish reality",
       "long-term memory gaps."
     ],
-    "safety": "",
-    "toxicity": "Extremely toxic. Even a few flower petals can induce hospitalization. Death has occurred from unmeasured ingestion.",
-    "toxicity_ld50": "Scopolamine: ~400 mg/kg (rats, oral)",
+    "contraindications": [
+      "all unsupervised use",
+      "never safe recreationally. dangerous for anyone with cardiovascular",
+      "neurological",
+      "or psychiatric conditions."
+    ],
+    "therapeutic": "none officially sanctioned. occasionally explored for dream states or initiatory visions in traditional contexts.",
     "tags": [
       "🌸 tropane",
       "⚠️ toxic",
@@ -1828,6 +5600,19 @@
       "Journal of Ethnopharmacology",
       "2001"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "anticholinergics",
+      "cns depressants",
+      "highly dangerous with sedatives",
+      "stimulants",
+      "or other anticholinergics."
+    ],
+    "toxicity": "Extremely toxic. Even a few flower petals can induce hospitalization. Death has occurred from unmeasured ingestion.",
     "image": ""
   },
   {
@@ -1836,28 +5621,19 @@
     "common": "",
     "scientific": "Brunfelsia grandiflora",
     "category": "shamanic / tropane-like",
-    "subcategory": "",
-    "intensity": "Moderate–Strong",
-    "region": "amazon (peru, ecuador, colombia)",
-    "regiontags": [],
-    "legalstatus": "Legal; not scheduled internationally",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a powerful and rare plant used in amazonian diets and initiations. sometimes used in conjunction with ayahuasca. it contains alkaloids structurally similar to tropanes but with unique visionary effects.",
     "effects": "Altered perception;Hallucinations;Sedation;Purging",
+    "intensity": "Moderate–Strong",
+    "region": "amazon (peru, ecuador, colombia)",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal; not scheduled internationally",
     "mechanism": "Believed to contain scopoletin, brunfelsamidine, and possibly tropane-like alkaloids. Effects include CNS sedation and GABAergic modulation, with visionary experiences at high doses.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for energetic cleansing, dream incubation, and emotional healing in vegetalismo traditions. no clinical use.",
-    "interactions": [
-      "dangerous with deliriants or gabaergic drugs. may interfere with maois or ssris."
-    ],
-    "contraindications": [
-      "avoid with other cns depressants",
-      "anticholinergics",
-      "or in pregnancy. not for casual or recreational use."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Not established; presumed low threshold for toxicity",
+    "safety": "",
     "sideeffects": [
       "strong purge",
       "nausea",
@@ -1865,9 +5641,12 @@
       "tremors",
       "and temporary disorientation. possibly neurotoxic at high doses."
     ],
-    "safety": "",
-    "toxicity": "Potential neurotoxicity from tropane-like compounds. Improper use can lead to hospitalization.",
-    "toxicity_ld50": "Not established; presumed low threshold for toxicity",
+    "contraindications": [
+      "avoid with other cns depressants",
+      "anticholinergics",
+      "or in pregnancy. not for casual or recreational use."
+    ],
+    "therapeutic": "used for energetic cleansing, dream incubation, and emotional healing in vegetalismo traditions. no clinical use.",
     "tags": [
       "🌀 dreamwork",
       "⚠️ tropane risk",
@@ -1880,6 +5659,15 @@
       "Hofmann",
       "Ayahuasca.com: Chiric Sanango Field Reports"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "dangerous with deliriants or gabaergic drugs. may interfere with maois or ssris."
+    ],
+    "toxicity": "Potential neurotoxicity from tropane-like compounds. Improper use can lead to hospitalization.",
     "image": ""
   },
   {
@@ -1888,43 +5676,46 @@
     "common": "Butterbur",
     "scientific": "Petasites hybridus",
     "category": "dissociative / sedative",
-    "subcategory": "",
-    "intensity": "Mild to moderate",
-    "region": "europe, asia",
-    "regiontags": [],
-    "legalstatus": "Legal with restrictions (PA-free only)",
-    "schedule": "",
-    "legalnotes": "",
     "description": "also known as butterbur, this european root was historically used as a remedy for migraines and spasms. contains pyrrolizidine alkaloids, so safe extracts must be purified.",
     "effects": "Relaxation;muscle relief;headache reduction",
+    "intensity": "Mild to moderate",
+    "region": "europe, asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal with restrictions (PA-free only)",
     "mechanism": "Antispasmodic and anti-inflammatory effects; calcium channel modulation",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Petasin",
       "Isopetasin"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "migraine prevention, allergies, anxiety",
-    "interactions": [
-      "avoid hepatotoxic meds"
+    "toxicity_ld50": "~950 mg/kg (mouse, oral, unpurified)",
+    "safety": "",
+    "sideeffects": [
+      "liver toxicity risk from unpurified products"
     ],
     "contraindications": [
       "liver conditions",
       "pregnancy",
       "raw extract use"
     ],
-    "sideeffects": [
-      "liver toxicity risk from unpurified products"
-    ],
-    "safety": "",
-    "toxicity": "Moderate to high (raw plant)",
-    "toxicity_ld50": "~950 mg/kg (mouse, oral, unpurified)",
+    "therapeutic": "migraine prevention, allergies, anxiety",
     "tags": [
       "⚠️ pa toxins",
       "🌿 herbal",
       "🧠 headache"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "avoid hepatotoxic meds"
+    ],
+    "toxicity": "Moderate to high (raw plant)",
     "image": ""
   },
   {
@@ -1933,34 +5724,28 @@
     "common": "",
     "scientific": "Caesalpinia sepiaria",
     "category": "traditional / stimulant",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "thailand, india, southeast asia",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a thorny climbing shrub used in traditional southeast asian medicine. found in certain thai herbal stimulant blends (yaa chud), though its active compounds are poorly characterized.",
     "effects": "Stimulation;Increased stamina;Traditional energizing",
+    "intensity": "Mild–Moderate",
+    "region": "thailand, india, southeast asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Poorly studied. Likely contains alkaloids and tannins with mild CNS effects. May act as a peripheral stimulant and astringent.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for fatigue, fever, and vitality in traditional thai and ayurvedic systems. often combined with other herbs.",
-    "interactions": [
-      "avoid with strong stimulants or blood pressure medications."
-    ],
-    "contraindications": [
-      "not recommended during pregnancy or with hypertension due to possible stimulant effects."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "",
+    "safety": "",
     "sideeffects": [
       "not well documented. possible gi upset",
       "dizziness",
       "or overstimulation in high doses."
     ],
-    "safety": "",
-    "toxicity": "Low to moderate. Long-term effects not well studied.",
-    "toxicity_ld50": "",
+    "contraindications": [
+      "not recommended during pregnancy or with hypertension due to possible stimulant effects."
+    ],
+    "therapeutic": "used for fatigue, fever, and vitality in traditional thai and ayurvedic systems. often combined with other herbs.",
     "tags": [
       "🪴 thai herbalism",
       "⚡ mild stimulant",
@@ -1971,6 +5756,15 @@
       "Thai Traditional Medicine Pharmacopoeia",
       "Herbal Remedies of Southeast Asia – WHO"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "avoid with strong stimulants or blood pressure medications."
+    ],
+    "toxicity": "Low to moderate. Long-term effects not well studied.",
     "image": ""
   },
   {
@@ -1979,34 +5773,28 @@
     "common": "",
     "scientific": "Calea ternifolia",
     "category": "oneirogen / bitter tonic",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "mexico, central america",
-    "regiontags": [],
-    "legalstatus": "Generally legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "calea is a traditional mexican dream herb used by the chontal people to enhance dream clarity and lucidity. often consumed as a tea or smoked before sleep.",
     "effects": "Lucid dreaming;Vivid dreams;Mild sedation;Dream recall",
+    "intensity": "Mild–Moderate",
+    "region": "mexico, central america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Generally legal",
     "mechanism": "Contains calein and germacranolides that may influence GABAergic and cholinergic systems related to REM sleep modulation.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "dream induction and clarity",
-    "interactions": [
-      "may interact with cns depressants"
-    ],
-    "contraindications": [
-      "avoid in pregnancy and with sedatives"
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Not well established",
+    "safety": "",
     "sideeffects": [
       "bitterness",
       "mild nausea",
       "vivid dreams"
     ],
-    "safety": "",
-    "toxicity": "Low to moderate",
-    "toxicity_ld50": "Not well established",
+    "contraindications": [
+      "avoid in pregnancy and with sedatives"
+    ],
+    "therapeutic": "dream induction and clarity",
     "tags": [
       "🌿 dream",
       "😴 sleep",
@@ -2018,6 +5806,15 @@
       "Journal of Ethnopharmacology",
       "1986"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interact with cns depressants"
+    ],
+    "toxicity": "Low to moderate",
     "image": ""
   },
   {
@@ -2026,39 +5823,30 @@
     "common": "",
     "scientific": "Calliandra angustifolia",
     "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "amazon basin: peru, brazil, ecuador",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "bobinsana is a shrubby tree native to the amazon basin, used in traditional dieta practices for emotional healing and dreamwork. often referred to as a 'plant teacher' with gentle, uplifting effects.",
     "effects": "Heart-opening;Dreamlike calm;Energetic cleansing",
+    "intensity": "Mild",
+    "region": "amazon basin: peru, brazil, ecuador",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Contains flavonoids and alkaloids that may have GABAergic and adaptogenic effects. Precise pharmacology is not well studied.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for grief, heartbreak, fatigue, and as an energetic tonic. some modern practitioners use it as a mild antidepressant or empathogen.",
-    "interactions": [
-      "unknown",
-      "caution with serotonergics",
-      "mild theoretical risk with sedatives or maois",
-      "especially in ceremonial contexts."
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "drowsiness",
+      "mild emotional vulnerability",
+      "generally well tolerated. some report increased emotional sensitivity or lightheadedness."
     ],
     "contraindications": [
       "pregnancy",
       "psychiatric disorders",
       "avoid during pregnancy. caution with antidepressants or other cns modulators."
     ],
-    "sideeffects": [
-      "drowsiness",
-      "mild emotional vulnerability",
-      "generally well tolerated. some report increased emotional sensitivity or lightheadedness."
-    ],
-    "safety": "",
-    "toxicity": "Very low. Considered safe in traditional doses.",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "used for grief, heartbreak, fatigue, and as an energetic tonic. some modern practitioners use it as a mild antidepressant or empathogen.",
     "tags": [
       "✅ safe",
       "🌿 herbal",
@@ -2073,6 +5861,17 @@
       "2009",
       "Plants of the Gods – Schultes & Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "caution with serotonergics",
+      "mild theoretical risk with sedatives or maois",
+      "especially in ceremonial contexts."
+    ],
+    "toxicity": "Very low. Considered safe in traditional doses.",
     "image": ""
   },
   {
@@ -2081,33 +5880,27 @@
     "common": "",
     "scientific": "Camellia japonica",
     "category": "medicinal / cosmetic",
-    "subcategory": "",
-    "intensity": "",
-    "region": "japan, korea, china; ornamental worldwide",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a flowering plant native to east asia, best known for its oil-rich seeds. unlike camellia sinensis, it is not caffeinated, but valued for its emollient and skin-protective properties.",
     "effects": "Skin soothing;Antioxidant;Mild anti-inflammatory",
+    "intensity": "",
+    "region": "japan, korea, china; ornamental worldwide",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Rich in oleic acid, tocopherols (Vitamin E), and polyphenols. These compounds hydrate the skin and reduce oxidative damage.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used in traditional korean and japanese medicine for dry skin, burns, hair conditioning, and inflammation.",
-    "interactions": [
-      "none significant reported."
+    "compounds": [],
+    "toxicity_ld50": "Not established; similar to olive oil in safety",
+    "safety": "",
+    "sideeffects": [
+      "rare. may cause mild allergic skin reactions in sensitive individuals."
     ],
     "contraindications": [
       "topical only",
       "not suitable for injection or open wounds. monitor for contact dermatitis."
     ],
-    "sideeffects": [
-      "rare. may cause mild allergic skin reactions in sensitive individuals."
-    ],
-    "safety": "",
-    "toxicity": "Very low. Used widely in cosmetics and culinary oils.",
-    "toxicity_ld50": "Not established; similar to olive oil in safety",
+    "therapeutic": "used in traditional korean and japanese medicine for dry skin, burns, hair conditioning, and inflammation.",
     "tags": [
       "💧 emollient",
       "🌸 skincare",
@@ -2119,6 +5912,15 @@
       "2014",
       "Asian Botanical Dermatology Manual"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "none significant reported."
+    ],
+    "toxicity": "Very low. Used widely in cosmetics and culinary oils.",
     "image": ""
   },
   {
@@ -2127,38 +5929,31 @@
     "common": "",
     "scientific": "Camellia sinensis",
     "category": "stimulant / nootropic",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "china, india, worldwide cultivation",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "source of green and black tea; contains caffeine and theanine for balanced stimulation.",
     "effects": "Alertness;relaxed focus",
+    "intensity": "Mild",
+    "region": "china, india, worldwide cultivation",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Caffeine antagonizes adenosine receptors; L-theanine modulates glutamate and GABA.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Caffeine"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "improved cognition, antioxidant, metabolism boost.",
-    "interactions": [
-      "potentiates other stimulants",
-      "may reduce sedative efficacy"
-    ],
-    "contraindications": [
-      "heart conditions",
-      "pregnancy (high amounts)."
-    ],
+    "toxicity_ld50": "Caffeine LD50 ~190 mg/kg (rats)",
+    "safety": "",
     "sideeffects": [
       "jitters",
       "insomnia",
       "digestive upset"
     ],
-    "safety": "",
-    "toxicity": "High intake can cause jitteriness or insomnia.",
-    "toxicity_ld50": "Caffeine LD50 ~190 mg/kg (rats)",
+    "contraindications": [
+      "heart conditions",
+      "pregnancy (high amounts)."
+    ],
+    "therapeutic": "improved cognition, antioxidant, metabolism boost.",
     "tags": [
       "☕ caffeine",
       "🍵 tea"
@@ -2169,6 +5964,16 @@
       "2013",
       "Theanine and Mental Performance – Nutritional Neuroscience"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "potentiates other stimulants",
+      "may reduce sedative efficacy"
+    ],
+    "toxicity": "High intake can cause jitteriness or insomnia.",
     "image": ""
   },
   {
@@ -2177,32 +5982,26 @@
     "common": "",
     "scientific": "Campsiandra angustifolia",
     "category": "shamanic / tonic / adaptogen",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "amazon basin (peru, brazil, colombia)",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a powerful amazonian tree used as a general tonic and aphrodisiac. often added to ayahuasca brews for stamina, libido, and protection. bark decoctions are the primary preparation.",
     "effects": "Anti-inflammatory;Aphrodisiac;Tonic;Mild stimulation",
+    "intensity": "Mild–Moderate",
+    "region": "amazon basin (peru, brazil, colombia)",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Contains triterpenes, alkaloids, and flavonoids with antioxidant and potential hormonal activity. Exact pharmacodynamics not fully mapped.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for arthritis, sexual debility, digestive issues, fatigue, and spiritual protection.",
-    "interactions": [
-      "theoretical interactions with hormone therapies or strong anti-inflammatories."
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "mild nausea or overstimulation possible with high doses. rare allergic reactions."
     ],
     "contraindications": [
       "caution in pregnancy or with autoimmune disorders. limited data on immunomodulatory effects."
     ],
-    "sideeffects": [
-      "mild nausea or overstimulation possible with high doses. rare allergic reactions."
-    ],
-    "safety": "",
-    "toxicity": "Low in traditional dosing. Bark is the safest part; seeds unstudied.",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "used for arthritis, sexual debility, digestive issues, fatigue, and spiritual protection.",
     "tags": [
       "🌳 tonic tree",
       "💪 aphrodisiac",
@@ -2213,6 +6012,15 @@
       "Plants of the Gods – Rätsch",
       "Rainforest Database: Chuchuhuasi Monograph"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "theoretical interactions with hormone therapies or strong anti-inflammatories."
+    ],
+    "toxicity": "Low in traditional dosing. Bark is the safest part; seeds unstudied.",
     "image": ""
   },
   {
@@ -2221,33 +6029,26 @@
     "common": "",
     "scientific": "Cananga odorata",
     "category": "aromatic / relaxant",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "philippines, indonesia, polynesia",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a tropical flowering tree native to southeast asia. its flowers yield ylang-ylang essential oil, a sweet floral extract used in perfumery and aromatherapy to reduce stress and promote sensuality.",
     "effects": "Euphoria;Relaxation;Aphrodisiac;Mild sedation",
+    "intensity": "Mild–Moderate",
+    "region": "philippines, indonesia, polynesia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Contains linalool, germacrene, and benzyl acetate, which act on GABA and dopaminergic pathways to induce calming and mood-lifting effects.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used to ease anxiety, insomnia, high blood pressure, and as a romantic enhancer in aromatherapy.",
-    "interactions": [
-      "none significant",
-      "but may mildly potentiate sedatives."
+    "compounds": [],
+    "toxicity_ld50": "Unknown (topical only)",
+    "safety": "",
+    "sideeffects": [
+      "may cause headaches or nausea in high concentrations. possible skin irritation if undiluted."
     ],
     "contraindications": [
       "avoid internal use. dilute before skin application. use with caution in pregnancy."
     ],
-    "sideeffects": [
-      "may cause headaches or nausea in high concentrations. possible skin irritation if undiluted."
-    ],
-    "safety": "",
-    "toxicity": "Low. Generally regarded as safe (GRAS) when used correctly.",
-    "toxicity_ld50": "Unknown (topical only)",
+    "therapeutic": "used to ease anxiety, insomnia, high blood pressure, and as a romantic enhancer in aromatherapy.",
     "tags": [
       "🌺 aromatherapy",
       "💆 relaxant",
@@ -2259,6 +6060,16 @@
       "Journal of Natural Products",
       "2006"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "none significant",
+      "but may mildly potentiate sedatives."
+    ],
+    "toxicity": "Low. Generally regarded as safe (GRAS) when used correctly.",
     "image": ""
   },
   {
@@ -2267,39 +6078,33 @@
     "common": "",
     "scientific": "Cannabis sativa",
     "category": "psychedelic / relaxant",
-    "subcategory": "",
-    "intensity": "Variable",
-    "region": "cultivated worldwide",
-    "regiontags": [],
-    "legalstatus": "Varies by jurisdiction",
-    "schedule": "",
-    "legalnotes": "",
     "description": "",
     "effects": "euphoria;relaxation;altered perception",
+    "intensity": "Variable",
+    "region": "cultivated worldwide",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Varies by jurisdiction",
     "mechanism": "THC acts on cannabinoid receptors CB1 and CB2",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "THC",
       "CBD"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "pain relief, appetite stimulation, anxiety reduction",
-    "interactions": [
-      "may interact with cns depressants and alcohol"
+    "toxicity_ld50": ">1 g/kg THC in animals",
+    "safety": "",
+    "sideeffects": [
+      "dry mouth",
+      "short-term memory impairment",
+      "anxiety in high doses"
     ],
     "contraindications": [
       "psychosis",
       "heart conditions",
       "pregnancy"
     ],
-    "sideeffects": [
-      "dry mouth",
-      "short-term memory impairment",
-      "anxiety in high doses"
-    ],
-    "safety": "",
-    "toxicity": "Low physiological toxicity",
-    "toxicity_ld50": ">1 g/kg THC in animals",
+    "therapeutic": "pain relief, appetite stimulation, anxiety reduction",
     "tags": [
       "cbd",
       "thc",
@@ -2311,6 +6116,15 @@
       "2021",
       "The Health Effects of Cannabis and Cannabinoids – National Academies"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interact with cns depressants and alcohol"
+    ],
+    "toxicity": "Low physiological toxicity",
     "image": ""
   },
   {
@@ -2319,38 +6133,31 @@
     "common": "",
     "scientific": "Capsicum annuum",
     "category": "stimulant / analgesic",
-    "subcategory": "",
-    "intensity": "Mild to Intense (Scoville Heat Units dependent)",
-    "region": "mexico, central america; cultivated globally",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "the source of most culinary chili peppers, c. annuum is valued for both its heat and its therapeutic effects. capsaicin, the active compound, causes a burning sensation and triggers endorphin release.",
     "effects": "Stimulation;Endorphin release;Heat sensation;Pain modulation",
+    "intensity": "Mild to Intense (Scoville Heat Units dependent)",
+    "region": "mexico, central america; cultivated globally",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Capsaicin binds to TRPV1 receptors on sensory neurons, causing depolarization, heat/pain sensation, and eventual desensitization.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "topical creams for arthritis and nerve pain. internally used to boost metabolism, circulation, and digestion.",
-    "interactions": [
-      "may enhance blood-thinners",
-      "irritate gi if combined with nsaids."
-    ],
-    "contraindications": [
-      "avoid on open wounds",
-      "in ulcers",
-      "or in sensitive individuals. caution with anticoagulants."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Capsaicin: ~47.2 mg/kg (mice, oral)",
+    "safety": "",
     "sideeffects": [
       "burning",
       "irritation (skin or gi)",
       "sweating",
       "increased heart rate. can cause nausea if overconsumed."
     ],
-    "safety": "",
-    "toxicity": "Low. Overconsumption can cause GI distress. Pure capsaicin is toxic at high doses.",
-    "toxicity_ld50": "Capsaicin: ~47.2 mg/kg (mice, oral)",
+    "contraindications": [
+      "avoid on open wounds",
+      "in ulcers",
+      "or in sensitive individuals. caution with anticoagulants."
+    ],
+    "therapeutic": "topical creams for arthritis and nerve pain. internally used to boost metabolism, circulation, and digestion.",
     "tags": [
       "🌶️ capsaicin",
       "🔥 stimulant",
@@ -2362,6 +6169,16 @@
       "2014",
       "Capsaicin Handbook – CRC Press"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may enhance blood-thinners",
+      "irritate gi if combined with nsaids."
+    ],
+    "toxicity": "Low. Overconsumption can cause GI distress. Pure capsaicin is toxic at high doses.",
     "image": ""
   },
   {
@@ -2370,32 +6187,26 @@
     "common": "",
     "scientific": "Carica papaya",
     "category": "digestive / antiparasitic",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "tropics worldwide",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "while best known for its fruit, papaya’s leaves and seeds are used medicinally for digestion, dengue fever recovery, and as a vermifuge. the seeds have a sharp flavor and act as mild natural dewormers.",
     "effects": "Digestive support;Antiparasitic;Anti-inflammatory;Immune modulation",
+    "intensity": "Mild",
+    "region": "tropics worldwide",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Papain (a proteolytic enzyme) aids digestion and reduces inflammation. Seeds contain benzyl isothiocyanate, which may have antiparasitic and antimicrobial effects.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for bloating, intestinal worms, liver detox, and increasing platelet count in dengue fever.",
-    "interactions": [
-      "caution with anticoagulants (may increase bleeding risk)."
+    "compounds": [],
+    "toxicity_ld50": "Papaya seed extract LD50: ~1500 mg/kg (rats, oral)",
+    "safety": "",
+    "sideeffects": [
+      "possible nausea or allergic reactions. papain can irritate mucosa in excess. seeds are mildly toxic at high doses."
     ],
     "contraindications": [
       "avoid in pregnancy (uterine stimulant). papain may interfere with blood thinners."
     ],
-    "sideeffects": [
-      "possible nausea or allergic reactions. papain can irritate mucosa in excess. seeds are mildly toxic at high doses."
-    ],
-    "safety": "",
-    "toxicity": "Low to moderate. Seeds can cause toxicity in large doses (nausea, CNS symptoms in animals).",
-    "toxicity_ld50": "Papaya seed extract LD50: ~1500 mg/kg (rats, oral)",
+    "therapeutic": "used for bloating, intestinal worms, liver detox, and increasing platelet count in dengue fever.",
     "tags": [
       "🍃 digestive",
       "🦠 antiparasitic",
@@ -2407,6 +6218,15 @@
       "2015",
       "Ethnobotany of Tropical Plants – CRC Press"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "caution with anticoagulants (may increase bleeding risk)."
+    ],
+    "toxicity": "Low to moderate. Seeds can cause toxicity in large doses (nausea, CNS symptoms in animals).",
     "image": ""
   },
   {
@@ -2415,25 +6235,27 @@
     "common": "",
     "scientific": "Catha edulis",
     "category": "stimulant / euphoric",
-    "subcategory": "",
-    "intensity": "Moderate",
-    "region": "yemen, ethiopia, kenya, somalia",
-    "regiontags": [],
-    "legalstatus": "Illegal in many countries (Schedule I in US, Class C in UK); legal in some East African nations",
-    "schedule": "",
-    "legalnotes": "",
     "description": "khat is a flowering shrub native to east africa and the arabian peninsula. chewed for centuries in social rituals, it contains cathinone, a natural amphetamine-like stimulant with short-lived euphoric effects.",
     "effects": "Euphoria;Increased alertness;Sociability;Appetite suppression",
+    "intensity": "Moderate",
+    "region": "yemen, ethiopia, kenya, somalia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Illegal in many countries (Schedule I in US, Class C in UK); legal in some East African nations",
     "mechanism": "Cathinone is a monoamine-releasing agent, increasing dopamine, norepinephrine, and serotonin. Structurally related to amphetamine.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditionally used to combat fatigue, hunger, and for social interaction. some studies explore antidepressant effects.",
-    "interactions": [
-      "dangerous with maois",
-      "stimulants",
-      "or antidepressants. increases blood pressure and heart rate.",
-      "avoid with stimulants or maois"
+    "compounds": [],
+    "toxicity_ld50": "Cathinone est. ~50–100 mg/kg (mice, oral)",
+    "safety": "",
+    "sideeffects": [
+      "insomnia",
+      "dry mouth",
+      "hypertension",
+      "anxiety",
+      "irritability",
+      "rebound fatigue. chronic use may lead to dependence.",
+      "increased heart rate"
     ],
     "contraindications": [
       "avoid in heart disease",
@@ -2444,18 +6266,7 @@
       "pregnancy",
       "maois."
     ],
-    "sideeffects": [
-      "insomnia",
-      "dry mouth",
-      "hypertension",
-      "anxiety",
-      "irritability",
-      "rebound fatigue. chronic use may lead to dependence.",
-      "increased heart rate"
-    ],
-    "safety": "",
-    "toxicity": "Moderate. Chronic use linked to cardiovascular, dental, and GI issues.",
-    "toxicity_ld50": "Cathinone est. ~50–100 mg/kg (mice, oral)",
+    "therapeutic": "traditionally used to combat fatigue, hunger, and for social interaction. some studies explore antidepressant effects.",
     "tags": [
       "🌿 euphoric",
       "⚡ cathinone",
@@ -2471,6 +6282,18 @@
       "UNODC Khat Report",
       "2006"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "dangerous with maois",
+      "stimulants",
+      "or antidepressants. increases blood pressure and heart rate.",
+      "avoid with stimulants or maois"
+    ],
+    "toxicity": "Moderate. Chronic use linked to cardiovascular, dental, and GI issues.",
     "image": ""
   },
   {
@@ -2479,34 +6302,28 @@
     "common": "Catnip",
     "scientific": "Nepeta cataria",
     "category": "nervine / mild sedative / folk remedy",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "europe, north america",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "best known for its effects on cats, catnip is also a gentle human nervine herb traditionally used for digestion, colds, and sleep. it has a subtle calming effect and is often included in herbal teas.",
     "effects": "Relaxation;Mild euphoria;Digestive aid;Sleep support",
+    "intensity": "Mild",
+    "region": "europe, north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Nepetalactone interacts with GABAergic and opioid pathways in humans. Also antispasmodic and diaphoretic.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Nepetalactone"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for anxiety, insomnia, indigestion, fever, and colic. also a mild menstrual relaxant.",
-    "interactions": [
-      "may interact with sedatives or barbiturates."
+    "toxicity_ld50": ">3000 mg/kg (rats, oral)",
+    "safety": "",
+    "sideeffects": [
+      "mild drowsiness or stomach upset. rare allergic reaction."
     ],
     "contraindications": [
       "avoid during pregnancy (stimulates uterus). not recommended before operating machinery."
     ],
-    "sideeffects": [
-      "mild drowsiness or stomach upset. rare allergic reaction."
-    ],
-    "safety": "",
-    "toxicity": "Very low. Safe in tea form at moderate doses.",
-    "toxicity_ld50": ">3000 mg/kg (rats, oral)",
+    "therapeutic": "used for anxiety, insomnia, indigestion, fever, and colic. also a mild menstrual relaxant.",
     "tags": [
       "🐱 cat herb",
       "🧘 calm",
@@ -2518,6 +6335,15 @@
       "Herbal Medicine – Mills & Bone",
       "Materia Medica – David Hoffman"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interact with sedatives or barbiturates."
+    ],
+    "toxicity": "Very low. Safe in tea form at moderate doses.",
     "image": ""
   },
   {
@@ -2526,33 +6352,27 @@
     "common": "",
     "scientific": "Centella asiatica",
     "category": "cognitive",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "asia",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "known as gotu kola, used in ayurvedic medicine to aid cognition.",
     "effects": "Mental clarity;calm focus",
+    "intensity": "Mild",
+    "region": "asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Triterpenoids may modulate GABA and promote neurogenesis",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "memory enhancement, anxiety relief",
-    "interactions": [
-      "may potentiate sedatives"
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "rare headache or nausea"
     ],
     "contraindications": [
       "pregnancy",
       "liver issues"
     ],
-    "sideeffects": [
-      "rare headache or nausea"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "memory enhancement, anxiety relief",
     "tags": [
       "✅ safe",
       "🌿 leaf",
@@ -2564,6 +6384,15 @@
       "2013",
       "Ayurvedic Pharmacopoeia of India"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may potentiate sedatives"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -2572,28 +6401,19 @@
     "common": "",
     "scientific": "Cestrum nocturnum",
     "category": "aromatic / toxic",
-    "subcategory": "",
-    "intensity": "Mild–Moderate (olfactory)",
-    "region": "india, southeast asia, caribbean, central america",
-    "regiontags": [],
-    "legalstatus": "Legal as ornamental; not for ingestion",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a strongly fragrant flowering shrub known for its intoxicating nighttime aroma. traditionally used in folk remedies for anxiety and respiratory issues — but contains toxic alkaloids and should not be ingested.",
     "effects": "Sedation;Headache (aroma);Potential hallucinations (in folklore)",
+    "intensity": "Mild–Moderate (olfactory)",
+    "region": "india, southeast asia, caribbean, central america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal as ornamental; not for ingestion",
     "mechanism": "Contains solanine-like glycoalkaloids and tropane-related compounds. The fragrance may act as a mild CNS modulator, but oral use is toxic.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "rarely used in formal medicine. aromatherapy use for insomnia and nervous agitation. some regional folklore suggests use in dream induction.",
-    "interactions": [
-      "none studied — avoid combining with sedatives or anticholinergics."
-    ],
-    "contraindications": [
-      "do not ingest. avoid for children",
-      "pets",
-      "or in enclosed spaces with strong aroma."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Solanine (analogue): ~590 mg/kg (mice, oral)",
+    "safety": "",
     "sideeffects": [
       "headache",
       "nausea",
@@ -2601,9 +6421,12 @@
       "delirium",
       "or paralysis."
     ],
-    "safety": "",
-    "toxicity": "Moderate to high. Toxic alkaloids accumulate in leaves and berries.",
-    "toxicity_ld50": "Solanine (analogue): ~590 mg/kg (mice, oral)",
+    "contraindications": [
+      "do not ingest. avoid for children",
+      "pets",
+      "or in enclosed spaces with strong aroma."
+    ],
+    "therapeutic": "rarely used in formal medicine. aromatherapy use for insomnia and nervous agitation. some regional folklore suggests use in dream induction.",
     "tags": [
       "🌙 aromatic",
       "⚠️ toxic",
@@ -2616,6 +6439,15 @@
       "Flora of the Caribbean – Botanical Review",
       "2008"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "none studied — avoid combining with sedatives or anticholinergics."
+    ],
+    "toxicity": "Moderate to high. Toxic alkaloids accumulate in leaves and berries.",
     "image": ""
   },
   {
@@ -2624,45 +6456,47 @@
     "common": "Chilean holly",
     "scientific": "Desfontainia spinosa",
     "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Strong",
-    "region": "chile, colombia, andes",
-    "regiontags": [],
-    "legalstatus": "Legal but obscure",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a rare south american shrub used by the mapuche and other indigenous groups in chile and colombia as a ritual intoxicant. known for unpredictable and potent effects.",
     "effects": "Hallucinations;disorientation;dreamlike state",
+    "intensity": "Strong",
+    "region": "chile, colombia, andes",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal but obscure",
     "mechanism": "Unknown; possibly tropane alkaloid activity or diterpenes",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Desfontainin"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditional visionary plant; not clinically established",
-    "interactions": [
-      "unknown",
-      "avoid cns drugs"
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "strong nausea",
+      "confusion",
+      "pupil dilation"
     ],
     "contraindications": [
       "mental illness",
       "cardiovascular risk",
       "pregnancy"
     ],
-    "sideeffects": [
-      "strong nausea",
-      "confusion",
-      "pupil dilation"
-    ],
-    "safety": "",
-    "toxicity": "Potentially high at ritual doses",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "traditional visionary plant; not clinically established",
     "tags": [
       "⚠️ rare",
       "🌿 andes",
       "🧠 vision"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "avoid cns drugs"
+    ],
+    "toxicity": "Potentially high at ritual doses",
     "image": ""
   },
   {
@@ -2671,36 +6505,30 @@
     "common": "",
     "scientific": "Cichorium intybus",
     "category": "digestive / prebiotic / tonic",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "europe, asia, north america",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a bitter blue-flowered herb widely used as a coffee substitute, digestive tonic, and prebiotic. its root is rich in inulin, supporting gut health and liver detoxification.",
     "effects": "Liver support;Mild stimulant (roasted);Prebiotic;Digestive aid",
+    "intensity": "Mild",
+    "region": "europe, asia, north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Inulin acts as a prebiotic fiber, feeding gut flora. Bitter compounds stimulate bile secretion and improve digestion. Roasted root contains lactones that mildly stimulate the CNS.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for sluggish digestion, fatty liver, gallbladder issues, and gut flora restoration. roasted root used to reduce caffeine intake.",
-    "interactions": [
-      "may alter absorption of some drugs by modulating gut transit or flora."
+    "compounds": [],
+    "toxicity_ld50": "Inulin: >10 g/kg (oral, rats)",
+    "safety": "",
+    "sideeffects": [
+      "may cause gas",
+      "bloating",
+      "or diarrhea if inulin dose is too high. bitter taste may cause nausea."
     ],
     "contraindications": [
       "avoid in gallstones",
       "bile duct obstruction",
       "or fructan intolerance."
     ],
-    "sideeffects": [
-      "may cause gas",
-      "bloating",
-      "or diarrhea if inulin dose is too high. bitter taste may cause nausea."
-    ],
-    "safety": "",
-    "toxicity": "Very low. Widely used as food and medicine.",
-    "toxicity_ld50": "Inulin: >10 g/kg (oral, rats)",
+    "therapeutic": "used for sluggish digestion, fatty liver, gallbladder issues, and gut flora restoration. roasted root used to reduce caffeine intake.",
     "tags": [
       "🌿 prebiotic",
       "☕ coffee alternative",
@@ -2712,6 +6540,15 @@
       "2015",
       "Herbal Medicine Monographs – WHO"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may alter absorption of some drugs by modulating gut transit or flora."
+    ],
+    "toxicity": "Very low. Widely used as food and medicine.",
     "image": ""
   },
   {
@@ -2720,37 +6557,31 @@
     "common": "",
     "scientific": "Claviceps purpurea",
     "category": "ergolines / toxic",
-    "subcategory": "",
-    "intensity": "Strong",
-    "region": "worldwide on cereal grains",
-    "regiontags": [],
-    "legalstatus": "Controlled in many countries",
-    "schedule": "",
-    "legalnotes": "",
     "description": "",
     "effects": "vasoconstriction;hallucinations;numbness",
+    "intensity": "Strong",
+    "region": "worldwide on cereal grains",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Controlled in many countries",
     "mechanism": "Produces ergot alkaloids acting on serotonin and adrenergic receptors",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Ergotamine"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "historically used to induce labor and treat migraines",
-    "interactions": [
-      "potentiates triptans and other vasoconstrictors"
-    ],
-    "contraindications": [
-      "pregnancy",
-      "vascular disease"
-    ],
+    "toxicity_ld50": "~5 mg/kg lysergic acid amide (mouse)",
+    "safety": "",
     "sideeffects": [
       "nausea",
       "convulsions",
       "gangrene in high doses"
     ],
-    "safety": "",
-    "toxicity": "High; risk of ergotism",
-    "toxicity_ld50": "~5 mg/kg lysergic acid amide (mouse)",
+    "contraindications": [
+      "pregnancy",
+      "vascular disease"
+    ],
+    "therapeutic": "historically used to induce labor and treat migraines",
     "tags": [
       "ergot",
       "fungus",
@@ -2763,6 +6594,15 @@
       "Wasson",
       "Ruck"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "potentiates triptans and other vasoconstrictors"
+    ],
+    "toxicity": "High; risk of ergotism",
     "image": ""
   },
   {
@@ -2771,35 +6611,38 @@
     "common": "Clavo Huasca",
     "scientific": "",
     "category": "",
-    "subcategory": "",
-    "intensity": "",
-    "region": "amazon rainforest",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "",
     "effects": "aphrodisiac;warming;digestive aid",
+    "intensity": "",
+    "region": "amazon rainforest",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "TRPV1 activation, increases circulation and warmth",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Eugenol",
       "Tynanthin"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "aphrodisiac",
       "folk",
       "warming"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -2808,32 +6651,26 @@
     "common": "",
     "scientific": "Clitoria ternatea",
     "category": "nootropic / adaptogen / nervine",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "india, thailand, malaysia, tropics worldwide",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a striking blue-flowered vine used in ayurvedic and southeast asian medicine. known for its nootropic, anti-anxiety, and anti-inflammatory effects. often brewed into vivid blue tea and used ceremonially in thailand and india.",
     "effects": "Cognitive enhancement;Anxiolytic;Neuroprotective;Mild sedation",
+    "intensity": "Mild",
+    "region": "india, thailand, malaysia, tropics worldwide",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Contains anthocyanins (ternatins), flavonoids, and cyclotides. May modulate acetylcholine and GABA signaling, as well as BDNF expression in the brain.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditionally used to enhance memory, relieve stress, calm nerves, and as a visual eye tonic. topical extracts also used for hair and skin.",
-    "interactions": [
-      "may mildly potentiate sedatives or anxiolytics."
+    "compounds": [],
+    "toxicity_ld50": "No established human LD50; >2000 mg/kg (rats, oral, extract)",
+    "safety": "",
+    "sideeffects": [
+      "very few reported. some may experience mild drowsiness or hypotension."
     ],
     "contraindications": [
       "caution with hypotensive drugs. avoid during pregnancy until more data is available."
     ],
-    "sideeffects": [
-      "very few reported. some may experience mild drowsiness or hypotension."
-    ],
-    "safety": "",
-    "toxicity": "Very low. Consumed widely as food and medicine.",
-    "toxicity_ld50": "No established human LD50; >2000 mg/kg (rats, oral, extract)",
+    "therapeutic": "traditionally used to enhance memory, relieve stress, calm nerves, and as a visual eye tonic. topical extracts also used for hair and skin.",
     "tags": [
       "🌸 blue tea",
       "🧠 brain tonic",
@@ -2846,6 +6683,15 @@
       "2010",
       "Ayurvedic Pharmacopoeia of India"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may mildly potentiate sedatives or anxiolytics."
+    ],
+    "toxicity": "Very low. Consumed widely as food and medicine.",
     "image": ""
   },
   {
@@ -2854,38 +6700,41 @@
     "common": "",
     "scientific": "Coffea arabica",
     "category": "stimulant",
-    "subcategory": "",
-    "intensity": "",
-    "region": "worldwide",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "beloved beverage plant containing caffeine.",
     "effects": "alertness;energy",
+    "intensity": "",
+    "region": "worldwide",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Caffeine blocks adenosine receptors increasing neurotransmitter release",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "50–150 mg caffeine",
-    "therapeutic": "fatigue reduction",
-    "interactions": [
-      "stimulants",
-      "maois"
-    ],
-    "contraindications": [
-      "heart arrhythmia"
-    ],
+    "compounds": [],
+    "toxicity_ld50": "~192 mg/kg (rats)",
+    "safety": "",
     "sideeffects": [
       "jitters",
       "insomnia"
     ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "~192 mg/kg (rats)",
+    "contraindications": [
+      "heart arrhythmia"
+    ],
+    "therapeutic": "fatigue reduction",
     "tags": [
       "☕ brewable"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "50–150 mg caffeine",
+    "interactions": [
+      "stimulants",
+      "maois"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -2894,39 +6743,31 @@
     "common": "",
     "scientific": "Cola acuminata",
     "category": "stimulant / cultural",
-    "subcategory": "",
-    "intensity": "Moderate",
-    "region": "west africa; cultivated globally",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a caffeine-rich seed native to west africa, traditionally chewed in ceremonies and social settings. kola nut is a powerful natural stimulant, historically used in early coca-cola formulas and as a fatigue-fighting tonic.",
     "effects": "Stimulation;Increased alertness;Mood elevation;Appetite suppression",
+    "intensity": "Moderate",
+    "region": "west africa; cultivated globally",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Contains caffeine, theobromine, and kolanin. These stimulate the central nervous system via adenosine receptor antagonism and mild dopaminergic effects.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used to combat fatigue, enhance performance, support digestion, and as a social stimulant. also used in weight loss supplements.",
-    "interactions": [
-      "interacts with maois",
-      "beta-blockers",
-      "and other stimulants. may reduce sedative effects of some medications."
-    ],
-    "contraindications": [
-      "avoid with heart conditions",
-      "insomnia",
-      "or in combination with strong stimulants."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Caffeine LD50: ~192 mg/kg (rats, oral)",
+    "safety": "",
     "sideeffects": [
       "insomnia",
       "anxiety",
       "jitteriness",
       "increased heart rate. long-term overuse may affect adrenal function."
     ],
-    "safety": "",
-    "toxicity": "Moderate at high doses (caffeine-related).",
-    "toxicity_ld50": "Caffeine LD50: ~192 mg/kg (rats, oral)",
+    "contraindications": [
+      "avoid with heart conditions",
+      "insomnia",
+      "or in combination with strong stimulants."
+    ],
+    "therapeutic": "used to combat fatigue, enhance performance, support digestion, and as a social stimulant. also used in weight loss supplements.",
     "tags": [
       "⚡ caffeine",
       "🥥 traditional stimulant",
@@ -2938,6 +6779,17 @@
       "2013",
       "The Cultural Uses of Cola – African Medicine Studies"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "interacts with maois",
+      "beta-blockers",
+      "and other stimulants. may reduce sedative effects of some medications."
+    ],
+    "toxicity": "Moderate at high doses (caffeine-related).",
     "image": ""
   },
   {
@@ -2946,40 +6798,43 @@
     "common": "",
     "scientific": "Cola nitida",
     "category": "stimulant",
-    "subcategory": "",
-    "intensity": "Moderate",
-    "region": "africa",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "kola nut used in energy drinks and ceremonies.",
     "effects": "Alertness;reduced fatigue",
+    "intensity": "Moderate",
+    "region": "africa",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Caffeine and kolanin stimulate CNS",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditional energizer",
-    "interactions": [
-      "other stimulants"
+    "compounds": [],
+    "toxicity_ld50": "Caffeine LD50 ~192 mg/kg (rat)",
+    "safety": "",
+    "sideeffects": [
+      "insomnia",
+      "jitteriness"
     ],
     "contraindications": [
       "heart conditions",
       "pregnancy"
     ],
-    "sideeffects": [
-      "insomnia",
-      "jitteriness"
-    ],
-    "safety": "",
-    "toxicity": "Moderate",
-    "toxicity_ld50": "Caffeine LD50 ~192 mg/kg (rat)",
+    "therapeutic": "traditional energizer",
     "tags": [
       "stimulant",
       "✅ safe",
       "🌿 seed"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "other stimulants"
+    ],
+    "toxicity": "Moderate",
     "image": ""
   },
   {
@@ -2988,34 +6843,37 @@
     "common": "",
     "scientific": "Convolvulus arvensis",
     "category": "ethnobotanical",
-    "subcategory": "",
-    "intensity": "",
-    "region": "europe, north america",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "bindweed, a relative of morning glory, contains ergoline alkaloids and is under investigation for mild entheogenic potential.",
     "effects": "light euphoria;subtle visual shifts",
+    "intensity": "",
+    "region": "europe, north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "5-HT2A agonist (potential)",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Ergoline alkaloids (trace)"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "entheogen",
       "ergoline",
       "wild plant"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -3024,34 +6882,26 @@
     "common": "",
     "scientific": "Convolvulus pluricaulis",
     "category": "ayurvedic / nootropic / nervine",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "india, nepal, southeast asia",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "one of ayurveda’s most revered medhya rasayanas (brain tonics). shankhpushpi is used to enhance memory, reduce anxiety, and balance vata/pitta energies. often prescribed for insomnia, fatigue, and poor concentration.",
     "effects": "Memory enhancement;Stress reduction;Mental clarity;Mild sedation",
+    "intensity": "Mild",
+    "region": "india, nepal, southeast asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Contains alkaloids like convolvine and flavonoids that may modulate GABA and acetylcholine pathways. Also shows antioxidant and adaptogenic activity.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for cognitive decline, anxiety, adhd, insomnia, and as a rejuvenating adaptogen. may assist in ptsd and stress disorders.",
-    "interactions": [
-      "may mildly potentiate benzodiazepines",
-      "barbiturates",
-      "or other cns depressants."
+    "compounds": [],
+    "toxicity_ld50": ">2 g/kg (rats, oral, extract)",
+    "safety": "",
+    "sideeffects": [
+      "very mild. excessive use may cause drowsiness or lowered blood pressure."
     ],
     "contraindications": [
       "none major. caution with sedatives or in hypotension."
     ],
-    "sideeffects": [
-      "very mild. excessive use may cause drowsiness or lowered blood pressure."
-    ],
-    "safety": "",
-    "toxicity": "Very low. Widely used in Ayurvedic pediatric formulas.",
-    "toxicity_ld50": ">2 g/kg (rats, oral, extract)",
+    "therapeutic": "used for cognitive decline, anxiety, adhd, insomnia, and as a rejuvenating adaptogen. may assist in ptsd and stress disorders.",
     "tags": [
       "🧠 medhya",
       "🌿 ayurvedic nootropic",
@@ -3063,6 +6913,17 @@
       "Journal of Ethnopharmacology",
       "2010"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may mildly potentiate benzodiazepines",
+      "barbiturates",
+      "or other cns depressants."
+    ],
+    "toxicity": "Very low. Widely used in Ayurvedic pediatric formulas.",
     "image": ""
   },
   {
@@ -3071,32 +6932,26 @@
     "common": "",
     "scientific": "Crataegus monogyna",
     "category": "cardiovascular / tonic / nervine",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "europe, north africa, west asia",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a thorny shrub known for its small red berries and heart-boosting properties. used in european herbalism for centuries to support circulation, reduce anxiety, and tone the cardiovascular system.",
     "effects": "Heart tonic;Circulation support;Anxiolytic;Antioxidant",
+    "intensity": "Mild",
+    "region": "europe, north africa, west asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Rich in flavonoids and proanthocyanidins. Improves coronary blood flow, reduces vascular resistance, and has mild ACE-inhibiting properties. Antioxidant effects may protect endothelial tissue.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for mild heart failure, high blood pressure, arrhythmia, anxiety, and fatigue. may improve exercise tolerance in cardiovascular conditions.",
-    "interactions": [
-      "may potentiate beta-blockers or ace inhibitors. avoid with nitrates without supervision."
+    "compounds": [],
+    "toxicity_ld50": ">3000 mg/kg (rats, oral)",
+    "safety": "",
+    "sideeffects": [
+      "very rare. possible dizziness or nausea in high doses."
     ],
     "contraindications": [
       "caution with digitalis drugs or other cardiac medications. monitor blood pressure closely."
     ],
-    "sideeffects": [
-      "very rare. possible dizziness or nausea in high doses."
-    ],
-    "safety": "",
-    "toxicity": "Very low. Considered safe in standard dosing.",
-    "toxicity_ld50": ">3000 mg/kg (rats, oral)",
+    "therapeutic": "used for mild heart failure, high blood pressure, arrhythmia, anxiety, and fatigue. may improve exercise tolerance in cardiovascular conditions.",
     "tags": [
       "❤️ heart tonic",
       "🍒 berry",
@@ -3108,6 +6963,15 @@
       "2019",
       "Herbal Medicine Monographs – WHO"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may potentiate beta-blockers or ace inhibitors. avoid with nitrates without supervision."
+    ],
+    "toxicity": "Very low. Considered safe in standard dosing.",
     "image": ""
   },
   {
@@ -3116,36 +6980,28 @@
     "common": "",
     "scientific": "Crocus sativus",
     "category": "nootropic / mood enhancer / culinary",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "iran, india (kashmir), greece, spain",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "the world’s most expensive spice, saffron has been used for thousands of years in cooking, medicine, and ritual. its stigma threads contain compounds that brighten mood, enhance cognition, and protect neural function.",
     "effects": "Euphoria;Antidepressant;Cognitive support;Visual clarity",
+    "intensity": "Mild–Moderate",
+    "region": "iran, india (kashmir), greece, spain",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Contains crocin, safranal, and picrocrocin. These modulate serotonin, dopamine, and GABA signaling. Also antioxidant and anti-inflammatory.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for depression, pms, cognitive decline, and visual fatigue. studies show efficacy comparable to ssris at low doses.",
-    "interactions": [
-      "possible synergistic effects with ssris",
-      "maois",
-      "or sedatives."
-    ],
-    "contraindications": [
-      "avoid in pregnancy or with strong antidepressants unless supervised."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Crocetin LD50: ~2000 mg/kg (mice, oral)",
+    "safety": "",
     "sideeffects": [
       "rare. high doses may cause nausea",
       "dizziness",
       "or uterine stimulation."
     ],
-    "safety": "",
-    "toxicity": "Low at standard doses; high doses (>5g) may be toxic.",
-    "toxicity_ld50": "Crocetin LD50: ~2000 mg/kg (mice, oral)",
+    "contraindications": [
+      "avoid in pregnancy or with strong antidepressants unless supervised."
+    ],
+    "therapeutic": "used for depression, pms, cognitive decline, and visual fatigue. studies show efficacy comparable to ssris at low doses.",
     "tags": [
       "🌼 mood-lifting",
       "🧠 nootropic",
@@ -3158,6 +7014,17 @@
       "2016",
       "Traditional Persian Medicine – Avicenna Canon"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "possible synergistic effects with ssris",
+      "maois",
+      "or sedatives."
+    ],
+    "toxicity": "Low at standard doses; high doses (>5g) may be toxic.",
     "image": ""
   },
   {
@@ -3166,36 +7033,28 @@
     "common": "",
     "scientific": "Curcuma longa",
     "category": "anti-inflammatory / adaptogen / culinary",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "india, southeast asia",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a golden root revered in ayurveda and traditional chinese medicine. curcumin, its key compound, fights inflammation, supports liver health, and improves brain function. used widely in cooking, teas, and supplements.",
     "effects": "Anti-inflammatory;Antioxidant;Liver tonic;Joint pain relief",
+    "intensity": "Mild",
+    "region": "india, southeast asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Curcumin inhibits COX-2 and NF-κB, reduces pro-inflammatory cytokines, and modulates glutathione and serotonin levels. Bioavailability enhanced with black pepper (piperine).",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for arthritis, inflammation, liver detox, depression, cognitive decline, metabolic syndrome, and gut repair.",
-    "interactions": [
-      "interacts with anticoagulants",
-      "nsaids",
-      "and some chemotherapeutics."
+    "compounds": [],
+    "toxicity_ld50": ">2000 mg/kg (rats, oral)",
+    "safety": "",
+    "sideeffects": [
+      "may cause stomach upset in high doses. risk of gallbladder contraction or bleeding at large doses."
     ],
     "contraindications": [
       "caution with gallstones",
       "bleeding disorders",
       "or blood thinners."
     ],
-    "sideeffects": [
-      "may cause stomach upset in high doses. risk of gallbladder contraction or bleeding at large doses."
-    ],
-    "safety": "",
-    "toxicity": "Very low. Doses up to 8g/day studied safely.",
-    "toxicity_ld50": ">2000 mg/kg (rats, oral)",
+    "therapeutic": "used for arthritis, inflammation, liver detox, depression, cognitive decline, metabolic syndrome, and gut repair.",
     "tags": [
       "💛 anti-inflammatory",
       "🧠 brain support",
@@ -3207,6 +7066,17 @@
       "Journal of Alternative and Complementary Medicine",
       "2015"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "interacts with anticoagulants",
+      "nsaids",
+      "and some chemotherapeutics."
+    ],
+    "toxicity": "Very low. Doses up to 8g/day studied safely.",
     "image": ""
   },
   {
@@ -3215,35 +7085,38 @@
     "common": "",
     "scientific": "Cyperus articulatus",
     "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "africa, caribbean, amazon",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "known as piripiri or guinea rush, this sedge is used in afro-caribbean and amazonian rituals for mild visionary states and spiritual grounding.",
     "effects": "Calm;focus;light trance",
+    "intensity": "Mild",
+    "region": "africa, caribbean, amazon",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Unknown; may involve sesquiterpenes",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "spiritual clarity, dream work, digestion",
-    "interactions": [],
-    "contraindications": [],
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
     "sideeffects": [
       "rare",
       "mild sedation"
     ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "contraindications": [],
+    "therapeutic": "spiritual clarity, dream work, digestion",
     "tags": [
       "✅ safe",
       "🌿 piripiri",
       "🧘 ritual"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -3252,30 +7125,19 @@
     "common": "",
     "scientific": "Cytisus scoparius",
     "category": "stimulant / toxic / cardiovascular",
-    "subcategory": "",
-    "intensity": "Moderate to Strong (dose-dependent)",
-    "region": "europe, north america (naturalized)",
-    "regiontags": [],
-    "legalstatus": "Legal in most countries but discouraged or regulated in herbal supplements",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a yellow-flowered shrub traditionally used as a cardiac stimulant and diuretic. contains sparteine, a toxic alkaloid with stimulant and hallucinogenic potential in high doses. use with caution — pharmacologically active but potentially dangerous.",
     "effects": "Cardiac stimulation;Diuretic;Mood elevation;Mild hallucinations (high dose)",
+    "intensity": "Moderate to Strong (dose-dependent)",
+    "region": "europe, north america (naturalized)",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal in most countries but discouraged or regulated in herbal supplements",
     "mechanism": "Sparteine acts on cardiac sodium channels and can influence rhythm and contractility. Also modulates adrenergic and muscarinic pathways.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used historically for arrhythmias, edema, and as a uterine tonic. some traditional european accounts suggest mild trance-like states at high doses.",
-    "interactions": [
-      "may dangerously interact with antiarrhythmics",
-      "maois",
-      "and cardiac medications."
-    ],
-    "contraindications": [
-      "do not use during pregnancy",
-      "in heart conditions",
-      "or with maois or stimulants."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Sparteine est. ~50 mg/kg (rats, oral)",
+    "safety": "",
     "sideeffects": [
       "tachycardia",
       "nausea",
@@ -3283,9 +7145,12 @@
       "visual disturbances",
       "and convulsions in overdose. narrow margin of safety."
     ],
-    "safety": "",
-    "toxicity": "High. Sparteine is cardiotoxic at moderate to high doses.",
-    "toxicity_ld50": "Sparteine est. ~50 mg/kg (rats, oral)",
+    "contraindications": [
+      "do not use during pregnancy",
+      "in heart conditions",
+      "or with maois or stimulants."
+    ],
+    "therapeutic": "used historically for arrhythmias, edema, and as a uterine tonic. some traditional european accounts suggest mild trance-like states at high doses.",
     "tags": [
       "⚠️ toxic",
       "❤️ heart-active",
@@ -3296,6 +7161,17 @@
       "Traditional Herbal Medicines in Europe – ESCOP",
       "Botanical Safety Handbook – 2nd Ed."
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may dangerously interact with antiarrhythmics",
+      "maois",
+      "and cardiac medications."
+    ],
+    "toxicity": "High. Sparteine is cardiotoxic at moderate to high doses.",
     "image": ""
   },
   {
@@ -3304,40 +7180,33 @@
     "common": "Damiana",
     "scientific": "Turnera diffusa",
     "category": "empathogen / euphoriant",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "mexico, texas, central america",
-    "regiontags": [],
-    "legalstatus": "Legal / Unregulated",
-    "schedule": "",
-    "legalnotes": "",
     "description": "used traditionally in mexico and central america for libido, relaxation, and mild stimulation. sometimes blended in herbal smoking mixes.",
     "effects": "aphrodisiac;mood-enhancing;anxiolytic",
+    "intensity": "Mild",
+    "region": "mexico, texas, central america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
     "mechanism": "Likely modulates serotonin, dopamine, and GABA neurotransmission via flavonoids and tannins [8, 6].",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Damianin"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "aphrodisiac, mood enhancement, stress relief [8, 6].",
-    "interactions": [
-      "may interact with blood sugar meds",
-      "serotonergic medications."
-    ],
-    "contraindications": [
-      "pregnancy",
-      "urinary tract conditions",
-      "maoi coadministration."
-    ],
+    "toxicity_ld50": "Not well established",
+    "safety": "1",
     "sideeffects": [
       "mild headaches or gi discomfort",
       "mild headache",
       "insomnia at high doses [8",
       "6]."
     ],
-    "safety": "1",
-    "toxicity": "Low in traditional doses.",
-    "toxicity_ld50": "Not well established",
+    "contraindications": [
+      "pregnancy",
+      "urinary tract conditions",
+      "maoi coadministration."
+    ],
+    "therapeutic": "aphrodisiac, mood enhancement, stress relief [8, 6].",
     "tags": [
       "✅ safe",
       "🔥 aphrodisiac",
@@ -3351,6 +7220,16 @@
       "Plants of Love – Christian Rätsch",
       "Herbal Medicine – Mills & Bone"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interact with blood sugar meds",
+      "serotonergic medications."
+    ],
+    "toxicity": "Low in traditional doses.",
     "image": ""
   },
   {
@@ -3359,29 +7238,19 @@
     "common": "",
     "scientific": "Datura inoxia",
     "category": "deliriant / toxic / visionary",
-    "subcategory": "",
-    "intensity": "Extreme",
-    "region": "southwestern us, mexico, central america",
-    "regiontags": [],
-    "legalstatus": "Legal to grow ornamentally; restricted in some countries for psychoactive use",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a night-blooming white-flowered species of datura, known for its powerful deliriant and anticholinergic properties. used in shamanic rituals in mesoamerica, but also responsible for many poisonings due to its unpredictability.",
     "effects": "Intense delirium;Anticholinergic trance;Hallucinations;Amnesia",
+    "intensity": "Extreme",
+    "region": "southwestern us, mexico, central america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal to grow ornamentally; restricted in some countries for psychoactive use",
     "mechanism": "Contains tropane alkaloids (scopolamine, hyoscyamine, atropine) that block muscarinic acetylcholine receptors, leading to hallucinations, confusion, and autonomic dysfunction.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditionally used in extremely small doses for asthma, pain, or divination. modern use is rare and discouraged due to risk.",
-    "interactions": [
-      "severe interactions with antipsychotics",
-      "antihistamines",
-      "maois",
-      "and alcohol."
-    ],
-    "contraindications": [
-      "unsafe in all doses without expert guidance. never combine with other cns depressants or anticholinergics."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Scopolamine LD50: ~300 mg/kg (mice, oral)",
+    "safety": "",
     "sideeffects": [
       "severe dry mouth",
       "vision loss",
@@ -3391,9 +7260,10 @@
       "terrifying hallucinations",
       "and death in overdose."
     ],
-    "safety": "",
-    "toxicity": "Very high. One seed or leaf may be lethal.",
-    "toxicity_ld50": "Scopolamine LD50: ~300 mg/kg (mice, oral)",
+    "contraindications": [
+      "unsafe in all doses without expert guidance. never combine with other cns depressants or anticholinergics."
+    ],
+    "therapeutic": "traditionally used in extremely small doses for asthma, pain, or divination. modern use is rare and discouraged due to risk.",
     "tags": [
       "🌙 deliriant",
       "🌀 dangerous",
@@ -3406,6 +7276,18 @@
       "Journal of Ethnopharmacology",
       "1994"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "severe interactions with antipsychotics",
+      "antihistamines",
+      "maois",
+      "and alcohol."
+    ],
+    "toxicity": "Very high. One seed or leaf may be lethal.",
     "image": ""
   },
   {
@@ -3414,40 +7296,43 @@
     "common": "",
     "scientific": "Datura spp.",
     "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Extremely strong",
-    "region": "americas, mediterranean",
-    "regiontags": [],
-    "legalstatus": "Legal but restricted in many countries",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a powerful and dangerous tropane alkaloid plant traditionally used in witchcraft and shamanic rituals. highly toxic.",
     "effects": "Delirium;hallucinations;disorientation",
+    "intensity": "Extremely strong",
+    "region": "americas, mediterranean",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal but restricted in many countries",
     "mechanism": "Anticholinergic – blocks acetylcholine via scopolamine, atropine",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "rarely used medically; historically for pain/spiritual rites",
-    "interactions": [
-      "all cns-affecting meds"
-    ],
-    "contraindications": [
-      "everything — extremely risky"
-    ],
+    "compounds": [],
+    "toxicity_ld50": "~50 mg/kg (atropine/scopolamine)",
+    "safety": "",
     "sideeffects": [
       "severe hallucinations",
       "amnesia",
       "potential death"
     ],
-    "safety": "",
-    "toxicity": "Very high",
-    "toxicity_ld50": "~50 mg/kg (atropine/scopolamine)",
+    "contraindications": [
+      "everything — extremely risky"
+    ],
+    "therapeutic": "rarely used medically; historically for pain/spiritual rites",
     "tags": [
       "☠️ toxic",
       "⚠️ caution",
       "🧠 vision"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "all cns-affecting meds"
+    ],
+    "toxicity": "Very high",
     "image": ""
   },
   {
@@ -3456,40 +7341,43 @@
     "common": "",
     "scientific": "Datura stramonium",
     "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "",
-    "region": "worldwide",
-    "regiontags": [],
-    "legalstatus": "Unregulated but dangerous",
-    "schedule": "",
-    "legalnotes": "",
     "description": "common weed producing powerful delirium when misused.",
     "effects": "delirium;hallucinations",
+    "intensity": "",
+    "region": "worldwide",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Unregulated but dangerous",
     "mechanism": "Scopolamine and atropine block muscarinic receptors",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "5–15 seeds",
-    "therapeutic": "historically asthma treatment",
-    "interactions": [
-      "anticholinergics",
-      "antihistamines"
+    "compounds": [],
+    "toxicity_ld50": "~50 mg/kg (atropine)",
+    "safety": "",
+    "sideeffects": [
+      "severe confusion",
+      "elevated heart rate"
     ],
     "contraindications": [
       "heart conditions",
       "mental illness"
     ],
-    "sideeffects": [
-      "severe confusion",
-      "elevated heart rate"
-    ],
-    "safety": "",
-    "toxicity": "Very high",
-    "toxicity_ld50": "~50 mg/kg (atropine)",
+    "therapeutic": "historically asthma treatment",
     "tags": [
       "☠️ toxic",
       "⚠️ caution"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "5–15 seeds",
+    "interactions": [
+      "anticholinergics",
+      "antihistamines"
+    ],
+    "toxicity": "Very high",
     "image": ""
   },
   {
@@ -3498,35 +7386,29 @@
     "common": "",
     "scientific": "Derris elliptica",
     "category": "insecticide / ethnobotanical / toxic",
-    "subcategory": "",
-    "intensity": "Severe (if ingested)",
-    "region": "southeast asia, pacific islands",
-    "regiontags": [],
-    "legalstatus": "Restricted or banned in many regions",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a tropical vine traditionally used as a natural fish poison. contains rotenone, a potent neurotoxin that disrupts mitochondrial respiration. used in agriculture but dangerous to humans in concentrated doses.",
     "effects": "Paralysis (insects/fish);Mild euphoria (folklore);Toxicity",
+    "intensity": "Severe (if ingested)",
+    "region": "southeast asia, pacific islands",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Restricted or banned in many regions",
     "mechanism": "Rotenone inhibits NADH dehydrogenase in the electron transport chain, disrupting ATP production and causing cellular hypoxia.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "no modern internal medical uses. occasionally used externally in veterinary or agricultural settings.",
-    "interactions": [
-      "n/a – not used internally."
-    ],
-    "contraindications": [
-      "unsafe for human consumption. do not ingest or inhale powdered forms."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Rotenone ~132 mg/kg (rats, oral)",
+    "safety": "",
     "sideeffects": [
       "nausea",
       "vomiting",
       "respiratory depression",
       "muscle paralysis. long-term rotenone exposure linked to parkinson’s-like symptoms."
     ],
-    "safety": "",
-    "toxicity": "Very high. Rotenone has been used in rodenticides and insecticides.",
-    "toxicity_ld50": "Rotenone ~132 mg/kg (rats, oral)",
+    "contraindications": [
+      "unsafe for human consumption. do not ingest or inhale powdered forms."
+    ],
+    "therapeutic": "no modern internal medical uses. occasionally used externally in veterinary or agricultural settings.",
     "tags": [
       "⚠️ toxic",
       "🌊 ethnobotany",
@@ -3538,6 +7420,15 @@
       "WHO Pesticide Evaluation Report – Rotenone",
       "Traditional Plant Lore of Southeast Asia – 2010"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "n/a – not used internally."
+    ],
+    "toxicity": "Very high. Rotenone has been used in rodenticides and insecticides.",
     "image": ""
   },
   {
@@ -3546,41 +7437,44 @@
     "common": "",
     "scientific": "Desmanthus illinoensis",
     "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Strong",
-    "region": "central and southern united states",
-    "regiontags": [],
-    "legalstatus": "DMT restricted in many countries",
-    "schedule": "",
-    "legalnotes": "",
     "description": "also called illinois bundleflower; its root bark contains notable amounts of dmt.",
     "effects": "visual enhancements;introspection;altered perception",
+    "intensity": "Strong",
+    "region": "central and southern united states",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "DMT restricted in many countries",
     "mechanism": "Root bark contains DMT; usually combined with MAOIs to be active orally",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used in underground ayahuasca analogs for spiritual exploration",
-    "interactions": [
-      "dangerous with maois or serotonergic drugs"
-    ],
-    "contraindications": [
-      "mental health issues",
-      "maoi or ssri medication"
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
     "sideeffects": [
       "nausea",
       "anxiety",
       "powerful visions"
     ],
-    "safety": "",
-    "toxicity": "Low physiological, high psychological risk",
-    "toxicity_ld50": "Not established",
+    "contraindications": [
+      "mental health issues",
+      "maoi or ssri medication"
+    ],
+    "therapeutic": "used in underground ayahuasca analogs for spiritual exploration",
     "tags": [
       "american",
       "dmt",
       "root"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "dangerous with maois or serotonergic drugs"
+    ],
+    "toxicity": "Low physiological, high psychological risk",
     "image": ""
   },
   {
@@ -3589,35 +7483,38 @@
     "common": "Desmodium",
     "scientific": "",
     "category": "",
-    "subcategory": "",
-    "intensity": "",
-    "region": "west africa, south america",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "",
     "effects": "bronchodilator;liver support;anti-allergic",
+    "intensity": "",
+    "region": "west africa, south america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "Smooth muscle relaxation and anti-inflammatory flavonoid activity",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Desmodin",
       "Astragalin"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "bronchodilator",
       "folk",
       "detox"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -3626,32 +7523,26 @@
     "common": "",
     "scientific": "Desmodium gangeticum",
     "category": "ayurvedic / tonic / anti-inflammatory",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "india, nepal, sri lanka",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "an ayurvedic herb used in dashamoola and other classical formulas. known for its rejuvenating, nervine, and anti-inflammatory actions, salparni is often used for vata balancing and in convalescence.",
     "effects": "Nervine support;Anti-inflammatory;Rejuvenation;Mild sedation",
+    "intensity": "Mild",
+    "region": "india, nepal, sri lanka",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Contains alkaloids (gangetin), flavonoids, and isoflavones with CNS modulating and antioxidant properties. Shows immunomodulatory and anti-inflammatory effects.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for asthma, arthritis, fever, low immunity, fatigue, and neurological weakness. common in rasayana therapy.",
-    "interactions": [
-      "may mildly potentiate immune-modulators or anti-inflammatories."
+    "compounds": [],
+    "toxicity_ld50": ">2000 mg/kg (rats, oral extract)",
+    "safety": "",
+    "sideeffects": [
+      "rare. mild gi discomfort in high doses."
     ],
     "contraindications": [
       "none known. traditionally safe even in pediatrics."
     ],
-    "sideeffects": [
-      "rare. mild gi discomfort in high doses."
-    ],
-    "safety": "",
-    "toxicity": "Very low.",
-    "toxicity_ld50": ">2000 mg/kg (rats, oral extract)",
+    "therapeutic": "used for asthma, arthritis, fever, low immunity, fatigue, and neurological weakness. common in rasayana therapy.",
     "tags": [
       "🌿 rasayana",
       "🧘 nervine",
@@ -3664,6 +7555,15 @@
       "Journal of Ethnopharmacology",
       "2006"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may mildly potentiate immune-modulators or anti-inflammatories."
+    ],
+    "toxicity": "Very low.",
     "image": ""
   },
   {
@@ -3672,35 +7572,38 @@
     "common": "Devil's Trumpet",
     "scientific": "",
     "category": "",
-    "subcategory": "",
-    "intensity": "",
-    "region": "asia, africa",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "",
     "effects": "hallucinogenic;deliriant;anticholinergic",
+    "intensity": "",
+    "region": "asia, africa",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "Antagonist of muscarinic acetylcholine receptors",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Scopolamine",
       "Atropine"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "hallucinogen",
       "deliriant",
       "toxic"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -3709,39 +7612,42 @@
     "common": "",
     "scientific": "Digitalis purpurea",
     "category": "other",
-    "subcategory": "",
-    "intensity": "",
-    "region": "europe",
-    "regiontags": [],
-    "legalstatus": "Regulated as medicinal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "source of cardiac glycosides used for heart failure; overdose is fatal.",
     "effects": "cardiac stimulation",
+    "intensity": "",
+    "region": "europe",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Regulated as medicinal",
     "mechanism": "Cardiac glycosides inhibit Na⁺/K⁺-ATPase",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "0.1 g dried leaf equivalent",
-    "therapeutic": "heart failure medication",
-    "interactions": [
-      "diuretics",
-      "calcium channel blockers"
-    ],
-    "contraindications": [
-      "existing heart disease without supervision"
-    ],
+    "compounds": [],
+    "toxicity_ld50": "3 mg/kg (digitoxin, oral)",
+    "safety": "",
     "sideeffects": [
       "arrhythmia",
       "vision changes"
     ],
-    "safety": "",
-    "toxicity": "Very high",
-    "toxicity_ld50": "3 mg/kg (digitoxin, oral)",
+    "contraindications": [
+      "existing heart disease without supervision"
+    ],
+    "therapeutic": "heart failure medication",
     "tags": [
       "☠️ toxic",
       "💊 oral"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "0.1 g dried leaf equivalent",
+    "interactions": [
+      "diuretics",
+      "calcium channel blockers"
+    ],
+    "toxicity": "Very high",
     "image": ""
   },
   {
@@ -3750,32 +7656,26 @@
     "common": "",
     "scientific": "Dioscorea villosa",
     "category": "hormonal / anti-inflammatory / women's health",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "north america",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "wild yam is a north american root long used to support women's reproductive health, digestion, and inflammation. its active compound, diosgenin, is a steroidal saponin used in pharmaceutical hormone synthesis.",
     "effects": "Hormone balance;Menstrual relief;Anti-inflammatory;Digestive support",
+    "intensity": "Mild",
+    "region": "north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Contains diosgenin, which mimics precursors of progesterone. Modulates prostaglandin synthesis and may balance estrogenic effects.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for pms, menopausal symptoms, cramping, gallbladder support, and joint inflammation.",
-    "interactions": [
-      "may interact with hormone therapy or birth control. no major acute interactions."
+    "compounds": [],
+    "toxicity_ld50": ">5000 mg/kg (rats, oral)",
+    "safety": "",
+    "sideeffects": [
+      "generally well tolerated. rare gi upset or skin sensitivity from creams."
     ],
     "contraindications": [
       "caution in hormone-sensitive cancers. not a replacement for prescribed hormone therapy."
     ],
-    "sideeffects": [
-      "generally well tolerated. rare gi upset or skin sensitivity from creams."
-    ],
-    "safety": "",
-    "toxicity": "Low. Long-term use considered safe.",
-    "toxicity_ld50": ">5000 mg/kg (rats, oral)",
+    "therapeutic": "used for pms, menopausal symptoms, cramping, gallbladder support, and joint inflammation.",
     "tags": [
       "🌿 women's health",
       "🔥 anti-inflammatory",
@@ -3786,6 +7686,15 @@
       "Botanical Safety Handbook – 2nd Ed.",
       "American Herbal Pharmacopoeia – Wild Yam Monograph"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interact with hormone therapy or birth control. no major acute interactions."
+    ],
+    "toxicity": "Low. Long-term use considered safe.",
     "image": ""
   },
   {
@@ -3794,39 +7703,42 @@
     "common": "",
     "scientific": "Diplopterys cabrerana",
     "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "",
-    "region": "amazon",
-    "regiontags": [],
-    "legalstatus": "DMT restricted in most regions",
-    "schedule": "",
-    "legalnotes": "",
     "description": "ayahuasca admixture leaf high in tryptamines.",
     "effects": "visions;introspection",
+    "intensity": "",
+    "region": "amazon",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "DMT restricted in most regions",
     "mechanism": "Leaves contain DMT and 5-MeO-DMT acting on serotonin receptors",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "25–50 g leaves",
-    "therapeutic": "shamanic healing",
-    "interactions": [
-      "maois",
-      "ssris"
-    ],
-    "contraindications": [
-      "mental health disorders"
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
     "sideeffects": [
       "nausea",
       "intense visions"
     ],
-    "safety": "",
-    "toxicity": "Low physiological",
-    "toxicity_ld50": "Not established",
+    "contraindications": [
+      "mental health disorders"
+    ],
+    "therapeutic": "shamanic healing",
     "tags": [
       "⚠️ caution",
       "🧪 dmt"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "25–50 g leaves",
+    "interactions": [
+      "maois",
+      "ssris"
+    ],
+    "toxicity": "Low physiological",
     "image": ""
   },
   {
@@ -3835,43 +7747,46 @@
     "common": "Dream Herb",
     "scientific": "Calea ternifolia (zacatechichi)",
     "category": "oneirogen",
-    "subcategory": "",
-    "intensity": "Mild to moderate",
-    "region": "mexico, central america",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "known as the 'dream herb' of the chontal people of mexico, calea is traditionally used to enhance dreams and mental clarity during sleep.",
     "effects": "Lucid dreaming;dream recall;hypnagogic imagery",
+    "intensity": "Mild to moderate",
+    "region": "mexico, central america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "May modulate GABAergic or cholinergic pathways; unclear",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Germacranolides"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "sleep induction, dream work",
-    "interactions": [
-      "avoid sedatives",
-      "alcohol"
+    "toxicity_ld50": "Not known",
+    "safety": "",
+    "sideeffects": [
+      "bitterness",
+      "mild nausea"
     ],
     "contraindications": [
       "pregnancy",
       "sedative use"
     ],
-    "sideeffects": [
-      "bitterness",
-      "mild nausea"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not known",
+    "therapeutic": "sleep induction, dream work",
     "tags": [
       "✅ safe",
       "🌙 dream",
       "🧘 calm"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "avoid sedatives",
+      "alcohol"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -3880,39 +7795,31 @@
     "common": "",
     "scientific": "Duboisia hopwoodii",
     "category": "stimulant / indigenous / nicotine analog",
-    "subcategory": "",
-    "intensity": "Moderate",
-    "region": "australia (central and northern deserts)",
-    "regiontags": [],
-    "legalstatus": "Legal in Australia (cultural protection); restricted elsewhere due to alkaloid content",
-    "schedule": "",
-    "legalnotes": "",
     "description": "an indigenous australian shrub whose dried leaves are used as a traditional stimulant. pituri contains nicotine and nor-nicotine alkaloids, and is chewed with ash for enhanced absorption.",
     "effects": "Stimulation;Alertness;Appetite suppression;Euphoria (mild)",
+    "intensity": "Moderate",
+    "region": "australia (central and northern deserts)",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal in Australia (cultural protection); restricted elsewhere due to alkaloid content",
     "mechanism": "Alkaloids bind to nicotinic acetylcholine receptors, stimulating the CNS, suppressing hunger, and inducing focus.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditionally used by aboriginal groups for endurance, ritual, and social bonding. not commonly used in modern herbalism.",
-    "interactions": [
-      "may interact with stimulants",
-      "maois",
-      "or vasodilators."
-    ],
-    "contraindications": [
-      "avoid in heart conditions",
-      "pregnancy",
-      "or with other stimulants or nicotine products."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Nicotine ~50 mg/kg (rats, oral)",
+    "safety": "",
     "sideeffects": [
       "nausea",
       "dizziness",
       "hypertension",
       "or toxicity at high doses. dependence may develop with regular use."
     ],
-    "safety": "",
-    "toxicity": "Moderate. Nor-nicotine more toxic than nicotine in some strains.",
-    "toxicity_ld50": "Nicotine ~50 mg/kg (rats, oral)",
+    "contraindications": [
+      "avoid in heart conditions",
+      "pregnancy",
+      "or with other stimulants or nicotine products."
+    ],
+    "therapeutic": "traditionally used by aboriginal groups for endurance, ritual, and social bonding. not commonly used in modern herbalism.",
     "tags": [
       "⚡ nicotine",
       "🧠 stimulant",
@@ -3924,6 +7831,17 @@
       "Aboriginal Pharmacopoeia Australia",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interact with stimulants",
+      "maois",
+      "or vasodilators."
+    ],
+    "toxicity": "Moderate. Nor-nicotine more toxic than nicotine in some strains.",
     "image": ""
   },
   {
@@ -3932,35 +7850,38 @@
     "common": "",
     "scientific": "Dysphania ambrosioides",
     "category": "ethnobotanical",
-    "subcategory": "",
-    "intensity": "",
-    "region": "mexico",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "also known as epazote, used in mesoamerican rituals. contains cns-stimulating compounds but is toxic at high doses.",
     "effects": "dreamlike;stimulant",
+    "intensity": "",
+    "region": "mexico",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "CNS excitation at high doses",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Ascaridole",
       "p-Cymene"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "ritual",
       "visionary",
       "potentially toxic"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -3969,36 +7890,39 @@
     "common": "",
     "scientific": "Echinacea purpurea",
     "category": "immune / mild stimulant",
-    "subcategory": "",
-    "intensity": "",
-    "region": "north america",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "purple coneflower commonly used for colds",
     "effects": "immune boost;slight energy",
+    "intensity": "",
+    "region": "north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Phenolic compounds like echinacoside modulate immune response",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "1-2 g dried",
-    "therapeutic": "immune support",
-    "interactions": [
-      "immunosuppressants"
+    "compounds": [],
+    "toxicity_ld50": ">2.5 g/kg (rats)",
+    "safety": "",
+    "sideeffects": [
+      "rare allergic rash"
     ],
     "contraindications": [
       "autoimmune disorders"
     ],
-    "sideeffects": [
-      "rare allergic rash"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": ">2.5 g/kg (rats)",
+    "therapeutic": "immune support",
     "tags": [
       "🌿 root"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "1-2 g dried",
+    "interactions": [
+      "immunosuppressants"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -4007,36 +7931,39 @@
     "common": "",
     "scientific": "Echinopsis lageniformis",
     "category": "psychedelic",
-    "subcategory": "",
-    "intensity": "",
-    "region": "andes",
-    "regiontags": [],
-    "legalstatus": "Cactus legal; mescaline controlled",
-    "schedule": "",
-    "legalnotes": "",
     "description": "another mescaline-rich andean cactus.",
     "effects": "visions;clarity",
+    "intensity": "",
+    "region": "andes",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Cactus legal; mescaline controlled",
     "mechanism": "Mescaline as 5-HT2A agonist",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "20–40 cm fresh cactus",
-    "therapeutic": "visionary rituals",
-    "interactions": [
-      "maois"
+    "compounds": [],
+    "toxicity_ld50": ">1 g/kg (rats)",
+    "safety": "",
+    "sideeffects": [
+      "nausea"
     ],
     "contraindications": [
       "heart conditions"
     ],
-    "sideeffects": [
-      "nausea"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": ">1 g/kg (rats)",
+    "therapeutic": "visionary rituals",
     "tags": [
       "🌵 cactus"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "20–40 cm fresh cactus",
+    "interactions": [
+      "maois"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -4045,37 +7972,31 @@
     "common": "",
     "scientific": "Echinopsis pachanoi",
     "category": "psychedelic cactus",
-    "subcategory": "",
-    "intensity": "Strong",
-    "region": "andes, cultivated worldwide",
-    "regiontags": [],
-    "legalstatus": "Cactus legal in many areas; mescaline often controlled",
-    "schedule": "",
-    "legalnotes": "",
     "description": "",
     "effects": "visuals;euphoria;spiritual insight",
+    "intensity": "Strong",
+    "region": "andes, cultivated worldwide",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Cactus legal in many areas; mescaline often controlled",
     "mechanism": "Contains mescaline, a 5‑HT2A agonist phenethylamine",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Mescaline"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "andean traditional medicine for divination and healing",
-    "interactions": [
-      "avoid combining with stimulants or maois"
-    ],
-    "contraindications": [
-      "heart issues",
-      "mental disorders"
-    ],
+    "toxicity_ld50": "Not well established",
+    "safety": "",
     "sideeffects": [
       "nausea",
       "increased heart rate",
       "anxiety"
     ],
-    "safety": "",
-    "toxicity": "Low physiological but intense psychological effects",
-    "toxicity_ld50": "Not well established",
+    "contraindications": [
+      "heart issues",
+      "mental disorders"
+    ],
+    "therapeutic": "andean traditional medicine for divination and healing",
     "tags": [
       "san pedro",
       "cactus",
@@ -4087,6 +8008,15 @@
       "Shamanic Plant Medicine – San Pedro",
       "2019"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "avoid combining with stimulants or maois"
+    ],
+    "toxicity": "Low physiological but intense psychological effects",
     "image": ""
   },
   {
@@ -4095,40 +8025,43 @@
     "common": "",
     "scientific": "Echinopsis peruviana",
     "category": "psychedelic",
-    "subcategory": "",
-    "intensity": "",
-    "region": "andes",
-    "regiontags": [],
-    "legalstatus": "Cactus legal; mescaline controlled",
-    "schedule": "",
-    "legalnotes": "",
     "description": "cactus rich in mescaline similar to san pedro.",
     "effects": "visions;empathy",
+    "intensity": "",
+    "region": "andes",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Cactus legal; mescaline controlled",
     "mechanism": "Mescaline acts as a 5-HT2A agonist",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "20–30 cm fresh cactus",
-    "therapeutic": "spiritual insight",
-    "interactions": [
-      "maois",
-      "stimulants"
+    "compounds": [],
+    "toxicity_ld50": ">1 g/kg (rats)",
+    "safety": "",
+    "sideeffects": [
+      "nausea",
+      "dilated pupils"
     ],
     "contraindications": [
       "heart issues",
       "pregnancy"
     ],
-    "sideeffects": [
-      "nausea",
-      "dilated pupils"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": ">1 g/kg (rats)",
+    "therapeutic": "spiritual insight",
     "tags": [
       "🌀 visionary",
       "🌵 cactus"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "20–30 cm fresh cactus",
+    "interactions": [
+      "maois",
+      "stimulants"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -4137,32 +8070,26 @@
     "common": "",
     "scientific": "Eleutherococcus senticosus",
     "category": "stimulant / adaptogen",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "siberia",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "also called siberian ginseng, popular adaptogen.",
     "effects": "Energy;stress resistance",
+    "intensity": "Mild",
+    "region": "siberia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Eleutherosides modulate stress hormones",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "enhance stamina and immune function",
-    "interactions": [
-      "may interact with digoxin"
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "insomnia in sensitive individuals"
     ],
     "contraindications": [
       "hypertension"
     ],
-    "sideeffects": [
-      "insomnia in sensitive individuals"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "enhance stamina and immune function",
     "tags": [
       "stimulant",
       "✅ safe",
@@ -4174,6 +8101,15 @@
       "2010",
       "WHO Monographs on Selected Medicinal Plants"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interact with digoxin"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -4182,45 +8118,48 @@
     "common": "Epena",
     "scientific": "Virola theiodora",
     "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Very strong",
-    "region": "amazon (brazil, venezuela)",
-    "regiontags": [],
-    "legalstatus": "DMT controlled in most countries",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a snuff plant from the amazon containing dmt and 5-meo-dmt. used by yanomami and other tribes for potent visionary rituals.",
     "effects": "Strong visuals;spiritual experiences;disorientation",
+    "intensity": "Very strong",
+    "region": "amazon (brazil, venezuela)",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "DMT controlled in most countries",
     "mechanism": "DMT and 5-MeO-DMT – 5-HT2A agonists",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "DMT",
       "5-MeO-DMT"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "shamanic ritual; purging and vision work",
-    "interactions": [
-      "maois",
-      "antidepressants"
-    ],
-    "contraindications": [
-      "maois",
-      "mental health issues"
-    ],
+    "toxicity_ld50": "",
+    "safety": "",
     "sideeffects": [
       "nausea",
       "tremors",
       "vomiting"
     ],
-    "safety": "",
-    "toxicity": "High psychological, moderate physical",
-    "toxicity_ld50": "",
+    "contraindications": [
+      "maois",
+      "mental health issues"
+    ],
+    "therapeutic": "shamanic ritual; purging and vision work",
     "tags": [
       "⚠️ vision",
       "🌬️ snuff",
       "🧠 dmt"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "maois",
+      "antidepressants"
+    ],
+    "toxicity": "High psychological, moderate physical",
     "image": ""
   },
   {
@@ -4229,37 +8168,40 @@
     "common": "",
     "scientific": "Ephedra nevadensis",
     "category": "stimulant",
-    "subcategory": "",
-    "intensity": "",
-    "region": "north america",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "mild stimulant desert shrub without strong ephedra content.",
     "effects": "mild stimulation",
+    "intensity": "",
+    "region": "north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Contains ephedrine-like alkaloids releasing norepinephrine",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "5–10 g dried stems",
-    "therapeutic": "decongestant",
-    "interactions": [
-      "stimulants",
-      "decongestants"
+    "compounds": [],
+    "toxicity_ld50": ">500 mg/kg (mice)",
+    "safety": "",
+    "sideeffects": [
+      "increased heart rate"
     ],
     "contraindications": [
       "hypertension"
     ],
-    "sideeffects": [
-      "increased heart rate"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": ">500 mg/kg (mice)",
+    "therapeutic": "decongestant",
     "tags": [
       "☕ brewable"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "5–10 g dried stems",
+    "interactions": [
+      "stimulants",
+      "decongestants"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -4268,36 +8210,30 @@
     "common": "",
     "scientific": "Ephedra sinica",
     "category": "stimulant / decongestant",
-    "subcategory": "",
-    "intensity": "Strong",
-    "region": "china and central asia",
-    "regiontags": [],
-    "legalstatus": "Regulated in many countries",
-    "schedule": "",
-    "legalnotes": "",
     "description": "shrubby plant known as ma huang; source of ephedrine used both medicinally and recreationally.",
     "effects": "Energy boost;bronchodilation",
+    "intensity": "Strong",
+    "region": "china and central asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Regulated in many countries",
     "mechanism": "Ephedrine and pseudoephedrine stimulate adrenergic receptors and release norepinephrine.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditional chinese medicine for asthma, colds, and as a stimulant.",
-    "interactions": [
-      "dangerous with other stimulants or maois"
+    "compounds": [],
+    "toxicity_ld50": "Ephedrine LD50 ~50 mg/kg (rats)",
+    "safety": "",
+    "sideeffects": [
+      "jitters",
+      "elevated heart rate",
+      "insomnia"
     ],
     "contraindications": [
       "heart disease",
       "hypertension",
       "maois."
     ],
-    "sideeffects": [
-      "jitters",
-      "elevated heart rate",
-      "insomnia"
-    ],
-    "safety": "",
-    "toxicity": "High doses can raise blood pressure and cause cardiovascular stress.",
-    "toxicity_ld50": "Ephedrine LD50 ~50 mg/kg (rats)",
+    "therapeutic": "traditional chinese medicine for asthma, colds, and as a stimulant.",
     "tags": [
       "⚠️ potent",
       "🌿 ma huang"
@@ -4307,6 +8243,15 @@
       "FDA Ephedra Ban Report (2004)",
       "Pharmacopoeia of the People’s Republic of China"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "dangerous with other stimulants or maois"
+    ],
+    "toxicity": "High doses can raise blood pressure and cause cardiovascular stress.",
     "image": ""
   },
   {
@@ -4315,40 +8260,43 @@
     "common": "",
     "scientific": "Erythrina americana",
     "category": "sedative / anxiolytic",
-    "subcategory": "",
-    "intensity": "Mild to Moderate",
-    "region": "mexico",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "known locally as colorín; its red flowers are brewed into a soothing bedtime drink.",
     "effects": "relaxation;dreaminess;reduced anxiety",
+    "intensity": "Mild to Moderate",
+    "region": "mexico",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Contains erythrinan alkaloids acting as GABAergic depressants",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "mexican folk remedy for insomnia and nervous tension",
-    "interactions": [
-      "may enhance effects of other sedatives"
+    "compounds": [],
+    "toxicity_ld50": "Not well established",
+    "safety": "",
+    "sideeffects": [
+      "drowsiness",
+      "dizziness"
     ],
     "contraindications": [
       "pregnancy",
       "combining with cns depressants"
     ],
-    "sideeffects": [
-      "drowsiness",
-      "dizziness"
-    ],
-    "safety": "",
-    "toxicity": "Low to moderate",
-    "toxicity_ld50": "Not well established",
+    "therapeutic": "mexican folk remedy for insomnia and nervous tension",
     "tags": [
       "mexico",
       "flower",
       "sleep"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may enhance effects of other sedatives"
+    ],
+    "toxicity": "Low to moderate",
     "image": ""
   },
   {
@@ -4357,34 +8305,28 @@
     "common": "",
     "scientific": "Erythrina mulungu",
     "category": "sedative / anxiolytic",
-    "subcategory": "",
-    "intensity": "Moderate",
-    "region": "brazil and neighboring countries",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "flowering tree whose bark is prized in brazilian folk medicine for calming nerves and promoting sleep.",
     "effects": "deep relaxation;anxiety relief;sleepiness",
+    "intensity": "Moderate",
+    "region": "brazil and neighboring countries",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Erythrinan alkaloids interact with GABA receptors causing CNS depression",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "south american remedy for insomnia and stress",
-    "interactions": [
-      "may potentiate other cns depressants"
+    "compounds": [],
+    "toxicity_ld50": "Not well documented",
+    "safety": "",
+    "sideeffects": [
+      "drowsiness",
+      "lowered blood pressure"
     ],
     "contraindications": [
       "pregnancy",
       "combining with strong sedatives"
     ],
-    "sideeffects": [
-      "drowsiness",
-      "lowered blood pressure"
-    ],
-    "safety": "",
-    "toxicity": "Relatively safe at moderate doses",
-    "toxicity_ld50": "Not well documented",
+    "therapeutic": "south american remedy for insomnia and stress",
     "tags": [
       "brazil",
       "root",
@@ -4397,6 +8339,15 @@
       "Rainforest Remedies – Taylor",
       "2003"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may potentiate other cns depressants"
+    ],
+    "toxicity": "Relatively safe at moderate doses",
     "image": ""
   },
   {
@@ -4405,37 +8356,30 @@
     "common": "",
     "scientific": "Erythroxylum catuaba",
     "category": "aphrodisiac / nootropic",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "brazil, amazon, south america",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a traditional brazilian aphrodisiac made from the bark of various erythroxylum species (mainly e. catuaba). catuaba is used to boost libido, mental clarity, and mood — both in traditional medicine and modern supplements.",
     "effects": "Stimulation;Enhanced libido;Mild euphoria;Cognitive enhancement",
+    "intensity": "Mild–Moderate",
+    "region": "brazil, amazon, south america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Contains alkaloids, flavonoids, and possibly tropane-related compounds. Stimulates central nervous system and may increase nitric oxide availability.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Catuabine"
     ],
-    "preparations": [],
-    "dosage": "1-2 g bark",
-    "therapeutic": "used traditionally for sexual debility, fatigue, poor memory, and stress. often paired with muira puama.",
-    "interactions": [
-      "may mildly potentiate stimulants or maois. interacts with dopaminergic drugs.",
-      "stimulants"
+    "toxicity_ld50": "Not well documented",
+    "safety": "",
+    "sideeffects": [
+      "rare. may cause mild overstimulation or insomnia in sensitive individuals.",
+      "restlessness"
     ],
     "contraindications": [
       "caution with anxiety disorders or insomnia. avoid in pregnancy due to insufficient data.",
       "insomnia"
     ],
-    "sideeffects": [
-      "rare. may cause mild overstimulation or insomnia in sensitive individuals.",
-      "restlessness"
-    ],
-    "safety": "",
-    "toxicity": "Low. Considered very safe in traditional dosing.",
-    "toxicity_ld50": "Not well documented",
+    "therapeutic": "used traditionally for sexual debility, fatigue, poor memory, and stress. often paired with muira puama.",
     "tags": [
       "🔥 aphrodisiac",
       "🧠 nootropic",
@@ -4448,6 +8392,16 @@
       "2005",
       "The Healing Power of Rainforest Herbs – Leslie Taylor"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "1-2 g bark",
+    "interactions": [
+      "may mildly potentiate stimulants or maois. interacts with dopaminergic drugs.",
+      "stimulants"
+    ],
+    "toxicity": "Low. Considered very safe in traditional dosing.",
     "image": ""
   },
   {
@@ -4456,24 +8410,24 @@
     "common": "",
     "scientific": "Erythroxylum coca",
     "category": "stimulant",
-    "subcategory": "",
-    "intensity": "Moderate",
-    "region": "andean south america",
-    "regiontags": [],
-    "legalstatus": "Cultivation regulated; cocaine controlled",
-    "schedule": "",
-    "legalnotes": "",
     "description": "traditional andean stimulant leaf.",
     "effects": "alertness;reduced fatigue;mild euphoria",
+    "intensity": "Moderate",
+    "region": "andean south america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Cultivation regulated; cocaine controlled",
     "mechanism": "Leaves contain cocaine acting as a dopamine and norepinephrine reuptake inhibitor",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "1–3 g dried leaves",
-    "therapeutic": "altitude sickness relief, energy boost, appetite suppression",
-    "interactions": [
-      "stimulants",
-      "maois",
-      "dangerous with maois or stimulants"
+    "compounds": [],
+    "toxicity_ld50": "~95 mg/kg (rat, cocaine)",
+    "safety": "",
+    "sideeffects": [
+      "elevated heart rate",
+      "insomnia",
+      "increased heart rate",
+      "potential dependence"
     ],
     "contraindications": [
       "heart issues",
@@ -4481,15 +8435,7 @@
       "heart disease",
       "hypertension"
     ],
-    "sideeffects": [
-      "elevated heart rate",
-      "insomnia",
-      "increased heart rate",
-      "potential dependence"
-    ],
-    "safety": "",
-    "toxicity": "Low in leaf form; purified alkaloid is addictive",
-    "toxicity_ld50": "~95 mg/kg (rat, cocaine)",
+    "therapeutic": "altitude sickness relief, energy boost, appetite suppression",
     "tags": [
       "⚠️ restricted",
       "🌿 leaf",
@@ -4498,6 +8444,17 @@
       "coca leaf"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "1–3 g dried leaves",
+    "interactions": [
+      "stimulants",
+      "maois",
+      "dangerous with maois or stimulants"
+    ],
+    "toxicity": "Low in leaf form; purified alkaloid is addictive",
     "image": ""
   },
   {
@@ -4506,32 +8463,26 @@
     "common": "",
     "scientific": "Eschscholzia californica",
     "category": "dissociative / sedative",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "north america",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "california poppy with gentle relaxing properties.",
     "effects": "Sedation;mild euphoria",
+    "intensity": "Mild",
+    "region": "north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Protopine alkaloids interact with GABA receptors",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "anxiety and sleep support",
-    "interactions": [
-      "potentiates cns depressants"
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "drowsiness"
     ],
     "contraindications": [
       "use caution with other sedatives"
     ],
-    "sideeffects": [
-      "drowsiness"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "anxiety and sleep support",
     "tags": [
       "✅ safe",
       "🌿 flower",
@@ -4543,6 +8494,15 @@
       "Journal of Natural Medicines",
       "2011"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "potentiates cns depressants"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -4551,33 +8511,26 @@
     "common": "",
     "scientific": "Espeletia grandiflora",
     "category": "respiratory / folk medicine / andean",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "colombia, ecuador, andean cloud forests",
-    "regiontags": [],
-    "legalstatus": "Legal (not widely commercialized)",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a fuzzy-leaved plant from the páramo cloud forests of the andes. used in colombian and ecuadorian folk medicine for respiratory and throat ailments. its woolly foliage helps conserve water and reduce inflammation when brewed.",
     "effects": "Cough relief;Lung support;Anti-inflammatory;Moisture retention",
+    "intensity": "Mild",
+    "region": "colombia, ecuador, andean cloud forests",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal (not widely commercialized)",
     "mechanism": "Contains sesquiterpenes and flavonoids with anti-inflammatory and soothing properties. Traditionally believed to aid mucosal healing.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used in herbal teas for bronchitis, sore throat, dry cough, and cold weather ailments. also respected as a spiritual guardian plant by andean communities.",
-    "interactions": [
-      "none documented",
-      "likely safe with most respiratory herbs."
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "mild gi discomfort if taken in excess. limited formal studies."
     ],
     "contraindications": [
       "avoid during pregnancy due to unknown effects. no known toxicities in folk doses."
     ],
-    "sideeffects": [
-      "mild gi discomfort if taken in excess. limited formal studies."
-    ],
-    "safety": "",
-    "toxicity": "Very low. Long traditional use in small communities.",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "used in herbal teas for bronchitis, sore throat, dry cough, and cold weather ailments. also respected as a spiritual guardian plant by andean communities.",
     "tags": [
       "🌫️ andean",
       "💨 lung tonic",
@@ -4590,6 +8543,16 @@
       "Ethnobotany of the Andes",
       "2019"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "none documented",
+      "likely safe with most respiratory herbs."
+    ],
+    "toxicity": "Very low. Long traditional use in small communities.",
     "image": ""
   },
   {
@@ -4598,36 +8561,28 @@
     "common": "",
     "scientific": "Eurycoma longifolia",
     "category": "aphrodisiac / adaptogen / hormonal",
-    "subcategory": "",
-    "intensity": "Moderate",
-    "region": "malaysia, indonesia, thailand",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a southeast asian root revered for enhancing libido, strength, and masculinity. traditionally used by men to improve vitality and hormonal health. now globally marketed as a natural testosterone booster.",
     "effects": "Testosterone boost;Energy;Stress resilience;Libido enhancement",
+    "intensity": "Moderate",
+    "region": "malaysia, indonesia, thailand",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Contains quassinoids like eurycomanone that may increase free testosterone, reduce cortisol, and stimulate dopaminergic and androgenic pathways.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for erectile dysfunction, fatigue, depression, infertility, and athletic performance. studied for stress-induced cortisol reduction.",
-    "interactions": [
-      "may interact with hormone therapies",
-      "ssris",
-      "or antihypertensives."
-    ],
-    "contraindications": [
-      "avoid in hormone-sensitive conditions or with steroids. not for pregnant individuals."
-    ],
+    "compounds": [],
+    "toxicity_ld50": ">3000 mg/kg (rats, oral)",
+    "safety": "",
     "sideeffects": [
       "mild restlessness",
       "insomnia",
       "or irritability in high doses. not typically sedating."
     ],
-    "safety": "",
-    "toxicity": "Low in normal doses. High doses can overstimulate.",
-    "toxicity_ld50": ">3000 mg/kg (rats, oral)",
+    "contraindications": [
+      "avoid in hormone-sensitive conditions or with steroids. not for pregnant individuals."
+    ],
+    "therapeutic": "used for erectile dysfunction, fatigue, depression, infertility, and athletic performance. studied for stress-induced cortisol reduction.",
     "tags": [
       "🔥 aphrodisiac",
       "🏋️ testosterone",
@@ -4640,6 +8595,17 @@
       "2013",
       "Malaysian Herbal Monographs"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interact with hormone therapies",
+      "ssris",
+      "or antihypertensives."
+    ],
+    "toxicity": "Low in normal doses. High doses can overstimulate.",
     "image": ""
   },
   {
@@ -4648,44 +8614,46 @@
     "common": "Galbulimima",
     "scientific": "Galbulimima belgraveana",
     "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Moderate to Strong",
-    "region": "papua new guinea and northern australia",
-    "regiontags": [],
-    "legalstatus": "Little formal regulation",
-    "schedule": "",
-    "legalnotes": "",
     "description": "rare rainforest tree providing psychoactive bark traditionally used in new guinea for visionary experiences.",
     "effects": "dreamlike visions;dizziness;altered consciousness",
+    "intensity": "Moderate to Strong",
+    "region": "papua new guinea and northern australia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Little formal regulation",
     "mechanism": "Contains himbacine-type alkaloids with muscarinic antagonist activity",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Himbacine",
       "Galbulimimine"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used by papuan tribes for shamanic rituals and hunting magic",
-    "interactions": [
-      "avoid combining with other anticholinergics"
-    ],
-    "contraindications": [
-      "unknown",
-      "caution due to potent effects"
-    ],
+    "toxicity_ld50": "Not established",
+    "safety": "",
     "sideeffects": [
       "nausea",
       "vertigo",
       "intense dreams"
     ],
-    "safety": "",
-    "toxicity": "Reports of toxicity at high doses; data limited",
-    "toxicity_ld50": "Not established",
+    "contraindications": [
+      "caution due to potent effects"
+    ],
+    "therapeutic": "used by papuan tribes for shamanic rituals and hunting magic",
     "tags": [
       "papua new guinea",
       "hallucinogen",
       "tree"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "avoid combining with other anticholinergics"
+    ],
+    "toxicity": "Reports of toxicity at high doses; data limited",
     "image": ""
   },
   {
@@ -4694,32 +8662,26 @@
     "common": "",
     "scientific": "Galphimia glauca",
     "category": "anxiolytic / sedative / mexican traditional",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "mexico, central america",
-    "regiontags": [],
-    "legalstatus": "Legal (limited international awareness)",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a mexican herb used to treat anxiety, phobias, and restlessness. clinical studies in mexico show it to be comparable to benzodiazepines in reducing anxiety — but without sedation or dependency.",
     "effects": "Anxiety relief;Tranquility;Sleep aid;Reduced reactivity",
+    "intensity": "Mild–Moderate",
+    "region": "mexico, central america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal (limited international awareness)",
     "mechanism": "Contains galphimine B, a nor-seco-triterpenoid that modulates GABAergic and dopaminergic systems, particularly by blocking dopaminergic overactivation in limbic areas.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for anxiety, panic attacks, emotional hyper-reactivity, and stress-related insomnia. studied in treatment of specific phobias and social anxiety.",
-    "interactions": [
-      "mild additive effects with sedatives or alcohol."
+    "compounds": [],
+    "toxicity_ld50": ">5000 mg/kg (rats, oral extract)",
+    "safety": "",
+    "sideeffects": [
+      "very few. rare reports of mild dizziness or gi upset. no withdrawal or dependence noted."
     ],
     "contraindications": [
       "avoid combining with benzodiazepines or strong cns depressants. insufficient data in pregnancy."
     ],
-    "sideeffects": [
-      "very few. rare reports of mild dizziness or gi upset. no withdrawal or dependence noted."
-    ],
-    "safety": "",
-    "toxicity": "Low. No observed toxicity at clinical doses.",
-    "toxicity_ld50": ">5000 mg/kg (rats, oral extract)",
+    "therapeutic": "used for anxiety, panic attacks, emotional hyper-reactivity, and stress-related insomnia. studied in treatment of specific phobias and social anxiety.",
     "tags": [
       "🌼 anti-anxiety",
       "🧘 calm",
@@ -4733,6 +8695,15 @@
       "Phytomedicine",
       "2012"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "mild additive effects with sedatives or alcohol."
+    ],
+    "toxicity": "Low. No observed toxicity at clinical doses.",
     "image": ""
   },
   {
@@ -4741,40 +8712,43 @@
     "common": "",
     "scientific": "Ganoderma lucidum",
     "category": "other",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "🇨🇳 east asia",
-    "regiontags": [],
-    "legalstatus": "Legal / Unregulated",
-    "schedule": "",
-    "legalnotes": "",
     "description": "tonic fungus revered in asia for boosting immunity and easing stress.",
     "effects": "Immune support;calm focus",
+    "intensity": "Mild",
+    "region": "🇨🇳 east asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
     "mechanism": "Triterpenoids and beta-glucans modulate immune response.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "immune enhancement, stress resilience, antioxidant.",
-    "interactions": [
-      "anticoagulants",
-      "immunosuppressants."
+    "compounds": [],
+    "toxicity_ld50": "Not established; safe in traditional use.",
+    "safety": "1",
+    "sideeffects": [
+      "rare digestive upset or rash."
     ],
     "contraindications": [
       "bleeding disorders",
       "surgery."
     ],
-    "sideeffects": [
-      "rare digestive upset or rash."
-    ],
-    "safety": "1",
-    "toxicity": "Very low toxicity; widely consumed as tonic.",
-    "toxicity_ld50": "Not established; safe in traditional use.",
+    "therapeutic": "immune enhancement, stress resilience, antioxidant.",
     "tags": [
       "\\u2615 brewable",
       "\\ud83e\\udde0 cognitive",
       "\\u2705 safe"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "anticoagulants",
+      "immunosuppressants."
+    ],
+    "toxicity": "Very low toxicity; widely consumed as tonic.",
     "image": ""
   },
   {
@@ -4783,32 +8757,26 @@
     "common": "",
     "scientific": "Gastrodia elata",
     "category": "neuroprotective / anticonvulsant / traditional chinese",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "china, korea, taiwan, japan",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a prized root in traditional chinese medicine used to calm internal wind and treat dizziness, seizures, and nervous system disorders. it grows symbiotically with fungi in shaded forest floors.",
     "effects": "Calms the liver;Relieves tremors;Supports cognition;Anti-epileptic",
+    "intensity": "Mild–Moderate",
+    "region": "china, korea, taiwan, japan",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Contains gastrodin and vanillin derivatives that modulate GABA activity, reduce neuroinflammation, and support mitochondrial health. Protective against seizures and neurodegeneration.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for epilepsy, tremors, dizziness, stroke recovery, and tension headaches. also supports memory and is studied for alzheimer's and parkinson’s models.",
-    "interactions": [
-      "may potentiate antiepileptics or anxiolytics. monitor if used with neuroactive prescriptions."
+    "compounds": [],
+    "toxicity_ld50": ">5000 mg/kg (rats, oral extract)",
+    "safety": "",
+    "sideeffects": [
+      "rare. occasionally mild sedation or dry mouth."
     ],
     "contraindications": [
       "none significant. caution with cns depressants or seizure meds."
     ],
-    "sideeffects": [
-      "rare. occasionally mild sedation or dry mouth."
-    ],
-    "safety": "",
-    "toxicity": "Low. Used safely in TCM for centuries.",
-    "toxicity_ld50": ">5000 mg/kg (rats, oral extract)",
+    "therapeutic": "used for epilepsy, tremors, dizziness, stroke recovery, and tension headaches. also supports memory and is studied for alzheimer's and parkinson’s models.",
     "tags": [
       "🧠 neuroprotective",
       "🌿 tcm",
@@ -4821,6 +8789,15 @@
       "2015",
       "Chinese Pharmacopoeia – Tian Ma Entry"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may potentiate antiepileptics or anxiolytics. monitor if used with neuroactive prescriptions."
+    ],
+    "toxicity": "Low. Used safely in TCM for centuries.",
     "image": ""
   },
   {
@@ -4829,33 +8806,19 @@
     "common": "",
     "scientific": "Gelsemium sempervirens",
     "category": "toxic / nervine / homeopathic",
-    "subcategory": "",
-    "intensity": "Strong (toxic)",
-    "region": "southeastern u.s., mexico",
-    "regiontags": [],
-    "legalstatus": "Legal but restricted in some areas",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a beautiful yet highly poisonous vine native to the southeastern u.s. used in extremely low doses for anxiety, migraines, and spasms — but lethal in excess. homeopathy and some experimental medicine have explored it for nervous tension.",
     "effects": "Muscle relaxation;Nervous system inhibition;Pain relief;Delirium (toxic doses)",
+    "intensity": "Strong (toxic)",
+    "region": "southeastern u.s., mexico",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal but restricted in some areas",
     "mechanism": "Contains gelsemine and gelseminine, which act as glycine receptor agonists and inhibit spinal reflexes. High doses paralyze the respiratory center.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "5–10 drops tincture",
-    "therapeutic": "historically used for neuralgia, migraines, fevers, and anxiety — but now mostly used homeopathically. still researched for neuropathic pain.",
-    "interactions": [
-      "sedatives",
-      "muscle relaxants",
-      "fatal when mixed with depressants",
-      "alcohol",
-      "opioids",
-      "or sedatives."
-    ],
-    "contraindications": [
-      "pregnancy",
-      "heart issues",
-      "do not self-administer. avoid entirely unless under trained guidance. toxic to children and animals."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Gelsemine ~10 mg/kg (mice, oral)",
+    "safety": "",
     "sideeffects": [
       "respiratory depression in overdose",
       "dizziness",
@@ -4864,9 +8827,12 @@
       "muscle weakness",
       "respiratory depression. fatal in high doses."
     ],
-    "safety": "",
-    "toxicity": "Extremely high. One drop of extract may be fatal.",
-    "toxicity_ld50": "Gelsemine ~10 mg/kg (mice, oral)",
+    "contraindications": [
+      "pregnancy",
+      "heart issues",
+      "do not self-administer. avoid entirely unless under trained guidance. toxic to children and animals."
+    ],
+    "therapeutic": "historically used for neuralgia, migraines, fevers, and anxiety — but now mostly used homeopathically. still researched for neuropathic pain.",
     "tags": [
       "⚠️ caution",
       "⚠️ toxic",
@@ -4880,6 +8846,20 @@
       "American Journal of Therapeutics",
       "2012"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "5–10 drops tincture",
+    "interactions": [
+      "sedatives",
+      "muscle relaxants",
+      "fatal when mixed with depressants",
+      "alcohol",
+      "opioids",
+      "or sedatives."
+    ],
+    "toxicity": "Extremely high. One drop of extract may be fatal.",
     "image": ""
   },
   {
@@ -4888,32 +8868,26 @@
     "common": "",
     "scientific": "Genipa americana",
     "category": "traditional / ritual / antimicrobial",
-    "subcategory": "",
-    "intensity": "Mild (topical); moderate (oral folk prep)",
-    "region": "amazon basin, central & south america",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "an amazonian fruit tree whose juice oxidizes into a black-blue dye. used for temporary body art, sun protection, insect repellent, and ritual purification. sometimes used in decoctions for fever or wounds.",
     "effects": "Skin staining;Mild antibacterial;Cooling sensation;Symbolic use",
+    "intensity": "Mild (topical); moderate (oral folk prep)",
+    "region": "amazon basin, central & south america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Genipin (active compound) crosslinks with amino acids in skin keratin, forming a black pigment. Also displays mild antimicrobial and antioxidant properties.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "topical use for decoration, bug repellent, minor skin infection; internal folk uses for respiratory infections and inflammation.",
-    "interactions": [
-      "none known."
+    "compounds": [],
+    "toxicity_ld50": "Genipin LD50 >5000 mg/kg (rats, oral)",
+    "safety": "",
+    "sideeffects": [
+      "none when used externally. large internal doses may cause gi upset or hypotension."
     ],
     "contraindications": [
       "not for use on open wounds or in pregnancy (internal use)."
     ],
-    "sideeffects": [
-      "none when used externally. large internal doses may cause gi upset or hypotension."
-    ],
-    "safety": "",
-    "toxicity": "Low topically. Caution with internal use due to limited data.",
-    "toxicity_ld50": "Genipin LD50 >5000 mg/kg (rats, oral)",
+    "therapeutic": "topical use for decoration, bug repellent, minor skin infection; internal folk uses for respiratory infections and inflammation.",
     "tags": [
       "🌌 body paint",
       "🦟 insect repellent",
@@ -4927,6 +8901,15 @@
       "Amazonian Plant Medicine – Taylor",
       "2002"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "none known."
+    ],
+    "toxicity": "Low topically. Caution with internal use due to limited data.",
     "image": ""
   },
   {
@@ -4935,35 +8918,29 @@
     "common": "",
     "scientific": "Ginkgo biloba",
     "category": "nootropic / circulatory",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "china, cultivated worldwide",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "",
     "effects": "improved cognition;circulation boost;alertness",
+    "intensity": "Mild",
+    "region": "china, cultivated worldwide",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Flavone glycosides and terpenoids enhance blood flow and modulate neurotransmission",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for memory loss, dementia, and circulatory issues",
-    "interactions": [
-      "potentiates blood thinners like warfarin"
-    ],
-    "contraindications": [
-      "bleeding disorders",
-      "anticoagulant use"
-    ],
+    "compounds": [],
+    "toxicity_ld50": ">5 g/kg in animals",
+    "safety": "",
     "sideeffects": [
       "headache",
       "upset stomach",
       "possible bleeding risk"
     ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": ">5 g/kg in animals",
+    "contraindications": [
+      "bleeding disorders",
+      "anticoagulant use"
+    ],
+    "therapeutic": "used for memory loss, dementia, and circulatory issues",
     "tags": [
       "ancient",
       "blood flow",
@@ -4975,6 +8952,15 @@
       "2001",
       "ESCOP Monograph – Ginkgo"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "potentiates blood thinners like warfarin"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -4983,38 +8969,41 @@
     "common": "",
     "scientific": "Glaucium flavum",
     "category": "other",
-    "subcategory": "",
-    "intensity": "",
-    "region": "mediterranean",
-    "regiontags": [],
-    "legalstatus": "Varies",
-    "schedule": "",
-    "legalnotes": "",
     "description": "coastal poppy used occasionally for its glaucine content.",
     "effects": "mild euphoria;sedation",
+    "intensity": "",
+    "region": "mediterranean",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Varies",
     "mechanism": "Contains glaucine, a bronchodilator acting on dopamine receptors",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "10–20 mg glaucine",
-    "therapeutic": "cough suppressant",
-    "interactions": [
-      "cns depressants"
-    ],
-    "contraindications": [
-      "pregnancy"
-    ],
+    "compounds": [],
+    "toxicity_ld50": ">300 mg/kg (mice)",
+    "safety": "",
     "sideeffects": [
       "dizziness",
       "nausea"
     ],
-    "safety": "",
-    "toxicity": "Moderate",
-    "toxicity_ld50": ">300 mg/kg (mice)",
+    "contraindications": [
+      "pregnancy"
+    ],
+    "therapeutic": "cough suppressant",
     "tags": [
       "🌀 visionary",
       "💊 oral"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "10–20 mg glaucine",
+    "interactions": [
+      "cns depressants"
+    ],
+    "toxicity": "Moderate",
     "image": ""
   },
   {
@@ -5023,32 +9012,26 @@
     "common": "",
     "scientific": "Gliricidia sepium",
     "category": "antiparasitic / agricultural / ethnovet",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "central america, philippines, tropical zones",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a fast-growing tropical tree used in traditional medicine and animal care. known for treating scabies, wounds, and skin infections. leaves contain natural insecticidal compounds.",
     "effects": "Topical antiparasitic;Wound healing;Insect repellent;Mild analgesic",
+    "intensity": "Mild–Moderate",
+    "region": "central america, philippines, tropical zones",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Rich in tannins and coumarins with insecticidal, antibacterial, and anti-inflammatory effects. Used externally to kill lice, fleas, and skin pathogens.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for skin diseases, minor wounds, and pest repellent in animals and humans. also used as a green manure and fencing material.",
-    "interactions": [
-      "none known topically."
+    "compounds": [],
+    "toxicity_ld50": "Not well established",
+    "safety": "",
+    "sideeffects": [
+      "topical irritation in sensitive skin. toxic to livestock if ingested raw in large quantities."
     ],
     "contraindications": [
       "avoid ingestion unless properly prepared. not for internal use in humans."
     ],
-    "sideeffects": [
-      "topical irritation in sensitive skin. toxic to livestock if ingested raw in large quantities."
-    ],
-    "safety": "",
-    "toxicity": "Moderate (internal); safe topically in folk doses.",
-    "toxicity_ld50": "Not well established",
+    "therapeutic": "used for skin diseases, minor wounds, and pest repellent in animals and humans. also used as a green manure and fencing material.",
     "tags": [
       "🦠 antiparasitic",
       "🌿 ethnoveterinary",
@@ -5061,6 +9044,15 @@
       "Agroforestry & Ethnomedicine Reports",
       "2018"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "none known topically."
+    ],
+    "toxicity": "Moderate (internal); safe topically in folk doses.",
     "image": ""
   },
   {
@@ -5069,37 +9061,40 @@
     "common": "",
     "scientific": "Gloriosa superba",
     "category": "other",
-    "subcategory": "",
-    "intensity": "",
-    "region": "africa, asia",
-    "regiontags": [],
-    "legalstatus": "Ornamental; toxic",
-    "schedule": "",
-    "legalnotes": "",
     "description": "highly poisonous ornamental sometimes misused.",
     "effects": "intense nausea;weak delirium",
+    "intensity": "",
+    "region": "africa, asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Ornamental; toxic",
     "mechanism": "Contains colchicine disrupting microtubules",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "<5 seeds",
-    "therapeutic": "traditional poison and medicine",
-    "interactions": [
-      "none documented"
-    ],
-    "contraindications": [
-      "any internal use"
-    ],
+    "compounds": [],
+    "toxicity_ld50": "20 mg/kg (mice)",
+    "safety": "",
     "sideeffects": [
       "severe vomiting",
       "organ failure"
     ],
-    "safety": "",
-    "toxicity": "Very high",
-    "toxicity_ld50": "20 mg/kg (mice)",
+    "contraindications": [
+      "any internal use"
+    ],
+    "therapeutic": "traditional poison and medicine",
     "tags": [
       "☠️ toxic"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "<5 seeds",
+    "interactions": [
+      "none documented"
+    ],
+    "toxicity": "Very high",
     "image": ""
   },
   {
@@ -5108,34 +9103,28 @@
     "common": "",
     "scientific": "Gymnema sylvestre",
     "category": "metabolic / nootropic",
-    "subcategory": "",
-    "intensity": "",
-    "region": "india",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "ayurvedic herb that dulls sugar perception",
     "effects": "reduced sweet taste;focus",
+    "intensity": "",
+    "region": "india",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Gymnemic acids block sweet receptors and modulate glucose absorption",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Gymnemic Acids"
     ],
-    "preparations": [],
-    "dosage": "0.5-1 g leaf",
-    "therapeutic": "diabetes support, appetite",
-    "interactions": [
-      "antidiabetic drugs"
+    "toxicity_ld50": ">3 g/kg (rats)",
+    "safety": "",
+    "sideeffects": [
+      "temporary loss of sweet taste"
     ],
     "contraindications": [
       "hypoglycemia"
     ],
-    "sideeffects": [
-      "temporary loss of sweet taste"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": ">3 g/kg (rats)",
+    "therapeutic": "diabetes support, appetite",
     "tags": [
       "🍃 leaf"
     ],
@@ -5145,6 +9134,15 @@
       "2011",
       "Ayurvedic Pharmacopoeia of India"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "0.5-1 g leaf",
+    "interactions": [
+      "antidiabetic drugs"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -5153,37 +9151,40 @@
     "common": "",
     "scientific": "Gynostemma pentaphyllum",
     "category": "other",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "china",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "called jiaogulan, reputed longevity herb.",
     "effects": "Adaptogenic;anti-inflammatory",
+    "intensity": "Mild",
+    "region": "china",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Gypenosides modulate nitric oxide and cortisol",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "stress resilience, metabolic support",
-    "interactions": [
-      "may enhance anticoagulants"
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "rare digestive upset"
     ],
     "contraindications": [
       "none known"
     ],
-    "sideeffects": [
-      "rare digestive upset"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "stress resilience, metabolic support",
     "tags": [
       "✅ safe",
       "🌿 leaf"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may enhance anticoagulants"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -5192,28 +9193,28 @@
     "common": "Hawaiian baby woodrose",
     "scientific": "Argyreia nervosa",
     "category": "psychedelic / ergolines",
-    "subcategory": "",
-    "intensity": "Moderate",
-    "region": "india, hawaii, tropical regions",
-    "regiontags": [],
-    "legalstatus": "Legal to possess in most countries; LSA may be restricted.",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a climbing vine native to india and widely cultivated in hawaii. its seeds contain lsa (lysergic acid amide), a naturally occurring psychedelic related to lsd.",
     "effects": "Euphoria;Time distortion;Closed-eye visuals;Body heaviness;Drowsiness",
+    "intensity": "Moderate",
+    "region": "india, hawaii, tropical regions",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal to possess in most countries; LSA may be restricted.",
     "mechanism": "LSA (ergine) is a serotonergic compound acting primarily as a partial agonist at 5-HT2A receptors, similar to LSD but with more sedative effects.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "LSA (lysergic acid amide)"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "historically used in ayurveda for nervine and aphrodisiac properties. psychedelic use is experimental only.",
-    "interactions": [
-      "avoid combining with stimulants",
-      "maois",
-      "ssris",
-      "or vasoconstrictive drugs.",
-      "avoid with vasoconstrictors or other psychedelics"
+    "toxicity_ld50": "Unknown (ergine considered relatively low in acute toxicity)",
+    "safety": "",
+    "sideeffects": [
+      "strong nausea",
+      "vasoconstriction",
+      "lethargy",
+      "and confusion are common. may cause dizziness and chills.",
+      "nausea",
+      "sedation"
     ],
     "contraindications": [
       "not recommended for people with cardiovascular",
@@ -5223,17 +9224,7 @@
       "liver issues",
       "maois."
     ],
-    "sideeffects": [
-      "strong nausea",
-      "vasoconstriction",
-      "lethargy",
-      "and confusion are common. may cause dizziness and chills.",
-      "nausea",
-      "sedation"
-    ],
-    "safety": "",
-    "toxicity": "Mild to moderate; effects mostly unpleasant rather than dangerous. Improper preparation increases risk.",
-    "toxicity_ld50": "Unknown (ergine considered relatively low in acute toxicity)",
+    "therapeutic": "historically used in ayurveda for nervine and aphrodisiac properties. psychedelic use is experimental only.",
     "tags": [
       "🌱 seed",
       "🌀 lsa",
@@ -5247,6 +9238,19 @@
       "Journal of Ethnopharmacology",
       "1996"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "avoid combining with stimulants",
+      "maois",
+      "ssris",
+      "or vasoconstrictive drugs.",
+      "avoid with vasoconstrictors or other psychedelics"
+    ],
+    "toxicity": "Mild to moderate; effects mostly unpleasant rather than dangerous. Improper preparation increases risk.",
     "image": ""
   },
   {
@@ -5255,37 +9259,40 @@
     "common": "",
     "scientific": "Heimia myrtifolia",
     "category": "dissociative / sedative",
-    "subcategory": "",
-    "intensity": "",
-    "region": "mexico",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "relative of sinicuichi used similarly for mild trance",
     "effects": "auditory shift;relaxation",
+    "intensity": "",
+    "region": "mexico",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Alkaloids like vertine may alter neurotransmission",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "1-2 g leaves",
-    "therapeutic": "folk auditory enhancement",
-    "interactions": [
-      "caution with cns depressants"
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "dry mouth"
     ],
     "contraindications": [
       "pregnancy"
     ],
-    "sideeffects": [
-      "dry mouth"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "folk auditory enhancement",
     "tags": [
       "🌀 altered sound",
       "🌿 leaf"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "1-2 g leaves",
+    "interactions": [
+      "caution with cns depressants"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -5294,39 +9301,42 @@
     "common": "",
     "scientific": "Helichrysum odoratissimum",
     "category": "calming / ritual",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "southern africa",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "",
     "effects": "relaxation;mild euphoria;dream enhancement",
+    "intensity": "Mild",
+    "region": "southern africa",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Aromatic compounds interact with GABA and serotonin systems",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Essential oils",
       "Flavonoids"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used by south african healers for cleansing and ancestor communication",
-    "interactions": [],
-    "contraindications": [
-      "asthma or respiratory issues when smoked"
-    ],
+    "toxicity_ld50": "Not established",
+    "safety": "",
     "sideeffects": [
       "mild headache from smoke inhalation"
     ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "contraindications": [
+      "asthma or respiratory issues when smoked"
+    ],
+    "therapeutic": "used by south african healers for cleansing and ancestor communication",
     "tags": [
       "south africa",
       "imphepho",
       "smoke"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -5335,37 +9345,30 @@
     "common": "",
     "scientific": "Hericium erinaceus",
     "category": "nootropic / mushroom / neuroregenerative",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "china, japan, north america (temperate forests)",
-    "regiontags": [],
-    "legalstatus": "Legal / Unregulated",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a shaggy white mushroom revered for its ability to stimulate ngf (nerve growth factor) and support brain regeneration. used in both traditional chinese medicine and modern nootropic stacks.",
     "effects": "Nerve growth;Memory enhancement;Mood support;Cognitive clarity",
+    "intensity": "Mild",
+    "region": "china, japan, north america (temperate forests)",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
     "mechanism": "Contains hericenones and erinacines that cross the blood-brain barrier and promote neurogenesis by upregulating NGF. Also modulates inflammation and gut-brain axis.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for mild cognitive impairment, memory loss, anxiety, depression, and neurodegenerative conditions (alzheimer's, parkinson’s).",
-    "interactions": [
-      "may enhance neuroplasticity synergistically with other nootropics or antidepressants.",
-      "no major interactions documented."
+    "compounds": [],
+    "toxicity_ld50": "Not established; considered safe.",
+    "safety": "1",
+    "sideeffects": [
+      "very rare. may cause mild digestive upset or skin itching in sensitive individuals.",
+      "rare allergic reactions",
+      "generally well-tolerated."
     ],
     "contraindications": [
       "none major. caution in mushroom allergies.",
       "allergy to mushrooms",
       "pregnancy (limited data)."
     ],
-    "sideeffects": [
-      "very rare. may cause mild digestive upset or skin itching in sensitive individuals.",
-      "rare allergic reactions",
-      "generally well-tolerated."
-    ],
-    "safety": "1",
-    "toxicity": "Low toxicity; consumed as food in many cultures.",
-    "toxicity_ld50": "Not established; considered safe.",
+    "therapeutic": "used for mild cognitive impairment, memory loss, anxiety, depression, and neurodegenerative conditions (alzheimer's, parkinson’s).",
     "tags": [
       "🧠 brain growth",
       "🍄 mushroom",
@@ -5381,6 +9384,16 @@
       "2017",
       "Chinese Herbal Materia Medica"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may enhance neuroplasticity synergistically with other nootropics or antidepressants.",
+      "no major interactions documented."
+    ],
+    "toxicity": "Low toxicity; consumed as food in many cultures.",
     "image": ""
   },
   {
@@ -5389,34 +9402,28 @@
     "common": "",
     "scientific": "Hibiscus sabdariffa",
     "category": "relaxant / beverage",
-    "subcategory": "",
-    "intensity": "",
-    "region": "tropics",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "roselle flowers used for tart refreshing tea",
     "effects": "mild calm;vitamin C",
+    "intensity": "",
+    "region": "tropics",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Anthocyanins provide antioxidant and hypotensive actions",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Anthocyanins"
     ],
-    "preparations": [],
-    "dosage": "2-4 g dried",
-    "therapeutic": "cooling beverage, mild relaxation",
-    "interactions": [
-      "may potentiate antihypertensives"
+    "toxicity_ld50": ">5 g/kg (rats)",
+    "safety": "",
+    "sideeffects": [
+      "acidic on stomach"
     ],
     "contraindications": [
       "pregnancy large amounts"
     ],
-    "sideeffects": [
-      "acidic on stomach"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": ">5 g/kg (rats)",
+    "therapeutic": "cooling beverage, mild relaxation",
     "tags": [
       "🍵 tea"
     ],
@@ -5426,6 +9433,15 @@
       "2008",
       "African Herbal Pharmacopoeia"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "2-4 g dried",
+    "interactions": [
+      "may potentiate antihypertensives"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -5434,42 +9450,45 @@
     "common": "",
     "scientific": "Huperzia serrata",
     "category": "nootropic / cognitive",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "china, southeast asia",
-    "regiontags": [],
-    "legalstatus": "Legal in most countries",
-    "schedule": "",
-    "legalnotes": "",
     "description": "club moss used in traditional chinese medicine; source of huperzine a nootropic.",
     "effects": "Improved memory;alertness",
+    "intensity": "Mild",
+    "region": "china, southeast asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal in most countries",
     "mechanism": "Provides huperzine A, a reversible acetylcholinesterase inhibitor.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Huperzine A"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "memory enhancement, research for alzheimer’s disease.",
-    "interactions": [
-      "potentiates cholinergic drugs or acetylcholinesterase inhibitors"
-    ],
-    "contraindications": [
-      "bradycardia",
-      "cholinergic medications."
-    ],
+    "toxicity_ld50": "LD50 >2 mg/kg (rats, huperzine A)",
+    "safety": "",
     "sideeffects": [
       "nausea",
       "sweating",
       "muscle twitching at high doses"
     ],
-    "safety": "",
-    "toxicity": "Generally safe at low doses; high doses may cause cholinergic effects.",
-    "toxicity_ld50": "LD50 >2 mg/kg (rats, huperzine A)",
+    "contraindications": [
+      "bradycardia",
+      "cholinergic medications."
+    ],
+    "therapeutic": "memory enhancement, research for alzheimer’s disease.",
     "tags": [
       "⚗️ alkaloid",
       "🧠 memory"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "potentiates cholinergic drugs or acetylcholinesterase inhibitors"
+    ],
+    "toxicity": "Generally safe at low doses; high doses may cause cholinergic effects.",
     "image": ""
   },
   {
@@ -5478,29 +9497,19 @@
     "common": "",
     "scientific": "Hyoscyamus niger",
     "category": "deliriant / toxic / visionary",
-    "subcategory": "",
-    "intensity": "Extreme",
-    "region": "europe, north africa, asia",
-    "regiontags": [],
-    "legalstatus": "Legal in some countries, restricted elsewhere",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a notorious nightshade plant used historically in european witchcraft, sedatives, and flying ointments. contains powerful tropane alkaloids that can induce delirium, amnesia, and visionary states.",
     "effects": "Hallucinations;Disorientation;Sedation;Dryness;Trance",
+    "intensity": "Extreme",
+    "region": "europe, north africa, asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal in some countries, restricted elsewhere",
     "mechanism": "Scopolamine, hyoscyamine, and atropine block muscarinic acetylcholine receptors (anticholinergic), disrupting sensory and cognitive processing.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used in minute doses for pain, asthma, or surgery pre-medication. historically employed in magic and sedation.",
-    "interactions": [
-      "dangerous with cns depressants",
-      "alcohol",
-      "maois",
-      "or other anticholinergics."
-    ],
-    "contraindications": [
-      "unsafe in all non-clinical contexts. avoid with any psychiatric history or cardiovascular conditions."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Scopolamine LD50 ~300 mg/kg (mice, oral)",
+    "safety": "",
     "sideeffects": [
       "extreme dry mouth",
       "confusion",
@@ -5509,9 +9518,10 @@
       "pupil dilation",
       "urinary retention. risk of fatal respiratory failure."
     ],
-    "safety": "",
-    "toxicity": "Very high. Narrow therapeutic index.",
-    "toxicity_ld50": "Scopolamine LD50 ~300 mg/kg (mice, oral)",
+    "contraindications": [
+      "unsafe in all non-clinical contexts. avoid with any psychiatric history or cardiovascular conditions."
+    ],
+    "therapeutic": "used in minute doses for pain, asthma, or surgery pre-medication. historically employed in magic and sedation.",
     "tags": [
       "⚠️ deadly nightshade",
       "🌙 visionary",
@@ -5523,6 +9533,18 @@
       "Plants of the Gods – Rätsch",
       "Handbook of Medicinal Plants – CRC Press"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "dangerous with cns depressants",
+      "alcohol",
+      "maois",
+      "or other anticholinergics."
+    ],
+    "toxicity": "Very high. Narrow therapeutic index.",
     "image": ""
   },
   {
@@ -5531,43 +9553,46 @@
     "common": "",
     "scientific": "Hypericum perforatum",
     "category": "antidepressant / nootropic",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "europe, naturalized elsewhere",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "",
     "effects": "improved mood;reduced anxiety;light sedation",
+    "intensity": "Mild",
+    "region": "europe, naturalized elsewhere",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Hyperforin and hypericin inhibit reuptake of serotonin, dopamine, and norepinephrine",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "mild to moderate depression, anxiety, sleep issues",
-    "interactions": [
-      "strong inducer of liver enzymes",
-      "reduces efficacy of many medications"
+    "compounds": [],
+    "toxicity_ld50": ">2 g/kg in rodents",
+    "safety": "",
+    "sideeffects": [
+      "photosensitivity",
+      "dry mouth",
+      "gastrointestinal upset"
     ],
     "contraindications": [
       "use with ssris",
       "pregnancy",
       "strong sunlight exposure"
     ],
-    "sideeffects": [
-      "photosensitivity",
-      "dry mouth",
-      "gastrointestinal upset"
-    ],
-    "safety": "",
-    "toxicity": "Low to moderate",
-    "toxicity_ld50": ">2 g/kg in rodents",
+    "therapeutic": "mild to moderate depression, anxiety, sleep issues",
     "tags": [
       "maoi",
       "st. john's wort",
       "mood"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "strong inducer of liver enzymes",
+      "reduces efficacy of many medications"
+    ],
+    "toxicity": "Low to moderate",
     "image": ""
   },
   {
@@ -5576,38 +9601,41 @@
     "common": "",
     "scientific": "Hyssopus officinalis",
     "category": "stimulant / expectorant",
-    "subcategory": "",
-    "intensity": "",
-    "region": "mediterranean",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "traditional biblical herb used for colds and rituals",
     "effects": "respiratory relief;mild alertness",
+    "intensity": "",
+    "region": "mediterranean",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Monoterpenes like pinocamphone stimulate circulation",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "1-2 g dried leaf",
-    "therapeutic": "coughs, focus",
-    "interactions": [
-      "other stimulants"
+    "compounds": [],
+    "toxicity_ld50": ">1 g/kg (oil)",
+    "safety": "",
+    "sideeffects": [
+      "high doses may cause seizures"
     ],
     "contraindications": [
       "epilepsy",
       "pregnancy"
     ],
-    "sideeffects": [
-      "high doses may cause seizures"
-    ],
-    "safety": "",
-    "toxicity": "Moderate",
-    "toxicity_ld50": ">1 g/kg (oil)",
+    "therapeutic": "coughs, focus",
     "tags": [
       "⚠️ strong oil",
       "🍵 tea"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "1-2 g dried leaf",
+    "interactions": [
+      "other stimulants"
+    ],
+    "toxicity": "Moderate",
     "image": ""
   },
   {
@@ -5616,24 +9644,23 @@
     "common": "",
     "scientific": "Ilex guayusa",
     "category": "stimulant / amazonian / adaptogen",
-    "subcategory": "",
-    "intensity": "Mild to moderate",
-    "region": "amazon (ecuador, peru, colombia)",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a caffeinated amazonian holly tree leaf used for lucid dreaming, focus, and ritual wakefulness. known as the 'dreaming tea' by the kichwa people. smoother than yerba mate and less jittery than coffee.",
     "effects": "Smooth stimulation;Vivid dreams;Antioxidant;Focus;Energy",
+    "intensity": "Mild to moderate",
+    "region": "amazon (ecuador, peru, colombia)",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Contains caffeine, theobromine, and L-theanine. Stimulates CNS while providing a relaxing balance via L-theanine’s GABAergic modulation.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for morning energy, digestion, lucid dream preparation, and antioxidant support. traditionally used before hunting or dreaming ceremonies.",
-    "interactions": [
-      "stimulants",
-      "caffeine",
-      "mild interactions with stimulants or sedatives. may mask fatigue."
+    "compounds": [],
+    "toxicity_ld50": "Caffeine LD50 ~192 mg/kg (rats, oral)",
+    "safety": "",
+    "sideeffects": [
+      "restlessness",
+      "jitteriness in sensitive individuals",
+      "mild insomnia or jitters at high doses. gentler than most stimulants."
     ],
     "contraindications": [
       "pregnancy",
@@ -5643,14 +9670,7 @@
       "during pregnancy",
       "or with cardiac arrhythmia."
     ],
-    "sideeffects": [
-      "restlessness",
-      "jitteriness in sensitive individuals",
-      "mild insomnia or jitters at high doses. gentler than most stimulants."
-    ],
-    "safety": "",
-    "toxicity": "Low. Comparable to green tea.",
-    "toxicity_ld50": "Caffeine LD50 ~192 mg/kg (rats, oral)",
+    "therapeutic": "used for morning energy, digestion, lucid dream preparation, and antioxidant support. traditionally used before hunting or dreaming ceremonies.",
     "tags": [
       "stimulant",
       "✅ safe",
@@ -5666,6 +9686,17 @@
       "2011",
       "Amazonian Shamanic Tea Practices – 2020"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "stimulants",
+      "caffeine",
+      "mild interactions with stimulants or sedatives. may mask fatigue."
+    ],
+    "toxicity": "Low. Comparable to green tea.",
     "image": ""
   },
   {
@@ -5674,41 +9705,44 @@
     "common": "",
     "scientific": "Ilex vomitoria",
     "category": "stimulant / ritual",
-    "subcategory": "",
-    "intensity": "Moderate",
-    "region": "southeastern united states",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "",
     "effects": "alertness;mild euphoria;cleansing",
+    "intensity": "Moderate",
+    "region": "southeastern united states",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Contains caffeine and theobromine acting as adenosine receptor antagonists",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "native american ceremonial drink for stimulation and purification",
-    "interactions": [
-      "additive with other stimulants"
+    "compounds": [],
+    "toxicity_ld50": ">1 g/kg caffeine in animals",
+    "safety": "",
+    "sideeffects": [
+      "nausea in excess",
+      "insomnia"
     ],
     "contraindications": [
       "heart conditions",
       "pregnancy",
       "anxiety disorders"
     ],
-    "sideeffects": [
-      "nausea in excess",
-      "insomnia"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": ">1 g/kg caffeine in animals",
+    "therapeutic": "native american ceremonial drink for stimulation and purification",
     "tags": [
       "north america",
       "caffeine",
       "yaupon"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "additive with other stimulants"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -5717,32 +9751,26 @@
     "common": "",
     "scientific": "Impatiens balsamina",
     "category": "anti-inflammatory / antifungal / traditional",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "south and east asia",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a colorful flowering plant native to asia, known for its soothing effects on skin infections, wounds, and fungal issues. used in traditional medicine systems of china, korea, and india.",
     "effects": "Wound healing;Antimicrobial;Anti-itch;Skin soothing",
+    "intensity": "Mild–Moderate",
+    "region": "south and east asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Contains flavonoids, naphthoquinones, and essential oils with antifungal, antibacterial, and anti-inflammatory properties. Lawsone (also found in henna) contributes to antifungal effects.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used to treat ringworm, athlete’s foot, nail infections, eczema, and inflamed wounds. also applied to burns and bites.",
-    "interactions": [
-      "none known (topical use)."
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "rare. mild skin irritation possible with overuse."
     ],
     "contraindications": [
       "avoid internal use due to lack of safety data. caution on broken or hypersensitive skin."
     ],
-    "sideeffects": [
-      "rare. mild skin irritation possible with overuse."
-    ],
-    "safety": "",
-    "toxicity": "Low in external application. Some species mildly toxic if ingested.",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "used to treat ringworm, athlete’s foot, nail infections, eczema, and inflamed wounds. also applied to burns and bites.",
     "tags": [
       "🌸 skin",
       "🦠 antifungal",
@@ -5755,6 +9783,15 @@
       "2005",
       "Korean Pharmacopoeia"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "none known (topical use)."
+    ],
+    "toxicity": "Low in external application. Some species mildly toxic if ingested.",
     "image": ""
   },
   {
@@ -5763,35 +9800,29 @@
     "common": "Intellect Tree",
     "scientific": "Celastrus paniculatus",
     "category": "empathogen / euphoriant",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "india, sri lanka, southeast asia",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "often called the 'intellect tree', this ayurvedic plant is used to support memory, learning, and vivid dreams. contains sesquiterpenes that may stimulate cholinergic activity.",
     "effects": "Cognitive clarity;memory enhancement;dream vividness",
+    "intensity": "Mild",
+    "region": "india, sri lanka, southeast asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Cholinergic modulation; antioxidant and neuroprotective effects",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Celastrine",
       "Paniculatin"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "memory support, neuroprotection, dream recall",
-    "interactions": [
-      "none well documented"
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "headache or stimulation at high doses"
     ],
     "contraindications": [
       "pregnancy"
     ],
-    "sideeffects": [
-      "headache or stimulation at high doses"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "memory support, neuroprotection, dream recall",
     "tags": [
       "✅ safe",
       "🌿 herbal",
@@ -5803,6 +9834,15 @@
       "2011",
       "Indian Materia Medica – Nadkarni"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "none well documented"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -5811,40 +9851,31 @@
     "common": "",
     "scientific": "Ipomoea tricolor",
     "category": "psychedelic / traditional / visionary",
-    "subcategory": "",
-    "intensity": "Moderate–Strong",
-    "region": "mexico, central america",
-    "regiontags": [],
-    "legalstatus": "Legal to grow; seeds often labeled 'not for consumption'",
-    "schedule": "",
-    "legalnotes": "",
     "description": "this morning glory species contains lsa (lysergic acid amide), a natural psychedelic alkaloid structurally similar to lsd. used by aztec priests and modern psychonauts for altered states.",
     "effects": "Visual distortions;Dream-like state;Nausea;Time alteration",
+    "intensity": "Moderate–Strong",
+    "region": "mexico, central america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal to grow; seeds often labeled 'not for consumption'",
     "mechanism": "LSA is a serotonin 5-HT2A partial agonist, producing dream-like hallucinations and euphoria. Less stimulating than LSD but longer-lasting.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditional ritual use for divination, reflection, and spiritual cleansing. some modern use in microdosing or introspective journeys.",
-    "interactions": [
-      "do not mix with maois",
-      "ssris",
-      "stimulants",
-      "or alcohol."
-    ],
-    "contraindications": [
-      "unsafe in pregnancy. avoid with vasoconstrictors",
-      "maois",
-      "or psychiatric medications."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "LSA estimated LD50 >150 mg/kg (rats, oral)",
+    "safety": "",
     "sideeffects": [
       "nausea",
       "vasoconstriction",
       "lethargy",
       "disorientation. seeds sold commercially may be coated with toxins."
     ],
-    "safety": "",
-    "toxicity": "Low–moderate in raw form. Seed coatings can be toxic.",
-    "toxicity_ld50": "LSA estimated LD50 >150 mg/kg (rats, oral)",
+    "contraindications": [
+      "unsafe in pregnancy. avoid with vasoconstrictors",
+      "maois",
+      "or psychiatric medications."
+    ],
+    "therapeutic": "traditional ritual use for divination, reflection, and spiritual cleansing. some modern use in microdosing or introspective journeys.",
     "tags": [
       "🌸 psychedelic",
       "🌈 visionary",
@@ -5857,6 +9888,18 @@
       "Journal of Psychoactive Drugs",
       "2006"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "do not mix with maois",
+      "ssris",
+      "stimulants",
+      "or alcohol."
+    ],
+    "toxicity": "Low–moderate in raw form. Seed coatings can be toxic.",
     "image": ""
   },
   {
@@ -5865,33 +9908,29 @@
     "common": "Iporuru",
     "scientific": "Alchornea castaneifolia",
     "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "amazon basin",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "used in amazonian shamanic rituals for its spiritual and anti-inflammatory effects. often included in ayahuasca blends.",
     "effects": "Anti-inflammatory;spiritual clarity;energetic cleansing",
+    "intensity": "Mild",
+    "region": "amazon basin",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Unknown; may involve tannins and flavonoids",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Alchorneine"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "rheumatism, arthritis, spiritual cleansing",
-    "interactions": [],
-    "contraindications": [
-      "pregnancy"
-    ],
+    "toxicity_ld50": "Not established",
+    "safety": "",
     "sideeffects": [
       "minimal",
       "bitter taste"
     ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "contraindications": [
+      "pregnancy"
+    ],
+    "therapeutic": "rheumatism, arthritis, spiritual cleansing",
     "tags": [
       "✅ safe",
       "🌿 amazon",
@@ -5903,6 +9942,13 @@
       "Journal of Ethnopharmacology",
       "2007"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -5911,36 +9957,30 @@
     "common": "",
     "scientific": "Justicia adhatoda",
     "category": "stimulant / bronchodilator",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "indian subcontinent",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "known as vasaka or malabar nut, this shrub’s leaves ease breathing and offer a subtle stimulating effect.",
     "effects": "calming;respiratory clearing;mild sedation",
+    "intensity": "Mild",
+    "region": "indian subcontinent",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Alkaloids such as vasicine act as bronchodilators and respiratory stimulants",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Vasicine",
       "Vasicinone"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "ayurvedic herb for asthma, coughs and general vitality",
-    "interactions": [
-      "may potentiate other bronchodilators"
+    "toxicity_ld50": ">2 g/kg in rodents",
+    "safety": "",
+    "sideeffects": [
+      "digestive upset at large doses"
     ],
     "contraindications": [
       "pregnancy",
       "high doses may cause vomiting"
     ],
-    "sideeffects": [
-      "digestive upset at large doses"
-    ],
-    "safety": "",
-    "toxicity": "Generally safe at therapeutic doses",
-    "toxicity_ld50": ">2 g/kg in rodents",
+    "therapeutic": "ayurvedic herb for asthma, coughs and general vitality",
     "tags": [
       "ayurveda",
       "respiratory",
@@ -5954,6 +9994,15 @@
       "7(1):37-44.",
       "Ayurvedic Pharmacopoeia of India"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may potentiate other bronchodilators"
+    ],
+    "toxicity": "Generally safe at therapeutic doses",
     "image": ""
   },
   {
@@ -5962,41 +10011,44 @@
     "common": "",
     "scientific": "Lactuca canadensis",
     "category": "dissociative / sedative",
-    "subcategory": "",
-    "intensity": "Mild to moderate",
-    "region": "north america",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "wild lettuce species containing lactucarium for gentle analgesia.",
     "effects": "Relaxation;pain relief;drowsiness",
+    "intensity": "Mild to moderate",
+    "region": "north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Mild opioid-like action via lactucin/lactucopicrin",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "insomnia, pain, cough relief",
-    "interactions": [
-      "cns depressants",
-      "alcohol"
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "1",
+    "sideeffects": [
+      "drowsiness",
+      "gi upset at high doses"
     ],
     "contraindications": [
       "sedatives",
       "pregnancy"
     ],
-    "sideeffects": [
-      "drowsiness",
-      "gi upset at high doses"
-    ],
-    "safety": "1",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "insomnia, pain, cough relief",
     "tags": [
       "✅ safe",
       "🌿 opium lettuce",
       "😴 sedative"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "cns depressants",
+      "alcohol"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -6005,38 +10057,41 @@
     "common": "",
     "scientific": "Lagochilus inebrians",
     "category": "sedative / euphoric",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "central asia",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "known as intoxicating mint; produces a pleasant calm and slight euphoria when brewed.",
     "effects": "relaxation;mild euphoria;reduced anxiety",
+    "intensity": "Mild",
+    "region": "central asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Contains lagochilin which depresses the CNS and may interact with GABA",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "folk remedy in uzbekistan and kazakhstan for tension and insomnia",
-    "interactions": [
-      "could potentiate other depressants"
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "drowsiness"
     ],
     "contraindications": [
       "none documented but caution when operating machinery"
     ],
-    "sideeffects": [
-      "drowsiness"
-    ],
-    "safety": "",
-    "toxicity": "Little toxicity noted at customary doses",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "folk remedy in uzbekistan and kazakhstan for tension and insomnia",
     "tags": [
       "central asia",
       "calming",
       "intoxicating mint"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "could potentiate other depressants"
+    ],
+    "toxicity": "Little toxicity noted at customary doses",
     "image": ""
   },
   {
@@ -6045,36 +10100,39 @@
     "common": "",
     "scientific": "Lavandula angustifolia",
     "category": "relaxant / aromatic",
-    "subcategory": "",
-    "intensity": "",
-    "region": "mediterranean",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "fragrant lavender widely used for relaxation",
     "effects": "calm;sleep aid",
+    "intensity": "",
+    "region": "mediterranean",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Linalool and linalyl acetate modulate GABA",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "1-2 g dried or few drops oil",
-    "therapeutic": "anxiety, insomnia",
-    "interactions": [
-      "sedatives"
+    "compounds": [],
+    "toxicity_ld50": ">2 g/kg (rats, oil)",
+    "safety": "",
+    "sideeffects": [
+      "rare skin irritation"
     ],
     "contraindications": [
       "pregnancy large amounts"
     ],
-    "sideeffects": [
-      "rare skin irritation"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": ">2 g/kg (rats, oil)",
+    "therapeutic": "anxiety, insomnia",
     "tags": [
       "🌸 aroma"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "1-2 g dried or few drops oil",
+    "interactions": [
+      "sedatives"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -6083,36 +10141,29 @@
     "common": "",
     "scientific": "Leonotis leonurus",
     "category": "relaxant / euphoric",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "southern africa",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "orange-flowered shrub also called lion’s tail; smoked traditionally for mild cannabis-like effects.",
     "effects": "Mild euphoria;relaxation",
+    "intensity": "Mild",
+    "region": "southern africa",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Contains leonurine; may act on serotonin and cannabinoid receptors.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "folk remedy for coughs, fever and as a mild psychoactive when smoked.",
-    "interactions": [
-      "limited data",
-      "may potentiate other sedatives"
-    ],
-    "contraindications": [
-      "none known",
-      "avoid during pregnancy or with heart conditions."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
     "sideeffects": [
       "dizziness with heavy use",
       "dry mouth",
       "slight dizziness"
     ],
-    "safety": "",
-    "toxicity": "Low; high doses may cause dizziness or nausea.",
-    "toxicity_ld50": "Not established",
+    "contraindications": [
+      "none known",
+      "avoid during pregnancy or with heart conditions."
+    ],
+    "therapeutic": "folk remedy for coughs, fever and as a mild psychoactive when smoked.",
     "tags": [
       "✅ safe",
       "🌿 leaf",
@@ -6126,6 +10177,16 @@
       "2005",
       "African Herbal Medicine Compendium"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "limited data",
+      "may potentiate other sedatives"
+    ],
+    "toxicity": "Low; high doses may cause dizziness or nausea.",
     "image": ""
   },
   {
@@ -6134,40 +10195,43 @@
     "common": "",
     "scientific": "Leonurus sibiricus",
     "category": "calming / dream",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "native to asia, cultivated in the americas",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "sometimes called marihuanilla or siberian motherwort, providing gentle calming effects and subtle dreaminess.",
     "effects": "mild sedation;light euphoria;dream enhancement",
+    "intensity": "Mild",
+    "region": "native to asia, cultivated in the americas",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Contains leonurine and other alkaloids that depress CNS activity",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Leonurine"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used in latin american and asian folk medicine for relaxation and spiritual rituals",
-    "interactions": [
-      "may enhance effects of other sedatives"
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "drowsiness at high doses"
     ],
     "contraindications": [
       "none known"
     ],
-    "sideeffects": [
-      "drowsiness at high doses"
-    ],
-    "safety": "",
-    "toxicity": "Considered safe in moderate amounts",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "used in latin american and asian folk medicine for relaxation and spiritual rituals",
     "tags": [
       "marihuanilla",
       "mint family",
       "sedative"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may enhance effects of other sedatives"
+    ],
+    "toxicity": "Considered safe in moderate amounts",
     "image": ""
   },
   {
@@ -6176,34 +10240,28 @@
     "common": "",
     "scientific": "Lepidium meyenii",
     "category": "adaptogen / hormonal / nutritional",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "peru, andes mountains",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a peruvian root vegetable and superfood traditionally consumed to increase energy, stamina, fertility, and hormonal resilience. grown high in the andes, maca is revered as a nutritional tonic and endocrine modulator.",
     "effects": "Hormone balancing;Energy boost;Libido enhancement;Mood support",
+    "intensity": "Mild–Moderate",
+    "region": "peru, andes mountains",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Contains macamides, macaenes, and glucosinolates. These influence the hypothalamic-pituitary axis, modulate neurotransmitters, and support hormonal balance without introducing phytohormones.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for fatigue, low libido, pms, menopause, mood swings, and athletic endurance.",
-    "interactions": [
-      "may interact with hormone therapies. mild hypoglycemic synergy."
-    ],
-    "contraindications": [
-      "caution in thyroid disorders due to goitrogens. not advised in hormonal cancers without consultation."
-    ],
+    "compounds": [],
+    "toxicity_ld50": ">15 g/kg (rats, oral)",
+    "safety": "",
     "sideeffects": [
       "may cause gas",
       "thyroid suppression (in high doses/raw)",
       "or overstimulation in some."
     ],
-    "safety": "",
-    "toxicity": "Low. Widely used as food.",
-    "toxicity_ld50": ">15 g/kg (rats, oral)",
+    "contraindications": [
+      "caution in thyroid disorders due to goitrogens. not advised in hormonal cancers without consultation."
+    ],
+    "therapeutic": "used for fatigue, low libido, pms, menopause, mood swings, and athletic endurance.",
     "tags": [
       "🏋️ energy",
       "🧬 endocrine",
@@ -6216,6 +10274,15 @@
       "2009",
       "Peruvian Herbal Compendium"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interact with hormone therapies. mild hypoglycemic synergy."
+    ],
+    "toxicity": "Low. Widely used as food.",
     "image": ""
   },
   {
@@ -6224,36 +10291,30 @@
     "common": "Linden",
     "scientific": "Tilia europaea",
     "category": "nervine / anxiolytic / antispasmodic",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "europe, western asia, north america (ornamental)",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "linden flowers are fragrant and soothing, traditionally used in europe as a gentle sedative and nerve tonic. often brewed into calming teas to relieve stress, tension, and digestive upset.",
     "effects": "Calm;Stress relief;Muscle relaxation;Sleep support",
+    "intensity": "Mild",
+    "region": "europe, western asia, north america (ornamental)",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Contains flavonoids (e.g., quercetin, kaempferol) and volatile oils that act as mild GABA modulators and muscle relaxants.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Farnesol",
       "Kaempferol"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for anxiety, tension headaches, high blood pressure, insomnia, and muscle cramps. also supports digestion and reduces inflammation.",
-    "interactions": [
-      "minimal. may slightly enhance effects of sedatives or diuretics."
-    ],
-    "contraindications": [
-      "none significant. use with caution if allergic to pollen or linden trees."
-    ],
+    "toxicity_ld50": "Not established (very safe at therapeutic levels)",
+    "safety": "",
     "sideeffects": [
       "very rare",
       "occasional mild drowsiness or allergic reaction."
     ],
-    "safety": "",
-    "toxicity": "Very low",
-    "toxicity_ld50": "Not established (very safe at therapeutic levels)",
+    "contraindications": [
+      "none significant. use with caution if allergic to pollen or linden trees."
+    ],
+    "therapeutic": "used for anxiety, tension headaches, high blood pressure, insomnia, and muscle cramps. also supports digestion and reduces inflammation.",
     "tags": [
       "🧘 calm",
       "💤 sleep",
@@ -6265,6 +10326,15 @@
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "minimal. may slightly enhance effects of sedatives or diuretics."
+    ],
+    "toxicity": "Very low",
     "image": ""
   },
   {
@@ -6273,28 +10343,19 @@
     "common": "",
     "scientific": "Lobelia inflata",
     "category": "respiratory / nervine / strong medicinal",
-    "subcategory": "",
-    "intensity": "Moderate–Strong",
-    "region": "north america",
-    "regiontags": [],
-    "legalstatus": "Legal with caution",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a powerful respiratory herb used by native americans and western herbalists to aid breathing, reduce asthma spasms, and stimulate detoxification. sometimes called ‘the thinking herb’ for its clarity-inducing effects.",
     "effects": "Bronchodilation;Muscle relaxation;Emetic (high dose);Stimulates breath",
+    "intensity": "Moderate–Strong",
+    "region": "north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal with caution",
     "mechanism": "Contains lobeline, a nicotinic acetylcholine receptor partial agonist that stimulates respiration and clears airways. Also acts as a relaxant in low doses.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for asthma, bronchitis, whooping cough, tension, and as a smoke cessation aid. in high doses, historically used to induce vomiting in detox protocols.",
-    "interactions": [
-      "potentiates sedatives or respiratory stimulants."
-    ],
-    "contraindications": [
-      "avoid in pregnancy",
-      "with heart disease",
-      "or alongside strong sedatives. use cautiously."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "~0.6 g/kg lobeline in animals (est.)",
+    "safety": "",
     "sideeffects": [
       "nausea",
       "vomiting",
@@ -6302,9 +10363,12 @@
       "dizziness",
       "or tingling. overdose may cause respiratory distress."
     ],
-    "safety": "",
-    "toxicity": "Moderate to high in excess. Use under guidance.",
-    "toxicity_ld50": "~0.6 g/kg lobeline in animals (est.)",
+    "contraindications": [
+      "avoid in pregnancy",
+      "with heart disease",
+      "or alongside strong sedatives. use cautiously."
+    ],
+    "therapeutic": "used for asthma, bronchitis, whooping cough, tension, and as a smoke cessation aid. in high doses, historically used to induce vomiting in detox protocols.",
     "tags": [
       "🌬️ respiratory",
       "🫁 bronchodilator",
@@ -6316,6 +10380,15 @@
       "American Herbal Pharmacopoeia – Lobelia",
       "Materia Medica – Eclectic School"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "potentiates sedatives or respiratory stimulants."
+    ],
+    "toxicity": "Moderate to high in excess. Use under guidance.",
     "image": ""
   },
   {
@@ -6324,26 +10397,26 @@
     "common": "",
     "scientific": "Lophophora williamsii",
     "category": "psychedelic / entheogen / sacred",
-    "subcategory": "",
-    "intensity": "Strong",
-    "region": "southwestern u.s., mexico",
-    "regiontags": [],
-    "legalstatus": "Illegal in many countries; ceremonial exemption in U.S. (NAC)",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a small cactus revered for centuries in native american and mesoamerican spiritual traditions. contains mescaline, a potent psychedelic that induces visionary, heart-centered, and introspective states. still legally protected for ceremonial use in some indigenous groups.",
     "effects": "Visuals;Emotional opening;Ego dissolution;Sacred insight",
+    "intensity": "Strong",
+    "region": "southwestern u.s., mexico",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Illegal in many countries; ceremonial exemption in U.S. (NAC)",
     "mechanism": "Mescaline is a serotonin 5-HT2A agonist and also modulates dopamine and norepinephrine. Alters perception, emotion, and time sense.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Mescaline"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for ptsd, addiction, grief, personal transformation, and connection to spirit. studied for antidepressant and anti-addictive properties.",
-    "interactions": [
-      "do not combine with antidepressants",
-      "stimulants",
-      "or antihypertensives."
+    "toxicity_ld50": "Mescaline LD50 ~880 mg/kg (rats, oral)",
+    "safety": "",
+    "sideeffects": [
+      "nausea",
+      "vomiting (especially in raw cactus)",
+      "emotional overload",
+      "overstimulation. physically safe but requires emotional preparedness."
     ],
     "contraindications": [
       "avoid with ssris",
@@ -6351,15 +10424,7 @@
       "heart conditions",
       "or psychosis history. not for casual or unsupervised use."
     ],
-    "sideeffects": [
-      "nausea",
-      "vomiting (especially in raw cactus)",
-      "emotional overload",
-      "overstimulation. physically safe but requires emotional preparedness."
-    ],
-    "safety": "",
-    "toxicity": "Low physiological toxicity. High psychological intensity.",
-    "toxicity_ld50": "Mescaline LD50 ~880 mg/kg (rats, oral)",
+    "therapeutic": "used for ptsd, addiction, grief, personal transformation, and connection to spirit. studied for antidepressant and anti-addictive properties.",
     "tags": [
       "🌵 psychedelic",
       "🌀 visionary",
@@ -6372,6 +10437,17 @@
       "Journal of Psychoactive Drugs",
       "2013"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "do not combine with antidepressants",
+      "stimulants",
+      "or antihypertensives."
+    ],
+    "toxicity": "Low physiological toxicity. High psychological intensity.",
     "image": ""
   },
   {
@@ -6380,34 +10456,28 @@
     "common": "",
     "scientific": "Lycopodium clavatum",
     "category": "homeopathic / traditional / anticholinergic (spores)",
-    "subcategory": "",
-    "intensity": "Very mild",
-    "region": "europe, north america, eurasia",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a moss-like vascular plant traditionally used in european folk and homeopathic medicine. its yellow spores were used in rituals and historically as flash powder due to their flammability. internally, it has been used for digestive and urinary complaints.",
     "effects": "Cognitive stimulation (mild);Digestive tonic;Symbolic use;Spore dispersal agent",
+    "intensity": "Very mild",
+    "region": "europe, north america, eurasia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Spores are inert unless extracted. Extracts may act mildly as cholinergic modulators or anti-inflammatory agents. In homeopathy, extremely diluted preparations are used for liver, bladder, and memory issues.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used in homeopathy for digestive bloating, urinary retention, liver stress, and memory loss. folk use includes treating gout, kidney stones, and fevers.",
-    "interactions": [
-      "none documented at low doses."
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "rare. may cause irritation if spores inhaled or applied to wounds. avoid raw use in respiratory conditions."
     ],
     "contraindications": [
       "avoid in dry cough",
       "asthma",
       "or lung sensitivity (spores may irritate). not for use in pregnancy."
     ],
-    "sideeffects": [
-      "rare. may cause irritation if spores inhaled or applied to wounds. avoid raw use in respiratory conditions."
-    ],
-    "safety": "",
-    "toxicity": "Low externally; internal extracts used with caution.",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "used in homeopathy for digestive bloating, urinary retention, liver stress, and memory loss. folk use includes treating gout, kidney stones, and fevers.",
     "tags": [
       "🌿 moss",
       "⚗️ homeopathy",
@@ -6420,6 +10490,15 @@
       "Phytotherapy Research",
       "2002"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "none documented at low doses."
+    ],
+    "toxicity": "Low externally; internal extracts used with caution.",
     "image": ""
   },
   {
@@ -6428,42 +10507,45 @@
     "common": "",
     "scientific": "Lysergic acid diethylamide",
     "category": "psychedelic",
-    "subcategory": "",
-    "intensity": "High",
-    "region": "🌎 synthetic",
-    "regiontags": [],
-    "legalstatus": "Controlled / Illegal in many regions",
-    "schedule": "",
-    "legalnotes": "",
     "description": "semi-synthetic ergoline discovered in 1938; among the most potent psychedelics.",
     "effects": "Intense visuals;ego dissolution;synesthesia",
+    "intensity": "High",
+    "region": "🌎 synthetic",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Controlled / Illegal in many regions",
     "mechanism": "Potent 5-HT2A receptor agonist affecting serotonin and dopamine systems.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "investigated for cluster headaches, anxiety, and addiction therapy.",
-    "interactions": [
-      "ssris may blunt effects",
-      "maois potentiate."
-    ],
-    "contraindications": [
-      "psychosis",
-      "severe cardiovascular disease."
-    ],
+    "compounds": [],
+    "toxicity_ld50": ">14 mg/kg (mice, intravenous)",
+    "safety": "2",
     "sideeffects": [
       "anxiety",
       "confusion",
       "possible flashbacks at high doses."
     ],
-    "safety": "2",
-    "toxicity": "Very low physiological toxicity but strong psychological effects.",
-    "toxicity_ld50": ">14 mg/kg (mice, intravenous)",
+    "contraindications": [
+      "psychosis",
+      "severe cardiovascular disease."
+    ],
+    "therapeutic": "investigated for cluster headaches, anxiety, and addiction therapy.",
     "tags": [
       "⚠️ restricted",
       "🌀 visionary",
       "💊 oral"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "ssris may blunt effects",
+      "maois potentiate."
+    ],
+    "toxicity": "Very low physiological toxicity but strong psychological effects.",
     "image": ""
   },
   {
@@ -6472,32 +10554,19 @@
     "common": "",
     "scientific": "Mandragora officinarum",
     "category": "deliriant / hallucinogenic / historical magic",
-    "subcategory": "",
-    "intensity": "Extreme",
-    "region": "mediterranean, europe, near east",
-    "regiontags": [],
-    "legalstatus": "Restricted or regulated in some countries",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a legendary plant of myth and medicine, mandrake has deep roots in european witchcraft, alchemy, and ancient anesthetic practices. the humanoid root contains potent tropane alkaloids similar to deadly nightshades.",
     "effects": "Hallucinations;Sedation;Amnesia;Pain relief (historical)",
+    "intensity": "Extreme",
+    "region": "mediterranean, europe, near east",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Restricted or regulated in some countries",
     "mechanism": "Scopolamine, hyoscyamine, and atropine act as central anticholinergics, disrupting memory, balance, perception, and consciousness. Mimics effects of belladonna and henbane.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "0.1–0.3 g dried root",
-    "therapeutic": "historically used for surgery anesthesia, pain, sleep, and aphrodisiac purposes. modern use is rare and dangerous.",
-    "interactions": [
-      "fatal with other anticholinergics",
-      "sedatives",
-      "maois",
-      "or alcohol.",
-      "anticholinergic medications"
-    ],
-    "contraindications": [
-      "unsafe in almost all settings. avoid with any cns-active substances or psychiatric history.",
-      "heart conditions",
-      "pregnancy"
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Atropine ~453 mg/kg (rats, oral); scopolamine lower",
+    "safety": "",
     "sideeffects": [
       "confusion",
       "visual hallucinations",
@@ -6507,9 +10576,12 @@
       "respiratory distress. easily overdosed.",
       "delirium"
     ],
-    "safety": "",
-    "toxicity": "Very high. Even small doses can be toxic or fatal.",
-    "toxicity_ld50": "Atropine ~453 mg/kg (rats, oral); scopolamine lower",
+    "contraindications": [
+      "unsafe in almost all settings. avoid with any cns-active substances or psychiatric history.",
+      "heart conditions",
+      "pregnancy"
+    ],
+    "therapeutic": "historically used for surgery anesthesia, pain, sleep, and aphrodisiac purposes. modern use is rare and dangerous.",
     "tags": [
       "💀 toxic",
       "🌙 magical",
@@ -6523,6 +10595,19 @@
       "Plants of the Gods – Rätsch",
       "Toxicology in Herbal Medicine – 2020"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "0.1–0.3 g dried root",
+    "interactions": [
+      "fatal with other anticholinergics",
+      "sedatives",
+      "maois",
+      "or alcohol.",
+      "anticholinergic medications"
+    ],
+    "toxicity": "Very high. Even small doses can be toxic or fatal.",
     "image": ""
   },
   {
@@ -6531,34 +10616,28 @@
     "common": "",
     "scientific": "Marrubium vulgare",
     "category": "expectorant / bitter",
-    "subcategory": "",
-    "intensity": "",
-    "region": "europe, north africa",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "also known as horehound, used in cough drops",
     "effects": "digestive stimulation;clear lungs",
+    "intensity": "",
+    "region": "europe, north africa",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Diterpene lactone marrubiin stimulates mucus production",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Marrubiin"
     ],
-    "preparations": [],
-    "dosage": "1-2 g dried",
-    "therapeutic": "coughs, digestion",
-    "interactions": [
-      "none noted"
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "bitter taste"
     ],
     "contraindications": [
       "pregnancy high doses"
     ],
-    "sideeffects": [
-      "bitter taste"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "coughs, digestion",
     "tags": [
       "🍬 candy"
     ],
@@ -6567,6 +10646,15 @@
       "ESCOP Monograph – Marrubium",
       "American Herbal Pharmacopoeia – Horehound"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "1-2 g dried",
+    "interactions": [
+      "none noted"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -6575,35 +10663,28 @@
     "common": "",
     "scientific": "Matricaria chamomilla",
     "category": "nervine / digestive / anti-inflammatory",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "europe, north africa, western asia (now global)",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a gentle daisy-like flower used worldwide for calming nerves, reducing inflammation, and aiding digestion. chamomile tea is one of the most common herbal remedies for stress and insomnia.",
     "effects": "Calming;Sleep aid;Soothes digestion;Mild pain relief",
+    "intensity": "Mild",
+    "region": "europe, north africa, western asia (now global)",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Contains apigenin, a flavonoid that binds to benzodiazepine receptors. Also anti-inflammatory through COX-2 inhibition and spasmolytic via smooth muscle relaxation.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for anxiety, insomnia, gi discomfort, colic, pms, and skin inflammation. also common in baby teas and skin creams.",
-    "interactions": [
-      "mild interaction with blood thinners",
-      "sedatives."
+    "compounds": [],
+    "toxicity_ld50": ">5 g/kg (rats, oral)",
+    "safety": "",
+    "sideeffects": [
+      "rare. may cause allergic reaction in ragweed-sensitive individuals. mild sedation."
     ],
     "contraindications": [
       "avoid with warfarin (may potentiate)",
       "pregnancy (in very large doses)",
       "or severe allergies to asteraceae."
     ],
-    "sideeffects": [
-      "rare. may cause allergic reaction in ragweed-sensitive individuals. mild sedation."
-    ],
-    "safety": "",
-    "toxicity": "Very low. Commonly consumed as food/tea.",
-    "toxicity_ld50": ">5 g/kg (rats, oral)",
+    "therapeutic": "used for anxiety, insomnia, gi discomfort, colic, pms, and skin inflammation. also common in baby teas and skin creams.",
     "tags": [
       "🧘 calm",
       "🌼 sleep",
@@ -6615,6 +10696,16 @@
       "ESCOP Monograph – Chamomilla",
       "The Complete German Commission E Monographs"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "mild interaction with blood thinners",
+      "sedatives."
+    ],
+    "toxicity": "Very low. Commonly consumed as food/tea.",
     "image": ""
   },
   {
@@ -6623,32 +10714,26 @@
     "common": "",
     "scientific": "Melissa officinalis",
     "category": "nervine / antiviral / cognitive",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "mediterranean, now global",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a fragrant member of the mint family, lemon balm has been used for centuries to calm the nervous system, lift the mood, and improve memory. its subtle citrus aroma makes it popular in teas and tinctures.",
     "effects": "Anti-anxiety;Cognitive clarity;Mood boost;Antiviral",
+    "intensity": "Mild",
+    "region": "mediterranean, now global",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "GABA-T inhibition and acetylcholine modulation. Rich in rosmarinic acid and flavonoids, which contribute to anxiolytic and nootropic effects.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for stress, overthinking, anxiety, herpes simplex outbreaks, restlessness, and cognitive focus.",
-    "interactions": [
-      "may potentiate sedatives or thyroid medications."
+    "compounds": [],
+    "toxicity_ld50": ">5 g/kg (rats, oral)",
+    "safety": "",
+    "sideeffects": [
+      "rare. may cause drowsiness or lowered alertness in some. mild gi upset if taken in excess."
     ],
     "contraindications": [
       "avoid large doses in hypothyroidism (may suppress tsh)."
     ],
-    "sideeffects": [
-      "rare. may cause drowsiness or lowered alertness in some. mild gi upset if taken in excess."
-    ],
-    "safety": "",
-    "toxicity": "Very low.",
-    "toxicity_ld50": ">5 g/kg (rats, oral)",
+    "therapeutic": "used for stress, overthinking, anxiety, herpes simplex outbreaks, restlessness, and cognitive focus.",
     "tags": [
       "🍋 uplifting",
       "🧘 nootropic",
@@ -6661,6 +10746,15 @@
       "2004",
       "Herbal Medicine – Mills & Bone"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may potentiate sedatives or thyroid medications."
+    ],
+    "toxicity": "Very low.",
     "image": ""
   },
   {
@@ -6669,36 +10763,28 @@
     "common": "",
     "scientific": "Mentha piperita",
     "category": "digestive / stimulant / antispasmodic",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "global cultivation",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a cooling, aromatic herb widely used for digestive and nervous system support. common in teas, extracts, and aromatherapy. historically used in european, middle eastern, and asian herbalism.",
     "effects": "Soothes digestion;Stimulates focus;Relieves cramps;Cools",
+    "intensity": "Mild",
+    "region": "global cultivation",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Menthol and other essential oils act as calcium channel blockers in smooth muscle and desensitize cold receptors (TRPM8), producing cooling and antispasmodic effects.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for ibs, nausea, headache, muscle cramps, and focus. may be used topically for tension or inhaled for alertness.",
-    "interactions": [
-      "may interact with antacids",
-      "cyclosporine",
-      "or calcium channel drugs."
+    "compounds": [],
+    "toxicity_ld50": "Menthol LD50 ~3300 mg/kg (rats, oral)",
+    "safety": "",
+    "sideeffects": [
+      "may cause heartburn or skin sensitivity. excess can cause nausea."
     ],
     "contraindications": [
       "avoid in gerd",
       "gallstones",
       "or infants (risk of respiratory spasm)."
     ],
-    "sideeffects": [
-      "may cause heartburn or skin sensitivity. excess can cause nausea."
-    ],
-    "safety": "",
-    "toxicity": "Low. Essential oil can be toxic in large doses.",
-    "toxicity_ld50": "Menthol LD50 ~3300 mg/kg (rats, oral)",
+    "therapeutic": "used for ibs, nausea, headache, muscle cramps, and focus. may be used topically for tension or inhaled for alertness.",
     "tags": [
       "🌱 digestive",
       "❄️ cooling",
@@ -6710,6 +10796,17 @@
       "ESCOP Monographs",
       "Herbal Medicine – New Oxford Textbook"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interact with antacids",
+      "cyclosporine",
+      "or calcium channel drugs."
+    ],
+    "toxicity": "Low. Essential oil can be toxic in large doses.",
     "image": ""
   },
   {
@@ -6718,34 +10815,28 @@
     "common": "",
     "scientific": "Mimosa pudica",
     "category": "nervine / anti-parasitic / mysterious plant movement",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "south america, southeast asia, india",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "known for its rapid leaf-closing reflex, this tropical creeping plant is used in ayurvedic and modern herbal medicine for gut detox, parasite cleansing, and calming the nerves.",
     "effects": "Intestinal cleanse;Antiparasitic;Calming;Unique tactile motion",
+    "intensity": "Mild–Moderate",
+    "region": "south america, southeast asia, india",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Contains mimosine, alkaloids, and tannins. Antiparasitic action through mechanical mucilage binding and gut wall modulation. Also mildly acts on serotonin and GABA pathways.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for intestinal worms, heavy metal detox, gi inflammation, gut-brain axis repair, and nervous tension.",
-    "interactions": [
-      "may bind to medications and reduce absorption. space doses accordingly."
-    ],
-    "contraindications": [
-      "avoid in pregnancy. use caution in constipation or with gi disorders unless guided."
-    ],
+    "compounds": [],
+    "toxicity_ld50": ">2000 mg/kg (rats, oral extract)",
+    "safety": "",
     "sideeffects": [
       "possible constipation",
       "fatigue",
       "or gut discomfort in first few days. rare allergic response."
     ],
-    "safety": "",
-    "toxicity": "Low–Moderate. Use within appropriate dose ranges.",
-    "toxicity_ld50": ">2000 mg/kg (rats, oral extract)",
+    "contraindications": [
+      "avoid in pregnancy. use caution in constipation or with gi disorders unless guided."
+    ],
+    "therapeutic": "used for intestinal worms, heavy metal detox, gi inflammation, gut-brain axis repair, and nervous tension.",
     "tags": [
       "🧬 gut health",
       "🪱 parasite cleanse",
@@ -6758,6 +10849,15 @@
       "Journal of Parasitology Research",
       "2017"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may bind to medications and reduce absorption. space doses accordingly."
+    ],
+    "toxicity": "Low–Moderate. Use within appropriate dose ranges.",
     "image": ""
   },
   {
@@ -6766,37 +10866,30 @@
     "common": "",
     "scientific": "Mimosa tenuiflora",
     "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Strong",
-    "region": "brazil, central america",
-    "regiontags": [],
-    "legalstatus": "DMT controlled in many countries",
-    "schedule": "",
-    "legalnotes": "",
     "description": "highly sought after for its dmt-rich root bark. used in anahuasca brews as a substitute for chacruna or yopo.",
     "effects": "Visionary states;purging;emotional release",
+    "intensity": "Strong",
+    "region": "brazil, central america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "DMT controlled in many countries",
     "mechanism": "DMT – 5-HT2A agonist (requires MAOI orally)",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "spiritual healing, insight, skin regeneration (topical)",
-    "interactions": [
-      "maois",
-      "antidepressants"
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "intense purging",
+      "nausea",
+      "anxiety"
     ],
     "contraindications": [
       "mental disorders",
       "maois",
       "ssris"
     ],
-    "sideeffects": [
-      "intense purging",
-      "nausea",
-      "anxiety"
-    ],
-    "safety": "",
-    "toxicity": "Low physiological, high psychological",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "spiritual healing, insight, skin regeneration (topical)",
     "tags": [
       "⚠️ visionary",
       "🌿 anahuasca",
@@ -6808,6 +10901,16 @@
       "Journal of Ethnopharmacology",
       "1993"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "maois",
+      "antidepressants"
+    ],
+    "toxicity": "Low physiological, high psychological",
     "image": ""
   },
   {
@@ -6816,35 +10919,38 @@
     "common": "",
     "scientific": "Mitchella repens",
     "category": "ethnobotanical",
-    "subcategory": "",
-    "intensity": "",
-    "region": "north america",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "known as partridgeberry, used as a uterine tonic and mild relaxing agent in north american herbalism.",
     "effects": "relaxation;nervine",
+    "intensity": "",
+    "region": "north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "Smooth muscle relaxant",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Saponins",
       "Iridoids"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "calming",
       "uterine",
       "folk remedy"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -6853,36 +10959,30 @@
     "common": "",
     "scientific": "Mitragyna hirsuta",
     "category": "stimulant / relaxant / kratom alternative",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "thailand, southeast asia",
-    "regiontags": [],
-    "legalstatus": "Legal in most regions",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a close relative of mitragyna speciosa (kratom), this thai tree is used as a legal alternative with gentler psychoactive effects. traditionally chewed by laborers for stamina and focus.",
     "effects": "Mild euphoria;Calm stimulation;Analgesia;Energy boost",
+    "intensity": "Mild–Moderate",
+    "region": "thailand, southeast asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal in most regions",
     "mechanism": "Contains mitraphylline and isomitraphylline — alkaloids that act on opioid receptors (mu, delta) and possibly serotonin/dopamine pathways, though weaker than kratom.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for mood lift, fatigue reduction, mild pain relief, and kratom tapering.",
-    "interactions": [
-      "similar caution as with kratom — potential additive effect with sedatives."
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "mild nausea",
+      "dry mouth",
+      "light sedation. fewer side effects than kratom. little to no dependency reported."
     ],
     "contraindications": [
       "avoid combining with opioids",
       "depressants",
       "or alcohol. safety in pregnancy unknown."
     ],
-    "sideeffects": [
-      "mild nausea",
-      "dry mouth",
-      "light sedation. fewer side effects than kratom. little to no dependency reported."
-    ],
-    "safety": "",
-    "toxicity": "Low to moderate. No confirmed toxicity in traditional doses.",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "used for mood lift, fatigue reduction, mild pain relief, and kratom tapering.",
     "tags": [
       "🍃 kratom-like",
       "⚡ energy",
@@ -6895,6 +10995,15 @@
       "2016",
       "Thai Botanical Index – 2014"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "similar caution as with kratom — potential additive effect with sedatives."
+    ],
+    "toxicity": "Low to moderate. No confirmed toxicity in traditional doses.",
     "image": ""
   },
   {
@@ -6903,33 +11012,19 @@
     "common": "",
     "scientific": "Mitragyna speciosa",
     "category": "stimulant / opioid-like / traditional / controversial",
-    "subcategory": "",
-    "intensity": "Mild–Strong (dose-dependent)",
-    "region": "thailand, indonesia, malaysia",
-    "regiontags": [],
-    "legalstatus": "Legal in some regions; banned or restricted in others (e.g. Thailand, Australia, some U.S. states)",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a tropical tree whose leaves are traditionally chewed for stamina and pain relief in southeast asia. kratom has gained global attention as both a potential therapeutic tool and a substance of concern due to its opioid-like effects.",
     "effects": "Energy;Euphoria;Pain relief;Calm focus",
+    "intensity": "Mild–Strong (dose-dependent)",
+    "region": "thailand, indonesia, malaysia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal in some regions; banned or restricted in others (e.g. Thailand, Australia, some U.S. states)",
     "mechanism": "Mitragynine and 7-hydroxymitragynine are partial mu-opioid agonists with stimulant properties at low doses and sedative effects at higher doses. Also interacts with adrenergic and serotonergic systems.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "2–5 g leaf powder",
-    "therapeutic": "used for pain management, anxiety, fatigue, opioid withdrawal, and mood enhancement. reported as helpful in tapering off prescription opioids.",
-    "interactions": [
-      "opioids",
-      "depressants",
-      "potentiates cns depressants. interacts with liver enzymes (cyp3a4",
-      "cyp2d6)."
-    ],
-    "contraindications": [
-      "opioid addiction recovery",
-      "avoid with other opioids",
-      "benzodiazepines",
-      "alcohol",
-      "or in heart/liver conditions."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Mitragynine LD50 >500 mg/kg (rats, oral)",
+    "safety": "",
     "sideeffects": [
       "nausea",
       "dependence",
@@ -6938,9 +11033,14 @@
       "dependency",
       "withdrawal symptoms with chronic use. some cardiac risk at high doses."
     ],
-    "safety": "",
-    "toxicity": "Moderate at high doses or with poly-drug use. Risk of dependency.",
-    "toxicity_ld50": "Mitragynine LD50 >500 mg/kg (rats, oral)",
+    "contraindications": [
+      "opioid addiction recovery",
+      "avoid with other opioids",
+      "benzodiazepines",
+      "alcohol",
+      "or in heart/liver conditions."
+    ],
+    "therapeutic": "used for pain management, anxiety, fatigue, opioid withdrawal, and mood enhancement. reported as helpful in tapering off prescription opioids.",
     "tags": [
       "🌀 euphoric",
       "💊 oral",
@@ -6956,6 +11056,18 @@
       "WHO Kratom Review Report",
       "2021"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "2–5 g leaf powder",
+    "interactions": [
+      "opioids",
+      "depressants",
+      "potentiates cns depressants. interacts with liver enzymes (cyp3a4",
+      "cyp2d6)."
+    ],
+    "toxicity": "Moderate at high doses or with poly-drug use. Risk of dependency.",
     "image": ""
   },
   {
@@ -6964,39 +11076,42 @@
     "common": "",
     "scientific": "Mitragyna speciosa hybrids",
     "category": "stimulant / analgesic",
-    "subcategory": "",
-    "intensity": "",
-    "region": "cultivated southeast asia",
-    "regiontags": [],
-    "legalstatus": "Varies by region",
-    "schedule": "",
-    "legalnotes": "",
     "description": "selective breeding of kratom species for varied alkaloid ratios",
     "effects": "energy;pain relief",
+    "intensity": "",
+    "region": "cultivated southeast asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Varies by region",
     "mechanism": "Indole alkaloids act as partial mu-opioid agonists",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "2-5 g leaf",
-    "therapeutic": "pain relief, mood lift",
-    "interactions": [
-      "opioids and sedatives"
+    "compounds": [],
+    "toxicity_ld50": ">200 mg/kg (rats, mitragynine)",
+    "safety": "",
+    "sideeffects": [
+      "nausea",
+      "dependency"
     ],
     "contraindications": [
       "heart conditions",
       "maois"
     ],
-    "sideeffects": [
-      "nausea",
-      "dependency"
-    ],
-    "safety": "",
-    "toxicity": "Moderate",
-    "toxicity_ld50": ">200 mg/kg (rats, mitragynine)",
+    "therapeutic": "pain relief, mood lift",
     "tags": [
       "⚠️ use caution",
       "🍃 leaf"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "2-5 g leaf",
+    "interactions": [
+      "opioids and sedatives"
+    ],
+    "toxicity": "Moderate",
     "image": ""
   },
   {
@@ -7005,40 +11120,42 @@
     "common": "",
     "scientific": "Monotropa uniflora",
     "category": "dissociative / sedative",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "temperate forests of north america and asia",
-    "regiontags": [],
-    "legalstatus": "Legal (but rare and protected in places)",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a ghostly white forest plant used in native american medicine for pain and spiritual insight. non-photosynthetic and mysterious.",
     "effects": "Analgesia;calm;emotional detachment",
+    "intensity": "Mild",
+    "region": "temperate forests of north america and asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal (but rare and protected in places)",
     "mechanism": "Contains monotropin; acts possibly on NMDA or opioid systems (hypothetical)",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "pain relief, emotional trauma support (traditional)",
-    "interactions": [
-      "possibly cns depressants"
-    ],
-    "contraindications": [
-      "unknown",
-      "limited modern use"
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
     "sideeffects": [
       "unknown at pharmacological doses",
       "rare usage"
     ],
-    "safety": "",
-    "toxicity": "",
-    "toxicity_ld50": "Not established",
+    "contraindications": [
+      "limited modern use"
+    ],
+    "therapeutic": "pain relief, emotional trauma support (traditional)",
     "tags": [
       "🌲 pain relief",
       "👻 ghost plant",
       "🧠 emotional"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "possibly cns depressants"
+    ],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -7047,36 +11164,30 @@
     "common": "Motherwort",
     "scientific": "Leonurus cardiaca",
     "category": "cardiotonic / nervine / women’s health",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "europe, north america, asia",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a traditional european nervine used to ease tension, heart flutter, and menstrual discomfort. known as ‘mother’s herb’ for its supportive effects during emotional distress and hormonal fluctuations.",
     "effects": "Calms heart palpitations;Reduces anxiety;Uterine tonic;Regulates menstrual tension",
+    "intensity": "Mild",
+    "region": "europe, north america, asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Alkaloids such as leonurine and stachydrine provide mild sedative, antispasmodic, and cardiotonic effects, possibly modulating GABA and muscarinic pathways.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Leonurine",
       "Stachydrine"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for pms, menopause, anxiety, nervous heart conditions, and postpartum recovery. may support vagal tone and reduce sympathetic overdrive.",
-    "interactions": [
-      "caution with heart medications or sedatives."
-    ],
-    "contraindications": [
-      "avoid in pregnancy (uterine stimulant). may slightly lower blood pressure."
-    ],
+    "toxicity_ld50": "Not established in humans",
+    "safety": "",
     "sideeffects": [
       "bitter taste",
       "possible drowsiness or stomach upset in some. generally well tolerated."
     ],
-    "safety": "",
-    "toxicity": "Low. Used widely in folk medicine.",
-    "toxicity_ld50": "Not established in humans",
+    "contraindications": [
+      "avoid in pregnancy (uterine stimulant). may slightly lower blood pressure."
+    ],
+    "therapeutic": "used for pms, menopause, anxiety, nervous heart conditions, and postpartum recovery. may support vagal tone and reduce sympathetic overdrive.",
     "tags": [
       "🫀 heart support",
       "🌸 women’s health",
@@ -7088,6 +11199,15 @@
       "Herbal Medicine – Mills & Bone",
       "British Herbal Compendium"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "caution with heart medications or sedatives."
+    ],
+    "toxicity": "Low. Used widely in folk medicine.",
     "image": ""
   },
   {
@@ -7096,33 +11216,27 @@
     "common": "",
     "scientific": "Mucuna pruriens",
     "category": "stimulant / nootropic",
-    "subcategory": "",
-    "intensity": "Moderate",
-    "region": "tropical asia and africa",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "also called velvet bean; boosts dopamine and serves as a traditional tonic in ayurvedic practice.",
     "effects": "increased motivation;energy;elevated mood",
+    "intensity": "Moderate",
+    "region": "tropical asia and africa",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Seeds contain L‑DOPA which increases brain dopamine levels",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used in ayurveda for parkinson's disease, mood disorders and vitality",
-    "interactions": [
-      "avoid with maois or dopamine medications"
+    "compounds": [],
+    "toxicity_ld50": ">6 g/kg in rodents",
+    "safety": "",
+    "sideeffects": [
+      "nausea or headache with excessive intake"
     ],
     "contraindications": [
       "psychosis",
       "concurrent l‑dopa medication"
     ],
-    "sideeffects": [
-      "nausea or headache with excessive intake"
-    ],
-    "safety": "",
-    "toxicity": "Generally safe at typical doses; high doses may cause nausea",
-    "toxicity_ld50": ">6 g/kg in rodents",
+    "therapeutic": "used in ayurveda for parkinson's disease, mood disorders and vitality",
     "tags": [
       "ayurveda",
       "dopamine",
@@ -7134,6 +11248,15 @@
       "2015",
       "Ayurvedic Materia Medica"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "avoid with maois or dopamine medications"
+    ],
+    "toxicity": "Generally safe at typical doses; high doses may cause nausea",
     "image": ""
   },
   {
@@ -7142,35 +11265,38 @@
     "common": "Nance",
     "scientific": "",
     "category": "sedative",
-    "subcategory": "",
-    "intensity": "",
-    "region": "central and south america",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "",
     "effects": "mild sedative;calming;tonic",
+    "intensity": "",
+    "region": "central and south america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "Flavonoid antioxidant and neuroprotective action",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Catechins",
       "Quercetin"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "sedative",
       "folk",
       "antioxidant"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -7179,34 +11305,37 @@
     "common": "Nasturtium",
     "scientific": "",
     "category": "stimulant",
-    "subcategory": "",
-    "intensity": "",
-    "region": "south america (peru, andes)",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "",
     "effects": "mild stimulant;respiratory enhancer",
+    "intensity": "",
+    "region": "south america (peru, andes)",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "Antimicrobial and expectorant, may enhance breathing clarity.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Benzyl isothiocyanate"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "stimulant",
       "respiratory",
       "folk"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -7215,34 +11344,28 @@
     "common": "",
     "scientific": "Nelumbo lutea",
     "category": "nervine / sacred / hormonal",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "north america",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a north american relative of the sacred lotus, nelumbo lutea has similar calming, euphoric properties. it has been used by native american groups for its edible seeds and roots, and possibly ceremonial effects when brewed from the flower.",
     "effects": "Tranquility;Heart-opening;Sensual awareness;Lucid dreaming",
+    "intensity": "Mild",
+    "region": "north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Contains alkaloids such as nuciferine and neferine, modulating dopamine and serotonin receptors. Mildly sedative and possibly aphrodisiac.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used traditionally for calming the mind, balancing hormones, dreamwork, and as a meditative herb.",
-    "interactions": [
-      "may potentiate sedatives or antihypertensives."
-    ],
-    "contraindications": [
-      "avoid with sedatives or hypotension. safety during pregnancy not well studied."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
     "sideeffects": [
       "drowsiness",
       "lowered blood pressure",
       "dry mouth in sensitive users."
     ],
-    "safety": "",
-    "toxicity": "Low at traditional doses.",
-    "toxicity_ld50": "Not established",
+    "contraindications": [
+      "avoid with sedatives or hypotension. safety during pregnancy not well studied."
+    ],
+    "therapeutic": "used traditionally for calming the mind, balancing hormones, dreamwork, and as a meditative herb.",
     "tags": [
       "🪷 sacred",
       "🌿 native american",
@@ -7254,6 +11377,15 @@
       "Ethnobotany of North American Indians – 1993",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may potentiate sedatives or antihypertensives."
+    ],
+    "toxicity": "Low at traditional doses.",
     "image": ""
   },
   {
@@ -7262,39 +11394,42 @@
     "common": "",
     "scientific": "Nicotiana tabacum",
     "category": "stimulant",
-    "subcategory": "",
-    "intensity": "",
-    "region": "worldwide",
-    "regiontags": [],
-    "legalstatus": "Regulated",
-    "schedule": "",
-    "legalnotes": "",
     "description": "common tobacco plant widely used recreationally",
     "effects": "alertness;mild euphoria",
+    "intensity": "",
+    "region": "worldwide",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Regulated",
     "mechanism": "Nicotine stimulates nicotinic acetylcholine receptors releasing dopamine",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "1-2 cigarettes equivalent",
-    "therapeutic": "traditional ceremonies, appetite suppression",
-    "interactions": [
-      "additive with stimulants"
+    "compounds": [],
+    "toxicity_ld50": "50 mg/kg (rats)",
+    "safety": "",
+    "sideeffects": [
+      "addiction",
+      "cardiovascular strain"
     ],
     "contraindications": [
       "heart disease",
       "pregnancy"
     ],
-    "sideeffects": [
-      "addiction",
-      "cardiovascular strain"
-    ],
-    "safety": "",
-    "toxicity": "Moderate",
-    "toxicity_ld50": "50 mg/kg (rats)",
+    "therapeutic": "traditional ceremonies, appetite suppression",
     "tags": [
       "⚠️ addictive",
       "🚬 smoke"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "1-2 cigarettes equivalent",
+    "interactions": [
+      "additive with stimulants"
+    ],
+    "toxicity": "Moderate",
     "image": ""
   },
   {
@@ -7303,38 +11438,32 @@
     "common": "Nutmeg",
     "scientific": "Myristica fragrans",
     "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Strong",
-    "region": "indonesia",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "nutmeg seeds can be psychoactive in large amounts.",
     "effects": "Deliriant states;nausea",
+    "intensity": "Strong",
+    "region": "indonesia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Myristicin metabolizes to MMDA-like compounds",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Myristicin",
       "Elemicin"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "rarely used therapeutically",
-    "interactions": [
-      "potential maoi interaction"
-    ],
-    "contraindications": [
-      "pregnancy",
-      "psychiatric conditions"
-    ],
+    "toxicity_ld50": "Myristicin LD50 ~400 mg/kg (mouse)",
+    "safety": "",
     "sideeffects": [
       "nausea",
       "dehydration",
       "delirium"
     ],
-    "safety": "",
-    "toxicity": "High at large doses",
-    "toxicity_ld50": "Myristicin LD50 ~400 mg/kg (mouse)",
+    "contraindications": [
+      "pregnancy",
+      "psychiatric conditions"
+    ],
+    "therapeutic": "rarely used therapeutically",
     "tags": [
       "⚠️ caution",
       "🌿 seed",
@@ -7345,6 +11474,15 @@
       "Plants of the Gods – Rätsch",
       "Toxicology of Spices – 2012"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "potential maoi interaction"
+    ],
+    "toxicity": "High at large doses",
     "image": ""
   },
   {
@@ -7353,39 +11491,42 @@
     "common": "",
     "scientific": "Nymphaea ampla",
     "category": "oneirogen",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "mexico, central america",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "related to blue lotus, this sacred flower from mesoamerican traditions is used to promote meditation and lucid dreaming.",
     "effects": "Calm;light sedation;dream potentiation",
+    "intensity": "Mild",
+    "region": "mexico, central america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Contains aporphine alkaloids (dopamine agonist)",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "relaxation, aphrodisiac, dream enhancement",
-    "interactions": [
-      "avoid cns depressants"
-    ],
-    "contraindications": [
-      "pregnancy"
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
     "sideeffects": [
       "drowsiness",
       "vivid dreams"
     ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "contraindications": [
+      "pregnancy"
+    ],
+    "therapeutic": "relaxation, aphrodisiac, dream enhancement",
     "tags": [
       "✅ safe",
       "🌸 calm",
       "🌿 sedative"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "avoid cns depressants"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -7394,38 +11535,41 @@
     "common": "",
     "scientific": "Nymphaea lotus",
     "category": "calming / dream",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "africa and southeast asia",
-    "regiontags": [],
-    "legalstatus": "Generally legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "also called the egyptian white lotus, historically revered for its gentle calming and dreamlike qualities.",
     "effects": "relaxation;dream enhancement;mild euphoria",
+    "intensity": "Mild",
+    "region": "africa and southeast asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Generally legal",
     "mechanism": "Contains aporphine alkaloids that act on dopamine and serotonin receptors",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used in ancient egypt for sedation and ritual ceremonies",
-    "interactions": [
-      "may add to effects of other sedatives"
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "drowsiness at high doses"
     ],
     "contraindications": [
       "none known but caution with sedatives"
     ],
-    "sideeffects": [
-      "drowsiness at high doses"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "used in ancient egypt for sedation and ritual ceremonies",
     "tags": [
       "egyptian lotus",
       "sedative",
       "water lily"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may add to effects of other sedatives"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -7434,34 +11578,28 @@
     "common": "",
     "scientific": "Nymphaea nouchali",
     "category": "sacred / calming / dream herb",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "india, sri lanka, southeast asia",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a revered flower across south and southeast asia, often confused with blue lotus. it holds symbolic significance in buddhism and ayurveda. the flowers are known for inducing a soft, euphoric state when steeped or smoked.",
     "effects": "Calm euphoria;Sensual clarity;Dream enhancement;Mild sedation",
+    "intensity": "Mild–Moderate",
+    "region": "india, sri lanka, southeast asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Contains aporphine and related alkaloids that affect dopamine and serotonin receptors. Mildly sedative and introspective.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditionally used for anxiety, libido, meditation, and emotional calm. may enhance clarity in dreams.",
-    "interactions": [
-      "may potentiate cns depressants and interact with ssris or maois."
-    ],
-    "contraindications": [
-      "avoid with other sedatives or during pregnancy unless guided by a practitioner."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
     "sideeffects": [
       "mild lethargy",
       "dry mouth",
       "or dizziness in high doses."
     ],
-    "safety": "",
-    "toxicity": "Low at traditional use levels.",
-    "toxicity_ld50": "Not established",
+    "contraindications": [
+      "avoid with other sedatives or during pregnancy unless guided by a practitioner."
+    ],
+    "therapeutic": "traditionally used for anxiety, libido, meditation, and emotional calm. may enhance clarity in dreams.",
     "tags": [
       "🌺 sacred",
       "🧘 relaxant",
@@ -7473,6 +11611,15 @@
       "Ayurvedic Pharmacopeia of India",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may potentiate cns depressants and interact with ssris or maois."
+    ],
+    "toxicity": "Low at traditional use levels.",
     "image": ""
   },
   {
@@ -7481,36 +11628,39 @@
     "common": "",
     "scientific": "Nymphaea rubra",
     "category": "sedative / euphoric",
-    "subcategory": "",
-    "intensity": "",
-    "region": "south asia",
-    "regiontags": [],
-    "legalstatus": "Varies",
-    "schedule": "",
-    "legalnotes": "",
     "description": "red lotus used similarly to blue lotus for relaxation",
     "effects": "calming;dreamy state",
+    "intensity": "",
+    "region": "south asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Varies",
     "mechanism": "Alkaloids like apomorphine interact with dopamine receptors",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "3-5 g petals",
-    "therapeutic": "mild euphoria, aphrodisiac",
-    "interactions": [
-      "sedatives"
+    "compounds": [],
+    "toxicity_ld50": "Not well studied",
+    "safety": "",
+    "sideeffects": [
+      "drowsiness"
     ],
     "contraindications": [
       "pregnancy"
     ],
-    "sideeffects": [
-      "drowsiness"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not well studied",
+    "therapeutic": "mild euphoria, aphrodisiac",
     "tags": [
       "🌸 flower"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "3-5 g petals",
+    "interactions": [
+      "sedatives"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -7519,34 +11669,26 @@
     "common": "",
     "scientific": "Ocimum sanctum",
     "category": "adaptogen / nervine / immune",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "india, southeast asia",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a sacred ayurvedic herb used for spiritual purification, resilience, and vitality. known as 'tulsi' in india, it’s revered for its uplifting, adaptogenic, and rejuvenating properties.",
     "effects": "Stress reduction;Mental clarity;Immune modulation;Anti-inflammatory",
+    "intensity": "Mild",
+    "region": "india, southeast asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Rich in eugenol, ursolic acid, and flavonoids. Acts as an adaptogen through HPA axis modulation, antioxidant pathways, and mild cortisol-lowering activity.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for adrenal fatigue, anxiety, cognitive enhancement, colds, blood sugar balance, and spiritual rituals.",
-    "interactions": [
-      "may enhance effects of insulin",
-      "anxiolytics",
-      "and anticoagulants."
+    "compounds": [],
+    "toxicity_ld50": ">5000 mg/kg (rats, oral)",
+    "safety": "",
+    "sideeffects": [
+      "rare. mild nausea or drowsiness in sensitive individuals."
     ],
     "contraindications": [
       "avoid in pregnancy without supervision. may lower blood sugar."
     ],
-    "sideeffects": [
-      "rare. mild nausea or drowsiness in sensitive individuals."
-    ],
-    "safety": "",
-    "toxicity": "Very low. Widely consumed in tea form.",
-    "toxicity_ld50": ">5000 mg/kg (rats, oral)",
+    "therapeutic": "used for adrenal fatigue, anxiety, cognitive enhancement, colds, blood sugar balance, and spiritual rituals.",
     "tags": [
       "🌿 adaptogen",
       "🧘 calm",
@@ -7558,6 +11700,17 @@
       "Ayurvedic Materia Medica",
       "Journal of Ayurveda and Integrative Medicine"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may enhance effects of insulin",
+      "anxiolytics",
+      "and anticoagulants."
+    ],
+    "toxicity": "Very low. Widely consumed in tea form.",
     "image": ""
   },
   {
@@ -7566,39 +11719,42 @@
     "common": "",
     "scientific": "Panax ginseng",
     "category": "empathogen / euphoriant",
-    "subcategory": "",
-    "intensity": "",
-    "region": "asia",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "classic tonic herb for stamina and cognition.",
     "effects": "vitality;adaptogen",
+    "intensity": "",
+    "region": "asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Ginsenosides modulate HPA axis and nitric oxide pathways",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "1–2 g dried root",
-    "therapeutic": "energy, immune support",
-    "interactions": [
-      "stimulants",
-      "anticoagulants"
-    ],
-    "contraindications": [
-      "hypertension"
-    ],
+    "compounds": [],
+    "toxicity_ld50": ">2000 mg/kg (rats)",
+    "safety": "",
     "sideeffects": [
       "headache",
       "insomnia"
     ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": ">2000 mg/kg (rats)",
+    "contraindications": [
+      "hypertension"
+    ],
+    "therapeutic": "energy, immune support",
     "tags": [
       "🌿 root",
       "💊 oral"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "1–2 g dried root",
+    "interactions": [
+      "stimulants",
+      "anticoagulants"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -7607,39 +11763,42 @@
     "common": "",
     "scientific": "Panax quinquefolius",
     "category": "empathogen / euphoriant",
-    "subcategory": "",
-    "intensity": "",
-    "region": "north america",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "north american species prized for restorative effects.",
     "effects": "calm energy",
+    "intensity": "",
+    "region": "north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Similar ginsenosides modulate neurotransmitters",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "1–3 g dried root",
-    "therapeutic": "energy, stress relief",
-    "interactions": [
-      "stimulants",
-      "anticoagulants"
-    ],
-    "contraindications": [
-      "hypertension"
-    ],
+    "compounds": [],
+    "toxicity_ld50": ">2000 mg/kg (rats)",
+    "safety": "",
     "sideeffects": [
       "headache",
       "insomnia"
     ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": ">2000 mg/kg (rats)",
+    "contraindications": [
+      "hypertension"
+    ],
+    "therapeutic": "energy, stress relief",
     "tags": [
       "🌿 root",
       "💊 oral"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "1–3 g dried root",
+    "interactions": [
+      "stimulants",
+      "anticoagulants"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -7648,40 +11807,43 @@
     "common": "",
     "scientific": "Papaver somniferum",
     "category": "other",
-    "subcategory": "",
-    "intensity": "",
-    "region": "worldwide",
-    "regiontags": [],
-    "legalstatus": "Highly controlled",
-    "schedule": "",
-    "legalnotes": "",
     "description": "primary source of medicinal opiates.",
     "effects": "analgesia;euphoria",
+    "intensity": "",
+    "region": "worldwide",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Highly controlled",
     "mechanism": "Morphine alkaloids activate mu-opioid receptors",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "50–200 mg opium",
-    "therapeutic": "pain relief",
-    "interactions": [
-      "cns depressants",
-      "alcohol"
+    "compounds": [],
+    "toxicity_ld50": "~150 mg/kg (morphine, rats)",
+    "safety": "",
+    "sideeffects": [
+      "respiratory depression",
+      "addiction"
     ],
     "contraindications": [
       "respiratory issues",
       "pregnancy"
     ],
-    "sideeffects": [
-      "respiratory depression",
-      "addiction"
-    ],
-    "safety": "",
-    "toxicity": "High",
-    "toxicity_ld50": "~150 mg/kg (morphine, rats)",
+    "therapeutic": "pain relief",
     "tags": [
       "☠️ addictive",
       "💊 oral"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "50–200 mg opium",
+    "interactions": [
+      "cns depressants",
+      "alcohol"
+    ],
+    "toxicity": "High",
     "image": ""
   },
   {
@@ -7690,26 +11852,24 @@
     "common": "",
     "scientific": "Passiflora incarnata",
     "category": "nervine / anxiolytic / sleep",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "southeastern u.s., latin america",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a beautiful climbing flower used to calm restlessness, anxiety, and insomnia. native to the southeastern u.s., passionflower is valued for its non-habit-forming, gently sedative qualities.",
     "effects": "Anxiety relief;Mild sedation;Muscle relaxation;Sleep support",
+    "intensity": "Mild–Moderate",
+    "region": "southeastern u.s., latin america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Rich in flavonoids like chrysin and vitexin that modulate GABA-A receptors. Also may inhibit MAO and reduce neuronal excitability.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for anxiety, sleep difficulty, muscle spasms, withdrawal symptoms, and nervous gi issues.",
-    "interactions": [
-      "may potentiate benzodiazepines",
-      "opioids",
-      "and alcohol.",
-      "cns depressants",
-      "maois"
+    "compounds": [],
+    "toxicity_ld50": ">3000 mg/kg (mice, oral)",
+    "safety": "1",
+    "sideeffects": [
+      "drowsiness",
+      "vivid dreams",
+      "or mild nausea. rare allergic reactions.",
+      "dizziness"
     ],
     "contraindications": [
       "avoid with strong sedatives",
@@ -7718,15 +11878,7 @@
       "pregnancy",
       "cns depressants"
     ],
-    "sideeffects": [
-      "drowsiness",
-      "vivid dreams",
-      "or mild nausea. rare allergic reactions.",
-      "dizziness"
-    ],
-    "safety": "1",
-    "toxicity": "Very low. Safe in therapeutic range.",
-    "toxicity_ld50": ">3000 mg/kg (mice, oral)",
+    "therapeutic": "used for anxiety, sleep difficulty, muscle spasms, withdrawal symptoms, and nervous gi issues.",
     "tags": [
       "🛌 sleep",
       "🧘 anti-anxiety",
@@ -7741,6 +11893,19 @@
       "ESCOP Monograph – Passiflora",
       "Herbal Medicine – Mills & Bone"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may potentiate benzodiazepines",
+      "opioids",
+      "and alcohol.",
+      "cns depressants",
+      "maois"
+    ],
+    "toxicity": "Very low. Safe in therapeutic range.",
     "image": ""
   },
   {
@@ -7749,27 +11914,26 @@
     "common": "",
     "scientific": "Paullinia cupana",
     "category": "stimulant / nootropic / metabolic",
-    "subcategory": "",
-    "intensity": "Moderate–Strong",
-    "region": "brazil, amazon rainforest",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a highly caffeinated amazonian seed used traditionally for endurance, alertness, and ritual vigor. now a common additive in energy drinks, guaraná offers a longer-lasting stimulation than coffee due to slow-release alkaloids and tannins.",
     "effects": "Energy;Focus;Mood boost;Appetite suppression",
+    "intensity": "Moderate–Strong",
+    "region": "brazil, amazon rainforest",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "High caffeine content (~2–6% by weight) acts as an adenosine receptor antagonist. Also contains theobromine and catechins for extended alertness.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for fatigue, cognitive performance, mild depression, sexual energy, and metabolism enhancement.",
-    "interactions": [
-      "potentiates other stimulants",
-      "may interfere with sedatives",
-      "synergistic with other stimulants",
-      "avoid with maois",
-      "ssris",
-      "or cardiac drugs."
+    "compounds": [],
+    "toxicity_ld50": "Caffeine LD50 ~192 mg/kg (humans)",
+    "safety": "",
+    "sideeffects": [
+      "jitteriness",
+      "stomach upset",
+      "restlessness",
+      "insomnia",
+      "irritability",
+      "or digestive upset in sensitive individuals."
     ],
     "contraindications": [
       "heart problems",
@@ -7779,17 +11943,7 @@
       "hypertension",
       "or with other stimulants."
     ],
-    "sideeffects": [
-      "jitteriness",
-      "stomach upset",
-      "restlessness",
-      "insomnia",
-      "irritability",
-      "or digestive upset in sensitive individuals."
-    ],
-    "safety": "",
-    "toxicity": "Overuse leads to restlessness, insomnia, or tachycardia.",
-    "toxicity_ld50": "Caffeine LD50 ~192 mg/kg (humans)",
+    "therapeutic": "used for fatigue, cognitive performance, mild depression, sexual energy, and metabolism enhancement.",
     "tags": [
       "☕ high caffeine",
       "🍫 seed",
@@ -7805,6 +11959,20 @@
       "Phytochemistry Reviews",
       "2008"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "potentiates other stimulants",
+      "may interfere with sedatives",
+      "synergistic with other stimulants",
+      "avoid with maois",
+      "ssris",
+      "or cardiac drugs."
+    ],
+    "toxicity": "Overuse leads to restlessness, insomnia, or tachycardia.",
     "image": ""
   },
   {
@@ -7813,42 +11981,45 @@
     "common": "",
     "scientific": "Paullinia yoco",
     "category": "stimulant / ritual",
-    "subcategory": "",
-    "intensity": "Moderate",
-    "region": "amazon rainforest",
-    "regiontags": [],
-    "legalstatus": "Generally legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "liana used by several amazonian tribes; the bark yields a potent caffeinated beverage for energy.",
     "effects": "alertness;energy;reduced fatigue",
+    "intensity": "Moderate",
+    "region": "amazon rainforest",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Generally legal",
     "mechanism": "Bark rich in caffeine acts as an adenosine receptor antagonist",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used by indigenous amazonian peoples for stamina on hunts",
-    "interactions": [
-      "potentiates other stimulants and certain medications"
+    "compounds": [],
+    "toxicity_ld50": "Caffeine LD50 ~192 mg/kg in rats",
+    "safety": "",
+    "sideeffects": [
+      "jitters",
+      "rapid heartbeat",
+      "sleeplessness"
     ],
     "contraindications": [
       "heart problems",
       "insomnia",
       "sensitivity to caffeine"
     ],
-    "sideeffects": [
-      "jitters",
-      "rapid heartbeat",
-      "sleeplessness"
-    ],
-    "safety": "",
-    "toxicity": "Comparable to other caffeinated products",
-    "toxicity_ld50": "Caffeine LD50 ~192 mg/kg in rats",
+    "therapeutic": "used by indigenous amazonian peoples for stamina on hunts",
     "tags": [
       "amazon",
       "caffeine",
       "vine"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "potentiates other stimulants and certain medications"
+    ],
+    "toxicity": "Comparable to other caffeinated products",
     "image": ""
   },
   {
@@ -7857,36 +12028,19 @@
     "common": "",
     "scientific": "Pausinystalia johimbe",
     "category": "stimulant / aphrodisiac / vasodilator",
-    "subcategory": "",
-    "intensity": "Moderate–Strong",
-    "region": "west africa (cameroon, nigeria, gabon)",
-    "regiontags": [],
-    "legalstatus": "Regulated in some countries; available OTC or by prescription in others",
-    "schedule": "",
-    "legalnotes": "",
     "description": "an african tree bark used as a traditional male aphrodisiac and stimulant. contains yohimbine, an alkaloid used in pharmaceuticals for erectile dysfunction and athletic performance.",
     "effects": "Increased libido;Stimulation;Increased blood flow;Alertness",
+    "intensity": "Moderate–Strong",
+    "region": "west africa (cameroon, nigeria, gabon)",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Regulated in some countries; available OTC or by prescription in others",
     "mechanism": "Yohimbine is an alpha-2 adrenergic receptor antagonist, increasing norepinephrine release and blood flow. Also affects serotonin and dopamine.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for sexual dysfunction, athletic enhancement, weight loss, and sometimes as a stimulant. traditional use includes ceremonial energizing purposes.",
-    "interactions": [
-      "dangerous with ssris",
-      "maois",
-      "stimulants",
-      "or antihypertensives.",
-      "interacts with stimulants and antihypertensives"
-    ],
-    "contraindications": [
-      "avoid in heart conditions",
-      "anxiety",
-      "schizophrenia",
-      "or with stimulants. not for use in pregnancy.",
-      "heart disease",
-      "anxiety disorders",
-      "maois."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "LD50 ~50 mg/kg (rats, yohimbine)",
+    "safety": "",
     "sideeffects": [
       "anxiety",
       "increased heart rate",
@@ -7897,9 +12051,16 @@
       "jitteriness",
       "insomnia"
     ],
-    "safety": "",
-    "toxicity": "High doses cause anxiety, hypertension, or hallucinations.",
-    "toxicity_ld50": "LD50 ~50 mg/kg (rats, yohimbine)",
+    "contraindications": [
+      "avoid in heart conditions",
+      "anxiety",
+      "schizophrenia",
+      "or with stimulants. not for use in pregnancy.",
+      "heart disease",
+      "anxiety disorders",
+      "maois."
+    ],
+    "therapeutic": "used for sexual dysfunction, athletic enhancement, weight loss, and sometimes as a stimulant. traditional use includes ceremonial energizing purposes.",
     "tags": [
       "🔥 aphrodisiac",
       "⚠️ stimulant",
@@ -7914,6 +12075,19 @@
       "International Journal of Impotence Research",
       "2002"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "dangerous with ssris",
+      "maois",
+      "stimulants",
+      "or antihypertensives.",
+      "interacts with stimulants and antihypertensives"
+    ],
+    "toxicity": "High doses cause anxiety, hypertension, or hallucinations.",
     "image": ""
   },
   {
@@ -7922,41 +12096,44 @@
     "common": "",
     "scientific": "Pausinystalia yohimbe",
     "category": "stimulant",
-    "subcategory": "",
-    "intensity": "Moderate",
-    "region": "africa",
-    "regiontags": [],
-    "legalstatus": "Regulated in some regions",
-    "schedule": "",
-    "legalnotes": "",
     "description": "potent bark traditionally used as an aphrodisiac.",
     "effects": "Aphrodisiac;stimulant",
+    "intensity": "Moderate",
+    "region": "africa",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Regulated in some regions",
     "mechanism": "Yohimbine is an adrenergic receptor antagonist",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "erectile dysfunction treatment",
-    "interactions": [
-      "maois",
-      "stimulants"
+    "compounds": [],
+    "toxicity_ld50": "Yohimbine LD50 ~50 mg/kg (mouse)",
+    "safety": "",
+    "sideeffects": [
+      "anxiety",
+      "hypertension"
     ],
     "contraindications": [
       "heart disease",
       "anxiety disorders"
     ],
-    "sideeffects": [
-      "anxiety",
-      "hypertension"
-    ],
-    "safety": "",
-    "toxicity": "Moderate",
-    "toxicity_ld50": "Yohimbine LD50 ~50 mg/kg (mouse)",
+    "therapeutic": "erectile dysfunction treatment",
     "tags": [
       "⚠️ caution",
       "🌿 bark",
       "🔥 intensity"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "maois",
+      "stimulants"
+    ],
+    "toxicity": "Moderate",
     "image": ""
   },
   {
@@ -7965,25 +12142,28 @@
     "common": "",
     "scientific": "Peganum harmala",
     "category": "maoi / entheogen / traditional medicine",
-    "subcategory": "",
-    "intensity": "Moderate–Strong",
-    "region": "middle east, north africa, central asia",
-    "regiontags": [],
-    "legalstatus": "Legal in most countries; restricted in some due to MAOI activity",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a desert shrub revered in persian, middle eastern, and central asian traditions. its seeds contain harmala alkaloids (harmine, harmaline, tetrahydroharmine) that act as reversible mao-a inhibitors and are used both spiritually and medicinally.",
     "effects": "MAO inhibition;Dream enhancement;Entheogenic potentiation;Altered perception",
+    "intensity": "Moderate–Strong",
+    "region": "middle east, north africa, central asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal in most countries; restricted in some due to MAOI activity",
     "mechanism": "Reversible inhibition of monoamine oxidase A (MAO-A), increasing serotonin, dopamine, and other monoamines. Also mild SSRI and hallucinogenic potentiator.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Harmine"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditionally used for depression, spiritual ritual, antiparasitic cleansing, and as a potentiator of dmt-containing plants.",
-    "interactions": [
-      "strong interaction with serotonergic drugs. serotonin syndrome risk.",
-      "dangerous with other maois or serotonergic drugs"
+    "toxicity_ld50": "LD50 ~150 mg/kg (harmaline, mice)",
+    "safety": "",
+    "sideeffects": [
+      "nausea",
+      "vomiting",
+      "dizziness",
+      "tremors",
+      "anxiety. strong purgative effect possible. tyramine reaction risk.",
+      "weakness"
     ],
     "contraindications": [
       "avoid with ssris",
@@ -7994,17 +12174,7 @@
       "pregnancy.",
       "or liver disease."
     ],
-    "sideeffects": [
-      "nausea",
-      "vomiting",
-      "dizziness",
-      "tremors",
-      "anxiety. strong purgative effect possible. tyramine reaction risk.",
-      "weakness"
-    ],
-    "safety": "",
-    "toxicity": "Moderate–High. Purified alkaloids more dangerous than seed prep.",
-    "toxicity_ld50": "LD50 ~150 mg/kg (harmaline, mice)",
+    "therapeutic": "traditionally used for depression, spiritual ritual, antiparasitic cleansing, and as a potentiator of dmt-containing plants.",
     "tags": [
       "🧠 maoi",
       "🌌 entheogen",
@@ -8019,6 +12189,16 @@
       "Journal of Ethnopharmacology",
       "1997"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "strong interaction with serotonergic drugs. serotonin syndrome risk.",
+      "dangerous with other maois or serotonergic drugs"
+    ],
+    "toxicity": "Moderate–High. Purified alkaloids more dangerous than seed prep.",
     "image": ""
   },
   {
@@ -8027,35 +12207,38 @@
     "common": "",
     "scientific": "Perilla frutescens",
     "category": "ethnobotanical",
-    "subcategory": "",
-    "intensity": "",
-    "region": "east asia",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "used in east asian cuisine and medicine, this leaf contains mild mood-elevating and cognitive enhancing properties.",
     "effects": "uplifting;calm clarity",
+    "intensity": "",
+    "region": "east asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "Cholinergic + antioxidant effects",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Perillaldehyde",
       "Rosmarinic Acid"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "mild nootropic",
       "culinary",
       "relaxing"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -8064,35 +12247,38 @@
     "common": "",
     "scientific": "Peumus boldus",
     "category": "ethnobotanical",
-    "subcategory": "",
-    "intensity": "",
-    "region": "chile",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "boldo is a south american medicinal herb with liver-supportive and mild hypnotic properties.",
     "effects": "calming;digestive aid;dreamy",
+    "intensity": "",
+    "region": "chile",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "Cholinergic + serotonergic",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Boldine",
       "Ascaridole"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "digestive",
       "sleep aid",
       "folk medicine"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -8101,35 +12287,29 @@
     "common": "",
     "scientific": "Piper auritum",
     "category": "culinary / mild relaxant / traditional mesoamerican",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "mexico, central america",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a large-leaved herb with a root beer aroma, used in traditional mexican cuisine and healing rituals. also called 'hoja santa', it is believed to gently support digestion, lungs, and emotional balance.",
     "effects": "Digestive aid;Calming;Flavor enhancer;Mild euphoria (traditional use)",
+    "intensity": "Mild",
+    "region": "mexico, central america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Contains safrole and other aromatic compounds that may mildly modulate GABA and dopamine activity. Primary use is culinary, with subtle psychoactivity in large doses.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Safrole"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for indigestion, respiratory soothing, menstrual support, and mild calming. culturally linked to rituals and purification.",
-    "interactions": [
-      "may inhibit cyp enzymes. avoid combining with hepatotoxic substances."
-    ],
-    "contraindications": [
-      "avoid chronic high-dose consumption. not for pregnant users or liver conditions."
-    ],
+    "toxicity_ld50": "Safrole ~1950 mg/kg (rats, oral)",
+    "safety": "",
     "sideeffects": [
       "in large doses: nausea",
       "drowsiness. safrole is a known liver carcinogen at high doses in animals."
     ],
-    "safety": "",
-    "toxicity": "Low at culinary doses. Chronic use of concentrated extract not advised.",
-    "toxicity_ld50": "Safrole ~1950 mg/kg (rats, oral)",
+    "contraindications": [
+      "avoid chronic high-dose consumption. not for pregnant users or liver conditions."
+    ],
+    "therapeutic": "used for indigestion, respiratory soothing, menstrual support, and mild calming. culturally linked to rituals and purification.",
     "tags": [
       "🌿 digestive",
       "🌮 culinary",
@@ -8142,6 +12322,15 @@
       "2005",
       "Ethnobotany of Mexico – 2012"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may inhibit cyp enzymes. avoid combining with hepatotoxic substances."
+    ],
+    "toxicity": "Low at culinary doses. Chronic use of concentrated extract not advised.",
     "image": ""
   },
   {
@@ -8150,25 +12339,23 @@
     "common": "",
     "scientific": "Piper methysticum",
     "category": "dissociative / sedative",
-    "subcategory": "",
-    "intensity": "Mild to moderate",
-    "region": "polynesia, micronesia, melanesia",
-    "regiontags": [],
-    "legalstatus": "Legal; restricted in some EU countries",
-    "schedule": "",
-    "legalnotes": "",
     "description": "south pacific root brew known for its relaxing and anxiolytic effects.",
     "effects": "Relaxation;social ease;mild euphoria",
+    "intensity": "Mild to moderate",
+    "region": "polynesia, micronesia, melanesia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal; restricted in some EU countries",
     "mechanism": "Kavalactones modulate GABA, block sodium and calcium channels",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "anxiety relief, social relaxation",
-    "interactions": [
-      "cns depressants",
-      "alcohol",
-      "liver-metabolized drugs",
-      "potentiates sedatives and alcohol"
+    "compounds": [],
+    "toxicity_ld50": "Kavain LD50 ~920 mg/kg (mouse)",
+    "safety": "2",
+    "sideeffects": [
+      "liver strain (rare)",
+      "drowsiness",
+      "potential hepatotoxicity"
     ],
     "contraindications": [
       "liver conditions",
@@ -8177,14 +12364,7 @@
       "liver disease",
       "heavy alcohol use"
     ],
-    "sideeffects": [
-      "liver strain (rare)",
-      "drowsiness",
-      "potential hepatotoxicity"
-    ],
-    "safety": "2",
-    "toxicity": "Low to moderate; caution with prolonged use",
-    "toxicity_ld50": "Kavain LD50 ~920 mg/kg (mouse)",
+    "therapeutic": "anxiety relief, social relaxation",
     "tags": [
       "🌿 root",
       "🍵 social",
@@ -8198,6 +12378,18 @@
       "Journal of Clinical Psychopharmacology",
       "2013"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "cns depressants",
+      "alcohol",
+      "liver-metabolized drugs",
+      "potentiates sedatives and alcohol"
+    ],
+    "toxicity": "Low to moderate; caution with prolonged use",
     "image": ""
   },
   {
@@ -8206,37 +12398,40 @@
     "common": "",
     "scientific": "Plectranthus scutellarioides",
     "category": "psychedelic / ornamental",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "tropical asia",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "",
     "effects": "mild visuals;color enhancement;relaxation",
+    "intensity": "Mild",
+    "region": "tropical asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Unclear; may act on serotonergic pathways",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "rarely used; some folk use for divination",
-    "interactions": [],
-    "contraindications": [
-      "none known"
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
     "sideeffects": [
       "headache",
       "nausea at high doses"
     ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "contraindications": [
+      "none known"
+    ],
+    "therapeutic": "rarely used; some folk use for divination",
     "tags": [
       "lamiaceae",
       "painted nettle",
       "visionary"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -8245,35 +12440,38 @@
     "common": "",
     "scientific": "Pogostemon cablin",
     "category": "ethnobotanical",
-    "subcategory": "",
-    "intensity": "",
-    "region": "asia",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "patchouli, while mainly aromatic, has mild psychoactive effects in traditional incense rituals.",
     "effects": "sensory enhancement;calm focus;uplifted mood",
+    "intensity": "",
+    "region": "asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "Aromatherapeutic + serotonergic",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Patchoulol",
       "Alpha-bulnesene"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "aromatic",
       "ritual",
       "uplifting"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -8282,36 +12480,39 @@
     "common": "",
     "scientific": "Polygala tenuifolia",
     "category": "nootropic / adaptogen",
-    "subcategory": "",
-    "intensity": "",
-    "region": "east asia",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "called yuan zhi in tcm; promotes mental clarity",
     "effects": "focus;mood lift",
+    "intensity": "",
+    "region": "east asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Tenuigenin saponins modulate neurochemistry and neurotrophic factors",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "1-2 g root",
-    "therapeutic": "memory, stress",
-    "interactions": [
-      "none known"
+    "compounds": [],
+    "toxicity_ld50": ">3 g/kg (rats)",
+    "safety": "",
+    "sideeffects": [
+      "gi upset"
     ],
     "contraindications": [
       "severe gastritis"
     ],
-    "sideeffects": [
-      "gi upset"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": ">3 g/kg (rats)",
+    "therapeutic": "memory, stress",
     "tags": [
       "🧠 focus"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "1-2 g root",
+    "interactions": [
+      "none known"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -8320,42 +12521,45 @@
     "common": "",
     "scientific": "Psilocybin",
     "category": "psychedelic",
-    "subcategory": "",
-    "intensity": "Moderate",
-    "region": "🌎 global",
-    "regiontags": [],
-    "legalstatus": "Controlled in many countries",
-    "schedule": "",
-    "legalnotes": "",
     "description": "active compound in psychedelic mushrooms producing profound perceptual changes.",
     "effects": "Visual patterns;mystical insight;emotional release",
+    "intensity": "Moderate",
+    "region": "🌎 global",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Controlled in many countries",
     "mechanism": "Converted to psilocin which acts as 5-HT2A agonist.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "promising treatment for depression, addiction, and end-of-life anxiety.",
-    "interactions": [
-      "ssris may reduce effects",
-      "avoid maois."
-    ],
-    "contraindications": [
-      "psychosis",
-      "uncontrolled hypertension."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "285 mg/kg (rats, oral) for psilocybin",
+    "safety": "2",
     "sideeffects": [
       "nausea",
       "anxiety",
       "transient increase in heart rate."
     ],
-    "safety": "2",
-    "toxicity": "Low toxicity; wide margin of safety.",
-    "toxicity_ld50": "285 mg/kg (rats, oral) for psilocybin",
+    "contraindications": [
+      "psychosis",
+      "uncontrolled hypertension."
+    ],
+    "therapeutic": "promising treatment for depression, addiction, and end-of-life anxiety.",
     "tags": [
       "⚠️ restricted",
       "🌀 visionary",
       "💊 oral"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "ssris may reduce effects",
+      "avoid maois."
+    ],
+    "toxicity": "Low toxicity; wide margin of safety.",
     "image": ""
   },
   {
@@ -8364,41 +12568,44 @@
     "common": "",
     "scientific": "Psychotria carthagenensis",
     "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Strong",
-    "region": "amazon basin",
-    "regiontags": [],
-    "legalstatus": "DMT restricted in many countries",
-    "schedule": "",
-    "legalnotes": "",
     "description": "amazonian shrub also known as chaliponga; its dmt-rich leaves are valued in shamanic ceremonies.",
     "effects": "visual effects;introspection;spiritual insight",
+    "intensity": "Strong",
+    "region": "amazon basin",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "DMT restricted in many countries",
     "mechanism": "Leaves contain N,N-dimethyltryptamine acting as a serotonin agonist; requires MAO inhibition orally",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used in ayahuasca analogues for visionary experiences",
-    "interactions": [
-      "dangerous with serotonergic drugs or other maois"
-    ],
-    "contraindications": [
-      "mental health conditions",
-      "maoi or ssri medication"
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
     "sideeffects": [
       "nausea",
       "intense visions",
       "possible anxiety"
     ],
-    "safety": "",
-    "toxicity": "Low physiological but intense psychological effects",
-    "toxicity_ld50": "Not established",
+    "contraindications": [
+      "mental health conditions",
+      "maoi or ssri medication"
+    ],
+    "therapeutic": "used in ayahuasca analogues for visionary experiences",
     "tags": [
       "amazon",
       "dmt",
       "chaliponga"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "dangerous with serotonergic drugs or other maois"
+    ],
+    "toxicity": "Low physiological but intense psychological effects",
     "image": ""
   },
   {
@@ -8407,38 +12614,41 @@
     "common": "",
     "scientific": "Psychotria carthaginensis",
     "category": "psychedelic",
-    "subcategory": "",
-    "intensity": "",
-    "region": "south america",
-    "regiontags": [],
-    "legalstatus": "Often legal; DMT controlled",
-    "schedule": "",
-    "legalnotes": "",
     "description": "chacruna relative sometimes used as admixture in brews",
     "effects": "visions;euphoria",
+    "intensity": "",
+    "region": "south america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Often legal; DMT controlled",
     "mechanism": "Leaves contain DMT acting on 5-HT2A when combined with MAOI",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "50-100 g fresh leaves",
-    "therapeutic": "visionary states",
-    "interactions": [
-      "maois",
-      "ssris"
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "nausea with maoi"
     ],
     "contraindications": [
       "mental health disorders"
     ],
-    "sideeffects": [
-      "nausea with maoi"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "visionary states",
     "tags": [
       "🌿 ayahuasca",
       "🍃 leaf"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "50-100 g fresh leaves",
+    "interactions": [
+      "maois",
+      "ssris"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -8447,23 +12657,26 @@
     "common": "",
     "scientific": "Psychotria viridis",
     "category": "entheogen / dmt source / shamanic",
-    "subcategory": "",
-    "intensity": "Strong",
-    "region": "amazon basin (peru, brazil, colombia)",
-    "regiontags": [],
-    "legalstatus": "Restricted in many countries due to DMT",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a tropical shrub from the amazon traditionally used in ayahuasca brews. its leaves contain high concentrations of n,n-dmt, making it a primary admixture plant in visionary ceremonies.",
     "effects": "Psychedelic visions;Emotional processing;Spiritual insight;Sensory enhancement",
+    "intensity": "Strong",
+    "region": "amazon basin (peru, brazil, colombia)",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Restricted in many countries due to DMT",
     "mechanism": "Contains N,N-DMT, a potent serotonergic psychedelic that acts as a 5-HT2A receptor agonist. Requires MAOI (such as harmala alkaloids) to be orally active.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used in traditional amazonian healing for soul retrieval, trauma, depression, and spiritual communion. western research suggests benefit in mental health and addiction therapy.",
-    "interactions": [
-      "dangerous with antidepressants or stimulants",
-      "dangerous with serotonergic drugs. do not combine with other psychedelics unless experienced."
+    "compounds": [],
+    "toxicity_ld50": "Not established in humans",
+    "safety": "",
+    "sideeffects": [
+      "intense visuals",
+      "vomiting",
+      "nausea",
+      "vomiting (purging)",
+      "anxiety",
+      "dissociation. can be intense or destabilizing in unprepared individuals."
     ],
     "contraindications": [
       "mental health disorders",
@@ -8473,17 +12686,7 @@
       "antipsychotics",
       "or in those with severe psychiatric conditions."
     ],
-    "sideeffects": [
-      "intense visuals",
-      "vomiting",
-      "nausea",
-      "vomiting (purging)",
-      "anxiety",
-      "dissociation. can be intense or destabilizing in unprepared individuals."
-    ],
-    "safety": "",
-    "toxicity": "Low at standard doses. Risk increases with improper preparation or interaction.",
-    "toxicity_ld50": "Not established in humans",
+    "therapeutic": "used in traditional amazonian healing for soul retrieval, trauma, depression, and spiritual communion. western research suggests benefit in mental health and addiction therapy.",
     "tags": [
       "⚠️ caution",
       "🧠 vision",
@@ -8499,6 +12702,16 @@
       "Journal of Ethnopharmacology",
       "2010"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "dangerous with antidepressants or stimulants",
+      "dangerous with serotonergic drugs. do not combine with other psychedelics unless experienced."
+    ],
+    "toxicity": "Low at standard doses. Risk increases with improper preparation or interaction.",
     "image": ""
   },
   {
@@ -8507,38 +12720,41 @@
     "common": "",
     "scientific": "Ptychopetalum olacoides",
     "category": "stimulant",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "amazon",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "known as muira puama, used for vitality and libido.",
     "effects": "Libido boost;mild stimulation",
+    "intensity": "Mild",
+    "region": "amazon",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Alkaloids may act on dopamine pathways",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "aphrodisiac and tonic",
-    "interactions": [
-      "none known"
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "rare insomnia"
     ],
     "contraindications": [
       "pregnancy"
     ],
-    "sideeffects": [
-      "rare insomnia"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "aphrodisiac and tonic",
     "tags": [
       "stimulant",
       "✅ safe",
       "🌿 bark"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "none known"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -8547,41 +12763,44 @@
     "common": "",
     "scientific": "Pulsatilla vulgaris",
     "category": "sedative / analgesic",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "europe and western asia",
-    "regiontags": [],
-    "legalstatus": "Legal but not widely sold",
-    "schedule": "",
-    "legalnotes": "",
     "description": "also called pasque flower; once used by herbalists for calming nerves and relieving pain.",
     "effects": "calm;pain relief;mild altered awareness",
+    "intensity": "Mild",
+    "region": "europe and western asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal but not widely sold",
     "mechanism": "Contains lactones derived from protoanemonin that depress the central nervous system",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "european folk remedy for anxiety, insomnia and menstrual pain",
-    "interactions": [
-      "may potentiate other sedatives or analgesics"
+    "compounds": [],
+    "toxicity_ld50": "Not well established",
+    "safety": "",
+    "sideeffects": [
+      "nausea",
+      "stomach irritation if taken fresh"
     ],
     "contraindications": [
       "pregnancy",
       "open wounds",
       "large doses"
     ],
-    "sideeffects": [
-      "nausea",
-      "stomach irritation if taken fresh"
-    ],
-    "safety": "",
-    "toxicity": "Fresh plant is irritant and toxic until dried",
-    "toxicity_ld50": "Not well established",
+    "therapeutic": "european folk remedy for anxiety, insomnia and menstrual pain",
     "tags": [
       "anodyne",
       "folk",
       "sedative"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may potentiate other sedatives or analgesics"
+    ],
+    "toxicity": "Fresh plant is irritant and toxic until dried",
     "image": ""
   },
   {
@@ -8590,35 +12809,38 @@
     "common": "Red Raspberry Leaf",
     "scientific": "",
     "category": "tonic",
-    "subcategory": "",
-    "intensity": "",
-    "region": "europe, north america",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "",
     "effects": "uterine tonic;calming;digestive support",
+    "intensity": "",
+    "region": "europe, north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "Smooth muscle modulation and antioxidant action",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Fragarine",
       "Tiliroside"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "folk",
       "uterine",
       "tonic"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -8627,35 +12849,38 @@
     "common": "Rue",
     "scientific": "Ruta graveolens",
     "category": "ethnobotanical",
-    "subcategory": "",
-    "intensity": "",
-    "region": "mediterranean",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "common rue, used historically as a sedative, an abortifacient, and for spiritual protection.",
     "effects": "relaxation;hypnotic;mystical",
+    "intensity": "",
+    "region": "mediterranean",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "GABA-A modulation, alkaloid effects",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Rutarin",
       "Graveoline"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "ritual",
       "bitter",
       "traditional medicine"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -8664,35 +12889,38 @@
     "common": "Russian Olive",
     "scientific": "",
     "category": "sedative",
-    "subcategory": "",
-    "intensity": "",
-    "region": "central asia, middle east, europe",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "",
     "effects": "anxiolytic;sedative;pain-relieving",
+    "intensity": "",
+    "region": "central asia, middle east, europe",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "GABAergic effects and antioxidant pathways",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Elaeagnin",
       "Flavonoids"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "sedative",
       "analgesic",
       "folk"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -8701,35 +12929,38 @@
     "common": "Sacred Fig",
     "scientific": "",
     "category": "sedative",
-    "subcategory": "",
-    "intensity": "",
-    "region": "india, southeast asia",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "",
     "effects": "calming;mood-balancing;mild sedative",
+    "intensity": "",
+    "region": "india, southeast asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "Neuroprotective antioxidant and serotonin modulation",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Furanocoumarins",
       "Tannins"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "spiritual",
       "sedative",
       "folk"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -8738,27 +12969,27 @@
     "common": "Sacred Lotus",
     "scientific": "Nelumbo nucifera",
     "category": "dissociative / sedative",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "india, china, southeast asia",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "sacred flower in buddhism and hinduism, with mild psychoactive and calming properties. often used in teas or tinctures.",
     "effects": "Relaxation;dream enhancement;calm euphoria",
+    "intensity": "Mild",
+    "region": "india, china, southeast asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Likely GABAergic and dopaminergic effects (alkaloids: nuciferine, aporphine)",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Nuciferine",
       "Neferine"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "calm, aphrodisiac, meditation support",
-    "interactions": [
-      "sedatives",
-      "cns depressants",
-      "avoid cns depressants"
+    "toxicity_ld50": "Not established",
+    "safety": "1",
+    "sideeffects": [
+      "drowsiness",
+      "dizziness",
+      "sedation",
+      "mild dizziness"
     ],
     "contraindications": [
       "pregnancy (caution)",
@@ -8766,15 +12997,7 @@
       "sedatives",
       "pregnancy"
     ],
-    "sideeffects": [
-      "drowsiness",
-      "dizziness",
-      "sedation",
-      "mild dizziness"
-    ],
-    "safety": "1",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "calm, aphrodisiac, meditation support",
     "tags": [
       "🌊 spiritual",
       "🌸 sacred",
@@ -8788,6 +13011,17 @@
       "Ayurvedic Herbal Compendium",
       "Chinese Pharmacopoeia"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "sedatives",
+      "cns depressants",
+      "avoid cns depressants"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -8796,37 +13030,31 @@
     "common": "Sakae Naa",
     "scientific": "Combretum quadrangulare",
     "category": "stimulant",
-    "subcategory": "",
-    "intensity": "Mild to Moderate",
-    "region": "laos, cambodia, thailand",
-    "regiontags": [],
-    "legalstatus": "Legal with little regulation",
-    "schedule": "",
-    "legalnotes": "",
     "description": "often marketed as “sakae naa,” this plant is used as a mild energizing substitute for kratom.",
     "effects": "heightened alertness;subtle euphoria;increased focus",
+    "intensity": "Mild to Moderate",
+    "region": "laos, cambodia, thailand",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal with little regulation",
     "mechanism": "Leaves contain combretol and related alkaloids acting on adrenergic systems",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Combretol",
       "Combretin"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditional stimulant and tonic in laos and thailand",
-    "interactions": [
-      "may potentiate other stimulants"
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "jitters",
+      "insomnia if overused"
     ],
     "contraindications": [
       "hypertension",
       "heart conditions"
     ],
-    "sideeffects": [
-      "jitters",
-      "insomnia if overused"
-    ],
-    "safety": "",
-    "toxicity": "Limited data but appears low at customary doses",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "traditional stimulant and tonic in laos and thailand",
     "tags": [
       "sakae naa",
       "southeast asia",
@@ -8838,6 +13066,15 @@
       "2015",
       "Ethnopharmacology of Southeast Asia – WHO Report"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may potentiate other stimulants"
+    ],
+    "toxicity": "Limited data but appears low at customary doses",
     "image": ""
   },
   {
@@ -8846,35 +13083,38 @@
     "common": "",
     "scientific": "Salvia sclarea",
     "category": "ethnobotanical",
-    "subcategory": "",
-    "intensity": "",
-    "region": "mediterranean",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "clary sage, used aromatically and medicinally for mild euphoria, hormonal balancing, and clarity.",
     "effects": "clarity;relief;uplifting",
+    "intensity": "",
+    "region": "mediterranean",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "GABA-A modulation, estrogenic activity",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Linalyl acetate",
       "Sclareol"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "aromatic",
       "elevating",
       "folk remedy"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -8883,39 +13123,42 @@
     "common": "",
     "scientific": "Sassafras albidum",
     "category": "stimulant / traditional",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "eastern north america",
-    "regiontags": [],
-    "legalstatus": "Restricted as food additive in the U.S.",
-    "schedule": "",
-    "legalnotes": "",
     "description": "fragrant tree whose root bark and oil were once common flavorings; contains safrole with mild psychoactive properties.",
     "effects": "Mild euphoria;warmth",
+    "intensity": "Mild",
+    "region": "eastern north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Restricted as food additive in the U.S.",
     "mechanism": "Safrole may modulate dopamine release and acts as a mild hallucinogen at high doses.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "historically used as spring tonic, aromatic beverage, and folk medicine.",
-    "interactions": [
-      "may interact with maois or increase hepatotoxic drugs"
+    "compounds": [],
+    "toxicity_ld50": "Safrole LD50 ~1.95 g/kg (rats)",
+    "safety": "",
+    "sideeffects": [
+      "nausea",
+      "possible hepatotoxicity"
     ],
     "contraindications": [
       "liver disease",
       "pregnancy."
     ],
-    "sideeffects": [
-      "nausea",
-      "possible hepatotoxicity"
-    ],
-    "safety": "",
-    "toxicity": "Safrole is hepatotoxic and potentially carcinogenic in high amounts.",
-    "toxicity_ld50": "Safrole LD50 ~1.95 g/kg (rats)",
+    "therapeutic": "historically used as spring tonic, aromatic beverage, and folk medicine.",
     "tags": [
       "🌳 root bark",
       "🌿 tea"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interact with maois or increase hepatotoxic drugs"
+    ],
+    "toxicity": "Safrole is hepatotoxic and potentially carcinogenic in high amounts.",
     "image": ""
   },
   {
@@ -8924,37 +13167,21 @@
     "common": "",
     "scientific": "Sceletium tortuosum",
     "category": "mood enhancer / traditional / ssri-like",
-    "subcategory": "",
-    "intensity": "Mild to moderate",
-    "region": "south africa, namibia",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide (except select EU countries)",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a succulent plant native to south africa, kanna has been chewed, snuffed, and brewed for centuries by khoisan peoples to ease stress, elevate mood, and promote social connection. it’s now gaining modern popularity as a legal natural serotonin booster.",
     "effects": "Euphoria;Reduced anxiety;Social enhancement;Emotional softening",
+    "intensity": "Mild to moderate",
+    "region": "south africa, namibia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide (except select EU countries)",
     "mechanism": "Contains mesembrine alkaloids that act as selective serotonin reuptake inhibitors (SSRI), PDE4 inhibitors, and mild serotonin releasing agents (SRA). Also mildly acts on dopamine.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Mesembrine"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for anxiety, mild depression, public speaking stress, trauma relief, and social disconnection. studied for antidepressant properties.",
-    "interactions": [
-      "antidepressants",
-      "serotonergic agents",
-      "potentially dangerous with other serotonergic substances (e.g.",
-      "mdma",
-      "ssris",
-      "st. john's wort)."
-    ],
-    "contraindications": [
-      "ssris",
-      "maois",
-      "bipolar disorder",
-      "do not combine with ssris",
-      "or serotonergic drugs (risk of serotonin syndrome). avoid during pregnancy or with bipolar disorder."
-    ],
+    "toxicity_ld50": "Not established (safe in traditional use)",
+    "safety": "",
     "sideeffects": [
       "headache",
       "nausea",
@@ -8963,9 +13190,14 @@
       "slight sedation",
       "or overstimulation if combined with caffeine. excessive doses may cause emotional blunting or nausea."
     ],
-    "safety": "",
-    "toxicity": "Low in traditional or moderate modern doses. No known fatalities or organ toxicity.",
-    "toxicity_ld50": "Not established (safe in traditional use)",
+    "contraindications": [
+      "ssris",
+      "maois",
+      "bipolar disorder",
+      "do not combine with ssris",
+      "or serotonergic drugs (risk of serotonin syndrome). avoid during pregnancy or with bipolar disorder."
+    ],
+    "therapeutic": "used for anxiety, mild depression, public speaking stress, trauma relief, and social disconnection. studied for antidepressant properties.",
     "tags": [
       "🌼 euphoric",
       "🧘 calm",
@@ -8981,6 +13213,20 @@
       "2013",
       "South African Herbal Compendium"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "antidepressants",
+      "serotonergic agents",
+      "potentially dangerous with other serotonergic substances (e.g.",
+      "mdma",
+      "ssris",
+      "st. john's wort)."
+    ],
+    "toxicity": "Low in traditional or moderate modern doses. No known fatalities or organ toxicity.",
     "image": ""
   },
   {
@@ -8989,37 +13235,40 @@
     "common": "",
     "scientific": "Sida acuta",
     "category": "stimulant / nootropic",
-    "subcategory": "",
-    "intensity": "",
-    "region": "tropical regions",
-    "regiontags": [],
-    "legalstatus": "Varies",
-    "schedule": "",
-    "legalnotes": "",
     "description": "weedy plant sometimes used as a mild stimulant",
     "effects": "energy;focus",
+    "intensity": "",
+    "region": "tropical regions",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Varies",
     "mechanism": "Contains ephedrine-like alkaloids stimulating adrenergic receptors",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "1-3 g dried leaf",
-    "therapeutic": "traditional fever remedy",
-    "interactions": [
-      "stimulants"
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "increased heart rate"
     ],
     "contraindications": [
       "hypertension"
     ],
-    "sideeffects": [
-      "increased heart rate"
-    ],
-    "safety": "",
-    "toxicity": "Moderate",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "traditional fever remedy",
     "tags": [
       "stimulant",
       "🍃 leaf"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "1-3 g dried leaf",
+    "interactions": [
+      "stimulants"
+    ],
+    "toxicity": "Moderate",
     "image": ""
   },
   {
@@ -9028,34 +13277,28 @@
     "common": "",
     "scientific": "Silene capensis",
     "category": "oneirogen",
-    "subcategory": "",
-    "intensity": "Mild to moderate",
-    "region": "south africa",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "known as 'xhosa dream root', silene capensis is a sacred plant used by the xhosa people of south africa for initiating vivid and prophetic dreams.",
     "effects": "Lucid dreaming;enhanced dream recall;vivid visions",
+    "intensity": "Mild to moderate",
+    "region": "south africa",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Likely acts on cholinergic and serotonergic systems; exact mechanism unknown",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "dream recall, ancestral communication (traditional)",
-    "interactions": [
-      "none well documented"
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "mild nausea or grogginess if overdosed",
+      "mild nausea if taken in excess"
     ],
     "contraindications": [
       "none well established",
       "pregnancy"
     ],
-    "sideeffects": [
-      "mild nausea or grogginess if overdosed",
-      "mild nausea if taken in excess"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "dream recall, ancestral communication (traditional)",
     "tags": [
       "✅ safe",
       "🌙 dream",
@@ -9072,6 +13315,15 @@
       "African Ethnobotany in the Americas",
       "2014"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "none well documented"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -9080,37 +13332,40 @@
     "common": "",
     "scientific": "Silybum marianum",
     "category": "other",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "mediterranean",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "milk thistle seeds support liver function.",
     "effects": "Liver protection",
+    "intensity": "Mild",
+    "region": "mediterranean",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Silymarin acts as antioxidant and hepatoprotective",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "liver detox support",
-    "interactions": [
-      "may affect drug metabolism"
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "digestive upset"
     ],
     "contraindications": [
       "allergy to asteraceae"
     ],
-    "sideeffects": [
-      "digestive upset"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "liver detox support",
     "tags": [
       "✅ safe",
       "🌿 seed"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may affect drug metabolism"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -9119,26 +13374,28 @@
     "common": "Sinicuichi",
     "scientific": "Heimia salicifolia",
     "category": "oneirogen / traditional / mildly psychoactive",
-    "subcategory": "",
-    "intensity": "Mild to moderate",
-    "region": "mexico, central america",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a yellow-flowering shrub used by indigenous mexican peoples for vision quests and dream work. traditionally prepared via solar fermentation, sinicuichi is known for inducing auditory changes and memory recall.",
     "effects": "Dream enhancement;Auditory distortion;Relaxation;Trance-like state",
+    "intensity": "Mild to moderate",
+    "region": "mexico, central america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Contains cryogenine and lythrine, which may modulate acetylcholine and GABA receptors, inducing mild CNS depression and altered perception.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Cryogenine",
       "Lyfoline"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used in folk medicine for muscle pain, fevers, and spiritual visions. anecdotally used for lucid dreaming and relaxation.",
-    "interactions": [
-      "may amplify effects of cns depressants.",
-      "avoid cns depressants or alcohol"
+    "toxicity_ld50": "Not well established",
+    "safety": "",
+    "sideeffects": [
+      "dry mouth",
+      "heavy limbs",
+      "auditory distortions. rare reports of ‘golden vision’ or slow-motion perception.",
+      "yellow vision",
+      "dizziness"
     ],
     "contraindications": [
       "avoid with sedatives",
@@ -9147,16 +13404,7 @@
       "pregnancy",
       "driving"
     ],
-    "sideeffects": [
-      "dry mouth",
-      "heavy limbs",
-      "auditory distortions. rare reports of ‘golden vision’ or slow-motion perception.",
-      "yellow vision",
-      "dizziness"
-    ],
-    "safety": "",
-    "toxicity": "Low in traditional doses; some anecdotal toxicity in concentrated extracts.",
-    "toxicity_ld50": "Not well established",
+    "therapeutic": "used in folk medicine for muscle pain, fevers, and spiritual visions. anecdotally used for lucid dreaming and relaxation.",
     "tags": [
       "🌙 dream herb",
       "🧠 memory",
@@ -9172,6 +13420,16 @@
       "1992",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may amplify effects of cns depressants.",
+      "avoid cns depressants or alcohol"
+    ],
+    "toxicity": "Low in traditional doses; some anecdotal toxicity in concentrated extracts.",
     "image": ""
   },
   {
@@ -9180,38 +13438,41 @@
     "common": "",
     "scientific": "Solandra maxima",
     "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "",
-    "region": "mexico",
-    "regiontags": [],
-    "legalstatus": "Unregulated",
-    "schedule": "",
-    "legalnotes": "",
     "description": "rarely used solanaceous vine with powerful effects.",
     "effects": "visions;disorientation",
+    "intensity": "",
+    "region": "mexico",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Unregulated",
     "mechanism": "Tropane alkaloids similar to datura",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "visionary rituals",
-    "interactions": [
-      "anticholinergics"
+    "compounds": [],
+    "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [
+      "severe confusion",
+      "amnesia"
     ],
     "contraindications": [
       "pregnancy",
       "heart issues"
     ],
-    "sideeffects": [
-      "severe confusion",
-      "amnesia"
-    ],
-    "safety": "",
-    "toxicity": "High",
-    "toxicity_ld50": "",
+    "therapeutic": "visionary rituals",
     "tags": [
       "☠️ toxic"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "anticholinergics"
+    ],
+    "toxicity": "High",
     "image": ""
   },
   {
@@ -9220,34 +13481,37 @@
     "common": "",
     "scientific": "Sophora secundiflora",
     "category": "ethnobotanical",
-    "subcategory": "",
-    "intensity": "",
-    "region": "southwestern us, mexico",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "mescal bean, used ceremonially by native american tribes. highly toxic, formerly used as an ordeal poison.",
     "effects": "delirium;visions;dizziness",
+    "intensity": "",
+    "region": "southwestern us, mexico",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "Nicotinic receptor agonist",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Cytisine"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "ceremonial",
       "toxic",
       "visionary"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -9256,37 +13520,29 @@
     "common": "",
     "scientific": "Spigelia marilandica",
     "category": "anthelmintic / nervine / traditional native american",
-    "subcategory": "",
-    "intensity": "Moderate–Strong (dose-dependent)",
-    "region": "southeastern united states",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a striking woodland plant native to the southeastern u.s., traditionally used for expelling intestinal parasites. it has mild nervine and sedative effects, but can cause strong reactions in high doses.",
     "effects": "Parasitic cleanse;Mild sedation;Vision changes (in excess);Calming",
+    "intensity": "Moderate–Strong (dose-dependent)",
+    "region": "southeastern united states",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Alkaloids (spigeline and others) are toxic to parasitic worms and may also affect the central nervous system. In high doses, can produce dizziness and visual distortion.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "historically used for intestinal worms, especially in children, and as a calming nervine in small doses.",
-    "interactions": [
-      "may interact with sedatives",
-      "anti-parasitics",
-      "or neuroactive herbs."
-    ],
-    "contraindications": [
-      "avoid in pregnancy or with seizure disorders. dose carefully due to narrow safety margin."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Not well established; potentially toxic at high doses",
+    "safety": "",
     "sideeffects": [
       "high doses may cause headache",
       "visual disturbances",
       "nausea",
       "or even convulsions."
     ],
-    "safety": "",
-    "toxicity": "Moderate. Therapeutic window is narrow.",
-    "toxicity_ld50": "Not well established; potentially toxic at high doses",
+    "contraindications": [
+      "avoid in pregnancy or with seizure disorders. dose carefully due to narrow safety margin."
+    ],
+    "therapeutic": "historically used for intestinal worms, especially in children, and as a calming nervine in small doses.",
     "tags": [
       "🪱 antiparasitic",
       "🌿 native american",
@@ -9298,6 +13554,17 @@
       "Native American Ethnobotany – Moerman",
       "Herbal Medicine – Mills & Bone"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interact with sedatives",
+      "anti-parasitics",
+      "or neuroactive herbs."
+    ],
+    "toxicity": "Moderate. Therapeutic window is narrow.",
     "image": ""
   },
   {
@@ -9306,36 +13573,30 @@
     "common": "Sweet Violet",
     "scientific": "Viola odorata",
     "category": "respiratory / nervine / floral sedative",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "europe, western asia, north africa",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a fragrant violet flower traditionally used for respiratory and emotional conditions. offers calming, anti-inflammatory, and mucilaginous support, often in teas or syrups.",
     "effects": "Soothing;Anti-inflammatory;Sleep support;Cough relief",
+    "intensity": "Mild",
+    "region": "europe, western asia, north africa",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Contains salicylic acid derivatives, mucilage, and volatile oils. Gently modulates GABA and prostaglandins. Mild expectorant and anti-inflammatory activity.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Violine",
       "Methyl salicylate"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for sore throats, coughs, grief, insomnia, and skin irritation. can be taken internally or applied topically.",
-    "interactions": [
-      "mild anticoagulant effects. may enhance other sedatives slightly."
-    ],
-    "contraindications": [
-      "none known in normal doses. use caution in salicylate-sensitive individuals."
-    ],
+    "toxicity_ld50": "Not established (safe in folk medicine)",
+    "safety": "",
     "sideeffects": [
       "mild",
       "possible skin reaction or gi upset with large doses."
     ],
-    "safety": "",
-    "toxicity": "Very low",
-    "toxicity_ld50": "Not established (safe in folk medicine)",
+    "contraindications": [
+      "none known in normal doses. use caution in salicylate-sensitive individuals."
+    ],
+    "therapeutic": "used for sore throats, coughs, grief, insomnia, and skin irritation. can be taken internally or applied topically.",
     "tags": [
       "🌸 floral",
       "🧘 nervine",
@@ -9347,6 +13608,15 @@
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "mild anticoagulant effects. may enhance other sedatives slightly."
+    ],
+    "toxicity": "Very low",
     "image": ""
   },
   {
@@ -9355,36 +13625,39 @@
     "common": "",
     "scientific": "Tabernaemontana sananho",
     "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "",
-    "region": "amazon",
-    "regiontags": [],
-    "legalstatus": "Unregulated",
-    "schedule": "",
-    "legalnotes": "",
     "description": "shamanic plant sometimes added to ayahuasca.",
     "effects": "dream enhancement;mild stimulation",
+    "intensity": "",
+    "region": "amazon",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Unregulated",
     "mechanism": "Iboga-type alkaloids act on NMDA and serotonin receptors",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "10–20 g root",
-    "therapeutic": "traditional spiritual healer",
-    "interactions": [
-      "maois"
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "nausea"
     ],
     "contraindications": [
       "heart conditions"
     ],
-    "sideeffects": [
-      "nausea"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "traditional spiritual healer",
     "tags": [
       "🌿 root"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "10–20 g root",
+    "interactions": [
+      "maois"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -9393,38 +13666,32 @@
     "common": "",
     "scientific": "Tabernanthe iboga",
     "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Very strong",
-    "region": "central africa",
-    "regiontags": [],
-    "legalstatus": "Controlled or prescription in many countries",
-    "schedule": "",
-    "legalnotes": "",
     "description": "sacred shrub central to bwiti ceremonies; contains ibogaine producing intense visionary states and potential addiction therapy.",
     "effects": "Powerful visions;spiritual insight;stimulation",
+    "intensity": "Very strong",
+    "region": "central africa",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Controlled or prescription in many countries",
     "mechanism": "Ibogaine acts on NMDA, kappa-opioid, and serotonin systems while promoting neurotrophic factors.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Ibogaine"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditional bwiti initiation; studied for addiction interruption.",
-    "interactions": [
-      "dangerous with other stimulants or opioids"
+    "toxicity_ld50": "Ibogaine LD50 ~50 mg/kg (mice)",
+    "safety": "",
+    "sideeffects": [
+      "nausea",
+      "ataxia",
+      "prolonged recovery"
     ],
     "contraindications": [
       "heart conditions",
       "psychiatric disorders",
       "maois."
     ],
-    "sideeffects": [
-      "nausea",
-      "ataxia",
-      "prolonged recovery"
-    ],
-    "safety": "",
-    "toxicity": "Cardiotoxic and neurotoxic at high doses; medical supervision required.",
-    "toxicity_ld50": "Ibogaine LD50 ~50 mg/kg (mice)",
+    "therapeutic": "traditional bwiti initiation; studied for addiction interruption.",
     "tags": [
       "⚠️ intense",
       "🌿 root bark"
@@ -9435,6 +13702,15 @@
       "Journal of Ethnopharmacology",
       "2014"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "dangerous with other stimulants or opioids"
+    ],
+    "toxicity": "Cardiotoxic and neurotoxic at high doses; medical supervision required.",
     "image": ""
   },
   {
@@ -9443,32 +13719,26 @@
     "common": "",
     "scientific": "Tagetes lucida",
     "category": "oneirogen / digestive / traditional mesoamerican",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "mexico, central america",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "used by the aztecs and modern curanderos, this aromatic herb has both culinary and psychoactive properties. smoked or brewed, it can enhance dreams and alter perception gently.",
     "effects": "Mild euphoria;Vision enhancement;Lucid dreaming;Digestive aid",
+    "intensity": "Mild–Moderate",
+    "region": "mexico, central america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Contains estragole, ocimene, and anethole, which may mildly modulate GABA and serotonergic pathways. Psychoactive effects are subtle and dose-dependent.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for digestive issues, anxiety, and ceremonial purposes. also employed for lucid dreaming and spirit communication in traditional rituals.",
-    "interactions": [
-      "minimal in traditional doses. theoretical synergy with other calming or dream herbs."
+    "compounds": [],
+    "toxicity_ld50": "Estragole: ~1500 mg/kg (rat, oral)",
+    "safety": "",
+    "sideeffects": [
+      "mild nausea or dizziness in excess. estragole is a potential carcinogen at high doses in animals."
     ],
     "contraindications": [
       "avoid in pregnancy or with hormone-sensitive conditions. not for chronic high-dose use."
     ],
-    "sideeffects": [
-      "mild nausea or dizziness in excess. estragole is a potential carcinogen at high doses in animals."
-    ],
-    "safety": "",
-    "toxicity": "Low at ceremonial/culinary doses. Estragole raises caution at high concentrations.",
-    "toxicity_ld50": "Estragole: ~1500 mg/kg (rat, oral)",
+    "therapeutic": "used for digestive issues, anxiety, and ceremonial purposes. also employed for lucid dreaming and spirit communication in traditional rituals.",
     "tags": [
       "🌼 floral",
       "🌙 dream herb",
@@ -9481,6 +13751,15 @@
       "Journal of Ethnopharmacology",
       "2005"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "minimal in traditional doses. theoretical synergy with other calming or dream herbs."
+    ],
+    "toxicity": "Low at ceremonial/culinary doses. Estragole raises caution at high concentrations.",
     "image": ""
   },
   {
@@ -9489,35 +13768,38 @@
     "common": "Tamarind",
     "scientific": "",
     "category": "",
-    "subcategory": "",
-    "intensity": "",
-    "region": "africa, south asia",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "",
     "effects": "laxative;digestive aid;cooling",
+    "intensity": "",
+    "region": "africa, south asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "Promotes gastrointestinal motility and antioxidant action",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Tartaric acid",
       "Lupeol"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "digestive",
       "folk",
       "cooling"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -9526,40 +13808,43 @@
     "common": "",
     "scientific": "Tetradenia riparia",
     "category": "calming / analgesic",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "eastern and southern africa",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "fragrant african shrub sometimes called iboza; provides a relaxing effect and mild pain relief.",
     "effects": "relaxation;pain relief;lightheadedness",
+    "intensity": "Mild",
+    "region": "eastern and southern africa",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Aromatic diterpenes may modulate GABA and opioid receptors",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used in african folk medicine for headaches and anxiety",
-    "interactions": [
-      "may enhance sedatives or blood pressure medications"
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "dizziness",
+      "low blood pressure"
     ],
     "contraindications": [
       "pregnancy",
       "caution with hypotensive drugs"
     ],
-    "sideeffects": [
-      "dizziness",
-      "low blood pressure"
-    ],
-    "safety": "",
-    "toxicity": "Limited research; appears safe in small amounts",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "used in african folk medicine for headaches and anxiety",
     "tags": [
       "african",
       "iboza",
       "aromatic"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may enhance sedatives or blood pressure medications"
+    ],
+    "toxicity": "Limited research; appears safe in small amounts",
     "image": ""
   },
   {
@@ -9568,38 +13853,41 @@
     "common": "",
     "scientific": "Thymus vulgaris",
     "category": "aromatic / antimicrobial",
-    "subcategory": "",
-    "intensity": "",
-    "region": "mediterranean",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "common thyme used medicinally and as spice",
     "effects": "alertness;respiratory relief",
+    "intensity": "",
+    "region": "mediterranean",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Essential oil rich in thymol acts as antimicrobial and mild stimulant",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Thymol"
     ],
-    "preparations": [],
-    "dosage": "1 g dried leaf",
-    "therapeutic": "coughs, focus",
-    "interactions": [
-      "anticoagulants"
+    "toxicity_ld50": "880 mg/kg (rats, thymol)",
+    "safety": "",
+    "sideeffects": [
+      "gi upset high doses"
     ],
     "contraindications": [
       "pregnancy large doses"
     ],
-    "sideeffects": [
-      "gi upset high doses"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "880 mg/kg (rats, thymol)",
+    "therapeutic": "coughs, focus",
     "tags": [
       "🌿 culinary"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "1 g dried leaf",
+    "interactions": [
+      "anticoagulants"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -9608,32 +13896,26 @@
     "common": "",
     "scientific": "Tilia cordata",
     "category": "nervine / sedative / cardiovascular",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "europe, temperate asia",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "linden flowers, from the lime tree (not citrus), are a gentle remedy for stress, insomnia, and tension-related heart symptoms. often used in relaxing teas and rituals.",
     "effects": "Calming;Antispasmodic;Cardiovascular support;Mild hypnotic",
+    "intensity": "Mild",
+    "region": "europe, temperate asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Flavonoids (quercetin), volatile oils, and mucilage reduce anxiety, soothe the digestive tract, and support vasodilation. GABA modulation contributes to calming effect.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for anxiety, palpitations, high blood pressure, colds, insomnia, and mild headaches.",
-    "interactions": [
-      "may mildly potentiate sedatives or antihypertensives."
+    "compounds": [],
+    "toxicity_ld50": "Not established; traditionally safe",
+    "safety": "",
+    "sideeffects": [
+      "very well tolerated. rare allergic reactions possible in pollen-sensitive individuals."
     ],
     "contraindications": [
       "none major. monitor in heart medications due to blood pressure effects."
     ],
-    "sideeffects": [
-      "very well tolerated. rare allergic reactions possible in pollen-sensitive individuals."
-    ],
-    "safety": "",
-    "toxicity": "Very low",
-    "toxicity_ld50": "Not established; traditionally safe",
+    "therapeutic": "used for anxiety, palpitations, high blood pressure, colds, insomnia, and mild headaches.",
     "tags": [
       "🌸 floral",
       "💤 sedative",
@@ -9645,6 +13927,15 @@
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may mildly potentiate sedatives or antihypertensives."
+    ],
+    "toxicity": "Very low",
     "image": ""
   },
   {
@@ -9653,35 +13944,38 @@
     "common": "",
     "scientific": "Tilia tomentosa",
     "category": "ethnobotanical",
-    "subcategory": "",
-    "intensity": "",
-    "region": "europe",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "silver linden, used as a calming tea in europe. shows sedative and anti-anxiety effects.",
     "effects": "calming;sleep aid;nervine",
+    "intensity": "",
+    "region": "europe",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "GABAergic, anti-inflammatory",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Quercetin",
       "Volatile oils"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "relaxing",
       "tea",
       "folk medicine"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -9690,37 +13984,30 @@
     "common": "Tilo",
     "scientific": "Justicia pectoralis",
     "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "amazon basin",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "aromatic herb called tilo, brewed or smoked for calming effects.",
     "effects": "Relaxation;light euphoria;spiritual dreams",
+    "intensity": "Mild",
+    "region": "amazon basin",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Likely GABAergic; coumarins may modulate CNS",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Coumarin",
       "Umelliferone"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "anxiety, insomnia, spiritual enhancement",
-    "interactions": [
-      "coumarin-sensitive meds (e.g.",
-      "blood thinners)"
+    "toxicity_ld50": "Not established",
+    "safety": "1",
+    "sideeffects": [
+      "liver risk in excess due to coumarin"
     ],
     "contraindications": [
       "liver disorders",
       "pregnancy"
     ],
-    "sideeffects": [
-      "liver risk in excess due to coumarin"
-    ],
-    "safety": "1",
-    "toxicity": "Low–moderate with excess",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "anxiety, insomnia, spiritual enhancement",
     "tags": [
       "✅ legal",
       "🌿 ayahuasca-additive",
@@ -9732,6 +14019,16 @@
       "1999",
       "Shamanic Pharmacopoeia – Amazonian Plants"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "coumarin-sensitive meds (e.g.",
+      "blood thinners)"
+    ],
+    "toxicity": "Low–moderate with excess",
     "image": ""
   },
   {
@@ -9740,37 +14037,31 @@
     "common": "Toothache Tree",
     "scientific": "Zanthoxylum clava-herculis",
     "category": "analgesic / stimulant",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "southeastern united states",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "also called the toothache tree; its bark creates a tingling numbness and light stimulation when chewed.",
     "effects": "mouth numbness;mild stimulation;pain relief",
+    "intensity": "Mild",
+    "region": "southeastern united states",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Bark contains sanshools that cause paresthesia and stimulate trigeminal nerves",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Pellitorine",
       "Sanshools"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "native american remedy for toothaches and sore throats; also used as a tonic",
-    "interactions": [
-      "may interact with other numbing agents"
-    ],
-    "contraindications": [
-      "mouth ulcers or sensitive gums"
-    ],
+    "toxicity_ld50": "Not established",
+    "safety": "",
     "sideeffects": [
       "tingling",
       "salivation",
       "mild stomach upset"
     ],
-    "safety": "",
-    "toxicity": "Low in customary doses",
-    "toxicity_ld50": "Not established",
+    "contraindications": [
+      "mouth ulcers or sensitive gums"
+    ],
+    "therapeutic": "native american remedy for toothaches and sore throats; also used as a tonic",
     "tags": [
       "north america",
       "tingling",
@@ -9781,6 +14072,15 @@
       "Native American Ethnobotany – Moerman",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interact with other numbing agents"
+    ],
+    "toxicity": "Low in customary doses",
     "image": ""
   },
   {
@@ -9789,35 +14089,38 @@
     "common": "",
     "scientific": "Turnera diffusa var. aphrodisiaca",
     "category": "ethnobotanical",
-    "subcategory": "",
-    "intensity": "",
-    "region": "mexico",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a variant of damiana known for its aphrodisiac and mood-brightening properties. traditionally used as a tonic.",
     "effects": "aphrodisiac;mood enhancer",
+    "intensity": "",
+    "region": "mexico",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "Dopaminergic and GABAergic synergy",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Damianin",
       "Flavonoids"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "aphrodisiac",
       "tonic",
       "euphoric"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -9826,30 +14129,26 @@
     "common": "",
     "scientific": "Turnera ulmifolia",
     "category": "empathogen / euphoriant",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "central and south america",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "closely related to damiana (turnera diffusa), this species is also used traditionally in folk medicine for reproductive health and mood.",
     "effects": "Relaxation;mood elevation;aphrodisiac",
+    "intensity": "Mild",
+    "region": "central and south america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Unknown; may modulate GABA or serotonin",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "libido, menstrual cramps, anxiety",
-    "interactions": [],
-    "contraindications": [
-      "pregnancy"
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
     "sideeffects": [
       "mild sedation"
     ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "contraindications": [
+      "pregnancy"
+    ],
+    "therapeutic": "libido, menstrual cramps, anxiety",
     "tags": [
       "✅ safe",
       "🌺 aphrodisiac",
@@ -9861,6 +14160,13 @@
       "2013",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -9869,34 +14175,28 @@
     "common": "",
     "scientific": "Tussilago farfara",
     "category": "respiratory / expectorant / traditional european",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "europe, western asia, north america",
-    "regiontags": [],
-    "legalstatus": "Regulated or banned in some countries for internal use",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a yellow-flowered plant long revered in european herbalism for its effects on the respiratory tract. coltsfoot is soothing to irritated lungs and commonly used in herbal cough formulas.",
     "effects": "Cough suppression;Lung soothing;Mild sedation;Anti-inflammatory",
+    "intensity": "Mild",
+    "region": "europe, western asia, north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Regulated or banned in some countries for internal use",
     "mechanism": "Contains mucilage, flavonoids, and alkaloids. Mucilage soothes mucous membranes; pyrrolizidine alkaloids (PAs) pose some risk to the liver.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for coughs, bronchitis, asthma, sore throats, and hoarseness. traditionally smoked or brewed.",
-    "interactions": [
-      "potential hepatotoxicity if combined with other liver-sensitive drugs."
+    "compounds": [],
+    "toxicity_ld50": "PAs vary; cumulative risk more relevant than acute dose",
+    "safety": "",
+    "sideeffects": [
+      "generally mild. long-term use linked to potential liver toxicity from pas."
     ],
     "contraindications": [
       "avoid during pregnancy",
       "liver disease",
       "or prolonged use. use pa-free extracts if possible."
     ],
-    "sideeffects": [
-      "generally mild. long-term use linked to potential liver toxicity from pas."
-    ],
-    "safety": "",
-    "toxicity": "Moderate (due to PAs); safe short-term with proper prep.",
-    "toxicity_ld50": "PAs vary; cumulative risk more relevant than acute dose",
+    "therapeutic": "used for coughs, bronchitis, asthma, sore throats, and hoarseness. traditionally smoked or brewed.",
     "tags": [
       "🌬️ respiratory",
       "🫁 expectorant",
@@ -9908,6 +14208,15 @@
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "potential hepatotoxicity if combined with other liver-sensitive drugs."
+    ],
+    "toxicity": "Moderate (due to PAs); safe short-term with proper prep.",
     "image": ""
   },
   {
@@ -9916,36 +14225,28 @@
     "common": "",
     "scientific": "Tylophora indica",
     "category": "respiratory / immunomodulator / ayurvedic",
-    "subcategory": "",
-    "intensity": "Moderate",
-    "region": "india, sri lanka, southeast asia",
-    "regiontags": [],
-    "legalstatus": "Legal in India; regulated in some countries due to emetic effects",
-    "schedule": "",
-    "legalnotes": "",
     "description": "an ayurvedic herb used for bronchial conditions, immune regulation, and allergic responses. known as indian ipecac for its traditional role in treating asthma and respiratory issues.",
     "effects": "Asthma relief;Anti-allergy;Immunoregulation;Expectorant",
+    "intensity": "Moderate",
+    "region": "india, sri lanka, southeast asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal in India; regulated in some countries due to emetic effects",
     "mechanism": "Contains tylophorine alkaloids with immunosuppressive, anti-inflammatory, and antiallergic properties. Reduces histamine release and cytokine activity.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for asthma, allergies, bronchitis, autoimmune flare-ups, and inflammation. sometimes used topically for skin disorders.",
-    "interactions": [
-      "may interfere with immune therapies",
-      "steroids",
-      "or antihistamines."
+    "compounds": [],
+    "toxicity_ld50": "~100 mg/kg (mice, oral) – estimated",
+    "safety": "",
+    "sideeffects": [
+      "nausea and vomiting in higher doses. gi discomfort is common early in treatment."
     ],
     "contraindications": [
       "avoid during pregnancy",
       "with immunosuppressants",
       "or in emaciated individuals. not for long-term high-dose use."
     ],
-    "sideeffects": [
-      "nausea and vomiting in higher doses. gi discomfort is common early in treatment."
-    ],
-    "safety": "",
-    "toxicity": "Moderate in high doses. Emetic effects limit overuse.",
-    "toxicity_ld50": "~100 mg/kg (mice, oral) – estimated",
+    "therapeutic": "used for asthma, allergies, bronchitis, autoimmune flare-ups, and inflammation. sometimes used topically for skin disorders.",
     "tags": [
       "🫁 respiratory",
       "🌿 ayurvedic",
@@ -9958,6 +14259,17 @@
       "Journal of Ethnopharmacology",
       "2004"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interfere with immune therapies",
+      "steroids",
+      "or antihistamines."
+    ],
+    "toxicity": "Moderate in high doses. Emetic effects limit overuse.",
     "image": ""
   },
   {
@@ -9966,40 +14278,43 @@
     "common": "",
     "scientific": "Tynanthus panurensis",
     "category": "empathogen / euphoriant",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "amazon basin",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "amazonian vine used in both physical and spiritual medicine. traditionally consumed as a libido enhancer and pre-ayahuasca preparation.",
     "effects": "Aphrodisiac;calming;digestive",
+    "intensity": "Mild",
+    "region": "amazon basin",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Alkaloids may modulate dopamine and serotonin; warming vasodilator",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "aphrodisiac, digestive aid in amazonian medicine",
-    "interactions": [
-      "avoid cns depressants",
-      "alcohol"
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "mild hypotension or fatigue"
     ],
     "contraindications": [
       "pregnancy",
       "blood pressure meds"
     ],
-    "sideeffects": [
-      "mild hypotension or fatigue"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "aphrodisiac, digestive aid in amazonian medicine",
     "tags": [
       "✅ safe",
       "🌿 amazonian",
       "🔥 aphrodisiac"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "avoid cns depressants",
+      "alcohol"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -10008,33 +14323,27 @@
     "common": "",
     "scientific": "Ulex europaeus",
     "category": "mood / flower essence / traditional european",
-    "subcategory": "",
-    "intensity": "Mild (emotional)",
-    "region": "western europe, naturalized elsewhere",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a bright yellow-flowered shrub associated with resilience and hope in celtic and bach flower traditions. while not widely used internally, its flowers have gentle nervine and uplifting properties.",
     "effects": "Mood elevation;Hope restoration;Mild nervous system support",
+    "intensity": "Mild (emotional)",
+    "region": "western europe, naturalized elsewhere",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Primarily used in energetic and flower essence systems. Contains flavonoids and trace alkaloids which may mildly affect neurotransmission.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used to combat despair, mental fatigue, and chronic discouragement. often chosen in flower therapy blends.",
-    "interactions": [
-      "none known."
-    ],
-    "contraindications": [
-      "avoid large internal doses. primarily for emotional support or ritual use."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Not well documented; external use traditionally preferred",
+    "safety": "",
     "sideeffects": [
       "rare. in high doses",
       "possible gi discomfort."
     ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not well documented; external use traditionally preferred",
+    "contraindications": [
+      "avoid large internal doses. primarily for emotional support or ritual use."
+    ],
+    "therapeutic": "used to combat despair, mental fatigue, and chronic discouragement. often chosen in flower therapy blends.",
     "tags": [
       "🌼 flower essence",
       "🌞 mood uplift",
@@ -10046,6 +14355,15 @@
       "Plants of the Gods – Rätsch",
       "Bach Flower Remedies"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "none known."
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -10054,38 +14372,41 @@
     "common": "",
     "scientific": "Uncaria rhynchophylla",
     "category": "dissociative / sedative",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "china",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "known as gou teng in chinese medicine.",
     "effects": "Calming;anticonvulsant",
+    "intensity": "Mild",
+    "region": "china",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Rhynchophylline blocks NMDA receptors",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditional treatment for tremors and agitation",
-    "interactions": [
-      "may potentiate sedatives"
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "drowsiness"
     ],
     "contraindications": [
       "none documented"
     ],
-    "sideeffects": [
-      "drowsiness"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "traditional treatment for tremors and agitation",
     "tags": [
       "✅ safe",
       "🌿 vine",
       "💤 sedation"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may potentiate sedatives"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -10094,32 +14415,26 @@
     "common": "",
     "scientific": "Uncaria tomentosa",
     "category": "other",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "amazon",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "known as cat's claw, used in peruvian medicine.",
     "effects": "Immune modulation",
+    "intensity": "Mild",
+    "region": "amazon",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Oxindole alkaloids stimulate immune function",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "anti-inflammatory, immune support",
-    "interactions": [
-      "may interact with immunosuppressants"
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "stomach upset in some"
     ],
     "contraindications": [
       "autoimmune conditions caution"
     ],
-    "sideeffects": [
-      "stomach upset in some"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "anti-inflammatory, immune support",
     "tags": [
       "✅ safe",
       "🌿 bark",
@@ -10131,6 +14446,15 @@
       "Journal of Ethnopharmacology",
       "2001"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interact with immunosuppressants"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -10139,35 +14463,28 @@
     "common": "",
     "scientific": "Urtica dioica",
     "category": "dissociative / sedative",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "europe, north america, asia",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "known as stinging nettle, this european herb has been used for centuries to relieve joint pain, allergies, and fatigue. its psychoactivity is subtle, mostly somatic.",
     "effects": "Stimulation;anti-inflammatory;tonic",
+    "intensity": "Mild",
+    "region": "europe, north america, asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Histamine release and anti-inflammatory cytokine modulation",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "allergies, joint pain, urinary tract support",
-    "interactions": [
-      "diuretics",
-      "anticoagulants"
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "mild stomach upset",
+      "skin irritation"
     ],
     "contraindications": [
       "pregnancy",
       "blood thinners"
     ],
-    "sideeffects": [
-      "mild stomach upset",
-      "skin irritation"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "allergies, joint pain, urinary tract support",
     "tags": [
       "✅ safe",
       "🌿 anti-inflammatory",
@@ -10178,6 +14495,16 @@
       "Herbal Medicine – Mills & Bone",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "diuretics",
+      "anticoagulants"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -10186,32 +14513,26 @@
     "common": "",
     "scientific": "Urtica urens",
     "category": "nutritive / skin & immune / homeopathic–traditional",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "europe, north america",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a close relative of urtica dioica, this smaller species is used for similar purposes, especially in homeopathy and traditional european herbalism. known for calming itchy skin and boosting the blood.",
     "effects": "Skin soothing;Detox support;Mineral boost;Allergy modulation",
+    "intensity": "Mild",
+    "region": "europe, north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Similar to stinging nettle: silica, flavonoids, and histamine-like compounds that support immunity, reduce inflammation, and supply trace minerals.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for hives, eczema, gout, allergies, and fatigue. often included in mineral-building tonics and allergy blends.",
-    "interactions": [
-      "may enhance effect of antihistamines or diuretics."
+    "compounds": [],
+    "toxicity_ld50": "Not established; widely used in folk and clinical practice",
+    "safety": "",
+    "sideeffects": [
+      "stinging hairs can irritate skin raw. mild diuretic effect or digestive upset possible."
     ],
     "contraindications": [
       "caution in pregnancy or kidney disorders. may lower blood pressure slightly."
     ],
-    "sideeffects": [
-      "stinging hairs can irritate skin raw. mild diuretic effect or digestive upset possible."
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established; widely used in folk and clinical practice",
+    "therapeutic": "used for hives, eczema, gout, allergies, and fatigue. often included in mineral-building tonics and allergy blends.",
     "tags": [
       "🌿 nutritive",
       "🌱 allergy mod",
@@ -10223,6 +14544,15 @@
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may enhance effect of antihistamines or diuretics."
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -10231,32 +14561,26 @@
     "common": "",
     "scientific": "Vachellia farnesiana",
     "category": "aromatic / nervine / traditional perfume & medicine",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "tropical americas, asia, australia",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a fragrant, thorny shrub with yellow puffball flowers, historically used in perfumery and herbal medicine. its flowers and pods have soothing, mildly euphoric properties and are used in aromatic and topical blends.",
     "effects": "Relaxation;Calming;Uplifting mood;Aromatic euphoria",
+    "intensity": "Mild",
+    "region": "tropical americas, asia, australia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Volatile oils such as benzyl acetate, linalool, and coumarins provide gentle aromatic CNS modulation and possible GABAergic effects.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditionally used as a sedative, aphrodisiac, digestive aid, and mood enhancer. also used in fragrance and sacred incense.",
-    "interactions": [
-      "none well documented."
+    "compounds": [],
+    "toxicity_ld50": "Not established; used widely in perfumery and teas",
+    "safety": "",
+    "sideeffects": [
+      "none common in traditional doses. high aromatic concentrations may cause nausea."
     ],
     "contraindications": [
       "none significant. caution with allergies to fabaceae plants."
     ],
-    "sideeffects": [
-      "none common in traditional doses. high aromatic concentrations may cause nausea."
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established; used widely in perfumery and teas",
+    "therapeutic": "traditionally used as a sedative, aphrodisiac, digestive aid, and mood enhancer. also used in fragrance and sacred incense.",
     "tags": [
       "🌸 fragrant",
       "🧘 aromatic",
@@ -10268,6 +14592,15 @@
       "Plants of the Gods – Rätsch",
       "Indian Journal of Pharmacognosy"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "none well documented."
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -10276,32 +14609,26 @@
     "common": "",
     "scientific": "Vachellia nilotica",
     "category": "astringent / antimicrobial / traditional african–indian",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "africa, middle east, indian subcontinent",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a widely used tree in african and indian traditional medicine. its bark, pods, and gum are rich in tannins and have potent astringent and antiseptic properties.",
     "effects": "Wound healing;Oral health;Diarrhea relief;Antimicrobial",
+    "intensity": "Mild–Moderate",
+    "region": "africa, middle east, indian subcontinent",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Tannins, flavonoids, and saponins exert antimicrobial, anti-inflammatory, and astringent effects. Helps constrict tissues and protect mucosa.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for dysentery, gum disease, wounds, sore throats, and as a contraceptive in traditional systems. bark decoction or powder is common.",
-    "interactions": [
-      "may reduce absorption of minerals or medications when taken orally."
+    "compounds": [],
+    "toxicity_ld50": "Not well documented; used safely in traditional medicine",
+    "safety": "",
+    "sideeffects": [
+      "mild gi irritation if overused. may cause constipation in high doses due to tannins."
     ],
     "contraindications": [
       "caution with chronic constipation or iron absorption issues."
     ],
-    "sideeffects": [
-      "mild gi irritation if overused. may cause constipation in high doses due to tannins."
-    ],
-    "safety": "",
-    "toxicity": "Low–moderate",
-    "toxicity_ld50": "Not well documented; used safely in traditional medicine",
+    "therapeutic": "used for dysentery, gum disease, wounds, sore throats, and as a contraceptive in traditional systems. bark decoction or powder is common.",
     "tags": [
       "🌿 astringent",
       "🦷 oral health",
@@ -10313,6 +14640,15 @@
       "Journal of Ethnopharmacology",
       "Indian Journal of Traditional Knowledge"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may reduce absorption of minerals or medications when taken orally."
+    ],
+    "toxicity": "Low–moderate",
     "image": ""
   },
   {
@@ -10321,34 +14657,28 @@
     "common": "",
     "scientific": "Valeriana jatamansi",
     "category": "sedative / anxiolytic",
-    "subcategory": "",
-    "intensity": "",
-    "region": "india",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "indian valerian used similarly to v. officinalis",
     "effects": "calming;sleep",
+    "intensity": "",
+    "region": "india",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Sesquiterpenes like valeranon interact with GABA",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Valeranon"
     ],
-    "preparations": [],
-    "dosage": "1-3 g root",
-    "therapeutic": "insomnia, anxiety",
-    "interactions": [
-      "sedatives"
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "drowsiness"
     ],
     "contraindications": [
       "pregnancy"
     ],
-    "sideeffects": [
-      "drowsiness"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "insomnia, anxiety",
     "tags": [
       "🌿 root"
     ],
@@ -10357,6 +14687,15 @@
       "Ayurvedic Pharmacopoeia of India",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "1-3 g root",
+    "interactions": [
+      "sedatives"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -10365,28 +14704,26 @@
     "common": "",
     "scientific": "Valeriana officinalis",
     "category": "sedative / sleep aid / nervine",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "europe, western asia, north america (cultivated)",
-    "regiontags": [],
-    "legalstatus": "Legal / Unregulated",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a strong-smelling root long used as a natural sedative and anxiety aid. valerian is commonly included in sleep teas, tinctures, and stress blends.",
     "effects": "Sleep induction;Calm;Anxiety reduction;Muscle relaxation",
+    "intensity": "Mild–Moderate",
+    "region": "europe, western asia, north america (cultivated)",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal / Unregulated",
     "mechanism": "Acts on GABA-A receptors via valerenic acid and other sesquiterpenes. May inhibit GABA breakdown and modulate serotonin and adenosine.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for insomnia, nervousness, anxiety, muscle tension, and restlessness. may reduce time to fall asleep and improve sleep quality.",
-    "interactions": [
-      "sedatives",
-      "alcohol.",
-      "additive with cns depressants",
-      "benzodiazepines",
-      "barbiturates",
-      "and alcohol.",
-      "additive with benzodiazepines or alcohol"
+    "compounds": [],
+    "toxicity_ld50": "LD50 >3 g/kg (mouse, extract)",
+    "safety": "1",
+    "sideeffects": [
+      "grogginess",
+      "vivid dreams",
+      "headache.",
+      "drowsiness",
+      "headache",
+      "gi upset. rare paradoxical stimulation."
     ],
     "contraindications": [
       "pregnancy",
@@ -10396,17 +14733,7 @@
       "or heavy machinery. not advised during pregnancy without guidance.",
       "avoid with other sedatives or during pregnancy."
     ],
-    "sideeffects": [
-      "grogginess",
-      "vivid dreams",
-      "headache.",
-      "drowsiness",
-      "headache",
-      "gi upset. rare paradoxical stimulation."
-    ],
-    "safety": "1",
-    "toxicity": "Generally safe; high doses may cause headaches or dizziness.",
-    "toxicity_ld50": "LD50 >3 g/kg (mouse, extract)",
+    "therapeutic": "used for insomnia, nervousness, anxiety, muscle tension, and restlessness. may reduce time to fall asleep and improve sleep quality.",
     "tags": [
       "\\u2615 brewable",
       "\\ud83e\\uddd8 sedation",
@@ -10423,6 +14750,21 @@
       "Herbal Medicine – Mills & Bone",
       "British Herbal Pharmacopoeia"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "sedatives",
+      "alcohol.",
+      "additive with cns depressants",
+      "benzodiazepines",
+      "barbiturates",
+      "and alcohol.",
+      "additive with benzodiazepines or alcohol"
+    ],
+    "toxicity": "Generally safe; high doses may cause headaches or dizziness.",
     "image": ""
   },
   {
@@ -10431,36 +14773,28 @@
     "common": "",
     "scientific": "Valeriana wallichii",
     "category": "sedative / nervine / ayurvedic",
-    "subcategory": "",
-    "intensity": "Moderate–Strong",
-    "region": "himalayas, nepal, india",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a potent aromatic root used in ayurveda as a tranquilizing agent. it has a similar but stronger scent and effect profile compared to european valerian. known locally as tagar ganthoda.",
     "effects": "Sleep aid;Mental calm;Muscle relaxant;Tranquilizer",
+    "intensity": "Moderate–Strong",
+    "region": "himalayas, nepal, india",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Valerenic acid and valepotriates modulate GABA-A receptors, decreasing nervous excitability. Sedative effects supported by sesquiterpenes and lignans.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for insomnia, epilepsy, anxiety, muscle spasms, and stress-induced hypertension.",
-    "interactions": [
-      "potentiates sedatives",
-      "hypnotics",
-      "benzodiazepines."
-    ],
-    "contraindications": [
-      "avoid with cns depressants or alcohol. caution in pregnancy and hypotension."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Not well documented",
+    "safety": "",
     "sideeffects": [
       "drowsiness",
       "grogginess",
       "or gi upset. possible paradoxical excitement."
     ],
-    "safety": "",
-    "toxicity": "Low–Moderate",
-    "toxicity_ld50": "Not well documented",
+    "contraindications": [
+      "avoid with cns depressants or alcohol. caution in pregnancy and hypotension."
+    ],
+    "therapeutic": "used for insomnia, epilepsy, anxiety, muscle spasms, and stress-induced hypertension.",
     "tags": [
       "🛏️ sedative",
       "🧘 calm",
@@ -10472,6 +14806,17 @@
       "Indian Journal of Pharmacognosy",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "potentiates sedatives",
+      "hypnotics",
+      "benzodiazepines."
+    ],
+    "toxicity": "Low–Moderate",
     "image": ""
   },
   {
@@ -10480,37 +14825,31 @@
     "common": "Velvetleaf",
     "scientific": "Cissampelos pareira",
     "category": "ayurvedic / antispasmodic / antimalarial",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "india, south america, southeast asia",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a climbing herb used in ayurveda and traditional amazonian medicine. often called ‘laghu patha’ in sanskrit, it is prized for menstrual support, malaria treatment, and as an adjunct to ayahuasca.",
     "effects": "Uterine tonic;Muscle relaxant;Antimalarial;Mild sedative",
+    "intensity": "Mild–Moderate",
+    "region": "india, south america, southeast asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Contains alkaloids like pareirine and cissamine. These modulate smooth muscle tone, and may exert anti-inflammatory, uterotonic, and antimicrobial effects.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Pareirine",
       "Cissamine"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for menstrual cramps, utis, inflammation, diarrhea, and malaria. in south america, used spiritually as a ‘feminine vine’ complementary to banisteriopsis caapi.",
-    "interactions": [
-      "potential interactions with antimalarials or muscle relaxants. may mildly lower blood pressure."
-    ],
-    "contraindications": [
-      "avoid during early pregnancy due to uterine effects. use caution with blood pressure medications."
-    ],
+    "toxicity_ld50": "Not established",
+    "safety": "",
     "sideeffects": [
       "well tolerated in moderate doses. large doses may cause dizziness",
       "nausea",
       "or mild hypotension."
     ],
-    "safety": "",
-    "toxicity": "Low to moderate depending on alkaloid concentration.",
-    "toxicity_ld50": "Not established",
+    "contraindications": [
+      "avoid during early pregnancy due to uterine effects. use caution with blood pressure medications."
+    ],
+    "therapeutic": "used for menstrual cramps, utis, inflammation, diarrhea, and malaria. in south america, used spiritually as a ‘feminine vine’ complementary to banisteriopsis caapi.",
     "tags": [
       "🌿 ayurvedic",
       "🌙 feminine vine",
@@ -10523,6 +14862,15 @@
       "2011",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "potential interactions with antimalarials or muscle relaxants. may mildly lower blood pressure."
+    ],
+    "toxicity": "Low to moderate depending on alkaloid concentration.",
     "image": ""
   },
   {
@@ -10531,33 +14879,27 @@
     "common": "",
     "scientific": "Verbascum thapsus",
     "category": "respiratory / demulcent / anti-inflammatory",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "europe, naturalized in americas and asia",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a tall, fuzzy-leaved plant with bright yellow flowers, mullein is a classic remedy for respiratory complaints. its soft leaves and flowers are demulcent, soothing inflamed tissues and promoting gentle expectoration.",
     "effects": "Lung soothing;Cough relief;Anti-inflammatory;Mucus clearing",
+    "intensity": "Mild",
+    "region": "europe, naturalized in americas and asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Saponins and mucilage coat and soothe mucous membranes, while flavonoids and iridoids reduce inflammation and stimulate immune response.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for dry cough, bronchitis, sore throat, asthma, earaches (flower oil), and inflammation of lungs and throat.",
-    "interactions": [
-      "none known."
-    ],
-    "contraindications": [
-      "none significant. avoid inhaling loose hairs."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Not established; widely regarded as safe",
+    "safety": "",
     "sideeffects": [
       "very mild",
       "possible gi upset if taken in large quantities. fuzzy hairs may irritate throat if not properly strained."
     ],
-    "safety": "",
-    "toxicity": "Very low",
-    "toxicity_ld50": "Not established; widely regarded as safe",
+    "contraindications": [
+      "none significant. avoid inhaling loose hairs."
+    ],
+    "therapeutic": "used for dry cough, bronchitis, sore throat, asthma, earaches (flower oil), and inflammation of lungs and throat.",
     "tags": [
       "🫁 lung herb",
       "🩹 soothing",
@@ -10569,6 +14911,15 @@
       "Plants of the Gods – Rätsch",
       "British Herbal Compendium"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "none known."
+    ],
+    "toxicity": "Very low",
     "image": ""
   },
   {
@@ -10577,32 +14928,26 @@
     "common": "",
     "scientific": "Verbena hastata",
     "category": "nervine / relaxant / digestive–emotional",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "north america",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a native north american vervain with bitter, calming properties. traditionally used by indigenous and eclectic physicians for tension, insomnia, and digestive sluggishness tied to anxiety.",
     "effects": "Stress relief;Mood regulation;Tension release;Digestive stimulation",
+    "intensity": "Mild–Moderate",
+    "region": "north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Iridoid glycosides (verbenalin) and bitter principles act as mild GABA modulators and cholagogues, relaxing the nervous system while aiding digestion.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for nervous tension, stress headaches, insomnia, grief, indigestion, and menstrual discomfort. especially useful for 'overthinkers'.",
-    "interactions": [
-      "may enhance effects of sedatives or antispasmodics."
+    "compounds": [],
+    "toxicity_ld50": "Not well established; widely regarded as safe",
+    "safety": "",
+    "sideeffects": [
+      "possible nausea due to bitterness. rare allergic reaction."
     ],
     "contraindications": [
       "avoid during pregnancy due to potential uterine stimulation."
     ],
-    "sideeffects": [
-      "possible nausea due to bitterness. rare allergic reaction."
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not well established; widely regarded as safe",
+    "therapeutic": "used for nervous tension, stress headaches, insomnia, grief, indigestion, and menstrual discomfort. especially useful for 'overthinkers'.",
     "tags": [
       "🧘 nervine",
       "🌿 bitter",
@@ -10614,6 +14959,15 @@
       "Eclectic Materia Medica – Felter",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may enhance effects of sedatives or antispasmodics."
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -10622,34 +14976,28 @@
     "common": "Vervain",
     "scientific": "Verbena officinalis",
     "category": "mild sedative",
-    "subcategory": "",
-    "intensity": "",
-    "region": "europe",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "common vervain valued for gentle calming",
     "effects": "relaxation;digestive aid",
+    "intensity": "",
+    "region": "europe",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Iridoid glycosides like verbenalin may influence GABA",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Verbenalin"
     ],
-    "preparations": [],
-    "dosage": "2-3 g dried",
-    "therapeutic": "tension, digestion",
-    "interactions": [
-      "none known"
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "rare gi upset"
     ],
     "contraindications": [
       "pregnancy"
     ],
-    "sideeffects": [
-      "rare gi upset"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "tension, digestion",
     "tags": [
       "🌿 tea"
     ],
@@ -10658,6 +15006,15 @@
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "2-3 g dried",
+    "interactions": [
+      "none known"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -10666,32 +15023,26 @@
     "common": "",
     "scientific": "Viburnum opulus",
     "category": "antispasmodic / uterine tonic / nervine",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "europe, north america",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a classic herbal remedy used for centuries to relieve muscular and menstrual cramping. cramp bark calms smooth muscles, especially in the uterus and digestive tract.",
     "effects": "Muscle relaxation;Menstrual relief;Sedative;Uterine support",
+    "intensity": "Mild–Moderate",
+    "region": "europe, north america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Contains viburnin, salicin, and valerenic acid-like compounds that act as antispasmodics and mild sedatives, likely via GABA modulation and smooth muscle relaxation.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for dysmenorrhea, muscle spasms, back pain, nervous tension, and sometimes asthma-related tension.",
-    "interactions": [
-      "may enhance effects of muscle relaxants or sedatives."
+    "compounds": [],
+    "toxicity_ld50": "Not well established; safe in traditional doses",
+    "safety": "",
+    "sideeffects": [
+      "mild drowsiness or gi upset. rare allergic responses."
     ],
     "contraindications": [
       "avoid during pregnancy unless directed by a practitioner. may cause hypotension in sensitive individuals."
     ],
-    "sideeffects": [
-      "mild drowsiness or gi upset. rare allergic responses."
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not well established; safe in traditional doses",
+    "therapeutic": "used for dysmenorrhea, muscle spasms, back pain, nervous tension, and sometimes asthma-related tension.",
     "tags": [
       "🩸 menstrual",
       "🧘 nervine",
@@ -10703,6 +15054,15 @@
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may enhance effects of muscle relaxants or sedatives."
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -10711,34 +15071,37 @@
     "common": "Vietnamese Balm",
     "scientific": "",
     "category": "stimulant",
-    "subcategory": "",
-    "intensity": "",
-    "region": "east and southeast asia",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "",
     "effects": "uplifting;digestive aid;mental clarity",
+    "intensity": "",
+    "region": "east and southeast asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "Stimulates gastrointestinal and olfactory receptors",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Elsholtzia ketone"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "stimulant",
       "folk",
       "clarity"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -10747,38 +15110,30 @@
     "common": "",
     "scientific": "Vinca minor",
     "category": "cognitive / circulatory / alkaloid-based",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "europe, cultivated globally",
-    "regiontags": [],
-    "legalstatus": "Regulated or restricted in some regions due to alkaloid content",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a low-growing evergreen plant whose alkaloid-rich leaves are used for memory, focus, and circulatory enhancement. related to the nootropic vinpocetine.",
     "effects": "Cognitive enhancement;Vasodilation;Memory support;Cerebral blood flow",
+    "intensity": "Mild–Moderate",
+    "region": "europe, cultivated globally",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Regulated or restricted in some regions due to alkaloid content",
     "mechanism": "Contains vincamine, a vasodilatory alkaloid that improves cerebral blood flow. Vinpocetine, a semi-synthetic derivative, is used in neuroprotection studies.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for cognitive decline, tinnitus, dizziness, poor peripheral circulation, and memory support.",
-    "interactions": [
-      "may interact with blood thinners",
-      "vasodilators",
-      "or antihypertensives."
+    "compounds": [],
+    "toxicity_ld50": "~75 mg/kg (rats, oral)",
+    "safety": "",
+    "sideeffects": [
+      "low blood pressure",
+      "headache",
+      "or gi upset possible. excess may cause hypotension or bradycardia."
     ],
     "contraindications": [
       "avoid in hypotension",
       "pregnancy",
       "or with anticoagulants."
     ],
-    "sideeffects": [
-      "low blood pressure",
-      "headache",
-      "or gi upset possible. excess may cause hypotension or bradycardia."
-    ],
-    "safety": "",
-    "toxicity": "Moderate (dose-dependent)",
-    "toxicity_ld50": "~75 mg/kg (rats, oral)",
+    "therapeutic": "used for cognitive decline, tinnitus, dizziness, poor peripheral circulation, and memory support.",
     "tags": [
       "🧠 cognitive",
       "💉 circulatory",
@@ -10790,6 +15145,17 @@
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interact with blood thinners",
+      "vasodilators",
+      "or antihypertensives."
+    ],
+    "toxicity": "Moderate (dose-dependent)",
     "image": ""
   },
   {
@@ -10798,34 +15164,27 @@
     "common": "",
     "scientific": "Viola tricolor",
     "category": "nervine / skin support / respiratory",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "europe, naturalized elsewhere",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a small wildflower with colorful petals, known traditionally for emotional soothing ('heartsease'), as well as support for skin issues, respiratory inflammation, and mild nervous conditions.",
     "effects": "Calming;Anti-inflammatory;Expectorant;Skin soothing",
+    "intensity": "Mild",
+    "region": "europe, naturalized elsewhere",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Contains flavonoids, salicylates, and mucilage. Modulates inflammatory mediators and has demulcent, expectorant, and nervine effects.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for eczema, cradle cap, dry cough, mild anxiety, and urinary inflammation. often included in spring tonics.",
-    "interactions": [
-      "minimal",
-      "theoretical additive effect with anti-inflammatory or sedative herbs."
-    ],
-    "contraindications": [
-      "none known. considered very gentle."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Not established; widely used in children",
+    "safety": "",
     "sideeffects": [
       "very mild",
       "large doses may cause stomach upset or diarrhea."
     ],
-    "safety": "",
-    "toxicity": "Very low",
-    "toxicity_ld50": "Not established; widely used in children",
+    "contraindications": [
+      "none known. considered very gentle."
+    ],
+    "therapeutic": "used for eczema, cradle cap, dry cough, mild anxiety, and urinary inflammation. often included in spring tonics.",
     "tags": [
       "🌸 calming",
       "🩹 skin support",
@@ -10837,6 +15196,16 @@
       "British Herbal Pharmacopoeia",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "minimal",
+      "theoretical additive effect with anti-inflammatory or sedative herbs."
+    ],
+    "toxicity": "Very low",
     "image": ""
   },
   {
@@ -10845,36 +15214,30 @@
     "common": "",
     "scientific": "Viscum album",
     "category": "immunomodulator / nervine / traditional european",
-    "subcategory": "",
-    "intensity": "Moderate",
-    "region": "europe, western asia",
-    "regiontags": [],
-    "legalstatus": "Legal but regulated in some countries",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a sacred plant in ancient druidic and european traditions, mistletoe has been used both ritually and medicinally for nervous disorders, cancer support, and hypertension. often associated with peace and protection.",
     "effects": "Immune regulation;Sedation;Nervous system balance;Blood pressure modulation",
+    "intensity": "Moderate",
+    "region": "europe, western asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal but regulated in some countries",
     "mechanism": "Contains viscotoxins, lectins, and alkaloids that affect immune cells, induce apoptosis, and modulate autonomic nervous system activity. Used in anthroposophic cancer therapy.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for anxiety, epilepsy, hypertension, and integrative cancer care. noted for its calming and immune-balancing effects.",
-    "interactions": [
-      "may interfere with immunosuppressants or chemotherapeutics."
+    "compounds": [],
+    "toxicity_ld50": "~2.5 mg/kg (IV, mice – viscotoxins)",
+    "safety": "",
+    "sideeffects": [
+      "injection-site inflammation",
+      "allergic reactions",
+      "or flu-like symptoms possible. oral use milder but requires caution."
     ],
     "contraindications": [
       "avoid in pregnancy",
       "active infection",
       "or autoimmune conditions without supervision. toxic at high doses."
     ],
-    "sideeffects": [
-      "injection-site inflammation",
-      "allergic reactions",
-      "or flu-like symptoms possible. oral use milder but requires caution."
-    ],
-    "safety": "",
-    "toxicity": "Moderate–high (dose-dependent)",
-    "toxicity_ld50": "~2.5 mg/kg (IV, mice – viscotoxins)",
+    "therapeutic": "used for anxiety, epilepsy, hypertension, and integrative cancer care. noted for its calming and immune-balancing effects.",
     "tags": [
       "🎄 nervine",
       "🛡️ immune",
@@ -10886,6 +15249,15 @@
       "European Medicines Agency",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interfere with immunosuppressants or chemotherapeutics."
+    ],
+    "toxicity": "Moderate–high (dose-dependent)",
     "image": ""
   },
   {
@@ -10894,36 +15266,30 @@
     "common": "",
     "scientific": "Vitex agnus-castus",
     "category": "endocrine / hormonal / reproductive",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "mediterranean, western asia",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a mediterranean shrub used traditionally to balance female hormones, regulate menstrual cycles, and support fertility. also known as monk’s pepper due to its historical use in suppressing libido.",
     "effects": "Hormone regulation;Menstrual cycle balancing;Mood support;Fertility enhancement",
+    "intensity": "Mild–Moderate",
+    "region": "mediterranean, western asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Acts on dopamine D2 receptors to modulate pituitary prolactin levels. Indirectly balances estrogen and progesterone.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for pms, breast tenderness, irregular menstruation, pcos, fertility support, and mild hormonal acne.",
-    "interactions": [
-      "may interact with dopamine-related medications or hormone therapies."
+    "compounds": [],
+    "toxicity_ld50": "Not well established; traditionally safe",
+    "safety": "",
+    "sideeffects": [
+      "mild gi upset",
+      "headache",
+      "or rash. may alter menstrual cycle timing."
     ],
     "contraindications": [
       "avoid during pregnancy",
       "breastfeeding",
       "or with hormone-sensitive conditions unless guided by a practitioner."
     ],
-    "sideeffects": [
-      "mild gi upset",
-      "headache",
-      "or rash. may alter menstrual cycle timing."
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not well established; traditionally safe",
+    "therapeutic": "used for pms, breast tenderness, irregular menstruation, pcos, fertility support, and mild hormonal acne.",
     "tags": [
       "🩸 hormone balance",
       "♀️ reproductive",
@@ -10935,6 +15301,15 @@
       "British Herbal Compendium",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interact with dopamine-related medications or hormone therapies."
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -10943,32 +15318,26 @@
     "common": "",
     "scientific": "Vitex negundo",
     "category": "anti-inflammatory / respiratory / analgesic",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "india, southeast asia",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a traditional ayurvedic and siddha herb used for joint pain, respiratory disorders, and menstrual issues. though related to vitex agnus-castus, its actions differ and it is widely used in south and southeast asia.",
     "effects": "Pain relief;Anti-inflammatory;Respiratory support;Menstrual regulation",
+    "intensity": "Mild–Moderate",
+    "region": "india, southeast asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Flavonoids, alkaloids, and iridoid glycosides modulate prostaglandins, inhibit COX enzymes, and relax bronchial muscles. Some dopaminergic modulation noted.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for rheumatism, asthma, cough, sinusitis, fever, and gynecological conditions. also used topically for wounds and inflammation.",
-    "interactions": [
-      "may interact with nsaids or dopaminergic agents."
+    "compounds": [],
+    "toxicity_ld50": "Not well established; considered safe in traditional doses",
+    "safety": "",
+    "sideeffects": [
+      "well tolerated. high doses may cause mild stomach upset or dizziness."
     ],
     "contraindications": [
       "avoid during pregnancy unless prescribed. caution in liver conditions."
     ],
-    "sideeffects": [
-      "well tolerated. high doses may cause mild stomach upset or dizziness."
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not well established; considered safe in traditional doses",
+    "therapeutic": "used for rheumatism, asthma, cough, sinusitis, fever, and gynecological conditions. also used topically for wounds and inflammation.",
     "tags": [
       "🌿 ayurvedic",
       "🔥 anti-inflammatory",
@@ -10980,6 +15349,15 @@
       "Indian Journal of Traditional Knowledge",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interact with nsaids or dopaminergic agents."
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -10988,34 +15366,28 @@
     "common": "",
     "scientific": "Vitis vinifera (seed)",
     "category": "antioxidant / cardiovascular / nootropic adjunct",
-    "subcategory": "",
-    "intensity": "Mild–Moderate (non-psychoactive)",
-    "region": "mediterranean, global cultivation",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "extracted from the seeds of red grapes, this compound is rich in oligomeric proanthocyanidins (opcs) — potent antioxidants shown to support circulation, reduce inflammation, and protect cellular integrity.",
     "effects": "Vascular support;Free radical scavenging;Skin protection;Cognitive enhancement (adjunct)",
+    "intensity": "Mild–Moderate (non-psychoactive)",
+    "region": "mediterranean, global cultivation",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "OPCs reduce oxidative stress, inhibit inflammatory enzymes (like COX-2), and strengthen collagen and capillaries. Also modulates nitric oxide and enhances endothelial function.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for varicose veins, cardiovascular protection, cognitive longevity, eye health, and skin aging. may help mitigate nootropic stimulant stress.",
-    "interactions": [
-      "may enhance effect of blood thinners or antihypertensives."
-    ],
-    "contraindications": [
-      "caution in bleeding disorders or with anticoagulants."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "~5000 mg/kg (rats, oral)",
+    "safety": "",
     "sideeffects": [
       "mild gi upset",
       "headache",
       "or dizziness possible. rare allergic responses."
     ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "~5000 mg/kg (rats, oral)",
+    "contraindications": [
+      "caution in bleeding disorders or with anticoagulants."
+    ],
+    "therapeutic": "used for varicose veins, cardiovascular protection, cognitive longevity, eye health, and skin aging. may help mitigate nootropic stimulant stress.",
     "tags": [
       "🍇 antioxidant",
       "🩸 circulation",
@@ -11027,6 +15399,15 @@
       "Journal of Medicinal Food",
       "European Medicines Agency"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may enhance effect of blood thinners or antihypertensives."
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -11035,37 +15416,29 @@
     "common": "",
     "scientific": "Voacanga africana",
     "category": "ritual / visionary",
-    "subcategory": "",
-    "intensity": "Strong",
-    "region": "west africa",
-    "regiontags": [],
-    "legalstatus": "Unscheduled; may be regulated for alkaloids",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a powerful african plant containing voacangine and iboga alkaloids. used traditionally in ritual contexts and studied as a potential ibogaine precursor.",
     "effects": "Stimulation;psychedelic effects;cardiovascular activation",
+    "intensity": "Strong",
+    "region": "west africa",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Unscheduled; may be regulated for alkaloids",
     "mechanism": "Voacangine is a prodrug to ibogaine (NMDA antagonist, serotonin transporter blocker)",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "experimental use in addiction therapy (via ibogaine synthesis)",
-    "interactions": [
-      "avoid all stimulants",
-      "antidepressants",
-      "maois"
-    ],
-    "contraindications": [
-      "heart conditions",
-      "psychiatric disorders"
-    ],
+    "compounds": [],
+    "toxicity_ld50": "~90–120 mg/kg (est. voacangine)",
+    "safety": "",
     "sideeffects": [
       "vomiting",
       "overstimulation",
       "visual distortions"
     ],
-    "safety": "",
-    "toxicity": "High in overdose; cardiotoxic potential",
-    "toxicity_ld50": "~90–120 mg/kg (est. voacangine)",
+    "contraindications": [
+      "heart conditions",
+      "psychiatric disorders"
+    ],
+    "therapeutic": "experimental use in addiction therapy (via ibogaine synthesis)",
     "tags": [
       "⚠️ caution",
       "🌍 african",
@@ -11077,6 +15450,17 @@
       "Voacanga africana: Ethnobotany and Chemistry – J Ethnopharmacol",
       "2014"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "avoid all stimulants",
+      "antidepressants",
+      "maois"
+    ],
+    "toxicity": "High in overdose; cardiotoxic potential",
     "image": ""
   },
   {
@@ -11085,40 +15469,43 @@
     "common": "White Sage",
     "scientific": "Salvia apiana",
     "category": "ritual / aromatic",
-    "subcategory": "",
-    "intensity": "",
-    "region": "southwestern us",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "white sage revered for cleansing ceremonies",
     "effects": "calm;clarity",
+    "intensity": "",
+    "region": "southwestern us",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Essential oils like cineole and thujone provide mild GABA modulation",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Cineole",
       "Rosmarinic acid"
     ],
-    "preparations": [],
-    "dosage": "Smoke small bundle or 1 g in tea",
-    "therapeutic": "purification rites, relaxation",
-    "interactions": [
-      "none known"
+    "toxicity_ld50": "Not well studied",
+    "safety": "",
+    "sideeffects": [
+      "rare allergic cough"
     ],
     "contraindications": [
       "pregnancy high doses"
     ],
-    "sideeffects": [
-      "rare allergic cough"
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not well studied",
+    "therapeutic": "purification rites, relaxation",
     "tags": [
       "🌿 ritual",
       "🪔 incense"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "Smoke small bundle or 1 g in tea",
+    "interactions": [
+      "none known"
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -11127,34 +15514,37 @@
     "common": "White Sapote",
     "scientific": "Casimiroa edulis",
     "category": "ethnobotanical",
-    "subcategory": "",
-    "intensity": "",
-    "region": "central america",
-    "regiontags": [],
-    "legalstatus": "",
-    "schedule": "",
-    "legalnotes": "",
     "description": "the fruit of the white sapote tree is used as a sedative in traditional mexican herbal medicine.",
     "effects": "sedative;sleep aid",
+    "intensity": "",
+    "region": "central america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "",
     "mechanism": "Possible GABAergic activity",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Zapotin"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "",
-    "interactions": [],
-    "contraindications": [],
-    "sideeffects": [],
-    "safety": "",
-    "toxicity": "",
     "toxicity_ld50": "",
+    "safety": "",
+    "sideeffects": [],
+    "contraindications": [],
+    "therapeutic": "",
     "tags": [
       "sedative",
       "fruit",
       "folk medicine"
     ],
     "sources": [],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [],
+    "toxicity": "",
     "image": ""
   },
   {
@@ -11163,27 +15553,28 @@
     "common": "Wild Lettuce",
     "scientific": "Lactuca virosa",
     "category": "sedative / analgesic / nervine",
-    "subcategory": "",
-    "intensity": "Mild to moderate",
-    "region": "europe, north america, asia",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a tall, bitter plant sometimes called 'opium lettuce' due to its historical use for pain and sleep. it contains lactucopicrin and lactucin, compounds with mild sedative and analgesic properties. used in western herbalism since the 19th century.",
     "effects": "Pain relief;Mild euphoria;Sedation;Calming",
+    "intensity": "Mild to moderate",
+    "region": "europe, north america, asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Lactucin and lactucopicrin are sesquiterpene lactones that interact with GABAergic systems and have antinociceptive properties.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Lactucin",
       "Lactucopicrin"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for pain, insomnia, anxiety, coughing, and muscle tension. popular in herbal tinctures and teas.",
-    "interactions": [
-      "potentiates sedatives or alcohol.",
-      "avoid with sedatives",
-      "opioids"
+    "toxicity_ld50": "Not well documented in humans; extracts assumed safe below 500 mg/kg",
+    "safety": "1",
+    "sideeffects": [
+      "may cause dizziness",
+      "nausea",
+      "or mild hallucinations at high doses. bitter taste often deters excess use.",
+      "drowsiness",
+      "nausea at high doses"
     ],
     "contraindications": [
       "avoid in pregnancy",
@@ -11192,16 +15583,7 @@
       "pregnancy",
       "cns depressants"
     ],
-    "sideeffects": [
-      "may cause dizziness",
-      "nausea",
-      "or mild hallucinations at high doses. bitter taste often deters excess use.",
-      "drowsiness",
-      "nausea at high doses"
-    ],
-    "safety": "1",
-    "toxicity": "Low to moderate. High doses may cause CNS depression.",
-    "toxicity_ld50": "Not well documented in humans; extracts assumed safe below 500 mg/kg",
+    "therapeutic": "used for pain, insomnia, anxiety, coughing, and muscle tension. popular in herbal tinctures and teas.",
     "tags": [
       "💤 sedative",
       "🌿 analgesic",
@@ -11217,6 +15599,17 @@
       "4th Ed. – Barnes et al.",
       "A Modern Herbal – Grieve"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "potentiates sedatives or alcohol.",
+      "avoid with sedatives",
+      "opioids"
+    ],
+    "toxicity": "Low to moderate. High doses may cause CNS depression.",
     "image": ""
   },
   {
@@ -11225,36 +15618,28 @@
     "common": "",
     "scientific": "Withania somnifera",
     "category": "adaptogen / nervine / endocrine support",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "india, middle east, north africa",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "one of the most revered herbs in ayurveda, ashwagandha is a potent adaptogen used to reduce stress, improve sleep, and balance the nervous and endocrine systems. often called 'indian ginseng'.",
     "effects": "Stress reduction;Cortisol regulation;Sleep support;Cognitive enhancement",
+    "intensity": "Mild–Moderate",
+    "region": "india, middle east, north africa",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Withanolides modulate the hypothalamic-pituitary-adrenal (HPA) axis, lower cortisol, reduce oxidative stress, and improve GABAergic signaling.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for anxiety, fatigue, insomnia, adrenal support, libido, thyroid balance, and immune modulation.",
-    "interactions": [
-      "may enhance effects of sedatives",
-      "thyroid meds",
-      "or immunosuppressants."
+    "compounds": [],
+    "toxicity_ld50": ">5000 mg/kg (rats, oral)",
+    "safety": "",
+    "sideeffects": [
+      "mild gi upset or drowsiness. rare headaches or allergic reactions."
     ],
     "contraindications": [
       "avoid with hyperthyroidism",
       "sedative medications",
       "or during pregnancy without supervision."
     ],
-    "sideeffects": [
-      "mild gi upset or drowsiness. rare headaches or allergic reactions."
-    ],
-    "safety": "",
-    "toxicity": "Very low. High doses may affect thyroid hormone levels.",
-    "toxicity_ld50": ">5000 mg/kg (rats, oral)",
+    "therapeutic": "used for anxiety, fatigue, insomnia, adrenal support, libido, thyroid balance, and immune modulation.",
     "tags": [
       "🧘 adaptogen",
       "💤 sleep",
@@ -11267,6 +15652,17 @@
       "Indian Journal of Psychological Medicine",
       "2012"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may enhance effects of sedatives",
+      "thyroid meds",
+      "or immunosuppressants."
+    ],
+    "toxicity": "Very low. High doses may affect thyroid hormone levels.",
     "image": ""
   },
   {
@@ -11275,28 +15671,28 @@
     "common": "Wormwood",
     "scientific": "Artemisia absinthium",
     "category": "deliriant / digestive bitter",
-    "subcategory": "",
-    "intensity": "Mild to moderate",
-    "region": "europe, north africa, western asia",
-    "regiontags": [],
-    "legalstatus": "Thujone content regulated in beverages (e.g. EU and US); plant itself legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a bitter herb best known as the flavoring in traditional absinthe. contains thujone, a gaba receptor antagonist that can cause excitatory and convulsive effects in high doses.",
     "effects": "Euphoria;Mild hallucinations;Stimulation;Appetite stimulant",
+    "intensity": "Mild to moderate",
+    "region": "europe, north africa, western asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Thujone content regulated in beverages (e.g. EU and US); plant itself legal",
     "mechanism": "Thujone is a GABA-A antagonist, reducing inhibitory signaling in the brain. At high doses, this may induce seizures or hallucinations. Also contains bitter principles that stimulate digestion.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Thujone"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used as a bitter tonic for digestion, appetite stimulation, and historically as an anthelmintic. occasionally explored for mood elevation in aromatherapy.",
-    "interactions": [
-      "may reduce effectiveness of anticonvulsants. dangerous with gabaergic drugs",
-      "alcohol",
-      "or stimulants.",
-      "avoid alcohol",
-      "cns drugs"
+    "toxicity_ld50": "Thujone: ~87.5 mg/kg (rats, oral)",
+    "safety": "",
+    "sideeffects": [
+      "nausea",
+      "dizziness",
+      "vomiting",
+      "neurotoxicity at high doses. prolonged use may irritate kidneys and liver.",
+      "headache",
+      "tremors at high doses"
     ],
     "contraindications": [
       "avoid in epilepsy",
@@ -11306,17 +15702,7 @@
       "epilepsy",
       "high doses"
     ],
-    "sideeffects": [
-      "nausea",
-      "dizziness",
-      "vomiting",
-      "neurotoxicity at high doses. prolonged use may irritate kidneys and liver.",
-      "headache",
-      "tremors at high doses"
-    ],
-    "safety": "",
-    "toxicity": "High doses or chronic use may lead to tremors, seizures, and neurotoxicity ('absinthism').",
-    "toxicity_ld50": "Thujone: ~87.5 mg/kg (rats, oral)",
+    "therapeutic": "used as a bitter tonic for digestion, appetite stimulation, and historically as an anthelmintic. occasionally explored for mood elevation in aromatherapy.",
     "tags": [
       "🍸 absinthium",
       "⚠️ neurotoxic",
@@ -11333,6 +15719,19 @@
       "Journal of Ethnopharmacology",
       "2003"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may reduce effectiveness of anticonvulsants. dangerous with gabaergic drugs",
+      "alcohol",
+      "or stimulants.",
+      "avoid alcohol",
+      "cns drugs"
+    ],
+    "toxicity": "High doses or chronic use may lead to tremors, seizures, and neurotoxicity ('absinthism').",
     "image": ""
   },
   {
@@ -11341,32 +15740,26 @@
     "common": "",
     "scientific": "Xylopia aethiopica",
     "category": "spice / respiratory / afro-caribbean traditional",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "west africa, caribbean",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a spicy fruit used in west african and caribbean cuisine and medicine. traditionally employed to treat respiratory and digestive issues, and as a warming tonic for colds and fatigue.",
     "effects": "Warming;Decongestant;Digestive aid;Mild stimulant",
+    "intensity": "Mild–Moderate",
+    "region": "west africa, caribbean",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Contains volatile oils (e.g. eugenol, β-pinene) that have antimicrobial, warming, and stimulant actions. May stimulate mucous clearance and circulation.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for coughs, bronchitis, gas, malaria prevention, postpartum recovery, and flavoring food and medicine.",
-    "interactions": [
-      "minimal. may interact with stimulants or other warming agents."
+    "compounds": [],
+    "toxicity_ld50": "Not well documented",
+    "safety": "",
+    "sideeffects": [
+      "in large doses may cause stomach irritation or overstimulation."
     ],
     "contraindications": [
       "avoid in pregnancy unless under traditional guidance due to uterine stimulant effect."
     ],
-    "sideeffects": [
-      "in large doses may cause stomach irritation or overstimulation."
-    ],
-    "safety": "",
-    "toxicity": "Low at culinary or traditional doses",
-    "toxicity_ld50": "Not well documented",
+    "therapeutic": "used for coughs, bronchitis, gas, malaria prevention, postpartum recovery, and flavoring food and medicine.",
     "tags": [
       "🌶️ spice",
       "🌬️ decongestant",
@@ -11378,6 +15771,15 @@
       "Journal of Ethnopharmacology",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "minimal. may interact with stimulants or other warming agents."
+    ],
+    "toxicity": "Low at culinary or traditional doses",
     "image": ""
   },
   {
@@ -11386,37 +15788,31 @@
     "common": "Yanhusuo",
     "scientific": "Corydalis yanhusuo",
     "category": "sedative / analgesic",
-    "subcategory": "",
-    "intensity": "Moderate",
-    "region": "china and east asia",
-    "regiontags": [],
-    "legalstatus": "Legal",
-    "schedule": "",
-    "legalnotes": "",
     "description": "tubers of this asian herb provide notable pain relief and a tranquil state when used as tea or pills.",
     "effects": "analgesia;relaxation;subtle dreaminess",
+    "intensity": "Moderate",
+    "region": "china and east asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal",
     "mechanism": "Alkaloids such as tetrahydropalmatine act on dopamine and GABA receptors",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Tetrahydropalmatine (THP)"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "traditional chinese remedy for pain and insomnia",
-    "interactions": [
-      "may potentiate sedatives or dopaminergic drugs"
+    "toxicity_ld50": ">1 g/kg in rodents",
+    "safety": "",
+    "sideeffects": [
+      "drowsiness",
+      "dizziness"
     ],
     "contraindications": [
       "pregnancy",
       "liver disease",
       "large doses"
     ],
-    "sideeffects": [
-      "drowsiness",
-      "dizziness"
-    ],
-    "safety": "",
-    "toxicity": "Overuse may cause liver stress",
-    "toxicity_ld50": ">1 g/kg in rodents",
+    "therapeutic": "traditional chinese remedy for pain and insomnia",
     "tags": [
       "tcm",
       "dopamine",
@@ -11428,6 +15824,15 @@
       "2013",
       "Pharmacopoeia of the People’s Republic of China"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may potentiate sedatives or dopaminergic drugs"
+    ],
+    "toxicity": "Overuse may cause liver stress",
     "image": ""
   },
   {
@@ -11436,30 +15841,29 @@
     "common": "Yerba Mate",
     "scientific": "Ilex paraguariensis",
     "category": "stimulant / tonic / social",
-    "subcategory": "",
-    "intensity": "Mild to moderate",
-    "region": "argentina, brazil, paraguay, uruguay",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a south american herbal infusion made from the dried leaves of the yerba mate plant. revered for its energizing and antioxidant effects, mate is consumed in communal rituals or daily focus routines.",
     "effects": "Mental alertness;Appetite control;Social energy;Metabolism boost",
+    "intensity": "Mild to moderate",
+    "region": "argentina, brazil, paraguay, uruguay",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Caffeine, theobromine, and chlorogenic acid act as CNS stimulants and antioxidants. Enhances focus while reducing fatigue.",
+    "pharmacology": "",
+    "preparations": [],
     "compounds": [
       "Caffeine",
       "Theobromine",
       "Chlorogenic acid"
     ],
-    "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for fatigue, digestion, weight loss, cognitive enhancement, and mild depression.",
-    "interactions": [
-      "interacts with maois",
-      "stimulants",
-      "or blood pressure meds. may influence cyp enzymes.",
-      "cns stimulants",
-      "caffeine"
+    "toxicity_ld50": "Caffeine LD50 ~192 mg/kg (rats, oral)",
+    "safety": "",
+    "sideeffects": [
+      "insomnia",
+      "gi irritation",
+      "or agitation at high doses. possible link to esophageal cancer when consumed very hot frequently.",
+      "jitteriness",
+      "gi discomfort in sensitive individuals"
     ],
     "contraindications": [
       "caution in hypertension",
@@ -11468,16 +15872,7 @@
       "anxiety",
       "heart conditions"
     ],
-    "sideeffects": [
-      "insomnia",
-      "gi irritation",
-      "or agitation at high doses. possible link to esophageal cancer when consumed very hot frequently.",
-      "jitteriness",
-      "gi discomfort in sensitive individuals"
-    ],
-    "safety": "",
-    "toxicity": "Low to moderate (long-term use linked to GI issues)",
-    "toxicity_ld50": "Caffeine LD50 ~192 mg/kg (rats, oral)",
+    "therapeutic": "used for fatigue, digestion, weight loss, cognitive enhancement, and mild depression.",
     "tags": [
       "☕ social",
       "🔥 thermogenic",
@@ -11493,6 +15888,19 @@
       "Journal of Human Nutrition and Dietetics",
       "2008"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "interacts with maois",
+      "stimulants",
+      "or blood pressure meds. may influence cyp enzymes.",
+      "cns stimulants",
+      "caffeine"
+    ],
+    "toxicity": "Low to moderate (long-term use linked to GI issues)",
     "image": ""
   },
   {
@@ -11501,32 +15909,26 @@
     "common": "",
     "scientific": "Zanthoxylum americanum",
     "category": "analgesic / circulatory stimulant / traditional native american",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "north america (northern u.s., canada)",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "northern relative of zanthoxylum clava-herculis, this species was widely used by native americans for toothaches, cold limbs, and digestion. like its southern cousin, it produces a numbing and buzzing sensation when chewed.",
     "effects": "Tingling;Local analgesia;Salivation;Circulation boost",
+    "intensity": "Mild–Moderate",
+    "region": "north america (northern u.s., canada)",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Sanshools (alkylamides) modulate TRPV1 and TRPA1 channels on nerve endings, producing a buzzing, tingling analgesic effect. Also stimulates saliva and gastric secretions.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used topically or chewed for oral pain, indigestion, sluggish circulation, or nerve support. historically used in decoctions or salves.",
-    "interactions": [
-      "minimal. theoretical interaction with oral analgesics or vasodilators."
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "local irritation or tingling. mild drooling or numbing. rare allergic reactions."
     ],
     "contraindications": [
       "avoid in broken oral tissue or wounds. caution with hot spices or ulcers."
     ],
-    "sideeffects": [
-      "local irritation or tingling. mild drooling or numbing. rare allergic reactions."
-    ],
-    "safety": "",
-    "toxicity": "Low in traditional use",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "used topically or chewed for oral pain, indigestion, sluggish circulation, or nerve support. historically used in decoctions or salves.",
     "tags": [
       "🦷 oral care",
       "🌿 native american",
@@ -11538,6 +15940,15 @@
       "Native American Ethnobotany – Moerman",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "minimal. theoretical interaction with oral analgesics or vasodilators."
+    ],
+    "toxicity": "Low in traditional use",
     "image": ""
   },
   {
@@ -11546,32 +15957,26 @@
     "common": "",
     "scientific": "Zanthoxylum bungeanum",
     "category": "digestive / circulatory / sensory-modulating",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "china, east asia",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "used in chinese cuisine and medicine, sichuan pepper causes a tingling numbness and has been traditionally used to support digestion and stimulate circulation. its unique effect is due to hydroxy-alpha-sanshool.",
     "effects": "Tingling sensation;Digestive stimulant;Mild analgesia;Circulation support",
+    "intensity": "Mild–Moderate",
+    "region": "china, east asia",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Sanshools activate somatosensory ion channels (TRPA1, TRPV1) leading to a buzzing/tingling anesthetic effect. Also improves gastric secretions and peripheral blood flow.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used to improve digestion, relieve stomach cramps, stimulate salivation, reduce cold extremities, and in topical pain blends.",
-    "interactions": [
-      "may alter absorption of other herbs or drugs via gi stimulation."
+    "compounds": [],
+    "toxicity_ld50": "Not fully established; safe in culinary and moderate medicinal use",
+    "safety": "",
+    "sideeffects": [
+      "can cause intense tingling. overuse may irritate gi tract or cause local numbness."
     ],
     "contraindications": [
       "avoid in mucosal lesions or in large doses during pregnancy."
     ],
-    "sideeffects": [
-      "can cause intense tingling. overuse may irritate gi tract or cause local numbness."
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not fully established; safe in culinary and moderate medicinal use",
+    "therapeutic": "used to improve digestion, relieve stomach cramps, stimulate salivation, reduce cold extremities, and in topical pain blends.",
     "tags": [
       "🌶️ tingling",
       "🍽️ digestive",
@@ -11583,6 +15988,15 @@
       "Chinese Herbal Materia Medica",
       "Journal of Ethnopharmacology"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may alter absorption of other herbs or drugs via gi stimulation."
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -11591,32 +16005,26 @@
     "common": "",
     "scientific": "Zea mays (stigma)",
     "category": "diuretic / urinary tract / soothing",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "worldwide (where corn is cultivated)",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "the long threads of corn (called silk) are a gentle herbal remedy for urinary tract issues, swelling, and kidney function. used in teas for centuries in both native american and chinese traditions.",
     "effects": "Urine flow increase;Soothing;Kidney support;Anti-inflammatory",
+    "intensity": "Mild",
+    "region": "worldwide (where corn is cultivated)",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Contains flavonoids, saponins, and potassium that increase urine output, reduce inflammation, and soothe irritated tissues.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for utis, bladder inflammation, bedwetting, kidney stones, and fluid retention. also mildly calming.",
-    "interactions": [
-      "may enhance diuretics or alter potassium levels. mild blood pressure effects."
+    "compounds": [],
+    "toxicity_ld50": "Not established; extremely safe at traditional doses",
+    "safety": "",
+    "sideeffects": [
+      "rare. may cause mild electrolyte loss or allergic reaction in corn-sensitive individuals."
     ],
     "contraindications": [
       "avoid with diuretic medications or in cases of severe kidney disease unless supervised."
     ],
-    "sideeffects": [
-      "rare. may cause mild electrolyte loss or allergic reaction in corn-sensitive individuals."
-    ],
-    "safety": "",
-    "toxicity": "Very low",
-    "toxicity_ld50": "Not established; extremely safe at traditional doses",
+    "therapeutic": "used for utis, bladder inflammation, bedwetting, kidney stones, and fluid retention. also mildly calming.",
     "tags": [
       "🌾 kidney support",
       "💧 diuretic",
@@ -11629,6 +16037,15 @@
       "Journal of Medicinal Plants Research",
       "2011"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may enhance diuretics or alter potassium levels. mild blood pressure effects."
+    ],
+    "toxicity": "Very low",
     "image": ""
   },
   {
@@ -11637,35 +16054,29 @@
     "common": "",
     "scientific": "Zingiber officinale",
     "category": "digestive / anti-inflammatory / stimulant",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "tropical asia, cultivated globally",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a pungent rhizome widely used for its warming, carminative, and anti-inflammatory effects. revered in ayurvedic and traditional chinese medicine for treating nausea, coldness, and sluggish digestion.",
     "effects": "Digestive support;Anti-nausea;Circulation boost;Mild stimulation",
+    "intensity": "Mild–Moderate",
+    "region": "tropical asia, cultivated globally",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Contains gingerols and shogaols that modulate prostaglandins, TRP ion channels, and serotonin receptors involved in nausea.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for nausea, morning sickness, motion sickness, colds, pain, and poor circulation. also a culinary spice and tea staple.",
-    "interactions": [
-      "may interact with blood thinners or diabetes meds. synergistic with anti-nausea agents."
+    "compounds": [],
+    "toxicity_ld50": ">5000 mg/kg (rats, oral)",
+    "safety": "",
+    "sideeffects": [
+      "heartburn",
+      "stomach upset in large doses. rare allergic reactions."
     ],
     "contraindications": [
       "caution with anticoagulants",
       "gallstones",
       "or gastritis in high doses."
     ],
-    "sideeffects": [
-      "heartburn",
-      "stomach upset in large doses. rare allergic reactions."
-    ],
-    "safety": "",
-    "toxicity": "Very low",
-    "toxicity_ld50": ">5000 mg/kg (rats, oral)",
+    "therapeutic": "used for nausea, morning sickness, motion sickness, colds, pain, and poor circulation. also a culinary spice and tea staple.",
     "tags": [
       "🌶️ warming",
       "🫖 anti-nausea",
@@ -11677,6 +16088,15 @@
       "Herbal Medicine – Mills & Bone",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may interact with blood thinners or diabetes meds. synergistic with anti-nausea agents."
+    ],
+    "toxicity": "Very low",
     "image": ""
   },
   {
@@ -11685,32 +16105,26 @@
     "common": "",
     "scientific": "Zingiber zerumbet",
     "category": "anti-inflammatory / aromatic / dermatological",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "hawaii, southeast asia, pacific islands",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a tropical ginger species prized for its aromatic rhizomes and milky juice-filled cones used in traditional polynesian medicine and hair care. mildly relaxing and soothing, both internally and externally.",
     "effects": "Skin and hair care;Topical anti-inflammatory;Digestive aid;Aromatic relaxant",
+    "intensity": "Mild",
+    "region": "hawaii, southeast asia, pacific islands",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Zerumbone and essential oils contribute to anti-inflammatory, antioxidant, and antimicrobial effects. Soothes skin, modulates TRP channels, and supports digestion.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used topically for hair conditioning, inflammation, burns, and fungal issues. internally for nausea, digestive support, and respiratory infections.",
-    "interactions": [
-      "may mildly enhance absorption or circulation of co-administered compounds."
+    "compounds": [],
+    "toxicity_ld50": "Not well established; traditionally regarded as safe",
+    "safety": "",
+    "sideeffects": [
+      "rare. may cause skin sensitivity in some. avoid in large oral doses without preparation."
     ],
     "contraindications": [
       "caution during pregnancy. not for chronic high-dose ingestion."
     ],
-    "sideeffects": [
-      "rare. may cause skin sensitivity in some. avoid in large oral doses without preparation."
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not well established; traditionally regarded as safe",
+    "therapeutic": "used topically for hair conditioning, inflammation, burns, and fungal issues. internally for nausea, digestive support, and respiratory infections.",
     "tags": [
       "🫧 hair care",
       "🌿 soothing",
@@ -11722,6 +16136,15 @@
       "Hawaiian Ethnobotany – Beatrice Krauss",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may mildly enhance absorption or circulation of co-administered compounds."
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -11730,33 +16153,27 @@
     "common": "",
     "scientific": "Ziziphus jujuba",
     "category": "sedative / adaptogen / digestive",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "china, middle east, mediterranean",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a traditional fruit in chinese and middle eastern medicine, jujube is used as a tonic, sleep aid, and digestive harmonizer. rich in antioxidants and calming saponins.",
     "effects": "Sleep support;Stress reduction;Digestive regulation;Immune modulation",
+    "intensity": "Mild",
+    "region": "china, middle east, mediterranean",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Jujubosides interact with GABA-A receptors and modulate cortisol. Flavonoids and triterpenes provide antioxidant and anti-inflammatory effects.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for insomnia, anxiety, poor appetite, fatigue, and gastrointestinal upset. often included in tcm formulas like suan zao ren tang.",
-    "interactions": [
-      "may enhance sedative or anxiolytic medications."
-    ],
-    "contraindications": [
-      "none major. caution in hypotensive patients due to mild sedative effects."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Not well documented; safe in dietary and medicinal use",
+    "safety": "",
     "sideeffects": [
       "rare",
       "well tolerated. mild drowsiness or loose stool at high doses."
     ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not well documented; safe in dietary and medicinal use",
+    "contraindications": [
+      "none major. caution in hypotensive patients due to mild sedative effects."
+    ],
+    "therapeutic": "used for insomnia, anxiety, poor appetite, fatigue, and gastrointestinal upset. often included in tcm formulas like suan zao ren tang.",
     "tags": [
       "🍎 tcm",
       "💤 sleep",
@@ -11768,6 +16185,15 @@
       "Journal of Ethnopharmacology",
       "Chinese Herbal Medicine – Bensky & Gamble"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may enhance sedative or anxiolytic medications."
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -11776,34 +16202,26 @@
     "common": "",
     "scientific": "Ziziphus spinosa",
     "category": "sedative / anxiolytic / traditional chinese medicine",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "china, korea, japan",
-    "regiontags": [],
-    "legalstatus": "Legal worldwide",
-    "schedule": "",
-    "legalnotes": "",
     "description": "the seeds of this wild jujube are used in traditional chinese medicine (tcm) for calming the spirit and nourishing the heart. a key herb in formulas for insomnia and anxiety, including suan zao ren tang.",
     "effects": "Sleep promotion;Anxiety relief;Dream regulation;Heart-calming",
+    "intensity": "Mild–Moderate",
+    "region": "china, korea, japan",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal worldwide",
     "mechanism": "Jujubosides and flavonoids interact with GABA receptors and modulate neurotransmitters like serotonin and dopamine. Mildly hypnotic and anxiolytic.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for insomnia, restlessness, palpitations, excessive dreaming, and mental fatigue.",
-    "interactions": [
-      "may enhance effects of sedatives",
-      "hypnotics",
-      "or anxiolytics."
+    "compounds": [],
+    "toxicity_ld50": "Not well documented; safe in traditional use",
+    "safety": "",
+    "sideeffects": [
+      "rare. large doses may cause mild gi upset or daytime drowsiness."
     ],
     "contraindications": [
       "caution in hypotension or concurrent sedative use."
     ],
-    "sideeffects": [
-      "rare. large doses may cause mild gi upset or daytime drowsiness."
-    ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not well documented; safe in traditional use",
+    "therapeutic": "used for insomnia, restlessness, palpitations, excessive dreaming, and mental fatigue.",
     "tags": [
       "💤 sleep",
       "🧘 calm",
@@ -11815,6 +16233,17 @@
       "Chinese Herbal Medicine – Bensky",
       "Plants of the Gods – Rätsch"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may enhance effects of sedatives",
+      "hypnotics",
+      "or anxiolytics."
+    ],
+    "toxicity": "Low",
     "image": ""
   },
   {
@@ -11823,32 +16252,26 @@
     "common": "",
     "scientific": "Zornia diphylla",
     "category": "calming / respiratory / psychoactive adjunct",
-    "subcategory": "",
-    "intensity": "Mild",
-    "region": "south america, caribbean",
-    "regiontags": [],
-    "legalstatus": "Legal in most regions",
-    "schedule": "",
-    "legalnotes": "",
     "description": "a lesser-known south american herb with calming, slightly psychoactive properties. sometimes used similarly to zornia latifolia in herbal smoking blends and indigenous rituals.",
     "effects": "Relaxation;Mild psychoactive;Cough soothing;Mood lifting",
+    "intensity": "Mild",
+    "region": "south america, caribbean",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal in most regions",
     "mechanism": "Likely contains flavonoids and volatile oils with CNS-depressant and bronchodilatory effects. Specific constituents under-studied.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for calming anxiety, promoting mild euphoria, relieving cough or bronchial irritation, and enhancing relaxation in blend formulas.",
-    "interactions": [
-      "may enhance effects of other cns depressants or respiratory herbs."
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
+    "sideeffects": [
+      "very mild. may cause sedation or lightheadedness in large amounts."
     ],
     "contraindications": [
       "avoid use with strong sedatives or during pregnancy. limited safety data."
     ],
-    "sideeffects": [
-      "very mild. may cause sedation or lightheadedness in large amounts."
-    ],
-    "safety": "",
-    "toxicity": "Unknown but presumed low based on traditional use",
-    "toxicity_ld50": "Not established",
+    "therapeutic": "used for calming anxiety, promoting mild euphoria, relieving cough or bronchial irritation, and enhancing relaxation in blend formulas.",
     "tags": [
       "🌀 psychoactive-adjunct",
       "🛌 calm",
@@ -11860,6 +16283,15 @@
       "Plants of the Gods – Rätsch",
       "Amazonian Ethnobotany Archives"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "may enhance effects of other cns depressants or respiratory herbs."
+    ],
+    "toxicity": "Unknown but presumed low based on traditional use",
     "image": ""
   },
   {
@@ -11868,33 +16300,27 @@
     "common": "",
     "scientific": "Zornia latifolia",
     "category": "psychoactive / calming / south american traditional",
-    "subcategory": "",
-    "intensity": "Mild–Moderate",
-    "region": "brazil, paraguay, south america",
-    "regiontags": [],
-    "legalstatus": "Legal in most regions",
-    "schedule": "",
-    "legalnotes": "",
     "description": "known as 'false marijuana' in brazil, this south american herb produces a relaxing, slightly euphoric state when smoked or brewed. used traditionally in rituals and to aid sleep or meditation.",
     "effects": "Mild euphoria;Mental calm;Lucid dreaming;Cannabinoid mimicry",
+    "intensity": "Mild–Moderate",
+    "region": "brazil, paraguay, south america",
+    "duration": "",
+    "onset": "",
+    "legalstatus": "Legal in most regions",
     "mechanism": "Flavonoids and potential endocannabinoid-modulating compounds interact with CB1/CB2 receptors, though exact active constituents remain under-researched.",
-    "compounds": [],
+    "pharmacology": "",
     "preparations": [],
-    "dosage": "",
-    "therapeutic": "used for anxiety, insomnia, meditation enhancement, and as a legal cannabis substitute in some herbal blends.",
-    "interactions": [
-      "theoretical synergy with gabaergic or cannabinoid-active compounds."
-    ],
-    "contraindications": [
-      "avoid mixing with alcohol or sedatives. not for use in pregnancy."
-    ],
+    "compounds": [],
+    "toxicity_ld50": "Not established",
+    "safety": "",
     "sideeffects": [
       "very mild",
       "potential sedation or grogginess. high doses may cause dizziness."
     ],
-    "safety": "",
-    "toxicity": "Low",
-    "toxicity_ld50": "Not established",
+    "contraindications": [
+      "avoid mixing with alcohol or sedatives. not for use in pregnancy."
+    ],
+    "therapeutic": "used for anxiety, insomnia, meditation enhancement, and as a legal cannabis substitute in some herbal blends.",
     "tags": [
       "🌿 psychoactive",
       "🛌 dream herb",
@@ -11906,6 +16332,15 @@
       "Plants of the Gods – Rätsch",
       "Journal of Ethnopharmacology"
     ],
+    "subcategory": "",
+    "regiontags": [],
+    "schedule": "",
+    "legalnotes": "",
+    "dosage": "",
+    "interactions": [
+      "theoretical synergy with gabaergic or cannabinoid-active compounds."
+    ],
+    "toxicity": "Low",
     "image": ""
   }
 ]


### PR DESCRIPTION
## Summary
- normalize herb CSV ingestion to support herb_index_master_v1.28 aliases and sanitize values before export
- regenerate herbs.normalized.json with unified columns and derived metadata fields

## Testing
- node scripts/convert-herbs.mjs
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e45b0cd6f88323ab5851e0612655ee