### PR TITLE
Harden workbook parsing and normalization for herb_monograph_master.xlsx

### DIFF
--- a/scripts/export-workbook-to-json.mjs
+++ b/scripts/export-workbook-to-json.mjs
@@ -5,7 +5,12 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import XLSX from 'xlsx'
 import { resolveWorkbookPath } from './workbook-source.mjs'
-import { canonicalizeWorkbookRow } from './workbook-column-mapping.mjs'
+import {
+  canonicalizeWorkbookRow,
+  hasMeaningfulWorkbookValue,
+  normalizeWorkbookCell,
+  normalizeWorkbookMultiValue,
+} from './workbook-column-mapping.mjs'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -14,7 +19,6 @@ const workbookPath = resolveWorkbookPath(repoRoot)
 const dataDir = path.join(repoRoot, 'public', 'data')
 const EXPORT_WORKBOOK_SHEETS = ['Herb Monographs', 'Compound Master V3', 'Herb Compound Map V3', 'Production Export V1']
 const OPTIONAL_WORKBOOK_SHEETS = new Set(['Production Export V1'])
-const WEAK_TEXT_VALUES = new Set(['nan', 'null', 'undefined', 'n/a', 'na', 'none', 'nil'])
 const SHEET_REQUIRED_COLUMNS = {
   'Herb Monographs': ['name', 'publishStatus'],
   'Compound Master V3': ['compoundName'],
@@ -39,28 +43,24 @@ function createDiagnostics() {
 }
 
 function toCleanString(value) {
-  const text = String(value ?? '').trim()
-  if (!text) return ''
-  if (WEAK_TEXT_VALUES.has(text.toLowerCase())) return ''
-  return text
+  const cleaned = normalizeWorkbookCell(value)
+  if (cleaned === '') return ''
+  return String(cleaned).trim()
 }
 
 function splitList(value, pattern = /[;|]/) {
-  const text = toCleanString(value)
-  if (!text) return []
-  return [...new Set(text.split(pattern).map(item => toCleanString(item)).filter(Boolean))]
+  return normalizeWorkbookMultiValue(value, pattern).map(item => toCleanString(item)).filter(Boolean)
 }
 
 function cleanScalar(value) {
-  if (value == null) return ''
-  if (typeof value === 'string') return toCleanString(value)
-  return value
+  const normalized = normalizeWorkbookCell(value)
+  if (normalized === '') return ''
+  if (typeof normalized === 'string') return toCleanString(normalized)
+  return normalized
 }
 
 function isMeaningfulValue(value) {
-  if (value == null) return false
-  if (typeof value === 'string') return toCleanString(value) !== ''
-  return true
+  return hasMeaningfulWorkbookValue(value)
 }
 
 function splitSemicolonOrCommaList(value) {
@@ -286,7 +286,8 @@ function writeJson(filename, records) {
 
 function main() {
   const diagnostics = createDiagnostics()
-  const workbook = XLSX.readFile(workbookPath)
+  const workbook = XLSX.readFile(workbookPath, { sheets: EXPORT_WORKBOOK_SHEETS })
+  const ignoredSheets = workbook.SheetNames.filter(sheetName => !EXPORT_WORKBOOK_SHEETS.includes(sheetName))
 
   for (const sheetName of EXPORT_WORKBOOK_SHEETS) {
     if (!workbook.Sheets[sheetName] && !OPTIONAL_WORKBOOK_SHEETS.has(sheetName)) {
@@ -298,6 +299,10 @@ function main() {
   writeJson('workbook-compounds.json', exportCompounds(workbook, diagnostics))
   writeJson('workbook-herb-compound-map.json', exportHerbCompoundMap(workbook, diagnostics))
   writeJson('workbook-goal-bundles.json', exportGoalBundles(workbook, diagnostics))
+
+  console.log(
+    `[export][diagnostics] ignored non-target sheets: ${ignoredSheets.length > 0 ? ignoredSheets.join(', ') : '(none)'}`
+  )
 
   for (const sheetName of EXPORT_WORKBOOK_SHEETS) {
     const sheetDiagnostics = diagnostics.sheets[sheetName]

--- a/scripts/import-xlsx-monographs.mjs
+++ b/scripts/import-xlsx-monographs.mjs
@@ -5,7 +5,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import XLSX from 'xlsx'
 import { resolveWorkbookPath } from './workbook-source.mjs'
-import { canonicalizeWorkbookRow } from './workbook-column-mapping.mjs'
+import { canonicalizeWorkbookRow, hasMeaningfulWorkbookValue, normalizeWorkbookCell } from './workbook-column-mapping.mjs'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -13,6 +13,14 @@ const repoRoot = path.resolve(__dirname, '..')
 
 const workbookPath = resolveWorkbookPath(repoRoot)
 const REQUIRED_WORKBOOK_SHEETS = ['Herb Monographs', 'Compound Master V3']
+const TARGET_WORKBOOK_SHEETS = ['Herb Monographs', 'Compound Master V3', 'Herb Compound Map V3', 'Production Export V1']
+const OPTIONAL_WORKBOOK_SHEETS = new Set(['Production Export V1'])
+const SHEET_REQUIRED_COLUMNS = {
+  'Herb Monographs': ['name'],
+  'Compound Master V3': ['compoundName'],
+  'Herb Compound Map V3': ['herbSlug', 'canonicalCompoundId'],
+  'Production Export V1': ['goal'],
+}
 
 const herbsPath = path.join(repoRoot, 'public', 'data', 'herbs.json')
 const compoundsPath = path.join(repoRoot, 'public', 'data', 'compounds.json')
@@ -70,7 +78,8 @@ function parseArgs(argv) {
 }
 
 function cleanText(value) {
-  const input = String(value ?? '').trim()
+  const normalized = normalizeWorkbookCell(value)
+  const input = String(normalized ?? '').trim()
   if (!input) return ''
 
   let output = input
@@ -358,9 +367,26 @@ function canonicalizeRow(row) {
   return out
 }
 
-function parseSheet(workbook, sheetName) {
+function createDiagnostics() {
+  return {
+    sheets: Object.fromEntries(
+      TARGET_WORKBOOK_SHEETS.map(sheetName => [
+        sheetName,
+        { loadedRows: 0, skippedRows: 0, parseWarnings: [], missingRequiredColumns: [] },
+      ])
+    ),
+    ignoredSheets: [],
+  }
+}
+
+function parseSheet(workbook, sheetName, diagnostics, { optional = false } = {}) {
+  const sheetDiagnostics = diagnostics.sheets[sheetName]
   const sheet = workbook.Sheets[sheetName]
   if (!sheet) {
+    if (optional) {
+      sheetDiagnostics.parseWarnings.push('Sheet not present; treated as optional and skipped.')
+      return []
+    }
     throw new Error(`[import-xlsx-monographs] Missing required worksheet: ${sheetName}`)
   }
 
@@ -369,8 +395,22 @@ function parseSheet(workbook, sheetName) {
     raw: false,
     blankrows: false,
   })
+  sheetDiagnostics.loadedRows = rows.length
 
-  return rows.map(row => canonicalizeWorkbookRow(canonicalizeRow(row), sheetName))
+  const canonicalRows = rows.map(row => canonicalizeWorkbookRow(canonicalizeRow(row), sheetName))
+  const requiredColumns = SHEET_REQUIRED_COLUMNS[sheetName] || []
+  const observedColumns = new Set(canonicalRows.flatMap(row => Object.keys(row || {})))
+  const missingRequiredColumns = requiredColumns.filter(column => !observedColumns.has(column))
+  if (missingRequiredColumns.length > 0) {
+    sheetDiagnostics.missingRequiredColumns = missingRequiredColumns
+    sheetDiagnostics.parseWarnings.push(`Missing required columns: ${missingRequiredColumns.join(', ')}`)
+  }
+
+  return canonicalRows.filter(row => {
+    const hasData = Object.values(row || {}).some(hasMeaningfulWorkbookValue)
+    if (!hasData) sheetDiagnostics.skippedRows += 1
+    return hasData
+  })
 }
 
 function slugify(value) {
@@ -762,14 +802,18 @@ function writeJson(filePath, data) {
 
 function main() {
   const options = parseArgs(process.argv.slice(2))
+  const diagnostics = createDiagnostics()
 
   if (!fs.existsSync(workbookPath)) {
     throw new Error(`[import-xlsx-monographs] Workbook not found at ${workbookPath}`)
   }
 
-  const workbook = XLSX.readFile(workbookPath, { sheets: REQUIRED_WORKBOOK_SHEETS })
-  const herbRows = parseSheet(workbook, REQUIRED_WORKBOOK_SHEETS[0])
-  const compoundRows = parseSheet(workbook, REQUIRED_WORKBOOK_SHEETS[1])
+  const workbook = XLSX.readFile(workbookPath, { sheets: TARGET_WORKBOOK_SHEETS })
+  diagnostics.ignoredSheets = workbook.SheetNames.filter(sheetName => !TARGET_WORKBOOK_SHEETS.includes(sheetName))
+  const herbRows = parseSheet(workbook, REQUIRED_WORKBOOK_SHEETS[0], diagnostics)
+  const compoundRows = parseSheet(workbook, REQUIRED_WORKBOOK_SHEETS[1], diagnostics)
+  parseSheet(workbook, 'Herb Compound Map V3', diagnostics)
+  parseSheet(workbook, 'Production Export V1', diagnostics, { optional: OPTIONAL_WORKBOOK_SHEETS.has('Production Export V1') })
 
   const herbs = JSON.parse(fs.readFileSync(herbsPath, 'utf8'))
   const compounds = JSON.parse(fs.readFileSync(compoundsPath, 'utf8'))
@@ -873,6 +917,9 @@ function main() {
 
   console.log(`[import-xlsx-monographs] mode: ${options.dryRun ? 'dry-run' : 'apply'}`)
   console.log(`[import-xlsx-monographs] workbook: ${workbookPath}`)
+  console.log(
+    `[import-xlsx-monographs] ignored non-target sheets: ${diagnostics.ignoredSheets.length > 0 ? diagnostics.ignoredSheets.join(', ') : '(none)'}`
+  )
   console.log(`[import-xlsx-monographs] rows read => herbs: ${herbRows.length}, compounds: ${compoundRows.length}`)
   console.log(
     `[import-xlsx-monographs] herb matches => direct: ${herbMatchTypeCounts.direct}, alias-fallback: ${herbMatchTypeCounts.aliasFallback}`
@@ -896,6 +943,18 @@ function main() {
   console.log(`[import-xlsx-monographs] compound field patch counts: ${JSON.stringify(fieldPatchCounts.compounds)}`)
   console.log(`[import-xlsx-monographs] unmatched herb report: ${path.relative(repoRoot, unmatchedHerbsReportPath)}`)
   console.log(`[import-xlsx-monographs] unmatched compound report: ${path.relative(repoRoot, unmatchedCompoundsReportPath)}`)
+  for (const sheetName of TARGET_WORKBOOK_SHEETS) {
+    const sheetDiagnostics = diagnostics.sheets[sheetName]
+    console.log(`[import-xlsx-monographs][diagnostics] ${sheetName}: loaded=${sheetDiagnostics.loadedRows} skipped=${sheetDiagnostics.skippedRows}`)
+    if (sheetDiagnostics.missingRequiredColumns.length > 0) {
+      console.warn(
+        `[import-xlsx-monographs][diagnostics] ${sheetName}: missing required columns => ${sheetDiagnostics.missingRequiredColumns.join(', ')}`
+      )
+    }
+    for (const warning of sheetDiagnostics.parseWarnings) {
+      console.warn(`[import-xlsx-monographs][diagnostics] ${sheetName}: warning => ${warning}`)
+    }
+  }
 }
 
 try {

--- a/scripts/workbook-column-mapping.mjs
+++ b/scripts/workbook-column-mapping.mjs
@@ -1,4 +1,5 @@
 const HEADER_NORMALIZATION_PATTERN = /[^a-z0-9]+/g
+const WEAK_TEXT_VALUES = new Set(['nan', 'null', 'undefined', 'n/a', 'na', 'none', 'nil'])
 
 const SHEET_HEADER_ALIASES = {
   'Herb Monographs': {
@@ -46,6 +47,34 @@ function normalizeHeaderKey(value) {
     .replace(HEADER_NORMALIZATION_PATTERN, '')
 }
 
+export function normalizeWorkbookCell(value) {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'number' && Number.isNaN(value)) return ''
+  if (typeof value === 'string') {
+    const text = value.trim()
+    if (!text) return ''
+    if (WEAK_TEXT_VALUES.has(text.toLowerCase())) return ''
+    return text
+  }
+  return value
+}
+
+export function hasMeaningfulWorkbookValue(value) {
+  const normalized = normalizeWorkbookCell(value)
+  if (normalized === '') return false
+  if (Array.isArray(normalized)) return normalized.length > 0
+  return normalized !== null && normalized !== undefined
+}
+
+export function normalizeWorkbookMultiValue(value, splitPattern = /[;|]/) {
+  if (Array.isArray(value)) {
+    return [...new Set(value.map(item => normalizeWorkbookCell(item)).filter(Boolean))]
+  }
+  const text = normalizeWorkbookCell(value)
+  if (typeof text !== 'string' || !text) return []
+  return [...new Set(text.split(splitPattern).map(item => normalizeWorkbookCell(item)).filter(Boolean))]
+}
+
 export function canonicalizeWorkbookRow(row, sheetName) {
   const aliases = SHEET_HEADER_ALIASES[sheetName] || {}
   const out = {}
@@ -56,7 +85,7 @@ export function canonicalizeWorkbookRow(row, sheetName) {
 
     const normalizedKey = normalizeHeaderKey(trimmedKey)
     const mappedKey = aliases[normalizedKey] || trimmedKey
-    out[mappedKey] = value
+    out[mappedKey] = normalizeWorkbookCell(value)
   }
 
   return out


### PR DESCRIPTION
### Motivation
- Make parsing of `data-sources/herb_monograph_master.xlsx` safer and more consistent for the Herb Monographs and Compound flows while preserving existing frontend contracts. 
- Centralize normalization so weak cell values (null/undefined/NaN/empty/whitespace/weak tokens) and multi-value fields are handled uniformly and non-target sheets are ignored by default. 
- Remaining parsing risks: required-column checks are presence-based not content-quality checks, delimiter assumptions (`;`, `|`, `,`) may still miss unusual punctuation, and the Map/Production sheets are parsed for diagnostics only so further guarded integration would be needed if they must drive behavior.

### Description
- Added shared helpers to `scripts/workbook-column-mapping.mjs`: `normalizeWorkbookCell`, `hasMeaningfulWorkbookValue`, and `normalizeWorkbookMultiValue`, and changed `canonicalizeWorkbookRow` to normalize each cell value.
- Updated `scripts/export-workbook-to-json.mjs` to use the shared normalization and multi-value helpers, read only the target sheets (`Herb Monographs`, `Compound Master V3`, `Herb Compound Map V3`, optional `Production Export V1`), and log ignored non-target sheets and per-sheet diagnostics (loaded/skipped rows, missing required columns, warnings).
- Updated `scripts/import-xlsx-monographs.mjs` to use the same helpers, parse the same target sheet set (including optional `Production Export V1` for diagnostics), add per-sheet diagnostics and missing-column warnings, and keep importing/applying patches only from the Herb and Compound sheets to preserve backward compatibility; `cleanText` now begins from normalized cell values.
- Changed files: `scripts/workbook-column-mapping.mjs`, `scripts/export-workbook-to-json.mjs`, `scripts/import-xlsx-monographs.mjs`.

### Testing
- Ran syntax checks: `node --check scripts/workbook-column-mapping.mjs`, `node --check scripts/export-workbook-to-json.mjs`, and `node --check scripts/import-xlsx-monographs.mjs`, and all checks passed. 
- Pre-commit linting (`eslint --max-warnings=0`) ran as part of the commit flow and passed on the modified `.mjs` files. 
- No automated runtime integration tests were added; changes are limited to normalization and diagnostics and preserve existing external schema/column names.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db84ca48088323bf265ae234a5098c)