### PR TITLE
Add optional workbook import pipeline to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,33 @@ jobs:
       - name: Enrichment release gate
         run: npm run enrichment:release:gate
 
+      # === Workbook Data Pipeline ===
+      # Runs when HERB_WORKBOOK_B64 secret is set.
+      # Exports workbook sheets → JSON, rebuilds publication manifest,
+      # regenerates sitemap. No-op if secret is absent.
+      - name: Decode workbook from HERB_WORKBOOK_B64 secret
+        env:
+          HERB_WORKBOOK_B64: ${{ secrets.HERB_WORKBOOK_B64 }}
+        run: |
+          if [ -z "$HERB_WORKBOOK_B64" ]; then
+            echo "::warning::HERB_WORKBOOK_B64 secret is not set. Skipping workbook download."
+            exit 0
+          fi
+
+          mkdir -p data-sources
+          printf '%s' "$HERB_WORKBOOK_B64" | base64 --decode > data-sources/herb_monograph_master.xlsx
+          echo "[deploy] Workbook decoded to data-sources/herb_monograph_master.xlsx"
+
+      - name: Run workbook import + manifest rebuild
+        run: |
+          if [ -f "data-sources/herb_monograph_master.xlsx" ]; then
+            node scripts/export-workbook-to-json.mjs
+            node scripts/build-publication-manifest-from-workbook.mjs
+            node scripts/generate-sitemap.mjs
+          else
+            echo "::warning::data-sources/herb_monograph_master.xlsx not found. Skipping workbook pipeline."
+          fi
+
       - name: Build production site (includes prebuild + postbuild)
         run: npm run build
 


### PR DESCRIPTION
### Motivation
- Integrate the workbook import and publication-manifest rebuild into the deploy pipeline so the site can regenerate JSON and sitemap automatically when a workbook is provided.
- Ensure the workbook file is never committed to git by sourcing it from the `HERB_WORKBOOK_B64` secret and make the pipeline a no-op with warnings when the secret or file is absent.

### Description
- Added a comment block and two steps to `.github/workflows/deploy.yml` before the build step: a decode step that writes `data-sources/herb_monograph_master.xlsx` from the `HERB_WORKBOOK_B64` secret, and a guarded step that runs `node scripts/export-workbook-to-json.mjs`, `node scripts/build-publication-manifest-from-workbook.mjs`, and `node scripts/generate-sitemap.mjs` only if the workbook file exists.
- Both steps exit gracefully with `::warning::` messages when the secret is unset or the file is missing, and no existing build, test, or deploy steps were changed.

### Testing
- Reviewed the workflow diff with `git diff -- .github/workflows/deploy.yml` to confirm the new steps were inserted before the build step, which succeeded.
- Inspected the updated file with `nl -ba .github/workflows/deploy.yml | sed -n '20,90p'` and committed the change via `git commit`; no CI runs were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da712af4ac83239e711b610aafb134)