### PR TITLE
Make workbook herb/compound slugs collision-safe

### DIFF
--- a/public/data/workbook-compounds.json
+++ b/public/data/workbook-compounds.json
@@ -107,7 +107,7 @@
   },
   {
     "id": "5-meo-dmt",
-    "slug": "5-meo-dmt",
+    "slug": "5-meo-dmt-wb",
     "canonicalCompoundId": "5-meo-dmt",
     "name": "5-meo-dmt",
     "compoundName": "5-meo-dmt",
@@ -155,7 +155,7 @@
   },
   {
     "id": "7-hydroxymitragynine",
-    "slug": "7-hydroxymitragynine",
+    "slug": "7-hydroxymitragynine-wb",
     "canonicalCompoundId": "7-hydroxymitragynine",
     "name": "7-hydroxymitragynine",
     "compoundName": "7-hydroxymitragynine",
@@ -260,7 +260,7 @@
   },
   {
     "id": "aconitine",
-    "slug": "aconitine",
+    "slug": "aconitine-wb",
     "canonicalCompoundId": "aconitine",
     "name": "aconitine",
     "compoundName": "aconitine",
@@ -396,7 +396,7 @@
   },
   {
     "id": "agrimoniin",
-    "slug": "agrimoniin",
+    "slug": "agrimoniin-wb",
     "canonicalCompoundId": "agrimoniin",
     "name": "agrimoniin",
     "compoundName": "agrimoniin",
@@ -502,7 +502,7 @@
   },
   {
     "id": "alchorneine",
-    "slug": "alchorneine",
+    "slug": "alchorneine-wb",
     "canonicalCompoundId": "alchorneine",
     "name": "alchorneine",
     "compoundName": "alchorneine",
@@ -592,7 +592,7 @@
   },
   {
     "id": "alpha-asarone",
-    "slug": "alpha-asarone",
+    "slug": "alpha-asarone-wb",
     "canonicalCompoundId": "alpha-asarone",
     "name": "alpha-asarone",
     "compoundName": "alpha-asarone",
@@ -727,7 +727,7 @@
   },
   {
     "id": "anabasine",
-    "slug": "anabasine",
+    "slug": "anabasine-wb",
     "canonicalCompoundId": "anabasine",
     "name": "anabasine",
     "compoundName": "anabasine",
@@ -848,7 +848,7 @@
   },
   {
     "id": "apigenin",
-    "slug": "apigenin",
+    "slug": "apigenin-wb",
     "canonicalCompoundId": "apigenin",
     "name": "Apigenin",
     "compoundName": "Apigenin",
@@ -896,7 +896,7 @@
   },
   {
     "id": "arbutin",
-    "slug": "arbutin",
+    "slug": "arbutin-wb",
     "canonicalCompoundId": "arbutin",
     "name": "arbutin",
     "compoundName": "arbutin",
@@ -1211,7 +1211,7 @@
   },
   {
     "id": "atropine",
-    "slug": "atropine",
+    "slug": "atropine-wb",
     "canonicalCompoundId": "atropine",
     "name": "atropine",
     "compoundName": "atropine",
@@ -1333,7 +1333,7 @@
   },
   {
     "id": "baicalin",
-    "slug": "baicalin",
+    "slug": "baicalin-wb",
     "canonicalCompoundId": "baicalin",
     "name": "Baicalin",
     "compoundName": "Baicalin",
@@ -1365,7 +1365,7 @@
   },
   {
     "id": "benzyl-isothiocyanate",
-    "slug": "benzyl-isothiocyanate",
+    "slug": "benzyl-isothiocyanate-wb",
     "canonicalCompoundId": "benzyl-isothiocyanate",
     "name": "benzyl isothiocyanate",
     "compoundName": "benzyl isothiocyanate",
@@ -1425,7 +1425,7 @@
   },
   {
     "id": "beta-asarone",
-    "slug": "beta-asarone",
+    "slug": "beta-asarone-wb",
     "canonicalCompoundId": "beta-asarone",
     "name": "beta-asarone",
     "compoundName": "beta-asarone",
@@ -1622,7 +1622,7 @@
   },
   {
     "id": "boldine",
-    "slug": "boldine",
+    "slug": "boldine-wb",
     "canonicalCompoundId": "boldine",
     "name": "boldine",
     "compoundName": "boldine",
@@ -1682,7 +1682,7 @@
   },
   {
     "id": "bufotenin",
-    "slug": "bufotenin",
+    "slug": "bufotenin-wb",
     "canonicalCompoundId": "bufotenin",
     "name": "bufotenin",
     "compoundName": "bufotenin",
@@ -1742,7 +1742,7 @@
   },
   {
     "id": "caffeic-acid",
-    "slug": "caffeic-acid",
+    "slug": "caffeic-acid-wb",
     "canonicalCompoundId": "caffeic-acid",
     "name": "caffeic acid",
     "compoundName": "caffeic acid",
@@ -1757,7 +1757,7 @@
   },
   {
     "id": "caffeine",
-    "slug": "caffeine",
+    "slug": "caffeine-wb",
     "canonicalCompoundId": "caffeine",
     "name": "Caffeine",
     "compoundName": "Caffeine",
@@ -1790,7 +1790,7 @@
   },
   {
     "id": "camphor",
-    "slug": "camphor",
+    "slug": "camphor-wb",
     "canonicalCompoundId": "camphor",
     "name": "camphor",
     "compoundName": "camphor",
@@ -1943,7 +1943,7 @@
   },
   {
     "id": "carvacrol",
-    "slug": "carvacrol",
+    "slug": "carvacrol-wb",
     "canonicalCompoundId": "carvacrol",
     "name": "carvacrol",
     "compoundName": "carvacrol",
@@ -2018,7 +2018,7 @@
   },
   {
     "id": "catechin",
-    "slug": "catechin",
+    "slug": "catechin-wb",
     "canonicalCompoundId": "catechin",
     "name": "Catechin",
     "compoundName": "Catechin",
@@ -2033,7 +2033,7 @@
   },
   {
     "id": "catechins",
-    "slug": "catechins",
+    "slug": "catechins-wb",
     "canonicalCompoundId": "catechins",
     "name": "catechins",
     "compoundName": "catechins",
@@ -2078,7 +2078,7 @@
   },
   {
     "id": "cbd",
-    "slug": "cbd",
+    "slug": "cbd-wb",
     "canonicalCompoundId": "cbd",
     "name": "cbd",
     "compoundName": "cbd",
@@ -2123,7 +2123,7 @@
   },
   {
     "id": "celastrine",
-    "slug": "celastrine",
+    "slug": "celastrine-wb",
     "canonicalCompoundId": "celastrine",
     "name": "Celastrine",
     "compoundName": "Celastrine",
@@ -2138,7 +2138,7 @@
   },
   {
     "id": "cephaeline",
-    "slug": "cephaeline",
+    "slug": "cephaeline-wb",
     "canonicalCompoundId": "cephaeline",
     "name": "cephaeline",
     "compoundName": "cephaeline",
@@ -2168,7 +2168,7 @@
   },
   {
     "id": "chamazulene",
-    "slug": "chamazulene",
+    "slug": "chamazulene-wb",
     "canonicalCompoundId": "chamazulene",
     "name": "chamazulene",
     "compoundName": "chamazulene",
@@ -2273,7 +2273,7 @@
   },
   {
     "id": "chlorogenic-acid",
-    "slug": "chlorogenic-acid",
+    "slug": "chlorogenic-acid-wb",
     "canonicalCompoundId": "chlorogenic-acid",
     "name": "chlorogenic acid",
     "compoundName": "chlorogenic acid",
@@ -2394,7 +2394,7 @@
   },
   {
     "id": "cineole",
-    "slug": "cineole",
+    "slug": "cineole-wb",
     "canonicalCompoundId": "cineole",
     "name": "cineole",
     "compoundName": "cineole",
@@ -2469,7 +2469,7 @@
   },
   {
     "id": "citral",
-    "slug": "citral",
+    "slug": "citral-wb",
     "canonicalCompoundId": "citral",
     "name": "citral",
     "compoundName": "citral",
@@ -2529,7 +2529,7 @@
   },
   {
     "id": "codeine",
-    "slug": "codeine",
+    "slug": "codeine-wb",
     "canonicalCompoundId": "codeine",
     "name": "codeine",
     "compoundName": "codeine",
@@ -2679,7 +2679,7 @@
   },
   {
     "id": "coronaridine",
-    "slug": "coronaridine",
+    "slug": "coronaridine-wb",
     "canonicalCompoundId": "coronaridine",
     "name": "coronaridine",
     "compoundName": "coronaridine",
@@ -2754,7 +2754,7 @@
   },
   {
     "id": "cryogenine-vertine",
-    "slug": "cryogenine-vertine",
+    "slug": "cryogenine-vertine-wb",
     "canonicalCompoundId": "cryogenine-vertine",
     "name": "cryogenine vertine",
     "compoundName": "cryogenine vertine",
@@ -3185,7 +3185,7 @@
   },
   {
     "id": "dmt",
-    "slug": "dmt",
+    "slug": "dmt-wb",
     "canonicalCompoundId": "dmt",
     "name": "dmt",
     "compoundName": "dmt",
@@ -3306,7 +3306,7 @@
   },
   {
     "id": "ellagic-acid",
-    "slug": "ellagic-acid",
+    "slug": "ellagic-acid-wb",
     "canonicalCompoundId": "ellagic-acid",
     "name": "ellagic acid",
     "compoundName": "ellagic acid",
@@ -3351,7 +3351,7 @@
   },
   {
     "id": "ephedrine",
-    "slug": "ephedrine",
+    "slug": "ephedrine-wb",
     "canonicalCompoundId": "ephedrine",
     "name": "ephedrine",
     "compoundName": "ephedrine",
@@ -3427,7 +3427,7 @@
   },
   {
     "id": "ergine",
-    "slug": "ergine",
+    "slug": "ergine-wb",
     "canonicalCompoundId": "ergine",
     "name": "ergine",
     "compoundName": "ergine",
@@ -3487,7 +3487,7 @@
   },
   {
     "id": "estragole",
-    "slug": "estragole",
+    "slug": "estragole-wb",
     "canonicalCompoundId": "estragole",
     "name": "estragole",
     "compoundName": "estragole",
@@ -3517,7 +3517,7 @@
   },
   {
     "id": "eucalyptol",
-    "slug": "eucalyptol",
+    "slug": "eucalyptol-wb",
     "canonicalCompoundId": "eucalyptol",
     "name": "eucalyptol",
     "compoundName": "eucalyptol",
@@ -3547,7 +3547,7 @@
   },
   {
     "id": "eugenol",
-    "slug": "eugenol",
+    "slug": "eugenol-wb",
     "canonicalCompoundId": "eugenol",
     "name": "Eugenol",
     "compoundName": "Eugenol",
@@ -3683,7 +3683,7 @@
   },
   {
     "id": "ferulic-acid",
-    "slug": "ferulic-acid",
+    "slug": "ferulic-acid-wb",
     "canonicalCompoundId": "ferulic-acid",
     "name": "ferulic acid",
     "compoundName": "ferulic acid",
@@ -3819,7 +3819,7 @@
   },
   {
     "id": "gallic-acid",
-    "slug": "gallic-acid",
+    "slug": "gallic-acid-wb",
     "canonicalCompoundId": "gallic-acid",
     "name": "gallic acid",
     "compoundName": "gallic acid",
@@ -4014,7 +4014,7 @@
   },
   {
     "id": "geranial",
-    "slug": "geranial",
+    "slug": "geranial-wb",
     "canonicalCompoundId": "geranial",
     "name": "geranial",
     "compoundName": "geranial",
@@ -4356,7 +4356,7 @@
   },
   {
     "id": "gramine",
-    "slug": "gramine",
+    "slug": "gramine-wb",
     "canonicalCompoundId": "gramine",
     "name": "gramine",
     "compoundName": "gramine",
@@ -4431,7 +4431,7 @@
   },
   {
     "id": "gymnemic-acids",
-    "slug": "gymnemic-acids",
+    "slug": "gymnemic-acids-wb",
     "canonicalCompoundId": "gymnemic-acids",
     "name": "gymnemic acids",
     "compoundName": "gymnemic acids",
@@ -4461,7 +4461,7 @@
   },
   {
     "id": "harmaline",
-    "slug": "harmaline",
+    "slug": "harmaline-wb",
     "canonicalCompoundId": "harmaline",
     "name": "Harmaline",
     "compoundName": "Harmaline",
@@ -4478,7 +4478,7 @@
   },
   {
     "id": "harmalol",
-    "slug": "harmalol",
+    "slug": "harmalol-wb",
     "canonicalCompoundId": "harmalol",
     "name": "harmalol",
     "compoundName": "harmalol",
@@ -4493,7 +4493,7 @@
   },
   {
     "id": "harmine",
-    "slug": "harmine",
+    "slug": "harmine-wb",
     "canonicalCompoundId": "harmine",
     "name": "Harmine",
     "compoundName": "Harmine",
@@ -4615,7 +4615,7 @@
   },
   {
     "id": "histamine",
-    "slug": "histamine",
+    "slug": "histamine-wb",
     "canonicalCompoundId": "histamine",
     "name": "histamine",
     "compoundName": "histamine",
@@ -4645,7 +4645,7 @@
   },
   {
     "id": "huperzine-a",
-    "slug": "huperzine-a",
+    "slug": "huperzine-a-wb",
     "canonicalCompoundId": "huperzine-a",
     "name": "huperzine a",
     "compoundName": "huperzine a",
@@ -4750,7 +4750,7 @@
   },
   {
     "id": "hyoscyamine",
-    "slug": "hyoscyamine",
+    "slug": "hyoscyamine-wb",
     "canonicalCompoundId": "hyoscyamine",
     "name": "hyoscyamine",
     "compoundName": "hyoscyamine",
@@ -4765,7 +4765,7 @@
   },
   {
     "id": "hypaconitine",
-    "slug": "hypaconitine",
+    "slug": "hypaconitine-wb",
     "canonicalCompoundId": "hypaconitine",
     "name": "hypaconitine",
     "compoundName": "hypaconitine",
@@ -4814,7 +4814,7 @@
   },
   {
     "id": "ibogaine",
-    "slug": "ibogaine",
+    "slug": "ibogaine-wb",
     "canonicalCompoundId": "ibogaine",
     "name": "Ibogaine",
     "compoundName": "Ibogaine",
@@ -4833,7 +4833,7 @@
   },
   {
     "id": "ibotenic-acid",
-    "slug": "ibotenic-acid",
+    "slug": "ibotenic-acid-wb",
     "canonicalCompoundId": "ibotenic-acid",
     "name": "ibotenic acid",
     "compoundName": "ibotenic acid",
@@ -4979,7 +4979,7 @@
   },
   {
     "id": "isoergine",
-    "slug": "isoergine",
+    "slug": "isoergine-wb",
     "canonicalCompoundId": "isoergine",
     "name": "isoergine",
     "compoundName": "isoergine",
@@ -5070,7 +5070,7 @@
   },
   {
     "id": "isorhamnetin",
-    "slug": "isorhamnetin",
+    "slug": "isorhamnetin-wb",
     "canonicalCompoundId": "isorhamnetin",
     "name": "Isorhamnetin",
     "compoundName": "Isorhamnetin",
@@ -5130,7 +5130,7 @@
   },
   {
     "id": "isovaleric-acid",
-    "slug": "isovaleric-acid",
+    "slug": "isovaleric-acid-wb",
     "canonicalCompoundId": "isovaleric-acid",
     "name": "isovaleric acid",
     "compoundName": "isovaleric acid",
@@ -5220,7 +5220,7 @@
   },
   {
     "id": "kaempferol",
-    "slug": "kaempferol",
+    "slug": "kaempferol-wb",
     "canonicalCompoundId": "kaempferol",
     "name": "Kaempferol",
     "compoundName": "Kaempferol",
@@ -5357,7 +5357,7 @@
   },
   {
     "id": "l-theanine",
-    "slug": "l-theanine",
+    "slug": "l-theanine-wb",
     "canonicalCompoundId": "l-theanine",
     "name": "l-theanine",
     "compoundName": "l-theanine",
@@ -5372,7 +5372,7 @@
   },
   {
     "id": "l-tryptophan",
-    "slug": "l-tryptophan",
+    "slug": "l-tryptophan-wb",
     "canonicalCompoundId": "l-tryptophan",
     "name": "l-tryptophan",
     "compoundName": "l-tryptophan",
@@ -5402,7 +5402,7 @@
   },
   {
     "id": "lactucin",
-    "slug": "lactucin",
+    "slug": "lactucin-wb",
     "canonicalCompoundId": "lactucin",
     "name": "lactucin",
     "compoundName": "lactucin",
@@ -5417,7 +5417,7 @@
   },
   {
     "id": "lactucopicrin",
-    "slug": "lactucopicrin",
+    "slug": "lactucopicrin-wb",
     "canonicalCompoundId": "lactucopicrin",
     "name": "lactucopicrin",
     "compoundName": "lactucopicrin",
@@ -5462,7 +5462,7 @@
   },
   {
     "id": "leonurine",
-    "slug": "leonurine",
+    "slug": "leonurine-wb",
     "canonicalCompoundId": "leonurine",
     "name": "leonurine",
     "compoundName": "leonurine",
@@ -5492,7 +5492,7 @@
   },
   {
     "id": "limonene",
-    "slug": "limonene",
+    "slug": "limonene-wb",
     "canonicalCompoundId": "limonene",
     "name": "limonene",
     "compoundName": "limonene",
@@ -5507,7 +5507,7 @@
   },
   {
     "id": "linalool",
-    "slug": "linalool",
+    "slug": "linalool-wb",
     "canonicalCompoundId": "linalool",
     "name": "linalool",
     "compoundName": "linalool",
@@ -5522,7 +5522,7 @@
   },
   {
     "id": "linalyl-acetate",
-    "slug": "linalyl-acetate",
+    "slug": "linalyl-acetate-wb",
     "canonicalCompoundId": "linalyl-acetate",
     "name": "linalyl acetate",
     "compoundName": "linalyl acetate",
@@ -5642,7 +5642,7 @@
   },
   {
     "id": "lupeol",
-    "slug": "lupeol",
+    "slug": "lupeol-wb",
     "canonicalCompoundId": "lupeol",
     "name": "lupeol",
     "compoundName": "lupeol",
@@ -5672,7 +5672,7 @@
   },
   {
     "id": "luteolin",
-    "slug": "luteolin",
+    "slug": "luteolin-wb",
     "canonicalCompoundId": "luteolin",
     "name": "Luteolin",
     "compoundName": "Luteolin",
@@ -5732,7 +5732,7 @@
   },
   {
     "id": "lythrine",
-    "slug": "lythrine",
+    "slug": "lythrine-wb",
     "canonicalCompoundId": "lythrine",
     "name": "lythrine",
     "compoundName": "lythrine",
@@ -5807,7 +5807,7 @@
   },
   {
     "id": "magnesium",
-    "slug": "magnesium",
+    "slug": "magnesium-wb",
     "canonicalCompoundId": "magnesium",
     "name": "magnesium",
     "compoundName": "magnesium",
@@ -5837,7 +5837,7 @@
   },
   {
     "id": "maltol",
-    "slug": "maltol",
+    "slug": "maltol-wb",
     "canonicalCompoundId": "maltol",
     "name": "maltol",
     "compoundName": "maltol",
@@ -5867,7 +5867,7 @@
   },
   {
     "id": "marmelosin",
-    "slug": "marmelosin",
+    "slug": "marmelosin-wb",
     "canonicalCompoundId": "marmelosin",
     "name": "marmelosin",
     "compoundName": "marmelosin",
@@ -5897,7 +5897,7 @@
   },
   {
     "id": "melatonin",
-    "slug": "melatonin",
+    "slug": "melatonin-wb",
     "canonicalCompoundId": "melatonin",
     "name": "melatonin",
     "compoundName": "melatonin",
@@ -5927,7 +5927,7 @@
   },
   {
     "id": "menthol",
-    "slug": "menthol",
+    "slug": "menthol-wb",
     "canonicalCompoundId": "menthol",
     "name": "menthol",
     "compoundName": "menthol",
@@ -5942,7 +5942,7 @@
   },
   {
     "id": "menthone",
-    "slug": "menthone",
+    "slug": "menthone-wb",
     "canonicalCompoundId": "menthone",
     "name": "menthone",
     "compoundName": "menthone",
@@ -5957,7 +5957,7 @@
   },
   {
     "id": "menthyl-acetate",
-    "slug": "menthyl-acetate",
+    "slug": "menthyl-acetate-wb",
     "canonicalCompoundId": "menthyl-acetate",
     "name": "menthyl acetate",
     "compoundName": "menthyl acetate",
@@ -5972,7 +5972,7 @@
   },
   {
     "id": "mesaconitine",
-    "slug": "mesaconitine",
+    "slug": "mesaconitine-wb",
     "canonicalCompoundId": "mesaconitine",
     "name": "mesaconitine",
     "compoundName": "mesaconitine",
@@ -5987,7 +5987,7 @@
   },
   {
     "id": "mescaline",
-    "slug": "mescaline",
+    "slug": "mescaline-wb",
     "canonicalCompoundId": "mescaline",
     "name": "mescaline",
     "compoundName": "mescaline",
@@ -6032,7 +6032,7 @@
   },
   {
     "id": "mesembrenol",
-    "slug": "mesembrenol",
+    "slug": "mesembrenol-wb",
     "canonicalCompoundId": "mesembrenol",
     "name": "mesembrenol",
     "compoundName": "mesembrenol",
@@ -6047,7 +6047,7 @@
   },
   {
     "id": "mesembrenone",
-    "slug": "mesembrenone",
+    "slug": "mesembrenone-wb",
     "canonicalCompoundId": "mesembrenone",
     "name": "mesembrenone",
     "compoundName": "mesembrenone",
@@ -6062,7 +6062,7 @@
   },
   {
     "id": "mesembrine",
-    "slug": "mesembrine",
+    "slug": "mesembrine-wb",
     "canonicalCompoundId": "mesembrine",
     "name": "mesembrine",
     "compoundName": "mesembrine",
@@ -6077,7 +6077,7 @@
   },
   {
     "id": "methyl-salicylate",
-    "slug": "methyl-salicylate",
+    "slug": "methyl-salicylate-wb",
     "canonicalCompoundId": "methyl-salicylate",
     "name": "methyl salicylate",
     "compoundName": "methyl salicylate",
@@ -6092,7 +6092,7 @@
   },
   {
     "id": "methysticin",
-    "slug": "methysticin",
+    "slug": "methysticin-wb",
     "canonicalCompoundId": "methysticin",
     "name": "methysticin",
     "compoundName": "methysticin",
@@ -6122,7 +6122,7 @@
   },
   {
     "id": "mitragynine",
-    "slug": "mitragynine",
+    "slug": "mitragynine-wb",
     "canonicalCompoundId": "mitragynine",
     "name": "mitragynine",
     "compoundName": "mitragynine",
@@ -6212,7 +6212,7 @@
   },
   {
     "id": "morphine",
-    "slug": "morphine",
+    "slug": "morphine-wb",
     "canonicalCompoundId": "morphine",
     "name": "morphine",
     "compoundName": "morphine",
@@ -6242,7 +6242,7 @@
   },
   {
     "id": "muscimol",
-    "slug": "muscimol",
+    "slug": "muscimol-wb",
     "canonicalCompoundId": "muscimol",
     "name": "muscimol",
     "compoundName": "muscimol",
@@ -6287,7 +6287,7 @@
   },
   {
     "id": "myricetin",
-    "slug": "myricetin",
+    "slug": "myricetin-wb",
     "canonicalCompoundId": "myricetin",
     "name": "myricetin",
     "compoundName": "myricetin",
@@ -6302,7 +6302,7 @@
   },
   {
     "id": "myristicin",
-    "slug": "myristicin",
+    "slug": "myristicin-wb",
     "canonicalCompoundId": "myristicin",
     "name": "myristicin",
     "compoundName": "myristicin",
@@ -6407,7 +6407,7 @@
   },
   {
     "id": "n-methyltryptamine",
-    "slug": "n-methyltryptamine",
+    "slug": "n-methyltryptamine-wb",
     "canonicalCompoundId": "n-methyltryptamine",
     "name": "n-methyltryptamine",
     "compoundName": "n-methyltryptamine",
@@ -6482,7 +6482,7 @@
   },
   {
     "id": "nesodine",
-    "slug": "nesodine",
+    "slug": "nesodine-wb",
     "canonicalCompoundId": "nesodine",
     "name": "nesodine",
     "compoundName": "nesodine",
@@ -6512,7 +6512,7 @@
   },
   {
     "id": "nicotine",
-    "slug": "nicotine",
+    "slug": "nicotine-wb",
     "canonicalCompoundId": "nicotine",
     "name": "nicotine",
     "compoundName": "nicotine",
@@ -6602,7 +6602,7 @@
   },
   {
     "id": "nornicotine",
-    "slug": "nornicotine",
+    "slug": "nornicotine-wb",
     "canonicalCompoundId": "nornicotine",
     "name": "nornicotine",
     "compoundName": "nornicotine",
@@ -6632,7 +6632,7 @@
   },
   {
     "id": "nuciferine",
-    "slug": "nuciferine",
+    "slug": "nuciferine-wb",
     "canonicalCompoundId": "nuciferine",
     "name": "nuciferine",
     "compoundName": "nuciferine",
@@ -6827,7 +6827,7 @@
   },
   {
     "id": "paniculatin",
-    "slug": "paniculatin",
+    "slug": "paniculatin-wb",
     "canonicalCompoundId": "paniculatin",
     "name": "paniculatin",
     "compoundName": "paniculatin",
@@ -6902,7 +6902,7 @@
   },
   {
     "id": "perillaldehyde",
-    "slug": "perillaldehyde",
+    "slug": "perillaldehyde-wb",
     "canonicalCompoundId": "perillaldehyde",
     "name": "perillaldehyde",
     "compoundName": "perillaldehyde",
@@ -6932,7 +6932,7 @@
   },
   {
     "id": "petasin",
-    "slug": "petasin",
+    "slug": "petasin-wb",
     "canonicalCompoundId": "petasin",
     "name": "petasin",
     "compoundName": "petasin",
@@ -7007,7 +7007,7 @@
   },
   {
     "id": "pinene",
-    "slug": "pinene",
+    "slug": "pinene-wb",
     "canonicalCompoundId": "pinene",
     "name": "pinene",
     "compoundName": "pinene",
@@ -7022,7 +7022,7 @@
   },
   {
     "id": "pinocembrin",
-    "slug": "pinocembrin",
+    "slug": "pinocembrin-wb",
     "canonicalCompoundId": "pinocembrin",
     "name": "pinocembrin",
     "compoundName": "pinocembrin",
@@ -7129,7 +7129,7 @@
   },
   {
     "id": "probiotics",
-    "slug": "probiotics",
+    "slug": "probiotics-wb",
     "canonicalCompoundId": "probiotics",
     "name": "probiotics",
     "compoundName": "probiotics",
@@ -7189,7 +7189,7 @@
   },
   {
     "id": "pseudoephedrine",
-    "slug": "pseudoephedrine",
+    "slug": "pseudoephedrine-wb",
     "canonicalCompoundId": "pseudoephedrine",
     "name": "pseudoephedrine",
     "compoundName": "pseudoephedrine",
@@ -7279,7 +7279,7 @@
   },
   {
     "id": "pulegone",
-    "slug": "pulegone",
+    "slug": "pulegone-wb",
     "canonicalCompoundId": "pulegone",
     "name": "pulegone",
     "compoundName": "pulegone",
@@ -7384,7 +7384,7 @@
   },
   {
     "id": "quercetin",
-    "slug": "quercetin",
+    "slug": "quercetin-wb",
     "canonicalCompoundId": "quercetin",
     "name": "Quercetin",
     "compoundName": "Quercetin",
@@ -7402,7 +7402,7 @@
   },
   {
     "id": "quercitrin",
-    "slug": "quercitrin",
+    "slug": "quercitrin-wb",
     "canonicalCompoundId": "quercitrin",
     "name": "quercitrin",
     "compoundName": "quercitrin",
@@ -7447,7 +7447,7 @@
   },
   {
     "id": "resveratrol",
-    "slug": "resveratrol",
+    "slug": "resveratrol-wb",
     "canonicalCompoundId": "resveratrol",
     "name": "Resveratrol",
     "compoundName": "Resveratrol",
@@ -7618,7 +7618,7 @@
   },
   {
     "id": "rosmarinic-acid",
-    "slug": "rosmarinic-acid",
+    "slug": "rosmarinic-acid-wb",
     "canonicalCompoundId": "rosmarinic-acid",
     "name": "Rosmarinic acid",
     "compoundName": "Rosmarinic acid",
@@ -7651,7 +7651,7 @@
   },
   {
     "id": "rutin",
-    "slug": "rutin",
+    "slug": "rutin-wb",
     "canonicalCompoundId": "rutin",
     "name": "rutin",
     "compoundName": "rutin",
@@ -7711,7 +7711,7 @@
   },
   {
     "id": "safrole",
-    "slug": "safrole",
+    "slug": "safrole-wb",
     "canonicalCompoundId": "safrole",
     "name": "safrole",
     "compoundName": "safrole",
@@ -7954,7 +7954,7 @@
   },
   {
     "id": "scopolamine",
-    "slug": "scopolamine",
+    "slug": "scopolamine-wb",
     "canonicalCompoundId": "scopolamine",
     "name": "scopolamine",
     "compoundName": "scopolamine",
@@ -7969,7 +7969,7 @@
   },
   {
     "id": "scopoletin",
-    "slug": "scopoletin",
+    "slug": "scopoletin-wb",
     "canonicalCompoundId": "scopoletin",
     "name": "scopoletin",
     "compoundName": "scopoletin",
@@ -7984,7 +7984,7 @@
   },
   {
     "id": "scutellarin",
-    "slug": "scutellarin",
+    "slug": "scutellarin-wb",
     "canonicalCompoundId": "scutellarin",
     "name": "scutellarin",
     "compoundName": "scutellarin",
@@ -7999,7 +7999,7 @@
   },
   {
     "id": "selenium",
-    "slug": "selenium",
+    "slug": "selenium-wb",
     "canonicalCompoundId": "selenium",
     "name": "selenium",
     "compoundName": "selenium",
@@ -8029,7 +8029,7 @@
   },
   {
     "id": "serotonin",
-    "slug": "serotonin",
+    "slug": "serotonin-wb",
     "canonicalCompoundId": "serotonin",
     "name": "serotonin",
     "compoundName": "serotonin",
@@ -8239,7 +8239,7 @@
   },
   {
     "id": "solanine",
-    "slug": "solanine",
+    "slug": "solanine-wb",
     "canonicalCompoundId": "solanine",
     "name": "solanine",
     "compoundName": "solanine",
@@ -8254,7 +8254,7 @@
   },
   {
     "id": "spilanthol",
-    "slug": "spilanthol",
+    "slug": "spilanthol-wb",
     "canonicalCompoundId": "spilanthol",
     "name": "spilanthol",
     "compoundName": "spilanthol",
@@ -8269,7 +8269,7 @@
   },
   {
     "id": "stachydrine",
-    "slug": "stachydrine",
+    "slug": "stachydrine-wb",
     "canonicalCompoundId": "stachydrine",
     "name": "stachydrine",
     "compoundName": "stachydrine",
@@ -8376,7 +8376,7 @@
   },
   {
     "id": "tartaric-acid",
-    "slug": "tartaric-acid",
+    "slug": "tartaric-acid-wb",
     "canonicalCompoundId": "tartaric-acid",
     "name": "tartaric acid",
     "compoundName": "tartaric acid",
@@ -8481,7 +8481,7 @@
   },
   {
     "id": "tetrahydroharmine",
-    "slug": "tetrahydroharmine",
+    "slug": "tetrahydroharmine-wb",
     "canonicalCompoundId": "tetrahydroharmine",
     "name": "tetrahydroharmine",
     "compoundName": "tetrahydroharmine",
@@ -8541,7 +8541,7 @@
   },
   {
     "id": "thc",
-    "slug": "thc",
+    "slug": "thc-wb",
     "canonicalCompoundId": "thc",
     "name": "thc",
     "compoundName": "thc",
@@ -8574,7 +8574,7 @@
   },
   {
     "id": "thebaine",
-    "slug": "thebaine",
+    "slug": "thebaine-wb",
     "canonicalCompoundId": "thebaine",
     "name": "thebaine",
     "compoundName": "thebaine",
@@ -8589,7 +8589,7 @@
   },
   {
     "id": "theobromine",
-    "slug": "theobromine",
+    "slug": "theobromine-wb",
     "canonicalCompoundId": "theobromine",
     "name": "theobromine",
     "compoundName": "theobromine",
@@ -8604,7 +8604,7 @@
   },
   {
     "id": "theophylline",
-    "slug": "theophylline",
+    "slug": "theophylline-wb",
     "canonicalCompoundId": "theophylline",
     "name": "theophylline",
     "compoundName": "theophylline",
@@ -8649,7 +8649,7 @@
   },
   {
     "id": "thujone",
-    "slug": "thujone",
+    "slug": "thujone-wb",
     "canonicalCompoundId": "thujone",
     "name": "thujone",
     "compoundName": "thujone",
@@ -8664,7 +8664,7 @@
   },
   {
     "id": "thymol",
-    "slug": "thymol",
+    "slug": "thymol-wb",
     "canonicalCompoundId": "thymol",
     "name": "thymol",
     "compoundName": "thymol",
@@ -8905,7 +8905,7 @@
   },
   {
     "id": "umbelliferone",
-    "slug": "umbelliferone",
+    "slug": "umbelliferone-wb",
     "canonicalCompoundId": "umbelliferone",
     "name": "umbelliferone",
     "compoundName": "umbelliferone",
@@ -8965,7 +8965,7 @@
   },
   {
     "id": "ursolic-acid",
-    "slug": "ursolic-acid",
+    "slug": "ursolic-acid-wb",
     "canonicalCompoundId": "ursolic-acid",
     "name": "Ursolic acid",
     "compoundName": "Ursolic acid",
@@ -9041,7 +9041,7 @@
   },
   {
     "id": "valerenic-acid",
-    "slug": "valerenic-acid",
+    "slug": "valerenic-acid-wb",
     "canonicalCompoundId": "valerenic-acid",
     "name": "valerenic acid",
     "compoundName": "valerenic acid",
@@ -9116,7 +9116,7 @@
   },
   {
     "id": "vasicine",
-    "slug": "vasicine",
+    "slug": "vasicine-wb",
     "canonicalCompoundId": "vasicine",
     "name": "Vasicine",
     "compoundName": "Vasicine",
@@ -9133,7 +9133,7 @@
   },
   {
     "id": "vasicinone",
-    "slug": "vasicinone",
+    "slug": "vasicinone-wb",
     "canonicalCompoundId": "vasicinone",
     "name": "vasicinone",
     "compoundName": "vasicinone",
@@ -9148,7 +9148,7 @@
   },
   {
     "id": "verbascoside",
-    "slug": "verbascoside",
+    "slug": "verbascoside-wb",
     "canonicalCompoundId": "verbascoside",
     "name": "verbascoside",
     "compoundName": "verbascoside",
@@ -9253,7 +9253,7 @@
   },
   {
     "id": "voacangine",
-    "slug": "voacangine",
+    "slug": "voacangine-wb",
     "canonicalCompoundId": "voacangine",
     "name": "voacangine",
     "compoundName": "voacangine",
@@ -9379,7 +9379,7 @@
   },
   {
     "id": "wogonin",
-    "slug": "wogonin",
+    "slug": "wogonin-wb",
     "canonicalCompoundId": "wogonin",
     "name": "wogonin",
     "compoundName": "wogonin",
@@ -9469,7 +9469,7 @@
   },
   {
     "id": "yangonin",
-    "slug": "yangonin",
+    "slug": "yangonin-wb",
     "canonicalCompoundId": "yangonin",
     "name": "yangonin",
     "compoundName": "yangonin",
@@ -9484,7 +9484,7 @@
   },
   {
     "id": "yohimbine",
-    "slug": "yohimbine",
+    "slug": "yohimbine-wb",
     "canonicalCompoundId": "yohimbine",
     "name": "Yohimbine",
     "compoundName": "Yohimbine",

--- a/public/data/workbook-herbs.json
+++ b/public/data/workbook-herbs.json
@@ -1,6 +1,6 @@
 [
   {
-    "slug": "ashwagandha",
+    "slug": "ashwagandha-wb",
     "name": "Ashwagandha",
     "scientificName": "Withania somnifera",
     "latin": "Withania somnifera",
@@ -69,7 +69,7 @@
     ]
   },
   {
-    "slug": "black-cohosh",
+    "slug": "black-cohosh-wb",
     "name": "Black Cohosh",
     "scientificName": "Actaea racemosa",
     "latin": "Actaea racemosa",
@@ -136,7 +136,7 @@
     ]
   },
   {
-    "slug": "echinacea-purpurea",
+    "slug": "echinacea-purpurea-wb",
     "name": "Echinacea Purpurea",
     "scientificName": "Echinacea purpurea",
     "latin": "Echinacea purpurea",
@@ -258,7 +258,7 @@
     ]
   },
   {
-    "slug": "ginger",
+    "slug": "ginger-wb",
     "name": "Ginger",
     "scientificName": "Zingiber officinale",
     "latin": "Zingiber officinale",
@@ -321,7 +321,7 @@
     ]
   },
   {
-    "slug": "ginkgo-biloba",
+    "slug": "ginkgo-biloba-wb",
     "name": "Ginkgo Biloba",
     "scientificName": "Ginkgo biloba",
     "latin": "Ginkgo biloba",
@@ -399,7 +399,7 @@
     ]
   },
   {
-    "slug": "holy-basil",
+    "slug": "holy-basil-wb",
     "name": "Holy Basil",
     "scientificName": "Ocimum tenuiflorum",
     "latin": "Ocimum tenuiflorum",
@@ -456,7 +456,7 @@
     ]
   },
   {
-    "slug": "kava",
+    "slug": "kava-wb",
     "name": "Kava",
     "scientificName": "Piper methysticum",
     "latin": "Piper methysticum",
@@ -523,7 +523,7 @@
     ]
   },
   {
-    "slug": "lemon-balm",
+    "slug": "lemon-balm-wb",
     "name": "Lemon Balm",
     "scientificName": "Melissa officinalis",
     "latin": "Melissa officinalis",
@@ -576,7 +576,7 @@
     ]
   },
   {
-    "slug": "maca",
+    "slug": "maca-wb",
     "name": "Maca",
     "scientificName": "Lepidium meyenii",
     "latin": "Lepidium meyenii",
@@ -684,7 +684,7 @@
     ]
   },
   {
-    "slug": "peppermint",
+    "slug": "peppermint-wb",
     "name": "Peppermint",
     "scientificName": "Mentha × piperita",
     "latin": "Mentha × piperita",
@@ -744,7 +744,7 @@
     ]
   },
   {
-    "slug": "rhodiola-rosea",
+    "slug": "rhodiola-rosea-wb",
     "name": "Rhodiola Rosea",
     "scientificName": "Rhodiola rosea",
     "latin": "Rhodiola rosea",
@@ -931,7 +931,7 @@
     ]
   },
   {
-    "slug": "turmeric",
+    "slug": "turmeric-wb",
     "name": "Turmeric",
     "scientificName": "Curcuma longa",
     "latin": "Curcuma longa",
@@ -992,7 +992,7 @@
     ]
   },
   {
-    "slug": "valerian",
+    "slug": "valerian-wb",
     "name": "Valerian",
     "scientificName": "Valeriana officinalis",
     "latin": "Valeriana officinalis",
@@ -1051,7 +1051,7 @@
     ]
   },
   {
-    "slug": "guarana",
+    "slug": "guarana-wb",
     "name": "Guarana",
     "scientificName": "Paullinia cupana",
     "latin": "Paullinia cupana",
@@ -1099,7 +1099,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "yerba-mate",
+    "slug": "yerba-mate-wb",
     "name": "Yerba Mate",
     "scientificName": "Ilex paraguariensis",
     "latin": "Ilex paraguariensis",
@@ -1148,7 +1148,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "damiana",
+    "slug": "damiana-wb",
     "name": "Damiana",
     "scientificName": "Turnera diffusa",
     "latin": "Turnera diffusa",
@@ -1196,7 +1196,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "blue-lotus",
+    "slug": "blue-lotus-wb",
     "name": "Blue Lotus",
     "scientificName": "Nymphaea caerulea",
     "latin": "Nymphaea caerulea",
@@ -1287,7 +1287,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "yarrow",
+    "slug": "yarrow-wb",
     "name": "Yarrow",
     "scientificName": "Achillea millefolium",
     "latin": "Achillea millefolium",
@@ -1335,7 +1335,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "feverfew",
+    "slug": "feverfew-wb",
     "name": "Feverfew",
     "scientificName": "Tanacetum parthenium",
     "latin": "Tanacetum parthenium",
@@ -1942,7 +1942,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "chamomile",
+    "slug": "chamomile-wb",
     "name": "Chamomile",
     "scientificName": "Matricaria chamomilla",
     "latin": "Matricaria chamomilla",
@@ -2125,7 +2125,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "pau-darco",
+    "slug": "pau-d-arco",
     "name": "Pau d'Arco",
     "scientificName": "Handroanthus impetiginosus",
     "latin": "Handroanthus impetiginosus",
@@ -2213,7 +2213,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "banaba",
+    "slug": "banaba-wb",
     "name": "Banaba",
     "scientificName": "Lagerstroemia speciosa",
     "latin": "Lagerstroemia speciosa",
@@ -2257,7 +2257,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "mulberry-leaf",
+    "slug": "mulberry-leaf-wb",
     "name": "Mulberry Leaf",
     "scientificName": "Morus alba",
     "latin": "Morus alba",
@@ -2346,7 +2346,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "mugwort",
+    "slug": "mugwort-wb",
     "name": "Mugwort",
     "scientificName": "Artemisia vulgaris",
     "latin": "Artemisia vulgaris",
@@ -2436,7 +2436,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "milky-oats",
+    "slug": "milk-oats",
     "name": "Milk Oats",
     "scientificName": "Avena sativa",
     "latin": "Avena sativa",
@@ -2482,7 +2482,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "cissus",
+    "slug": "cissus-wb",
     "name": "Cissus",
     "scientificName": "Cissus quadrangularis",
     "latin": "Cissus quadrangularis",
@@ -2524,7 +2524,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "ashitaba",
+    "slug": "ashitaba-wb",
     "name": "Ashitaba",
     "scientificName": "Angelica keiskei",
     "latin": "Angelica keiskei",
@@ -2664,7 +2664,7 @@
     ]
   },
   {
-    "slug": "arjuna",
+    "slug": "arjuna-wb",
     "name": "Arjuna",
     "scientificName": "Terminalia arjuna",
     "latin": "Terminalia arjuna",
@@ -2763,7 +2763,7 @@
     ]
   },
   {
-    "slug": "cranberry",
+    "slug": "cranberry-wb",
     "name": "Cranberry",
     "scientificName": "Vaccinium macrocarpon",
     "latin": "Vaccinium macrocarpon",
@@ -2907,7 +2907,7 @@
     ]
   },
   {
-    "slug": "myrtle",
+    "slug": "myrtle-wb",
     "name": "Myrtle",
     "scientificName": "Myrtus communis",
     "latin": "Myrtus communis",
@@ -2956,7 +2956,7 @@
     ]
   },
   {
-    "slug": "acerola",
+    "slug": "acerola-wb",
     "name": "Acerola",
     "scientificName": "Malpighia emarginata",
     "latin": "Malpighia emarginata",
@@ -3002,7 +3002,7 @@
     ]
   },
   {
-    "slug": "mangosteen",
+    "slug": "mangosteen-wb",
     "name": "Mangosteen",
     "scientificName": "Garcinia mangostana",
     "latin": "Garcinia mangostana",
@@ -3051,7 +3051,7 @@
     ]
   },
   {
-    "slug": "boldo",
+    "slug": "boldo-wb",
     "name": "Boldo",
     "scientificName": "Peumus boldus",
     "latin": "Peumus boldus",
@@ -3099,7 +3099,7 @@
     ]
   },
   {
-    "slug": "suma",
+    "slug": "suma-wb",
     "name": "Suma",
     "scientificName": "Pfaffia paniculata",
     "latin": "Pfaffia paniculata",
@@ -3149,7 +3149,7 @@
     ]
   },
   {
-    "slug": "maral-root",
+    "slug": "maral-root-wb",
     "name": "Maral Root",
     "scientificName": "Rhaponticum carthamoides",
     "latin": "Rhaponticum carthamoides",
@@ -3295,7 +3295,7 @@
     ]
   },
   {
-    "slug": "ashoka",
+    "slug": "ashoka-wb",
     "name": "Ashoka",
     "scientificName": "Saraca asoca",
     "latin": "Saraca asoca",
@@ -3343,7 +3343,7 @@
     ]
   },
   {
-    "slug": "shankhpushpi",
+    "slug": "shankhpushpi-wb",
     "name": "Shankhpushpi",
     "scientificName": "Convolvulus pluricaulis",
     "latin": "Convolvulus pluricaulis",
@@ -3391,7 +3391,7 @@
     ]
   },
   {
-    "slug": "hops",
+    "slug": "hops-wb",
     "name": "Hops",
     "scientificName": "Humulus lupulus",
     "latin": "Humulus lupulus",
@@ -3541,7 +3541,7 @@
     ]
   },
   {
-    "slug": "carob",
+    "slug": "carob-wb",
     "name": "Carob",
     "scientificName": "Ceratonia siliqua",
     "latin": "Ceratonia siliqua",
@@ -3630,7 +3630,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "eucommia",
+    "slug": "eucommia-wb",
     "name": "Eucommia",
     "scientificName": "Eucommia ulmoides",
     "latin": "Eucommia ulmoides",
@@ -3675,7 +3675,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "cistanche",
+    "slug": "cistanche-wb",
     "name": "Cistanche",
     "scientificName": "Cistanche deserticola",
     "latin": "Cistanche deserticola",
@@ -3720,7 +3720,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "jujube",
+    "slug": "jujube-wb",
     "name": "Jujube",
     "scientificName": "Ziziphus jujuba",
     "latin": "Ziziphus jujuba",
@@ -3763,7 +3763,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "longan",
+    "slug": "longan-wb",
     "name": "Longan",
     "scientificName": "Dimocarpus longan",
     "latin": "Dimocarpus longan",
@@ -3899,7 +3899,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "white-peony",
+    "slug": "white-peony-wb",
     "name": "White Peony",
     "scientificName": "Paeonia lactiflora",
     "latin": "Paeonia lactiflora",
@@ -3984,7 +3984,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "codonopsis",
+    "slug": "codonopsis-wb",
     "name": "Codonopsis",
     "scientificName": "Codonopsis pilosula",
     "latin": "Codonopsis pilosula",
@@ -4072,7 +4072,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "ophiopogon",
+    "slug": "ophiopogon-wb",
     "name": "Ophiopogon",
     "scientificName": "Ophiopogon japonicus",
     "latin": "Ophiopogon japonicus",
@@ -4114,7 +4114,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "houttuynia",
+    "slug": "houttuynia-wb",
     "name": "Houttuynia",
     "scientificName": "Houttuynia cordata",
     "latin": "Houttuynia cordata",
@@ -4159,7 +4159,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "isatis",
+    "slug": "isatis-wb",
     "name": "Isatis",
     "scientificName": "Isatis tinctoria",
     "latin": "Isatis tinctoria",
@@ -4205,7 +4205,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "sophora-flavescens",
+    "slug": "sophora-flavescens-wb",
     "name": "Sophora Flavescens",
     "scientificName": "Sophora flavescens",
     "latin": "Sophora flavescens",
@@ -4250,7 +4250,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "notoginseng",
+    "slug": "notoginseng-wb",
     "name": "Notoginseng",
     "scientificName": "Panax notoginseng",
     "latin": "Panax notoginseng",
@@ -4293,7 +4293,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "luo-han-guo",
+    "slug": "luo-han-guo-wb",
     "name": "Luo Han Guo",
     "scientificName": "Siraitia grosvenorii",
     "latin": "Siraitia grosvenorii",
@@ -4335,7 +4335,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "kuding-tea",
+    "slug": "kuding-tea-wb",
     "name": "Kuding Tea",
     "scientificName": "Ilex kudingcha",
     "latin": "Ilex kudingcha",
@@ -4463,7 +4463,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "catuaba",
+    "slug": "catuba",
     "name": "Catuba",
     "scientificName": "Erythroxylum catuaba",
     "latin": "Erythroxylum catuaba",
@@ -4505,7 +4505,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "muira-puama",
+    "slug": "muira-puama-wb",
     "name": "Muira Puama",
     "scientificName": "Ptychopetalum olacoides",
     "latin": "Ptychopetalum olacoides",
@@ -4550,7 +4550,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "maitake-d-fraction",
+    "slug": "maitake-d-fraction-wb",
     "name": "Maitake D-Fraction",
     "scientificName": "Grifola frondosa",
     "latin": "Grifola frondosa",
@@ -4639,7 +4639,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "rehmannia-prepared",
+    "slug": "rehmannia-prepared-wb",
     "name": "Rehmannia Prepared",
     "scientificName": "Rehmannia glutinosa praeparata",
     "latin": "Rehmannia glutinosa praeparata",
@@ -4684,7 +4684,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "agarikon",
+    "slug": "agarikon-wb",
     "name": "Agarikon",
     "scientificName": "Fomitopsis officinalis",
     "latin": "Fomitopsis officinalis",
@@ -4864,7 +4864,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "black-pepper",
+    "slug": "black-pepper-wb",
     "name": "Black Pepper",
     "scientificName": "Piper nigrum",
     "latin": "Piper nigrum",
@@ -4914,7 +4914,7 @@
     "pathway_count": "3"
   },
   {
-    "slug": "cardamom",
+    "slug": "cardamom-wb",
     "name": "Cardamom",
     "scientificName": "Elettaria cardamomum",
     "latin": "Elettaria cardamomum",
@@ -5045,7 +5045,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "caraway",
+    "slug": "caraway-wb",
     "name": "Caraway",
     "scientificName": "Carum carvi",
     "latin": "Carum carvi",
@@ -5090,7 +5090,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "ajwain",
+    "slug": "ajwain-wb",
     "name": "Ajwain",
     "scientificName": "Trachyspermum ammi",
     "latin": "Trachyspermum ammi",
@@ -5179,7 +5179,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "curry-leaf",
+    "slug": "curry-leaf-wb",
     "name": "Curry Leaf",
     "scientificName": "Murraya koenigii",
     "latin": "Murraya koenigii",
@@ -5357,7 +5357,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "rhodiola",
+    "slug": "rhodiola-wb",
     "name": "Rhodiola",
     "scientificName": "Rhodiola rosea",
     "latin": "Rhodiola rosea",
@@ -5446,7 +5446,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "lions-mane",
+    "slug": "lion-s-mane-wb",
     "name": "Lion's Mane",
     "scientificName": "Hericium erinaceus",
     "latin": "Hericium erinaceus",
@@ -5489,7 +5489,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "panax-ginseng",
+    "slug": "panax-ginseng-wb",
     "name": "Panax Ginseng",
     "scientificName": "Panax ginseng",
     "latin": "Panax ginseng",
@@ -5537,7 +5537,7 @@
     "pathway_count": "8"
   },
   {
-    "slug": "passionflower",
+    "slug": "passionflower-wb",
     "name": "Passionflower",
     "scientificName": "Passiflora incarnata",
     "latin": "Passiflora incarnata",
@@ -5580,7 +5580,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "yohimbe",
+    "slug": "yohimbe-wb",
     "name": "Yohimbe",
     "scientificName": "Pausinystalia johimbe",
     "latin": "Pausinystalia johimbe",
@@ -5623,7 +5623,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "skullcap",
+    "slug": "skullcap-wb",
     "name": "Skullcap",
     "scientificName": "Scutellaria lateriflora",
     "latin": "Scutellaria lateriflora",
@@ -5706,7 +5706,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "gotu-kola",
+    "slug": "gotu-kola-wb",
     "name": "Gotu Kola",
     "scientificName": "Centella asiatica",
     "latin": "Centella asiatica",
@@ -5869,7 +5869,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "turkey-tail",
+    "slug": "turkey-tail-wb",
     "name": "Turkey Tail",
     "scientificName": "Trametes versicolor",
     "latin": "Trametes versicolor",
@@ -6081,7 +6081,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "bacopa",
+    "slug": "bacopa-wb",
     "name": "Bacopa",
     "scientificName": "Bacopa monnieri",
     "latin": "Bacopa monnieri",
@@ -6220,7 +6220,7 @@
     "pathway_count": "3"
   },
   {
-    "slug": "tongkat-ali",
+    "slug": "tongkat-ali-wb",
     "name": "Tongkat Ali",
     "scientificName": "Eurycoma longifolia",
     "latin": "Eurycoma longifolia",
@@ -6309,7 +6309,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "pueraria-mirifica",
+    "slug": "pueraria-mirifica-wb",
     "name": "Pueraria Mirifica",
     "scientificName": "Pueraria mirifica",
     "latin": "Pueraria mirifica",
@@ -6397,7 +6397,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "rooibos",
+    "slug": "rooibos-wb",
     "name": "Rooibos",
     "scientificName": "Aspalathus linearis",
     "latin": "Aspalathus linearis",
@@ -6442,7 +6442,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "cats-claw",
+    "slug": "cat-s-claw",
     "name": "Cat's Claw",
     "scientificName": "Uncaria tomentosa",
     "latin": "Uncaria tomentosa",
@@ -6487,7 +6487,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "lavender",
+    "slug": "lavender-wb",
     "name": "Lavender",
     "scientificName": "Lavandula angustifolia",
     "latin": "Lavandula angustifolia",
@@ -6663,7 +6663,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "aloe-vera",
+    "slug": "aloe-vera-wb",
     "name": "Aloe Vera",
     "scientificName": "Aloe vera",
     "latin": "Aloe vera",
@@ -6712,7 +6712,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "american-ginseng",
+    "slug": "american-ginseng-wb",
     "name": "American Ginseng",
     "scientificName": "Panax quinquefolius",
     "latin": "Panax quinquefolius",
@@ -6755,7 +6755,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "artemisia-annua",
+    "slug": "artemisia-annua-wb",
     "name": "Artemisia Annua",
     "scientificName": "Artemisia annua",
     "latin": "Artemisia annua",
@@ -6804,7 +6804,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "celastrus-paniculatus",
+    "slug": "celastrus-paniculatus-wb",
     "name": "Celastrus Paniculatus",
     "scientificName": "Celastrus paniculatus",
     "latin": "Celastrus paniculatus",
@@ -6850,7 +6850,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "acorus-calamus",
+    "slug": "calamus-wb",
     "name": "Calamus",
     "scientificName": "Acorus calamus",
     "latin": "Acorus calamus",
@@ -6894,7 +6894,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "capsicum-annuum",
+    "slug": "cayenne",
     "name": "Cayenne",
     "scientificName": "Capsicum annuum",
     "latin": "Capsicum annuum",
@@ -6937,7 +6937,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "corydalis-yanhusuo",
+    "slug": "corydalis",
     "name": "Corydalis",
     "scientificName": "Corydalis yanhusuo",
     "latin": "Corydalis yanhusuo",
@@ -6985,7 +6985,7 @@
     "pathway_count": "3"
   },
   {
-    "slug": "scutellaria-baicalensis",
+    "slug": "chinese-skullcap",
     "name": "Chinese Skullcap",
     "scientificName": "Scutellaria baicalensis",
     "latin": "Scutellaria baicalensis",
@@ -7034,7 +7034,7 @@
     "pathway_count": "3"
   },
   {
-    "slug": "phellodendron-amurense",
+    "slug": "phellodendron",
     "name": "Phellodendron",
     "scientificName": "Phellodendron amurense",
     "latin": "Phellodendron amurense",
@@ -7078,7 +7078,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "coptis-chinensis",
+    "slug": "coptis",
     "name": "Coptis",
     "scientificName": "Coptis chinensis",
     "latin": "Coptis chinensis",
@@ -7122,7 +7122,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "crocus-sativus",
+    "slug": "saffron",
     "name": "Saffron",
     "scientificName": "Crocus sativus",
     "latin": "Crocus sativus",
@@ -7165,7 +7165,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "carica-papaya",
+    "slug": "papaya-leaf",
     "name": "Papaya Leaf",
     "scientificName": "Carica papaya",
     "latin": "Carica papaya",
@@ -7208,7 +7208,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "sceletium-tortuosum",
+    "slug": "kanna-wb",
     "name": "Kanna",
     "scientificName": "Sceletium tortuosum",
     "latin": "Sceletium tortuosum",
@@ -7251,7 +7251,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "camellia-sinensis",
+    "slug": "green-tea",
     "name": "Green Tea",
     "scientificName": "Camellia sinensis",
     "latin": "Camellia sinensis",
@@ -7304,7 +7304,7 @@
     "pathway_count": "9"
   },
   {
-    "slug": "hydrastis-canadensis",
+    "slug": "goldenseal",
     "name": "Goldenseal",
     "scientificName": "Hydrastis canadensis",
     "latin": "Hydrastis canadensis",
@@ -7347,7 +7347,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "salacia-reticulata",
+    "slug": "salacia",
     "name": "Salacia",
     "scientificName": "Salacia reticulata",
     "latin": "Salacia reticulata",
@@ -7389,7 +7389,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "ligusticum-chuanxiong",
+    "slug": "chuanxiong",
     "name": "Chuanxiong",
     "scientificName": "Ligusticum chuanxiong",
     "latin": "Ligusticum chuanxiong",
@@ -7438,7 +7438,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "boesenbergia-rotunda",
+    "slug": "fingerroot",
     "name": "Fingerroot",
     "scientificName": "Boesenbergia rotunda",
     "latin": "Boesenbergia rotunda",
@@ -7480,7 +7480,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "artemisia-absinthium",
+    "slug": "wormwood-wb",
     "name": "Wormwood",
     "scientificName": "Artemisia absinthium",
     "latin": "Artemisia absinthium",
@@ -7522,7 +7522,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "aesculus-hippocastanum",
+    "slug": "horse-chestnut",
     "name": "Horse Chestnut",
     "scientificName": "Aesculus hippocastanum",
     "latin": "Aesculus hippocastanum",
@@ -7570,7 +7570,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "aegle-marmelos",
+    "slug": "bael",
     "name": "Bael",
     "scientificName": "Aegle marmelos",
     "latin": "Aegle marmelos",
@@ -7612,7 +7612,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "ilex-guayusa",
+    "slug": "guayusa-wb",
     "name": "Guayusa",
     "scientificName": "Ilex guayusa",
     "latin": "Ilex guayusa",
@@ -7656,7 +7656,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "lonicera-japonica",
+    "slug": "honeysuckle",
     "name": "Honeysuckle",
     "scientificName": "Lonicera japonica",
     "latin": "Lonicera japonica",
@@ -7698,7 +7698,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "cassia-alata",
+    "slug": "cassia-alata-wb",
     "name": "Cassia Alata",
     "scientificName": "Senna alata",
     "latin": "Senna alata",
@@ -7740,7 +7740,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "nelumbo-lutea",
+    "slug": "american-yellow-lotus-wb",
     "name": "American Yellow Lotus",
     "scientificName": "Nelumbo lutea",
     "latin": "Nelumbo lutea",
@@ -7783,7 +7783,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "agastache-foeniculum",
+    "slug": "anise-hyssop",
     "name": "Anise Hyssop",
     "scientificName": "Agastache foeniculum",
     "latin": "Agastache foeniculum",
@@ -7825,7 +7825,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "althaea-officinalis",
+    "slug": "marshmallow",
     "name": "Marshmallow",
     "scientificName": "Althaea officinalis",
     "latin": "Althaea officinalis",
@@ -7872,7 +7872,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "glycyrrhiza-glabra",
+    "slug": "licorice",
     "name": "Licorice",
     "scientificName": "Glycyrrhiza glabra",
     "latin": "Glycyrrhiza glabra",
@@ -7912,7 +7912,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "sambucus-nigra",
+    "slug": "elderberry",
     "name": "Elderberry",
     "scientificName": "Sambucus nigra",
     "latin": "Sambucus nigra",
@@ -7961,7 +7961,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "boerhavia-diffusa",
+    "slug": "punarnava",
     "name": "Punarnava",
     "scientificName": "Boerhavia diffusa",
     "latin": "Boerhavia diffusa",
@@ -8013,7 +8013,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "coffee",
+    "slug": "coffee-cherry",
     "name": "Coffee Cherry",
     "scientificName": "Coffea arabica",
     "latin": "Coffea arabica",


### PR DESCRIPTION
### Motivation
- Prevent slug collisions when ingesting workbook data by ensuring workbook-generated slugs do not conflict with canonical `public/data/herbs.json` and `public/data/compounds.json` prior to routing or further processing. 
- Keep changes strictly limited to workbook files and preserve existing canonical datasets and routing behavior. 
- Use a predictable, reversible suffixing strategy so workbook entries remain identifiable while avoiding collisions during downstream use.

### Description
- Regenerated slugs inside `public/data/workbook-herbs.json` and `public/data/workbook-compounds.json` from the record `name`/compound name fields and replaced slug values in-place. 
- Collision resolution policy: if the generated base slug exists in the canonical dataset, prefer appending `-wb`, and if that also exists, fall back to numeric suffixes (`-2`, `-3`, ...) until unique. 
- Only the two workbook JSON files were modified; no routing, schema, or canonical data files were changed. 
- Example adjusted slugs include `ashwagandha-wb`, `black-cohosh-wb`, `5-meo-dmt-wb`, and `aconitine-wb` to prevent collisions with canonical records.

### Testing
- Ran the one-off updater and verifier with Node invocations that regenerated slugs and wrote the workbook files, using commands such as `node <<'NODE' ... NODE` and `node -e '...report...'`, which completed successfully. 
- Verification output reported `collisionsHandled: 82` for `public/data/workbook-herbs.json` and `collisionsHandled: 131` for `public/data/workbook-compounds.json`. 
- Post-change checks confirmed no remaining collisions with canonical data and no duplicate slugs inside the workbook files (`collisionsWithExisting: 0` and `duplicateWorkbookSlugs: 0` for both files). 
- Changed files committed: `public/data/workbook-herbs.json` and `public/data/workbook-compounds.json`, and the automated verification scripts succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbac1d4f608323bf6a8893bbe2aafd)