### PR TITLE
Add nightly data refresh workflow

### DIFF
--- a/.github/workflows/nightly-data-refresh.yml
+++ b/.github/workflows/nightly-data-refresh.yml
@@ -1,0 +1,75 @@
+name: Nightly Data Refresh
+
+on:
+  schedule:
+    - cron: "17 5 * * *"   # 05:17 UTC daily (1:17am ET)
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install
+        run: npm ci
+
+      - name: Run data pipeline (convert → autofill → validate → audit → report)
+        run: npm run data:checkup
+
+      - name: Collect coverage artifacts
+        if: always()
+        run: |
+          mkdir -p scripts/out
+          echo "Artifacts in scripts/out:"
+          ls -la scripts/out || true
+
+      - name: Save git changes (dry check)
+        id: diff
+        run: |
+          git status --porcelain
+          echo "changed=$(git status --porcelain | wc -l)" >> $GITHUB_OUTPUT
+
+      - name: Compute PR body
+        id: prbody
+        run: |
+          CHANGED=$(git diff --name-only)
+          node scripts/ci-prepare-pr.mjs $CHANGED
+        shell: bash
+
+      - name: Create or update PR
+        if: steps.diff.outputs.changed != '0'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(data): nightly refresh & coverage artifacts"
+          title: "chore(data): nightly refresh — $(date -u +'%Y-%m-%d')"
+          body: ${{ steps.prbody.outputs.pr_body }}
+          branch: ci/nightly-data-refresh-auto
+          labels: |
+            data
+            automated
+            nightly
+          add-paths: |
+            src/data/herbs/herbs.normalized.json
+            scripts/out/**
+
+      - name: Upload coverage artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: herb-data-coverage
+          path: scripts/out/

--- a/scripts/ci-prepare-pr.mjs
+++ b/scripts/ci-prepare-pr.mjs
@@ -1,0 +1,63 @@
+import fs from "node:fs";
+
+const FILES = [
+  "src/data/herbs/herbs.normalized.json",
+  "scripts/out/coverage.json",
+  "scripts/out/coverage.md",
+  "scripts/out/missing_key_fields.csv"
+];
+
+function fileExists(p) {
+  try {
+    return fs.statSync(p).isFile();
+  } catch {
+    return false;
+  }
+}
+
+const changed = process.argv.slice(2); // git diff --name-only passed from workflow
+const interesting = changed.filter((p) => FILES.some((f) => p.endsWith(f)));
+
+let body = `## Nightly data refresh
+
+This PR was created automatically by the nightly workflow.
+
+### What’s included
+- Converted CSV → normalized JSON
+- Autofilled missing key fields (effects / description / legalstatus) as needed
+- Validated schema & audited coverage
+- Coverage artifacts attached
+
+`;
+
+const coverageMd = fileExists("scripts/out/coverage.md")
+  ? fs.readFileSync("scripts/out/coverage.md", "utf-8")
+  : "";
+
+if (coverageMd) {
+  body += `### Coverage summary\n\n` + coverageMd.slice(0, 5000) + "\n\n";
+}
+
+if (fileExists("scripts/out/missing_key_fields.csv")) {
+  const csv = fs.readFileSync("scripts/out/missing_key_fields.csv", "utf-8");
+  const lines = csv.split(/\r?\n/).slice(0, 10).join("\n");
+  body +=
+    `### First rows with missing key fields (preview)\n\n` +
+    "```\n" +
+    lines +
+    "\n```\n\n";
+}
+
+const outputFile = process.env.GITHUB_OUTPUT;
+if (outputFile) {
+  const output = [
+    "pr_body<<EOF",
+    body,
+    "EOF",
+    `changed_count=${interesting.length}`
+  ].join("\n");
+  fs.appendFileSync(outputFile, output + "\n");
+} else {
+  console.log(body);
+  console.log(JSON.stringify({ changed_count: interesting.length }));
+}


### PR DESCRIPTION
## Summary
- add a nightly workflow that runs the full data pipeline, gathers artifacts, and opens/updates a PR when changes occur
- add a helper script to prepare the nightly PR body with coverage results and missing field previews

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e52f39aed88323bb47bc0d0110e116