### PR TITLE
Reset UI to a darker, premium minimal visual system

### DIFF
--- a/src/components/EffectExplorer.tsx
+++ b/src/components/EffectExplorer.tsx
@@ -36,8 +36,8 @@ export default function EffectExplorer({ herbs }: EffectExplorerProps) {
 
   return (
     <section id='effect-search' className='container mx-auto max-w-4xl px-4 pt-5 sm:px-6'>
-      <div className='ds-card-lg border-violet-300/30 bg-violet-500/10'>
-        <p className='label-specimen text-violet-100/85'>
+      <div className='ds-card-lg border-emerald-200/20 bg-emerald-400/[0.06]'>
+        <p className='label-specimen text-emerald-100/80'>
           Effect search
         </p>
         <h2 className='mt-2 text-2xl font-semibold'>What outcome are you looking for?</h2>
@@ -56,7 +56,7 @@ export default function EffectExplorer({ herbs }: EffectExplorerProps) {
             value={query}
             onChange={event => setQuery(event.target.value)}
             placeholder='Try “relaxation”, “focus”, “sleep”…'
-            className='w-full rounded-xl border border-white/15 bg-white/5 px-4 py-3 text-white placeholder:text-white/45 focus:border-violet-300/40 focus:outline-none'
+            className='w-full rounded-xl border border-white/15 bg-white/5 px-4 py-3 text-white placeholder:text-white/45 focus:border-emerald-300/40 focus:outline-none'
           />
           <datalist id='effect-explorer-suggestions'>
             {suggestions.map(suggestion => (
@@ -64,9 +64,9 @@ export default function EffectExplorer({ herbs }: EffectExplorerProps) {
             ))}
           </datalist>
           {!normalizedQuery && (
-            <p className='mt-2 text-xs text-violet-100/75'>
+            <p className='mt-2 text-xs text-emerald-100/75'>
               Showing top matches for{' '}
-              <span className='font-semibold text-violet-100'>relaxation</span> to help you start
+              <span className='font-semibold text-emerald-100'>relaxation</span> to help you start
               quickly.
             </p>
           )}
@@ -124,14 +124,14 @@ export default function EffectExplorer({ herbs }: EffectExplorerProps) {
                   key={`${slug}-${index}`}
                   className={`ds-card flex h-full flex-col gap-3 p-4 ${
                     isTopThree
-                      ? 'border-violet-200/45 bg-violet-500/15 shadow-lg shadow-violet-900/30'
+                      ? 'border-emerald-200/35 bg-emerald-400/[0.09]'
                       : ''
                   }`}
                 >
                   <div className='flex items-start justify-between gap-2'>
                     <h3 className='text-base font-semibold text-white'>{herbLabel}</h3>
                     <span
-                      className={`rounded-full border px-2 py-0.5 text-xs ${isTopThree ? 'border-violet-200/60 bg-violet-400/20 text-violet-50' : 'border-violet-300/40 bg-violet-500/10 text-violet-100'}`}
+                      className={`rounded-full border px-2 py-0.5 text-xs ${isTopThree ? 'border-emerald-200/55 bg-emerald-300/15 text-emerald-50' : 'border-emerald-300/35 bg-emerald-500/10 text-emerald-100'}`}
                     >
                       #{index + 1} {isTopThree ? 'Top match' : ''}
                     </span>
@@ -144,7 +144,7 @@ export default function EffectExplorer({ herbs }: EffectExplorerProps) {
                       {tags.map(tag => (
                         <span
                           key={`${slug}-${tag}`}
-                          className='rounded-full border border-fuchsia-300/35 bg-fuchsia-500/10 px-2.5 py-1 text-[11px] text-fuchsia-100'
+                          className='rounded-full border border-white/20 bg-white/[0.04] px-2.5 py-1 text-[11px] text-white/80'
                         >
                           {tag}
                         </span>
@@ -156,7 +156,7 @@ export default function EffectExplorer({ herbs }: EffectExplorerProps) {
                     {topEffects.slice(0, 3).map(effect => (
                       <span
                         key={`${slug}-${effect}`}
-                        className='rounded-full border border-violet-300/35 bg-violet-500/15 px-2.5 py-1 text-[11px] text-violet-100'
+                        className='rounded-full border border-emerald-300/30 bg-emerald-500/12 px-2.5 py-1 text-[11px] text-emerald-100'
                       >
                         {effect}
                       </span>
@@ -199,7 +199,7 @@ export default function EffectExplorer({ herbs }: EffectExplorerProps) {
                     {slug && (
                       <Link
                         to={`/herbs/${encodeURIComponent(slug)}`}
-                        className='inline-flex text-sm text-violet-200 underline underline-offset-4 hover:text-violet-100'
+                        className='inline-flex text-sm text-emerald-200 underline underline-offset-4 hover:text-emerald-100'
                       >
                         View herb details
                       </Link>
@@ -210,22 +210,22 @@ export default function EffectExplorer({ herbs }: EffectExplorerProps) {
             })}
           </div>
 
-          <div className='mt-5 rounded-xl border border-violet-300/35 bg-violet-500/10 p-4'>
-            <p className='label-specimen text-violet-100/85'>
+          <div className='mt-5 rounded-xl border border-white/15 bg-white/[0.03] p-4'>
+            <p className='label-specimen text-emerald-100/80'>
               Next actions
             </p>
             <div className='mt-3 grid gap-2 text-sm'>
               <Link
-                className='underline underline-offset-4 hover:text-violet-100'
+                className='underline underline-offset-4 hover:text-emerald-100'
                 to='/build-blend'
               >
                 Build a blend with these herbs
               </Link>
-              <Link className='underline underline-offset-4 hover:text-violet-100' to='/compare'>
+              <Link className='underline underline-offset-4 hover:text-emerald-100' to='/compare'>
                 Compare top herbs
               </Link>
               <Link
-                className='underline underline-offset-4 hover:text-violet-100'
+                className='underline underline-offset-4 hover:text-emerald-100'
                 to='/interactions'
               >
                 Check interactions

--- a/src/components/GuideDownloadCard.tsx
+++ b/src/components/GuideDownloadCard.tsx
@@ -21,10 +21,10 @@ export default function GuideDownloadCard({
 }: GuideDownloadCardProps) {
   return (
     <section
-      className={`ds-card-lg border border-violet-200/20 bg-gradient-to-br from-violet-500/10 via-slate-900/80 to-emerald-500/10 shadow-[0_0_36px_-24px_rgba(139,92,246,0.8)] ${className}`.trim()}
+      className={`ds-card-lg border border-white/14 bg-gradient-to-br from-slate-950/90 via-slate-900/84 to-slate-950/92 ${className}`.trim()}
     >
       {eyebrow && (
-        <p className='text-xs font-semibold uppercase tracking-[0.22em] text-violet-100/80'>
+        <p className='text-xs font-semibold uppercase tracking-[0.22em] text-emerald-100/80'>
           {eyebrow}
         </p>
       )}

--- a/src/index.css
+++ b/src/index.css
@@ -59,7 +59,7 @@ body::before {
   z-index: 1;
   background:
     radial-gradient(120% 100% at 50% 42%, rgba(3, 5, 12, 0) 48%, rgba(1, 2, 8, 0.68) 100%),
-    radial-gradient(80% 58% at 50% 22%, rgba(90, 42, 138, 0.07) 0%, rgba(5, 8, 20, 0) 72%);
+    radial-gradient(82% 60% at 50% 20%, rgba(22, 36, 56, 0.05) 0%, rgba(5, 8, 20, 0) 72%);
 }
 
 .prerender-content.sr-only {
@@ -124,8 +124,8 @@ a:hover {
   .ds-card {
     @apply rounded-2xl border border-white/14 bg-white/[0.03] p-3 sm:p-3 backdrop-blur-md transition-all duration-150;
     box-shadow:
-      0 8px 20px -20px rgba(16, 185, 129, 0.26),
-      0 12px 24px -24px rgba(0, 0, 0, 0.75);
+      0 8px 20px -22px rgba(20, 30, 46, 0.45),
+      0 14px 30px -26px rgba(0, 0, 0, 0.8);
   }
 
   .ds-card:hover {
@@ -225,23 +225,22 @@ a:hover {
   }
 
   .btn-primary {
-    border-color: rgba(182, 104, 242, 0.34);
-    background: linear-gradient(180deg, rgba(122, 54, 150, 0.82), rgba(71, 40, 118, 0.84));
-    color: rgba(249, 241, 255, 0.94);
+    border-color: rgba(70, 178, 161, 0.42);
+    background: linear-gradient(180deg, rgba(22, 99, 90, 0.92), rgba(16, 72, 68, 0.9));
+    color: rgba(236, 251, 248, 0.96);
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.14),
-      0 0 0 1px rgba(205, 123, 255, 0.08),
-      0 12px 34px -24px rgba(205, 123, 255, 0.42);
+      inset 0 1px 0 rgba(255, 255, 255, 0.12),
+      0 0 0 1px rgba(70, 178, 161, 0.12),
+      0 10px 24px -20px rgba(14, 82, 76, 0.5);
   }
 
   .btn-primary:hover {
-    border-color: rgba(209, 132, 255, 0.48);
-    background: linear-gradient(180deg, rgba(132, 60, 165, 0.86), rgba(79, 44, 132, 0.88));
+    border-color: rgba(92, 202, 182, 0.5);
+    background: linear-gradient(180deg, rgba(24, 110, 101, 0.94), rgba(18, 80, 74, 0.92));
     box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.14),
-      0 0 0 1px rgba(208, 133, 255, 0.14),
-      0 0 26px -14px rgba(230, 126, 255, 0.62),
-      0 12px 30px -22px rgba(78, 214, 246, 0.34);
+      inset 0 1px 0 rgba(255, 255, 255, 0.12),
+      0 0 0 1px rgba(94, 206, 186, 0.18),
+      0 12px 24px -20px rgba(16, 92, 84, 0.56);
   }
 
   .btn-secondary,
@@ -254,11 +253,9 @@ a:hover {
 
   .btn-secondary:hover,
   .btn-ghost:hover {
-    border-color: rgba(174, 214, 255, 0.36);
+    border-color: rgba(112, 188, 176, 0.34);
     background: rgba(255, 255, 255, 0.055);
-    box-shadow:
-      0 0 18px -14px rgba(112, 223, 255, 0.42),
-      0 0 22px -16px rgba(224, 122, 255, 0.28);
+    box-shadow: 0 10px 22px -24px rgba(10, 30, 46, 0.62);
     transform: translateY(-1px);
   }
 
@@ -289,11 +286,10 @@ a:hover {
     z-index: -1;
     pointer-events: none;
     background:
-      radial-gradient(60% 48% at 50% 44%, rgba(235, 86, 204, 0.22) 0%, rgba(235, 86, 204, 0.08) 40%, rgba(235, 86, 204, 0) 72%),
-      radial-gradient(56% 52% at 57% 46%, rgba(146, 96, 255, 0.24) 0%, rgba(146, 96, 255, 0.1) 40%, rgba(146, 96, 255, 0) 76%),
-      radial-gradient(42% 36% at 43% 56%, rgba(86, 222, 248, 0.14) 0%, rgba(86, 222, 248, 0.06) 34%, rgba(86, 222, 248, 0) 74%);
-    filter: blur(40px) saturate(110%);
-    opacity: 0.74;
+      radial-gradient(56% 44% at 50% 44%, rgba(46, 138, 126, 0.16) 0%, rgba(46, 138, 126, 0.06) 40%, rgba(46, 138, 126, 0) 72%),
+      radial-gradient(54% 46% at 57% 46%, rgba(56, 126, 164, 0.1) 0%, rgba(56, 126, 164, 0.04) 40%, rgba(56, 126, 164, 0) 76%);
+    filter: blur(34px) saturate(104%);
+    opacity: 0.5;
   }
 }
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -139,8 +139,8 @@ export default function Home() {
       <EffectExplorer herbs={homepageData.effectExplorerHerbs} />
 
       <section className='ds-section container mx-auto max-w-4xl px-4 sm:px-6'>
-        <div className='ds-card-lg border-amber-300/30 bg-amber-500/10'>
-          <p className='text-xs font-semibold uppercase tracking-[0.24em] text-amber-100/80'>
+        <div className='ds-card-lg border-white/14 bg-white/[0.03]'>
+          <p className='text-xs font-semibold uppercase tracking-[0.24em] text-emerald-100/80'>
             Trust & safety
           </p>
           <h2 className='mt-2 text-2xl font-semibold text-white'>
@@ -182,7 +182,7 @@ export default function Home() {
                 <a
                   key={effect}
                   href='#effect-search'
-                  className='rounded-full border border-violet-300/40 bg-violet-500/10 px-3 py-1.5 text-xs font-medium capitalize text-violet-100 transition hover:border-violet-200/60 hover:bg-violet-500/15'
+                  className='rounded-full border border-emerald-300/35 bg-emerald-500/10 px-3 py-1.5 text-xs font-medium capitalize text-emerald-100 transition hover:border-emerald-200/55 hover:bg-emerald-500/15'
                 >
                   {effect}
                 </a>

--- a/src/styles/galaxy.css
+++ b/src/styles/galaxy.css
@@ -15,10 +15,10 @@
 
 .cosmic-base {
   background:
-    radial-gradient(120% 80% at 50% -20%, rgba(24, 18, 44, 0.24) 0%, rgba(8, 10, 20, 0.08) 46%, rgba(4, 6, 14, 0) 78%),
-    radial-gradient(108% 86% at 8% 74%, rgba(10, 30, 52, 0.14) 0%, rgba(6, 12, 24, 0.04) 54%, rgba(3, 7, 15, 0) 78%),
-    radial-gradient(96% 76% at 92% 16%, rgba(54, 18, 70, 0.12) 0%, rgba(18, 10, 28, 0.02) 52%, rgba(6, 6, 14, 0) 82%),
-    linear-gradient(164deg, rgba(2, 4, 10, 0.995) 0%, rgba(3, 5, 12, 0.99) 48%, rgba(2, 3, 8, 0.995) 100%),
+    radial-gradient(110% 74% at 50% -18%, rgba(16, 22, 34, 0.24) 0%, rgba(6, 10, 18, 0.1) 44%, rgba(4, 8, 14, 0) 78%),
+    radial-gradient(98% 82% at 8% 76%, rgba(12, 20, 34, 0.16) 0%, rgba(6, 12, 20, 0.06) 54%, rgba(3, 7, 15, 0) 78%),
+    radial-gradient(94% 70% at 92% 14%, rgba(18, 28, 40, 0.12) 0%, rgba(8, 14, 24, 0.03) 52%, rgba(6, 6, 14, 0) 82%),
+    linear-gradient(164deg, rgba(2, 4, 10, 0.996) 0%, rgba(3, 5, 12, 0.992) 48%, rgba(2, 3, 8, 0.996) 100%),
     #030409;
 }
 
@@ -29,27 +29,27 @@
 }
 
 .cosmic-aurora--one {
-  opacity: 0.19;
+  opacity: 0.09;
   background:
-    radial-gradient(46% 34% at 62% 28%, rgba(198, 98, 255, 0.24) 0%, rgba(104, 56, 178, 0.16) 42%, rgba(9, 8, 24, 0) 80%),
-    radial-gradient(34% 30% at 28% 62%, rgba(48, 198, 236, 0.14) 0%, rgba(12, 34, 50, 0) 84%);
+    radial-gradient(42% 30% at 62% 28%, rgba(57, 182, 161, 0.12) 0%, rgba(20, 52, 56, 0.08) 42%, rgba(9, 8, 24, 0) 80%),
+    radial-gradient(32% 28% at 28% 62%, rgba(34, 118, 170, 0.1) 0%, rgba(10, 26, 40, 0) 84%);
 }
 
 .cosmic-aurora--two {
-  opacity: 0.16;
+  opacity: 0.07;
   background:
-    radial-gradient(40% 30% at 74% 70%, rgba(58, 212, 244, 0.16) 0%, rgba(20, 88, 116, 0.11) 42%, rgba(6, 20, 34, 0) 82%),
-    radial-gradient(44% 30% at 18% 30%, rgba(244, 94, 198, 0.16) 0%, rgba(96, 40, 128, 0.11) 42%, rgba(8, 10, 26, 0) 86%);
+    radial-gradient(40% 30% at 74% 70%, rgba(40, 128, 168, 0.12) 0%, rgba(16, 52, 76, 0.09) 42%, rgba(6, 20, 34, 0) 82%),
+    radial-gradient(40% 30% at 18% 30%, rgba(48, 120, 136, 0.11) 0%, rgba(20, 46, 64, 0.08) 42%, rgba(8, 10, 26, 0) 86%);
 }
 
 .cosmic-glow {
   inset: -10%;
-  opacity: 0.15;
-  filter: blur(88px);
+  opacity: 0.06;
+  filter: blur(82px);
   mix-blend-mode: soft-light;
   background:
-    radial-gradient(38% 28% at 72% 30%, rgba(196, 82, 224, 0.14) 0%, rgba(42, 20, 70, 0) 88%),
-    radial-gradient(40% 34% at 34% 78%, rgba(62, 192, 224, 0.12) 0%, rgba(14, 30, 48, 0) 86%);
+    radial-gradient(34% 24% at 72% 30%, rgba(36, 118, 144, 0.12) 0%, rgba(18, 30, 42, 0) 88%),
+    radial-gradient(36% 30% at 34% 78%, rgba(42, 132, 120, 0.1) 0%, rgba(14, 30, 48, 0) 86%);
 }
 
 .cosmic-vignette {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -57,8 +57,8 @@
 
 :root {
   --hs-card: 255 255 255;
-  --glow-sm: 0 10px 24px -18px rgba(45, 212, 191, 0.45);
-  --glow-lg: 0 20px 45px -36px rgba(16, 185, 129, 0.65);
+  --glow-sm: 0 10px 24px -20px rgba(20, 50, 68, 0.32);
+  --glow-lg: 0 18px 42px -34px rgba(16, 62, 78, 0.38);
   color-scheme: dark;
 }
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -9,8 +9,8 @@
   --space-unit: 0.25rem;
 
   --accent-h: 166;
-  --accent-s: 70%;
-  --accent-l: 52%;
+  --accent-s: 58%;
+  --accent-l: 44%;
   --accent: hsl(var(--accent-h) var(--accent-s) var(--accent-l));
   --accent-rgb: 35 212 177;
 
@@ -30,22 +30,22 @@
   --amber-l: 58%;
   --amber: hsl(var(--amber-h) var(--amber-s) var(--amber-l));
 
-  --bg: 28 8% 7%;
-  --surface: 30 7% 10%;
-  --card: 30 7% 12%;
+  --bg: 220 22% 6%;
+  --surface: 220 20% 10%;
+  --card: 220 18% 12%;
   --text: 210 10% 96%;
   --fg: 210 10% 96%;
   --mute: 35 10% 60%;
   --muted: 35 10% 60%;
-  --border: 30 8% 20%;
-  --ring: 166 70% 52%;
+  --border: 220 14% 22%;
+  --ring: 166 58% 44%;
 
   --bg-c: hsl(var(--bg));
-  --surface-c: hsla(220, 18%, 20%, 0.68);
-  --card-c: hsla(220, 18%, 22%, 0.78);
+  --surface-c: hsla(220, 20%, 14%, 0.72);
+  --card-c: hsla(220, 18%, 16%, 0.82);
   --text-c: hsl(var(--text));
   --muted-c: hsla(210, 6%, 72%, 0.85);
-  --border-c: hsla(220, 16%, 28%, 0.55);
+  --border-c: hsla(220, 14%, 26%, 0.58);
 }
 
 [data-theme='light'] {


### PR DESCRIPTION
### Motivation
- Revert the recent neon/purple-heavy visual direction and remove gimmicky ambient effects while preserving all data logic, routes, and behavior. 
- Move the visual system toward a tighter, dark-only, premium look using typography, spacing, and subtle depth rather than bright glows and multicolor washes. 
- Apply a single restrained accent and reduce decorative noise so pages and cards feel consistent, calm, and intentional.

### Description
- Updated core theme tokens to a deeper near-black / deep-navy base and tuned the accent to a restrained emerald-teal (`--accent-h: 166`, `--accent-s: 58%`, `--accent-l: 44%`) to enforce a single-accent system. (files changed: `src/styles/theme.css`, `src/styles/global.css`).
- Toned down and neutralized ambient/background aurora blobs and cosmic glow layers, reduced opacity/blur and swapped saturated purple/cyan gradients for low-chroma deep-teal/navy variants. (file changed: `src/styles/galaxy.css`).
- Reworked button, card, and hero decorative styles to reduce glow and saturation, simplify hover states, and strengthen typographic contrast (cleaner fills, restrained borders, subtler shadows). (files changed: `src/index.css`, `src/styles/global.css`).
- Aligned visible UI components and homepage surfaces to the new system by replacing violet/fuchsia classes with neutral or emerald variants on the Effect Explorer, Guide Download card, and homepage chips/sections. (files changed: `src/components/EffectExplorer.tsx`, `src/components/GuideDownloadCard.tsx`, `src/pages/Home.tsx`).
- Files changed in this PR: `src/styles/theme.css`, `src/styles/galaxy.css`, `src/styles/global.css`, `src/index.css`, `src/components/EffectExplorer.tsx`, `src/components/GuideDownloadCard.tsx`, and `src/pages/Home.tsx`.
- What glow/effect styling was removed or toned down: removed multi-color neon/fuchsia/cyan aurora blobs, reduced cosmic/cosmic-glow opacity and blur, removed purple-heavy hero haze, and desaturated bright card/button glows to subtle, low-opacity depth layers. (See the CSS changes in `galaxy.css`, `index.css`, and `global.css`).
- New base palette and accent: base = near-black / deep-navy tokens (`--bg: 220 22% 6%`, `--surface`/`--card` tuned toward navy-charcoal), accent = restrained emerald-teal (hsl(166 58% 44%)).
- Why this feels more premium: fewer decorative washes, lower chroma ambient layers, cleaner button geometry and states, subtle shadows and borders for separation, and consistent single-accent usage across components.

### Testing
- Built the site to validate styling and asset compilation using `npm run build`, which completed successfully. 
- Ran a targeted compile step `npm run build:compile` to confirm the production bundling pipeline, which also completed successfully. 
- No unit or runtime behavior tests were changed and all data, routes, and logic were left intact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc633ed428832399ab62da489c75b1)