### PR TITLE
Enhance interaction scoring, mechanism reasoning, and report output

### DIFF
--- a/src/components/interactions/InteractionReportCard.tsx
+++ b/src/components/interactions/InteractionReportCard.tsx
@@ -57,6 +57,13 @@ function FindingRow({ finding }: { finding: InteractionFinding }) {
         </span>
       </div>
       <p className='text-sm text-white/85'>{finding.summary}</p>
+      <p className='rounded-lg border border-white/10 bg-black/20 px-3 py-2 text-sm text-white/80'>
+        {finding.explanation}
+      </p>
+      <p className='text-xs text-white/70'>
+        signal strength: shared tags {finding.sharedTagCount} · overlapping mechanisms{' '}
+        {finding.overlappingMechanismCount} · confidence score {finding.confidenceScore}/100
+      </p>
       {finding.evidenceBasis.length > 0 && (
         <details className='rounded-lg border border-white/10 bg-black/20 p-3'>
           <summary className='cursor-pointer text-xs font-medium uppercase tracking-wide text-white/75'>
@@ -109,12 +116,13 @@ export default function InteractionReportCard({
         <span
           className={`rounded-full border px-2.5 py-1 text-xs uppercase tracking-wide ${confidenceClasses(report.overallConfidence)}`}
         >
-          overall confidence: {report.overallConfidence}
+          overall confidence: {report.overallConfidence} ({report.overallConfidenceScore}/100)
         </span>
         {actions ? <div className='ml-auto flex flex-wrap gap-2'>{actions}</div> : null}
       </div>
 
       <div className='rounded-xl border border-white/10 bg-white/[0.02] px-4 py-3 text-xs text-white/75'>
+        <p className='mb-2 text-sm text-white/85'>{report.summary}</p>
         <p>
           <span className='font-semibold text-white/90'>Severity</span> estimates the strength of
           overlap/caution signals across your selected items.
@@ -124,6 +132,19 @@ export default function InteractionReportCard({
           available structured mechanism/safety data, not certainty of real-world outcomes.
         </p>
       </div>
+
+      {report.keySignals.length > 0 && (
+        <div className='rounded-xl border border-white/10 bg-white/[0.02] px-4 py-3 text-sm text-white/80'>
+          <h3 className='mb-2 text-xs font-semibold uppercase tracking-wide text-white/70'>
+            Key interaction signals
+          </h3>
+          <ul className='list-disc space-y-1 pl-5'>
+            {report.keySignals.map(signal => (
+              <li key={signal}>{signal}</li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       {report.dataLimited && (
         <p className='rounded-xl border border-amber-300/35 bg-amber-500/10 px-4 py-3 text-sm text-amber-100'>

--- a/src/types/interactions.ts
+++ b/src/types/interactions.ts
@@ -8,16 +8,24 @@ export type InteractionFinding = {
   title: string
   severity: InteractionSeverity
   confidence: InteractionConfidence
+  confidenceScore: number
   basis: InteractionFindingBasis
   summary: string
+  explanation: string
+  sharedTagCount: number
+  overlappingMechanismCount: number
+  overlappingMechanisms: string[]
   evidenceBasis: string[]
 }
 
 export type InteractionReport = {
   items: string[]
   findings: InteractionFinding[]
+  summary: string
+  keySignals: string[]
   overallSeverity: InteractionSeverity
   overallConfidence: InteractionConfidence
+  overallConfidenceScore: number
   dataLimited: boolean
   notes: string[]
 }

--- a/src/utils/interactions/checkInteractions.ts
+++ b/src/utils/interactions/checkInteractions.ts
@@ -19,6 +19,29 @@ function pushUniqueFindings(findings: InteractionFinding[], finding: Interaction
   findings.push(finding)
 }
 
+function clampScore(value: number, min = 0, max = 100): number {
+  return Math.max(min, Math.min(max, Math.round(value)))
+}
+
+function severityToBaseScore(severity: InteractionSeverity): number {
+  if (severity === 'high') return 90
+  if (severity === 'moderate') return 62
+  if (severity === 'low') return 38
+  return 20
+}
+
+function scoreToSeverity(score: number): InteractionSeverity {
+  if (score >= 75) return 'high'
+  if (score >= 48) return 'moderate'
+  return 'low'
+}
+
+function scoreToConfidence(score: number): InteractionConfidence {
+  if (score >= 74) return 'high'
+  if (score >= 46) return 'medium'
+  return 'low'
+}
+
 function maxSeverity(severities: InteractionSeverity[]): InteractionSeverity {
   const rank: Record<InteractionSeverity, number> = { unknown: 0, low: 1, moderate: 2, high: 3 }
   return severities.reduce(
@@ -27,25 +50,60 @@ function maxSeverity(severities: InteractionSeverity[]): InteractionSeverity {
   )
 }
 
-function overallConfidenceFromFindings(
-  findings: InteractionFinding[],
-  dataLimited: boolean
-): InteractionConfidence {
-  if (findings.length === 0) return dataLimited ? 'low' : 'medium'
-  const rank: Record<InteractionConfidence, number> = { low: 1, medium: 2, high: 3 }
-  const total = findings.reduce((sum, finding) => sum + rank[finding.confidence], 0)
-  const average = total / findings.length
+function normalizePhrase(phrase: string): string {
+  return phrase
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
 
-  if (dataLimited && average < 2.6) return 'low'
-  if (average >= 2.6) return 'high'
-  if (average >= 1.8) return 'medium'
-  return 'low'
+function extractMechanismPhrases(item: InteractionSourceItem): string[] {
+  const source = `${item.mechanism ?? ''} | ${(item.interactionNotes ?? []).join(' | ')}`
+  if (!source.trim()) return []
+
+  return source
+    .split(/[.;,|]/)
+    .map(entry => normalizePhrase(entry))
+    .filter(entry => entry.length >= 4)
+}
+
+function getSharedTagCount(matchedItems: ReturnType<typeof extractInteractionSignals>[]): number {
+  if (matchedItems.length < 2) return 0
+  const tagCounts = new Map<string, number>()
+  matchedItems.forEach(item => {
+    item.tags.forEach(tag => {
+      tagCounts.set(tag, (tagCounts.get(tag) ?? 0) + 1)
+    })
+  })
+
+  return Array.from(tagCounts.values()).filter(count => count >= 2).length
+}
+
+function getOverlappingMechanisms(
+  matchedItems: ReturnType<typeof extractInteractionSignals>[]
+): string[] {
+  if (matchedItems.length < 2) return []
+
+  const mechanismCounts = new Map<string, number>()
+  matchedItems.forEach(item => {
+    const uniquePhrases = new Set(extractMechanismPhrases(item.item))
+    uniquePhrases.forEach(phrase => {
+      mechanismCounts.set(phrase, (mechanismCounts.get(phrase) ?? 0) + 1)
+    })
+  })
+
+  return Array.from(mechanismCounts.entries())
+    .filter(([, count]) => count >= 2)
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([phrase]) => phrase)
+    .slice(0, 3)
 }
 
 function resolveFindingBasisAndConfidence(
   matchedItems: ReturnType<typeof extractInteractionSignals>[],
   signalTags: string[]
-): { basis: InteractionFindingBasis; confidence: InteractionConfidence } {
+): { basis: InteractionFindingBasis; sourceConfidence: InteractionConfidence } {
   const usedSources = new Set<InteractionSignalSource>()
 
   matchedItems.forEach(item => {
@@ -58,9 +116,9 @@ function resolveFindingBasisAndConfidence(
   const hasStructured = usedSources.has('structured')
   const hasInferred = usedSources.has('inferred')
 
-  if (hasStructured && hasInferred) return { basis: 'mixed', confidence: 'medium' }
-  if (hasStructured) return { basis: 'structured', confidence: 'high' }
-  return { basis: 'inferred', confidence: 'low' }
+  if (hasStructured && hasInferred) return { basis: 'mixed', sourceConfidence: 'medium' }
+  if (hasStructured) return { basis: 'structured', sourceConfidence: 'high' }
+  return { basis: 'inferred', sourceConfidence: 'low' }
 }
 
 function collectEvidence(
@@ -76,6 +134,94 @@ function collectEvidence(
   )
 }
 
+function toDisplayMechanismLabel(phrase: string): string {
+  return phrase.replace(/\b\w/g, char => char.toUpperCase())
+}
+
+function buildFindingExplanation(
+  signalLabel: string,
+  sharedTags: number,
+  overlappingMechanisms: string[]
+): string {
+  const mechanismClause = overlappingMechanisms.length
+    ? ` They also share mechanism clues (${overlappingMechanisms
+        .map(toDisplayMechanismLabel)
+        .join(', ')}), which supports this signal.`
+    : ''
+
+  const sharedTagClause =
+    sharedTags > 1
+      ? ` Multiple aligned interaction tags (${sharedTags}) point in the same direction.`
+      : sharedTags === 1
+        ? ' One aligned interaction tag appears across the selected items.'
+        : ''
+
+  return `${signalLabel}${sharedTagClause}${mechanismClause}`
+}
+
+function createScoredFinding({
+  title,
+  summary,
+  baseSeverity,
+  signalLabel,
+  matchedItems,
+  signalTags,
+  evidenceBasis,
+}: {
+  title: string
+  summary: string
+  baseSeverity: InteractionSeverity
+  signalLabel: string
+  matchedItems: ReturnType<typeof extractInteractionSignals>[]
+  signalTags: string[]
+  evidenceBasis: string[]
+}): InteractionFinding {
+  const { basis, sourceConfidence } = resolveFindingBasisAndConfidence(matchedItems, signalTags)
+  const sharedTagCount = getSharedTagCount(matchedItems)
+  const overlappingMechanisms = getOverlappingMechanisms(matchedItems)
+  const overlappingMechanismCount = overlappingMechanisms.length
+
+  const weightedScore = clampScore(
+    severityToBaseScore(baseSeverity) +
+      sharedTagCount * 6 +
+      overlappingMechanismCount * 8 +
+      (sourceConfidence === 'high' ? 6 : sourceConfidence === 'medium' ? 2 : -6)
+  )
+
+  return {
+    title,
+    severity: scoreToSeverity(weightedScore),
+    confidence: scoreToConfidence(weightedScore),
+    confidenceScore: weightedScore,
+    basis,
+    summary,
+    explanation: buildFindingExplanation(signalLabel, sharedTagCount, overlappingMechanisms),
+    sharedTagCount,
+    overlappingMechanismCount,
+    overlappingMechanisms,
+    evidenceBasis,
+  }
+}
+
+function buildReportSummary(reportFindings: InteractionFinding[], dataLimited: boolean): string {
+  if (reportFindings.length === 0) {
+    return dataLimited
+      ? 'No clear overlap signal was detected, but missing structured fields limit confidence.'
+      : 'No strong structured overlap signals were detected for this combination.'
+  }
+
+  const highCount = reportFindings.filter(finding => finding.severity === 'high').length
+  const moderateCount = reportFindings.filter(finding => finding.severity === 'moderate').length
+
+  if (highCount > 0) {
+    return `${highCount} high-priority interaction signal(s) were detected. Use conservative timing and avoid stacking similar effects.`
+  }
+  if (moderateCount > 0) {
+    return `${moderateCount} moderate interaction signal(s) were detected. Consider dose spacing and avoid rapid dose escalation.`
+  }
+  return 'Only low-strength overlap signals were detected, but caution is still appropriate when combining items.'
+}
+
 export function checkInteractions(items: InteractionSourceItem[]): InteractionReport {
   const selected = items.slice(0, 3)
   const extracted = selected.map(extractInteractionSignals)
@@ -85,124 +231,161 @@ export function checkInteractions(items: InteractionSourceItem[]): InteractionRe
     hasAny(tags, ['sedative', 'cns-depressant', 'gabaergic'])
   )
   if (sedativeItems.length >= 2) {
-    const basis = resolveFindingBasisAndConfidence(sedativeItems, [
-      'sedative',
-      'cns-depressant',
-      'gabaergic',
-    ])
-    pushUniqueFindings(findings, {
-      title: 'Sedative overlap signal',
-      severity: sedativeItems.length >= 3 ? 'moderate' : 'low',
-      confidence: basis.confidence,
-      basis: basis.basis,
-      summary:
-        'More than one selected item has calming or sedating signals. Taking them together may increase drowsiness, slowed reaction time, or next-day grogginess.',
-      evidenceBasis: collectEvidence(sedativeItems, ['sedative', 'cns-depressant', 'gabaergic']),
-    })
+    pushUniqueFindings(
+      findings,
+      createScoredFinding({
+        title: 'Sedative overlap signal',
+        baseSeverity: sedativeItems.length >= 3 ? 'moderate' : 'low',
+        signalLabel:
+          'These items all point toward calming/CNS-depressant effects, which can compound sedation and slow reaction time.',
+        summary:
+          'More than one selected item has calming or sedating signals. Taking them together may increase drowsiness, slowed reaction time, or next-day grogginess.',
+        matchedItems: sedativeItems,
+        signalTags: ['sedative', 'cns-depressant', 'gabaergic'],
+        evidenceBasis: collectEvidence(sedativeItems, ['sedative', 'cns-depressant', 'gabaergic']),
+      })
+    )
   }
 
   const stimulantItems = extracted.filter(({ tags }) => tags.has('stimulant'))
   if (stimulantItems.length >= 2) {
-    const basis = resolveFindingBasisAndConfidence(stimulantItems, ['stimulant'])
-    pushUniqueFindings(findings, {
-      title: 'Stimulant overlap signal',
-      severity: stimulantItems.length >= 3 ? 'moderate' : 'low',
-      confidence: basis.confidence,
-      basis: basis.basis,
-      summary:
-        'More than one selected item has stimulating signals. Combining them may raise the chance of jitters, anxiety, faster heart rate, or trouble sleeping.',
-      evidenceBasis: collectEvidence(stimulantItems, ['stimulant']),
-    })
+    pushUniqueFindings(
+      findings,
+      createScoredFinding({
+        title: 'Stimulant overlap signal',
+        baseSeverity: stimulantItems.length >= 3 ? 'moderate' : 'low',
+        signalLabel:
+          'These compounds and herbs both increase activating signals, which can add up to overstimulation.',
+        summary:
+          'More than one selected item has stimulating signals. Combining them may raise the chance of jitters, anxiety, faster heart rate, or trouble sleeping.',
+        matchedItems: stimulantItems,
+        signalTags: ['stimulant'],
+        evidenceBasis: collectEvidence(stimulantItems, ['stimulant']),
+      })
+    )
   }
 
   const serotonergicItems = extracted.filter(({ tags }) => tags.has('serotonergic'))
   if (serotonergicItems.length >= 2) {
-    const basis = resolveFindingBasisAndConfidence(serotonergicItems, ['serotonergic'])
-    pushUniqueFindings(findings, {
-      title: 'Serotonergic overlap signal',
-      severity: 'moderate',
-      confidence: basis.confidence,
-      basis: basis.basis,
-      summary:
-        'Multiple selected items show serotonin-related activity. The combination deserves extra caution, especially with conservative dosing and timing.',
-      evidenceBasis: collectEvidence(serotonergicItems, ['serotonergic']),
-    })
+    pushUniqueFindings(
+      findings,
+      createScoredFinding({
+        title: 'Serotonergic overlap signal',
+        baseSeverity: 'moderate',
+        signalLabel:
+          'These compounds both increase serotonergic activity, which may raise risk of serotonin-related side effects.',
+        summary:
+          'Multiple selected items show serotonin-related activity. The combination deserves extra caution, especially with conservative dosing and timing.',
+        matchedItems: serotonergicItems,
+        signalTags: ['serotonergic'],
+        evidenceBasis: collectEvidence(serotonergicItems, ['serotonergic']),
+      })
+    )
   }
 
   const maoItems = extracted.filter(({ tags }) => tags.has('maoi'))
   if (maoItems.length >= 1 && (serotonergicItems.length >= 1 || stimulantItems.length >= 1)) {
-    const severity: InteractionSeverity =
+    const baseSeverity: InteractionSeverity =
       maoItems.length >= 1 && serotonergicItems.length >= 1 && stimulantItems.length >= 1
         ? 'high'
         : 'moderate'
-    const basis = resolveFindingBasisAndConfidence(
-      [...maoItems, ...serotonergicItems, ...stimulantItems],
-      ['maoi', 'serotonergic', 'stimulant']
+    const mergedItems = [...new Set([...maoItems, ...serotonergicItems, ...stimulantItems])]
+    pushUniqueFindings(
+      findings,
+      createScoredFinding({
+        title: 'MAOI combination caution',
+        baseSeverity,
+        signalLabel:
+          'MAOI-related activity can intensify serotonergic or stimulant pathways, which raises interaction complexity.',
+        summary:
+          'An MAO-related signal appears with serotonin-related or stimulant signals. That pattern can increase interaction concern, so a conservative approach is important.',
+        matchedItems: mergedItems,
+        signalTags: ['maoi', 'serotonergic', 'stimulant'],
+        evidenceBasis: [
+          ...collectEvidence(maoItems, ['maoi']),
+          ...collectEvidence(serotonergicItems, ['serotonergic']),
+          ...collectEvidence(stimulantItems, ['stimulant']),
+        ],
+      })
     )
-    pushUniqueFindings(findings, {
-      title: 'MAOI combination caution',
-      severity,
-      confidence: severity === 'high' && basis.confidence === 'high' ? 'high' : basis.confidence,
-      basis: basis.basis,
-      summary:
-        'An MAO-related signal appears with serotonin-related or stimulant signals. That pattern can increase interaction concern, so a conservative approach is important.',
-      evidenceBasis: [
-        ...collectEvidence(maoItems, ['maoi']),
-        ...collectEvidence(serotonergicItems, ['serotonergic']),
-        ...collectEvidence(stimulantItems, ['stimulant']),
-      ],
-    })
   }
 
   const cardioItems = extracted.filter(({ tags }) => hasAny(tags, ['cardioactive', 'stimulant']))
   if (cardioItems.length >= 2) {
-    const basis = resolveFindingBasisAndConfidence(cardioItems, ['cardioactive', 'stimulant'])
-    pushUniqueFindings(findings, {
-      title: 'Cardiovascular caution overlap',
-      severity: cardioItems.length >= 3 ? 'moderate' : 'low',
-      confidence: basis.confidence,
-      basis: basis.basis,
-      summary:
-        'Selected items share heart or stimulant-related caution signals. Together they may add strain on heart rate or blood pressure.',
-      evidenceBasis: collectEvidence(cardioItems, ['cardioactive', 'stimulant']),
-    })
+    pushUniqueFindings(
+      findings,
+      createScoredFinding({
+        title: 'Cardiovascular caution overlap',
+        baseSeverity: cardioItems.length >= 3 ? 'moderate' : 'low',
+        signalLabel:
+          'These items share cardiovascular or activating tags that can combine into higher pulse/blood-pressure load.',
+        summary:
+          'Selected items share heart or stimulant-related caution signals. Together they may add strain on heart rate or blood pressure.',
+        matchedItems: cardioItems,
+        signalTags: ['cardioactive', 'stimulant'],
+        evidenceBasis: collectEvidence(cardioItems, ['cardioactive', 'stimulant']),
+      })
+    )
   }
 
   const hepaticItems = extracted.filter(({ tags }) => tags.has('hepatotoxic'))
   if (hepaticItems.length >= 2) {
-    const basis = resolveFindingBasisAndConfidence(hepaticItems, ['hepatotoxic'])
-    pushUniqueFindings(findings, {
-      title: 'Liver burden overlap signal',
-      severity: hepaticItems.length >= 3 ? 'moderate' : 'low',
-      confidence: basis.confidence,
-      basis: basis.basis,
-      summary:
-        'More than one selected item includes liver-related caution signals. Using them together may increase overall liver burden.',
-      evidenceBasis: collectEvidence(hepaticItems, ['hepatotoxic']),
-    })
+    pushUniqueFindings(
+      findings,
+      createScoredFinding({
+        title: 'Liver burden overlap signal',
+        baseSeverity: hepaticItems.length >= 3 ? 'moderate' : 'low',
+        signalLabel:
+          'Shared liver-stress tags suggest cumulative metabolic burden may be higher when these are combined.',
+        summary:
+          'More than one selected item includes liver-related caution signals. Using them together may increase overall liver burden.',
+        matchedItems: hepaticItems,
+        signalTags: ['hepatotoxic'],
+        evidenceBasis: collectEvidence(hepaticItems, ['hepatotoxic']),
+      })
+    )
   }
 
   const sparseDataItems = extracted.filter(item => item.dataCoverageScore <= 1)
   const dataLimited = sparseDataItems.length > 0
 
   if (dataLimited) {
-    pushUniqueFindings(findings, {
+    findings.push({
       title: 'Sparse data warning',
-      severity: 'unknown',
+      severity: 'low',
       confidence: 'low',
+      confidenceScore: 24,
       basis: 'inferred',
       summary:
         'At least one selected item has limited structured mechanism or safety data, so this report has lower reliability and may miss signals.',
+      explanation:
+        'The dataset for one or more selected items is thin, so absence of signals should not be treated as absence of risk.',
+      sharedTagCount: 0,
+      overlappingMechanismCount: 0,
+      overlappingMechanisms: [],
       evidenceBasis: sparseDataItems.map(item => `${item.item.name}: limited structured fields`),
     })
   }
 
-  const overallSeverity = maxSeverity(findings.map(item => item.severity))
-  const overallConfidence = overallConfidenceFromFindings(findings, dataLimited)
+  const primaryFindings = findings.filter(finding => finding.title !== 'Sparse data warning')
+  const overallSeverity = maxSeverity(primaryFindings.map(item => item.severity))
+  const weightedAverage = primaryFindings.length
+    ? clampScore(
+        primaryFindings.reduce((sum, finding) => sum + finding.confidenceScore, 0) /
+          primaryFindings.length -
+          (dataLimited ? 12 : 0)
+      )
+    : clampScore(dataLimited ? 30 : 50)
+  const overallConfidence = scoreToConfidence(weightedAverage)
 
+  const keySignals = primaryFindings.map(
+    finding =>
+      `${finding.title} — ${finding.severity} severity (${finding.confidenceScore}/100 confidence score)`
+  )
   const notes = [
-    'This tool surfaces structured overlap signals to support harm-reduction decisions; it is not medical advice.',
-    'Findings are caution signals, not proof of a specific outcome.',
+    'This tool highlights overlap patterns for harm reduction planning; it is not medical advice.',
+    'These results are caution signals, not proof that a specific adverse outcome will occur.',
+    'If you choose to combine items, consider lower starting amounts and wider spacing to reduce risk.',
   ]
 
   if (dataLimited) {
@@ -212,8 +395,11 @@ export function checkInteractions(items: InteractionSourceItem[]): InteractionRe
   return {
     items: selected.map(item => item.name),
     findings,
+    summary: buildReportSummary(primaryFindings, dataLimited),
+    keySignals,
     overallSeverity,
     overallConfidence,
+    overallConfidenceScore: weightedAverage,
     dataLimited,
     notes,
   }

--- a/src/utils/interactions/reportSharing.ts
+++ b/src/utils/interactions/reportSharing.ts
@@ -116,6 +116,9 @@ export function saveReport(items: InteractionCatalogItem[]): SavedInteractionRep
 
 export function buildReportSummary(report: InteractionReport): string {
   const itemLine = report.items.join(' + ')
+  const keySignalLines = report.keySignals.length
+    ? report.keySignals.map(signal => `- ${signal}`)
+    : ['- No key interaction signals were generated.']
   const summaryLines = report.findings.length
     ? report.findings.map(finding => {
         const confidenceDetail =
@@ -124,7 +127,7 @@ export function buildReportSummary(report: InteractionReport): string {
             : finding.basis === 'mixed'
               ? 'structured + inferred signals'
               : 'inferred signals'
-        return `- ${finding.title}: ${finding.summary} (Severity: ${finding.severity}; Confidence: ${finding.confidence} - ${confidenceDetail})`
+        return `- ${finding.title}: ${finding.summary} ${finding.explanation} (Severity: ${finding.severity}; Confidence: ${finding.confidence} [${finding.confidenceScore}/100] - ${confidenceDetail})`
       })
     : ['- No strong structured interaction signals were detected in the current dataset.']
 
@@ -132,10 +135,16 @@ export function buildReportSummary(report: InteractionReport): string {
     itemLine,
     '',
     'Summary:',
+    report.summary,
+    '',
+    'Key interaction signals:',
+    ...keySignalLines,
+    '',
+    'Detailed signals:',
     ...summaryLines,
     '',
     `Overall severity: ${report.overallSeverity}`,
-    `Overall confidence: ${report.overallConfidence}`,
+    `Overall confidence: ${report.overallConfidence} (${report.overallConfidenceScore}/100)`,
     '',
     'Note:',
     'This tool is for harm reduction and educational purposes only.',


### PR DESCRIPTION
### Motivation
- Improve how the interaction engine interprets enriched dataset signals (structured interaction tags, mechanisms, interaction notes) so results are clearer, more actionable, and better grounded in mechanisms. 
- Provide numeric confidence and richer explanations to help users make harm-reduction decisions without changing selection/flow semantics. 
- Surface mechanism-based reasoning and concise human-readable explanations instead of generic "these may interact" wording. 

### Description
- Reworked the interaction scorer in `src/utils/interactions/checkInteractions.ts` to compute a numeric `confidenceScore` per finding and `overallConfidenceScore` for the report by combining a base severity, number of shared interaction tags, number of overlapping mechanism phrases, and source quality (structured vs inferred). 
- Added mechanism phrase extraction and overlap detection helpers and generated per-signal `explanation`, `sharedTagCount`, `overlappingMechanismCount`, and `overlappingMechanisms` so each finding states why it was flagged. 
- Extended the types in `src/types/interactions.ts` to include the new fields (`confidenceScore`, `explanation`, `sharedTagCount`, `overlappingMechanisms`, `summary`, `keySignals`, `overallConfidenceScore`). 
- Updated UI rendering in `src/components/interactions/InteractionReportCard.tsx` to display the report `summary`, `keySignals`, each finding's `explanation`, and numeric confidence metrics while preserving the existing selection/check flow. 
- Enhanced share/export text in `src/utils/interactions/reportSharing.ts` to include the new summary, key signals, per-finding explanations, and confidence scores. 

### Testing
- Ran a full production build with `npm run build`, which completed successfully. 
- Performed a manual runtime check by importing and running `checkInteractions` with sample enriched items via Node (using the `--import tsx` approach), which produced a richer summary, explicit key signals, and numeric confidence values. 
- Attempted linting with `npx eslint ...` which failed due to repository environment/config resolution for `typescript-eslint` (an existing repo config/package issue unrelated to the new logic).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2b1ce95c8832393ce140d8d2a6b18)