### PR TITLE
Truncate long card titles and prevent excessive wrapping on Herb & Compound cards

### DIFF
--- a/src/components/CompoundCard.tsx
+++ b/src/components/CompoundCard.tsx
@@ -35,6 +35,14 @@ function confidenceBadgeClass(level: ConfidenceLevel) {
   return 'border-rose-300/50 bg-rose-500/15 text-rose-100 shadow-[0_0_18px_rgba(244,63,94,0.35)]'
 }
 
+function truncateTitle(name: string, maxLength = 60): string {
+  if (name.length <= maxLength) return name
+  const trimmed = name.slice(0, maxLength - 1).trimEnd()
+  const cutoff = trimmed.lastIndexOf(' ')
+  if (cutoff >= Math.floor(maxLength * 0.55)) return `${trimmed.slice(0, cutoff)}…`
+  return `${trimmed}…`
+}
+
 export default function CompoundCard({ compound }: { compound: CompoundWithRefs }) {
   const mechanism = getMechanism(compound)
   const effects = Array.isArray(compound.effects) ? compound.effects : []
@@ -48,6 +56,8 @@ export default function CompoundCard({ compound }: { compound: CompoundWithRefs 
   const visiblePrimaryEffects = primaryEffects.slice(0, 2)
   const visibleHerbs = compound.herbsFound.slice(0, 2)
   const hiddenHerbCount = Math.max(compound.herbsFound.length - visibleHerbs.length, 0)
+  const title = truncateTitle(compound.name, 60)
+  const isTitleTruncated = title !== compound.name
   const summary = buildCardSummary({
     effects,
     mechanism,
@@ -67,7 +77,12 @@ export default function CompoundCard({ compound }: { compound: CompoundWithRefs 
       >
         {confidence}
       </span>
-      <h2 className='mb-0.5 text-base font-semibold leading-tight text-emerald-200'>{compound.name}</h2>
+      <h2
+        title={isTitleTruncated ? compound.name : undefined}
+        className='mb-0.5 line-clamp-2 break-words text-base font-semibold leading-tight text-emerald-200'
+      >
+        {title}
+      </h2>
       <div className='mb-1 flex flex-wrap gap-1.5 pr-14'>
         <TagBadge label={compound.type ?? compound.category ?? 'compound'} />
         {compound.effectClass && <TagBadge label={compound.effectClass} variant='blue' />}

--- a/src/components/HerbCard.tsx
+++ b/src/components/HerbCard.tsx
@@ -55,7 +55,8 @@ function HerbCard({
   const fallbackEvidence = normalizedEvidenceTier ? '' : (evidenceLevel || '').trim()
   const showMetadata =
     hasCompoundCount || Boolean(normalizedEvidenceTier) || Boolean(fallbackEvidence)
-  const title = compact ? truncateTitle(name, 54) : name
+  const title = truncateTitle(name, 60)
+  const isTitleTruncated = title !== name
 
   return (
     <div className='HerbCardTilt group relative h-full transition-transform duration-200 ease-out hover:scale-[1.01]'>
@@ -67,11 +68,11 @@ function HerbCard({
       >
         <header className={compact ? 'space-y-1' : 'space-y-2'}>
           <h2
-            title={name}
+            title={isTitleTruncated ? name : undefined}
             className={
               compact
-                ? 'line-clamp-2 text-base font-semibold leading-tight text-lime-200'
-                : 'text-[1.35rem] font-semibold leading-tight text-lime-200 sm:text-2xl'
+                ? 'line-clamp-2 break-words text-base font-semibold leading-tight text-lime-200'
+                : 'line-clamp-2 break-words text-[1.35rem] font-semibold leading-tight text-lime-200 sm:text-2xl'
             }
           >
             {title}


### PR DESCRIPTION
### Motivation
- Long herb and compound names were causing card titles to wrap into 4–5 lines and made card heights inconsistent.  
- Chemical/compound names in particular forced uneven layouts on browse and discovery cards.  
- Preserve access to the full name while keeping cards visually consistent by truncating in-place and exposing the full title on hover or the detail page.

### Description
- Added truncation to herb titles (now using a 60-character truncation) and always render the truncated string in the card title, with the full name exposed via `title` only when truncated.  
- Added a `truncateTitle` helper and applied the same 60-character truncation + conditional `title` tooltip to `CompoundCard`.  
- Prevented excessive wrapping by applying `line-clamp-2` and `break-words` to card title `h2` elements in both compact and standard modes.  
- Changes applied to `src/components/HerbCard.tsx` and `src/components/CompoundCard.tsx` to unify title behavior across herb and compound browse cards.

### Testing
- Ran a fast production compile with `npm run build:compile`, which completed successfully.  
- Pre-commit tasks ran `eslint --max-warnings=0` on the changed TS/TSX files and passed during commit.  
- No unit tests were modified; visual verification should be done in-browser if further refinements are needed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe2d5f904832391aac7f82b4ae439)