### PR TITLE
Normalize workbook columns and harden import/export of workbook data

### DIFF
--- a/scripts/export-workbook-to-json.mjs
+++ b/scripts/export-workbook-to-json.mjs
@@ -4,6 +4,7 @@ import fs from 'node:fs'
 import path from 'node:path'
 import XLSX from 'xlsx'
 import { resolveWorkbookPath } from './workbook-source.mjs'
+import { canonicalizeWorkbookRow } from './workbook-column-mapping.mjs'
 
 const repoRoot = process.cwd()
 const workbookPath = resolveWorkbookPath(repoRoot)
@@ -26,6 +27,14 @@ function cleanScalar(value) {
   return value
 }
 
+function slugify(value) {
+  return toCleanString(value)
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
 function dedupeBy(records, keyFn) {
   const seen = new Set()
   const output = []
@@ -44,11 +53,13 @@ function readSheetRows(workbook, sheetName, { optional = false } = {}) {
     if (optional) return []
     throw new Error(`Missing sheet: ${sheetName}`)
   }
-  return XLSX.utils.sheet_to_json(sheet, {
+  const rows = XLSX.utils.sheet_to_json(sheet, {
     defval: '',
     raw: false,
     blankrows: false,
   })
+
+  return rows.map(row => canonicalizeWorkbookRow(row, sheetName))
 }
 
 function exportHerbs(workbook) {
@@ -103,8 +114,8 @@ function exportHerbs(workbook) {
 function exportCompounds(workbook) {
   const rows = readSheetRows(workbook, 'Compound Master V3')
   const records = rows.map(row => ({
-    id: cleanScalar(row.canonicalCompoundId),
-    name: cleanScalar(row.compoundName),
+    id: cleanScalar(row.canonicalCompoundId) || slugify(row.compoundName || row.canonicalCompoundName || row.Compound),
+    name: cleanScalar(row.compoundName || row.canonicalCompoundName || row.Compound),
     aliases: splitList(row.aliases),
     compoundClass: cleanScalar(row.compoundClass),
     mechanism: cleanScalar(row.mechanism),

--- a/scripts/import-xlsx-monographs.mjs
+++ b/scripts/import-xlsx-monographs.mjs
@@ -5,6 +5,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import XLSX from 'xlsx'
 import { resolveWorkbookPath } from './workbook-source.mjs'
+import { canonicalizeWorkbookRow } from './workbook-column-mapping.mjs'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -315,9 +316,9 @@ function buildCompoundSources(row) {
 }
 
 function canonicalizeRow(row) {
-  const out = {}
-  for (const [key, value] of Object.entries(row || {})) {
-    out[String(key).trim()] = typeof value === 'string' ? cleanText(value) : value
+  const out = canonicalizeWorkbookRow(row, 'unknown')
+  for (const [key, value] of Object.entries(out)) {
+    out[key] = typeof value === 'string' ? cleanText(value) : value
   }
   return out
 }
@@ -334,7 +335,15 @@ function parseSheet(workbook, sheetName) {
     blankrows: false,
   })
 
-  return rows.map(canonicalizeRow)
+  return rows.map(row => canonicalizeWorkbookRow(canonicalizeRow(row), sheetName))
+}
+
+function slugify(value) {
+  return cleanText(value)
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
 }
 
 function applyValueIfChanged(record, key, value) {
@@ -467,12 +476,12 @@ function indexCompounds(compounds) {
   const byVariant = new Map()
 
   for (const compound of compounds) {
-    const id = cleanText(compound.id)
-    const name = cleanText(compound.name)
+    const id = cleanText(compound.id || compound.canonicalCompoundId)
+    const name = cleanText(compound.name || compound.compoundName || compound.canonicalCompoundName)
     if (id) addLookupEntry(byId, id, compound)
     if (name) addLookupEntry(byName, name.toLowerCase(), compound)
 
-    for (const value of [compound.id, compound.name]) {
+    for (const value of [compound.id, compound.canonicalCompoundId, compound.name, compound.compoundName]) {
       for (const variant of buildLookupVariants(value)) {
         addLookupEntry(byVariant, variant, compound)
       }
@@ -511,9 +520,28 @@ function resolveCompound(compoundIndex, row) {
 function patchCompound(compound, row) {
   let patched = false
 
+  const canonicalId = cleanText(row.canonicalCompoundId) || slugify(row.compoundName || row.canonicalCompoundName)
+  if (shouldPatchScalar(compound.canonicalCompoundId, canonicalId, { minCandidateLength: 3, minGain: 0 })) {
+    patched = applyValueIfChanged(compound, 'canonicalCompoundId', canonicalId) || patched
+  }
+  if (shouldPatchScalar(compound.id, canonicalId, { minCandidateLength: 3, minGain: 0 })) {
+    patched = applyValueIfChanged(compound, 'id', canonicalId) || patched
+  }
+
+  const compoundName = cleanText(row.compoundName || row.canonicalCompoundName)
+  if (shouldPatchScalar(compound.compoundName, compoundName, { minCandidateLength: 3, minGain: 0 })) {
+    patched = applyValueIfChanged(compound, 'compoundName', compoundName) || patched
+  }
+  if (shouldPatchScalar(compound.name, compoundName, { minCandidateLength: 3, minGain: 0 })) {
+    patched = applyValueIfChanged(compound, 'name', compoundName) || patched
+  }
+
   const classCandidate = cleanText(row.compoundClass)
   if (shouldPatchScalar(compound.category, classCandidate, { minCandidateLength: 4, minGain: 12 })) {
     patched = applyValueIfChanged(compound, 'category', classCandidate) || patched
+  }
+  if (shouldPatchScalar(compound.compoundClass, classCandidate, { minCandidateLength: 3, minGain: 0 })) {
+    patched = applyValueIfChanged(compound, 'compoundClass', classCandidate) || patched
   }
 
   const mechanismCandidate = cleanText(row.mechanism)
@@ -537,14 +565,52 @@ function patchCompound(compound, row) {
     patched = applyValueIfChanged(compound, 'contraindications', contraindicationCandidate) || patched
   }
 
+  const safetyNotes = cleanText(row.safetyNotes)
+  if (shouldPatchScalar(compound.safetyNotes, safetyNotes, { minCandidateLength: 3, minGain: 0 })) {
+    patched = applyValueIfChanged(compound, 'safetyNotes', safetyNotes) || patched
+  }
+
+  const drugInteractions = cleanText(row.drugInteractions)
+  if (shouldPatchScalar(compound.drugInteractions, drugInteractions, { minCandidateLength: 3, minGain: 0 })) {
+    patched = applyValueIfChanged(compound, 'drugInteractions', drugInteractions) || patched
+  }
+
   const herbLinksCandidate = dedupeStrings(splitSemicolonDelimited(row.relatedHerbSlugs))
   if (shouldPatchArray(compound.herbs, herbLinksCandidate, { minItems: 1, minGain: 16 })) {
     patched = applyValueIfChanged(compound, 'herbs', herbLinksCandidate) || patched
+  }
+  if (shouldPatchScalar(compound.relatedHerbSlugs, herbLinksCandidate.join('; '), { minCandidateLength: 3, minGain: 0 })) {
+    patched = applyValueIfChanged(compound, 'relatedHerbSlugs', herbLinksCandidate.join('; ')) || patched
   }
 
   const sourceCandidates = buildCompoundSources(row)
   if (shouldPatchArray(compound.sources, sourceCandidates, { minItems: 1, minGain: 18 })) {
     patched = applyValueIfChanged(compound, 'sources', sourceCandidates) || patched
+  }
+
+  const sourceUrls = dedupeStrings(parseSourceUrls(row.sourceUrls))
+  if (shouldPatchScalar(compound.sourceUrls, sourceUrls.join(' | '), { minCandidateLength: 8, minGain: 0 })) {
+    patched = applyValueIfChanged(compound, 'sourceUrls', sourceUrls.join(' | ')) || patched
+  }
+
+  const confidence = cleanText(row.confidence)
+  if (shouldPatchScalar(compound.confidence, confidence, { minCandidateLength: 2, minGain: 0 })) {
+    patched = applyValueIfChanged(compound, 'confidence', confidence) || patched
+  }
+
+  const evidence = cleanText(row.evidence)
+  if (shouldPatchScalar(compound.evidence, evidence, { minCandidateLength: 2, minGain: 0 })) {
+    patched = applyValueIfChanged(compound, 'evidence', evidence) || patched
+  }
+
+  const mechanismTags = dedupeStrings(splitSemicolonDelimited(row.mechanismTags))
+  if (shouldPatchScalar(compound.mechanismTags, mechanismTags.join('; '), { minCandidateLength: 2, minGain: 0 })) {
+    patched = applyValueIfChanged(compound, 'mechanismTags', mechanismTags.join('; ')) || patched
+  }
+
+  const pathwayTargets = dedupeStrings(splitSemicolonDelimited(row.pathwayTargets))
+  if (shouldPatchScalar(compound.pathwayTargets, pathwayTargets.join('; '), { minCandidateLength: 2, minGain: 0 })) {
+    patched = applyValueIfChanged(compound, 'pathwayTargets', pathwayTargets.join('; ')) || patched
   }
 
   return patched

--- a/scripts/sync-updated-datasets.mjs
+++ b/scripts/sync-updated-datasets.mjs
@@ -108,6 +108,15 @@ hydrateUpdatedDatasetSlugs('compounds_combined_updated.json', 'compounds')
 
 const workbookPath = resolveWorkbookPath(root)
 if (fs.existsSync(workbookPath)) {
+  console.log(`[data-sync] Exporting workbook datasets from ${workbookPath}`)
+  execFileSync('node', ['scripts/export-workbook-to-json.mjs'], {
+    cwd: root,
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      HERB_XLSX_PATH: path.relative(root, workbookPath),
+    },
+  })
   console.log(`[data-sync] Applying workbook overlay from ${workbookPath}`)
   execFileSync('node', ['scripts/import-xlsx-monographs.mjs'], {
     cwd: root,

--- a/scripts/workbook-column-mapping.mjs
+++ b/scripts/workbook-column-mapping.mjs
@@ -1,0 +1,47 @@
+const HEADER_NORMALIZATION_PATTERN = /[^a-z0-9]+/g
+
+const SHEET_HEADER_ALIASES = {
+  'Herb Monographs': {
+    reviewpriority: 'reviewPriority',
+  },
+  'Compound Master V3': {
+    compound: 'compoundName',
+    canonicalcompoundname: 'canonicalCompoundName',
+    canonicalcompoundid: 'canonicalCompoundId',
+    class: 'compoundClass',
+    mechanism: 'mechanism',
+    mechanismtags: 'mechanismTags',
+    mechanismtagsv2: 'mechanismTags',
+    pathwaytargets: 'pathwayTargets',
+    knownaliases: 'aliases',
+    sourceherb: 'sourceHerb',
+  },
+  'Herb Compound Map V3': {
+    canonicalcompoundname: 'canonicalCompoundName',
+    canonicalcompoundid: 'canonicalCompoundId',
+  },
+  'Production Export V1': {},
+}
+
+function normalizeHeaderKey(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(HEADER_NORMALIZATION_PATTERN, '')
+}
+
+export function canonicalizeWorkbookRow(row, sheetName) {
+  const aliases = SHEET_HEADER_ALIASES[sheetName] || {}
+  const out = {}
+
+  for (const [rawKey, value] of Object.entries(row || {})) {
+    const trimmedKey = String(rawKey || '').trim()
+    if (!trimmedKey) continue
+
+    const normalizedKey = normalizeHeaderKey(trimmedKey)
+    const mappedKey = aliases[normalizedKey] || trimmedKey
+    out[mappedKey] = value
+  }
+
+  return out
+}


### PR DESCRIPTION
### Motivation

- Support multiple workbook header variants and make row keys stable across worksheet versions to avoid fragile string-based lookups.
- Improve robustness of compound and herb import/export by providing sensible fallbacks for missing IDs/names and normalizing values.
- Ensure syncing runs a fresh workbook export before applying the workbook overlay so datasets are derived consistently from the current workbook.

### Description

- Add `scripts/workbook-column-mapping.mjs` which normalizes header names and provides `canonicalizeWorkbookRow` with per-sheet header aliases. 
- Update `scripts/export-workbook-to-json.mjs` to use `canonicalizeWorkbookRow`, add a `slugify` fallback for compound IDs, and map alternate column names when producing exported JSON. 
- Update `scripts/import-xlsx-monographs.mjs` to canonicalize rows when parsing sheets, add `slugify`, expand compound/herb indexing variants, and add a number of additional patched fields and normalization rules (IDs, names, classes, safetyNotes, drugInteractions, relatedHerbSlugs, sourceUrls, confidence, evidence, mechanismTags, pathwayTargets). 
- Update `scripts/sync-updated-datasets.mjs` to export workbook datasets prior to applying the workbook overlay and add logging for that step.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db04cadbcc8323888be8139d072fbf)