### PR TITLE
Make updated workbook the canonical herb/compound source in data scripts

### DIFF
--- a/scripts/export-workbook-to-json.mjs
+++ b/scripts/export-workbook-to-json.mjs
@@ -3,9 +3,10 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import XLSX from 'xlsx'
+import { resolveWorkbookPath } from './workbook-source.mjs'
 
 const repoRoot = process.cwd()
-const workbookPath = path.join(repoRoot, 'data-sources', 'herb_monograph_master.xlsx')
+const workbookPath = resolveWorkbookPath(repoRoot)
 const dataDir = path.join(repoRoot, 'public', 'data')
 
 function toCleanString(value) {

--- a/scripts/generate-monograph-projection.mjs
+++ b/scripts/generate-monograph-projection.mjs
@@ -4,12 +4,12 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import XLSX from 'xlsx'
+import { resolveWorkbookPath } from './workbook-source.mjs'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const repoRoot = path.resolve(__dirname, '..')
 
-const DEFAULT_XLSX_PATH = path.join(repoRoot, 'data-sources', 'herb_monograph_master.xlsx')
 const DEFAULT_OUTPUT_DIR = path.join(repoRoot, 'public', 'data', 'projections', 'monograph-runtime')
 const DEFAULT_COMPOUNDS_PATH = path.join(repoRoot, 'public', 'data', 'compounds.json')
 const DEFAULT_REPAIR_REPORT_PATH = path.join(repoRoot, 'reports', 'workbook-repair-pass.json')
@@ -363,7 +363,7 @@ function computeRuntimeCoverage(herbs) {
 }
 
 function main() {
-  const workbookPath = process.env.HERB_XLSX_PATH ? path.resolve(repoRoot, process.env.HERB_XLSX_PATH) : DEFAULT_XLSX_PATH
+  const workbookPath = resolveWorkbookPath(repoRoot)
   const outputDir = process.env.MONOGRAPH_PROJECTION_OUTPUT_DIR
     ? path.resolve(repoRoot, process.env.MONOGRAPH_PROJECTION_OUTPUT_DIR)
     : DEFAULT_OUTPUT_DIR

--- a/scripts/import-xlsx-monographs.mjs
+++ b/scripts/import-xlsx-monographs.mjs
@@ -4,13 +4,13 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import XLSX from 'xlsx'
+import { resolveWorkbookPath } from './workbook-source.mjs'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const repoRoot = path.resolve(__dirname, '..')
 
-const DEFAULT_XLSX_PATH = path.join('data-sources', 'herb_monograph_master.xlsx')
-const workbookPath = path.resolve(repoRoot, process.env.HERB_XLSX_PATH || DEFAULT_XLSX_PATH)
+const workbookPath = resolveWorkbookPath(repoRoot)
 
 const herbsPath = path.join(repoRoot, 'public', 'data', 'herbs.json')
 const compoundsPath = path.join(repoRoot, 'public', 'data', 'compounds.json')

--- a/scripts/sync-updated-datasets.mjs
+++ b/scripts/sync-updated-datasets.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import fs from 'node:fs'
 import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { resolveWorkbookPath } from './workbook-source.mjs'
 
 const root = process.cwd()
 const outDir = path.join(root, 'public', 'data')
@@ -103,3 +105,18 @@ for (const file of FILES) {
 
 hydrateUpdatedDatasetSlugs('herbs_combined_updated.json', 'herbs')
 hydrateUpdatedDatasetSlugs('compounds_combined_updated.json', 'compounds')
+
+const workbookPath = resolveWorkbookPath(root)
+if (fs.existsSync(workbookPath)) {
+  console.log(`[data-sync] Applying workbook overlay from ${workbookPath}`)
+  execFileSync('node', ['scripts/import-xlsx-monographs.mjs'], {
+    cwd: root,
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      HERB_XLSX_PATH: path.relative(root, workbookPath),
+    },
+  })
+} else {
+  console.log('[data-sync] Skipping workbook overlay; no workbook file found.')
+}

--- a/scripts/verify-workbook-import-reconciliation.mjs
+++ b/scripts/verify-workbook-import-reconciliation.mjs
@@ -4,9 +4,10 @@ import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import XLSX from 'xlsx'
+import { resolveWorkbookPath } from './workbook-source.mjs'
 
 const repoRoot = process.cwd()
-const workbookPath = path.join(repoRoot, 'data-sources', 'herb_monograph_master.xlsx')
+const workbookPath = resolveWorkbookPath(repoRoot)
 const herbsPath = path.join(repoRoot, 'public', 'data', 'herbs.json')
 const compoundsPath = path.join(repoRoot, 'public', 'data', 'compounds.json')
 

--- a/scripts/workbook-source.mjs
+++ b/scripts/workbook-source.mjs
@@ -1,0 +1,20 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const DEFAULT_WORKBOOK_CANDIDATES = [
+  'data-sources/herb_monograph_master_updated_pass15.xlsx',
+  'data-sources/herb_monograph_master.xlsx',
+]
+
+export function resolveWorkbookPath(rootDir, { envPath = process.env.HERB_XLSX_PATH } = {}) {
+  if (typeof envPath === 'string' && envPath.trim()) {
+    return path.resolve(rootDir, envPath.trim())
+  }
+
+  for (const relativePath of DEFAULT_WORKBOOK_CANDIDATES) {
+    const candidate = path.resolve(rootDir, relativePath)
+    if (fs.existsSync(candidate)) return candidate
+  }
+
+  return path.resolve(rootDir, DEFAULT_WORKBOOK_CANDIDATES[0])
+}


### PR DESCRIPTION
### Motivation
- Make the uploaded workbook the operational source-of-truth for herb and compound data without changing downstream site surfaces or large rewrites. 
- Preserve the existing prebuild/data pipeline and ensure workbook-derived updates are reconciled into the canonical `public/data` JSON used by manifest/indexables/homepage generation. 

### Description
- Add `scripts/workbook-source.mjs` which resolves the workbook path, preferring `data-sources/herb_monograph_master_updated_pass15.xlsx` and falling back to `data-sources/herb_monograph_master.xlsx`, while honoring `HERB_XLSX_PATH` overrides. 
- Wire the resolver into workbook-consuming scripts: `scripts/import-xlsx-monographs.mjs`, `scripts/generate-monograph-projection.mjs`, `scripts/export-workbook-to-json.mjs`, and `scripts/verify-workbook-import-reconciliation.mjs`. 
- Update `scripts/sync-updated-datasets.mjs` to invoke `import-xlsx-monographs.mjs` (workbook overlay) after copying updated JSON, so the workbook is applied into `public/data/herbs.json` and `public/data/compounds.json` used by the rest of `prebuild`. 
- Changed files: `scripts/workbook-source.mjs` (new), `scripts/sync-updated-datasets.mjs`, `scripts/import-xlsx-monographs.mjs`, `scripts/generate-monograph-projection.mjs`, `scripts/export-workbook-to-json.mjs`, and `scripts/verify-workbook-import-reconciliation.mjs`. 

### Testing
- Ran syntax checks `node --check` against modified scripts which succeeded. 
- Executed `node scripts/sync-updated-datasets.mjs` which copied existing updated JSON and ran the workbook import overlay; the importer ran in apply mode and reported matched/patched counts (import step completed). 
- Ran `npm run prebuild`, which progressed through sync, dedupe, quality gates, indexable/manifest and homepage generation but ultimately failed at the existing affiliate verification (`verify-curated-affiliates`) stage (pre-existing data/entity-page mismatches) and therefore did not fully succeed. 
- Ran `node scripts/verify-workbook-import-reconciliation.mjs` which failed an existing baseline assertion (`Compound reconciliation did not improve match coverage`), indicating repository data state requires manual review independent of these wiring changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da80e38fd08323b0e2705779ec0776)