### PR TITLE
Reframe herb & compound pages for decision-first UX

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -46,7 +46,7 @@ body {
   line-height: 1.55;
   letter-spacing: 0;
   overscroll-behavior-y: none;
-  background: #05070a;
+  background: #050506;
   @apply antialiased;
 }
 
@@ -56,7 +56,7 @@ body::before {
   inset: 0;
   pointer-events: none;
   z-index: 1;
-  background: radial-gradient(120% 90% at 50% 46%, rgba(5, 7, 10, 0) 58%, rgba(2, 4, 7, 0.52) 100%);
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.14), rgba(0, 0, 0, 0.28));
 }
 
 .prerender-content.sr-only {
@@ -121,7 +121,7 @@ a:hover {
   .ds-card-paper,
   .ds-card-tight,
   .ds-card-lg {
-    @apply rounded-xl border border-white/10 bg-white/[0.02] shadow-none;
+    @apply rounded-lg border border-white/10 bg-white/[0.015] shadow-none;
   }
 
   .ds-card {

--- a/src/pages/CompoundDetail.tsx
+++ b/src/pages/CompoundDetail.tsx
@@ -309,6 +309,7 @@ export default function CompoundDetail() {
   })
 
   const primaryEffects = extractPrimaryEffects(compoundEffects, 4)
+  const decisionEffects = primaryEffects.slice(0, 2)
 
   const sourceCount = compound.sources.length
   const cautionCount = countCautionSignals({
@@ -511,6 +512,43 @@ export default function CompoundDetail() {
               {compoundDescription || topSummary}
             </p>
           )}
+          {(doesText || whyItMatters || foundInHerbLinks.length > 0) && (
+            <div className='mt-4 grid gap-3 sm:grid-cols-3'>
+              <div className='rounded-lg border border-white/12 bg-white/[0.02] p-3'>
+                <p className='text-[10px] font-semibold uppercase tracking-[0.14em] text-white/55'>What it is</p>
+                <p className='mt-1 line-clamp-3 text-xs text-white/78'>{compoundDescription || 'Active plant constituent.'}</p>
+              </div>
+              <div className='rounded-lg border border-white/12 bg-white/[0.02] p-3'>
+                <p className='text-[10px] font-semibold uppercase tracking-[0.14em] text-white/55'>Why it matters</p>
+                <p className='mt-1 line-clamp-3 text-xs text-white/78'>
+                  {whyItMatters ? `Tracked outcomes: ${whyItMatters}.` : 'Mechanism and effect context is still being expanded.'}
+                </p>
+              </div>
+              <div className='rounded-lg border border-white/12 bg-white/[0.02] p-3'>
+                <p className='text-[10px] font-semibold uppercase tracking-[0.14em] text-white/55'>Where it appears</p>
+                <p className='mt-1 line-clamp-3 text-xs text-white/78'>
+                  {foundInHerbLinks.length > 0
+                    ? foundInHerbLinks.slice(0, 3).map(item => item.label).join(', ')
+                    : 'Herb mapping in progress.'}
+                </p>
+              </div>
+            </div>
+          )}
+          {decisionEffects.length > 0 && (
+            <div className='mt-4 flex flex-wrap gap-1'>
+              {decisionEffects.map(effect => (
+                <span key={effect} className='ds-pill'>{effect}</span>
+              ))}
+            </div>
+          )}
+          <section className='mt-3 rounded-lg border border-amber-300/30 bg-amber-500/10 p-3'>
+            <p className='text-[10px] font-semibold uppercase tracking-[0.14em] text-amber-100'>Safety context</p>
+            <p className='mt-1 text-xs text-amber-50/90'>
+              {compoundContraindications[0]
+                ? `Watch for: ${compoundContraindications[0]}.`
+                : 'Use interaction checking before combining with other agents.'}
+            </p>
+          </section>
           {(confidence || evidence || sourceCount > 0 || cautionCount > 0) && (
             <div className='mt-3 flex flex-wrap gap-1.5'>
               {confidence && (
@@ -551,51 +589,7 @@ export default function CompoundDetail() {
         </header>
 
         {/* Core fields — only render when value is present */}
-        {compoundDescription && compoundDescription !== topSummary && (
-          <Section title='Overview'>
-            {compoundDescription}
-            {topSummary && <p className='mt-3 text-white/80'>{topSummary}</p>}
-            {displayClass && (
-              <p className='mt-3 label-specimen'>
-                Category: {displayClass}
-              </p>
-            )}
-          </Section>
-        )}
-
-        {/* Primary effects pills */}
-        {primaryEffects.length > 0 && (
-          <div className='mt-5 flex flex-wrap gap-2'>
-            {primaryEffects.map(effect => (
-              <span
-                key={effect}
-                className='rounded-full border border-cyan-300/30 bg-cyan-500/10 px-2.5 py-1 text-xs text-cyan-100'
-              >
-                {effect}
-              </span>
-            ))}
-          </div>
-        )}
-
-        {(doesText || whyItMatters) && (
-          <Section title='Why This Compound Matters'>
-            <div className='space-y-2'>
-              {doesText && (
-                <p>
-                  <span className='font-semibold text-white'>What it does:</span> {doesText}
-                </p>
-              )}
-              {whyItMatters && (
-                <p>
-                  <span className='font-semibold text-white'>Why it matters:</span> This helps
-                  explain why {name} is discussed in herbal profiles for{' '}
-                  {linkedHerbs.length > 0 ? `${linkedHerbs.length} herb(s)` : 'multiple herbs'}.
-                  Commonly tracked outcomes include {whyItMatters}.
-                </p>
-              )}
-            </div>
-          </Section>
-        )}
+        {displayClass && <Section title='Category'>{displayClass}</Section>}
 
         {compoundMechanism && <Section title='Mechanism of Action'>{compoundMechanism}</Section>}
 
@@ -678,7 +672,7 @@ export default function CompoundDetail() {
         {/* Found in */}
         {foundInHerbLinks.length > 0 && (
           <section id='related-herbs' className='border-white/8 mt-6 border-t pt-5'>
-            <Collapse title={`Found In (${foundInHerbLinks.length})`}>
+            <Collapse title={`Related herbs (${foundInHerbLinks.length})`}>
               <div className='space-y-4 text-sm leading-relaxed text-white/85'>
                 {linkedHerbCards.length > 0 && (
                   <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
@@ -693,22 +687,6 @@ export default function CompoundDetail() {
                     ))}
                   </div>
                 )}
-                <div>
-                  <h3 className='mb-2 text-xs font-semibold uppercase tracking-[0.14em] text-white/55'>
-                    Quick Links
-                  </h3>
-                  <div className='flex flex-wrap gap-2.5'>
-                    {foundInHerbLinks.map(item => (
-                      <Link
-                        key={item.to}
-                        to={item.to}
-                        className='inline-flex items-center rounded-full border border-white/12 bg-white/[0.05] px-3 py-1.5 text-xs font-medium tracking-[0.01em] text-white/86 transition duration-200 hover:border-white/24 hover:bg-white/[0.085] hover:text-white'
-                      >
-                        {item.label}
-                      </Link>
-                    ))}
-                  </div>
-                </div>
               </div>
             </Collapse>
           </section>

--- a/src/pages/Compounds.tsx
+++ b/src/pages/Compounds.tsx
@@ -105,9 +105,9 @@ export default function CompoundsPage() {
       />
 
       <header className='ds-card-lg mb-8'>
-        <h1 className='text-3xl font-semibold sm:text-4xl'>Compounds</h1>
+        <h1 className='text-3xl font-semibold sm:text-4xl'>Compound Context Guide</h1>
         <p className='mt-2 max-w-3xl text-sm text-white/76 sm:text-base'>
-          Search compounds by mechanism and effects, then filter by confidence and category.
+          See what each compound is, why it matters, and which herbs it appears in.
         </p>
       </header>
 
@@ -269,7 +269,7 @@ export default function CompoundsPage() {
             ].slice(0, 2)
 
             return (
-              <article key={compound.id} className='ds-card flex h-full flex-col gap-2 p-3'>
+              <article key={compound.id} className='ds-card flex h-full flex-col gap-2.5 p-3'>
                 <div className='flex items-start justify-between gap-2'>
                   <h2
                     title={compound.name}
@@ -277,11 +277,6 @@ export default function CompoundsPage() {
                   >
                     {title}
                   </h2>
-                  <span
-                    className={`shrink-0 rounded-full border px-1.5 py-0 text-[10px] font-semibold uppercase tracking-wide ${confidenceBadgeClass(confidence)}`}
-                  >
-                    {confidence}
-                  </span>
                 </div>
                 <p className='line-clamp-2 text-xs leading-[1.35] text-white/72'>{summarize(compound)}</p>
                 {chips.length > 0 && (
@@ -296,17 +291,21 @@ export default function CompoundsPage() {
                     ))}
                   </div>
                 )}
-                <div className='text-[11px] text-white/56'>
-                  <p>
-                    {compound.herbs.length} {compound.herbs.length === 1 ? 'herb' : 'herbs'}{' '}
-                    associated
+                <div className='flex items-center justify-between gap-2'>
+                  <span
+                    className={`shrink-0 rounded-full border px-1.5 py-0 text-[10px] font-semibold uppercase tracking-wide ${confidenceBadgeClass(confidence)}`}
+                  >
+                    {confidence}
+                  </span>
+                  <p className='text-[11px] text-white/56'>
+                    In {compound.herbs.length} {compound.herbs.length === 1 ? 'herb' : 'herbs'}
                   </p>
                 </div>
                 <Link
                   to={`/compounds/${compound.slug}`}
-                  className='mt-auto inline-flex w-fit items-center rounded-md border border-white/15 bg-white/[0.03] px-2 py-1 text-[11px] font-medium text-white/80 transition hover:border-cyan-300/45 hover:text-white'
+                  className='btn-secondary mt-auto inline-flex w-fit text-[11px]'
                 >
-                  View details
+                  Open context
                 </Link>
               </article>
             )

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -300,6 +300,7 @@ export default function HerbDetail() {
   )
   const sources = toSources(herb.sources)
   const primaryEffects = extractPrimaryEffects(effects, 5)
+  const decisionEffects = primaryEffects.slice(0, 2)
   const compoundByName = new Map(compounds.map(compound => [normalizeKey(compound.name), compound]))
   const herbByKey = new Map<string, { label: string; slug: string }>()
 
@@ -677,16 +678,6 @@ export default function HerbDetail() {
           { label: herbDisplayName },
         ]}
       />
-      <nav className='mb-2 text-xs text-white/60'>
-        <Link to='/' className='hover:text-white'>
-          Home
-        </Link>{' '}
-        &gt;{' '}
-        <Link to='/herbs' className='hover:text-white'>
-          Herbs
-        </Link>{' '}
-        &gt; <span className='text-white/80'>{herbDisplayName}</span>
-      </nav>
       <div className='flex flex-wrap items-center gap-2'>
         <Link to='/herbs' className='btn-secondary inline-flex items-center'>
           ← Back to herbs
@@ -725,25 +716,32 @@ export default function HerbDetail() {
               )}
             </div>
           </div>
-          {/* Primary effects are elevated directly under the name. */}
-          {primaryEffects.length > 0 && (
-            <ul className='mt-3 list-disc space-y-1 pl-5 text-sm text-white/85'>
-              {primaryEffects.map(effect => (
-                <li key={effect}>{effect}</li>
-              ))}
-            </ul>
-          )}
           {/* Keep summary concise above the fold; deep explanation is pushed lower. */}
           {(shortSummary || description) && (
             <p className='mt-4 max-w-3xl text-sm leading-relaxed text-white/80'>
               {shortSummary}
             </p>
           )}
-          {contraindications.length > 0 && (
-            <div className='mt-3 rounded-xl border border-amber-300/35 bg-amber-500/10 px-3 py-2 text-xs text-amber-100'>
-              Safety callout: {contraindications[0]}
-            </div>
+          {decisionEffects.length > 0 && (
+            <section className='mt-4'>
+              <p className='text-xs font-semibold uppercase tracking-[0.16em] text-white/55'>Key effects</p>
+              <ul className='mt-2 list-disc space-y-1 pl-5 text-sm text-white/85'>
+                {decisionEffects.map(effect => (
+                  <li key={effect}>{effect}</li>
+                ))}
+              </ul>
+            </section>
           )}
+          <section className='mt-4 rounded-lg border border-amber-300/30 bg-amber-500/10 p-3'>
+            <p className='text-xs font-semibold uppercase tracking-[0.16em] text-amber-100'>
+              Should you use this?
+            </p>
+            <p className='mt-1 text-xs text-amber-50/90'>
+              {contraindications[0]
+                ? `Use caution if ${contraindications[0].toLowerCase()}.`
+                : 'Review interactions and your context before use.'}
+            </p>
+          </section>
 
           <div className='mt-3 flex flex-wrap gap-1.5'>
             {evidenceLevel && (
@@ -778,9 +776,9 @@ export default function HerbDetail() {
         </header>
 
         {/* Core content */}
-        {description && (
+        {description && description !== shortSummary && (
           <section className='border-white/8 mt-6 border-t pt-5'>
-            <Collapse title='Summary' defaultOpen>
+            <Collapse title='Deep dive summary'>
               {description}
             </Collapse>
           </section>

--- a/src/pages/Herbs.tsx
+++ b/src/pages/Herbs.tsx
@@ -20,6 +20,7 @@ import type { EnrichmentFilter } from '@/types/enrichmentDiscovery'
 import { trackGovernedEvent } from '@/lib/governedAnalytics'
 import { slugify } from '@/lib/slug'
 import { Link } from 'react-router-dom'
+import { extractPrimaryEffects } from '@/utils/extractPrimaryEffects'
 
 const CARD_PLACEHOLDER_PATTERN = /Herb profile|reference profile|No direct|Contextual inference/i
 
@@ -111,9 +112,9 @@ export default function HerbsPage() {
       />
 
       <header className='ds-card-lg mb-8'>
-        <h1 className='text-3xl font-semibold sm:text-4xl'>Herb Knowledge Database</h1>
+        <h1 className='text-3xl font-semibold sm:text-4xl'>Herb Decision Guide</h1>
         <p className='mt-2 max-w-3xl text-sm text-white/76 sm:text-base'>
-          Search and filter herbs by effect tags, confidence, and class to quickly compare entries.
+          Compare what each herb does, how strong the evidence is, and whether it fits your goal.
         </p>
       </header>
 
@@ -273,20 +274,27 @@ export default function HerbsPage() {
           {visibleHerbs.map((herb, index) => (
             <article
               key={herb.slug || herb.id || `${herb.common}-${index}`}
-              className='rounded-2xl border border-white/10 bg-white/[0.03] p-4'
+              className='ds-card flex h-full flex-col gap-2.5 p-3'
             >
-              <h2 className='text-lg font-semibold text-white'>
+              <h2 className='line-clamp-2 text-base font-semibold text-white'>
                 {toTitleCase(String(herb.common || herb.scientific || herb.name || 'Herb'))}
               </h2>
-              <p className='mt-2 text-sm text-white/75'>
+              <p className='line-clamp-2 text-xs text-white/75'>
                 {cleanSummary(String(herb.summary || herb.description || herb.mechanism || ''))}
               </p>
-              {String(herb.qualityTier || '').toLowerCase() === 'strong' && (
-                <span className='mt-3 inline-flex rounded-full border border-emerald-300/30 bg-emerald-500/10 px-2.5 py-1 text-[11px] text-emerald-100'>
-                  Well Documented
+              <div className='flex flex-wrap gap-1'>
+                {extractPrimaryEffects(Array.isArray(herb.effects) ? herb.effects : [], 2).map(effect => (
+                  <span key={`${herb.slug || herb.id}-${effect}`} className='ds-pill'>
+                    {effect}
+                  </span>
+                ))}
+              </div>
+              <div className='flex items-center justify-between gap-2'>
+                <span className='ds-pill'>
+                  {String(herb.qualityTier || '').toLowerCase() === 'strong'
+                    ? 'Well documented'
+                    : 'Early evidence'}
                 </span>
-              )}
-              <div className='mt-4'>
                 <Link
                   to={
                     herb.slug
@@ -295,9 +303,9 @@ export default function HerbsPage() {
                           slugify(String(herb.common || herb.scientific || herb.name || '')),
                         )}`
                   }
-                  className='text-sm font-medium text-cyan-200 hover:text-cyan-100'
+                  className='btn-secondary ml-auto text-[11px]'
                 >
-                  Open herb profile →
+                  Should I use this?
                 </Link>
               </div>
             </article>


### PR DESCRIPTION
### Motivation
- Convert the dataset-style browse/detail surfaces into a decision-focused tool that surfaces signal over completeness and reduces duplication. 
- Improve scan-speed, hierarchy, and trust by compressing card content and elevating a single, decisive above-the-fold summary per profile. 
- Apply a simpler visual baseline (darker neutral, reduced glow, sharper cards) to support the new hierarchy.

### Description
- Rewrote herb browse cards into a decision-first layout showing: `Name`, one-line summary, up to two effect chips, one status pill, and a clear CTA (`Should I use this?`). (See `src/pages/Herbs.tsx`.)
- Reworked compound browse cards to emphasize context: compact summary, up to two chips, confidence/status + herb count row, and a focused CTA (`Open context`). (See `src/pages/Compounds.tsx`.)
- Restructured herb detail top-of-page to prioritize decision signals: short summary, `Key effects` (max 2 shown), and a single `Should you use this?` safety callout above fold; deep summary is gated and only shown when different. (See `src/pages/HerbDetail.tsx`.)
- Restructured compound detail top-of-page into three context cards (`What it is` / `Why it matters` / `Where it appears`), then key effects and a compact safety context before deeper technical sections. Also removed duplicated lower quick-links. (See `src/pages/CompoundDetail.tsx`.)
- Visual and spacing tweaks: near-black background, reduced radial glow, slightly smaller card rounding and lighter card fill to tighten visual language. (See `src/index.css`.)
- Changed files: `src/pages/Herbs.tsx`, `src/pages/Compounds.tsx`, `src/pages/HerbDetail.tsx`, `src/pages/CompoundDetail.tsx`, `src/index.css`.

### Testing
- Ran `npm run build` and the full build + prerender pipeline completed successfully.
- Ran `npx vitest run src/__tests__/HerbList.test.tsx src/__tests__/titleDisplay.test.ts`; this failed in the current environment due to inability to resolve `vitest/config` (environment-specific dependency resolution), not code assertions.
- No other automated test failures were introduced in the build step; follow-up CI runs should run the full test suite in a proper test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dce505b01883238e7e61ddb5669db9)