### PR TITLE
feat(ui): Botanical Laboratory design system — typography, amber accents & paper cards

### DIFF
--- a/src/components/CompoundCard.tsx
+++ b/src/components/CompoundCard.tsx
@@ -77,7 +77,7 @@ export default function CompoundCard({ compound }: { compound: CompoundWithRefs 
     <motion.article
       whileHover={{ scale: 1.005 }}
       title={compound.herbsFound.map(h => h.name).join(', ')}
-      className='ds-card relative flex flex-col rounded-2xl p-2 text-left transition hover:border-white/25 sm:p-2.5'
+      className='ds-card ds-card-paper relative flex flex-col rounded-2xl p-2 text-left transition hover:border-white/25 sm:p-2.5'
     >
       <h2
         title={isTitleTruncated ? compound.name : undefined}

--- a/src/components/EffectExplorer.tsx
+++ b/src/components/EffectExplorer.tsx
@@ -37,7 +37,7 @@ export default function EffectExplorer({ herbs }: EffectExplorerProps) {
   return (
     <section id='effect-search' className='container mx-auto max-w-4xl px-4 pt-5 sm:px-6'>
       <div className='ds-card-lg border-violet-300/30 bg-violet-500/10'>
-        <p className='text-xs font-semibold uppercase tracking-[0.24em] text-violet-100/85'>
+        <p className='label-specimen text-violet-100/85'>
           Effect search
         </p>
         <h2 className='mt-2 text-2xl font-semibold'>What outcome are you looking for?</h2>
@@ -78,7 +78,7 @@ export default function EffectExplorer({ herbs }: EffectExplorerProps) {
               key={chip}
               type='button'
               onClick={() => setQuery(chip)}
-              className='rounded-full border border-violet-300/40 bg-violet-500/10 px-3 py-1.5 text-xs font-medium capitalize text-violet-100 transition hover:border-violet-200/60 hover:bg-violet-500/15'
+              className='effect-pill-active rounded-full border px-3 py-1.5 text-xs font-medium capitalize transition hover:border-amber-200/60 hover:bg-amber-500/20'
             >
               {chip}
             </button>
@@ -211,7 +211,7 @@ export default function EffectExplorer({ herbs }: EffectExplorerProps) {
           </div>
 
           <div className='mt-5 rounded-xl border border-violet-300/35 bg-violet-500/10 p-4'>
-            <p className='text-xs font-semibold uppercase tracking-[0.2em] text-violet-100/85'>
+            <p className='label-specimen text-violet-100/85'>
               Next actions
             </p>
             <div className='mt-3 grid gap-2 text-sm'>

--- a/src/components/EmailCapture.tsx
+++ b/src/components/EmailCapture.tsx
@@ -79,9 +79,7 @@ export default function EmailCapture({
 
         <div className='relative space-y-5'>
           <div className='space-y-2'>
-            <p className='text-xs font-semibold uppercase tracking-[0.24em] text-white/75'>
-              Research notes
-            </p>
+            <p className='label-specimen mb-2'>Field Notes — Daily Dispatch</p>
             <h2 className='text-[1.4rem] font-semibold tracking-tight text-white sm:text-3xl'>
               {title || 'Get a beginner-safe herbal blend guide (free)'}
             </h2>
@@ -119,7 +117,7 @@ export default function EmailCapture({
             <button
               type='submit'
               disabled={status === 'pending'}
-              className='min-h-11 rounded-xl border border-emerald-200/35 bg-emerald-400 px-4 py-2.5 text-sm font-semibold text-slate-950 transition hover:bg-emerald-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-200/80 disabled:cursor-not-allowed disabled:opacity-70'
+              className='btn-primary min-h-11 rounded-xl border border-transparent bg-amber-500 px-4 py-2.5 text-sm font-semibold text-amber-950 shadow-[0_6px_18px_-8px_hsl(38_92%_58%/0.6)] transition hover:bg-amber-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-200/80 disabled:cursor-not-allowed disabled:opacity-70'
             >
               {status === 'pending' ? 'Submitting…' : buttonLabel || CTA.conversion.getGuide}
             </button>

--- a/src/components/HerbCard.tsx
+++ b/src/components/HerbCard.tsx
@@ -88,7 +88,7 @@ function HerbCard({
     <div className='HerbCardTilt group relative h-full transition-transform duration-200 ease-out hover:scale-[1.004]'>
       <div className='HerbCardGlow pointer-events-none absolute inset-0 rounded-[1.25rem] opacity-0 transition-opacity duration-200 group-hover:opacity-100' />
       <Card
-        className={`card-pad border-white/12 relative flex h-full flex-col bg-white/[0.05] transition duration-200 ease-out group-hover:border-white/20 group-hover:bg-white/[0.07] ${
+        className={`ds-card-paper card-pad border-white/12 relative flex h-full flex-col bg-white/[0.05] transition duration-200 ease-out group-hover:border-white/20 group-hover:bg-white/[0.07] ${
           compact ? 'gap-1 p-1.5' : 'gap-1.5 p-2 sm:p-2.5'
         }`}
       >

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -18,12 +18,12 @@ export default function Hero() {
           <div className='relative space-y-10 py-6 sm:space-y-14 sm:py-10'>
             <div className='space-y-2.5 sm:space-y-4.5'>
               <motion.p
-                initial={reduceMotion ? undefined : { opacity: 0, y: 10 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true }}
-                className='text-xs font-semibold uppercase tracking-[0.24em] text-white/65'
+                initial={reduceMotion ? undefined : { opacity: 0, y: 6 }}
+                animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
+                transition={reduceMotion ? undefined : { duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+                className='label-specimen mb-3'
               >
-                The Hippie Scientist
+                Specimen No. 001 — Harm Reduction Research
               </motion.p>
               <motion.h1
                 initial={reduceMotion ? undefined : { opacity: 0, y: 12 }}
@@ -34,7 +34,7 @@ export default function Hero() {
                     ? undefined
                     : { delay: 0.05, duration: 0.4, ease: [0.22, 1, 0.36, 1] }
                 }
-                className='max-w-4xl text-[2.4rem] font-semibold leading-[0.97] tracking-[-0.025em] text-white sm:text-[4.75rem]'
+                className='max-w-4xl font-display text-[2.4rem] font-normal italic leading-[0.97] tracking-[-0.02em] text-white sm:text-[4.75rem]'
               >
                 Clarity before you experiment
               </motion.h1>
@@ -55,6 +55,7 @@ export default function Hero() {
             </div>
 
             <HeroCTA />
+            <hr className='mt-10 border-0 border-t border-amber-400/15' />
           </div>
         </motion.div>
       </Tilt>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -34,10 +34,31 @@ export default function NavBar() {
         <div className='flex items-center justify-between gap-2 py-2 sm:py-2.5'>
           <Link
             to='/'
-            className={`shrink-0 rounded-xl px-2 py-1.5 font-semibold tracking-tight transition hover:text-white ${isHome ? 'text-sm text-white/70 sm:text-base' : 'text-base text-white/95 sm:text-lg'}`}
+            className='shrink-0 rounded-xl px-2 py-1.5 transition hover:text-white'
             onClick={() => setMenuOpen(false)}
           >
-            Hippie Scientist
+            <span className='flex items-center gap-2'>
+              <svg width='18' height='18' viewBox='0 0 18 18' fill='none' aria-hidden='true'>
+                <path
+                  d='M9 2C5 2 2 6 2 10c0 3 2 5 5 5 2 0 4-1 5-3 1-2 1-5-1-7'
+                  stroke='currentColor'
+                  strokeWidth='1.5'
+                  strokeLinecap='round'
+                  className='text-emerald-400'
+                />
+                <path
+                  d='M9 16V9M9 9C9 6 11 4 14 3'
+                  stroke='currentColor'
+                  strokeWidth='1.25'
+                  strokeLinecap='round'
+                  strokeDasharray='2 2'
+                  className='text-emerald-400/60'
+                />
+              </svg>
+              <span className={`font-display text-lg italic tracking-tight ${isHome ? 'text-white/80' : 'text-white'}`}>
+                The Hippie Scientist
+              </span>
+            </span>
           </Link>
 
           <button

--- a/src/components/StatPill.tsx
+++ b/src/components/StatPill.tsx
@@ -14,11 +14,11 @@ export default function StatPill({ to, value, label, testId, onClick }: StatPill
       data-testid={testId}
       to={to}
       onClick={onClick}
-      className='border-white/12 hover:border-white/24 group relative flex items-center gap-3 rounded-2xl border bg-white/[0.035] px-4 py-3 text-sm text-white/85 shadow-[inset_0_1px_0_rgba(255,255,255,.05)] backdrop-blur-md transition-all duration-200 hover:-translate-y-0.5 hover:bg-white/[0.07] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-300/70 active:translate-y-0 active:scale-[.99]'
+      className='border-white/12 hover:border-white/24 group relative flex items-center gap-3 rounded-2xl border bg-white/[0.035] px-4 py-3 text-sm text-white/85 shadow-[inset_0_1px_0_rgba(255,255,255,.05)] backdrop-blur-md transition-all duration-200 hover:-translate-y-0.5 hover:bg-white/[0.07] hover:shadow-[0_0_20px_-8px_hsl(38_92%_58%/0.5)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-300/70 active:translate-y-0 active:scale-[.99]'
       aria-label={`${value} ${label}`}
     >
-      <span className='grid h-10 w-10 place-content-center rounded-xl border border-white/20 bg-white/10 text-base font-bold tabular-nums text-white sm:text-lg'>
-        {value}
+      <span className='grid h-10 w-10 place-content-center rounded-xl border border-amber-300/25 bg-amber-500/10 sm:text-lg'>
+        <span className='font-mono text-2xl font-medium tabular-nums text-amber-300'>{value}+</span>
       </span>
       <span className='text-white/82 leading-tight'>{label}</span>
       <span aria-hidden className='ml-auto text-white/55 transition group-hover:text-white/80'>

--- a/src/index.css
+++ b/src/index.css
@@ -133,6 +133,30 @@ a:hover {
     transform: translateY(-1px) scale(1.003);
   }
 
+  .ds-card-paper {
+    background: color-mix(in oklab, hsl(var(--card)) 85%, hsl(38 30% 14%) 15%);
+    border: 1px solid color-mix(in oklab, hsl(var(--border)) 60%, hsl(38 50% 30%) 40%);
+    border-radius: var(--radius);
+    box-shadow:
+      0 0 0 1px rgba(255, 200, 80, 0.04),
+      0 12px 40px -8px rgba(0, 0, 0, 0.5),
+      inset 0 1px 0 rgba(255, 210, 100, 0.06);
+    position: relative;
+  }
+
+  .ds-card-paper::before {
+    content: '';
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    width: 18px;
+    height: 18px;
+    border-top: 1px solid hsl(var(--amber-h) var(--amber-s) var(--amber-l) / 0.25);
+    border-right: 1px solid hsl(var(--amber-h) var(--amber-s) var(--amber-l) / 0.25);
+    border-radius: 0 4px 0 0;
+    pointer-events: none;
+  }
+
   .ds-card-lg {
     @apply ds-card p-3.5 sm:p-4;
   }
@@ -245,6 +269,13 @@ a:hover {
     transform: translateY(0);
   }
 
+  .effect-pill-active {
+    background: hsl(var(--amber-h) var(--amber-s) var(--amber-l) / 0.15);
+    border-color: hsl(var(--amber-h) var(--amber-s) var(--amber-l) / 0.45);
+    color: hsl(38 92% 80%);
+    box-shadow: 0 0 12px -4px hsl(38 92% 58% / 0.3);
+  }
+
   .hero-focus-glow {
     isolation: isolate;
   }
@@ -304,4 +335,19 @@ a:hover {
   .ambient-cursor {
     display: none;
   }
+}
+
+::-webkit-scrollbar { width: 6px; }
+::-webkit-scrollbar-track { background: hsl(var(--bg)); }
+::-webkit-scrollbar-thumb {
+  background: hsl(var(--amber-h) var(--amber-s) var(--amber-l) / 0.35);
+  border-radius: 999px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: hsl(var(--amber-h) var(--amber-s) var(--amber-l) / 0.55);
+}
+
+::selection {
+  background: hsl(166 70% 52% / 0.25);
+  color: hsl(166 80% 90%);
 }

--- a/src/pages/CompoundDetail.tsx
+++ b/src/pages/CompoundDetail.tsx
@@ -512,25 +512,25 @@ export default function CompoundDetail() {
             </p>
           )}
           {(confidence || evidence || sourceCount > 0 || cautionCount > 0) && (
-            <div className='mt-3 flex flex-wrap gap-1.5 text-[11px] text-white/65'>
+            <div className='mt-3 flex flex-wrap gap-1.5'>
               {confidence && (
-                <span className='rounded-full border border-white/20 bg-white/[0.03] px-2 py-0.5'>
-                  Confidence: {confidence}
+                <span className='inline-flex items-center gap-1.5 rounded-sm border border-emerald-400/35 bg-emerald-500/8 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.18em] text-emerald-200'>
+                  <span aria-hidden='true'>✓</span> Confidence: {confidence}
                 </span>
               )}
               {evidence && (
-                <span className='rounded-full border border-white/20 bg-white/[0.03] px-2 py-0.5'>
-                  Evidence: {evidence}
+                <span className='inline-flex items-center gap-1.5 rounded-sm border border-emerald-400/35 bg-emerald-500/8 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.18em] text-emerald-200'>
+                  <span aria-hidden='true'>✓</span> Evidence: {evidence}
                 </span>
               )}
               {sourceCount > 0 && (
-                <span className='rounded-full border border-white/20 bg-white/[0.03] px-2 py-0.5'>
-                  {sourceCount} source{sourceCount === 1 ? '' : 's'}
+                <span className='inline-flex items-center gap-1.5 rounded-sm border border-emerald-400/35 bg-emerald-500/8 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.18em] text-emerald-200'>
+                  <span aria-hidden='true'>✓</span> {sourceCount} source{sourceCount === 1 ? '' : 's'}
                 </span>
               )}
               {cautionCount > 0 && (
-                <span className='rounded-full border border-amber-300/25 bg-amber-500/8 px-2 py-0.5 text-amber-100/85'>
-                  {cautionCount} caution signal{cautionCount === 1 ? '' : 's'}
+                <span className='inline-flex items-center gap-1.5 rounded-sm border border-amber-400/40 bg-amber-500/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.18em] text-amber-200'>
+                  <span aria-hidden='true'>⚠</span> {cautionCount} caution signal{cautionCount === 1 ? '' : 's'}
                 </span>
               )}
             </div>
@@ -556,7 +556,7 @@ export default function CompoundDetail() {
             {compoundDescription}
             {topSummary && <p className='mt-3 text-white/80'>{topSummary}</p>}
             {displayClass && (
-              <p className='mt-3 text-xs uppercase tracking-[0.12em] text-white/55'>
+              <p className='mt-3 label-specimen'>
                 Category: {displayClass}
               </p>
             )}

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -708,18 +708,18 @@ export default function HerbDetail() {
             </p>
           )}
 
-          <div className='mt-3 flex flex-wrap gap-1.5 text-[11px] text-white/65'>
+          <div className='mt-3 flex flex-wrap gap-1.5'>
             {evidenceLevel && (
-              <span className='rounded-full border border-white/20 bg-white/[0.03] px-2 py-0.5'>
-                {evidenceLevel}
+              <span className='inline-flex items-center gap-1.5 rounded-sm border border-emerald-400/35 bg-emerald-500/8 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.18em] text-emerald-200'>
+                <span aria-hidden='true'>✓</span> {evidenceLevel}
               </span>
             )}
-            <span className='rounded-full border border-white/20 bg-white/[0.03] px-2 py-0.5'>
-              {sourceCount} source{sourceCount === 1 ? '' : 's'}
+            <span className='inline-flex items-center gap-1.5 rounded-sm border border-emerald-400/35 bg-emerald-500/8 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.18em] text-emerald-200'>
+              <span aria-hidden='true'>✓</span> {sourceCount} source{sourceCount === 1 ? '' : 's'}
             </span>
             {cautionCount > 0 && (
-              <span className='rounded-full border border-amber-300/25 bg-amber-500/8 px-2 py-0.5 text-amber-100/85'>
-                {cautionCount} caution signal{cautionCount === 1 ? '' : 's'}
+              <span className='inline-flex items-center gap-1.5 rounded-sm border border-amber-400/40 bg-amber-500/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.18em] text-amber-200'>
+                <span aria-hidden='true'>⚠</span> {cautionCount} caution signal{cautionCount === 1 ? '' : 's'}
               </span>
             )}
           </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -92,7 +92,7 @@ export default function Home() {
       <section className='container mx-auto max-w-4xl px-4 pt-8 sm:px-6 sm:pt-12'>
         <div className='grid gap-8 sm:grid-cols-2 sm:gap-10'>
           <div className='h-full space-y-2'>
-            <p className='text-[11px] font-semibold uppercase tracking-[0.2em] text-white/45'>
+            <p className='label-specimen'>
               First move
             </p>
             <h2 className='text-base font-medium text-white/82'>Search by effect, not hype</h2>
@@ -104,7 +104,7 @@ export default function Home() {
             </a>
           </div>
           <div className='h-full space-y-2'>
-            <p className='text-[11px] font-semibold uppercase tracking-[0.2em] text-white/45'>
+            <p className='label-specimen'>
               Quick tools
             </p>
             <h2 className='text-base font-medium text-white/82'>Run a second check</h2>
@@ -190,8 +190,8 @@ export default function Home() {
             </div>
             <div className='ds-card-grid sm:grid-cols-3'>
               {curated.map(item => (
-                <article key={`starter-${item.kind}-${item.slug}`} className='ds-card h-full'>
-                  <p className='text-xs uppercase tracking-[0.12em] text-white/55'>
+                <article key={`starter-${item.kind}-${item.slug}`} className='ds-card ds-card-paper h-full'>
+                  <p className='label-specimen'>
                     starter profile
                   </p>
                   <h3 className='mt-1 text-sm font-semibold text-white'>{item.name}</h3>
@@ -227,7 +227,7 @@ export default function Home() {
 
       <section className='ds-section container mx-auto max-w-4xl px-4 sm:px-6'>
         <div className='ds-card-lg ds-stack'>
-          <p className='text-xs font-semibold uppercase tracking-[0.24em] text-white/60'>
+          <p className='label-specimen'>
             Knowledge scope
           </p>
           <p className='text-sm text-white/75'>
@@ -272,7 +272,7 @@ export default function Home() {
 
       {dailyDiscovery && (
         <section className='ds-section container mx-auto max-w-4xl px-4 sm:px-6'>
-          <div className='ds-card-lg border-emerald-200/20 bg-emerald-400/5'>
+          <div className='ds-card-lg ds-card-paper border-emerald-200/20 bg-emerald-400/5'>
             <p className='text-xs font-semibold uppercase tracking-[0.24em] text-emerald-100/80'>
               Today&apos;s discovery
             </p>
@@ -312,7 +312,7 @@ export default function Home() {
       {items.length > 0 && (
         <section className='ds-section container mx-auto max-w-4xl px-4 sm:px-6'>
           <div className='ds-card-lg ds-stack'>
-            <p className='text-xs font-semibold uppercase tracking-[0.24em] text-white/60'>
+            <p className='label-specimen'>
               Saved items
             </p>
             <h2 className='ds-heading'>Pick up where you left off</h2>

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,7 +1,10 @@
+@import url('https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=DM+Mono:wght@400;500&family=Instrument+Sans:ital,wght@0,400;0,500;0,600;1,400&display=swap');
+
 :root {
   color-scheme: dark;
-  --font-body: 'Inter', system-ui, sans-serif;
-  --font-display: 'Inter', system-ui, sans-serif;
+  --font-display: 'DM Serif Display', Georgia, serif;
+  --font-body: 'Instrument Sans', system-ui, sans-serif;
+  --font-mono: 'DM Mono', 'Fira Code', monospace;
   --radius: 1rem;
   --space-unit: 0.25rem;
 
@@ -22,14 +25,19 @@
   --space-hero-y: clamp(1.25rem, 5vw, 3.5rem);
   --space-hero-gap: clamp(0.5rem, 2vw, 1.25rem);
 
-  --bg: 220 15% 8%;
-  --surface: 220 14% 11%;
-  --card: 220 14% 13%;
+  --amber-h: 38;
+  --amber-s: 92%;
+  --amber-l: 58%;
+  --amber: hsl(var(--amber-h) var(--amber-s) var(--amber-l));
+
+  --bg: 28 8% 7%;
+  --surface: 30 7% 10%;
+  --card: 30 7% 12%;
   --text: 210 10% 96%;
   --fg: 210 10% 96%;
-  --mute: 210 6% 65%;
-  --muted: 210 6% 65%;
-  --border: 220 12% 22%;
+  --mute: 35 10% 60%;
+  --muted: 35 10% 60%;
+  --border: 30 8% 20%;
   --ring: 166 70% 52%;
 
   --bg-c: hsl(var(--bg));
@@ -162,12 +170,19 @@ main {
 }
 
 h1,
-h2,
+h2 {
+  font-family: var(--font-display);
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+  font-weight: 400;
+  color: var(--text-c);
+}
+
 h3,
 h4,
 h5,
 h6 {
-  font-family: var(--font-display);
+  font-family: var(--font-body);
   letter-spacing: -0.01em;
   line-height: 1.2;
   font-weight: 600;
@@ -184,6 +199,14 @@ h3 {
   font-size: 1.2rem;
 }
 
+.label-specimen {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  opacity: 0.55;
+}
+
 * {
   border-color: color-mix(in oklab, var(--border-c) 70%, transparent 30%);
 }
@@ -196,9 +219,9 @@ h3 {
   z-index: -1;
   pointer-events: none;
   background:
-    radial-gradient(70% 60% at 25% 30%, hsl(var(--accent-h) 85% 40% / 0.15), transparent 70%),
-    radial-gradient(60% 40% at 80% 25%, hsl(260 90% 60% / 0.12), transparent 70%),
-    radial-gradient(50% 50% at 60% 75%, hsl(130 65% 55% / 0.1), transparent 70%);
+    radial-gradient(70% 60% at 25% 30%, hsl(166 85% 40% / 0.12), transparent 70%),
+    radial-gradient(60% 40% at 80% 25%, hsl(38 90% 55% / 0.09), transparent 70%),
+    radial-gradient(50% 50% at 60% 75%, hsl(130 65% 45% / 0.08), transparent 70%);
   animation: aurora-move 40s ease-in-out infinite alternate;
   background-attachment: fixed;
   filter: blur(45px) saturate(115%);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,15 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  darkMode: "class",
-  content: ["./index.html", "./src/**/*.{ts,tsx,js,jsx,mdx}"],
-  theme: { extend: {} },
-  plugins: []
-};
+  darkMode: 'class',
+  content: ['./index.html', './src/**/*.{ts,tsx,js,jsx,mdx}'],
+  theme: {
+    extend: {
+      fontFamily: {
+        display: ['DM Serif Display', 'Georgia', 'serif'],
+        body: ['Instrument Sans', 'system-ui', 'sans-serif'],
+        mono: ['DM Mono', 'monospace'],
+      },
+    },
+  },
+  plugins: [],
+}


### PR DESCRIPTION
### Motivation
- Introduce a targeted UI/UX uplift (“Botanical Laboratory”) to give the site a warm, field-note / lab-journal aesthetic without touching data, routes, or business logic.
- Provide a reusable set of design tokens and component-level updates so herb/compound content reads like specimen labels and warm paper cards while preserving the existing emerald accent.

### Description
- Typography and tokens: add Google Fonts and new tokens (`--font-display`, `--font-body`, `--font-mono`), introduce amber accent tokens and warmer dark palette values, split heading font rules (serif display for `h1`/`h2`, body for `h3`–`h6`), and add `.label-specimen` utility. (file: `src/styles/theme.css`)
- New surface & utilities: add `.ds-card-paper` warm-paper card variant, `.effect-pill-active` amber active state, custom scrollbar and selection polish. (file: `src/index.css`)
- Tailwind config: expose `font-display`, `font-body`, `font-mono` families. (file: `tailwind.config.ts`)
- Component updates: hero (specimen pre-line, serif italic headline, amber rule), navbar wordmark with inline leaf SVG and serif wordmark, amber-styled stat pill, EmailCapture eyebrow + amber CTA, EffectExplorer specimen labels + amber-active chips, apply `ds-card-paper` to herb/compound cards, and convert detail-page safety/review badges to specimen-style amber/emerald chips. (files: `src/components/Hero.tsx`, `src/components/NavBar.tsx`, `src/components/StatPill.tsx`, `src/components/EmailCapture.tsx`, `src/components/EffectExplorer.tsx`, `src/components/HerbCard.tsx`, `src/components/CompoundCard.tsx`, `src/pages/Home.tsx`, `src/pages/HerbDetail.tsx`, `src/pages/CompoundDetail.tsx`)
- Changed files (UI-only): `src/styles/theme.css`, `src/index.css`, `tailwind.config.ts`, `src/components/{Hero,NavBar,StatPill,EmailCapture,EffectExplorer,HerbCard,CompoundCard}.tsx`, `src/pages/{Home,HerbDetail,CompoundDetail}.tsx`.

### Testing
- Commands run: `npm run lint` and `npm run build` (build executes the project pre/postbuild tasks in this repo). Other inspection commands used during the change: `rg`, `sed`, `nl`, and targeted `git` actions to prepare the change.
- Verification results: `npm run lint` completed with no new lint errors and pre-commit hooks passed; `npm run build` completed successfully (Vite build and prerender/postbuild checks succeeded) with only existing non-blocking warnings from toolchain dependencies.
- Key diffs verified: hero headline now uses `font-display` italic serif and a `label-specimen` preline; `ds-card-paper` added and applied to herb/compound/home cards; safety badges converted to specimen-style amber/emerald chips; effect pills have an amber-active treatment.
- Risks / follow-ups: Google Fonts are imported via `@import` in `src/styles/theme.css`, which may require updating CSP (allow `fonts.googleapis.com` / `fonts.gstatic.com`) in production; `npm run build` runs data-generation steps — generated public/data artifacts were intentionally excluded from this UI-only change and should not be committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc5cca9a908323b1df2c3e14fd6359)