### PR TITLE
Create subtle global galaxy/nebula atmospheric background

### DIFF
--- a/src/components/BackgroundStage.tsx
+++ b/src/components/BackgroundStage.tsx
@@ -1,5 +1,4 @@
 'use client'
-import { useEffect, useMemo, useRef } from 'react'
 
 type EffectName = 'aura' | 'nebula' | 'vapor' | 'plasma'
 
@@ -8,212 +7,25 @@ type BackgroundStageProps = {
   enabled?: boolean
 }
 
+const EFFECT_CLASS: Record<EffectName, string> = {
+  aura: 'galaxy--aura',
+  nebula: 'galaxy--nebula',
+  vapor: 'galaxy--vapor',
+  plasma: 'galaxy--plasma'
+}
+
 export default function BackgroundStage({ effect = 'aura', enabled = true }: BackgroundStageProps) {
-  const canvasRef = useRef<HTMLCanvasElement | null>(null)
-  const rafRef = useRef<number>(0)
-  const scrollY = useRef(0)
-  const pointer = useRef({ x: 0.5, y: 0.5 })
-  const dpr = typeof window !== 'undefined' ? Math.min(window.devicePixelRatio || 1, 2) : 1
-
-  const draw = useMemo(() => {
-    const TAU = Math.PI * 2
-
-    const aura = (ctx: CanvasRenderingContext2D, t: number, w: number, h: number) => {
-      ctx.globalCompositeOperation = 'source-over'
-      ctx.clearRect(0, 0, w, h)
-
-      const base = ctx.createRadialGradient(
-        w * 0.5,
-        h * 0.25,
-        0,
-        w * 0.5,
-        h * 0.5,
-        Math.max(w, h) * 0.9
-      )
-      base.addColorStop(0, 'rgba(8,12,20,0.05)')
-      base.addColorStop(1, 'rgba(2,6,12,0.45)')
-      ctx.fillStyle = base
-      ctx.fillRect(0, 0, w, h)
-
-      for (let i = 0; i < 3; i += 1) {
-        const cx = w * (0.35 + 0.3 * Math.sin(t * 0.15 + i + pointer.current.x * 0.8))
-        const cy = h * (0.35 + 0.3 * Math.cos(t * 0.13 + i + pointer.current.y * 0.8))
-        const r = Math.max(w, h) * (0.35 + 0.05 * Math.sin(t * 0.27 + i))
-        const g = ctx.createRadialGradient(cx, cy, 0, cx, cy, r)
-        g.addColorStop(0, 'rgba(56,189,248,0.22)')
-        g.addColorStop(0.5, 'rgba(147,51,234,0.20)')
-        g.addColorStop(1, 'rgba(0,0,0,0)')
-        ctx.fillStyle = g
-        ctx.beginPath()
-        ctx.arc(cx, cy, r, 0, TAU)
-        ctx.fill()
-      }
-    }
-
-    const nebula = (ctx: CanvasRenderingContext2D, t: number, w: number, h: number) => {
-      ctx.globalCompositeOperation = 'source-over'
-      ctx.clearRect(0, 0, w, h)
-
-      const wash = ctx.createLinearGradient(0, 0, 0, h)
-      wash.addColorStop(0, 'rgba(5, 25, 39, 0.55)')
-      wash.addColorStop(1, 'rgba(3, 13, 22, 0.52)')
-      ctx.fillStyle = wash
-      ctx.fillRect(0, 0, w, h)
-
-      for (let i = 0; i < 5; i += 1) {
-        const cx = w * (0.5 + 0.35 * Math.sin(t * 0.12 + i * 1.7 + pointer.current.x * 1.2))
-        const cy = h * (0.5 + 0.35 * Math.cos(t * 0.1 + i * 1.3 + scrollY.current * 0.0006))
-        const r = Math.max(w, h) * (0.28 + 0.08 * Math.sin(t * 0.22 + i))
-        const g = ctx.createRadialGradient(cx, cy, 0, cx, cy, r)
-        g.addColorStop(0, 'rgba(34,197,94,0.16)')
-        g.addColorStop(0.6, 'rgba(59,130,246,0.14)')
-        g.addColorStop(1, 'rgba(0,0,0,0)')
-        ctx.fillStyle = g
-        ctx.beginPath()
-        ctx.arc(cx, cy, r, 0, TAU)
-        ctx.fill()
-      }
-    }
-
-    const vapor = (ctx: CanvasRenderingContext2D, t: number, w: number, h: number) => {
-      ctx.globalCompositeOperation = 'source-over'
-      ctx.clearRect(0, 0, w, h)
-      ctx.fillStyle = 'rgba(3, 7, 18, 0.45)'
-      ctx.fillRect(0, 0, w, h)
-
-      for (let i = 0; i < 6; i += 1) {
-        const y = h + ((t * 30 + i * 180) % (h * 2)) - h
-        const grd = ctx.createLinearGradient(0, y - 120, 0, y + 120)
-        grd.addColorStop(0, 'rgba(99,102,241,0)')
-        grd.addColorStop(0.5, 'rgba(168,85,247,0.18)')
-        grd.addColorStop(1, 'rgba(56,189,248,0)')
-        ctx.fillStyle = grd
-        ctx.fillRect(0, y - 140, w, 280)
-      }
-    }
-
-    const plasma = (ctx: CanvasRenderingContext2D, t: number, w: number, h: number) => {
-      ctx.globalCompositeOperation = 'source-over'
-      ctx.clearRect(0, 0, w, h)
-      ctx.fillStyle = 'rgba(2, 4, 9, 0.45)'
-      ctx.fillRect(0, 0, w, h)
-
-      for (let i = 0; i < 4; i += 1) {
-        const k = i + 1
-        const cx = w * (0.5 + 0.22 * Math.sin((t * 0.9) / k + pointer.current.x * 1.3))
-        const cy = h * (0.5 + 0.22 * Math.cos((t * 0.8) / k + scrollY.current * 0.0008))
-        const r = Math.max(w, h) * (0.22 + 0.05 * Math.sin((t * 1.2) / k))
-        const g = ctx.createRadialGradient(cx, cy, 0, cx, cy, r)
-        g.addColorStop(0, 'rgba(244,63,94,0.22)')
-        g.addColorStop(0.5, 'rgba(234,179,8,0.18)')
-        g.addColorStop(1, 'rgba(0,0,0,0)')
-        ctx.fillStyle = g
-        ctx.beginPath()
-        ctx.arc(cx, cy, r, 0, TAU)
-        ctx.fill()
-      }
-    }
-
-    return { aura, nebula, vapor, plasma } as const
-  }, [])
-
-  useEffect(() => {
-    if (!enabled) return
-
-    const onMove = (event: PointerEvent) => {
-      const { innerWidth, innerHeight } = window
-      pointer.current.x = Math.max(0, Math.min(1, event.clientX / innerWidth))
-      pointer.current.y = Math.max(0, Math.min(1, event.clientY / innerHeight))
-    }
-
-    const onScroll = () => {
-      scrollY.current = window.scrollY
-    }
-
-    window.addEventListener('pointermove', onMove, { passive: true })
-    window.addEventListener('scroll', onScroll, { passive: true })
-    onScroll()
-
-    return () => {
-      window.removeEventListener('pointermove', onMove)
-      window.removeEventListener('scroll', onScroll)
-    }
-  }, [enabled])
-
-  useEffect(() => {
-    const canvas = canvasRef.current
-    if (!canvas || !enabled) return
-    const ctx = canvas.getContext('2d', { alpha: true })
-    if (!ctx) return
-
-    const fx = draw as Record<EffectName, typeof draw.aura>
-    let lastTime = 0
-
-    const renderFrame = (time: number) => {
-      lastTime = time
-      const animator = fx[effect] ?? fx.aura
-      animator(ctx, time, canvas.width / dpr, canvas.height / dpr)
-    }
-
-    const resize = () => {
-      const { innerWidth, innerHeight } = window
-      canvas.width = Math.floor(innerWidth * dpr)
-      canvas.height = Math.floor(innerHeight * dpr)
-      canvas.style.width = `${innerWidth}px`
-      canvas.style.height = `${innerHeight}px`
-      ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
-      renderFrame(lastTime)
-    }
-
-    resize()
-    window.addEventListener('resize', resize)
-
-    const reduceMotion =
-      typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches
-
-    if (reduceMotion) {
-      renderFrame(0)
-      return () => {
-        window.removeEventListener('resize', resize)
-      }
-    }
-
-    const start = performance.now()
-    const tick = (now: number) => {
-      const t = (now - start) / 1000
-      renderFrame(t)
-      rafRef.current = window.requestAnimationFrame(tick)
-    }
-
-    rafRef.current = window.requestAnimationFrame(tick)
-
-    return () => {
-      window.cancelAnimationFrame(rafRef.current)
-      window.removeEventListener('resize', resize)
-      ctx.clearRect(0, 0, canvas.width, canvas.height)
-    }
-  }, [draw, effect, enabled, dpr])
-
-  if (!enabled) {
-    return (
-      <div
-        aria-hidden
-        className='fixed inset-0 -z-20 bg-gradient-to-br from-indigo-950 via-slate-950 to-black'
-      />
-    )
-  }
+  const effectClass = EFFECT_CLASS[effect] ?? EFFECT_CLASS.aura
 
   return (
-    <>
-      <canvas
-        ref={canvasRef}
-        className='pointer-events-none fixed inset-0 -z-20 opacity-75 mix-blend-screen transition-opacity duration-700 will-change-transform motion-safe:animate-none motion-reduce:hidden'
-        aria-hidden
-      />
-      <div
-        aria-hidden
-        className='motion-safe:animate-breathe fixed inset-0 -z-30 bg-gradient-to-br from-indigo-950/95 via-slate-950/95 to-slate-950 transition-opacity duration-700'
-      />
-    </>
+    <div aria-hidden className={`galaxy-stage ${enabled ? 'is-animated' : 'is-static'} ${effectClass}`}>
+      <div className='galaxy-layer galaxy-base' />
+      <div className='galaxy-layer galaxy-nebula galaxy-nebula--one' />
+      <div className='galaxy-layer galaxy-nebula galaxy-nebula--two' />
+      <div className='galaxy-layer galaxy-stars galaxy-stars--near' />
+      <div className='galaxy-layer galaxy-stars galaxy-stars--far' />
+      <div className='galaxy-layer galaxy-vignette' />
+      <div className='galaxy-layer galaxy-overlay' />
+    </div>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,7 @@
 @import './styles/clamp.css';
 @import './styles/glass.css';
 @import './styles/melt.css';
+@import './styles/galaxy.css';
 @import './styles/global.css';
 
 @tailwind base;
@@ -68,7 +69,9 @@ body::before {
   position: fixed;
   inset: 0;
   z-index: -20;
-  background: radial-gradient(circle at 50% 20%, #0b1120 0%, #030712 68%, #010409 100%);
+  background:
+    radial-gradient(110% 80% at 50% 0%, rgba(10, 18, 34, 0.22) 0%, rgba(2, 7, 16, 0.54) 64%, rgba(1, 4, 11, 0.8) 100%),
+    linear-gradient(180deg, rgba(1, 5, 12, 0.28) 0%, rgba(1, 4, 10, 0.7) 100%);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/styles/galaxy.css
+++ b/src/styles/galaxy.css
@@ -1,0 +1,176 @@
+.galaxy-stage {
+  position: fixed;
+  inset: 0;
+  z-index: -30;
+  pointer-events: none;
+  overflow: hidden;
+  isolation: isolate;
+  background: #030711;
+}
+
+.galaxy-layer {
+  position: absolute;
+  inset: -8%;
+  will-change: transform, opacity;
+}
+
+.galaxy-base {
+  inset: 0;
+  background:
+    radial-gradient(160% 120% at 50% -20%, rgba(57, 88, 160, 0.24) 0%, rgba(5, 10, 25, 0) 56%),
+    radial-gradient(120% 140% at 20% 100%, rgba(9, 24, 55, 0.36) 0%, rgba(2, 6, 16, 0) 58%),
+    linear-gradient(180deg, #040915 0%, #030710 45%, #02050d 100%);
+}
+
+.galaxy-nebula {
+  filter: blur(36px);
+  mix-blend-mode: screen;
+  opacity: 0.34;
+}
+
+.galaxy-nebula--one {
+  background:
+    radial-gradient(58% 50% at 18% 24%, rgba(63, 105, 190, 0.38) 0%, rgba(28, 55, 108, 0.2) 34%, transparent 74%),
+    radial-gradient(48% 42% at 76% 20%, rgba(22, 96, 138, 0.3) 0%, rgba(12, 45, 82, 0.14) 42%, transparent 76%),
+    radial-gradient(46% 44% at 56% 76%, rgba(38, 76, 145, 0.22) 0%, rgba(19, 36, 82, 0.1) 52%, transparent 80%);
+}
+
+.galaxy-nebula--two {
+  background:
+    radial-gradient(38% 40% at 72% 64%, rgba(73, 92, 178, 0.18) 0%, rgba(25, 34, 82, 0.08) 54%, transparent 82%),
+    radial-gradient(44% 36% at 28% 72%, rgba(30, 94, 126, 0.18) 0%, rgba(17, 44, 71, 0.1) 46%, transparent 76%),
+    radial-gradient(36% 34% at 50% 18%, rgba(55, 75, 132, 0.16) 0%, rgba(22, 31, 60, 0.06) 50%, transparent 78%);
+  opacity: 0.25;
+}
+
+.galaxy-stars {
+  inset: 0;
+  background-repeat: repeat;
+  opacity: 0.22;
+}
+
+.galaxy-stars--near {
+  background-image:
+    radial-gradient(circle at 20% 30%, rgba(210, 226, 255, 0.6) 0 0.5px, transparent 1px),
+    radial-gradient(circle at 80% 65%, rgba(214, 230, 255, 0.45) 0 0.7px, transparent 1.2px),
+    radial-gradient(circle at 42% 82%, rgba(194, 219, 255, 0.36) 0 0.6px, transparent 1px),
+    radial-gradient(circle at 66% 24%, rgba(170, 206, 255, 0.3) 0 0.8px, transparent 1.1px);
+  background-size:
+    260px 260px,
+    340px 340px,
+    420px 420px,
+    520px 520px;
+}
+
+.galaxy-stars--far {
+  opacity: 0.12;
+  background-image:
+    radial-gradient(circle at 12% 22%, rgba(204, 220, 250, 0.36) 0 0.45px, transparent 1px),
+    radial-gradient(circle at 62% 44%, rgba(186, 210, 245, 0.34) 0 0.4px, transparent 1px),
+    radial-gradient(circle at 84% 12%, rgba(176, 205, 244, 0.28) 0 0.5px, transparent 1px);
+  background-size:
+    210px 210px,
+    300px 300px,
+    400px 400px;
+}
+
+.galaxy-vignette {
+  inset: 0;
+  background:
+    radial-gradient(130% 96% at 50% 45%, rgba(2, 8, 18, 0) 58%, rgba(2, 6, 14, 0.58) 85%, rgba(1, 4, 10, 0.9) 100%),
+    linear-gradient(180deg, rgba(1, 6, 14, 0.45) 0%, rgba(1, 4, 10, 0.76) 100%);
+}
+
+.galaxy-overlay {
+  inset: 0;
+  background: rgba(2, 8, 17, 0.3);
+}
+
+.galaxy-stage.is-animated .galaxy-nebula--one {
+  animation: galaxy-drift-one 72s ease-in-out infinite alternate;
+}
+
+.galaxy-stage.is-animated .galaxy-nebula--two {
+  animation: galaxy-drift-two 96s ease-in-out infinite alternate;
+}
+
+.galaxy-stage.is-animated .galaxy-stars--near {
+  animation: galaxy-twinkle 14s ease-in-out infinite;
+}
+
+.galaxy-stage.is-animated .galaxy-stars--far {
+  animation: galaxy-twinkle 18s ease-in-out infinite reverse;
+}
+
+.galaxy-stage.is-animated .galaxy-overlay {
+  animation: galaxy-breathe 22s ease-in-out infinite;
+}
+
+.galaxy--nebula .galaxy-nebula,
+.galaxy--plasma .galaxy-nebula {
+  opacity: 0.31;
+}
+
+.galaxy--vapor .galaxy-nebula--two,
+.galaxy--plasma .galaxy-nebula--two {
+  opacity: 0.2;
+}
+
+@keyframes galaxy-drift-one {
+  0% {
+    transform: translate3d(-1.5%, 0.8%, 0) scale(1.03);
+  }
+  100% {
+    transform: translate3d(1.4%, -1%, 0) scale(1.06);
+  }
+}
+
+@keyframes galaxy-drift-two {
+  0% {
+    transform: translate3d(1.2%, -0.6%, 0) scale(1.04);
+  }
+  100% {
+    transform: translate3d(-1.2%, 1.1%, 0) scale(1.07);
+  }
+}
+
+@keyframes galaxy-twinkle {
+  0%,
+  100% {
+    opacity: 0.14;
+  }
+  50% {
+    opacity: 0.2;
+  }
+}
+
+@keyframes galaxy-breathe {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.94;
+  }
+}
+
+@media (max-width: 768px) {
+  .galaxy-nebula {
+    filter: blur(28px);
+    opacity: 0.28;
+  }
+
+  .galaxy-stars--near {
+    opacity: 0.16;
+  }
+
+  .galaxy-stars--far {
+    opacity: 0.08;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .galaxy-stage.is-animated .galaxy-layer {
+    animation: none;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a dark-mode, premium, subtle cosmic atmosphere across the site without changing routes, data logic, or page structure.
- Replace a relatively heavy canvas-driven ambient implementation with a lighter, CSS-first approach to preserve mobile performance and respect reduced-motion preferences.
- Ensure the background supports content legibility by adding a layered vignette/overlay and tuning global dark washes.

### Description
- Replaced the canvas-based ambient implementation with a layered DOM background component in `src/components/BackgroundStage.tsx` that emits semantic layers (`galaxy-base`, `galaxy-nebula*`, `galaxy-stars*`, `galaxy-vignette`, `galaxy-overlay`).
- Added `src/styles/galaxy.css` implementing deep navy/indigo base gradients, two nebula cloud layers, sparse two-depth starfields, a vignette, a subtle overlay, and slow low-intensity animations for drift, pulse, and twinkle with `prefers-reduced-motion` support. 
- Imported the new stylesheet and tuned the site-level dark wash by updating `src/index.css` (adjusted `body::before`) so depth is visible while maintaining high text contrast and readability.
- Kept integration surface minimal by reusing the existing `SiteLayout`/`BackgroundStage` hook points so major pages receive the background without structural changes.

### Testing
- Ran the production compile via `npm run build:compile` and the build completed successfully with no fatal errors. 
- Pre-commit hooks and `eslint` checks ran as part of the commit and passed. 
- Verified reduced-motion is respected by the CSS `@media (prefers-reduced-motion: reduce)` rule, and responsive opacity/blur adjustments were added for mobile breakpoints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc2dcaa160832393d367bd5b6cc936)