### PR TITLE
Refactor herb/compound filter UI to reduce initial visual load

### DIFF
--- a/src/components/filters/ActiveFiltersBar.tsx
+++ b/src/components/filters/ActiveFiltersBar.tsx
@@ -34,6 +34,9 @@ export default function ActiveFiltersBar({
 
   return (
     <div className='flex flex-wrap items-center gap-2 rounded-2xl border border-white/10 bg-white/[0.03] p-3'>
+      <span className='mr-1 text-xs font-semibold uppercase tracking-wide text-white/55'>
+        Active
+      </span>
       {state.query && (
         <button
           type='button'

--- a/src/components/filters/ConfidenceFilter.tsx
+++ b/src/components/filters/ConfidenceFilter.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import type { ConfidenceFilter as ConfidenceFilterValue } from '@/utils/filterModel'
 
 type ConfidenceFilterProps = {
@@ -6,30 +7,73 @@ type ConfidenceFilterProps = {
 }
 
 const OPTIONS: ConfidenceFilterValue[] = ['all', 'high', 'medium', 'low']
+const MORE_FILTERS_EVENT = 'filters:more-toggle'
 
 export default function ConfidenceFilter({ value, onChange }: ConfidenceFilterProps) {
+  const [moreOpen, setMoreOpen] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return window.localStorage.getItem('filters:more-open') === 'true'
+  })
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+
+    const handleChange = (event: Event) => {
+      const detail = (event as CustomEvent<{ open?: boolean }>).detail
+      if (typeof detail?.open === 'boolean') {
+        setMoreOpen(detail.open)
+      }
+    }
+
+    window.addEventListener(MORE_FILTERS_EVENT, handleChange as EventListener)
+    return () => window.removeEventListener(MORE_FILTERS_EVENT, handleChange as EventListener)
+  }, [])
+
+  const toggleMoreFilters = () => {
+    const next = !moreOpen
+    setMoreOpen(next)
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('filters:more-open', String(next))
+      window.dispatchEvent(new CustomEvent(MORE_FILTERS_EVENT, { detail: { open: next } }))
+    }
+  }
+
   return (
     <section className='rounded-2xl border border-white/10 bg-white/[0.03] p-3'>
-      <h3 className='mb-2 text-sm font-semibold text-white'>Confidence</h3>
-      <div className='flex flex-wrap gap-2'>
-        {OPTIONS.map(option => {
-          const active = value === option
-          return (
-            <button
-              key={option}
-              type='button'
-              onClick={() => onChange(option)}
-              className={`rounded-full border px-3 py-1 text-xs uppercase tracking-wide transition ${
-                active
-                  ? 'border-cyan-300/60 bg-cyan-500/20 text-cyan-100'
-                  : 'border-white/15 bg-white/[0.03] text-white/80 hover:bg-white/10'
-              }`}
-            >
-              {option}
-            </button>
-          )
-        })}
-      </div>
+      <button
+        type='button'
+        onClick={toggleMoreFilters}
+        className='flex w-full items-center justify-between gap-2 rounded-xl border border-white/15 bg-white/[0.03] px-3 py-2 text-left transition hover:bg-white/10'
+        aria-expanded={moreOpen}
+      >
+        <span className='text-sm font-semibold text-white'>More filters</span>
+        <span className='text-xs text-white/70'>{moreOpen ? 'Hide' : 'Show'}</span>
+      </button>
+
+      {moreOpen && (
+        <div className='mt-3'>
+          <h3 className='mb-2 text-sm font-semibold text-white'>Confidence</h3>
+          <div className='flex flex-wrap gap-2'>
+            {OPTIONS.map(option => {
+              const active = value === option
+              return (
+                <button
+                  key={option}
+                  type='button'
+                  onClick={() => onChange(option)}
+                  className={`rounded-full border px-3 py-1 text-xs uppercase tracking-wide transition ${
+                    active
+                      ? 'border-cyan-300/60 bg-cyan-500/20 text-cyan-100'
+                      : 'border-white/15 bg-white/[0.03] text-white/80 hover:bg-white/10'
+                  }`}
+                >
+                  {option}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      )}
     </section>
   )
 }

--- a/src/components/filters/EffectFilter.tsx
+++ b/src/components/filters/EffectFilter.tsx
@@ -1,4 +1,6 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+
+const MORE_FILTERS_EVENT = 'filters:more-toggle'
 
 type EffectFilterProps = {
   options: string[]
@@ -8,11 +10,32 @@ type EffectFilterProps = {
 
 export default function EffectFilter({ options, selected, onToggle }: EffectFilterProps) {
   const [expanded, setExpanded] = useState(false)
+  const [moreFiltersOpen, setMoreFiltersOpen] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return window.localStorage.getItem('filters:more-open') === 'true'
+  })
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+
+    const handleChange = (event: Event) => {
+      const detail = (event as CustomEvent<{ open?: boolean }>).detail
+      if (typeof detail?.open === 'boolean') {
+        setMoreFiltersOpen(detail.open)
+      }
+    }
+
+    window.addEventListener(MORE_FILTERS_EVENT, handleChange as EventListener)
+    return () => window.removeEventListener(MORE_FILTERS_EVENT, handleChange as EventListener)
+  }, [])
+
   const hasOverflow = options.length > 18
   const visible = useMemo(() => {
     if (expanded || !hasOverflow) return options
     return options.slice(0, 18)
   }, [expanded, hasOverflow, options])
+
+  if (!moreFiltersOpen) return null
 
   return (
     <section className='rounded-2xl border border-white/10 bg-white/[0.03] p-3'>

--- a/src/components/filters/SearchBar.tsx
+++ b/src/components/filters/SearchBar.tsx
@@ -20,6 +20,9 @@ export default function SearchBar({
   return (
     <div className={`sticky top-2 z-20 ${className}`}>
       <div className='rounded-2xl border border-white/15 bg-black/35 p-2 shadow-[0_0_18px_rgba(168,85,247,0.16)] backdrop-blur'>
+        <div className='mb-1 px-1 text-[11px] font-medium uppercase tracking-wide text-white/55'>
+          Search
+        </div>
         <div className='flex items-center gap-2'>
           <input
             value={value}

--- a/src/components/filters/TypeFilter.tsx
+++ b/src/components/filters/TypeFilter.tsx
@@ -1,3 +1,8 @@
+import { useEffect, useState } from 'react'
+
+const MORE_FILTERS_EVENT = 'filters:more-toggle'
+const ADVANCED_LABELS = new Set(['Research signal'])
+
 type TypeFilterProps = {
   label: string
   options: string[]
@@ -5,7 +10,35 @@ type TypeFilterProps = {
   onChange: (value: string) => void
 }
 
+function useMoreFiltersOpen() {
+  const [open, setOpen] = useState(() => {
+    if (typeof window === 'undefined') return false
+    return window.localStorage.getItem('filters:more-open') === 'true'
+  })
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined
+
+    const handleChange = (event: Event) => {
+      const detail = (event as CustomEvent<{ open?: boolean }>).detail
+      if (typeof detail?.open === 'boolean') {
+        setOpen(detail.open)
+      }
+    }
+
+    window.addEventListener(MORE_FILTERS_EVENT, handleChange as EventListener)
+    return () => window.removeEventListener(MORE_FILTERS_EVENT, handleChange as EventListener)
+  }, [])
+
+  return open
+}
+
 export default function TypeFilter({ label, options, value, onChange }: TypeFilterProps) {
+  const isAdvanced = ADVANCED_LABELS.has(label)
+  const moreFiltersOpen = useMoreFiltersOpen()
+
+  if (isAdvanced && !moreFiltersOpen) return null
+
   return (
     <label className='block rounded-2xl border border-white/10 bg-white/[0.03] p-3'>
       <span className='mb-2 block text-sm font-semibold text-white'>{label}</span>


### PR DESCRIPTION
### Motivation
- Reduce initial visual clutter on herb/compound listing pages by surfacing only the search input and the highest-value filters while hiding lower-priority controls behind a collapsed "More filters" section. 
- Keep existing filtering behavior and callback wiring untouched so functionality is preserved while the visual surface is reduced.

### Description
- Added a compact `Search` label and preserved the same input/clear behavior in `SearchBar.tsx` to make the primary control more visually distinct. 
- Implemented a default-closed `More filters` toggle in `ConfidenceFilter.tsx` that persists open/closed state to `localStorage` and emits a `filters:more-toggle` event so other filter components can mirror visibility. 
- Updated `TypeFilter.tsx` to render normally for primary labels but hide advanced labels (currently `Research signal`) unless `More filters` is open. 
- Hid `EffectFilter.tsx` behind the `More filters` toggle while preserving its chip toggles and overflow expansion behavior, and added a small visual hierarchy update in `ActiveFiltersBar.tsx` (`Active` label) with no logic changes. 

### Testing
- Ran `npm run build:compile` (Vite build) and the compilation completed successfully. 
- Pre-commit hooks and ESLint checks ran during the commit and passed (`eslint --max-warnings=0` on staged TS/TSX files). 
- Changes are UI-only and no runtime filter logic or data mutations were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd856d43083239494eb958a5a0c40)