### PR TITLE
Add data refresh scripts and audit workflow

### DIFF
--- a/.github/workflows/data-audit.yml
+++ b/.github/workflows/data-audit.yml
@@ -1,0 +1,21 @@
+name: Data audit
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run data:refresh
+      # If you want to build on CI too, uncomment:
+      # - run: npm run data:refresh+build

--- a/README.md
+++ b/README.md
@@ -56,3 +56,8 @@ This repository includes a variety of learning materials:
 ## Contributing
 
 Pull requests and issue reports are welcome. Please open an issue first if you would like to discuss a major change.
+
+### Data maintenance
+
+- Refresh + validate dataset locally: `npm run data:refresh`
+- Refresh + validate + build: `npm run data:refresh+build`

--- a/package.json
+++ b/package.json
@@ -7,15 +7,17 @@
     "dev:data": "node scripts/convert-herbs.mjs",
     "prebuild:data": "node scripts/convert-herbs.mjs",
     "autofill:data": "node scripts/autofill-herbs.mjs",
-    "prebuild:validate": "npm run validate-herbs",
-    "rebuild:data": "npm run prebuild:data && npm run autofill:data && npm run prebuild:validate",
-    "build": "npm run rebuild:data && vite build",
+    "prebuild:validate": "node scripts/validate-herbs.mjs",
+    "rebuild:data": "npm run data:refresh",
+    "build": "npm run data:refresh+build",
     "preview": "vite preview",
     "deploy": "gh-pages -d dist",
     "test": "echo \"No tests specified\" && exit 0",
     "validate-herbs": "node scripts/validateHerbs.js",
     "verify:data": "npm run autofill:data && npm run audit:data",
-    "audit:data": "node scripts/audit-herbs.mjs"
+    "audit:data": "node scripts/audit-herbs.mjs",
+    "data:refresh": "npm run prebuild:data && npm run autofill:data && npm run prebuild:validate && npm run audit:data",
+    "data:refresh+build": "npm run data:refresh && vite build"
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.16",

--- a/scripts/convert-herbs.mjs
+++ b/scripts/convert-herbs.mjs
@@ -229,6 +229,50 @@ async function main() {
   }
   out = Array.from(byKey.values());
 
+  // secondary dedupe: ensure slug uniqueness
+  const bySlug = new Map();
+  for (const r of out) {
+    const key = r.slug || r.id;
+    if (!key) continue;
+    if (!bySlug.has(key)) {
+      bySlug.set(key, r);
+      continue;
+    }
+    const prev = bySlug.get(key);
+    bySlug.set(key, {
+      ...prev,
+      id: prev.id || r.id,
+      slug: prev.slug || r.slug,
+      common: prefer(prev.common, r.common),
+      scientific: prefer(prev.scientific, r.scientific),
+      category: prefer(prev.category, r.category),
+      subcategory: prefer(prev.subcategory, r.subcategory),
+      intensity: prefer(prev.intensity, r.intensity),
+      region: prefer(prev.region, r.region),
+      regiontags: mergeArrays(prev.regiontags, r.regiontags),
+      legalstatus: prefer(prev.legalstatus, r.legalstatus),
+      schedule: prefer(prev.schedule, r.schedule),
+      legalnotes: prefer(prev.legalnotes, r.legalnotes),
+      description: prefer(prev.description, r.description),
+      effects: prefer(prev.effects, r.effects),
+      mechanism: prefer(prev.mechanism, r.mechanism),
+      compounds: mergeArrays(prev.compounds, r.compounds),
+      preparations: mergeArrays(prev.preparations, r.preparations),
+      dosage: prefer(prev.dosage, r.dosage),
+      therapeutic: prefer(prev.therapeutic, r.therapeutic),
+      interactions: mergeArrays(prev.interactions, r.interactions),
+      contraindications: mergeArrays(prev.contraindications, r.contraindications),
+      sideeffects: mergeArrays(prev.sideeffects, r.sideeffects),
+      safety: prefer(prev.safety, r.safety),
+      toxicity: prefer(prev.toxicity, r.toxicity),
+      toxicity_ld50: prefer(prev.toxicity_ld50, r.toxicity_ld50),
+      tags: mergeArrays(prev.tags, r.tags),
+      sources: mergeArrays(prev.sources, r.sources),
+      image: prefer(prev.image, r.image),
+    });
+  }
+  out = Array.from(bySlug.values());
+
   // optional: sort merged by common name for stable output
   out.sort((a, b) =>
     String(a.common || a.scientific).localeCompare(String(b.common || b.scientific))

--- a/scripts/validate-herbs.mjs
+++ b/scripts/validate-herbs.mjs
@@ -1,0 +1,118 @@
+import fs from "node:fs";
+
+const FILE = "src/data/herbs/herbs.normalized.json";
+
+if (!fs.existsSync(FILE)) {
+  console.error(`✖ Missing data file: ${FILE}`);
+  process.exit(1);
+}
+
+const raw = JSON.parse(fs.readFileSync(FILE, "utf-8"));
+
+if (!Array.isArray(raw)) {
+  console.error(`✖ Expected an array in ${FILE}, received ${typeof raw}`);
+  process.exit(1);
+}
+
+const LIST_FIELDS = [
+  "preparations",
+  "compounds",
+  "sideeffects",
+  "contraindications",
+  "tags",
+  "sources",
+];
+
+const STRING_FIELDS = [
+  "id",
+  "slug",
+  "common",
+  "scientific",
+  "category",
+  "description",
+  "effects",
+  "intensity",
+  "region",
+  "duration",
+  "onset",
+  "legalstatus",
+  "mechanism",
+  "pharmacology",
+  "toxicity_ld50",
+  "safety",
+  "therapeutic",
+  "legalnotes",
+];
+
+const errors = [];
+const warnings = [];
+const slugs = new Set();
+
+const hasString = (value) => typeof value === "string" && value.trim().length > 0;
+
+raw.forEach((row, index) => {
+  if (typeof row !== "object" || row === null) {
+    errors.push(`Row ${index + 1}: Expected object, received ${typeof row}`);
+    return;
+  }
+
+  const slug = row.slug;
+  if (!hasString(slug)) {
+    errors.push(`Row ${index + 1}: Missing slug`);
+  } else if (slugs.has(slug.trim())) {
+    errors.push(`Row ${index + 1}: Duplicate slug '${slug}'`);
+  } else {
+    slugs.add(slug.trim());
+  }
+
+  if (!hasString(row.common) && !hasString(row.scientific)) {
+    warnings.push(`Row ${index + 1}: Missing both common and scientific names`);
+  }
+
+  for (const field of STRING_FIELDS) {
+    const value = row[field];
+    if (value == null) continue;
+    if (typeof value !== "string") {
+      errors.push(`Row ${index + 1}: Field '${field}' should be a string`);
+    }
+  }
+
+  for (const field of LIST_FIELDS) {
+    const value = row[field];
+    if (value == null) continue;
+    if (!Array.isArray(value)) {
+      errors.push(`Row ${index + 1}: Field '${field}' should be an array`);
+      continue;
+    }
+    for (const [i, entry] of value.entries()) {
+      if (entry == null) continue;
+      if (typeof entry !== "string") {
+        errors.push(
+          `Row ${index + 1}: Field '${field}' entry #${i + 1} should be a string`
+        );
+      }
+    }
+  }
+});
+
+if (errors.length) {
+  console.error(`\n✖ Validation failed with ${errors.length} issue(s):`);
+  for (const msg of errors.slice(0, 50)) {
+    console.error(` - ${msg}`);
+  }
+  if (errors.length > 50) {
+    console.error(` ...and ${errors.length - 50} more.`);
+  }
+  process.exit(1);
+}
+
+console.log(`Herb dataset valid. Checked ${raw.length} row(s).`);
+if (warnings.length) {
+  console.warn(`\n⚠ Warnings (${warnings.length}):`);
+  for (const msg of warnings.slice(0, 20)) {
+    console.warn(` - ${msg}`);
+  }
+  if (warnings.length > 20) {
+    console.warn(` ...and ${warnings.length - 20} more.`);
+  }
+}


### PR DESCRIPTION
## Summary
- add composite npm scripts to regenerate, autofill, validate, audit, and optionally build herb data
- ensure the conversion script removes duplicate slugs and add a modern validator for normalized herb data
- wire up a README note and CI workflow that runs the refresh pipeline on pushes and pull requests

## Testing
- npm run data:refresh

------
https://chatgpt.com/codex/tasks/task_e_68e51e511acc8323a9b620a7aa4f701c