### PR TITLE
Wire workbook herb JSON into merged herb exports

### DIFF
--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -20,6 +20,16 @@ export type Entity = {
   sources?: { title: string; url: string }[]
 }
 
+export async function loadPublicJsonArray<T>(path: string): Promise<T[]> {
+  const response = await fetch(path, { cache: 'no-store' })
+  if (!response.ok) {
+    throw new Error(`Failed to load ${path}`)
+  }
+
+  const payload = (await response.json()) as unknown
+  return Array.isArray(payload) ? (payload as T[]) : []
+}
+
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' && !Array.isArray(value)
     ? (value as Record<string, unknown>)

--- a/src/lib/herbs.ts
+++ b/src/lib/herbs.ts
@@ -1,4 +1,6 @@
 import type { Herb } from '../types'
+import type { HerbRecord } from '@/types/herb'
+import { loadPublicJsonArray } from '@/lib/data'
 
 const CLASS_MAP: Record<string, string> = {
   phenethylamine: 'Phenethylamine',
@@ -24,6 +26,71 @@ const PHARM_MAP = [
 ] as const
 
 type ListLike = string | string[] | null | undefined
+
+function normalizeSlug(slug: unknown): string {
+  return typeof slug === 'string' ? slug.trim().toLowerCase() : ''
+}
+
+function isNonEmptyValue(value: unknown): boolean {
+  if (value == null) return false
+  if (typeof value === 'string') return value.trim().length > 0
+  if (Array.isArray(value)) return value.length > 0
+  return true
+}
+
+function mergeHerbRecord(legacy: HerbRecord, workbook: HerbRecord): HerbRecord {
+  const merged: HerbRecord = { ...legacy }
+  for (const [key, value] of Object.entries(workbook)) {
+    if (isNonEmptyValue(value)) {
+      merged[key] = value
+    }
+  }
+  return merged
+}
+
+async function loadWorkbookHerbData(): Promise<HerbRecord[]> {
+  if (typeof window === 'undefined') return []
+  return loadPublicJsonArray<HerbRecord>('/data/workbook-herbs.json')
+}
+
+async function loadLegacyHerbData(): Promise<HerbRecord[]> {
+  const legacyModule = await import('@/data/herbs_enriched.json')
+  const payload = (legacyModule.default ?? legacyModule) as unknown
+  return Array.isArray(payload) ? (payload as HerbRecord[]) : []
+}
+
+const workbookHerbsPromise = loadWorkbookHerbData().catch(() => [])
+const allHerbsPromise = Promise.all([workbookHerbsPromise, loadLegacyHerbData()]).then(
+  ([workbook, legacy]) => {
+    const legacyBySlug = new Map<string, HerbRecord>()
+    legacy.forEach(herb => {
+      const slug = normalizeSlug(herb.slug)
+      if (!slug) return
+      legacyBySlug.set(slug, herb)
+    })
+
+    const mergedBySlug = new Map<string, HerbRecord>(legacyBySlug)
+
+    workbook.forEach(workbookHerb => {
+      const slug = normalizeSlug(workbookHerb.slug)
+      if (!slug) return
+
+      const legacyHerb = legacyBySlug.get(slug)
+      mergedBySlug.set(slug, legacyHerb ? mergeHerbRecord(legacyHerb, workbookHerb) : workbookHerb)
+    })
+
+    return Array.from(mergedBySlug.values())
+  },
+)
+
+export const workbookHerbs: HerbRecord[] = await workbookHerbsPromise
+export const allHerbs: HerbRecord[] = await allHerbsPromise
+
+export function getHerbBySlug(slug: string): HerbRecord | undefined {
+  const slugKey = normalizeSlug(slug)
+  if (!slugKey) return undefined
+  return allHerbs.find(herb => normalizeSlug(herb.slug) === slugKey)
+}
 
 function normList(value?: ListLike): string[] {
   const source = Array.isArray(value) ? value.join(',') : (value ?? '')


### PR DESCRIPTION
### Motivation
- Load the new workbook-authoritative herb JSON and preserve the legacy enriched herb array so workbook entries can progressively replace legacy data without breaking existing consumers.
- Provide both a merged herb export for site-wide use and a workbook-only export for pages that need authoritative workbook records.
- Reuse the repo's public JSON loading idiom and keep merge logic deterministic by keying on slug.

### Description
- Added `loadPublicJsonArray` helper in `src/lib/data.ts` to fetch public JSON arrays with `cache: 'no-store'`.
- Updated `src/lib/herbs.ts` to lazily load workbook data from `/data/workbook-herbs.json` (browser fetch) and legacy data from `src/data/herbs_enriched.json` (dynamic import) and to merge them by slug.
- Implemented merge behavior where legacy records are the baseline and workbook values override only non-empty fields, preserved legacy-only herbs, and initialized module-level promises so loading happens at module init time.
- Exported `workbookHerbs` (workbook-only array), `allHerbs` (merged array), and `getHerbBySlug`, while keeping existing herb-decoration helpers unchanged; modified files: `src/lib/herbs.ts`, `src/lib/data.ts`.

### Testing
- Ran `npx tsc --noEmit` which completed successfully with no type errors.
- Pre-commit hooks ran `eslint --max-warnings=0` on the changed TypeScript files and passed during validation.
- Changed files: `src/lib/herbs.ts`, `src/lib/data.ts`.
- Risk/follow-up: workbook fetch is guarded to run only in the browser (`typeof window`), so server-side contexts will see an empty workbook array and rely on the legacy dataset; consider adding an SSR-safe loading path if workbook data is required during server rendering.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da50b923648323adaf250849913b16)