### PR TITLE
feat: add static blog index and clean URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:blog": "node scripts/build-blog.mjs",
     "build:graph": "node scripts/build-graph.mjs",
     "build:compounds": "tsx scripts/extract-compounds.ts",
-    "prebuild": "node scripts/build-blog.mjs && node scripts/generate-rss.mjs",
+    "prebuild": "node scripts/build-blog.mjs && node scripts/generate-rss.mjs && node scripts/generate-blog-index.mjs",
     "preview": "vite preview",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint . --ext .js,.jsx,.ts,.tsx --max-warnings=0",
     "format": "prettier --write .",

--- a/public/blog/index.html
+++ b/public/blog/index.html
@@ -1,0 +1,565 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>The Hippie Scientist — Blog</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Latest research notes and field reports from The Hippie Scientist." />
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background-color: #05060a;
+        color: #f4f6fb;
+      }
+      body {
+        margin: 0;
+        padding: 3rem 1.5rem;
+        display: flex;
+        justify-content: center;
+      }
+      main {
+        width: min(720px, 100%);
+      }
+      h1 {
+        font-size: clamp(2rem, 5vw, 2.5rem);
+        margin-bottom: 1.5rem;
+      }
+      ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 1.5rem;
+      }
+      li {
+        background: rgba(255, 255, 255, 0.04);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: 1rem;
+        padding: 1.25rem 1.5rem;
+      }
+      h2 {
+        margin: 0 0 0.5rem;
+        font-size: clamp(1.35rem, 4vw, 1.75rem);
+      }
+      a {
+        color: #8da7ff;
+        text-decoration: none;
+      }
+      a:hover,
+      a:focus {
+        text-decoration: underline;
+      }
+      .meta {
+        margin: 0 0 0.75rem;
+        font-size: 0.95rem;
+        color: rgba(244, 246, 251, 0.8);
+      }
+      .summary {
+        margin: 0;
+        line-height: 1.6;
+        color: rgba(244, 246, 251, 0.85);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>The Hippie Scientist Blog</h1>
+        <p>Recent field notes, research logs, and herbal musings from The Hippie Scientist.</p>
+      </header>
+      <ul>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-10-14-field-notes-damiana-tuesday-notes/">Field Notes — Damiana (Tuesday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-10-14">Oct 14, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-10-13-formulation-tips-valerian-monday-notes/">Formulation Tips — Valerian (Monday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-10-13">Oct 13, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-10-12-psychoactive-botany-skullcap-sunday-notes/">Psychoactive Botany — Skullcap (Sunday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-10-12">Oct 12, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-10-11-blend-craft-reishi-saturday-notes/">Blend Craft — Reishi (Saturday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-10-11">Oct 11, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-10-10-bioassays-damiana-friday-notes/">Bioassays — Damiana (Friday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-10-10">Oct 10, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-10-09-bioassays-rhodiola-thursday-notes/">Bioassays — Rhodiola (Thursday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-10-09">Oct 9, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-10-08-safety-set-setting-cordyceps-wednesday-notes/">Safety &amp; Set/Setting — Cordyceps (Wednesday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-10-08">Oct 8, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-10-07-cultivar-notes-amanita-muscaria-tuesday-notes/">Cultivar Notes — Amanita muscaria (Tuesday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-10-07">Oct 7, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-10-06-formulation-tips-lion-s-mane-monday-notes/">Formulation Tips — Lion&#39;s Mane (Monday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-10-06">Oct 6, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-10-05-microdosing-log-kava-sunday-notes/">Microdosing Log — Kava (Sunday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-10-05">Oct 5, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-10-04-blend-craft-damiana-saturday-notes/">Blend Craft — Damiana (Saturday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-10-04">Oct 4, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-10-03-safety-set-setting-calea-zacatechichi-friday-notes/">Safety &amp; Set/Setting — Calea zacatechichi (Friday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-10-03">Oct 3, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-10-02-safety-set-setting-valerian-thursday-notes/">Safety &amp; Set/Setting — Valerian (Thursday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-10-02">Oct 2, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-10-01-field-notes-ashwagandha-wednesday-notes/">Field Notes — Ashwagandha (Wednesday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-10-01">Oct 1, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-30-cultivar-notes-amanita-muscaria-tuesday-notes/">Cultivar Notes — Amanita muscaria (Tuesday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-30">Sep 30, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-29-bioassays-mugwort-monday-notes/">Bioassays — Mugwort (Monday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-29">Sep 29, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-28-field-notes-valerian-sunday-notes/">Field Notes — Valerian (Sunday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-28">Sep 28, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-27-formulation-tips-cordyceps-saturday-notes/">Formulation Tips — Cordyceps (Saturday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-27">Sep 27, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-26-microdosing-log-skullcap-friday-notes/">Microdosing Log — Skullcap (Friday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-26">Sep 26, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-25-traditional-use-mugwort-thursday-notes/">Traditional Use — Mugwort (Thursday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-25">Sep 25, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-24-traditional-use-rhodiola-wednesday-notes/">Traditional Use — Rhodiola (Wednesday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-24">Sep 24, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-23-extraction-101-kava-tuesday-notes/">Extraction 101 — Kava (Tuesday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-23">Sep 23, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-22-field-notes-lion-s-mane-monday-notes/">Field Notes — Lion&#39;s Mane (Monday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-22">Sep 22, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-21-research-digest-calea-zacatechichi-sunday-notes/">Research Digest — Calea zacatechichi (Sunday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-21">Sep 21, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-20-microdosing-log-cordyceps-saturday-notes/">Microdosing Log — Cordyceps (Saturday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-20">Sep 20, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-19-blend-craft-calea-zacatechichi-friday-notes/">Blend Craft — Calea zacatechichi (Friday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-19">Sep 19, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-18-psychoactive-botany-ashwagandha-thursday-notes/">Psychoactive Botany — Ashwagandha (Thursday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-18">Sep 18, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-17-psychoactive-botany-amanita-muscaria-wednesday-notes/">Psychoactive Botany — Amanita muscaria (Wednesday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-17">Sep 17, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-16-cultivar-notes-damiana-tuesday-notes/">Cultivar Notes — Damiana (Tuesday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-16">Sep 16, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-15-traditional-use-gotu-kola-monday-notes/">Traditional Use — Gotu Kola (Monday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-15">Sep 15, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-14-bioassays-ashwagandha-sunday-notes/">Bioassays — Ashwagandha (Sunday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-14">Sep 14, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-13-formulation-tips-mugwort-saturday-notes/">Formulation Tips — Mugwort (Saturday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-13">Sep 13, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-12-safety-set-setting-gotu-kola-friday-notes/">Safety &amp; Set/Setting — Gotu Kola (Friday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-12">Sep 12, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-11-formulation-tips-skullcap-thursday-notes/">Formulation Tips — Skullcap (Thursday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-11">Sep 11, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-10-field-notes-damiana-wednesday-notes/">Field Notes — Damiana (Wednesday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-10">Sep 10, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-09-bioassays-blue-lotus-tuesday-notes/">Bioassays — Blue Lotus (Tuesday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-09">Sep 9, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-08-safety-set-setting-gotu-kola-monday-notes/">Safety &amp; Set/Setting — Gotu Kola (Monday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-08">Sep 8, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-07-pharmacology-basics-blue-lotus-sunday-notes/">Pharmacology Basics — Blue Lotus (Sunday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-07">Sep 7, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-06-pharmacology-basics-rhodiola-saturday-notes/">Pharmacology Basics — Rhodiola (Saturday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-06">Sep 6, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-05-bioassays-reishi-friday-notes/">Bioassays — Reishi (Friday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-05">Sep 5, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-04-bioassays-blue-lotus-thursday-notes/">Bioassays — Blue Lotus (Thursday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-04">Sep 4, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-03-pharmacology-basics-damiana-wednesday-notes/">Pharmacology Basics — Damiana (Wednesday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-03">Sep 3, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-02-cultivar-notes-rhodiola-tuesday-notes/">Cultivar Notes — Rhodiola (Tuesday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-02">Sep 2, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-09-01-microdosing-log-blue-lotus-monday-notes/">Microdosing Log — Blue Lotus (Monday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-09-01">Sep 1, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-08-31-safety-set-setting-amanita-muscaria-sunday-notes/">Safety &amp; Set/Setting — Amanita muscaria (Sunday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-08-31">Aug 31, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-08-30-blend-craft-reishi-saturday-notes/">Blend Craft — Reishi (Saturday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-08-30">Aug 30, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-08-29-blend-craft-passionflower-friday-notes/">Blend Craft — Passionflower (Friday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-08-29">Aug 29, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-08-28-research-digest-gotu-kola-thursday-notes/">Research Digest — Gotu Kola (Thursday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-08-28">Aug 28, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-08-27-blend-craft-calea-zacatechichi-wednesday-notes/">Blend Craft — Calea zacatechichi (Wednesday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-08-27">Aug 27, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-08-26-pharmacology-basics-rhodiola-tuesday-notes/">Pharmacology Basics — Rhodiola (Tuesday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-08-26">Aug 26, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-08-25-extraction-101-passionflower-monday-notes/">Extraction 101 — Passionflower (Monday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-08-25">Aug 25, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-08-24-safety-set-setting-skullcap-sunday-notes/">Safety &amp; Set/Setting — Skullcap (Sunday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-08-24">Aug 24, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-08-23-psychoactive-botany-cordyceps-saturday-notes/">Psychoactive Botany — Cordyceps (Saturday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-08-23">Aug 23, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-08-22-safety-set-setting-cordyceps-friday-notes/">Safety &amp; Set/Setting — Cordyceps (Friday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-08-22">Aug 22, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-08-21-pharmacology-basics-gotu-kola-thursday-notes/">Pharmacology Basics — Gotu Kola (Thursday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-08-21">Aug 21, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-08-20-blend-craft-kava-wednesday-notes/">Blend Craft — Kava (Wednesday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-08-20">Aug 20, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-08-19-formulation-tips-passionflower-tuesday-notes/">Formulation Tips — Passionflower (Tuesday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-08-19">Aug 19, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-08-18-research-digest-cordyceps-monday-notes/">Research Digest — Cordyceps (Monday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-08-18">Aug 18, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-08-17-traditional-use-calea-zacatechichi-sunday-notes/">Traditional Use — Calea zacatechichi (Sunday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-08-17">Aug 17, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/2025-08-16-psychoactive-botany-rhodiola-saturday-notes/">Psychoactive Botany — Rhodiola (Saturday Notes)</a></h2>
+          <p class="meta"><time datetime="2025-08-16">Aug 16, 2025</time></p>
+          <p class="summary">import Callout from &#39;@/components/Callout&#39; /* safe to leave; if missing, remove this line */</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/rhodiola-vs-ashwagandha/">Rhodiola vs. Ashwagandha: Matching Adaptogens to Your Needs</a></h2>
+          <p class="meta"><time datetime="2024-05-20">May 20, 2024</time></p>
+          <p class="summary">Rhodiola (*Rhodiola rosea*) and ashwagandha (*Withania somnifera*) are two of the most popular adaptogens for stress resilience. While both herbs modulate the hypothalamic-pituitary-adrenal (HPA) axis, their personaliti</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/kava-safety-kavalactones/">Kava Safety: Kavalactones, Extraction, and Liver Risk</a></h2>
+          <p class="meta"><time datetime="2024-05-18">May 18, 2024</time></p>
+          <p class="summary">Kava (*Piper methysticum*) carries a dual reputation: a beloved ceremonial relaxant in the South Pacific and a controversial herb in Western regulatory circles. This article examines how kavalactone chemistry, extractio</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/cacao-theobromine-stimulant/">Cacao and Theobromine: A Gentle Stimulant Profile</a></h2>
+          <p class="meta"><time datetime="2024-05-15">May 15, 2024</time></p>
+          <p class="summary">Cacao ceremonies and morning cacao tonics are surging in popularity as people seek alternatives to coffee. Theobromine-rich cacao offers a smoother stimulant experience that supports focus, heart opening, and creative f</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/blue-lotus-aporphines/">Blue Lotus (Nymphaea) and Aporphines for Gentle Sedation</a></h2>
+          <p class="meta"><time datetime="2024-05-14">May 14, 2024</time></p>
+          <p class="summary">Blue lotus (*Nymphaea caerulea*) evokes images of ancient Egyptian rites and tranquil pools. Today, herbal enthusiasts infuse its petals in tea, wine, or tinctures for serene evenings. The key to understanding blue lotu</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/nightly-blend-guide/">Start Here: Building a Simple Nightly Herb Blend</a></h2>
+          <p class="meta"><time datetime="2024-05-13">May 13, 2024</time></p>
+          <p class="summary">Creating a nightly herb blend can transform bedtime from a scramble into a nourishing ritual. Instead of chasing complex formulas, start with a thoughtful foundation that aligns with your constitution, schedule, and sle</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/lions-mane-bdnf/">Lion&#39;s Mane and BDNF: What the Evidence Shows</a></h2>
+          <p class="meta"><time datetime="2024-05-12">May 12, 2024</time></p>
+          <p class="summary">Lion’s mane mushroom (*Hericium erinaceus*) has become synonymous with brain health in modern herbal circles. Central to its reputation is brain-derived neurotrophic factor (BDNF), a signaling protein that supports syna</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/yerba-mate-vs-green-tea/">Yerba Mate vs. Green Tea: Balancing Caffeine and L-Theanine</a></h2>
+          <p class="meta"><time datetime="2024-05-11">May 11, 2024</time></p>
+          <p class="summary">Yerba mate and green tea share a reputation for steady energy, yet their chemistry and cultural contexts diverge. Mate gourds clink in South American plazas, while Japanese tea ceremonies unfold with precise choreograph</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/kanna-mood-focus/">Kanna (Sceletium) for Mood and Focus</a></h2>
+          <p class="meta"><time datetime="2024-05-10">May 10, 2024</time></p>
+          <p class="summary">Kanna, or *Sceletium tortuosum*, has long been chewed, smoked, and brewed across southern Africa for its calming lift. Today the succulent is finding a new audience among people who want gentle emotional buoyancy withou</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/reishi-sleep-immunity/">Reishi for Sleep and Immunity: What the Studies Say</a></h2>
+          <p class="meta"><time datetime="2024-05-09">May 9, 2024</time></p>
+          <p class="summary">Reishi (*Ganoderma lucidum*) is revered as the “mushroom of immortality” in East Asian traditions. Modern research explores its beta-glucans, triterpenes, and polysaccharides for immune modulation and stress resilience.</p>
+        </article>
+      </li>
+      <li>
+        <article>
+          <h2><a href="/blog/mugwort-dreaming-tradition/">Mugwort and Dreaming: Tradition Meets Evidence</a></h2>
+          <p class="meta"><time datetime="2024-05-08">May 8, 2024</time></p>
+          <p class="summary">Mugwort (*Artemisia vulgaris*) has woven itself into dream lore across Europe, Asia, and North America. Herbalists burn it as smudge, tuck sprigs under pillows, or sip it as bedtime tea to stimulate vivid dreams. But ho</p>
+        </article>
+      </li>
+      </ul>
+    </main>
+  </body>
+</html>

--- a/scripts/generate-blog-index.mjs
+++ b/scripts/generate-blog-index.mjs
@@ -1,0 +1,155 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, "..");
+const blogDataPath = path.join(projectRoot, "public", "blogdata", "index.json");
+const outputDir = path.join(projectRoot, "public", "blog");
+const outputPath = path.join(outputDir, "index.html");
+
+function escapeHtml(value = "") {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function formatDate(iso) {
+  if (!iso) return "";
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) return iso;
+  return new Intl.DateTimeFormat("en", { month: "short", day: "numeric", year: "numeric" }).format(parsed);
+}
+
+async function generate() {
+  const raw = await fs.readFile(blogDataPath, "utf8");
+  const parsed = JSON.parse(raw);
+  const posts = Array.isArray(parsed) ? parsed : [];
+
+  await fs.mkdir(outputDir, { recursive: true });
+
+  const sortedPosts = posts.slice().sort((a, b) => {
+    const da = Date.parse(a?.date ?? "");
+    const db = Date.parse(b?.date ?? "");
+    const safeDa = Number.isNaN(da) ? 0 : da;
+    const safeDb = Number.isNaN(db) ? 0 : db;
+    return safeDb - safeDa;
+  });
+
+  const listItems = sortedPosts
+    .map((post) => {
+      const slug = String(post.slug || "").trim();
+      if (!slug) return null;
+      const title = escapeHtml(String(post.title || slug));
+      const url = `/blog/${slug}/`;
+      const formattedDate = formatDate(post.date);
+      const description = escapeHtml(
+        String(post.description || post.summary || "").trim().replace(/\s+/g, " "),
+      );
+
+      const meta = [
+        formattedDate ? `<time datetime="${escapeHtml(post.date)}">${formattedDate}</time>` : "",
+      ]
+        .filter(Boolean)
+        .join(" ");
+
+      return `      <li>
+        <article>
+          <h2><a href="${url}">${title}</a></h2>
+          ${meta ? `<p class="meta">${meta}</p>` : ""}
+          ${description ? `<p class="summary">${description}</p>` : ""}
+        </article>
+      </li>`;
+    })
+    .filter(Boolean)
+    .join("\n") || "      <li><p>No posts published yet.</p></li>";
+
+  const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>The Hippie Scientist — Blog</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Latest research notes and field reports from The Hippie Scientist." />
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background-color: #05060a;
+        color: #f4f6fb;
+      }
+      body {
+        margin: 0;
+        padding: 3rem 1.5rem;
+        display: flex;
+        justify-content: center;
+      }
+      main {
+        width: min(720px, 100%);
+      }
+      h1 {
+        font-size: clamp(2rem, 5vw, 2.5rem);
+        margin-bottom: 1.5rem;
+      }
+      ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 1.5rem;
+      }
+      li {
+        background: rgba(255, 255, 255, 0.04);
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: 1rem;
+        padding: 1.25rem 1.5rem;
+      }
+      h2 {
+        margin: 0 0 0.5rem;
+        font-size: clamp(1.35rem, 4vw, 1.75rem);
+      }
+      a {
+        color: #8da7ff;
+        text-decoration: none;
+      }
+      a:hover,
+      a:focus {
+        text-decoration: underline;
+      }
+      .meta {
+        margin: 0 0 0.75rem;
+        font-size: 0.95rem;
+        color: rgba(244, 246, 251, 0.8);
+      }
+      .summary {
+        margin: 0;
+        line-height: 1.6;
+        color: rgba(244, 246, 251, 0.85);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>The Hippie Scientist Blog</h1>
+        <p>Recent field notes, research logs, and herbal musings from The Hippie Scientist.</p>
+      </header>
+      <ul>
+${listItems}
+      </ul>
+    </main>
+  </body>
+</html>
+`;
+
+  await fs.writeFile(outputPath, html);
+}
+
+generate().catch((error) => {
+  console.error("Failed to generate blog index:", error);
+  process.exitCode = 1;
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,91 +1,91 @@
-import React from 'react';
-import { Routes, Route, Outlet, useLocation, Navigate } from 'react-router-dom';
-import { AnimatePresence, motion } from 'framer-motion';
-import Home from './pages/Home';
-import About from './pages/About';
-import HerbsPage from './pages/Herbs';
-import Favorites from './pages/Favorites';
-import BuildBlend from './pages/BuildBlend';
-import NotFound from './pages/NotFound';
-import { RedirectHandler } from './RedirectHandler';
-import { useGA } from './lib/useGA';
-import HerbIndex from './pages/HerbIndex';
-import CompoundIndex from './pages/CompoundIndex';
-import CompoundsPage from './pages/Compounds';
-import HerbDetail from './pages/HerbDetail';
-import Compare from './pages/Compare';
-import DataReport from './pages/DataReport';
-import DataFix from './pages/DataFix';
-import Sitemap from './pages/Sitemap';
-import Newsletter from './pages/Newsletter';
-import Contact from './pages/Contact';
-import Footer from './components/Footer';
-import AppToaster from './components/ui/Toaster';
-import ConsentBanner from './components/ConsentBanner';
-import AmbientCursor from './components/AmbientCursor';
-import SiteLayout from '@/components/SiteLayout';
-import BlogList from './pages/BlogList';
-import BlogPost from './pages/BlogPost';
-import GraphPage from './pages/Graph';
-import Theme from './pages/Theme';
-import CompoundDetail from './pages/CompoundDetail';
-import { useTrippy } from '@/lib/trippy';
+import React from 'react'
+import { Routes, Route, Outlet, useLocation, Navigate } from 'react-router-dom'
+import { AnimatePresence, motion } from 'framer-motion'
+import Home from './pages/Home'
+import About from './pages/About'
+import HerbsPage from './pages/Herbs'
+import Favorites from './pages/Favorites'
+import BuildBlend from './pages/BuildBlend'
+import NotFound from './pages/NotFound'
+import { RedirectHandler } from './RedirectHandler'
+import { useGA } from './lib/useGA'
+import HerbIndex from './pages/HerbIndex'
+import CompoundIndex from './pages/CompoundIndex'
+import CompoundsPage from './pages/Compounds'
+import HerbDetail from './pages/HerbDetail'
+import Compare from './pages/Compare'
+import DataReport from './pages/DataReport'
+import DataFix from './pages/DataFix'
+import Sitemap from './pages/Sitemap'
+import Newsletter from './pages/Newsletter'
+import Contact from './pages/Contact'
+import Footer from './components/Footer'
+import AppToaster from './components/ui/Toaster'
+import ConsentBanner from './components/ConsentBanner'
+import AmbientCursor from './components/AmbientCursor'
+import SiteLayout from '@/components/SiteLayout'
+import BlogList from './pages/BlogList'
+import BlogPost from './pages/BlogPost'
+import GraphPage from './pages/Graph'
+import Theme from './pages/Theme'
+import CompoundDetail from './pages/CompoundDetail'
+import { useTrippy } from '@/lib/trippy'
 // Import other pages as needed
 
 export default function App() {
-  useGA();
-  const { level } = useTrippy();
+  useGA()
+  const { level } = useTrippy()
   return (
-    <div id="app-root">
+    <div id='app-root'>
       <SiteLayout>
-        <div className="relative z-10">
+        <div className='relative z-10'>
           <RedirectHandler />
-          {level !== "off" && <AmbientCursor />}
+          {level !== 'off' && <AmbientCursor />}
           <Routes>
             <Route element={<RootLayout />}>
-              <Route path="/" element={<Home />} />
-              <Route path="/about" element={<About />} />
-              <Route path="/database" element={<Navigate to="/herbs" replace />} />
-              <Route path="/herbs" element={<HerbsPage />} />
-              <Route path="/compounds" element={<CompoundsPage />} />
-              <Route path="/browse" element={<Navigate to="/browse/herbs" replace />} />
-              <Route path="/browse/herbs" element={<HerbIndex />} />
-              <Route path="/browse/compounds" element={<CompoundIndex />} />
-              <Route path="/blend" element={<BuildBlend />} />
-              <Route path="/build" element={<BuildBlend />} />
-              <Route path="/favorites" element={<Favorites />} />
-              <Route path="/newsletter" element={<Newsletter />} />
-              <Route path="/contact" element={<Contact />} />
+              <Route path='/' element={<Home />} />
+              <Route path='/about' element={<About />} />
+              <Route path='/database' element={<Navigate to='/herbs' replace />} />
+              <Route path='/herbs' element={<HerbsPage />} />
+              <Route path='/compounds' element={<CompoundsPage />} />
+              <Route path='/browse' element={<Navigate to='/browse/herbs' replace />} />
+              <Route path='/browse/herbs' element={<HerbIndex />} />
+              <Route path='/browse/compounds' element={<CompoundIndex />} />
+              <Route path='/blend' element={<BuildBlend />} />
+              <Route path='/build' element={<BuildBlend />} />
+              <Route path='/favorites' element={<Favorites />} />
+              <Route path='/newsletter' element={<Newsletter />} />
+              <Route path='/contact' element={<Contact />} />
               {/* Add other routes here */}
-              <Route path="/blog" element={<BlogList />} />
-              <Route path="/blog/page/:page" element={<BlogList />} />
-              <Route path="/blog/:slug" element={<BlogPost />} />
-              <Route path="/theme" element={<Theme />} />
-              <Route path="/herb-index" element={<HerbIndex />} />
-              <Route path="/herb/:slug" element={<HerbDetail />} />
-              <Route path="/herbs/:slug" element={<HerbDetail />} />
-              <Route path="/compounds/:slug" element={<CompoundDetail />} />
-              <Route path="/compare" element={<Compare />} />
-              <Route path="/data-report" element={<DataReport />} />
-              <Route path="/data-fix" element={<DataFix />} />
-              <Route path="/sitemap" element={<Sitemap />} />
+              <Route path='/blog' element={<BlogList />} />
+              <Route path='/blog/page/:page' element={<BlogList />} />
+              <Route path='/blog/:slug/*' element={<BlogPost />} />
+              <Route path='/theme' element={<Theme />} />
+              <Route path='/herb-index' element={<HerbIndex />} />
+              <Route path='/herb/:slug' element={<HerbDetail />} />
+              <Route path='/herbs/:slug' element={<HerbDetail />} />
+              <Route path='/compounds/:slug' element={<CompoundDetail />} />
+              <Route path='/compare' element={<Compare />} />
+              <Route path='/data-report' element={<DataReport />} />
+              <Route path='/data-fix' element={<DataFix />} />
+              <Route path='/sitemap' element={<Sitemap />} />
             </Route>
-            <Route path="/graph" element={<GraphPage />} />
-            <Route path="*" element={<NotFound />} />
+            <Route path='/graph' element={<GraphPage />} />
+            <Route path='*' element={<NotFound />} />
           </Routes>
         </div>
       </SiteLayout>
     </div>
-  );
+  )
 }
 
 function RootLayout() {
-  const location = useLocation();
+  const location = useLocation()
 
   return (
-    <div className="relative flex min-h-screen flex-col">
-      <main id="App_main" className="main relative z-10 flex-1">
-        <AnimatePresence mode="wait">
+    <div className='relative flex min-h-screen flex-col'>
+      <main id='App_main' className='main relative z-10 flex-1'>
+        <AnimatePresence mode='wait'>
           <motion.div
             key={location.pathname}
             initial={{ opacity: 0, y: 8 }}
@@ -101,5 +101,5 @@ function RootLayout() {
       <ConsentBanner />
       <AppToaster />
     </div>
-  );
+  )
 }

--- a/src/components/BlogList.tsx
+++ b/src/components/BlogList.tsx
@@ -12,17 +12,14 @@ export default function BlogList({ posts }: { posts: PostPreview[] }) {
       {posts.map(post => (
         <article
           key={post.slug}
-          className="rounded-xl border border-[color:color-mix(in_oklab,var(--border-c)_80%,transparent_20%)] bg-[color-mix(in_oklab,var(--surface-c)_90%,transparent_10%)] p-4 backdrop-blur"
+          className='rounded-xl border border-[color:color-mix(in_oklab,var(--border-c)_80%,transparent_20%)] bg-[color-mix(in_oklab,var(--surface-c)_90%,transparent_10%)] p-4 backdrop-blur'
         >
-          <h3 className="text-xl font-semibold text-[color:var(--text-c)]">
-            <Link
-              to={`/blog/${post.slug}`}
-              className="link text-[color:var(--accent)]"
-            >
+          <h3 className='text-xl font-semibold text-[color:var(--text-c)]'>
+            <Link to={`/blog/${post.slug}/`} className='link text-[color:var(--accent)]'>
               {post.title}
             </Link>
           </h3>
-          <p className="text-[color:var(--muted-c)]">{post.summary}</p>
+          <p className='text-[color:var(--muted-c)]'>{post.summary}</p>
         </article>
       ))}
     </section>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,41 +1,43 @@
-import { useEffect, useState } from "react";
-import ConsentManager from "./ConsentManager";
-import { onOpenConsent } from "../lib/consentBus";
-import NonEmpty from "./NonEmpty";
-import { toHash } from "../lib/routing";
+import { useEffect, useState } from 'react'
+import ConsentManager from './ConsentManager'
+import { onOpenConsent } from '../lib/consentBus'
+import NonEmpty from './NonEmpty'
+import { toHash } from '../lib/routing'
 
 const exploreLinks = [
-  { href: "/herbs", label: "Herb Database" },
-  { href: "/compounds", label: "Compounds" },
-  { href: "/build", label: "Build a Blend" },
-  { href: "/blog", label: "Blog" },
-  { href: "/graph", label: "NeuroHerbGraph" },
-];
+  { href: '/herbs', label: 'Herb Database' },
+  { href: '/compounds', label: 'Compounds' },
+  { href: '/build', label: 'Build a Blend' },
+  { href: '/blog/', label: 'Blog' },
+  { href: '/graph', label: 'NeuroHerbGraph' },
+]
 
 const legalLinks = [
-  { href: "/privacy", label: "Privacy Policy" },
-  { href: "/disclaimer", label: "Disclaimer" },
-  { href: "/contact", label: "Contact" },
-  { href: "/sitemap", label: "Sitemap" },
-];
+  { href: '/privacy', label: 'Privacy Policy' },
+  { href: '/disclaimer', label: 'Disclaimer' },
+  { href: '/contact', label: 'Contact' },
+  { href: '/sitemap', label: 'Sitemap' },
+]
 
 export default function Footer() {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(false)
 
-  useEffect(() => onOpenConsent(() => setOpen(true)), []);
+  useEffect(() => onOpenConsent(() => setOpen(true)), [])
 
   return (
-    <footer className="relative mx-auto max-w-screen-md w-full px-4 py-10">
-      <div className="rounded-3xl bg-white/5 ring-1 ring-white/10 backdrop-blur-xl p-6 sm:p-7">
-        <div className="grid gap-8 sm:grid-cols-2">
+    <footer className='relative mx-auto w-full max-w-screen-md px-4 py-10'>
+      <div className='rounded-3xl bg-white/5 p-6 ring-1 ring-white/10 backdrop-blur-xl sm:p-7'>
+        <div className='grid gap-8 sm:grid-cols-2'>
           <NonEmpty>
             {exploreLinks.length > 0 && (
               <div>
-                <h4 className="mb-3 text-sm font-semibold uppercase tracking-wide text-white/70">Explore</h4>
-                <ul className="space-y-1 text-sm text-white/75">
+                <h4 className='mb-3 text-sm font-semibold uppercase tracking-wide text-white/70'>
+                  Explore
+                </h4>
+                <ul className='space-y-1 text-sm text-white/75'>
                   {exploreLinks.map(link => (
                     <li key={link.href}>
-                      <a className="transition hover:text-white" href={toHash(link.href)}>
+                      <a className='transition hover:text-white' href={toHash(link.href)}>
                         {link.label}
                       </a>
                     </li>
@@ -47,19 +49,21 @@ export default function Footer() {
           <NonEmpty>
             {legalLinks.length > 0 && (
               <div>
-                <h4 className="mb-3 text-sm font-semibold uppercase tracking-wide text-white/70">Stay safe</h4>
-                <ul className="space-y-1 text-sm text-white/75">
+                <h4 className='mb-3 text-sm font-semibold uppercase tracking-wide text-white/70'>
+                  Stay safe
+                </h4>
+                <ul className='space-y-1 text-sm text-white/75'>
                   {legalLinks.map(link => (
                     <li key={link.href}>
-                      <a className="transition hover:text-white" href={toHash(link.href)}>
+                      <a className='transition hover:text-white' href={toHash(link.href)}>
                         {link.label}
                       </a>
                     </li>
                   ))}
                   <li>
                     <button
-                      className="text-white/70 underline decoration-dotted underline-offset-4 transition hover:text-white"
-                      type="button"
+                      className='text-white/70 underline decoration-dotted underline-offset-4 transition hover:text-white'
+                      type='button'
                       onClick={() => setOpen(true)}
                     >
                       Privacy settings
@@ -71,11 +75,11 @@ export default function Footer() {
           </NonEmpty>
         </div>
 
-        <div className="mt-8 border-t border-white/10 pt-4 text-xs text-white/60">
+        <div className='mt-8 border-t border-white/10 pt-4 text-xs text-white/60'>
           © 2025 The Hippie Scientist — All Rights Reserved
         </div>
       </div>
       <ConsentManager open={open} onClose={() => setOpen(false)} />
     </footer>
-  );
+  )
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,81 +1,81 @@
 // src/components/Header.tsx
-import { useEffect, useState } from "react";
-import { Link, useLocation } from "react-router-dom";
-import { useTrippy } from "@/lib/trippy";
-import { useMelt } from "@/melt/useMelt";
+import { useEffect, useState } from 'react'
+import { Link, useLocation } from 'react-router-dom'
+import { useTrippy } from '@/lib/trippy'
+import { useMelt } from '@/melt/useMelt'
 
 const links = [
-  { label: "Browse Herbs", to: "/herbs" },
-  { label: "Build a Blend", to: "/build" },
-  { label: "Compounds", to: "/compounds" },
-  { label: "Blog", to: "/blog" },
-];
+  { label: 'Browse Herbs', to: '/herbs' },
+  { label: 'Build a Blend', to: '/build' },
+  { label: 'Compounds', to: '/compounds' },
+  { label: 'Blog', to: '/blog/' },
+]
 
 export default function Header() {
-  const { enabled: motionEnabled } = useTrippy();
-  const { setEnabled } = useMelt();
-  const location = useLocation();
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const { enabled: motionEnabled } = useTrippy()
+  const { setEnabled } = useMelt()
+  const location = useLocation()
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false)
 
   useEffect(() => {
-    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
-    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+    const media = window.matchMedia('(prefers-reduced-motion: reduce)')
 
-    const update = () => setPrefersReducedMotion(media.matches);
-    update();
+    const update = () => setPrefersReducedMotion(media.matches)
+    update()
 
-    const handler = (event: MediaQueryListEvent) => setPrefersReducedMotion(event.matches);
+    const handler = (event: MediaQueryListEvent) => setPrefersReducedMotion(event.matches)
 
-    if (typeof media.addEventListener === "function") {
-      media.addEventListener("change", handler);
-      return () => media.removeEventListener("change", handler);
+    if (typeof media.addEventListener === 'function') {
+      media.addEventListener('change', handler)
+      return () => media.removeEventListener('change', handler)
     }
 
-    if (typeof media.addListener === "function") {
-      media.addListener(handler);
-      return () => media.removeListener(handler);
+    if (typeof media.addListener === 'function') {
+      media.addListener(handler)
+      return () => media.removeListener(handler)
     }
 
-    return undefined;
-  }, []);
+    return undefined
+  }, [])
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
+    if (typeof window === 'undefined') return
     const handleKeyDown = (event: KeyboardEvent) => {
-      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === "t") {
-        event.preventDefault();
-        if (!motionEnabled || prefersReducedMotion) return;
-        setEnabled(!useMelt.getState().enabled);
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 't') {
+        event.preventDefault()
+        if (!motionEnabled || prefersReducedMotion) return
+        setEnabled(!useMelt.getState().enabled)
       }
-    };
+    }
 
-    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener('keydown', handleKeyDown)
     return () => {
-      window.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [motionEnabled, prefersReducedMotion, setEnabled]);
+      window.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [motionEnabled, prefersReducedMotion, setEnabled])
 
   return (
-    <header className="sticky top-0 z-50 bg-transparent backdrop-blur supports-[backdrop-filter]:bg-black/20">
+    <header className='sticky top-0 z-50 bg-transparent backdrop-blur supports-[backdrop-filter]:bg-black/20'>
       <a
-        href="#main"
-        className="sr-only focus:not-sr-only focus:absolute focus:left-3 focus:top-3 focus:z-[999] rounded bg-black/70 px-3 py-2 text-sm font-medium text-white"
+        href='#main'
+        className='sr-only rounded bg-black/70 px-3 py-2 text-sm font-medium text-white focus:not-sr-only focus:absolute focus:left-3 focus:top-3 focus:z-[999]'
       >
         Skip to content
       </a>
-      <div className="mx-auto max-w-5xl px-4">
-        <div className="flex items-center justify-between py-3" aria-label="Site">
-          <Link to="/" className="flex items-center gap-2 shrink-0">
-            <span className="h-6 w-2.5 rounded-full bg-gradient-to-b from-teal-300 via-sky-400 to-fuchsia-400" />
-            <span className="font-semibold tracking-tight text-white">THS</span>
+      <div className='mx-auto max-w-5xl px-4'>
+        <div className='flex items-center justify-between py-3' aria-label='Site'>
+          <Link to='/' className='flex shrink-0 items-center gap-2'>
+            <span className='h-6 w-2.5 rounded-full bg-gradient-to-b from-teal-300 via-sky-400 to-fuchsia-400' />
+            <span className='font-semibold tracking-tight text-white'>THS</span>
           </Link>
 
           <nav
-            className="ml-4 flex min-w-0 items-center gap-2 overflow-x-auto no-scrollbar"
-            aria-label="Primary"
+            className='no-scrollbar ml-4 flex min-w-0 items-center gap-2 overflow-x-auto'
+            aria-label='Primary'
           >
-            {links.map((link) => {
-              const active = location.pathname.startsWith(link.to);
+            {links.map(link => {
+              const active = location.pathname.startsWith(link.to)
               return (
                 <Link
                   key={link.to}
@@ -84,11 +84,11 @@ export default function Header() {
                 >
                   {link.label}
                 </Link>
-              );
+              )
             })}
           </nav>
         </div>
       </div>
     </header>
-  );
+  )
 }

--- a/src/components/HeaderNav.tsx
+++ b/src/components/HeaderNav.tsx
@@ -1,42 +1,42 @@
-import { NavLink } from "react-router-dom";
+import { NavLink } from 'react-router-dom'
 
 const tabs = [
-  { to: "/", short: "THS", full: "THS" },
-  { to: "/herbs", short: "Herbs", full: "Browse" },
-  { to: "/compounds", short: "Comp.", full: "Compounds" },
-  { to: "/build", short: "Build", full: "Build" },
-  { to: "/blog", short: "Blog", full: "Blog" },
-];
+  { to: '/', short: 'THS', full: 'THS' },
+  { to: '/herbs', short: 'Herbs', full: 'Browse' },
+  { to: '/compounds', short: 'Comp.', full: 'Compounds' },
+  { to: '/build', short: 'Build', full: 'Build' },
+  { to: '/blog/', short: 'Blog', full: 'Blog' },
+]
 
 export default function HeaderNav() {
   return (
-    <header className="sticky top-0 z-40 backdrop-blur supports-[backdrop-filter]:bg-black/30">
-      <nav aria-label="Primary" className="px-2 py-2 [overflow:clip]">
-        <ul className="grid grid-cols-5 gap-1">
-          {tabs.map((t) => (
-            <li key={t.to} className="min-w-0">
+    <header className='sticky top-0 z-40 backdrop-blur supports-[backdrop-filter]:bg-black/30'>
+      <nav aria-label='Primary' className='px-2 py-2 [overflow:clip]'>
+        <ul className='grid grid-cols-5 gap-1'>
+          {tabs.map(t => (
+            <li key={t.to} className='min-w-0'>
               <NavLink
                 to={t.to}
                 className={({ isActive }) =>
                   [
-                    "w-full min-w-0 inline-flex items-center justify-center",
+                    'inline-flex w-full min-w-0 items-center justify-center',
                     // compact on phones, a touch larger on sm+
-                    "h-8 sm:h-9 rounded-full px-2 sm:px-3",
-                    "text-[11px] sm:text-sm leading-none tracking-tight",
-                    "bg-white/5 hover:bg-white/10 ring-1 ring-white/10 transition-colors",
-                    isActive ? "bg-white/15 ring-white/20" : "",
-                  ].join(" ")
+                    'h-8 rounded-full px-2 sm:h-9 sm:px-3',
+                    'text-[11px] leading-none tracking-tight sm:text-sm',
+                    'bg-white/5 ring-1 ring-white/10 transition-colors hover:bg-white/10',
+                    isActive ? 'bg-white/15 ring-white/20' : '',
+                  ].join(' ')
                 }
               >
                 {/* short label on mobile */}
-                <span className="truncate sm:hidden">{t.short}</span>
+                <span className='truncate sm:hidden'>{t.short}</span>
                 {/* full label on sm+ */}
-                <span className="hidden sm:block truncate">{t.full}</span>
+                <span className='hidden truncate sm:block'>{t.full}</span>
               </NavLink>
             </li>
           ))}
         </ul>
       </nav>
     </header>
-  );
+  )
 }

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,69 +1,85 @@
-import { motion, useReducedMotion } from "framer-motion";
-import Tilt from "./Tilt";
-import StatPill from "./StatPill";
-import HeroCTA from "./HeroCTA";
+import { motion, useReducedMotion } from 'framer-motion'
+import Tilt from './Tilt'
+import StatPill from './StatPill'
+import HeroCTA from './HeroCTA'
 
 type HeroCounts = {
-  herbs: number;
-  compounds: number;
-  articles: number;
-};
+  herbs: number
+  compounds: number
+  articles: number
+}
 
 type HeroProps = {
-  counts?: HeroCounts;
-};
+  counts?: HeroCounts
+}
 
 export default function Hero({ counts }: HeroProps) {
-  const reduceMotion = useReducedMotion();
-  const { herbs = 0, compounds = 0, articles = 0 } = counts ?? {};
+  const reduceMotion = useReducedMotion()
+  const { herbs = 0, compounds = 0, articles = 0 } = counts ?? {}
 
   return (
-    <section className="relative mx-auto max-w-3xl px-4 py-12 sm:px-6">
-      <div aria-hidden className="pointer-events-none absolute inset-0 -z-10 grid place-items-center">
-        <div className="size-[52rem] rounded-full bg-gradient-to-br from-emerald-500/15 via-fuchsia-500/10 to-indigo-500/15 blur-3xl animate-breathe" />
+    <section className='relative mx-auto max-w-3xl px-4 py-12 sm:px-6'>
+      <div
+        aria-hidden
+        className='pointer-events-none absolute inset-0 -z-10 grid place-items-center'
+      >
+        <div className='size-[52rem] animate-breathe rounded-full bg-gradient-to-br from-emerald-500/15 via-fuchsia-500/10 to-indigo-500/15 blur-3xl' />
       </div>
 
-      <Tilt maxTilt={6} perspective={900} className="relative">
+      <Tilt maxTilt={6} perspective={900} className='relative'>
         <motion.div
           initial={reduceMotion ? undefined : { opacity: 0, y: 18, scale: 0.985 }}
           animate={reduceMotion ? undefined : { opacity: 1, y: 0, scale: 1 }}
           transition={reduceMotion ? undefined : { duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
-          className="relative overflow-hidden rounded-[28px] border border-white/10 bg-white/5 backdrop-blur-xl shadow-halo"
+          className='relative overflow-hidden rounded-[28px] border border-white/10 bg-white/5 shadow-halo backdrop-blur-xl'
         >
-          <div className="pointer-events-none absolute -top-24 left-0 right-0 h-48 bg-gradient-to-b from-white/10 to-transparent" aria-hidden />
+          <div
+            className='pointer-events-none absolute -top-24 left-0 right-0 h-48 bg-gradient-to-b from-white/10 to-transparent'
+            aria-hidden
+          />
 
-          <div className="relative p-6 sm:p-10">
+          <div className='relative p-6 sm:p-10'>
             <motion.h1
               initial={reduceMotion ? undefined : { opacity: 0, y: 12 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
-              transition={reduceMotion ? undefined : { delay: 0.05, duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
-              className="text-4xl font-extrabold leading-[1.05] tracking-tight text-white sm:text-6xl"
+              transition={
+                reduceMotion ? undefined : { delay: 0.05, duration: 0.4, ease: [0.22, 1, 0.36, 1] }
+              }
+              className='text-4xl font-extrabold leading-[1.05] tracking-tight text-white sm:text-6xl'
             >
-              The Hippie <br className="hidden sm:block" /> Scientist
+              The Hippie <br className='hidden sm:block' /> Scientist
             </motion.h1>
             <motion.p
               initial={reduceMotion ? undefined : { opacity: 0, y: 12 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
-              transition={reduceMotion ? undefined : { delay: 0.12, duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
-              className="mt-4 max-w-2xl text-base text-white/80 sm:text-lg"
+              transition={
+                reduceMotion ? undefined : { delay: 0.12, duration: 0.4, ease: [0.22, 1, 0.36, 1] }
+              }
+              className='mt-4 max-w-2xl text-base text-white/80 sm:text-lg'
             >
-              Psychedelic botany, mindful blends, and evidence-forward guidance for curious explorers.
+              Psychedelic botany, mindful blends, and evidence-forward guidance for curious
+              explorers.
             </motion.p>
 
-            <div className="mt-6">
+            <div className='mt-6'>
               <HeroCTA />
             </div>
 
-            <nav aria-label="Site stats" className="mt-6 flex flex-wrap gap-2 sm:gap-3">
-              <StatPill to="/herbs" value={herbs} label="psychoactive herbs" testId="pill-herbs" />
-              <StatPill to="/compounds" value={compounds} label="active compounds" testId="pill-compounds" />
-              <StatPill to="/blog" value={articles} label="articles" testId="pill-articles" />
+            <nav aria-label='Site stats' className='mt-6 flex flex-wrap gap-2 sm:gap-3'>
+              <StatPill to='/herbs' value={herbs} label='psychoactive herbs' testId='pill-herbs' />
+              <StatPill
+                to='/compounds'
+                value={compounds}
+                label='active compounds'
+                testId='pill-compounds'
+              />
+              <StatPill to='/blog/' value={articles} label='articles' testId='pill-articles' />
             </nav>
           </div>
         </motion.div>
       </Tilt>
     </section>
-  );
+  )
 }

--- a/src/components/SiteLayout.tsx
+++ b/src/components/SiteLayout.tsx
@@ -1,99 +1,102 @@
-import { PropsWithChildren, useEffect, useState } from "react";
-import { Link, useLocation } from "react-router-dom";
-import BackgroundStage from "./BackgroundStage";
-import { useTrippy } from "@/lib/trippy";
-import { useMelt } from "@/melt/useMelt";
+import { PropsWithChildren, useEffect, useState } from 'react'
+import { Link, useLocation } from 'react-router-dom'
+import BackgroundStage from './BackgroundStage'
+import { useTrippy } from '@/lib/trippy'
+import { useMelt } from '@/melt/useMelt'
 
 const links = [
-  { label: "Browse", to: "/herbs" },
-  { label: "Compounds", to: "/compounds" },
-  { label: "Build", to: "/build" },
-  { label: "Blog", to: "/blog" },
-];
+  { label: 'Browse', to: '/herbs' },
+  { label: 'Compounds', to: '/compounds' },
+  { label: 'Build', to: '/build' },
+  { label: 'Blog', to: '/blog/' },
+]
 
 export default function SiteLayout({ children }: PropsWithChildren) {
-  const location = useLocation();
-  const { level, enabled: trippyEnabled } = useTrippy();
-  const { enabled, setEnabled, effect } = useMelt();
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const location = useLocation()
+  const { level, enabled: trippyEnabled } = useTrippy()
+  const { enabled, setEnabled, effect } = useMelt()
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false)
 
   useEffect(() => {
-    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
-    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return
+    const media = window.matchMedia('(prefers-reduced-motion: reduce)')
 
-    const update = () => setPrefersReducedMotion(media.matches);
-    update();
+    const update = () => setPrefersReducedMotion(media.matches)
+    update()
 
-    const handler = (event: MediaQueryListEvent) => setPrefersReducedMotion(event.matches);
+    const handler = (event: MediaQueryListEvent) => setPrefersReducedMotion(event.matches)
 
-    if (typeof media.addEventListener === "function") {
-      media.addEventListener("change", handler);
-      return () => media.removeEventListener("change", handler);
+    if (typeof media.addEventListener === 'function') {
+      media.addEventListener('change', handler)
+      return () => media.removeEventListener('change', handler)
     }
 
-    if (typeof media.addListener === "function") {
-      media.addListener(handler);
-      return () => media.removeListener(handler);
+    if (typeof media.addListener === 'function') {
+      media.addListener(handler)
+      return () => media.removeListener(handler)
     }
 
-    return undefined;
-  }, []);
+    return undefined
+  }, [])
 
   useEffect(() => {
     if (prefersReducedMotion && enabled) {
-      setEnabled(false);
+      setEnabled(false)
     }
-  }, [enabled, prefersReducedMotion, setEnabled]);
+  }, [enabled, prefersReducedMotion, setEnabled])
 
-  const shouldAnimate = trippyEnabled && level !== "off" && enabled && !prefersReducedMotion;
+  const shouldAnimate = trippyEnabled && level !== 'off' && enabled && !prefersReducedMotion
 
   return (
-    <div className="relative min-h-svh overflow-x-hidden">
+    <div className='relative min-h-svh overflow-x-hidden'>
       <BackgroundStage enabled={shouldAnimate} effect={effect} />
 
       <a
-        href="#main"
-        className="sr-only focus:not-sr-only focus:absolute focus:left-3 focus:top-3 focus:z-[999] rounded bg-black/70 px-3 py-2 text-sm font-medium text-white"
+        href='#main'
+        className='sr-only rounded bg-black/70 px-3 py-2 text-sm font-medium text-white focus:not-sr-only focus:absolute focus:left-3 focus:top-3 focus:z-[999]'
       >
         Skip to content
       </a>
 
-      <header className="sticky top-0 z-50 border-b border-white/10 bg-black/40 shadow-[0_0_24px_-12px_rgba(147,51,234,0.6)] backdrop-blur">
-        <nav className="container-safe mx-auto flex max-w-6xl items-center gap-3 px-4 py-3" aria-label="Site">
+      <header className='sticky top-0 z-50 border-b border-white/10 bg-black/40 shadow-[0_0_24px_-12px_rgba(147,51,234,0.6)] backdrop-blur'>
+        <nav
+          className='container-safe mx-auto flex max-w-6xl items-center gap-3 px-4 py-3'
+          aria-label='Site'
+        >
           <Link
-            to="/"
+            to='/'
             className={`inline-flex items-center gap-3 rounded-full border border-white/10 px-4 py-2.5 text-sm font-semibold transition ${
-              location.pathname === "/"
-                ? "bg-white/15 text-white shadow-[0_0_18px_-10px_rgba(147,51,234,0.7)]"
-                : "bg-white/5 text-white/80 hover:bg-white/10 hover:text-white"
+              location.pathname === '/'
+                ? 'bg-white/15 text-white shadow-[0_0_18px_-10px_rgba(147,51,234,0.7)]'
+                : 'bg-white/5 text-white/80 hover:bg-white/10 hover:text-white'
             }`}
           >
             THS
           </Link>
-          <div className="flex flex-1 items-center gap-2">
-            {links.map((link) => {
-              const active = location.pathname.startsWith(link.to);
+          <div className='flex flex-1 items-center gap-2'>
+            {links.map(link => {
+              const active = location.pathname.startsWith(link.to)
               return (
                 <Link
                   key={link.to}
                   to={link.to}
                   className={`inline-flex items-center gap-2 rounded-full border border-white/10 px-4 py-2.5 text-sm font-medium transition ${
                     active
-                      ? "bg-white/15 text-white shadow-[0_0_16px_-12px_rgba(147,51,234,0.6)]"
-                      : "bg-white/5 text-white/75 hover:bg-white/10 hover:text-white"
+                      ? 'bg-white/15 text-white shadow-[0_0_16px_-12px_rgba(147,51,234,0.6)]'
+                      : 'bg-white/5 text-white/75 hover:bg-white/10 hover:text-white'
                   }`}
                 >
                   {link.label}
                 </Link>
-              );
+              )
             })}
           </div>
         </nav>
       </header>
 
-      <main id="SiteLayout_main" className="relative z-10 flex-1">
+      <main id='SiteLayout_main' className='relative z-10 flex-1'>
         {children}
       </main>
     </div>
-  );
+  )
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,36 +1,35 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import { HashRouter } from 'react-router-dom';
-import { HelmetProvider } from 'react-helmet-async';
-import App from './App';
-import ErrorBoundary from './components/ErrorBoundary';
-import { TrippyProvider } from '@/lib/trippy';
-import { initConsentDefault } from './lib/consent';
-import { loadAnalytics, onConsentChange } from './lib/loadAnalytics';
-import { unregisterServiceWorkers } from './sw-unregister';
-import './index.css';
-import './styles/clamp.css';
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import { HelmetProvider } from 'react-helmet-async'
+import App from './App'
+import ErrorBoundary from './components/ErrorBoundary'
+import { TrippyProvider } from '@/lib/trippy'
+import { initConsentDefault } from './lib/consent'
+import { loadAnalytics, onConsentChange } from './lib/loadAnalytics'
+import { unregisterServiceWorkers } from './sw-unregister'
+import './index.css'
+import './styles/clamp.css'
 
-unregisterServiceWorkers();
+unregisterServiceWorkers()
 
-initConsentDefault();
-loadAnalytics();
+initConsentDefault()
+loadAnalytics()
 
 window.addEventListener('storage', (event: StorageEvent) => {
-  if (event.key === 'consent.v1') onConsentChange();
-});
+  if (event.key === 'consent.v1') onConsentChange()
+})
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <HelmetProvider>
       <ErrorBoundary>
-        {/* HashRouter prevents 404 on refresh by using URL hash for routing */}
-        <HashRouter>
+        <BrowserRouter basename={import.meta.env.BASE_URL}>
           <TrippyProvider>
             <App />
           </TrippyProvider>
-        </HashRouter>
+        </BrowserRouter>
       </ErrorBoundary>
     </HelmetProvider>
   </React.StrictMode>
-);
+)

--- a/src/pages/BlogList.tsx
+++ b/src/pages/BlogList.tsx
@@ -1,121 +1,118 @@
-import { useEffect, useMemo, useState } from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
-import { motion, useReducedMotion } from "framer-motion";
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { motion, useReducedMotion } from 'framer-motion'
 
-import { paginateCollection, resolveBlogIndexUrl, sortPostsByDateDesc } from "@/lib/blog";
+import { paginateCollection, resolveBlogIndexUrl, sortPostsByDateDesc } from '@/lib/blog'
 
 type PostIndex = {
-  slug: string;
-  title: string;
-  date: string | null;
-  description?: string | null;
-  summary?: string | null;
-  tags?: string[];
-  readingTime?: string | null;
-};
+  slug: string
+  title: string
+  date: string | null
+  description?: string | null
+  summary?: string | null
+  tags?: string[]
+  readingTime?: string | null
+}
 
-const PER_PAGE = 12;
+const PER_PAGE = 12
 
 export default function BlogList() {
-  const { page: pageParam } = useParams<{ page?: string }>();
-  const navigate = useNavigate();
-  const reduceMotion = useReducedMotion();
-  const [posts, setPosts] = useState<PostIndex[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { page: pageParam } = useParams<{ page?: string }>()
+  const navigate = useNavigate()
+  const reduceMotion = useReducedMotion()
+  const [posts, setPosts] = useState<PostIndex[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
 
-  const indexUrl = useMemo(
-    () => resolveBlogIndexUrl(import.meta.env.BASE_URL || "/"),
-    [],
-  );
+  const indexUrl = useMemo(() => resolveBlogIndexUrl(import.meta.env.BASE_URL || '/'), [])
 
-  const requestedPage = Number.parseInt(pageParam ?? "1", 10);
-  const hasParam = typeof pageParam !== "undefined";
-  const isValidPage = Number.isFinite(requestedPage) && requestedPage > 0;
-  const currentPage = isValidPage ? requestedPage : 1;
+  const requestedPage = Number.parseInt(pageParam ?? '1', 10)
+  const hasParam = typeof pageParam !== 'undefined'
+  const isValidPage = Number.isFinite(requestedPage) && requestedPage > 0
+  const currentPage = isValidPage ? requestedPage : 1
 
   useEffect(() => {
-    let alive = true;
-    setLoading(true);
-    setError(null);
-    fetch(indexUrl, { cache: "no-store" })
-      .then((r) => (r.ok ? r.json() : []))
-      .then((data) => {
-        if (!alive) return;
-        const rows = Array.isArray(data) ? data : [];
-        setPosts(sortPostsByDateDesc(rows));
+    let alive = true
+    setLoading(true)
+    setError(null)
+    fetch(indexUrl, { cache: 'no-store' })
+      .then(r => (r.ok ? r.json() : []))
+      .then(data => {
+        if (!alive) return
+        const rows = Array.isArray(data) ? data : []
+        setPosts(sortPostsByDateDesc(rows))
       })
       .catch(() => {
-        if (!alive) return;
-        setPosts([]);
-        setError("Failed to load blog posts.");
+        if (!alive) return
+        setPosts([])
+        setError('Failed to load blog posts.')
       })
       .finally(() => {
-        if (!alive) return;
-        setLoading(false);
-      });
+        if (!alive) return
+        setLoading(false)
+      })
     return () => {
-      alive = false;
-    };
-  }, [indexUrl]);
+      alive = false
+    }
+  }, [indexUrl])
 
   const pagination = useMemo(
     () => paginateCollection(posts, currentPage, PER_PAGE),
-    [posts, currentPage],
-  );
+    [posts, currentPage]
+  )
 
   useEffect(() => {
-    if (loading) return;
+    if (loading) return
     if (!posts.length) {
-      if (currentPage !== 1) navigate("/blog", { replace: true });
-      return;
+      if (currentPage !== 1) navigate('/blog/', { replace: true })
+      return
     }
     if (!isValidPage && hasParam) {
-      navigate("/blog", { replace: true });
-      return;
+      navigate('/blog/', { replace: true })
+      return
     }
     if (currentPage !== pagination.page) {
-      const target = pagination.page === 1 ? "/blog" : `/blog/page/${pagination.page}`;
-      navigate(target, { replace: true });
+      const target = pagination.page === 1 ? '/blog/' : `/blog/page/${pagination.page}`
+      navigate(target, { replace: true })
     }
-  }, [loading, posts.length, currentPage, pagination.page, isValidPage, hasParam, navigate]);
+  }, [loading, posts.length, currentPage, pagination.page, isValidPage, hasParam, navigate])
 
-  if (loading) return <div className="p-6 opacity-80">Loading…</div>;
-  if (error) return <div className="p-6 opacity-80">{error}</div>;
-  if (!posts.length) return <div className="p-6 opacity-80">No posts yet.</div>;
+  if (loading) return <div className='p-6 opacity-80'>Loading…</div>
+  if (error) return <div className='p-6 opacity-80'>{error}</div>
+  if (!posts.length) return <div className='p-6 opacity-80'>No posts yet.</div>
 
-  const heading = pagination.page > 1 ? `Blog — Page ${pagination.page}` : "Blog";
+  const heading = pagination.page > 1 ? `Blog — Page ${pagination.page}` : 'Blog'
   const intro =
-    "Daily notes, research digests, and herb craft. Fresh posts drop in chronological order.";
+    'Daily notes, research digests, and herb craft. Fresh posts drop in chronological order.'
 
   return (
-    <div className="container-page space-y-6 py-8">
-      <header className="space-y-3">
-        <h1 className="text-4xl font-extrabold tracking-tight">{heading}</h1>
-        <p className="max-w-2xl text-white/70">{intro}</p>
+    <div className='container-page space-y-6 py-8'>
+      <header className='space-y-3'>
+        <h1 className='text-4xl font-extrabold tracking-tight'>{heading}</h1>
+        <p className='max-w-2xl text-white/70'>{intro}</p>
       </header>
 
-      <div className="space-y-6">
-        {pagination.items.map((p) => (
+      <div className='space-y-6'>
+        {pagination.items.map(p => (
           <motion.article
             key={p.slug}
             initial={reduceMotion ? false : { opacity: 0, y: 8 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
-            className="glass-elev rounded-3xl p-5 text-white transition hover:translate-y-[-2px] hover:shadow-glow sm:p-6"
+            className='glass-elev rounded-3xl p-5 text-white transition hover:translate-y-[-2px] hover:shadow-glow sm:p-6'
           >
-            <h2 className="text-xl font-semibold tracking-tight sm:text-2xl">
-              <Link to={`/blog/${p.slug}`} className="text-accent-200 hover:text-accent-100">
+            <h2 className='text-xl font-semibold tracking-tight sm:text-2xl'>
+              <Link to={`/blog/${p.slug}/`} className='text-accent-200 hover:text-accent-100'>
                 {p.title}
               </Link>
             </h2>
-            <div className="mt-2 text-sm text-white/60">
-              <time dateTime={p.date || undefined}>{formatDate(p.date || "")}</time>
+            <div className='mt-2 text-sm text-white/60'>
+              <time dateTime={p.date || undefined}>{formatDate(p.date || '')}</time>
               {p.readingTime && <> • {p.readingTime}</>}
             </div>
-            <p className="mt-3 text-white/80">{p.summary || p.description}</p>
-            <div className="mt-4">
-              <Link to={`/blog/${p.slug}`} className="btn-primary">
+            <p className='mt-3 text-white/80'>{p.summary || p.description}</p>
+            <div className='mt-4'>
+              <Link to={`/blog/${p.slug}/`} className='btn-primary'>
                 Read post
               </Link>
             </div>
@@ -125,42 +122,42 @@ export default function BlogList() {
 
       <PaginationNav current={pagination.page} totalPages={pagination.totalPages} />
     </div>
-  );
+  )
 }
 
 function PaginationNav({ current, totalPages }: { current: number; totalPages: number }) {
-  if (totalPages <= 1) return null;
+  if (totalPages <= 1) return null
   return (
     <nav
-      aria-label="Blog pagination"
-      className="flex flex-wrap items-center justify-center gap-2 pt-4"
+      aria-label='Blog pagination'
+      className='flex flex-wrap items-center justify-center gap-2 pt-4'
     >
       {Array.from({ length: totalPages }).map((_, index) => {
-        const pageNumber = index + 1;
-        const to = pageNumber === 1 ? "/blog" : `/blog/page/${pageNumber}`;
-        const active = pageNumber === current;
+        const pageNumber = index + 1
+        const to = pageNumber === 1 ? '/blog/' : `/blog/page/${pageNumber}`
+        const active = pageNumber === current
         return (
           <Link
             key={pageNumber}
             to={to}
-            aria-current={active ? "page" : undefined}
+            aria-current={active ? 'page' : undefined}
             className={`rounded-full border px-3 py-1.5 text-sm transition ${
               active
-                ? "border-white/30 bg-white/15 text-white"
-                : "border-white/10 bg-white/5 text-white/80 hover:bg-white/10"
+                ? 'border-white/30 bg-white/15 text-white'
+                : 'border-white/10 bg-white/5 text-white/80 hover:bg-white/10'
             }`}
           >
             {pageNumber}
           </Link>
-        );
+        )
       })}
     </nav>
-  );
+  )
 }
 
 function formatDate(iso: string) {
-  if (!iso) return "";
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso;
-  return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
 }

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -1,84 +1,90 @@
-import React, { useEffect, useMemo, useState } from "react";
-import { useParams } from "react-router-dom";
-import DOMPurify from "dompurify";
-import { ensureTrailingSlash, resolveBlogIndexUrl } from "@/lib/blog";
+import React, { useEffect, useMemo, useState } from 'react'
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
+import DOMPurify from 'dompurify'
+import { ensureTrailingSlash, resolveBlogIndexUrl } from '@/lib/blog'
 
 type PostMeta = {
-  slug: string;
-  title: string;
-  date: string;
-  description?: string;
-  tags?: string[];
-  readingTime?: string;
-};
+  slug: string
+  title: string
+  date: string
+  description?: string
+  tags?: string[]
+  readingTime?: string
+}
 
 export default function BlogPost() {
-  const { slug = "" } = useParams();
-  const [meta, setMeta] = useState<PostMeta | null>(null);
-  const [html, setHtml] = useState<string>("");
-  const [error, setError] = useState<string>("");
-  const base = useMemo(
-    () => ensureTrailingSlash(import.meta.env.BASE_URL || "/"),
-    [],
-  );
-  const indexUrl = useMemo(() => resolveBlogIndexUrl(base), [base]);
+  const { slug = '' } = useParams()
+  const location = useLocation()
+  const navigate = useNavigate()
+  const [meta, setMeta] = useState<PostMeta | null>(null)
+  const [html, setHtml] = useState<string>('')
+  const [error, setError] = useState<string>('')
+  const base = useMemo(() => ensureTrailingSlash(import.meta.env.BASE_URL || '/'), [])
+  const indexUrl = useMemo(() => resolveBlogIndexUrl(base), [base])
 
   useEffect(() => {
-    let alive = true;
+    if (!slug) return
+    if (!location.pathname.endsWith('/')) {
+      navigate(
+        { pathname: `${location.pathname}/`, search: location.search, hash: location.hash },
+        { replace: true }
+      )
+    }
+  }, [slug, location.pathname, location.search, location.hash, navigate])
+
+  useEffect(() => {
+    let alive = true
     async function load() {
       try {
-        const idx = await fetch(indexUrl, { cache: "no-cache" }).then((r) => r.json());
-        const m = idx.find((p: PostMeta) => p.slug === slug) ?? null;
-        if (alive) setMeta(m);
+        const idx = await fetch(indexUrl, { cache: 'no-cache' }).then(r => r.json())
+        const m = idx.find((p: PostMeta) => p.slug === slug) ?? null
+        if (alive) setMeta(m)
 
-        const h = await fetch(`${base}blogdata/posts/${slug}.html`, { cache: "no-cache" });
-        if (!h.ok) throw new Error(`Post HTML not found: ${slug}`);
-        const text = await h.text();
-        if (alive) setHtml(text);
+        const h = await fetch(`${base}blogdata/posts/${slug}.html`, { cache: 'no-cache' })
+        if (!h.ok) throw new Error(`Post HTML not found: ${slug}`)
+        const text = await h.text()
+        if (alive) setHtml(text)
       } catch (e: any) {
-        if (alive) setError(e.message || "Failed to load post.");
+        if (alive) setError(e.message || 'Failed to load post.')
       }
     }
-    load();
+    load()
     return () => {
-      alive = false;
-    };
-  }, [slug, base, indexUrl]);
+      alive = false
+    }
+  }, [slug, base, indexUrl])
 
   if (error) {
     return (
-      <main className="container-page py-8">
-        <p className="text-red-400">{error}</p>
-        <a className="underline" href="/#/blog">
+      <main className='container-page py-8'>
+        <p className='text-red-400'>{error}</p>
+        <Link className='underline' to='/blog/'>
           ← Back to blog
-        </a>
+        </Link>
       </main>
-    );
+    )
   }
 
   return (
-    <main className="container-page py-8">
-      <header className="glass-elev mb-8 rounded-3xl p-6 sm:p-8">
-        <a href="/#/blog" className="text-sm text-accent-300 hover:text-accent-200">
+    <main className='container-page py-8'>
+      <header className='glass-elev mb-8 rounded-3xl p-6 sm:p-8'>
+        <Link to='/blog/' className='text-sm text-accent-300 hover:text-accent-200'>
           ← Back to Blog
-        </a>
-        <h1 className="mt-2 text-4xl font-extrabold tracking-tight text-white">
-          {meta?.title || "Loading…"}
+        </Link>
+        <h1 className='mt-2 text-4xl font-extrabold tracking-tight text-white'>
+          {meta?.title || 'Loading…'}
         </h1>
 
-        <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-2 text-sm text-white/60">
+        <div className='mt-2 flex flex-wrap items-center gap-x-3 gap-y-2 text-sm text-white/60'>
           {meta?.date && <time dateTime={meta.date}>{formatDate(meta.date)}</time>}
-          {meta?.readingTime && <span aria-hidden="true">•</span>}
+          {meta?.readingTime && <span aria-hidden='true'>•</span>}
           {meta?.readingTime && <span>{meta.readingTime}</span>}
           {meta?.tags?.length ? (
             <>
-              <span aria-hidden="true">•</span>
-              <ul className="flex flex-wrap gap-2">
-                {meta.tags.map((t) => (
-                  <li
-                    key={t}
-                    className="pill bg-white/10 text-[12px] text-white/70"
-                  >
+              <span aria-hidden='true'>•</span>
+              <ul className='flex flex-wrap gap-2'>
+                {meta.tags.map(t => (
+                  <li key={t} className='pill bg-white/10 text-[12px] text-white/70'>
                     {t}
                   </li>
                 ))}
@@ -90,30 +96,23 @@ export default function BlogPost() {
 
       {/* Markdown HTML */}
       <article
-        className="
-          prose prose-invert max-w-none
-          prose-a:text-accent-200 hover:prose-a:text-accent-100
-          prose-strong:text-white prose-li:marker:text-white/50
-          prose-blockquote:text-white/70 prose-blockquote:border-l-white/30
-          prose-pre:bg-black/60 prose-code:text-pink-300
-          prose-headings:scroll-mt-24 prose-img:rounded-xl
-        "
+        className='prose prose-invert max-w-none prose-headings:scroll-mt-24 prose-a:text-accent-200 hover:prose-a:text-accent-100 prose-blockquote:border-l-white/30 prose-blockquote:text-white/70 prose-strong:text-white prose-code:text-pink-300 prose-pre:bg-black/60 prose-li:marker:text-white/50 prose-img:rounded-xl'
         dangerouslySetInnerHTML={{
           __html: DOMPurify.sanitize(html, { USE_PROFILES: { html: true } }),
         }}
       />
 
-      <footer className="mt-10 border-t border-white/10 pt-6">
-        <p className="text-xs text-white/50">
+      <footer className='mt-10 border-t border-white/10 pt-6'>
+        <p className='text-xs text-white/50'>
           Educational content only. Not medical advice. Consult a qualified professional before use.
         </p>
       </footer>
     </main>
-  );
+  )
 }
 
 function formatDate(iso: string) {
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso;
-  return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
 }

--- a/src/pages/Graph.tsx
+++ b/src/pages/Graph.tsx
@@ -147,7 +147,7 @@ export default function GraphPage() {
                 if (node.group === 'herb') {
                   openInNewTab(`/herb/${node.slug}`)
                 } else if (node.group === 'post') {
-                  openInNewTab(`/blog/${node.slug}`)
+                  openInNewTab(`/blog/${node.slug}/`)
                 }
               }}
               nodeCanvasObject={(

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -38,7 +38,7 @@ function RelatedPosts({ slug }: { slug?: string }) {
       <ul className='mt-3 space-y-3'>
         {posts.map(p => (
           <li key={p.slug} className='text-sm text-[color:var(--muted-c)]'>
-            <Link to={`/blog/${p.slug}`} className='link text-[color:var(--accent)]'>
+            <Link to={`/blog/${p.slug}/`} className='link text-[color:var(--accent)]'>
               {p.title}
             </Link>
             {p.date && (
@@ -59,7 +59,7 @@ function RelatedPosts({ slug }: { slug?: string }) {
         ))}
       </ul>
       <div className='mt-4 text-sm text-[color:var(--muted-c)]'>
-        <Link to='/blog' className='link text-[color:var(--accent)]'>
+        <Link to='/blog/' className='link text-[color:var(--accent)]'>
           View all posts →
         </Link>
       </div>

--- a/src/pages/Newsletter.tsx
+++ b/src/pages/Newsletter.tsx
@@ -1,142 +1,147 @@
-import React, { FormEvent, useEffect, useState } from "react";
-import { Link } from "react-router-dom";
-import Meta from "../components/Meta";
+import React, { FormEvent, useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import Meta from '../components/Meta'
 
 function encodeForm(data: FormData) {
-  const params = new URLSearchParams();
+  const params = new URLSearchParams()
   data.forEach((value, key) => {
-    params.append(key, value.toString());
-  });
-  return params.toString();
+    params.append(key, value.toString())
+  })
+  return params.toString()
 }
 
 export default function Newsletter() {
-  const [sent, setSent] = useState(false);
+  const [sent, setSent] = useState(false)
 
   useEffect(() => {
     if (sent) {
       try {
-        (window as any).gtag?.("event", "newsletter_signup_success");
+        ;(window as any).gtag?.('event', 'newsletter_signup_success')
       } catch {
         /* noop */
       }
     }
-  }, [sent]);
+  }, [sent])
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+    event.preventDefault()
 
-    const form = event.currentTarget;
-    const formData = new FormData(form);
-    formData.set("form-name", "newsletter");
+    const form = event.currentTarget
+    const formData = new FormData(form)
+    formData.set('form-name', 'newsletter')
 
     try {
-      (window as any).gtag?.("event", "newsletter_signup_submit", { method: "netlify" });
+      ;(window as any).gtag?.('event', 'newsletter_signup_submit', { method: 'netlify' })
     } catch {
       /* noop */
     }
 
-    fetch("/", {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    fetch('/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: encodeForm(formData),
     }).catch(() => {
       /* Netlify will still capture submission on navigation fallback */
-    });
+    })
 
-    setSent(true);
-    form.reset();
-  };
+    setSent(true)
+    form.reset()
+  }
 
   return (
     <>
       <Meta
-        title="Newsletter — The Hippie Scientist"
-        description="Get new herb profiles, safety notes, and blend ideas in your inbox."
-        path="/newsletter"
-        pageType="website"
+        title='Newsletter — The Hippie Scientist'
+        description='Get new herb profiles, safety notes, and blend ideas in your inbox.'
+        path='/newsletter'
+        pageType='website'
       />
-      <main className="container mx-auto max-w-2xl space-y-6 px-4 py-10">
-        <header className="glass-soft rounded-2xl p-6">
-          <h1 className="bg-gradient-to-r from-lime-300 via-cyan-300 to-pink-400 bg-clip-text text-3xl font-extrabold text-transparent">
+      <main className='container mx-auto max-w-2xl space-y-6 px-4 py-10'>
+        <header className='glass-soft rounded-2xl p-6'>
+          <h1 className='bg-gradient-to-r from-lime-300 via-cyan-300 to-pink-400 bg-clip-text text-3xl font-extrabold text-transparent'>
             Join the newsletter
           </h1>
-          <p className="mt-2 text-white/75">
+          <p className='mt-2 text-white/75'>
             Occasional updates: new herb pages, safety advisories, and research roundups. No spam.
           </p>
         </header>
 
         {!sent ? (
           <form
-            name="newsletter"
-            method="POST"
-            data-netlify="true"
-            netlify-honeypot="bot-field"
-            className="glass-soft space-y-4 rounded-2xl p-6"
+            name='newsletter'
+            method='POST'
+            data-netlify='true'
+            netlify-honeypot='bot-field'
+            className='glass-soft space-y-4 rounded-2xl p-6'
             onSubmit={handleSubmit}
           >
-            <input type="hidden" name="form-name" value="newsletter" />
-            <p className="hidden">
+            <input type='hidden' name='form-name' value='newsletter' />
+            <p className='hidden'>
               <label>
-                Don’t fill this out: <input name="bot-field" />
+                Don’t fill this out: <input name='bot-field' />
               </label>
             </p>
 
-            <label className="block">
-              <span className="text-sm text-white/80">Email address</span>
+            <label className='block'>
+              <span className='text-sm text-white/80'>Email address</span>
               <input
                 required
-                type="email"
-                name="email"
-                autoComplete="email"
-                placeholder="you@example.com"
-                className="mt-1 w-full rounded-lg border border-white/20 bg-white/16 px-3 py-2 placeholder-white/50 backdrop-blur"
+                type='email'
+                name='email'
+                autoComplete='email'
+                placeholder='you@example.com'
+                className='bg-white/16 mt-1 w-full rounded-lg border border-white/20 px-3 py-2 placeholder-white/50 backdrop-blur'
               />
             </label>
 
-            <label className="block">
-              <span className="text-sm text-white/80">First name (optional)</span>
+            <label className='block'>
+              <span className='text-sm text-white/80'>First name (optional)</span>
               <input
-                type="text"
-                name="firstName"
-                autoComplete="given-name"
-                placeholder="Will"
-                className="mt-1 w-full rounded-lg border border-white/20 bg-white/16 px-3 py-2 placeholder-white/50 backdrop-blur"
+                type='text'
+                name='firstName'
+                autoComplete='given-name'
+                placeholder='Will'
+                className='bg-white/16 mt-1 w-full rounded-lg border border-white/20 px-3 py-2 placeholder-white/50 backdrop-blur'
               />
             </label>
 
-            <button className="rounded-lg border border-lime-300/20 bg-gradient-to-r from-lime-400/30 to-cyan-400/20 px-4 py-2 text-sm font-medium text-lime-200 hover:from-lime-400/40 hover:to-cyan-400/30">
+            <button className='rounded-lg border border-lime-300/20 bg-gradient-to-r from-lime-400/30 to-cyan-400/20 px-4 py-2 text-sm font-medium text-lime-200 hover:from-lime-400/40 hover:to-cyan-400/30'>
               Subscribe
             </button>
 
-            <p className="pt-2 text-xs text-white/60">
-              By subscribing, you agree to our
-              {" "}
-              <Link className="underline" to="/privacy">
+            <p className='pt-2 text-xs text-white/60'>
+              By subscribing, you agree to our{' '}
+              <Link className='underline' to='/privacy'>
                 Privacy Policy
-              </Link>
-              {" "}
-              and
-              {" "}
-              <Link className="underline" to="/disclaimer">
+              </Link>{' '}
+              and{' '}
+              <Link className='underline' to='/disclaimer'>
                 Disclaimer
               </Link>
               .
             </p>
 
-            <p className="text-xs text-white/50">
-              Not using Netlify? Email us instead: <a className="underline" href="mailto:hello@thehippiescientist.net?subject=Newsletter%20Signup">hello@thehippiescientist.net</a>
+            <p className='text-xs text-white/50'>
+              Not using Netlify? Email us instead:{' '}
+              <a
+                className='underline'
+                href='mailto:hello@thehippiescientist.net?subject=Newsletter%20Signup'
+              >
+                hello@thehippiescientist.net
+              </a>
             </p>
           </form>
         ) : (
-          <div className="glass-soft rounded-2xl p-6">
-            <h2 className="font-semibold text-lime-300">You're on the list ✦</h2>
-            <p className="mt-1 text-white/75">Check your inbox for a confirmation. Welcome aboard.</p>
-            <nav className="mt-4 text-sm">
-              <Link className="mr-3 underline" to="/herbs">
+          <div className='glass-soft rounded-2xl p-6'>
+            <h2 className='font-semibold text-lime-300'>You're on the list ✦</h2>
+            <p className='mt-1 text-white/75'>
+              Check your inbox for a confirmation. Welcome aboard.
+            </p>
+            <nav className='mt-4 text-sm'>
+              <Link className='mr-3 underline' to='/herbs'>
                 Browse database
               </Link>
-              <Link className="underline" to="/blog">
+              <Link className='underline' to='/blog/'>
                 Read the blog
               </Link>
             </nav>
@@ -144,5 +149,5 @@ export default function Newsletter() {
         )}
       </main>
     </>
-  );
+  )
 }

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -102,7 +102,7 @@ export default function NotFound() {
           <Link className='mr-4 underline' to='/herbs'>
             Browse database
           </Link>
-          <Link className='mr-4 underline' to='/blog'>
+          <Link className='mr-4 underline' to='/blog/'>
             Read the blog
           </Link>
           <Link className='underline' to='/'>

--- a/src/pages/Sitemap.tsx
+++ b/src/pages/Sitemap.tsx
@@ -55,7 +55,7 @@ export default function Sitemap() {
               </Link>
             </li>
             <li>
-              <Link className='underline' to='/blog'>
+              <Link className='underline' to='/blog/'>
                 Blog
               </Link>
             </li>
@@ -88,7 +88,7 @@ export default function Sitemap() {
             <ul className='list-inside list-disc space-y-1 text-white/70'>
               {blogPosts.map((p, i) => (
                 <li key={i}>
-                  <Link className='underline' to={`/blog/${p.slug}`}>
+                  <Link className='underline' to={`/blog/${p.slug}/`}>
                     {p.title}
                   </Link>
                 </li>


### PR DESCRIPTION
## Summary
- add a generate-blog-index script that emits a static /blog/index.html from blogdata
- wire the static generator into the prebuild chain and switch routing to BrowserRouter with trailing slash handling
- link to clean /blog/{slug}/ URLs throughout the app and check in the generated index template

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f2aa40e1a08323a18e8fb367059e90