### PR TITLE
feat: restore global melt background

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Routes, Route, Outlet, useLocation } from 'react-router-dom';
+import { HashRouter, Routes, Route, Outlet, useLocation } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
 import Home from './pages/Home';
 import About from './pages/About';
@@ -28,6 +28,7 @@ import BlogPost from './pages/BlogPost';
 import GraphPage from './pages/Graph';
 import Theme from './pages/Theme';
 import { useTrippy } from '@/lib/trippy';
+import GlobalMelt from '@/components/GlobalMelt';
 // Import other pages as needed
 
 export default function App() {
@@ -35,35 +36,38 @@ export default function App() {
   const { level } = useTrippy();
   const trippyActive = level !== "off";
   return (
-    <div className="min-h-screen overflow-x-hidden text-text">
-      <RedirectHandler />
-      {trippyActive && <TrippyBackground />}
-      {trippyActive && <AmbientCursor />}
-      <Routes>
-        <Route element={<RootLayout />}>
-          <Route path="/" element={<Home />} />
-          <Route path="/about" element={<About />} />
-          <Route path="/database" element={<Database />} />
-          <Route path="/blend" element={<BuildBlend />} />
-          <Route path="/build" element={<BuildBlend />} />
-          <Route path="/favorites" element={<Favorites />} />
-          <Route path="/newsletter" element={<Newsletter />} />
-          <Route path="/contact" element={<Contact />} />
-          {/* Add other routes here */}
-          <Route path="/blog" element={<BlogList />} />
-          <Route path="/blog/:slug" element={<BlogPost />} />
-          <Route path="/theme" element={<Theme />} />
-          <Route path="/herb-index" element={<HerbIndex />} />
-          <Route path="/herb/:slug" element={<HerbDetail />} />
-          <Route path="/compare" element={<Compare />} />
-          <Route path="/data-report" element={<DataReport />} />
-          <Route path="/data-fix" element={<DataFix />} />
-          <Route path="/sitemap" element={<Sitemap />} />
-        </Route>
-        <Route path="/graph" element={<GraphPage />} />
-        <Route path="*" element={<NotFound />} />
-      </Routes>
-    </div>
+    <HashRouter>
+      <GlobalMelt />
+      <div className="relative min-h-screen overflow-x-hidden text-text">
+        <RedirectHandler />
+        {trippyActive && <TrippyBackground />}
+        {trippyActive && <AmbientCursor />}
+        <Routes>
+          <Route element={<RootLayout />}>
+            <Route path="/" element={<Home />} />
+            <Route path="/about" element={<About />} />
+            <Route path="/database" element={<Database />} />
+            <Route path="/blend" element={<BuildBlend />} />
+            <Route path="/build" element={<BuildBlend />} />
+            <Route path="/favorites" element={<Favorites />} />
+            <Route path="/newsletter" element={<Newsletter />} />
+            <Route path="/contact" element={<Contact />} />
+            {/* Add other routes here */}
+            <Route path="/blog" element={<BlogList />} />
+            <Route path="/blog/:slug" element={<BlogPost />} />
+            <Route path="/theme" element={<Theme />} />
+            <Route path="/herb-index" element={<HerbIndex />} />
+            <Route path="/herb/:slug" element={<HerbDetail />} />
+            <Route path="/compare" element={<Compare />} />
+            <Route path="/data-report" element={<DataReport />} />
+            <Route path="/data-fix" element={<DataFix />} />
+            <Route path="/sitemap" element={<Sitemap />} />
+          </Route>
+          <Route path="/graph" element={<GraphPage />} />
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </div>
+    </HashRouter>
   );
 }
 
@@ -75,7 +79,7 @@ function RootLayout() {
       <Header />
       <main
         id="main"
-        className="flex-1"
+        className="relative z-0 flex-1"
       >
         <AnimatePresence mode="wait">
           <motion.div

--- a/src/components/GlobalMelt.tsx
+++ b/src/components/GlobalMelt.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+
+function MeltCanvas() {
+  const ref = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const c = ref.current!;
+    const ctx = c.getContext("2d", { alpha: true })!;
+    let raf = 0;
+    const DPR = Math.min(window.devicePixelRatio || 1, 2);
+
+    const resize = () => {
+      const w = window.innerWidth;
+      const h = window.innerHeight;
+      c.width = Math.floor(w * DPR);
+      c.height = Math.floor(h * DPR);
+      c.style.width = w + "px";
+      c.style.height = h + "px";
+      ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
+    };
+    resize();
+    window.addEventListener("resize", resize);
+
+    // soft blobby gradient “melt”
+    const blobs = Array.from({ length: 4 }).map((_, i) => ({
+      x: Math.random() * window.innerWidth,
+      y: Math.random() * window.innerHeight,
+      r: 180 + Math.random() * 140,
+      t: Math.random() * Math.PI * 2,
+      s: 0.35 + Math.random() * 0.65,
+      hue: (i * 90 + 200) % 360,
+    }));
+
+    const frame = () => {
+      ctx.clearRect(0, 0, c.width, c.height);
+      ctx.globalCompositeOperation = "lighter";
+      for (const b of blobs) {
+        b.t += 0.002 * b.s;
+        const nx = b.x + Math.cos(b.t) * 40;
+        const ny = b.y + Math.sin(b.t * 0.9) * 40;
+        const g = ctx.createRadialGradient(nx, ny, 0, nx, ny, b.r);
+        g.addColorStop(0, `hsla(${b.hue},85%,60%,.26)`);
+        g.addColorStop(1, `hsla(${b.hue},85%,60%,0)`);
+        ctx.fillStyle = g;
+        ctx.beginPath();
+        ctx.arc(nx, ny, b.r, 0, Math.PI * 2);
+        ctx.fill();
+      }
+      ctx.globalCompositeOperation = "source-over";
+      raf = requestAnimationFrame(frame);
+    };
+    raf = requestAnimationFrame(frame);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("resize", resize);
+    };
+  }, []);
+
+  return (
+    <div
+      id="melt-layer"
+      className="pointer-events-none fixed inset-0 -z-10"
+      aria-hidden
+    >
+      <canvas ref={ref} className="block h-full w-full" />
+    </div>
+  );
+}
+
+export default function GlobalMelt() {
+  // mount into <body> so routes/stacking can’t hide it
+  return createPortal(<MeltCanvas />, document.body);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -50,7 +50,7 @@ html,
 body {
   margin: 0;
   overflow-x: hidden;
-  background: #0b0f12;
+  background: transparent;
 }
 
 #root {
@@ -64,6 +64,16 @@ body {
   color: var(--text-c);
   line-height: 1.6;
   letter-spacing: -0.01em;
+}
+
+/* nuke accidental top band overlays */
+.hero-top-mask,
+.header-vignette,
+.scanline,
+body::before,
+body::after {
+  display: none !important;
+  content: none !important;
 }
 
 a {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { HashRouter } from 'react-router-dom';
 import { HelmetProvider } from 'react-helmet-async';
 import App from './App';
 import ErrorBoundary from './components/ErrorBoundary';
@@ -26,12 +25,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <HelmetProvider>
       <ErrorBoundary>
-        {/* HashRouter prevents 404 on refresh by using URL hash for routing */}
-        <HashRouter>
-          <TrippyProvider>
-            <App />
-          </TrippyProvider>
-        </HashRouter>
+        <TrippyProvider>
+          <App />
+        </TrippyProvider>
       </ErrorBoundary>
     </HelmetProvider>
   </React.StrictMode>

--- a/src/pages/BlogList.tsx
+++ b/src/pages/BlogList.tsx
@@ -39,33 +39,35 @@ export default function BlogList() {
   if (!posts.length) return <div className="p-6 opacity-80">No posts yet.</div>;
 
   return (
-    <div className="container-page space-y-6 py-8">
-      <h1 className="text-4xl font-extrabold tracking-tight">Blog</h1>
-      {posts.map((p) => (
-        <motion.article
-          key={p.slug}
-          initial={reduceMotion ? false : { opacity: 0, y: 8 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true }}
-          className="glass p-5 text-white transition hover:translate-y-[-2px] hover:shadow-glow sm:p-6"
-        >
-          <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
-            <a href={`/#/blog/${p.slug}`} className="text-accent-200 hover:text-accent-100">
-              {p.title}
-            </a>
-          </h2>
-          <div className="mt-2 text-sm text-white/60">
-            <time dateTime={p.date || undefined}>{formatDate(p.date || "")}</time>
-            {p.readingTime && <> • {p.readingTime}</>}
-          </div>
-          <p className="mt-3 text-white/80">{p.description}</p>
-          <div className="mt-4">
-            <a href={`/#/blog/${p.slug}`} className="btn-primary">
-              Read post
-            </a>
-          </div>
-        </motion.article>
-      ))}
+    <div className="container-page py-8">
+      <div className="space-y-6 rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur-xl sm:p-8">
+        <h1 className="text-4xl font-extrabold tracking-tight">Blog</h1>
+        {posts.map((p) => (
+          <motion.article
+            key={p.slug}
+            initial={reduceMotion ? false : { opacity: 0, y: 8 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            className="glass p-5 text-white transition hover:translate-y-[-2px] hover:shadow-glow sm:p-6"
+          >
+            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
+              <a href={`/#/blog/${p.slug}`} className="text-accent-200 hover:text-accent-100">
+                {p.title}
+              </a>
+            </h2>
+            <div className="mt-2 text-sm text-white/60">
+              <time dateTime={p.date || undefined}>{formatDate(p.date || "")}</time>
+              {p.readingTime && <> • {p.readingTime}</>}
+            </div>
+            <p className="mt-3 text-white/80">{p.description}</p>
+            <div className="mt-4">
+              <a href={`/#/blog/${p.slug}`} className="btn-primary">
+                Read post
+              </a>
+            </div>
+          </motion.article>
+        ))}
+      </div>
     </div>
   );
 }

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -42,64 +42,68 @@ export default function BlogPost() {
   if (error) {
     return (
       <main className="container-page py-8">
-        <p className="text-red-400">{error}</p>
-        <a className="underline" href="/#/blog">
-          ← Back to blog
-        </a>
+        <div className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur-xl sm:p-8">
+          <p className="text-red-400">{error}</p>
+          <a className="underline" href="/#/blog">
+            ← Back to blog
+          </a>
+        </div>
       </main>
     );
   }
 
   return (
     <main className="container-page py-8">
-      <header className="mb-8">
-        <a href="/#/blog" className="text-sm text-accent-300 hover:text-accent-200">
-          ← Back to Blog
-        </a>
-        <h1 className="mt-2 text-4xl font-extrabold tracking-tight text-white">
-          {meta?.title || "Loading…"}
-        </h1>
+      <div className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur-xl sm:p-8">
+        <header className="mb-8">
+          <a href="/#/blog" className="text-sm text-accent-300 hover:text-accent-200">
+            ← Back to Blog
+          </a>
+          <h1 className="mt-2 text-4xl font-extrabold tracking-tight text-white">
+            {meta?.title || "Loading…"}
+          </h1>
 
-        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-2 text-sm text-white/60">
-          {meta?.date && <time dateTime={meta.date}>{formatDate(meta.date)}</time>}
-          {meta?.readingTime && <span aria-hidden="true">•</span>}
-          {meta?.readingTime && <span>{meta.readingTime}</span>}
-          {meta?.tags?.length ? (
-            <>
-              <span aria-hidden="true">•</span>
-              <ul className="flex flex-wrap gap-2">
-                {meta.tags.map((t) => (
-                  <li
-                    key={t}
-                    className="chip border-white/15 bg-white/5 px-2 py-0.5 text-xs text-white/70"
-                  >
-                    {t}
-                  </li>
-                ))}
-              </ul>
-            </>
-          ) : null}
-        </div>
-      </header>
+          <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-2 text-sm text-white/60">
+            {meta?.date && <time dateTime={meta.date}>{formatDate(meta.date)}</time>}
+            {meta?.readingTime && <span aria-hidden="true">•</span>}
+            {meta?.readingTime && <span>{meta.readingTime}</span>}
+            {meta?.tags?.length ? (
+              <>
+                <span aria-hidden="true">•</span>
+                <ul className="flex flex-wrap gap-2">
+                  {meta.tags.map((t) => (
+                    <li
+                      key={t}
+                      className="chip border-white/15 bg-white/5 px-2 py-0.5 text-xs text-white/70"
+                    >
+                      {t}
+                    </li>
+                  ))}
+                </ul>
+              </>
+            ) : null}
+          </div>
+        </header>
 
-      {/* Markdown HTML */}
-      <article
-        className="
-          prose prose-invert max-w-none
-          prose-a:text-accent-200 hover:prose-a:text-accent-100
-          prose-strong:text-white prose-li:marker:text-white/50
-          prose-blockquote:text-white/70 prose-blockquote:border-l-white/30
-          prose-pre:bg-black/60 prose-code:text-pink-300
-          prose-headings:scroll-mt-24 prose-img:rounded-xl
-        "
-        dangerouslySetInnerHTML={{ __html: html }}
-      />
+        {/* Markdown HTML */}
+        <article
+          className="
+            prose prose-invert max-w-none
+            prose-a:text-accent-200 hover:prose-a:text-accent-100
+            prose-strong:text-white prose-li:marker:text-white/50
+            prose-blockquote:text-white/70 prose-blockquote:border-l-white/30
+            prose-pre:bg-black/60 prose-code:text-pink-300
+            prose-headings:scroll-mt-24 prose-img:rounded-xl
+          "
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
 
-      <footer className="mt-10 border-t border-white/10 pt-6">
-        <p className="text-xs text-white/50">
-          Educational content only. Not medical advice. Consult a qualified professional before use.
-        </p>
-      </footer>
+        <footer className="mt-10 border-t border-white/10 pt-6">
+          <p className="text-xs text-white/50">
+            Educational content only. Not medical advice. Consult a qualified professional before use.
+          </p>
+        </footer>
+      </div>
     </main>
   );
 }

--- a/src/pages/Database.tsx
+++ b/src/pages/Database.tsx
@@ -47,8 +47,8 @@ export default function Database() {
         description='Browse psychoactive herb profiles with scientific and cultural context.'
         path='/database'
       />
-      <div className="aurora relative isolate min-h-screen">
-        <section className="relative z-20 w-full overflow-hidden rounded-3xl border border-white/10 bg-gradient-to-br from-emerald-500/10 via-sky-500/5 to-fuchsia-500/10 py-10 sm:py-12 lg:py-14">
+      <div className="relative isolate min-h-screen px-4 py-10 sm:px-6 lg:px-8">
+        <section className="relative z-20 w-full overflow-hidden rounded-3xl border border-white/10 bg-white/5 backdrop-blur-xl py-10 sm:py-12 lg:py-14">
           <div className="relative mx-auto max-w-screen-xl px-4 sm:px-6 lg:px-8">
             <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">Herb Database</h1>
             <p className="mt-2 text-white/70">Search and explore the library.</p>


### PR DESCRIPTION
## Summary
- add a GlobalMelt canvas portal that renders the animated background at the document level
- mount the melt layer from the app shell, clear global overlays, and remove opaque page backgrounds
- restyle database and blog surfaces as glass panels so the melt backdrop remains visible

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68eb0c5eebec8323a0794b49ff05585b