### PR TITLE
Refactor browse cards for compact, scan-first layout

### DIFF
--- a/src/components/CompoundCard.tsx
+++ b/src/components/CompoundCard.tsx
@@ -1,15 +1,11 @@
-import React from 'react'
 import { motion } from '@/lib/motion'
-import { Link } from 'react-router-dom'
 import type { Compound } from '@/types/compound'
-import TagBadge from './TagBadge'
 import { buildCardSummary } from '@/lib/summary'
 import { extractPrimaryEffects } from '@/utils/extractPrimaryEffects'
 import { calculateCompoundConfidence, type ConfidenceLevel } from '@/utils/calculateConfidence'
 
 interface HerbRef {
   name: string
-  slug?: string
 }
 
 export interface CompoundWithRefs extends Compound {
@@ -53,77 +49,71 @@ export default function CompoundCard({ compound }: { compound: CompoundWithRefs 
     compounds: compound.herbsFound.map(h => h.name),
   })
   const primaryEffects = extractPrimaryEffects(effects, 3)
-  const visiblePrimaryEffects = primaryEffects.slice(0, 2)
   const visibleHerbs = compound.herbsFound.slice(0, 2)
   const hiddenHerbCount = Math.max(compound.herbsFound.length - visibleHerbs.length, 0)
   const title = truncateTitle(compound.name, 60)
   const isTitleTruncated = title !== compound.name
-  const summary = buildCardSummary({
+  const generatedSummary = buildCardSummary({
     effects,
     mechanism,
     description: compound.description,
     activeCompounds: compound.herbsFound.map(h => h.name),
     maxLen: 170,
   })
+  const summary = generatedSummary?.trim() || 'Summary coming soon.'
+  const herbSourceSummary =
+    visibleHerbs.length > 0
+      ? `Found in ${visibleHerbs.map(h => h.name).join(', ')}${hiddenHerbCount > 0 ? ` +${hiddenHerbCount} more` : ''}.`
+      : 'Herb source mapping in progress.'
+  const categoryChip = compound.effectClass || compound.type || compound.category || null
+  const chipItems = [
+    { key: 'confidence', label: confidence, className: confidenceBadgeClass(confidence), uppercase: true },
+    categoryChip
+      ? {
+          key: 'category',
+          label: categoryChip,
+          className: 'border-sky-300/35 bg-sky-500/12 text-sky-100',
+          uppercase: false,
+        }
+      : null,
+  ].filter(Boolean) as Array<{ key: string; label: string; className: string; uppercase: boolean }>
 
   return (
     <motion.article
-      whileHover={{ scale: 1.03 }}
+      whileHover={{ scale: 1.01 }}
       title={compound.herbsFound.map(h => h.name).join(', ')}
-      className='ds-card relative flex flex-col rounded-2xl p-2.5 text-left transition hover:border-white/25'
+      className='ds-card relative flex flex-col rounded-2xl p-2 text-left transition hover:border-white/25 sm:p-2.5'
     >
-      <span
-        className={`absolute right-2.5 top-2.5 rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${confidenceBadgeClass(confidence)}`}
-      >
-        {confidence}
-      </span>
       <h2
         title={isTitleTruncated ? compound.name : undefined}
-        className='mb-0.5 line-clamp-2 break-words text-base font-semibold leading-tight text-emerald-200'
+        className='mb-0.5 line-clamp-2 break-words pr-10 text-[0.95rem] font-semibold leading-tight text-emerald-200 sm:text-base'
       >
         {title}
       </h2>
-      <div className='mb-1 flex flex-wrap gap-1.5 pr-14'>
-        <TagBadge label={compound.type ?? compound.category ?? 'compound'} />
-        {compound.effectClass && <TagBadge label={compound.effectClass} variant='blue' />}
+      <div className='mb-1 flex flex-wrap gap-1'>
+        {chipItems.slice(0, 2).map(chip => (
+          <span
+            key={`${compound.name}-${chip.key}`}
+            className={`inline-flex max-w-full items-center rounded-full border px-1.5 py-0.5 text-[10px] font-medium ${chip.uppercase ? 'uppercase tracking-wide' : ''} ${chip.className}`}
+          >
+            <span className='truncate'>{chip.label}</span>
+          </span>
+        ))}
       </div>
-      {visiblePrimaryEffects.length > 0 && (
-        <div className='mb-1 flex flex-wrap gap-1'>
-          {visiblePrimaryEffects.map(effect => (
-            <span
-              key={`${compound.name}-${effect}`}
-              className='rounded-full border border-violet-300/35 bg-violet-500/15 px-2 py-0.5 text-[10px] text-violet-100 shadow-[0_0_14px_rgba(139,92,246,0.3)]'
-            >
-              {effect}
-            </span>
-          ))}
-        </div>
+      <p className='mb-1 line-clamp-2 text-xs leading-tight text-white/75 sm:text-sm'>{summary}</p>
+      {primaryEffects.length > 0 && (
+        <p className='mb-1 line-clamp-1 text-[11px] text-violet-100/80'>
+          {primaryEffects.slice(0, 2).join(' • ')}
+        </p>
       )}
-      <p className='mb-1 line-clamp-2 text-sm leading-tight text-white/75'>{summary}</p>
+      <p className='mb-1 line-clamp-1 text-[11px] text-white/55'>{herbSourceSummary}</p>
       {confidence === 'low' && (
-        <div className='mb-1 inline-flex items-center gap-1 text-[11px] text-amber-100/90'>
+        <div className='mb-1 inline-flex items-center gap-1 text-[10px] text-amber-100/90'>
           <span aria-hidden='true'>⚠️</span>
           <span className='truncate'>Entry incomplete, verification in progress.</span>
         </div>
       )}
-      <div className='mt-auto flex flex-wrap gap-1'>
-        {visibleHerbs.map(h =>
-          h.slug ? (
-            <Link
-              key={h.name}
-              to={`/herbs/${h.slug}`}
-              className='ds-pill px-2 py-0.5 text-[11px] transition hover:border-white/30'
-            >
-              {h.name}
-            </Link>
-          ) : (
-            <span key={h.name} className='ds-pill px-2 py-0.5 text-[11px]'>
-              {h.name}
-            </span>
-          )
-        )}
-        {hiddenHerbCount > 0 && <span className='ds-pill px-2 py-0.5 text-[11px]'>+{hiddenHerbCount}</span>}
-      </div>
+      <div className='mt-auto' />
     </motion.article>
   )
 }

--- a/src/components/HerbCard.tsx
+++ b/src/components/HerbCard.tsx
@@ -49,85 +49,101 @@ function HerbCard({
   compact = false,
 }: HerbCardProps) {
   const mergedTags = Array.from(new Set([...tags, ...mechanismTags].filter(Boolean)))
-  const visibleTags = mergedTags.slice(0, 2)
+  const primaryTag = mergedTags[0]
   const hasCompoundCount = typeof compound_count === 'number' && compound_count > 0
   const normalizedEvidenceTier = (evidence_tier || '').trim()
   const fallbackEvidence = normalizedEvidenceTier ? '' : (evidenceLevel || '').trim()
-  const showMetadata =
-    hasCompoundCount || Boolean(normalizedEvidenceTier) || Boolean(fallbackEvidence)
   const title = truncateTitle(name, 60)
   const isTitleTruncated = title !== name
+  const summaryText = summary?.trim() || 'Overview coming soon.'
+
+  const priorityChips = [
+    normalizedEvidenceTier
+      ? {
+          key: `tier-${normalizedEvidenceTier}`,
+          label: normalizedEvidenceTier,
+          className:
+            EVIDENCE_TIER_BADGE_CLASS[normalizedEvidenceTier] ??
+            'border-white/20 bg-white/[0.05] text-white/75',
+        }
+      : fallbackEvidence
+        ? {
+            key: `evidence-${fallbackEvidence}`,
+            label: fallbackEvidence.slice(0, 24),
+            className: 'border-white/20 bg-white/[0.05] text-white/75',
+          }
+        : null,
+    hasCompoundCount
+      ? {
+          key: 'compound-count',
+          label: `${compound_count} compounds`,
+          className: 'border-white/20 bg-white/[0.05] text-white/70',
+        }
+      : null,
+    primaryTag
+      ? {
+          key: `tag-${primaryTag}`,
+          label: primaryTag,
+          className: 'border-white/15 bg-white/[0.03] text-white/70',
+        }
+      : null,
+  ]
+    .filter(Boolean)
+    .slice(0, 2) as Array<{ key: string; label: string; className: string }>
 
   return (
-    <div className='HerbCardTilt group relative h-full transition-transform duration-200 ease-out hover:scale-[1.01]'>
+    <div className='HerbCardTilt group relative h-full transition-transform duration-200 ease-out hover:scale-[1.005]'>
       <div className='HerbCardGlow pointer-events-none absolute inset-0 rounded-[1.25rem] opacity-0 transition-opacity duration-200 group-hover:opacity-100' />
       <Card
         className={`card-pad border-white/12 relative flex h-full flex-col bg-white/[0.05] transition duration-200 ease-out group-hover:border-white/20 group-hover:bg-white/[0.07] ${
-          compact ? 'gap-2 p-2.5' : 'gap-3 p-3'
+          compact ? 'gap-1.5 p-2' : 'gap-2 p-2.5 sm:p-3'
         }`}
       >
-        <header className={compact ? 'space-y-1' : 'space-y-2'}>
+        <header className='space-y-0.5'>
           <h2
             title={isTitleTruncated ? name : undefined}
             className={
               compact
-                ? 'line-clamp-2 break-words text-base font-semibold leading-tight text-lime-200'
-                : 'line-clamp-2 break-words text-[1.35rem] font-semibold leading-tight text-lime-200 sm:text-2xl'
+                ? 'line-clamp-2 break-words text-[0.95rem] font-semibold leading-tight text-lime-200'
+                : 'line-clamp-2 break-words text-base font-semibold leading-tight text-lime-200 sm:text-lg'
             }
           >
             {title}
           </h2>
         </header>
 
-        <section className={compact ? 'space-y-1.5 text-white/80' : 'space-y-2 text-white/80'}>
+        <section className='space-y-1 text-white/80'>
           <p
-            className={`line-clamp-2 text-sm text-white/70 ${compact ? 'leading-tight' : 'leading-5'}`}
+            className={`line-clamp-2 text-xs text-white/70 ${compact ? 'leading-tight' : 'leading-snug sm:text-sm'}`}
           >
-            {summary}
+            {summaryText}
           </p>
-          {visibleTags.length > 0 && (
-            <div className='flex flex-wrap gap-1.5'>
-              {visibleTags.map(tag => (
+          {priorityChips.length > 0 && (
+            <div className='flex flex-wrap gap-1'>
+              {priorityChips.map(chip => (
                 <span
-                  key={tag}
-                  className='rounded-full border border-white/15 bg-white/[0.03] px-2 py-0.5 text-[11px] font-medium text-white/70'
+                  key={chip.key}
+                  className={`inline-flex max-w-full items-center rounded-full border px-1.5 py-0.5 text-[10px] font-medium ${chip.className}`}
                 >
-                  {tag}
+                  <span className='truncate'>{chip.label}</span>
                 </span>
               ))}
             </div>
           )}
-          {showMetadata && (
-            <div className='flex min-h-0 flex-wrap items-center gap-1'>
-              {hasCompoundCount && (
-                <span className='inline-flex items-center gap-1 text-[11px] text-white/55'>
-                  <FlaskConical className='h-3 w-3' aria-hidden='true' />
-                  {compound_count} compounds
-                </span>
-              )}
-              {normalizedEvidenceTier && (
-                <span
-                  className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium ${
-                    EVIDENCE_TIER_BADGE_CLASS[normalizedEvidenceTier] ??
-                    'border-white/20 bg-white/[0.05] text-white/75'
-                  }`}
-                >
-                  {normalizedEvidenceTier}
-                </span>
-              )}
-              {!normalizedEvidenceTier && fallbackEvidence && (
-                <span className='inline-flex max-w-[11rem] items-center rounded-full border border-white/20 bg-white/[0.05] px-2 py-0.5 text-[11px] font-medium text-white/75'>
-                  <span className='truncate'>{fallbackEvidence.slice(0, 24)}</span>
-                </span>
-              )}
-            </div>
-          )}
         </section>
 
-        <footer className='mt-auto flex items-center justify-end text-sm'>
+        <footer className='mt-auto flex items-center justify-between pt-0.5'>
+          {hasCompoundCount ? (
+            <span className='inline-flex items-center gap-1 text-[10px] text-white/50'>
+              <FlaskConical className='h-3 w-3' aria-hidden='true' />
+              {compound_count}
+            </span>
+          ) : (
+            <span className='text-[10px] text-white/40'>Profile</span>
+          )}
           <Link
             to={detailUrl}
-            className='inline-flex min-h-7 items-center rounded-md border border-white/15 bg-white/[0.04] px-2 py-1 text-[11px] font-medium text-white/75 transition duration-200 ease-out hover:border-white/30 hover:bg-white/[0.08] hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300'
+            className='inline-flex min-h-6 items-center rounded-md border border-white/12 bg-white/[0.03] px-1.5 py-0.5 text-[10px] font-medium text-white/70 transition duration-200 ease-out hover:border-white/25 hover:bg-white/[0.06] hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300'
           >
             View details
           </Link>


### PR DESCRIPTION
### Motivation
- Make browse cards much shorter and faster to scan by tightening vertical rhythm, reducing padding and visual weight, clamping summary text, and limiting badges, while preserving routing and data loading.

### Description
- `HerbCard` (`src/components/HerbCard.tsx`): reduced padding/gaps and heading/body scale, enforced a 2-line summary (`line-clamp-2`) with fallback text, consolidated metadata into a prioritized list of up to two chips (evidence tier/evidence fallback, compound count, primary tag), and shrank the CTA styling and footer spacing.
- `CompoundCard` (`src/components/CompoundCard.tsx`): reduced hover scale and padding, limited chips to two (confidence + one classification), replaced multi-pill herb links with a compact one-line herb-source summary, clamped summary to two lines with fallback, and lowered text weight for secondary warnings.
- Changed files: `src/components/HerbCard.tsx` and `src/components/CompoundCard.tsx`.
- Before/After structure: Herb cards went from Title → Summary → tag chips → metadata row → larger CTA to Title → 2-line summary → max 2 priority chips → compact footer, and Compound cards went from floating badge + title + many pills + summary + herb pills to Title → max 2 chips → 2-line summary → concise effects/meta rows → optional warning.

### Testing
- Commands run: `npm run build` (full prebuild/postbuild/prerender flow ran) and the repo pre-commit lint tasks (`eslint --max-warnings=0`) executed as part of the commit hooks.
- Results: the build completed successfully and the pre-commit lint checks passed with no warnings or errors.
- Risks / follow-ups: no routing or data-loading code was changed, but visual QA across device sizes is recommended to confirm spacing and truncation look as expected, and screenshots or a quick visual review would be a useful follow-up.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbf0dbbef4832387b7404a373ad72b)