### PR TITLE
Add brand tokens and update header branding

### DIFF
--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,6 @@
+<svg width="220" height="48" viewBox="0 0 220 48" xmlns="http://www.w3.org/2000/svg">
+  <defs><linearGradient id="g" x1="0" y1="0" x2="220" y2="0">
+    <stop offset="0%" stop-color="#c7ff57"/><stop offset="50%" stop-color="#52e1ff"/>
+    <stop offset="100%" stop-color="#ff7adf"/></linearGradient></defs>
+  <text x="0" y="32" font-family="Inter, system-ui" font-size="22" font-weight="800" fill="url(#g)">THE HIPPIE SCIENTIST</text>
+</svg>

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,4 +1,5 @@
 import { Link, NavLink } from 'react-router-dom';
+import logo from '/logo.svg';
 
 const links = [
   { to: '/database', label: 'Database' },
@@ -8,11 +9,12 @@ const links = [
 
 export default function SiteHeader() {
   return (
-    <header className="sticky top-0 z-20 backdrop-blur">
+    <div className="sticky top-0 z-30 bg-[color:var(--bg)]/80 backdrop-blur">
       <div className="container">
-        <div className="flex flex-wrap items-center justify-between gap-4 py-4">
-          <Link to="/" className="h1-grad text-2xl font-bold tracking-tight">
-            The Hippie Scientist
+        <div className="flex items-center justify-between py-3">
+          <Link to="/" className="flex items-center gap-3">
+            <img src={logo} alt="The Hippie Scientist" className="h-8 w-auto" />
+            <span className="h1-grad text-xl font-bold">The Hippie Scientist</span>
           </Link>
           <nav className="flex flex-wrap items-center gap-3 text-sm text-sub">
             {links.map(link => (
@@ -30,8 +32,7 @@ export default function SiteHeader() {
             ))}
           </nav>
         </div>
-        <div className="hr" />
       </div>
-    </header>
+    </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -141,3 +141,16 @@ a:hover {
 .prose td {
   @apply border border-white/10 px-3 py-2;
 }
+:root{
+  --bg:#0a0d10; --panel:rgba(255,255,255,0.04); --border:rgba(255,255,255,0.10);
+  --text:#e8ecf2; --sub:#aab3c0; --lime:#c7ff57; --cyan:#52e1ff; --magenta:#ff7adf;
+}
+body{ font-family:Inter, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
+  background:
+    radial-gradient(120% 80% at 80% 0%, rgba(82,225,255,0.07), transparent 60%),
+    radial-gradient(80% 60% at 10% 100%, rgba(199,255,87,0.06), transparent 60%),
+    var(--bg);
+  color:var(--text);
+}
+.blur-panel{ background:var(--panel); border:1px solid var(--border); backdrop-filter:blur(6px); border-radius:16px; }
+.h1-grad{ background:linear-gradient(90deg,var(--lime),var(--cyan),var(--magenta)); -webkit-background-clip:text; background-clip:text; color:transparent; }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,20 +5,29 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        bg: '#0c0f12',
+        bg: '#0a0d10',
         panel: 'rgba(255,255,255,0.04)',
-        border: 'rgba(255,255,255,0.08)',
-        text: '#e6eaf0',
-        sub: 'rgba(230,234,240,0.75)',
+        border: 'rgba(255,255,255,0.1)',
+        text: '#e8ecf2',
+        sub: '#aab3c0',
+        base: {
+          bg: '#0a0d10',
+          panel: 'rgba(255,255,255,0.04)',
+          border: 'rgba(255,255,255,0.1)',
+          text: '#e8ecf2',
+          sub: '#aab3c0',
+        },
         brand: {
           lime: '#c7ff57',
           cyan: '#52e1ff',
           pink: '#ff7adf',
+          magenta: '#ff7adf',
         },
       },
       boxShadow: {
         soft: '0 6px 24px rgba(0,0,0,0.25)',
         glow: '0 0 0 1px rgba(199,255,87,0.18), 0 8px 32px rgba(199,255,87,0.08)',
+        card: '0 8px 30px rgba(0,0,0,0.3)',
       },
       borderRadius: {
         xl2: '18px',


### PR DESCRIPTION
## Summary
- add base and brand color tokens plus card shadow to the Tailwind config
- append shared CSS variables and gradient helper styles, and add the header logo asset
- update the site header to show the SVG logo with gradient title while keeping existing nav links

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6870ea5888323abafc18f76bfc844