### PR TITLE
UI: Dark-minimal redesign and compact card/detail overhaul

### DIFF
--- a/src/components/CompoundCard.tsx
+++ b/src/components/CompoundCard.tsx
@@ -2,7 +2,7 @@ import { motion } from '@/lib/motion'
 import type { Compound } from '@/types/compound'
 import { buildCardSummary } from '@/lib/summary'
 import { extractPrimaryEffects } from '@/utils/extractPrimaryEffects'
-import { calculateCompoundConfidence, type ConfidenceLevel } from '@/utils/calculateConfidence'
+import { calculateCompoundConfidence } from '@/utils/calculateConfidence'
 import { formatBrowseTitle } from '@/utils/titleDisplay'
 
 interface HerbRef {
@@ -24,84 +24,50 @@ function getMechanism(compound: CompoundWithRefs): string {
   return typeof legacyMechanism === 'string' ? legacyMechanism : ''
 }
 
-function confidenceBadgeClass(level: ConfidenceLevel) {
-  if (level === 'high')
-    return 'border-emerald-300/40 bg-emerald-500/12 text-emerald-100'
-  if (level === 'medium')
-    return 'border-amber-300/35 bg-amber-500/12 text-amber-100'
-  return 'border-rose-300/35 bg-rose-500/10 text-rose-100/90'
-}
-
 export default function CompoundCard({ compound }: { compound: CompoundWithRefs }) {
   const mechanism = getMechanism(compound)
   const effects = Array.isArray(compound.effects) ? compound.effects : []
-
   const confidence = calculateCompoundConfidence({
     mechanism,
     effects,
     compounds: compound.herbsFound.map(h => h.name),
   })
-  const primaryEffects = extractPrimaryEffects(effects, 3)
+  const primaryEffects = extractPrimaryEffects(effects, 2)
   const visibleHerbs = compound.herbsFound.slice(0, 2)
   const hiddenHerbCount = Math.max(compound.herbsFound.length - visibleHerbs.length, 0)
   const title = formatBrowseTitle(compound.name, 60)
   const isTitleTruncated = title !== compound.name
-  const generatedSummary = buildCardSummary({
-    effects,
-    mechanism,
-    description: compound.description,
-    activeCompounds: compound.herbsFound.map(h => h.name),
-    maxLen: 170,
-  })
-  const summary = generatedSummary?.trim() || 'Summary coming soon.'
-  const herbSourceSummary =
+  const summary =
+    buildCardSummary({
+      effects,
+      mechanism,
+      description: compound.description,
+      activeCompounds: compound.herbsFound.map(h => h.name),
+      maxLen: 120,
+    })?.trim() || 'Summary coming soon.'
+  const sourceLine =
     visibleHerbs.length > 0
-      ? `Found in ${visibleHerbs.map(h => h.name).join(', ')}${hiddenHerbCount > 0 ? ` +${hiddenHerbCount} more` : ''}.`
-      : 'Herb source mapping in progress.'
-  const categoryChip = compound.effectClass || compound.type || compound.category || null
-  const chipItems = [
-    { key: 'confidence', label: confidence, className: confidenceBadgeClass(confidence), uppercase: true },
-    categoryChip
-      ? {
-          key: 'category',
-          label: categoryChip,
-          className: 'border-sky-300/35 bg-sky-500/12 text-sky-100',
-          uppercase: false,
-        }
-      : null,
-  ].filter(Boolean) as Array<{ key: string; label: string; className: string; uppercase: boolean }>
-
-  const metadataLine = confidence === 'low' ? `${herbSourceSummary} ⚠ Limited data.` : herbSourceSummary
+      ? `Found in ${visibleHerbs.map(h => h.name).join(', ')}${hiddenHerbCount > 0 ? ` +${hiddenHerbCount}` : ''}`
+      : 'Source mapping in progress'
 
   return (
     <motion.article
-      whileHover={{ scale: 1.005 }}
+      whileHover={{ scale: 1.003 }}
       title={compound.herbsFound.map(h => h.name).join(', ')}
-      className='ds-card ds-card-paper relative flex flex-col rounded-2xl p-2 text-left transition hover:border-white/25 sm:p-2.5'
+      className='ds-card relative flex h-full flex-col gap-2 rounded-xl border-white/12 bg-white/[0.02] p-3 text-left'
     >
       <h2
         title={isTitleTruncated ? compound.name : undefined}
-        className='mb-0.5 line-clamp-2 min-h-[2.1rem] break-all text-[0.93rem] font-semibold leading-tight text-emerald-200 sm:text-[0.98rem]'
+        className='line-clamp-2 min-h-[2.2rem] break-all text-[0.95rem] font-semibold leading-tight text-white sm:text-base'
       >
         {title}
       </h2>
-      <div className='mb-1 flex flex-wrap gap-1'>
-        {chipItems.slice(0, 2).map(chip => (
-          <span
-            key={`${compound.name}-${chip.key}`}
-            className={`inline-flex max-w-full items-center rounded-full border px-1.5 py-0.5 text-[10px] font-medium ${chip.uppercase ? 'uppercase tracking-wide' : ''} ${chip.className}`}
-          >
-            <span className='truncate'>{chip.label}</span>
-          </span>
-        ))}
+      <p className='line-clamp-2 text-xs leading-[1.35] text-white/72'>{summary}</p>
+      <div className='flex flex-wrap gap-1'>
+        <span className='ds-pill'>{confidence}</span>
+        {primaryEffects[0] && <span className='ds-pill'>{primaryEffects[0]}</span>}
       </div>
-      <p className='mb-1 line-clamp-2 text-xs leading-tight text-white/72'>{summary}</p>
-      {primaryEffects.length > 0 && (
-        <p className='mb-1 line-clamp-1 text-[11px] text-violet-100/75'>
-          {primaryEffects.slice(0, 2).join(' • ')}
-        </p>
-      )}
-      <p className='mb-1 line-clamp-1 text-[11px] text-white/52'>{metadataLine}</p>
+      <p className='line-clamp-1 text-[11px] text-white/56'>{sourceLine}</p>
       <div className='mt-auto' />
     </motion.article>
   )

--- a/src/components/CosmicBackground.tsx
+++ b/src/components/CosmicBackground.tsx
@@ -6,9 +6,6 @@ export default function CosmicBackground({ animated = true }: CosmicBackgroundPr
   return (
     <div aria-hidden className={`cosmic-background ${animated ? 'is-animated' : 'is-static'}`}>
       <div className='cosmic-layer cosmic-base' />
-      <div className='cosmic-layer cosmic-aurora cosmic-aurora--one' />
-      <div className='cosmic-layer cosmic-aurora cosmic-aurora--two' />
-      <div className='cosmic-layer cosmic-glow' />
       <div className='cosmic-layer cosmic-vignette' />
     </div>
   )

--- a/src/components/HerbCard.tsx
+++ b/src/components/HerbCard.tsx
@@ -1,16 +1,8 @@
-/**
- * CANONICAL HERB CARD
- *
- * This is the ONLY allowed herb card component.
- * Do NOT create variants.
- * Extend via props only.
- */
 import { memo } from 'react'
 import { FlaskConical } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import Card from './ui/Card'
 import { formatBrowseTitle } from '@/utils/titleDisplay'
-import './HerbCard.css'
 
 interface HerbCardProps {
   name: string
@@ -22,12 +14,6 @@ interface HerbCardProps {
   evidenceLevel?: string
   detailUrl: string
   compact?: boolean
-}
-
-const EVIDENCE_TIER_BADGE_CLASS: Record<string, string> = {
-  'Tier 1': 'border-emerald-300/35 bg-emerald-400/15 text-emerald-200',
-  'Tier 2': 'border-sky-300/35 bg-sky-400/15 text-sky-200',
-  'Tier 3': 'border-amber-300/35 bg-amber-400/15 text-amber-200',
 }
 
 function HerbCard({
@@ -44,105 +30,58 @@ function HerbCard({
   const mergedTags = Array.from(new Set([...tags, ...mechanismTags].filter(Boolean)))
   const primaryTag = mergedTags[0]
   const hasCompoundCount = typeof compound_count === 'number' && compound_count > 0
-  const normalizedEvidenceTier = (evidence_tier || '').trim()
-  const fallbackEvidence = normalizedEvidenceTier ? '' : (evidenceLevel || '').trim()
   const title = formatBrowseTitle(name, 60)
   const isTitleTruncated = title !== name
   const summaryText = summary?.trim() || 'Overview coming soon.'
 
-  const priorityChips = [
-    normalizedEvidenceTier
-      ? {
-          key: `tier-${normalizedEvidenceTier}`,
-          label: normalizedEvidenceTier,
-          className:
-            EVIDENCE_TIER_BADGE_CLASS[normalizedEvidenceTier] ??
-            'border-white/20 bg-white/[0.05] text-white/75',
-        }
-      : fallbackEvidence
-        ? {
-            key: `evidence-${fallbackEvidence}`,
-            label: fallbackEvidence.slice(0, 24),
-            className: 'border-white/20 bg-white/[0.05] text-white/75',
-          }
-        : null,
-    hasCompoundCount
-      ? {
-          key: 'compound-count',
-          label: `${compound_count} compounds`,
-          className: 'border-white/20 bg-white/[0.05] text-white/70',
-        }
-      : null,
-    primaryTag
-      ? {
-          key: `tag-${primaryTag}`,
-          label: primaryTag,
-          className: 'border-white/15 bg-white/[0.03] text-white/70',
-        }
-      : null,
-  ]
-    .filter(Boolean)
-    .slice(0, 2) as Array<{ key: string; label: string; className: string }>
+  const chipItems = [evidence_tier || evidenceLevel || '', primaryTag || ''].filter(Boolean).slice(0, 2)
 
   return (
-    <div className='HerbCardTilt group relative h-full transition-transform duration-200 ease-out hover:scale-[1.004]'>
-      <div className='HerbCardGlow pointer-events-none absolute inset-0 rounded-[1.25rem] opacity-0 transition-opacity duration-200 group-hover:opacity-100' />
-      <Card
-        className={`ds-card-paper card-pad border-white/12 relative flex h-full flex-col bg-white/[0.05] transition duration-200 ease-out group-hover:border-white/20 group-hover:bg-white/[0.07] ${
-          compact ? 'gap-1 p-1.5' : 'gap-1.5 p-2 sm:p-2.5'
-        }`}
-      >
-        <header className='space-y-0'>
-          <h2
-            title={isTitleTruncated ? name : undefined}
-            className={
-              compact
-                ? 'line-clamp-2 min-h-[2.1rem] break-all text-[0.9rem] font-semibold leading-tight text-lime-200'
-                : 'line-clamp-2 min-h-[2.3rem] break-all text-[0.96rem] font-semibold leading-tight text-lime-200 sm:text-base'
-            }
-          >
-            {title}
-          </h2>
-        </header>
+    <Card
+      className={`ds-card relative flex h-full flex-col border-white/12 bg-white/[0.02] ${compact ? 'gap-1.5 p-2.5' : 'gap-2 p-3'}`}
+    >
+      <header>
+        <h2
+          title={isTitleTruncated ? name : undefined}
+          className='line-clamp-2 min-h-[2.2rem] break-all text-[0.95rem] font-semibold leading-tight text-white sm:text-base'
+        >
+          {title}
+        </h2>
+      </header>
 
-        <section className='space-y-0.5 text-white/80'>
-          <p
-            className={`line-clamp-2 text-[11px] text-white/68 ${compact ? 'leading-tight' : 'leading-snug sm:text-xs'}`}
-          >
-            {summaryText}
-          </p>
-          {priorityChips.length > 0 && (
-            <div className='flex flex-wrap gap-1'>
-              {priorityChips.map(chip => (
-                <span
-                  key={chip.key}
-                  className={`inline-flex max-w-full items-center rounded-full border px-1.5 py-0 text-[10px] font-medium ${chip.className}`}
-                >
-                  <span className='truncate'>{chip.label}</span>
-                </span>
-              ))}
-            </div>
-          )}
-        </section>
+      <p className='line-clamp-2 text-xs leading-[1.35] text-white/72'>{summaryText}</p>
 
-        <footer className='mt-auto flex items-center justify-between pt-0'>
+      <div className='flex items-center justify-between gap-2 text-[11px] text-white/58'>
+        <div className='truncate'>
           {hasCompoundCount ? (
-            <span className='inline-flex items-center gap-1 text-[10px] text-white/45'>
+            <span className='inline-flex items-center gap-1'>
               <FlaskConical className='h-3 w-3' aria-hidden='true' />
-              {compound_count}
+              {compound_count} compounds
             </span>
           ) : (
-            <span className='text-[10px] text-white/35'>Profile</span>
+            <span>Profile</span>
           )}
-          <Link
-            to={detailUrl}
-            className='inline-flex min-h-5 items-center rounded-md border border-white/12 bg-white/[0.03] px-1.5 py-0 text-[10px] font-medium text-white/68 transition duration-200 ease-out hover:border-white/25 hover:bg-white/[0.06] hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300'
-          >
-            View details
-          </Link>
-        </footer>
-      </Card>
-    </div>
+        </div>
+        {chipItems.length > 0 && (
+          <div className='flex items-center gap-1'>
+            {chipItems.map(chip => (
+              <span key={chip} className='ds-pill max-w-[92px] truncate'>
+                {chip}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <footer className='mt-auto pt-0.5'>
+        <Link
+          to={detailUrl}
+          className='inline-flex min-h-7 items-center rounded-md border border-white/15 bg-white/[0.03] px-2 py-1 text-[11px] font-medium text-white/78 transition hover:border-cyan-300/45 hover:text-white'
+        >
+          View details
+        </Link>
+      </footer>
+    </Card>
   )
 }
 

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,64 +1,28 @@
 import { motion, useReducedMotion } from '@/lib/motion'
-import Tilt from './Tilt'
 import HeroCTA from './HeroCTA'
 
 export default function Hero() {
   const reduceMotion = useReducedMotion()
 
   return (
-    <section className='hero-focus-glow relative mx-auto mt-2 max-w-6xl px-4 py-16 sm:mt-4 sm:px-6 sm:py-24'>
-
-      <Tilt maxTilt={4} perspective={900} className='relative'>
-        <motion.div
-          initial={reduceMotion ? undefined : { opacity: 0, y: 16, scale: 0.99 }}
-          animate={reduceMotion ? undefined : { opacity: 1, y: 0, scale: 1 }}
-          transition={reduceMotion ? undefined : { duration: 0.55, ease: [0.22, 1, 0.36, 1] }}
-          className='relative'
-        >
-          <div className='relative space-y-10 py-6 sm:space-y-14 sm:py-10'>
-            <div className='space-y-2.5 sm:space-y-4.5'>
-              <motion.p
-                initial={reduceMotion ? undefined : { opacity: 0, y: 6 }}
-                animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
-                transition={reduceMotion ? undefined : { duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
-                className='label-specimen mb-3'
-              >
-                Specimen No. 001 — Harm Reduction Research
-              </motion.p>
-              <motion.h1
-                initial={reduceMotion ? undefined : { opacity: 0, y: 12 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true }}
-                transition={
-                  reduceMotion
-                    ? undefined
-                    : { delay: 0.05, duration: 0.4, ease: [0.22, 1, 0.36, 1] }
-                }
-                className='max-w-4xl font-display text-[2.4rem] font-normal italic leading-[0.97] tracking-[-0.02em] text-white sm:text-[4.75rem]'
-              >
-                Clarity before you experiment
-              </motion.h1>
-              <motion.p
-                initial={reduceMotion ? undefined : { opacity: 0, y: 12 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true }}
-                transition={
-                  reduceMotion
-                    ? undefined
-                    : { delay: 0.12, duration: 0.4, ease: [0.22, 1, 0.36, 1] }
-                }
-                className='max-w-2xl text-[0.88rem] leading-[1.45] text-white/68 sm:text-[0.95rem]'
-              >
-                Research signals, risk flags, and hard questions — before you put anything in your
-                body.
-              </motion.p>
-            </div>
-
-            <HeroCTA />
-            <hr className='mt-10 border-0 border-t border-amber-400/15' />
-          </div>
-        </motion.div>
-      </Tilt>
+    <section className='hero-focus-glow relative mx-auto mt-2 max-w-6xl px-4 py-14 sm:mt-4 sm:px-6 sm:py-20'>
+      <motion.div
+        initial={reduceMotion ? undefined : { opacity: 0, y: 10 }}
+        animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
+        transition={reduceMotion ? undefined : { duration: 0.4, ease: [0.22, 1, 0.36, 1] }}
+        className='relative'
+      >
+        <div className='max-w-3xl space-y-6'>
+          <p className='label-specimen'>Specimen No. 001 — Harm Reduction Research</p>
+          <h1 className='font-display text-[2.2rem] leading-[0.95] tracking-[-0.02em] text-white sm:text-[4rem]'>
+            Clarity before you <span className='text-cyan-300'>experiment</span>
+          </h1>
+          <p className='max-w-xl text-sm leading-relaxed text-white/70 sm:text-base'>
+            Research signals, risk flags, and hard questions so you can make safer decisions.
+          </p>
+          <HeroCTA />
+        </div>
+      </motion.div>
     </section>
   )
 }

--- a/src/components/HeroCTA.tsx
+++ b/src/components/HeroCTA.tsx
@@ -1,28 +1,22 @@
 import { Link } from 'react-router-dom'
 
 const baseButtonClasses =
-  'btn w-full sm:w-auto text-sm sm:text-base focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/45'
+  'btn w-full sm:w-auto text-sm sm:text-base focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/50'
 
 export default function HeroCTA() {
   return (
-    <div className='w-full space-y-5 sm:space-y-7'>
-      <div className='pt-3 sm:pt-4'>
+    <div className='w-full space-y-3'>
+      <div>
         <a href='#effect-search' className={`${baseButtonClasses} btn-primary`}>
           Start with Effect Search
         </a>
       </div>
-      <div className='flex flex-wrap gap-2.5'>
-        <Link
-          to='/interactions'
-          className='text-xs text-white/45 underline-offset-4 transition hover:text-white/65 hover:underline'
-        >
+      <div className='flex flex-wrap gap-2 text-xs text-white/58'>
+        <Link to='/interactions' className='underline-offset-4 transition hover:text-white/80 hover:underline'>
           Interaction Checker
         </Link>
-        <span className='text-white/40'>•</span>
-        <Link
-          to='/build'
-          className='text-xs text-white/45 underline-offset-4 transition hover:text-white/65 hover:underline'
-        >
+        <span>•</span>
+        <Link to='/build' className='underline-offset-4 transition hover:text-white/80 hover:underline'>
           Blend Builder
         </Link>
       </div>

--- a/src/components/filters/ActiveFiltersBar.tsx
+++ b/src/components/filters/ActiveFiltersBar.tsx
@@ -32,61 +32,40 @@ export default function ActiveFiltersBar({
 
   if (!hasActive) return null
 
+  const chipClass = 'rounded-full border border-white/15 bg-white/[0.03] px-2.5 py-1 text-xs text-white/82'
+
   return (
-    <div className='flex flex-wrap items-center gap-2 rounded-2xl border border-white/10 bg-white/[0.03] p-3'>
-      <span className='mr-1 text-xs font-semibold uppercase tracking-wide text-white/55'>
-        Active
-      </span>
+    <div className='flex flex-wrap items-center gap-1.5 rounded-xl border border-white/10 bg-white/[0.02] p-2.5'>
+      <span className='mr-1 text-[11px] uppercase tracking-wide text-white/50'>Active</span>
       {state.query && (
-        <button
-          type='button'
-          onClick={onClearQuery}
-          className='rounded-full border border-white/20 bg-white/5 px-3 py-1 text-xs text-white/90'
-        >
+        <button type='button' onClick={onClearQuery} className={chipClass}>
           Query: {state.query} ×
         </button>
       )}
-      {state.selectedEffects.map(effect => (
-        <button
-          key={effect}
-          type='button'
-          onClick={() => onRemoveEffect(effect)}
-          className='rounded-full border border-violet-300/40 bg-violet-500/15 px-3 py-1 text-xs text-violet-100'
-        >
-          Effect: {effect} ×
+      {state.selectedEffects.slice(0, 2).map(effect => (
+        <button key={effect} type='button' onClick={() => onRemoveEffect(effect)} className={chipClass}>
+          {effect} ×
         </button>
       ))}
       {state.confidence !== 'all' && (
-        <button
-          type='button'
-          onClick={onClearConfidence}
-          className='rounded-full border border-cyan-300/40 bg-cyan-500/15 px-3 py-1 text-xs text-cyan-100'
-        >
+        <button type='button' onClick={onClearConfidence} className={chipClass}>
           Confidence: {state.confidence} ×
         </button>
       )}
       {state.type !== 'all' && (
-        <button
-          type='button'
-          onClick={onClearType}
-          className='rounded-full border border-emerald-300/40 bg-emerald-500/15 px-3 py-1 text-xs text-emerald-100'
-        >
+        <button type='button' onClick={onClearType} className={chipClass}>
           {typeLabel}: {state.type} ×
         </button>
       )}
       {state.enrichment !== 'all' && (
-        <button
-          type='button'
-          onClick={onClearEnrichment}
-          className='rounded-full border border-amber-300/40 bg-amber-500/15 px-3 py-1 text-xs text-amber-100'
-        >
+        <button type='button' onClick={onClearEnrichment} className={chipClass}>
           Research: {enrichmentLabel || state.enrichment} ×
         </button>
       )}
       <button
         type='button'
         onClick={onClear}
-        className='ml-auto rounded-full border border-white/25 bg-white/5 px-3 py-1 text-xs font-semibold text-white/90 hover:bg-white/10'
+        className='ml-auto rounded-full border border-cyan-300/35 bg-cyan-500/10 px-2.5 py-1 text-xs font-semibold text-cyan-100'
       >
         Clear all
       </button>

--- a/src/components/filters/EffectFilter.tsx
+++ b/src/components/filters/EffectFilter.tsx
@@ -29,29 +29,29 @@ export default function EffectFilter({ options, selected, onToggle }: EffectFilt
     return () => window.removeEventListener(MORE_FILTERS_EVENT, handleChange as EventListener)
   }, [])
 
-  const hasOverflow = options.length > 18
+  const hasOverflow = options.length > 16
   const visible = useMemo(() => {
     if (expanded || !hasOverflow) return options
-    return options.slice(0, 18)
+    return options.slice(0, 16)
   }, [expanded, hasOverflow, options])
 
   if (!moreFiltersOpen) return null
 
   return (
-    <section className='rounded-2xl border border-white/10 bg-white/[0.03] p-3'>
+    <section className='rounded-xl border border-white/10 bg-white/[0.02] p-2.5'>
       <div className='mb-2 flex items-center justify-between gap-2'>
         <h3 className='text-sm font-semibold text-white'>Effects</h3>
         {hasOverflow && (
           <button
             type='button'
             onClick={() => setExpanded(value => !value)}
-            className='text-xs text-white/75 underline underline-offset-4 hover:text-white'
+            className='text-xs text-white/70 underline underline-offset-4 hover:text-white'
           >
             {expanded ? 'Show less' : `Show all (${options.length})`}
           </button>
         )}
       </div>
-      <div className='flex flex-wrap gap-2'>
+      <div className='flex flex-wrap gap-1.5'>
         {visible.map(effect => {
           const active = selected.includes(effect)
           return (
@@ -59,10 +59,10 @@ export default function EffectFilter({ options, selected, onToggle }: EffectFilt
               key={effect}
               type='button'
               onClick={() => onToggle(effect)}
-              className={`rounded-full border px-3 py-1 text-xs transition ${
+              className={`rounded-full border px-2.5 py-1 text-xs transition ${
                 active
-                  ? 'border-violet-300/60 bg-violet-500/25 text-violet-100 shadow-[0_0_14px_rgba(139,92,246,0.3)]'
-                  : 'border-white/15 bg-white/[0.03] text-white/80 hover:bg-white/10'
+                  ? 'border-cyan-300/45 bg-cyan-500/12 text-cyan-100'
+                  : 'border-white/14 bg-white/[0.02] text-white/78 hover:bg-white/[0.07]'
               }`}
             >
               {effect}

--- a/src/components/filters/SearchBar.tsx
+++ b/src/components/filters/SearchBar.tsx
@@ -7,34 +7,27 @@ type SearchBarProps = {
   className?: string
 }
 
-export default function SearchBar({
-  value,
-  onChange,
-  placeholder,
-  className = '',
-}: SearchBarProps) {
+export default function SearchBar({ value, onChange, placeholder, className = '' }: SearchBarProps) {
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     onChange(event.target.value)
   }
 
   return (
     <div className={`sticky top-2 z-20 ${className}`}>
-      <div className='rounded-2xl border border-white/15 bg-black/35 p-2 shadow-[0_0_18px_rgba(168,85,247,0.16)] backdrop-blur'>
-        <div className='mb-1 px-1 text-[11px] font-medium uppercase tracking-wide text-white/55'>
-          Search
-        </div>
+      <div className='rounded-xl border border-white/12 bg-black/30 p-2'>
+        <div className='mb-1 px-1 text-[11px] font-medium uppercase tracking-wide text-white/55'>Search</div>
         <div className='flex items-center gap-2'>
           <input
             value={value}
             onChange={handleChange}
             placeholder={placeholder}
-            className='w-full rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder:text-white/55 focus:outline-none focus:ring-2 focus:ring-violet-400/40'
+            className='w-full rounded-lg border border-white/12 bg-white/[0.02] px-3 py-2 text-sm text-white placeholder:text-white/45 focus:outline-none focus:ring-2 focus:ring-cyan-400/35'
             aria-label='Search entries'
           />
           {value && (
             <button
               type='button'
-              className='rounded-xl border border-white/20 bg-white/5 px-3 py-2 text-xs font-medium text-white/85 transition hover:bg-white/10'
+              className='rounded-lg border border-white/20 bg-white/[0.03] px-3 py-2 text-xs font-medium text-white/80 transition hover:bg-white/[0.08]'
               onClick={() => onChange('')}
             >
               Clear

--- a/src/index.css
+++ b/src/index.css
@@ -18,8 +18,6 @@ html {
 :root {
   --headerH: 64px;
   --footerH: 280px;
-  --glass: rgba(255, 255, 255, 0.06);
-  --glass-strong: rgba(255, 255, 255, 0.1);
   color-scheme: dark;
 }
 
@@ -45,9 +43,10 @@ body {
     Arial,
     'Apple Color Emoji',
     'Segoe UI Emoji';
-  line-height: 1.54;
+  line-height: 1.55;
   letter-spacing: 0;
   overscroll-behavior-y: none;
+  background: #05070a;
   @apply antialiased;
 }
 
@@ -57,9 +56,7 @@ body::before {
   inset: 0;
   pointer-events: none;
   z-index: 1;
-  background:
-    radial-gradient(120% 100% at 50% 42%, rgba(3, 5, 12, 0) 48%, rgba(1, 2, 8, 0.68) 100%),
-    radial-gradient(80% 58% at 50% 22%, rgba(90, 42, 138, 0.07) 0%, rgba(5, 8, 20, 0) 72%);
+  background: radial-gradient(120% 90% at 50% 46%, rgba(5, 7, 10, 0) 58%, rgba(2, 4, 7, 0.52) 100%);
 }
 
 .prerender-content.sr-only {
@@ -74,7 +71,6 @@ body::before {
   white-space: nowrap;
   border: 0;
 }
-
 
 @media (prefers-reduced-motion: reduce) {
   * {
@@ -98,13 +94,13 @@ svg {
 }
 
 a {
-  color: color-mix(in oklab, var(--accent) 88%, white 12%);
+  color: color-mix(in oklab, var(--accent) 86%, white 14%);
   text-decoration: none;
-  transition: color 0.2s ease;
+  transition: color 0.15s ease;
 }
 
 a:hover {
-  color: color-mix(in oklab, var(--accent) 80%, white 20%);
+  color: color-mix(in oklab, var(--accent) 76%, white 24%);
   text-decoration: underline;
 }
 
@@ -114,60 +110,31 @@ a:hover {
   }
 
   .ds-section {
-    @apply mb-12 border-t border-white/10 pt-7 sm:mb-16 sm:pt-9;
+    @apply mb-10 border-t border-white/10 pt-6 sm:mb-12 sm:pt-8;
   }
 
   .ds-stack {
-    @apply space-y-3 sm:space-y-4;
+    @apply space-y-3;
+  }
+
+  .ds-card,
+  .ds-card-paper,
+  .ds-card-tight,
+  .ds-card-lg {
+    @apply rounded-xl border border-white/10 bg-white/[0.02] shadow-none;
   }
 
   .ds-card {
-    @apply rounded-2xl border border-white/14 bg-white/[0.03] p-3 sm:p-3 backdrop-blur-md transition-all duration-150;
-    box-shadow:
-      0 8px 20px -20px rgba(16, 185, 129, 0.26),
-      0 12px 24px -24px rgba(0, 0, 0, 0.75);
-  }
-
-  .ds-card:hover {
-    @apply border-white/20 bg-white/[0.04];
-    transform: translateY(-1px) scale(1.003);
-  }
-
-  .ds-card-paper {
-    background: color-mix(in oklab, hsl(var(--card)) 85%, hsl(38 30% 14%) 15%);
-    border: 1px solid color-mix(in oklab, hsl(var(--border)) 60%, hsl(38 50% 30%) 40%);
-    border-radius: var(--radius);
-    box-shadow:
-      0 0 0 1px rgba(255, 200, 80, 0.04),
-      0 12px 40px -8px rgba(0, 0, 0, 0.5),
-      inset 0 1px 0 rgba(255, 210, 100, 0.06);
-    position: relative;
-  }
-
-  .ds-card-paper::before {
-    content: '';
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    width: 18px;
-    height: 18px;
-    border-top: 1px solid hsl(var(--amber-h) var(--amber-s) var(--amber-l) / 0.25);
-    border-right: 1px solid hsl(var(--amber-h) var(--amber-s) var(--amber-l) / 0.25);
-    border-radius: 0 4px 0 0;
-    pointer-events: none;
+    @apply p-3;
   }
 
   .ds-card-lg {
-    @apply ds-card p-3.5 sm:p-4;
+    @apply p-4;
   }
 
   .ds-card-grid {
-    @apply grid gap-4 sm:gap-6;
+    @apply grid gap-3 sm:gap-4;
     grid-auto-rows: 1fr;
-  }
-
-  .ds-card-tight {
-    @apply rounded-2xl border border-white/14 bg-white/[0.03] p-3.5;
   }
 
   .ds-action-row {
@@ -175,125 +142,71 @@ a:hover {
   }
 
   .ds-heading {
-    @apply text-base font-semibold tracking-tight text-white sm:text-lg;
+    @apply text-lg font-semibold tracking-tight text-white;
   }
 
   .ds-subheading {
-    @apply text-sm font-semibold tracking-tight text-white/90 sm:text-base;
+    @apply text-sm font-semibold tracking-tight text-white/90;
   }
 
   .ds-text {
-    @apply max-w-[64ch] text-sm leading-[1.5] text-white/80 sm:text-[0.94rem];
+    @apply max-w-[64ch] text-sm leading-[1.5] text-white/80;
   }
 
   .ds-text-muted {
-    @apply max-w-[64ch] text-sm leading-[1.48] text-white/70 sm:text-[0.92rem];
-  }
-
-  .ds-metadata {
-    @apply text-[0.72rem] font-medium tracking-[0.02em] text-white/50 sm:text-xs;
+    @apply max-w-[64ch] text-sm leading-[1.48] text-white/70;
   }
 
   .ds-pill,
   .pill {
-    @apply inline-flex items-center rounded-full border border-white/14 bg-white/[0.035] px-2 py-0.5 text-[0.68rem] font-medium text-white/75 transition-all duration-150;
-  }
-
-  .ds-pill:hover,
-  .pill:hover {
-    @apply border-white/20 bg-white/[0.05] text-white/85;
+    @apply inline-flex items-center rounded-full border px-2 py-0.5 text-[0.68rem] font-medium;
+    border-color: rgba(255, 255, 255, 0.16);
+    background: rgba(255, 255, 255, 0.03);
+    color: rgba(244, 246, 251, 0.78);
   }
 
   .btn,
   .btn-primary,
   .btn-secondary,
   .btn-ghost {
-    @apply inline-flex min-h-9 items-center justify-center gap-1.5 rounded-xl border px-3 py-1.5 text-xs font-medium leading-none transition-all duration-150 sm:px-3.5 sm:py-1.5 sm:text-sm;
+    @apply inline-flex min-h-9 items-center justify-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium leading-none transition-colors;
   }
 
-  .btn {
-    border-color: rgba(255, 255, 255, 0.14);
-    background: linear-gradient(180deg, rgba(27, 33, 46, 0.9), rgba(19, 24, 34, 0.88));
-    color: rgba(244, 246, 255, 0.9);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  .btn,
+  .btn-secondary,
+  .btn-ghost {
+    border-color: rgba(255, 255, 255, 0.16);
+    background: rgba(255, 255, 255, 0.03);
+    color: rgba(241, 245, 249, 0.86);
   }
 
-  .btn:hover {
-    border-color: rgba(255, 255, 255, 0.2);
-    background: linear-gradient(180deg, rgba(31, 38, 52, 0.92), rgba(21, 27, 38, 0.9));
-    transform: translateY(-1px);
+  .btn:hover,
+  .btn-secondary:hover,
+  .btn-ghost:hover {
+    border-color: rgba(255, 255, 255, 0.24);
+    background: rgba(255, 255, 255, 0.055);
   }
 
   .btn-primary {
-    border-color: rgba(182, 104, 242, 0.34);
-    background: linear-gradient(180deg, rgba(122, 54, 150, 0.82), rgba(71, 40, 118, 0.84));
-    color: rgba(249, 241, 255, 0.94);
-    box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.14),
-      0 0 0 1px rgba(205, 123, 255, 0.08),
-      0 12px 34px -24px rgba(205, 123, 255, 0.42);
+    border-color: hsl(var(--accent-h) var(--accent-s) var(--accent-l) / 0.48);
+    background: hsl(var(--accent-h) var(--accent-s) 37%);
+    color: rgb(236 255 252 / 0.95);
   }
 
   .btn-primary:hover {
-    border-color: rgba(209, 132, 255, 0.48);
-    background: linear-gradient(180deg, rgba(132, 60, 165, 0.86), rgba(79, 44, 132, 0.88));
-    box-shadow:
-      inset 0 1px 0 rgba(255, 255, 255, 0.14),
-      0 0 0 1px rgba(208, 133, 255, 0.14),
-      0 0 26px -14px rgba(230, 126, 255, 0.62),
-      0 12px 30px -22px rgba(78, 214, 246, 0.34);
-  }
-
-  .btn-secondary,
-  .btn-ghost {
-    border-color: rgba(255, 255, 255, 0.14);
-    background: rgba(255, 255, 255, 0.03);
-    color: rgba(241, 245, 249, 0.8);
-    box-shadow: none;
-  }
-
-  .btn-secondary:hover,
-  .btn-ghost:hover {
-    border-color: rgba(174, 214, 255, 0.36);
-    background: rgba(255, 255, 255, 0.055);
-    box-shadow:
-      0 0 18px -14px rgba(112, 223, 255, 0.42),
-      0 0 22px -16px rgba(224, 122, 255, 0.28);
-    transform: translateY(-1px);
-  }
-
-  .btn:active,
-  .btn-primary:active,
-  .btn-secondary:active,
-  .btn-ghost:active {
-    transform: translateY(0);
+    border-color: hsl(var(--accent-h) var(--accent-s) var(--accent-l) / 0.62);
+    background: hsl(var(--accent-h) var(--accent-s) 41%);
   }
 
   .effect-pill-active {
-    background: hsl(var(--amber-h) var(--amber-s) var(--amber-l) / 0.15);
-    border-color: hsl(var(--amber-h) var(--amber-s) var(--amber-l) / 0.45);
-    color: hsl(38 92% 80%);
-    box-shadow: 0 0 12px -4px hsl(38 92% 58% / 0.3);
-  }
-
-  .hero-focus-glow {
-    isolation: isolate;
+    background: hsl(var(--accent-h) var(--accent-s) var(--accent-l) / 0.14);
+    border-color: hsl(var(--accent-h) var(--accent-s) var(--accent-l) / 0.4);
+    color: hsl(var(--accent-h) 72% 86%);
+    box-shadow: none;
   }
 
   .hero-focus-glow::before {
-    content: '';
-    position: absolute;
-    inset: clamp(8%, 14vw, 20%) clamp(8%, 12vw, 16%) auto;
-    height: clamp(220px, 44vw, 420px);
-    border-radius: 999px;
-    z-index: -1;
-    pointer-events: none;
-    background:
-      radial-gradient(60% 48% at 50% 44%, rgba(235, 86, 204, 0.22) 0%, rgba(235, 86, 204, 0.08) 40%, rgba(235, 86, 204, 0) 72%),
-      radial-gradient(56% 52% at 57% 46%, rgba(146, 96, 255, 0.24) 0%, rgba(146, 96, 255, 0.1) 40%, rgba(146, 96, 255, 0) 76%),
-      radial-gradient(42% 36% at 43% 56%, rgba(86, 222, 248, 0.14) 0%, rgba(86, 222, 248, 0.06) 34%, rgba(86, 222, 248, 0) 74%);
-    filter: blur(40px) saturate(110%);
-    opacity: 0.74;
+    content: none;
   }
 }
 
@@ -315,39 +228,4 @@ a:hover {
 
 .no-scrollbar::-webkit-scrollbar {
   display: none;
-}
-
-.melt-layer {
-  position: fixed;
-  inset: 0;
-  z-index: -1;
-  pointer-events: none;
-  contain: layout style size;
-}
-
-.ambient-cursor {
-  transition:
-    opacity 500ms ease-out,
-    filter 500ms ease-out;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .ambient-cursor {
-    display: none;
-  }
-}
-
-::-webkit-scrollbar { width: 6px; }
-::-webkit-scrollbar-track { background: hsl(var(--bg)); }
-::-webkit-scrollbar-thumb {
-  background: hsl(var(--amber-h) var(--amber-s) var(--amber-l) / 0.35);
-  border-radius: 999px;
-}
-::-webkit-scrollbar-thumb:hover {
-  background: hsl(var(--amber-h) var(--amber-s) var(--amber-l) / 0.55);
-}
-
-::selection {
-  background: hsl(166 70% 52% / 0.25);
-  color: hsl(166 80% 90%);
 }

--- a/src/pages/CompoundDetail.tsx
+++ b/src/pages/CompoundDetail.tsx
@@ -569,7 +569,7 @@ export default function CompoundDetail() {
             {primaryEffects.map(effect => (
               <span
                 key={effect}
-                className='rounded-full border border-violet-300/35 bg-violet-500/10 px-2.5 py-1 text-xs text-violet-100'
+                className='rounded-full border border-cyan-300/30 bg-cyan-500/10 px-2.5 py-1 text-xs text-cyan-100'
               >
                 {effect}
               </span>
@@ -647,17 +647,9 @@ export default function CompoundDetail() {
                     <h3 className='mb-2 text-xs font-semibold uppercase tracking-[0.14em] text-white/55'>
                       Contraindications
                     </h3>
-                    <ul className='space-y-2'>
+                    <ul className='list-disc space-y-1 pl-5'>
                       {compoundContraindications.map(item => (
-                        <li
-                          key={item}
-                          className='rounded-xl border border-rose-400/40 bg-rose-500/10 px-3 py-2 text-rose-100'
-                        >
-                          <span aria-hidden='true' className='mr-1'>
-                            ⚠
-                          </span>
-                          {item}
-                        </li>
+                        <li key={item}>{item}</li>
                       ))}
                     </ul>
                   </div>

--- a/src/pages/Compounds.tsx
+++ b/src/pages/Compounds.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useState } from 'react'
-import { AlertTriangle } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import Meta from '@/components/Meta'
 import ActiveFiltersBar from '@/components/filters/ActiveFiltersBar'
@@ -105,14 +104,14 @@ export default function CompoundsPage() {
         path='/compounds'
       />
 
-      <header className='ds-card-lg mb-10'>
+      <header className='ds-card-lg mb-8'>
         <h1 className='text-3xl font-semibold sm:text-4xl'>Compounds</h1>
         <p className='mt-2 max-w-3xl text-sm text-white/76 sm:text-base'>
           Search compounds by mechanism and effects, then filter by confidence and category.
         </p>
       </header>
 
-      <section className='mb-9 space-y-3'>
+      <section className='mb-8 space-y-2.5'>
         <SearchBar
           value={filters.query}
           onChange={value => {
@@ -235,14 +234,14 @@ export default function CompoundsPage() {
         />
       </section>
 
-      <p className='mb-5 text-xs text-white/60 sm:text-sm'>{filtered.length} results</p>
+      <p className='mb-4 text-xs text-white/60 sm:text-sm'>{filtered.length} results</p>
 
       {filtered.length === 0 ? (
         <div className='rounded-2xl border border-white/10 bg-white/[0.03] p-6 text-center text-white/80'>
           No compounds match your current filters.
         </div>
       ) : (
-        <section className='grid gap-3 sm:grid-cols-2 sm:gap-4 lg:grid-cols-3'>
+        <section className='grid gap-2.5 sm:grid-cols-2 sm:gap-3 lg:grid-cols-3'>
           {visibleCompounds.map(compound => {
             const confidence =
               compound.confidence ??
@@ -270,11 +269,11 @@ export default function CompoundsPage() {
             ].slice(0, 2)
 
             return (
-              <article key={compound.id} className='ds-card flex h-full flex-col gap-1.5 p-2.5 sm:p-3'>
+              <article key={compound.id} className='ds-card flex h-full flex-col gap-2 p-3'>
                 <div className='flex items-start justify-between gap-2'>
                   <h2
                     title={compound.name}
-                    className='line-clamp-2 min-h-[2.2rem] break-all text-[0.96rem] font-semibold leading-tight sm:text-base'
+                    className='line-clamp-2 min-h-[2.2rem] break-all text-[0.95rem] font-semibold leading-tight text-white sm:text-base'
                   >
                     {title}
                   </h2>
@@ -284,40 +283,28 @@ export default function CompoundsPage() {
                     {confidence}
                   </span>
                 </div>
-                <p className='text-white/76 line-clamp-2 text-xs sm:text-sm'>{summarize(compound)}</p>
+                <p className='line-clamp-2 text-xs leading-[1.35] text-white/72'>{summarize(compound)}</p>
                 {chips.length > 0 && (
                   <div className='flex flex-wrap gap-1'>
                     {chips.map(chip => (
                       <span
                         key={`${compound.id}-${chip.label}`}
-                        className={`rounded-full border px-1.5 py-0 text-[10px] ${
-                          chip.tone === 'warning'
-                            ? 'bg-amber-500/8 border-amber-300/25 text-amber-100/85'
-                            : chip.tone === 'evidence'
-                              ? 'border-cyan-300/35 bg-cyan-500/15 text-cyan-100'
-                              : 'border-violet-300/35 bg-violet-500/15 text-violet-100'
-                        }`}
+                        className='ds-pill'
                       >
                         {chip.label}
                       </span>
                     ))}
                   </div>
                 )}
-                <div className='flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px]'>
-                  {confidence === 'low' && (
-                    <span className='inline-flex items-center gap-1 rounded-full border border-amber-300/20 bg-amber-400/[0.04] px-1.5 py-0 text-amber-100/65'>
-                      <AlertTriangle className='h-3 w-3' aria-hidden='true' />
-                      Limited data
-                    </span>
-                  )}
-                  <p className='text-white/58'>
+                <div className='text-[11px] text-white/56'>
+                  <p>
                     {compound.herbs.length} {compound.herbs.length === 1 ? 'herb' : 'herbs'}{' '}
                     associated
                   </p>
                 </div>
                 <Link
                   to={`/compounds/${compound.slug}`}
-                  className='mt-auto inline-flex w-fit items-center rounded-md border border-white/20 bg-white/[0.05] px-2 py-1 text-[11px] font-medium text-white/80 transition hover:border-white/35 hover:bg-white/[0.1]'
+                  className='mt-auto inline-flex w-fit items-center rounded-md border border-white/15 bg-white/[0.03] px-2 py-1 text-[11px] font-medium text-white/80 transition hover:border-cyan-300/45 hover:text-white'
                 >
                   View details
                 </Link>

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -662,7 +662,7 @@ export default function HerbDetail() {
         </Link>
         <button
           type='button'
-          className='inline-flex rounded-full border border-white/20 px-3 py-1 text-sm text-white/85 transition hover:border-white/35 hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-300'
+          className='inline-flex rounded-full border border-white/20 px-3 py-1 text-sm text-white/85 transition hover:border-white/35 hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-300'
           onClick={() =>
             toggle({
               type: 'herb',
@@ -694,7 +694,7 @@ export default function HerbDetail() {
               {primaryEffects.map(effect => (
                 <span
                   key={effect}
-                  className='rounded-full border border-violet-300/35 bg-violet-500/10 px-2.5 py-1 text-xs text-violet-100'
+                  className='rounded-full border border-cyan-300/30 bg-cyan-500/10 px-2.5 py-1 text-xs text-cyan-100'
                 >
                   {effect}
                 </span>
@@ -748,13 +748,9 @@ export default function HerbDetail() {
         )}
 
         {isDataIncomplete && (
-          <div className='bg-amber-500/8 mt-4 rounded-xl border border-amber-300/30 p-3 text-sm text-amber-100'>
-            <p className='font-semibold'>Incomplete profile</p>
-            <p className='mt-1 text-amber-50/80'>
-              Key evidence fields are missing. Treat this as a draft — cross-check before making
-              decisions.
-            </p>
-          </div>
+          <p className='mt-3 text-xs text-white/58'>
+            Note: key evidence fields are still being completed for this profile.
+          </p>
         )}
 
         {/* Confidence explanations are now hidden by default to reduce initial clutter. */}
@@ -993,12 +989,7 @@ export default function HerbDetail() {
           </Section>
         )}
 
-        {qualityConcerns && (
-          <div className='mt-4 rounded-xl border border-amber-300/35 bg-amber-500/12 p-3 text-sm text-amber-100'>
-            <p className='font-semibold'>⚠ Quality concerns</p>
-            <p className='mt-1 text-amber-50/90'>{qualityConcerns}</p>
-          </div>
-        )}
+        {qualityConcerns && <Section title='Quality concerns'>{qualityConcerns}</Section>}
 
         <PremiumDataSection details={premiumDetails} />
 

--- a/src/pages/Herbs.tsx
+++ b/src/pages/Herbs.tsx
@@ -96,17 +96,17 @@ export default function HerbsPage() {
         path='/herbs'
       />
 
-      <header className='ds-card-lg mb-10'>
+      <header className='ds-card-lg mb-8'>
         <h1 className='text-3xl font-semibold sm:text-4xl'>Herb Knowledge Database</h1>
         <p className='mt-2 max-w-3xl text-sm text-white/76 sm:text-base'>
           Search and filter herbs by effect tags, confidence, and class to quickly compare entries.
         </p>
       </header>
 
-      <section className='mb-10 rounded-2xl border border-violet-300/20 bg-violet-500/8 p-3.5 sm:p-4'>
+      <section className='mb-8 rounded-xl border border-white/10 bg-white/[0.02] p-3'>
         <div className='flex flex-wrap items-center justify-between gap-3'>
           <div>
-            <h2 className='text-lg font-semibold text-violet-100'>Effect Explorer</h2>
+            <h2 className='text-lg font-semibold text-white'>Effect Explorer</h2>
             <p className='text-sm text-white/75'>
               Open on demand for ranked matches by outcome (sleep, focus, relaxation).
             </p>
@@ -123,7 +123,7 @@ export default function HerbsPage() {
         {showEffectExplorer && <EffectExplorer herbs={decoratedHerbs} />}
       </section>
 
-      <section className='mb-9 space-y-3'>
+      <section className='mb-8 space-y-2.5'>
         <SearchBar
           value={filters.query}
           onChange={value => {
@@ -246,7 +246,7 @@ export default function HerbsPage() {
         />
       </section>
 
-      <p className='mb-5 text-xs text-white/60 sm:text-sm'>
+      <p className='mb-4 text-xs text-white/60 sm:text-sm'>
         {filtered.length} results · {effectIndex.size} indexed effects
       </p>
 
@@ -255,7 +255,7 @@ export default function HerbsPage() {
           No herbs match your current filters.
         </div>
       ) : (
-        <section className='grid gap-3 sm:grid-cols-2 sm:gap-4 lg:grid-cols-3'>
+        <section className='grid gap-2.5 sm:grid-cols-2 sm:gap-3 lg:grid-cols-3'>
           {visibleHerbs.map((herb, index) => (
             <HerbCard
               key={herb.slug || herb.id || `${herb.common}-${index}`}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -89,7 +89,7 @@ export default function Home() {
 
       <Hero />
 
-      <section className='container mx-auto max-w-4xl px-4 pt-8 sm:px-6 sm:pt-12'>
+      <section className='container mx-auto max-w-4xl px-4 pt-6 sm:px-6 sm:pt-8'>
         <div className='grid gap-8 sm:grid-cols-2 sm:gap-10'>
           <div className='h-full space-y-2'>
             <p className='label-specimen'>
@@ -139,7 +139,7 @@ export default function Home() {
       <EffectExplorer herbs={homepageData.effectExplorerHerbs} />
 
       <section className='ds-section container mx-auto max-w-4xl px-4 sm:px-6'>
-        <div className='ds-card-lg border-amber-300/30 bg-amber-500/10'>
+        <div className='ds-card-lg'>
           <p className='text-xs font-semibold uppercase tracking-[0.24em] text-amber-100/80'>
             Trust & safety
           </p>
@@ -182,7 +182,7 @@ export default function Home() {
                 <a
                   key={effect}
                   href='#effect-search'
-                  className='rounded-full border border-violet-300/40 bg-violet-500/10 px-3 py-1.5 text-xs font-medium capitalize text-violet-100 transition hover:border-violet-200/60 hover:bg-violet-500/15'
+                  className='rounded-full border border-white/12 bg-white/[0.02] px-3 py-1 text-xs font-medium capitalize text-white/80 transition hover:border-cyan-300/35 hover:text-white'
                 >
                   {effect}
                 </a>

--- a/src/styles/galaxy.css
+++ b/src/styles/galaxy.css
@@ -4,119 +4,23 @@
   z-index: 0;
   pointer-events: none;
   overflow: hidden;
-  background: #030409;
+  background: #05070a;
 }
 
 .cosmic-layer {
   position: absolute;
   inset: 0;
-  will-change: transform, opacity;
 }
 
 .cosmic-base {
-  background:
-    radial-gradient(120% 80% at 50% -20%, rgba(24, 18, 44, 0.24) 0%, rgba(8, 10, 20, 0.08) 46%, rgba(4, 6, 14, 0) 78%),
-    radial-gradient(108% 86% at 8% 74%, rgba(10, 30, 52, 0.14) 0%, rgba(6, 12, 24, 0.04) 54%, rgba(3, 7, 15, 0) 78%),
-    radial-gradient(96% 76% at 92% 16%, rgba(54, 18, 70, 0.12) 0%, rgba(18, 10, 28, 0.02) 52%, rgba(6, 6, 14, 0) 82%),
-    linear-gradient(164deg, rgba(2, 4, 10, 0.995) 0%, rgba(3, 5, 12, 0.99) 48%, rgba(2, 3, 8, 0.995) 100%),
-    #030409;
+  background: #05070a;
 }
 
-.cosmic-aurora {
-  inset: -16%;
-  filter: blur(124px) saturate(106%);
-  mix-blend-mode: screen;
-}
-
-.cosmic-aurora--one {
-  opacity: 0.19;
-  background:
-    radial-gradient(46% 34% at 62% 28%, rgba(198, 98, 255, 0.24) 0%, rgba(104, 56, 178, 0.16) 42%, rgba(9, 8, 24, 0) 80%),
-    radial-gradient(34% 30% at 28% 62%, rgba(48, 198, 236, 0.14) 0%, rgba(12, 34, 50, 0) 84%);
-}
-
-.cosmic-aurora--two {
-  opacity: 0.16;
-  background:
-    radial-gradient(40% 30% at 74% 70%, rgba(58, 212, 244, 0.16) 0%, rgba(20, 88, 116, 0.11) 42%, rgba(6, 20, 34, 0) 82%),
-    radial-gradient(44% 30% at 18% 30%, rgba(244, 94, 198, 0.16) 0%, rgba(96, 40, 128, 0.11) 42%, rgba(8, 10, 26, 0) 86%);
-}
-
+.cosmic-aurora,
 .cosmic-glow {
-  inset: -10%;
-  opacity: 0.15;
-  filter: blur(88px);
-  mix-blend-mode: soft-light;
-  background:
-    radial-gradient(38% 28% at 72% 30%, rgba(196, 82, 224, 0.14) 0%, rgba(42, 20, 70, 0) 88%),
-    radial-gradient(40% 34% at 34% 78%, rgba(62, 192, 224, 0.12) 0%, rgba(14, 30, 48, 0) 86%);
+  display: none;
 }
 
 .cosmic-vignette {
-  background:
-    linear-gradient(108deg, rgba(2, 3, 8, 0.82) 0%, rgba(2, 5, 12, 0.5) 30%, rgba(4, 8, 16, 0.32) 54%, rgba(3, 6, 14, 0.62) 100%),
-    radial-gradient(132% 102% at 50% 46%, rgba(2, 7, 16, 0) 48%, rgba(1, 3, 9, 0.88) 100%);
-}
-
-.cosmic-background.is-animated .cosmic-aurora--one {
-  animation: ambient-drift-a 78s ease-in-out infinite alternate;
-}
-
-.cosmic-background.is-animated .cosmic-aurora--two {
-  animation: ambient-drift-b 92s ease-in-out infinite alternate;
-}
-
-.cosmic-background.is-animated .cosmic-glow {
-  animation: ambient-breathe 68s ease-in-out infinite;
-}
-
-@keyframes ambient-drift-a {
-  0% {
-    transform: translate3d(-2%, 1.2%, 0) scale(1.02);
-    opacity: 0.22;
-  }
-  100% {
-    transform: translate3d(2.4%, -1.8%, 0) scale(1.08);
-    opacity: 0.3;
-  }
-}
-
-@keyframes ambient-drift-b {
-  0% {
-    transform: translate3d(1.6%, -1.4%, 0) scale(1.01);
-    opacity: 0.19;
-  }
-  100% {
-    transform: translate3d(-2.2%, 1.9%, 0) scale(1.06);
-    opacity: 0.26;
-  }
-}
-
-@keyframes ambient-breathe {
-  0%,
-  100% {
-    opacity: 0.17;
-    transform: scale(1.01);
-  }
-  50% {
-    opacity: 0.24;
-    transform: scale(1.05);
-  }
-}
-
-@media (max-width: 768px) {
-  .cosmic-aurora {
-    filter: blur(94px) saturate(104%);
-  }
-
-  .cosmic-glow {
-    opacity: 0.19;
-    filter: blur(68px);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .cosmic-background.is-animated .cosmic-layer {
-    animation: none;
-  }
+  background: radial-gradient(110% 90% at 50% 48%, rgba(5, 7, 10, 0) 58%, rgba(2, 4, 8, 0.64) 100%);
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -5,134 +5,30 @@
   --font-display: 'DM Serif Display', Georgia, serif;
   --font-body: 'Instrument Sans', system-ui, sans-serif;
   --font-mono: 'DM Mono', 'Fira Code', monospace;
-  --radius: 1rem;
-  --space-unit: 0.25rem;
+  --radius: 0.75rem;
 
-  --accent-h: 166;
-  --accent-s: 70%;
-  --accent-l: 52%;
+  --accent-h: 186;
+  --accent-s: 62%;
+  --accent-l: 50%;
   --accent: hsl(var(--accent-h) var(--accent-s) var(--accent-l));
-  --accent-rgb: 35 212 177;
 
-  /* glass tokens (tuned for readability on Melt) */
-  --glass-bg: rgba(20, 24, 28, 0.55);
-  --glass-elev: rgba(20, 24, 28, 0.62);
-  --glass-border: rgba(255, 255, 255, 0.16);
-  --glass-shadow: 0 6px 24px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+  --bg: 220 25% 4%;
+  --surface: 215 22% 8%;
+  --card: 215 20% 11%;
+  --text: 210 22% 96%;
+  --fg: 210 22% 96%;
+  --mute: 210 10% 64%;
+  --muted: 210 10% 64%;
+  --border: 215 18% 22%;
+  --ring: 186 62% 50%;
 
+  --bg-c: hsl(var(--bg));
+  --surface-c: hsl(var(--surface));
+  --card-c: hsl(var(--card));
+  --text-c: hsl(var(--text));
+  --muted-c: hsl(var(--muted));
+  --border-c: hsl(var(--border));
   --header-h: 60px;
-  /* hero vertical padding */
-  --space-hero-y: clamp(1.25rem, 5vw, 3.5rem);
-  --space-hero-gap: clamp(0.5rem, 2vw, 1.25rem);
-
-  --amber-h: 38;
-  --amber-s: 92%;
-  --amber-l: 58%;
-  --amber: hsl(var(--amber-h) var(--amber-s) var(--amber-l));
-
-  --bg: 28 8% 7%;
-  --surface: 30 7% 10%;
-  --card: 30 7% 12%;
-  --text: 210 10% 96%;
-  --fg: 210 10% 96%;
-  --mute: 35 10% 60%;
-  --muted: 35 10% 60%;
-  --border: 30 8% 20%;
-  --ring: 166 70% 52%;
-
-  --bg-c: hsl(var(--bg));
-  --surface-c: hsla(220, 18%, 20%, 0.68);
-  --card-c: hsla(220, 18%, 22%, 0.78);
-  --text-c: hsl(var(--text));
-  --muted-c: hsla(210, 6%, 72%, 0.85);
-  --border-c: hsla(220, 16%, 28%, 0.55);
-}
-
-[data-theme='light'] {
-  color-scheme: light;
-  --bg: 210 40% 98%;
-  --surface: 210 30% 96%;
-  --card: 210 25% 95%;
-  --text: 220 20% 18%;
-  --fg: 220 20% 18%;
-  --mute: 215 16% 48%;
-  --muted: 215 16% 48%;
-  --border: 210 25% 82%;
-  --ring: 166 55% 48%;
-
-  --bg-c: hsl(var(--bg));
-  --surface-c: hsla(210, 32%, 92%, 0.85);
-  --card-c: hsla(210, 30%, 90%, 0.9);
-  --text-c: hsl(var(--text));
-  --muted-c: hsla(215, 16%, 40%, 0.7);
-  --border-c: hsla(210, 25%, 78%, 0.8);
-  --accent-rgb: 35 212 177;
-}
-
-/* alternate accents (optional) */
-[data-accent='blue'] {
-  --accent-h: 200;
-  --accent-s: 85%;
-  --accent-l: 65%;
-}
-[data-accent='lime'] {
-  --accent-h: 95;
-  --accent-s: 80%;
-  --accent-l: 60%;
-}
-[data-accent='pink'] {
-  --accent-h: 320;
-  --accent-s: 78%;
-  --accent-l: 62%;
-}
-
-/* base */
-:root,
-[data-theme] {
-  transition:
-    background-color 0.6s ease,
-    color 0.4s ease,
-    border-color 0.4s ease;
-}
-
-.header--sticky {
-  transition:
-    backdrop-filter 0.2s ease,
-    background-color 0.2s ease;
-}
-
-.header--compact {
-  backdrop-filter: saturate(1.2) blur(8px);
-  background: rgba(10, 12, 16, 0.55);
-}
-
-.glass {
-  background: var(--glass-bg);
-  backdrop-filter: blur(24px);
-  border: 1px solid var(--glass-border);
-  box-shadow: var(--glass-shadow);
-}
-
-.glass-elev {
-  background: var(--glass-elev);
-  backdrop-filter: blur(24px);
-  border: 1px solid var(--glass-border);
-  box-shadow: var(--glass-shadow);
-  border-radius: 1.25rem;
-}
-
-.glass-soft {
-  background: var(--glass-bg);
-  backdrop-filter: blur(18px);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 1rem;
-}
-
-@media (max-width: 480px) {
-  :root {
-    --glass-bg: rgba(20, 24, 28, 0.6);
-    --glass-elev: rgba(20, 24, 28, 0.68);
-  }
 }
 
 html,
@@ -143,13 +39,9 @@ body {
 body {
   font-family: var(--font-body);
   color: hsl(var(--text));
-  line-height: 1.62;
-  letter-spacing: 0.005em;
+  line-height: 1.58;
+  letter-spacing: 0.002em;
   font-size: 15px;
-  scroll-behavior: smooth;
-  transition:
-    background-color 0.6s ease,
-    color 0.4s ease;
 }
 
 main {
@@ -158,22 +50,11 @@ main {
   max-width: 1600px;
 }
 
-.focus-visible\:ring-accent\/60:focus-visible {
-  box-shadow: 0 0 0 2px hsl(var(--accent-h) var(--accent-s) var(--accent-l) / 0.6);
-}
-
-/* keep animations subtle for motion-sensitive users */
-@media (prefers-reduced-motion: reduce) {
-  .logo-glow {
-    filter: none;
-  }
-}
-
 h1,
 h2 {
   font-family: var(--font-display);
   letter-spacing: -0.01em;
-  line-height: 1.2;
+  line-height: 1.08;
   font-weight: 400;
   color: var(--text-c);
 }
@@ -184,258 +65,31 @@ h5,
 h6 {
   font-family: var(--font-body);
   letter-spacing: -0.01em;
-  line-height: 1.2;
+  line-height: 1.25;
   font-weight: 600;
   color: var(--text-c);
 }
 
 h1 {
-  font-size: clamp(1.85rem, 1.35rem + 1.35vw, 2.45rem);
+  font-size: clamp(1.95rem, 1.45rem + 1.5vw, 3.1rem);
 }
+
 h2 {
-  font-size: clamp(1.45rem, 1.1rem + 0.9vw, 2rem);
+  font-size: clamp(1.35rem, 1.05rem + 0.9vw, 2rem);
 }
+
 h3 {
-  font-size: 1.2rem;
+  font-size: 1.05rem;
 }
 
 .label-specimen {
   font-family: var(--font-mono);
   font-size: 0.65rem;
-  letter-spacing: 0.22em;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
-  opacity: 0.55;
+  opacity: 0.6;
 }
 
 * {
-  border-color: color-mix(in oklab, var(--border-c) 70%, transparent 30%);
-}
-
-/* aurora background */
-.app-aurora {
-  position: fixed;
-  inset: 0;
-  height: 100%;
-  z-index: -1;
-  pointer-events: none;
-  background:
-    radial-gradient(70% 60% at 25% 30%, hsl(166 85% 40% / 0.12), transparent 70%),
-    radial-gradient(60% 40% at 80% 25%, hsl(38 90% 55% / 0.09), transparent 70%),
-    radial-gradient(50% 50% at 60% 75%, hsl(130 65% 45% / 0.08), transparent 70%);
-  animation: aurora-move 40s ease-in-out infinite alternate;
-  background-attachment: fixed;
-  filter: blur(45px) saturate(115%);
-}
-
-@keyframes aurora-move {
-  0% {
-    background-position:
-      0% 0%,
-      0% 0%,
-      0% 0%;
-  }
-  50% {
-    background-position:
-      10% 5%,
-      -5% 10%,
-      5% -10%;
-  }
-  100% {
-    background-position:
-      -10% -5%,
-      5% -10%,
-      -5% 10%;
-  }
-}
-
-.aurora-bg {
-  background:
-    radial-gradient(80vh 60vh at 20% 15%, rgba(120, 180, 255, 0.18), transparent 70%),
-    radial-gradient(70vh 56vh at 75% 25%, rgba(255, 120, 220, 0.14), transparent 65%),
-    radial-gradient(90vh 70vh at 50% 80%, rgba(0, 200, 160, 0.14), transparent 60%),
-    linear-gradient(rgba(5, 8, 15, 0.82), rgba(7, 10, 19, 0.82));
-  animation: floatGlow 18s ease-in-out infinite alternate;
-  filter: blur(0.25px) saturate(1.06);
-}
-
-@keyframes floatGlow {
-  0% {
-    transform: translateY(0px) scale(1);
-    opacity: 0.95;
-  }
-  50% {
-    transform: translateY(-10px) scale(1.03);
-    opacity: 1;
-  }
-  100% {
-    transform: translateY(0px) scale(1);
-    opacity: 0.95;
-  }
-}
-
-/* components */
-.container {
-  max-width: 1100px;
-  margin-inline: auto;
-  padding-inline: 1rem;
-}
-.mix-blend-overlay {
-  mix-blend-mode: overlay;
-}
-.grid {
-  display: grid;
-}
-@media (min-width: 640px) {
-  .sm\:grid-cols-2 {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-@media (min-width: 1024px) {
-  .lg\:grid-cols-3 {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-.card {
-  background: color-mix(in oklab, var(--card-c) 90%, black 10%);
-  border: 1px solid color-mix(in oklab, var(--border-c) 70%, transparent 30%);
-  border-radius: var(--radius);
-  box-shadow:
-    0 0 0 1px rgba(255, 255, 255, 0.03),
-    0 12px 40px -8px rgba(0, 0, 0, 0.45);
-  transition:
-    transform 0.25s cubic-bezier(0.25, 0.8, 0.25, 1),
-    box-shadow 0.25s;
-}
-.card:hover {
-  transform: translateY(-3px);
-  box-shadow:
-    0 0 0 1px hsl(var(--amb-h, 200) 80% 60% / 0.25),
-    0 18px 48px -8px rgba(0, 0, 0, 0.55),
-    0 0 56px -18px hsl(var(--amb-h, 200) 90% 60% / 0.35);
-}
-.btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.55rem 0.9rem;
-  border-radius: 0.75rem;
-  border: 1px solid color-mix(in oklab, var(--border-c) 70%, transparent 30%);
-  background: color-mix(in oklab, var(--surface-c) 92%, black 8%);
-  color: var(--text-c);
-  transition:
-    transform 0.2s cubic-bezier(0.25, 0.8, 0.25, 1),
-    box-shadow 0.25s,
-    border-color 0.2s ease;
-}
-.btn:hover {
-  transform: translateY(-2px);
-  border-color: color-mix(in oklab, var(--accent), white 35%);
-  box-shadow:
-    0 10px 30px -10px rgba(0, 0, 0, 0.55),
-    0 0 18px -12px var(--accent);
-}
-.btn:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 3px;
-  box-shadow: 0 0 0 3px hsl(var(--accent-h) var(--accent-s) var(--accent-l) / 0.3);
-}
-.btn.primary {
-  background: var(--accent);
-  color: #03100f;
-  border-color: transparent;
-  box-shadow: 0 6px 18px -8px hsl(var(--accent-h) var(--accent-s) var(--accent-l) / 0.55);
-}
-.input {
-  width: 100%;
-  background: color-mix(in oklab, var(--surface-c) 88%, black 12%);
-  border: 1px solid color-mix(in oklab, var(--border-c) 65%, transparent 35%);
-  color: var(--text-c);
-  padding: 0.65rem 0.85rem;
-  border-radius: 0.9rem;
-  transition:
-    box-shadow 0.25s ease,
-    border-color 0.25s ease,
-    background 0.25s ease;
-}
-.input:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 3px;
-  box-shadow: 0 0 0 3px hsl(var(--accent-h) var(--accent-s) var(--accent-l) / 0.25);
-}
-.gradient-text {
-  background: linear-gradient(
-    90deg,
-    hsl(var(--accent-h) var(--accent-s) calc(var(--accent-l) + 5%)),
-    hsl(calc(var(--accent-h) + 30) var(--accent-s) calc(var(--accent-l) + 10%))
-  );
-  -webkit-background-clip: text;
-  color: transparent;
-  filter: drop-shadow(
-    0 0 6px hsl(var(--accent-h) var(--accent-s) calc(var(--accent-l) + 10%) / 0.4)
-  );
-}
-
-.gradient-text-animated {
-  background: linear-gradient(100deg, #7ef9ff, #89cff0, #a066ff, #7ef9ff);
-  background-size: 320% 320%;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  color: transparent;
-  animation: hueShift 12s ease-in-out infinite;
-  filter: drop-shadow(0 0 12px rgba(120, 200, 255, 0.35));
-}
-
-@keyframes hueShift {
-  0%,
-  100% {
-    background-position: 0% 50%;
-  }
-  50% {
-    background-position: 100% 50%;
-  }
-}
-
-.hover-glow:hover {
-  box-shadow: 0 0 12px -3px hsl(var(--accent-h) var(--accent-s) var(--accent-l) / 0.6);
-}
-
-.focus-glow:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 3px;
-  box-shadow: 0 0 0 3px hsl(var(--accent-h) var(--accent-s) var(--accent-l) / 0.3);
-}
-
-section {
-  padding-block: 2rem;
-}
-
-.site-header {
-  min-height: 64px;
-}
-
-footer {
-  padding-block: 3rem;
-}
-
-@media (max-width: 640px) {
-  .hero,
-  .aurora-bg {
-    min-height: 75vh;
-  }
-}
-
-/* motion safety */
-@media (prefers-reduced-motion: reduce) {
-  * {
-    transition: none;
-    animation: none;
-  }
-}
-
-.no-scrollbar::-webkit-scrollbar {
-  display: none;
-}
-.no-scrollbar {
-  -ms-overflow-style: none;
-  scrollbar-width: none;
+  border-color: color-mix(in oklab, var(--border-c) 78%, transparent 22%);
 }


### PR DESCRIPTION
### Motivation
- Replace the current flashy/aurora aesthetic with a calm, premium dark-minimal baseline to improve clarity and trust.  
- Enforce a single restrained cyan accent and a tighter hierarchy so pages answer “what is this”, “what matters”, and “what to do next” in under two seconds.  
- Reduce vertical bloat and duplicated warning surfaces across cards and detail pages to make entities scannable and information-dense without losing safety signals.

### Description
- Implemented a unified dark-minimal design system and single accent token adjustments (theme and index CSS), and removed glow/aurora decorations (CSS + background component).  
- Rebuilt the Hero and CTA cluster for tighter typography, one emphasized keyword, shorter subtext, and clearer CTAs.  
- Standardized and compacted card layouts for herbs and compounds to follow: Title → 2-line summary → compact metadata/chips (max 2) → small CTA.  
- Simplified explorer/search controls and active-filter chips for denser, more consistent filtering and reduced chip clutter.

Files changed:
- `src/index.css`, `src/styles/theme.css`, `src/styles/galaxy.css`
- `src/components/CosmicBackground.tsx`, `src/components/Hero.tsx`, `src/components/HeroCTA.tsx`
- `src/components/HerbCard.tsx`, `src/components/CompoundCard.tsx`
- `src/components/filters/SearchBar.tsx`, `src/components/filters/EffectFilter.tsx`, `src/components/filters/ActiveFiltersBar.tsx`
- `src/pages/Home.tsx`, `src/pages/Herbs.tsx`, `src/pages/Compounds.tsx`, `src/pages/HerbDetail.tsx`, `src/pages/CompoundDetail.tsx`

What was removed or simplified:
- Aurora/glow layers and animated cosmic effects were disabled and vignette reduced to a subtle background only.  
- Tilt/ambient card glow and tilt motion removed from the hero and card surfaces where present.  
- Heavy, repeated warning blocks on detail pages were converted to concise notes or standardized sections.

### Testing
- Ran `npm run build` which initially failed because the repository `prebuild` scripts update workbook-derived data in this environment; data regeneration was not desired and those generated data files were discarded.  
- Ran `npm run build:compile` (Vite production compile) which completed successfully and produced the site build artifacts.  
- Pre-commit tasks and linting executed as part of commit hooks and passed for the staged TypeScript changes.  

Verification results: `npm run build:compile` ✅; `npm run build` (full prebuild pipeline) intentionally avoided as it mutates workbook data in this environment and thus was not used to validate UI-only changes.  

Risks / follow-ups:  
- Some governed CTA/trust micro-components still use legacy tones (emerald/amber); a follow-up pass should fully collapse micro-variants to the single accent token for absolute palette consistency.  
- This PR intentionally avoids changing routing, back-end logic, or data pipelines; if downstream pages need further collapse of low-priority detail modules, that should be handled in a separate incremental pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc6485ae7483239f8673c4fa2e1e82)