### PR TITLE
Add herbs-only mode to monograph projection pipeline

### DIFF
--- a/scripts/generate-monograph-projection.mjs
+++ b/scripts/generate-monograph-projection.mjs
@@ -47,6 +47,12 @@ const RUNTIME_COVERAGE_FIELDS = [
 
 const JUNK_VALUES = new Set(['', 'na', 'n/a', 'none', 'null', 'undefined', 'unknown', 'unk', 'tbd', '-', '--'])
 
+function parseArgs(argv) {
+  return {
+    herbsOnly: argv.includes('--herbs-only'),
+  }
+}
+
 function cleanText(value) {
   const text = String(value ?? '').replace(/\s+/g, ' ').trim()
   return text
@@ -363,6 +369,7 @@ function computeRuntimeCoverage(herbs) {
 }
 
 function main() {
+  const { herbsOnly } = parseArgs(process.argv.slice(2))
   const workbookPath = resolveWorkbookPath(repoRoot)
   const outputDir = process.env.MONOGRAPH_PROJECTION_OUTPUT_DIR
     ? path.resolve(repoRoot, process.env.MONOGRAPH_PROJECTION_OUTPUT_DIR)
@@ -411,9 +418,11 @@ function main() {
     writeJson(path.join(detailDir, `${herb.slug}.json`), herb)
   }
 
-  writeJson(path.join(outputDir, 'workbook-cleaned-compound-master-v3.json'), dedupedCompounds.deduped)
-  writeJson(path.join(outputDir, 'workbook-cleaned-herb-compound-map-v3.json'), cleanedMap.cleaned)
-  writeJson(path.join(outputDir, 'workbook-cleaned-herb-enrichment-queue-v3.json'), cleanedQueueRows)
+  if (!herbsOnly) {
+    writeJson(path.join(outputDir, 'workbook-cleaned-compound-master-v3.json'), dedupedCompounds.deduped)
+    writeJson(path.join(outputDir, 'workbook-cleaned-herb-compound-map-v3.json'), cleanedMap.cleaned)
+    writeJson(path.join(outputDir, 'workbook-cleaned-herb-enrichment-queue-v3.json'), cleanedQueueRows)
+  }
 
   writeJson(repairReportPath, {
     workbookPath: path.relative(repoRoot, workbookPath),
@@ -441,6 +450,9 @@ function main() {
   console.log(`[generate-monograph-projection] runtimeFieldCoveragePct: ${runtimeCoverage.overallPct}`)
   console.log(`[generate-monograph-projection] output: ${path.relative(repoRoot, outputDir)}`)
   console.log(`[generate-monograph-projection] repairReport: ${path.relative(repoRoot, repairReportPath)}`)
+  if (herbsOnly) {
+    console.log('[generate-monograph-projection] mode: herbs-only')
+  }
 }
 
 main()


### PR DESCRIPTION
### Motivation
- Allow workbook-driven runs to emit herb projection outputs without regenerating compound/map/queue artifacts so diffs remain small and the workbook can be adopted as the source of truth incrementally.

### Description
- Added minimal CLI parsing and a `--herbs-only` flag to `scripts/generate-monograph-projection.mjs`, and conditionally skip writing the workbook cleaned compound/map/queue artifacts while keeping herb outputs and the repair report unchanged; change touches `scripts/generate-monograph-projection.mjs` only.

### Testing
- Ran `node --check scripts/generate-monograph-projection.mjs` (syntax check) which passed. 
- Commit hook ran `eslint --max-warnings=0` via `lint-staged` during the change and the linter passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da8e118df883238432bec9a4067092)