### PR TITLE
Decision‑first reframe for herb & compound pages

### DIFF
--- a/src/pages/CompoundDetail.tsx
+++ b/src/pages/CompoundDetail.tsx
@@ -417,6 +417,8 @@ export default function CompoundDetail() {
   const governedReviewFreshness = buildGovernedReviewFreshness(governedResearch)
   const topSummary =
     governedIntro.whatItIs || governedIntro.commonUse || compoundDescription || compoundMechanism
+  const topEffects = primaryEffects.slice(0, 2)
+  const whereAppears = foundInHerbLinks.slice(0, 3).map(item => item.label)
   const enrichmentRecommendations = buildEnrichmentRecommendations('compound', compound.slug)
   const quickCompareSection = buildGovernedQuickCompareSection('compound', compound.slug)
   const recommendationNames = {
@@ -506,33 +508,39 @@ export default function CompoundDetail() {
           <div className='flex flex-wrap items-start justify-between gap-3'>
             <h1 className='text-3xl font-semibold leading-tight'>{name}</h1>
           </div>
-          {(compoundDescription || topSummary) && (
+          {(topSummary || compoundDescription) && (
             <p className='mt-3 max-w-3xl text-sm leading-relaxed text-white/80'>
-              {compoundDescription || topSummary}
+              {topSummary || compoundDescription}
             </p>
           )}
-          {(confidence || evidence || sourceCount > 0 || cautionCount > 0) && (
+          <div className='mt-4 grid gap-3 sm:grid-cols-3'>
+            <section className='rounded-lg border border-white/10 bg-black/20 p-3'>
+              <h2 className='text-[11px] font-semibold uppercase tracking-[0.14em] text-white/56'>Why it matters</h2>
+              <p className='mt-1 text-xs text-white/80'>
+                {whyItMatters || 'Tracked for mechanism context and potential outcomes.'}
+              </p>
+            </section>
+            <section className='rounded-lg border border-white/10 bg-black/20 p-3'>
+              <h2 className='text-[11px] font-semibold uppercase tracking-[0.14em] text-white/56'>Key effects</h2>
+              <p className='mt-1 text-xs text-white/80'>{topEffects.join(' · ') || 'Effects being reviewed.'}</p>
+            </section>
+            <section className='rounded-lg border border-white/10 bg-black/20 p-3'>
+              <h2 className='text-[11px] font-semibold uppercase tracking-[0.14em] text-white/56'>Where it appears</h2>
+              <p className='mt-1 text-xs text-white/80'>
+                {whereAppears.join(', ') || 'Related herbs listed below.'}
+              </p>
+            </section>
+          </div>
+          {(confidence || sourceCount > 0 || cautionCount > 0) && (
             <div className='mt-3 flex flex-wrap gap-1.5'>
-              {confidence && (
-                <span className='inline-flex items-center gap-1.5 rounded-sm border border-emerald-400/35 bg-emerald-500/8 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.18em] text-emerald-200'>
-                  <span aria-hidden='true'>✓</span> Confidence: {confidence}
-                </span>
-              )}
-              {evidence && (
-                <span className='inline-flex items-center gap-1.5 rounded-sm border border-emerald-400/35 bg-emerald-500/8 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.18em] text-emerald-200'>
-                  <span aria-hidden='true'>✓</span> Evidence: {evidence}
-                </span>
-              )}
+              {confidence && <span className='ds-pill'>Confidence: {confidence}</span>}
               {sourceCount > 0 && (
-                <span className='inline-flex items-center gap-1.5 rounded-sm border border-emerald-400/35 bg-emerald-500/8 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.18em] text-emerald-200'>
-                  <span aria-hidden='true'>✓</span> {sourceCount} source{sourceCount === 1 ? '' : 's'}
+                <span className='ds-pill'>
+                  {sourceCount} source{sourceCount === 1 ? '' : 's'}
                 </span>
               )}
-              {cautionCount > 0 && (
-                <span className='inline-flex items-center gap-1.5 rounded-sm border border-amber-400/40 bg-amber-500/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.18em] text-amber-200'>
-                  <span aria-hidden='true'>⚠</span> {cautionCount} caution signal{cautionCount === 1 ? '' : 's'}
-                </span>
-              )}
+              {cautionCount > 0 && <span className='ds-pill'>Cautions: {cautionCount}</span>}
+              {evidence && <span className='ds-pill'>{evidence}</span>}
             </div>
           )}
           <Link
@@ -577,25 +585,7 @@ export default function CompoundDetail() {
           </div>
         )}
 
-        {(doesText || whyItMatters) && (
-          <Section title='Why This Compound Matters'>
-            <div className='space-y-2'>
-              {doesText && (
-                <p>
-                  <span className='font-semibold text-white'>What it does:</span> {doesText}
-                </p>
-              )}
-              {whyItMatters && (
-                <p>
-                  <span className='font-semibold text-white'>Why it matters:</span> This helps
-                  explain why {name} is discussed in herbal profiles for{' '}
-                  {linkedHerbs.length > 0 ? `${linkedHerbs.length} herb(s)` : 'multiple herbs'}.
-                  Commonly tracked outcomes include {whyItMatters}.
-                </p>
-              )}
-            </div>
-          </Section>
-        )}
+        {doesText && <Section title='Mechanism Context'>{doesText}</Section>}
 
         {compoundMechanism && <Section title='Mechanism of Action'>{compoundMechanism}</Section>}
 

--- a/src/pages/Compounds.tsx
+++ b/src/pages/Compounds.tsx
@@ -40,9 +40,18 @@ function confidenceBadgeClass(level: ConfidenceLevel) {
 }
 
 function summarize(compound: { description: string; effects: string[] }) {
-  if (compound.description) return compound.description
+  if (compound.description) {
+    const firstSentence = compound.description.split(/(?<=[.!?])\s+/)[0] || compound.description
+    return firstSentence
+  }
   if (compound.effects.length) return compound.effects.slice(0, 2).join(' · ')
-  return 'Mechanism and effects are still being researched.'
+  return 'Profile in progress.'
+}
+
+function getStatusTag(level: ConfidenceLevel) {
+  if (level === 'high') return 'Well supported'
+  if (level === 'medium') return 'Moderate evidence'
+  return 'Limited evidence'
 }
 
 export default function CompoundsPage() {
@@ -241,7 +250,7 @@ export default function CompoundsPage() {
           No compounds match your current filters.
         </div>
       ) : (
-        <section className='grid gap-2.5 sm:grid-cols-2 sm:gap-3 lg:grid-cols-3'>
+        <section className='grid gap-2 sm:grid-cols-2 lg:grid-cols-3'>
           {visibleCompounds.map(compound => {
             const confidence =
               compound.confidence ??
@@ -269,21 +278,14 @@ export default function CompoundsPage() {
             ].slice(0, 2)
 
             return (
-              <article key={compound.id} className='ds-card flex h-full flex-col gap-2 p-3'>
-                <div className='flex items-start justify-between gap-2'>
-                  <h2
-                    title={compound.name}
-                    className='line-clamp-2 min-h-[2.2rem] break-all text-[0.95rem] font-semibold leading-tight text-white sm:text-base'
-                  >
-                    {title}
-                  </h2>
-                  <span
-                    className={`shrink-0 rounded-full border px-1.5 py-0 text-[10px] font-semibold uppercase tracking-wide ${confidenceBadgeClass(confidence)}`}
-                  >
-                    {confidence}
-                  </span>
-                </div>
-                <p className='line-clamp-2 text-xs leading-[1.35] text-white/72'>{summarize(compound)}</p>
+              <article key={compound.id} className='ds-card flex h-full flex-col gap-1.5 rounded-lg p-3'>
+                <h2
+                  title={compound.name}
+                  className='line-clamp-2 min-h-[2.2rem] break-all text-[0.95rem] font-semibold leading-tight text-white sm:text-base'
+                >
+                  {title}
+                </h2>
+                <p className='line-clamp-1 text-xs leading-[1.35] text-white/72'>{summarize(compound)}</p>
                 {chips.length > 0 && (
                   <div className='flex flex-wrap gap-1'>
                     {chips.map(chip => (
@@ -296,17 +298,16 @@ export default function CompoundsPage() {
                     ))}
                   </div>
                 )}
-                <div className='text-[11px] text-white/56'>
-                  <p>
-                    {compound.herbs.length} {compound.herbs.length === 1 ? 'herb' : 'herbs'}{' '}
-                    associated
-                  </p>
-                </div>
+                <span
+                  className={`mt-1 inline-flex w-fit rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] ${confidenceBadgeClass(confidence)}`}
+                >
+                  {getStatusTag(confidence)}
+                </span>
                 <Link
                   to={`/compounds/${compound.slug}`}
                   className='mt-auto inline-flex w-fit items-center rounded-md border border-white/15 bg-white/[0.03] px-2 py-1 text-[11px] font-medium text-white/80 transition hover:border-cyan-300/45 hover:text-white'
                 >
-                  View details
+                  View context page
                 </Link>
               </article>
             )

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -159,6 +159,7 @@ export default function HerbDetail() {
   const summary = sentenceClamp(description, 3)
 
   const effects = dedupeCaseInsensitive(splitTextList(herb.primaryEffects || herb.effects)).slice(0, 6)
+  const keyEffects = effects.slice(0, 2)
   const activeCompounds = dedupeCaseInsensitive(splitTextList(herb.activeCompounds || herb.compounds))
   const mechanism = String(herb.mechanism || herb.mechanismOfAction || '').trim()
   const dosage = String(herb.dosage || '').trim()
@@ -184,6 +185,11 @@ export default function HerbDetail() {
 
   const sources = toSources(herb.sources)
   const confidenceLabel = toTitleCase(String(herb.evidenceLevel || herb.confidence || 'Limited'))
+  const shouldUseSummary =
+    priorityWarning ||
+    (confidenceLabel.toLowerCase().includes('limited')
+      ? 'Use cautiously when evidence is limited and start with conservative dosing.'
+      : 'May be useful when the target effects match your goal and safety notes are clear.')
   const pagePath = `/herbs/${herb.slug}`
   const relatedHerbs = herbs
     .filter(item => item.slug && item.slug !== herb.slug)
@@ -249,35 +255,37 @@ export default function HerbDetail() {
         <header className='rounded-2xl border border-white/10 bg-white/[0.03] p-4 sm:p-5'>
           <h1 className='text-3xl font-semibold sm:text-4xl'>{herbName}</h1>
           {scientificName && <p className='mt-1 text-sm italic text-white/55'>{scientificName}</p>}
-
-          <div className='mt-3 flex flex-wrap gap-2'>
-            {effects.map(effect => (
-              <span
-                key={effect}
-                className='rounded-full border border-emerald-300/30 bg-emerald-500/10 px-2.5 py-1 text-xs text-emerald-100'
-              >
-                {effect}
-              </span>
-            ))}
-          </div>
-
-          {descriptionIsPlaceholder ? (
-            <p className='mt-4 rounded-xl border border-cyan-300/30 bg-cyan-500/10 px-3 py-2 text-sm text-cyan-100'>
-              Full research profile coming soon. Check back for mechanism notes, dosage guidance, and source citations.
-            </p>
-          ) : (
-            <p className='mt-4 max-w-3xl text-sm leading-relaxed text-white/80'>{summary}</p>
+          {!descriptionIsPlaceholder && (
+            <p className='mt-3 max-w-3xl text-sm leading-relaxed text-white/80'>{summary}</p>
           )}
 
-          {priorityWarning && (
-            <div className='mt-4 rounded-xl border border-amber-300/35 bg-amber-500/10 px-3 py-2 text-sm text-amber-100'>
-              Safety warning: {priorityWarning}
+          <section className='mt-4'>
+            <h2 className='text-xs font-semibold uppercase tracking-[0.14em] text-white/58'>Key effects</h2>
+            <div className='mt-2 flex flex-wrap gap-2'>
+              {keyEffects.length > 0 ? (
+                keyEffects.map(effect => (
+                  <span
+                    key={effect}
+                    className='rounded-full border border-cyan-300/30 bg-cyan-500/10 px-2.5 py-1 text-xs text-cyan-100'
+                  >
+                    {effect}
+                  </span>
+                ))
+              ) : (
+                <span className='text-sm text-white/65'>Effects being reviewed.</span>
+              )}
             </div>
-          )}
+          </section>
 
-          <div className='mt-4 inline-flex rounded-full border border-white/20 bg-white/5 px-2.5 py-1 text-xs text-white/80'>
-            Evidence: {confidenceLabel}
-          </div>
+          <section className='mt-4 rounded-xl border border-white/10 bg-black/20 p-3'>
+            <h2 className='text-xs font-semibold uppercase tracking-[0.14em] text-white/58'>
+              Should you use this?
+            </h2>
+            <p className='mt-2 text-sm text-white/82'>{shouldUseSummary}</p>
+            <div className='mt-2 inline-flex rounded-full border border-white/20 bg-white/5 px-2.5 py-1 text-xs text-white/80'>
+              Evidence: {confidenceLabel}
+            </div>
+          </section>
         </header>
 
         <DisclosureSection title='Effects' defaultOpen>
@@ -292,13 +300,11 @@ export default function HerbDetail() {
           )}
         </DisclosureSection>
 
-        <DisclosureSection title='Full Description'>
-          {descriptionIsPlaceholder ? (
-            <p>Profile in progress.</p>
-          ) : (
+        {!descriptionIsPlaceholder && (
+          <DisclosureSection title='Full Description'>
             <p>{description}</p>
-          )}
-        </DisclosureSection>
+          </DisclosureSection>
+        )}
 
         <DisclosureSection title='Active Compounds'>
           {activeCompounds.length > 0 ? (

--- a/src/pages/Herbs.tsx
+++ b/src/pages/Herbs.tsx
@@ -55,6 +55,19 @@ const cleanSummary = (value: string, herbName = '') => {
   return `${normalized.slice(0, 117).trimEnd()}...`
 }
 
+const getKeyEffects = (herb: Record<string, unknown>) =>
+  (Array.isArray(herb.primaryEffects) ? herb.primaryEffects : Array.isArray(herb.effects) ? herb.effects : [])
+    .map(effect => toTitleCase(String(effect || '').trim()))
+    .filter(Boolean)
+    .slice(0, 2)
+
+const getStatusTag = (herb: Record<string, unknown>) => {
+  const tier = String(herb.qualityTier || herb.evidenceLevel || '').toLowerCase()
+  if (tier.includes('strong') || tier.includes('high')) return 'Well documented'
+  if (tier.includes('medium') || tier.includes('moderate')) return 'Moderate evidence'
+  return 'Limited evidence'
+}
+
 const ENRICHMENT_FILTER_OPTIONS: Array<{ value: EnrichmentFilter; label: string }> = [
   { value: 'all', label: 'All research states' },
   { value: 'enriched_reviewed', label: 'Enriched & reviewed' },
@@ -287,38 +300,32 @@ export default function HerbsPage() {
           No herbs match your current filters.
         </div>
       ) : (
-        <section className='grid gap-2.5 sm:grid-cols-2 sm:gap-3 lg:grid-cols-3'>
+        <section className='grid gap-2 sm:grid-cols-2 lg:grid-cols-3'>
           {visibleHerbs.map((herb, index) => (
             <article
               key={herb.slug || herb.id || `${herb.common}-${index}`}
-              className='rounded-2xl border border-white/10 bg-white/[0.03] p-4'
+              className='flex h-full flex-col rounded-lg border border-white/12 bg-white/[0.02] p-3'
             >
-              <h2 className='text-lg font-semibold text-white'>
+              <h2 className='text-base font-semibold text-white'>
                 {toTitleCase(String(herb.common || herb.scientific || herb.name || 'Herb'))}
               </h2>
-              <p className='mt-2 text-sm text-white/75'>
+              <p className='mt-1 line-clamp-1 text-xs text-white/72'>
                 {cleanSummary(String(herb.summary || herb.description || herb.mechanism || ''), String(herb.common || herb.name || ''))}
               </p>
-              <div className='mt-3 flex flex-wrap gap-1.5'>
-                {(Array.isArray(herb.primaryEffects) ? herb.primaryEffects : Array.isArray(herb.effects) ? herb.effects : [])
-                  .map(effect => String(effect || '').trim())
-                  .filter(Boolean)
-                  .slice(0, 3)
-                  .map(effect => (
-                    <span
-                      key={`${herb.slug}-${effect}`}
-                      className='inline-flex rounded-full border border-cyan-300/30 bg-cyan-500/10 px-2 py-0.5 text-[11px] text-cyan-100'
-                    >
-                      {toTitleCase(effect)}
-                    </span>
-                  ))}
+              <div className='mt-2 flex flex-wrap gap-1'>
+                {getKeyEffects(herb).map(effect => (
+                  <span
+                    key={`${herb.slug}-${effect}`}
+                    className='inline-flex rounded-full border border-cyan-300/28 bg-cyan-500/10 px-2 py-0.5 text-[10px] text-cyan-100'
+                  >
+                    {effect}
+                  </span>
+                ))}
               </div>
-              {String(herb.qualityTier || '').toLowerCase() === 'strong' && (
-                <span className='mt-2 inline-flex rounded-full border border-emerald-300/30 bg-emerald-500/10 px-2.5 py-1 text-[11px] text-emerald-100'>
-                  Well Documented
-                </span>
-              )}
-              <div className='mt-4'>
+              <span className='mt-2 inline-flex w-fit rounded-full border border-white/18 bg-white/[0.04] px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] text-white/75'>
+                {getStatusTag(herb)}
+              </span>
+              <div className='mt-auto pt-2'>
                 <Link
                   to={
                     herb.slug
@@ -327,9 +334,9 @@ export default function HerbsPage() {
                           slugify(String(herb.common || herb.scientific || herb.name || '')),
                         )}`
                   }
-                  className='text-sm font-medium text-cyan-200 hover:text-cyan-100'
+                  className='inline-flex items-center rounded-md border border-white/15 bg-white/[0.03] px-2 py-1 text-[11px] font-medium text-white/80 transition hover:border-cyan-300/45 hover:text-white'
                 >
-                  Open herb profile →
+                  View decision page
                 </Link>
               </div>
             </article>


### PR DESCRIPTION
### Motivation
- Convert the dataset-style browse and detail screens into a decision-first UI that conveys immediate value and reduces noise. 
- Prioritize signal over completeness by compressing card content, removing duplicate/placeholder language, and surfacing a clear CTA on first glance. 
- Improve hierarchy and trust by surfacing concise evidence/safety context at the top of detail pages rather than deep in long paragraphs.

### Description
- Reworked browse cards so both herbs and compounds follow the new compact structure: `Name` → one-line summary (first sentence) → up to 2 key effects/chips → single status tag → compact CTA; helpers added: `getKeyEffects` and `getStatusTag` (files: `src/pages/Herbs.tsx`, `src/pages/Compounds.tsx`).
- Herb detail header converted to a decision panel with `Key effects` and a `Should you use this?` safety/evidence block shown above the fold, and placeholder/full-description rendering suppressed when profile content is a placeholder (file: `src/pages/HerbDetail.tsx`).
- Compound detail header converted to a context panel answering `Why it matters`, `Key effects`, and `Where it appears` with condensed trust chips and the primary interaction CTA, and the longer “Why this matters” narrative moved to a compact `Mechanism Context` section (file: `src/pages/CompoundDetail.tsx`).
- Visual density and hierarchy tightened by reducing card padding/roundedness and clamping summaries/effect lists to prevent duplication and long paragraphs (files updated: `src/pages/Herbs.tsx`, `src/pages/Compounds.tsx`, `src/pages/HerbDetail.tsx`, `src/pages/CompoundDetail.tsx`).

### Testing
- Ran the site build pipeline via `npm run build`, which completed successfully in this environment and generated prerender artifacts. 
- Ran the production compile step via `npm run build:compile` (Vite build), which completed successfully. 
- Pre-commit lint checks (`eslint --max-warnings=0`) ran as part of the workflow and passed for the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dce9f54fa483239bd743c781c1a00c)