### PR TITLE
Add full-viewport animated cosmic background behind app content

### DIFF
--- a/src/components/CosmicBackground.tsx
+++ b/src/components/CosmicBackground.tsx
@@ -1,0 +1,15 @@
+type CosmicBackgroundProps = {
+  animated?: boolean
+}
+
+export default function CosmicBackground({ animated = true }: CosmicBackgroundProps) {
+  return (
+    <div aria-hidden className={`cosmic-background ${animated ? 'is-animated' : 'is-static'}`}>
+      <div className='cosmic-layer cosmic-base' />
+      <div className='cosmic-layer cosmic-nebula cosmic-nebula--one' />
+      <div className='cosmic-layer cosmic-nebula cosmic-nebula--two' />
+      <div className='cosmic-layer cosmic-stars' />
+      <div className='cosmic-layer cosmic-vignette' />
+    </div>
+  )
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -7,20 +7,13 @@ export default function Hero() {
 
   return (
     <section className='relative mx-auto mt-2 max-w-6xl px-4 py-16 sm:mt-4 sm:px-6 sm:py-24'>
-      <div
-        aria-hidden
-        className='pointer-events-none absolute inset-0 -z-10 grid place-items-center overflow-hidden'
-      >
-        <div className='animate-breathe h-[42rem] w-[76rem] rounded-full bg-[radial-gradient(circle,rgba(16,185,129,0.14)_0%,rgba(192,132,252,0.1)_52%,rgba(99,102,241,0.08)_100%)] blur-[120px]' />
-        <div className='absolute inset-0 bg-[radial-gradient(circle_at_50%_35%,rgba(255,255,255,0.08),rgba(11,15,23,0)_58%)]' />
-      </div>
 
       <Tilt maxTilt={4} perspective={900} className='relative'>
         <motion.div
           initial={reduceMotion ? undefined : { opacity: 0, y: 16, scale: 0.99 }}
           animate={reduceMotion ? undefined : { opacity: 1, y: 0, scale: 1 }}
           transition={reduceMotion ? undefined : { duration: 0.55, ease: [0.22, 1, 0.36, 1] }}
-          className='relative overflow-hidden'
+          className='relative'
         >
           <div className='relative space-y-10 py-6 sm:space-y-14 sm:py-10'>
             <div className='space-y-2.5 sm:space-y-4.5'>

--- a/src/components/SiteLayout.tsx
+++ b/src/components/SiteLayout.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren } from 'react'
-import BackgroundStage from './BackgroundStage'
+import CosmicBackground from './CosmicBackground'
 import { useTrippy } from '@/lib/trippy'
 import { useMelt } from '@/melt/useMelt'
 
@@ -9,13 +9,13 @@ type SiteLayoutProps = PropsWithChildren<{
 
 export default function SiteLayout({ children, ambientEnabled = true }: SiteLayoutProps) {
   const { level, enabled: trippyEnabled } = useTrippy()
-  const { enabled, effect } = useMelt()
+  const { enabled } = useMelt()
 
   const shouldAnimate = ambientEnabled && trippyEnabled && level !== 'off' && enabled
 
   return (
     <div className='relative min-h-svh overflow-x-hidden'>
-      <BackgroundStage enabled={shouldAnimate} effect={effect} />
+      <CosmicBackground animated={shouldAnimate} />
       <div className='relative z-10 flex min-h-svh flex-col'>{children}</div>
     </div>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -64,15 +64,6 @@ body {
   border: 0;
 }
 
-body::before {
-  content: '';
-  position: fixed;
-  inset: 0;
-  z-index: -20;
-  background:
-    radial-gradient(110% 80% at 50% 0%, rgba(10, 18, 34, 0.22) 0%, rgba(2, 7, 16, 0.54) 64%, rgba(1, 4, 11, 0.8) 100%),
-    linear-gradient(180deg, rgba(1, 5, 12, 0.28) 0%, rgba(1, 4, 10, 0.7) 100%);
-}
 
 @media (prefers-reduced-motion: reduce) {
   * {

--- a/src/styles/galaxy.css
+++ b/src/styles/galaxy.css
@@ -1,176 +1,120 @@
-.galaxy-stage {
+.cosmic-background {
   position: fixed;
-  inset: 0;
-  z-index: -30;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -40;
   pointer-events: none;
   overflow: hidden;
   isolation: isolate;
-  background: #030711;
+  background: #02040b;
 }
 
-.galaxy-layer {
+.cosmic-layer {
   position: absolute;
-  inset: -8%;
+  inset: 0;
   will-change: transform, opacity;
 }
 
-.galaxy-base {
-  inset: 0;
+.cosmic-base {
   background:
-    radial-gradient(160% 120% at 50% -20%, rgba(57, 88, 160, 0.24) 0%, rgba(5, 10, 25, 0) 56%),
-    radial-gradient(120% 140% at 20% 100%, rgba(9, 24, 55, 0.36) 0%, rgba(2, 6, 16, 0) 58%),
-    linear-gradient(180deg, #040915 0%, #030710 45%, #02050d 100%);
+    radial-gradient(140% 90% at 50% -14%, rgba(40, 70, 138, 0.36) 0%, rgba(10, 16, 32, 0.52) 52%, rgba(2, 5, 12, 0.96) 100%),
+    radial-gradient(120% 110% at 100% 100%, rgba(8, 24, 52, 0.4) 0%, rgba(2, 6, 14, 0) 62%),
+    #02040b;
 }
 
-.galaxy-nebula {
-  filter: blur(36px);
+.cosmic-nebula {
+  inset: -14%;
+  filter: blur(130px);
+  opacity: 0.32;
   mix-blend-mode: screen;
-  opacity: 0.34;
 }
 
-.galaxy-nebula--one {
-  background:
-    radial-gradient(58% 50% at 18% 24%, rgba(63, 105, 190, 0.38) 0%, rgba(28, 55, 108, 0.2) 34%, transparent 74%),
-    radial-gradient(48% 42% at 76% 20%, rgba(22, 96, 138, 0.3) 0%, rgba(12, 45, 82, 0.14) 42%, transparent 76%),
-    radial-gradient(46% 44% at 56% 76%, rgba(38, 76, 145, 0.22) 0%, rgba(19, 36, 82, 0.1) 52%, transparent 80%);
+.cosmic-nebula--one {
+  background: radial-gradient(45% 34% at 28% 32%, rgba(103, 123, 255, 0.44) 0%, rgba(62, 91, 208, 0.24) 43%, transparent 82%);
 }
 
-.galaxy-nebula--two {
-  background:
-    radial-gradient(38% 40% at 72% 64%, rgba(73, 92, 178, 0.18) 0%, rgba(25, 34, 82, 0.08) 54%, transparent 82%),
-    radial-gradient(44% 36% at 28% 72%, rgba(30, 94, 126, 0.18) 0%, rgba(17, 44, 71, 0.1) 46%, transparent 76%),
-    radial-gradient(36% 34% at 50% 18%, rgba(55, 75, 132, 0.16) 0%, rgba(22, 31, 60, 0.06) 50%, transparent 78%);
-  opacity: 0.25;
+.cosmic-nebula--two {
+  background: radial-gradient(42% 30% at 74% 62%, rgba(91, 208, 210, 0.24) 0%, rgba(121, 111, 247, 0.18) 48%, transparent 84%);
+  opacity: 0.24;
 }
 
-.galaxy-stars {
-  inset: 0;
+.cosmic-stars {
+  opacity: 0.18;
+  background-image:
+    radial-gradient(circle at 15% 22%, rgba(214, 230, 255, 0.75) 0 0.6px, transparent 1.3px),
+    radial-gradient(circle at 72% 64%, rgba(200, 222, 255, 0.55) 0 0.5px, transparent 1.2px),
+    radial-gradient(circle at 38% 78%, rgba(188, 214, 255, 0.48) 0 0.5px, transparent 1.1px),
+    radial-gradient(circle at 84% 28%, rgba(193, 220, 255, 0.42) 0 0.7px, transparent 1.3px);
+  background-size:
+    280px 280px,
+    380px 380px,
+    480px 480px,
+    620px 620px;
   background-repeat: repeat;
-  opacity: 0.22;
 }
 
-.galaxy-stars--near {
-  background-image:
-    radial-gradient(circle at 20% 30%, rgba(210, 226, 255, 0.6) 0 0.5px, transparent 1px),
-    radial-gradient(circle at 80% 65%, rgba(214, 230, 255, 0.45) 0 0.7px, transparent 1.2px),
-    radial-gradient(circle at 42% 82%, rgba(194, 219, 255, 0.36) 0 0.6px, transparent 1px),
-    radial-gradient(circle at 66% 24%, rgba(170, 206, 255, 0.3) 0 0.8px, transparent 1.1px);
-  background-size:
-    260px 260px,
-    340px 340px,
-    420px 420px,
-    520px 520px;
+.cosmic-vignette {
+  background: radial-gradient(120% 85% at 50% 45%, rgba(2, 7, 16, 0) 54%, rgba(1, 3, 9, 0.74) 100%);
 }
 
-.galaxy-stars--far {
-  opacity: 0.12;
-  background-image:
-    radial-gradient(circle at 12% 22%, rgba(204, 220, 250, 0.36) 0 0.45px, transparent 1px),
-    radial-gradient(circle at 62% 44%, rgba(186, 210, 245, 0.34) 0 0.4px, transparent 1px),
-    radial-gradient(circle at 84% 12%, rgba(176, 205, 244, 0.28) 0 0.5px, transparent 1px);
-  background-size:
-    210px 210px,
-    300px 300px,
-    400px 400px;
+.cosmic-background.is-animated .cosmic-nebula--one {
+  animation: cosmic-drift-a 48s ease-in-out infinite alternate;
 }
 
-.galaxy-vignette {
-  inset: 0;
-  background:
-    radial-gradient(130% 96% at 50% 45%, rgba(2, 8, 18, 0) 58%, rgba(2, 6, 14, 0.58) 85%, rgba(1, 4, 10, 0.9) 100%),
-    linear-gradient(180deg, rgba(1, 6, 14, 0.45) 0%, rgba(1, 4, 10, 0.76) 100%);
+.cosmic-background.is-animated .cosmic-nebula--two {
+  animation: cosmic-drift-b 56s ease-in-out infinite alternate;
 }
 
-.galaxy-overlay {
-  inset: 0;
-  background: rgba(2, 8, 17, 0.3);
+.cosmic-background.is-animated .cosmic-stars {
+  animation: cosmic-twinkle 24s ease-in-out infinite;
 }
 
-.galaxy-stage.is-animated .galaxy-nebula--one {
-  animation: galaxy-drift-one 72s ease-in-out infinite alternate;
-}
-
-.galaxy-stage.is-animated .galaxy-nebula--two {
-  animation: galaxy-drift-two 96s ease-in-out infinite alternate;
-}
-
-.galaxy-stage.is-animated .galaxy-stars--near {
-  animation: galaxy-twinkle 14s ease-in-out infinite;
-}
-
-.galaxy-stage.is-animated .galaxy-stars--far {
-  animation: galaxy-twinkle 18s ease-in-out infinite reverse;
-}
-
-.galaxy-stage.is-animated .galaxy-overlay {
-  animation: galaxy-breathe 22s ease-in-out infinite;
-}
-
-.galaxy--nebula .galaxy-nebula,
-.galaxy--plasma .galaxy-nebula {
-  opacity: 0.31;
-}
-
-.galaxy--vapor .galaxy-nebula--two,
-.galaxy--plasma .galaxy-nebula--two {
-  opacity: 0.2;
-}
-
-@keyframes galaxy-drift-one {
+@keyframes cosmic-drift-a {
   0% {
-    transform: translate3d(-1.5%, 0.8%, 0) scale(1.03);
+    transform: translate3d(-2%, 1.5%, 0) scale(1.03);
+    opacity: 0.28;
   }
   100% {
-    transform: translate3d(1.4%, -1%, 0) scale(1.06);
+    transform: translate3d(2.5%, -1.8%, 0) scale(1.08);
+    opacity: 0.37;
   }
 }
 
-@keyframes galaxy-drift-two {
+@keyframes cosmic-drift-b {
   0% {
-    transform: translate3d(1.2%, -0.6%, 0) scale(1.04);
+    transform: translate3d(1.6%, -1.4%, 0) scale(1.02);
+    opacity: 0.2;
   }
   100% {
-    transform: translate3d(-1.2%, 1.1%, 0) scale(1.07);
+    transform: translate3d(-2.2%, 1.5%, 0) scale(1.06);
+    opacity: 0.3;
   }
 }
 
-@keyframes galaxy-twinkle {
+@keyframes cosmic-twinkle {
   0%,
   100% {
-    opacity: 0.14;
+    opacity: 0.13;
   }
   50% {
     opacity: 0.2;
   }
 }
 
-@keyframes galaxy-breathe {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.94;
-  }
-}
-
 @media (max-width: 768px) {
-  .galaxy-nebula {
-    filter: blur(28px);
-    opacity: 0.28;
+  .cosmic-nebula {
+    filter: blur(96px);
   }
 
-  .galaxy-stars--near {
-    opacity: 0.16;
-  }
-
-  .galaxy-stars--far {
-    opacity: 0.08;
+  .cosmic-stars {
+    opacity: 0.14;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .galaxy-stage.is-animated .galaxy-layer {
+  .cosmic-background.is-animated .cosmic-layer {
     animation: none;
   }
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -65,7 +65,7 @@
 html,
 body {
   height: 100%;
-  background: radial-gradient(1200px 800px at 50% -10%, #0b2a3a 0%, #090f1a 60%, #070b12 100%);
+  background: #02040b;
 }
 
 body {


### PR DESCRIPTION
### Motivation

- Replace the flat dark/background overlay with a single full-viewport animated galaxy/nebula that sits behind the entire app rather than inside components.  
- Ensure the effect is global (not clipped by containers), visually deep (multiple layers) and calm (very slow motion) while preserving text readability and performance.  
- Keep accessibility/performance in mind by supporting `prefers-reduced-motion` and keeping pointer events off the background.

### Description

- Added a new `CosmicBackground` component that renders a fixed full-viewport layer with layered children for the base, two nebula blobs, sparse stars, and a vignette, and exposes an `animated` prop to toggle animations.  
- Implemented multi-layer CSS in `src/styles/galaxy.css` (renamed/rewired to cosmic styles) that provides: a deep radial base, two large blurred nebula blobs (soft edges, heavy blur), a repeated small-dot star field, a vignette for edge contrast, and slow keyframe animations (24s–56s) for drift/twinkle with reduced-motion support.  
- Mounted `CosmicBackground` in the root layout (`SiteLayout`) so the background sits behind all routes/pages and foreground content remains in a `z-10` wrapper; replaced the previous `BackgroundStage` usage.  
- Removed the local boxed/hero-only background markup and the `body::before` overlay so the hero and all sections render transparently over the global cosmic background.

### Testing

- Ran the production compile step with `npm run build:compile` (Vite), which completed successfully.  
- Pre-commit tasks including `eslint --max-warnings=0` ran as part of the commit flow and passed.  
- Verified the app builds without errors and the global background assets/styles are included in the compiled output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc3f76c7508323a58964c1c379bff9)