### PR TITLE
Configure Vercel Node runtime for API routes

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "ES2017",
-      "DOM",
-      "DOM.Iterable"
-    ],
+    "lib": ["ES2017", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "node",
     "jsx": "react-jsx",
@@ -18,8 +14,5 @@
       "@/*": ["*"]
     }
   },
-  "include": [
-    "src",
-    "public/blogdata/index.json"
-  ]
+  "include": ["src", "public/blogdata/index.json", "api/**/*.ts"]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "functions": {
+    "api/**/*.ts": {
+      "runtime": "@vercel/node"
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- The Vite frontend's fetch to `/api/subscribe` failed because Vercel did not recognize the file as a serverless function, causing the request to abort before a JSON response was returned.
- Make root-level API routes discoverable by Vercel so `/api/subscribe` is reachable in production without changing frontend behavior.

### Description
- Add a root `vercel.json` that maps `api/**/*.ts` to the `@vercel/node` runtime so Vercel treats `api/` TypeScript files as serverless Node functions.
- Add `api/**/*.ts` to the `include` list in `tsconfig.json` so API files are included in TypeScript checking; `api/subscribe.ts` already exports a default async `handler` and was not modified.

### Testing
- Ran `npm run build` and the Vite production build completed successfully.
- Ran `npx tsc --noEmit` which failed due to existing, project-wide TypeScript errors unrelated to the API-route change.
- Ran `npx tsc --noEmit api/subscribe.ts` which succeeded, and a local runtime invocation via `tsx` failed because the `RESEND_API_KEY` environment variable was not set locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb4c0110d4832382adcaa0e300080b)