### PR TITLE
Lock workbook source and sheet loading to authoritative workbook

### DIFF
--- a/scripts/export-workbook-to-json.mjs
+++ b/scripts/export-workbook-to-json.mjs
@@ -9,6 +9,7 @@ import { canonicalizeWorkbookRow } from './workbook-column-mapping.mjs'
 const repoRoot = process.cwd()
 const workbookPath = resolveWorkbookPath(repoRoot)
 const dataDir = path.join(repoRoot, 'public', 'data')
+const EXPORT_WORKBOOK_SHEETS = ['Herb Monographs', 'Compound Master V3', 'Herb Compound Map V3', 'Production Export V1']
 
 function toCleanString(value) {
   const text = String(value ?? '').replace(/\bnan\b/gi, '').trim()
@@ -193,7 +194,7 @@ function writeJson(filename, records) {
 }
 
 function main() {
-  const workbook = XLSX.readFile(workbookPath)
+  const workbook = XLSX.readFile(workbookPath, { sheets: EXPORT_WORKBOOK_SHEETS })
 
   writeJson('workbook-herbs.json', exportHerbs(workbook))
   writeJson('workbook-compounds.json', exportCompounds(workbook))

--- a/scripts/import-xlsx-monographs.mjs
+++ b/scripts/import-xlsx-monographs.mjs
@@ -12,6 +12,7 @@ const __dirname = path.dirname(__filename)
 const repoRoot = path.resolve(__dirname, '..')
 
 const workbookPath = resolveWorkbookPath(repoRoot)
+const REQUIRED_WORKBOOK_SHEETS = ['Herb Monographs', 'Compound Master V3']
 
 const herbsPath = path.join(repoRoot, 'public', 'data', 'herbs.json')
 const compoundsPath = path.join(repoRoot, 'public', 'data', 'compounds.json')
@@ -719,9 +720,9 @@ function main() {
     throw new Error(`[import-xlsx-monographs] Workbook not found at ${workbookPath}`)
   }
 
-  const workbook = XLSX.readFile(workbookPath)
-  const herbRows = parseSheet(workbook, 'Herb Monographs')
-  const compoundRows = parseSheet(workbook, 'Compound Master V3')
+  const workbook = XLSX.readFile(workbookPath, { sheets: REQUIRED_WORKBOOK_SHEETS })
+  const herbRows = parseSheet(workbook, REQUIRED_WORKBOOK_SHEETS[0])
+  const compoundRows = parseSheet(workbook, REQUIRED_WORKBOOK_SHEETS[1])
 
   const herbs = JSON.parse(fs.readFileSync(herbsPath, 'utf8'))
   const compounds = JSON.parse(fs.readFileSync(compoundsPath, 'utf8'))

--- a/scripts/verify-workbook-import-reconciliation.mjs
+++ b/scripts/verify-workbook-import-reconciliation.mjs
@@ -8,6 +8,7 @@ import { resolveWorkbookPath } from './workbook-source.mjs'
 
 const repoRoot = process.cwd()
 const workbookPath = resolveWorkbookPath(repoRoot)
+const REQUIRED_WORKBOOK_SHEETS = ['Herb Monographs', 'Compound Master V3']
 const herbsPath = path.join(repoRoot, 'public', 'data', 'herbs.json')
 const compoundsPath = path.join(repoRoot, 'public', 'data', 'compounds.json')
 
@@ -16,9 +17,9 @@ function clean(value) {
 }
 
 function baselineCounts() {
-  const workbook = XLSX.readFile(workbookPath)
-  const herbRows = XLSX.utils.sheet_to_json(workbook.Sheets['Herb Monographs'], { defval: '', raw: false, blankrows: false })
-  const compoundRows = XLSX.utils.sheet_to_json(workbook.Sheets['Compound Master V3'], { defval: '', raw: false, blankrows: false })
+  const workbook = XLSX.readFile(workbookPath, { sheets: REQUIRED_WORKBOOK_SHEETS })
+  const herbRows = XLSX.utils.sheet_to_json(workbook.Sheets[REQUIRED_WORKBOOK_SHEETS[0]], { defval: '', raw: false, blankrows: false })
+  const compoundRows = XLSX.utils.sheet_to_json(workbook.Sheets[REQUIRED_WORKBOOK_SHEETS[1]], { defval: '', raw: false, blankrows: false })
 
   const herbs = JSON.parse(fs.readFileSync(herbsPath, 'utf8'))
   const compounds = JSON.parse(fs.readFileSync(compoundsPath, 'utf8'))

--- a/scripts/workbook-source.mjs
+++ b/scripts/workbook-source.mjs
@@ -1,20 +1,11 @@
-import fs from 'node:fs'
 import path from 'node:path'
 
-const DEFAULT_WORKBOOK_CANDIDATES = [
-  'data-sources/herb_monograph_master_updated_pass15.xlsx',
-  'data-sources/herb_monograph_master.xlsx',
-]
+const DEFAULT_WORKBOOK_RELATIVE_PATH = 'data-sources/herb_monograph_master.xlsx'
 
 export function resolveWorkbookPath(rootDir, { envPath = process.env.HERB_XLSX_PATH } = {}) {
   if (typeof envPath === 'string' && envPath.trim()) {
     return path.resolve(rootDir, envPath.trim())
   }
 
-  for (const relativePath of DEFAULT_WORKBOOK_CANDIDATES) {
-    const candidate = path.resolve(rootDir, relativePath)
-    if (fs.existsSync(candidate)) return candidate
-  }
-
-  return path.resolve(rootDir, DEFAULT_WORKBOOK_CANDIDATES[0])
+  return path.resolve(rootDir, DEFAULT_WORKBOOK_RELATIVE_PATH)
 }


### PR DESCRIPTION
### Motivation

- Make workbook source resolution stable and deterministic by fixing the default workbook path to the canonical workbook file.
- Prevent unrelated workbook tabs from affecting importer/export behavior by ensuring scripts read only the sheets they actually need.
- Keep existing override behavior via `HERB_XLSX_PATH` and preserve compatibility with current build scripts.

### Description

- Set the default workbook to `data-sources/herb_monograph_master.xlsx` in `scripts/workbook-source.mjs` and remove the previous multi-candidate fallback logic.
- Restrict the importer to only load `Herb Monographs` and `Compound Master V3` by passing a `sheets` whitelist to `XLSX.readFile` in `scripts/import-xlsx-monographs.mjs`.
- Restrict the exporter to only load `Herb Monographs`, `Compound Master V3`, `Herb Compound Map V3`, and `Production Export V1` by passing a `sheets` whitelist to `XLSX.readFile` in `scripts/export-workbook-to-json.mjs`.
- Align the reconciliation verification script to read only the importer-required sheets in `scripts/verify-workbook-import-reconciliation.mjs`.
- Files changed: `scripts/workbook-source.mjs`, `scripts/import-xlsx-monographs.mjs`, `scripts/export-workbook-to-json.mjs`, `scripts/verify-workbook-import-reconciliation.mjs`.

### Testing

- Ran static checks with `node --check` on `scripts/workbook-source.mjs`, `scripts/import-xlsx-monographs.mjs`, `scripts/export-workbook-to-json.mjs`, and `scripts/verify-workbook-import-reconciliation.mjs`, which completed successfully.
- Verified `resolveWorkbookPath` output with `node -e "import('./scripts/workbook-source.mjs').then(m=>console.log(m.resolveWorkbookPath(process.cwd())))"` and it printed the fixed path `data-sources/herb_monograph_master.xlsx`.
- Verified sheet scoping by loading the workbook via `XLSX.readFile(..., { sheets: [...] })` for importer and exporter cases and confirmed only the requested sheets were parsed; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db0895ea5c832384dd687cf1a1fd12)