### PR TITLE
Add automated herb data watcher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tsparticles/engine": "^3.8.1",
         "@tsparticles/react": "^3.0.0",
         "autoprefixer": "^10.4.19",
+        "chokidar": "^3.5.3",
         "clsx": "^2.1.1",
         "file-saver": "^2.0.5",
         "framer-motion": "^10.16.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "data:merge+refresh": "node scripts/merge-herbs.mjs && npm run data:refresh",
     "data:merge+build": "node scripts/merge-herbs.mjs && npm run data:refresh+build",
     "data:report": "node scripts/report-herbs.mjs",
-    "data:checkup": "npm run data:refresh && npm run data:report"
+    "data:checkup": "npm run data:refresh && npm run data:report",
+    "data:watch": "node scripts/watch-herbs.mjs"
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.16",
@@ -45,6 +46,7 @@
     "react-markdown": "^10.1.0",
     "react-router-dom": "^6.22.3",
     "react-tooltip": "^5.20.0",
+    "chokidar": "^3.5.3",
     "rehype-raw": "^7.0.0",
     "tailwindcss": "^3.4.3",
     "tsparticles": "^3.8.1",

--- a/scripts/watch-herbs.mjs
+++ b/scripts/watch-herbs.mjs
@@ -1,0 +1,68 @@
+import chokidar from "chokidar";
+import { execSync } from "child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+const WATCH_DIR = "scripts/incoming";
+const MERGE_TARGET = "src/data/herbs/herbs.normalized.json";
+
+if (!fs.existsSync(WATCH_DIR)) fs.mkdirSync(WATCH_DIR, { recursive: true });
+
+console.log("👁️  Watching for new herb data in:", WATCH_DIR);
+console.log("Drop any .csv or .json file to auto-process.\n");
+
+let active = false;
+
+async function run(cmd) {
+  console.log(`\n→ ${cmd}`);
+  try {
+    execSync(cmd, { stdio: "inherit" });
+  } catch (e) {
+    console.error("⚠️  Command failed:", cmd);
+  }
+}
+
+async function handleFile(file) {
+  if (active) {
+    console.log("⏳ Still processing previous update, skipping...");
+    return;
+  }
+  active = true;
+  const ext = path.extname(file).toLowerCase();
+  const name = path.basename(file);
+  console.log(`\n📥 Detected update: ${name}`);
+  try {
+    if (ext === ".csv") {
+      // convert new CSV → normalized JSON → autofill → validate → audit
+      await run(`node scripts/convert-herbs.mjs`);
+      await run(`node scripts/autofill-herbs.mjs`);
+      await run(`node scripts/validate-herbs.mjs`);
+      await run(`node scripts/audit-herbs.mjs`);
+      await run(`npm run data:report`);
+    } else if (ext === ".json") {
+      // treat as patch and merge
+      await run(`npm run data:merge -- ${file}`);
+      await run(`npm run data:refresh`);
+    } else {
+      console.log("Ignoring non-data file:", name);
+    }
+
+    if (fs.existsSync(MERGE_TARGET)) {
+      const stats = fs.statSync(MERGE_TARGET);
+      console.log(`✅ Current dataset: ${MERGE_TARGET} (${(stats.size/1024).toFixed(1)} KB)`);
+    }
+  } finally {
+    active = false;
+    console.log("\nReady for next drop.\n");
+  }
+}
+
+chokidar
+  .watch(WATCH_DIR, { persistent: true, ignoreInitial: false })
+  .on("add", handleFile)
+  .on("change", handleFile);
+
+process.on("SIGINT", () => {
+  console.log("\n👋 Exiting watcher.");
+  process.exit(0);
+});


### PR DESCRIPTION
## Summary
- add a chokidar-powered watcher script to automatically process incoming herb data files
- expose the watcher via a new npm script and dependency update

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e52e19b5d08323a62c9bb5ba7130f4