### PR TITLE
Unify source counting, add canonical sanitization, and update generation scoring

### DIFF
--- a/ops/pass1-source-normalization-audit-2026-04-02.md
+++ b/ops/pass1-source-normalization-audit-2026-04-02.md
@@ -1,0 +1,25 @@
+# Pass 1 Audit: canonical data flow + source counting
+
+## Canonical data flow (current repo)
+
+1. **Raw input sync**: `scripts/sync-updated-datasets.mjs` copies `*_combined_updated.json` into `public/data/herbs.json` and `public/data/compounds.json` (plus `*_combined_updated.json` mirrors).  
+2. **Normalization/dedupe layer**: `scripts/dedupe-entities.mjs` deduplicates `public/data/herbs.json` and `public/data/compounds.json` in place.  
+3. **Quality/index gating**: `scripts/quality-gate-data.mjs` reads `public/data/herbs.json` + `public/data/compounds.json`, then writes:
+   - `public/data/publication-manifest.json`
+   - `public/data/indexable-herbs.json`
+   - `public/data/indexable-compounds.json`
+   - `public/data/quality-report.json`
+4. **Publication index**: `scripts/generate-publication-index.mjs` derives `public/data/publication-index.json` from `publication-manifest.json`.  
+5. **Homepage payload**: `scripts/generate-homepage-data.mjs` reads the gated/index files and writes `src/generated/homepage-data.json`.
+
+## Pass 1 source-counting fix scope applied
+
+- Unified homepage source scoring/buckets to use the same normalized source inputs (`sources`, `source`, `references`, `citations`) instead of only `sources`.
+- Updated dedupe completeness scoring to use normalized bootstrap source counting.
+- Updated route-manifest fallback scoring to use normalized bootstrap source counting.
+
+## Next steps (Pass 2/3)
+
+1. Add targeted sanitization pass for junk marker values and placeholder boilerplate.
+2. Re-run and compare before/after gate and blank-field counts after sanitization.
+3. Validate publication/homepage/sitemap outputs after sanitized regeneration.

--- a/ops/pass2-sanitization-report-2026-04-02.json
+++ b/ops/pass2-sanitization-report-2026-04-02.json
@@ -1,0 +1,37 @@
+{
+  "generatedAt": "2026-04-02T23:23:41.757Z",
+  "canonicalFiles": {
+    "herbs": "public/data/herbs.json",
+    "compounds": "public/data/compounds.json"
+  },
+  "cleanupCounts": {
+    "herbs": {
+      "removedJunkNameRecords": 0,
+      "cleanedJunkFieldValues": 0,
+      "cleanedPlaceholderSegments": 2
+    },
+    "compounds": {
+      "removedJunkNameRecords": 1,
+      "cleanedJunkFieldValues": 1,
+      "cleanedPlaceholderSegments": 0
+    }
+  },
+  "gateMetrics": {
+    "before": {
+      "herbsPassing": 37,
+      "compoundsPassing": 9,
+      "herbsZeroSources": 690,
+      "compoundsZeroSources": 382,
+      "herbsBlankDescriptions": 0,
+      "compoundsBlankDescriptions": 381
+    },
+    "after": {
+      "herbsPassing": 37,
+      "compoundsPassing": 9,
+      "herbsZeroSources": 690,
+      "compoundsZeroSources": 381,
+      "herbsBlankDescriptions": 0,
+      "compoundsBlankDescriptions": 380
+    }
+  }
+}

--- a/public/data/compounds.json
+++ b/public/data/compounds.json
@@ -30,7 +30,7 @@
     "lastUpdated": "2026-04-01T18:55:38.037Z"
   },
   {
-    "name": "[object Object]",
+    "name": "",
     "category": "general",
     "description": "",
     "herbs": [
@@ -94,29 +94,6 @@
         "url": "https://pubmed.ncbi.nlm.nih.gov/34401729/"
       }
     ],
-    "lastUpdated": "2026-04-01T18:55:38.037Z"
-  },
-  {
-    "name": "5",
-    "category": "general",
-    "description": "",
-    "herbs": [
-      "virola theiodora"
-    ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used by amazonian tribes as a snuff for spiritual rituals... No direct mechanismofaction data. Contextual inference: Used by amazonian tribes as a snuff for spiritual rituals... Used by Amazonian tribes as a snuff for spiritual rituals.. Used by Amazonian tribes as a snuff for spiritual rituals."
-    ],
-    "contraindications": [],
-    "interactions": [],
-    "therapeuticUses": [],
-    "activeCompounds": [],
-    "dosage": "",
-    "duration": "",
-    "region": "",
-    "preparation": "",
-    "legalStatus": "",
-    "sideEffects": [],
-    "sources": [],
     "lastUpdated": "2026-04-01T18:55:38.037Z"
   },
   {

--- a/public/data/herbs.json
+++ b/public/data/herbs.json
@@ -4823,7 +4823,6 @@
     "therapeuticUses": [],
     "traditionalUse": "; nan; nan",
     "sideEffects": [
-      "Insufficient data",
       "potentially mild GI effects based on related species"
     ]
   },
@@ -11015,7 +11014,7 @@
       "5].",
       "May potentiate serotonergic substances"
     ],
-    "safetyNotes": "nausea,vasoconstriction,headache [0,5].,Mild,GI discomfort from seed coatings.,Low,rodent LD50 ~200–300 mg/kg [0",
+    "safetyNotes": "nausea,vasoconstriction,headache [0,5].,Mild,GI discomfort from seed coatings.,Low,rodent LD50 ~200–300 mg/kg [0",
     "sources": [],
     "lastUpdated": "2026-04-01T18:55:37.949Z",
     "description": "Ornamental morning glory whose seeds contain LSA.",
@@ -18740,7 +18739,6 @@
     "therapeuticUses": [],
     "traditionalUse": "; nan; nan",
     "sideEffects": [
-      "Insufficient data",
       "unknown toxicity profile"
     ]
   },

--- a/public/data/indexable-compounds.json
+++ b/public/data/indexable-compounds.json
@@ -5,10 +5,10 @@
     "name": "CBD",
     "kind": "compound",
     "title": "CBD | The Hippie Scientist",
-    "description": "Human evidence exists for selected neurologic indications and safety liabilities; interaction management is central to risk reduction.",
-    "completenessScore": 16,
+    "description": "Cannabidiol (CBD) is a non-intoxicating phytocannabinoid with approved use in specific seizure disorders and broad off-label consumer exposure. Human revie",
+    "completenessScore": 23,
     "tier": "stub",
-    "lastmod": "2026-04-01"
+    "lastmod": "2026-04-02"
   },
   {
     "slug": "agrimoniin",
@@ -16,21 +16,10 @@
     "name": "Agrimoniin",
     "kind": "compound",
     "title": "Agrimoniin | The Hippie Scientist",
-    "description": "Evidence is mainly mechanistic/preclinical, with uncertain clinical translation.",
-    "completenessScore": 13,
+    "description": "Agrimoniin is an ellagitannin studied for redox and inflammatory pathway effects in preclinical models. Human clinical evidence is limited.",
+    "completenessScore": 17,
     "tier": "stub",
-    "lastmod": "2026-04-01"
-  },
-  {
-    "slug": "asarone",
-    "route": "/compounds/asarone",
-    "name": "Asarone (alpha/beta isomers)",
-    "kind": "compound",
-    "title": "Asarone (alpha/beta isomers) | The Hippie Scientist",
-    "description": "Evidence is strongest for safety concern framing rather than proven therapeutic efficacy.",
-    "completenessScore": 13,
-    "tier": "stub",
-    "lastmod": "2026-04-01"
+    "lastmod": "2026-04-02"
   },
   {
     "slug": "luteolin",
@@ -38,32 +27,10 @@
     "name": "Luteolin",
     "kind": "compound",
     "title": "Luteolin | The Hippie Scientist",
-    "description": "Evidence supports mechanistic activity with plausible interaction risk, but robust condition-specific clinical efficacy remains limited.",
-    "completenessScore": 13,
+    "description": "Luteolin is a dietary flavone studied for anti-inflammatory and redox-active pharmacology. Evidence includes mechanistic studies and translational safety r",
+    "completenessScore": 17,
     "tier": "stub",
-    "lastmod": "2026-04-01"
-  },
-  {
-    "slug": "asarone",
-    "route": "/compounds/asarone",
-    "name": "Asarone (alpha/beta isomers)",
-    "kind": "compound",
-    "title": "Asarone (alpha/beta isomers) | The Hippie Scientist",
-    "description": "Evidence is strongest for safety concern framing rather than proven therapeutic efficacy.",
-    "completenessScore": 13,
-    "tier": "stub",
-    "lastmod": "2026-04-01"
-  },
-  {
-    "slug": "asarone",
-    "route": "/compounds/asarone",
-    "name": "Asarone (alpha/beta isomers)",
-    "kind": "compound",
-    "title": "Asarone (alpha/beta isomers) | The Hippie Scientist",
-    "description": "Evidence is strongest for safety concern framing rather than proven therapeutic efficacy.",
-    "completenessScore": 13,
-    "tier": "stub",
-    "lastmod": "2026-04-01"
+    "lastmod": "2026-04-02"
   },
   {
     "slug": "2-4-5-trimethoxybenzaldehyde",
@@ -71,10 +38,21 @@
     "name": "2,4,5-Trimethoxybenzaldehyde",
     "kind": "compound",
     "title": "2,4,5-Trimethoxybenzaldehyde | The Hippie Scientist",
-    "description": "Current evidence is preclinical/contextual, not definitive for clinical claims.",
-    "completenessScore": 10,
+    "description": "2,4,5-Trimethoxybenzaldehyde is an aromatic aldehyde reported in Acorus phytochemistry. Direct clinical evidence for efficacy or safety is sparse, so inter",
+    "completenessScore": 11,
     "tier": "stub",
-    "lastmod": "2026-04-01"
+    "lastmod": "2026-04-02"
+  },
+  {
+    "slug": "7-hydroxymitragynine",
+    "route": "/compounds/7-hydroxymitragynine",
+    "name": "7-Hydroxymitragynine",
+    "kind": "compound",
+    "title": "7-Hydroxymitragynine | The Hippie Scientist",
+    "description": "7-Hydroxymitragynine is a kratom-associated indole alkaloid with high opioid-receptor potency relative to parent mitragynine. Recent reviews frame it as a ",
+    "completenessScore": 11,
+    "tier": "stub",
+    "lastmod": "2026-04-02"
   },
   {
     "slug": "aconine",
@@ -82,10 +60,10 @@
     "name": "Aconine",
     "kind": "compound",
     "title": "Aconine | The Hippie Scientist",
-    "description": "Evidence is insufficient for efficacy claims; safety interpretation relies on class-level toxicology context.",
-    "completenessScore": 10,
+    "description": "Aconine is an Aconitum-related diterpenoid alkaloid generally discussed within aconitum toxicology rather than therapeutic pharmacology. Direct human evide",
+    "completenessScore": 11,
     "tier": "stub",
-    "lastmod": "2026-04-01"
+    "lastmod": "2026-04-02"
   },
   {
     "slug": "aconitine",
@@ -93,10 +71,10 @@
     "name": "Aconitine",
     "kind": "compound",
     "title": "Aconitine | The Hippie Scientist",
-    "description": "Evidence supports major toxicity risk; there is no high-quality evidence supporting routine therapeutic oral use.",
-    "completenessScore": 10,
+    "description": "Aconitine is a highly toxic diterpenoid alkaloid from Aconitum species and is primarily characterized by poisoning literature rather than therapeutic trial",
+    "completenessScore": 11,
     "tier": "stub",
-    "lastmod": "2026-04-01"
+    "lastmod": "2026-04-02"
   },
   {
     "slug": "anabasine",
@@ -104,9 +82,20 @@
     "name": "Anabasine",
     "kind": "compound",
     "title": "Anabasine | The Hippie Scientist",
-    "description": "Human observational evidence supports exposure relevance and safety concern framing, not efficacy claims.",
-    "completenessScore": 10,
+    "description": "Anabasine is a minor tobacco alkaloid with nicotinic pharmacology and recognized use as an exposure biomarker. Evidence is strongest for toxicology and exp",
+    "completenessScore": 11,
     "tier": "stub",
-    "lastmod": "2026-04-01"
+    "lastmod": "2026-04-02"
+  },
+  {
+    "slug": "asarone-alpha-beta-isomers",
+    "route": "/compounds/asarone-alpha-beta-isomers",
+    "name": "Asarone (alpha/beta isomers)",
+    "kind": "compound",
+    "title": "Asarone (alpha/beta isomers) | The Hippie Scientist",
+    "description": "Asarone refers primarily to alpha- and beta-isomers found in Acorus species. Current literature emphasizes toxicology, interaction potential, and uncertain",
+    "completenessScore": 5,
+    "tier": "stub",
+    "lastmod": "2026-04-02"
   }
 ]

--- a/public/data/indexable-herbs.json
+++ b/public/data/indexable-herbs.json
@@ -1,69 +1,25 @@
 [
   {
-    "slug": "heimia-salicifolia",
-    "route": "/herbs/heimia-salicifolia",
+    "slug": "ipomoea-tricolor",
+    "route": "/herbs/ipomoea-tricolor",
+    "name": "ipomoea tricolor",
+    "kind": "herb",
+    "title": "ipomoea tricolor | The Hippie Scientist",
+    "description": "Ipomoea tricolor (morning glory) is discussed in ethnobotanical and plant-symbiosis literature, including ergoline-associated chemistry.",
+    "completenessScore": 16,
+    "tier": "stub",
+    "lastmod": "2026-04-02"
+  },
+  {
+    "slug": "heimia-salicifolia-sinicuichi",
+    "route": "/herbs/heimia-salicifolia-sinicuichi",
     "name": "heimia salicifolia (sinicuichi)",
     "kind": "herb",
     "title": "heimia salicifolia (sinicuichi) | The Hippie Scientist",
-    "description": "Heimia salicifolia has traditional ethnobotanical use for altered perception and calming effects, while modern controlled clinical evidence is limited.",
-    "completenessScore": 43,
-    "tier": "partial",
-    "lastmod": "2026-04-01"
-  },
-  {
-    "slug": "papaver-somniferum",
-    "route": "/herbs/papaver-somniferum",
-    "name": "papaver somniferum",
-    "kind": "herb",
-    "title": "papaver somniferum | The Hippie Scientist",
-    "description": "This plant has strong opioid-related pharmacology and safety liabilities; non-medical use carries high overdose and dependence risk.",
-    "completenessScore": 37,
-    "tier": "partial",
-    "lastmod": "2026-04-01"
-  },
-  {
-    "slug": "mentha-piperita",
-    "route": "/herbs/mentha-piperita",
-    "name": "mentha piperita",
-    "kind": "herb",
-    "title": "mentha piperita | The Hippie Scientist",
-    "description": "Mentha piperita has human and preclinical evidence for gastrointestinal symptom support, while efficacy depends on preparation and indication.",
-    "completenessScore": 27,
-    "tier": "partial",
-    "lastmod": "2026-04-01"
-  },
-  {
-    "slug": "achillea-millefolium",
-    "route": "/herbs/achillea-millefolium",
-    "name": "achillea millefolium",
-    "kind": "herb",
-    "title": "achillea millefolium | The Hippie Scientist",
-    "description": "Achillea millefolium is used for digestive, inflammatory, and wound-related traditional indications with mixed modern evidence quality.",
-    "completenessScore": 26,
-    "tier": "partial",
-    "lastmod": "2026-04-01"
-  },
-  {
-    "slug": "nepeta-cataria",
-    "route": "/herbs/nepeta-cataria",
-    "name": "nepeta cataria",
-    "kind": "herb",
-    "title": "nepeta cataria | The Hippie Scientist",
-    "description": "Nepeta cataria is traditionally used for mild calming and digestive support, with limited modern clinical evidence.",
-    "completenessScore": 22,
+    "description": "Traditional Mexican herb used for altered states and memory recall",
+    "completenessScore": 14,
     "tier": "stub",
-    "lastmod": "2026-04-01"
-  },
-  {
-    "slug": "rivea-corymbosa",
-    "route": "/herbs/rivea-corymbosa",
-    "name": "rivea corymbosa",
-    "kind": "herb",
-    "title": "rivea corymbosa | The Hippie Scientist",
-    "description": "Morning glory species used in Mesoamerican rituals.",
-    "completenessScore": 22,
-    "tier": "stub",
-    "lastmod": "2026-04-01"
+    "lastmod": "2026-04-02"
   },
   {
     "slug": "calliandra-anomala",
@@ -72,9 +28,42 @@
     "kind": "herb",
     "title": "calliandra anomala | The Hippie Scientist",
     "description": "Shrubby Fabaceae species with bright pink flowers; limited pharmacological research.",
-    "completenessScore": 21,
+    "completenessScore": 12,
     "tier": "stub",
-    "lastmod": "2026-04-01"
+    "lastmod": "2026-04-02"
+  },
+  {
+    "slug": "papaver-somniferum",
+    "route": "/herbs/papaver-somniferum",
+    "name": "papaver somniferum",
+    "kind": "herb",
+    "title": "papaver somniferum | The Hippie Scientist",
+    "description": "Papaver somniferum is the botanical source of opiate alkaloids associated with analgesic and sedative pharmacology and substantial dependence risk.",
+    "completenessScore": 12,
+    "tier": "stub",
+    "lastmod": "2026-04-02"
+  },
+  {
+    "slug": "withania-somnifera",
+    "route": "/herbs/withania-somnifera",
+    "name": "withania somnifera",
+    "kind": "herb",
+    "title": "withania somnifera | The Hippie Scientist",
+    "description": "Withania somnifera is the scientific name for ashwagandha and is used in Ayurvedic practice and modern standardized supplements.",
+    "completenessScore": 12,
+    "tier": "stub",
+    "lastmod": "2026-04-02"
+  },
+  {
+    "slug": "achillea-millefolium",
+    "route": "/herbs/achillea-millefolium",
+    "name": "achillea millefolium",
+    "kind": "herb",
+    "title": "achillea millefolium | The Hippie Scientist",
+    "description": "A flowering plant native to temperate regions, used for centuries in traditional medicine for wound healing, digestion, and fever reduction.",
+    "completenessScore": 11,
+    "tier": "stub",
+    "lastmod": "2026-04-02"
   },
   {
     "slug": "tylophora-indica",
@@ -83,9 +72,9 @@
     "kind": "herb",
     "title": "tylophora indica | The Hippie Scientist",
     "description": "an ayurvedic herb used for bronchial conditions, immune regulation, and allergic responses. known as indian ipecac for its traditional role in treating ast",
-    "completenessScore": 14,
+    "completenessScore": 11,
     "tier": "stub",
-    "lastmod": "2026-04-01"
+    "lastmod": "2026-04-02"
   },
   {
     "slug": "alectra-sessiliflora",
@@ -94,20 +83,9 @@
     "kind": "herb",
     "title": "alectra sessiliflora | The Hippie Scientist",
     "description": "Parasitic herb in the Orobanchaceae family; possibly used in traditional African medicine.",
-    "completenessScore": 13,
+    "completenessScore": 10,
     "tier": "stub",
-    "lastmod": "2026-04-01"
-  },
-  {
-    "slug": "ipomoea-tricolor",
-    "route": "/herbs/ipomoea-tricolor",
-    "name": "ipomoea tricolor",
-    "kind": "herb",
-    "title": "ipomoea tricolor | The Hippie Scientist",
-    "description": "Current promoted evidence for Ipomoea tricolor is mechanistic and ecological, not human clinical efficacy evidence.",
-    "completenessScore": 13,
-    "tier": "stub",
-    "lastmod": "2026-04-01"
+    "lastmod": "2026-04-02"
   },
   {
     "slug": "mandrake-root",
@@ -116,9 +94,31 @@
     "kind": "herb",
     "title": "mandrake root | The Hippie Scientist",
     "description": "A legendary plant with anthropomorphic root; used as sedative and aphrodisiac.",
-    "completenessScore": 13,
+    "completenessScore": 10,
     "tier": "stub",
-    "lastmod": "2026-04-01"
+    "lastmod": "2026-04-02"
+  },
+  {
+    "slug": "mentha-piperita",
+    "route": "/herbs/mentha-piperita",
+    "name": "mentha piperita",
+    "kind": "herb",
+    "title": "mentha piperita | The Hippie Scientist",
+    "description": "A hybrid mint (Mentha aquatica × Mentha spicata) widely used for digestive support, flavoring, and aromatherapy; possesses antispasmodic, carminative, and ",
+    "completenessScore": 10,
+    "tier": "stub",
+    "lastmod": "2026-04-02"
+  },
+  {
+    "slug": "rivea-corymbosa",
+    "route": "/herbs/rivea-corymbosa",
+    "name": "rivea corymbosa",
+    "kind": "herb",
+    "title": "rivea corymbosa | The Hippie Scientist",
+    "description": "Morning glory species used in Mesoamerican rituals.",
+    "completenessScore": 10,
+    "tier": "stub",
+    "lastmod": "2026-04-02"
   },
   {
     "slug": "henbane",
@@ -127,9 +127,9 @@
     "kind": "herb",
     "title": "henbane | The Hippie Scientist",
     "description": "A toxic plant used historically as an anesthetic, sedative, and hallucinogen.",
-    "completenessScore": 12,
+    "completenessScore": 9,
     "tier": "stub",
-    "lastmod": "2026-04-01"
+    "lastmod": "2026-04-02"
   },
   {
     "slug": "ipomoea-tricolor-heavenly-blue",
@@ -138,9 +138,9 @@
     "kind": "herb",
     "title": "ipomoea tricolor (heavenly blue) | The Hippie Scientist",
     "description": "Ornamental morning glory whose seeds contain LSA.",
-    "completenessScore": 12,
+    "completenessScore": 9,
     "tier": "stub",
-    "lastmod": "2026-04-01"
+    "lastmod": "2026-04-02"
   },
   {
     "slug": "mistletoe",
@@ -149,9 +149,31 @@
     "kind": "herb",
     "title": "mistletoe | The Hippie Scientist",
     "description": "a sacred plant in ancient druidic and european traditions, mistletoe has been used both ritually and medicinally for nervous disorders, cancer support, and",
-    "completenessScore": 12,
+    "completenessScore": 9,
     "tier": "stub",
-    "lastmod": "2026-04-01"
+    "lastmod": "2026-04-02"
+  },
+  {
+    "slug": "pausinystalia-johimbe",
+    "route": "/herbs/pausinystalia-johimbe",
+    "name": "Pausinystalia johimbe",
+    "kind": "herb",
+    "title": "Pausinystalia johimbe | The Hippie Scientist",
+    "description": "West African tree bark traditionally used as an aphrodisiac and stimulant, especially for male sexual dysfunction.",
+    "completenessScore": 9,
+    "tier": "stub",
+    "lastmod": "2026-04-02"
+  },
+  {
+    "slug": "sinicuichi-heimia-salicifolia",
+    "route": "/herbs/sinicuichi-heimia-salicifolia",
+    "name": "Sinicuichi (Heimia salicifolia)",
+    "kind": "herb",
+    "title": "Sinicuichi (Heimia salicifolia) | The Hippie Scientist",
+    "description": "Sinicuichi is a traditional Mexican herb used for inducing auditory distortions, mild sedation, and dream enhancement. It has historical use in spiritual a",
+    "completenessScore": 9,
+    "tier": "stub",
+    "lastmod": "2026-04-02"
   },
   {
     "slug": "anisoptera-thurifera",
@@ -160,9 +182,9 @@
     "kind": "herb",
     "title": "anisoptera thurifera | The Hippie Scientist",
     "description": "Dipterocarpaceae tree native to Southeast Asia; known for aromatic resin.",
-    "completenessScore": 11,
+    "completenessScore": 8,
     "tier": "stub",
-    "lastmod": "2026-04-01"
+    "lastmod": "2026-04-02"
   },
   {
     "slug": "iresine-herbstii",
@@ -171,9 +193,9 @@
     "kind": "herb",
     "title": "iresine herbstii | The Hippie Scientist",
     "description": "Vibrant ornamental plant; used in folk remedies.",
-    "completenessScore": 11,
+    "completenessScore": 8,
     "tier": "stub",
-    "lastmod": "2026-04-01"
+    "lastmod": "2026-04-02"
   },
   {
     "slug": "jatropha-podagrica",
@@ -182,9 +204,64 @@
     "kind": "herb",
     "title": "jatropha podagrica | The Hippie Scientist",
     "description": "Ornamental and medicinal plant with thick stem and red flowers.",
-    "completenessScore": 11,
+    "completenessScore": 8,
     "tier": "stub",
-    "lastmod": "2026-04-01"
+    "lastmod": "2026-04-02"
+  },
+  {
+    "slug": "cestrum-parqui",
+    "route": "/herbs/cestrum-parqui",
+    "name": "Cestrum parqui",
+    "kind": "herb",
+    "title": "Cestrum parqui | The Hippie Scientist",
+    "description": "Toxic ornamental shrub sometimes misused for psychoactive effects",
+    "completenessScore": 8,
+    "tier": "stub",
+    "lastmod": "2026-04-02"
+  },
+  {
+    "slug": "solandra-grandiflora",
+    "route": "/herbs/solandra-grandiflora",
+    "name": "Solandra grandiflora",
+    "kind": "herb",
+    "title": "Solandra grandiflora | The Hippie Scientist",
+    "description": "Powerful deliriant used in Huichol rituals; causes intense hallucinations and confusion.",
+    "completenessScore": 8,
+    "tier": "stub",
+    "lastmod": "2026-04-02"
+  },
+  {
+    "slug": "herba-lucidum-fictus",
+    "route": "/herbs/herba-lucidum-fictus",
+    "name": "Herba lucidum fictus",
+    "kind": "herb",
+    "title": "Herba lucidum fictus | The Hippie Scientist",
+    "description": "Used to promote vivid and lucid dreams in traditional cultures.",
+    "completenessScore": 8,
+    "tier": "stub",
+    "lastmod": "2026-04-02"
+  },
+  {
+    "slug": "calliandra-lucidum",
+    "route": "/herbs/calliandra-lucidum",
+    "name": "Calliandra lucidum",
+    "kind": "herb",
+    "title": "Calliandra lucidum | The Hippie Scientist",
+    "description": "Traditional plant believed to induce visionary states.",
+    "completenessScore": 8,
+    "tier": "stub",
+    "lastmod": "2026-04-02"
+  },
+  {
+    "slug": "nepeta-cataria",
+    "route": "/herbs/nepeta-cataria",
+    "name": "nepeta cataria",
+    "kind": "herb",
+    "title": "nepeta cataria | The Hippie Scientist",
+    "description": "A member of the mint family known for its euphoric effects on cats and mild sedative properties in humans. Traditionally used for colds, anxiety, and cramp",
+    "completenessScore": 8,
+    "tier": "stub",
+    "lastmod": "2026-04-02"
   },
   {
     "slug": "pedicularis-groenlandica",
@@ -193,9 +270,9 @@
     "kind": "herb",
     "title": "pedicularis groenlandica | The Hippie Scientist",
     "description": "High-altitude flowering plant known for CNS and muscle relaxation.",
-    "completenessScore": 11,
+    "completenessScore": 8,
     "tier": "stub",
-    "lastmod": "2026-04-01"
+    "lastmod": "2026-04-02"
   },
   {
     "slug": "sceletium-tortuosum-kanna",
@@ -204,9 +281,20 @@
     "kind": "herb",
     "title": "sceletium tortuosum (kanna) | The Hippie Scientist",
     "description": "south african succulent chewed to elevate mood and decrease tension.",
-    "completenessScore": 11,
+    "completenessScore": 8,
     "tier": "stub",
-    "lastmod": "2026-04-01"
+    "lastmod": "2026-04-02"
+  },
+  {
+    "slug": "aquilegia-vulgaris",
+    "route": "/herbs/aquilegia-vulgaris",
+    "name": "aquilegia vulgaris",
+    "kind": "herb",
+    "title": "aquilegia vulgaris | The Hippie Scientist",
+    "description": "Decorative European herb; historically used medicinally despite toxicity.",
+    "completenessScore": 7,
+    "tier": "stub",
+    "lastmod": "2026-04-02"
   },
   {
     "slug": "delosperma-cooperi",
@@ -215,9 +303,9 @@
     "kind": "herb",
     "title": "delosperma cooperi | The Hippie Scientist",
     "description": "Succulent used as groundcover; mild traditional use.",
-    "completenessScore": 10,
+    "completenessScore": 7,
     "tier": "stub",
-    "lastmod": "2026-04-01"
+    "lastmod": "2026-04-02"
   },
   {
     "slug": "kra-thum-na-kok",
@@ -226,9 +314,86 @@
     "kind": "herb",
     "title": "kra thum na / kok | The Hippie Scientist",
     "description": "southeast asian tree related to kratom with stimulating leaves.",
-    "completenessScore": 10,
+    "completenessScore": 7,
     "tier": "stub",
-    "lastmod": "2026-04-01"
+    "lastmod": "2026-04-02"
+  },
+  {
+    "slug": "rhynchosia-pyramidalis",
+    "route": "/herbs/rhynchosia-pyramidalis",
+    "name": "Rhynchosia pyramidalis",
+    "kind": "herb",
+    "title": "Rhynchosia pyramidalis | The Hippie Scientist",
+    "description": "Traditional African medicinal herb with analgesic and anti-inflammatory use",
+    "completenessScore": 7,
+    "tier": "stub",
+    "lastmod": "2026-04-02"
+  },
+  {
+    "slug": "trichilia-monadelpha",
+    "route": "/herbs/trichilia-monadelpha",
+    "name": "Trichilia monadelpha",
+    "kind": "herb",
+    "title": "Trichilia monadelpha | The Hippie Scientist",
+    "description": "West African medicinal plant used for malaria and inflammation",
+    "completenessScore": 7,
+    "tier": "stub",
+    "lastmod": "2026-04-02"
+  },
+  {
+    "slug": "gymnosporia-senegalensis",
+    "route": "/herbs/gymnosporia-senegalensis",
+    "name": "Gymnosporia senegalensis",
+    "kind": "herb",
+    "title": "Gymnosporia senegalensis | The Hippie Scientist",
+    "description": "Shrub used traditionally to treat pain and joint issues",
+    "completenessScore": 7,
+    "tier": "stub",
+    "lastmod": "2026-04-02"
+  },
+  {
+    "slug": "zanthoxylum-zanthoxyloides",
+    "route": "/herbs/zanthoxylum-zanthoxyloides",
+    "name": "Zanthoxylum zanthoxyloides",
+    "kind": "herb",
+    "title": "Zanthoxylum zanthoxyloides | The Hippie Scientist",
+    "description": "Traditional remedy for toothache, worms, and infections",
+    "completenessScore": 7,
+    "tier": "stub",
+    "lastmod": "2026-04-02"
+  },
+  {
+    "slug": "entada-africana",
+    "route": "/herbs/entada-africana",
+    "name": "Entada africana",
+    "kind": "herb",
+    "title": "Entada africana | The Hippie Scientist",
+    "description": "Used in traditional medicine for inflammation, liver support, and pain",
+    "completenessScore": 7,
+    "tier": "stub",
+    "lastmod": "2026-04-02"
+  },
+  {
+    "slug": "vernonia-amygdalina",
+    "route": "/herbs/vernonia-amygdalina",
+    "name": "Vernonia amygdalina",
+    "kind": "herb",
+    "title": "Vernonia amygdalina | The Hippie Scientist",
+    "description": "Widely used in West Africa for malaria, diabetes, and cancer adjunct therapy",
+    "completenessScore": 7,
+    "tier": "stub",
+    "lastmod": "2026-04-02"
+  },
+  {
+    "slug": "boswellia-dalzielii",
+    "route": "/herbs/boswellia-dalzielii",
+    "name": "Boswellia dalzielii",
+    "kind": "herb",
+    "title": "Boswellia dalzielii | The Hippie Scientist",
+    "description": "Gum resin used in ethnomedicine for arthritis, ulcers, and infections",
+    "completenessScore": 7,
+    "tier": "stub",
+    "lastmod": "2026-04-02"
   },
   {
     "slug": "pedicularis-densiflora-indian-warrior",
@@ -237,19 +402,8 @@
     "kind": "herb",
     "title": "pedicularis densiflora (indian warrior) | The Hippie Scientist",
     "description": "north american wildflower smoked for muscle relaxation.",
-    "completenessScore": 10,
+    "completenessScore": 7,
     "tier": "stub",
-    "lastmod": "2026-04-01"
-  },
-  {
-    "slug": "withania-somnifera",
-    "route": "/herbs/withania-somnifera",
-    "name": "withania somnifera",
-    "kind": "herb",
-    "title": "withania somnifera | The Hippie Scientist",
-    "description": "Withania somnifera has moderate randomized evidence for stress-related symptom improvements in standardized extracts, with unresolved long-term safety and ",
-    "completenessScore": 9,
-    "tier": "stub",
-    "lastmod": "2026-04-01"
+    "lastmod": "2026-04-02"
   }
 ]

--- a/public/data/publication-manifest.json
+++ b/public/data/publication-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-01T14:40:00.989Z",
+  "generatedAt": "2026-04-02T23:23:41.757Z",
   "thresholds": {
     "minDescriptionLength": 30,
     "minSources": 2,
@@ -10,70 +10,26 @@
   "entities": {
     "herbs": [
       {
-        "slug": "heimia-salicifolia",
-        "route": "/herbs/heimia-salicifolia",
+        "slug": "ipomoea-tricolor",
+        "route": "/herbs/ipomoea-tricolor",
+        "name": "ipomoea tricolor",
+        "kind": "herb",
+        "title": "ipomoea tricolor | The Hippie Scientist",
+        "description": "Ipomoea tricolor (morning glory) is discussed in ethnobotanical and plant-symbiosis literature, including ergoline-associated chemistry.",
+        "completenessScore": 16,
+        "tier": "stub",
+        "lastmod": "2026-04-02"
+      },
+      {
+        "slug": "heimia-salicifolia-sinicuichi",
+        "route": "/herbs/heimia-salicifolia-sinicuichi",
         "name": "heimia salicifolia (sinicuichi)",
         "kind": "herb",
         "title": "heimia salicifolia (sinicuichi) | The Hippie Scientist",
-        "description": "Heimia salicifolia has traditional ethnobotanical use for altered perception and calming effects, while modern controlled clinical evidence is limited.",
-        "completenessScore": 43,
-        "tier": "partial",
-        "lastmod": "2026-04-01"
-      },
-      {
-        "slug": "papaver-somniferum",
-        "route": "/herbs/papaver-somniferum",
-        "name": "papaver somniferum",
-        "kind": "herb",
-        "title": "papaver somniferum | The Hippie Scientist",
-        "description": "This plant has strong opioid-related pharmacology and safety liabilities; non-medical use carries high overdose and dependence risk.",
-        "completenessScore": 37,
-        "tier": "partial",
-        "lastmod": "2026-04-01"
-      },
-      {
-        "slug": "mentha-piperita",
-        "route": "/herbs/mentha-piperita",
-        "name": "mentha piperita",
-        "kind": "herb",
-        "title": "mentha piperita | The Hippie Scientist",
-        "description": "Mentha piperita has human and preclinical evidence for gastrointestinal symptom support, while efficacy depends on preparation and indication.",
-        "completenessScore": 27,
-        "tier": "partial",
-        "lastmod": "2026-04-01"
-      },
-      {
-        "slug": "achillea-millefolium",
-        "route": "/herbs/achillea-millefolium",
-        "name": "achillea millefolium",
-        "kind": "herb",
-        "title": "achillea millefolium | The Hippie Scientist",
-        "description": "Achillea millefolium is used for digestive, inflammatory, and wound-related traditional indications with mixed modern evidence quality.",
-        "completenessScore": 26,
-        "tier": "partial",
-        "lastmod": "2026-04-01"
-      },
-      {
-        "slug": "nepeta-cataria",
-        "route": "/herbs/nepeta-cataria",
-        "name": "nepeta cataria",
-        "kind": "herb",
-        "title": "nepeta cataria | The Hippie Scientist",
-        "description": "Nepeta cataria is traditionally used for mild calming and digestive support, with limited modern clinical evidence.",
-        "completenessScore": 22,
+        "description": "Traditional Mexican herb used for altered states and memory recall",
+        "completenessScore": 14,
         "tier": "stub",
-        "lastmod": "2026-04-01"
-      },
-      {
-        "slug": "rivea-corymbosa",
-        "route": "/herbs/rivea-corymbosa",
-        "name": "rivea corymbosa",
-        "kind": "herb",
-        "title": "rivea corymbosa | The Hippie Scientist",
-        "description": "Morning glory species used in Mesoamerican rituals.",
-        "completenessScore": 22,
-        "tier": "stub",
-        "lastmod": "2026-04-01"
+        "lastmod": "2026-04-02"
       },
       {
         "slug": "calliandra-anomala",
@@ -82,9 +38,42 @@
         "kind": "herb",
         "title": "calliandra anomala | The Hippie Scientist",
         "description": "Shrubby Fabaceae species with bright pink flowers; limited pharmacological research.",
-        "completenessScore": 21,
+        "completenessScore": 12,
         "tier": "stub",
-        "lastmod": "2026-04-01"
+        "lastmod": "2026-04-02"
+      },
+      {
+        "slug": "papaver-somniferum",
+        "route": "/herbs/papaver-somniferum",
+        "name": "papaver somniferum",
+        "kind": "herb",
+        "title": "papaver somniferum | The Hippie Scientist",
+        "description": "Papaver somniferum is the botanical source of opiate alkaloids associated with analgesic and sedative pharmacology and substantial dependence risk.",
+        "completenessScore": 12,
+        "tier": "stub",
+        "lastmod": "2026-04-02"
+      },
+      {
+        "slug": "withania-somnifera",
+        "route": "/herbs/withania-somnifera",
+        "name": "withania somnifera",
+        "kind": "herb",
+        "title": "withania somnifera | The Hippie Scientist",
+        "description": "Withania somnifera is the scientific name for ashwagandha and is used in Ayurvedic practice and modern standardized supplements.",
+        "completenessScore": 12,
+        "tier": "stub",
+        "lastmod": "2026-04-02"
+      },
+      {
+        "slug": "achillea-millefolium",
+        "route": "/herbs/achillea-millefolium",
+        "name": "achillea millefolium",
+        "kind": "herb",
+        "title": "achillea millefolium | The Hippie Scientist",
+        "description": "A flowering plant native to temperate regions, used for centuries in traditional medicine for wound healing, digestion, and fever reduction.",
+        "completenessScore": 11,
+        "tier": "stub",
+        "lastmod": "2026-04-02"
       },
       {
         "slug": "tylophora-indica",
@@ -93,9 +82,9 @@
         "kind": "herb",
         "title": "tylophora indica | The Hippie Scientist",
         "description": "an ayurvedic herb used for bronchial conditions, immune regulation, and allergic responses. known as indian ipecac for its traditional role in treating ast",
-        "completenessScore": 14,
+        "completenessScore": 11,
         "tier": "stub",
-        "lastmod": "2026-04-01"
+        "lastmod": "2026-04-02"
       },
       {
         "slug": "alectra-sessiliflora",
@@ -104,20 +93,9 @@
         "kind": "herb",
         "title": "alectra sessiliflora | The Hippie Scientist",
         "description": "Parasitic herb in the Orobanchaceae family; possibly used in traditional African medicine.",
-        "completenessScore": 13,
+        "completenessScore": 10,
         "tier": "stub",
-        "lastmod": "2026-04-01"
-      },
-      {
-        "slug": "ipomoea-tricolor",
-        "route": "/herbs/ipomoea-tricolor",
-        "name": "ipomoea tricolor",
-        "kind": "herb",
-        "title": "ipomoea tricolor | The Hippie Scientist",
-        "description": "Current promoted evidence for Ipomoea tricolor is mechanistic and ecological, not human clinical efficacy evidence.",
-        "completenessScore": 13,
-        "tier": "stub",
-        "lastmod": "2026-04-01"
+        "lastmod": "2026-04-02"
       },
       {
         "slug": "mandrake-root",
@@ -126,9 +104,31 @@
         "kind": "herb",
         "title": "mandrake root | The Hippie Scientist",
         "description": "A legendary plant with anthropomorphic root; used as sedative and aphrodisiac.",
-        "completenessScore": 13,
+        "completenessScore": 10,
         "tier": "stub",
-        "lastmod": "2026-04-01"
+        "lastmod": "2026-04-02"
+      },
+      {
+        "slug": "mentha-piperita",
+        "route": "/herbs/mentha-piperita",
+        "name": "mentha piperita",
+        "kind": "herb",
+        "title": "mentha piperita | The Hippie Scientist",
+        "description": "A hybrid mint (Mentha aquatica × Mentha spicata) widely used for digestive support, flavoring, and aromatherapy; possesses antispasmodic, carminative, and ",
+        "completenessScore": 10,
+        "tier": "stub",
+        "lastmod": "2026-04-02"
+      },
+      {
+        "slug": "rivea-corymbosa",
+        "route": "/herbs/rivea-corymbosa",
+        "name": "rivea corymbosa",
+        "kind": "herb",
+        "title": "rivea corymbosa | The Hippie Scientist",
+        "description": "Morning glory species used in Mesoamerican rituals.",
+        "completenessScore": 10,
+        "tier": "stub",
+        "lastmod": "2026-04-02"
       },
       {
         "slug": "henbane",
@@ -137,9 +137,9 @@
         "kind": "herb",
         "title": "henbane | The Hippie Scientist",
         "description": "A toxic plant used historically as an anesthetic, sedative, and hallucinogen.",
-        "completenessScore": 12,
+        "completenessScore": 9,
         "tier": "stub",
-        "lastmod": "2026-04-01"
+        "lastmod": "2026-04-02"
       },
       {
         "slug": "ipomoea-tricolor-heavenly-blue",
@@ -148,9 +148,9 @@
         "kind": "herb",
         "title": "ipomoea tricolor (heavenly blue) | The Hippie Scientist",
         "description": "Ornamental morning glory whose seeds contain LSA.",
-        "completenessScore": 12,
+        "completenessScore": 9,
         "tier": "stub",
-        "lastmod": "2026-04-01"
+        "lastmod": "2026-04-02"
       },
       {
         "slug": "mistletoe",
@@ -159,9 +159,31 @@
         "kind": "herb",
         "title": "mistletoe | The Hippie Scientist",
         "description": "a sacred plant in ancient druidic and european traditions, mistletoe has been used both ritually and medicinally for nervous disorders, cancer support, and",
-        "completenessScore": 12,
+        "completenessScore": 9,
         "tier": "stub",
-        "lastmod": "2026-04-01"
+        "lastmod": "2026-04-02"
+      },
+      {
+        "slug": "pausinystalia-johimbe",
+        "route": "/herbs/pausinystalia-johimbe",
+        "name": "Pausinystalia johimbe",
+        "kind": "herb",
+        "title": "Pausinystalia johimbe | The Hippie Scientist",
+        "description": "West African tree bark traditionally used as an aphrodisiac and stimulant, especially for male sexual dysfunction.",
+        "completenessScore": 9,
+        "tier": "stub",
+        "lastmod": "2026-04-02"
+      },
+      {
+        "slug": "sinicuichi-heimia-salicifolia",
+        "route": "/herbs/sinicuichi-heimia-salicifolia",
+        "name": "Sinicuichi (Heimia salicifolia)",
+        "kind": "herb",
+        "title": "Sinicuichi (Heimia salicifolia) | The Hippie Scientist",
+        "description": "Sinicuichi is a traditional Mexican herb used for inducing auditory distortions, mild sedation, and dream enhancement. It has historical use in spiritual a",
+        "completenessScore": 9,
+        "tier": "stub",
+        "lastmod": "2026-04-02"
       },
       {
         "slug": "anisoptera-thurifera",
@@ -170,9 +192,9 @@
         "kind": "herb",
         "title": "anisoptera thurifera | The Hippie Scientist",
         "description": "Dipterocarpaceae tree native to Southeast Asia; known for aromatic resin.",
-        "completenessScore": 11,
+        "completenessScore": 8,
         "tier": "stub",
-        "lastmod": "2026-04-01"
+        "lastmod": "2026-04-02"
       },
       {
         "slug": "iresine-herbstii",
@@ -181,9 +203,9 @@
         "kind": "herb",
         "title": "iresine herbstii | The Hippie Scientist",
         "description": "Vibrant ornamental plant; used in folk remedies.",
-        "completenessScore": 11,
+        "completenessScore": 8,
         "tier": "stub",
-        "lastmod": "2026-04-01"
+        "lastmod": "2026-04-02"
       },
       {
         "slug": "jatropha-podagrica",
@@ -192,9 +214,64 @@
         "kind": "herb",
         "title": "jatropha podagrica | The Hippie Scientist",
         "description": "Ornamental and medicinal plant with thick stem and red flowers.",
-        "completenessScore": 11,
+        "completenessScore": 8,
         "tier": "stub",
-        "lastmod": "2026-04-01"
+        "lastmod": "2026-04-02"
+      },
+      {
+        "slug": "cestrum-parqui",
+        "route": "/herbs/cestrum-parqui",
+        "name": "Cestrum parqui",
+        "kind": "herb",
+        "title": "Cestrum parqui | The Hippie Scientist",
+        "description": "Toxic ornamental shrub sometimes misused for psychoactive effects",
+        "completenessScore": 8,
+        "tier": "stub",
+        "lastmod": "2026-04-02"
+      },
+      {
+        "slug": "solandra-grandiflora",
+        "route": "/herbs/solandra-grandiflora",
+        "name": "Solandra grandiflora",
+        "kind": "herb",
+        "title": "Solandra grandiflora | The Hippie Scientist",
+        "description": "Powerful deliriant used in Huichol rituals; causes intense hallucinations and confusion.",
+        "completenessScore": 8,
+        "tier": "stub",
+        "lastmod": "2026-04-02"
+      },
+      {
+        "slug": "herba-lucidum-fictus",
+        "route": "/herbs/herba-lucidum-fictus",
+        "name": "Herba lucidum fictus",
+        "kind": "herb",
+        "title": "Herba lucidum fictus | The Hippie Scientist",
+        "description": "Used to promote vivid and lucid dreams in traditional cultures.",
+        "completenessScore": 8,
+        "tier": "stub",
+        "lastmod": "2026-04-02"
+      },
+      {
+        "slug": "calliandra-lucidum",
+        "route": "/herbs/calliandra-lucidum",
+        "name": "Calliandra lucidum",
+        "kind": "herb",
+        "title": "Calliandra lucidum | The Hippie Scientist",
+        "description": "Traditional plant believed to induce visionary states.",
+        "completenessScore": 8,
+        "tier": "stub",
+        "lastmod": "2026-04-02"
+      },
+      {
+        "slug": "nepeta-cataria",
+        "route": "/herbs/nepeta-cataria",
+        "name": "nepeta cataria",
+        "kind": "herb",
+        "title": "nepeta cataria | The Hippie Scientist",
+        "description": "A member of the mint family known for its euphoric effects on cats and mild sedative properties in humans. Traditionally used for colds, anxiety, and cramp",
+        "completenessScore": 8,
+        "tier": "stub",
+        "lastmod": "2026-04-02"
       },
       {
         "slug": "pedicularis-groenlandica",
@@ -203,9 +280,9 @@
         "kind": "herb",
         "title": "pedicularis groenlandica | The Hippie Scientist",
         "description": "High-altitude flowering plant known for CNS and muscle relaxation.",
-        "completenessScore": 11,
+        "completenessScore": 8,
         "tier": "stub",
-        "lastmod": "2026-04-01"
+        "lastmod": "2026-04-02"
       },
       {
         "slug": "sceletium-tortuosum-kanna",
@@ -214,9 +291,20 @@
         "kind": "herb",
         "title": "sceletium tortuosum (kanna) | The Hippie Scientist",
         "description": "south african succulent chewed to elevate mood and decrease tension.",
-        "completenessScore": 11,
+        "completenessScore": 8,
         "tier": "stub",
-        "lastmod": "2026-04-01"
+        "lastmod": "2026-04-02"
+      },
+      {
+        "slug": "aquilegia-vulgaris",
+        "route": "/herbs/aquilegia-vulgaris",
+        "name": "aquilegia vulgaris",
+        "kind": "herb",
+        "title": "aquilegia vulgaris | The Hippie Scientist",
+        "description": "Decorative European herb; historically used medicinally despite toxicity.",
+        "completenessScore": 7,
+        "tier": "stub",
+        "lastmod": "2026-04-02"
       },
       {
         "slug": "delosperma-cooperi",
@@ -225,9 +313,9 @@
         "kind": "herb",
         "title": "delosperma cooperi | The Hippie Scientist",
         "description": "Succulent used as groundcover; mild traditional use.",
-        "completenessScore": 10,
+        "completenessScore": 7,
         "tier": "stub",
-        "lastmod": "2026-04-01"
+        "lastmod": "2026-04-02"
       },
       {
         "slug": "kra-thum-na-kok",
@@ -236,9 +324,86 @@
         "kind": "herb",
         "title": "kra thum na / kok | The Hippie Scientist",
         "description": "southeast asian tree related to kratom with stimulating leaves.",
-        "completenessScore": 10,
+        "completenessScore": 7,
         "tier": "stub",
-        "lastmod": "2026-04-01"
+        "lastmod": "2026-04-02"
+      },
+      {
+        "slug": "rhynchosia-pyramidalis",
+        "route": "/herbs/rhynchosia-pyramidalis",
+        "name": "Rhynchosia pyramidalis",
+        "kind": "herb",
+        "title": "Rhynchosia pyramidalis | The Hippie Scientist",
+        "description": "Traditional African medicinal herb with analgesic and anti-inflammatory use",
+        "completenessScore": 7,
+        "tier": "stub",
+        "lastmod": "2026-04-02"
+      },
+      {
+        "slug": "trichilia-monadelpha",
+        "route": "/herbs/trichilia-monadelpha",
+        "name": "Trichilia monadelpha",
+        "kind": "herb",
+        "title": "Trichilia monadelpha | The Hippie Scientist",
+        "description": "West African medicinal plant used for malaria and inflammation",
+        "completenessScore": 7,
+        "tier": "stub",
+        "lastmod": "2026-04-02"
+      },
+      {
+        "slug": "gymnosporia-senegalensis",
+        "route": "/herbs/gymnosporia-senegalensis",
+        "name": "Gymnosporia senegalensis",
+        "kind": "herb",
+        "title": "Gymnosporia senegalensis | The Hippie Scientist",
+        "description": "Shrub used traditionally to treat pain and joint issues",
+        "completenessScore": 7,
+        "tier": "stub",
+        "lastmod": "2026-04-02"
+      },
+      {
+        "slug": "zanthoxylum-zanthoxyloides",
+        "route": "/herbs/zanthoxylum-zanthoxyloides",
+        "name": "Zanthoxylum zanthoxyloides",
+        "kind": "herb",
+        "title": "Zanthoxylum zanthoxyloides | The Hippie Scientist",
+        "description": "Traditional remedy for toothache, worms, and infections",
+        "completenessScore": 7,
+        "tier": "stub",
+        "lastmod": "2026-04-02"
+      },
+      {
+        "slug": "entada-africana",
+        "route": "/herbs/entada-africana",
+        "name": "Entada africana",
+        "kind": "herb",
+        "title": "Entada africana | The Hippie Scientist",
+        "description": "Used in traditional medicine for inflammation, liver support, and pain",
+        "completenessScore": 7,
+        "tier": "stub",
+        "lastmod": "2026-04-02"
+      },
+      {
+        "slug": "vernonia-amygdalina",
+        "route": "/herbs/vernonia-amygdalina",
+        "name": "Vernonia amygdalina",
+        "kind": "herb",
+        "title": "Vernonia amygdalina | The Hippie Scientist",
+        "description": "Widely used in West Africa for malaria, diabetes, and cancer adjunct therapy",
+        "completenessScore": 7,
+        "tier": "stub",
+        "lastmod": "2026-04-02"
+      },
+      {
+        "slug": "boswellia-dalzielii",
+        "route": "/herbs/boswellia-dalzielii",
+        "name": "Boswellia dalzielii",
+        "kind": "herb",
+        "title": "Boswellia dalzielii | The Hippie Scientist",
+        "description": "Gum resin used in ethnomedicine for arthritis, ulcers, and infections",
+        "completenessScore": 7,
+        "tier": "stub",
+        "lastmod": "2026-04-02"
       },
       {
         "slug": "pedicularis-densiflora-indian-warrior",
@@ -247,20 +412,9 @@
         "kind": "herb",
         "title": "pedicularis densiflora (indian warrior) | The Hippie Scientist",
         "description": "north american wildflower smoked for muscle relaxation.",
-        "completenessScore": 10,
+        "completenessScore": 7,
         "tier": "stub",
-        "lastmod": "2026-04-01"
-      },
-      {
-        "slug": "withania-somnifera",
-        "route": "/herbs/withania-somnifera",
-        "name": "withania somnifera",
-        "kind": "herb",
-        "title": "withania somnifera | The Hippie Scientist",
-        "description": "Withania somnifera has moderate randomized evidence for stress-related symptom improvements in standardized extracts, with unresolved long-term safety and ",
-        "completenessScore": 9,
-        "tier": "stub",
-        "lastmod": "2026-04-01"
+        "lastmod": "2026-04-02"
       }
     ],
     "compounds": [
@@ -270,10 +424,10 @@
         "name": "CBD",
         "kind": "compound",
         "title": "CBD | The Hippie Scientist",
-        "description": "Human evidence exists for selected neurologic indications and safety liabilities; interaction management is central to risk reduction.",
-        "completenessScore": 16,
+        "description": "Cannabidiol (CBD) is a non-intoxicating phytocannabinoid with approved use in specific seizure disorders and broad off-label consumer exposure. Human revie",
+        "completenessScore": 23,
         "tier": "stub",
-        "lastmod": "2026-04-01"
+        "lastmod": "2026-04-02"
       },
       {
         "slug": "agrimoniin",
@@ -281,21 +435,10 @@
         "name": "Agrimoniin",
         "kind": "compound",
         "title": "Agrimoniin | The Hippie Scientist",
-        "description": "Evidence is mainly mechanistic/preclinical, with uncertain clinical translation.",
-        "completenessScore": 13,
+        "description": "Agrimoniin is an ellagitannin studied for redox and inflammatory pathway effects in preclinical models. Human clinical evidence is limited.",
+        "completenessScore": 17,
         "tier": "stub",
-        "lastmod": "2026-04-01"
-      },
-      {
-        "slug": "asarone",
-        "route": "/compounds/asarone",
-        "name": "Asarone (alpha/beta isomers)",
-        "kind": "compound",
-        "title": "Asarone (alpha/beta isomers) | The Hippie Scientist",
-        "description": "Evidence is strongest for safety concern framing rather than proven therapeutic efficacy.",
-        "completenessScore": 13,
-        "tier": "stub",
-        "lastmod": "2026-04-01"
+        "lastmod": "2026-04-02"
       },
       {
         "slug": "luteolin",
@@ -303,32 +446,10 @@
         "name": "Luteolin",
         "kind": "compound",
         "title": "Luteolin | The Hippie Scientist",
-        "description": "Evidence supports mechanistic activity with plausible interaction risk, but robust condition-specific clinical efficacy remains limited.",
-        "completenessScore": 13,
+        "description": "Luteolin is a dietary flavone studied for anti-inflammatory and redox-active pharmacology. Evidence includes mechanistic studies and translational safety r",
+        "completenessScore": 17,
         "tier": "stub",
-        "lastmod": "2026-04-01"
-      },
-      {
-        "slug": "asarone",
-        "route": "/compounds/asarone",
-        "name": "Asarone (alpha/beta isomers)",
-        "kind": "compound",
-        "title": "Asarone (alpha/beta isomers) | The Hippie Scientist",
-        "description": "Evidence is strongest for safety concern framing rather than proven therapeutic efficacy.",
-        "completenessScore": 13,
-        "tier": "stub",
-        "lastmod": "2026-04-01"
-      },
-      {
-        "slug": "asarone",
-        "route": "/compounds/asarone",
-        "name": "Asarone (alpha/beta isomers)",
-        "kind": "compound",
-        "title": "Asarone (alpha/beta isomers) | The Hippie Scientist",
-        "description": "Evidence is strongest for safety concern framing rather than proven therapeutic efficacy.",
-        "completenessScore": 13,
-        "tier": "stub",
-        "lastmod": "2026-04-01"
+        "lastmod": "2026-04-02"
       },
       {
         "slug": "2-4-5-trimethoxybenzaldehyde",
@@ -336,10 +457,21 @@
         "name": "2,4,5-Trimethoxybenzaldehyde",
         "kind": "compound",
         "title": "2,4,5-Trimethoxybenzaldehyde | The Hippie Scientist",
-        "description": "Current evidence is preclinical/contextual, not definitive for clinical claims.",
-        "completenessScore": 10,
+        "description": "2,4,5-Trimethoxybenzaldehyde is an aromatic aldehyde reported in Acorus phytochemistry. Direct clinical evidence for efficacy or safety is sparse, so inter",
+        "completenessScore": 11,
         "tier": "stub",
-        "lastmod": "2026-04-01"
+        "lastmod": "2026-04-02"
+      },
+      {
+        "slug": "7-hydroxymitragynine",
+        "route": "/compounds/7-hydroxymitragynine",
+        "name": "7-Hydroxymitragynine",
+        "kind": "compound",
+        "title": "7-Hydroxymitragynine | The Hippie Scientist",
+        "description": "7-Hydroxymitragynine is a kratom-associated indole alkaloid with high opioid-receptor potency relative to parent mitragynine. Recent reviews frame it as a ",
+        "completenessScore": 11,
+        "tier": "stub",
+        "lastmod": "2026-04-02"
       },
       {
         "slug": "aconine",
@@ -347,10 +479,10 @@
         "name": "Aconine",
         "kind": "compound",
         "title": "Aconine | The Hippie Scientist",
-        "description": "Evidence is insufficient for efficacy claims; safety interpretation relies on class-level toxicology context.",
-        "completenessScore": 10,
+        "description": "Aconine is an Aconitum-related diterpenoid alkaloid generally discussed within aconitum toxicology rather than therapeutic pharmacology. Direct human evide",
+        "completenessScore": 11,
         "tier": "stub",
-        "lastmod": "2026-04-01"
+        "lastmod": "2026-04-02"
       },
       {
         "slug": "aconitine",
@@ -358,10 +490,10 @@
         "name": "Aconitine",
         "kind": "compound",
         "title": "Aconitine | The Hippie Scientist",
-        "description": "Evidence supports major toxicity risk; there is no high-quality evidence supporting routine therapeutic oral use.",
-        "completenessScore": 10,
+        "description": "Aconitine is a highly toxic diterpenoid alkaloid from Aconitum species and is primarily characterized by poisoning literature rather than therapeutic trial",
+        "completenessScore": 11,
         "tier": "stub",
-        "lastmod": "2026-04-01"
+        "lastmod": "2026-04-02"
       },
       {
         "slug": "anabasine",
@@ -369,75 +501,100 @@
         "name": "Anabasine",
         "kind": "compound",
         "title": "Anabasine | The Hippie Scientist",
-        "description": "Human observational evidence supports exposure relevance and safety concern framing, not efficacy claims.",
-        "completenessScore": 10,
+        "description": "Anabasine is a minor tobacco alkaloid with nicotinic pharmacology and recognized use as an exposure biomarker. Evidence is strongest for toxicology and exp",
+        "completenessScore": 11,
         "tier": "stub",
-        "lastmod": "2026-04-01"
+        "lastmod": "2026-04-02"
+      },
+      {
+        "slug": "asarone-alpha-beta-isomers",
+        "route": "/compounds/asarone-alpha-beta-isomers",
+        "name": "Asarone (alpha/beta isomers)",
+        "kind": "compound",
+        "title": "Asarone (alpha/beta isomers) | The Hippie Scientist",
+        "description": "Asarone refers primarily to alpha- and beta-isomers found in Acorus species. Current literature emphasizes toxicology, interaction potential, and uncertain",
+        "completenessScore": 5,
+        "tier": "stub",
+        "lastmod": "2026-04-02"
       }
     ]
   },
   "routes": {
     "herbs": [
-      "/herbs/heimia-salicifolia",
-      "/herbs/papaver-somniferum",
-      "/herbs/mentha-piperita",
-      "/herbs/achillea-millefolium",
-      "/herbs/nepeta-cataria",
-      "/herbs/rivea-corymbosa",
+      "/herbs/ipomoea-tricolor",
+      "/herbs/heimia-salicifolia-sinicuichi",
       "/herbs/calliandra-anomala",
+      "/herbs/papaver-somniferum",
+      "/herbs/withania-somnifera",
+      "/herbs/achillea-millefolium",
       "/herbs/tylophora-indica",
       "/herbs/alectra-sessiliflora",
-      "/herbs/ipomoea-tricolor",
       "/herbs/mandrake-root",
+      "/herbs/mentha-piperita",
+      "/herbs/rivea-corymbosa",
       "/herbs/henbane",
       "/herbs/ipomoea-tricolor-heavenly-blue",
       "/herbs/mistletoe",
+      "/herbs/pausinystalia-johimbe",
+      "/herbs/sinicuichi-heimia-salicifolia",
       "/herbs/anisoptera-thurifera",
       "/herbs/iresine-herbstii",
       "/herbs/jatropha-podagrica",
+      "/herbs/cestrum-parqui",
+      "/herbs/solandra-grandiflora",
+      "/herbs/herba-lucidum-fictus",
+      "/herbs/calliandra-lucidum",
+      "/herbs/nepeta-cataria",
       "/herbs/pedicularis-groenlandica",
       "/herbs/sceletium-tortuosum-kanna",
+      "/herbs/aquilegia-vulgaris",
       "/herbs/delosperma-cooperi",
       "/herbs/kra-thum-na-kok",
-      "/herbs/pedicularis-densiflora-indian-warrior",
-      "/herbs/withania-somnifera"
+      "/herbs/rhynchosia-pyramidalis",
+      "/herbs/trichilia-monadelpha",
+      "/herbs/gymnosporia-senegalensis",
+      "/herbs/zanthoxylum-zanthoxyloides",
+      "/herbs/entada-africana",
+      "/herbs/vernonia-amygdalina",
+      "/herbs/boswellia-dalzielii",
+      "/herbs/pedicularis-densiflora-indian-warrior"
     ],
     "compounds": [
       "/compounds/cbd",
       "/compounds/agrimoniin",
-      "/compounds/asarone",
       "/compounds/luteolin",
-      "/compounds/asarone",
-      "/compounds/asarone",
       "/compounds/2-4-5-trimethoxybenzaldehyde",
+      "/compounds/7-hydroxymitragynine",
       "/compounds/aconine",
       "/compounds/aconitine",
-      "/compounds/anabasine"
+      "/compounds/anabasine",
+      "/compounds/asarone-alpha-beta-isomers"
     ]
   },
   "summaries": {
     "herbs": {
-      "total": 699,
-      "indexable": 23,
-      "excluded": 676,
+      "total": 698,
+      "indexable": 37,
+      "excluded": 661,
       "excludedByReason": {
-        "weakDescription": 634,
-        "placeholderText": 660,
-        "insufficientEffects": 197,
-        "invalidNameOrSlug": 27,
-        "nanArtifacts": 22
+        "placeholderText": 658,
+        "weakDescription": 535,
+        "insufficientEffects": 174,
+        "insufficientEvidenceOrCompleteness": 149,
+        "invalidNameOrSlug": 7
       }
     },
     "compounds": {
-      "total": 393,
-      "indexable": 10,
-      "excluded": 383,
+      "total": 390,
+      "indexable": 9,
+      "excluded": 381,
       "excludedByReason": {
-        "invalidNameOrSlug": 12,
-        "weakDescription": 382,
-        "placeholderText": 222,
-        "insufficientEffects": 52,
-        "insufficientEvidenceOrCompleteness": 40
+        "invalidNameOrSlug": 11,
+        "weakDescription": 380,
+        "placeholderText": 220,
+        "insufficientEffects": 51,
+        "nanArtifacts": 1,
+        "insufficientEvidenceOrCompleteness": 39
       }
     },
     "blogIndex": {

--- a/public/data/quality-report.json
+++ b/public/data/quality-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-01T14:40:00.989Z",
+  "generatedAt": "2026-04-02T23:23:41.757Z",
   "thresholds": {
     "minDescriptionLength": 30,
     "minSources": 2,
@@ -8,27 +8,28 @@
     "minSlugLength": 2
   },
   "herbs": {
-    "total": 699,
-    "indexable": 23,
-    "excluded": 676,
+    "total": 698,
+    "indexable": 37,
+    "excluded": 661,
     "excludedByReason": {
-      "weakDescription": 634,
-      "placeholderText": 660,
-      "insufficientEffects": 197,
-      "invalidNameOrSlug": 27,
-      "nanArtifacts": 22
+      "placeholderText": 658,
+      "weakDescription": 535,
+      "insufficientEffects": 174,
+      "insufficientEvidenceOrCompleteness": 149,
+      "invalidNameOrSlug": 7
     }
   },
   "compounds": {
-    "total": 393,
-    "indexable": 10,
-    "excluded": 383,
+    "total": 390,
+    "indexable": 9,
+    "excluded": 381,
     "excludedByReason": {
-      "invalidNameOrSlug": 12,
-      "weakDescription": 382,
-      "placeholderText": 222,
-      "insufficientEffects": 52,
-      "insufficientEvidenceOrCompleteness": 40
+      "invalidNameOrSlug": 11,
+      "weakDescription": 380,
+      "placeholderText": 220,
+      "insufficientEffects": 51,
+      "nanArtifacts": 1,
+      "insufficientEvidenceOrCompleteness": 39
     }
   },
   "blogIndex": {

--- a/scripts/dedupe-entities.mjs
+++ b/scripts/dedupe-entities.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fs from 'node:fs'
 import path from 'node:path'
+import { countBootstrapSources } from './source-normalization.mjs'
 
 const ROOT = process.cwd()
 
@@ -113,7 +114,7 @@ function mergeArrays(a, b) {
 }
 
 function completenessScore(record) {
-  const sources = asArray(record?.sources).length
+  const sources = countBootstrapSources([record?.sources, record?.source, record?.references, record?.citations])
   const effects = asArray(record?.effects).length
   const contraindications = asArray(record?.contraindications).length
   const hasDescription = text(record?.description || record?.summary).length > 0 ? 1 : 0

--- a/scripts/generate-homepage-data.mjs
+++ b/scripts/generate-homepage-data.mjs
@@ -116,6 +116,10 @@ function scoreSources(value) {
   return { score: Math.min(16, good * 6), hasWeakSources: false }
 }
 
+function gatherSourceInputs(record) {
+  return [record?.sources, record?.source, record?.references, record?.citations]
+}
+
 function toQualityBadge(quality, governedSummary) {
   if (governedSummary?.enrichedAndReviewed) return 'Enriched + reviewed'
   if (quality.flags.isIncomplete) return 'Incomplete'
@@ -140,7 +144,7 @@ function scoreHerbQuality(herb) {
   if (splitClean(herb.interactions).length > 0) score += 8
   if (sanitizeSurfaceText(herb.description).length >= 70) score += 8
 
-  const sourceQuality = scoreSources(herb.sources)
+  const sourceQuality = scoreSources(gatherSourceInputs(herb.__raw || herb))
   score += sourceQuality.score
 
   const hasPlaceholder = [herb.description, herb.effects, herb.mechanism, herb.mechanismOfAction, herb.therapeuticUses].some(
@@ -171,7 +175,7 @@ function scoreCompoundQuality(compound) {
   if (splitClean(compound.interactions).length > 0) score += 6
   if (sanitizeSurfaceText(compound.description).length >= 50) score += 8
 
-  const sourceQuality = scoreSources(compound.sources)
+  const sourceQuality = scoreSources(gatherSourceInputs(compound.__raw || compound))
   score += sourceQuality.score
 
   const hasPlaceholder = [compound.description, compound.effects, compound.mechanism, compound.mechanismOfAction].some(
@@ -314,12 +318,13 @@ function buildHomepageData() {
             url: cleanText(item?.url),
           }))
         : [],
+      __raw: herb,
     }))
 
   const herbItemBySlug = new Map((Array.isArray(herbsSummary) ? herbsSummary : []).map(item => [cleanText(item.slug), item]))
   const compoundItemBySlug = new Map((Array.isArray(compoundsSummary) ? compoundsSummary : []).map(item => [cleanText(item.slug), item]))
-  const herbSourceBuckets = sourceCountBuckets((Array.isArray(herbs) ? herbs : []).map(herb => herb?.sources))
-  const compoundSourceBuckets = sourceCountBuckets((Array.isArray(compounds) ? compounds : []).map(compound => compound?.sources))
+  const herbSourceBuckets = sourceCountBuckets((Array.isArray(herbs) ? herbs : []).map(gatherSourceInputs))
+  const compoundSourceBuckets = sourceCountBuckets((Array.isArray(compounds) ? compounds : []).map(gatherSourceInputs))
 
   const herbItems = effectExplorerHerbs.map(herb => {
     const key = `herb:${herb.slug}`

--- a/scripts/sanitize-canonical-data.mjs
+++ b/scripts/sanitize-canonical-data.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+
+const ROOT = process.cwd()
+const TARGETS = [
+  { kind: 'herbs', file: 'public/data/herbs.json' },
+  { kind: 'compounds', file: 'public/data/compounds.json' },
+]
+
+const JUNK_EXACT = new Set(['nan', 'null', 'undefined', '[object object]'])
+const PLACEHOLDER_EXACT = new Set([
+  'no direct effects data',
+  'contextual inference',
+  'no direct mechanism data',
+  'no direct mechanism',
+  'insufficient data',
+  'placeholder',
+])
+const NUMERIC_ONLY = /^\d+(?:[\s.,/-]\d+)*$/
+
+const asText = value => String(value ?? '').trim()
+const cleanWhitespace = value => asText(value).replace(/\s+/g, ' ')
+
+function isJunkString(value) {
+  return JUNK_EXACT.has(cleanWhitespace(value).toLowerCase())
+}
+
+function isPlaceholderText(value) {
+  const text = cleanWhitespace(value).toLowerCase()
+  if (!text) return false
+  if (PLACEHOLDER_EXACT.has(text)) return true
+  if (/^no direct [a-z\s-]+$/i.test(text)) return true
+  return false
+}
+
+function pickDisplayName(record, kind) {
+  const fields =
+    kind === 'herbs'
+      ? [record?.common, record?.commonName, record?.name, record?.latin, record?.latinName, record?.scientific]
+      : [record?.name, record?.commonName, record?.common, record?.latin, record?.latinName]
+  return fields.map(cleanWhitespace).find(Boolean) || ''
+}
+
+function isJunkRecordName(name) {
+  if (!name) return true
+  const lowered = name.toLowerCase()
+  if (lowered === 'nan' || lowered === 'null' || lowered === 'undefined') return true
+  if (NUMERIC_ONLY.test(name)) return true
+  return false
+}
+
+function sanitizeTextValue(value, counters) {
+  const original = cleanWhitespace(value)
+  if (!original) return ''
+  if (isJunkString(original)) {
+    counters.cleanedJunkFieldValues += 1
+    return ''
+  }
+
+  if (isPlaceholderText(original)) {
+    counters.cleanedPlaceholderSegments += 1
+    return ''
+  }
+
+  const repeatedChunk = original.match(/^(.{16,}?)(?:\s*(?:\||;|,|\/|\.)\s*\1){1,}$/i)
+  if (repeatedChunk) {
+    counters.cleanedPlaceholderSegments += 1
+    return cleanWhitespace(repeatedChunk[1])
+  }
+
+  return original
+}
+
+function sanitizeValue(value, counters) {
+  if (typeof value === 'string') return sanitizeTextValue(value, counters)
+  if (Array.isArray(value)) {
+    return value.map(item => sanitizeValue(item, counters)).filter(item => {
+      if (typeof item === 'string') return cleanWhitespace(item).length > 0
+      return item !== null && item !== undefined
+    })
+  }
+  if (value && typeof value === 'object') {
+    const out = {}
+    for (const [key, nested] of Object.entries(value)) {
+      const cleaned = sanitizeValue(nested, counters)
+      out[key] = cleaned
+    }
+    return out
+  }
+  return value
+}
+
+function readJson(relativePath) {
+  const full = path.join(ROOT, relativePath)
+  return JSON.parse(fs.readFileSync(full, 'utf8'))
+}
+
+function writeJson(relativePath, data) {
+  const full = path.join(ROOT, relativePath)
+  fs.writeFileSync(full, `${JSON.stringify(data, null, 2)}\n`, 'utf8')
+}
+
+function sanitizeDataset(kind, records) {
+  const counters = {
+    removedJunkNameRecords: 0,
+    cleanedJunkFieldValues: 0,
+    cleanedPlaceholderSegments: 0,
+  }
+
+  const sanitized = []
+  for (const record of Array.isArray(records) ? records : []) {
+    if (!record || typeof record !== 'object') continue
+    const name = pickDisplayName(record, kind)
+    if (isJunkRecordName(name)) {
+      counters.removedJunkNameRecords += 1
+      continue
+    }
+    sanitized.push(sanitizeValue(record, counters))
+  }
+
+  return { sanitized, counters }
+}
+
+function run() {
+  const report = { generatedAt: new Date().toISOString(), datasets: {} }
+  for (const target of TARGETS) {
+    const input = readJson(target.file)
+    const { sanitized, counters } = sanitizeDataset(target.kind, input)
+    writeJson(target.file, sanitized)
+    report.datasets[target.kind] = {
+      file: target.file,
+      before: Array.isArray(input) ? input.length : 0,
+      after: sanitized.length,
+      ...counters,
+    }
+  }
+  console.log(JSON.stringify(report, null, 2))
+}
+
+run()

--- a/scripts/shared-route-manifest.mjs
+++ b/scripts/shared-route-manifest.mjs
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import { countBootstrapSources } from './source-normalization.mjs'
 
 const ROOT = process.cwd()
 const BLOG_PER_PAGE = 12
@@ -232,7 +233,7 @@ const normalizeDate = value => {
 }
 
 function scoreEntity(record) {
-  const sources = Array.isArray(record?.sources) ? record.sources.length : 0
+  const sources = countBootstrapSources([record?.sources, record?.source, record?.references, record?.citations])
   const effects = Array.isArray(record?.effects) ? record.effects.length : 0
   const hasMechanism = String(record?.mechanism || '').trim().length > 0 ? 1 : 0
   const hasDescription = String(record?.description || record?.summary || '').trim().length > 0 ? 1 : 0

--- a/scripts/source-normalization.mjs
+++ b/scripts/source-normalization.mjs
@@ -23,8 +23,23 @@ function normalizeSourceEntriesInner(value) {
   return []
 }
 
+function sourceDedupeKey(value) {
+  const text = asText(value).replace(/\s+/g, ' ')
+  if (!text) return ''
+  if (/^https?:\/\//i.test(text)) return text.replace(/\/+$/g, '').toLowerCase()
+  return text.toLowerCase()
+}
+
 export function normalizeSourceEntries(value) {
-  return normalizeSourceEntriesInner(value)
+  const seen = new Set()
+  const deduped = []
+  for (const entry of normalizeSourceEntriesInner(value)) {
+    const key = sourceDedupeKey(entry)
+    if (!key || seen.has(key)) continue
+    seen.add(key)
+    deduped.push(asText(entry))
+  }
+  return deduped
 }
 
 export function isBootstrapSource(value) {


### PR DESCRIPTION
### Motivation

- Ensure source counting and scoring use the same normalized inputs across the pipeline to avoid inconsistent completeness/route fallback decisions. 
- Remove junk/placeholder data segments and invalid name records from canonical JSON to improve downstream gating and indexability. 
- Improve deduplication and normalization of source entries to produce stable source buckets for homepage and publication generation.

### Description

- Added `scripts/source-normalization.mjs` improvements: dedupe keys (`sourceDedupeKey`), stronger `normalizeSourceEntries` and exported `countBootstrapSources` and `sourceCountBuckets`. 
- Switched scoring to normalized bootstrap source counts by using `countBootstrapSources` in `scripts/dedupe-entities.mjs` and `scripts/shared-route-manifest.mjs`. 
- Updated homepage generation in `scripts/generate-homepage-data.mjs` to gather source inputs from multiple fields via a new `gatherSourceInputs` helper and to attach `__raw` for accurate scoring. 
- Added `scripts/sanitize-canonical-data.mjs` which strips junk name records, cleans junk field values and placeholder segments, and writes cleaned canonical JSON back to `public/data/*.json`. 
- Regenerated artifacts and reports: updated `public/data/*` outputs (`herbs.json`, `compounds.json`, `indexable-herbs.json`, `indexable-compounds.json`, `publication-manifest.json`, `quality-report.json`) and added ops artifacts `ops/pass1-source-normalization-audit-2026-04-02.md` and `ops/pass2-sanitization-report-2026-04-02.json` reflecting the new metrics and timestamps. 

### Testing

- Executed the sanitization and generation pipeline by running `scripts/sanitize-canonical-data.mjs`, `scripts/dedupe-entities.mjs`, and the homepage/publication generation steps which produced updated `public/data/*` and `ops/pass2-sanitization-report-2026-04-02.json`; the run completed and produced the new artifact files. 
- Verified `publication-manifest.json` and `quality-report.json` were regenerated with updated thresholds/timestamps and corrected `summaries` and `routes` counts. 
- No unit tests were modified; this change was validated via the automated data-regeneration pipeline and resulting report metrics (sanitization counts and gate metrics) indicate the expected cleanup and re-scoring.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceed6e28608323b47d13a0bd85d22b)