### PR TITLE
Add workbook fallback for herb and compound detail pages

### DIFF
--- a/src/lib/compound-data.ts
+++ b/src/lib/compound-data.ts
@@ -90,6 +90,7 @@ function normalizeEnrichmentSummary(value: unknown): PublishSafeEnrichmentSummar
 }
 
 let compoundsSummaryPromise: Promise<CompoundSummaryRecord[]> | null = null
+let workbookCompoundsPromise: Promise<Record<string, unknown>[]> | null = null
 const compoundDetailPromiseBySlug = new Map<string, Promise<CompoundRecord | null>>()
 
 function isPresent(value: unknown): boolean {
@@ -119,6 +120,47 @@ function normalizeSlugCandidate(value: string): string {
     .toLowerCase()
     .replace(/\band\b/g, '')
     .replace(/[^a-z0-9]+/g, '')
+}
+
+function loadWorkbookCompoundRows(): Promise<Record<string, unknown>[]> {
+  if (!workbookCompoundsPromise) {
+    workbookCompoundsPromise = fetch('/data/workbook-compounds.json', { cache: 'no-store' })
+      .then(response => {
+        if (!response.ok) throw new Error('Failed to load /data/workbook-compounds.json')
+        return response.json()
+      })
+      .then(payload => (Array.isArray(payload) ? (payload as Record<string, unknown>[]) : []))
+      .catch(error => {
+        workbookCompoundsPromise = null
+        throw error
+      })
+  }
+
+  return workbookCompoundsPromise
+}
+
+async function loadWorkbookCompoundDetailBySlug(slug: string): Promise<CompoundRecord | null> {
+  const needle = normalizeSlugCandidate(slug)
+  if (!needle) return null
+
+  const workbookRows = await loadWorkbookCompoundRows().catch(() => [])
+  const match = workbookRows.find(row => {
+    const record = row as Record<string, unknown>
+    const aliases = splitClean(record.aliases)
+    const candidates = [
+      String(record.slug || ''),
+      String(record.id || ''),
+      String(record.name || ''),
+      String(record.compoundName || ''),
+      String(record.canonicalCompoundId || ''),
+      String(record.canonicalCompoundName || ''),
+      ...aliases,
+    ]
+    return candidates.some(candidate => normalizeSlugCandidate(candidate) === needle)
+  })
+
+  if (!match) return null
+  return normalizeCompound(match)
 }
 
 async function resolveCompoundDetailSlug(slug: string): Promise<string | null> {
@@ -308,18 +350,21 @@ export async function loadCompoundDetailBySlug(slug: string): Promise<CompoundRe
     .then(async response => {
       if (response.status === 404) {
         const resolvedSlug = await resolveCompoundDetailSlug(slugKey)
-        if (!resolvedSlug || resolvedSlug === slugKey) return null
-        const fallbackResponse = await fetch(
-          `/data/compounds-detail/${encodeURIComponent(resolvedSlug)}.json`,
-          {
-            cache: 'no-store',
-          },
-        )
-        if (fallbackResponse.status === 404) return null
-        if (!fallbackResponse.ok) {
-          throw new Error(`Failed to load /data/compounds-detail/${resolvedSlug}.json`)
+        if (resolvedSlug && resolvedSlug !== slugKey) {
+          const fallbackResponse = await fetch(
+            `/data/compounds-detail/${encodeURIComponent(resolvedSlug)}.json`,
+            {
+              cache: 'no-store',
+            },
+          )
+          if (fallbackResponse.ok) {
+            return fallbackResponse.json()
+          }
+          if (fallbackResponse.status !== 404) {
+            throw new Error(`Failed to load /data/compounds-detail/${resolvedSlug}.json`)
+          }
         }
-        return fallbackResponse.json()
+        return loadWorkbookCompoundDetailBySlug(resolvedSlug || slugKey)
       }
       if (!response.ok) {
         throw new Error(`Failed to load /data/compounds-detail/${slugKey}.json`)

--- a/src/lib/herb-data.ts
+++ b/src/lib/herb-data.ts
@@ -72,6 +72,7 @@ function normalizeEnrichmentSummary(value: unknown): PublishSafeEnrichmentSummar
 }
 
 let herbSummariesPromise: Promise<HerbSummary[]> | null = null
+let workbookHerbsPromise: Promise<Record<string, unknown>[]> | null = null
 const herbDetailPromiseBySlug = new Map<string, Promise<Herb | null>>()
 
 function isPresent(value: unknown): boolean {
@@ -98,6 +99,49 @@ function normalizeSlugCandidate(value: string): string {
     .toLowerCase()
     .replace(/\band\b/g, '')
     .replace(/[^a-z0-9]+/g, '')
+}
+
+function loadWorkbookHerbRows(): Promise<Record<string, unknown>[]> {
+  if (!workbookHerbsPromise) {
+    workbookHerbsPromise = fetch('/data/workbook-herbs.json', { cache: 'no-store' })
+      .then(response => {
+        if (!response.ok) throw new Error('Failed to load /data/workbook-herbs.json')
+        return response.json()
+      })
+      .then(payload => (Array.isArray(payload) ? (payload as Record<string, unknown>[]) : []))
+      .catch(error => {
+        workbookHerbsPromise = null
+        throw error
+      })
+  }
+
+  return workbookHerbsPromise
+}
+
+async function loadWorkbookHerbDetailBySlug(slug: string): Promise<Herb | null> {
+  const needle = normalizeSlugCandidate(slug)
+  if (!needle) return null
+
+  const workbookRows = await loadWorkbookHerbRows().catch(() => [])
+  const match = workbookRows.find(row => {
+    const record = row as Record<string, unknown>
+    const aliases = splitClean(record.aliases)
+    const candidates = [
+      String(record.slug || ''),
+      String(record.id || ''),
+      String(record.common || ''),
+      String(record.name || ''),
+      String(record.commonName || ''),
+      String(record.scientific || ''),
+      String(record.scientificName || ''),
+      String(record.latin || ''),
+      ...aliases,
+    ]
+    return candidates.some(candidate => normalizeSlugCandidate(candidate) === needle)
+  })
+
+  if (!match) return null
+  return normalizeHerbRow(match)
 }
 
 async function resolveHerbDetailSlug(slug: string): Promise<string | null> {
@@ -366,18 +410,21 @@ export async function loadHerbDetailBySlug(slug: string): Promise<Herb | null> {
     .then(async response => {
       if (response.status === 404) {
         const resolvedSlug = await resolveHerbDetailSlug(slugKey)
-        if (!resolvedSlug || resolvedSlug === slugKey) return null
-        const fallbackResponse = await fetch(
-          `/data/herbs-detail/${encodeURIComponent(resolvedSlug)}.json`,
-          {
-            cache: 'no-store',
-          },
-        )
-        if (fallbackResponse.status === 404) return null
-        if (!fallbackResponse.ok) {
-          throw new Error(`Failed to load /data/herbs-detail/${resolvedSlug}.json`)
+        if (resolvedSlug && resolvedSlug !== slugKey) {
+          const fallbackResponse = await fetch(
+            `/data/herbs-detail/${encodeURIComponent(resolvedSlug)}.json`,
+            {
+              cache: 'no-store',
+            },
+          )
+          if (fallbackResponse.ok) {
+            return fallbackResponse.json()
+          }
+          if (fallbackResponse.status !== 404) {
+            throw new Error(`Failed to load /data/herbs-detail/${resolvedSlug}.json`)
+          }
         }
-        return fallbackResponse.json()
+        return loadWorkbookHerbDetailBySlug(resolvedSlug || slugKey)
       }
       if (!response.ok) {
         throw new Error(`Failed to load /data/herbs-detail/${slugKey}.json`)


### PR DESCRIPTION
### Motivation
- Workbook-derived herbs and compounds sometimes appear in summary/index datasets but lack generated per-entity detail JSON, causing detail routes to 404; this change ensures those workbook-only entities can still render detail pages.
- Preserve existing routing and data precedence so canonical detail JSON remains primary and workbook rows are only a safe fallback.

### Description
- Added cached workbook loaders and matchers: `loadWorkbookHerbRows` / `loadWorkbookHerbDetailBySlug` and `loadWorkbookCompoundRows` / `loadWorkbookCompoundDetailBySlug` to locate workbook rows by multiple slug/name candidates.
- Updated `loadHerbDetailBySlug` and `loadCompoundDetailBySlug` to keep the existing flow (direct detail JSON first, then resolved canonical slug) and to fall back to the corresponding workbook-detail loader when no detail JSON is available.
- Reused existing normalizers (`normalizeHerbRow` / `normalizeCompound`) so missing optional fields are replaced with safe defaults and pages render without runtime errors.
- Changed files: `src/lib/herb-data.ts` and `src/lib/compound-data.ts` (workbook loaders + fallback logic added, ~114 insertions / 22 deletions combined).

### Testing
- Commands run: `npm run build:compile` and the project prebuild flow during local `npm run build`, plus a node script that loaded `/public/data/workbook-*.json` and exercised `loadHerbDetailBySlug` / `loadCompoundDetailBySlug` against sample workbook-only slugs.
- Verification results: workbook-only counts discovered were `workbook-only herbs: 168`, `workbook-only compounds: 222`, and `total workbook-only pages: 390` and the fallback path resolved those pages.
- Sample checks: 3 workbook-only herbs (`ashwagandha-wb`, `black-cohosh-wb`, `echinacea-purpurea-wb`) and 3 workbook-only compounds (`1-deoxynojirimycin`, `4-hydroxyderricin`, `5-hydroxytryptophan-5-htp`) successfully resolved and returned normalized records, with pages rendering using safe defaults.
- Missing-field issues: some workbook compound rows (sampled above) have blank `description` fields but this is handled by existing normalizers and does not break rendering; consider content enrichment as a follow-up.
- Result: automated build and the data checks completed successfully and the fallback enables workbook-derived detail pages to load.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbaee24e408323ba6464cca71853ca)