### PR TITLE
Add high-confidence herb identity mappings for butterbur and nettle root

### DIFF
--- a/data/identity/herb-identity-map.json
+++ b/data/identity/herb-identity-map.json
@@ -1,10 +1,12 @@
 {
   "bupleurum": "bupleurum-falcatum",
+  "butterbur": "petasites-hybridus",
   "cacao": "theobroma-cacao",
   "cordyceps": "cordyceps-sinensis",
   "dendrobium": "dendrobium-nobile",
   "holy basil purple": "holy-basil",
   "holy basil seed": "holy-basil",
+  "nettle root": "urtica-dioica",
   "ocimum sanctum": "holy-basil",
   "poria": "poria-cocos",
   "reishi": "reishi-mushroom",

--- a/reports/workbook-unmatched-herbs.json
+++ b/reports/workbook-unmatched-herbs.json
@@ -15,11 +15,6 @@
     "scientificName": "Tanacetum parthenium"
   },
   {
-    "slug": "butterbur",
-    "name": "Butterbur",
-    "scientificName": "Petasites hybridus"
-  },
-  {
     "slug": "pau-darco",
     "name": "Pau d'Arco",
     "scientificName": "Handroanthus impetiginosus"
@@ -188,11 +183,6 @@
     "slug": "turkey-tail",
     "name": "Turkey Tail",
     "scientificName": "Trametes versicolor"
-  },
-  {
-    "slug": "nettle-root",
-    "name": "Nettle Root",
-    "scientificName": "Urtica dioica"
   },
   {
     "slug": "epimedium",


### PR DESCRIPTION
### Motivation
- Resolve remaining exact-match unmatched herbs from the workbook import by supplying only high-confidence identity mappings without changing architecture, sheet/column names, or slug system.

### Description
- Inserted two high-confidence mappings into `data/identity/herb-identity-map.json`: `"butterbur": "petasites-hybridus"` and `"nettle root": "urtica-dioica"`, and removed the now-matched rows from `reports/workbook-unmatched-herbs.json` after re-running the matching flow.

### Testing
- Ran `npm run import:xlsx:monographs -- --dry-run` which completed successfully (herb rows read: 172; matched: 132; remaining unmatched: 40; newly matched: 2) and verified the updated files `data/identity/herb-identity-map.json` and `reports/workbook-unmatched-herbs.json`; note coverage is now 76.74% (still below 90%), so additional verified mappings or entity additions are required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dba06eb0a083239c0a35526f213515)