### PR TITLE
Enable workbook-only herb and compound detail fallbacks

### DIFF
--- a/src/lib/compound-data.ts
+++ b/src/lib/compound-data.ts
@@ -45,6 +45,8 @@ export type CompoundRecord = {
   researchEnrichment?: ResearchEnrichment
   researchEnrichmentSummary?: PublishSafeEnrichmentSummary
   sourceCount?: number
+  compounds?: string[]
+  benefits?: string[]
 }
 
 export type CompoundSummaryRecord = {
@@ -90,6 +92,7 @@ function normalizeEnrichmentSummary(value: unknown): PublishSafeEnrichmentSummar
 }
 
 let compoundsSummaryPromise: Promise<CompoundSummaryRecord[]> | null = null
+let canonicalCompoundsSummaryPromise: Promise<CompoundSummaryRecord[]> | null = null
 let workbookCompoundsPromise: Promise<Record<string, unknown>[]> | null = null
 const compoundDetailPromiseBySlug = new Map<string, Promise<CompoundRecord | null>>()
 
@@ -139,6 +142,26 @@ function loadWorkbookCompoundRows(): Promise<Record<string, unknown>[]> {
   return workbookCompoundsPromise
 }
 
+function loadCanonicalCompoundSummaryRows(): Promise<CompoundSummaryRecord[]> {
+  if (!canonicalCompoundsSummaryPromise) {
+    canonicalCompoundsSummaryPromise = fetch('/data/compounds-summary.json', { cache: 'no-store' })
+      .then(response => {
+        if (!response.ok) throw new Error('Failed to load /data/compounds-summary.json')
+        return response.json()
+      })
+      .then(payload => {
+        const rows = Array.isArray(payload) ? payload : []
+        return rows.map(row => normalizeCompoundSummary(row as Record<string, unknown>))
+      })
+      .catch(error => {
+        canonicalCompoundsSummaryPromise = null
+        throw error
+      })
+  }
+
+  return canonicalCompoundsSummaryPromise
+}
+
 async function loadWorkbookCompoundDetailBySlug(slug: string): Promise<CompoundRecord | null> {
   const needle = normalizeSlugCandidate(slug)
   if (!needle) return null
@@ -168,6 +191,19 @@ async function resolveCompoundDetailSlug(slug: string): Promise<string | null> {
   if (!needle) return null
 
   const summaries = await loadCompoundSummaryData()
+  const match = summaries.find(item => {
+    const candidates = [item.slug, item.id, item.name, ...item.aliases]
+    return candidates.some(candidate => normalizeSlugCandidate(candidate) === needle)
+  })
+
+  return match?.slug || null
+}
+
+async function resolveCanonicalCompoundDetailSlug(slug: string): Promise<string | null> {
+  const needle = normalizeSlugCandidate(slug)
+  if (!needle) return null
+
+  const summaries = await loadCanonicalCompoundSummaryRows()
   const match = summaries.find(item => {
     const candidates = [item.slug, item.id, item.name, ...item.aliases]
     return candidates.some(candidate => normalizeSlugCandidate(candidate) === needle)
@@ -217,6 +253,8 @@ function normalizeCompound(raw: Record<string, unknown>): CompoundRecord {
   const relatedEntities = splitClean(data.relatedEntities)
   const relatedCompounds = splitClean(data.relatedCompounds)
   const linkedHerbs = splitClean(data.linkedHerbs)
+  const compounds = splitClean(data.compounds ?? data.relatedCompounds)
+  const benefits = splitClean(data.benefits ?? data.effects)
   const sources = normalizeSources(data.sources)
 
   return {
@@ -230,6 +268,7 @@ function normalizeCompound(raw: Record<string, unknown>): CompoundRecord {
     mechanism,
     activeCompounds: splitClean(data.activeCompounds),
     effects,
+    benefits,
     therapeuticUses: splitClean(data.therapeuticUses),
     contraindications: splitClean(data.contraindications),
     interactions: splitClean(data.interactions),
@@ -247,6 +286,7 @@ function normalizeCompound(raw: Record<string, unknown>): CompoundRecord {
     evidenceLevel,
     relatedEntities,
     relatedCompounds,
+    compounds,
     linkedHerbs,
     confidence: calculateCompoundConfidence({ mechanism, effects, compounds: herbs }),
     sources,
@@ -344,32 +384,23 @@ export async function loadCompoundDetailBySlug(slug: string): Promise<CompoundRe
   const cached = compoundDetailPromiseBySlug.get(slugKey)
   if (cached) return cached
 
-  const request = fetch(`/data/compounds-detail/${encodeURIComponent(slugKey)}.json`, {
-    cache: 'no-store',
-  })
-    .then(async response => {
-      if (response.status === 404) {
-        const resolvedSlug = await resolveCompoundDetailSlug(slugKey)
-        if (resolvedSlug && resolvedSlug !== slugKey) {
-          const fallbackResponse = await fetch(
-            `/data/compounds-detail/${encodeURIComponent(resolvedSlug)}.json`,
-            {
-              cache: 'no-store',
-            },
-          )
-          if (fallbackResponse.ok) {
-            return fallbackResponse.json()
-          }
-          if (fallbackResponse.status !== 404) {
-            throw new Error(`Failed to load /data/compounds-detail/${resolvedSlug}.json`)
-          }
+  const request = resolveCanonicalCompoundDetailSlug(slugKey)
+    .then(async resolvedCanonicalSlug => {
+      if (resolvedCanonicalSlug) {
+        const canonicalResponse = await fetch(
+          `/data/compounds-detail/${encodeURIComponent(resolvedCanonicalSlug)}.json`,
+          { cache: 'no-store' },
+        )
+        if (canonicalResponse.ok) {
+          return canonicalResponse.json()
         }
-        return loadWorkbookCompoundDetailBySlug(resolvedSlug || slugKey)
+        if (canonicalResponse.status !== 404) {
+          throw new Error(`Failed to load /data/compounds-detail/${resolvedCanonicalSlug}.json`)
+        }
       }
-      if (!response.ok) {
-        throw new Error(`Failed to load /data/compounds-detail/${slugKey}.json`)
-      }
-      return response.json()
+
+      const resolvedSlug = await resolveCompoundDetailSlug(slugKey)
+      return loadWorkbookCompoundDetailBySlug(resolvedSlug || slugKey)
     })
     .then(payload => {
       if (!payload || typeof payload !== 'object') return null

--- a/src/lib/herb-data.ts
+++ b/src/lib/herb-data.ts
@@ -72,6 +72,7 @@ function normalizeEnrichmentSummary(value: unknown): PublishSafeEnrichmentSummar
 }
 
 let herbSummariesPromise: Promise<HerbSummary[]> | null = null
+let canonicalHerbSummariesPromise: Promise<HerbSummary[]> | null = null
 let workbookHerbsPromise: Promise<Record<string, unknown>[]> | null = null
 const herbDetailPromiseBySlug = new Map<string, Promise<Herb | null>>()
 
@@ -118,6 +119,26 @@ function loadWorkbookHerbRows(): Promise<Record<string, unknown>[]> {
   return workbookHerbsPromise
 }
 
+function loadCanonicalHerbSummaryRows(): Promise<HerbSummary[]> {
+  if (!canonicalHerbSummariesPromise) {
+    canonicalHerbSummariesPromise = fetch('/data/herbs-summary.json', { cache: 'no-store' })
+      .then(response => {
+        if (!response.ok) throw new Error('Failed to load /data/herbs-summary.json')
+        return response.json()
+      })
+      .then(payload => {
+        const rows = Array.isArray(payload) ? payload : []
+        return rows.map(row => normalizeHerbSummaryRow(row as Record<string, unknown>))
+      })
+      .catch(error => {
+        canonicalHerbSummariesPromise = null
+        throw error
+      })
+  }
+
+  return canonicalHerbSummariesPromise
+}
+
 async function loadWorkbookHerbDetailBySlug(slug: string): Promise<Herb | null> {
   const needle = normalizeSlugCandidate(slug)
   if (!needle) return null
@@ -149,6 +170,26 @@ async function resolveHerbDetailSlug(slug: string): Promise<string | null> {
   if (!needle) return null
 
   const summaries = await loadHerbSummaryData()
+  const match = summaries.find(item => {
+    const candidates = [
+      item.slug,
+      item.id,
+      item.common,
+      item.scientific,
+      item.name,
+      ...item.aliases,
+    ]
+    return candidates.some(candidate => normalizeSlugCandidate(candidate) === needle)
+  })
+
+  return match?.slug || null
+}
+
+async function resolveCanonicalHerbDetailSlug(slug: string): Promise<string | null> {
+  const needle = normalizeSlugCandidate(slug)
+  if (!needle) return null
+
+  const summaries = await loadCanonicalHerbSummaryRows()
   const match = summaries.find(item => {
     const candidates = [
       item.slug,
@@ -249,6 +290,7 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
   const identity = cleanText(data.identity) || ''
   const categoryUseContext = cleanText(data.categoryUseContext ?? data.category_use_context) || ''
   const evidenceLevel = cleanText(data.evidenceLevel ?? data.evidence_level) || ''
+  const benefits = splitClean(data.benefits ?? data.effects)
 
   return {
     ...(data as Herb),
@@ -264,6 +306,7 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
     region,
     mechanism,
     effects,
+    benefits,
     therapeuticUses,
     contraindications,
     interactions,
@@ -404,32 +447,23 @@ export async function loadHerbDetailBySlug(slug: string): Promise<Herb | null> {
   const cached = herbDetailPromiseBySlug.get(slugKey)
   if (cached) return cached
 
-  const request = fetch(`/data/herbs-detail/${encodeURIComponent(slugKey)}.json`, {
-    cache: 'no-store',
-  })
-    .then(async response => {
-      if (response.status === 404) {
-        const resolvedSlug = await resolveHerbDetailSlug(slugKey)
-        if (resolvedSlug && resolvedSlug !== slugKey) {
-          const fallbackResponse = await fetch(
-            `/data/herbs-detail/${encodeURIComponent(resolvedSlug)}.json`,
-            {
-              cache: 'no-store',
-            },
-          )
-          if (fallbackResponse.ok) {
-            return fallbackResponse.json()
-          }
-          if (fallbackResponse.status !== 404) {
-            throw new Error(`Failed to load /data/herbs-detail/${resolvedSlug}.json`)
-          }
+  const request = resolveCanonicalHerbDetailSlug(slugKey)
+    .then(async resolvedCanonicalSlug => {
+      if (resolvedCanonicalSlug) {
+        const canonicalResponse = await fetch(
+          `/data/herbs-detail/${encodeURIComponent(resolvedCanonicalSlug)}.json`,
+          { cache: 'no-store' },
+        )
+        if (canonicalResponse.ok) {
+          return canonicalResponse.json()
         }
-        return loadWorkbookHerbDetailBySlug(resolvedSlug || slugKey)
+        if (canonicalResponse.status !== 404) {
+          throw new Error(`Failed to load /data/herbs-detail/${resolvedCanonicalSlug}.json`)
+        }
       }
-      if (!response.ok) {
-        throw new Error(`Failed to load /data/herbs-detail/${slugKey}.json`)
-      }
-      return response.json()
+
+      const resolvedSlug = await resolveHerbDetailSlug(slugKey)
+      return loadWorkbookHerbDetailBySlug(resolvedSlug || slugKey)
     })
     .then(payload => {
       if (!payload || typeof payload !== 'object') return null


### PR DESCRIPTION
### Motivation
- Allow detail pages for herbs and compounds that only exist in the workbook export without changing listing behavior, identity maps, or canonical data files.  
- Ensure pages render safely when workbook rows omit optional fields by providing deterministic fallbacks for `description`, `compounds`, and `benefits`.  
- Keep the smallest, local changes confined to the detail loader and normalization code so existing routes and detail pages are preserved.

### Description
- Updated herb detail loader to resolve slugs against the canonical `herbs-summary.json` first and fetch canonical `/data/herbs-detail/{slug}.json` when present, and otherwise fall back to matching rows in `workbook-herbs.json`.  
- Applied the same canonical-first, workbook-fallback logic to the compound detail loader using `compounds-summary.json` and `workbook-compounds.json`.  
- Added normalization defaults so workbook-derived payloads produce safe fields: `description` falls back to `''`, `compounds` and `benefits` normalize to arrays (herb `benefits` now derives from `effects` when absent).  
- Changed files: `src/lib/herb-data.ts`, `src/lib/compound-data.ts` (added canonical summary caches/resolvers, loader decision path changes, and normalization additions).

### Testing
- Ran a production compile with `npm run build:compile` which completed successfully.  
- Verified workbook-only counts with a Node inspection script which found `workbook-only herbs: 168` and `workbook-only compounds: 624`.  
- Confirmed rendering for samples by running the preview server and requesting 3 workbook-only herb routes and 3 workbook-only compound routes (paths returned HTTP 200 and rendered root HTML for each).  
- Audited workbook dataset missing-field exposure and found raw workbook gaps (herbs: `missingBenefits=172`, compounds: `missingDescription=630, missingCompounds=630, missingBenefits=630`) that are covered by the loader normalization; all automated checks passed except a headful Puppeteer run which failed due to missing system library (`libatk-1.0.so.0`) in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbb1fcf59883238c3d9d8354530c6c)