### PR TITLE
Sanitize compound effects and tighten Compound detail/index rendering

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,18 +8,18 @@ import { isAnalyticsRouteEnabled } from '@/lib/analyticsAccess'
 const exploreLinks = [
   { href: '/herbs', label: 'Herb Database' },
   { href: '/compounds', label: 'Compounds' },
-  { href: '/collections/herbs-for-relaxation', label: 'SEO Collections' },
   { href: '/build', label: 'Build a Blend' },
-  { href: '/blog', label: 'Blog' },
-  { href: '/contribute', label: 'Contribute / Help improve this data' },
-  { href: '/graph', label: 'NeuroHerbGraph' },
+  { href: '/collections/herbs-for-relaxation', label: 'Collections' },
+]
+
+const safetyLinks = [
+  { href: '/methodology', label: 'Methodology' },
+  { href: '/disclaimer', label: 'Disclaimer' },
+  { href: '/contact', label: 'Contact' },
 ]
 
 const legalLinks = [
-  { href: '/methodology', label: 'Methodology' },
   { href: '/privacy', label: 'Privacy Policy' },
-  { href: '/disclaimer', label: 'Disclaimer' },
-  { href: '/contact', label: 'Contact' },
   { href: '/sitemap', label: 'Sitemap' },
 ]
 
@@ -34,7 +34,7 @@ function formatBuildDate(isoDate: string) {
 export default function Footer() {
   const [open, setOpen] = useState(false)
   const availableLegalLinks = isAnalyticsRouteEnabled()
-    ? [...legalLinks, { href: '/analytics', label: 'Site Analytics' }]
+    ? [...legalLinks, { href: '/analytics', label: 'Analytics' }]
     : legalLinks
 
   useEffect(() => onOpenConsent(() => setOpen(true)), [])
@@ -48,7 +48,7 @@ export default function Footer() {
   return (
     <footer className='relative mx-auto mt-8 w-full max-w-screen-lg px-4 pb-8 pt-4'>
       <div className='border-white/12 ring-white/8 rounded-2xl border bg-white/5 p-5 ring-1 backdrop-blur-xl sm:p-6'>
-        <div className='grid gap-6 sm:grid-cols-2 sm:gap-8'>
+        <div className='grid gap-6 sm:grid-cols-3 sm:gap-8'>
           <NonEmpty>
             {exploreLinks.length > 0 && (
               <div>
@@ -68,13 +68,13 @@ export default function Footer() {
             )}
           </NonEmpty>
           <NonEmpty>
-            {availableLegalLinks.length > 0 && (
+            {safetyLinks.length > 0 && (
               <div>
                 <h4 className='text-white/62 mb-3 text-xs font-semibold uppercase tracking-[0.24em]'>
-                  Trust & safety
+                  Safety
                 </h4>
                 <ul className='text-white/78 space-y-2 text-sm'>
-                  {availableLegalLinks.map(link => (
+                  {safetyLinks.map(link => (
                     <li key={link.href}>
                       <Link className='transition hover:text-white' to={link.href}>
                         {link.label}
@@ -90,6 +90,24 @@ export default function Footer() {
                       Privacy settings
                     </button>
                   </li>
+                </ul>
+              </div>
+            )}
+          </NonEmpty>
+          <NonEmpty>
+            {availableLegalLinks.length > 0 && (
+              <div>
+                <h4 className='text-white/62 mb-3 text-xs font-semibold uppercase tracking-[0.24em]'>
+                  Legal
+                </h4>
+                <ul className='text-white/78 space-y-2 text-sm'>
+                  {availableLegalLinks.map(link => (
+                    <li key={link.href}>
+                      <Link className='transition hover:text-white' to={link.href}>
+                        {link.label}
+                      </Link>
+                    </li>
+                  ))}
                 </ul>
               </div>
             )}

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -38,6 +38,12 @@ const JUNK_WHOLE_VALUE: RegExp[] = [
 
 const NUMERIC_ONLY = /^\d+(?:[\s.,/-]\d+)*$/
 const BROKEN_TOKEN = /^(anti|sedat|anxiol|analg|adapt|stimul|effect|effects?)$/i
+const FILLER_CHIP_PATTERNS = [
+  /^reported in\b/i,
+  /^currently mentions\b/i,
+  /^related herbs?\b/i,
+  /^contextual inference\b/i,
+]
 
 /** True if a string is entirely junk — should not be rendered at all. */
 export function isJunk(value: unknown): boolean {
@@ -185,6 +191,27 @@ function looksBroken(value: string): boolean {
   return false
 }
 
+function normalizeEffectFragment(value: string): string {
+  const normalized = value
+    .trim()
+    .replace(/^contextual inference:\s*/i, '')
+    .replace(/^reported in\s+/i, '')
+    .replace(/^currently mentions\s+/i, '')
+    .replace(/^related herbs?:?\s*/i, '')
+    .replace(/\s+/g, ' ')
+
+  if (normalized.toLowerCase() === 'anti inflammatory') return 'anti-inflammatory'
+  if (normalized.toLowerCase() === 'anti anxiety') return 'anti-anxiety'
+  if (normalized.toLowerCase() === 'anti oxidant') return 'antioxidant'
+  return normalized
+}
+
+function shouldDropChip(value: string): boolean {
+  if (looksBroken(value)) return true
+  if (value.split(/\s+/).length > 3) return true
+  return FILLER_CHIP_PATTERNS.some(pattern => pattern.test(value))
+}
+
 export function normalizePresentationLabel(value: unknown): string {
   const cleaned = sanitizeReadableText(value)
     .replace(/^contextual inference:\s*/i, '')
@@ -207,6 +234,36 @@ export function dedupePresentationList(value: unknown, maxItems = 8): string[] {
       seen.add(key)
       output.push(entry)
     })
+  return output.slice(0, Math.max(0, maxItems))
+}
+
+export function cleanEffectChips(value: unknown, maxItems = 5): string[] {
+  const parts = splitClean(value)
+  const seen = new Set<string>()
+  const output: string[] = []
+
+  for (let index = 0; index < parts.length; index += 1) {
+    const current = normalizeEffectFragment(parts[index] || '')
+    const next = normalizeEffectFragment(parts[index + 1] || '')
+
+    if (current.toLowerCase() === 'anti' && next.toLowerCase() === 'inflammatory') {
+      const merged = 'anti-inflammatory'
+      if (!seen.has(merged)) {
+        seen.add(merged)
+        output.push(merged)
+      }
+      index += 1
+      continue
+    }
+
+    const normalized = normalizePresentationLabel(current)
+    if (!normalized || shouldDropChip(normalized)) continue
+    const key = normalizeGuardKey(normalized)
+    if (!key || seen.has(key)) continue
+    seen.add(key)
+    output.push(normalized)
+  }
+
   return output.slice(0, Math.max(0, maxItems))
 }
 

--- a/src/lib/trust.ts
+++ b/src/lib/trust.ts
@@ -73,7 +73,7 @@ export function getTrustNote({
   hasFallbackContent,
 }: TrustNoteInput): string {
   if (hasFallbackContent) {
-    return 'Some copy is fallback-derived or placeholder-adjacent. Treat claims as provisional.'
+    return 'Some insights are inferred and require further validation.'
   }
   if (hasInferredContent) {
     return 'Some statements are inferred from indirect evidence; certainty is limited.'

--- a/src/pages/CompoundDetail.tsx
+++ b/src/pages/CompoundDetail.tsx
@@ -4,7 +4,13 @@ import Meta from '@/components/Meta'
 import DataTrustPanel from '@/components/trust/DataTrustPanel'
 import { useCompoundDataState, useCompoundDetailState } from '@/lib/compound-data'
 import { useHerbDataState } from '@/lib/herb-data'
-import { sanitizeReadableText, splitClean, uniqueNormalizedList } from '@/lib/sanitize'
+import {
+  cleanEffectChips,
+  sanitizeReadableText,
+  sanitizeSummaryText,
+  splitClean,
+  uniqueNormalizedList,
+} from '@/lib/sanitize'
 import { pickNonEmptyKeys } from '@/lib/nonEmptyFields'
 import { calculateCompoundConfidence } from '@/utils/calculateConfidence'
 import { getCompoundDataCompleteness } from '@/utils/getDataCompleteness'
@@ -195,12 +201,12 @@ export default function CompoundDetail() {
   const pathwayTargets = uniqueNormalizedList(splitClean(compoundRecord.pathwayTargets))
   const workbookSources = uniqueNormalizedList(splitPipeList(compoundRecord.sourceUrls))
   const relatedHerbSlugs = uniqueNormalizedList(splitClean(compoundRecord.relatedHerbSlugs))
-  const compoundEffects = uniqueNormalizedList(compound.effects)
+  const compoundEffects = cleanEffectChips(compound.effects, 12)
   const compoundContraindications = uniqueNormalizedList(compound.contraindications)
   const compoundSideEffects = uniqueNormalizedList(compound.sideEffects)
   const compoundTherapeuticUses = uniqueNormalizedList(compound.therapeuticUses)
   const compoundInteractions = uniqueNormalizedList(compound.interactions)
-  const compoundDescription = sanitizeReadableText(compound.description)
+  const compoundDescription = sanitizeSummaryText(compound.description, 2)
   const compoundMechanism = sanitizeReadableText(compound.mechanism)
   const drugInteractions = normalizeTextValue(compoundRecord.drugInteractions)
   const uniqueDrugInteractionItems = Array.from(
@@ -234,8 +240,7 @@ export default function CompoundDetail() {
     })
   })
 
-  const whyItMatters = compoundEffects.slice(0, 2).join(' + ')
-  const doesText = compoundMechanism || compoundDescription
+  const whyItMatters = sanitizeSummaryText(compoundEffects.slice(0, 2).join(' + '), 1)
   const premiumDetails = [
     { title: 'Identity', value: compound.identity },
     {
@@ -308,7 +313,7 @@ export default function CompoundDetail() {
     herbs: compound.herbs,
   })
 
-  const primaryEffects = extractPrimaryEffects(compoundEffects, 4)
+  const primaryEffects = cleanEffectChips(extractPrimaryEffects(compoundEffects, 8), 5)
 
   const sourceCount = compound.sources.length
   const cautionCount = countCautionSignals({
@@ -415,9 +420,11 @@ export default function CompoundDetail() {
     sourceCount,
   })
   const governedReviewFreshness = buildGovernedReviewFreshness(governedResearch)
-  const topSummary =
-    governedIntro.whatItIs || governedIntro.commonUse || compoundDescription || compoundMechanism
-  const topEffects = primaryEffects.slice(0, 2)
+  const topSummary = sanitizeSummaryText(
+    governedIntro.whatItIs || governedIntro.commonUse || compoundDescription || compoundMechanism,
+    1,
+  )
+  const topEffects = primaryEffects.slice(0, 4)
   const whereAppears = foundInHerbLinks.slice(0, 3).map(item => item.label)
   const enrichmentRecommendations = buildEnrichmentRecommendations('compound', compound.slug)
   const quickCompareSection = buildGovernedQuickCompareSection('compound', compound.slug)
@@ -508,9 +515,9 @@ export default function CompoundDetail() {
           <div className='flex flex-wrap items-start justify-between gap-3'>
             <h1 className='text-3xl font-semibold leading-tight'>{name}</h1>
           </div>
-          {(topSummary || compoundDescription) && (
+          {topSummary && (
             <p className='mt-3 max-w-3xl text-sm leading-relaxed text-white/80'>
-              {topSummary || compoundDescription}
+              {topSummary}
             </p>
           )}
           <div className='mt-4 grid gap-3 sm:grid-cols-3'>
@@ -522,7 +529,17 @@ export default function CompoundDetail() {
             </section>
             <section className='rounded-lg border border-white/10 bg-black/20 p-3'>
               <h2 className='text-[11px] font-semibold uppercase tracking-[0.14em] text-white/56'>Key effects</h2>
-              <p className='mt-1 text-xs text-white/80'>{topEffects.join(' · ') || 'Effects being reviewed.'}</p>
+              <div className='mt-1 flex flex-wrap gap-1.5'>
+                {topEffects.length > 0 ? (
+                  topEffects.map(effect => (
+                    <span key={`top-effect-${effect}`} className='ds-pill text-[11px]'>
+                      {effect}
+                    </span>
+                  ))
+                ) : (
+                  <p className='text-xs text-white/80'>Effects being reviewed.</p>
+                )}
+              </div>
             </section>
             <section className='rounded-lg border border-white/10 bg-black/20 p-3'>
               <h2 className='text-[11px] font-semibold uppercase tracking-[0.14em] text-white/56'>Where it appears</h2>
@@ -562,7 +579,6 @@ export default function CompoundDetail() {
         {compoundDescription && compoundDescription !== topSummary && (
           <Section title='Overview'>
             {compoundDescription}
-            {topSummary && <p className='mt-3 text-white/80'>{topSummary}</p>}
             {displayClass && (
               <p className='mt-3 label-specimen'>
                 Category: {displayClass}
@@ -585,13 +601,11 @@ export default function CompoundDetail() {
           </div>
         )}
 
-        {doesText && <Section title='Mechanism Context'>{doesText}</Section>}
-
         {compoundMechanism && <Section title='Mechanism of Action'>{compoundMechanism}</Section>}
 
         {compoundEffects.length > 0 && (
           <Section title='Effects'>
-            <ListSection items={compoundEffects} maxVisible={6} />
+            <ListSection items={compoundEffects} maxVisible={5} />
           </Section>
         )}
 

--- a/src/pages/Compounds.tsx
+++ b/src/pages/Compounds.tsx
@@ -18,6 +18,7 @@ import { calculateCompoundConfidence, type ConfidenceLevel } from '@/utils/calcu
 import type { EnrichmentFilter } from '@/types/enrichmentDiscovery'
 import { trackGovernedEvent } from '@/lib/governedAnalytics'
 import { formatBrowseTitle } from '@/utils/titleDisplay'
+import { cleanEffectChips, sanitizeSummaryText } from '@/lib/sanitize'
 
 const ENRICHMENT_FILTER_OPTIONS: Array<{ value: EnrichmentFilter; label: string }> = [
   { value: 'all', label: 'All research states' },
@@ -40,11 +41,10 @@ function confidenceBadgeClass(level: ConfidenceLevel) {
 }
 
 function summarize(compound: { description: string; effects: string[] }) {
-  if (compound.description) {
-    const firstSentence = compound.description.split(/(?<=[.!?])\s+/)[0] || compound.description
-    return firstSentence
-  }
-  if (compound.effects.length) return compound.effects.slice(0, 2).join(' · ')
+  const cleanedDescription = sanitizeSummaryText(compound.description, 1)
+  if (cleanedDescription) return cleanedDescription
+  const chipFallback = cleanEffectChips(compound.effects, 2)
+  if (chipFallback.length) return chipFallback.join(' · ')
   return 'Profile in progress.'
 }
 
@@ -259,7 +259,7 @@ export default function CompoundsPage() {
                 effects: compound.effects,
                 compounds: compound.herbs,
               })
-            const primaryEffects = extractPrimaryEffects(compound.effects, 3)
+            const primaryEffects = cleanEffectChips(extractPrimaryEffects(compound.effects, 8), 2)
 
             const title = formatBrowseTitle(compound.name, 58)
             const chips = [


### PR DESCRIPTION
### Motivation
- Prevent low-signal, duplicated, or auto-generated fragments from surfacing in compound effect chips and summaries. 
- Reduce redundancy and verbose prose in the compound detail hero and effects list for immediate clarity. 
- Make trust messaging and footer navigation clearer and more actionable for readers. 

### Description
- Added a focused effect sanitation helper `cleanEffectChips` that normalizes fragments, drops junk/filler patterns, merges split terms (e.g. `anti` + `inflammatory` → `anti-inflammatory`), dedupes, and caps chips; implemented in `src/lib/sanitize.ts`.
- Wired the sanitation into compound rendering paths by using `cleanEffectChips` and `sanitizeSummaryText` in `src/pages/CompoundDetail.tsx` to produce a one-line top summary, concise chip-based key effects, and a capped effects list (5 visible before expansion).
- Applied the same sanitation to the compounds index so cards use a cleaned one-line summary fallback and a strict 2-chip limit (`src/pages/Compounds.tsx`).
- Replaced fallback trust copy with the requested authoritative phrasing in `src/lib/trust.ts` and simplified footer IA into `Explore` / `Safety` / `Legal` groups in `src/components/Footer.tsx` to reduce clutter.
- Files changed: `src/lib/sanitize.ts`, `src/pages/CompoundDetail.tsx`, `src/pages/Compounds.tsx`, `src/lib/trust.ts`, `src/components/Footer.tsx`.

### Testing
- Built the site frontend with `npm run build:compile` and the build completed successfully without errors. 
- Pre-commit hooks ran `eslint --max-warnings=0` for changed TS/TSX files and passed during staging checks. 
- Changed-file list: `src/lib/sanitize.ts`, `src/pages/CompoundDetail.tsx`, `src/pages/Compounds.tsx`, `src/lib/trust.ts`, `src/components/Footer.tsx` (sanitation, hero/effects wiring, trust copy, footer IA). 
- Notes / follow-ups: verify a sample of high-value compound pages manually for unintended chip drops (edge cases where multi-word effects were truncated), and consider adding unit tests for `cleanEffectChips` to lock behaviour for future changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcf8de6c6c8323856e6ad93781396e)