### PR TITLE
Enable SPA clean URLs fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,16 @@
 <html lang="en" class="dark">
   <head>
     <meta charset="UTF-8" />
+    <script>
+      // Read redirect query created by 404.html and restore the real URL
+      (function(l) {
+        if (l.search && l.search[1] === '/') {
+          var decoded = l.search.slice(1).split('&').map(function(s){ return s.replace(/~and~/g, '&') }).join('?');
+          var clean = decoded + (l.hash || '');
+          window.history.replaceState(null, null, clean);
+        }
+      })(window.location);
+    </script>
     <link rel="icon" href="/icon-512x512.png" type="image/png" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/public/404.html
+++ b/public/404.html
@@ -1,8 +1,20 @@
-<!doctype html><meta charset="utf-8">
-<script>
-  (function () {
-    var p = location.pathname + location.search + location.hash;
-    location.replace("/#" + p.replace(/^\//, ""));
-  })();
-</script>
-<p>Not found. <a href="/">Go home</a>.</p>
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Redirecting…</title>
+    <meta http-equiv="refresh" content="0;url='/'">
+    <script>
+      // Single Page Apps for GitHub Pages — https://github.com/rafgraph/spa-github-pages
+      // pathSegmentsToKeep = 0 for a custom domain at the site root
+      var pathSegmentsToKeep = 0;
+      var l = window.location;
+      var path = l.pathname.split('/').slice(1 + pathSegmentsToKeep).join('/');
+      var search = l.search.slice(1).replace(/&/g, '~and~');
+      var url = l.protocol + '//' + l.host + (l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/')) +
+        '/?/' + path + (search ? '&' + search : '') + l.hash;
+      l.replace(url);
+    </script>
+  </head>
+  <body>Redirecting…</body>
+</html>


### PR DESCRIPTION
## Summary
- replace the legacy hash-based 404 page with the standard GitHub Pages SPA fallback script
- add an initialization script to restore clean URLs when redirects occur

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f3d1aeb7688323a856ec0803033cc6