### PR TITLE
Refine premium neon glow system while preserving dark-theme readability

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -57,7 +57,9 @@ body::before {
   inset: 0;
   pointer-events: none;
   z-index: 1;
-  background: radial-gradient(140% 120% at 50% 40%, rgba(2, 3, 10, 0) 52%, rgba(1, 2, 7, 0.45) 100%);
+  background:
+    radial-gradient(120% 100% at 50% 42%, rgba(3, 5, 12, 0) 48%, rgba(1, 2, 8, 0.68) 100%),
+    radial-gradient(80% 58% at 50% 22%, rgba(90, 42, 138, 0.07) 0%, rgba(5, 8, 20, 0) 72%);
 }
 
 .prerender-content.sr-only {
@@ -200,22 +202,22 @@ a:hover {
 
   .btn-primary {
     border-color: rgba(182, 104, 242, 0.34);
-    background: linear-gradient(180deg, rgba(126, 56, 156, 0.84), rgba(75, 42, 124, 0.84));
+    background: linear-gradient(180deg, rgba(122, 54, 150, 0.82), rgba(71, 40, 118, 0.84));
     color: rgba(249, 241, 255, 0.94);
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, 0.14),
       0 0 0 1px rgba(205, 123, 255, 0.08),
-      0 12px 36px -24px rgba(205, 123, 255, 0.5);
+      0 12px 34px -24px rgba(205, 123, 255, 0.42);
   }
 
   .btn-primary:hover {
     border-color: rgba(209, 132, 255, 0.48);
-    background: linear-gradient(180deg, rgba(136, 62, 171, 0.88), rgba(82, 46, 136, 0.88));
+    background: linear-gradient(180deg, rgba(132, 60, 165, 0.86), rgba(79, 44, 132, 0.88));
     box-shadow:
       inset 0 1px 0 rgba(255, 255, 255, 0.14),
       0 0 0 1px rgba(208, 133, 255, 0.14),
-      0 0 24px -12px rgba(220, 132, 255, 0.64),
-      0 14px 36px -24px rgba(71, 224, 255, 0.38);
+      0 0 26px -14px rgba(230, 126, 255, 0.62),
+      0 12px 30px -22px rgba(78, 214, 246, 0.34);
   }
 
   .btn-secondary,
@@ -228,9 +230,11 @@ a:hover {
 
   .btn-secondary:hover,
   .btn-ghost:hover {
-    border-color: rgba(172, 217, 255, 0.34);
-    background: rgba(255, 255, 255, 0.05);
-    box-shadow: 0 0 20px -15px rgba(112, 223, 255, 0.45);
+    border-color: rgba(174, 214, 255, 0.36);
+    background: rgba(255, 255, 255, 0.055);
+    box-shadow:
+      0 0 18px -14px rgba(112, 223, 255, 0.42),
+      0 0 22px -16px rgba(224, 122, 255, 0.28);
     transform: translateY(-1px);
   }
 
@@ -254,11 +258,11 @@ a:hover {
     z-index: -1;
     pointer-events: none;
     background:
-      radial-gradient(62% 52% at 50% 46%, rgba(225, 94, 196, 0.2) 0%, rgba(225, 94, 196, 0.08) 44%, rgba(225, 94, 196, 0) 74%),
-      radial-gradient(58% 56% at 56% 48%, rgba(143, 98, 255, 0.22) 0%, rgba(143, 98, 255, 0.08) 42%, rgba(143, 98, 255, 0) 76%),
-      radial-gradient(46% 40% at 42% 56%, rgba(94, 218, 246, 0.14) 0%, rgba(94, 218, 246, 0.06) 38%, rgba(94, 218, 246, 0) 74%);
-    filter: blur(36px) saturate(108%);
-    opacity: 0.85;
+      radial-gradient(60% 48% at 50% 44%, rgba(235, 86, 204, 0.22) 0%, rgba(235, 86, 204, 0.08) 40%, rgba(235, 86, 204, 0) 72%),
+      radial-gradient(56% 52% at 57% 46%, rgba(146, 96, 255, 0.24) 0%, rgba(146, 96, 255, 0.1) 40%, rgba(146, 96, 255, 0) 76%),
+      radial-gradient(42% 36% at 43% 56%, rgba(86, 222, 248, 0.14) 0%, rgba(86, 222, 248, 0.06) 34%, rgba(86, 222, 248, 0) 74%);
+    filter: blur(40px) saturate(110%);
+    opacity: 0.74;
   }
 }
 

--- a/src/styles/galaxy.css
+++ b/src/styles/galaxy.css
@@ -4,7 +4,7 @@
   z-index: 0;
   pointer-events: none;
   overflow: hidden;
-  background: #04050b;
+  background: #030409;
 }
 
 .cosmic-layer {
@@ -15,46 +15,47 @@
 
 .cosmic-base {
   background:
-    radial-gradient(140% 90% at 50% -12%, rgba(37, 22, 64, 0.22) 0%, rgba(13, 13, 28, 0.1) 48%, rgba(5, 6, 12, 0) 78%),
-    radial-gradient(105% 92% at -10% 72%, rgba(11, 44, 68, 0.14) 0%, rgba(4, 12, 20, 0) 64%),
-    linear-gradient(168deg, rgba(3, 4, 10, 0.99) 0%, rgba(5, 7, 14, 0.98) 52%, rgba(3, 5, 11, 0.99) 100%),
-    #04050b;
+    radial-gradient(120% 80% at 50% -20%, rgba(24, 18, 44, 0.24) 0%, rgba(8, 10, 20, 0.08) 46%, rgba(4, 6, 14, 0) 78%),
+    radial-gradient(108% 86% at 8% 74%, rgba(10, 30, 52, 0.14) 0%, rgba(6, 12, 24, 0.04) 54%, rgba(3, 7, 15, 0) 78%),
+    radial-gradient(96% 76% at 92% 16%, rgba(54, 18, 70, 0.12) 0%, rgba(18, 10, 28, 0.02) 52%, rgba(6, 6, 14, 0) 82%),
+    linear-gradient(164deg, rgba(2, 4, 10, 0.995) 0%, rgba(3, 5, 12, 0.99) 48%, rgba(2, 3, 8, 0.995) 100%),
+    #030409;
 }
 
 .cosmic-aurora {
   inset: -16%;
-  filter: blur(136px) saturate(104%);
+  filter: blur(124px) saturate(106%);
   mix-blend-mode: screen;
 }
 
 .cosmic-aurora--one {
-  opacity: 0.23;
+  opacity: 0.19;
   background:
-    radial-gradient(50% 38% at 76% 26%, rgba(156, 94, 255, 0.28) 0%, rgba(86, 58, 170, 0.2) 42%, rgba(8, 10, 26, 0) 80%),
-    radial-gradient(38% 34% at 26% 68%, rgba(34, 152, 192, 0.18) 0%, rgba(10, 28, 42, 0) 84%);
+    radial-gradient(46% 34% at 62% 28%, rgba(198, 98, 255, 0.24) 0%, rgba(104, 56, 178, 0.16) 42%, rgba(9, 8, 24, 0) 80%),
+    radial-gradient(34% 30% at 28% 62%, rgba(48, 198, 236, 0.14) 0%, rgba(12, 34, 50, 0) 84%);
 }
 
 .cosmic-aurora--two {
-  opacity: 0.19;
+  opacity: 0.16;
   background:
-    radial-gradient(42% 34% at 66% 72%, rgba(53, 198, 228, 0.2) 0%, rgba(24, 84, 110, 0.14) 44%, rgba(4, 16, 28, 0) 82%),
-    radial-gradient(46% 34% at 16% 24%, rgba(224, 88, 188, 0.18) 0%, rgba(86, 42, 122, 0.13) 42%, rgba(7, 10, 26, 0) 86%);
+    radial-gradient(40% 30% at 74% 70%, rgba(58, 212, 244, 0.16) 0%, rgba(20, 88, 116, 0.11) 42%, rgba(6, 20, 34, 0) 82%),
+    radial-gradient(44% 30% at 18% 30%, rgba(244, 94, 198, 0.16) 0%, rgba(96, 40, 128, 0.11) 42%, rgba(8, 10, 26, 0) 86%);
 }
 
 .cosmic-glow {
   inset: -10%;
-  opacity: 0.2;
-  filter: blur(98px);
+  opacity: 0.15;
+  filter: blur(88px);
   mix-blend-mode: soft-light;
   background:
-    radial-gradient(42% 30% at 72% 30%, rgba(174, 72, 186, 0.16) 0%, rgba(42, 20, 70, 0) 88%),
-    radial-gradient(48% 40% at 36% 82%, rgba(48, 152, 186, 0.14) 0%, rgba(14, 30, 48, 0) 86%);
+    radial-gradient(38% 28% at 72% 30%, rgba(196, 82, 224, 0.14) 0%, rgba(42, 20, 70, 0) 88%),
+    radial-gradient(40% 34% at 34% 78%, rgba(62, 192, 224, 0.12) 0%, rgba(14, 30, 48, 0) 86%);
 }
 
 .cosmic-vignette {
   background:
-    linear-gradient(108deg, rgba(2, 3, 8, 0.72) 0%, rgba(2, 5, 12, 0.36) 30%, rgba(4, 8, 16, 0.24) 54%, rgba(4, 8, 16, 0.52) 100%),
-    radial-gradient(132% 102% at 50% 46%, rgba(2, 7, 16, 0) 52%, rgba(2, 4, 10, 0.8) 100%);
+    linear-gradient(108deg, rgba(2, 3, 8, 0.82) 0%, rgba(2, 5, 12, 0.5) 30%, rgba(4, 8, 16, 0.32) 54%, rgba(3, 6, 14, 0.62) 100%),
+    radial-gradient(132% 102% at 50% 46%, rgba(2, 7, 16, 0) 48%, rgba(1, 3, 9, 0.88) 100%);
 }
 
 .cosmic-background.is-animated .cosmic-aurora--one {
@@ -72,45 +73,45 @@
 @keyframes ambient-drift-a {
   0% {
     transform: translate3d(-2%, 1.2%, 0) scale(1.02);
-    opacity: 0.28;
+    opacity: 0.22;
   }
   100% {
     transform: translate3d(2.4%, -1.8%, 0) scale(1.08);
-    opacity: 0.38;
+    opacity: 0.3;
   }
 }
 
 @keyframes ambient-drift-b {
   0% {
     transform: translate3d(1.6%, -1.4%, 0) scale(1.01);
-    opacity: 0.22;
+    opacity: 0.19;
   }
   100% {
     transform: translate3d(-2.2%, 1.9%, 0) scale(1.06);
-    opacity: 0.32;
+    opacity: 0.26;
   }
 }
 
 @keyframes ambient-breathe {
   0%,
   100% {
-    opacity: 0.24;
+    opacity: 0.17;
     transform: scale(1.01);
   }
   50% {
-    opacity: 0.36;
+    opacity: 0.24;
     transform: scale(1.05);
   }
 }
 
 @media (max-width: 768px) {
   .cosmic-aurora {
-    filter: blur(104px) saturate(104%);
+    filter: blur(94px) saturate(104%);
   }
 
   .cosmic-glow {
-    opacity: 0.26;
-    filter: blur(74px);
+    opacity: 0.19;
+    filter: blur(68px);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Move away from a flat blue background toward a deeper, neutral near-black base while adding a controlled neon glow system to give the UI a subtle, premium psychedelic accent. 
- Keep all layout and functionality unchanged and maintain high text contrast/readability while introducing magenta, violet, and cyan accents.

### Description
- Tuned global ambient background layers and vignette in `src/styles/galaxy.css` to deepen the base tone and soften / reduce the spread of aurora glows. 
- Retuned animated glow opacities, blur radii, and keyframe envelopes to keep the ambient effect noticeable but restrained and non‑overwhelming. 
- Implemented a focused hero glow (layered blurred radial gradients) in `src/index.css` under `.hero-focus-glow::before` to draw attention to the headline without adding DOM elements. 
- Softened interactive bloom on `.btn-primary`, `.btn-secondary`, and `.btn-ghost` hover states to introduce a subtle magenta/cyan lift while preserving contrast and avoiding harsh neon spikes.
- Files changed: `src/styles/galaxy.css`, `src/index.css` (style-only changes; no layout/JS changes).

### Testing
- Ran the full build pipeline with `npm run build` and it completed successfully (build warnings about chunk size were expected and not related to these CSS changes). 
- Ran `npm run verify:redirects` which passed with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc5b67958883238e07278adeb7f7f7)