### PR TITLE
Refactor herb detail UI hierarchy and progressive disclosure

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState } from 'react'
+import { type FormEvent, useEffect, useMemo, useState } from 'react'
 import { Menu, X } from 'lucide-react'
-import { Link, NavLink, useLocation } from 'react-router-dom'
+import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom'
 import { getDailyDiscoverySnippet } from '@/utils/contentSnippets'
 
 const linkBase =
@@ -14,12 +14,21 @@ const linkActive =
 
 export default function NavBar() {
   const [menuOpen, setMenuOpen] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
   const location = useLocation()
+  const navigate = useNavigate()
   const isHome = location.pathname === '/'
   const dailyDiscovery = useMemo(() => getDailyDiscoverySnippet(), [])
   useEffect(() => {
     setMenuOpen(false)
   }, [location])
+
+  function handleSearchSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const query = searchQuery.trim()
+    navigate(query ? `/herbs?q=${encodeURIComponent(query)}` : '/herbs')
+    setMenuOpen(false)
+  }
 
   return (
     <header className='sticky top-0 z-50 border-b border-white/10 bg-black/60 backdrop-blur-xl supports-[backdrop-filter]:bg-black/40'>
@@ -44,6 +53,20 @@ export default function NavBar() {
           </button>
 
           <div className='hidden min-w-0 flex-1 items-center justify-end gap-1.5 md:flex'>
+            {/* Sticky quick search keeps discovery accessible while reading long detail pages. */}
+            <form onSubmit={handleSearchSubmit} className='mr-1 hidden lg:block'>
+              <label htmlFor='site-search-desktop' className='sr-only'>
+                Search herbs
+              </label>
+              <input
+                id='site-search-desktop'
+                type='search'
+                value={searchQuery}
+                onChange={event => setSearchQuery(event.target.value)}
+                placeholder='Search herbs...'
+                className='min-h-11 w-44 rounded-xl border border-white/15 bg-white/7 px-3 text-sm text-white placeholder:text-white/45 focus:border-emerald-300/45 focus:outline-none'
+              />
+            </form>
             <NavLink
               to='/herbs'
               className={({ isActive }) => `${linkBase} ${isActive ? linkActive : linkSolid}`}
@@ -96,6 +119,20 @@ export default function NavBar() {
         </div>
         {menuOpen && (
           <div className='border-white/12 mb-2 grid gap-2 rounded-2xl border bg-black/40 p-2.5 backdrop-blur-xl md:hidden'>
+            {/* Mobile-first: keep search in the hamburger panel so it remains one tap away. */}
+            <form onSubmit={handleSearchSubmit} className='mb-1'>
+              <label htmlFor='site-search-mobile' className='sr-only'>
+                Search herbs
+              </label>
+              <input
+                id='site-search-mobile'
+                type='search'
+                value={searchQuery}
+                onChange={event => setSearchQuery(event.target.value)}
+                placeholder='Search herbs...'
+                className='min-h-11 w-full rounded-xl border border-white/15 bg-white/7 px-3 text-sm text-white placeholder:text-white/45 focus:border-emerald-300/45 focus:outline-none'
+              />
+            </form>
             <NavLink
               to='/herbs'
               className={({ isActive }) =>

--- a/src/components/navigation/BreadcrumbTrail.tsx
+++ b/src/components/navigation/BreadcrumbTrail.tsx
@@ -14,7 +14,10 @@ export default function BreadcrumbTrail({ items, className = '' }: BreadcrumbTra
   if (!items.length) return null
 
   return (
-    <nav aria-label='Breadcrumb' className={`mb-3 text-xs text-white/70 ${className}`.trim()}>
+    <nav
+      aria-label='Breadcrumb'
+      className={`mb-3 rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-xs text-white/70 ${className}`.trim()}
+    >
       <ol className='flex flex-wrap items-center gap-1.5'>
         {items.map((item, index) => {
           const isLast = index === items.length - 1

--- a/src/components/ui/Collapse.tsx
+++ b/src/components/ui/Collapse.tsx
@@ -1,4 +1,6 @@
 import { type ReactNode, useId, useState } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
+import { ChevronDown } from 'lucide-react'
 
 export default function Collapse({
   title,
@@ -32,13 +34,26 @@ export default function Collapse({
         <span className='text-sm font-semibold uppercase tracking-[0.16em] text-white/75'>
           {title}
         </span>
-        <span className='text-xs text-white/70'>{open ? 'Hide' : 'Show'}</span>
+        <span className='inline-flex items-center gap-2 text-xs text-white/70'>
+          {open ? 'Hide' : 'Show'}
+          <ChevronDown size={14} className={`transition-transform ${open ? 'rotate-180' : ''}`} />
+        </span>
       </button>
-      {open && (
-        <div id={contentId} className='border-white/8 border-t px-4 py-3'>
-          {children}
-        </div>
-      )}
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            key='collapse-content'
+            id={contentId}
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.22, ease: 'easeInOut' }}
+            className='overflow-hidden'
+          >
+            <div className='border-white/8 border-t px-4 py-3'>{children}</div>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </section>
   )
 }

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -588,7 +588,7 @@ export default function HerbDetail() {
   }
 
   return (
-    <main className='container mx-auto max-w-4xl px-4 py-8 text-white'>
+    <main className='container mx-auto max-w-5xl px-4 py-6 text-white sm:py-8'>
       <Meta
         title={herbMetaTitle}
         description={herbMetaDescription}
@@ -631,27 +631,29 @@ export default function HerbDetail() {
           { label: herbDisplayName },
         ]}
       />
-      <Link to='/herbs' className='btn-secondary inline-flex items-center'>
-        ← Back to herbs
-      </Link>
-      <button
-        type='button'
-        className='ml-2 inline-flex rounded-full border border-white/20 px-3 py-1 text-sm text-white/85 transition hover:border-white/35 hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300'
-        onClick={() =>
-          toggle({
-            type: 'herb',
-            slug: herb.slug,
-            title: herb.common || herb.name || herb.slug,
-            href: `/herbs/${herb.slug}`,
-            note: description,
-          })
-        }
-      >
-        {isSaved('herb', herb.slug) ? '★ Favorited' : '☆ Favorite'}
-      </button>
+      <div className='flex flex-wrap items-center gap-2'>
+        <Link to='/herbs' className='btn-secondary inline-flex items-center'>
+          ← Back to herbs
+        </Link>
+        <button
+          type='button'
+          className='inline-flex rounded-full border border-white/20 px-3 py-1 text-sm text-white/85 transition hover:border-white/35 hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300'
+          onClick={() =>
+            toggle({
+              type: 'herb',
+              slug: herb.slug,
+              title: herb.common || herb.name || herb.slug,
+              href: `/herbs/${herb.slug}`,
+              note: description,
+            })
+          }
+        >
+          {isSaved('herb', herb.slug) ? '★ Favorited' : '☆ Favorite'}
+        </button>
+      </div>
 
       <article className='ds-card-lg mt-4'>
-        {/* Header */}
+        {/* Refactor: move highest-signal content to the very top for immediate scanning. */}
         <header>
           <div className='flex flex-col gap-2'>
             <div>
@@ -661,16 +663,27 @@ export default function HerbDetail() {
               )}
             </div>
           </div>
-          {(description || shortSummary) && (
-            <p className='mt-3 max-w-3xl text-sm leading-relaxed text-white/80'>
-              {description || shortSummary}
+          {/* Primary effects are elevated directly under the name. */}
+          {primaryEffects.length > 0 && (
+            <div className='mt-3 flex flex-wrap gap-2'>
+              {primaryEffects.map(effect => (
+                <span
+                  key={effect}
+                  className='rounded-full border border-violet-300/35 bg-violet-500/10 px-2.5 py-1 text-xs text-violet-100'
+                >
+                  {effect}
+                </span>
+              ))}
+            </div>
+          )}
+          {/* Keep summary concise above the fold; deep explanation is pushed lower. */}
+          {(shortSummary || description) && (
+            <p className='mt-4 max-w-3xl text-sm leading-relaxed text-white/80'>
+              {shortSummary || description}
             </p>
           )}
 
           <div className='mt-3 flex flex-wrap gap-1.5 text-[11px] text-white/65'>
-            <span className='rounded-full border border-white/20 bg-white/[0.03] px-2 py-0.5'>
-              Confidence: {confidence}
-            </span>
             {evidenceLevel && (
               <span className='rounded-full border border-white/20 bg-white/[0.03] px-2 py-0.5'>
                 {evidenceLevel}
@@ -709,36 +722,6 @@ export default function HerbDetail() {
           </Section>
         )}
 
-        {/* Primary effects pills — high-signal summary */}
-        {primaryEffects.length > 0 && (
-          <div className='mt-5 flex flex-wrap gap-2'>
-            {primaryEffects.map(effect => (
-              <span
-                key={effect}
-                className='rounded-full border border-violet-300/35 bg-violet-500/10 px-2.5 py-1 text-xs text-violet-100'
-              >
-                {effect}
-              </span>
-            ))}
-          </div>
-        )}
-
-        {shortSummary && shortSummary !== description && (
-          <section className='border-white/8 mt-6 border-t pt-5'>
-            <p className='max-w-3xl text-base leading-relaxed text-white/88'>{shortSummary}</p>
-          </section>
-        )}
-
-        <GovernedReviewFreshnessPanel
-          decision={governedReviewFreshness}
-          nextStepHref='#governed-safety-interactions'
-          analyticsContext={{
-            pageType: 'herb_detail',
-            entityType: 'herb',
-            entitySlug: herb.slug,
-          }}
-        />
-
         {isDataIncomplete && (
           <div className='bg-amber-500/8 mt-4 rounded-xl border border-amber-300/30 p-3 text-sm text-amber-100'>
             <p className='font-semibold'>Incomplete profile</p>
@@ -749,16 +732,32 @@ export default function HerbDetail() {
           </div>
         )}
 
-        <DataTrustPanel
-          entity='herb'
-          confidence={confidence}
-          completeness={completeness}
-          sourceCount={sourceCount}
-          lastReviewed={lastUpdated}
-          cautionCount={cautionCount}
-          hasInferredContent={hasInferredContent}
-          hasFallbackContent={hasFallbackContent}
-        />
+        {/* Confidence explanations are now hidden by default to reduce initial clutter. */}
+        <section className='border-white/8 mt-6 border-t pt-5'>
+          <Collapse title='Confidence & data quality'>
+            <div className='space-y-4'>
+              <GovernedReviewFreshnessPanel
+                decision={governedReviewFreshness}
+                nextStepHref='#governed-safety-interactions'
+                analyticsContext={{
+                  pageType: 'herb_detail',
+                  entityType: 'herb',
+                  entitySlug: herb.slug,
+                }}
+              />
+              <DataTrustPanel
+                entity='herb'
+                confidence={confidence}
+                completeness={completeness}
+                sourceCount={sourceCount}
+                lastReviewed={lastUpdated}
+                cautionCount={cautionCount}
+                hasInferredContent={hasInferredContent}
+                hasFallbackContent={hasFallbackContent}
+              />
+            </div>
+          </Collapse>
+        </section>
 
         <StructuredDetailIntro
           confidence={confidence}
@@ -976,7 +975,35 @@ export default function HerbDetail() {
           </div>
         )}
 
-        <PremiumDataSection details={premiumDetails} relationGroups={relationGroups} />
+        <PremiumDataSection details={premiumDetails} />
+
+        {relationGroups.length > 0 && (
+          <section className='border-white/8 mt-6 border-t pt-5'>
+            {/* Related entities are grouped into a dedicated accordion for cleaner information hierarchy. */}
+            <Collapse title='Related herbs & compounds'>
+              <div className='space-y-4'>
+                {relationGroups.map(group => (
+                  <div key={group.title}>
+                    <p className='text-xs font-semibold uppercase tracking-[0.14em] text-white/60'>
+                      {group.title}
+                    </p>
+                    <div className='mt-2 flex flex-wrap gap-2'>
+                      {group.items.map(item => (
+                        <Link
+                          key={`${group.title}-${item.to}`}
+                          to={item.to}
+                          className='ds-pill transition hover:border-white/30'
+                        >
+                          {item.label}
+                        </Link>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </Collapse>
+          </section>
+        )}
 
         {compoundCount !== null && (
           <section className='border-white/8 mt-6 border-t pt-5'>
@@ -1163,19 +1190,6 @@ export default function HerbDetail() {
           </section>
         )}
 
-        {governedResearch && governedFaq && governedRelatedQuestions && (
-          <GovernedResearchSections
-            enrichment={governedResearch}
-            governedFaq={governedFaq}
-            relatedQuestions={governedRelatedQuestions}
-            analyticsContext={{
-              pageType: 'herb_detail',
-              entityType: 'herb',
-              entitySlug: herb.slug,
-            }}
-          />
-        )}
-
         {effects.length > 0 && (
           <Section title='Effects'>
             <ListSection items={effects} />
@@ -1201,24 +1215,40 @@ export default function HerbDetail() {
         {region && <Section title='Region'>{region}</Section>}
         {legalStatus && <Section title='Legal Status'>{legalStatus}</Section>}
 
-        {/* Sources */}
-        {sources.length > 0 && (
+        {(sources.length > 0 || (governedResearch && governedFaq && governedRelatedQuestions)) && (
           <section className='border-white/8 mt-6 border-t pt-5'>
-            <Collapse title='References'>
-              <ol className='list-decimal space-y-1 pl-5 text-sm leading-relaxed text-white/85'>
-                {sources.map((source, index) => (
-                  <li key={`${source.url}-${index}`}>
-                    {/^https?:\/\//i.test(source.url) ? (
-                      <a href={source.url} target='_blank' rel='noreferrer' className='link'>
-                        {source.title}
-                      </a>
-                    ) : (
-                      source.title
-                    )}
-                    {source.note && <span className='ml-2 text-white/55'>— {source.note}</span>}
-                  </li>
-                ))}
-              </ol>
+            {/* Research bundle moved to bottom to avoid overload above the fold. */}
+            <Collapse title='Research'>
+              <div className='space-y-4'>
+                {governedResearch && governedFaq && governedRelatedQuestions && (
+                  <GovernedResearchSections
+                    enrichment={governedResearch}
+                    governedFaq={governedFaq}
+                    relatedQuestions={governedRelatedQuestions}
+                    analyticsContext={{
+                      pageType: 'herb_detail',
+                      entityType: 'herb',
+                      entitySlug: herb.slug,
+                    }}
+                  />
+                )}
+                {sources.length > 0 && (
+                  <ol className='list-decimal space-y-1 pl-5 text-sm leading-relaxed text-white/85'>
+                    {sources.map((source, index) => (
+                      <li key={`${source.url}-${index}`}>
+                        {/^https?:\/\//i.test(source.url) ? (
+                          <a href={source.url} target='_blank' rel='noreferrer' className='link'>
+                            {source.title}
+                          </a>
+                        ) : (
+                          source.title
+                        )}
+                        {source.note && <span className='ml-2 text-white/55'>— {source.note}</span>}
+                      </li>
+                    ))}
+                  </ol>
+                )}
+              </div>
             </Collapse>
           </section>
         )}


### PR DESCRIPTION
### Motivation
- Improve herb detail scanability by surfacing the herb name, primary effects, and a concise summary immediately above the fold and reducing top-of-page information overload.
- Reduce visual noise and preserve trust context by hiding confidence/data-quality details and deep research behind collapsible sections while keeping them discoverable.
- Improve navigation clarity with framed breadcrumbs and a sticky search in the header (desktop + mobile hamburger) so users can quickly move across the site.

### Description
- Files changed: `src/pages/HerbDetail.tsx`, `src/components/ui/Collapse.tsx`, `src/components/NavBar.tsx`, and `src/components/navigation/BreadcrumbTrail.tsx`.
- Key technical changes: elevated primary effects chips and concise summary into the hero area and grouped back/favorite actions for immediate scanning; moved confidence UI into a `Collapse` titled `Confidence & data quality`; consolidated citations and governed research into a bottom `Research` accordion; added a `Related herbs & compounds` accordion to separate relationships from the main reading flow; breadcrumbs are now framed with subtle background/border for clarity; header nav now exposes a compact search input on desktop and a search field inside the mobile hamburger.
- Component/UX improvements: the shared `Collapse` component now uses Framer Motion (`AnimatePresence` + `motion.div`) and a chevron affordance for smooth animated expand/collapse transitions while maintaining the existing Tailwind/dark-mode styles.
- Inline comments were added at key changes to explain hierarchy intent and are present in the modified files for future reviewers.
- Risks / follow-ups: the repo’s build includes a heavy pre/postbuild data generation pipeline that runs during `npm run build`; consider splitting large data generation from UI-only CI for faster UI iterations and to avoid noise in change artifacts.

### Testing
- Automated tests run: `npm run build` (includes prebuild/postbuild scripts) completed successfully without build errors.
- Linting: staged TS/TSX pre-commit hooks (ESLint via lint-staged) ran and passed during the change flow.
- Commands executed: `npm run build` (build + prerender/verification pipeline).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc15ac810483238609689310a4e593)