### PR TITLE
Harden workbook importer matching fallbacks and dedupe safety

### DIFF
--- a/scripts/import-xlsx-monographs.mjs
+++ b/scripts/import-xlsx-monographs.mjs
@@ -434,10 +434,17 @@ function indexHerbs(herbs) {
 function resolveHerb(herbIndex, row) {
   const slug = cleanText(row.slug).toLowerCase()
   const name = cleanText(row.name).toLowerCase()
+  const workbookAliases = dedupeStrings([
+    ...splitSemicolonDelimited(row.aliases),
+    ...splitSemicolonDelimited(row.commonNames),
+    name,
+    normalizeLookupBase(name).replace(/[^a-z0-9\s]/g, ' ').replace(/\s+/g, ' ').trim(),
+  ])
 
   const aliasTargets = [
     ...buildLookupVariants(slug),
     ...buildLookupVariants(name),
+    ...workbookAliases.flatMap((value) => buildLookupVariants(value)),
     HERB_EXPLICIT_ALIASES[normalizeLookupBase(slug)] || '',
     HERB_EXPLICIT_ALIASES[normalizeLookupBase(name)] || '',
   ].filter(Boolean)
@@ -499,11 +506,19 @@ function patchHerb(herb, row, fieldPatchCounts) {
     patched = patchField(herb, 'region', regionCandidate, fieldPatchCounts) || patched
   }
 
-  const aliasCandidate = dedupeStrings([
-    ...splitSemicolonDelimited(row.commonNames),
-    ...splitSemicolonDelimited(row.aliases),
+  const workbookAliases = splitSemicolonDelimited(row.aliases)
+  const commonNames = splitSemicolonDelimited(row.commonNames)
+  const nameVariants = dedupeStrings([
+    cleanText(row.name),
+    normalizeLookupBase(row.name).replace(/[^a-z0-9\s]/g, ' ').replace(/\s+/g, ' ').trim(),
   ])
-  if (shouldPatchArray(herb.aliases, aliasCandidate, { minItems: 1, minGain: 30 })) {
+  const aliasCandidate = dedupeStrings([
+    ...workbookAliases,
+    ...(workbookAliases.length === 0 ? commonNames : []),
+    ...(workbookAliases.length === 0 && commonNames.length === 0 ? nameVariants : []),
+  ])
+  const hasExistingAliases = Array.isArray(herb.aliases) && herb.aliases.length > 0
+  if (!hasExistingAliases && shouldPatchArray(herb.aliases, aliasCandidate, { minItems: 1, minGain: 30 })) {
     patched = patchField(herb, 'aliases', aliasCandidate, fieldPatchCounts) || patched
   }
 
@@ -543,57 +558,82 @@ function indexCompounds(compounds) {
   const byId = new Map()
   const byName = new Map()
   const byVariant = new Map()
+  const bySlug = new Map()
 
   for (const compound of compounds) {
     const id = cleanText(compound.id || compound.canonicalCompoundId)
     const name = cleanText(compound.name || compound.compoundName || compound.canonicalCompoundName)
     if (id) addLookupEntry(byId, id, compound)
     if (name) addLookupEntry(byName, name.toLowerCase(), compound)
+    if (id) addLookupEntry(bySlug, slugify(id), compound)
+    if (name) addLookupEntry(bySlug, slugify(name), compound)
 
-    for (const value of [compound.id, compound.canonicalCompoundId, compound.name, compound.compoundName]) {
+    for (const value of [compound.id, compound.canonicalCompoundId, compound.name, compound.compoundName, compound.canonicalCompoundName]) {
       for (const variant of buildLookupVariants(value)) {
         addLookupEntry(byVariant, variant, compound)
       }
     }
   }
 
-  return { byId, byName, byVariant }
+  return { byId, byName, byVariant, bySlug }
 }
 
 function resolveCompound(compoundIndex, row) {
   const canonicalId = cleanText(row.canonicalCompoundId)
   const compoundName = cleanText(row.compoundName)
+  const canonicalCompoundName = cleanText(row.canonicalCompoundName)
+  const compoundNameSlug = slugify(compoundName)
+  const canonicalCompoundNameSlug = slugify(canonicalCompoundName)
 
   const aliasTargets = [
     ...buildLookupVariants(canonicalId),
     ...buildLookupVariants(compoundName),
+    ...buildLookupVariants(canonicalCompoundName),
+    compoundNameSlug,
+    canonicalCompoundNameSlug,
     COMPOUND_EXPLICIT_ALIASES[normalizeLookupBase(canonicalId)] || '',
     COMPOUND_EXPLICIT_ALIASES[normalizeLookupBase(compoundName)] || '',
+    COMPOUND_EXPLICIT_ALIASES[normalizeLookupBase(canonicalCompoundName)] || '',
   ].filter(Boolean)
 
   if (canonicalId && compoundIndex.byId.get(canonicalId)) {
-    return { compound: compoundIndex.byId.get(canonicalId), matchType: 'slug' }
+    return { compound: compoundIndex.byId.get(canonicalId), matchType: 'id' }
   }
 
   if (compoundName && compoundIndex.byName.get(compoundName.toLowerCase())) {
-    return { compound: compoundIndex.byName.get(compoundName.toLowerCase()), matchType: 'name' }
+    return { compound: compoundIndex.byName.get(compoundName.toLowerCase()), matchType: 'name-fallback' }
+  }
+
+  if (canonicalCompoundName && compoundIndex.byName.get(canonicalCompoundName.toLowerCase())) {
+    return { compound: compoundIndex.byName.get(canonicalCompoundName.toLowerCase()), matchType: 'name-fallback' }
+  }
+
+  if (compoundNameSlug && compoundIndex.bySlug.get(compoundNameSlug)) {
+    return { compound: compoundIndex.bySlug.get(compoundNameSlug), matchType: 'name-fallback' }
+  }
+
+  if (canonicalCompoundNameSlug && compoundIndex.bySlug.get(canonicalCompoundNameSlug)) {
+    return { compound: compoundIndex.bySlug.get(canonicalCompoundNameSlug), matchType: 'name-fallback' }
   }
 
   const aliasMatch = aliasTargets
     .map(
       (value) =>
-        compoundIndex.byVariant.get(value) || compoundIndex.byId.get(value) || compoundIndex.byName.get(value.toLowerCase())
+        compoundIndex.byVariant.get(value) ||
+        compoundIndex.bySlug.get(slugify(value)) ||
+        compoundIndex.byId.get(value) ||
+        compoundIndex.byName.get(value.toLowerCase())
     )
     .find(Boolean)
 
   if (aliasMatch) {
-    return { compound: aliasMatch, matchType: 'variant' }
+    return { compound: aliasMatch, matchType: 'name-fallback' }
   }
 
   return { compound: null, matchType: 'unmatched' }
 }
 
-function patchCompound(compound, row, fieldPatchCounts) {
+function patchCompound(compound, row, compoundIndex, fieldPatchCounts) {
   let patched = false
 
   const workbookCanonicalId = cleanText(row.canonicalCompoundId)
@@ -603,10 +643,17 @@ function patchCompound(compound, row, fieldPatchCounts) {
     (workbookCanonicalId && isStableSlug(workbookCanonicalId)) ||
     (weakScalar(compound.canonicalCompoundId, { minLength: 3 }) && isStableSlug(fallbackCanonicalId))
 
-  if (canPatchCanonicalId && shouldPatchScalar(compound.canonicalCompoundId, canonicalId, { minCandidateLength: 3, minGain: 0 })) {
+  const canonicalIdOwner = canonicalId ? compoundIndex.byId.get(canonicalId) : null
+  const canonicalIdIsUnique = !canonicalIdOwner || canonicalIdOwner === compound
+
+  if (
+    canonicalIdIsUnique &&
+    canPatchCanonicalId &&
+    shouldPatchScalar(compound.canonicalCompoundId, canonicalId, { minCandidateLength: 3, minGain: 0 })
+  ) {
     patched = patchField(compound, 'canonicalCompoundId', canonicalId, fieldPatchCounts) || patched
   }
-  if (canPatchCanonicalId && shouldPatchScalar(compound.id, canonicalId, { minCandidateLength: 3, minGain: 0 })) {
+  if (canonicalIdIsUnique && canPatchCanonicalId && shouldPatchScalar(compound.id, canonicalId, { minCandidateLength: 3, minGain: 0 })) {
     patched = patchField(compound, 'id', canonicalId, fieldPatchCounts) || patched
   }
 
@@ -737,8 +784,8 @@ function main() {
     herbs: {},
     compounds: {},
   }
-  const herbMatchTypeCounts = { slug: 0, name: 0, variant: 0 }
-  const compoundMatchTypeCounts = { slug: 0, name: 0, variant: 0 }
+  const herbMatchTypeCounts = { direct: 0, aliasFallback: 0 }
+  const compoundMatchTypeCounts = { id: 0, nameFallback: 0, unmatched: 0 }
 
   const herbLog = {
     matchedAndPatched: [],
@@ -761,7 +808,11 @@ function main() {
       })
       continue
     }
-    herbMatchTypeCounts[matchType] = (herbMatchTypeCounts[matchType] || 0) + 1
+    if (matchType === 'slug' || matchType === 'name') {
+      herbMatchTypeCounts.direct += 1
+    } else {
+      herbMatchTypeCounts.aliasFallback += 1
+    }
 
     const patched = patchHerb(herb, row, fieldPatchCounts.herbs)
     const payload = {
@@ -788,9 +839,13 @@ function main() {
       })
       continue
     }
-    compoundMatchTypeCounts[matchType] = (compoundMatchTypeCounts[matchType] || 0) + 1
+    if (matchType === 'id') {
+      compoundMatchTypeCounts.id += 1
+    } else {
+      compoundMatchTypeCounts.nameFallback += 1
+    }
 
-    const patched = patchCompound(compound, row, fieldPatchCounts.compounds)
+    const patched = patchCompound(compound, row, compoundIndex, fieldPatchCounts.compounds)
     const payload = {
       rowCompoundId: cleanText(row.canonicalCompoundId),
       rowCompoundName: cleanText(row.compoundName),
@@ -805,6 +860,7 @@ function main() {
       compoundLog.matchedNoChange.push(payload)
     }
   }
+  compoundMatchTypeCounts.unmatched = compoundLog.unmatched.length
 
   ensureReportsDir()
   writeJson(unmatchedHerbsReportPath, herbLog.unmatched)
@@ -819,10 +875,10 @@ function main() {
   console.log(`[import-xlsx-monographs] workbook: ${workbookPath}`)
   console.log(`[import-xlsx-monographs] rows read => herbs: ${herbRows.length}, compounds: ${compoundRows.length}`)
   console.log(
-    `[import-xlsx-monographs] rows matched by slug => herbs: ${herbMatchTypeCounts.slug}, compounds: ${compoundMatchTypeCounts.slug}`
+    `[import-xlsx-monographs] herb matches => direct: ${herbMatchTypeCounts.direct}, alias-fallback: ${herbMatchTypeCounts.aliasFallback}`
   )
   console.log(
-    `[import-xlsx-monographs] rows matched by name/variant => herbs: ${herbMatchTypeCounts.name + herbMatchTypeCounts.variant}, compounds: ${compoundMatchTypeCounts.name + compoundMatchTypeCounts.variant}`
+    `[import-xlsx-monographs] compound matches => by-id: ${compoundMatchTypeCounts.id}, by-name-fallback: ${compoundMatchTypeCounts.nameFallback}, unmatched: ${compoundMatchTypeCounts.unmatched}`
   )
   console.log(
     `[import-xlsx-monographs] rows patched => herbs: ${herbLog.matchedAndPatched.length}, compounds: ${compoundLog.matchedAndPatched.length}`


### PR DESCRIPTION
### Motivation
- Reduce fragility when workbook rows lack `canonicalCompoundId` by using additional deterministic fallbacks and more name signals. 
- Improve herb matching by using workbook-provided alias/common-name signals and normalized name variants as safe fallbacks. 
- Prevent accidental overwrites or duplicate slugs/IDs when merging workbook data into existing site data.

### Description
- Key file changed: `scripts/import-xlsx-monographs.mjs`.
- Compound matching: added a `bySlug` lookup index and expanded `resolveCompound` to check `compoundName`, `canonicalCompoundName`, and deterministic slug fallbacks before variant lookup, while preserving direct canonical-ID precedence. 
- Compound safety: `patchCompound` now checks the pre-built `compoundIndex` to ensure a `canonicalCompoundId`/`id` is only assigned if it is unowned or already owned by the same record to avoid creating duplicate slugs/IDs during merge. 
- Herb alias fallback: `resolveHerb` now includes workbook `aliases`, `commonNames`, and normalized name variants in alias-targets, and `patchHerb` applies a tiered alias patch (`aliases` → `commonNames` → name variants) but does not overwrite an existing non-empty `herb.aliases` array. 
- Logging: replaced the old match-type counters with explicit counters and log lines reporting herb matches as `direct` vs `alias-fallback` and compound matches as `by-id` vs `by-name-fallback` vs `unmatched`.
- Matching strategy (concise): Herbs: slug/name first, then workbook aliases → commonNames → normalized name variants → explicit alias map; Compounds: canonical ID first, then `compoundName`/`canonicalCompoundName` exact-name, slugified name fallbacks, then variant/explicit aliases, with duplicate-ID guard before any `id`/`canonicalCompoundId` patch.

### Testing
- Commands run: `node scripts/import-xlsx-monographs.mjs --dry-run` and `git commit` (pre-commit hooks / `eslint` passed). 
- Verification results: dry-run completed successfully and printed match/patch counts (example run): `rows read => herbs: 172, compounds: 630`, `herb matches => direct: 17, alias-fallback: 0`, `compound matches => by-id: 0, by-name-fallback: 530, unmatched: 100`, `rows patched => herbs: 5, compounds: 40`.
- Automated checks: pre-commit linting executed during commit and passed.
- Remaining weak points / follow-ups: the uniqueness guard relies on the initial `compoundIndex` (it does not re-index mid-run for IDs patched earlier in the same run), and workbook text quality/noise can still cause unmatched herbs or compounds so expanding explicit alias dictionaries remains beneficial.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db145a56b483239c23797ee322e198)