### PR TITLE
Preserve compound mechanismTags arrays during workbook import

### DIFF
--- a/scripts/import-xlsx-monographs.mjs
+++ b/scripts/import-xlsx-monographs.mjs
@@ -962,8 +962,6 @@ function patchCompound(compound, row, reservedCanonicalIds, fieldPatchCounts) {
   const mechanismTags = dedupeStrings(splitSemicolonDelimited(row.mechanismTags))
   if (shouldPatchArray(compound.mechanismTags, mechanismTags, { minItems: 1, minGain: 12 })) {
     patched = patchField(compound, 'mechanismTags', mechanismTags, fieldPatchCounts) || patched
-  } else if (shouldPatchScalar(compound.mechanismTags, mechanismTags.join('; '), { minCandidateLength: 2, minGain: 0 })) {
-    patched = patchField(compound, 'mechanismTags', mechanismTags.join('; '), fieldPatchCounts) || patched
   }
 
   const pathwayTargets = dedupeStrings(splitSemicolonDelimited(row.pathwayTargets))


### PR DESCRIPTION
### Motivation
- Prevent the workbook importer from converting `compound.mechanismTags` arrays into semicolon-delimited strings, which can cause type drift and break frontend consumers that expect arrays.

### Description
- Removed the scalar fallback branch in `patchCompound` so `mechanismTags` are only patched as arrays (2-line deletion in `scripts/import-xlsx-monographs.mjs`), preserving existing array-path behavior and identity-map matching.

### Testing
- Ran `npm run import:xlsx:monographs`, `node scripts/import-xlsx-monographs.mjs --dry-run`, and `npm run verify:workbook-import`; results: baseline exact-match coverage `herbs 68/172`, `compounds 0/630`, reconciled dry-run `herbs 130/172`, `compounds 132/630`, identity-map matches `herbs 9`, `compounds 2`, unmatched `herbs 42`, `compounds 498`, herb improvement +62 matches (+91.18% relative) and compound absolute gain +132 matches (+20.95 percentage points), and `npm run data:refresh` failed in this environment due to missing local CSV inputs (expected for operator-local refresh).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db9dc77f048323a6d4325464d012cf)