### PR TITLE
Tone down low-confidence warning on compound browse cards

### DIFF
--- a/src/pages/Compounds.tsx
+++ b/src/pages/Compounds.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import { AlertTriangle } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import Meta from '@/components/Meta'
 import ActiveFiltersBar from '@/components/filters/ActiveFiltersBar'
@@ -305,13 +306,18 @@ export default function CompoundsPage() {
                     ))}
                   </div>
                 )}
-                {confidence === 'low' && (
-                  <p className='text-[11px] text-amber-100/90'>⚠ Limited verified data.</p>
-                )}
-                <p className='text-[11px] text-white/70'>
-                  {compound.herbs.length} {compound.herbs.length === 1 ? 'herb' : 'herbs'}{' '}
-                  associated
-                </p>
+                <div className='flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px]'>
+                  {confidence === 'low' && (
+                    <span className='inline-flex items-center gap-1 rounded-full border border-amber-300/20 bg-amber-400/[0.06] px-1.5 py-0.5 text-amber-100/75'>
+                      <AlertTriangle className='h-3 w-3' aria-hidden='true' />
+                      Limited data
+                    </span>
+                  )}
+                  <p className='text-white/70'>
+                    {compound.herbs.length} {compound.herbs.length === 1 ? 'herb' : 'herbs'}{' '}
+                    associated
+                  </p>
+                </div>
                 <Link
                   to={`/compounds/${compound.slug}`}
                   className='mt-auto inline-flex w-fit items-center rounded-md border border-white/20 bg-white/[0.06] px-2.5 py-1.5 text-xs font-medium text-white/85 transition hover:border-white/35 hover:bg-white/[0.12]'


### PR DESCRIPTION
### Motivation
- Browse cards were overly dominated by a standalone low-confidence warning line, making titles and summaries visually weaker. 
- The intent is to surface uncertainty without changing confidence logic or removing warning detail on detail pages. 

### Description
- Changed file `src/pages/Compounds.tsx` to adjust the browse-card UI and added `AlertTriangle` import from `lucide-react`. 
- Replaced the standalone warning line `⚠ Limited verified data.` with a compact inline pill showing a small icon and short label `Limited data`, using subtle border/background styling and preserving the existing `confidence === 'low'` gating. 
- Scope is limited to the compounds browse cards so detail pages retain the full explicit warning treatment. 
- Files changed: `src/pages/Compounds.tsx`.

### Testing
- Ran `npm run build` which completed successfully and prerender checks passed. 
- Ran `npx eslint src/pages/Compounds.tsx` which passed for the modified file (non-blocking environment warnings were emitted). 
- Verification: build and lint succeeded, and the change is UI-only so no logic tests were required; there is no change to confidence calculation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbf97e13c88323ac2389e109e7878b)