### PR TITLE
Deduplicate & sanitize detail pages, cap lists, simplify header

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,7 +1,6 @@
-import { type FormEvent, useEffect, useMemo, useState } from 'react'
+import { type FormEvent, useEffect, useState } from 'react'
 import { Menu, X } from 'lucide-react'
 import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom'
-import { getDailyDiscoverySnippet } from '@/utils/contentSnippets'
 
 const linkBase =
   'inline-flex min-h-11 items-center justify-center rounded-xl px-3.5 text-sm font-medium transition-all duration-200'
@@ -18,7 +17,6 @@ export default function NavBar() {
   const location = useLocation()
   const navigate = useNavigate()
   const isHome = location.pathname === '/'
-  const dailyDiscovery = useMemo(() => getDailyDiscoverySnippet(), [])
   useEffect(() => {
     setMenuOpen(false)
   }, [location])
@@ -208,30 +206,6 @@ export default function NavBar() {
           </div>
         )}
       </nav>
-      <div className='border-white/8 border-t bg-white/[0.03]'>
-        <div className='mx-auto flex max-w-7xl flex-wrap items-center gap-x-5 gap-y-1 px-4 py-1.5 text-[11px] tracking-[0.08em] text-white/55 sm:px-6'>
-          {dailyDiscovery && (
-            <Link
-              to={dailyDiscovery.ctaPath}
-              className='text-emerald-100/80 hover:text-emerald-100'
-            >
-              Today&apos;s discovery: {dailyDiscovery.title}
-            </Link>
-          )}
-          <span className='inline-flex items-center gap-1.5 whitespace-nowrap'>
-            <span aria-hidden='true'>🧪</span>
-            Research-based herbal knowledge
-          </span>
-          <span className='inline-flex items-center gap-1.5 whitespace-nowrap'>
-            <span aria-hidden='true'>⚠️</span>
-            Safety-first, harm-reduction approach
-          </span>
-          <span className='inline-flex items-center gap-1.5 whitespace-nowrap'>
-            <span aria-hidden='true'>↻</span>
-            Continuously updated database
-          </span>
-        </div>
-      </div>
     </header>
   )
 }

--- a/src/components/detail/PremiumDataSection.tsx
+++ b/src/components/detail/PremiumDataSection.tsx
@@ -28,11 +28,27 @@ export default function PremiumDataSection({
   details = [],
   relationGroups = [],
 }: PremiumDataSectionProps) {
-  const visibleDetails = details.filter(detail => detail.value.trim())
+  const visibleDetails = details
+    .map(detail => ({
+      ...detail,
+      title: detail.title.trim(),
+      value: detail.value.trim(),
+    }))
+    .filter(detail => detail.value)
   const visibleRelationGroups = relationGroups
     .map(group => ({
       ...group,
-      items: group.items.filter(item => item.label.trim()),
+      items: Array.from(
+        new Map(
+          group.items
+            .map(item => ({ ...item, label: item.label.trim(), to: item.to?.trim() }))
+            .filter(item => item.label)
+            .map(item => [
+              `${item.label.toLowerCase()}|${(item.to || '').toLowerCase()}`,
+              item,
+            ]),
+        ).values(),
+      ),
     }))
     .filter(group => group.items.length > 0)
 

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -108,3 +108,59 @@ export function splitClean(value: unknown): string[] {
 
   return []
 }
+
+function normalizeForDedup(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^\w\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function ensureTerminalPunctuation(value: string): string {
+  if (!value) return value
+  return /[.!?]$/.test(value) ? value : `${value}.`
+}
+
+/** Remove duplicated/near-duplicated list entries and cap length when needed. */
+export function uniqueNormalizedList(value: unknown, maxItems?: number): string[] {
+  const unique = new Map<string, string>()
+
+  cleanList(value).forEach(item => {
+    const key = normalizeForDedup(item)
+    if (!key || unique.has(key)) return
+    unique.set(key, item)
+  })
+
+  const values = Array.from(unique.values())
+  return typeof maxItems === 'number' ? values.slice(0, Math.max(0, maxItems)) : values
+}
+
+/** Clean malformed punctuation/spacing and remove repeated sentence fragments in prose strings. */
+export function sanitizeReadableText(value: unknown): string {
+  const base = cleanText(value)
+  if (!base) return ''
+
+  const normalized = base
+    .replace(/\s+/g, ' ')
+    .replace(/\s*([,;:.!?])\s*/g, '$1 ')
+    .replace(/([,;:.!?]){2,}/g, '$1')
+    .replace(/(?:\.\s*){2,}/g, '. ')
+    .replace(/,\s*\./g, '. ')
+    .trim()
+
+  const sentenceParts = normalized
+    .split(/(?<=[.!?])\s+/)
+    .map(part => part.trim())
+    .filter(Boolean)
+
+  const deduped = new Map<string, string>()
+  sentenceParts.forEach(part => {
+    const withPunctuation = ensureTerminalPunctuation(part.replace(/[.!?]+$/g, '').trim())
+    const key = normalizeForDedup(withPunctuation)
+    if (!key || deduped.has(key)) return
+    deduped.set(key, withPunctuation)
+  })
+
+  return Array.from(deduped.values()).join(' ').trim()
+}

--- a/src/pages/CompoundDetail.tsx
+++ b/src/pages/CompoundDetail.tsx
@@ -1,10 +1,10 @@
-import { type ReactNode } from 'react'
+import { type ReactNode, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import Meta from '@/components/Meta'
 import DataTrustPanel from '@/components/trust/DataTrustPanel'
 import { useCompoundDataState, useCompoundDetailState } from '@/lib/compound-data'
 import { useHerbDataState } from '@/lib/herb-data'
-import { splitClean } from '@/lib/sanitize'
+import { sanitizeReadableText, splitClean, uniqueNormalizedList } from '@/lib/sanitize'
 import { pickNonEmptyKeys } from '@/lib/nonEmptyFields'
 import { calculateCompoundConfidence } from '@/utils/calculateConfidence'
 import { getCompoundDataCompleteness } from '@/utils/getDataCompleteness'
@@ -66,14 +66,29 @@ function Section({ title, children }: { title: string; children: ReactNode }) {
   )
 }
 
-function ListSection({ items }: { items: string[] }) {
+function ListSection({ items, maxVisible = 8 }: { items: string[]; maxVisible?: number }) {
+  const [expanded, setExpanded] = useState(false)
   if (!items.length) return null
+  const cappedMax = Math.max(1, maxVisible)
+  const visibleItems = expanded ? items : items.slice(0, cappedMax)
+  const hasOverflow = items.length > cappedMax
   return (
-    <ul className='list-disc space-y-1 pl-5'>
-      {items.map(item => (
-        <li key={item}>{item}</li>
-      ))}
-    </ul>
+    <>
+      <ul className='list-disc space-y-1 pl-5'>
+        {visibleItems.map(item => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+      {hasOverflow && (
+        <button
+          type='button'
+          className='mt-2 text-xs font-medium text-emerald-200/90 hover:text-emerald-100'
+          onClick={() => setExpanded(value => !value)}
+        >
+          {expanded ? 'Show less' : `Show ${items.length - cappedMax} more`}
+        </button>
+      )}
+    </>
   )
 }
 
@@ -175,15 +190,22 @@ export default function CompoundDetail() {
     normalizeTextValue(compoundRecord.name) ||
     normalizeTextValue(compoundRecord.id) ||
     'Unknown compound'
-  const evidence = normalizeTextValue(compoundRecord.evidence)
-  const pharmacokinetics = normalizeTextValue(compoundRecord.pharmacokinetics)
-  const pathwayTargets = splitClean(compoundRecord.pathwayTargets)
-  const workbookSources = splitPipeList(compoundRecord.sourceUrls)
-  const relatedHerbSlugs = splitClean(compoundRecord.relatedHerbSlugs)
+  const evidence = sanitizeReadableText(compoundRecord.evidence)
+  const pharmacokinetics = sanitizeReadableText(compoundRecord.pharmacokinetics)
+  const pathwayTargets = uniqueNormalizedList(splitClean(compoundRecord.pathwayTargets))
+  const workbookSources = uniqueNormalizedList(splitPipeList(compoundRecord.sourceUrls))
+  const relatedHerbSlugs = uniqueNormalizedList(splitClean(compoundRecord.relatedHerbSlugs))
+  const compoundEffects = uniqueNormalizedList(compound.effects)
+  const compoundContraindications = uniqueNormalizedList(compound.contraindications)
+  const compoundSideEffects = uniqueNormalizedList(compound.sideEffects)
+  const compoundTherapeuticUses = uniqueNormalizedList(compound.therapeuticUses)
+  const compoundInteractions = uniqueNormalizedList(compound.interactions)
+  const compoundDescription = sanitizeReadableText(compound.description)
+  const compoundMechanism = sanitizeReadableText(compound.mechanism)
   const drugInteractions = normalizeTextValue(compoundRecord.drugInteractions)
   const uniqueDrugInteractionItems = Array.from(
     new Map(
-      [...compound.interactions, ...(drugInteractions ? [drugInteractions] : [])]
+      [...compoundInteractions, ...(drugInteractions ? [sanitizeReadableText(drugInteractions)] : [])]
         .map(item => normalizeTextValue(item))
         .filter(Boolean)
         .map(item => [normalizeKey(item), item]),
@@ -212,8 +234,8 @@ export default function CompoundDetail() {
     })
   })
 
-  const whyItMatters = compound.effects.slice(0, 2).join(' + ')
-  const doesText = compound.mechanism || compound.description
+  const whyItMatters = compoundEffects.slice(0, 2).join(' + ')
+  const doesText = compoundMechanism || compoundDescription
   const premiumDetails = [
     { title: 'Identity', value: compound.identity },
     {
@@ -273,39 +295,39 @@ export default function CompoundDetail() {
   const confidence =
     compound.confidence ??
     calculateCompoundConfidence({
-      mechanism: compound.mechanism,
-      effects: compound.effects,
+      mechanism: compoundMechanism,
+      effects: compoundEffects,
       compounds: compound.herbs,
     })
 
   const completeness = getCompoundDataCompleteness({
-    mechanism: compound.mechanism,
-    effects: compound.effects,
-    contraindications: compound.contraindications,
-    interactions: compound.interactions,
+    mechanism: compoundMechanism,
+    effects: compoundEffects,
+    contraindications: compoundContraindications,
+    interactions: compoundInteractions,
     herbs: compound.herbs,
   })
 
-  const primaryEffects = extractPrimaryEffects(compound.effects, 4)
+  const primaryEffects = extractPrimaryEffects(compoundEffects, 4)
 
   const sourceCount = compound.sources.length
   const cautionCount = countCautionSignals({
-    contraindications: compound.contraindications,
-    interactions: compound.interactions,
-    sideEffects: compound.sideEffects,
+    contraindications: compoundContraindications,
+    interactions: compoundInteractions,
+    sideEffects: compoundSideEffects,
   })
   const { hasInferredContent, hasFallbackContent } = inferContentFlags({
-    description: compound.description,
-    mechanism: compound.mechanism,
-    effects: compound.effects,
-    therapeuticUses: compound.therapeuticUses,
+    description: compoundDescription,
+    mechanism: compoundMechanism,
+    effects: compoundEffects,
+    therapeuticUses: compoundTherapeuticUses,
   })
 
   const keyFields = pickNonEmptyKeys(
     {
-      mechanism: compound.mechanism,
-      effects: compound.effects,
-      contraindications: compound.contraindications,
+      mechanism: compoundMechanism,
+      effects: compoundEffects,
+      contraindications: compoundContraindications,
       herbs: compound.herbs,
     },
     ['mechanism', 'effects', 'contraindications', 'herbs'],
@@ -373,17 +395,17 @@ export default function CompoundDetail() {
       : null
   const fallbackIntro = buildFallbackCompoundIntro({
     compoundName: name,
-    description: compound.description,
-    mechanism: compound.mechanism,
-    therapeuticUses: compound.therapeuticUses,
+    description: compoundDescription,
+    mechanism: compoundMechanism,
+    therapeuticUses: compoundTherapeuticUses,
     primaryEffects,
     linkedHerbCount: linkedHerbs.length,
     confidence,
     sourceCount,
     cautionCount,
-    contraindications: compound.contraindications,
-    interactions: compound.interactions,
-    sideEffects: compound.sideEffects,
+    contraindications: compoundContraindications,
+    interactions: compoundInteractions,
+    sideEffects: compoundSideEffects,
     introFacts,
   })
   const governedIntro = buildGovernedDetailIntro({
@@ -394,7 +416,7 @@ export default function CompoundDetail() {
   })
   const governedReviewFreshness = buildGovernedReviewFreshness(governedResearch)
   const topSummary =
-    governedIntro.whatItIs || governedIntro.commonUse || compound.description || compound.mechanism
+    governedIntro.whatItIs || governedIntro.commonUse || compoundDescription || compoundMechanism
   const enrichmentRecommendations = buildEnrichmentRecommendations('compound', compound.slug)
   const quickCompareSection = buildGovernedQuickCompareSection('compound', compound.slug)
   const recommendationNames = {
@@ -405,12 +427,12 @@ export default function CompoundDetail() {
   // Derive a display class — category only if it's meaningful
   const displayClass =
     compound.className || (compound.category !== 'Uncategorized' ? compound.category : '')
-  const compoundEffectsMetaText = Array.isArray(compound.effects)
-    ? compound.effects.join(', ').slice(0, 155)
+  const compoundEffectsMetaText = Array.isArray(compoundEffects)
+    ? compoundEffects.join(', ').slice(0, 155)
     : ''
   const compoundDescriptionSource = (
-    compound.description ||
-    compound.mechanism ||
+    compoundDescription ||
+    compoundMechanism ||
     compoundEffectsMetaText
   ).trim()
   const baseCompoundMetaDescription = formatMetaDescription(
@@ -484,9 +506,9 @@ export default function CompoundDetail() {
           <div className='flex flex-wrap items-start justify-between gap-3'>
             <h1 className='text-3xl font-semibold leading-tight'>{name}</h1>
           </div>
-          {(compound.description || topSummary) && (
+          {(compoundDescription || topSummary) && (
             <p className='mt-3 max-w-3xl text-sm leading-relaxed text-white/80'>
-              {compound.description || topSummary}
+              {compoundDescription || topSummary}
             </p>
           )}
           {(confidence || evidence || sourceCount > 0 || cautionCount > 0) && (
@@ -529,9 +551,9 @@ export default function CompoundDetail() {
         </header>
 
         {/* Core fields — only render when value is present */}
-        {compound.description && compound.description !== topSummary && (
+        {compoundDescription && compoundDescription !== topSummary && (
           <Section title='Overview'>
-            {compound.description}
+            {compoundDescription}
             {topSummary && <p className='mt-3 text-white/80'>{topSummary}</p>}
             {displayClass && (
               <p className='mt-3 text-xs uppercase tracking-[0.12em] text-white/55'>
@@ -575,11 +597,11 @@ export default function CompoundDetail() {
           </Section>
         )}
 
-        {compound.mechanism && <Section title='Mechanism of Action'>{compound.mechanism}</Section>}
+        {compoundMechanism && <Section title='Mechanism of Action'>{compoundMechanism}</Section>}
 
-        {compound.effects.length > 0 && (
+        {compoundEffects.length > 0 && (
           <Section title='Effects'>
-            <ListSection items={compound.effects} />
+            <ListSection items={compoundEffects} maxVisible={6} />
           </Section>
         )}
 
@@ -602,31 +624,31 @@ export default function CompoundDetail() {
           </section>
         )}
 
-        {compound.therapeuticUses.length > 0 && (
+        {compoundTherapeuticUses.length > 0 && (
           <section className='border-white/8 mt-6 border-t pt-5'>
             <Collapse title='Traditional & Therapeutic Use'>
               <div className='text-sm leading-relaxed text-white/85'>
-                <ListSection items={compound.therapeuticUses} />
+                <ListSection items={compoundTherapeuticUses} maxVisible={6} />
               </div>
             </Collapse>
           </section>
         )}
 
         {/* Safety */}
-        {(compound.contraindications.length > 0 ||
-          compound.interactions.length > 0 ||
-          compound.sideEffects.length > 0 ||
+        {(compoundContraindications.length > 0 ||
+          compoundInteractions.length > 0 ||
+          compoundSideEffects.length > 0 ||
           uniqueDrugInteractionItems.length > 0) && (
           <section id='governed-safety-interactions' className='border-white/8 mt-6 border-t pt-5'>
             <Collapse title='Safety Notes'>
               <div className='space-y-4 text-sm leading-relaxed text-white/85'>
-                {compound.contraindications.length > 0 && (
+                {compoundContraindications.length > 0 && (
                   <div>
                     <h3 className='mb-2 text-xs font-semibold uppercase tracking-[0.14em] text-white/55'>
                       Contraindications
                     </h3>
                     <ul className='space-y-2'>
-                      {compound.contraindications.map(item => (
+                      {compoundContraindications.map(item => (
                         <li
                           key={item}
                           className='rounded-xl border border-rose-400/40 bg-rose-500/10 px-3 py-2 text-rose-100'
@@ -645,15 +667,15 @@ export default function CompoundDetail() {
                     <h3 className='mb-2 text-xs font-semibold uppercase tracking-[0.14em] text-white/55'>
                       Drug Interactions
                     </h3>
-                    <ListSection items={uniqueDrugInteractionItems} />
+                    <ListSection items={uniqueDrugInteractionItems} maxVisible={6} />
                   </div>
                 )}
-                {compound.sideEffects.length > 0 && (
+                {compoundSideEffects.length > 0 && (
                   <div>
                     <h3 className='mb-2 text-xs font-semibold uppercase tracking-[0.14em] text-white/55'>
                       Side Effects
                     </h3>
-                    <ListSection items={compound.sideEffects} />
+                    <ListSection items={compoundSideEffects} maxVisible={6} />
                   </div>
                 )}
               </div>

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -10,7 +10,7 @@ import { HerbDetailSkeleton } from '@/components/skeletons/DetailSkeletons'
 import { pickNonEmptyKeys } from '@/lib/nonEmptyFields'
 import { extractPrimaryEffects } from '@/utils/extractPrimaryEffects'
 import { getHerbDataCompleteness } from '@/utils/getDataCompleteness'
-import { splitClean } from '@/lib/sanitize'
+import { sanitizeReadableText, splitClean, uniqueNormalizedList } from '@/lib/sanitize'
 import { pushRecentlyViewed, useSavedItems } from '@/lib/growth'
 import {
   breadcrumbJsonLd,
@@ -63,7 +63,8 @@ type SourceRef = { title: string; url: string; note?: string }
 
 function toSources(value: unknown): SourceRef[] {
   if (!Array.isArray(value)) return []
-  return value
+  const unique = new Map<string, SourceRef>()
+  value
     .map(item => {
       if (typeof item === 'string') {
         const t = item.trim()
@@ -78,6 +79,11 @@ function toSources(value: unknown): SourceRef[] {
       return { title: title || url, url: url || title, note: note || undefined }
     })
     .filter((item): item is SourceRef => Boolean(item))
+    .forEach(item => {
+      const key = `${item.url.trim().toLowerCase()}|${item.title.trim().toLowerCase()}`
+      if (!unique.has(key)) unique.set(key, item)
+    })
+  return Array.from(unique.values())
 }
 
 // Only renders if children is a non-empty string, non-empty array, or explicit ReactNode
@@ -92,14 +98,29 @@ function Section({ title, children }: { title: string; children: ReactNode }) {
   )
 }
 
-function ListSection({ items }: { items: string[] }) {
+function ListSection({ items, maxVisible = 8 }: { items: string[]; maxVisible?: number }) {
+  const [expanded, setExpanded] = useState(false)
   if (!items.length) return null
+  const cappedMax = Math.max(1, maxVisible)
+  const visibleItems = expanded ? items : items.slice(0, cappedMax)
+  const hasOverflow = items.length > cappedMax
   return (
-    <ul className='list-disc space-y-1 pl-5'>
-      {items.map(item => (
-        <li key={item}>{item}</li>
-      ))}
-    </ul>
+    <>
+      <ul className='list-disc space-y-1 pl-5'>
+        {visibleItems.map(item => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+      {hasOverflow && (
+        <button
+          type='button'
+          className='mt-2 text-xs font-medium text-emerald-200/90 hover:text-emerald-100'
+          onClick={() => setExpanded(value => !value)}
+        >
+          {expanded ? 'Show less' : `Show ${items.length - cappedMax} more`}
+        </button>
+      )}
+    </>
   )
 }
 
@@ -243,22 +264,22 @@ export default function HerbDetail() {
   }
 
   // All list fields are already cleaned arrays from herb-data.ts
-  const effects = Array.isArray(herb.effects) ? herb.effects : splitClean(herb.effects)
-  const activeCompounds = Array.isArray(herb.activeCompounds)
-    ? herb.activeCompounds
-    : splitClean(herb.activeCompounds)
-  const contraindications = Array.isArray(herb.contraindications)
-    ? herb.contraindications
-    : splitClean(herb.contraindications)
-  const interactions = Array.isArray(herb.interactions)
-    ? herb.interactions
-    : splitClean(herb.interactions)
-  const therapeuticUses = Array.isArray(herb.therapeuticUses)
-    ? herb.therapeuticUses
-    : splitClean(herb.therapeuticUses)
-  const sideEffects = Array.isArray(herb.sideeffects)
-    ? herb.sideeffects
-    : splitClean(herb.sideeffects)
+  const effects = uniqueNormalizedList(Array.isArray(herb.effects) ? herb.effects : splitClean(herb.effects))
+  const activeCompounds = uniqueNormalizedList(
+    Array.isArray(herb.activeCompounds) ? herb.activeCompounds : splitClean(herb.activeCompounds),
+  )
+  const contraindications = uniqueNormalizedList(
+    Array.isArray(herb.contraindications) ? herb.contraindications : splitClean(herb.contraindications),
+  )
+  const interactions = uniqueNormalizedList(
+    Array.isArray(herb.interactions) ? herb.interactions : splitClean(herb.interactions),
+  )
+  const therapeuticUses = uniqueNormalizedList(
+    Array.isArray(herb.therapeuticUses) ? herb.therapeuticUses : splitClean(herb.therapeuticUses),
+  )
+  const sideEffects = uniqueNormalizedList(
+    Array.isArray(herb.sideeffects) ? herb.sideeffects : splitClean(herb.sideeffects),
+  )
   const sources = toSources(herb.sources)
   const primaryEffects = extractPrimaryEffects(effects, 4)
   const compoundByName = new Map(compounds.map(compound => [normalizeKey(compound.name), compound]))
@@ -356,20 +377,24 @@ export default function HerbDetail() {
     : `${herbDisplayName} Herb Guide: Effects, Uses & Safety`
 
   // Scalar fields already cleaned by normalization
-  const description = herb.description || ''
-  const mechanism = herb.mechanism || ''
+  const description = sanitizeReadableText(herb.description)
+  const mechanism = sanitizeReadableText(herb.mechanism)
   const intensity = herb.intensity || ''
   const region = herb.region || ''
-  const duration = herb.duration || ''
-  const dosage = herb.dosage || ''
-  const preparation = herb.preparation || ''
+  const duration = sanitizeReadableText(herb.duration)
+  const dosage = sanitizeReadableText(herb.dosage)
+  const preparation = sanitizeReadableText(herb.preparation)
   const standardization = String(herb.standardization || '').trim()
   const legalStatus = herb.legalStatus || ''
-  const qualityConcerns = String(herb.qualityConcerns || '').trim()
-  const herbClass = String(herb.class || herb.category || '')
+  const qualityConcerns = sanitizeReadableText(herb.qualityConcerns)
+  const herbClass = sanitizeReadableText(herb.class || herb.category)
   const evidenceLevel = String(herb.evidenceLevel || '').trim()
-  const mechanismTags = Array.isArray(herb.mechanismTags) ? splitClean(herb.mechanismTags) : []
-  const pathwayTargets = Array.isArray(herb.pathwayTargets) ? splitClean(herb.pathwayTargets) : []
+  const mechanismTags = Array.isArray(herb.mechanismTags)
+    ? uniqueNormalizedList(splitClean(herb.mechanismTags))
+    : []
+  const pathwayTargets = Array.isArray(herb.pathwayTargets)
+    ? uniqueNormalizedList(splitClean(herb.pathwayTargets))
+    : []
   const compoundCount =
     typeof herb.compound_count === 'number' && Number.isFinite(herb.compound_count)
       ? herb.compound_count
@@ -952,19 +977,19 @@ export default function HerbDetail() {
 
         {therapeuticUses.length > 0 && (
           <Section title='What it’s used for'>
-            <ListSection items={therapeuticUses} />
+            <ListSection items={therapeuticUses} maxVisible={6} />
           </Section>
         )}
 
         {contraindications.length > 0 && (
           <Section title='Who should be careful'>
-            <ListSection items={contraindications} />
+            <ListSection items={contraindications} maxVisible={6} />
           </Section>
         )}
 
         {sideEffects.length > 0 && (
           <Section title='Possible side effects'>
-            <ListSection items={sideEffects} />
+            <ListSection items={sideEffects} maxVisible={6} />
           </Section>
         )}
 
@@ -1192,7 +1217,7 @@ export default function HerbDetail() {
 
         {effects.length > 0 && (
           <Section title='Effects'>
-            <ListSection items={effects} />
+            <ListSection items={effects} maxVisible={6} />
           </Section>
         )}
 
@@ -1200,7 +1225,7 @@ export default function HerbDetail() {
           <section className='border-white/8 mt-6 border-t pt-5'>
             <Collapse title='Drug interactions'>
               <div className='text-sm leading-relaxed text-white/85'>
-                <ListSection items={interactions} />
+                <ListSection items={interactions} maxVisible={6} />
               </div>
             </Collapse>
           </section>


### PR DESCRIPTION
### Motivation
- The herb and compound detail pages were rendering duplicated and malformed content from mixed/merged data sources, producing repeated list items and noisy prose. 
- Long unbounded lists and a verbose top header reduced readability and pushed useful content below the fold. 

### Description
- Add sanitization and normalization helpers in `src/lib/sanitize.ts` (`sanitizeReadableText`, `uniqueNormalizedList`) and apply them to prose and list fields to remove repeated sentence fragments, collapse malformed punctuation, and dedupe near-identical items. 
- Normalize/dedupe and cap list rendering in `HerbDetail` and `CompoundDetail` by replacing direct renders with `uniqueNormalizedList` + a `ListSection` component that shows a capped number of items and a lightweight `Show more / Show less` affordance. 
- Harden source/relation rendering by deduping `toSources` and normalizing relation groups in `PremiumDataSection`, and simplify the top navigation by removing the secondary discovery/promo strip in `NavBar`. 
- Files changed: `src/lib/sanitize.ts`, `src/pages/HerbDetail.tsx`, `src/pages/CompoundDetail.tsx`, `src/components/NavBar.tsx`, and `src/components/detail/PremiumDataSection.tsx`. 
- How duplicates are prevented: list fields are normalized and keyed via a canonicalized map before render, prose is sanitized and de-duplicated at sentence granularity, and related/source links are keyed and filtered to unique entries. 

### Testing
- Built and validated the app with `npm run build:compile` and `npm run build`, both completed successfully. 
- Pre-commit hooks ran and `eslint --max-warnings=0` passed for the changed files, and the changes were committed with the message `Fix duplicate detail rendering and simplify header`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc1dfc801c8323826a809f3c0cdd36)