### PR TITLE
Add guard-layer sanitization for herb effects, chips, and summaries

### DIFF
--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -37,6 +37,7 @@ const JUNK_WHOLE_VALUE: RegExp[] = [
 ]
 
 const NUMERIC_ONLY = /^\d+(?:[\s.,/-]\d+)*$/
+const BROKEN_TOKEN = /^(anti|sedat|anxiol|analg|adapt|stimul|effect|effects?)$/i
 
 /** True if a string is entirely junk — should not be rendered at all. */
 export function isJunk(value: unknown): boolean {
@@ -163,4 +164,56 @@ export function sanitizeReadableText(value: unknown): string {
   })
 
   return Array.from(deduped.values()).join(' ').trim()
+}
+
+function normalizeGuardKey(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/^contextual inference:\s*/i, '')
+    .replace(/\([^)]*\)/g, ' ')
+    .replace(/[^\w\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function looksBroken(value: string): boolean {
+  const normalized = value.trim()
+  if (!normalized) return true
+  if (normalized.length < 4) return true
+  if (BROKEN_TOKEN.test(normalized)) return true
+  if (!/[a-z]/i.test(normalized)) return true
+  return false
+}
+
+export function normalizePresentationLabel(value: unknown): string {
+  const cleaned = sanitizeReadableText(value)
+    .replace(/^contextual inference:\s*/i, '')
+    .replace(/\(inferred from related species\)/gi, '(inferred)')
+    .replace(/\s+/g, ' ')
+    .trim()
+  if (!cleaned || looksBroken(cleaned)) return ''
+  return cleaned
+}
+
+export function dedupePresentationList(value: unknown, maxItems = 8): string[] {
+  const seen = new Set<string>()
+  const output: string[] = []
+  splitClean(value)
+    .map(entry => normalizePresentationLabel(entry))
+    .filter(Boolean)
+    .forEach(entry => {
+      const key = normalizeGuardKey(entry)
+      if (!key || seen.has(key)) return
+      seen.add(key)
+      output.push(entry)
+    })
+  return output.slice(0, Math.max(0, maxItems))
+}
+
+export function sanitizeSummaryText(value: unknown, maxSentences = 2): string {
+  const cleaned = sanitizeReadableText(value)
+  if (!cleaned) return ''
+  const sentences = cleaned.match(/[^.!?]+[.!?]?/g) || [cleaned]
+  const kept = dedupePresentationList(sentences, maxSentences)
+  return kept.join(' ').trim()
 }

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -5,6 +5,11 @@ import { Link, useParams } from 'react-router-dom'
 import Meta from '@/components/Meta'
 import { useCompoundDataState } from '@/lib/compound-data'
 import { useHerbDataState, useHerbDetailState } from '@/lib/herb-data'
+import {
+  dedupePresentationList,
+  normalizePresentationLabel,
+  sanitizeSummaryText,
+} from '@/lib/sanitize'
 import { HerbDetailSkeleton } from '@/components/skeletons/DetailSkeletons'
 import { SITE_URL, breadcrumbJsonLd, herbJsonLd } from '@/lib/seo'
 
@@ -23,16 +28,6 @@ function toTitleCase(value: string) {
     .replace(/\b\w/g, letter => letter.toUpperCase())
 }
 
-function sentenceClamp(text: string, maxSentences = 3) {
-  const cleaned = String(text || '').replace(/\s+/g, ' ').trim()
-  if (!cleaned) return ''
-  const sentences = cleaned.match(/[^.!?]+[.!?]?/g) || [cleaned]
-  return sentences
-    .slice(0, maxSentences)
-    .map(s => s.trim())
-    .join(' ')
-}
-
 function splitTextList(value: unknown): string[] {
   if (Array.isArray(value)) {
     return value
@@ -43,35 +38,6 @@ function splitTextList(value: unknown): string[] {
     .split(/[;,]/)
     .map(item => item.trim())
     .filter(Boolean)
-}
-
-function dedupeCaseInsensitive(values: string[]) {
-  const seen = new Set<string>()
-  const unique: string[] = []
-  values.forEach(value => {
-    const key = value.trim().toLowerCase()
-    if (!key || seen.has(key)) return
-    seen.add(key)
-    unique.push(value.trim())
-  })
-  return unique
-}
-
-function cleanReadableLabel(value: string) {
-  return String(value || '')
-    .replace(/\([^)]*\)/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim()
-}
-
-function isMalformedEffectLabel(value: string) {
-  const normalized = cleanReadableLabel(value).toLowerCase()
-  if (!normalized) return true
-  if (normalized.length < 5) return true
-  if (/^[a-z]+$/.test(normalized) && normalized.length <= 6) return true
-  if (/^(anti|sedat|anxiol|analg|adapt|stimul)$/i.test(normalized)) return true
-  if (!/[a-z]/i.test(normalized)) return true
-  return false
 }
 
 function toEvidenceStrengthLabel(value: string) {
@@ -182,15 +148,12 @@ export default function HerbDetail() {
   const scientificName = String(herb.scientific || herb.latinName || '').trim()
   const description = String(herb.description || herb.summary || '').trim()
   const descriptionIsPlaceholder = isPlaceholder(description, herbName)
-  const summary = sentenceClamp(description, 2)
+  const summary = sanitizeSummaryText(description, 2)
 
-  const effects = dedupeCaseInsensitive(splitTextList(herb.primaryEffects || herb.effects))
-    .map(cleanReadableLabel)
-    .filter(effect => !isMalformedEffectLabel(effect))
+  const effects = dedupePresentationList(splitTextList(herb.primaryEffects || herb.effects), 8)
     .map(toTitleCase)
-    .slice(0, 8)
   const keyEffects = effects.slice(0, 4)
-  const activeCompounds = dedupeCaseInsensitive(splitTextList(herb.activeCompounds || herb.compounds))
+  const activeCompounds = dedupePresentationList(splitTextList(herb.activeCompounds || herb.compounds), 10)
   const mechanism = String(herb.mechanism || herb.mechanismOfAction || '').trim()
   const dosage = String(herb.dosage || '').trim()
   const duration = String(herb.duration || '').trim()
@@ -201,14 +164,14 @@ export default function HerbDetail() {
   const sideEffects = splitTextList(herb.sideeffects || herb.sideEffects)
   const safety = splitTextList((herb as Record<string, unknown>).safetyNotes || (herb as Record<string, unknown>).safety)
 
-  const safetyNotes = dedupeCaseInsensitive([
+  const safetyNotes = dedupePresentationList([
     ...contraindications,
     ...interactions,
     ...sideEffects,
     ...safety,
-  ])
-    .map(note => note.replace(/\s+/g, ' ').trim())
-    .filter(note => note.length >= 5)
+  ], 8)
+    .map(note => normalizePresentationLabel(note))
+    .filter(Boolean)
     .map(toTitleCase)
 
   const priorityWarning = safetyNotes.find(note => /(pregnancy|cardiac|avoid)/i.test(note))
@@ -283,7 +246,6 @@ export default function HerbDetail() {
         <div className='sr-only' aria-hidden='true'>
           <h1>{herbName}</h1>
           <p>{description}</p>
-          <ul>{effects.map(effect => <li key={`static-effect-${effect}`}>{effect}</li>)}</ul>
           <ul>{safetyNotes.map(note => <li key={`static-safety-${note}`}>{note}</li>)}</ul>
         </div>
 

--- a/src/pages/Herbs.tsx
+++ b/src/pages/Herbs.tsx
@@ -19,6 +19,7 @@ import EffectExplorer from '@/components/EffectExplorer'
 import type { EnrichmentFilter } from '@/types/enrichmentDiscovery'
 import { trackGovernedEvent } from '@/lib/governedAnalytics'
 import { slugify } from '@/lib/slug'
+import { dedupePresentationList, sanitizeSummaryText } from '@/lib/sanitize'
 import { Link } from 'react-router-dom'
 
 
@@ -47,19 +48,20 @@ const toTitleCase = (value: string) =>
     .replace(/\b\w/g, letter => letter.toUpperCase())
 
 const cleanSummary = (value: string, herbName = '') => {
-  const normalized = String(value || '').replace(/\s+/g, ' ').trim()
+  const normalized = sanitizeSummaryText(value, 2)
   if (!normalized) return 'Profile in progress'
   if (isPlaceholder(normalized, herbName)) return 'Profile in progress'
-  const firstSentence = normalized.split(/(?<=[.!?])\s+/)[0] || normalized
-  if (firstSentence.length <= 120) return firstSentence
+  if (normalized.length <= 120) return normalized
   return `${normalized.slice(0, 117).trimEnd()}...`
 }
 
 const getKeyEffects = (herb: Record<string, unknown>) =>
-  (Array.isArray(herb.primaryEffects) ? herb.primaryEffects : Array.isArray(herb.effects) ? herb.effects : [])
-    .map(effect => toTitleCase(String(effect || '').trim()))
-    .filter(Boolean)
-    .slice(0, 2)
+  dedupePresentationList(
+    Array.isArray(herb.primaryEffects) ? herb.primaryEffects : Array.isArray(herb.effects) ? herb.effects : [],
+    3,
+  )
+    .map(toTitleCase)
+    .slice(0, 3)
 
 const getStatusTag = (herb: Record<string, unknown>) => {
   const tier = String(herb.qualityTier || herb.evidenceLevel || '').toLowerCase()


### PR DESCRIPTION
### Motivation
- Prevent low-quality, duplicate, or malformed text from reaching the UI by applying a presentation-side guard layer that enforces deduplication, broken-string filtering, and concise summary normalization.
- Ensure effects/tags/summaries follow the project presentation rules (no duplicates, no partial labels, short summaries, limited chips) without changing source schemas or raw data files.

### Description
- Added presentation guard helpers in `src/lib/sanitize.ts`: `normalizePresentationLabel`, `dedupePresentationList`, and `sanitizeSummaryText` to normalize phrases, drop broken tokens, and collapse near-duplicates before render. 
- Wired the guard utilities into herb pages so herb detail uses cleaned `effects`, `activeCompounds`, `safetyNotes`, and `summary`, and the herbs index/cards use `sanitizeSummaryText` and `dedupePresentationList` for card summaries and chips. 
- Removed duplicate sr-only effects list from `HerbDetail` so effects are shown only once (visible chips), and capped visible effect chips to 3 on cards and 4 on the herb detail header. 
- Changed files: `src/lib/sanitize.ts`, `src/pages/HerbDetail.tsx`, `src/pages/Herbs.tsx`.

### Testing
- Ran `npm run build:compile` which completed successfully and produced a working production bundle. 
- Commit hooks ran `eslint --max-warnings=0` on touched files during commit and passed. 
- Ran a Node audit script over `public/data/herbs-detail/*.json` using the new normalization logic which reported removal of presentation junk (example: ~845 items removed of 2,694 candidates in the examined detail files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf20de7008323b186741660c0ea14)