### PR TITLE
Improve browse quality gating and compact browse card presentation

### DIFF
--- a/src/components/HerbCard.tsx
+++ b/src/components/HerbCard.tsx
@@ -20,12 +20,21 @@ interface HerbCardProps {
   evidence_tier?: string
   evidenceLevel?: string
   detailUrl: string
+  compact?: boolean
 }
 
 const EVIDENCE_TIER_BADGE_CLASS: Record<string, string> = {
   'Tier 1': 'border-emerald-300/35 bg-emerald-400/15 text-emerald-200',
   'Tier 2': 'border-sky-300/35 bg-sky-400/15 text-sky-200',
   'Tier 3': 'border-amber-300/35 bg-amber-400/15 text-amber-200',
+}
+
+function truncateTitle(name: string, maxLength: number): string {
+  if (name.length <= maxLength) return name
+  const trimmed = name.slice(0, maxLength - 1).trimEnd()
+  const cutoff = trimmed.lastIndexOf(' ')
+  if (cutoff >= Math.floor(maxLength * 0.55)) return `${trimmed.slice(0, cutoff)}…`
+  return `${trimmed}…`
 }
 
 function HerbCard({
@@ -37,44 +46,67 @@ function HerbCard({
   evidence_tier,
   evidenceLevel,
   detailUrl,
+  compact = false,
 }: HerbCardProps) {
   const mergedTags = Array.from(new Set([...tags, ...mechanismTags].filter(Boolean)))
+  const visibleTags = compact ? mergedTags.slice(0, 2) : mergedTags
   const hasCompoundCount = typeof compound_count === 'number' && compound_count > 0
   const normalizedEvidenceTier = (evidence_tier || '').trim()
   const fallbackEvidence = normalizedEvidenceTier ? '' : (evidenceLevel || '').trim()
-  const showMetadata = hasCompoundCount || Boolean(normalizedEvidenceTier) || Boolean(fallbackEvidence)
+  const showMetadata =
+    hasCompoundCount || Boolean(normalizedEvidenceTier) || Boolean(fallbackEvidence)
+  const title = compact ? truncateTitle(name, 54) : name
 
   return (
-    <div className='group relative h-full transition-transform duration-200 ease-out HerbCardTilt hover:scale-[1.01]'>
+    <div className='HerbCardTilt group relative h-full transition-transform duration-200 ease-out hover:scale-[1.01]'>
       <div className='HerbCardGlow pointer-events-none absolute inset-0 rounded-[1.25rem] opacity-0 transition-opacity duration-200 group-hover:opacity-100' />
-      <Card className='card-pad relative flex h-full flex-col gap-5 border-white/12 bg-white/[0.05] p-5 transition duration-200 ease-out group-hover:border-white/20 group-hover:bg-white/[0.07]'>
-        <header className='space-y-2'>
-          <h2 className='text-[1.35rem] font-semibold leading-tight text-lime-200 sm:text-2xl'>{name}</h2>
+      <Card
+        className={`card-pad border-white/12 relative flex h-full flex-col bg-white/[0.05] transition duration-200 ease-out group-hover:border-white/20 group-hover:bg-white/[0.07] ${
+          compact ? 'gap-3 p-3.5' : 'gap-5 p-5'
+        }`}
+      >
+        <header className={compact ? 'space-y-1' : 'space-y-2'}>
+          <h2
+            title={name}
+            className={
+              compact
+                ? 'line-clamp-2 text-base font-semibold leading-tight text-lime-200'
+                : 'text-[1.35rem] font-semibold leading-tight text-lime-200 sm:text-2xl'
+            }
+          >
+            {title}
+          </h2>
         </header>
 
-        <section className='space-y-4 text-white/80'>
-          <p className='line-clamp-3 text-sm leading-6 text-white/70'>{summary}</p>
-          <div className='flex flex-wrap gap-2'>
-            {mergedTags.map(tag => (
-              <span
-                key={tag}
-                className='rounded-full border border-white/15 bg-white/[0.03] px-2.5 py-1 text-xs font-medium text-white/70'
-              >
-                {tag}
-              </span>
-            ))}
-          </div>
+        <section className={compact ? 'space-y-2 text-white/80' : 'space-y-4 text-white/80'}>
+          <p
+            className={`line-clamp-2 text-sm text-white/70 ${compact ? 'leading-5' : 'leading-6'}`}
+          >
+            {summary}
+          </p>
+          {visibleTags.length > 0 && (
+            <div className='flex flex-wrap gap-1.5'>
+              {visibleTags.map(tag => (
+                <span
+                  key={tag}
+                  className='rounded-full border border-white/15 bg-white/[0.03] px-2 py-0.5 text-[11px] font-medium text-white/70'
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
           {showMetadata && (
-            <div className='min-h-0 flex flex-wrap items-center gap-2'>
+            <div className='flex min-h-0 flex-wrap items-center gap-1.5'>
               {hasCompoundCount && (
-                <span className='inline-flex items-center gap-1.5 text-xs text-white/55'>
-                  <FlaskConical className='h-3.5 w-3.5' aria-hidden='true' />
+                <span className='inline-flex items-center gap-1 text-[11px] text-white/55'>
+                  <FlaskConical className='h-3 w-3' aria-hidden='true' />
                   {compound_count} compounds
                 </span>
               )}
               {normalizedEvidenceTier && (
                 <span
-                  className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-medium ${
+                  className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium ${
                     EVIDENCE_TIER_BADGE_CLASS[normalizedEvidenceTier] ??
                     'border-white/20 bg-white/[0.05] text-white/75'
                   }`}
@@ -83,7 +115,7 @@ function HerbCard({
                 </span>
               )}
               {!normalizedEvidenceTier && fallbackEvidence && (
-                <span className='inline-flex max-w-[12rem] items-center rounded-full border border-white/20 bg-white/[0.05] px-2.5 py-1 text-xs font-medium text-white/75'>
+                <span className='inline-flex max-w-[11rem] items-center rounded-full border border-white/20 bg-white/[0.05] px-2 py-0.5 text-[11px] font-medium text-white/75'>
                   <span className='truncate'>{fallbackEvidence.slice(0, 24)}</span>
                 </span>
               )}
@@ -91,10 +123,10 @@ function HerbCard({
           )}
         </section>
 
-        <footer className='mt-auto flex items-center justify-end pt-2 text-sm'>
+        <footer className='mt-auto flex items-center justify-end text-sm'>
           <Link
             to={detailUrl}
-            className='inline-flex min-h-10 items-center rounded-lg border border-white/20 bg-white/[0.06] px-3 py-2 text-sm font-medium text-white/85 transition duration-200 ease-out hover:border-white/35 hover:bg-white/[0.12] hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300'
+            className='inline-flex min-h-8 items-center rounded-md border border-white/20 bg-white/[0.06] px-2.5 py-1.5 text-xs font-medium text-white/85 transition duration-200 ease-out hover:border-white/35 hover:bg-white/[0.12] hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300'
           >
             View details
           </Link>

--- a/src/pages/Compounds.tsx
+++ b/src/pages/Compounds.tsx
@@ -37,6 +37,14 @@ function confidenceBadgeClass(level: ConfidenceLevel) {
   return 'border-rose-300/50 bg-rose-500/15 text-rose-100 shadow-[0_0_18px_rgba(244,63,94,0.35)]'
 }
 
+function truncateBrowseTitle(name: string, maxLength = 58) {
+  if (name.length <= maxLength) return name
+  const trimmed = name.slice(0, maxLength - 1).trimEnd()
+  const split = trimmed.lastIndexOf(' ')
+  if (split >= Math.floor(maxLength * 0.55)) return `${trimmed.slice(0, split)}…`
+  return `${trimmed}…`
+}
+
 function summarize(compound: { description: string; effects: string[] }) {
   if (compound.description) return compound.description
   if (compound.effects.length) return compound.effects.slice(0, 2).join(' · ')
@@ -187,7 +195,10 @@ export default function CompoundsPage() {
         <TypeFilter
           label='Research signal'
           options={ENRICHMENT_FILTER_OPTIONS.map(option => option.label)}
-          value={ENRICHMENT_FILTER_OPTIONS.find(option => option.value === filters.enrichment)?.label || ENRICHMENT_FILTER_OPTIONS[0].label}
+          value={
+            ENRICHMENT_FILTER_OPTIONS.find(option => option.value === filters.enrichment)?.label ||
+            ENRICHMENT_FILTER_OPTIONS[0].label
+          }
           onChange={label => {
             const next = ENRICHMENT_FILTER_OPTIONS.find(option => option.label === label)
             setFilters(prev => ({ ...prev, enrichment: next?.value || 'all' }))
@@ -244,63 +255,67 @@ export default function CompoundsPage() {
               })
             const primaryEffects = extractPrimaryEffects(compound.effects, 3)
 
+            const title = truncateBrowseTitle(compound.name)
+            const chips = [
+              ...primaryEffects.map(effect => ({ label: effect, tone: 'effect' as const })),
+              ...(compound.researchEnrichmentSummary
+                ? [
+                    {
+                      label: compound.researchEnrichmentSummary.evidenceLabelTitle,
+                      tone: 'evidence' as const,
+                    },
+                    ...(compound.researchEnrichmentSummary.safetyCautionsPresent
+                      ? [{ label: 'Safety cautions', tone: 'warning' as const }]
+                      : []),
+                  ]
+                : []),
+            ].slice(0, 2)
+
             return (
-              <article key={compound.id} className='ds-card-lg flex h-full flex-col'>
-                <div className='flex flex-wrap items-start justify-between gap-2'>
-                  <h2 className='text-xl font-semibold'>{compound.name}</h2>
+              <article key={compound.id} className='ds-card flex h-full flex-col gap-2.5 p-3.5'>
+                <div className='flex items-start justify-between gap-2'>
+                  <h2
+                    title={compound.name}
+                    className='line-clamp-2 text-base font-semibold leading-tight'
+                  >
+                    {title}
+                  </h2>
                   <span
-                    className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide ${confidenceBadgeClass(confidence)}`}
+                    className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${confidenceBadgeClass(confidence)}`}
                   >
                     {confidence}
                   </span>
                 </div>
-                <p className='mt-2 line-clamp-4 flex-1 text-sm text-white/85'>
-                  {summarize(compound)}
-                </p>
-                {primaryEffects.length > 0 && (
-                  <div className='mt-3 flex flex-wrap gap-1.5'>
-                    {primaryEffects.map(effect => (
+                <p className='text-white/82 line-clamp-2 text-sm'>{summarize(compound)}</p>
+                {chips.length > 0 && (
+                  <div className='flex flex-wrap gap-1'>
+                    {chips.map(chip => (
                       <span
-                        key={`${compound.id}-${effect}`}
-                        className='rounded-full border border-violet-300/35 bg-violet-500/15 px-2.5 py-1 text-[11px] text-violet-100'
+                        key={`${compound.id}-${chip.label}`}
+                        className={`rounded-full border px-2 py-0.5 text-[10px] ${
+                          chip.tone === 'warning'
+                            ? 'bg-amber-500/12 border-amber-300/35 text-amber-100'
+                            : chip.tone === 'evidence'
+                              ? 'border-cyan-300/35 bg-cyan-500/15 text-cyan-100'
+                              : 'border-violet-300/35 bg-violet-500/15 text-violet-100'
+                        }`}
                       >
-                        {effect}
+                        {chip.label}
                       </span>
                     ))}
                   </div>
                 )}
-                {compound.researchEnrichmentSummary && (
-                  <div className='mt-3 flex flex-wrap gap-1.5'>
-                    <span className='rounded-full border border-cyan-300/35 bg-cyan-500/15 px-2.5 py-1 text-[11px] text-cyan-100'>
-                      {compound.researchEnrichmentSummary.evidenceLabelTitle}
-                    </span>
-                    {compound.researchEnrichmentSummary.safetyCautionsPresent && (
-                      <span className='rounded-full border border-amber-300/35 bg-amber-500/15 px-2.5 py-1 text-[11px] text-amber-100'>
-                        Safety cautions noted
-                      </span>
-                    )}
-                    {compound.researchEnrichmentSummary.conflictingEvidence && (
-                      <span className='rounded-full border border-rose-300/35 bg-rose-500/15 px-2.5 py-1 text-[11px] text-rose-100'>
-                        Conflicting evidence
-                      </span>
-                    )}
-                    {compound.researchEnrichmentSummary.traditionalUseOnly && (
-                      <span className='rounded-full border border-yellow-300/35 bg-yellow-500/15 px-2.5 py-1 text-[11px] text-yellow-100'>
-                        Traditional-use context
-                      </span>
-                    )}
-                  </div>
-                )}
                 {confidence === 'low' && (
-                  <p className='mt-3 rounded-lg border border-amber-300/35 bg-amber-500/10 px-3 py-2 text-xs text-amber-100'>
-                    ⚠️ This entry has limited verified data.
-                  </p>
+                  <p className='text-[11px] text-amber-100/90'>⚠ Limited verified data.</p>
                 )}
-                <p className='mt-3 text-xs text-white/80'>
+                <p className='text-[11px] text-white/70'>
                   {compound.herbs.length} {compound.herbs.length === 1 ? 'herb' : 'herbs'}{' '}
                   associated
                 </p>
-                <Link to={`/compounds/${compound.slug}`} className='btn-primary mt-4 w-fit'>
+                <Link
+                  to={`/compounds/${compound.slug}`}
+                  className='mt-auto inline-flex w-fit items-center rounded-md border border-white/20 bg-white/[0.06] px-2.5 py-1.5 text-xs font-medium text-white/85 transition hover:border-white/35 hover:bg-white/[0.12]'
+                >
                   View details
                 </Link>
               </article>

--- a/src/pages/Herbs.tsx
+++ b/src/pages/Herbs.tsx
@@ -88,7 +88,7 @@ export default function HerbsPage() {
   const clearAll = () => setFilters(DEFAULT_FILTER_STATE)
 
   return (
-    <main className='container mx-auto max-w-6xl px-4 py-8 sm:py-10 text-white'>
+    <main className='container mx-auto max-w-6xl px-4 py-8 text-white sm:py-10'>
       <Meta
         title='Herb Knowledge Database | The Hippie Scientist'
         description='Search effects, classification, confidence, and safety context across the herb library.'
@@ -200,7 +200,10 @@ export default function HerbsPage() {
         <TypeFilter
           label='Research signal'
           options={ENRICHMENT_FILTER_OPTIONS.map(option => option.label)}
-          value={ENRICHMENT_FILTER_OPTIONS.find(option => option.value === filters.enrichment)?.label || ENRICHMENT_FILTER_OPTIONS[0].label}
+          value={
+            ENRICHMENT_FILTER_OPTIONS.find(option => option.value === filters.enrichment)?.label ||
+            ENRICHMENT_FILTER_OPTIONS[0].label
+          }
           onChange={label => {
             const next = ENRICHMENT_FILTER_OPTIONS.find(option => option.label === label)
             setFilters(prev => ({ ...prev, enrichment: next?.value || 'all' }))
@@ -248,7 +251,7 @@ export default function HerbsPage() {
           No herbs match your current filters.
         </div>
       ) : (
-        <section className='grid gap-5 sm:gap-6 sm:grid-cols-2 lg:grid-cols-3'>
+        <section className='grid gap-5 sm:grid-cols-2 sm:gap-6 lg:grid-cols-3'>
           {visibleHerbs.map((herb, index) => (
             <HerbCard
               key={herb.slug || herb.id || `${herb.common}-${index}`}
@@ -260,15 +263,16 @@ export default function HerbsPage() {
                   description: herb.description,
                   activeCompounds: herb.compounds,
                   therapeuticUses: herb.therapeuticUses,
-                  maxLen: 130,
+                  maxLen: 110,
                 }) || 'Learn more about this herb and its potential uses.'
               }
               tags={extractPrimaryEffects(Array.isArray(herb.effects) ? herb.effects : [], 2)}
+              compact
               detailUrl={
                 hasVal(herb.slug)
                   ? `/herbs/${encodeURIComponent(String(herb.slug))}`
                   : `/herbs/${encodeURIComponent(
-                      slugify(String(herb.common || herb.scientific || herb.name || ''))
+                      slugify(String(herb.common || herb.scientific || herb.name || '')),
                     )}`
               }
             />

--- a/src/utils/browseQuality.ts
+++ b/src/utils/browseQuality.ts
@@ -1,0 +1,195 @@
+const PLACEHOLDER_PATTERNS = [
+  /still being (researched|verified|expanded)/i,
+  /profile still being expanded/i,
+  /data is still being verified/i,
+  /limited verified data/i,
+  /no direct (effects|mechanism)/i,
+  /contextual inference/i,
+  /\bn\/a\b/i,
+  /^\s*(unknown|tbd|na|n\.a\.)\s*$/i,
+]
+
+const FRAGMENT_PATTERNS = [/^[^a-zA-Z]*$/, /^\d+(?:[\d\s.,-])*$/, /^[a-zA-Z]{1,2}$/]
+
+const AUTHORITY_SUFFIX_PATTERN =
+  /\b(?:l\.?|linn\.?|willd\.?|dc\.?|benth\.?|mill\.?|lam\.?|gaertn\.?|auct\.?|sp\.?|spp\.?)\b/gi
+
+const COMMON_STOP_WORDS = new Set(['the', 'and', 'of', 'extract', 'compound', 'herb'])
+
+export type BrowseQualityAssessment = {
+  hide: boolean
+  demote: boolean
+  dedupeKey: string
+  qualityScore: number
+  reasons: string[]
+}
+
+function cleanText(value: unknown): string {
+  return String(value || '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function hasPlaceholderOnly(text: string): boolean {
+  if (!text) return true
+  const normalized = text.toLowerCase()
+  return PLACEHOLDER_PATTERNS.some(pattern => pattern.test(normalized))
+}
+
+function hasMalformedName(name: string): boolean {
+  if (!name) return true
+  if (name.length < 3) return true
+  return FRAGMENT_PATTERNS.some(pattern => pattern.test(name))
+}
+
+function isUltraLongChemicalName(name: string): boolean {
+  if (name.length >= 72) return true
+  const punctuationHeavy = (name.match(/[(),-]/g) || []).length >= 8
+  const tokenCount = name.split(/\s+/).filter(Boolean).length
+  return punctuationHeavy && tokenCount >= 8
+}
+
+function buildDedupeKey(name: string): string {
+  const normalized = name
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/\([^)]*\)/g, ' ')
+    .replace(AUTHORITY_SUFFIX_PATTERN, ' ')
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  const compact = normalized
+    .split(/[\s-]+/)
+    .filter(token => token && !COMMON_STOP_WORDS.has(token))
+    .slice(0, 4)
+
+  return compact.join(' ')
+}
+
+function computeStrength(input: {
+  summary: string
+  description: string
+  mechanism: string
+  effectsCount: number
+  sourceCount: number
+  hasEvidence: boolean
+}): number {
+  let score = 0
+  if (input.summary.length >= 40 && !hasPlaceholderOnly(input.summary)) score += 2
+  if (input.description.length >= 40) score += 1
+  if (input.mechanism.length >= 24) score += 1
+  if (input.effectsCount >= 2) score += 1
+  if (input.sourceCount >= 2) score += 1
+  if (input.hasEvidence) score += 1
+  return score
+}
+
+export function assessBrowseRecord(input: {
+  name: unknown
+  summary: unknown
+  description?: unknown
+  mechanism?: unknown
+  effects?: unknown[]
+  sourceCount?: unknown
+  hasEvidence?: unknown
+}): BrowseQualityAssessment {
+  const name = cleanText(input.name)
+  const summary = cleanText(input.summary)
+  const description = cleanText(input.description)
+  const mechanism = cleanText(input.mechanism)
+  const effectsCount = Array.isArray(input.effects) ? input.effects.filter(Boolean).length : 0
+  const sourceCount = Number(input.sourceCount) || 0
+  const hasEvidence = Boolean(input.hasEvidence)
+  const qualityScore = computeStrength({
+    summary,
+    description,
+    mechanism,
+    effectsCount,
+    sourceCount,
+    hasEvidence,
+  })
+
+  const reasons: string[] = []
+
+  if (hasMalformedName(name)) reasons.push('malformed_name')
+  if (hasPlaceholderOnly(summary) && qualityScore < 3) reasons.push('placeholder_summary')
+  if (summary.length > 0 && summary.length < 24 && qualityScore < 3) reasons.push('weak_summary')
+  if (!summary && qualityScore < 2) reasons.push('missing_summary')
+
+  const longChemicalName = isUltraLongChemicalName(name)
+  if (longChemicalName && qualityScore < 2) reasons.push('long_name_low_metadata')
+
+  return {
+    hide: reasons.length > 0,
+    demote: longChemicalName || (summary.length > 0 && summary.length < 40),
+    dedupeKey: buildDedupeKey(name),
+    qualityScore,
+    reasons,
+  }
+}
+
+export function applyBrowseQualityGate<T>(
+  items: T[],
+  assess: (item: T) => BrowseQualityAssessment,
+): {
+  items: T[]
+  assessments: Map<T, BrowseQualityAssessment>
+  hiddenCount: number
+  dedupedCount: number
+  demotedCount: number
+} {
+  const assessments = new Map<T, BrowseQualityAssessment>()
+  const survivors: T[] = []
+  let hiddenCount = 0
+
+  for (const item of items) {
+    const assessment = assess(item)
+    assessments.set(item, assessment)
+    if (assessment.hide) {
+      hiddenCount += 1
+      continue
+    }
+    survivors.push(item)
+  }
+
+  const deduped = new Map<string, T>()
+  let dedupedCount = 0
+
+  for (const item of survivors) {
+    const assessment = assessments.get(item)
+    if (!assessment) continue
+    const key = assessment.dedupeKey
+    if (!key) {
+      deduped.set(`__${deduped.size}`, item)
+      continue
+    }
+
+    const existing = deduped.get(key)
+    if (!existing) {
+      deduped.set(key, item)
+      continue
+    }
+
+    const currentScore = assessments.get(existing)?.qualityScore ?? 0
+    if (assessment.qualityScore > currentScore) {
+      deduped.set(key, item)
+    }
+    dedupedCount += 1
+  }
+
+  const dedupedItems = Array.from(deduped.values())
+  const demotedCount = dedupedItems.reduce(
+    (count, item) => count + (assessments.get(item)?.demote ? 1 : 0),
+    0,
+  )
+
+  return {
+    items: dedupedItems,
+    assessments,
+    hiddenCount,
+    dedupedCount,
+    demotedCount,
+  }
+}

--- a/src/utils/filterCompounds.ts
+++ b/src/utils/filterCompounds.ts
@@ -5,6 +5,7 @@ import { searchEntries } from './searchEntries'
 import type { EntryFilterState } from './filterModel'
 import { asStringArray } from './asStringArray'
 import { getReviewFreshnessState, matchesEnrichmentFilter } from '@/lib/enrichmentDiscovery'
+import { applyBrowseQualityGate, assessBrowseRecord } from '@/utils/browseQuality'
 
 function getConfidenceRank(level: string) {
   if (level === 'high') return 3
@@ -43,7 +44,7 @@ function getFreshnessRank(compound: CompoundSummaryRecord) {
 
 export function filterCompounds(
   compounds: CompoundSummaryRecord[],
-  filters: EntryFilterState
+  filters: EntryFilterState,
 ): CompoundSummaryRecord[] {
   const searched = searchEntries(compounds, filters.query, compound => ({
     name: compound.name,
@@ -65,19 +66,34 @@ export function filterCompounds(
 
     if (effectNeedles.length > 0) {
       const hasAllEffects = effectNeedles.every(effect =>
-        effects.some(compoundEffect => compoundEffect.includes(effect))
+        effects.some(compoundEffect => compoundEffect.includes(effect)),
       )
       if (!hasAllEffects) return false
     }
 
     if (filters.confidence !== 'all' && confidence !== filters.confidence) return false
     if (typeNeedle !== 'all' && typeNeedle && category !== typeNeedle) return false
-    if (!matchesEnrichmentFilter(compound.researchEnrichmentSummary, filters.enrichment)) return false
+    if (!matchesEnrichmentFilter(compound.researchEnrichmentSummary, filters.enrichment))
+      return false
 
     return true
   })
 
-  return filtered.sort((a, b) => {
+  const browseQuality = applyBrowseQualityGate(filtered, compound =>
+    assessBrowseRecord({
+      name: compound.name,
+      summary: compound.summaryShort || compound.description,
+      description: compound.description,
+      mechanism: compound.mechanism,
+      effects: asStringArray(compound.effects),
+      sourceCount: compound.sourceCount,
+      hasEvidence: Boolean(compound.researchEnrichmentSummary?.evidenceLabel),
+    }),
+  )
+
+  const qualityFiltered = browseQuality.items
+
+  return qualityFiltered.sort((a, b) => {
     if (filters.sort === 'az') return a.name.localeCompare(b.name)
 
     if (filters.sort === 'confidence') {
@@ -109,6 +125,10 @@ export function filterCompounds(
       if (conflictDiff !== 0) return conflictDiff
       return getEvidenceRank(b) - getEvidenceRank(a)
     }
+
+    const aDemoted = Number(Boolean(browseQuality.assessments.get(a)?.demote))
+    const bDemoted = Number(Boolean(browseQuality.assessments.get(b)?.demote))
+    if (aDemoted !== bDemoted) return aDemoted - bDemoted
 
     const effectCountDiff = asStringArray(b.effects).length - asStringArray(a.effects).length
     if (effectCountDiff !== 0) return effectCountDiff

--- a/src/utils/filterHerbs.ts
+++ b/src/utils/filterHerbs.ts
@@ -4,6 +4,7 @@ import { searchEntries } from './searchEntries'
 import type { EntryFilterState } from './filterModel'
 import { asStringArray } from './asStringArray'
 import { getReviewFreshnessState, matchesEnrichmentFilter } from '@/lib/enrichmentDiscovery'
+import { applyBrowseQualityGate, assessBrowseRecord } from '@/utils/browseQuality'
 
 function getConfidenceRank(level: string) {
   if (level === 'high') return 3
@@ -56,12 +57,12 @@ export function filterHerbs(herbs: Herb[], filters: EntryFilterState): Herb[] {
     const herbEffects = asStringArray(herb.effects).map(effect => normalizeText(effect))
     const confidence = getHerbConfidence(herb)
     const herbType = normalizeText(
-      String((herb as Record<string, unknown>).class || herb.category || '')
+      String((herb as Record<string, unknown>).class || herb.category || ''),
     )
 
     if (effectNeedles.length > 0) {
       const hasAllEffects = effectNeedles.every(effect =>
-        herbEffects.some(herbEffect => herbEffect.includes(effect))
+        herbEffects.some(herbEffect => herbEffect.includes(effect)),
       )
       if (!hasAllEffects) return false
     }
@@ -73,10 +74,24 @@ export function filterHerbs(herbs: Herb[], filters: EntryFilterState): Herb[] {
     return true
   })
 
-  return filtered.sort((a, b) => {
+  const browseQuality = applyBrowseQualityGate(filtered, herb =>
+    assessBrowseRecord({
+      name: herb.common || herb.name || herb.scientific || herb.slug,
+      summary: herb.summaryShort || herb.description,
+      description: herb.description,
+      mechanism: herb.mechanism || herb.mechanismOfAction,
+      effects: asStringArray(herb.effects),
+      sourceCount: (herb as Record<string, unknown>).sourceCount,
+      hasEvidence: Boolean(herb.researchEnrichmentSummary?.evidenceLabel),
+    }),
+  )
+
+  const qualityFiltered = browseQuality.items
+
+  return qualityFiltered.sort((a, b) => {
     if (filters.sort === 'az') {
       return String(a.common || a.name || a.scientific || '').localeCompare(
-        String(b.common || b.name || b.scientific || '')
+        String(b.common || b.name || b.scientific || ''),
       )
     }
 
@@ -108,11 +123,15 @@ export function filterHerbs(herbs: Herb[], filters: EntryFilterState): Herb[] {
       return getEvidenceRank(b) - getEvidenceRank(a)
     }
 
+    const aDemoted = Number(Boolean(browseQuality.assessments.get(a)?.demote))
+    const bDemoted = Number(Boolean(browseQuality.assessments.get(b)?.demote))
+    if (aDemoted !== bDemoted) return aDemoted - bDemoted
+
     const effectCountDiff = asStringArray(b.effects).length - asStringArray(a.effects).length
     if (effectCountDiff !== 0) return effectCountDiff
 
     return String(a.common || a.name || a.scientific || '').localeCompare(
-      String(b.common || b.name || b.scientific || '')
+      String(b.common || b.name || b.scientific || ''),
     )
   })
 }


### PR DESCRIPTION
### Motivation
- The browse index was overwhelmed by low-quality, malformed, duplicate-like, and visually bloated records which hurt scanability and discovery. The change aims to improve listing quality and card hierarchy at the presentation layer only. 
- Preserve detail pages, workbook import logic, and underlying data while preferring to hide/demote low-value records in browse surfaces. 
- Make cards materially shorter and less visually noisy so users can scan more entries quickly.

### Description
- Add a reusable browse-quality utility that assesses and scores records then hides/dedupes/demotes poor listing rows; the main functions are `assessBrowseRecord` and `applyBrowseQualityGate` in `src/utils/browseQuality.ts`. 
- Wire the browse-quality gate into listing flows so it runs after existing filtering and before final sorting in `filterHerbs` and `filterCompounds`, and make default ordering demotion-aware so long/weak records fall lower. Files changed: `src/utils/filterHerbs.ts`, `src/utils/filterCompounds.ts`. 
- Implement a compact browse card mode and tightened hierarchy: update the canonical herb card to a compact presentation with truncated title, 2-line summary clamp, smaller CTA, and at-most-2 chips; switch herb browse page to use compact cards and shorten summary length. Update compound listing cards to a compact layout with truncated titles, 2-line summary clamp, max 2 chips, and toned-down warning presentation. Files changed: `src/components/HerbCard.tsx`, `src/pages/Herbs.tsx`, `src/pages/Compounds.tsx`. 
- Exact browse filtering/presentation rules added (listing layer only): malformed-name detection (missing, <3 chars, numeric or fragment-only names), placeholder-summary detection (phrases like "still being researched/verified/expanded", "limited verified data", "no direct effects/mechanism", "contextual inference", `n/a`), weak-summary (summary < 24 chars with weak metadata), missing-summary with weak metadata, ultra-long chemical-name handling (hide when very long + low metadata, otherwise demote), and duplicate-like collapse via a normalized dedupe key that strips authority suffixes/parentheticals and keeps the highest-quality representative. 
- Files changed
  - Added: `src/utils/browseQuality.ts` (new assessment + gate)
  - Modified: `src/utils/filterHerbs.ts`, `src/utils/filterCompounds.ts`, `src/components/HerbCard.tsx`, `src/pages/Herbs.tsx`, `src/pages/Compounds.tsx`

### Testing
- Ran a local static validation using the browse-quality gate against the checked-in summary + workbook payloads to report before/after counts; results (merged summary + workbook payloads): Herbs before 185 → after 161 (hidden 24, deduped 0, demoted 16); Compounds before 1023 → after 379 (hidden 627, deduped 17, demoted 0). 
- Automated checks executed: `npx eslint` and `npx prettier` on modified files passed as part of pre-commit and the commit succeeded. 
- Site build: `npm run build` (including prebuild tasks and prerender) completed successfully during validation. 
- Typecheck: `npx tsc --noEmit` failed due to a pre-existing, unrelated type error in `src/lib/herb-data.ts` (Type mismatch reported), so a full repo typecheck is blocked by that unrelated issue; lint and build checks for the changed files passed. 

If you want thresholds tuned (currently strict for compounds), I can adjust the placeholder/summary/length thresholds or make the rules configurable via a small mapping in `src/utils/browseQuality.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd98eaf9c832388a16783deb7777a)