### PR TITLE
Refocus homepage hero for stronger visual hierarchy

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -6,12 +6,12 @@ export default function Hero() {
   const reduceMotion = useReducedMotion()
 
   return (
-    <section className='relative mx-auto mt-4 max-w-4xl px-4 py-8 sm:mt-6 sm:px-6 sm:py-12'>
+    <section className='relative mx-auto mt-4 max-w-4xl px-4 py-10 sm:mt-6 sm:px-6 sm:py-14'>
       <div
         aria-hidden
         className='pointer-events-none absolute inset-0 -z-10 grid place-items-center'
       >
-        <div className='animate-breathe from-emerald-500/8 to-indigo-500/8 size-[52rem] rounded-full bg-gradient-to-br via-fuchsia-500/5 blur-[120px]' />
+        <div className='animate-breathe from-emerald-500/10 to-indigo-500/8 size-[54rem] rounded-full bg-gradient-to-br via-fuchsia-500/10 blur-[130px]' />
       </div>
 
       <Tilt maxTilt={4} perspective={900} className='relative'>
@@ -22,7 +22,11 @@ export default function Hero() {
           className='shadow-halo border-white/12 relative overflow-hidden rounded-[24px] border bg-white/[0.04] backdrop-blur-2xl sm:rounded-[28px]'
         >
           <div
-            className='pointer-events-none absolute inset-0 bg-gradient-to-br from-white/[0.09] via-transparent to-violet-300/[0.08]'
+            className='pointer-events-none absolute inset-0 bg-gradient-to-br from-white/[0.1] via-transparent to-violet-300/[0.1]'
+            aria-hidden
+          />
+          <div
+            className='pointer-events-none absolute inset-[1px] rounded-[23px] border border-white/10 sm:rounded-[27px]'
             aria-hidden
           />
           <div
@@ -30,8 +34,8 @@ export default function Hero() {
             aria-hidden
           />
 
-          <div className='relative space-y-7 p-5 sm:space-y-9 sm:p-10'>
-            <div className='space-y-3 sm:space-y-4'>
+          <div className='relative space-y-8 p-5 sm:space-y-12 sm:p-10'>
+            <div className='space-y-3 sm:space-y-5'>
               <motion.p
                 initial={reduceMotion ? undefined : { opacity: 0, y: 10 }}
                 whileInView={{ opacity: 1, y: 0 }}
@@ -49,9 +53,9 @@ export default function Hero() {
                     ? undefined
                     : { delay: 0.05, duration: 0.4, ease: [0.22, 1, 0.36, 1] }
                 }
-                className='text-[2.05rem] font-semibold leading-[1.06] tracking-tight text-white sm:text-6xl'
+                className='text-[2.15rem] font-semibold leading-[1.02] tracking-[-0.02em] text-white sm:text-[4.2rem]'
               >
-                Understand psychoactive herbs before you try them
+                Clarity before you experiment
               </motion.h1>
               <motion.p
                 initial={reduceMotion ? undefined : { opacity: 0, y: 12 }}
@@ -62,24 +66,10 @@ export default function Hero() {
                     ? undefined
                     : { delay: 0.12, duration: 0.4, ease: [0.22, 1, 0.36, 1] }
                 }
-                className='max-w-2xl text-[0.98rem] leading-[1.72] text-white/80 sm:text-lg'
+                className='max-w-xl text-[0.95rem] leading-[1.6] text-white/80 sm:text-base'
               >
-                Independent research on psychoactive herbs, entheogens, and plant compounds —
-                effects, mechanisms, interactions, and safety context in one place.
-              </motion.p>
-              <motion.p
-                initial={reduceMotion ? undefined : { opacity: 0, y: 12 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true }}
-                transition={
-                  reduceMotion
-                    ? undefined
-                    : { delay: 0.17, duration: 0.4, ease: [0.22, 1, 0.36, 1] }
-                }
-                className='max-w-2xl text-sm leading-[1.75] text-white/75 sm:text-base'
-              >
-                Start with Effect Search to match herbs to your goals, or browse the full database
-                with interaction checker and blend builder.
+                Research signals, risk flags, and hard questions — before you put anything in your
+                body.
               </motion.p>
             </div>
 

--- a/src/components/HeroCTA.tsx
+++ b/src/components/HeroCTA.tsx
@@ -5,24 +5,24 @@ const baseButtonClasses =
 
 export default function HeroCTA() {
   return (
-    <div className='w-full'>
-      <div className='grid grid-cols-1 gap-3 sm:max-w-xl sm:grid-cols-2'>
-        <Link to='/herbs' className={`${baseButtonClasses} btn-primary`}>
-          Browse Herbs
-        </Link>
-        <a href='#effect-search' className={`${baseButtonClasses} btn-secondary`}>
-          Effect Search
+    <div className='w-full space-y-4 sm:space-y-5'>
+      <div className='pt-1 sm:pt-2'>
+        <a href='#effect-search' className={`${baseButtonClasses} btn-primary`}>
+          Start with Effect Search
         </a>
       </div>
-      <div className='mt-3 flex flex-wrap gap-2'>
+      <div className='flex flex-wrap gap-2'>
         <Link
           to='/interactions'
-          className='text-xs text-white/75 underline-offset-4 hover:underline'
+          className='text-xs text-white/60 underline-offset-4 transition hover:text-white/80 hover:underline'
         >
           Interaction Checker
         </Link>
         <span className='text-white/40'>•</span>
-        <Link to='/build' className='text-xs text-white/75 underline-offset-4 hover:underline'>
+        <Link
+          to='/build'
+          className='text-xs text-white/60 underline-offset-4 transition hover:text-white/80 hover:underline'
+        >
           Blend Builder
         </Link>
       </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -92,26 +92,26 @@ export default function Home() {
       <section className='ds-section container mx-auto max-w-4xl px-4 pt-2 sm:px-6'>
         <div className='ds-card-grid sm:grid-cols-2'>
           <div className='ds-card h-full'>
-            <p className='text-xs font-semibold uppercase tracking-[0.2em] text-white/60'>
-              Start here
+            <p className='text-xs font-semibold uppercase tracking-[0.2em] text-white/55'>
+              First move
             </p>
-            <h2 className='mt-2 text-lg font-semibold text-white'>Find a herb by outcome</h2>
-            <p className='mt-1 text-sm text-white/75'>
-              Use Effect Search for goals like better sleep, calmer mood, or improved focus.
+            <h2 className='mt-2 text-lg font-semibold text-white'>Search by effect, not hype</h2>
+            <p className='mt-1 text-sm text-white/70'>
+              Start with the outcome you want. Then pressure-test safety.
             </p>
-            <a href='#effect-search' className='btn-primary mt-3 inline-flex'>
+            <a href='#effect-search' className='btn-primary mt-4 inline-flex'>
               Open Effect Search
             </a>
           </div>
           <div className='ds-card h-full'>
-            <p className='text-xs font-semibold uppercase tracking-[0.2em] text-white/60'>
-              Primary actions
+            <p className='text-xs font-semibold uppercase tracking-[0.2em] text-white/55'>
+              Quick tools
             </p>
-            <h2 className='mt-2 text-lg font-semibold text-white'>Choose your next step</h2>
-            <div className='ds-action-row mt-3'>
+            <h2 className='mt-2 text-lg font-semibold text-white'>Run a second check</h2>
+            <div className='mt-3 flex flex-wrap items-center gap-2 text-sm text-white/70'>
               <Link
                 to='/herbs'
-                className='btn-secondary'
+                className='underline-offset-4 transition hover:text-white hover:underline'
                 onClick={() =>
                   trackHomepageEntityClick({
                     targetType: 'herb',
@@ -122,14 +122,16 @@ export default function Home() {
               >
                 Browse Herbs
               </Link>
-              <Link to='/interactions' className='btn-secondary'>
+              <span className='text-white/35'>•</span>
+              <Link to='/interactions' className='underline-offset-4 transition hover:text-white hover:underline'>
                 Interaction Checker
               </Link>
-              <Link to='/build' className='btn-secondary'>
+              <span className='text-white/35'>•</span>
+              <Link to='/build' className='underline-offset-4 transition hover:text-white hover:underline'>
                 Blend Builder
               </Link>
             </div>
-            <p className='mt-3 text-xs text-white/65'>Most people start with one tool, then compare details.</p>
+            <p className='mt-3 text-xs text-white/60'>One action, then verify.</p>
           </div>
         </div>
       </section>


### PR DESCRIPTION
### Motivation
- Remove the generic, explanatory tone and convert the hero into a concise, curiosity-driven entry that reads instantly. 
- Create stronger visual contrast and tighter hierarchy so the headline hits first and supporting text reads quickly. 
- Make the primary action obvious and reduce cognitive load by demoting secondary choices and slimming copy.

### Description
- Replaced the long hero headline with a short, high-impact line: `Clarity before you experiment`, and tightened headline typography (`leading`, `tracking`, scale) to increase visual tension. 
- Removed a redundant supporting paragraph and replaced remaining copy with shorter, sharper language focused on caution/curiosity. 
- Added subtle identity depth: slightly stronger soft glow behind the hero and a faint inner highlight edge on the hero card for dimensionality while keeping the dark theme. 
- Enforced CTA dominance by making Effect Search the single primary CTA and demoting other tools to quiet inline links, and refined the adjacent top-section copy and spacing for clearer flows. 
- Files changed: `src/components/Hero.tsx`, `src/components/HeroCTA.tsx`, and `src/pages/Home.tsx` (top section only). No backend or data logic was modified.

### Testing
- Ran `npm run build:compile` and the build completed successfully. 
- Pre-commit checks ran `eslint --max-warnings=0` on staged TypeScript/TSX files and passed. 
- Verified the homepage bundle compiled and prerender steps were exercised during build; no runtime or type errors surfaced in the build output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc21a083508323b75da54dc39c611d)