### PR TITLE
Add script to backfill daily blog posts

### DIFF
--- a/content/blog/2025-08-16-psychoactive-botany-rhodiola-saturday-notes.mdx
+++ b/content/blog/2025-08-16-psychoactive-botany-rhodiola-saturday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Psychoactive Botany — Rhodiola (Saturday Notes)"
+date: "2025-08-16T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Cordyceps with a focus on practical use, active compounds like Hordenine, and safe experimentation."
+tags: ["Safety","Herbs"]
+cover: "/blog/psychoactive-botany-rhodiola-saturday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Psychoactive Botany — Rhodiola (Saturday Notes)
+
+_Daily notes on Cordyceps with a focus on practical use, active compounds like Hordenine, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Blue Lotus** with **L-Theanine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Safety, Herbs.*

--- a/content/blog/2025-08-17-traditional-use-calea-zacatechichi-sunday-notes.mdx
+++ b/content/blog/2025-08-17-traditional-use-calea-zacatechichi-sunday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Traditional Use — Calea zacatechichi (Sunday Notes)"
+date: "2025-08-17T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Kava with a focus on practical use, active compounds like Choline, and safe experimentation."
+tags: ["Blend Ideas","Herbs"]
+cover: "/blog/traditional-use-calea-zacatechichi-sunday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Traditional Use — Calea zacatechichi (Sunday Notes)
+
+_Daily notes on Kava with a focus on practical use, active compounds like Choline, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Rhodiola** with **Myriscin** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Blend Ideas, Herbs.*

--- a/content/blog/2025-08-18-research-digest-cordyceps-monday-notes.mdx
+++ b/content/blog/2025-08-18-research-digest-cordyceps-monday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Research Digest — Cordyceps (Monday Notes)"
+date: "2025-08-18T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Valerian with a focus on practical use, active compounds like Mesembrine, and safe experimentation."
+tags: ["Safety","Culture"]
+cover: "/blog/research-digest-cordyceps-monday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Research Digest — Cordyceps (Monday Notes)
+
+_Daily notes on Valerian with a focus on practical use, active compounds like Mesembrine, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Mugwort** with **L-Theanine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Safety, Culture.*

--- a/content/blog/2025-08-19-formulation-tips-passionflower-tuesday-notes.mdx
+++ b/content/blog/2025-08-19-formulation-tips-passionflower-tuesday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Formulation Tips — Passionflower (Tuesday Notes)"
+date: "2025-08-19T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Kava with a focus on practical use, active compounds like Mesembrine, and safe experimentation."
+tags: ["Research","Herbs"]
+cover: "/blog/formulation-tips-passionflower-tuesday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Formulation Tips — Passionflower (Tuesday Notes)
+
+_Daily notes on Kava with a focus on practical use, active compounds like Mesembrine, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Amanita muscaria** with **Harmine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Research, Herbs.*

--- a/content/blog/2025-08-20-blend-craft-kava-wednesday-notes.mdx
+++ b/content/blog/2025-08-20-blend-craft-kava-wednesday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Blend Craft — Kava (Wednesday Notes)"
+date: "2025-08-20T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Amanita muscaria with a focus on practical use, active compounds like Hordenine, and safe experimentation."
+tags: ["Field Notes","Herbs"]
+cover: "/blog/blend-craft-kava-wednesday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Blend Craft — Kava (Wednesday Notes)
+
+_Daily notes on Amanita muscaria with a focus on practical use, active compounds like Hordenine, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Gotu Kola** with **Thujone** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Field Notes, Herbs.*

--- a/content/blog/2025-08-21-pharmacology-basics-gotu-kola-thursday-notes.mdx
+++ b/content/blog/2025-08-21-pharmacology-basics-gotu-kola-thursday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Pharmacology Basics — Gotu Kola (Thursday Notes)"
+date: "2025-08-21T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Valerian with a focus on practical use, active compounds like Eugenol, and safe experimentation."
+tags: ["Safety","Compounds"]
+cover: "/blog/pharmacology-basics-gotu-kola-thursday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Pharmacology Basics — Gotu Kola (Thursday Notes)
+
+_Daily notes on Valerian with a focus on practical use, active compounds like Eugenol, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Kava** with **Eugenol** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Safety, Compounds.*

--- a/content/blog/2025-08-22-safety-set-setting-cordyceps-friday-notes.mdx
+++ b/content/blog/2025-08-22-safety-set-setting-cordyceps-friday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Safety & Set/Setting — Cordyceps (Friday Notes)"
+date: "2025-08-22T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Damiana with a focus on practical use, active compounds like Apigenin, and safe experimentation."
+tags: ["Safety","Culture"]
+cover: "/blog/safety-set-setting-cordyceps-friday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Safety & Set/Setting — Cordyceps (Friday Notes)
+
+_Daily notes on Damiana with a focus on practical use, active compounds like Apigenin, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Calea zacatechichi** with **Mesembrine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Safety, Culture.*

--- a/content/blog/2025-08-23-psychoactive-botany-cordyceps-saturday-notes.mdx
+++ b/content/blog/2025-08-23-psychoactive-botany-cordyceps-saturday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Psychoactive Botany — Cordyceps (Saturday Notes)"
+date: "2025-08-23T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Cordyceps with a focus on practical use, active compounds like Mesembrine, and safe experimentation."
+tags: ["Blend Ideas","Herbs"]
+cover: "/blog/psychoactive-botany-cordyceps-saturday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Psychoactive Botany — Cordyceps (Saturday Notes)
+
+_Daily notes on Cordyceps with a focus on practical use, active compounds like Mesembrine, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Lion's Mane** with **Choline** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Blend Ideas, Herbs.*

--- a/content/blog/2025-08-24-safety-set-setting-skullcap-sunday-notes.mdx
+++ b/content/blog/2025-08-24-safety-set-setting-skullcap-sunday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Safety & Set/Setting — Skullcap (Sunday Notes)"
+date: "2025-08-24T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Damiana with a focus on practical use, active compounds like Myriscin, and safe experimentation."
+tags: ["Research","Compounds"]
+cover: "/blog/safety-set-setting-skullcap-sunday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Safety & Set/Setting — Skullcap (Sunday Notes)
+
+_Daily notes on Damiana with a focus on practical use, active compounds like Myriscin, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Passionflower** with **Apigenin** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Research, Compounds.*

--- a/content/blog/2025-08-25-extraction-101-passionflower-monday-notes.mdx
+++ b/content/blog/2025-08-25-extraction-101-passionflower-monday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Extraction 101 — Passionflower (Monday Notes)"
+date: "2025-08-25T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Calea zacatechichi with a focus on practical use, active compounds like Hordenine, and safe experimentation."
+tags: ["Blend Ideas","Compounds"]
+cover: "/blog/extraction-101-passionflower-monday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Extraction 101 — Passionflower (Monday Notes)
+
+_Daily notes on Calea zacatechichi with a focus on practical use, active compounds like Hordenine, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Skullcap** with **Mesembrine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Blend Ideas, Compounds.*

--- a/content/blog/2025-08-26-pharmacology-basics-rhodiola-tuesday-notes.mdx
+++ b/content/blog/2025-08-26-pharmacology-basics-rhodiola-tuesday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Pharmacology Basics — Rhodiola (Tuesday Notes)"
+date: "2025-08-26T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Ashwagandha with a focus on practical use, active compounds like Myriscin, and safe experimentation."
+tags: ["Safety","Compounds"]
+cover: "/blog/pharmacology-basics-rhodiola-tuesday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Pharmacology Basics — Rhodiola (Tuesday Notes)
+
+_Daily notes on Ashwagandha with a focus on practical use, active compounds like Myriscin, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Skullcap** with **Hordenine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Safety, Compounds.*

--- a/content/blog/2025-08-27-blend-craft-calea-zacatechichi-wednesday-notes.mdx
+++ b/content/blog/2025-08-27-blend-craft-calea-zacatechichi-wednesday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Blend Craft — Calea zacatechichi (Wednesday Notes)"
+date: "2025-08-27T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Valerian with a focus on practical use, active compounds like Eugenol, and safe experimentation."
+tags: ["Field Notes","Culture"]
+cover: "/blog/blend-craft-calea-zacatechichi-wednesday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Blend Craft — Calea zacatechichi (Wednesday Notes)
+
+_Daily notes on Valerian with a focus on practical use, active compounds like Eugenol, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Valerian** with **Apigenin** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Field Notes, Culture.*

--- a/content/blog/2025-08-28-research-digest-gotu-kola-thursday-notes.mdx
+++ b/content/blog/2025-08-28-research-digest-gotu-kola-thursday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Research Digest — Gotu Kola (Thursday Notes)"
+date: "2025-08-28T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Blue Lotus with a focus on practical use, active compounds like Eugenol, and safe experimentation."
+tags: ["Field Notes","Compounds"]
+cover: "/blog/research-digest-gotu-kola-thursday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Research Digest — Gotu Kola (Thursday Notes)
+
+_Daily notes on Blue Lotus with a focus on practical use, active compounds like Eugenol, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Reishi** with **Choline** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Field Notes, Compounds.*

--- a/content/blog/2025-08-29-blend-craft-passionflower-friday-notes.mdx
+++ b/content/blog/2025-08-29-blend-craft-passionflower-friday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Blend Craft — Passionflower (Friday Notes)"
+date: "2025-08-29T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Gotu Kola with a focus on practical use, active compounds like Beta-caryophyllene, and safe experimentation."
+tags: ["Field Notes","Herbs"]
+cover: "/blog/blend-craft-passionflower-friday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Blend Craft — Passionflower (Friday Notes)
+
+_Daily notes on Gotu Kola with a focus on practical use, active compounds like Beta-caryophyllene, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Mugwort** with **Thujone** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Field Notes, Herbs.*

--- a/content/blog/2025-08-30-blend-craft-reishi-saturday-notes.mdx
+++ b/content/blog/2025-08-30-blend-craft-reishi-saturday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Blend Craft — Reishi (Saturday Notes)"
+date: "2025-08-30T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Skullcap with a focus on practical use, active compounds like Choline, and safe experimentation."
+tags: ["Research","Compounds"]
+cover: "/blog/blend-craft-reishi-saturday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Blend Craft — Reishi (Saturday Notes)
+
+_Daily notes on Skullcap with a focus on practical use, active compounds like Choline, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Cordyceps** with **Beta-caryophyllene** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Research, Compounds.*

--- a/content/blog/2025-08-31-safety-set-setting-amanita-muscaria-sunday-notes.mdx
+++ b/content/blog/2025-08-31-safety-set-setting-amanita-muscaria-sunday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Safety & Set/Setting — Amanita muscaria (Sunday Notes)"
+date: "2025-08-31T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Reishi with a focus on practical use, active compounds like Mesembrine, and safe experimentation."
+tags: ["Safety","Culture"]
+cover: "/blog/safety-set-setting-amanita-muscaria-sunday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Safety & Set/Setting — Amanita muscaria (Sunday Notes)
+
+_Daily notes on Reishi with a focus on practical use, active compounds like Mesembrine, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Mugwort** with **Eugenol** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Safety, Culture.*

--- a/content/blog/2025-09-01-microdosing-log-blue-lotus-monday-notes.mdx
+++ b/content/blog/2025-09-01-microdosing-log-blue-lotus-monday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Microdosing Log — Blue Lotus (Monday Notes)"
+date: "2025-09-01T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Blue Lotus with a focus on practical use, active compounds like L-Theanine, and safe experimentation."
+tags: ["Blend Ideas","Culture"]
+cover: "/blog/microdosing-log-blue-lotus-monday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Microdosing Log — Blue Lotus (Monday Notes)
+
+_Daily notes on Blue Lotus with a focus on practical use, active compounds like L-Theanine, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Kava** with **L-Theanine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Blend Ideas, Culture.*

--- a/content/blog/2025-09-02-cultivar-notes-rhodiola-tuesday-notes.mdx
+++ b/content/blog/2025-09-02-cultivar-notes-rhodiola-tuesday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Cultivar Notes — Rhodiola (Tuesday Notes)"
+date: "2025-09-02T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Skullcap with a focus on practical use, active compounds like Hordenine, and safe experimentation."
+tags: ["Field Notes","Herbs"]
+cover: "/blog/cultivar-notes-rhodiola-tuesday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Cultivar Notes — Rhodiola (Tuesday Notes)
+
+_Daily notes on Skullcap with a focus on practical use, active compounds like Hordenine, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Skullcap** with **Beta-caryophyllene** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Field Notes, Herbs.*

--- a/content/blog/2025-09-03-pharmacology-basics-damiana-wednesday-notes.mdx
+++ b/content/blog/2025-09-03-pharmacology-basics-damiana-wednesday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Pharmacology Basics — Damiana (Wednesday Notes)"
+date: "2025-09-03T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Valerian with a focus on practical use, active compounds like Apigenin, and safe experimentation."
+tags: ["Safety","Herbs"]
+cover: "/blog/pharmacology-basics-damiana-wednesday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Pharmacology Basics — Damiana (Wednesday Notes)
+
+_Daily notes on Valerian with a focus on practical use, active compounds like Apigenin, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Reishi** with **Thujone** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Safety, Herbs.*

--- a/content/blog/2025-09-04-bioassays-blue-lotus-thursday-notes.mdx
+++ b/content/blog/2025-09-04-bioassays-blue-lotus-thursday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Bioassays — Blue Lotus (Thursday Notes)"
+date: "2025-09-04T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Passionflower with a focus on practical use, active compounds like Eugenol, and safe experimentation."
+tags: ["Blend Ideas","Compounds"]
+cover: "/blog/bioassays-blue-lotus-thursday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Bioassays — Blue Lotus (Thursday Notes)
+
+_Daily notes on Passionflower with a focus on practical use, active compounds like Eugenol, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Gotu Kola** with **L-Theanine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Blend Ideas, Compounds.*

--- a/content/blog/2025-09-05-bioassays-reishi-friday-notes.mdx
+++ b/content/blog/2025-09-05-bioassays-reishi-friday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Bioassays — Reishi (Friday Notes)"
+date: "2025-09-05T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Amanita muscaria with a focus on practical use, active compounds like L-Theanine, and safe experimentation."
+tags: ["Safety","Compounds"]
+cover: "/blog/bioassays-reishi-friday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Bioassays — Reishi (Friday Notes)
+
+_Daily notes on Amanita muscaria with a focus on practical use, active compounds like L-Theanine, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Mugwort** with **Thujone** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Safety, Compounds.*

--- a/content/blog/2025-09-06-pharmacology-basics-rhodiola-saturday-notes.mdx
+++ b/content/blog/2025-09-06-pharmacology-basics-rhodiola-saturday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Pharmacology Basics — Rhodiola (Saturday Notes)"
+date: "2025-09-06T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Ashwagandha with a focus on practical use, active compounds like Myriscin, and safe experimentation."
+tags: ["Research","Compounds"]
+cover: "/blog/pharmacology-basics-rhodiola-saturday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Pharmacology Basics — Rhodiola (Saturday Notes)
+
+_Daily notes on Ashwagandha with a focus on practical use, active compounds like Myriscin, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Mugwort** with **Hordenine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Research, Compounds.*

--- a/content/blog/2025-09-07-pharmacology-basics-blue-lotus-sunday-notes.mdx
+++ b/content/blog/2025-09-07-pharmacology-basics-blue-lotus-sunday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Pharmacology Basics — Blue Lotus (Sunday Notes)"
+date: "2025-09-07T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Kava with a focus on practical use, active compounds like Hordenine, and safe experimentation."
+tags: ["Blend Ideas","Compounds"]
+cover: "/blog/pharmacology-basics-blue-lotus-sunday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Pharmacology Basics — Blue Lotus (Sunday Notes)
+
+_Daily notes on Kava with a focus on practical use, active compounds like Hordenine, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Amanita muscaria** with **Choline** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Blend Ideas, Compounds.*

--- a/content/blog/2025-09-08-safety-set-setting-gotu-kola-monday-notes.mdx
+++ b/content/blog/2025-09-08-safety-set-setting-gotu-kola-monday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Safety & Set/Setting — Gotu Kola (Monday Notes)"
+date: "2025-09-08T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Passionflower with a focus on practical use, active compounds like L-Theanine, and safe experimentation."
+tags: ["Safety","Culture"]
+cover: "/blog/safety-set-setting-gotu-kola-monday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Safety & Set/Setting — Gotu Kola (Monday Notes)
+
+_Daily notes on Passionflower with a focus on practical use, active compounds like L-Theanine, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Ashwagandha** with **Myriscin** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Safety, Culture.*

--- a/content/blog/2025-09-09-bioassays-blue-lotus-tuesday-notes.mdx
+++ b/content/blog/2025-09-09-bioassays-blue-lotus-tuesday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Bioassays — Blue Lotus (Tuesday Notes)"
+date: "2025-09-09T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Blue Lotus with a focus on practical use, active compounds like Eugenol, and safe experimentation."
+tags: ["Research","Culture"]
+cover: "/blog/bioassays-blue-lotus-tuesday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Bioassays — Blue Lotus (Tuesday Notes)
+
+_Daily notes on Blue Lotus with a focus on practical use, active compounds like Eugenol, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Passionflower** with **Harmine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Research, Culture.*

--- a/content/blog/2025-09-10-field-notes-damiana-wednesday-notes.mdx
+++ b/content/blog/2025-09-10-field-notes-damiana-wednesday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Field Notes — Damiana (Wednesday Notes)"
+date: "2025-09-10T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Blue Lotus with a focus on practical use, active compounds like Beta-caryophyllene, and safe experimentation."
+tags: ["Field Notes","Compounds"]
+cover: "/blog/field-notes-damiana-wednesday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Field Notes — Damiana (Wednesday Notes)
+
+_Daily notes on Blue Lotus with a focus on practical use, active compounds like Beta-caryophyllene, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Cordyceps** with **Harmine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Field Notes, Compounds.*

--- a/content/blog/2025-09-11-formulation-tips-skullcap-thursday-notes.mdx
+++ b/content/blog/2025-09-11-formulation-tips-skullcap-thursday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Formulation Tips — Skullcap (Thursday Notes)"
+date: "2025-09-11T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Ashwagandha with a focus on practical use, active compounds like Apigenin, and safe experimentation."
+tags: ["Research","Compounds"]
+cover: "/blog/formulation-tips-skullcap-thursday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Formulation Tips — Skullcap (Thursday Notes)
+
+_Daily notes on Ashwagandha with a focus on practical use, active compounds like Apigenin, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Gotu Kola** with **L-Theanine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Research, Compounds.*

--- a/content/blog/2025-09-12-safety-set-setting-gotu-kola-friday-notes.mdx
+++ b/content/blog/2025-09-12-safety-set-setting-gotu-kola-friday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Safety & Set/Setting — Gotu Kola (Friday Notes)"
+date: "2025-09-12T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Skullcap with a focus on practical use, active compounds like Harmine, and safe experimentation."
+tags: ["Blend Ideas","Compounds"]
+cover: "/blog/safety-set-setting-gotu-kola-friday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Safety & Set/Setting — Gotu Kola (Friday Notes)
+
+_Daily notes on Skullcap with a focus on practical use, active compounds like Harmine, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Damiana** with **Myriscin** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Blend Ideas, Compounds.*

--- a/content/blog/2025-09-13-formulation-tips-mugwort-saturday-notes.mdx
+++ b/content/blog/2025-09-13-formulation-tips-mugwort-saturday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Formulation Tips — Mugwort (Saturday Notes)"
+date: "2025-09-13T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Blue Lotus with a focus on practical use, active compounds like Harmine, and safe experimentation."
+tags: ["Blend Ideas","Herbs"]
+cover: "/blog/formulation-tips-mugwort-saturday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Formulation Tips — Mugwort (Saturday Notes)
+
+_Daily notes on Blue Lotus with a focus on practical use, active compounds like Harmine, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Mugwort** with **Hordenine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Blend Ideas, Herbs.*

--- a/content/blog/2025-09-14-bioassays-ashwagandha-sunday-notes.mdx
+++ b/content/blog/2025-09-14-bioassays-ashwagandha-sunday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Bioassays — Ashwagandha (Sunday Notes)"
+date: "2025-09-14T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Damiana with a focus on practical use, active compounds like Choline, and safe experimentation."
+tags: ["Field Notes","Compounds"]
+cover: "/blog/bioassays-ashwagandha-sunday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Bioassays — Ashwagandha (Sunday Notes)
+
+_Daily notes on Damiana with a focus on practical use, active compounds like Choline, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Valerian** with **Harmine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Field Notes, Compounds.*

--- a/content/blog/2025-09-15-traditional-use-gotu-kola-monday-notes.mdx
+++ b/content/blog/2025-09-15-traditional-use-gotu-kola-monday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Traditional Use — Gotu Kola (Monday Notes)"
+date: "2025-09-15T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Calea zacatechichi with a focus on practical use, active compounds like Choline, and safe experimentation."
+tags: ["Field Notes","Compounds"]
+cover: "/blog/traditional-use-gotu-kola-monday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Traditional Use — Gotu Kola (Monday Notes)
+
+_Daily notes on Calea zacatechichi with a focus on practical use, active compounds like Choline, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Rhodiola** with **L-Theanine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Field Notes, Compounds.*

--- a/content/blog/2025-09-16-cultivar-notes-damiana-tuesday-notes.mdx
+++ b/content/blog/2025-09-16-cultivar-notes-damiana-tuesday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Cultivar Notes — Damiana (Tuesday Notes)"
+date: "2025-09-16T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Skullcap with a focus on practical use, active compounds like Thujone, and safe experimentation."
+tags: ["Field Notes","Compounds"]
+cover: "/blog/cultivar-notes-damiana-tuesday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Cultivar Notes — Damiana (Tuesday Notes)
+
+_Daily notes on Skullcap with a focus on practical use, active compounds like Thujone, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Lion's Mane** with **Choline** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Field Notes, Compounds.*

--- a/content/blog/2025-09-17-psychoactive-botany-amanita-muscaria-wednesday-notes.mdx
+++ b/content/blog/2025-09-17-psychoactive-botany-amanita-muscaria-wednesday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Psychoactive Botany — Amanita muscaria (Wednesday Notes)"
+date: "2025-09-17T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Mugwort with a focus on practical use, active compounds like Eugenol, and safe experimentation."
+tags: ["Research","Compounds"]
+cover: "/blog/psychoactive-botany-amanita-muscaria-wednesday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Psychoactive Botany — Amanita muscaria (Wednesday Notes)
+
+_Daily notes on Mugwort with a focus on practical use, active compounds like Eugenol, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Cordyceps** with **Thujone** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Research, Compounds.*

--- a/content/blog/2025-09-18-psychoactive-botany-ashwagandha-thursday-notes.mdx
+++ b/content/blog/2025-09-18-psychoactive-botany-ashwagandha-thursday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Psychoactive Botany — Ashwagandha (Thursday Notes)"
+date: "2025-09-18T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Damiana with a focus on practical use, active compounds like Choline, and safe experimentation."
+tags: ["Blend Ideas","Herbs"]
+cover: "/blog/psychoactive-botany-ashwagandha-thursday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Psychoactive Botany — Ashwagandha (Thursday Notes)
+
+_Daily notes on Damiana with a focus on practical use, active compounds like Choline, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Blue Lotus** with **Hordenine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Blend Ideas, Herbs.*

--- a/content/blog/2025-09-19-blend-craft-calea-zacatechichi-friday-notes.mdx
+++ b/content/blog/2025-09-19-blend-craft-calea-zacatechichi-friday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Blend Craft — Calea zacatechichi (Friday Notes)"
+date: "2025-09-19T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Reishi with a focus on practical use, active compounds like Beta-caryophyllene, and safe experimentation."
+tags: ["Safety","Culture"]
+cover: "/blog/blend-craft-calea-zacatechichi-friday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Blend Craft — Calea zacatechichi (Friday Notes)
+
+_Daily notes on Reishi with a focus on practical use, active compounds like Beta-caryophyllene, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Damiana** with **Harmine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Safety, Culture.*

--- a/content/blog/2025-09-20-microdosing-log-cordyceps-saturday-notes.mdx
+++ b/content/blog/2025-09-20-microdosing-log-cordyceps-saturday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Microdosing Log — Cordyceps (Saturday Notes)"
+date: "2025-09-20T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Reishi with a focus on practical use, active compounds like L-Theanine, and safe experimentation."
+tags: ["Field Notes","Culture"]
+cover: "/blog/microdosing-log-cordyceps-saturday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Microdosing Log — Cordyceps (Saturday Notes)
+
+_Daily notes on Reishi with a focus on practical use, active compounds like L-Theanine, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Rhodiola** with **Harmine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Field Notes, Culture.*

--- a/content/blog/2025-09-21-research-digest-calea-zacatechichi-sunday-notes.mdx
+++ b/content/blog/2025-09-21-research-digest-calea-zacatechichi-sunday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Research Digest — Calea zacatechichi (Sunday Notes)"
+date: "2025-09-21T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Valerian with a focus on practical use, active compounds like Apigenin, and safe experimentation."
+tags: ["Research","Compounds"]
+cover: "/blog/research-digest-calea-zacatechichi-sunday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Research Digest — Calea zacatechichi (Sunday Notes)
+
+_Daily notes on Valerian with a focus on practical use, active compounds like Apigenin, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Valerian** with **Hordenine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Research, Compounds.*

--- a/content/blog/2025-09-22-field-notes-lion-s-mane-monday-notes.mdx
+++ b/content/blog/2025-09-22-field-notes-lion-s-mane-monday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Field Notes — Lion's Mane (Monday Notes)"
+date: "2025-09-22T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Ashwagandha with a focus on practical use, active compounds like Myriscin, and safe experimentation."
+tags: ["Field Notes","Culture"]
+cover: "/blog/field-notes-lion-s-mane-monday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Field Notes — Lion's Mane (Monday Notes)
+
+_Daily notes on Ashwagandha with a focus on practical use, active compounds like Myriscin, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Ashwagandha** with **Choline** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Field Notes, Culture.*

--- a/content/blog/2025-09-23-extraction-101-kava-tuesday-notes.mdx
+++ b/content/blog/2025-09-23-extraction-101-kava-tuesday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Extraction 101 — Kava (Tuesday Notes)"
+date: "2025-09-23T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Kava with a focus on practical use, active compounds like Thujone, and safe experimentation."
+tags: ["Field Notes","Herbs"]
+cover: "/blog/extraction-101-kava-tuesday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Extraction 101 — Kava (Tuesday Notes)
+
+_Daily notes on Kava with a focus on practical use, active compounds like Thujone, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Skullcap** with **Beta-caryophyllene** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Field Notes, Herbs.*

--- a/content/blog/2025-09-24-traditional-use-rhodiola-wednesday-notes.mdx
+++ b/content/blog/2025-09-24-traditional-use-rhodiola-wednesday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Traditional Use — Rhodiola (Wednesday Notes)"
+date: "2025-09-24T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Kava with a focus on practical use, active compounds like Myriscin, and safe experimentation."
+tags: ["Blend Ideas","Culture"]
+cover: "/blog/traditional-use-rhodiola-wednesday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Traditional Use — Rhodiola (Wednesday Notes)
+
+_Daily notes on Kava with a focus on practical use, active compounds like Myriscin, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Damiana** with **Myriscin** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Blend Ideas, Culture.*

--- a/content/blog/2025-09-25-traditional-use-mugwort-thursday-notes.mdx
+++ b/content/blog/2025-09-25-traditional-use-mugwort-thursday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Traditional Use — Mugwort (Thursday Notes)"
+date: "2025-09-25T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Lion's Mane with a focus on practical use, active compounds like L-Theanine, and safe experimentation."
+tags: ["Blend Ideas","Compounds"]
+cover: "/blog/traditional-use-mugwort-thursday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Traditional Use — Mugwort (Thursday Notes)
+
+_Daily notes on Lion's Mane with a focus on practical use, active compounds like L-Theanine, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Gotu Kola** with **Myriscin** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Blend Ideas, Compounds.*

--- a/content/blog/2025-09-26-microdosing-log-skullcap-friday-notes.mdx
+++ b/content/blog/2025-09-26-microdosing-log-skullcap-friday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Microdosing Log — Skullcap (Friday Notes)"
+date: "2025-09-26T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Mugwort with a focus on practical use, active compounds like Beta-caryophyllene, and safe experimentation."
+tags: ["Safety","Herbs"]
+cover: "/blog/microdosing-log-skullcap-friday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Microdosing Log — Skullcap (Friday Notes)
+
+_Daily notes on Mugwort with a focus on practical use, active compounds like Beta-caryophyllene, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Amanita muscaria** with **Thujone** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Safety, Herbs.*

--- a/content/blog/2025-09-27-formulation-tips-cordyceps-saturday-notes.mdx
+++ b/content/blog/2025-09-27-formulation-tips-cordyceps-saturday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Formulation Tips — Cordyceps (Saturday Notes)"
+date: "2025-09-27T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Valerian with a focus on practical use, active compounds like Thujone, and safe experimentation."
+tags: ["Field Notes","Culture"]
+cover: "/blog/formulation-tips-cordyceps-saturday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Formulation Tips — Cordyceps (Saturday Notes)
+
+_Daily notes on Valerian with a focus on practical use, active compounds like Thujone, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Amanita muscaria** with **Apigenin** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Field Notes, Culture.*

--- a/content/blog/2025-09-28-field-notes-valerian-sunday-notes.mdx
+++ b/content/blog/2025-09-28-field-notes-valerian-sunday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Field Notes — Valerian (Sunday Notes)"
+date: "2025-09-28T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Passionflower with a focus on practical use, active compounds like Harmine, and safe experimentation."
+tags: ["Field Notes","Herbs"]
+cover: "/blog/field-notes-valerian-sunday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Field Notes — Valerian (Sunday Notes)
+
+_Daily notes on Passionflower with a focus on practical use, active compounds like Harmine, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Lion's Mane** with **Myriscin** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Field Notes, Herbs.*

--- a/content/blog/2025-09-29-bioassays-mugwort-monday-notes.mdx
+++ b/content/blog/2025-09-29-bioassays-mugwort-monday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Bioassays — Mugwort (Monday Notes)"
+date: "2025-09-29T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Calea zacatechichi with a focus on practical use, active compounds like Myriscin, and safe experimentation."
+tags: ["Safety","Herbs"]
+cover: "/blog/bioassays-mugwort-monday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Bioassays — Mugwort (Monday Notes)
+
+_Daily notes on Calea zacatechichi with a focus on practical use, active compounds like Myriscin, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Gotu Kola** with **Hordenine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Safety, Herbs.*

--- a/content/blog/2025-09-30-cultivar-notes-amanita-muscaria-tuesday-notes.mdx
+++ b/content/blog/2025-09-30-cultivar-notes-amanita-muscaria-tuesday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Cultivar Notes — Amanita muscaria (Tuesday Notes)"
+date: "2025-09-30T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Skullcap with a focus on practical use, active compounds like Beta-caryophyllene, and safe experimentation."
+tags: ["Safety","Culture"]
+cover: "/blog/cultivar-notes-amanita-muscaria-tuesday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Cultivar Notes — Amanita muscaria (Tuesday Notes)
+
+_Daily notes on Skullcap with a focus on practical use, active compounds like Beta-caryophyllene, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Calea zacatechichi** with **L-Theanine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Safety, Culture.*

--- a/content/blog/2025-10-01-field-notes-ashwagandha-wednesday-notes.mdx
+++ b/content/blog/2025-10-01-field-notes-ashwagandha-wednesday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Field Notes — Ashwagandha (Wednesday Notes)"
+date: "2025-10-01T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Cordyceps with a focus on practical use, active compounds like Mesembrine, and safe experimentation."
+tags: ["Field Notes","Culture"]
+cover: "/blog/field-notes-ashwagandha-wednesday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Field Notes — Ashwagandha (Wednesday Notes)
+
+_Daily notes on Cordyceps with a focus on practical use, active compounds like Mesembrine, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Valerian** with **Mesembrine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Field Notes, Culture.*

--- a/content/blog/2025-10-02-safety-set-setting-valerian-thursday-notes.mdx
+++ b/content/blog/2025-10-02-safety-set-setting-valerian-thursday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Safety & Set/Setting — Valerian (Thursday Notes)"
+date: "2025-10-02T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Damiana with a focus on practical use, active compounds like Apigenin, and safe experimentation."
+tags: ["Research","Herbs"]
+cover: "/blog/safety-set-setting-valerian-thursday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Safety & Set/Setting — Valerian (Thursday Notes)
+
+_Daily notes on Damiana with a focus on practical use, active compounds like Apigenin, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Kava** with **L-Theanine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Research, Herbs.*

--- a/content/blog/2025-10-03-safety-set-setting-calea-zacatechichi-friday-notes.mdx
+++ b/content/blog/2025-10-03-safety-set-setting-calea-zacatechichi-friday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Safety & Set/Setting — Calea zacatechichi (Friday Notes)"
+date: "2025-10-03T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Gotu Kola with a focus on practical use, active compounds like Hordenine, and safe experimentation."
+tags: ["Field Notes","Compounds"]
+cover: "/blog/safety-set-setting-calea-zacatechichi-friday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Safety & Set/Setting — Calea zacatechichi (Friday Notes)
+
+_Daily notes on Gotu Kola with a focus on practical use, active compounds like Hordenine, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Cordyceps** with **Eugenol** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Field Notes, Compounds.*

--- a/content/blog/2025-10-04-blend-craft-damiana-saturday-notes.mdx
+++ b/content/blog/2025-10-04-blend-craft-damiana-saturday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Blend Craft — Damiana (Saturday Notes)"
+date: "2025-10-04T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Calea zacatechichi with a focus on practical use, active compounds like Myriscin, and safe experimentation."
+tags: ["Field Notes","Compounds"]
+cover: "/blog/blend-craft-damiana-saturday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Blend Craft — Damiana (Saturday Notes)
+
+_Daily notes on Calea zacatechichi with a focus on practical use, active compounds like Myriscin, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Blue Lotus** with **Choline** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Field Notes, Compounds.*

--- a/content/blog/2025-10-05-microdosing-log-kava-sunday-notes.mdx
+++ b/content/blog/2025-10-05-microdosing-log-kava-sunday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Microdosing Log — Kava (Sunday Notes)"
+date: "2025-10-05T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Kava with a focus on practical use, active compounds like Thujone, and safe experimentation."
+tags: ["Field Notes","Herbs"]
+cover: "/blog/microdosing-log-kava-sunday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Microdosing Log — Kava (Sunday Notes)
+
+_Daily notes on Kava with a focus on practical use, active compounds like Thujone, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Calea zacatechichi** with **L-Theanine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Field Notes, Herbs.*

--- a/content/blog/2025-10-06-formulation-tips-lion-s-mane-monday-notes.mdx
+++ b/content/blog/2025-10-06-formulation-tips-lion-s-mane-monday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Formulation Tips — Lion's Mane (Monday Notes)"
+date: "2025-10-06T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Amanita muscaria with a focus on practical use, active compounds like Myriscin, and safe experimentation."
+tags: ["Research","Herbs"]
+cover: "/blog/formulation-tips-lion-s-mane-monday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Formulation Tips — Lion's Mane (Monday Notes)
+
+_Daily notes on Amanita muscaria with a focus on practical use, active compounds like Myriscin, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Amanita muscaria** with **Beta-caryophyllene** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Research, Herbs.*

--- a/content/blog/2025-10-07-cultivar-notes-amanita-muscaria-tuesday-notes.mdx
+++ b/content/blog/2025-10-07-cultivar-notes-amanita-muscaria-tuesday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Cultivar Notes — Amanita muscaria (Tuesday Notes)"
+date: "2025-10-07T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Blue Lotus with a focus on practical use, active compounds like Beta-caryophyllene, and safe experimentation."
+tags: ["Safety","Herbs"]
+cover: "/blog/cultivar-notes-amanita-muscaria-tuesday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Cultivar Notes — Amanita muscaria (Tuesday Notes)
+
+_Daily notes on Blue Lotus with a focus on practical use, active compounds like Beta-caryophyllene, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Mugwort** with **Mesembrine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Safety, Herbs.*

--- a/content/blog/2025-10-08-safety-set-setting-cordyceps-wednesday-notes.mdx
+++ b/content/blog/2025-10-08-safety-set-setting-cordyceps-wednesday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Safety & Set/Setting — Cordyceps (Wednesday Notes)"
+date: "2025-10-08T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Gotu Kola with a focus on practical use, active compounds like Hordenine, and safe experimentation."
+tags: ["Blend Ideas","Compounds"]
+cover: "/blog/safety-set-setting-cordyceps-wednesday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Safety & Set/Setting — Cordyceps (Wednesday Notes)
+
+_Daily notes on Gotu Kola with a focus on practical use, active compounds like Hordenine, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Rhodiola** with **Thujone** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Blend Ideas, Compounds.*

--- a/content/blog/2025-10-09-bioassays-rhodiola-thursday-notes.mdx
+++ b/content/blog/2025-10-09-bioassays-rhodiola-thursday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Bioassays — Rhodiola (Thursday Notes)"
+date: "2025-10-09T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Damiana with a focus on practical use, active compounds like Apigenin, and safe experimentation."
+tags: ["Field Notes","Compounds"]
+cover: "/blog/bioassays-rhodiola-thursday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Bioassays — Rhodiola (Thursday Notes)
+
+_Daily notes on Damiana with a focus on practical use, active compounds like Apigenin, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Cordyceps** with **Myriscin** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Field Notes, Compounds.*

--- a/content/blog/2025-10-10-bioassays-damiana-friday-notes.mdx
+++ b/content/blog/2025-10-10-bioassays-damiana-friday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Bioassays — Damiana (Friday Notes)"
+date: "2025-10-10T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Reishi with a focus on practical use, active compounds like Myriscin, and safe experimentation."
+tags: ["Field Notes","Culture"]
+cover: "/blog/bioassays-damiana-friday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Bioassays — Damiana (Friday Notes)
+
+_Daily notes on Reishi with a focus on practical use, active compounds like Myriscin, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Lion's Mane** with **Mesembrine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Field Notes, Culture.*

--- a/content/blog/2025-10-11-blend-craft-reishi-saturday-notes.mdx
+++ b/content/blog/2025-10-11-blend-craft-reishi-saturday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Blend Craft — Reishi (Saturday Notes)"
+date: "2025-10-11T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Ashwagandha with a focus on practical use, active compounds like Mesembrine, and safe experimentation."
+tags: ["Research","Herbs"]
+cover: "/blog/blend-craft-reishi-saturday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Blend Craft — Reishi (Saturday Notes)
+
+_Daily notes on Ashwagandha with a focus on practical use, active compounds like Mesembrine, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Rhodiola** with **L-Theanine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Research, Herbs.*

--- a/content/blog/2025-10-12-psychoactive-botany-skullcap-sunday-notes.mdx
+++ b/content/blog/2025-10-12-psychoactive-botany-skullcap-sunday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Psychoactive Botany — Skullcap (Sunday Notes)"
+date: "2025-10-12T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Kava with a focus on practical use, active compounds like Mesembrine, and safe experimentation."
+tags: ["Safety","Herbs"]
+cover: "/blog/psychoactive-botany-skullcap-sunday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Psychoactive Botany — Skullcap (Sunday Notes)
+
+_Daily notes on Kava with a focus on practical use, active compounds like Mesembrine, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Rhodiola** with **Choline** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Safety, Herbs.*

--- a/content/blog/2025-10-13-formulation-tips-valerian-monday-notes.mdx
+++ b/content/blog/2025-10-13-formulation-tips-valerian-monday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Formulation Tips — Valerian (Monday Notes)"
+date: "2025-10-13T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Mugwort with a focus on practical use, active compounds like Mesembrine, and safe experimentation."
+tags: ["Safety","Compounds"]
+cover: "/blog/formulation-tips-valerian-monday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Formulation Tips — Valerian (Monday Notes)
+
+_Daily notes on Mugwort with a focus on practical use, active compounds like Mesembrine, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Blue Lotus** with **Eugenol** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Safety, Compounds.*

--- a/content/blog/2025-10-14-field-notes-damiana-tuesday-notes.mdx
+++ b/content/blog/2025-10-14-field-notes-damiana-tuesday-notes.mdx
@@ -1,0 +1,34 @@
+---
+title: "Field Notes — Damiana (Tuesday Notes)"
+date: "2025-10-14T09:30:00.000Z"
+author: "The Hippie Scientist"
+summary: "Daily notes on Skullcap with a focus on practical use, active compounds like Beta-caryophyllene, and safe experimentation."
+tags: ["Research","Culture"]
+cover: "/blog/field-notes-damiana-tuesday-notes.svg"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# Field Notes — Damiana (Tuesday Notes)
+
+_Daily notes on Skullcap with a focus on practical use, active compounds like Beta-caryophyllene, and safe experimentation._
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **Valerian** with **Harmine** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: Research, Culture.*

--- a/public/blog/bioassays-ashwagandha-sunday-notes.svg
+++ b/public/blog/bioassays-ashwagandha-sunday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(97,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(19,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/bioassays-blue-lotus-thursday-notes.svg
+++ b/public/blog/bioassays-blue-lotus-thursday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(347,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(209,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/bioassays-blue-lotus-tuesday-notes.svg
+++ b/public/blog/bioassays-blue-lotus-tuesday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(42,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(294,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/bioassays-damiana-friday-notes.svg
+++ b/public/blog/bioassays-damiana-friday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(311,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(317,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/bioassays-mugwort-monday-notes.svg
+++ b/public/blog/bioassays-mugwort-monday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(262,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(274,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/bioassays-reishi-friday-notes.svg
+++ b/public/blog/bioassays-reishi-friday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(286,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(82,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/bioassays-rhodiola-thursday-notes.svg
+++ b/public/blog/bioassays-rhodiola-thursday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(12,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(84,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/blend-craft-calea-zacatechichi-friday-notes.svg
+++ b/public/blog/blend-craft-calea-zacatechichi-friday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(152,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(104,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/blend-craft-calea-zacatechichi-wednesday-notes.svg
+++ b/public/blog/blend-craft-calea-zacatechichi-wednesday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(115,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(145,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/blend-craft-damiana-saturday-notes.svg
+++ b/public/blog/blend-craft-damiana-saturday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(317,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(359,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/blend-craft-kava-wednesday-notes.svg
+++ b/public/blog/blend-craft-kava-wednesday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(182,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(314,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/blend-craft-passionflower-friday-notes.svg
+++ b/public/blog/blend-craft-passionflower-friday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(353,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(251,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/blend-craft-reishi-saturday-notes.svg
+++ b/public/blog/blend-craft-reishi-saturday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(250,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(190,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/cultivar-notes-amanita-muscaria-tuesday-notes.svg
+++ b/public/blog/cultivar-notes-amanita-muscaria-tuesday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(134,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(338,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/cultivar-notes-damiana-tuesday-notes.svg
+++ b/public/blog/cultivar-notes-damiana-tuesday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(335,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(125,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/cultivar-notes-rhodiola-tuesday-notes.svg
+++ b/public/blog/cultivar-notes-rhodiola-tuesday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(109,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(103,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/extraction-101-kava-tuesday-notes.svg
+++ b/public/blog/extraction-101-kava-tuesday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(268,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(316,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/extraction-101-passionflower-monday-notes.svg
+++ b/public/blog/extraction-101-passionflower-monday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(237,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(39,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/field-notes-ashwagandha-wednesday-notes.svg
+++ b/public/blog/field-notes-ashwagandha-wednesday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(140,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(20,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/field-notes-damiana-tuesday-notes.svg
+++ b/public/blog/field-notes-damiana-tuesday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(67,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(169,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/field-notes-damiana-wednesday-notes.svg
+++ b/public/blog/field-notes-damiana-wednesday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(341,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(167,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/field-notes-lion-s-mane-monday-notes.svg
+++ b/public/blog/field-notes-lion-s-mane-monday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(329,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(83,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/field-notes-valerian-sunday-notes.svg
+++ b/public/blog/field-notes-valerian-sunday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(323,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(41,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/formulation-tips-cordyceps-saturday-notes.svg
+++ b/public/blog/formulation-tips-cordyceps-saturday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(24,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(168,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/formulation-tips-lion-s-mane-monday-notes.svg
+++ b/public/blog/formulation-tips-lion-s-mane-monday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(195,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(105,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/formulation-tips-mugwort-saturday-notes.svg
+++ b/public/blog/formulation-tips-mugwort-saturday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(158,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(146,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/formulation-tips-passionflower-tuesday-notes.svg
+++ b/public/blog/formulation-tips-passionflower-tuesday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(243,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(81,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/formulation-tips-skullcap-thursday-notes.svg
+++ b/public/blog/formulation-tips-skullcap-thursday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(280,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(40,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/formulation-tips-valerian-monday-notes.svg
+++ b/public/blog/formulation-tips-valerian-monday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(128,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(296,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/microdosing-log-blue-lotus-monday-notes.svg
+++ b/public/blog/microdosing-log-blue-lotus-monday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(170,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(230,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/microdosing-log-cordyceps-saturday-notes.svg
+++ b/public/blog/microdosing-log-cordyceps-saturday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(91,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(337,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/microdosing-log-kava-sunday-notes.svg
+++ b/public/blog/microdosing-log-kava-sunday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(256,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(232,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/microdosing-log-skullcap-friday-notes.svg
+++ b/public/blog/microdosing-log-skullcap-friday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(85,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(295,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/pharmacology-basics-blue-lotus-sunday-notes.svg
+++ b/public/blog/pharmacology-basics-blue-lotus-sunday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(164,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(188,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/pharmacology-basics-damiana-wednesday-notes.svg
+++ b/public/blog/pharmacology-basics-damiana-wednesday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(48,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(336,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/pharmacology-basics-gotu-kola-thursday-notes.svg
+++ b/public/blog/pharmacology-basics-gotu-kola-thursday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(121,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(187,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/pharmacology-basics-rhodiola-saturday-notes.svg
+++ b/public/blog/pharmacology-basics-rhodiola-saturday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(225,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(315,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/pharmacology-basics-rhodiola-tuesday-notes.svg
+++ b/public/blog/pharmacology-basics-rhodiola-tuesday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(176,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(272,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/psychoactive-botany-amanita-muscaria-wednesday-notes.svg
+++ b/public/blog/psychoactive-botany-amanita-muscaria-wednesday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(274,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(358,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/psychoactive-botany-ashwagandha-thursday-notes.svg
+++ b/public/blog/psychoactive-botany-ashwagandha-thursday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(213,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(231,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/psychoactive-botany-cordyceps-saturday-notes.svg
+++ b/public/blog/psychoactive-botany-cordyceps-saturday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(359,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(293,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/psychoactive-botany-rhodiola-saturday-notes.svg
+++ b/public/blog/psychoactive-botany-rhodiola-saturday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(66,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(102,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/psychoactive-botany-skullcap-sunday-notes.svg
+++ b/public/blog/psychoactive-botany-skullcap-sunday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(189,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(63,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/research-digest-calea-zacatechichi-sunday-notes.svg
+++ b/public/blog/research-digest-calea-zacatechichi-sunday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(30,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(210,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/research-digest-cordyceps-monday-notes.svg
+++ b/public/blog/research-digest-cordyceps-monday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(304,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(208,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/research-digest-gotu-kola-thursday-notes.svg
+++ b/public/blog/research-digest-gotu-kola-thursday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(54,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(18,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/safety-set-setting-amanita-muscaria-sunday-notes.svg
+++ b/public/blog/safety-set-setting-amanita-muscaria-sunday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(231,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(357,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/safety-set-setting-calea-zacatechichi-friday-notes.svg
+++ b/public/blog/safety-set-setting-calea-zacatechichi-friday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(18,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(126,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/safety-set-setting-cordyceps-friday-notes.svg
+++ b/public/blog/safety-set-setting-cordyceps-friday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(60,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(60,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/safety-set-setting-cordyceps-wednesday-notes.svg
+++ b/public/blog/safety-set-setting-cordyceps-wednesday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(73,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(211,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/safety-set-setting-gotu-kola-friday-notes.svg
+++ b/public/blog/safety-set-setting-gotu-kola-friday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(219,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(273,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/safety-set-setting-gotu-kola-monday-notes.svg
+++ b/public/blog/safety-set-setting-gotu-kola-monday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(103,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(61,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/safety-set-setting-skullcap-sunday-notes.svg
+++ b/public/blog/safety-set-setting-skullcap-sunday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(298,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(166,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/safety-set-setting-valerian-thursday-notes.svg
+++ b/public/blog/safety-set-setting-valerian-thursday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(79,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(253,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/traditional-use-calea-zacatechichi-sunday-notes.svg
+++ b/public/blog/traditional-use-calea-zacatechichi-sunday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(5,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(335,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/traditional-use-gotu-kola-monday-notes.svg
+++ b/public/blog/traditional-use-gotu-kola-monday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(36,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(252,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/traditional-use-mugwort-thursday-notes.svg
+++ b/public/blog/traditional-use-mugwort-thursday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(146,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(62,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/public/blog/traditional-use-rhodiola-wednesday-notes.svg
+++ b/public/blog/traditional-use-rhodiola-wednesday-notes.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(207,70%,60%)" />
+      <stop offset="100%" stop-color="hsl(189,60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>

--- a/scripts/generate-backdated-posts.mjs
+++ b/scripts/generate-backdated-posts.mjs
@@ -1,0 +1,161 @@
+// scripts/generate-backdated-posts.mjs
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const BLOG_DIR = path.join(process.cwd(), 'content', 'blog');
+const PUBLIC_BLOG_DIR = path.join(process.cwd(), 'public', 'blog');
+
+// Config
+const DAYS_BACK = 60;             // ~two months
+const POST_TIME = { hour: 9, minute: 30 }; // 09:30 local each day
+const AUTHOR = 'The Hippie Scientist';
+
+const topics = [
+  'Psychoactive Botany','Blend Craft','Cultivar Notes','Research Digest',
+  'Field Notes','Pharmacology Basics','Traditional Use','Formulation Tips',
+  'Safety & Set/Setting','Extraction 101','Bioassays','Microdosing Log'
+];
+
+const herbs = [
+  'Kava','Calea zacatechichi','Lion\'s Mane','Blue Lotus','Mugwort',
+  'Damiana','Passionflower','Skullcap','Ashwagandha','Valerian',
+  'Rhodiola','Gotu Kola','Amanita muscaria','Reishi','Cordyceps'
+];
+
+const compounds = [
+  'L-Theanine','Apigenin','Harmine','Myriscin','Mesembrine',
+  'Beta-caryophyllene','Eugenol','Thujone','Choline','Hordenine'
+];
+
+function ensureDir(p) {
+  if (!fs.existsSync(p)) fs.mkdirSync(p, { recursive: true });
+}
+
+function rand(arr) { return arr[Math.floor(Math.random()*arr.length)]; }
+function slugify(s) {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g,'-').replace(/(^-|-$)/g,'');
+}
+
+function dateForOffset(daysAgo) {
+  const d = new Date();
+  d.setDate(d.getDate() - daysAgo);
+  d.setHours(POST_TIME.hour, POST_TIME.minute, 0, 0);
+  return d;
+}
+
+function listExistingSlugs() {
+  ensureDir(BLOG_DIR);
+  const files = fs.readdirSync(BLOG_DIR).filter(f => f.endsWith('.md') || f.endsWith('.mdx'));
+  return new Set(files.map(f => f.replace(/\.(md|mdx)$/,'').toLowerCase()));
+}
+
+function postFilenameFromDate(date, slug) {
+  const iso = date.toISOString().slice(0,10); // YYYY-MM-DD
+  return `${iso}-${slug}.mdx`;
+}
+
+function svgGradient(seed) {
+  // deterministic-ish gradient from seed
+  const h1 = (seed * 61) % 360;
+  const h2 = (seed * 127) % 360;
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1600" height="900" viewBox="0 0 1600 900" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="g1" cx="30%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="hsl(${h1},70%,60%)" />
+      <stop offset="100%" stop-color="hsl(${h2},60%,12%)" />
+    </radialGradient>
+    <filter id="noise">
+      <feTurbulence baseFrequency="0.9" numOctaves="2" type="fractalNoise" />
+      <feColorMatrix type="saturate" values="0.2"/>
+      <feBlend mode="soft-light" in2="SourceGraphic"/>
+    </filter>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#g1)"/>
+  <rect width="100%" height="100%" fill="#000" opacity="0.1" filter="url(#noise)"/>
+</svg>`;
+}
+
+function mdxTemplate({title, dateISO, summary, tags, cover, slug}) {
+  return `---
+title: "${title}"
+date: "${dateISO}"
+author: "${AUTHOR}"
+summary: "${summary}"
+tags: ${JSON.stringify(tags)}
+cover: "${cover}"
+draft: false
+---
+
+import Callout from '@/components/Callout' /* safe to leave; if missing, remove this line */
+
+# ${title}
+
+_${summary}_
+
+<Callout emoji="🌿">This post is part of our daily field notes series.</Callout>
+
+## Highlights
+
+- Context and traditional use
+- Pharmacology snapshot and key actives
+- Practical tips: preparation, dosing ranges, safety
+
+## Quick Blend Idea
+
+Try pairing **${rand(herbs)}** with **${rand(compounds)}** for a complementary effect profile. Start low, go slow.
+
+## Further Reading
+
+- Placeholder reference A
+- Placeholder reference B
+
+*Filed in: ${tags.join(', ')}.*
+`;
+}
+
+function generate() {
+  ensureDir(BLOG_DIR);
+  ensureDir(PUBLIC_BLOG_DIR);
+  const existing = listExistingSlugs();
+  let created = 0;
+
+  for (let i = DAYS_BACK - 1; i >= 0; i--) {
+    const date = dateForOffset(i);
+    const dayLabel = date.toLocaleDateString('en-US', { weekday:'long' });
+    const title = `${rand(topics)} — ${rand(herbs)} (${dayLabel} Notes)`;
+    const slug = slugify(title);
+    const filename = postFilenameFromDate(date, slug);
+    const fileSlug = filename.replace(/\.(md|mdx)$/,'').toLowerCase();
+
+    if (existing.has(fileSlug)) continue; // skip if something already exists for that date+slug
+
+    const summary = `Daily notes on ${rand(herbs)} with a focus on practical use, active compounds like ${rand(compounds)}, and safe experimentation.`;
+    const tags = [rand(['Field Notes','Research','Blend Ideas','Safety']), rand(['Herbs','Compounds','Culture'])];
+
+    const coverPath = `/blog/${slug}.svg`;
+    const coverAbs = path.join(PUBLIC_BLOG_DIR, `${slug}.svg`);
+    fs.writeFileSync(coverAbs, svgGradient(i+7), 'utf8');
+
+    const body = mdxTemplate({
+      title,
+      dateISO: date.toISOString(),
+      summary,
+      tags,
+      cover: coverPath,
+      slug
+    });
+
+    const abs = path.join(BLOG_DIR, filename);
+    fs.writeFileSync(abs, body, 'utf8');
+    created++;
+  }
+
+  console.log(`✅ Generated ${created} backdated posts in ${BLOG_DIR}`);
+}
+
+generate();


### PR DESCRIPTION
## Summary
- add a generator script that backfills roughly 60 days of daily blog entries with MDX frontmatter and consistent content structure
- generate backdated MDX posts for each day in the past two months while preserving existing posts
- create matching SVG gradient covers for each generated post to keep the blog grid populated

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ee71d9a2d48323a1bcda995b0da1bc