### PR TITLE
Integrate semantic compression into herb/compound runtime data flow

### DIFF
--- a/src/components/EntityDatabasePage.tsx
+++ b/src/components/EntityDatabasePage.tsx
@@ -549,15 +549,13 @@ export default function EntityDatabasePage({
               name={String(item.common || item.scientific || item.name || 'Herb')}
               summary={
                 buildCardSummary({
-                  effects: item.effects,
-                  mechanism: item.mechanism,
-                  description: item.description,
-                  activeCompounds: item.compounds,
-                  therapeuticUses: item.therapeuticUses,
+                  effects: (item.curatedData?.keyEffects || item.effects) as unknown,
+                  mechanism: item.curatedData?.mechanism || item.mechanism,
+                  description: item.curatedData?.summary || '',
                   maxLen: 130,
                 }) || 'Learn more about this herb and its potential uses.'
               }
-              tags={extractPrimaryEffects(Array.isArray(item.effects) ? item.effects : [], 2)}
+              tags={extractPrimaryEffects(Array.isArray(item.curatedData?.keyEffects) ? item.curatedData.keyEffects : [], 2)}
               detailUrl={
                 hasVal(item.slug)
                   ? `${kind === 'compound' ? '/compounds' : '/herbs'}/${encodeURIComponent(String(item.slug))}`

--- a/src/lib/compound-data.ts
+++ b/src/lib/compound-data.ts
@@ -7,6 +7,7 @@ import { hasInvalidEntityName, sanitizeCompoundRecord } from '@/utils/sanitizeDa
 import { normalizeResearchEnrichment } from '@/lib/researchEnrichment'
 import type { PublishSafeEnrichmentSummary } from '@/types/enrichmentDiscovery'
 import type { ResearchEnrichment } from '@/types/researchEnrichment'
+import { getCuratedData, type CuratedData } from '@/lib/semanticCompression'
 
 export type SourceRef = { title: string; url: string; note?: string }
 
@@ -47,6 +48,8 @@ export type CompoundRecord = {
   sourceCount?: number
   compounds?: string[]
   benefits?: string[]
+  curatedData: CuratedData
+  rawData?: Record<string, unknown>
 }
 
 export type CompoundSummaryRecord = {
@@ -67,6 +70,8 @@ export type CompoundSummaryRecord = {
   aliases: string[]
   sourceCount?: number
   researchEnrichmentSummary?: PublishSafeEnrichmentSummary
+  curatedData: CuratedData
+  rawData?: Record<string, unknown>
 }
 
 function normalizeEnrichmentSummary(value: unknown): PublishSafeEnrichmentSummary | undefined {
@@ -294,6 +299,20 @@ function normalizeCompound(raw: Record<string, unknown>): CompoundRecord {
     researchEnrichmentSummary: normalizeEnrichmentSummary(data.researchEnrichmentSummary),
     sourceCount: sources.length,
     lastUpdated: String(data.lastUpdated || data.updatedAt || '').trim(),
+    curatedData: getCuratedData({
+      name,
+      summary: cleanText(data.summary) || cleanText(data.description) || '',
+      description: cleanText(data.description ?? data.summary) || '',
+      whyItMatters: cleanText(data.whyItMatters) || '',
+      primaryEffects: splitClean(data.primaryEffects ?? effects),
+      effects,
+      contraindications: splitClean(data.contraindications),
+      interactions: splitClean(data.interactions),
+      sideEffects: splitClean(data.sideEffects),
+      safety: splitClean(data.safety),
+      mechanism,
+    }),
+    rawData: data as Record<string, unknown>,
   }
 }
 
@@ -324,6 +343,8 @@ function normalizeCompoundSummary(raw: Record<string, unknown>): CompoundSummary
     aliases: splitClean(raw.aliases),
     sourceCount: Number.isFinite(Number(raw.sourceCount)) ? Number(raw.sourceCount) : undefined,
     researchEnrichmentSummary: normalizeEnrichmentSummary(raw.researchEnrichmentSummary),
+    curatedData: getCuratedData(raw),
+    rawData: raw,
   }
 }
 

--- a/src/lib/herb-data.ts
+++ b/src/lib/herb-data.ts
@@ -7,6 +7,7 @@ import { cleanText, splitClean } from '@/lib/sanitize'
 import { getHerbSeedInteractionData, mergeInteractionData } from '@/lib/interactionSeed'
 import { hasInvalidEntityName, sanitizeHerbRecord } from '@/utils/sanitizeData'
 import { normalizeResearchEnrichment } from '@/lib/researchEnrichment'
+import { getCuratedData, type CuratedData } from '@/lib/semanticCompression'
 import type { PublishSafeEnrichmentSummary } from '@/types/enrichmentDiscovery'
 
 type SourceRef = { title: string; url?: string; note?: string }
@@ -47,6 +48,8 @@ export type HerbSummary = {
   image: string
   aliases: string[]
   researchEnrichmentSummary?: PublishSafeEnrichmentSummary
+  curatedData: CuratedData
+  rawData?: Record<string, unknown>
   [key: string]: unknown
 }
 
@@ -357,6 +360,20 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
     researchEnrichment: researchEnrichment || undefined,
     productRecommendations,
     confidence: calculateHerbConfidence({ mechanism, effects, compounds: activeCompounds }),
+    curatedData: getCuratedData({
+      name: common || scientific || slug,
+      summary: description,
+      description,
+      whyItMatters: cleanText(data.whyItMatters) || description,
+      primaryEffects: splitClean(data.primaryEffects ?? effects),
+      effects,
+      contraindications,
+      interactions,
+      sideEffects: sideeffects,
+      safetyNotes,
+      mechanism,
+    }),
+    rawData: data as Record<string, unknown>,
   }
 }
 
@@ -415,6 +432,8 @@ function normalizeHerbSummaryRow(raw: Record<string, unknown>): HerbSummary {
     image: cleanText(raw.image) || '',
     aliases: splitClean(raw.aliases),
     researchEnrichmentSummary: normalizeEnrichmentSummary(raw.researchEnrichmentSummary),
+    curatedData: getCuratedData(raw),
+    rawData: raw,
   }
 }
 

--- a/src/lib/semanticCompression.ts
+++ b/src/lib/semanticCompression.ts
@@ -1,0 +1,109 @@
+import { cleanText, sanitizeSummaryText, splitClean } from '@/lib/sanitize'
+
+export type CuratedData = {
+  name: string
+  summary: string
+  whyItMatters: string
+  keyEffects: string[]
+  risk: string
+  mechanism: string
+}
+
+type RawCuratableRecord = Record<string, unknown>
+
+const MIN_SAFE_SUMMARY = 'Profile in progress. Data is being reviewed for clarity.'
+const MIN_SAFE_RISK = 'Review contraindications and interaction context before use.'
+
+function dedupe(items: string[], limit = 6): string[] {
+  const seen = new Set<string>()
+  const output: string[] = []
+  for (const raw of items) {
+    const value = raw.replace(/\s+/g, ' ').trim()
+    if (!value) continue
+    const key = value.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    output.push(value)
+    if (output.length >= limit) break
+  }
+  return output
+}
+
+function stripBrokenPhrases(value: string): string {
+  return value
+    .replace(/\banti\b\s*(?=[,.;]|$)/gi, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim()
+}
+
+function sanitizeLine(value: unknown): string {
+  return stripBrokenPhrases(cleanText(value) || '')
+}
+
+function sanitizeEffects(value: unknown): string[] {
+  return dedupe(splitClean(value).map(item => stripBrokenPhrases(item)), 4)
+}
+
+function semanticCompression(cleaned: CuratedData): CuratedData {
+  return {
+    name: cleaned.name,
+    summary: sanitizeSummaryText(cleaned.summary, 2) || MIN_SAFE_SUMMARY,
+    whyItMatters: sanitizeSummaryText(cleaned.whyItMatters, 1) || MIN_SAFE_SUMMARY,
+    keyEffects: dedupe(cleaned.keyEffects.map(item => sanitizeLine(item)), 4),
+    risk: sanitizeSummaryText(cleaned.risk, 1) || MIN_SAFE_RISK,
+    mechanism: sanitizeSummaryText(cleaned.mechanism, 1) || 'Mechanism notes are being reviewed.',
+  }
+}
+
+function buildFallback(rawData: RawCuratableRecord): CuratedData {
+  const name = sanitizeLine(rawData.name ?? rawData.commonName ?? rawData.common ?? rawData.slug) || 'Unknown profile'
+  const summary =
+    sanitizeLine(rawData.summary ?? rawData.description) ||
+    sanitizeLine(rawData.mechanism ?? rawData.mechanismOfAction) ||
+    MIN_SAFE_SUMMARY
+
+  const safetySignals = dedupe(
+    [
+      ...splitClean(rawData.safetyNotes),
+      ...splitClean(rawData.safety),
+      ...splitClean(rawData.sideEffects ?? rawData.sideeffects),
+      ...splitClean(rawData.contraindications),
+      ...splitClean(rawData.interactions),
+    ],
+    2,
+  )
+
+  return {
+    name,
+    summary,
+    whyItMatters: sanitizeLine(rawData.whyItMatters) || summary,
+    keyEffects: sanitizeEffects(rawData.primaryEffects ?? rawData.effects),
+    risk: safetySignals.join(' · ') || MIN_SAFE_RISK,
+    mechanism:
+      sanitizeLine(rawData.mechanism ?? rawData.mechanismOfAction) || 'Mechanism notes are being reviewed.',
+  }
+}
+
+export function getCuratedData(rawData: unknown): CuratedData {
+  const source = rawData && typeof rawData === 'object' ? (rawData as RawCuratableRecord) : {}
+
+  try {
+    const cleaned = buildFallback(source)
+    return semanticCompression(cleaned)
+  } catch {
+    // safety fallback: never expose unfiltered raw text directly
+    return {
+      name: 'Unknown profile',
+      summary: MIN_SAFE_SUMMARY,
+      whyItMatters: MIN_SAFE_SUMMARY,
+      keyEffects: [],
+      risk: MIN_SAFE_RISK,
+      mechanism: 'Mechanism notes are being reviewed.',
+    }
+  }
+}
+
+export function shouldShowRawDebug(search: string): boolean {
+  const params = new URLSearchParams(search)
+  return params.get('debug') === 'raw'
+}

--- a/src/pages/CompoundDetail.tsx
+++ b/src/pages/CompoundDetail.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useState } from 'react'
-import { Link, useParams } from 'react-router-dom'
+import { Link, useLocation, useParams } from 'react-router-dom'
 import Meta from '@/components/Meta'
 import DataTrustPanel from '@/components/trust/DataTrustPanel'
 import { useCompoundDataState, useCompoundDetailState } from '@/lib/compound-data'
@@ -50,6 +50,7 @@ import { buildGovernedQuickCompareSection } from '@/lib/governedQuickCompare'
 import { buildFallbackCompoundIntro, buildGovernedDetailIntro } from '@/lib/governedIntro'
 import { resolveGovernedCtaDecision } from '@/lib/governedCta'
 import { buildGovernedReviewFreshness } from '@/lib/governedReviewFreshness'
+import { shouldShowRawDebug } from '@/lib/semanticCompression'
 import {
   trackDetailBuilderClick,
   trackCtaSlotImpression,
@@ -160,6 +161,8 @@ function buildSourceLabel(rawUrl: string, fallbackTitle: string) {
 
 export default function CompoundDetail() {
   const { slug = '' } = useParams()
+  const location = useLocation()
+  const showRawDebug = shouldShowRawDebug(location.search)
   const { compounds, isLoading: isCompoundsLoading } = useCompoundDataState()
   const slugNeedle = normalizeKey(slug)
   const detailLookupSlug =
@@ -201,13 +204,14 @@ export default function CompoundDetail() {
   const pathwayTargets = uniqueNormalizedList(splitClean(compoundRecord.pathwayTargets))
   const workbookSources = uniqueNormalizedList(splitPipeList(compoundRecord.sourceUrls))
   const relatedHerbSlugs = uniqueNormalizedList(splitClean(compoundRecord.relatedHerbSlugs))
-  const compoundEffects = cleanEffectChips(compound.effects, 12)
+  const curatedData = compound.curatedData
+  const compoundEffects = cleanEffectChips(curatedData.keyEffects, 12)
   const compoundContraindications = uniqueNormalizedList(compound.contraindications)
   const compoundSideEffects = uniqueNormalizedList(compound.sideEffects)
   const compoundTherapeuticUses = uniqueNormalizedList(compound.therapeuticUses)
   const compoundInteractions = uniqueNormalizedList(compound.interactions)
-  const compoundDescription = sanitizeSummaryText(compound.description, 2)
-  const compoundMechanism = sanitizeReadableText(compound.mechanism)
+  const compoundDescription = sanitizeSummaryText(curatedData.summary, 2)
+  const compoundMechanism = sanitizeReadableText(curatedData.mechanism)
   const drugInteractions = normalizeTextValue(compoundRecord.drugInteractions)
   const uniqueDrugInteractionItems = Array.from(
     new Map(
@@ -240,7 +244,7 @@ export default function CompoundDetail() {
     })
   })
 
-  const whyItMatters = sanitizeSummaryText(compoundEffects.slice(0, 2).join(' + '), 1)
+  const whyItMatters = sanitizeSummaryText(curatedData.whyItMatters || compoundEffects.slice(0, 2).join(' + '), 1)
   const premiumDetails = [
     { title: 'Identity', value: compound.identity },
     {
@@ -751,16 +755,29 @@ export default function CompoundDetail() {
         )}
 
         {governedResearch && governedFaq && governedRelatedQuestions && (
-          <GovernedResearchSections
-            enrichment={governedResearch}
-            governedFaq={governedFaq}
-            relatedQuestions={governedRelatedQuestions}
-            analyticsContext={{
-              pageType: 'compound_detail',
-              entityType: 'compound',
-              entitySlug: compound.slug,
-            }}
-          />
+          <>
+            {showRawDebug && compound.rawData && (
+              <section className='rounded-2xl border border-amber-200/20 bg-black/20 p-4'>
+                <h2 className='text-[11px] font-semibold uppercase tracking-[0.14em] text-amber-100/80'>
+                  Debug raw data
+                </h2>
+                <pre className='mt-2 overflow-auto rounded-lg border border-amber-200/20 bg-black/30 p-3 text-[11px] text-amber-100/90'>
+                  {JSON.stringify(compound.rawData, null, 2)}
+                </pre>
+              </section>
+            )}
+
+            <GovernedResearchSections
+              enrichment={governedResearch}
+              governedFaq={governedFaq}
+              relatedQuestions={governedRelatedQuestions}
+              analyticsContext={{
+                pageType: 'compound_detail',
+                entityType: 'compound',
+                entitySlug: compound.slug,
+              }}
+            />
+          </>
         )}
 
         <DataTrustPanel

--- a/src/pages/Compounds.tsx
+++ b/src/pages/Compounds.tsx
@@ -259,7 +259,7 @@ export default function CompoundsPage() {
                 effects: compound.effects,
                 compounds: compound.herbs,
               })
-            const primaryEffects = cleanEffectChips(extractPrimaryEffects(compound.effects, 8), 2)
+            const primaryEffects = cleanEffectChips(extractPrimaryEffects(compound.curatedData?.keyEffects || compound.effects, 8), 2)
 
             const title = formatBrowseTitle(compound.name, 58)
             const chips = [
@@ -285,7 +285,7 @@ export default function CompoundsPage() {
                 >
                   {title}
                 </h2>
-                <p className='line-clamp-1 text-xs leading-[1.35] text-white/72'>{summarize(compound)}</p>
+                <p className='line-clamp-1 text-xs leading-[1.35] text-white/72'>{summarize({ description: compound.curatedData?.summary || '', effects: compound.curatedData?.keyEffects || [] })}</p>
                 {chips.length > 0 && (
                   <div className='flex flex-wrap gap-1'>
                     {chips.map(chip => (

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -1,7 +1,7 @@
 // UPDATED: Rebuilt herb detail with sr-only prerender block, placeholder/safety cleanup, and progressive disclosure sections.
 import { useState, type ReactNode } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
-import { Link, useParams } from 'react-router-dom'
+import { Link, useLocation, useParams } from 'react-router-dom'
 import Meta from '@/components/Meta'
 import { useCompoundDataState } from '@/lib/compound-data'
 import { useHerbDataState, useHerbDetailState } from '@/lib/herb-data'
@@ -12,6 +12,7 @@ import {
 } from '@/lib/sanitize'
 import { HerbDetailSkeleton } from '@/components/skeletons/DetailSkeletons'
 import { SITE_URL, breadcrumbJsonLd, herbJsonLd } from '@/lib/seo'
+import { shouldShowRawDebug } from '@/lib/semanticCompression'
 
 type SourceRef = { title: string; url: string; note?: string }
 
@@ -127,6 +128,8 @@ function DisclosureSection({ title, defaultOpen = false, children }: DisclosureP
 
 export default function HerbDetail() {
   const { slug = '' } = useParams()
+  const location = useLocation()
+  const showRawDebug = shouldShowRawDebug(location.search)
   const { herb, isLoading } = useHerbDetailState(slug)
   const { herbs } = useHerbDataState()
   const { compounds } = useCompoundDataState()
@@ -146,15 +149,15 @@ export default function HerbDetail() {
 
   const herbName = toTitleCase(herb.commonName || herb.common || herb.name || herb.slug)
   const scientificName = String(herb.scientific || herb.latinName || '').trim()
-  const description = String(herb.description || herb.summary || '').trim()
+  const curatedData = herb.curatedData
+  const description = String(curatedData.summary || '').trim()
   const descriptionIsPlaceholder = isPlaceholder(description, herbName)
   const summary = sanitizeSummaryText(description, 2)
 
-  const effects = dedupePresentationList(splitTextList(herb.primaryEffects || herb.effects), 8)
-    .map(toTitleCase)
+  const effects = dedupePresentationList(splitTextList(curatedData.keyEffects), 8).map(toTitleCase)
   const keyEffects = effects.slice(0, 4)
   const activeCompounds = dedupePresentationList(splitTextList(herb.activeCompounds || herb.compounds), 10)
-  const mechanism = String(herb.mechanism || herb.mechanismOfAction || '').trim()
+  const mechanism = String(curatedData.mechanism || '').trim()
   const dosage = String(herb.dosage || '').trim()
   const duration = String(herb.duration || '').trim()
   const preparation = String(herb.preparation || '').trim()
@@ -245,7 +248,7 @@ export default function HerbDetail() {
       <article className='space-y-3'>
         <div className='sr-only' aria-hidden='true'>
           <h1>{herbName}</h1>
-          <p>{description}</p>
+          <p>{curatedData.summary}</p>
           <ul>{safetyNotes.map(note => <li key={`static-safety-${note}`}>{note}</li>)}</ul>
         </div>
 
@@ -312,7 +315,7 @@ export default function HerbDetail() {
 
         {!descriptionIsPlaceholder && (
           <DisclosureSection title='Full Description'>
-            <p>{description}</p>
+            <p>{curatedData.summary}</p>
           </DisclosureSection>
         )}
 
@@ -357,6 +360,14 @@ export default function HerbDetail() {
             <p>Primary source citations are being added.</p>
           )}
         </DisclosureSection>
+
+        {showRawDebug && herb.rawData && (
+          <DisclosureSection title='Debug Raw Data'>
+            <pre className='overflow-auto rounded-lg border border-amber-200/20 bg-black/30 p-3 text-[11px] text-amber-100/90'>
+              {JSON.stringify(herb.rawData, null, 2)}
+            </pre>
+          </DisclosureSection>
+        )}
 
         <DisclosureSection title='Related Herbs & Compounds'>
           <div className='space-y-3'>

--- a/src/pages/Herbs.tsx
+++ b/src/pages/Herbs.tsx
@@ -57,7 +57,13 @@ const cleanSummary = (value: string, herbName = '') => {
 
 const getKeyEffects = (herb: Record<string, unknown>) =>
   dedupePresentationList(
-    Array.isArray(herb.primaryEffects) ? herb.primaryEffects : Array.isArray(herb.effects) ? herb.effects : [],
+    Array.isArray((herb.curatedData as Record<string, unknown> | undefined)?.keyEffects)
+      ? ((herb.curatedData as Record<string, unknown>).keyEffects as string[])
+      : Array.isArray(herb.primaryEffects)
+        ? herb.primaryEffects
+        : Array.isArray(herb.effects)
+          ? herb.effects
+          : [],
     3,
   )
     .map(toTitleCase)
@@ -312,7 +318,7 @@ export default function HerbsPage() {
                 {toTitleCase(String(herb.common || herb.scientific || herb.name || 'Herb'))}
               </h2>
               <p className='mt-1 line-clamp-1 text-xs text-white/72'>
-                {cleanSummary(String(herb.summary || herb.description || herb.mechanism || ''), String(herb.common || herb.name || ''))}
+                {cleanSummary(String((herb.curatedData as Record<string, unknown> | undefined)?.summary || ''), String(herb.common || herb.name || ''))}
               </p>
               <div className='mt-2 flex flex-wrap gap-1'>
                 {getKeyEffects(herb).map(effect => (


### PR DESCRIPTION
### Motivation
- Ensure that herb/compound UI never renders raw unfiltered text by inserting a semantic compression layer before any UI consumption. 
- Provide a deterministic, precomputable contract for curated content (`name`, `summary`, `whyItMatters`, `keyEffects`, `risk`, `mechanism`) with safe fallback behavior and a debug toggle. 

### Description
- Added a new compression module `src/lib/semanticCompression.ts` that implements `getCuratedData(rawData)` (sanitization, dedupe, phrase cleanup, shaping) and `shouldShowRawDebug(search)` for the `?debug=raw` toggle. 
- Integrated `getCuratedData()` into normalization paths so summaries and detail payloads include `curatedData` (and `rawData` for debug) inside `src/lib/herb-data.ts` and `src/lib/compound-data.ts`. 
- Updated UI consumers to read only from the curated contract: herb and compound detail pages now use `herb.curatedData` / `compound.curatedData`, and list/card surfaces (herbs, compounds, entity index) use curated fields for summaries, chips, and mechanism snippets. 
- Added safe fallback logic so failures never return raw unfiltered text and implemented debug panels surfaced by `?debug=raw` for side-by-side inspection without changing normal render behavior. 
- Files changed: `src/lib/semanticCompression.ts`, `src/lib/herb-data.ts`, `src/lib/compound-data.ts`, `src/pages/HerbDetail.tsx`, `src/pages/CompoundDetail.tsx`, `src/pages/Herbs.tsx`, `src/pages/Compounds.tsx`, `src/components/EntityDatabasePage.tsx`. 

### Testing
- Ran the production compile with `npm run build:compile`, which completed successfully after fixes. 
- Pre-commit linting (`eslint --max-warnings=0`) ran as part of the commit hook and passed. 
- Verified that herb and compound detail pages and list index cards render using the `curatedData` contract and that `?debug=raw` exposes the stored `rawData` for comparison (manual runtime verification during build/dev).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcfd0da8ac83239d8912af9f67d91e)