### PR TITLE
Add header trippy toggle with persisted defaults

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,7 @@
 // src/components/Header.tsx
-import React from "react";
+import React, { useEffect } from "react";
+import { Sparkles } from "lucide-react";
+import { useTrippy } from "../lib/trippy";
 
 const links = [
   { label: "Browse", href: "/#/database" },
@@ -7,7 +9,25 @@ const links = [
   { label: "Blog",   href: "/#/blog"      },
 ];
 
-export default function Header({ onOpenThemeMenu }: { onOpenThemeMenu?: () => void }) {
+export default function Header() {
+  const { trippy, setTrippy, enabled } = useTrippy();
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "t") {
+        event.preventDefault();
+        if (!enabled) return;
+        setTrippy(!trippy);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [enabled, setTrippy, trippy]);
+
   return (
     <header className="sticky top-0 z-50 border-b border-white/5 bg-black/60 backdrop-blur supports-[backdrop-filter]:bg-black/40">
       <div className="container-page flex items-center gap-4 py-3" aria-label="Site">
@@ -31,10 +51,21 @@ export default function Header({ onOpenThemeMenu }: { onOpenThemeMenu?: () => vo
           ))}
           <button
             type="button"
-            onClick={onOpenThemeMenu}
-            className="chip whitespace-nowrap text-white/80 hover:bg-white/10"
+            aria-pressed={trippy}
+            aria-label="Toggle trippy mode"
+            disabled={!enabled}
+            onClick={() => setTrippy(!trippy)}
+            className={`chip relative whitespace-nowrap text-white/80 transition ${
+              enabled ? "hover:bg-white/10" : "cursor-not-allowed opacity-50"
+            } ${trippy ? "ring-1 ring-emerald-400/40" : ""}`}
           >
-            Theme
+            <Sparkles className="mr-1 h-4 w-4" aria-hidden />
+            Trippy {enabled ? (trippy ? "On" : "Off") : ""}
+            <span
+              className={`pointer-events-none absolute -inset-4 -z-10 rounded-full blur-2xl ${
+                trippy ? "bg-emerald-500/10" : "hidden"
+              }`}
+            />
           </button>
         </nav>
       </div>

--- a/src/lib/trippy.tsx
+++ b/src/lib/trippy.tsx
@@ -15,13 +15,14 @@ function getPrefersReducedMotion(): boolean {
 
 export function TrippyProvider({ children }: { children: ReactNode }) {
   const [prefersReduced, setPrefersReduced] = useState(getPrefersReducedMotion);
-  const [trippy, setTrippyState] = useState(false);
-
-  useEffect(() => {
-    if (typeof window === "undefined") return;
+  const [trippy, setTrippyState] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    const prefersReduced = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
     const saved = window.localStorage.getItem("trippy-mode");
-    setTrippyState(saved === "1");
-  }, []);
+    if (saved === "1") return true;
+    if (saved === "0") return false;
+    return !prefersReduced;
+  });
 
   useEffect(() => {
     if (typeof window === "undefined" || !window.matchMedia) return;
@@ -53,7 +54,9 @@ export function TrippyProvider({ children }: { children: ReactNode }) {
     }
     if (typeof window === "undefined") return;
     const saved = window.localStorage.getItem("trippy-mode");
-    setTrippyState(saved === "1");
+    if (saved !== null) {
+      setTrippyState(saved === "1");
+    }
   }, [enabled]);
 
   const setTrippy = useCallback(


### PR DESCRIPTION
## Summary
- default trippy mode to respect saved preference and prefers-reduced-motion settings
- replace the header Theme pill with a Sparkles-powered trippy toggle and add a Ctrl/⌘+T shortcut

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68eadd74ee008323a880802608d0b586