### PR TITLE
chore: bump Vite toolchain dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@tailwindcss/typography": "^0.5.19",
     "@tsparticles/engine": "^3.8.1",
     "@tsparticles/react": "^3.0.0",
-    "autoprefixer": "^10.4.19",
+    "autoprefixer": "latest",
     "clsx": "^2.1.1",
     "dompurify": "^3.2.7",
     "file-saver": "^2.0.5",
@@ -88,12 +88,12 @@
     "react-force-graph-2d": "^1.29.0",
     "react-helmet-async": "^1.3.0",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^6.22.3",
+    "react-router-dom": "latest",
     "react-tooltip": "^5.20.0",
     "rehype-raw": "^7.0.0",
     "slugify": "^1.6.6",
     "sonner": "^2.0.7",
-    "tailwindcss": "^3.4.3",
+    "tailwindcss": "latest",
     "three": "^0.180.0",
     "tsparticles": "^3.8.1",
     "vite-plugin-pwa": "^1.0.1",
@@ -106,9 +106,9 @@
     "@types/node": "^24.1.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
-    "@vitejs/plugin-react": "^4.2.1",
+    "@vitejs/plugin-react": "latest",
     "chokidar": "^4.0.3",
-    "postcss": "^8.4.31",
+    "postcss": "latest",
     "@typescript-eslint/eslint-plugin": "^8.10.0",
     "@typescript-eslint/parser": "^8.10.0",
     "eslint": "^9.11.1",
@@ -126,6 +126,6 @@
     "ts-node": "^10.9.2",
     "tsx": "^4.19.2",
     "typescript": "^5.8.3",
-    "vite": "^4.5.14"
+    "vite": "latest"
   }
 }


### PR DESCRIPTION
## Summary
- bump core Vite toolchain dependencies to their latest releases
- update associated PostCSS/Tailwind packages to latest to match

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f66bf35a9c8323b43942fe172f0823