### PR TITLE
Unify workbook path resolution to repository root

### DIFF
--- a/scripts/export-workbook-to-json.mjs
+++ b/scripts/export-workbook-to-json.mjs
@@ -2,11 +2,14 @@
 
 import fs from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import XLSX from 'xlsx'
 import { resolveWorkbookPath } from './workbook-source.mjs'
 import { canonicalizeWorkbookRow } from './workbook-column-mapping.mjs'
 
-const repoRoot = process.cwd()
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const repoRoot = path.resolve(__dirname, '..')
 const workbookPath = resolveWorkbookPath(repoRoot)
 const dataDir = path.join(repoRoot, 'public', 'data')
 const EXPORT_WORKBOOK_SHEETS = ['Herb Monographs', 'Compound Master V3', 'Herb Compound Map V3', 'Production Export V1']

--- a/scripts/sync-updated-datasets.mjs
+++ b/scripts/sync-updated-datasets.mjs
@@ -2,9 +2,12 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { execFileSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
 import { resolveWorkbookPath } from './workbook-source.mjs'
 
-const root = process.cwd()
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const root = path.resolve(__dirname, '..')
 const outDir = path.join(root, 'public', 'data')
 
 const UPDATED_DATASETS_DIR = process.env.UPDATED_DATASETS_DIR

--- a/scripts/verify-workbook-import-reconciliation.mjs
+++ b/scripts/verify-workbook-import-reconciliation.mjs
@@ -3,10 +3,13 @@
 import { execFileSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import XLSX from 'xlsx'
 import { resolveWorkbookPath } from './workbook-source.mjs'
 
-const repoRoot = process.cwd()
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const repoRoot = path.resolve(__dirname, '..')
 const workbookPath = resolveWorkbookPath(repoRoot)
 const REQUIRED_WORKBOOK_SHEETS = ['Herb Monographs', 'Compound Master V3']
 const herbsPath = path.join(repoRoot, 'public', 'data', 'herbs.json')


### PR DESCRIPTION
### Motivation
- Ensure all importer/exporter/sync scripts consistently resolve the workbook at `data-sources/herb_monograph_master.xlsx` while preserving the `HERB_XLSX_PATH` override. 
- Remove ambiguity caused by scripts depending on the invocation CWD so path resolution is stable regardless of how scripts are run.

### Description
- Standardized repo-root derivation to use the script location via `fileURLToPath(import.meta.url)` and `path.resolve(__dirname, '..')` instead of `process.cwd()` in three scripts. 
- Updated `scripts/export-workbook-to-json.mjs`, `scripts/verify-workbook-import-reconciliation.mjs`, and `scripts/sync-updated-datasets.mjs` to import `fileURLToPath` and compute `repoRoot` before calling `resolveWorkbookPath(repoRoot)`. 
- Preserved central workbook resolution logic in `scripts/workbook-source.mjs` which prefers `HERB_XLSX_PATH` when set and otherwise falls back to `data-sources/herb_monograph_master.xlsx`, so the importer/exporter contract and workbook filename are unchanged. 
- Files changed: `scripts/export-workbook-to-json.mjs`, `scripts/sync-updated-datasets.mjs`, `scripts/verify-workbook-import-reconciliation.mjs`.

### Testing
- Verified fallback and override behavior with `node --input-type=module -e "import path from 'node:path'; import { resolveWorkbookPath } from './scripts/workbook-source.mjs'; const root=path.resolve('.'); console.log('fallback='+resolveWorkbookPath(root,{envPath:''})); console.log('override='+resolveWorkbookPath(root,{envPath:'data-sources/herb_monograph_master.xlsx'}));"`, and both resolved to the expected workbook path. (succeeded)
- Confirmed the workbook file exists with `test -f data-sources/herb_monograph_master.xlsx && echo "workbook exists"`. (succeeded)
- Pre-commit linting (`eslint --max-warnings=0`) ran successfully during the commit flow for the changed files. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db83f273f08323947525e035509b16)