### PR TITLE
Merge workbook data into herb and compound listing loaders

### DIFF
--- a/src/lib/compound-data.ts
+++ b/src/lib/compound-data.ts
@@ -92,6 +92,26 @@ function normalizeEnrichmentSummary(value: unknown): PublishSafeEnrichmentSummar
 let compoundsSummaryPromise: Promise<CompoundSummaryRecord[]> | null = null
 const compoundDetailPromiseBySlug = new Map<string, Promise<CompoundRecord | null>>()
 
+function isPresent(value: unknown): boolean {
+  if (value == null) return false
+  if (typeof value === 'string') return value.trim().length > 0
+  if (Array.isArray(value)) return value.length > 0
+  return true
+}
+
+function mergeCompoundSummaryRows(
+  existing: CompoundSummaryRecord,
+  workbook: CompoundSummaryRecord,
+): CompoundSummaryRecord {
+  const merged: CompoundSummaryRecord = { ...existing }
+  for (const [key, value] of Object.entries(workbook)) {
+    if (!isPresent(merged[key as keyof CompoundSummaryRecord]) && isPresent(value)) {
+      ;(merged as Record<string, unknown>)[key] = value
+    }
+  }
+  return merged
+}
+
 function normalizeSlugCandidate(value: string): string {
   return value
     .normalize('NFKD')
@@ -232,14 +252,39 @@ export function isRenderableCompound(raw: Record<string, unknown>): boolean {
 
 export async function loadCompoundSummaryData(): Promise<CompoundSummaryRecord[]> {
   if (!compoundsSummaryPromise) {
-    compoundsSummaryPromise = fetch('/data/compounds-summary.json', { cache: 'no-store' })
-      .then(response => {
+    compoundsSummaryPromise = Promise.all([
+      fetch('/data/compounds-summary.json', { cache: 'no-store' }).then(response => {
         if (!response.ok) throw new Error('Failed to load /data/compounds-summary.json')
         return response.json()
-      })
-      .then(payload => {
-        const rows = Array.isArray(payload) ? payload : []
-        return rows.map(row => normalizeCompoundSummary(row as Record<string, unknown>))
+      }),
+      fetch('/data/workbook-compounds.json', { cache: 'no-store' })
+        .then(response => {
+          if (!response.ok) throw new Error('Failed to load /data/workbook-compounds.json')
+          return response.json()
+        })
+        .catch(() => []),
+    ])
+      .then(([summaryPayload, workbookPayload]) => {
+        const summaryRows = Array.isArray(summaryPayload) ? summaryPayload : []
+        const workbookRows = Array.isArray(workbookPayload) ? workbookPayload : []
+        const mergedBySlug = new Map<string, CompoundSummaryRecord>()
+
+        summaryRows
+          .map(row => normalizeCompoundSummary(row as Record<string, unknown>))
+          .forEach(row => {
+            if (!row.slug) return
+            mergedBySlug.set(row.slug, row)
+          })
+
+        workbookRows
+          .map(row => normalizeCompoundSummary(row as Record<string, unknown>))
+          .forEach(row => {
+            if (!row.slug) return
+            const existing = mergedBySlug.get(row.slug)
+            mergedBySlug.set(row.slug, existing ? mergeCompoundSummaryRows(existing, row) : row)
+          })
+
+        return Array.from(mergedBySlug.values())
       })
       .catch(error => {
         compoundsSummaryPromise = null

--- a/src/lib/herb-data.ts
+++ b/src/lib/herb-data.ts
@@ -74,6 +74,23 @@ function normalizeEnrichmentSummary(value: unknown): PublishSafeEnrichmentSummar
 let herbSummariesPromise: Promise<HerbSummary[]> | null = null
 const herbDetailPromiseBySlug = new Map<string, Promise<Herb | null>>()
 
+function isPresent(value: unknown): boolean {
+  if (value == null) return false
+  if (typeof value === 'string') return value.trim().length > 0
+  if (Array.isArray(value)) return value.length > 0
+  return true
+}
+
+function mergeHerbSummaryRows(existing: HerbSummary, workbook: HerbSummary): HerbSummary {
+  const merged: HerbSummary = { ...existing }
+  for (const [key, value] of Object.entries(workbook)) {
+    if (!isPresent(merged[key]) && isPresent(value)) {
+      merged[key] = value
+    }
+  }
+  return merged
+}
+
 function normalizeSlugCandidate(value: string): string {
   return value
     .normalize('NFKD')
@@ -293,14 +310,39 @@ export function isRenderableHerbRow(raw: Record<string, unknown>): boolean {
 
 export async function loadHerbSummaryData(): Promise<HerbSummary[]> {
   if (!herbSummariesPromise) {
-    herbSummariesPromise = fetch('/data/herbs-summary.json', { cache: 'no-store' })
-      .then(response => {
+    herbSummariesPromise = Promise.all([
+      fetch('/data/herbs-summary.json', { cache: 'no-store' }).then(response => {
         if (!response.ok) throw new Error('Failed to load /data/herbs-summary.json')
         return response.json()
-      })
-      .then(payload => {
-        const rows = Array.isArray(payload) ? payload : []
-        return rows.map(row => normalizeHerbSummaryRow(row as Record<string, unknown>))
+      }),
+      fetch('/data/workbook-herbs.json', { cache: 'no-store' })
+        .then(response => {
+          if (!response.ok) throw new Error('Failed to load /data/workbook-herbs.json')
+          return response.json()
+        })
+        .catch(() => []),
+    ])
+      .then(([summaryPayload, workbookPayload]) => {
+        const summaryRows = Array.isArray(summaryPayload) ? summaryPayload : []
+        const workbookRows = Array.isArray(workbookPayload) ? workbookPayload : []
+        const mergedBySlug = new Map<string, HerbSummary>()
+
+        summaryRows
+          .map(row => normalizeHerbSummaryRow(row as Record<string, unknown>))
+          .forEach(row => {
+            if (!row.slug) return
+            mergedBySlug.set(row.slug, row)
+          })
+
+        workbookRows
+          .map(row => normalizeHerbSummaryRow(row as Record<string, unknown>))
+          .forEach(row => {
+            if (!row.slug) return
+            const existing = mergedBySlug.get(row.slug)
+            mergedBySlug.set(row.slug, existing ? mergeHerbSummaryRows(existing, row) : row)
+          })
+
+        return Array.from(mergedBySlug.values())
       })
       .catch(error => {
         herbSummariesPromise = null


### PR DESCRIPTION
### Motivation
- Make workbook-sourced herb and compound records visible in browse/listing pages by merging workbook payloads with existing summary datasets while preserving existing detail behavior.
- Ensure workbook data augments rather than replaces base summaries and that duplicate slugs are not shown in listings.
- Avoid touching detail page loading logic so detail routes remain unchanged.

### Description
- Updated herb summary loader in `src/lib/herb-data.ts` to `Promise.all`-fetch `'/data/herbs-summary.json'` and `'/data/workbook-herbs.json'`, normalize rows, merge by slug, and dedupe; added `isPresent` and `mergeHerbSummaryRows` helpers to fill only missing fields from workbook rows.
- Updated compound summary loader in `src/lib/compound-data.ts` to `Promise.all`-fetch `'/data/compounds-summary.json'` and `'/data/workbook-compounds.json'`, normalize rows, merge by slug, and dedupe; added `isPresent` and `mergeCompoundSummaryRows` helpers to fill only missing fields from workbook rows.
- Preserve existing summary values when duplicates occur and only fill blanks from workbook entries, keeping detail loading logic (`loadHerbDetailBySlug` / `loadCompoundDetailBySlug`) untouched.
- Changed files: `src/lib/herb-data.ts`, `src/lib/compound-data.ts`.

### Testing
- Ran `npm run build:compile` which completed successfully and produced a valid build without changing detail-route behavior.
- Verified merged listing counts with a Node check against `public/data/*` JSON payloads and confirmed new totals: herb listing increased to `185` unique slugs and compound listing increased to `1023` unique slugs.
- Confirmed duplicate slugs in the merged listing payloads are `0` for herbs and `0` for compounds using a slug-merging verification script; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbad0c4ffc83239aa43e82db889e00)