### PR TITLE
Clamp browse card titles, add formatBrowseTitle helper, demote sparse ultra‑long names

### DIFF
--- a/src/__tests__/browseRanking.test.ts
+++ b/src/__tests__/browseRanking.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { filterHerbs } from '@/utils/filterHerbs'
 import { filterCompounds } from '@/utils/filterCompounds'
 import { DEFAULT_FILTER_STATE } from '@/utils/filterModel'
+import { assessBrowseRecord } from '@/utils/browseQuality'
 import type { Herb } from '@/types'
 import type { CompoundSummaryRecord } from '@/lib/compound-data'
 
@@ -126,5 +127,34 @@ describe('default browse ranking', () => {
 
     const searchable = filterCompounds(compounds, { ...DEFAULT_FILTER_STATE, query: 'l.' })
     expect(searchable.map(item => item.slug)).toEqual(['rosmarinic-acid-extract'])
+  })
+
+  it('demotes long chemical names only when metadata is sparse', () => {
+    const longName =
+      '2,3,4,5,6,7,8,9-octamethyl-11-(2,4,6-trimethylphenyl)-tricyclo[7.3.1.0]trideca-1,3,5-triene'
+
+    const sparse = assessBrowseRecord({
+      name: longName,
+      summary: 'unknown',
+      description: 'data is still being verified',
+      mechanism: '',
+      effects: [],
+      associations: [],
+      sourceCount: 0,
+      hasEvidence: false,
+    })
+    expect(sparse.demote).toBe(true)
+
+    const rich = assessBrowseRecord({
+      name: longName,
+      summary: 'Detailed summary with high-signal context suitable for browse ranking.',
+      description: 'Rich metadata, useful mechanism detail, and direct associations to mapped herbs.',
+      mechanism: 'Mechanistic pathway has plausible receptor-level coverage and context.',
+      effects: ['calm', 'focus'],
+      associations: ['rosemary', 'lemon balm'],
+      sourceCount: 3,
+      hasEvidence: true,
+    })
+    expect(rich.demote).toBe(false)
   })
 })

--- a/src/__tests__/titleDisplay.test.ts
+++ b/src/__tests__/titleDisplay.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { formatBrowseTitle } from '@/utils/titleDisplay'
+
+describe('formatBrowseTitle', () => {
+  it('keeps short titles untouched', () => {
+    expect(formatBrowseTitle('Rosmarinic Acid', 58)).toBe('Rosmarinic Acid')
+  })
+
+  it('truncates long titles at semantic separators before hard cut', () => {
+    const input =
+      '2,3,4,5,6,7,8,9-octamethyl-11-(2,4,6-trimethylphenyl)-tricyclo[7.3.1.0]trideca-1,3,5-triene'
+    expect(formatBrowseTitle(input, 58)).toBe('2,3,4,5,6,7,8,9-octamethyl-11-(2,4,6-trimethylphenyl)…')
+  })
+})

--- a/src/components/CompoundCard.tsx
+++ b/src/components/CompoundCard.tsx
@@ -3,6 +3,7 @@ import type { Compound } from '@/types/compound'
 import { buildCardSummary } from '@/lib/summary'
 import { extractPrimaryEffects } from '@/utils/extractPrimaryEffects'
 import { calculateCompoundConfidence, type ConfidenceLevel } from '@/utils/calculateConfidence'
+import { formatBrowseTitle } from '@/utils/titleDisplay'
 
 interface HerbRef {
   name: string
@@ -31,14 +32,6 @@ function confidenceBadgeClass(level: ConfidenceLevel) {
   return 'border-rose-300/50 bg-rose-500/15 text-rose-100 shadow-[0_0_18px_rgba(244,63,94,0.35)]'
 }
 
-function truncateTitle(name: string, maxLength = 60): string {
-  if (name.length <= maxLength) return name
-  const trimmed = name.slice(0, maxLength - 1).trimEnd()
-  const cutoff = trimmed.lastIndexOf(' ')
-  if (cutoff >= Math.floor(maxLength * 0.55)) return `${trimmed.slice(0, cutoff)}…`
-  return `${trimmed}…`
-}
-
 export default function CompoundCard({ compound }: { compound: CompoundWithRefs }) {
   const mechanism = getMechanism(compound)
   const effects = Array.isArray(compound.effects) ? compound.effects : []
@@ -51,7 +44,7 @@ export default function CompoundCard({ compound }: { compound: CompoundWithRefs 
   const primaryEffects = extractPrimaryEffects(effects, 3)
   const visibleHerbs = compound.herbsFound.slice(0, 2)
   const hiddenHerbCount = Math.max(compound.herbsFound.length - visibleHerbs.length, 0)
-  const title = truncateTitle(compound.name, 60)
+  const title = formatBrowseTitle(compound.name, 60)
   const isTitleTruncated = title !== compound.name
   const generatedSummary = buildCardSummary({
     effects,
@@ -86,7 +79,7 @@ export default function CompoundCard({ compound }: { compound: CompoundWithRefs 
     >
       <h2
         title={isTitleTruncated ? compound.name : undefined}
-        className='mb-0.5 line-clamp-2 break-words pr-10 text-[0.95rem] font-semibold leading-tight text-emerald-200 sm:text-base'
+        className='mb-0.5 line-clamp-2 min-h-[2.3rem] break-all pr-10 text-[0.95rem] font-semibold leading-tight text-emerald-200 sm:text-base'
       >
         {title}
       </h2>

--- a/src/components/HerbCard.tsx
+++ b/src/components/HerbCard.tsx
@@ -9,6 +9,7 @@ import { memo } from 'react'
 import { FlaskConical } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import Card from './ui/Card'
+import { formatBrowseTitle } from '@/utils/titleDisplay'
 import './HerbCard.css'
 
 interface HerbCardProps {
@@ -29,14 +30,6 @@ const EVIDENCE_TIER_BADGE_CLASS: Record<string, string> = {
   'Tier 3': 'border-amber-300/35 bg-amber-400/15 text-amber-200',
 }
 
-function truncateTitle(name: string, maxLength: number): string {
-  if (name.length <= maxLength) return name
-  const trimmed = name.slice(0, maxLength - 1).trimEnd()
-  const cutoff = trimmed.lastIndexOf(' ')
-  if (cutoff >= Math.floor(maxLength * 0.55)) return `${trimmed.slice(0, cutoff)}…`
-  return `${trimmed}…`
-}
-
 function HerbCard({
   name,
   summary,
@@ -53,7 +46,7 @@ function HerbCard({
   const hasCompoundCount = typeof compound_count === 'number' && compound_count > 0
   const normalizedEvidenceTier = (evidence_tier || '').trim()
   const fallbackEvidence = normalizedEvidenceTier ? '' : (evidenceLevel || '').trim()
-  const title = truncateTitle(name, 60)
+  const title = formatBrowseTitle(name, 60)
   const isTitleTruncated = title !== name
   const summaryText = summary?.trim() || 'Overview coming soon.'
 
@@ -104,8 +97,8 @@ function HerbCard({
             title={isTitleTruncated ? name : undefined}
             className={
               compact
-                ? 'line-clamp-2 break-words text-[0.95rem] font-semibold leading-tight text-lime-200'
-                : 'line-clamp-2 break-words text-base font-semibold leading-tight text-lime-200 sm:text-lg'
+                ? 'line-clamp-2 min-h-[2.3rem] break-all text-[0.95rem] font-semibold leading-tight text-lime-200'
+                : 'line-clamp-2 min-h-[2.5rem] break-all text-base font-semibold leading-tight text-lime-200 sm:text-lg'
             }
           >
             {title}

--- a/src/pages/Compounds.tsx
+++ b/src/pages/Compounds.tsx
@@ -17,6 +17,7 @@ import { extractFilterOptions } from '@/utils/extractFilterOptions'
 import { calculateCompoundConfidence, type ConfidenceLevel } from '@/utils/calculateConfidence'
 import type { EnrichmentFilter } from '@/types/enrichmentDiscovery'
 import { trackGovernedEvent } from '@/lib/governedAnalytics'
+import { formatBrowseTitle } from '@/utils/titleDisplay'
 
 const ENRICHMENT_FILTER_OPTIONS: Array<{ value: EnrichmentFilter; label: string }> = [
   { value: 'all', label: 'All research states' },
@@ -36,14 +37,6 @@ function confidenceBadgeClass(level: ConfidenceLevel) {
   if (level === 'medium')
     return 'border-amber-300/45 bg-amber-500/15 text-amber-100 shadow-[0_0_18px_rgba(245,158,11,0.35)]'
   return 'border-rose-300/50 bg-rose-500/15 text-rose-100 shadow-[0_0_18px_rgba(244,63,94,0.35)]'
-}
-
-function truncateBrowseTitle(name: string, maxLength = 58) {
-  if (name.length <= maxLength) return name
-  const trimmed = name.slice(0, maxLength - 1).trimEnd()
-  const split = trimmed.lastIndexOf(' ')
-  if (split >= Math.floor(maxLength * 0.55)) return `${trimmed.slice(0, split)}…`
-  return `${trimmed}…`
 }
 
 function summarize(compound: { description: string; effects: string[] }) {
@@ -256,7 +249,7 @@ export default function CompoundsPage() {
               })
             const primaryEffects = extractPrimaryEffects(compound.effects, 3)
 
-            const title = truncateBrowseTitle(compound.name)
+            const title = formatBrowseTitle(compound.name, 58)
             const chips = [
               ...primaryEffects.map(effect => ({ label: effect, tone: 'effect' as const })),
               ...(compound.researchEnrichmentSummary
@@ -277,7 +270,7 @@ export default function CompoundsPage() {
                 <div className='flex items-start justify-between gap-2'>
                   <h2
                     title={compound.name}
-                    className='line-clamp-2 text-base font-semibold leading-tight'
+                    className='line-clamp-2 min-h-[2.5rem] break-all text-base font-semibold leading-tight'
                   >
                     {title}
                   </h2>

--- a/src/utils/browseQuality.ts
+++ b/src/utils/browseQuality.ts
@@ -185,7 +185,7 @@ export function assessBrowseRecord(input: {
   return {
     hide,
     demote:
-      longChemicalName ||
+      (longChemicalName && qualityScore <= 2) ||
       (summary.length > 0 && summary.length < 40) ||
       associationsCount === 0 ||
       rankScore < 20,

--- a/src/utils/titleDisplay.ts
+++ b/src/utils/titleDisplay.ts
@@ -1,0 +1,33 @@
+const TITLE_TOKEN_SPLIT = /([\s,/()[\]-]+)/
+
+function splitTitleTokens(name: string): string[] {
+  return name.split(TITLE_TOKEN_SPLIT).filter(Boolean)
+}
+
+/**
+ * Returns a card-safe display title while preserving canonical record names in data.
+ * Keeps a short semantic prefix and appends an ellipsis when truncating.
+ */
+export function formatBrowseTitle(name: string, maxLength = 60): string {
+  const normalized = String(name || '').replace(/\s+/g, ' ').trim()
+  if (!normalized || normalized.length <= maxLength) return normalized
+
+  const hardLimit = Math.max(24, maxLength - 1)
+  const minKeep = Math.floor(maxLength * 0.55)
+  const tokens = splitTitleTokens(normalized)
+
+  let candidate = ''
+  for (const token of tokens) {
+    const next = `${candidate}${token}`
+    if (next.length > hardLimit) break
+    candidate = next
+  }
+
+  let trimmed = candidate.trim()
+  if (!trimmed || trimmed.length < minKeep) {
+    trimmed = normalized.slice(0, hardLimit).trimEnd()
+  }
+
+  trimmed = trimmed.replace(/[\s,;:/-]+$/g, '').trim()
+  return `${trimmed}…`
+}


### PR DESCRIPTION
### Motivation
- Prevent ultra-long chemical or canonical names from expanding browse card headers into 4–5 lines and breaking layout while preserving full canonical names on detail pages. 
- Prefer readable, semantic truncation for browse cards and reduce prominence of long-name records that also have weak metadata.

### Description
- Added a shared display helper `formatBrowseTitle(name, maxLength)` that normalizes whitespace, tokenizes on semantic separators (spaces, commas, slashes, parentheses, brackets, hyphens), builds a semantic prefix up to a hard safe limit, and appends an ellipsis when truncation is needed; it falls back to a hard slice if tokens cannot satisfy a ~55% keep threshold. (`src/utils/titleDisplay.ts`)
- Updated browse card title rendering to use the helper and enforced a two-line title footprint with minimum heights and `line-clamp-2`/`break-all` to avoid 4–5 line titles in herb and compound cards and the compounds index. (components/pages updated: `src/components/HerbCard.tsx`, `src/components/CompoundCard.tsx`, `src/pages/Compounds.tsx`)
- Adjusted browse-quality demotion so ultra-long chemical names are only demoted when metadata is sparse (`longChemicalName && qualityScore <= 2`) rather than blanket-demoting all long canonical names. (`src/utils/browseQuality.ts`)
- Added tests for title formatting and for the conditional demotion rule and included a small sample before/after expectation. (tests added/updated: `src/__tests__/titleDisplay.test.ts`, `src/__tests__/browseRanking.test.ts`)
- Files changed: `src/utils/titleDisplay.ts`, `src/components/HerbCard.tsx`, `src/components/CompoundCard.tsx`, `src/pages/Compounds.tsx`, `src/utils/browseQuality.ts`, `src/__tests__/titleDisplay.test.ts`, `src/__tests__/browseRanking.test.ts`.
- Truncation rule (summary): normalize whitespace; if over max, accumulate tokens split by separators until a safe hard limit (max-1, with a lower bound of 24); prefer keeping >= ~55% of `maxLength` using token boundaries; else hard-slice; strip trailing punctuation/separators and append `…`.
- Sample before/after for the long chemical name input `2,3,4,5,6,7,8,9-octamethyl-11-(2,4,6-trimethylphenyl)-tricyclo[7.3.1.0]trideca-1,3,5-triene`:
  - Before: `2,3,4,5,6,7,8,9-octamethyl-11-(2,4,6-trimethylphenyl)-tri…`
  - After:  `2,3,4,5,6,7,8,9-octamethyl-11-(2,4,6-trimethylphenyl)…`

### Testing
- Ran ESLint against changed files and fixed a minor regex lint issue; linting completed without errors on touched files. (`npx eslint ...`).
- Added unit tests: `src/__tests__/titleDisplay.test.ts` validates formatting behavior and `src/__tests__/browseRanking.test.ts` includes a case asserting that long names are demoted only when metadata is sparse.
- Attempted to run tests with `vitest` in this environment; test execution failed due to missing local `vitest/config` wiring in the environment (project-level dev dependency/config resolution), so tests are present but could not be executed here. 
- Performed a quick Node script check to compare the old naive truncation vs `formatBrowseTitle` output for the sample string and confirmed the expected after-output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbfa6bb6108323aaa65ad6fad455a6)