### PR TITLE
Transform homepage hero into immersive full-width focal section

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -6,12 +6,13 @@ export default function Hero() {
   const reduceMotion = useReducedMotion()
 
   return (
-    <section className='relative mx-auto mt-4 max-w-4xl px-4 py-10 sm:mt-6 sm:px-6 sm:py-14'>
+    <section className='relative mx-auto mt-2 max-w-6xl px-4 py-16 sm:mt-4 sm:px-6 sm:py-24'>
       <div
         aria-hidden
-        className='pointer-events-none absolute inset-0 -z-10 grid place-items-center'
+        className='pointer-events-none absolute inset-0 -z-10 grid place-items-center overflow-hidden'
       >
-        <div className='animate-breathe from-emerald-500/10 to-indigo-500/8 size-[54rem] rounded-full bg-gradient-to-br via-fuchsia-500/10 blur-[130px]' />
+        <div className='animate-breathe h-[42rem] w-[76rem] rounded-full bg-[radial-gradient(circle,rgba(16,185,129,0.14)_0%,rgba(192,132,252,0.1)_52%,rgba(99,102,241,0.08)_100%)] blur-[120px]' />
+        <div className='absolute inset-0 bg-[radial-gradient(circle_at_50%_35%,rgba(255,255,255,0.08),rgba(11,15,23,0)_58%)]' />
       </div>
 
       <Tilt maxTilt={4} perspective={900} className='relative'>
@@ -19,23 +20,10 @@ export default function Hero() {
           initial={reduceMotion ? undefined : { opacity: 0, y: 16, scale: 0.99 }}
           animate={reduceMotion ? undefined : { opacity: 1, y: 0, scale: 1 }}
           transition={reduceMotion ? undefined : { duration: 0.55, ease: [0.22, 1, 0.36, 1] }}
-          className='shadow-halo border-white/12 relative overflow-hidden rounded-[24px] border bg-white/[0.04] backdrop-blur-2xl sm:rounded-[28px]'
+          className='relative overflow-hidden'
         >
-          <div
-            className='pointer-events-none absolute inset-0 bg-gradient-to-br from-white/[0.1] via-transparent to-violet-300/[0.1]'
-            aria-hidden
-          />
-          <div
-            className='pointer-events-none absolute inset-[1px] rounded-[23px] border border-white/10 sm:rounded-[27px]'
-            aria-hidden
-          />
-          <div
-            className='pointer-events-none absolute -top-24 left-0 right-0 h-48 bg-gradient-to-b from-white/[0.06] to-transparent'
-            aria-hidden
-          />
-
-          <div className='relative space-y-8 p-5 sm:space-y-12 sm:p-10'>
-            <div className='space-y-3 sm:space-y-5'>
+          <div className='relative space-y-10 py-6 sm:space-y-14 sm:py-10'>
+            <div className='space-y-2.5 sm:space-y-4.5'>
               <motion.p
                 initial={reduceMotion ? undefined : { opacity: 0, y: 10 }}
                 whileInView={{ opacity: 1, y: 0 }}
@@ -53,7 +41,7 @@ export default function Hero() {
                     ? undefined
                     : { delay: 0.05, duration: 0.4, ease: [0.22, 1, 0.36, 1] }
                 }
-                className='text-[2.15rem] font-semibold leading-[1.02] tracking-[-0.02em] text-white sm:text-[4.2rem]'
+                className='max-w-4xl text-[2.4rem] font-semibold leading-[0.97] tracking-[-0.025em] text-white sm:text-[4.75rem]'
               >
                 Clarity before you experiment
               </motion.h1>
@@ -66,7 +54,7 @@ export default function Hero() {
                     ? undefined
                     : { delay: 0.12, duration: 0.4, ease: [0.22, 1, 0.36, 1] }
                 }
-                className='max-w-xl text-[0.95rem] leading-[1.6] text-white/80 sm:text-base'
+                className='max-w-2xl text-[0.88rem] leading-[1.45] text-white/68 sm:text-[0.95rem]'
               >
                 Research signals, risk flags, and hard questions — before you put anything in your
                 body.

--- a/src/components/HeroCTA.tsx
+++ b/src/components/HeroCTA.tsx
@@ -5,23 +5,23 @@ const baseButtonClasses =
 
 export default function HeroCTA() {
   return (
-    <div className='w-full space-y-4 sm:space-y-5'>
-      <div className='pt-1 sm:pt-2'>
+    <div className='w-full space-y-5 sm:space-y-7'>
+      <div className='pt-3 sm:pt-4'>
         <a href='#effect-search' className={`${baseButtonClasses} btn-primary`}>
           Start with Effect Search
         </a>
       </div>
-      <div className='flex flex-wrap gap-2'>
+      <div className='flex flex-wrap gap-2.5'>
         <Link
           to='/interactions'
-          className='text-xs text-white/60 underline-offset-4 transition hover:text-white/80 hover:underline'
+          className='text-xs text-white/45 underline-offset-4 transition hover:text-white/65 hover:underline'
         >
           Interaction Checker
         </Link>
         <span className='text-white/40'>•</span>
         <Link
           to='/build'
-          className='text-xs text-white/60 underline-offset-4 transition hover:text-white/80 hover:underline'
+          className='text-xs text-white/45 underline-offset-4 transition hover:text-white/65 hover:underline'
         >
           Blend Builder
         </Link>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -89,26 +89,26 @@ export default function Home() {
 
       <Hero />
 
-      <section className='ds-section container mx-auto max-w-4xl px-4 pt-2 sm:px-6'>
-        <div className='ds-card-grid sm:grid-cols-2'>
-          <div className='ds-card h-full'>
-            <p className='text-xs font-semibold uppercase tracking-[0.2em] text-white/55'>
+      <section className='container mx-auto max-w-4xl px-4 pt-8 sm:px-6 sm:pt-12'>
+        <div className='grid gap-8 sm:grid-cols-2 sm:gap-10'>
+          <div className='h-full space-y-2'>
+            <p className='text-[11px] font-semibold uppercase tracking-[0.2em] text-white/45'>
               First move
             </p>
-            <h2 className='mt-2 text-lg font-semibold text-white'>Search by effect, not hype</h2>
-            <p className='mt-1 text-sm text-white/70'>
+            <h2 className='text-base font-medium text-white/82'>Search by effect, not hype</h2>
+            <p className='text-sm text-white/60'>
               Start with the outcome you want. Then pressure-test safety.
             </p>
             <a href='#effect-search' className='btn-primary mt-4 inline-flex'>
               Open Effect Search
             </a>
           </div>
-          <div className='ds-card h-full'>
-            <p className='text-xs font-semibold uppercase tracking-[0.2em] text-white/55'>
+          <div className='h-full space-y-2'>
+            <p className='text-[11px] font-semibold uppercase tracking-[0.2em] text-white/45'>
               Quick tools
             </p>
-            <h2 className='mt-2 text-lg font-semibold text-white'>Run a second check</h2>
-            <div className='mt-3 flex flex-wrap items-center gap-2 text-sm text-white/70'>
+            <h2 className='text-base font-medium text-white/82'>Run a second check</h2>
+            <div className='flex flex-wrap items-center gap-2 text-sm text-white/60'>
               <Link
                 to='/herbs'
                 className='underline-offset-4 transition hover:text-white hover:underline'
@@ -131,7 +131,7 @@ export default function Home() {
                 Blend Builder
               </Link>
             </div>
-            <p className='mt-3 text-xs text-white/60'>One action, then verify.</p>
+            <p className='pt-1 text-xs text-white/48'>One action, then verify.</p>
           </div>
         </div>
       </section>


### PR DESCRIPTION
### Motivation
- Make the hero feel like part of the page rather than a boxed card and establish a clear visual hierarchy above the fold. 
- Increase headline prominence and breathing room while de-emphasizing secondary UI elements so the CTA reads strongly. 
- Preserve existing functionality and the dark theme while only changing layout and styling.

### Description
- Removed the hero card framing and glass/border/rounded overlays so the hero reads unboxed and integrates with the page (`src/components/Hero.tsx`).
- Expanded hero envelope to `max-w-6xl` and increased vertical padding to give a stronger above-the-fold presence and added a soft radial lighting/background depth behind the hero (`src/components/Hero.tsx`).
- Tightened headline scale/leading/tracking and reduced supporting copy size/opacity to favor the H1 as the primary focal element (`src/components/Hero.tsx`).
- Emphasized a single primary CTA and lowered visual weight of secondary links, and replaced the boxed cards for the “First move”/“Quick tools” area with an open grid and lighter headings (`src/components/HeroCTA.tsx`, `src/pages/Home.tsx`).

### Testing
- Changed files: `src/components/Hero.tsx`, `src/components/HeroCTA.tsx`, and `src/pages/Home.tsx` and the commit was created. 
- Key diffs: hero card shell and inner gloss/outline removed, radial background added, headline increased/tightened, support text desaturated, secondary links lightened, and `ds-card` wrappers removed for the top follow-up section. 
- Commands run: `npm run build` (including prebuild/postbuild pipeline) and `git commit` were executed as part of validation. 
- Verification results: `npm run build` completed successfully and prerender/verification scripts passed, and the repo was committed with only the intended three files changed; follow-up risk: visual QA in a browser is recommended to confirm spacing across breakpoints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc26dc82bc83238076b87846a88ab1)