### PR TITLE
Fix cosmic background visibility by correcting global layer stacking

### DIFF
--- a/src/components/SiteLayout.tsx
+++ b/src/components/SiteLayout.tsx
@@ -14,7 +14,7 @@ export default function SiteLayout({ children, ambientEnabled = true }: SiteLayo
   const shouldAnimate = ambientEnabled && trippyEnabled && level !== 'off' && enabled
 
   return (
-    <div className='relative min-h-svh overflow-x-hidden'>
+    <div className='relative isolate min-h-svh overflow-x-hidden'>
       <CosmicBackground animated={shouldAnimate} />
       <div className='relative z-10 flex min-h-svh flex-col'>{children}</div>
     </div>

--- a/src/styles/galaxy.css
+++ b/src/styles/galaxy.css
@@ -1,14 +1,10 @@
 .cosmic-background {
   position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: -40;
+  inset: 0;
+  z-index: 0;
   pointer-events: none;
   overflow: hidden;
-  isolation: isolate;
-  background: #02040b;
+  background: #01040d;
 }
 
 .cosmic-layer {
@@ -19,29 +15,30 @@
 
 .cosmic-base {
   background:
-    radial-gradient(140% 90% at 50% -14%, rgba(40, 70, 138, 0.36) 0%, rgba(10, 16, 32, 0.52) 52%, rgba(2, 5, 12, 0.96) 100%),
-    radial-gradient(120% 110% at 100% 100%, rgba(8, 24, 52, 0.4) 0%, rgba(2, 6, 14, 0) 62%),
-    #02040b;
+    radial-gradient(145% 95% at 48% -10%, rgba(34, 78, 170, 0.72) 0%, rgba(15, 36, 84, 0.7) 42%, rgba(4, 10, 24, 0.92) 100%),
+    radial-gradient(120% 110% at 102% 100%, rgba(18, 92, 130, 0.52) 0%, rgba(3, 14, 30, 0) 62%),
+    linear-gradient(180deg, rgba(5, 12, 30, 0.9) 0%, rgba(3, 8, 20, 0.98) 100%),
+    #01040d;
 }
 
 .cosmic-nebula {
   inset: -14%;
-  filter: blur(130px);
-  opacity: 0.32;
+  filter: blur(120px);
+  opacity: 0.56;
   mix-blend-mode: screen;
 }
 
 .cosmic-nebula--one {
-  background: radial-gradient(45% 34% at 28% 32%, rgba(103, 123, 255, 0.44) 0%, rgba(62, 91, 208, 0.24) 43%, transparent 82%);
+  background: radial-gradient(48% 36% at 28% 32%, rgba(96, 132, 255, 0.82) 0%, rgba(46, 90, 224, 0.56) 44%, transparent 82%);
 }
 
 .cosmic-nebula--two {
-  background: radial-gradient(42% 30% at 74% 62%, rgba(91, 208, 210, 0.24) 0%, rgba(121, 111, 247, 0.18) 48%, transparent 84%);
-  opacity: 0.24;
+  background: radial-gradient(44% 34% at 74% 62%, rgba(50, 216, 198, 0.58) 0%, rgba(88, 142, 255, 0.4) 48%, transparent 84%);
+  opacity: 0.48;
 }
 
 .cosmic-stars {
-  opacity: 0.18;
+  opacity: 0.28;
   background-image:
     radial-gradient(circle at 15% 22%, rgba(214, 230, 255, 0.75) 0 0.6px, transparent 1.3px),
     radial-gradient(circle at 72% 64%, rgba(200, 222, 255, 0.55) 0 0.5px, transparent 1.2px),
@@ -56,7 +53,7 @@
 }
 
 .cosmic-vignette {
-  background: radial-gradient(120% 85% at 50% 45%, rgba(2, 7, 16, 0) 54%, rgba(1, 3, 9, 0.74) 100%);
+  background: radial-gradient(120% 90% at 50% 45%, rgba(2, 7, 16, 0) 58%, rgba(1, 3, 9, 0.62) 100%);
 }
 
 .cosmic-background.is-animated .cosmic-nebula--one {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -65,7 +65,7 @@
 html,
 body {
   height: 100%;
-  background: #02040b;
+  background: transparent;
 }
 
 body {


### PR DESCRIPTION
### Motivation
- The global cosmic/galaxy background was not visible because it was being flattened by page paint and stacking rules, producing an effectively flat black page. 
- Make the cosmic effect immediately obvious for debugging while preserving content readability and without changing routing or data logic. 

### Description
- `src/styles/galaxy.css`: changed `.cosmic-background` from `position: fixed` with `z-index: -40` to `inset: 0` and `z-index: 0`, and strengthened base/nebula/star gradients and opacities so the effect is clearly visible during debugging. 
- `src/components/SiteLayout.tsx`: added `isolate` to the root layout wrapper and preserved the content wrapper at `z-10` so the background sits behind all content while keeping an explicit stacking context. 
- `src/styles/global.css`: changed global `html, body` background from solid `#02040b` to `transparent` to avoid flattening the cosmic layer with a full-viewport dark fill. 

### Testing
- Ran the full build pipeline with `npm run build` (includes prebuild and postbuild steps), which completed successfully and emitted the production `dist` with prerendered pages. 
- Pre-commit linting passed (`eslint --max-warnings=0`) as part of the commit hook and the staged files were committed successfully. 
- Prerender/verify steps completed (`prerender` generated 616 route HTML files and `verify-prerender` / `verify-publishing` checks reported OK), and no failures were observed during automated verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc4cb3e64c83239deaea46e3296c13)