### PR TITLE
data: refresh workbook compound slugs via workbook sync pipeline

### DIFF
--- a/public/data/compounds.json
+++ b/public/data/compounds.json
@@ -12427,7 +12427,7 @@
       }
     ],
     "lastUpdated": "2026-04-04",
-    "slug": "niacin",
+    "slug": "niacin-vitamin-b3",
     "id": "niacin",
     "displayName": "Niacin (Vitamin B3)"
   },
@@ -12456,7 +12456,7 @@
       }
     ],
     "lastUpdated": "2026-04-04",
-    "slug": "omega-3-fatty-acids",
+    "slug": "omega-3-fatty-acids-epa-dha",
     "id": "omega-3-fatty-acids",
     "displayName": "Omega-3 Fatty Acids (EPA/DHA)"
   },
@@ -12481,7 +12481,7 @@
       }
     ],
     "lastUpdated": "2026-04-04",
-    "slug": "pyridoxine",
+    "slug": "pyridoxine-vitamin-b6",
     "id": "pyridoxine",
     "displayName": "Pyridoxine (Vitamin B6)"
   },
@@ -12506,7 +12506,7 @@
       }
     ],
     "lastUpdated": "2026-04-04",
-    "slug": "riboflavin",
+    "slug": "riboflavin-vitamin-b2",
     "id": "riboflavin",
     "displayName": "Riboflavin (Vitamin B2)"
   },
@@ -12535,7 +12535,7 @@
       }
     ],
     "lastUpdated": "2026-04-04",
-    "slug": "s-adenosyl-l-methionine",
+    "slug": "s-adenosyl-l-methionine-same",
     "id": "s-adenosyl-l-methionine",
     "displayName": "S-Adenosyl-L-Methionine (SAMe)"
   },
@@ -12563,7 +12563,7 @@
       }
     ],
     "lastUpdated": "2026-04-04",
-    "slug": "vitamin-d",
+    "slug": "vitamin-d-calciferols",
     "id": "vitamin-d",
     "displayName": "Vitamin D (Calciferols)"
   }


### PR DESCRIPTION
### Motivation
- Improve workbook → site reconciliation by applying the existing identity-map flow and re-running the full export/import/merge pipeline using the mandated workbook `data-sources/herb_monograph_master.xlsx`.
- Produce clear before/after coverage metrics and reports while preserving existing architecture, workbook sheet/column names, and frontend compatibility.

### Description
- No code/architecture or workbook schema changes were made; the run used the existing export/import/merge pipeline (`export` + `import overlay` + `merge`).
- Updated one data file: `public/data/compounds.json` to align several compound slugs with the workbook overlay output.
- Identity-map loading/application was exercised via the existing importer, and unmatched reports were written to `reports/workbook-unmatched-herbs.json` and `reports/workbook-unmatched-compounds.json` for inspection.
- Key slug updates in `public/data/compounds.json`: `niacin` → `niacin-vitamin-b3`, `omega-3-fatty-acids` → `omega-3-fatty-acids-epa-dha`, `pyridoxine` → `pyridoxine-vitamin-b6`, `riboflavin` → `riboflavin-vitamin-b2`, `s-adenosyl-l-methionine` → `s-adenosyl-l-methionine-same`, `vitamin-d` → `vitamin-d-calciferols`.

### Testing
- Ran `node scripts/verify-workbook-import-reconciliation.mjs` to capture baseline exact-match coverage and to parse importer output; the verification assertions passed (reports present and counts reconciled).
- Executed the full sync flow via `node scripts/sync-updated-datasets.mjs` which runs `export` then `import-xlsx-monographs.mjs`; the export wrote workbook JSON and the importer applied overlays and produced unmatched reports.
- Observed coverage metrics: herbs baseline `68/172` → reconciled `121/172` (+53 matched rows; +77.94% relative improvement; +30.81 percentage points coverage), compounds baseline `0/630` → reconciled `130/630` (+130 matched rows; +20.63 percentage points coverage; step-change from zero).
- Dataset counts remained stable: `public/data/herbs.json` 812 → 812 and `public/data/compounds.json` 407 → 407, and importer reported `matched via identity map: 0` for both herbs and compounds; unmatched reports contain 51 herbs and 500 compounds and are available in `reports/`.
- All automated verification checks completed successfully (coverage assertions and unmatched-report reconciliations passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db98e99fa0832392722376f198560e)