### PR TITLE
Refactor HerbCard and CompoundCard for compact browse layout

### DIFF
--- a/src/components/CompoundCard.tsx
+++ b/src/components/CompoundCard.tsx
@@ -45,6 +45,9 @@ export default function CompoundCard({ compound }: { compound: CompoundWithRefs 
     compounds: compound.herbsFound.map(h => h.name),
   })
   const primaryEffects = extractPrimaryEffects(effects, 3)
+  const visiblePrimaryEffects = primaryEffects.slice(0, 2)
+  const visibleHerbs = compound.herbsFound.slice(0, 2)
+  const hiddenHerbCount = Math.max(compound.herbsFound.length - visibleHerbs.length, 0)
   const summary = buildCardSummary({
     effects,
     mechanism,
@@ -57,52 +60,54 @@ export default function CompoundCard({ compound }: { compound: CompoundWithRefs 
     <motion.article
       whileHover={{ scale: 1.03 }}
       title={compound.herbsFound.map(h => h.name).join(', ')}
-      className='ds-card relative flex flex-col rounded-2xl p-4 text-left transition hover:border-white/25'
+      className='ds-card relative flex flex-col rounded-2xl p-2.5 text-left transition hover:border-white/25'
     >
       <span
-        className={`absolute right-4 top-4 rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide ${confidenceBadgeClass(confidence)}`}
+        className={`absolute right-2.5 top-2.5 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${confidenceBadgeClass(confidence)}`}
       >
         {confidence}
       </span>
-      <h2 className='mb-1 text-lg font-semibold text-emerald-200'>{compound.name}</h2>
-      <div className='mb-2 flex flex-wrap gap-2 pr-16'>
+      <h2 className='mb-0.5 text-base font-semibold leading-tight text-emerald-200'>{compound.name}</h2>
+      <div className='mb-1 flex flex-wrap gap-1.5 pr-14'>
         <TagBadge label={compound.type ?? compound.category ?? 'compound'} />
         {compound.effectClass && <TagBadge label={compound.effectClass} variant='blue' />}
       </div>
-      {primaryEffects.length > 0 && (
-        <div className='mb-2 flex flex-wrap gap-1.5'>
-          {primaryEffects.map(effect => (
+      {visiblePrimaryEffects.length > 0 && (
+        <div className='mb-1 flex flex-wrap gap-1'>
+          {visiblePrimaryEffects.map(effect => (
             <span
               key={`${compound.name}-${effect}`}
-              className='rounded-full border border-violet-300/35 bg-violet-500/15 px-2.5 py-1 text-[11px] text-violet-100 shadow-[0_0_14px_rgba(139,92,246,0.3)]'
+              className='rounded-full border border-violet-300/35 bg-violet-500/15 px-2 py-0.5 text-[10px] text-violet-100 shadow-[0_0_14px_rgba(139,92,246,0.3)]'
             >
               {effect}
             </span>
           ))}
         </div>
       )}
-      <p className='mb-2 line-clamp-2 text-sm text-white/75'>{summary}</p>
+      <p className='mb-1 line-clamp-2 text-sm leading-tight text-white/75'>{summary}</p>
       {confidence === 'low' && (
-        <p className='mb-2 rounded-lg border border-amber-300/35 bg-amber-500/10 px-2.5 py-1.5 text-xs text-amber-100'>
-          ⚠️ This entry is incomplete. Data is still being verified.
-        </p>
+        <div className='mb-1 inline-flex items-center gap-1 text-[11px] text-amber-100/90'>
+          <span aria-hidden='true'>⚠️</span>
+          <span className='truncate'>Entry incomplete, verification in progress.</span>
+        </div>
       )}
       <div className='mt-auto flex flex-wrap gap-1'>
-        {compound.herbsFound.map(h =>
+        {visibleHerbs.map(h =>
           h.slug ? (
             <Link
               key={h.name}
               to={`/herbs/${h.slug}`}
-              className='ds-pill text-xs transition hover:border-white/30'
+              className='ds-pill px-2 py-0.5 text-[11px] transition hover:border-white/30'
             >
               {h.name}
             </Link>
           ) : (
-            <span key={h.name} className='ds-pill text-xs'>
+            <span key={h.name} className='ds-pill px-2 py-0.5 text-[11px]'>
               {h.name}
             </span>
           )
         )}
+        {hiddenHerbCount > 0 && <span className='ds-pill px-2 py-0.5 text-[11px]'>+{hiddenHerbCount}</span>}
       </div>
     </motion.article>
   )

--- a/src/components/HerbCard.tsx
+++ b/src/components/HerbCard.tsx
@@ -49,7 +49,7 @@ function HerbCard({
   compact = false,
 }: HerbCardProps) {
   const mergedTags = Array.from(new Set([...tags, ...mechanismTags].filter(Boolean)))
-  const visibleTags = compact ? mergedTags.slice(0, 2) : mergedTags
+  const visibleTags = mergedTags.slice(0, 2)
   const hasCompoundCount = typeof compound_count === 'number' && compound_count > 0
   const normalizedEvidenceTier = (evidence_tier || '').trim()
   const fallbackEvidence = normalizedEvidenceTier ? '' : (evidenceLevel || '').trim()
@@ -62,7 +62,7 @@ function HerbCard({
       <div className='HerbCardGlow pointer-events-none absolute inset-0 rounded-[1.25rem] opacity-0 transition-opacity duration-200 group-hover:opacity-100' />
       <Card
         className={`card-pad border-white/12 relative flex h-full flex-col bg-white/[0.05] transition duration-200 ease-out group-hover:border-white/20 group-hover:bg-white/[0.07] ${
-          compact ? 'gap-3 p-3.5' : 'gap-5 p-5'
+          compact ? 'gap-2 p-2.5' : 'gap-3 p-3'
         }`}
       >
         <header className={compact ? 'space-y-1' : 'space-y-2'}>
@@ -78,9 +78,9 @@ function HerbCard({
           </h2>
         </header>
 
-        <section className={compact ? 'space-y-2 text-white/80' : 'space-y-4 text-white/80'}>
+        <section className={compact ? 'space-y-1.5 text-white/80' : 'space-y-2 text-white/80'}>
           <p
-            className={`line-clamp-2 text-sm text-white/70 ${compact ? 'leading-5' : 'leading-6'}`}
+            className={`line-clamp-2 text-sm text-white/70 ${compact ? 'leading-tight' : 'leading-5'}`}
           >
             {summary}
           </p>
@@ -97,7 +97,7 @@ function HerbCard({
             </div>
           )}
           {showMetadata && (
-            <div className='flex min-h-0 flex-wrap items-center gap-1.5'>
+            <div className='flex min-h-0 flex-wrap items-center gap-1'>
               {hasCompoundCount && (
                 <span className='inline-flex items-center gap-1 text-[11px] text-white/55'>
                   <FlaskConical className='h-3 w-3' aria-hidden='true' />
@@ -126,7 +126,7 @@ function HerbCard({
         <footer className='mt-auto flex items-center justify-end text-sm'>
           <Link
             to={detailUrl}
-            className='inline-flex min-h-8 items-center rounded-md border border-white/20 bg-white/[0.06] px-2.5 py-1.5 text-xs font-medium text-white/85 transition duration-200 ease-out hover:border-white/35 hover:bg-white/[0.12] hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300'
+            className='inline-flex min-h-7 items-center rounded-md border border-white/15 bg-white/[0.04] px-2 py-1 text-[11px] font-medium text-white/75 transition duration-200 ease-out hover:border-white/30 hover:bg-white/[0.08] hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300'
           >
             View details
           </Link>


### PR DESCRIPTION
### Motivation
- Make herb and compound browse cards denser and more scannable (~50% shorter) while preserving all existing data logic and computed values. 
- Reduce vertical padding, tighten inter-element spacing, lower CTA visual weight, and surface only the most important badges to speed up visual scanning. 

### Description
- Files changed: `src/components/HerbCard.tsx` and `src/components/CompoundCard.tsx`.
- `HerbCard` now limits visible badges to 2, reduces card padding/gaps, tightens summary line-height and metadata spacing, and uses a smaller, lower-weight `View details` CTA; `summary` remains clamped to 2 lines. 
- `CompoundCard` now caps primary-effect badges to 2 and herb pills to 2 (adds a `+N` overflow pill), reduces container/title/badge spacing and typographic density, and converts the low-confidence message into a compact inline warning row. 
- All changes are presentational only and do not alter any data computation or domain logic. 

### Testing
- Commands run: `npm run build:compile` and the repository pre-commit lint task which executed `eslint --max-warnings=0` on staged TS/TSX files. 
- Verification results: `npm run build:compile` completed successfully and the lint check passed with no warnings. 
- Risks / follow-ups: visual QA is recommended across listing pages and breakpoints to confirm the perceived height reduction and spacing across screen sizes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe1743d44832390ba30dfc0bacd8d)