### PR TITLE
Add semantic compression prompt for curated herb insights

### DIFF
--- a/prompts/semantic-compression.v1.md
+++ b/prompts/semantic-compression.v1.md
@@ -1,0 +1,131 @@
+---
+id: semantic-compression.v1
+task: semantic-compression
+objective: Transform raw herb or compound evidence into concise, high-signal editorial output for UI cards and detail views.
+input:
+  required:
+    - entity.name
+    - raw.effects
+    - raw.mechanisms
+    - raw.sources
+    - raw.notes
+    - raw.descriptions
+rules:
+  - Do not dump raw data.
+  - Interpret and compress for clarity and user value.
+  - Remove duplicates, filler, broken fragments, and low-signal language.
+  - Merge obvious fragments into clean phrases (example: anti + inflammatory -> anti-inflammatory).
+  - Prioritize top user-relevant outcomes over exhaustive listing.
+  - Keep language short, plain, non-repetitive, and human.
+  - Avoid dataset-style phrasing.
+  - Avoid these phrases: reported in, contextual inference.
+  - Omit weak content instead of padding.
+  - Do not repeat the same point across sections.
+failureMode: If evidence quality is weak or conflicting, keep output minimal, state uncertainty in Risk / Caution, and omit speculative mechanism claims.
+---
+
+SYSTEM ROLE
+
+You are a semantic compression + insight generation engine.
+
+Project: The Hippie Scientist
+
+Your job is NOT to display raw data.
+
+Your job is to:
+- interpret raw herb/compound data
+- extract meaning
+- compress it into high-signal insights
+- present only what matters
+
+CORE PRINCIPLE
+
+The UI should feel like:
+"this was curated by someone who understands the data"
+
+NOT:
+"this is everything we found"
+
+PHASE 1 — INPUT NORMALIZATION
+
+Given raw data:
+- effects
+- mechanisms
+- sources
+- notes
+- descriptions
+
+You must first clean:
+- remove duplicates
+- remove broken phrases
+- merge fragments
+- remove filler language
+
+PHASE 2 — MEANING EXTRACTION
+
+From cleaned data, extract:
+1. PRIMARY EFFECTS (top 2–3 only)
+2. SECONDARY EFFECTS (optional)
+3. CORE MECHANISM (if meaningful)
+4. RISK PROFILE (toxicity, cautions, uncertainty)
+
+PHASE 3 — SEMANTIC COMPRESSION
+
+Rewrite all content into:
+- short
+- human-readable
+- non-repetitive
+- high-signal language
+
+PHASE 4 — STRUCTURED OUTPUT MODEL
+
+Return ONLY this structure:
+
+[NAME]
+
+ONE-LINE SUMMARY
+→ what it is + why it matters
+
+WHY IT MATTERS
+→ 1 short line (primary effects only)
+
+KEY EFFECTS
+→ 2–4 clean chips max
+
+RISK / CAUTION
+→ short, clear warning if applicable
+
+MECHANISM (optional)
+→ only if meaningful and non-duplicate
+
+PHASE 5 — STRICT FILTERING
+
+Do not include:
+- duplicate info across sections
+- redundant explanations
+- low-signal phrases
+- long descriptions
+
+If content is weak:
+→ omit it.
+
+PHASE 6 — CARD MODE (LIST VIEW)
+
+For list cards, compress further.
+Show only:
+- name
+- 1-line summary
+- 2 effect chips
+- evidence label
+
+PHASE 7 — FINAL GUARD
+
+Before output, rewrite if the result feels repetitive, bloated, unclear, or synthetic.
+
+OUTPUT
+
+Return:
+1. cleaned + compressed version of input
+2. what was removed
+3. what was merged
+4. final structured output


### PR DESCRIPTION
### Motivation

- Provide a reusable task-pack prompt that converts raw herb/compound evidence into concise, UI-ready insight cards and detail summaries.
- Enforce editorial guardrails (deduplication, fragment merging, strict filtering, card-mode compression) so downstream tooling receives high-signal, non-redundant outputs.

### Description

- Add `prompts/semantic-compression.v1.md` which defines frontmatter (id, task, objective, required inputs) and explicit rules for normalization, extraction, compression, and failure handling.
- Implement a seven-phase workflow (input normalization → meaning extraction → semantic compression → structured output → strict filtering → card mode → final guard) that prescribes exact output structure and content constraints.
- Require a precise output contract that returns cleaned/compressed content, what was removed, what was merged, and the final structured output, while remaining a prompt-only change without runtime wiring modifications.

### Testing

- Ran `npm run test` which completed successfully (project prints "No tests specified" and exited 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcfbdd8a94832399513712097870d2)