### PR TITLE
Fix herb detail duplicate render, normalize safety notes, clean index cards and nav

### DIFF
--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,4 +1,4 @@
-// Simplified primary navigation to core destinations with a toggled search icon and mobile hamburger menu.
+// UPDATED: Streamlined dark-mode primary nav to home, herbs, compounds, blog, and search toggle.
 import { type FormEvent, useEffect, useState } from 'react'
 import { Menu, Search, X } from 'lucide-react'
 import { Link, NavLink, useLocation, useNavigate } from 'react-router-dom'
@@ -46,7 +46,7 @@ export default function NavBar() {
               Compounds
             </NavLink>
             <NavLink to='/blog' className={({ isActive }) => `${linkBase} ${isActive ? linkActive : linkDim}`}>
-              Research Notebook
+              Blog
             </NavLink>
             <button
               type='button'
@@ -102,7 +102,7 @@ export default function NavBar() {
               Compounds
             </NavLink>
             <NavLink to='/blog' className={({ isActive }) => `${linkBase} ${isActive ? linkActive : linkDim} justify-start`}>
-              Research Notebook
+              Blog
             </NavLink>
             {searchOpen && (
               <form onSubmit={handleSearchSubmit}>

--- a/src/lib/herb-data.ts
+++ b/src/lib/herb-data.ts
@@ -1,3 +1,4 @@
+// UPDATED: Added safety note normalization for clean deduplicated herb safety arrays.
 import { useEffect, useState } from 'react'
 import { slugify } from '@/lib/slug'
 import type { Herb } from '@/types'
@@ -229,6 +230,25 @@ function normalizeSources(value: unknown): SourceRef[] {
     .filter((entry): entry is SourceRef => entry !== null)
 }
 
+
+function normalizeSafetyNotes(...values: unknown[]): string[] {
+  const seen = new Set<string>()
+  const notes: string[] = []
+
+  values
+    .flatMap(value => splitClean(value))
+    .map(value => value.replace(/\s+/g, ' ').trim())
+    .filter(value => value.length >= 5)
+    .forEach(value => {
+      const key = value.toLowerCase()
+      if (!key || seen.has(key)) return
+      seen.add(key)
+      notes.push(value)
+    })
+
+  return notes
+}
+
 function normalizeProductRecommendations(value: unknown): ProductRecommendation[] {
   if (!Array.isArray(value)) return []
   return value
@@ -260,6 +280,13 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
   const contraindications = splitClean(data.contraindications)
   const interactions = splitClean(data.interactions)
   const sideeffects = splitClean(data.sideEffects ?? data.sideeffects)
+  const safetyNotes = normalizeSafetyNotes(
+    data.safetyNotes,
+    data.safety,
+    data.contraindications,
+    data.interactions,
+    data.sideEffects ?? data.sideeffects,
+  )
   const rawInteractionTags = splitClean(data.interactionTags)
   const rawInteractionNotes = splitClean(data.interactionNotes)
   const therapeuticUses = splitClean(data.therapeuticUses)
@@ -310,6 +337,7 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
     therapeuticUses,
     contraindications,
     interactions,
+    safetyNotes,
     interactionTags: mergedInteraction.interactionTags,
     interactionNotes: mergedInteraction.interactionNotes,
     dosage,

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -1,217 +1,19 @@
-// Restructured herb detail for single visible render, above-fold clarity, and collapsible progressive disclosure sections.
-import { type ReactNode, useEffect, useState } from 'react'
+// UPDATED: Rebuilt herb detail with sr-only prerender block, placeholder/safety cleanup, and progressive disclosure sections.
+import { useState, type ReactNode } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
 import { Link, useParams } from 'react-router-dom'
 import Meta from '@/components/Meta'
-import InfoTooltip from '@/components/InfoTooltip'
-import DataTrustPanel from '@/components/trust/DataTrustPanel'
-import { countCautionSignals, inferContentFlags } from '@/lib/trust'
-import { useHerbDataState, useHerbDetailState } from '@/lib/herb-data'
 import { useCompoundDataState } from '@/lib/compound-data'
+import { useHerbDataState, useHerbDetailState } from '@/lib/herb-data'
 import { HerbDetailSkeleton } from '@/components/skeletons/DetailSkeletons'
-import { pickNonEmptyKeys } from '@/lib/nonEmptyFields'
-import { extractPrimaryEffects } from '@/utils/extractPrimaryEffects'
-import { getHerbDataCompleteness } from '@/utils/getDataCompleteness'
-import { sanitizeReadableText, splitClean, uniqueNormalizedList } from '@/lib/sanitize'
-import { pushRecentlyViewed, useSavedItems } from '@/lib/growth'
-import {
-  breadcrumbJsonLd,
-  buildGovernedMetaDescription,
-  buildGovernedMetaTitle,
-  faqPageJsonLd,
-  formatMetaDescription,
-  herbJsonLd,
-  SITE_URL,
-} from '@/lib/seo'
-import CuratedProductModule from '@/components/CuratedProductModule'
-import CtaVariantLayout from '@/components/cta/CtaVariantLayout'
-import Collapse from '@/components/ui/Collapse'
-import { SEO_COLLECTIONS } from '@/data/seoCollections'
-import { filterHerbByCollection } from '@/lib/collectionQuality'
-import StructuredDetailIntro from '@/components/detail/StructuredDetailIntro'
-import GovernedResearchSections from '@/components/detail/GovernedResearchSections'
-import GovernedReviewFreshnessPanel from '@/components/detail/GovernedReviewFreshnessPanel'
-import EnrichmentRecommendationBlocks from '@/components/detail/EnrichmentRecommendationBlocks'
-import GovernedQuickCompareBlock from '@/components/detail/GovernedQuickCompareBlock'
-import PremiumDataSection from '@/components/detail/PremiumDataSection'
-import HerbBuyerGuidanceSection from '@/components/detail/HerbBuyerGuidanceSection'
-import HerbProductSection from '@/components/detail/HerbProductSection'
-import { resolveCtaVariant } from '@/config/ctaExperiments'
-import { getRenderableCuratedProducts } from '@/lib/curatedProducts'
-import BreadcrumbTrail from '@/components/navigation/BreadcrumbTrail'
-import { getGovernedResearchEnrichment } from '@/lib/governedResearch'
-import { buildGovernedFaqSectionContent } from '@/lib/governedFaq'
-import { buildGovernedRelatedQuestions } from '@/lib/governedRelatedQuestions'
-import { buildEnrichmentRecommendations } from '@/lib/enrichmentRecommendations'
-import { buildGovernedQuickCompareSection } from '@/lib/governedQuickCompare'
-import { buildFallbackHerbIntro, buildGovernedDetailIntro } from '@/lib/governedIntro'
-import { resolveGovernedCtaDecision } from '@/lib/governedCta'
-import { buildGovernedReviewFreshness } from '@/lib/governedReviewFreshness'
-import { getHerbRecommendation } from '@/lib/herbRecommendations'
-import { getHerbProducts } from '@/lib/herbProducts'
-import {
-  trackDetailBuilderClick,
-  trackCtaSlotImpression,
-  trackDetailCheckerClick,
-  trackDetailRelatedEntityClick,
-} from '@/lib/contentJourneyTracking'
-import { trackGovernedEvent } from '@/lib/governedAnalytics'
-import type { AffiliateUseCaseAnchor } from '@/lib/affiliateClickTracking'
-
-const ISSUE_TEMPLATE_URL =
-  'https://github.com/Razzleberrytt/survive-99-evolved/issues/new?template=evidence-update.yml'
+import { SITE_URL, breadcrumbJsonLd, herbJsonLd } from '@/lib/seo'
 
 type SourceRef = { title: string; url: string; note?: string }
 
-function toSources(value: unknown): SourceRef[] {
-  if (!Array.isArray(value)) return []
-  const unique = new Map<string, SourceRef>()
-  value
-    .map(item => {
-      if (typeof item === 'string') {
-        const t = item.trim()
-        return t ? { title: t, url: t } : null
-      }
-      if (!item || typeof item !== 'object') return null
-      const source = item as Record<string, unknown>
-      const title = String(source.title || source.url || '').trim()
-      const url = String(source.url || '').trim()
-      if (!title && !url) return null
-      const note = String(source.note || '').trim()
-      return { title: title || url, url: url || title, note: note || undefined }
-    })
-    .filter((item): item is SourceRef => Boolean(item))
-    .forEach(item => {
-      const key = `${item.url.trim().toLowerCase()}|${item.title.trim().toLowerCase()}`
-      if (!unique.has(key)) unique.set(key, item)
-    })
-  return Array.from(unique.values())
-}
-
-// Only renders if children is a non-empty string, non-empty array, or explicit ReactNode
-function Section({ title, children }: { title: string; children: ReactNode }) {
-  return (
-    <section className='border-white/8 mt-6 border-t pt-5'>
-      <h2 className='mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-white/50'>
-        {title}
-      </h2>
-      <div className='text-sm leading-relaxed text-white/85'>{children}</div>
-    </section>
-  )
-}
-
-function ListSection({ items, maxVisible = 8 }: { items: string[]; maxVisible?: number }) {
-  const [expanded, setExpanded] = useState(false)
-  if (!items.length) return null
-  const cappedMax = Math.max(1, maxVisible)
-  const visibleItems = expanded ? items : items.slice(0, cappedMax)
-  const hasOverflow = items.length > cappedMax
-  return (
-    <>
-      <ul className='list-disc space-y-1 pl-5'>
-        {visibleItems.map(item => (
-          <li key={item}>{item}</li>
-        ))}
-      </ul>
-      {hasOverflow && (
-        <button
-          type='button'
-          className='mt-2 text-xs font-medium text-emerald-200/90 hover:text-emerald-100'
-          onClick={() => setExpanded(value => !value)}
-        >
-          {expanded ? 'Show less' : `Show ${items.length - cappedMax} more`}
-        </button>
-      )}
-    </>
-  )
-}
-
-type RelatedLinkItem = {
-  label: string
-  to: string
-}
-
-type UseCaseAnchor = {
-  key: 'sleep' | 'anxiety' | 'focus'
-  question: string
-  guidance: string
-  keywords: string[]
-}
-
-type UseCaseRelatedHerbLink = {
-  leadIn: 'See also' | 'Compare with'
-  label: string
-  to: string
-}
-
-const USE_CASE_ANCHORS: UseCaseAnchor[] = [
-  {
-    key: 'sleep',
-    question: 'Best for sleep?',
-    guidance: 'Prioritize lower-friction evening formats and avoid stacking multiple sedating products.',
-    keywords: ['sleep', 'bedtime', 'evening wind-down', 'wind-down', 'night'],
-  },
-  {
-    key: 'anxiety',
-    question: 'Best for anxiety?',
-    guidance: 'Look for steadier daily formats first, then only adjust form if tolerability or routine fit is poor.',
-    keywords: ['anxiety', 'calm', 'stress', 'tension', 'gentle support', 'relax'],
-  },
-  {
-    key: 'focus',
-    question: 'Best for focus?',
-    guidance: 'Use labels and form consistency to compare options rather than relying on broad performance claims.',
-    keywords: ['focus', 'clarity', 'cognitive', 'daytime', 'alertness', 'concentration'],
-  },
-]
-
-function normalizeKey(value: string) {
-  return value.trim().toLowerCase()
-}
-
-function matchesUseCaseTag(bestForTag: string, keywords: string[]) {
-  const normalizedTag = normalizeKey(bestForTag)
-  return keywords.some(keyword => normalizedTag.includes(normalizeKey(keyword)))
-}
-
-function buildInteractionsLink(tokens: string[]) {
-  if (!tokens.length) return '/interactions'
-  return `/interactions?items=${tokens.join(',')}`
-}
-
-function dedupeRelatedLinks(items: Array<RelatedLinkItem | null | undefined>) {
-  const unique = new Map<string, RelatedLinkItem>()
-
-  items.forEach(item => {
-    if (!item?.label.trim() || !item.to.trim()) return
-    const key = normalizeKey(item.to)
-    if (!unique.has(key)) unique.set(key, item)
-  })
-
-  return Array.from(unique.values()).sort((a, b) => a.label.localeCompare(b.label))
-}
-
-function dedupeStrings(items: Array<string | null | undefined>) {
-  const seen = new Set<string>()
-  const values: string[] = []
-  items.forEach(item => {
-    const normalized = String(item || '').trim()
-    if (!normalized) return
-    const key = normalizeKey(normalized)
-    if (seen.has(key)) return
-    seen.add(key)
-    values.push(normalized)
-  })
-  return values
-}
-
-function buildShortSummary(therapeuticUses: string[]) {
-  const conciseUses = therapeuticUses
-    .map(item => String(item || '').trim())
-    .filter(Boolean)
-    .slice(0, 2)
-  if (!conciseUses.length) return ''
-  if (conciseUses.length === 1) return conciseUses[0]
-  return `${conciseUses[0]}. ${conciseUses[1]}`
+type DisclosureProps = {
+  title: string
+  defaultOpen?: boolean
+  children: ReactNode
 }
 
 function toTitleCase(value: string) {
@@ -221,29 +23,114 @@ function toTitleCase(value: string) {
     .replace(/\b\w/g, letter => letter.toUpperCase())
 }
 
-function toMaxSentences(text: string, max = 3) {
+function sentenceClamp(text: string, maxSentences = 3) {
   const cleaned = String(text || '').replace(/\s+/g, ' ').trim()
   if (!cleaned) return ''
-  const parts = cleaned.match(/[^.!?]+[.!?]?/g) || [cleaned]
-  return parts
-    .slice(0, max)
-    .map(part => part.trim())
+  const sentences = cleaned.match(/[^.!?]+[.!?]?/g) || [cleaned]
+  return sentences
+    .slice(0, maxSentences)
+    .map(s => s.trim())
     .join(' ')
 }
 
-function getEvidenceBadgeTone(evidenceLevel: string) {
-  const normalized = evidenceLevel.trim().toLowerCase()
-  if (!normalized) return 'border-white/20 bg-white/6 text-white/75'
-  if (normalized.includes('human')) return 'border-emerald-300/35 bg-emerald-500/12 text-emerald-100'
-  if (normalized.includes('preclinical + limited human'))
-    return 'border-amber-300/35 bg-amber-500/12 text-amber-100'
-  return 'border-white/20 bg-white/6 text-white/75'
+function splitTextList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .map(item => String(item || '').trim())
+      .filter(Boolean)
+  }
+  return String(value || '')
+    .split(/[;,]/)
+    .map(item => item.trim())
+    .filter(Boolean)
 }
 
-function getCompletenessLabel(completenessPct: number) {
-  if (completenessPct >= 80) return 'Well-documented'
-  if (completenessPct >= 50) return 'Partial data'
-  return 'Limited data'
+function dedupeCaseInsensitive(values: string[]) {
+  const seen = new Set<string>()
+  const unique: string[] = []
+  values.forEach(value => {
+    const key = value.trim().toLowerCase()
+    if (!key || seen.has(key)) return
+    seen.add(key)
+    unique.push(value.trim())
+  })
+  return unique
+}
+
+function isPlaceholder(text: string, herbName?: string) {
+  const value = String(text || '').trim().toLowerCase()
+  if (!value) return false
+  const normalizedHerb = String(herbName || '').trim().toLowerCase()
+  const genericPatterns = [
+    /^herb profile\.?$/i,
+    /^reference profile\.?$/i,
+    /^no direct/i,
+    /^contextual inference/i,
+  ]
+  if (genericPatterns.some(pattern => pattern.test(value))) return true
+  if (!normalizedHerb) return false
+  const escapedName = normalizedHerb.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const namedPattern = new RegExp(`^${escapedName}\\s+(herb|reference)\\s+profile\\.?$`, 'i')
+  return namedPattern.test(value)
+}
+
+function toSources(value: unknown): SourceRef[] {
+  if (!Array.isArray(value)) return []
+  const map = new Map<string, SourceRef>()
+  value.forEach(item => {
+    if (typeof item === 'string') {
+      const next = item.trim()
+      if (!next) return
+      const key = next.toLowerCase()
+      if (!map.has(key)) map.set(key, { title: next, url: next })
+      return
+    }
+    if (!item || typeof item !== 'object') return
+    const record = item as Record<string, unknown>
+    const title = String(record.title || record.url || '').trim()
+    const url = String(record.url || '').trim()
+    const note = String(record.note || '').trim()
+    if (!title && !url) return
+    const source: SourceRef = { title: title || url, url: url || title }
+    if (note) source.note = note
+    const key = `${source.title.toLowerCase()}|${source.url.toLowerCase()}`
+    if (!map.has(key)) map.set(key, source)
+  })
+  return Array.from(map.values())
+}
+
+function DisclosureSection({ title, defaultOpen = false, children }: DisclosureProps) {
+  const [open, setOpen] = useState(defaultOpen)
+
+  return (
+    <section className='rounded-2xl border border-white/10 bg-white/[0.02]'>
+      <button
+        type='button'
+        className='flex w-full items-center justify-between px-4 py-3 text-left'
+        onClick={() => setOpen(value => !value)}
+        aria-expanded={open}
+      >
+        <h2 className='text-sm font-semibold uppercase tracking-[0.16em] text-white/85'>{title}</h2>
+        <span className='text-xs text-white/60'>{open ? 'Hide' : 'Show'}</span>
+      </button>
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            key='content'
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: 'easeOut' }}
+            className='overflow-hidden'
+          >
+            <div className='border-t border-white/10 px-4 py-3 text-sm leading-relaxed text-white/80'>
+              {children}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </section>
+  )
 }
 
 export default function HerbDetail() {
@@ -251,433 +138,96 @@ export default function HerbDetail() {
   const { herb, isLoading } = useHerbDetailState(slug)
   const { herbs } = useHerbDataState()
   const { compounds } = useCompoundDataState()
-  const { toggle, isSaved } = useSavedItems()
-  const [activeUseCaseAnchor, setActiveUseCaseAnchor] = useState<AffiliateUseCaseAnchor | undefined>(
-    undefined,
-  )
 
-  useEffect(() => {
-    if (!herb?.slug) return
-    pushRecentlyViewed({
-      type: 'herb',
-      slug: herb.slug,
-      title: herb.common || herb.name || herb.slug,
-      href: `/herbs/${herb.slug}`,
-    })
-  }, [herb?.slug, herb?.common, herb?.name])
-
-  if (isLoading) {
-    return <HerbDetailSkeleton />
-  }
+  if (isLoading) return <HerbDetailSkeleton />
 
   if (!herb) {
     return (
-      <main className='container mx-auto max-w-3xl px-4 py-10 text-white'>
-        <p className='text-white/60'>Herb profile not found.</p>
+      <main className='container mx-auto max-w-4xl px-4 py-8 text-white'>
+        <p className='text-white/65'>Herb profile not found.</p>
         <Link to='/herbs' className='btn-secondary mt-4 inline-flex'>
-          ← Back to herbs
+          ← Back to Herbs
         </Link>
       </main>
     )
   }
 
-  // All list fields are already cleaned arrays from herb-data.ts
-  const effects = uniqueNormalizedList(Array.isArray(herb.effects) ? herb.effects : splitClean(herb.effects))
-  const activeCompounds = uniqueNormalizedList(
-    Array.isArray(herb.activeCompounds) ? herb.activeCompounds : splitClean(herb.activeCompounds),
-  )
-  const contraindications = uniqueNormalizedList(
-    Array.isArray(herb.contraindications) ? herb.contraindications : splitClean(herb.contraindications),
-  )
-  const interactions = uniqueNormalizedList(
-    Array.isArray(herb.interactions) ? herb.interactions : splitClean(herb.interactions),
-  )
-  const therapeuticUses = uniqueNormalizedList(
-    Array.isArray(herb.therapeuticUses) ? herb.therapeuticUses : splitClean(herb.therapeuticUses),
-  )
-  const sideEffects = uniqueNormalizedList(
-    Array.isArray(herb.sideeffects) ? herb.sideeffects : splitClean(herb.sideeffects),
-  )
-  const sources = toSources(herb.sources)
-  const primaryEffects = extractPrimaryEffects(effects, 5)
-  const compoundByName = new Map(compounds.map(compound => [normalizeKey(compound.name), compound]))
-  const herbByKey = new Map<string, { label: string; slug: string }>()
+  const herbName = toTitleCase(herb.commonName || herb.common || herb.name || herb.slug)
+  const scientificName = String(herb.scientific || herb.latinName || '').trim()
+  const description = String(herb.description || herb.summary || '').trim()
+  const descriptionIsPlaceholder = isPlaceholder(description, herbName)
+  const summary = sentenceClamp(description, 3)
 
-  herbs.forEach(item => {
-    const label = item.common || item.name || item.scientific || item.slug
-    const candidates = [item.slug, item.common, item.name, item.scientific]
-    candidates.forEach(candidate => {
-      const value = String(candidate || '').trim()
-      if (!value) return
-      herbByKey.set(normalizeKey(value), { label, slug: item.slug })
-    })
-  })
-
-  const linkedCompounds = activeCompounds.map(name => {
-    const record = compoundByName.get(normalizeKey(name))
-    return {
-      name,
-      slug: record?.slug || '',
-      explanation: record?.mechanism || record?.description || '',
-      whyItMatters: record?.effects?.slice(0, 2).join(' + ') || '',
-    }
-  })
-  const premiumDetails = [
-    { title: 'Identity', value: String(herb.identity || '').trim() },
-    {
-      title: 'Category / Use Context',
-      value: String(herb.categoryUseContext || '').trim(),
-    },
-    { title: 'Evidence Level', value: String(herb.evidenceLevel || '').trim() },
-  ]
-  const premiumRelatedHerbs = (Array.isArray(herb.relatedEntities) ? herb.relatedEntities : []).map(
-    entry => {
-      const normalized = herbByKey.get(normalizeKey(entry))
-      return normalized?.slug
-        ? {
-            label: normalized.label || entry,
-            to: `/herbs/${encodeURIComponent(normalized.slug)}`,
-          }
-        : null
-    },
-  )
-  const premiumRelatedCompounds = (
-    Array.isArray(herb.relatedCompounds) ? herb.relatedCompounds : []
-  ).map(entry => {
-    const normalized = compoundByName.get(normalizeKey(entry))
-    return normalized?.slug
-      ? {
-          label: normalized.name || entry,
-          to: `/compounds/${encodeURIComponent(normalized.slug)}`,
-        }
-      : null
-  })
-  const relatedHerbLinks = dedupeRelatedLinks(premiumRelatedHerbs)
-  const relatedCompoundLinks = dedupeRelatedLinks([
-    ...premiumRelatedCompounds,
-    ...linkedCompounds.map(compound =>
-      compound.slug
-        ? {
-            label: compound.name,
-            to: `/compounds/${encodeURIComponent(compound.slug)}`,
-          }
-        : null,
-    ),
-  ])
-  const relationGroups = [
-    {
-      title: `Related Herbs (${relatedHerbLinks.length})`,
-      items: relatedHerbLinks,
-    },
-    {
-      title: `Related Compounds (${relatedCompoundLinks.length})`,
-      items: relatedCompoundLinks,
-    },
-  ].filter(group => group.items.length > 0)
-
-  const herbDisplayName = toTitleCase(herb.commonName || herb.common || herb.name || herb.slug)
-  const primaryUse = String(therapeuticUses[0] || effects[0] || '').trim()
-  const shortSummary = toMaxSentences(
-    buildShortSummary(therapeuticUses) || String(herb.summary || herb.description || ''),
-    3,
-  )
-  const herbMetaDescriptionSource = (
-    herb.summary ||
-    herb.description ||
-    therapeuticUses[0] ||
-    effects.slice(0, 2).join(', ')
-  ).trim()
-  const baseHerbMetaDescription = formatMetaDescription(
-    herbMetaDescriptionSource,
-    primaryUse
-      ? `${herbDisplayName} herb guide for ${primaryUse.toLowerCase()} with effects, safety notes, and practical context.`
-      : `${herbDisplayName} herb guide with effects, safety notes, and practical context.`,
-  )
-  const baseHerbMetaTitle = primaryUse
-    ? `${herbDisplayName} for ${primaryUse} | Herb Benefits, Uses & Safety`
-    : `${herbDisplayName} Herb Guide: Effects, Uses & Safety`
-
-  // Scalar fields already cleaned by normalization
-  const description = sanitizeReadableText(herb.description)
-  const mechanism = sanitizeReadableText(herb.mechanism)
-  const intensity = herb.intensity || ''
-  const region = herb.region || ''
-  const duration = sanitizeReadableText(herb.duration)
-  const dosage = sanitizeReadableText(herb.dosage)
-  const preparation = sanitizeReadableText(herb.preparation)
+  const effects = dedupeCaseInsensitive(splitTextList(herb.primaryEffects || herb.effects)).slice(0, 6)
+  const activeCompounds = dedupeCaseInsensitive(splitTextList(herb.activeCompounds || herb.compounds))
+  const mechanism = String(herb.mechanism || herb.mechanismOfAction || '').trim()
+  const dosage = String(herb.dosage || '').trim()
+  const duration = String(herb.duration || '').trim()
+  const preparation = String(herb.preparation || '').trim()
   const standardization = String(herb.standardization || '').trim()
-  const legalStatus = herb.legalStatus || ''
-  const qualityConcerns = sanitizeReadableText(herb.qualityConcerns)
-  const herbClass = sanitizeReadableText(herb.class || herb.category)
-  const evidenceLevel = String(herb.evidenceLevel || '').trim()
-  const mechanismTags = Array.isArray(herb.mechanismTags)
-    ? uniqueNormalizedList(splitClean(herb.mechanismTags))
-    : []
-  const pathwayTargets = Array.isArray(herb.pathwayTargets)
-    ? uniqueNormalizedList(splitClean(herb.pathwayTargets))
-    : []
-  const compoundCount =
-    typeof herb.compound_count === 'number' && Number.isFinite(herb.compound_count)
-      ? herb.compound_count
-      : null
-  const completenessPct =
-    typeof herb.completenessPct === 'number' && Number.isFinite(herb.completenessPct)
-      ? herb.completenessPct
-      : null
-  const evidenceBadgeTone = getEvidenceBadgeTone(evidenceLevel)
-  const completenessLabel = completenessPct === null ? '' : getCompletenessLabel(completenessPct)
-  const lastUpdated = String((herb as Record<string, unknown>).lastUpdated || '').trim()
-  const sourceCount = sources.length
-  const cautionCount = countCautionSignals({
-    contraindications,
-    interactions,
-    sideEffects,
-  })
-  const { hasInferredContent, hasFallbackContent } = inferContentFlags({
-    description,
-    mechanism,
-    effects,
-    therapeuticUses,
-  })
+  const contraindications = splitTextList(herb.contraindications)
+  const interactions = splitTextList(herb.interactions)
+  const sideEffects = splitTextList(herb.sideeffects || herb.sideEffects)
+  const safety = splitTextList((herb as Record<string, unknown>).safetyNotes || (herb as Record<string, unknown>).safety)
 
-  const confidence =
-    herb.confidence === 'high' || herb.confidence === 'medium' ? herb.confidence : 'low'
+  const safetyNotes = dedupeCaseInsensitive([
+    ...contraindications,
+    ...interactions,
+    ...sideEffects,
+    ...safety,
+  ])
+    .map(note => note.replace(/\s+/g, ' ').trim())
+    .filter(note => note.length >= 5)
+    .map(toTitleCase)
 
-  const completeness = getHerbDataCompleteness({
-    mechanism,
-    effects,
-    activeCompounds,
-    contraindications,
-  })
+  const priorityWarning = safetyNotes.find(note => /(pregnancy|cardiac|avoid)/i.test(note))
 
-  const keyFields = pickNonEmptyKeys(
-    { mechanism, effects, activeCompounds, contraindications, interactions, sources },
-    ['mechanism', 'effects', 'activeCompounds', 'contraindications', 'interactions', 'sources'],
-  )
-  const isDataIncomplete = keyFields.length < 3
-
-  const renderableKeys = pickNonEmptyKeys(
-    { herbClass, activeCompounds, therapeuticUses, contraindications, interactions, legalStatus },
-    [
-      'herbClass',
-      'activeCompounds',
-      'therapeuticUses',
-      'contraindications',
-      'interactions',
-      'legalStatus',
-    ],
-  )
-  const missingFieldCount = 6 - renderableKeys.length
-  const shouldShowContributionCta = renderableKeys.length < 5
-  const practicalInfo = [
-    dosage ? `Dosage: ${dosage}` : '',
-    duration ? `Duration: ${duration}` : '',
-    preparation ? `Preparation: ${preparation}` : '',
-    standardization ? `Often standardized to: ${standardization}` : '',
-  ].filter(Boolean)
-  const herbToken = encodeURIComponent(`herb:${herb.slug}`)
-  const herbCheckerHref = buildInteractionsLink([herbToken])
-  const relatedCollections = SEO_COLLECTIONS.filter(collection => collection.itemType === 'herb')
-    .filter(collection =>
-      filterHerbByCollection(herb as unknown as Record<string, unknown>, collection.filters),
-    )
-    .slice(0, 5)
-  const introFacts = [
-    sourceCount > 0
-      ? `${sourceCount} source${sourceCount === 1 ? '' : 's'} listed`
-      : 'sources pending',
-    cautionCount > 0
-      ? `${cautionCount} caution signal${cautionCount === 1 ? '' : 's'}`
-      : 'no caution flags listed',
-  ]
-  const curatedProducts = getRenderableCuratedProducts({
-    entityType: 'herb',
-    entitySlug: herb.slug,
-    confidence,
-    sourceCount,
-    useCaseAnchor: activeUseCaseAnchor,
-  })
-  const useCaseAnchors = USE_CASE_ANCHORS.map(anchor => {
-    const matchedProducts = curatedProducts.filter(product =>
-      product.bestFor.some(tag => matchesUseCaseTag(tag, anchor.keywords)),
-    )
-    const relatedHerbLinks: UseCaseRelatedHerbLink[] = herbs
-      .filter(candidate => candidate.slug && candidate.slug !== herb.slug)
-      .map(candidate => {
-        const candidateProducts = getHerbProducts(candidate.slug)
-        const matchedTagCount = candidateProducts.reduce((count, product) => {
-          const hasMatch = product.attributes.some((tag: string) =>
-            matchesUseCaseTag(tag, anchor.keywords),
-          )
-          return hasMatch ? count + 1 : count
-        }, 0)
-        const label = String(
-          candidate.common || candidate.commonName || candidate.name || candidate.slug,
-        ).trim()
-        return {
-          slug: candidate.slug,
-          label,
-          matchedTagCount,
-        }
-      })
-      .filter(candidate => candidate.matchedTagCount > 0 && candidate.label)
-      .sort(
-        (a, b) => b.matchedTagCount - a.matchedTagCount || a.label.localeCompare(b.label),
-      )
-      .slice(0, 2)
-      .map((candidate, index) => ({
-        leadIn: index === 0 ? 'See also' : 'Compare with',
-        label: candidate.label,
-        to: `/herbs/${encodeURIComponent(candidate.slug)}`,
-      }))
-
-    return {
-      ...anchor,
-      matchedProducts,
-      relatedHerbLinks,
-      matchedTags: Array.from(
-        new Set(
-          matchedProducts.flatMap(product =>
-            product.bestFor.filter(tag => matchesUseCaseTag(tag, anchor.keywords)),
-          ),
-        ),
-      ),
-    }
-  }).filter(anchor => anchor.matchedProducts.length > 0)
-  const ctaExperiment = resolveCtaVariant({
-    pageType: 'herb_detail',
-    entityType: 'herb',
-    entitySlug: herb.slug,
-    cautionCount,
-  })
-  const ctaVariantId = ctaExperiment.activeVariantId
-  const governedResearch = getGovernedResearchEnrichment('herb', herb.slug)
-  const governedCta = resolveGovernedCtaDecision({
-    entityType: 'herb',
-    entitySlug: herb.slug,
-    cautionCount,
-    confidence,
-    sourceCount,
-    relatedCollectionCount: relatedCollections.length,
-    enrichment: governedResearch,
-  })
-  const governedFaq = governedResearch
-    ? buildGovernedFaqSectionContent({
-        entityType: 'herb',
-        entityName: herbDisplayName,
-        enrichment: governedResearch,
-      })
-    : null
-  const governedRelatedQuestions =
-    governedResearch && governedFaq
-      ? buildGovernedRelatedQuestions({
-          entityType: 'herb',
-          entityName: herbDisplayName,
-          enrichment: governedResearch,
-          governedFaq,
-          hasVisibleCompareSection: Boolean(linkedCompounds.length || relatedCollections.length),
-        })
-      : null
-  const fallbackIntro = buildFallbackHerbIntro({
-    herbDisplayName,
-    description,
-    mechanism,
-    therapeuticUses,
-    primaryEffects,
-    confidence,
-    sourceCount,
-    cautionCount,
-    contraindications,
-    interactions,
-    sideEffects,
-    introFacts,
-  })
-  const governedIntro = buildGovernedDetailIntro({
-    entityName: herbDisplayName,
-    fallback: fallbackIntro,
-    enrichment: governedResearch,
-    sourceCount,
-  })
-  const governedReviewFreshness = buildGovernedReviewFreshness(governedResearch)
-  const herbMetaTitle = buildGovernedMetaTitle(
-    baseHerbMetaTitle,
-    herbDisplayName,
-    'Herb',
-    herb.researchEnrichmentSummary,
-  )
-  const herbMetaDescription = buildGovernedMetaDescription(
-    baseHerbMetaDescription,
-    herb.researchEnrichmentSummary,
-  )
+  const sources = toSources(herb.sources)
+  const confidenceLabel = toTitleCase(String(herb.evidenceLevel || herb.confidence || 'Limited'))
   const pagePath = `/herbs/${herb.slug}`
-  const breadcrumbId = `${SITE_URL}${pagePath}#breadcrumb`
-  const enrichmentRecommendations = buildEnrichmentRecommendations('herb', herb.slug)
-  const quickCompareSection = buildGovernedQuickCompareSection('herb', herb.slug)
-  const herbRecommendation = getHerbRecommendation(herb.slug)
-  const herbProducts = getHerbProducts(herb.slug)
-  const whyPeopleChooseBullets = dedupeStrings([
-    herb.categoryUseContext,
-    herbRecommendation
-      ? `Common buyer formats: ${herbRecommendation.recommendedForms.slice(0, 3).join(', ')}.`
-      : null,
-    herbRecommendation ? `Quality checks buyers use: ${herbRecommendation.preferredAttributes[0]}.` : null,
-    relatedHerbLinks.length > 0
-      ? `Related alternatives: ${relatedHerbLinks
-          .slice(0, 3)
-          .map(item => item.label)
-          .join(', ')}.`
-      : null,
-  ]).slice(0, 4)
-  const recommendationNames = {
-    herb: new Map(herbs.map(item => [item.slug, item.common || item.name || item.slug])),
-    compound: new Map(compounds.map(item => [item.slug, item.name || item.slug])),
-  }
+  const relatedHerbs = herbs
+    .filter(item => item.slug && item.slug !== herb.slug)
+    .slice(0, 4)
+    .map(item => ({
+      label: toTitleCase(item.common || item.name || item.slug),
+      to: `/herbs/${item.slug}`,
+    }))
+
+  const compoundIndex = new Map(compounds.map(compound => [String(compound.name || '').toLowerCase(), compound]))
+  const relatedCompounds = activeCompounds
+    .map(name => {
+      const match = compoundIndex.get(name.toLowerCase())
+      if (!match?.slug) return null
+      return {
+        label: toTitleCase(match.name),
+        to: `/compounds/${match.slug}`,
+      }
+    })
+    .filter((item): item is { label: string; to: string } => Boolean(item))
 
   return (
     <main className='container mx-auto max-w-5xl px-4 py-6 text-white sm:py-8'>
       <Meta
-        title={herbMetaTitle}
-        description={herbMetaDescription}
+        title={`${herbName} Herb Guide | The Hippie Scientist`}
+        description={`${herbName} effects, dosage context, safety notes, and sources.`}
         path={pagePath}
         image={`/og/herb/${herb.slug}.png`}
         jsonLd={[
           herbJsonLd({
-            name: herbDisplayName,
+            name: herbName,
             slug: herb.slug,
-            description: herbMetaDescription,
-            latinName: herb.scientific || herb.latinName,
-            breadcrumbId,
-            governedSummary: herb.researchEnrichmentSummary,
+            description: description || `${herbName} herb profile`,
+            latinName: scientificName,
           }),
-          breadcrumbJsonLd(
-            [
-              { name: 'Home', url: SITE_URL },
-              { name: 'Herbs', url: `${SITE_URL}/herbs` },
-              { name: herbDisplayName, url: `${SITE_URL}${pagePath}` },
-            ],
-            { id: breadcrumbId },
-          ),
-          ...(governedFaq?.emitFaqSchema
-            ? [
-                faqPageJsonLd({
-                  pagePath,
-                  questions: governedFaq.faqItems.map(item => ({
-                    question: item.question,
-                    answer: item.answer,
-                  })),
-                }),
-              ]
-            : []),
-        ].filter(Boolean)}
-      />
-      <BreadcrumbTrail
-        items={[
-          { label: 'Home', to: '/' },
-          { label: 'Herbs', to: '/herbs' },
-          { label: herbDisplayName },
+          breadcrumbJsonLd([
+            { name: 'Home', url: SITE_URL },
+            { name: 'Herbs', url: `${SITE_URL}/herbs` },
+            { name: herbName, url: `${SITE_URL}${pagePath}` },
+          ]),
         ]}
       />
-      <nav className='mb-2 text-xs text-white/60'>
+
+      <div className='mb-2 text-xs text-white/60'>
         <Link to='/' className='hover:text-white'>
           Home
         </Link>{' '}
@@ -685,659 +235,168 @@ export default function HerbDetail() {
         <Link to='/herbs' className='hover:text-white'>
           Herbs
         </Link>{' '}
-        &gt; <span className='text-white/80'>{herbDisplayName}</span>
-      </nav>
-      <div className='flex flex-wrap items-center gap-2'>
-        <Link to='/herbs' className='btn-secondary inline-flex items-center'>
-          ← Back to herbs
-        </Link>
-        <button
-          type='button'
-          className='inline-flex rounded-full border border-white/20 px-3 py-1 text-sm text-white/85 transition hover:border-white/35 hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-cyan-300'
-          onClick={() =>
-            toggle({
-              type: 'herb',
-              slug: herb.slug,
-              title: herb.common || herb.name || herb.slug,
-              href: `/herbs/${herb.slug}`,
-              note: description,
-            })
-          }
-        >
-          {isSaved('herb', herb.slug) ? '★ Favorited' : '☆ Favorite'}
-        </button>
+        &gt; <span className='text-white/85'>{herbName}</span>
       </div>
 
-      <article className='ds-card-lg mt-4'>
-        <section className='sr-only' aria-hidden='true'>
-          <h1>{herbDisplayName}</h1>
+      <article className='space-y-4'>
+        <div className='sr-only' aria-hidden='true'>
+          <h1>{herbName}</h1>
           <p>{description}</p>
-          <ul>{primaryEffects.map(effect => <li key={`static-${effect}`}>{effect}</li>)}</ul>
-          <ul>{contraindications.slice(0, 3).map(item => <li key={`safety-${item}`}>{item}</li>)}</ul>
-        </section>
-        {/* Refactor: move highest-signal content to the very top for immediate scanning. */}
-        <header>
-          <div className='flex flex-col gap-2'>
-            <div>
-              <h1 className='text-3xl font-semibold leading-tight sm:text-4xl'>{herbDisplayName}</h1>
-              {herb.scientific && (
-                <p className='mt-1 text-sm italic text-white/55'>{herb.scientific}</p>
-              )}
-            </div>
+          <ul>{effects.map(effect => <li key={`static-effect-${effect}`}>{effect}</li>)}</ul>
+          <ul>{safetyNotes.map(note => <li key={`static-safety-${note}`}>{note}</li>)}</ul>
+        </div>
+
+        <header className='rounded-2xl border border-white/10 bg-white/[0.03] p-4 sm:p-5'>
+          <h1 className='text-3xl font-semibold sm:text-4xl'>{herbName}</h1>
+          {scientificName && <p className='mt-1 text-sm italic text-white/55'>{scientificName}</p>}
+
+          <div className='mt-3 flex flex-wrap gap-2'>
+            {effects.map(effect => (
+              <span
+                key={effect}
+                className='rounded-full border border-emerald-300/30 bg-emerald-500/10 px-2.5 py-1 text-xs text-emerald-100'
+              >
+                {effect}
+              </span>
+            ))}
           </div>
-          {/* Primary effects are elevated directly under the name. */}
-          {primaryEffects.length > 0 && (
-            <ul className='mt-3 list-disc space-y-1 pl-5 text-sm text-white/85'>
-              {primaryEffects.map(effect => (
-                <li key={effect}>{effect}</li>
-              ))}
-            </ul>
-          )}
-          {/* Keep summary concise above the fold; deep explanation is pushed lower. */}
-          {(shortSummary || description) && (
-            <p className='mt-4 max-w-3xl text-sm leading-relaxed text-white/80'>
-              {shortSummary}
+
+          {descriptionIsPlaceholder ? (
+            <p className='mt-4 rounded-xl border border-cyan-300/30 bg-cyan-500/10 px-3 py-2 text-sm text-cyan-100'>
+              Full research profile coming soon. Check back for mechanism notes, dosage guidance, and source citations.
             </p>
+          ) : (
+            <p className='mt-4 max-w-3xl text-sm leading-relaxed text-white/80'>{summary}</p>
           )}
-          {contraindications.length > 0 && (
-            <div className='mt-3 rounded-xl border border-amber-300/35 bg-amber-500/10 px-3 py-2 text-xs text-amber-100'>
-              Safety callout: {contraindications[0]}
+
+          {priorityWarning && (
+            <div className='mt-4 rounded-xl border border-amber-300/35 bg-amber-500/10 px-3 py-2 text-sm text-amber-100'>
+              Safety warning: {priorityWarning}
             </div>
           )}
 
-          <div className='mt-3 flex flex-wrap gap-1.5'>
-            {evidenceLevel && (
-              <span className='inline-flex items-center gap-1.5 rounded-sm border border-emerald-400/35 bg-emerald-500/8 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.18em] text-emerald-200'>
-                <span aria-hidden='true'>✓</span> {evidenceLevel}
-              </span>
-            )}
-            <span className='inline-flex items-center gap-1.5 rounded-sm border border-emerald-400/35 bg-emerald-500/8 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.18em] text-emerald-200'>
-              <span aria-hidden='true'>✓</span> {sourceCount} source{sourceCount === 1 ? '' : 's'}
-            </span>
-            {cautionCount > 0 && (
-              <span className='inline-flex items-center gap-1.5 rounded-sm border border-amber-400/40 bg-amber-500/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.18em] text-amber-200'>
-                <span aria-hidden='true'>⚠</span> {cautionCount} caution signal{cautionCount === 1 ? '' : 's'}
-              </span>
-            )}
-          </div>
-          <div className='mt-2'>
-            <Link
-              to={herbCheckerHref}
-              className='btn-primary inline-flex text-xs'
-              onClick={() =>
-                trackDetailCheckerClick({
-                  detailType: 'herb',
-                  detailSlug: herb.slug,
-                  placement: 'above_fold_primary_cta',
-                })
-              }
-            >
-              {governedCta.copy.toolButtonLabel}
-            </Link>
+          <div className='mt-4 inline-flex rounded-full border border-white/20 bg-white/5 px-2.5 py-1 text-xs text-white/80'>
+            Evidence: {confidenceLabel}
           </div>
         </header>
 
-        {/* Core content */}
-        {description && (
-          <section className='border-white/8 mt-6 border-t pt-5'>
-            <Collapse title='Summary' defaultOpen>
-              {description}
-            </Collapse>
-          </section>
-        )}
+        <DisclosureSection title='Effects' defaultOpen>
+          {effects.length > 0 ? (
+            <ul className='list-disc space-y-1 pl-5'>
+              {effects.map(effect => (
+                <li key={`effect-${effect}`}>{effect}</li>
+              ))}
+            </ul>
+          ) : (
+            <p>Effects profile is being expanded.</p>
+          )}
+        </DisclosureSection>
 
-        {isDataIncomplete && (
-          <p className='mt-3 text-xs text-white/58'>
-            Note: key evidence fields are still being completed for this profile.
-          </p>
-        )}
+        <DisclosureSection title='Full Description'>
+          {descriptionIsPlaceholder ? (
+            <p>Profile in progress.</p>
+          ) : (
+            <p>{description}</p>
+          )}
+        </DisclosureSection>
 
-        {/* Confidence explanations are now hidden by default to reduce initial clutter. */}
-        <section className='border-white/8 mt-6 border-t pt-5'>
-            <Collapse title='Confidence score + explanation'>
-            <div className='space-y-4'>
-              <GovernedReviewFreshnessPanel
-                decision={governedReviewFreshness}
-                nextStepHref='#governed-safety-interactions'
-                analyticsContext={{
-                  pageType: 'herb_detail',
-                  entityType: 'herb',
-                  entitySlug: herb.slug,
-                }}
-              />
-              <DataTrustPanel
-                entity='herb'
-                confidence={confidence}
-                completeness={completeness}
-                sourceCount={sourceCount}
-                lastReviewed={lastUpdated}
-                cautionCount={cautionCount}
-                hasInferredContent={hasInferredContent}
-                hasFallbackContent={hasFallbackContent}
-              />
-            </div>
-          </Collapse>
-        </section>
+        <DisclosureSection title='Active Compounds'>
+          {activeCompounds.length > 0 ? (
+            <ul className='list-disc space-y-1 pl-5'>
+              {activeCompounds.map(compound => (
+                <li key={compound}>{compound}</li>
+              ))}
+            </ul>
+          ) : (
+            <p>Compound list is being expanded.</p>
+          )}
+        </DisclosureSection>
 
-        <StructuredDetailIntro
-          confidence={confidence}
-          whatItIs={governedIntro.whatItIs}
-          commonUse={governedIntro.commonUse}
-          evidenceContext={governedIntro.evidenceContext}
-          cautionNote={governedIntro.cautionNote}
-          quickFacts={governedIntro.quickFacts}
-          nextSteps={[
-            { label: 'Check this herb in interactions', to: herbCheckerHref },
-            {
-              label: 'Review active compounds',
-              to: '#key-active-compounds',
-              variant: 'secondary',
-            },
-            { label: 'Add to stack builder', to: '/build', variant: 'secondary' },
-          ]}
-          onStepClick={step => {
-            if (step.to.startsWith('/interactions')) {
-              trackDetailCheckerClick({
-                detailType: 'herb',
-                detailSlug: herb.slug,
-                placement: 'quick_intro_next_steps',
-              })
-            }
-            if (step.to === '/build') {
-              trackDetailBuilderClick({
-                detailType: 'herb',
-                detailSlug: herb.slug,
-                placement: 'quick_intro_next_steps',
-              })
-            }
-          }}
-          analyticsContext={{
-            pageType: 'herb_detail',
-            entityType: 'herb',
-            entitySlug: herb.slug,
-            profile: governedIntro.decision.mode,
-          }}
-        />
+        <DisclosureSection title='Mechanism of Action'>
+          <p>{mechanism || 'Mechanism notes are being expanded.'}</p>
+        </DisclosureSection>
 
-        {intensity || evidenceLevel || completenessPct !== null ? (
-          <section className='border-white/8 mt-6 border-t pt-5'>
-            <div className='flex flex-wrap gap-2'>
-              {intensity && (
-                <span className='bg-white/6 rounded-full border border-white/20 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white/80'>
-                  {intensity}
-                </span>
-              )}
-              {evidenceLevel && (
-                <span
-                  className={`rounded-full border px-3 py-1 text-xs font-semibold tracking-wide ${evidenceBadgeTone}`}
-                >
-                  Evidence: {evidenceLevel}
-                </span>
-              )}
-              {completenessPct !== null && (
-                <span className='rounded-full border border-cyan-300/30 bg-cyan-500/10 px-3 py-1 text-xs font-semibold tracking-wide text-cyan-100'>
-                  {completenessLabel} ({Math.round(completenessPct)}%)
-                </span>
-              )}
-            </div>
-          </section>
-        ) : null}
+        <DisclosureSection title='Dosage & Usage'>
+          <ul className='list-disc space-y-1 pl-5'>
+            {dosage && <li>Dosage: {dosage}</li>}
+            {duration && <li>Duration: {duration}</li>}
+            {preparation && <li>Preparation: {preparation}</li>}
+            {standardization && <li>Standardization: {standardization}</li>}
+            {!dosage && !duration && !preparation && !standardization && (
+              <li>Dosage guidance is still being reviewed.</li>
+            )}
+          </ul>
+        </DisclosureSection>
 
-        <CtaVariantLayout
-          variant={ctaExperiment.variant}
-          slotOrderOverride={governedCta.slotOrder}
-          onSlotImpression={(slot, position) => {
-            const ctaType =
-              slot === 'tool'
-                ? 'tool'
-                : slot === 'builder'
-                  ? 'builder'
-                  : slot === 'affiliate'
-                    ? 'affiliate'
-                    : null
-            if (!ctaType) return
-            trackCtaSlotImpression({
-              sourceType: 'detail',
-              source: `herb:${herb.slug}`,
-              placement: 'cta_experiment_slot',
-              ctaMetadata: {
-                pageType: 'herb_detail',
-                entitySlug: herb.slug,
-                ctaType,
-                ctaPosition: `position_${position}`,
-                variantId: ctaVariantId,
-              },
-            })
-          }}
-          slots={{
-            tool: (
-              <div className='rounded-lg border border-emerald-300/30 bg-emerald-500/10 p-3'>
-                <p className='text-xs font-semibold uppercase tracking-[0.14em] text-emerald-100'>
-                  {governedCta.copy.toolTitle}
-                </p>
-                <p className='mt-1 text-xs text-white/75'>{governedCta.copy.toolBody}</p>
-                <Link
-                  to={herbCheckerHref}
-                  className='btn-primary mt-2 inline-flex text-xs'
-                  onClick={() =>
-                    trackDetailCheckerClick({
-                      detailType: 'herb',
-                      detailSlug: herb.slug,
-                      placement: 'cta_variant_tool',
-                      ctaMetadata: {
-                        pageType: 'herb_detail',
-                        entitySlug: herb.slug,
-                        ctaType: 'tool',
-                        ctaPosition: 'detail_tool_checker',
-                        variantId: ctaVariantId,
-                      },
-                    })
-                  }
-                >
-                  {governedCta.copy.toolButtonLabel}
-                </Link>
-              </div>
-            ),
-            builder: (
-              <div className='rounded-lg border border-cyan-300/25 bg-cyan-500/10 p-3'>
-                <p className='text-xs text-white/75'>{governedCta.copy.builderBody}</p>
-                <Link
-                  to='/build'
-                  className='btn-secondary mt-2 inline-flex text-xs'
-                  onClick={() =>
-                    trackDetailBuilderClick({
-                      detailType: 'herb',
-                      detailSlug: herb.slug,
-                      placement: 'cta_variant_builder',
-                      ctaMetadata: {
-                        pageType: 'herb_detail',
-                        entitySlug: herb.slug,
-                        ctaType: 'builder',
-                        ctaPosition: 'detail_stack_builder',
-                        variantId: ctaVariantId,
-                      },
-                    })
-                  }
-                >
-                  {governedCta.copy.builderButtonLabel}
-                </Link>
-              </div>
-            ),
-            related: relatedCollections.length > 0 && (
-              <div className='rounded-lg border border-white/10 bg-white/[0.02] p-3'>
-                <p className='text-xs font-semibold text-white'>{governedCta.copy.relatedTitle}</p>
-                <div className='mt-2 flex flex-wrap gap-2'>
-                  {relatedCollections.slice(0, 3).map(collection => (
-                    <Link
-                      key={`cta-${collection.slug}`}
-                      to={`/collections/${collection.slug}`}
-                      className='btn-secondary text-xs'
-                      onClick={() =>
-                        trackGovernedEvent({
-                          type: 'governed_cta_click',
-                          eventAction: 'click',
-                          pageType: 'herb_detail',
-                          entityType: 'herb',
-                          entitySlug: herb.slug,
-                          surfaceId: 'detail_cta_related',
-                          componentType: 'related_collection_cta',
-                          item: collection.slug,
-                          variantId: ctaVariantId,
-                          reviewedStatus: 'reviewed',
-                          freshnessState: 'not_applicable',
-                        })
-                      }
+        <DisclosureSection title='Safety & Interactions' defaultOpen={Boolean(priorityWarning)}>
+          {safetyNotes.length > 0 ? (
+            <ul className='list-disc space-y-1 pl-5'>
+              {safetyNotes.map(note => (
+                <li key={`safety-${note}`}>{note}</li>
+              ))}
+            </ul>
+          ) : (
+            <p>Safety notes are being compiled.</p>
+          )}
+        </DisclosureSection>
+
+        <DisclosureSection title='Research & Sources'>
+          {sources.length > 0 ? (
+            <ol className='list-decimal space-y-1 pl-5'>
+              {sources.map(source => (
+                <li key={`${source.title}-${source.url}`}>
+                  {source.url.startsWith('http') ? (
+                    <a
+                      href={source.url}
+                      target='_blank'
+                      rel='noreferrer'
+                      className='text-cyan-200 hover:text-cyan-100'
                     >
-                      {collection.title}
-                    </Link>
-                  ))}
-                </div>
-              </div>
-            ),
-            affiliate: curatedProducts.length > 0 && (
-              <CuratedProductModule
-                entityType='herb'
-                entitySlug={herb.slug}
-                products={curatedProducts}
-                positionContext='herb_detail_cta_variant'
-                pageType='herb_detail'
-                variantId={ctaVariantId}
-                ctaPosition='detail_affiliate_module'
-                preDisclosureGuidance={governedCta.copy.affiliateLeadIn}
-                useCaseAnchor={activeUseCaseAnchor}
-              />
-            ),
-          }}
-        />
-
-        {therapeuticUses.length > 0 && (
-          <Section title='What it’s used for'>
-            <ListSection items={therapeuticUses} maxVisible={6} />
-          </Section>
-        )}
-
-        {contraindications.length > 0 && (
-          <Section title='Who should be careful'>
-            <ListSection items={contraindications} maxVisible={6} />
-          </Section>
-        )}
-
-        {sideEffects.length > 0 && (
-          <Section title='Possible side effects'>
-            <ListSection items={sideEffects} maxVisible={6} />
-          </Section>
-        )}
-
-        {qualityConcerns && <Section title='Quality concerns'>{qualityConcerns}</Section>}
-
-        <PremiumDataSection details={premiumDetails} />
-
-        {relationGroups.length > 0 && (
-          <section className='border-white/8 mt-6 border-t pt-5'>
-            {/* Related entities are grouped into a dedicated accordion for cleaner information hierarchy. */}
-            <Collapse title='Related herbs and compounds'>
-              <div className='space-y-4'>
-                {relationGroups.map(group => (
-                  <div key={group.title}>
-                    <p className='text-xs font-semibold uppercase tracking-[0.14em] text-white/60'>
-                      {group.title}
-                    </p>
-                    <div className='mt-2 flex flex-wrap gap-2'>
-                      {group.items.map(item => (
-                        <Link
-                          key={`${group.title}-${item.to}`}
-                          to={item.to}
-                          className='ds-pill transition hover:border-white/30'
-                        >
-                          {item.label}
-                        </Link>
-                      ))}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            </Collapse>
-          </section>
-        )}
-
-        {compoundCount !== null && (
-          <section className='border-white/8 mt-6 border-t pt-5'>
-            <p className='text-xs uppercase tracking-[0.16em] text-white/55'>Workbook coverage</p>
-            <p className='mt-2 text-sm text-white/80'>
-              Compound records linked: <span className='font-semibold text-white'>{compoundCount}</span>
-            </p>
-          </section>
-        )}
-
-        {(whyPeopleChooseBullets.length > 0 || useCaseAnchors.length > 0) && (
-          <section className='border-white/8 mt-6 border-t pt-5'>
-            <div className='rounded-2xl border border-white/12 bg-white/[0.03] p-4'>
-              <h2 className='text-xs font-semibold uppercase tracking-[0.18em] text-white/55'>
-                Why it matters and how to choose
-              </h2>
-              {whyPeopleChooseBullets.length > 0 && (
-                <ul className='mt-3 list-disc space-y-1.5 pl-5 text-sm text-white/85'>
-                  {whyPeopleChooseBullets.map(item => (
-                    <li key={item}>{item}</li>
-                  ))}
-                </ul>
-              )}
-              {useCaseAnchors.length > 0 && (
-                <div className='mt-4 space-y-2'>
-                  {useCaseAnchors.map(anchor => (
-                    <article
-                      key={anchor.key}
-                      className='rounded-xl border border-white/12 bg-white/[0.02] p-3 text-sm text-white/85'
-                      onClick={() => setActiveUseCaseAnchor(anchor.key)}
-                    >
-                      <p className='text-sm font-semibold text-white'>{anchor.question}</p>
-                      <p className='mt-1 text-xs text-white/70'>{anchor.guidance}</p>
-                    </article>
-                  ))}
-                </div>
-              )}
-            </div>
-          </section>
-        )}
-
-        {herbRecommendation && <HerbBuyerGuidanceSection recommendation={herbRecommendation} />}
-        {herbProducts.length > 0 && (
-          <HerbProductSection
-            herbSlug={herb.slug}
-            products={herbProducts}
-            useCaseAnchor={activeUseCaseAnchor}
-          />
-        )}
-
-        {herbClass && <Section title='Class'>{herbClass}</Section>}
-
-        {mechanism && (
-          <Section title='Mechanism of action'>
-            <div className='space-y-3'>
-              <p>{mechanism}</p>
-              {mechanismTags.length > 0 && (
-                <div className='flex flex-wrap gap-2'>
-                  {mechanismTags.map(tag => (
-                    <span key={tag} className='ds-pill'>
-                      {tag}
-                    </span>
-                  ))}
-                </div>
-              )}
-            </div>
-          </Section>
-        )}
-
-        {pathwayTargets.length > 0 && (
-          <section className='border-white/8 mt-6 border-t pt-5'>
-            <Collapse title='Biological Pathways'>
-              <div className='flex flex-wrap gap-2 text-sm text-white/85'>
-                {pathwayTargets.map(target => (
-                  <span key={target} className='ds-pill'>
-                    {target}
-                  </span>
-                ))}
-              </div>
-            </Collapse>
-          </section>
-        )}
-
-        {linkedCompounds.length > 0 && (
-          <section id='key-active-compounds' className='border-white/8 mt-6 border-t pt-5'>
-            <Collapse title='Active compounds'>
-              <div className='space-y-3 text-sm leading-relaxed text-white/85'>
-                <div className='flex flex-wrap gap-2'>
-                  {linkedCompounds.map(compound =>
-                    compound.slug ? (
-                      <Link
-                        key={compound.name}
-                        to={`/compounds/${encodeURIComponent(compound.slug)}`}
-                        className='ds-pill transition hover:border-white/30'
-                        onClick={() =>
-                          trackDetailRelatedEntityClick({
-                            detailType: 'herb',
-                            detailSlug: herb.slug,
-                            targetType: 'compound',
-                            targetSlug: compound.slug,
-                            placement: 'key_active_compounds',
-                          })
-                        }
-                      >
-                        {compound.name}
-                      </Link>
-                    ) : (
-                      <span key={compound.name} className='ds-pill'>
-                        {compound.name}
-                      </span>
-                    ),
+                      {source.title}
+                    </a>
+                  ) : (
+                    <span>{source.title}</span>
                   )}
-                </div>
-                <div className='space-y-2 text-white/75'>
-                  {linkedCompounds.slice(0, 3).map(compound => (
-                    <p key={`${compound.name}-summary`}>
-                      <span className='font-semibold text-white'>{compound.name}:</span>{' '}
-                      {compound.explanation || 'Mechanism summary is still being expanded.'}{' '}
-                      {compound.whyItMatters ? `Why it matters: ${compound.whyItMatters}.` : ''}
-                    </p>
-                  ))}
-                </div>
-              </div>
-            </Collapse>
-          </section>
-        )}
+                  {source.note ? <span className='text-white/60'> — {source.note}</span> : null}
+                </li>
+              ))}
+            </ol>
+          ) : (
+            <p>Primary source citations are being added.</p>
+          )}
+        </DisclosureSection>
 
-        <section id='governed-compare-links'>
-          <GovernedQuickCompareBlock
-            section={quickCompareSection}
-            analyticsContext={{
-              pageType: 'herb_detail',
-              entityType: 'herb',
-              entitySlug: herb.slug,
-              evidenceLabel: governedResearch?.pageEvidenceJudgment?.evidenceLabel,
-              safetySignalPresent: cautionCount > 0,
-            }}
-          />
-          <EnrichmentRecommendationBlocks
-            bundle={enrichmentRecommendations}
-            names={recommendationNames}
-            onRecommendationClick={(item, placement) =>
-              trackDetailRelatedEntityClick({
-                detailType: 'herb',
-                detailSlug: herb.slug,
-                targetType: item.targetType,
-                targetSlug: item.targetSlug,
-                placement,
-              })
-            }
-          />
-        </section>
-
-        {relatedCollections.length > 0 && (
-          <section className='border-white/8 mt-6 border-t pt-5'>
-            <Collapse title='Explore Related Goal Collections'>
-              <div className='space-y-2 text-sm text-white/85'>
-                <p className='text-xs text-white/65'>
-                  Use these goal pages to compare alternatives with similar effect and interaction
-                  signatures.
-                </p>
+        <DisclosureSection title='Related Herbs & Compounds'>
+          <div className='space-y-3'>
+            {relatedHerbs.length > 0 && (
+              <div>
+                <p className='mb-1 text-xs uppercase tracking-[0.14em] text-white/55'>Herbs</p>
                 <div className='flex flex-wrap gap-2'>
-                  {relatedCollections.map(collection => (
-                    <Link
-                      key={collection.slug}
-                      to={`/collections/${collection.slug}`}
-                      className='btn-secondary text-xs'
-                      onClick={() =>
-                        trackDetailRelatedEntityClick({
-                          detailType: 'herb',
-                          detailSlug: herb.slug,
-                          targetType: 'collection',
-                          targetSlug: collection.slug,
-                          placement: 'related_collections',
-                        })
-                      }
-                    >
-                      {collection.title}
+                  {relatedHerbs.map(item => (
+                    <Link key={item.to} to={item.to} className='btn-secondary text-xs'>
+                      {item.label}
                     </Link>
                   ))}
                 </div>
               </div>
-            </Collapse>
-          </section>
-        )}
-
-        {effects.length > 0 && (
-          <section className='border-white/8 mt-6 border-t pt-5'>
-            <Collapse title='Effects' defaultOpen>
-              <ListSection items={effects} maxVisible={6} />
-            </Collapse>
-          </section>
-        )}
-
-        {interactions.length > 0 && (
-          <section className='border-white/8 mt-6 border-t pt-5'>
-            <Collapse title='Interactions'>
-              <div className='text-sm leading-relaxed text-white/85'>
-                <ListSection items={interactions} maxVisible={6} />
+            )}
+            {relatedCompounds.length > 0 && (
+              <div>
+                <p className='mb-1 text-xs uppercase tracking-[0.14em] text-white/55'>Compounds</p>
+                <div className='flex flex-wrap gap-2'>
+                  {relatedCompounds.map(item => (
+                    <Link key={item.to} to={item.to} className='btn-secondary text-xs'>
+                      {item.label}
+                    </Link>
+                  ))}
+                </div>
               </div>
-            </Collapse>
-          </section>
-        )}
-
-        {/* Practical info — merged for faster scanning */}
-        {practicalInfo.length > 0 && (
-          <section className='border-white/8 mt-6 border-t pt-5'>
-            <Collapse title='Dosage information'>
-              <ListSection items={practicalInfo} />
-            </Collapse>
-          </section>
-        )}
-        {region && <Section title='Region'>{region}</Section>}
-        {legalStatus && <Section title='Legal Status'>{legalStatus}</Section>}
-
-        {(sources.length > 0 || (governedResearch && governedFaq && governedRelatedQuestions)) && (
-          <section className='border-white/8 mt-6 border-t pt-5'>
-            {/* Research bundle moved to bottom to avoid overload above the fold. */}
-            <Collapse title='Sources and citations'>
-              <div className='space-y-4'>
-                {governedResearch && governedFaq && governedRelatedQuestions && (
-                  <GovernedResearchSections
-                    enrichment={governedResearch}
-                    governedFaq={governedFaq}
-                    relatedQuestions={governedRelatedQuestions}
-                    analyticsContext={{
-                      pageType: 'herb_detail',
-                      entityType: 'herb',
-                      entitySlug: herb.slug,
-                    }}
-                  />
-                )}
-                {sources.length > 0 && (
-                  <ol className='list-decimal space-y-1 pl-5 text-sm leading-relaxed text-white/85'>
-                    {sources.map((source, index) => (
-                      <li key={`${source.url}-${index}`}>
-                        {/^https?:\/\//i.test(source.url) ? (
-                          <a href={source.url} target='_blank' rel='noreferrer' className='link'>
-                            {source.title}
-                          </a>
-                        ) : (
-                          source.title
-                        )}
-                        {source.note && <span className='ml-2 text-white/55'>— {source.note}</span>}
-                      </li>
-                    ))}
-                  </ol>
-                )}
-              </div>
-            </Collapse>
-          </section>
-        )}
-
-        {/* Contribute CTA — only when data is thin */}
-        {shouldShowContributionCta && (
-          <div className='bg-cyan-300/8 mt-8 rounded-2xl border border-cyan-300/30 p-4 text-sm text-cyan-50'>
-            <p className='font-semibold'>Help improve this entry</p>
-            <p className='mt-1 text-cyan-100/80'>
-              Submit a source or correction to strengthen mechanism, safety, or reference quality.
-            </p>
-            <div className='mt-3 flex flex-wrap gap-2'>
-              <Link to='/contribute' className='btn-secondary'>
-                Contribute data
-              </Link>
-              <a href={ISSUE_TEMPLATE_URL} target='_blank' rel='noreferrer' className='btn-primary'>
-                Submit a source
-              </a>
-            </div>
+            )}
+            {relatedHerbs.length === 0 && relatedCompounds.length === 0 && (
+              <p>Related entities will appear here as coverage expands.</p>
+            )}
           </div>
-        )}
-
-        {/* Data completeness footer */}
-        <div className='bg-white/3 mt-6 flex items-center gap-2 rounded-xl border border-white/10 px-3 py-2.5 text-xs text-white/50'>
-          <span aria-hidden='true'>ℹ</span>
-          {missingFieldCount > 0
-            ? `${missingFieldCount} core evidence field${missingFieldCount !== 1 ? 's' : ''} still incomplete.`
-            : 'All core evidence fields present for this profile.'}
-          <InfoTooltip text='Values with published studies should be cross-checked against the Sources section.' />
-        </div>
+        </DisclosureSection>
       </article>
     </main>
   )

--- a/src/pages/Herbs.tsx
+++ b/src/pages/Herbs.tsx
@@ -1,4 +1,4 @@
-// Reworked herb cards to sanitize placeholder copy, enforce title-casing, and present concise CTA-focused summaries.
+// UPDATED: Cleaned herb cards with placeholder filtering, concise summaries, and effect badges.
 import { useEffect, useMemo, useState } from 'react'
 import Meta from '@/components/Meta'
 import ActiveFiltersBar from '@/components/filters/ActiveFiltersBar'
@@ -21,7 +21,24 @@ import { trackGovernedEvent } from '@/lib/governedAnalytics'
 import { slugify } from '@/lib/slug'
 import { Link } from 'react-router-dom'
 
-const CARD_PLACEHOLDER_PATTERN = /Herb profile|reference profile|No direct|Contextual inference/i
+
+function isPlaceholder(text: string, herbName = ''): boolean {
+  const value = String(text || '').trim().toLowerCase()
+  if (!value) return false
+  const escaped = String(herbName || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const patterns = [
+    /^herb profile\.?$/i,
+    /^reference profile\.?$/i,
+    /^no direct/i,
+    /^contextual inference/i,
+    escaped ? new RegExp(`^${escaped}\\s+herb\\s+profile\\.?$`, 'i') : null,
+    escaped ? new RegExp(`^${escaped}\\s+reference\\s+profile\\.?$`, 'i') : null,
+  ].filter(Boolean) as RegExp[]
+  return patterns.some(pattern => pattern.test(value))
+}
 
 const toTitleCase = (value: string) =>
   String(value || '')
@@ -29,11 +46,12 @@ const toTitleCase = (value: string) =>
     .toLowerCase()
     .replace(/\b\w/g, letter => letter.toUpperCase())
 
-const cleanSummary = (value: string) => {
+const cleanSummary = (value: string, herbName = '') => {
   const normalized = String(value || '').replace(/\s+/g, ' ').trim()
   if (!normalized) return 'Profile in progress'
-  if (CARD_PLACEHOLDER_PATTERN.test(normalized)) return 'Profile in progress'
-  if (normalized.length <= 120) return normalized
+  if (isPlaceholder(normalized, herbName)) return 'Profile in progress'
+  const firstSentence = normalized.split(/(?<=[.!?])\s+/)[0] || normalized
+  if (firstSentence.length <= 120) return firstSentence
   return `${normalized.slice(0, 117).trimEnd()}...`
 }
 
@@ -279,10 +297,24 @@ export default function HerbsPage() {
                 {toTitleCase(String(herb.common || herb.scientific || herb.name || 'Herb'))}
               </h2>
               <p className='mt-2 text-sm text-white/75'>
-                {cleanSummary(String(herb.summary || herb.description || herb.mechanism || ''))}
+                {cleanSummary(String(herb.summary || herb.description || herb.mechanism || ''), String(herb.common || herb.name || ''))}
               </p>
+              <div className='mt-3 flex flex-wrap gap-1.5'>
+                {(Array.isArray(herb.primaryEffects) ? herb.primaryEffects : Array.isArray(herb.effects) ? herb.effects : [])
+                  .map(effect => String(effect || '').trim())
+                  .filter(Boolean)
+                  .slice(0, 3)
+                  .map(effect => (
+                    <span
+                      key={`${herb.slug}-${effect}`}
+                      className='inline-flex rounded-full border border-cyan-300/30 bg-cyan-500/10 px-2 py-0.5 text-[11px] text-cyan-100'
+                    >
+                      {toTitleCase(effect)}
+                    </span>
+                  ))}
+              </div>
               {String(herb.qualityTier || '').toLowerCase() === 'strong' && (
-                <span className='mt-3 inline-flex rounded-full border border-emerald-300/30 bg-emerald-500/10 px-2.5 py-1 text-[11px] text-emerald-100'>
+                <span className='mt-2 inline-flex rounded-full border border-emerald-300/30 bg-emerald-500/10 px-2.5 py-1 text-[11px] text-emerald-100'>
                   Well Documented
                 </span>
               )}


### PR DESCRIPTION
### Motivation
- Prevent duplicate visible content where prerendered HTML and the React component both appear on herb detail pages.  
- Make safety notes readable by splitting comma/semicolon-delimited strings into deduplicated, cleaned list items.  
- Remove raw placeholder text leaking into the UI and provide sensible fallbacks.  
- Improve herb index card UX and simplify primary navigation to core destinations.

### Description
- Wrapped prerender/static SEO block in the detail page inside a hidden container and ensured only the React component renders visually by updating `src/pages/HerbDetail.tsx` to use `<div className="sr-only" aria-hidden="true">` for prerender content and a single visible React render path, plus above-the-fold summary and breadcrumb layout.  
- Normalized safety notes by splitting on commas/semicolons, filtering short items (<5 chars), deduplicating case-insensitively, title-casing results, and rendering them as a `<ul>` in `src/pages/HerbDetail.tsx`; added a normalization helper `normalizeSafetyNotes` in `src/lib/herb-data.ts` so normalized arrays are produced at data load time.  
- Added `isPlaceholder(...)` helper (matching patterns like `herb profile`, `reference profile`, `no direct`, `contextual inference`, and name-based placeholders) and applied it to replace placeholder text with user-friendly fallbacks: cards show `Profile in progress` and detail pages show the notice `Full research profile coming soon...` in `src/pages/Herbs.tsx` and `src/pages/HerbDetail.tsx`.  
- Reworked herb detail layout into progressive-disclosure sections using Framer Motion `AnimatePresence` (Effects open by default; Safety auto-opens for priority warnings) and showed a small evidence/confidence badge instead of verbose explanation by default in `src/pages/HerbDetail.tsx`.  
- Cleaned herb index cards to title-case names, show a 1-sentence/120-char summary (with placeholder filtering), display up to 3 effect badges, and show a `Well Documented` badge for `strong` quality tier in `src/pages/Herbs.tsx`.  
- Simplified primary navigation to Home, Herbs, Compounds, Blog, and a search toggle (desktop + mobile hamburger) in `src/components/NavBar.tsx`.  
- Confirmed `scripts/prerender-static.mjs` and `scripts/prerender-entities.mjs` are intentionally emitting SEO-only HTML and already wrap that static content for `sr-only` usage (no change to prerender intent).  
- Files changed: `src/pages/HerbDetail.tsx`, `src/pages/Herbs.tsx`, `src/components/NavBar.tsx`, and `src/lib/herb-data.ts`.

### Testing
- Ran `npm run build:compile` (Vite build) to verify production compile; the build completed successfully.  
- Ran the full `npm run build` / prebuild pipeline as part of validation and the postbuild prerender verification steps completed successfully.  
- Commit-time pre-commit checks ran `eslint --max-warnings=0` (via lint-staged) and passed during the commit operation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dce4b2ba7483239a82f8b452e8eb90)