### PR TITLE
Add restrained neon hero glow and refine cosmic background

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -6,7 +6,7 @@ export default function Hero() {
   const reduceMotion = useReducedMotion()
 
   return (
-    <section className='relative mx-auto mt-2 max-w-6xl px-4 py-16 sm:mt-4 sm:px-6 sm:py-24'>
+    <section className='hero-focus-glow relative mx-auto mt-2 max-w-6xl px-4 py-16 sm:mt-4 sm:px-6 sm:py-24'>
 
       <Tilt maxTilt={4} perspective={900} className='relative'>
         <motion.div

--- a/src/index.css
+++ b/src/index.css
@@ -51,6 +51,15 @@ body {
   @apply antialiased;
 }
 
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+  background: radial-gradient(140% 120% at 50% 40%, rgba(2, 3, 10, 0) 52%, rgba(1, 2, 7, 0.45) 100%);
+}
+
 .prerender-content.sr-only {
   position: absolute;
   width: 1px;
@@ -190,15 +199,23 @@ a:hover {
   }
 
   .btn-primary {
-    border-color: rgba(134, 198, 48, 0.34);
-    background: linear-gradient(180deg, rgba(86, 123, 34, 0.9), rgba(66, 96, 30, 0.9));
-    color: rgba(244, 252, 232, 0.92);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+    border-color: rgba(182, 104, 242, 0.34);
+    background: linear-gradient(180deg, rgba(126, 56, 156, 0.84), rgba(75, 42, 124, 0.84));
+    color: rgba(249, 241, 255, 0.94);
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.14),
+      0 0 0 1px rgba(205, 123, 255, 0.08),
+      0 12px 36px -24px rgba(205, 123, 255, 0.5);
   }
 
   .btn-primary:hover {
-    border-color: rgba(162, 214, 80, 0.46);
-    background: linear-gradient(180deg, rgba(96, 136, 38, 0.92), rgba(73, 107, 32, 0.92));
+    border-color: rgba(209, 132, 255, 0.48);
+    background: linear-gradient(180deg, rgba(136, 62, 171, 0.88), rgba(82, 46, 136, 0.88));
+    box-shadow:
+      inset 0 1px 0 rgba(255, 255, 255, 0.14),
+      0 0 0 1px rgba(208, 133, 255, 0.14),
+      0 0 24px -12px rgba(220, 132, 255, 0.64),
+      0 14px 36px -24px rgba(71, 224, 255, 0.38);
   }
 
   .btn-secondary,
@@ -211,8 +228,9 @@ a:hover {
 
   .btn-secondary:hover,
   .btn-ghost:hover {
-    border-color: rgba(255, 255, 255, 0.2);
+    border-color: rgba(172, 217, 255, 0.34);
     background: rgba(255, 255, 255, 0.05);
+    box-shadow: 0 0 20px -15px rgba(112, 223, 255, 0.45);
     transform: translateY(-1px);
   }
 
@@ -221,6 +239,26 @@ a:hover {
   .btn-secondary:active,
   .btn-ghost:active {
     transform: translateY(0);
+  }
+
+  .hero-focus-glow {
+    isolation: isolate;
+  }
+
+  .hero-focus-glow::before {
+    content: '';
+    position: absolute;
+    inset: clamp(8%, 14vw, 20%) clamp(8%, 12vw, 16%) auto;
+    height: clamp(220px, 44vw, 420px);
+    border-radius: 999px;
+    z-index: -1;
+    pointer-events: none;
+    background:
+      radial-gradient(62% 52% at 50% 46%, rgba(225, 94, 196, 0.2) 0%, rgba(225, 94, 196, 0.08) 44%, rgba(225, 94, 196, 0) 74%),
+      radial-gradient(58% 56% at 56% 48%, rgba(143, 98, 255, 0.22) 0%, rgba(143, 98, 255, 0.08) 42%, rgba(143, 98, 255, 0) 76%),
+      radial-gradient(46% 40% at 42% 56%, rgba(94, 218, 246, 0.14) 0%, rgba(94, 218, 246, 0.06) 38%, rgba(94, 218, 246, 0) 74%);
+    filter: blur(36px) saturate(108%);
+    opacity: 0.85;
   }
 }
 

--- a/src/styles/galaxy.css
+++ b/src/styles/galaxy.css
@@ -4,7 +4,7 @@
   z-index: 0;
   pointer-events: none;
   overflow: hidden;
-  background: #02050e;
+  background: #04050b;
 }
 
 .cosmic-layer {
@@ -15,46 +15,46 @@
 
 .cosmic-base {
   background:
-    radial-gradient(130% 95% at 78% -8%, rgba(56, 90, 166, 0.26) 0%, rgba(17, 30, 58, 0.18) 42%, rgba(3, 7, 18, 0) 74%),
-    radial-gradient(105% 95% at -8% 72%, rgba(24, 86, 104, 0.18) 0%, rgba(4, 14, 24, 0) 62%),
-    linear-gradient(162deg, rgba(2, 5, 13, 0.98) 0%, rgba(4, 8, 20, 0.97) 50%, rgba(2, 6, 16, 0.99) 100%),
-    #02050e;
+    radial-gradient(140% 90% at 50% -12%, rgba(37, 22, 64, 0.22) 0%, rgba(13, 13, 28, 0.1) 48%, rgba(5, 6, 12, 0) 78%),
+    radial-gradient(105% 92% at -10% 72%, rgba(11, 44, 68, 0.14) 0%, rgba(4, 12, 20, 0) 64%),
+    linear-gradient(168deg, rgba(3, 4, 10, 0.99) 0%, rgba(5, 7, 14, 0.98) 52%, rgba(3, 5, 11, 0.99) 100%),
+    #04050b;
 }
 
 .cosmic-aurora {
   inset: -16%;
-  filter: blur(128px) saturate(108%);
+  filter: blur(136px) saturate(104%);
   mix-blend-mode: screen;
 }
 
 .cosmic-aurora--one {
-  opacity: 0.34;
+  opacity: 0.23;
   background:
-    radial-gradient(52% 42% at 82% 22%, rgba(89, 123, 210, 0.44) 0%, rgba(82, 66, 164, 0.32) 36%, rgba(8, 14, 34, 0) 78%),
-    radial-gradient(38% 34% at 28% 66%, rgba(28, 122, 118, 0.24) 0%, rgba(10, 30, 42, 0) 82%);
+    radial-gradient(50% 38% at 76% 26%, rgba(156, 94, 255, 0.28) 0%, rgba(86, 58, 170, 0.2) 42%, rgba(8, 10, 26, 0) 80%),
+    radial-gradient(38% 34% at 26% 68%, rgba(34, 152, 192, 0.18) 0%, rgba(10, 28, 42, 0) 84%);
 }
 
 .cosmic-aurora--two {
-  opacity: 0.28;
+  opacity: 0.19;
   background:
-    radial-gradient(46% 40% at 64% 74%, rgba(39, 138, 124, 0.26) 0%, rgba(22, 78, 96, 0.16) 40%, rgba(4, 16, 28, 0) 80%),
-    radial-gradient(48% 34% at 14% 24%, rgba(78, 92, 170, 0.28) 0%, rgba(48, 56, 122, 0.16) 38%, rgba(7, 12, 30, 0) 84%);
+    radial-gradient(42% 34% at 66% 72%, rgba(53, 198, 228, 0.2) 0%, rgba(24, 84, 110, 0.14) 44%, rgba(4, 16, 28, 0) 82%),
+    radial-gradient(46% 34% at 16% 24%, rgba(224, 88, 188, 0.18) 0%, rgba(86, 42, 122, 0.13) 42%, rgba(7, 10, 26, 0) 86%);
 }
 
 .cosmic-glow {
   inset: -10%;
-  opacity: 0.32;
-  filter: blur(92px);
+  opacity: 0.2;
+  filter: blur(98px);
   mix-blend-mode: soft-light;
   background:
-    radial-gradient(44% 32% at 70% 34%, rgba(78, 134, 174, 0.22) 0%, rgba(30, 72, 98, 0) 88%),
-    radial-gradient(52% 46% at 38% 84%, rgba(66, 115, 136, 0.18) 0%, rgba(16, 36, 54, 0) 86%);
+    radial-gradient(42% 30% at 72% 30%, rgba(174, 72, 186, 0.16) 0%, rgba(42, 20, 70, 0) 88%),
+    radial-gradient(48% 40% at 36% 82%, rgba(48, 152, 186, 0.14) 0%, rgba(14, 30, 48, 0) 86%);
 }
 
 .cosmic-vignette {
   background:
-    linear-gradient(108deg, rgba(1, 4, 10, 0.64) 0%, rgba(2, 6, 14, 0.34) 30%, rgba(4, 9, 18, 0.24) 54%, rgba(5, 10, 20, 0.4) 100%),
-    radial-gradient(132% 102% at 50% 46%, rgba(2, 7, 16, 0) 54%, rgba(1, 4, 10, 0.68) 100%);
+    linear-gradient(108deg, rgba(2, 3, 8, 0.72) 0%, rgba(2, 5, 12, 0.36) 30%, rgba(4, 8, 16, 0.24) 54%, rgba(4, 8, 16, 0.52) 100%),
+    radial-gradient(132% 102% at 50% 46%, rgba(2, 7, 16, 0) 52%, rgba(2, 4, 10, 0.8) 100%);
 }
 
 .cosmic-background.is-animated .cosmic-aurora--one {


### PR DESCRIPTION
### Motivation
- Introduce a subtle, premium neon glow system (magenta/violet/cyan) to make the UI feel slightly psychedelic while preserving the existing dark theme, layout, and readability.
- Provide a focal lighting treatment behind the hero headline so attention is drawn to center content without adding UI elements or overwhelming color.
- Keep effects restrained and accessible: soft blurred radial gradients, low-opacity bloom, and no full-screen neon or harsh gradients.

### Description
- Retuned the global ambient backdrop in `src/styles/galaxy.css` to a deeper neutral near-black/navy base and replaced flatter blue-heavy gradients with low-opacity magenta/violet/cyan radial fields and softer blur/saturate settings.
- Added a dedicated `hero-focus-glow` hook and applied it to the hero section in `src/components/Hero.tsx` to render a layered, blurred radial glow behind the headline only.
- Introduced a subtle vignette overlay via `body::before` in `src/index.css` to darken edges and keep center focus premium.
- Updated CTA/button visuals in `src/index.css` to use restrained violet/magenta primary styling and faint cyan bloom on secondary/ghost hover states while preserving contrast and text legibility.

### Testing
- Automated build: ran `npm run build:compile` which completed successfully (Vite production build and prerender steps passed); no runtime errors reported during the build.
- Files changed: `src/styles/galaxy.css`, `src/index.css`, and `src/components/Hero.tsx`.
- Key verification: site prerender and postbuild verification scripts executed as part of the build and reported OK for routes and structured-data checks; CSS-only changes preserve layout and accessibility (no JS behavior changes).
- Follow-ups / risks: glow intensity was tuned conservatively to avoid readability regressions and motion issues; if a stronger effect is desired we can increase hero glow opacity by ~0.03–0.05 in `hero-focus-glow::before` while keeping edge vignette and saturation constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc58f1026083238c718d450bd2393e)