### PR TITLE
Governed enrichment-driven SEO metadata and deterministic refresh/reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,8 @@
     "report:compound-enrichment-wave": "node scripts/report-compound-enrichment-wave.mjs",
     "report:compound-propagation": "tsx scripts/report-compound-propagation.ts",
     "verify:compound-propagation": "tsx scripts/verify-compound-propagation.ts",
-    "report:homepage-enrichment-refresh": "node scripts/generate-homepage-data.mjs --report-refresh && node scripts/verify-homepage-payload.mjs"
+    "report:homepage-enrichment-refresh": "node scripts/generate-homepage-data.mjs --report-refresh && node scripts/verify-homepage-payload.mjs",
+    "report:seo-enrichment-refresh": "node scripts/report-seo-enrichment-refresh.mjs"
   },
   "engines": {
     "node": ">=20 <21"

--- a/scripts/prerender-static.mjs
+++ b/scripts/prerender-static.mjs
@@ -255,6 +255,7 @@ function makeCardList(items, fallbackText = 'Content is being updated.') {
 
 function renderRouteContent(route) {
   const heading = escapeHtml(routeMeta.get(route)?.title || SITE_NAME)
+  const routeDescription = escapeHtml(routeMeta.get(route)?.description || '')
   const staticContentByRoute = {
     '/about':
       'The Hippie Scientist publishes evidence-aware herbal explainers focused on mechanisms, practical risk boundaries, and transparent sourcing.',
@@ -341,7 +342,7 @@ function renderRouteContent(route) {
     const effects = textList(herb?.effects, 8).map(effect => `<li>${escapeHtml(effect)}</li>`)
     const warnings = textList(herb?.contraindications, 6).map(item => `<li>${escapeHtml(item)}</li>`)
 
-    return `<main id="main" class="container-page py-8 text-white"><article><h1>${name}</h1><p>${description}</p><p>This static profile is generated from the publication manifest and is intended to give search crawlers a readable summary before hydration adds interactive evidence controls.</p><section><h2>Tracked effects</h2>${makeCardList(effects, 'Effect data pending; editorial review continues as new references are validated.')}</section><section><h2>Safety notes</h2>${makeCardList(warnings, 'No contraindications listed in the source dataset yet. Use conservative assumptions and review interactions.')}</section></article></main>`
+    return `<main id="main" class="container-page py-8 text-white"><article><h1>${name}</h1><p>${routeDescription || description}</p><p>${description}</p><p>This static profile is generated from the publication manifest and is intended to give search crawlers a readable summary before hydration adds interactive evidence controls.</p><section><h2>Tracked effects</h2>${makeCardList(effects, 'Effect data pending; editorial review continues as new references are validated.')}</section><section><h2>Safety notes</h2>${makeCardList(warnings, 'No contraindications listed in the source dataset yet. Use conservative assumptions and review interactions.')}</section></article></main>`
   }
 
   if (route === '/compounds') {
@@ -363,7 +364,7 @@ function renderRouteContent(route) {
     const effects = textList(compound?.effects, 8).map(effect => `<li>${escapeHtml(effect)}</li>`)
     const interactions = textList(compound?.interactions, 6).map(item => `<li>${escapeHtml(item)}</li>`)
 
-    return `<main id="main" class="container-page py-8 text-white"><article><h1>${name}</h1><p>${description}</p><p>This prerendered route preserves canonical publication metadata and a static narrative snapshot for indexing while interactive analysis tools load after hydration.</p><section><h2>Tracked effects</h2>${makeCardList(effects, 'Effect data pending while this compound remains under active evidence review.')}</section><section><h2>Interaction notes</h2>${makeCardList(interactions, 'No interactions listed in the source dataset yet; verify with primary references before use decisions.')}</section></article></main>`
+    return `<main id="main" class="container-page py-8 text-white"><article><h1>${name}</h1><p>${routeDescription || description}</p><p>${description}</p><p>This prerendered route preserves canonical publication metadata and a static narrative snapshot for indexing while interactive analysis tools load after hydration.</p><section><h2>Tracked effects</h2>${makeCardList(effects, 'Effect data pending while this compound remains under active evidence review.')}</section><section><h2>Interaction notes</h2>${makeCardList(interactions, 'No interactions listed in the source dataset yet; verify with primary references before use decisions.')}</section></article></main>`
   }
 
   if (route.startsWith('/herbs-for-')) {
@@ -432,7 +433,7 @@ function renderRouteContent(route) {
         return `<li><a href="/compounds/${escapeHtml(item.slug)}">${name}</a></li>`
       })
 
-    return `<main id="main" class="container-page py-8 text-white"><article><h1>${heading}</h1><p>${intro}</p><p>${description}</p><section><h2>Who this page is for</h2><p>${whoFor || 'Audience guidance is being revised.'}</p></section><section><h2>How items were selected</h2><p>${selectionRationale || 'Selection criteria are being revised.'}</p></section><section><h2>Cautions and scope</h2>${makeCardList([...cautions, ...exclusions], 'Caution framing is being reviewed before publication.')}</section><section><h2>What to do next</h2><p>${ctaLabel || 'Open the interaction checker before trying combinations.'}</p></section><section><h2>Related alternatives</h2>${makeCardList(alternatives, 'Related alternatives are being curated.')}</section><section><h2>Related collections</h2>${makeCardList(relatedLinks, 'Related collections are being curated.')}</section><section><h2>Indexable herb profiles</h2>${makeCardList(topHerbs, 'No herb profiles currently meet publication thresholds.')}</section><section><h2>Indexable compound profiles</h2>${makeCardList(topCompounds, 'No compound profiles currently meet publication thresholds.')}</section></article></main>`
+    return `<main id="main" class="container-page py-8 text-white"><article><h1>${heading}</h1><p>${routeDescription || intro}</p><p>${intro}</p><p>${description}</p><section><h2>Who this page is for</h2><p>${whoFor || 'Audience guidance is being revised.'}</p></section><section><h2>How items were selected</h2><p>${selectionRationale || 'Selection criteria are being revised.'}</p></section><section><h2>Cautions and scope</h2>${makeCardList([...cautions, ...exclusions], 'Caution framing is being reviewed before publication.')}</section><section><h2>What to do next</h2><p>${ctaLabel || 'Open the interaction checker before trying combinations.'}</p></section><section><h2>Related alternatives</h2>${makeCardList(alternatives, 'Related alternatives are being curated.')}</section><section><h2>Related collections</h2>${makeCardList(relatedLinks, 'Related collections are being curated.')}</section><section><h2>Indexable herb profiles</h2>${makeCardList(topHerbs, 'No herb profiles currently meet publication thresholds.')}</section><section><h2>Indexable compound profiles</h2>${makeCardList(topCompounds, 'No compound profiles currently meet publication thresholds.')}</section></article></main>`
   }
 
   return `<main id="main" class="container-page py-8 text-white"><h1>${heading}</h1><p>This route is prerendered for SEO metadata. Interactive content loads after hydration.</p></main>`

--- a/scripts/report-seo-enrichment-refresh.mjs
+++ b/scripts/report-seo-enrichment-refresh.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+import { getSharedRouteManifest } from './shared-route-manifest.mjs'
+
+const ROOT = process.cwd()
+const REPORT_JSON_PATH = path.join(ROOT, 'ops', 'reports', 'seo-enrichment-refresh.json')
+const REPORT_MD_PATH = path.join(ROOT, 'ops', 'reports', 'seo-enrichment-refresh.md')
+
+const readJson = relativePath => {
+  const fullPath = path.join(ROOT, relativePath)
+  if (!fs.existsSync(fullPath)) return []
+  try {
+    return JSON.parse(fs.readFileSync(fullPath, 'utf8'))
+  } catch {
+    return []
+  }
+}
+
+const clip = (value, max = 155) => String(value || '').trim().slice(0, max)
+const safeStr = value => String(value || '').trim()
+
+function listBlockedEntities() {
+  const submissions = readJson('ops/enrichment-submissions.json')
+  if (!Array.isArray(submissions)) return new Set()
+  const blockedStatuses = new Set([
+    'blocked',
+    'rejected',
+    'revision_requested',
+    'draft_submission',
+    'ready_for_review',
+    'needs_review',
+    'in-review',
+  ])
+  return new Set(
+    submissions
+      .filter(
+        row => blockedStatuses.has(safeStr(row?.reviewStatus)) || row?.active !== true,
+      )
+      .map(row => `${safeStr(row?.entityType)}:${safeStr(row?.entitySlug)}`)
+      .filter(Boolean),
+  )
+}
+
+function getCollectionBaselines() {
+  const sourcePath = path.join(ROOT, 'src', 'data', 'seoCollections.ts')
+  if (!fs.existsSync(sourcePath)) return new Map()
+  const source = fs.readFileSync(sourcePath, 'utf8')
+  const match = source.match(/export const SEO_COLLECTIONS:\s*SeoCollection\[\]\s*=\s*(\[[\s\S]*?\n\])/)
+  if (!match?.[1]) return new Map()
+  try {
+    const parsed = Function(`"use strict"; return (${match[1]});`)()
+    const rows = Array.isArray(parsed) ? parsed : []
+    return new Map(
+      rows.map(item => {
+        const slug = safeStr(item?.slug)
+        const title = item?.title
+          ? `${safeStr(item.title)} Collection Guide`
+          : 'Collection Guide | The Hippie Scientist'
+        const description = clip(
+          safeStr(item?.description) ||
+            'Topic-focused collections for herb and compound exploration.',
+        )
+        return [slug, { title, description }]
+      }),
+    )
+  } catch {
+    return new Map()
+  }
+}
+
+function run() {
+  const now = new Date().toISOString()
+  const publicationManifest = readJson('public/data/publication-manifest.json')
+  const herbEntries = Array.isArray(publicationManifest?.entities?.herbs)
+    ? publicationManifest.entities.herbs
+    : []
+  const compoundEntries = Array.isArray(publicationManifest?.entities?.compounds)
+    ? publicationManifest.entities.compounds
+    : []
+
+  const baselineByRoute = new Map()
+  for (const entry of [...herbEntries, ...compoundEntries]) {
+    const route = safeStr(entry?.route)
+    if (!route) continue
+    baselineByRoute.set(route, {
+      title: safeStr(entry?.title) || `${safeStr(entry?.name)} | The Hippie Scientist`,
+      description: clip(safeStr(entry?.description) || `${safeStr(entry?.name)} reference profile.`),
+    })
+  }
+  const collectionBaselines = getCollectionBaselines()
+  for (const [slug, baseline] of collectionBaselines.entries()) {
+    baselineByRoute.set(`/collections/${slug}`, baseline)
+  }
+
+  const { routeMeta, metadata } = getSharedRouteManifest()
+  const refresh = metadata?.seoEnrichmentRefresh || { rows: [] }
+  const rows = Array.isArray(refresh.rows) ? refresh.rows : []
+
+  const improvements = []
+  const unchanged = []
+  const usedSignalCounts = {}
+  const excludedSignalCounts = {}
+
+  for (const row of rows) {
+    const route = safeStr(row.route)
+    const next = routeMeta.get(route) || { title: '', description: '' }
+    const baseline = baselineByRoute.get(route) || { title: next.title, description: next.description }
+    const changed = baseline.title !== next.title || baseline.description !== next.description
+
+    for (const signal of row.usedSignals || []) {
+      usedSignalCounts[signal] = (usedSignalCounts[signal] || 0) + 1
+    }
+    for (const signal of row.excludedSignals || []) {
+      excludedSignalCounts[signal] = (excludedSignalCounts[signal] || 0) + 1
+    }
+
+    const entry = {
+      route,
+      pageType: row.pageType,
+      entitySlug: row.entitySlug,
+      changed,
+      before: baseline,
+      after: next,
+      usedSignals: row.usedSignals || [],
+      excludedSignals: row.excludedSignals || [],
+      unchangedReason: row.unchangedReason || null,
+    }
+
+    if (changed) improvements.push(entry)
+    else unchanged.push(entry)
+  }
+
+  const blockedEntities = listBlockedEntities()
+  const blockedLeaks = improvements.filter(item => {
+    if (item.pageType !== 'herb_detail' && item.pageType !== 'compound_detail') return false
+    const entityType = item.pageType === 'herb_detail' ? 'herb' : 'compound'
+    return blockedEntities.has(`${entityType}:${safeStr(item.entitySlug)}`)
+  })
+
+  const titleToRoutes = new Map()
+  for (const [route, meta] of routeMeta.entries()) {
+    const title = safeStr(meta?.title)
+    if (!title) continue
+    const list = titleToRoutes.get(title) || []
+    list.push(route)
+    titleToRoutes.set(title, list)
+  }
+  const duplicateTitles = [...titleToRoutes.entries()]
+    .filter(([, routes]) => routes.length > 1)
+    .map(([title, routes]) => ({ title, routes: routes.sort() }))
+
+  const canonicalMetaSample = [...routeMeta.entries()].slice(0, 20).map(([route, meta]) => ({
+    route,
+    hasTitle: safeStr(meta?.title).length > 0,
+    hasDescription: safeStr(meta?.description).length > 0,
+  }))
+
+  const verification = {
+    approvedGovernedOnly: blockedLeaks.length === 0,
+    duplicateTitlesPrevented: duplicateTitles.length === 0,
+    canonicalDescriptionCoverage: canonicalMetaSample.every(
+      row => row.hasTitle && row.hasDescription,
+    ),
+    blockedRejectedRevisionRequestedIgnored: blockedLeaks.length === 0,
+  }
+
+  const report = {
+    generatedAt: now,
+    deterministicModelVersion: refresh.modelVersion || 'seo-enrichment-refresh-v1',
+    sources: {
+      publicationManifest: 'public/data/publication-manifest.json',
+      herbSummary: 'public/data/herbs-summary.json',
+      compoundSummary: 'public/data/compounds-summary.json',
+      governedArtifact: 'public/data/enrichment-governed.json',
+      submissions: 'ops/enrichment-submissions.json',
+    },
+    totals: {
+      evaluated: rows.length,
+      improved: improvements.length,
+      unchanged: unchanged.length,
+    },
+    improvedByPageType: improvements.reduce((acc, row) => {
+      acc[row.pageType] = (acc[row.pageType] || 0) + 1
+      return acc
+    }, {}),
+    usedSignalCounts,
+    excludedSignalCounts,
+    unchangedReasons: unchanged.reduce((acc, row) => {
+      const reason = row.unchangedReason || 'unknown'
+      acc[reason] = (acc[reason] || 0) + 1
+      return acc
+    }, {}),
+    improvements,
+    intentionallyUnchanged: unchanged,
+    excludedCandidates: {
+      blockedEntitiesCount: blockedEntities.size,
+      blockedEntityLeaks: blockedLeaks,
+    },
+    verification,
+    verificationDetails: {
+      duplicateTitles,
+      canonicalMetaSample,
+    },
+  }
+
+  fs.mkdirSync(path.dirname(REPORT_JSON_PATH), { recursive: true })
+  fs.writeFileSync(REPORT_JSON_PATH, JSON.stringify(report, null, 2) + '\n', 'utf8')
+
+  const md = [
+    '# SEO enrichment refresh report',
+    '',
+    `- Generated at: ${report.generatedAt}`,
+    `- Deterministic model version: ${report.deterministicModelVersion}`,
+    '',
+    '## Totals',
+    `- Evaluated routes: ${report.totals.evaluated}`,
+    `- Improved routes: ${report.totals.improved}`,
+    `- Intentionally unchanged routes: ${report.totals.unchanged}`,
+    '',
+    '## Improvements by page type',
+    ...Object.entries(report.improvedByPageType).map(([key, value]) => `- ${key}: ${value}`),
+    '',
+    '## Used governed signals',
+    ...Object.entries(report.usedSignalCounts).map(([key, value]) => `- ${key}: ${value}`),
+    '',
+    '## Excluded candidate signals',
+    ...Object.entries(report.excludedSignalCounts).map(([key, value]) => `- ${key}: ${value}`),
+    '',
+    '## Intentionally unchanged reasons',
+    ...Object.entries(report.unchangedReasons).map(([key, value]) => `- ${key}: ${value}`),
+    '',
+    '## Verification',
+    `- approvedGovernedOnly: ${report.verification.approvedGovernedOnly}`,
+    `- duplicateTitlesPrevented: ${report.verification.duplicateTitlesPrevented}`,
+    `- canonicalDescriptionCoverage: ${report.verification.canonicalDescriptionCoverage}`,
+    `- blockedRejectedRevisionRequestedIgnored: ${report.verification.blockedRejectedRevisionRequestedIgnored}`,
+  ]
+
+  fs.writeFileSync(REPORT_MD_PATH, md.join('\n') + '\n', 'utf8')
+
+  console.log(`[report:seo-enrichment-refresh] improved=${improvements.length} unchanged=${unchanged.length}`)
+  console.log(`[report:seo-enrichment-refresh] verification duplicateTitles=${duplicateTitles.length} blockedLeaks=${blockedLeaks.length}`)
+}
+
+run()

--- a/scripts/shared-route-manifest.mjs
+++ b/scripts/shared-route-manifest.mjs
@@ -71,12 +71,110 @@ const normalizePath = route => {
 const dedupe = routes => [...new Set(routes.map(normalizePath))]
 const clip = (value, max = 155) => String(value || '').trim().slice(0, max)
 const NAN_TOKEN_PATTERN = /(^|[\s;,.()-])nan([\s;,.()-]|$)/i
+const GOVERNED_MODEL_VERSION = 'seo-enrichment-refresh-v1'
+const WEAK_OR_UNCERTAIN_EVIDENCE = new Set([
+  'preclinical_only',
+  'traditional_use_only',
+  'insufficient_evidence',
+  'mixed_or_uncertain',
+  'conflicting_evidence',
+])
+const BLOCKED_ENRICHMENT_LABELS = new Set([
+  'blocked',
+  'rejected',
+  'revision_requested',
+  'partial',
+])
 
 function safeStr(value) {
   if (!value || typeof value === 'number' || value !== value) return ''
   const normalized = String(value).trim()
   if (!normalized || NAN_TOKEN_PATTERN.test(normalized)) return ''
   return normalized
+}
+
+function normalizeEvidenceLabelTitle(label) {
+  return String(label || 'insufficient_evidence')
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, char => char.toUpperCase())
+}
+
+function buildGovernedSeoMeta({ name, kind, fallbackTitle, fallbackDescription, summary, noindex }) {
+  if (noindex || !summary || summary.enrichedAndReviewed !== true) {
+    return {
+      title: fallbackTitle,
+      description: fallbackDescription,
+      changed: false,
+      reasons: noindex ? ['noindex-route'] : ['missing-governed-summary'],
+      usedSignals: [],
+      excludedSignals: [],
+    }
+  }
+
+  const evidenceLabel = safeStr(summary.evidenceLabel || 'insufficient_evidence')
+  const evidenceLabelTitle = safeStr(summary.evidenceLabelTitle) || normalizeEvidenceLabelTitle(evidenceLabel)
+  const weakOrUncertain = WEAK_OR_UNCERTAIN_EVIDENCE.has(evidenceLabel)
+
+  const usedSignals = [`evidence_label:${evidenceLabel}`, 'enriched_reviewed:true']
+  const excludedSignals = []
+
+  const descriptionParts = [`Governed review: ${evidenceLabelTitle.toLowerCase()}.`]
+  if (summary.supportedUseCoveragePresent && !weakOrUncertain) {
+    descriptionParts.push('Includes scoped supported-use context from approved sources.')
+    usedSignals.push('supported_use:included')
+  } else if (summary.supportedUseCoveragePresent && weakOrUncertain) {
+    excludedSignals.push('supported_use:excluded_weak_or_uncertain_evidence')
+  }
+
+  if (summary.safetyCautionsPresent) {
+    descriptionParts.push('Safety and interaction cautions are included.')
+    usedSignals.push('safety_interactions:present')
+  } else {
+    excludedSignals.push('safety_interactions:absent')
+  }
+
+  if (summary.mechanismOrConstituentCoveragePresent) {
+    descriptionParts.push('Mechanism and constituent coverage is available.')
+    usedSignals.push('mechanism_constituent:present')
+  } else {
+    excludedSignals.push('mechanism_constituent:absent')
+  }
+
+  if (summary.conflictingEvidence) {
+    descriptionParts.push('Evidence includes unresolved conflicts; avoid overconfident conclusions.')
+    usedSignals.push('conflict_uncertainty:present')
+  } else if (weakOrUncertain) {
+    descriptionParts.push(
+      'Evidence remains limited and should not be interpreted as strong human proof.',
+    )
+    usedSignals.push('weak_evidence_guardrail:applied')
+  }
+
+  const reviewedDate = normalizeDate(summary.lastReviewedAt)
+  if (reviewedDate) {
+    descriptionParts.push(`Last reviewed ${reviewedDate}.`)
+    usedSignals.push('last_reviewed:included')
+  }
+
+  descriptionParts.push('Educational reference only.')
+  const governedDescription = clip(descriptionParts.join(' '), 155)
+
+  let governedTitle = fallbackTitle
+  if (!weakOrUncertain && summary.hasHumanEvidence) {
+    governedTitle = `${name} ${kind} Guide | ${evidenceLabelTitle}`
+    usedSignals.push('title_enrichment:enabled')
+  } else {
+    excludedSignals.push('title_enrichment:excluded_weak_or_nonhuman')
+  }
+
+  return {
+    title: governedTitle,
+    description: governedDescription || fallbackDescription,
+    changed: governedTitle !== fallbackTitle || governedDescription !== fallbackDescription,
+    reasons: [],
+    usedSignals,
+    excludedSignals,
+  }
 }
 
 const readJson = relativePath => {
@@ -417,6 +515,19 @@ function getBlogEntries() {
   })
 }
 
+function getGovernedSummaryMap(filePath) {
+  const rows = readJson(filePath)
+  const map = new Map()
+  for (const row of rows) {
+    const slug = safeStr(row?.slug)
+    if (!slug) continue
+    const summary = row?.researchEnrichmentSummary
+    if (!summary || typeof summary !== 'object') continue
+    map.set(slug, summary)
+  }
+  return map
+}
+
 export function getSharedRouteManifest() {
   const routeMeta = new Map()
   const sitemapMeta = new Map()
@@ -424,6 +535,11 @@ export function getSharedRouteManifest() {
   const putRouteMeta = (route, title, description) => routeMeta.set(route, { title, description })
   const putSitemapMeta = (route, meta = {}) => sitemapMeta.set(route, meta)
   const putRouteDirectives = (route, directives = {}) => routeDirectives.set(route, directives)
+  const herbSummaryRows = readJson('public/data/herbs-summary.json')
+  const compoundSummaryRows = readJson('public/data/compounds-summary.json')
+  const herbGovernedSummaryBySlug = getGovernedSummaryMap('public/data/herbs-summary.json')
+  const compoundGovernedSummaryBySlug = getGovernedSummaryMap('public/data/compounds-summary.json')
+  const seoRefreshRows = []
 
   CORE_STATIC_ROUTES.forEach(route => {
     const meta = CORE_ROUTE_META.get(route)
@@ -440,9 +556,14 @@ export function getSharedRouteManifest() {
 
   const goalRoutes = extractGoalRoutes()
   goalRoutes.forEach(route => {
+    const goalLabel = route
+      .replace('/herbs-for-', '')
+      .split('-')
+      .map(token => token.charAt(0).toUpperCase() + token.slice(1))
+      .join(' ')
     putRouteMeta(
       route,
-      'Goal-Based Herb Guide | The Hippie Scientist',
+      `${goalLabel} Herb Guide | The Hippie Scientist`,
       'Explore herbs aligned to a specific effect goal with safety context.'
     )
     putSitemapMeta(route, { priority: 0.7, changefreq: 'weekly' })
@@ -453,9 +574,62 @@ export function getSharedRouteManifest() {
     compounds: readJson('public/data/compounds.json'),
     combos: readJson('public/data/prebuiltCombos.json'),
   })
+  const collections = parseSeoCollections()
+  const collectionBySlug = new Map(
+    collections.map(collection => [safeStr(collection?.slug), collection]),
+  )
   const collectionRoutes = collectionQuality.routes
   collectionRoutes.forEach(route => {
-    putRouteMeta(route, 'Collection Guide | The Hippie Scientist', 'Topic-focused collections for herb and compound exploration.')
+    const slug = safeStr(route.split('/').pop())
+    const collection = collectionBySlug.get(slug)
+    const baseTitle = collection?.title
+      ? `${collection.title} Collection Guide`
+      : 'Collection Guide | The Hippie Scientist'
+    const baseDescription = clip(
+      safeStr(collection?.description) || 'Topic-focused collections for herb and compound exploration.',
+    )
+    const itemType = safeStr(collection?.itemType || 'herb')
+    const matches =
+      itemType === 'herb'
+        ? herbSummaryRows.filter(entry => filterHerbByCollection(entry, collection?.filters || {}))
+        : itemType === 'compound'
+          ? compoundSummaryRows.filter(entry =>
+              filterCompoundByCollection(entry, collection?.filters || {}),
+            )
+          : []
+    const governedMatches = matches.filter(
+      entry => entry?.researchEnrichmentSummary?.enrichedAndReviewed === true,
+    )
+    const strongGovernedMatches = governedMatches.filter(entry => {
+      const label = safeStr(entry?.researchEnrichmentSummary?.evidenceLabel)
+      return label === 'stronger_human_support' || label === 'limited_human_support'
+    })
+    const finalDescription =
+      strongGovernedMatches.length > 0
+        ? clip(
+            `${baseDescription} Includes ${strongGovernedMatches.length} governed profiles with human-support labels and safety-aware comparison context.`,
+          )
+        : baseDescription
+    putRouteMeta(route, baseTitle, finalDescription)
+    seoRefreshRows.push({
+      route,
+      pageType: 'collection_page',
+      entitySlug: slug,
+      changed: finalDescription !== baseDescription,
+      usedSignals:
+        strongGovernedMatches.length > 0
+          ? [
+              'governed_collection_coverage:enabled',
+              `governed_stronger_or_limited:${strongGovernedMatches.length}`,
+            ]
+          : [],
+      excludedSignals:
+        strongGovernedMatches.length === 0
+          ? ['governed_collection_coverage:excluded_insufficient_human_signal']
+          : [],
+      unchangedReason:
+        strongGovernedMatches.length === 0 ? 'insufficient-strong-governed-coverage' : null,
+    })
     putSitemapMeta(route, { priority: 0.7, changefreq: 'weekly' })
   })
 
@@ -512,11 +686,38 @@ export function getSharedRouteManifest() {
   const toRouteEntry = (entry, fallbackKind) => {
     const route = normalizePath(entry?.route || `/${fallbackKind}s/${entry?.slug || ''}`)
     if (!route.startsWith(`/${fallbackKind}s/`)) return null
+    const slug = safeStr(route.split('/').pop())
+    const fallbackTitle =
+      safeStr(entry?.title) || `${safeStr(entry?.name) || route.split('/').pop()} | The Hippie Scientist`
+    const fallbackDescription = clip(
+      safeStr(entry?.description) || `${safeStr(entry?.name) || route.split('/').pop()} reference profile.`,
+    )
+    const summary =
+      fallbackKind === 'herb'
+        ? herbGovernedSummaryBySlug.get(slug)
+        : compoundGovernedSummaryBySlug.get(slug)
+    const governedSeo = buildGovernedSeoMeta({
+      name: safeStr(entry?.name) || slug,
+      kind: fallbackKind === 'herb' ? 'Herb' : 'Compound',
+      fallbackTitle,
+      fallbackDescription,
+      summary,
+      noindex: false,
+    })
+    seoRefreshRows.push({
+      route,
+      pageType: `${fallbackKind}_detail`,
+      entitySlug: slug,
+      changed: governedSeo.changed,
+      usedSignals: governedSeo.usedSignals,
+      excludedSignals: governedSeo.excludedSignals,
+      unchangedReason: governedSeo.changed ? null : governedSeo.reasons[0] || 'no-change',
+    })
     return {
       route,
       score: Number(entry?.completenessScore || 0),
-      title: safeStr(entry?.title) || `${safeStr(entry?.name) || route.split('/').pop()} | The Hippie Scientist`,
-      description: clip(safeStr(entry?.description) || `${safeStr(entry?.name) || route.split('/').pop()} reference profile.`),
+      title: governedSeo.title,
+      description: governedSeo.description,
       kind: fallbackKind,
       lastmod: normalizeDate(entry?.lastmod) || new Date().toISOString().slice(0, 10),
     }
@@ -594,6 +795,27 @@ export function getSharedRouteManifest() {
             })
             return acc
           }, {}),
+      },
+      seoEnrichmentRefresh: {
+        modelVersion: GOVERNED_MODEL_VERSION,
+        totalEvaluated: seoRefreshRows.length,
+        changedCount: seoRefreshRows.filter(row => row.changed).length,
+        unchangedCount: seoRefreshRows.filter(row => !row.changed).length,
+        changedByPageType: seoRefreshRows
+          .filter(row => row.changed)
+          .reduce((acc, row) => {
+            acc[row.pageType] = (acc[row.pageType] || 0) + 1
+            return acc
+          }, {}),
+        unchangedReasons: seoRefreshRows
+          .filter(row => !row.changed)
+          .reduce((acc, row) => {
+            const reason = row.unchangedReason || 'unknown'
+            acc[reason] = (acc[reason] || 0) + 1
+            return acc
+          }, {}),
+        blockedSignalPolicy: [...BLOCKED_ENRICHMENT_LABELS],
+        rows: seoRefreshRows,
       },
       indexableCollections: collectionQuality.audits.filter(audit => audit.approved),
       excludedCollections: collectionQuality.audits.filter(audit => !audit.approved),

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -12,6 +12,18 @@ export type BuildMetaArgs = {
   keepQueryParams?: string[]
 }
 
+export type GovernedSummarySignals = {
+  evidenceLabel?: string
+  evidenceLabelTitle?: string
+  hasHumanEvidence?: boolean
+  safetyCautionsPresent?: boolean
+  supportedUseCoveragePresent?: boolean
+  mechanismOrConstituentCoveragePresent?: boolean
+  conflictingEvidence?: boolean
+  enrichedAndReviewed?: boolean
+  lastReviewedAt?: string
+}
+
 type NormalizedMeta = {
   title: string
   description: string
@@ -94,6 +106,63 @@ export function formatMetaDescription(value: string, fallback: string, maxLength
   )
   const compact = (lastBreak > 90 ? cutoff.slice(0, lastBreak) : cutoff).trim()
   return `${compact}…`
+}
+
+const WEAK_OR_UNCERTAIN_LABELS = new Set([
+  'preclinical_only',
+  'traditional_use_only',
+  'insufficient_evidence',
+  'mixed_or_uncertain',
+  'conflicting_evidence',
+])
+
+export function buildGovernedMetaDescription(
+  fallbackDescription: string,
+  summary?: GovernedSummarySignals,
+): string {
+  if (!summary?.enrichedAndReviewed) return fallbackDescription
+  const evidenceLabel = String(summary.evidenceLabel || 'insufficient_evidence')
+  const weakOrUncertain = WEAK_OR_UNCERTAIN_LABELS.has(evidenceLabel)
+  const labelText = String(summary.evidenceLabelTitle || evidenceLabel.replace(/_/g, ' ')).toLowerCase()
+
+  const parts = [`Governed review: ${labelText}.`]
+  if (summary.supportedUseCoveragePresent && !weakOrUncertain) {
+    parts.push('Includes scoped supported-use context from approved sources.')
+  }
+  if (summary.safetyCautionsPresent) {
+    parts.push('Safety and interaction cautions are included.')
+  }
+  if (summary.mechanismOrConstituentCoveragePresent) {
+    parts.push('Mechanism and constituent coverage is available.')
+  }
+  if (summary.conflictingEvidence) {
+    parts.push('Evidence includes unresolved conflicts; avoid overconfident conclusions.')
+  } else if (weakOrUncertain) {
+    parts.push('Evidence remains limited and should not be interpreted as strong human proof.')
+  }
+  if (summary.lastReviewedAt) {
+    const reviewedDate = new Date(summary.lastReviewedAt)
+    if (!Number.isNaN(reviewedDate.getTime())) {
+      parts.push(`Last reviewed ${reviewedDate.toISOString().slice(0, 10)}.`)
+    }
+  }
+  parts.push('Educational reference only.')
+  return formatMetaDescription(parts.join(' '), fallbackDescription)
+}
+
+export function buildGovernedMetaTitle(
+  fallbackTitle: string,
+  name: string,
+  kind: 'Herb' | 'Compound',
+  summary?: GovernedSummarySignals,
+): string {
+  if (!summary?.enrichedAndReviewed) return fallbackTitle
+  const evidenceLabel = String(summary.evidenceLabel || 'insufficient_evidence')
+  const weakOrUncertain = WEAK_OR_UNCERTAIN_LABELS.has(evidenceLabel)
+  if (weakOrUncertain || !summary.hasHumanEvidence) return fallbackTitle
+  const labelTitle = String(summary.evidenceLabelTitle || '').trim()
+  if (!labelTitle) return fallbackTitle
+  return `${name} ${kind} Guide | ${labelTitle}`
 }
 
 export function websiteJsonLd() {

--- a/src/pages/CollectionPage.tsx
+++ b/src/pages/CollectionPage.tsx
@@ -90,6 +90,20 @@ function buildSeoDescription(collection: SeoCollection, topItems: CollectionEnti
   )
 }
 
+function buildGovernedCollectionSeoDescription(
+  baseline: string,
+  governedReviewedCount: number,
+  strongerHumanSupportCount: number,
+  limitedHumanSupportCount: number,
+) {
+  const strongHuman = strongerHumanSupportCount + limitedHumanSupportCount
+  if (strongHuman < 2 || governedReviewedCount < 2) return baseline
+  return formatMetaDescription(
+    `${baseline} Includes ${strongHuman} governed profiles with stronger or limited human-support evidence labels and safety-aware comparison framing.`,
+    baseline,
+  )
+}
+
 function summarizeItemValue(item: CollectionEntity): string {
   const rawEffects = 'common' in item ? item.effects : item.effects
   if (Array.isArray(rawEffects) && rawEffects.length > 0) {
@@ -355,7 +369,14 @@ export default function CollectionPage() {
     [topItems],
   )
   const pageTitle = collection ? `${collection.title} Collection Guide` : 'Collections'
-  const pageDescription = collection ? buildSeoDescription(collection, topItems) : ''
+  const pageDescription = collection
+    ? buildGovernedCollectionSeoDescription(
+        buildSeoDescription(collection, topItems),
+        governedCollectionSummary?.governedReviewedCount || 0,
+        governedCollectionSummary?.strongerHumanSupportCount || 0,
+        governedCollectionSummary?.limitedHumanSupportCount || 0,
+      )
+    : ''
 
   useEffect(() => {
     if (!shareToast) return

--- a/src/pages/CompoundDetail.tsx
+++ b/src/pages/CompoundDetail.tsx
@@ -12,7 +12,14 @@ import { CompoundDetailSkeleton } from '@/components/skeletons/DetailSkeletons'
 import { mapRelatedHerbsForCompound } from '@/lib/compoundHerbRelations'
 import RelatedHerbCard from '@/components/RelatedHerbCard'
 import Collapse from '@/components/ui/Collapse'
-import { breadcrumbJsonLd, compoundJsonLd, formatMetaDescription, SITE_URL } from '@/lib/seo'
+import {
+  breadcrumbJsonLd,
+  buildGovernedMetaDescription,
+  buildGovernedMetaTitle,
+  compoundJsonLd,
+  formatMetaDescription,
+  SITE_URL,
+} from '@/lib/seo'
 import { countCautionSignals, inferContentFlags } from '@/lib/trust'
 import { SEO_COLLECTIONS } from '@/data/seoCollections'
 import { filterCompoundByCollection } from '@/lib/collectionQuality'
@@ -210,11 +217,21 @@ export default function CompoundDetail() {
     compound.mechanism ||
     compoundEffectsMetaText
   ).trim()
-  const compoundMetaDescription = formatMetaDescription(
+  const baseCompoundMetaDescription = formatMetaDescription(
     compoundDescriptionSource,
     `${compound.name} compound guide with pharmacology, effects, and safety notes.`,
   )
-  const compoundMetaTitle = `${compound.name} Compound Guide: Mechanism, Effects & Safety`
+  const baseCompoundMetaTitle = `${compound.name} Compound Guide: Mechanism, Effects & Safety`
+  const compoundMetaTitle = buildGovernedMetaTitle(
+    baseCompoundMetaTitle,
+    compound.name,
+    'Compound',
+    compound.researchEnrichmentSummary,
+  )
+  const compoundMetaDescription = buildGovernedMetaDescription(
+    baseCompoundMetaDescription,
+    compound.researchEnrichmentSummary,
+  )
 
   return (
     <main className='container mx-auto max-w-4xl px-4 py-8 text-white'>

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -12,7 +12,14 @@ import { extractPrimaryEffects } from '@/utils/extractPrimaryEffects'
 import { getHerbDataCompleteness } from '@/utils/getDataCompleteness'
 import { splitClean } from '@/lib/sanitize'
 import { pushRecentlyViewed, useSavedItems } from '@/lib/growth'
-import { breadcrumbJsonLd, formatMetaDescription, herbJsonLd, SITE_URL } from '@/lib/seo'
+import {
+  breadcrumbJsonLd,
+  buildGovernedMetaDescription,
+  buildGovernedMetaTitle,
+  formatMetaDescription,
+  herbJsonLd,
+  SITE_URL,
+} from '@/lib/seo'
 import CuratedProductModule from '@/components/CuratedProductModule'
 import CtaVariantLayout from '@/components/cta/CtaVariantLayout'
 import Collapse from '@/components/ui/Collapse'
@@ -195,11 +202,11 @@ export default function HerbDetail() {
     therapeuticUses[0] ||
     effects.slice(0, 2).join(', ')
   ).trim()
-  const herbMetaDescription = formatMetaDescription(
+  const baseHerbMetaDescription = formatMetaDescription(
     herbMetaDescriptionSource,
     `${herbDisplayName} herb guide with effects, safety notes, and practical context.`,
   )
-  const herbMetaTitle = `${herbDisplayName} Herb Guide: Effects, Uses & Safety`
+  const baseHerbMetaTitle = `${herbDisplayName} Herb Guide: Effects, Uses & Safety`
 
   // Scalar fields already cleaned by normalization
   const description = herb.description || ''
@@ -305,6 +312,16 @@ export default function HerbDetail() {
   })
   const ctaVariantId = ctaExperiment.activeVariantId
   const governedResearch = getGovernedResearchEnrichment('herb', herb.slug)
+  const herbMetaTitle = buildGovernedMetaTitle(
+    baseHerbMetaTitle,
+    herbDisplayName,
+    'Herb',
+    herb.researchEnrichmentSummary,
+  )
+  const herbMetaDescription = buildGovernedMetaDescription(
+    baseHerbMetaDescription,
+    herb.researchEnrichmentSummary,
+  )
   const enrichmentRecommendations = buildEnrichmentRecommendations('herb', herb.slug)
   const recommendationNames = {
     herb: new Map(herbs.map(item => [item.slug, item.common || item.name || item.slug])),


### PR DESCRIPTION
### Motivation
- Improve search-facing titles, meta descriptions, and prerendered snippet copy using only approved governed enrichment signals while preserving safety and evidence-aware language.
- Ensure metadata upgrades do not overstate weak or non-human evidence and avoid changing noindex/low-quality pages.
- Provide a deterministic, reviewable report and verification that shows which pages changed, which governed signals were used or excluded, and that blocked/rejected enrichment didn’t leak into SEO output.

### Description
- Added evidence-aware SEO helpers in `src/lib/seo.ts` (`buildGovernedMetaTitle`, `buildGovernedMetaDescription`, and `GovernedSummarySignals`) that only apply when `enrichedAndReviewed` is true and guard against weak/uncertain evidence labels. (files changed: `src/lib/seo.ts`)
- Wired governed summaries into runtime pages so herb and compound detail pages use governed signals to generate titles/descriptions without overstating weak evidence. (files changed: `src/pages/HerbDetail.tsx`, `src/pages/CompoundDetail.tsx`)
- Extended shared route manifest and prerender pipeline to apply governed metadata to publication manifest routes and to surface route-level description text into prerendered HTML for herbs, compounds, and eligible collections while respecting collection quality/noindex gates. (files changed: `scripts/shared-route-manifest.mjs`, `scripts/prerender-static.mjs`, `src/pages/CollectionPage.tsx`)
- Added a deterministic reporter and npm entry point `npm run report:seo-enrichment-refresh` that writes `ops/reports/seo-enrichment-refresh.json` and `ops/reports/seo-enrichment-refresh.md` summarizing before/after diffs, used vs excluded signals, unchanged reasons, and verification flags. (files added/changed: `scripts/report-seo-enrichment-refresh.mjs`, `package.json`)
- Conservative governance behavior implemented: only publish-safe/enriched+reviewed summaries influence SEO; weak/non-human evidence labels are prevented from enabling title-strength changes; blocked/rejected/revision_requested or inactive submissions are excluded by verification checks.

### Testing
- Ran `npm run report:seo-enrichment-refresh` which produced a deterministic report and logged `improved=1 unchanged=18` and wrote `ops/reports/seo-enrichment-refresh.{json,md}`; command succeeded.
- Ran `npm run verify:governed-enrichment-rendering` (tsx script) which returned a PASS (`[verify-governed-enrichment-rendering] PASS rows=10 promotedEntities=10`).
- Ran `npm run verify:enrichment-discovery` which returned a PASS (`[verify-enrichment-discovery] PASS publishable=2 ineligible=8`).
- Executed `node scripts/prerender-routes.mjs | head -n 20` to sample the generated route manifest and confirm updated route meta entries; command produced expected route list.

Notes/verification summary: the automated verification in the report confirmed no blocked/rejected/revision_requested enrichment leaked into improved SEO output and duplicate-title checks passed after normalizing goal-route titles; canonical description coverage sampling passed but the report records any exceptions for reviewer inspection.

Risks / follow-ups
- The improvements are gated on governed enrichment coverage; to scale metadata upgrades, continue increasing approved/publishable governed summaries (esp. stronger/limited human-support coverage).
- Report artifacts live under `ops/reports/` (these files are often treated as generated outputs in this repo), so include them in review as operational artifacts rather than source fixtures.
- Suggested follow-ups: review the SEO report output in `ops/reports/seo-enrichment-refresh.*` and confirm editorial wording tweaks for any routes flagged as changed before wide publishing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbcf5c812c8323906fdef90b62b7c4)