### PR TITLE
Refresh UI with modern dark theme components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-import { Routes, Route } from 'react-router-dom';
+import { Routes, Route, Outlet } from 'react-router-dom';
 import Home from './pages/Home';
 import About from './pages/About';
 import Database from './pages/Database';
 import Favorites from './pages/Favorites';
 import BuildBlend from './pages/BuildBlend';
 import NotFound from './pages/NotFound';
-import Navbar from './components/Navbar';
 import { RedirectHandler } from './RedirectHandler';
 import { useGA } from './lib/useGA';
 import HerbIndex from './pages/HerbIndex';
@@ -14,6 +13,8 @@ import HerbDetail from './pages/HerbDetail';
 import Compare from './pages/Compare';
 import DataReport from './pages/DataReport';
 import DataFix from './pages/DataFix';
+import SiteHeader from './components/SiteHeader';
+import Footer from './components/Footer';
 // Import other pages as needed
 
 export default function App() {
@@ -21,21 +22,34 @@ export default function App() {
   return (
     <>
       <RedirectHandler />
-      <Navbar />
       <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/about" element={<About />} />
-        <Route path="/database" element={<Database />} />
-        <Route path="/blend" element={<BuildBlend />} />
-        <Route path="/favorites" element={<Favorites />} />
-        {/* Add other routes here */}
-        <Route path="/herb-index" element={<HerbIndex />} />
-        <Route path="/herb/:slug" element={<HerbDetail />} />
-        <Route path="/compare" element={<Compare />} />
-        <Route path="/data-report" element={<DataReport />} />
-        <Route path="/data-fix" element={<DataFix />} />
+        <Route element={<RootLayout />}>
+          <Route path="/" element={<Home />} />
+          <Route path="/about" element={<About />} />
+          <Route path="/database" element={<Database />} />
+          <Route path="/blend" element={<BuildBlend />} />
+          <Route path="/favorites" element={<Favorites />} />
+          {/* Add other routes here */}
+          <Route path="/herb-index" element={<HerbIndex />} />
+          <Route path="/herb/:slug" element={<HerbDetail />} />
+          <Route path="/compare" element={<Compare />} />
+          <Route path="/data-report" element={<DataReport />} />
+          <Route path="/data-fix" element={<DataFix />} />
+        </Route>
         <Route path="*" element={<NotFound />} />
       </Routes>
     </>
+  );
+}
+
+function RootLayout() {
+  return (
+    <div className="min-h-screen bg-bg text-text">
+      <SiteHeader />
+      <div className="pb-16">
+        <Outlet />
+      </div>
+      <Footer />
+    </div>
   );
 }

--- a/src/components/HerbCard.tsx
+++ b/src/components/HerbCard.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import Card from './ui/Card';
+import Badge from './ui/Badge';
+import { cleanLine, hasVal, titleCase } from '../lib/pretty';
+
+interface HerbCardProps {
+  herb: Record<string, any>;
+  index?: number;
+}
+
+export default function HerbCard({ herb, index = 0 }: HerbCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const intensity = String(herb.intensity || '').toLowerCase();
+  const intensityClass = intensity.includes('strong')
+    ? 'bg-red-500/20 border-red-500/20 text-red-200'
+    : intensity.includes('moderate')
+    ? 'bg-yellow-500/20 border-yellow-500/20 text-yellow-100'
+    : intensity.includes('mild')
+    ? 'bg-green-500/20 border-green-500/20 text-green-200'
+    : 'bg-white/10 border-white/10 text-white/80';
+
+  const compounds = Array.isArray(herb.compounds) ? herb.compounds.slice(0, 6) : [];
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 16, scale: 0.98 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      transition={{ duration: 0.3, delay: index * 0.02 }}
+      whileHover={{ translateY: -4 }}
+      className="h-full"
+    >
+      <Card className="flex h-full flex-col gap-4 p-4 md:p-5 transition duration-200 hover:shadow-glow">
+        <header className="space-y-1">
+          <h3 className="text-xl font-semibold text-brand-lime/90">
+            {herb.common || herb.scientific || herb.name}
+          </h3>
+          {hasVal(herb.scientific) && <p className="italic text-sub">{herb.scientific}</p>}
+          {hasVal(intensity) && (
+            <span className={`inline-block rounded-full px-2 py-1 text-xs font-semibold ${intensityClass}`}>
+              INTENSITY: {titleCase(intensity)}
+            </span>
+          )}
+        </header>
+
+        <section className="space-y-3 text-sm leading-relaxed text-sub">
+          {hasVal(herb.description) && (
+            <p>
+              <span className="font-semibold text-text">Description:</span>{' '}
+              <span className={expanded ? '' : 'clamp-3'}>{cleanLine(herb.description)}</span>
+            </p>
+          )}
+          {hasVal(herb.effects) && (
+            <p>
+              <span className="font-semibold text-text">Effects:</span>{' '}
+              <span className={expanded ? '' : 'clamp-3'}>{cleanLine(herb.effects)}</span>
+            </p>
+          )}
+          {hasVal(herb.legalstatus) && (
+            <p className="clamp-2">
+              <span className="font-semibold text-text">Legal:</span>{' '}
+              <span>{cleanLine(herb.legalstatus)}</span>
+            </p>
+          )}
+          {compounds.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {compounds.map((compound: string, id: number) => (
+                <Badge key={id}>{compound}</Badge>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <footer className="mt-auto flex items-center justify-between text-sm">
+          {(hasVal(herb.effects) || hasVal(herb.description)) && (
+            <button
+              type="button"
+              className="text-sub underline decoration-dotted underline-offset-4 transition hover:text-text"
+              onClick={() => setExpanded(value => !value)}
+            >
+              {expanded ? 'Show less' : 'Show more'}
+            </button>
+          )}
+          <Link
+            to={`/herb/${herb.slug ?? ''}`}
+            className="text-sub underline underline-offset-4 transition hover:text-text"
+          >
+            View details
+          </Link>
+        </footer>
+      </Card>
+    </motion.div>
+  );
+}

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,0 +1,37 @@
+import { Link, NavLink } from 'react-router-dom';
+
+const links = [
+  { to: '/database', label: 'Database' },
+  { to: '/blend', label: 'Build a Blend' },
+  { to: '/about', label: 'About' },
+];
+
+export default function SiteHeader() {
+  return (
+    <header className="sticky top-0 z-20 backdrop-blur">
+      <div className="container">
+        <div className="flex flex-wrap items-center justify-between gap-4 py-4">
+          <Link to="/" className="h1-grad text-2xl font-bold tracking-tight">
+            The Hippie Scientist
+          </Link>
+          <nav className="flex flex-wrap items-center gap-3 text-sm text-sub">
+            {links.map(link => (
+              <NavLink
+                key={link.to}
+                to={link.to}
+                className={({ isActive }) =>
+                  `rounded-full px-3 py-1 transition ${
+                    isActive ? 'bg-white/10 text-text' : 'hover:bg-white/10 hover:text-text'
+                  }`
+                }
+              >
+                {link.label}
+              </NavLink>
+            ))}
+          </nav>
+        </div>
+        <div className="hr" />
+      </div>
+    </header>
+  );
+}

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from 'react';
+
+export default function Badge({ children, className = '' }: { children: ReactNode; className?: string }) {
+  return <span className={`badge ${className}`}>{children}</span>;
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,21 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+
+const variantClasses: Record<'default' | 'primary' | 'ghost', string> = {
+  default: 'btn',
+  primary: 'btn btn-primary',
+  ghost: 'btn bg-transparent border-transparent hover:bg-white/5',
+};
+
+type ButtonProps = {
+  children: ReactNode;
+  variant?: 'default' | 'primary' | 'ghost';
+  className?: string;
+} & ButtonHTMLAttributes<HTMLButtonElement>;
+
+export function Button({ children, variant = 'default', className = '', ...props }: ButtonProps) {
+  return (
+    <button className={`${variantClasses[variant]} ${className}`.trim()} {...props}>
+      {children}
+    </button>
+  );
+}

--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from 'react';
+
+export default function Card({ children, className = '' }: { children: ReactNode; className?: string }) {
+  return <div className={`blur-panel shadow-soft ${className}`}>{children}</div>;
+}

--- a/src/components/ui/Toolbar.tsx
+++ b/src/components/ui/Toolbar.tsx
@@ -1,0 +1,5 @@
+import type { ReactNode } from 'react';
+
+export default function Toolbar({ children }: { children: ReactNode }) {
+  return <div className="blur-panel flex flex-wrap items-center gap-3 p-3 md:p-4">{children}</div>;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,314 +1,143 @@
-@import url('https://fonts.googleapis.com/css2?family=Comfortaa:wght@400;700&family=Inter:wght@400;700&family=Orbitron:wght@400;700&family=Pacifico&family=Righteous&family=Syne:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 @import './styles/tags.css';
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --bg: #0c0f12;
+  --panel: rgba(255, 255, 255, 0.04);
+  --border: rgba(255, 255, 255, 0.08);
+  --text: #e6eaf0;
+  --sub: rgba(230, 234, 240, 0.75);
+}
+
+html,
+body,
+#root {
+  height: 100%;
+}
+
 body {
-  @apply m-0 font-sans text-lg leading-relaxed tracking-tight bg-[#0f0f0f] text-sand;
-  transition:
-    background-color 0.5s ease,
-    color 0.5s ease;
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, 'Apple Color Emoji', 'Segoe UI Emoji';
+  color: var(--text);
+  background:
+    radial-gradient(120% 80% at 80% 0%, rgba(82, 225, 255, 0.07), transparent 60%),
+    radial-gradient(80% 60% at 10% 100%, rgba(199, 255, 87, 0.06), transparent 60%),
+    var(--bg);
+  line-height: 1.65;
+  letter-spacing: -0.01em;
 }
 
-body.light {
-  @apply bg-[#0f0f0f] text-sand;
+.container {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 1rem;
 }
 
-body.dark {
-  @apply bg-[#0f0f0f] text-sand;
-}
-
-html {
-  scroll-behavior: smooth;
-  transition:
-    background-color 0.5s ease,
-    color 0.5s ease;
+.hr {
+  height: 1px;
+  background: var(--border);
 }
 
 a {
-  @apply text-emerald-400 underline-offset-4 transition-colors hover:text-emerald-300;
+  color: #98e2ff;
+  text-decoration: none;
+  transition: color 0.2s ease;
 }
 
-/* Custom utility classes */
-@layer utilities {
-  .text-gradient {
-    @apply bg-gradient-to-r from-sky-400 via-fuchsia-500 to-purple-600 bg-clip-text text-transparent;
-  }
+a:hover {
+  text-decoration: underline;
+}
+
+.blur-panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  backdrop-filter: blur(10px);
+  border-radius: 16px;
+}
+
+.h1-grad {
+  background: linear-gradient(90deg, #c7ff57, #52e1ff);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.btn {
+  @apply inline-flex items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm font-medium text-[var(--text)] transition duration-200;
+}
+
+.btn:hover {
+  @apply border-white/20 bg-white/10;
+}
+
+.btn-primary {
+  @apply border-brand-lime/40 bg-brand-lime/20 text-brand-lime;
+}
+
+.btn-primary:hover {
+  @apply bg-brand-lime/25;
+}
+
+.badge {
+  @apply inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/10 px-2 py-1 text-xs font-medium text-sub;
+}
+
+.clamp-2 {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.clamp-3 {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.text-gradient {
+  @apply bg-gradient-to-r from-brand-lime via-brand-cyan to-brand-pink bg-clip-text text-transparent;
+}
 
 .glass-card {
-  @apply border border-black/10 bg-gradient-to-br from-white/40 via-white/60 to-white/80 text-black shadow-lg backdrop-blur-xl transition-shadow duration-300 hover:ring-2 hover:ring-fuchsia-500/50 dark:border-white/10 dark:from-white/10 dark:via-space-dark/50 dark:to-space-dark/80 dark:text-sand;
+  @apply border border-white/10 bg-white/10 shadow-soft backdrop-blur;
 }
 
 .glassmorphic-card {
-  @apply bg-black/40 backdrop-blur-md border border-neutral-700 text-shadow text-sand/90 dark:text-sand;
+  @apply border border-white/5 bg-white/5 shadow-soft backdrop-blur;
 }
 
-/* Prose overrides */
-.prose table {
-  @apply w-full table-auto border-collapse;
-}
-.prose thead {
-  @apply bg-comet/20;
-}
-.prose tbody tr:nth-child(even) {
-  @apply bg-black/10 dark:bg-white/10;
-}
-.prose th,
-.prose td {
-  @apply border border-comet/30 px-2 py-1;
-}
-
-.table-card {
-  @apply overflow-x-auto rounded-lg border border-comet/30 bg-white/60 shadow-glow backdrop-blur-md dark:bg-midnight-blue/50;
-}
-
-.ring-comet {
-  @apply ring-1 ring-comet/50;
-}
-
-.bg-psychedelic-gradient {
-  background-image: linear-gradient(135deg, #8b5cf6, #db2777);
-}
-
-.bg-cosmic-gradient {
-  background-image: radial-gradient(circle at 50% 50%, #312e81, #0c1126);
-}
-.bg-cosmic-forest {
-  background-image: linear-gradient(135deg, #0c1126, #1b4d3e, #312e81);
-}
-.bg-sunset-gradient {
-  background-image: linear-gradient(135deg, #ff7e5f, #feb47b);
-}
-/* Animations and extra utilities */
 .tag-pill {
-  @apply text-shadow inline-flex items-center gap-1 rounded-full border border-gray-200 bg-black/10 px-2 py-0.5 text-xs shadow ring-1 ring-white/20 backdrop-blur-sm transition-colors duration-300 hover:bg-black/20 dark:border-gray-800 dark:bg-white/10 dark:ring-black/30 dark:hover:bg-white/20;
-}
-
-@keyframes gradient-shift {
-  0%,
-  100% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
-  }
-}
-.animate-gradient {
-  background-size: 200% 200%;
-  animation: gradient-shift 15s ease infinite;
-}
-
-@keyframes ripple {
-  0%,
-  100% {
-    transform: scale(0.95);
-    opacity: 0.8;
-  }
-  50% {
-    transform: scale(1.05);
-    opacity: 1;
-  }
-}
-.animate-ripple {
-  animation: ripple 8s ease-in-out infinite;
-}
-
-@keyframes sparkle {
-  0%,
-  100% {
-    transform: scale(0.8);
-    opacity: 0.6;
-  }
-  50% {
-    transform: scale(1.2);
-    opacity: 1;
-  }
-}
-.animate-sparkle {
-  animation: sparkle 1s ease-in-out infinite;
-}
-
-.bg-rainbow-gradient {
-  background-image: linear-gradient(90deg, #f00, #ff0, #0f0, #0ff, #00f, #f0f);
-}
-
-.hover-glow {
-  @apply transition-shadow hover:shadow-intense hover:ring-2 hover:ring-psychedelic-pink/60;
-}
-
-.soft-border-glow {
-  position: relative;
-}
-.soft-border-glow::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  pointer-events: none;
-  opacity: 0;
-  box-shadow:
-    0 0 8px rgba(236, 72, 153, 0.4),
-    0 0 16px rgba(236, 72, 153, 0.3);
-  transition: opacity 0.3s ease;
-}
-.soft-border-glow:hover::after,
-.soft-border-glow:focus-visible::after {
-  opacity: 1;
-}
-
-.herb-card-surface {
-  position: relative;
-  overflow: hidden;
-  background: transparent;
-}
-
-.herb-card-surface::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background:
-    radial-gradient(140% 140% at 0% 0%, rgba(56, 189, 248, 0.18), transparent 60%),
-    radial-gradient(120% 120% at 100% 0%, rgba(192, 132, 252, 0.16), transparent 60%),
-    linear-gradient(135deg, rgba(15, 118, 110, 0.45), rgba(2, 6, 23, 0.85));
-  pointer-events: none;
-  opacity: 0.9;
-  transition: transform 0.6s ease, opacity 0.6s ease;
-}
-
-.herb-card-surface:hover::before,
-.herb-card-surface:focus-within::before {
-  transform: scale(1.03);
-  opacity: 1;
+  @apply inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/10 px-2 py-0.5 text-xs text-sub;
 }
 
 .no-scrollbar {
   scrollbar-width: none;
   -ms-overflow-style: none;
 }
+
 .no-scrollbar::-webkit-scrollbar {
   display: none;
 }
 
-  .card-contrast {
-    @apply shadow-inner shadow-white/10;
-  }
-
-  /* Improve text legibility */
-  .text-shadow {
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
-  }
-
-  .drop-shadow-glow {
-    filter: drop-shadow(0 0 10px rgba(255, 255, 255, 0.4));
-  }
+.prose table {
+  @apply w-full table-auto border-collapse text-left text-sm;
 }
 
-/* Hero layout utilities */
-.hero-section {
-  @apply relative flex min-h-hero flex-col items-center justify-between overflow-hidden px-4 text-center;
+.prose thead {
+  @apply bg-white/5 text-sub;
 }
 
-.pb-safe {
-  padding-bottom: env(safe-area-inset-bottom);
+.prose tbody tr:nth-child(even) {
+  @apply bg-white/5;
 }
 
-/* Learn page typography */
-.learn-section {
-  @apply my-8 rounded-xl border border-comet/20 bg-white/70 p-6 shadow-glow backdrop-blur-md dark:border-comet/40 dark:bg-midnight-blue/60;
-}
-
-.learn-title {
-  @apply mb-6 flex items-center gap-3 text-left text-3xl font-bold tracking-tight text-gradient drop-shadow-glow md:text-4xl;
-}
-
-.learn-prose h3,
-.learn-prose h4 {
-  @apply flex items-center gap-2;
-}
-
-.learn-prose h3 {
-  @apply text-2xl font-semibold md:text-3xl;
-}
-
-.learn-prose h4 {
-  @apply text-xl font-medium md:text-2xl;
-}
-
-.learn-prose p {
-  @apply leading-relaxed text-justify text-sand/90 md:text-lg;
-}
-
-.learn-prose ul,
-.learn-prose ol {
-  @apply my-4 list-disc space-y-1 pl-6 md:pl-8;
-}
-
-.learn-prose li {
-  @apply leading-relaxed;
-}
-
-.highlight {
-  @apply font-semibold text-psychedelic-pink drop-shadow-glow;
-}
-
-/* Accordion styling for Learn page */
-.learn-accordion summary {
-  @apply flex cursor-pointer items-center justify-between rounded-md bg-white/40 px-4 py-3 font-semibold shadow transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-psychedelic-purple dark:bg-midnight-blue/40 dark:text-sand dark:shadow-md soft-border-glow;
-}
-.learn-accordion[open] summary {
-  @apply text-psychedelic-purple bg-white/60 dark:bg-midnight-blue/60 soft-border-glow;
-}
-.accordion-summary::after {
-  content: '▾';
-  @apply ml-2 text-psychedelic-pink drop-shadow-glow transition-transform duration-300 ease-in-out;
-}
-.learn-accordion[open] .accordion-summary::after {
-  transform: rotate(-180deg);
-}
-
-.accordion-content {
-  @apply overflow-hidden transition-all duration-500;
-}
-/* Psychedelic background and scrollbars */
-.psychedelic-bg {
-  @apply bg-gradient-to-br from-deep-indigo via-space-dark to-black bg-fixed;
-}
-
-body {
-  scrollbar-color: theme('colors.psychedelic-purple') transparent;
-}
-
-::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
-::-webkit-scrollbar-thumb {
-  background: linear-gradient(135deg, theme('colors.psychedelic-pink'), theme('colors.psychedelic-purple'));
-  border-radius: 4px;
-}
-::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-/* Neon glass card */
-.neon-card {
-  @apply glass-card ring-1 ring-psychedelic-purple/30 hover:ring-psychedelic-pink/60 backdrop-blur-lg;
-}
-
-/* Bounce animation */
-@keyframes float-bounce {
-  0%, 100% { transform: translateY(0); }
-  50% { transform: translateY(-8px); }
-}
-.bounce {
-  animation: float-bounce 3s ease-in-out infinite;
-}
-
-/* Fog overlay */
-.fog-layer {
-  background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.15) 0%, rgba(255, 255, 255, 0) 70%);
-  backdrop-filter: blur(50px);
-  mix-blend-mode: overlay;
+.prose th,
+.prose td {
+  @apply border border-white/10 px-3 py-2;
 }

--- a/src/pages/BuildBlend.tsx
+++ b/src/pages/BuildBlend.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useMemo, useState } from "react";
 import data from "../data/herbs/herbs.normalized.json";
+import Card from "../components/ui/Card";
+import Badge from "../components/ui/Badge";
+import { Button } from "../components/ui/Button";
 
 type Herb = {
   id?: string;
@@ -415,70 +418,62 @@ export default function BuildBlend() {
   };
 
   return (
-    <main className="mx-auto max-w-6xl space-y-6 px-4 py-6 md:space-y-8 md:px-6">
-      <header className="space-y-2">
-        <p className="inline-flex items-center gap-2 rounded-full bg-lime-500/15 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-lime-200">
-          Experimental Mixer
-        </p>
-        <h1 className="bg-gradient-to-r from-lime-300 via-emerald-200 to-cyan-300 bg-clip-text text-3xl font-bold text-transparent md:text-4xl">
-          Build a Blend
-        </h1>
-        <p className="max-w-2xl text-sm text-white/70 md:text-base">
+    <main className="container space-y-6 py-8">
+      <header className="space-y-3">
+        <p className="text-xs uppercase tracking-[0.3em] text-sub">Experimental Mixer</p>
+        <h1 className="h1-grad text-3xl font-semibold md:text-4xl">Build a Blend</h1>
+        <p className="max-w-2xl text-sub">
           Curate herbs, adjust their ratios in percentages or grams, and watch potency and mood predictions update instantly.
         </p>
       </header>
 
       <section className="grid gap-6 lg:grid-cols-[2fr_1fr] lg:items-start">
         <div className="space-y-6">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div className="flex flex-wrap gap-2">
-              {Object.keys(PRESETS).map((preset) => (
-                <button
-                  key={preset}
-                  onClick={() => applyPreset(preset)}
-                  className={`rounded-full border border-white/10 px-3 py-1 text-xs font-medium transition ${
-                    activePreset === preset ? "bg-lime-500/30 text-lime-50" : "bg-white/5 hover:bg-white/10"
-                  }`}
-                >
-                  {preset}
-                </button>
-              ))}
-              {!!blend.length && (
-                <button
-                  onClick={resetBlend}
-                  className="rounded-full border border-white/10 px-3 py-1 text-xs font-medium text-white/70 hover:bg-white/10"
-                >
-                  Clear
-                </button>
-              )}
+          <Card className="flex flex-col gap-4 p-5">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div className="flex flex-wrap gap-2">
+                {Object.keys(PRESETS).map((preset) => (
+                  <Button
+                    key={preset}
+                    onClick={() => applyPreset(preset)}
+                    variant={activePreset === preset ? "primary" : "default"}
+                    className={`px-3 py-1 text-xs ${activePreset === preset ? "text-brand-lime" : "text-sub"}`}
+                  >
+                    {preset}
+                  </Button>
+                ))}
+                {!!blend.length && (
+                  <Button onClick={resetBlend} variant="ghost" className="px-3 py-1 text-xs text-sub hover:text-text">
+                    Clear blend
+                  </Button>
+                )}
+              </div>
+              <div className="flex items-center gap-2 rounded-full border border-border bg-panel p-1 text-xs font-medium text-sub">
+                {(Object.keys(RATIO_SETTINGS) as RatioMode[]).map((mode) => (
+                  <button
+                    key={mode}
+                    onClick={() => setRatioMode(mode)}
+                    className={`rounded-full px-3 py-1 transition ${
+                      ratioMode === mode ? "bg-brand-lime/25 text-text" : "hover:bg-white/10"
+                    }`}
+                  >
+                    {mode === "percent" ? "% ratios" : "Grams"}
+                  </button>
+                ))}
+              </div>
             </div>
-            <div className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 p-1 text-xs font-medium">
-              {(Object.keys(RATIO_SETTINGS) as RatioMode[]).map((mode) => (
-                <button
-                  key={mode}
-                  onClick={() => setRatioMode(mode)}
-                  className={`rounded-full px-3 py-1 transition ${
-                    ratioMode === mode ? "bg-lime-500/40 text-slate-950" : "text-white/70"
-                  }`}
-                >
-                  {mode === "percent" ? "% ratios" : "Grams"}
-                </button>
-              ))}
-            </div>
-          </div>
 
-          <div className="space-y-4">
             <div className="relative">
               <input
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
                 placeholder="Search herbs by name, effects, or vibe"
-                className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-lime-400 focus:outline-none focus:ring-2 focus:ring-lime-400/40"
+                className="w-full rounded-xl border border-border bg-panel px-4 py-3 text-sm text-text placeholder:text-sub/70 focus:border-brand-lime/60 focus:outline-none focus:ring-2 focus:ring-brand-lime/20"
               />
               {query && (
                 <button
                   onClick={() => setQuery("")}
-                  className="absolute inset-y-0 right-3 flex items-center text-xs text-white/60 hover:text-white"
+                  className="absolute inset-y-0 right-3 flex items-center text-xs text-sub transition hover:text-text"
                 >
                   Clear
                 </button>
@@ -491,45 +486,50 @@ export default function BuildBlend() {
                   <button
                     key={getHerbKey(herb)}
                     onClick={() => addHerbToBlend(herb)}
-                    className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-white/80 transition hover:border-lime-300 hover:bg-lime-400/30 hover:text-white"
+                    className="badge hover:border-brand-lime/40 hover:bg-brand-lime/10 hover:text-text"
                   >
                     {getHerbName(herb)}
                   </button>
                 ))}
               </div>
             )}
-          </div>
+          </Card>
 
           <section className="space-y-4">
             {!blend.length && (
-              <div className="rounded-2xl border border-dashed border-white/10 bg-white/5 p-6 text-center text-sm text-white/60">
+              <Card className="border-dashed p-6 text-center text-sm text-sub">
                 Use search or presets to start building your signature blend.
-              </div>
+              </Card>
             )}
             {blend.map((herb) => {
               const settings = RATIO_SETTINGS[ratioMode];
               const value = Number(herb.ratios[ratioMode].toFixed(ratioMode === "percent" ? 0 : 2));
               return (
-                <div
-                  key={herb.key}
-                  className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow-lg shadow-black/10 backdrop-blur"
-                >
+                <Card key={herb.key} className="space-y-4 p-5">
                   <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                    <div className="space-y-1">
-                      <div className="text-sm font-semibold text-white">
-                        {herb.displayName}
-                      </div>
-                      {herb.intensity && <p className="text-xs text-white/50">{herb.intensity}</p>}
-                      {herb.effects && <p className="text-xs text-white/60">{herb.effects}</p>}
+                    <div className="space-y-2">
+                      <p className="text-xs uppercase tracking-wide text-sub">Herb</p>
+                      <h2 className="text-lg font-semibold text-text">{herb.displayName}</h2>
+                      {herb.intensity && <Badge className="text-xs">{herb.intensity}</Badge>}
+                      {herb.effects && (
+                        <p className="text-xs text-sub">
+                          {herb.effects.substring(0, 160)}
+                          {herb.effects.length > 160 ? "…" : ""}
+                        </p>
+                      )}
                     </div>
-                    <button
-                      onClick={() => removeHerb(herb.key)}
-                      className="self-start rounded-full border border-white/10 px-2 py-1 text-xs text-white/60 transition hover:border-red-400 hover:text-red-300"
-                    >
-                      Remove
-                    </button>
+                    <div className="flex items-center gap-2">
+                      <Badge className="text-xs">{settings.label}</Badge>
+                      <Button
+                        variant="ghost"
+                        onClick={() => removeHerb(herb.key)}
+                        className="px-3 py-1 text-xs text-sub hover:text-text"
+                      >
+                        Remove
+                      </Button>
+                    </div>
                   </div>
-                  <div className="mt-4 space-y-3">
+                  <div className="space-y-3">
                     <input
                       type="range"
                       min={settings.min}
@@ -537,45 +537,45 @@ export default function BuildBlend() {
                       step={settings.step}
                       value={value}
                       onChange={(event) => updateRatio(herb.key, Number(event.target.value))}
-                      className="w-full accent-lime-400"
+                      className="w-full accent-brand-lime"
                     />
-                    <div className="flex items-center justify-between text-xs text-white/70">
-                      <div>
+                    <div className="flex items-center justify-between text-xs text-sub">
+                      <span>
                         {settings.min}
                         {settings.label}
-                      </div>
+                      </span>
                       <div className="flex items-center gap-2">
                         <input
                           type="number"
                           value={value}
                           onChange={(event) => updateRatio(herb.key, Number(event.target.value))}
-                          className="w-16 rounded-lg border border-white/10 bg-white/10 px-2 py-1 text-right text-xs text-white focus:border-lime-300 focus:outline-none"
+                          className="w-16 rounded-lg border border-border bg-panel px-2 py-1 text-right text-xs text-text focus:border-brand-lime/60 focus:outline-none"
                         />
-                        <span className="font-medium text-white">{settings.label}</span>
+                        <span className="font-semibold text-text">{settings.label}</span>
                       </div>
-                      <div>
+                      <span>
                         {settings.max}
                         {settings.label}
-                      </div>
+                      </span>
                     </div>
                   </div>
-                </div>
+                </Card>
               );
             })}
           </section>
         </div>
 
         <aside className="space-y-6">
-          <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-white/10 via-white/5 to-transparent p-5 shadow-lg shadow-black/20">
-            <h2 className="text-sm font-semibold uppercase tracking-wide text-white/70">Blend telemetry</h2>
-            <div className="mt-4 space-y-3 text-sm text-white/80">
+          <Card className="space-y-4 p-5">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-sub">Blend telemetry</h2>
+            <div className="space-y-3 text-sm text-sub">
               <div className="flex items-center justify-between">
                 <span>Total herbs</span>
-                <span className="font-semibold text-white">{blend.length}</span>
+                <span className="font-semibold text-text">{blend.length}</span>
               </div>
               <div className="flex items-center justify-between">
                 <span>Total {ratioMode === "percent" ? "ratio" : "weight"}</span>
-                <span className="font-semibold text-white">
+                <span className="font-semibold text-text">
                   {ratioMode === "percent"
                     ? `${totalAmount.toFixed(0)}%`
                     : `${totalAmount.toFixed(1)} g`}
@@ -583,62 +583,64 @@ export default function BuildBlend() {
               </div>
               <div className="flex items-center justify-between">
                 <span>Potency score</span>
-                <span className="font-semibold text-white">{potencyScore.toFixed(1)}</span>
+                <span className="font-semibold text-text">{potencyScore.toFixed(1)}</span>
               </div>
             </div>
-            <div className="mt-5 rounded-xl bg-white/5 p-4 text-sm text-white/80">
-              <p className="text-xs uppercase tracking-wide text-white/50">Mood projection</p>
-              <p className="mt-1 text-base font-semibold text-white">{moodInsight.headline}</p>
-              <p className="mt-1 text-xs text-white/60">{moodInsight.breakdown}</p>
+            <div className="rounded-xl border border-border bg-panel p-4 text-sm text-sub">
+              <p className="text-xs uppercase tracking-wide text-sub/70">Mood projection</p>
+              <p className="mt-1 text-base font-semibold text-text">{moodInsight.headline}</p>
+              <p className="mt-1 text-xs text-sub">{moodInsight.breakdown}</p>
             </div>
-            <div className="mt-5 flex flex-wrap gap-3 text-sm">
-              <button
+            <div className="flex flex-wrap gap-3 text-sm">
+              <Button
                 onClick={copyFormula}
-                className="flex-1 rounded-full border border-white/10 bg-white/10 px-3 py-2 font-medium text-white transition hover:border-lime-400 hover:bg-lime-400/30 hover:text-white"
+                className="flex-1 justify-center"
                 disabled={!blend.length}
               >
                 {copyState === "copied" ? "Copied!" : "Copy formula"}
-              </button>
-              <button
+              </Button>
+              <Button
                 onClick={saveBlend}
-                className="flex-1 rounded-full border border-white/10 bg-lime-500/30 px-3 py-2 font-medium text-white transition hover:bg-lime-400/50"
+                variant="primary"
+                className="flex-1 justify-center"
                 disabled={!blend.length}
               >
                 Save to favorites
-              </button>
+              </Button>
             </div>
-          </div>
+          </Card>
 
           {!!favorites.length && (
-            <div className="space-y-3 rounded-2xl border border-white/10 bg-white/5 p-5 text-sm text-white/70">
-              <h2 className="text-sm font-semibold uppercase tracking-wide text-white/70">Favorites</h2>
+            <Card className="space-y-4 p-5 text-sm text-sub">
+              <h2 className="text-sm font-semibold uppercase tracking-wide text-sub">Favorites</h2>
               <ul className="space-y-3">
                 {favorites.map((fav) => (
-                  <li key={fav.id} className="rounded-xl border border-white/10 bg-white/5 p-3">
+                  <li key={fav.id} className="rounded-xl border border-border bg-panel p-3">
                     <div className="flex items-center justify-between gap-2">
                       <div>
-                        <p className="font-semibold text-white">{fav.name}</p>
-                        <p className="text-xs text-white/50">
+                        <p className="font-semibold text-text">{fav.name}</p>
+                        <p className="text-xs text-sub/70">
                           {new Date(fav.createdAt).toLocaleDateString(undefined, {
                             month: "short",
                             day: "numeric",
                           })}
                         </p>
                       </div>
-                      <button
+                      <Button
                         onClick={() => loadFavorite(fav)}
-                        className="rounded-full border border-white/10 px-3 py-1 text-xs font-medium text-white transition hover:border-lime-300 hover:bg-lime-400/30"
+                        variant="ghost"
+                        className="px-3 py-1 text-xs text-sub hover:text-text"
                       >
                         Load
-                      </button>
+                      </Button>
                     </div>
-                    <p className="mt-2 text-xs text-white/60">
+                    <p className="mt-2 text-xs text-sub">
                       {fav.items.length} herbs · {ratioMode === "percent" ? "%" : "g"} ready
                     </p>
                   </li>
                 ))}
               </ul>
-            </div>
+            </Card>
           )}
         </aside>
       </section>

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -2,10 +2,12 @@ import { useDeferredValue, useMemo, useState } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import Fuse from 'fuse.js'
 import SEO from '../components/SEO'
-import StarfieldBackground from '../components/StarfieldBackground'
-import DatabaseHerbCard from '../components/DatabaseHerbCard'
 import ErrorBoundary from '../components/ErrorBoundary'
-import Chip from '../components/ui/Chip'
+import HerbCard from '../components/HerbCard'
+import Toolbar from '../components/ui/Toolbar'
+import Card from '../components/ui/Card'
+import Badge from '../components/ui/Badge'
+import { Button } from '../components/ui/Button'
 import type { Herb } from '../types'
 import herbsData from '../data/herbs/herbs.normalized.json'
 
@@ -61,8 +63,6 @@ export default function Database() {
   })
   const [sortBy, setSortBy] = useState('relevance')
   const deferredQuery = useDeferredValue(query)
-
-  const topHerbs = useMemo(() => herbs.slice(0, 4), [herbs])
 
   const categoryOptions = useMemo(() => {
     const set = new Set(
@@ -231,111 +231,58 @@ export default function Database() {
 
   return (
     <ErrorBoundary>
-      <div className='relative min-h-screen bg-space-dark/90 px-4 pt-20 text-sand'>
-        <SEO
-          title='Herb Database | The Hippie Scientist'
-          description='Browse psychoactive herb profiles with scientific and cultural context.'
-          canonical='https://thehippiescientist.net/database'
-        />
-        <StarfieldBackground />
-        <div className='relative mx-auto max-w-6xl pb-12'>
-          <header className='mb-8 text-center'>
-            <h1 className='text-gradient mb-3 text-4xl font-bold md:text-5xl'>Herb Database</h1>
-            <p className='mx-auto max-w-3xl text-base text-sand/80 md:text-lg'>
-              Explore our collection of psychoactive herbs. Use the smart search and quick filter chips below to find herbs by
-              category, intensity, compound, or region.
-            </p>
-          </header>
+      <SEO
+        title='Herb Database | The Hippie Scientist'
+        description='Browse psychoactive herb profiles with scientific and cultural context.'
+        canonical='https://thehippiescientist.net/database'
+      />
+      <main className='container space-y-6 py-8'>
+        <header className='space-y-2'>
+          <p className='text-xs uppercase tracking-[0.3em] text-sub'>Explorer</p>
+          <h1 className='h1-grad text-3xl font-semibold md:text-4xl'>Herb Database</h1>
+          <p className='max-w-2xl text-sub'>Explore, filter, and compare psychoactive herbs with rich descriptions and context.</p>
+        </header>
 
-          {topHerbs.length > 0 && (
-            <div className='mb-8 overflow-x-auto pb-2'>
-              <div className='flex min-w-full gap-4'>
-                {topHerbs.map(herb => {
-                  const sci = (herb.scientific || herb.scientificname || '').trim()
-                  return (
-                    <div
-                      key={herb.id}
-                      className='min-w-[14rem] rounded-xl bg-black/40 p-4 text-left shadow-lg backdrop-blur-md transition hover:bg-black/50'
-                    >
-                      <p className='text-xs uppercase tracking-wide text-sand/60'>Featured</p>
-                      <h2 className='mt-1 text-xl font-semibold text-lime-300'>{herb.common || herb.name}</h2>
-                      {sci && <p className='text-sm italic text-sand/70'>{sci}</p>}
-                      {herb.category && (
-                        <p className='mt-2 text-sm text-sand/80'>Category: {formatLabel(herb.category)}</p>
-                      )}
-                    </div>
-                  )
-                })}
-              </div>
-            </div>
-          )}
-
-          <section className='mb-6 space-y-4 rounded-2xl bg-black/30 p-5 backdrop-blur-md'>
-            <div className='flex flex-col gap-3 md:flex-row md:items-center'>
+        <motion.div
+          initial='hidden'
+          animate='visible'
+          variants={{
+            hidden: { opacity: 0, y: 12 },
+            visible: {
+              opacity: 1,
+              y: 0,
+              transition: { staggerChildren: 0.05, delayChildren: 0.05 },
+            },
+          }}
+        >
+          <Toolbar>
+            <motion.div variants={{ hidden: { opacity: 0, y: 10 }, visible: { opacity: 1, y: 0 } }} className='flex min-w-[220px] flex-1 items-center gap-2'>
               <label className='sr-only' htmlFor='herb-search-input'>Search herbs</label>
               <input
                 id='herb-search-input'
                 value={query}
                 onChange={event => setQuery(event.target.value)}
                 placeholder='Search herbs, compounds, effects...'
-                className='w-full rounded-lg border border-white/10 bg-black/40 px-4 py-2 text-sm text-sand placeholder-white/50 focus:border-lime-400 focus:outline-none focus:ring-1 focus:ring-lime-400 md:flex-1'
+                className='w-full rounded-lg border border-border bg-panel px-3 py-2 text-sm text-text placeholder:text-sub/70 focus:border-brand-lime/60 focus:outline-none focus:ring-2 focus:ring-brand-lime/20'
               />
-              <button
-                type='button'
-                onClick={clearAllFilters}
-                disabled={!hasActiveFilters}
-                className='inline-flex items-center justify-center rounded-full border border-white/10 px-4 py-2 text-sm transition disabled:cursor-not-allowed disabled:opacity-50 md:w-auto'
-              >
-                Clear All Filters
-              </button>
-            </div>
+              {query && (
+                <button
+                  type='button'
+                  onClick={() => setQuery('')}
+                  className='text-xs text-sub transition hover:text-text'
+                >
+                  Clear
+                </button>
+              )}
+            </motion.div>
 
-            {activeFilterChips.length > 0 && (
-              <div className='flex flex-wrap gap-2 border-t border-white/5 pt-3'>
-                {activeFilterChips.map(text => (
-                  <Chip key={text}>{text}</Chip>
-                ))}
-              </div>
-            )}
-
-            <div className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
-              <FilterGroup
-                title='Category'
-                options={categoryOptions}
-                selected={filters.categories}
-                onToggle={value => toggleFilter('categories', value)}
-              />
-              <FilterGroup
-                title='Intensity'
-                options={intensityOptions}
-                selected={filters.intensities}
-                onToggle={value => toggleFilter('intensities', value)}
-              />
-              <FilterGroup
-                title='Region'
-                options={regionOptions}
-                selected={filters.regions}
-                onToggle={value => toggleFilter('regions', value)}
-              />
-              <FilterGroup
-                title='Compound'
-                options={compoundOptions}
-                selected={filters.compounds}
-                onToggle={value => toggleFilter('compounds', value)}
-              />
-            </div>
-
-            <div className='flex flex-wrap items-center justify-between gap-3 text-sm text-sand/70'>
-              <div className='opacity-75 text-sm'>
-                {sortedHerbs.length} results{' '}
-                <span className='text-xs text-sand/60'>({herbs.length} total)</span>
-              </div>
-              <label className='flex items-center gap-2 text-sm'>
-                <span className='opacity-75'>Sort</span>
+            <motion.div variants={{ hidden: { opacity: 0, y: 10 }, visible: { opacity: 1, y: 0 } }} className='flex items-center gap-3'>
+              <label className='flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-sub'>
+                Sort
                 <select
                   value={sortBy}
                   onChange={event => setSortBy(event.target.value)}
-                  className='bg-white/10 border border-white/10 rounded-md px-2 py-1 text-sm'
+                  className='rounded-md border border-border bg-panel px-2 py-1 text-sm text-text focus:border-brand-lime/60 focus:outline-none focus:ring-1 focus:ring-brand-lime/30'
                 >
                   {SORTS.map(sort => (
                     <option key={sort.id} value={sort.id}>
@@ -344,37 +291,87 @@ export default function Database() {
                   ))}
                 </select>
               </label>
-            </div>
-          </section>
+            </motion.div>
 
-          <motion.section
-            layout
-            className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'
-            transition={{ duration: 0.25, ease: 'easeInOut' }}
-          >
-            <AnimatePresence initial={false} mode='popLayout'>
-              {sortedHerbs.map(herb => (
-                <motion.div
-                  key={herb.id}
-                  layout
-                  initial={{ opacity: 0, y: 12 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: -12 }}
-                  transition={{ duration: 0.2, ease: 'easeOut' }}
-                >
-                  <DatabaseHerbCard herb={herb} />
-                </motion.div>
-              ))}
-            </AnimatePresence>
-          </motion.section>
+            <motion.div variants={{ hidden: { opacity: 0, y: 10 }, visible: { opacity: 1, y: 0 } }}>
+              <Button
+                type='button'
+                onClick={clearAllFilters}
+                disabled={!hasActiveFilters}
+                className='disabled:opacity-50'
+              >
+                Clear all
+              </Button>
+            </motion.div>
+          </Toolbar>
+        </motion.div>
 
-          {sortedHerbs.length === 0 && (
-            <div className='col-span-full mt-10 text-center text-sand/60'>
-              No herbs found. Try adjusting your filters.
-            </div>
-          )}
+        {activeFilterChips.length > 0 && (
+          <div className='flex flex-wrap gap-2'>
+            {activeFilterChips.map(text => (
+              <Badge key={text}>{text}</Badge>
+            ))}
+          </div>
+        )}
+
+        <section className='grid gap-4 md:grid-cols-2 lg:grid-cols-4'>
+          <FilterGroup
+            title='Category'
+            options={categoryOptions}
+            selected={filters.categories}
+            onToggle={value => toggleFilter('categories', value)}
+          />
+          <FilterGroup
+            title='Intensity'
+            options={intensityOptions}
+            selected={filters.intensities}
+            onToggle={value => toggleFilter('intensities', value)}
+          />
+          <FilterGroup
+            title='Region'
+            options={regionOptions}
+            selected={filters.regions}
+            onToggle={value => toggleFilter('regions', value)}
+          />
+          <FilterGroup
+            title='Compound'
+            options={compoundOptions}
+            selected={filters.compounds}
+            onToggle={value => toggleFilter('compounds', value)}
+          />
+        </section>
+
+        <div className='flex flex-wrap items-center justify-between gap-3 text-sm text-sub'>
+          <span>
+            {sortedHerbs.length} results <span className='text-xs text-sub/70'>({herbs.length} total)</span>
+          </span>
         </div>
-      </div>
+
+        <motion.section
+          layout
+          className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'
+          transition={{ duration: 0.25, ease: 'easeInOut' }}
+        >
+          <AnimatePresence initial={false} mode='popLayout'>
+            {sortedHerbs.map((herb, index) => (
+              <motion.div
+                key={herb.id}
+                layout
+                initial={{ opacity: 0, y: 16 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -12 }}
+                transition={{ duration: 0.25, ease: 'easeOut' }}
+              >
+                <HerbCard herb={herb} index={index} />
+              </motion.div>
+            ))}
+          </AnimatePresence>
+        </motion.section>
+
+        {sortedHerbs.length === 0 && (
+          <Card className='p-6 text-center text-sub'>No herbs found. Try adjusting your filters.</Card>
+        )}
+      </main>
     </ErrorBoundary>
   )
 }
@@ -388,8 +385,11 @@ type FilterGroupProps = {
 
 function FilterGroup({ title, options, selected, onToggle }: FilterGroupProps) {
   return (
-    <div className='rounded-xl border border-white/5 bg-black/20 p-3'>
-      <h3 className='mb-2 text-xs font-semibold uppercase tracking-wide text-sand/60'>{title}</h3>
+    <Card className='flex flex-col gap-3 p-4'>
+      <div className='flex items-center justify-between'>
+        <h3 className='text-xs font-semibold uppercase tracking-wide text-sub'>{title}</h3>
+        <span className='text-xs text-sub/70'>{selected.length}</span>
+      </div>
       <div className='flex max-h-32 flex-wrap gap-2 overflow-y-auto pr-1'>
         {options.map(option => {
           const isActive = selected.includes(option.value)
@@ -397,10 +397,10 @@ function FilterGroup({ title, options, selected, onToggle }: FilterGroupProps) {
             <button
               key={option.value}
               onClick={() => onToggle(option.value)}
-              className={`rounded-full px-3 py-1 text-xs transition focus:outline-none focus-visible:ring-2 focus-visible:ring-lime-400 ${
+              className={`rounded-full px-3 py-1 text-xs transition focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-lime/40 ${
                 isActive
-                  ? 'bg-lime-400/40 text-white shadow-inner'
-                  : 'bg-white/10 text-sand/80 hover:bg-white/20'
+                  ? 'border border-brand-lime/40 bg-brand-lime/20 text-text'
+                  : 'border border-white/10 bg-white/5 text-sub hover:border-white/20 hover:bg-white/10'
               }`}
               type='button'
             >
@@ -408,8 +408,8 @@ function FilterGroup({ title, options, selected, onToggle }: FilterGroupProps) {
             </button>
           )
         })}
-        {options.length === 0 && <p className='text-xs text-sand/60'>No options available.</p>}
+        {options.length === 0 && <p className='text-xs text-sub/70'>No options available.</p>}
       </div>
-    </div>
+    </Card>
   )
 }

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -1,7 +1,9 @@
 import { useParams, Link } from "react-router-dom";
 import data from "../data/herbs/herbs.normalized.json";
 import Collapse from "../components/ui/Collapse";
-import Chip from "../components/ui/Chip";
+import Card from "../components/ui/Card";
+import Badge from "../components/ui/Badge";
+import { Button } from "../components/ui/Button";
 
 const hasVal = (v: any) =>
   Array.isArray(v) ? v.filter(Boolean).length > 0 : !!String(v ?? "").trim();
@@ -17,7 +19,7 @@ export default function HerbDetail() {
   const { slug } = useParams<Param>();
   const herb = data.find((h: Herb) => h.slug === slug);
 
-  if (!herb) return <main className="p-6">Not found.</main>;
+  if (!herb) return <main className="container py-6">Not found.</main>;
 
   const intensity = String(herb.intensity || "").toLowerCase();
   const intensityClass = intensity.includes("strong")
@@ -32,167 +34,168 @@ export default function HerbDetail() {
     (arr || [])
       .filter(Boolean)
       .map((x, i) => (
-        <Chip key={i}>{x}</Chip>
+        <Badge key={i}>{x}</Badge>
       ));
 
   return (
-    <main className="max-w-3xl mx-auto p-4 md:p-6 space-y-4">
-      {/* Header */}
-      <header className="bg-black/30 border border-white/10 rounded-2xl p-4 md:p-5 relative">
-        <h1 className="text-2xl md:text-3xl font-bold text-lime-300">
-          {herb.common || herb.scientific}
-        </h1>
-        {hasVal(herb.scientific) && (
-          <p className="italic opacity-80">{herb.scientific}</p>
+    <main className="container py-6">
+      <div className="mx-auto flex max-w-3xl flex-col gap-4 md:gap-6">
+        <Card className="relative space-y-4 p-5 md:p-6">
+          <header className="space-y-2">
+            <p className="text-xs uppercase tracking-[0.3em] text-sub">Profile</p>
+            <h1 className="text-3xl font-semibold text-brand-lime/90 md:text-4xl">
+              {herb.common || herb.scientific}
+            </h1>
+            {hasVal(herb.scientific) && <p className="italic text-sub">{herb.scientific}</p>}
+            {hasVal(intensity) && (
+              <span className={`inline-block rounded-full px-2 py-1 text-xs font-semibold ${intensityClass}`}>
+                INTENSITY: {titleCase(intensity)}
+              </span>
+            )}
+          </header>
+
+          <div className="flex flex-wrap gap-2 text-sm text-sub">
+            <Button variant="ghost" data-fav={herb.slug} className="px-3 py-1 text-sub hover:text-text">
+              ★ Favorite
+            </Button>
+            <Button variant="ghost" data-compare={herb.slug} className="px-3 py-1 text-sub hover:text-text">
+              ⇄ Compare
+            </Button>
+            <Button
+              variant="ghost"
+              className="px-3 py-1 text-sub hover:text-text"
+              onClick={() =>
+                navigator.share?.({
+                  title: herb.common || herb.scientific,
+                  url: typeof window !== "undefined" ? window.location.href : undefined,
+                })
+              }
+            >
+              ↗ Share
+            </Button>
+          </div>
+        </Card>
+
+        {hasVal(herb.legalstatus) && (
+          <Card className="space-y-2 p-5">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-sub">Legal</h2>
+            <p className="text-sm text-text/90">{herb.legalstatus}</p>
+            {hasVal(herb.legalnotes) && <p className="text-xs text-sub/80">{herb.legalnotes}</p>}
+          </Card>
         )}
-        {hasVal(intensity) && (
-          <span
-            className={`mt-3 inline-block text-xs px-2 py-1 rounded-full ${intensityClass}`}
-          >
-            INTENSITY: {titleCase(intensity)}
-          </span>
+
+        {(hasVal(herb.region) || hasVal(herb.regiontags)) && (
+          <Card className="space-y-2 p-5">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-sub">Region</h2>
+            <p className="text-sm text-text/90">{herb.region ? herb.region : (herb.regiontags || []).join(", ")}</p>
+          </Card>
         )}
 
-        {/* Quick actions */}
-        <div className="mt-3 flex flex-wrap gap-3 sticky top-3 z-10 bg-black/40 backdrop-blur-sm px-3 py-2 rounded-xl md:static md:bg-transparent md:backdrop-blur-0 md:px-0 md:py-0 md:rounded-none">
-          <button data-fav={herb.slug} className="underline opacity-90">
-            ★ Favorite
-          </button>
-          <button data-compare={herb.slug} className="underline opacity-90">
-            ⇄ Compare
-          </button>
-          <button
-            onClick={() =>
-              navigator.share?.({
-                title: herb.common || herb.scientific,
-                url:
-                  typeof window !== "undefined" ? window.location.href : undefined,
-              })
-            }
-            className="underline opacity-90"
-          >
-            ↗ Share
-          </button>
-        </div>
-      </header>
+        {hasVal(herb.description) && (
+          <Card className="p-5">
+            <Collapse title="Description" defaultOpen>
+              <p className="leading-relaxed text-sub">{herb.description}</p>
+            </Collapse>
+          </Card>
+        )}
 
-      {/* Legal banner */}
-      {hasVal(herb.legalstatus) && (
-        <div className="rounded-xl border border-white/10 bg-white/5 p-3">
-          <div className="font-semibold mb-1">Legal</div>
-          <p className="opacity-90">{herb.legalstatus}</p>
-          {hasVal(herb.legalnotes) && (
-            <p className="mt-1 text-sm opacity-75">{herb.legalnotes}</p>
-          )}
-        </div>
-      )}
+        {hasVal(herb.effects) && (
+          <Card className="p-5">
+            <Collapse title="Effects" defaultOpen>
+              <p className="leading-relaxed text-sub">{herb.effects}</p>
+            </Collapse>
+          </Card>
+        )}
 
-      {/* Region */}
-      {(hasVal(herb.region) || hasVal(herb.regiontags)) && (
-        <div className="rounded-xl border border-white/10 bg-white/5 p-3">
-          <div className="font-semibold mb-1">Region</div>
-          <p className="opacity-90">
-            {herb.region ? herb.region : (herb.regiontags || []).join(", ")}
-          </p>
-        </div>
-      )}
+        {(hasVal(herb.compounds) || hasVal(herb.tags) || hasVal(herb.preparations)) && (
+          <Card className="space-y-4 p-5">
+            {hasVal(herb.compounds) && (
+              <div className="space-y-2">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-sub">Active Compounds</h3>
+                <div className="flex flex-wrap gap-1.5">{chips(herb.compounds)}</div>
+              </div>
+            )}
+            {hasVal(herb.preparations) && (
+              <div className="space-y-2">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-sub">Preparations</h3>
+                <div className="flex flex-wrap gap-1.5">{chips(herb.preparations)}</div>
+              </div>
+            )}
+            {hasVal(herb.tags) && (
+              <div className="space-y-2">
+                <h3 className="text-sm font-semibold uppercase tracking-wide text-sub">Tags</h3>
+                <div className="flex flex-wrap gap-1.5">{chips(herb.tags)}</div>
+              </div>
+            )}
+          </Card>
+        )}
 
-      {/* Description / Effects */}
-      {hasVal(herb.description) && (
-        <Collapse title="Description" defaultOpen>
-          <p className="leading-relaxed">{herb.description}</p>
-        </Collapse>
-      )}
-      {hasVal(herb.effects) && (
-        <Collapse title="Effects" defaultOpen>
-          <p className="leading-relaxed">{herb.effects}</p>
-        </Collapse>
-      )}
-
-      {/* Compounds / Tags / Preparations */}
-      {(hasVal(herb.compounds) || hasVal(herb.tags) || hasVal(herb.preparations)) && (
-        <section className="grid gap-3">
-          {hasVal(herb.compounds) && (
-            <div>
-              <div className="font-semibold mb-1">Active Compounds</div>
-              <div>{chips(herb.compounds)}</div>
-            </div>
-          )}
-          {hasVal(herb.preparations) && (
-            <div>
-              <div className="font-semibold mb-1">Preparations</div>
-              <div>{chips(herb.preparations)}</div>
-            </div>
-          )}
-          {hasVal(herb.tags) && (
-            <div>
-              <div className="font-semibold mb-1">Tags</div>
-              <div>{chips(herb.tags)}</div>
-            </div>
-          )}
-        </section>
-      )}
-
-      {/* Safety / Contraindications / Interactions */}
-      {(hasVal(herb.safety) ||
-        hasVal(herb.contraindications) ||
-        hasVal(herb.interactions)) && (
-        <Collapse title="Safety & Contraindications">
-          {hasVal(herb.safety) && <p className="mb-2">{herb.safety}</p>}
-          {hasVal(herb.contraindications) && (
-            <div className="mb-2">
-              <div className="font-semibold">Contraindications</div>
-              <ul className="list-disc list-inside opacity-90">
-                {(herb.contraindications || []).map((x: string, i: number) => (
-                  <li key={i}>{x}</li>
-                ))}
-              </ul>
-            </div>
-          )}
-          {hasVal(herb.interactions) && (
-            <div>
-              <div className="font-semibold">Interactions</div>
-              <ul className="list-disc list-inside opacity-90">
-                {(herb.interactions || []).map((x: string, i: number) => (
-                  <li key={i}>{x}</li>
-                ))}
-              </ul>
-            </div>
-          )}
-        </Collapse>
-      )}
-
-      {/* Mechanism / Pharmacology (optional) */}
-      {(hasVal(herb.mechanism) || hasVal(herb.pharmacology)) && (
-        <Collapse title="Mechanism & Pharmacology">
-          {hasVal(herb.mechanism) && <p className="mb-2">{herb.mechanism}</p>}
-          {hasVal(herb.pharmacology) && <p>{herb.pharmacology}</p>}
-        </Collapse>
-      )}
-
-      {/* Sources */}
-      {hasVal(herb.sources) && (
-        <Collapse title="Sources">
-          <ul className="list-disc list-inside">
-            {(herb.sources || []).map((s: string, i: number) => (
-              <li key={i}>
-                {/^(https?:\/\/)/i.test(s) ? (
-                  <a className="underline" href={s} target="_blank" rel="noreferrer">
-                    {s}
-                  </a>
-                ) : (
-                  s
+        {(hasVal(herb.safety) || hasVal(herb.contraindications) || hasVal(herb.interactions)) && (
+          <Card className="p-5">
+            <Collapse title="Safety & Contraindications">
+              <div className="space-y-4 text-sub">
+                {hasVal(herb.safety) && <p>{herb.safety}</p>}
+                {hasVal(herb.contraindications) && (
+                  <div>
+                    <h4 className="text-sm font-semibold text-text">Contraindications</h4>
+                    <ul className="mt-2 list-disc space-y-1 pl-5 text-sm">
+                      {(herb.contraindications || []).map((x: string, i: number) => (
+                        <li key={i}>{x}</li>
+                      ))}
+                    </ul>
+                  </div>
                 )}
-              </li>
-            ))}
-          </ul>
-        </Collapse>
-      )}
+                {hasVal(herb.interactions) && (
+                  <div>
+                    <h4 className="text-sm font-semibold text-text">Interactions</h4>
+                    <ul className="mt-2 list-disc space-y-1 pl-5 text-sm">
+                      {(herb.interactions || []).map((x: string, i: number) => (
+                        <li key={i}>{x}</li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            </Collapse>
+          </Card>
+        )}
 
-      <div className="opacity-70 text-sm">
-        <Link to="/database" className="underline">
-          ← Back to Database
-        </Link>
+        {(hasVal(herb.mechanism) || hasVal(herb.pharmacology)) && (
+          <Card className="p-5">
+            <Collapse title="Mechanism & Pharmacology">
+              <div className="space-y-3 text-sub">
+                {hasVal(herb.mechanism) && <p>{herb.mechanism}</p>}
+                {hasVal(herb.pharmacology) && <p>{herb.pharmacology}</p>}
+              </div>
+            </Collapse>
+          </Card>
+        )}
+
+        {hasVal(herb.sources) && (
+          <Card className="p-5">
+            <Collapse title="Sources">
+              <ul className="list-disc space-y-1 pl-5 text-sub">
+                {(herb.sources || []).map((s: string, i: number) => (
+                  <li key={i}>
+                    {/^(https?:\/\/)/i.test(s) ? (
+                      <a className="underline decoration-dotted underline-offset-4" href={s} target="_blank" rel="noreferrer">
+                        {s}
+                      </a>
+                    ) : (
+                      s
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </Collapse>
+          </Card>
+        )}
+
+        <div className="text-sm text-sub">
+          <Link to="/database" className="underline decoration-dotted underline-offset-4">
+            ← Back to Database
+          </Link>
+        </div>
       </div>
     </main>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,52 +1,35 @@
-/* eslint-env node */
-/** @type {import('tailwindcss').Config} */
-export default {
-  // Enable dark mode using the `class` strategy so ThemeToggle works
-  darkMode: 'class',
-  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./index.html', './src/**/*.{ts,tsx,js,jsx}'],
   theme: {
     extend: {
       colors: {
-        midnight: '#0b1120',
-        sand: '#f1e9d0',
-        gold: '#d7b56d',
-        opal: '#b2d0c9',
-        'midnight-blue': '#0c1126',
-        lichen: '#88C057',
-        comet: '#4FC1E9',
-        'forest-green': '#1B4D3E',
-        'deep-indigo': '#312e81',
-        spore: '#FAFAFA',
-        moss: '#A4D4AE',
-        fungal: '#F2785C',
-        bark: '#1A1D1B',
-        'psychedelic-purple': '#8b5cf6',
-        // darkened slightly for better contrast in light mode
-        'psychedelic-pink': '#db2777',
-        'space-dark': '#0f172a',
-        'space-night': '#0c0c1a',
-        'cosmic-purple': '#7e22ce',
-        'space-gray': '#1e293b',
-        'light-beige': '#faf9f5',
+        bg: '#0c0f12',
+        panel: 'rgba(255,255,255,0.04)',
+        border: 'rgba(255,255,255,0.08)',
+        text: '#e6eaf0',
+        sub: 'rgba(230,234,240,0.75)',
+        brand: {
+          lime: '#c7ff57',
+          cyan: '#52e1ff',
+          pink: '#ff7adf',
+        },
       },
       boxShadow: {
-        glow: '0 0 12px rgba(136, 192, 87, 0.5)',
-        intense: '0 0 24px rgba(79, 193, 233, 0.4)',
+        soft: '0 6px 24px rgba(0,0,0,0.25)',
+        glow: '0 0 0 1px rgba(199,255,87,0.18), 0 8px 32px rgba(199,255,87,0.08)',
       },
-      dropShadow: {
-        glow: '0 0 10px rgba(255, 255, 255, 0.4)',
+      borderRadius: {
+        xl2: '18px',
       },
       fontFamily: {
+        sans: ['Inter', 'system-ui', '-apple-system', 'Segoe UI', 'Roboto', 'sans-serif'],
         display: ['"Unbounded"', '"Major Mono Display"', 'cursive'],
-        sans: ['"Inter"', '"Manrope"', 'sans-serif'],
-        herb: ['"Comfortaa"', '"Orbitron"', 'cursive'],
-      },
-      minHeight: {
-        'screen-nav': 'calc(100dvh - 5rem)',
-        // hero height accounts for fixed navbar (4rem) and safe area on modern devices
-        hero: 'calc(100dvh - 4rem - env(safe-area-inset-bottom))',
       },
     },
   },
-  plugins: [require('@tailwindcss/typography')],
-}
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- refresh the Tailwind palette and global styles to establish a unified modern dark theme
- add reusable Card, Button, Badge, and Toolbar components plus a new gradient site header layout
- restyle the database, herb detail, and blend builder experiences with glass cards, typography tweaks, and subtle motion

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e64aa9e49c8323a10374e670ebac3b