### PR TITLE
Regenerate workbook export JSON datasets

### DIFF
--- a/public/data/workbook-compounds.json
+++ b/public/data/workbook-compounds.json
@@ -107,7 +107,7 @@
   },
   {
     "id": "5-meo-dmt",
-    "slug": "5-meo-dmt-wb",
+    "slug": "5-meo-dmt",
     "canonicalCompoundId": "5-meo-dmt",
     "name": "5-meo-dmt",
     "compoundName": "5-meo-dmt",
@@ -155,7 +155,7 @@
   },
   {
     "id": "7-hydroxymitragynine",
-    "slug": "7-hydroxymitragynine-wb",
+    "slug": "7-hydroxymitragynine",
     "canonicalCompoundId": "7-hydroxymitragynine",
     "name": "7-hydroxymitragynine",
     "compoundName": "7-hydroxymitragynine",
@@ -260,7 +260,7 @@
   },
   {
     "id": "aconitine",
-    "slug": "aconitine-wb",
+    "slug": "aconitine",
     "canonicalCompoundId": "aconitine",
     "name": "aconitine",
     "compoundName": "aconitine",
@@ -396,7 +396,7 @@
   },
   {
     "id": "agrimoniin",
-    "slug": "agrimoniin-wb",
+    "slug": "agrimoniin",
     "canonicalCompoundId": "agrimoniin",
     "name": "agrimoniin",
     "compoundName": "agrimoniin",
@@ -502,7 +502,7 @@
   },
   {
     "id": "alchorneine",
-    "slug": "alchorneine-wb",
+    "slug": "alchorneine",
     "canonicalCompoundId": "alchorneine",
     "name": "alchorneine",
     "compoundName": "alchorneine",
@@ -592,7 +592,7 @@
   },
   {
     "id": "alpha-asarone",
-    "slug": "alpha-asarone-wb",
+    "slug": "alpha-asarone",
     "canonicalCompoundId": "alpha-asarone",
     "name": "alpha-asarone",
     "compoundName": "alpha-asarone",
@@ -727,7 +727,7 @@
   },
   {
     "id": "anabasine",
-    "slug": "anabasine-wb",
+    "slug": "anabasine",
     "canonicalCompoundId": "anabasine",
     "name": "anabasine",
     "compoundName": "anabasine",
@@ -848,7 +848,7 @@
   },
   {
     "id": "apigenin",
-    "slug": "apigenin-wb",
+    "slug": "apigenin",
     "canonicalCompoundId": "apigenin",
     "name": "Apigenin",
     "compoundName": "Apigenin",
@@ -896,7 +896,7 @@
   },
   {
     "id": "arbutin",
-    "slug": "arbutin-wb",
+    "slug": "arbutin",
     "canonicalCompoundId": "arbutin",
     "name": "arbutin",
     "compoundName": "arbutin",
@@ -1211,7 +1211,7 @@
   },
   {
     "id": "atropine",
-    "slug": "atropine-wb",
+    "slug": "atropine",
     "canonicalCompoundId": "atropine",
     "name": "atropine",
     "compoundName": "atropine",
@@ -1333,7 +1333,7 @@
   },
   {
     "id": "baicalin",
-    "slug": "baicalin-wb",
+    "slug": "baicalin",
     "canonicalCompoundId": "baicalin",
     "name": "Baicalin",
     "compoundName": "Baicalin",
@@ -1365,7 +1365,7 @@
   },
   {
     "id": "benzyl-isothiocyanate",
-    "slug": "benzyl-isothiocyanate-wb",
+    "slug": "benzyl-isothiocyanate",
     "canonicalCompoundId": "benzyl-isothiocyanate",
     "name": "benzyl isothiocyanate",
     "compoundName": "benzyl isothiocyanate",
@@ -1425,7 +1425,7 @@
   },
   {
     "id": "beta-asarone",
-    "slug": "beta-asarone-wb",
+    "slug": "beta-asarone",
     "canonicalCompoundId": "beta-asarone",
     "name": "beta-asarone",
     "compoundName": "beta-asarone",
@@ -1622,7 +1622,7 @@
   },
   {
     "id": "boldine",
-    "slug": "boldine-wb",
+    "slug": "boldine",
     "canonicalCompoundId": "boldine",
     "name": "boldine",
     "compoundName": "boldine",
@@ -1682,7 +1682,7 @@
   },
   {
     "id": "bufotenin",
-    "slug": "bufotenin-wb",
+    "slug": "bufotenin",
     "canonicalCompoundId": "bufotenin",
     "name": "bufotenin",
     "compoundName": "bufotenin",
@@ -1742,7 +1742,7 @@
   },
   {
     "id": "caffeic-acid",
-    "slug": "caffeic-acid-wb",
+    "slug": "caffeic-acid",
     "canonicalCompoundId": "caffeic-acid",
     "name": "caffeic acid",
     "compoundName": "caffeic acid",
@@ -1757,7 +1757,7 @@
   },
   {
     "id": "caffeine",
-    "slug": "caffeine-wb",
+    "slug": "caffeine",
     "canonicalCompoundId": "caffeine",
     "name": "Caffeine",
     "compoundName": "Caffeine",
@@ -1790,7 +1790,7 @@
   },
   {
     "id": "camphor",
-    "slug": "camphor-wb",
+    "slug": "camphor",
     "canonicalCompoundId": "camphor",
     "name": "camphor",
     "compoundName": "camphor",
@@ -1943,7 +1943,7 @@
   },
   {
     "id": "carvacrol",
-    "slug": "carvacrol-wb",
+    "slug": "carvacrol",
     "canonicalCompoundId": "carvacrol",
     "name": "carvacrol",
     "compoundName": "carvacrol",
@@ -2018,7 +2018,7 @@
   },
   {
     "id": "catechin",
-    "slug": "catechin-wb",
+    "slug": "catechin",
     "canonicalCompoundId": "catechin",
     "name": "Catechin",
     "compoundName": "Catechin",
@@ -2033,7 +2033,7 @@
   },
   {
     "id": "catechins",
-    "slug": "catechins-wb",
+    "slug": "catechins",
     "canonicalCompoundId": "catechins",
     "name": "catechins",
     "compoundName": "catechins",
@@ -2078,7 +2078,7 @@
   },
   {
     "id": "cbd",
-    "slug": "cbd-wb",
+    "slug": "cbd",
     "canonicalCompoundId": "cbd",
     "name": "cbd",
     "compoundName": "cbd",
@@ -2123,7 +2123,7 @@
   },
   {
     "id": "celastrine",
-    "slug": "celastrine-wb",
+    "slug": "celastrine",
     "canonicalCompoundId": "celastrine",
     "name": "Celastrine",
     "compoundName": "Celastrine",
@@ -2138,7 +2138,7 @@
   },
   {
     "id": "cephaeline",
-    "slug": "cephaeline-wb",
+    "slug": "cephaeline",
     "canonicalCompoundId": "cephaeline",
     "name": "cephaeline",
     "compoundName": "cephaeline",
@@ -2168,7 +2168,7 @@
   },
   {
     "id": "chamazulene",
-    "slug": "chamazulene-wb",
+    "slug": "chamazulene",
     "canonicalCompoundId": "chamazulene",
     "name": "chamazulene",
     "compoundName": "chamazulene",
@@ -2273,7 +2273,7 @@
   },
   {
     "id": "chlorogenic-acid",
-    "slug": "chlorogenic-acid-wb",
+    "slug": "chlorogenic-acid",
     "canonicalCompoundId": "chlorogenic-acid",
     "name": "chlorogenic acid",
     "compoundName": "chlorogenic acid",
@@ -2308,13 +2308,31 @@
     "name": "chrysin",
     "compoundName": "chrysin",
     "canonicalCompoundName": "chrysin",
-    "compoundClass": "chrysin",
-    "class": "chrysin",
-    "mechanism": "flavonoid",
+    "compoundClass": "flavonoid",
+    "class": "flavonoid",
+    "mechanism": "Flavonoid constituent sometimes discussed in relation to calming relevance, but constituent-level specificity is stronger than whole-herb clinical certainty.",
     "mechanismTags": [
-      "unclassified"
+      "flavonoid",
+      "calming support hypothesis",
+      "anti-inflammatory",
+      "antioxidant"
     ],
-    "evidenceTier": "Unknown"
+    "pathwayTargets": [
+      "possible GABAergic signaling",
+      "low target specificity"
+    ],
+    "confidence": "Low-Medium",
+    "confidenceLevel": "Low-Medium",
+    "evidence": "Preclinical",
+    "evidenceTier": "Preclinical",
+    "sourceUrls": [
+      "https://www.ema.europa.eu/en/medicines/herbal/passiflorae-herba|https://pubmed.ncbi.nlm.nih.gov/40872553/"
+    ],
+    "relatedHerbSlugs": [
+      "passionflower"
+    ],
+    "herbCount": "1",
+    "reverseLookupReady": "Yes"
   },
   {
     "id": "chrysoeriol",
@@ -2394,7 +2412,7 @@
   },
   {
     "id": "cineole",
-    "slug": "cineole-wb",
+    "slug": "cineole",
     "canonicalCompoundId": "cineole",
     "name": "cineole",
     "compoundName": "cineole",
@@ -2469,7 +2487,7 @@
   },
   {
     "id": "citral",
-    "slug": "citral-wb",
+    "slug": "citral",
     "canonicalCompoundId": "citral",
     "name": "citral",
     "compoundName": "citral",
@@ -2529,7 +2547,7 @@
   },
   {
     "id": "codeine",
-    "slug": "codeine-wb",
+    "slug": "codeine",
     "canonicalCompoundId": "codeine",
     "name": "codeine",
     "compoundName": "codeine",
@@ -2669,17 +2687,36 @@
     "name": "cordycepin",
     "compoundName": "cordycepin",
     "canonicalCompoundName": "cordycepin",
-    "compoundClass": "cordycepin",
-    "class": "cordycepin",
-    "mechanism": "polysaccharides",
+    "compoundClass": "nucleoside analogue",
+    "class": "nucleoside analogue",
+    "mechanism": "Cordycepin is a nucleoside analogue highlighted in cordyceps literature for anti-inflammatory and immunomodulatory signaling effects; evidence is strongest in preclinical systems.",
     "mechanismTags": [
-      "unclassified"
+      "anti-inflammatory",
+      "immune modulation",
+      "NF-kappaB modulation",
+      "Nrf2/HO-1"
     ],
-    "evidenceTier": "Unknown"
+    "pathwayTargets": [
+      "NF-kappaB",
+      "Nrf2/HO-1",
+      "RIP2/Caspase-1"
+    ],
+    "confidence": "Medium",
+    "confidenceLevel": "Medium",
+    "evidence": "Preclinical",
+    "evidenceTier": "Preclinical",
+    "sourceUrls": [
+      "https://pubmed.ncbi.nlm.nih.gov/34828915/|https://pubmed.ncbi.nlm.nih.gov/33090621/"
+    ],
+    "relatedHerbSlugs": [
+      "cordyceps"
+    ],
+    "herbCount": "1",
+    "reverseLookupReady": "Yes"
   },
   {
     "id": "coronaridine",
-    "slug": "coronaridine-wb",
+    "slug": "coronaridine",
     "canonicalCompoundId": "coronaridine",
     "name": "coronaridine",
     "compoundName": "coronaridine",
@@ -2754,7 +2791,7 @@
   },
   {
     "id": "cryogenine-vertine",
-    "slug": "cryogenine-vertine-wb",
+    "slug": "cryogenine-vertine",
     "canonicalCompoundId": "cryogenine-vertine",
     "name": "cryogenine vertine",
     "compoundName": "cryogenine vertine",
@@ -3185,7 +3222,7 @@
   },
   {
     "id": "dmt",
-    "slug": "dmt-wb",
+    "slug": "dmt",
     "canonicalCompoundId": "dmt",
     "name": "dmt",
     "compoundName": "dmt",
@@ -3306,7 +3343,7 @@
   },
   {
     "id": "ellagic-acid",
-    "slug": "ellagic-acid-wb",
+    "slug": "ellagic-acid",
     "canonicalCompoundId": "ellagic-acid",
     "name": "ellagic acid",
     "compoundName": "ellagic acid",
@@ -3351,7 +3388,7 @@
   },
   {
     "id": "ephedrine",
-    "slug": "ephedrine-wb",
+    "slug": "ephedrine",
     "canonicalCompoundId": "ephedrine",
     "name": "ephedrine",
     "compoundName": "ephedrine",
@@ -3389,10 +3426,13 @@
     "canonicalCompoundName": "Epimedin A",
     "compoundClass": "Flavonoid",
     "class": "Flavonoid",
-    "mechanism": "Nitric oxide and libido support",
+    "mechanism": "prenylated flavonoid glycoside",
     "mechanismTags": [
       "nitric oxide signaling"
     ],
+    "confidence": "Low-Medium",
+    "confidenceLevel": "Low-Medium",
+    "evidence": "preclinical + traditional-use context",
     "evidenceTier": "Preclinical"
   },
   {
@@ -3404,10 +3444,13 @@
     "canonicalCompoundName": "Epimedin B",
     "compoundClass": "Flavonoid",
     "class": "Flavonoid",
-    "mechanism": "Nitric oxide and libido support",
+    "mechanism": "prenylated flavonoid glycoside",
     "mechanismTags": [
       "nitric oxide signaling"
     ],
+    "confidence": "Low-Medium",
+    "confidenceLevel": "Low-Medium",
+    "evidence": "preclinical + traditional-use context",
     "evidenceTier": "Preclinical"
   },
   {
@@ -3419,15 +3462,18 @@
     "canonicalCompoundName": "Epimedin C",
     "compoundClass": "Flavonoid",
     "class": "Flavonoid",
-    "mechanism": "Nitric oxide and libido support",
+    "mechanism": "prenylated flavonoid glycoside",
     "mechanismTags": [
       "nitric oxide signaling"
     ],
+    "confidence": "Low-Medium",
+    "confidenceLevel": "Low-Medium",
+    "evidence": "preclinical + traditional-use context",
     "evidenceTier": "Preclinical"
   },
   {
     "id": "ergine",
-    "slug": "ergine-wb",
+    "slug": "ergine",
     "canonicalCompoundId": "ergine",
     "name": "ergine",
     "compoundName": "ergine",
@@ -3487,7 +3533,7 @@
   },
   {
     "id": "estragole",
-    "slug": "estragole-wb",
+    "slug": "estragole",
     "canonicalCompoundId": "estragole",
     "name": "estragole",
     "compoundName": "estragole",
@@ -3517,7 +3563,7 @@
   },
   {
     "id": "eucalyptol",
-    "slug": "eucalyptol-wb",
+    "slug": "eucalyptol",
     "canonicalCompoundId": "eucalyptol",
     "name": "eucalyptol",
     "compoundName": "eucalyptol",
@@ -3547,7 +3593,7 @@
   },
   {
     "id": "eugenol",
-    "slug": "eugenol-wb",
+    "slug": "eugenol",
     "canonicalCompoundId": "eugenol",
     "name": "Eugenol",
     "compoundName": "Eugenol",
@@ -3683,7 +3729,7 @@
   },
   {
     "id": "ferulic-acid",
-    "slug": "ferulic-acid-wb",
+    "slug": "ferulic-acid",
     "canonicalCompoundId": "ferulic-acid",
     "name": "ferulic acid",
     "compoundName": "ferulic acid",
@@ -3819,7 +3865,7 @@
   },
   {
     "id": "gallic-acid",
-    "slug": "gallic-acid-wb",
+    "slug": "gallic-acid",
     "canonicalCompoundId": "gallic-acid",
     "name": "gallic acid",
     "compoundName": "gallic acid",
@@ -4014,7 +4060,7 @@
   },
   {
     "id": "geranial",
-    "slug": "geranial-wb",
+    "slug": "geranial",
     "canonicalCompoundId": "geranial",
     "name": "geranial",
     "compoundName": "geranial",
@@ -4356,7 +4402,7 @@
   },
   {
     "id": "gramine",
-    "slug": "gramine-wb",
+    "slug": "gramine",
     "canonicalCompoundId": "gramine",
     "name": "gramine",
     "compoundName": "gramine",
@@ -4431,18 +4477,37 @@
   },
   {
     "id": "gymnemic-acids",
-    "slug": "gymnemic-acids-wb",
+    "slug": "gymnemic-acids",
     "canonicalCompoundId": "gymnemic-acids",
     "name": "gymnemic acids",
     "compoundName": "gymnemic acids",
     "canonicalCompoundName": "gymnemic acids",
-    "compoundClass": "gymnemic acids",
-    "class": "gymnemic acids",
-    "mechanism": "triterpene saponins",
+    "compoundClass": "triterpene glycosides",
+    "class": "triterpene glycosides",
+    "mechanism": "Gymnemic acids are triterpene glycosides associated with sweet-taste suppression and reduced intestinal glucose uptake, making them the clearest mechanism anchor for gymnema.",
     "mechanismTags": [
-      "unclassified"
+      "sweet taste suppression",
+      "T1R2/T1R3 modulation",
+      "glucose absorption modulation",
+      "glycemic support"
     ],
-    "evidenceTier": "Unknown"
+    "pathwayTargets": [
+      "T1R2/T1R3 sweet receptor",
+      "intestinal glucose transport"
+    ],
+    "confidence": "Medium",
+    "confidenceLevel": "Medium",
+    "evidence": "Mixed",
+    "evidenceTier": "Mixed",
+    "sourceUrls": [
+      "https://pubmed.ncbi.nlm.nih.gov/31736747/|https://pubmed.ncbi.nlm.nih.gov/25056955/|https://pubmed.ncbi.nlm.nih.gov/9152931/"
+    ],
+    "relatedHerbSlugs": [
+      "gymnema",
+      "gudmar"
+    ],
+    "herbCount": "2",
+    "reverseLookupReady": "Yes"
   },
   {
     "id": "gypenosides-dammarane-type-saponins",
@@ -4461,7 +4526,7 @@
   },
   {
     "id": "harmaline",
-    "slug": "harmaline-wb",
+    "slug": "harmaline",
     "canonicalCompoundId": "harmaline",
     "name": "Harmaline",
     "compoundName": "Harmaline",
@@ -4478,7 +4543,7 @@
   },
   {
     "id": "harmalol",
-    "slug": "harmalol-wb",
+    "slug": "harmalol",
     "canonicalCompoundId": "harmalol",
     "name": "harmalol",
     "compoundName": "harmalol",
@@ -4493,7 +4558,7 @@
   },
   {
     "id": "harmine",
-    "slug": "harmine-wb",
+    "slug": "harmine",
     "canonicalCompoundId": "harmine",
     "name": "Harmine",
     "compoundName": "Harmine",
@@ -4615,7 +4680,7 @@
   },
   {
     "id": "histamine",
-    "slug": "histamine-wb",
+    "slug": "histamine",
     "canonicalCompoundId": "histamine",
     "name": "histamine",
     "compoundName": "histamine",
@@ -4645,7 +4710,7 @@
   },
   {
     "id": "huperzine-a",
-    "slug": "huperzine-a-wb",
+    "slug": "huperzine-a",
     "canonicalCompoundId": "huperzine-a",
     "name": "huperzine a",
     "compoundName": "huperzine a",
@@ -4750,7 +4815,7 @@
   },
   {
     "id": "hyoscyamine",
-    "slug": "hyoscyamine-wb",
+    "slug": "hyoscyamine",
     "canonicalCompoundId": "hyoscyamine",
     "name": "hyoscyamine",
     "compoundName": "hyoscyamine",
@@ -4765,7 +4830,7 @@
   },
   {
     "id": "hypaconitine",
-    "slug": "hypaconitine-wb",
+    "slug": "hypaconitine",
     "canonicalCompoundId": "hypaconitine",
     "name": "hypaconitine",
     "compoundName": "hypaconitine",
@@ -4814,7 +4879,7 @@
   },
   {
     "id": "ibogaine",
-    "slug": "ibogaine-wb",
+    "slug": "ibogaine",
     "canonicalCompoundId": "ibogaine",
     "name": "Ibogaine",
     "compoundName": "Ibogaine",
@@ -4833,7 +4898,7 @@
   },
   {
     "id": "ibotenic-acid",
-    "slug": "ibotenic-acid-wb",
+    "slug": "ibotenic-acid",
     "canonicalCompoundId": "ibotenic-acid",
     "name": "ibotenic acid",
     "compoundName": "ibotenic acid",
@@ -4855,12 +4920,15 @@
     "canonicalCompoundName": "Icariin",
     "compoundClass": "Flavonoid",
     "class": "Flavonoid",
-    "mechanism": "prenylated flavonol glycoside",
+    "mechanism": "prenylated flavonol glycoside; PDE-related and nitric-oxide-linked signaling relevance",
     "mechanismTags": [
       "nitric oxide signaling",
       "pde5-related signaling",
       "unclassified"
     ],
+    "confidence": "Medium",
+    "confidenceLevel": "Medium",
+    "evidence": "preclinical + traditional-use context",
     "evidenceTier": "Unknown"
   },
   {
@@ -4979,7 +5047,7 @@
   },
   {
     "id": "isoergine",
-    "slug": "isoergine-wb",
+    "slug": "isoergine",
     "canonicalCompoundId": "isoergine",
     "name": "isoergine",
     "compoundName": "isoergine",
@@ -5070,7 +5138,7 @@
   },
   {
     "id": "isorhamnetin",
-    "slug": "isorhamnetin-wb",
+    "slug": "isorhamnetin",
     "canonicalCompoundId": "isorhamnetin",
     "name": "Isorhamnetin",
     "compoundName": "Isorhamnetin",
@@ -5130,7 +5198,7 @@
   },
   {
     "id": "isovaleric-acid",
-    "slug": "isovaleric-acid-wb",
+    "slug": "isovaleric-acid",
     "canonicalCompoundId": "isovaleric-acid",
     "name": "isovaleric acid",
     "compoundName": "isovaleric acid",
@@ -5220,7 +5288,7 @@
   },
   {
     "id": "kaempferol",
-    "slug": "kaempferol-wb",
+    "slug": "kaempferol",
     "canonicalCompoundId": "kaempferol",
     "name": "Kaempferol",
     "compoundName": "Kaempferol",
@@ -5357,7 +5425,7 @@
   },
   {
     "id": "l-theanine",
-    "slug": "l-theanine-wb",
+    "slug": "l-theanine",
     "canonicalCompoundId": "l-theanine",
     "name": "l-theanine",
     "compoundName": "l-theanine",
@@ -5372,7 +5440,7 @@
   },
   {
     "id": "l-tryptophan",
-    "slug": "l-tryptophan-wb",
+    "slug": "l-tryptophan",
     "canonicalCompoundId": "l-tryptophan",
     "name": "l-tryptophan",
     "compoundName": "l-tryptophan",
@@ -5402,7 +5470,7 @@
   },
   {
     "id": "lactucin",
-    "slug": "lactucin-wb",
+    "slug": "lactucin",
     "canonicalCompoundId": "lactucin",
     "name": "lactucin",
     "compoundName": "lactucin",
@@ -5417,7 +5485,7 @@
   },
   {
     "id": "lactucopicrin",
-    "slug": "lactucopicrin-wb",
+    "slug": "lactucopicrin",
     "canonicalCompoundId": "lactucopicrin",
     "name": "lactucopicrin",
     "compoundName": "lactucopicrin",
@@ -5462,7 +5530,7 @@
   },
   {
     "id": "leonurine",
-    "slug": "leonurine-wb",
+    "slug": "leonurine",
     "canonicalCompoundId": "leonurine",
     "name": "leonurine",
     "compoundName": "leonurine",
@@ -5492,7 +5560,7 @@
   },
   {
     "id": "limonene",
-    "slug": "limonene-wb",
+    "slug": "limonene",
     "canonicalCompoundId": "limonene",
     "name": "limonene",
     "compoundName": "limonene",
@@ -5507,7 +5575,7 @@
   },
   {
     "id": "linalool",
-    "slug": "linalool-wb",
+    "slug": "linalool",
     "canonicalCompoundId": "linalool",
     "name": "linalool",
     "compoundName": "linalool",
@@ -5522,7 +5590,7 @@
   },
   {
     "id": "linalyl-acetate",
-    "slug": "linalyl-acetate-wb",
+    "slug": "linalyl-acetate",
     "canonicalCompoundId": "linalyl-acetate",
     "name": "linalyl acetate",
     "compoundName": "linalyl acetate",
@@ -5642,7 +5710,7 @@
   },
   {
     "id": "lupeol",
-    "slug": "lupeol-wb",
+    "slug": "lupeol",
     "canonicalCompoundId": "lupeol",
     "name": "lupeol",
     "compoundName": "lupeol",
@@ -5672,7 +5740,7 @@
   },
   {
     "id": "luteolin",
-    "slug": "luteolin-wb",
+    "slug": "luteolin",
     "canonicalCompoundId": "luteolin",
     "name": "Luteolin",
     "compoundName": "Luteolin",
@@ -5732,7 +5800,7 @@
   },
   {
     "id": "lythrine",
-    "slug": "lythrine-wb",
+    "slug": "lythrine",
     "canonicalCompoundId": "lythrine",
     "name": "lythrine",
     "compoundName": "lythrine",
@@ -5807,7 +5875,7 @@
   },
   {
     "id": "magnesium",
-    "slug": "magnesium-wb",
+    "slug": "magnesium",
     "canonicalCompoundId": "magnesium",
     "name": "magnesium",
     "compoundName": "magnesium",
@@ -5837,7 +5905,7 @@
   },
   {
     "id": "maltol",
-    "slug": "maltol-wb",
+    "slug": "maltol",
     "canonicalCompoundId": "maltol",
     "name": "maltol",
     "compoundName": "maltol",
@@ -5867,7 +5935,7 @@
   },
   {
     "id": "marmelosin",
-    "slug": "marmelosin-wb",
+    "slug": "marmelosin",
     "canonicalCompoundId": "marmelosin",
     "name": "marmelosin",
     "compoundName": "marmelosin",
@@ -5897,7 +5965,7 @@
   },
   {
     "id": "melatonin",
-    "slug": "melatonin-wb",
+    "slug": "melatonin",
     "canonicalCompoundId": "melatonin",
     "name": "melatonin",
     "compoundName": "melatonin",
@@ -5927,7 +5995,7 @@
   },
   {
     "id": "menthol",
-    "slug": "menthol-wb",
+    "slug": "menthol",
     "canonicalCompoundId": "menthol",
     "name": "menthol",
     "compoundName": "menthol",
@@ -5942,7 +6010,7 @@
   },
   {
     "id": "menthone",
-    "slug": "menthone-wb",
+    "slug": "menthone",
     "canonicalCompoundId": "menthone",
     "name": "menthone",
     "compoundName": "menthone",
@@ -5957,7 +6025,7 @@
   },
   {
     "id": "menthyl-acetate",
-    "slug": "menthyl-acetate-wb",
+    "slug": "menthyl-acetate",
     "canonicalCompoundId": "menthyl-acetate",
     "name": "menthyl acetate",
     "compoundName": "menthyl acetate",
@@ -5972,7 +6040,7 @@
   },
   {
     "id": "mesaconitine",
-    "slug": "mesaconitine-wb",
+    "slug": "mesaconitine",
     "canonicalCompoundId": "mesaconitine",
     "name": "mesaconitine",
     "compoundName": "mesaconitine",
@@ -5987,7 +6055,7 @@
   },
   {
     "id": "mescaline",
-    "slug": "mescaline-wb",
+    "slug": "mescaline",
     "canonicalCompoundId": "mescaline",
     "name": "mescaline",
     "compoundName": "mescaline",
@@ -6032,7 +6100,7 @@
   },
   {
     "id": "mesembrenol",
-    "slug": "mesembrenol-wb",
+    "slug": "mesembrenol",
     "canonicalCompoundId": "mesembrenol",
     "name": "mesembrenol",
     "compoundName": "mesembrenol",
@@ -6047,7 +6115,7 @@
   },
   {
     "id": "mesembrenone",
-    "slug": "mesembrenone-wb",
+    "slug": "mesembrenone",
     "canonicalCompoundId": "mesembrenone",
     "name": "mesembrenone",
     "compoundName": "mesembrenone",
@@ -6062,7 +6130,7 @@
   },
   {
     "id": "mesembrine",
-    "slug": "mesembrine-wb",
+    "slug": "mesembrine",
     "canonicalCompoundId": "mesembrine",
     "name": "mesembrine",
     "compoundName": "mesembrine",
@@ -6077,7 +6145,7 @@
   },
   {
     "id": "methyl-salicylate",
-    "slug": "methyl-salicylate-wb",
+    "slug": "methyl-salicylate",
     "canonicalCompoundId": "methyl-salicylate",
     "name": "methyl salicylate",
     "compoundName": "methyl salicylate",
@@ -6092,7 +6160,7 @@
   },
   {
     "id": "methysticin",
-    "slug": "methysticin-wb",
+    "slug": "methysticin",
     "canonicalCompoundId": "methysticin",
     "name": "methysticin",
     "compoundName": "methysticin",
@@ -6122,7 +6190,7 @@
   },
   {
     "id": "mitragynine",
-    "slug": "mitragynine-wb",
+    "slug": "mitragynine",
     "canonicalCompoundId": "mitragynine",
     "name": "mitragynine",
     "compoundName": "mitragynine",
@@ -6212,7 +6280,7 @@
   },
   {
     "id": "morphine",
-    "slug": "morphine-wb",
+    "slug": "morphine",
     "canonicalCompoundId": "morphine",
     "name": "morphine",
     "compoundName": "morphine",
@@ -6242,7 +6310,7 @@
   },
   {
     "id": "muscimol",
-    "slug": "muscimol-wb",
+    "slug": "muscimol",
     "canonicalCompoundId": "muscimol",
     "name": "muscimol",
     "compoundName": "muscimol",
@@ -6287,7 +6355,7 @@
   },
   {
     "id": "myricetin",
-    "slug": "myricetin-wb",
+    "slug": "myricetin",
     "canonicalCompoundId": "myricetin",
     "name": "myricetin",
     "compoundName": "myricetin",
@@ -6302,7 +6370,7 @@
   },
   {
     "id": "myristicin",
-    "slug": "myristicin-wb",
+    "slug": "myristicin",
     "canonicalCompoundId": "myristicin",
     "name": "myristicin",
     "compoundName": "myristicin",
@@ -6407,7 +6475,7 @@
   },
   {
     "id": "n-methyltryptamine",
-    "slug": "n-methyltryptamine-wb",
+    "slug": "n-methyltryptamine",
     "canonicalCompoundId": "n-methyltryptamine",
     "name": "n-methyltryptamine",
     "compoundName": "n-methyltryptamine",
@@ -6482,7 +6550,7 @@
   },
   {
     "id": "nesodine",
-    "slug": "nesodine-wb",
+    "slug": "nesodine",
     "canonicalCompoundId": "nesodine",
     "name": "nesodine",
     "compoundName": "nesodine",
@@ -6512,7 +6580,7 @@
   },
   {
     "id": "nicotine",
-    "slug": "nicotine-wb",
+    "slug": "nicotine",
     "canonicalCompoundId": "nicotine",
     "name": "nicotine",
     "compoundName": "nicotine",
@@ -6602,7 +6670,7 @@
   },
   {
     "id": "nornicotine",
-    "slug": "nornicotine-wb",
+    "slug": "nornicotine",
     "canonicalCompoundId": "nornicotine",
     "name": "nornicotine",
     "compoundName": "nornicotine",
@@ -6632,7 +6700,7 @@
   },
   {
     "id": "nuciferine",
-    "slug": "nuciferine-wb",
+    "slug": "nuciferine",
     "canonicalCompoundId": "nuciferine",
     "name": "nuciferine",
     "compoundName": "nuciferine",
@@ -6827,7 +6895,7 @@
   },
   {
     "id": "paniculatin",
-    "slug": "paniculatin-wb",
+    "slug": "paniculatin",
     "canonicalCompoundId": "paniculatin",
     "name": "paniculatin",
     "compoundName": "paniculatin",
@@ -6902,7 +6970,7 @@
   },
   {
     "id": "perillaldehyde",
-    "slug": "perillaldehyde-wb",
+    "slug": "perillaldehyde",
     "canonicalCompoundId": "perillaldehyde",
     "name": "perillaldehyde",
     "compoundName": "perillaldehyde",
@@ -6932,18 +7000,36 @@
   },
   {
     "id": "petasin",
-    "slug": "petasin-wb",
+    "slug": "petasin",
     "canonicalCompoundId": "petasin",
     "name": "petasin",
     "compoundName": "petasin",
     "canonicalCompoundName": "petasin",
-    "compoundClass": "petasin",
-    "class": "petasin",
-    "mechanism": "sesquiterpene",
+    "compoundClass": "sesquiterpene ester",
+    "class": "sesquiterpene ester",
+    "mechanism": "Sesquiterpene ester linked to butterbur pharmacology; preclinical work suggests TRPA1/TRPV1-relevant modulation with downstream reduction of CGRP release, supporting the herb's migraine-oriented positioning.",
     "mechanismTags": [
-      "unclassified"
+      "TRPA1/TRPV1 modulation",
+      "CGRP modulation",
+      "anti-inflammatory"
     ],
-    "evidenceTier": "Unknown"
+    "pathwayTargets": [
+      "TRPA1",
+      "TRPV1",
+      "CGRP signaling"
+    ],
+    "confidence": "Medium",
+    "confidenceLevel": "Medium",
+    "evidence": "Preclinical",
+    "evidenceTier": "Preclinical",
+    "sourceUrls": [
+      "https://www.nccih.nih.gov/health/butterbur|https://pubmed.ncbi.nlm.nih.gov/35427728/|https://pubmed.ncbi.nlm.nih.gov/33849430/"
+    ],
+    "relatedHerbSlugs": [
+      "butterbur"
+    ],
+    "herbCount": "1",
+    "reverseLookupReady": "Yes"
   },
   {
     "id": "pfaffic-acid",
@@ -7007,7 +7093,7 @@
   },
   {
     "id": "pinene",
-    "slug": "pinene-wb",
+    "slug": "pinene",
     "canonicalCompoundId": "pinene",
     "name": "pinene",
     "compoundName": "pinene",
@@ -7022,7 +7108,7 @@
   },
   {
     "id": "pinocembrin",
-    "slug": "pinocembrin-wb",
+    "slug": "pinocembrin",
     "canonicalCompoundId": "pinocembrin",
     "name": "pinocembrin",
     "compoundName": "pinocembrin",
@@ -7129,7 +7215,7 @@
   },
   {
     "id": "probiotics",
-    "slug": "probiotics-wb",
+    "slug": "probiotics",
     "canonicalCompoundId": "probiotics",
     "name": "probiotics",
     "compoundName": "probiotics",
@@ -7189,7 +7275,7 @@
   },
   {
     "id": "pseudoephedrine",
-    "slug": "pseudoephedrine-wb",
+    "slug": "pseudoephedrine",
     "canonicalCompoundId": "pseudoephedrine",
     "name": "pseudoephedrine",
     "compoundName": "pseudoephedrine",
@@ -7279,7 +7365,7 @@
   },
   {
     "id": "pulegone",
-    "slug": "pulegone-wb",
+    "slug": "pulegone",
     "canonicalCompoundId": "pulegone",
     "name": "pulegone",
     "compoundName": "pulegone",
@@ -7384,7 +7470,7 @@
   },
   {
     "id": "quercetin",
-    "slug": "quercetin-wb",
+    "slug": "quercetin",
     "canonicalCompoundId": "quercetin",
     "name": "Quercetin",
     "compoundName": "Quercetin",
@@ -7402,7 +7488,7 @@
   },
   {
     "id": "quercitrin",
-    "slug": "quercitrin-wb",
+    "slug": "quercitrin",
     "canonicalCompoundId": "quercitrin",
     "name": "quercitrin",
     "compoundName": "quercitrin",
@@ -7447,7 +7533,7 @@
   },
   {
     "id": "resveratrol",
-    "slug": "resveratrol-wb",
+    "slug": "resveratrol",
     "canonicalCompoundId": "resveratrol",
     "name": "Resveratrol",
     "compoundName": "Resveratrol",
@@ -7618,7 +7704,7 @@
   },
   {
     "id": "rosmarinic-acid",
-    "slug": "rosmarinic-acid-wb",
+    "slug": "rosmarinic-acid",
     "canonicalCompoundId": "rosmarinic-acid",
     "name": "Rosmarinic acid",
     "compoundName": "Rosmarinic acid",
@@ -7651,7 +7737,7 @@
   },
   {
     "id": "rutin",
-    "slug": "rutin-wb",
+    "slug": "rutin",
     "canonicalCompoundId": "rutin",
     "name": "rutin",
     "compoundName": "rutin",
@@ -7711,7 +7797,7 @@
   },
   {
     "id": "safrole",
-    "slug": "safrole-wb",
+    "slug": "safrole",
     "canonicalCompoundId": "safrole",
     "name": "safrole",
     "compoundName": "safrole",
@@ -7954,7 +8040,7 @@
   },
   {
     "id": "scopolamine",
-    "slug": "scopolamine-wb",
+    "slug": "scopolamine",
     "canonicalCompoundId": "scopolamine",
     "name": "scopolamine",
     "compoundName": "scopolamine",
@@ -7969,7 +8055,7 @@
   },
   {
     "id": "scopoletin",
-    "slug": "scopoletin-wb",
+    "slug": "scopoletin",
     "canonicalCompoundId": "scopoletin",
     "name": "scopoletin",
     "compoundName": "scopoletin",
@@ -7984,7 +8070,7 @@
   },
   {
     "id": "scutellarin",
-    "slug": "scutellarin-wb",
+    "slug": "scutellarin",
     "canonicalCompoundId": "scutellarin",
     "name": "scutellarin",
     "compoundName": "scutellarin",
@@ -7999,7 +8085,7 @@
   },
   {
     "id": "selenium",
-    "slug": "selenium-wb",
+    "slug": "selenium",
     "canonicalCompoundId": "selenium",
     "name": "selenium",
     "compoundName": "selenium",
@@ -8029,7 +8115,7 @@
   },
   {
     "id": "serotonin",
-    "slug": "serotonin-wb",
+    "slug": "serotonin",
     "canonicalCompoundId": "serotonin",
     "name": "serotonin",
     "compoundName": "serotonin",
@@ -8239,7 +8325,7 @@
   },
   {
     "id": "solanine",
-    "slug": "solanine-wb",
+    "slug": "solanine",
     "canonicalCompoundId": "solanine",
     "name": "solanine",
     "compoundName": "solanine",
@@ -8254,7 +8340,7 @@
   },
   {
     "id": "spilanthol",
-    "slug": "spilanthol-wb",
+    "slug": "spilanthol",
     "canonicalCompoundId": "spilanthol",
     "name": "spilanthol",
     "compoundName": "spilanthol",
@@ -8269,7 +8355,7 @@
   },
   {
     "id": "stachydrine",
-    "slug": "stachydrine-wb",
+    "slug": "stachydrine",
     "canonicalCompoundId": "stachydrine",
     "name": "stachydrine",
     "compoundName": "stachydrine",
@@ -8376,7 +8462,7 @@
   },
   {
     "id": "tartaric-acid",
-    "slug": "tartaric-acid-wb",
+    "slug": "tartaric-acid",
     "canonicalCompoundId": "tartaric-acid",
     "name": "tartaric acid",
     "compoundName": "tartaric acid",
@@ -8481,7 +8567,7 @@
   },
   {
     "id": "tetrahydroharmine",
-    "slug": "tetrahydroharmine-wb",
+    "slug": "tetrahydroharmine",
     "canonicalCompoundId": "tetrahydroharmine",
     "name": "tetrahydroharmine",
     "compoundName": "tetrahydroharmine",
@@ -8541,7 +8627,7 @@
   },
   {
     "id": "thc",
-    "slug": "thc-wb",
+    "slug": "thc",
     "canonicalCompoundId": "thc",
     "name": "thc",
     "compoundName": "thc",
@@ -8574,7 +8660,7 @@
   },
   {
     "id": "thebaine",
-    "slug": "thebaine-wb",
+    "slug": "thebaine",
     "canonicalCompoundId": "thebaine",
     "name": "thebaine",
     "compoundName": "thebaine",
@@ -8589,7 +8675,7 @@
   },
   {
     "id": "theobromine",
-    "slug": "theobromine-wb",
+    "slug": "theobromine",
     "canonicalCompoundId": "theobromine",
     "name": "theobromine",
     "compoundName": "theobromine",
@@ -8604,7 +8690,7 @@
   },
   {
     "id": "theophylline",
-    "slug": "theophylline-wb",
+    "slug": "theophylline",
     "canonicalCompoundId": "theophylline",
     "name": "theophylline",
     "compoundName": "theophylline",
@@ -8649,7 +8735,7 @@
   },
   {
     "id": "thujone",
-    "slug": "thujone-wb",
+    "slug": "thujone",
     "canonicalCompoundId": "thujone",
     "name": "thujone",
     "compoundName": "thujone",
@@ -8664,7 +8750,7 @@
   },
   {
     "id": "thymol",
-    "slug": "thymol-wb",
+    "slug": "thymol",
     "canonicalCompoundId": "thymol",
     "name": "thymol",
     "compoundName": "thymol",
@@ -8905,7 +8991,7 @@
   },
   {
     "id": "umbelliferone",
-    "slug": "umbelliferone-wb",
+    "slug": "umbelliferone",
     "canonicalCompoundId": "umbelliferone",
     "name": "umbelliferone",
     "compoundName": "umbelliferone",
@@ -8965,7 +9051,7 @@
   },
   {
     "id": "ursolic-acid",
-    "slug": "ursolic-acid-wb",
+    "slug": "ursolic-acid",
     "canonicalCompoundId": "ursolic-acid",
     "name": "Ursolic acid",
     "compoundName": "Ursolic acid",
@@ -9041,7 +9127,7 @@
   },
   {
     "id": "valerenic-acid",
-    "slug": "valerenic-acid-wb",
+    "slug": "valerenic-acid",
     "canonicalCompoundId": "valerenic-acid",
     "name": "valerenic acid",
     "compoundName": "valerenic acid",
@@ -9116,7 +9202,7 @@
   },
   {
     "id": "vasicine",
-    "slug": "vasicine-wb",
+    "slug": "vasicine",
     "canonicalCompoundId": "vasicine",
     "name": "Vasicine",
     "compoundName": "Vasicine",
@@ -9133,7 +9219,7 @@
   },
   {
     "id": "vasicinone",
-    "slug": "vasicinone-wb",
+    "slug": "vasicinone",
     "canonicalCompoundId": "vasicinone",
     "name": "vasicinone",
     "compoundName": "vasicinone",
@@ -9148,7 +9234,7 @@
   },
   {
     "id": "verbascoside",
-    "slug": "verbascoside-wb",
+    "slug": "verbascoside",
     "canonicalCompoundId": "verbascoside",
     "name": "verbascoside",
     "compoundName": "verbascoside",
@@ -9253,7 +9339,7 @@
   },
   {
     "id": "voacangine",
-    "slug": "voacangine-wb",
+    "slug": "voacangine",
     "canonicalCompoundId": "voacangine",
     "name": "voacangine",
     "compoundName": "voacangine",
@@ -9379,7 +9465,7 @@
   },
   {
     "id": "wogonin",
-    "slug": "wogonin-wb",
+    "slug": "wogonin",
     "canonicalCompoundId": "wogonin",
     "name": "wogonin",
     "compoundName": "wogonin",
@@ -9469,7 +9555,7 @@
   },
   {
     "id": "yangonin",
-    "slug": "yangonin-wb",
+    "slug": "yangonin",
     "canonicalCompoundId": "yangonin",
     "name": "yangonin",
     "compoundName": "yangonin",
@@ -9484,19 +9570,24 @@
   },
   {
     "id": "yohimbine",
-    "slug": "yohimbine-wb",
+    "slug": "yohimbine",
     "canonicalCompoundId": "yohimbine",
     "name": "Yohimbine",
     "compoundName": "Yohimbine",
     "canonicalCompoundName": "Yohimbine",
     "compoundClass": "yohimbine",
     "class": "yohimbine",
-    "mechanism": "Adrenergic antagonist",
+    "mechanism": "indole alkaloid; alpha-2 adrenergic antagonist",
     "mechanismTags": [
       "adrenergic signaling",
       "alpha-2 adrenergic antagonism",
       "unclassified"
     ],
+    "safetyNotes": "Can amplify anxiety, blood-pressure instability, tachycardia, and overstimulation; not appropriate as a casual wellness compound.",
+    "drugInteractions": "Potential interaction concern with stimulants, antidepressants, blood-pressure agents, vasopressors, and other mood/cardiovascular-active compounds.",
+    "confidence": "Medium",
+    "confidenceLevel": "Medium",
+    "evidence": "limited human + strong safety signal",
     "evidenceTier": "Unknown"
   },
   {
@@ -9543,5 +9634,38 @@
       "unclassified"
     ],
     "evidenceTier": "Unknown"
+  },
+  {
+    "id": "isopetasin",
+    "slug": "isopetasin",
+    "canonicalCompoundId": "isopetasin",
+    "name": "isopetasin",
+    "compoundName": "isopetasin",
+    "canonicalCompoundName": "isopetasin",
+    "compoundClass": "sesquiterpene ester",
+    "class": "sesquiterpene ester",
+    "mechanism": "Sesquiterpene ester related to petasin and discussed in butterbur mechanistic literature as part of the herb's CGRP-relevant migraine-support pharmacology.",
+    "mechanismTags": [
+      "TRPA1/TRPV1 modulation",
+      "CGRP modulation",
+      "anti-inflammatory"
+    ],
+    "pathwayTargets": [
+      "TRPA1",
+      "TRPV1",
+      "CGRP signaling"
+    ],
+    "confidence": "Medium",
+    "confidenceLevel": "Medium",
+    "evidence": "Preclinical",
+    "evidenceTier": "Preclinical",
+    "sourceUrls": [
+      "https://www.nccih.nih.gov/health/butterbur|https://pubmed.ncbi.nlm.nih.gov/35427728/|https://pubmed.ncbi.nlm.nih.gov/33849430/"
+    ],
+    "relatedHerbSlugs": [
+      "butterbur"
+    ],
+    "herbCount": "1",
+    "reverseLookupReady": "Yes"
   }
 ]

--- a/public/data/workbook-herb-compound-map.json
+++ b/public/data/workbook-herb-compound-map.json
@@ -409,17 +409,22 @@
   {
     "herbSlug": "butterbur",
     "herbName": "Butterbur",
-    "rawCompound": "ferulic acid",
-    "normalizedAtom": "ferulic acid",
-    "canonicalCompoundId": "ferulic-acid",
-    "canonicalCompoundName": "ferulic acid",
-    "v3MatchType": "exact",
+    "rawCompound": "petasin",
+    "normalizedAtom": "petasin",
+    "canonicalCompoundId": "petasin",
+    "canonicalCompoundName": "petasin",
+    "v3MatchType": "exact_canonical_id",
     "mappingTier": "specific",
     "mechanismTags": [
-      "multi-domain"
+      "migraine support",
+      "anti-inflammatory",
+      "TRPA1/TRPV1 modulation",
+      "CGRP modulation"
     ],
     "pathwayTargets": [
-      "unknown"
+      "TRPA1",
+      "TRPV1",
+      "CGRP signaling"
     ]
   },
   {
@@ -665,10 +670,13 @@
     "v3MatchType": "exact_canonical_id",
     "mappingTier": "specific",
     "mechanismTags": [
-      "glycemic support"
+      "glycemic support",
+      "sweet taste suppression",
+      "T1R2/T1R3 modulation"
     ],
     "pathwayTargets": [
-      "general or unknown targets"
+      "T1R2/T1R3 sweet receptor",
+      "intestinal glucose transport"
     ]
   },
   {
@@ -1718,11 +1726,14 @@
     "v3MatchType": "exact_canonical_id",
     "mappingTier": "specific",
     "mechanismTags": [
+      "bulk laxative",
       "GI support",
-      "metabolic support"
+      "cholesterol support"
     ],
     "pathwayTargets": [
-      "general or unknown targets"
+      "gel-forming fiber",
+      "stool water retention",
+      "stool bulk"
     ]
   },
   {
@@ -1956,10 +1967,12 @@
     "mappingTier": "specific",
     "mechanismTags": [
       "calming support",
-      "sleep support"
+      "sleep support",
+      "traditional-use sedative"
     ],
     "pathwayTargets": [
-      "general or unknown targets"
+      "possible GABAergic signaling",
+      "low target specificity"
     ]
   },
   {
@@ -1972,11 +1985,14 @@
     "v3MatchType": "exact_canonical_id",
     "mappingTier": "specific",
     "mechanismTags": [
-      "energy support",
-      "immune modulation"
+      "immune modulation",
+      "anti-inflammatory",
+      "NF-kappaB modulation"
     ],
     "pathwayTargets": [
-      "general or unknown targets"
+      "NF-kappaB",
+      "Nrf2/HO-1",
+      "RIP2/Caspase-1"
     ]
   },
   {
@@ -2074,8 +2090,8 @@
     "v3MatchType": "exact-normalized",
     "mappingTier": "master-linked",
     "mechanismTags": [
-      "vascular modulation",
-      "bone signaling modulation"
+      "PDE-related signaling",
+      "nitric oxide signaling"
     ],
     "pathwayTargets": [
       "eNOS/NO signaling",
@@ -2092,8 +2108,8 @@
     "v3MatchType": "exact-normalized",
     "mappingTier": "master-linked",
     "mechanismTags": [
-      "adrenergic modulation",
-      "stimulant"
+      "adrenergic signaling",
+      "alpha-2 adrenergic antagonism"
     ],
     "pathwayTargets": [
       "alpha-2 adrenergic receptor antagonism"
@@ -2122,7 +2138,11 @@
   },
   {
     "herbSlug": "epimedium",
-    "herbName": "Icariin"
+    "herbName": "Icariin",
+    "mechanismTags": [
+      "flavonoid activity",
+      "nitric oxide signaling"
+    ]
   },
   {
     "herbSlug": "pausinystalia-yohimbe",
@@ -2596,6 +2616,7 @@
     "v3MatchType": "pass13-real-sweep",
     "mappingTier": "master-linked",
     "mechanismTags": [
+      "flavonoid activity",
       "nitric oxide signaling"
     ],
     "pathwayTargets": [
@@ -2612,6 +2633,7 @@
     "v3MatchType": "pass13-real-sweep",
     "mappingTier": "master-linked",
     "mechanismTags": [
+      "flavonoid activity",
       "nitric oxide signaling"
     ],
     "pathwayTargets": [
@@ -2628,6 +2650,7 @@
     "v3MatchType": "pass13-real-sweep",
     "mappingTier": "master-linked",
     "mechanismTags": [
+      "flavonoid activity",
       "nitric oxide signaling"
     ],
     "pathwayTargets": [
@@ -2918,5 +2941,26 @@
     "normalizedAtom": "desmethylicaritin",
     "canonicalCompoundId": "desmethylicaritin",
     "canonicalCompoundName": "Desmethylicaritin"
+  },
+  {
+    "herbSlug": "butterbur",
+    "herbName": "Butterbur",
+    "rawCompound": "isopetasin",
+    "normalizedAtom": "isopetasin",
+    "canonicalCompoundId": "isopetasin",
+    "canonicalCompoundName": "isopetasin",
+    "v3MatchType": "exact_canonical_id",
+    "mappingTier": "specific",
+    "mechanismTags": [
+      "migraine support",
+      "anti-inflammatory",
+      "TRPA1/TRPV1 modulation",
+      "CGRP modulation"
+    ],
+    "pathwayTargets": [
+      "TRPA1",
+      "TRPV1",
+      "CGRP signaling"
+    ]
   }
 ]

--- a/public/data/workbook-herbs.json
+++ b/public/data/workbook-herbs.json
@@ -1,6 +1,515 @@
 [
   {
-    "slug": "ashwagandha-wb",
+    "slug": "acerola",
+    "name": "Acerola",
+    "scientificName": "Malpighia emarginata",
+    "latin": "Malpighia emarginata",
+    "category": "fruit",
+    "class": "fruit",
+    "plantPartUsed": "fruit",
+    "commonNames": [
+      "acerola cherry"
+    ],
+    "region": "Caribbean; tropical Americas",
+    "summary": "Acerola is positioned for antioxidant and nutritive support.",
+    "description": "It is best framed as a vitamin-C-rich fruit botanical with food/supplement relevance.",
+    "mechanism": "Fruit polyphenols and vitamin content support antioxidant and nutritive positioning.",
+    "mechanismTags": [
+      "antioxidant",
+      "nutritive support"
+    ],
+    "evidenceLevel": "Unknown",
+    "activeCompounds": [
+      "ascorbic acid",
+      "carotenoids"
+    ],
+    "topCompounds": [
+      "ascorbic acid"
+    ],
+    "markerCompounds": [
+      "ascorbic acid"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with overextended immune claims."
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "frontendReadyFlag": "No",
+    "completenessPct": "0.55",
+    "priorityTier": "Medium",
+    "totalScore": "5",
+    "compound_count": "1",
+    "pathway_count": "0",
+    "sources": [
+      "Pass 125 curated expansion"
+    ]
+  },
+  {
+    "slug": "agarikon",
+    "name": "Agarikon",
+    "scientificName": "Fomitopsis officinalis",
+    "latin": "Fomitopsis officinalis",
+    "category": "fruiting body",
+    "class": "fruiting body",
+    "plantPartUsed": "fruiting body",
+    "commonNames": [
+      "agarikon"
+    ],
+    "region": "Europe, Asia, North America",
+    "summary": "Agarikon is positioned for traditional immune and respiratory support.",
+    "description": "It should be framed modestly because traditional use is much stronger than modern evidence.",
+    "mechanism": "Traditional fungal use and polysaccharides support immune-support positioning.",
+    "mechanismTags": [
+      "respiratory support",
+      "traditional immune support"
+    ],
+    "evidenceLevel": "Preclinical",
+    "activeCompounds": [
+      "agaric acid",
+      "polysaccharides"
+    ],
+    "topCompounds": [
+      "agaric acid"
+    ],
+    "markerCompounds": [
+      "agaric acid"
+    ],
+    "safetyNotes": "Use cautiously.",
+    "interactions": [
+      "Avoid exaggerated antimicrobial claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "ajwain",
+    "name": "Ajwain",
+    "scientificName": "Trachyspermum ammi",
+    "latin": "Trachyspermum ammi",
+    "category": "seed",
+    "class": "seed",
+    "plantPartUsed": "seed",
+    "commonNames": [
+      "ajwain"
+    ],
+    "region": "India and South Asia",
+    "summary": "Ajwain is positioned for digestive and aromatic support.",
+    "description": "It is best framed as a culinary-medicinal seed with strong traditional GI positioning.",
+    "mechanism": "Aromatic phenols support digestive and antimicrobial-adjacent positioning.",
+    "mechanismTags": [
+      "aromatic support",
+      "digestive support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "thymol"
+    ],
+    "topCompounds": [
+      "thymol"
+    ],
+    "markerCompounds": [
+      "thymol"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Avoid overextended antimicrobial claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "3",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "aloe-vera",
+    "name": "Aloe Vera",
+    "scientificName": "Aloe vera",
+    "latin": "Aloe vera",
+    "category": "botanical",
+    "class": "botanical",
+    "plantPartUsed": "varies",
+    "commonNames": [
+      "aloe vera"
+    ],
+    "summary": "Aloe Vera is an intake-stage monograph candidate linked to 1 internal compound records in the current workbook.",
+    "description": "Internal cross-linking supports Aloe Vera through compounds such as aloin.",
+    "mechanism": "Current internal mapping is compound-linked, with pathway resolution still limited.",
+    "mechanismTags": [
+      "anti-inflammatory",
+      "demulcent",
+      "digestive support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "acemannan",
+      "aloe-emodin",
+      "aloin"
+    ],
+    "topCompounds": [
+      "acemannan",
+      "aloe-emodin"
+    ],
+    "markerCompounds": [
+      "acemannan",
+      "aloe-emodin"
+    ],
+    "safetyNotes": "General use caution; distinguish inner gel from latex-rich stimulant-laxative fractions.",
+    "interactions": [
+      "May amplify laxative-heavy or glucose-lowering contexts"
+    ],
+    "contraindications": [
+      "Use caution with diarrhea-prone or pregnancy-sensitive contexts when latex fractions are relevant"
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "frontendReadyFlag": "No",
+    "completenessPct": "0.95",
+    "priorityTier": "High",
+    "totalScore": "4",
+    "compound_count": "0",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "american-ginseng",
+    "name": "American Ginseng",
+    "scientificName": "Panax quinquefolius",
+    "latin": "Panax quinquefolius",
+    "category": "botanical",
+    "class": "botanical",
+    "plantPartUsed": "varies",
+    "commonNames": [
+      "american ginseng"
+    ],
+    "summary": "American Ginseng is an intake-stage monograph candidate linked to 3 internal compound records and pathway tags including gabaergic_modulation, inflammatory_pathway_modulation.",
+    "description": "Internal cross-linking supports American Ginseng through compounds such as ginsenosides (including rb1, rg1), rb2.",
+    "mechanism": "Internal workbook mapping currently connects this herb to gabaergic_modulation, inflammatory_pathway_modulation.",
+    "mechanismTags": [
+      "gabaergic_modulation",
+      "inflammatory_pathway_modulation"
+    ],
+    "evidenceLevel": "Unknown",
+    "activeCompounds": [
+      "ginsenosides (including rb1",
+      "rg1)",
+      "rb2"
+    ],
+    "topCompounds": [
+      "ginsenosides (including rb1"
+    ],
+    "markerCompounds": [
+      "ginsenosides (including rb1"
+    ],
+    "safetyNotes": "Safety review required before publication.",
+    "interactions": [
+      "Interaction review required before publication."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "frontendReadyFlag": "No",
+    "completenessPct": "0.95",
+    "priorityTier": "High",
+    "totalScore": "6",
+    "compound_count": "0",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "angelica-root",
+    "name": "Angelica Root",
+    "scientificName": "Angelica archangelica",
+    "latin": "Angelica archangelica",
+    "category": "root",
+    "class": "root",
+    "plantPartUsed": "root",
+    "commonNames": [
+      "angelica root"
+    ],
+    "region": "Northern Europe",
+    "summary": "Angelica root is positioned for aromatic digestive and traditional cycle-related support.",
+    "description": "It should be framed carefully because furanocoumarin context matters for some use cases.",
+    "mechanism": "Aromatic compounds support digestive and traditional positioning.",
+    "mechanismTags": [
+      "digestive support",
+      "traditional cycle support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "angelicin",
+      "essential oils"
+    ],
+    "topCompounds": [
+      "angelicin"
+    ],
+    "markerCompounds": [
+      "angelicin"
+    ],
+    "safetyNotes": "Use cautiously.",
+    "interactions": [
+      "Use caution with photosensitivity-related contexts."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "arjuna",
+    "name": "Arjuna",
+    "scientificName": "Terminalia arjuna",
+    "latin": "Terminalia arjuna",
+    "category": "bark",
+    "class": "bark",
+    "plantPartUsed": "bark",
+    "commonNames": [
+      "arjuna"
+    ],
+    "region": "India and South Asia",
+    "summary": "Arjuna is positioned for cardiovascular and vascular support.",
+    "description": "It is best framed around bark polyphenols and triterpenes with specific cardiotonic-support positioning.",
+    "mechanism": "Triterpenes and polyphenols support cardiovascular and antioxidant positioning.",
+    "mechanismTags": [
+      "cardiovascular support",
+      "vascular support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "arjunolic acid",
+      "triterpenes"
+    ],
+    "topCompounds": [
+      "arjunolic acid"
+    ],
+    "markerCompounds": [
+      "arjunolic acid"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with blood-pressure-lowering strategies."
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "frontendReadyFlag": "No",
+    "completenessPct": "0.55",
+    "priorityTier": "Medium",
+    "totalScore": "5",
+    "pathwayTargets": [
+      "cardiovascular signaling",
+      "unclassified"
+    ],
+    "compound_count": "2",
+    "pathway_count": "2",
+    "sources": [
+      "Pass 125 curated expansion"
+    ]
+  },
+  {
+    "slug": "artemisia-annua",
+    "name": "Artemisia Annua",
+    "scientificName": "Artemisia annua",
+    "latin": "Artemisia annua",
+    "category": "botanical",
+    "class": "botanical",
+    "plantPartUsed": "varies",
+    "commonNames": [
+      "artemisia annua"
+    ],
+    "summary": "Artemisia Annua is an intake-stage monograph candidate linked to 1 internal compound records in the current workbook.",
+    "description": "Internal cross-linking supports Artemisia Annua through compounds such as artemisinin.",
+    "mechanism": "Current internal mapping is compound-linked, with pathway resolution still limited.",
+    "mechanismTags": [
+      "antimicrobial",
+      "immune support",
+      "oxidative stress modulation"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "artemisinin",
+      "arteannuin B",
+      "chrysosplenetin"
+    ],
+    "topCompounds": [
+      "artemisinin",
+      "arteannuin B"
+    ],
+    "markerCompounds": [
+      "artemisinin",
+      "arteannuin B"
+    ],
+    "safetyNotes": "Review interactions and contraindications.",
+    "interactions": [
+      "May interact with liver-metabolized stacks and intensive antimicrobial protocols"
+    ],
+    "contraindications": [
+      "Avoid pregnancy-sensitive contexts without stronger review"
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "frontendReadyFlag": "No",
+    "completenessPct": "0.95",
+    "priorityTier": "High",
+    "totalScore": "4",
+    "compound_count": "0",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "artichoke",
+    "name": "Artichoke",
+    "scientificName": "Cynara scolymus",
+    "latin": "Cynara scolymus",
+    "category": "leaf",
+    "class": "leaf",
+    "plantPartUsed": "leaf",
+    "commonNames": [
+      "artichoke leaf"
+    ],
+    "region": "Mediterranean; cultivated broadly",
+    "summary": "Artichoke is a leaf monograph positioned for hepatobiliary and digestive support.",
+    "description": "It is best framed around bitter-compound and phenolic support for digestion and bile-related positioning rather than broad detox claims.",
+    "mechanism": "Phenolic compounds are associated with choleretic and hepatometabolic-support positioning.",
+    "mechanismTags": [
+      "digestive support",
+      "hepatobiliary support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "cynarin",
+      "chlorogenic acid"
+    ],
+    "topCompounds": [
+      "cynarin"
+    ],
+    "markerCompounds": [
+      "cynarin"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Avoid with bile-duct obstruction or severe gallbladder issues."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "ashitaba",
+    "name": "Ashitaba",
+    "scientificName": "Angelica keiskei",
+    "latin": "Angelica keiskei",
+    "category": "leaf/stem",
+    "class": "leaf/stem",
+    "plantPartUsed": "leaf; stem",
+    "commonNames": [
+      "ashitaba"
+    ],
+    "region": "Japan",
+    "summary": "Ashitaba is positioned for metabolic and antioxidant support.",
+    "description": "It is best framed around chalcone-rich chemistry with modest translational evidence.",
+    "mechanism": "Chalcones are associated with antioxidant and metabolic-support positioning.",
+    "mechanismTags": [
+      "antioxidant",
+      "metabolic support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "xanthoangelol",
+      "4-hydroxyderricin"
+    ],
+    "topCompounds": [
+      "4-hydroxyderricin"
+    ],
+    "markerCompounds": [
+      "4-hydroxyderricin"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with concentrated extract marketing claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "ashoka",
+    "name": "Ashoka",
+    "scientificName": "Saraca asoca",
+    "latin": "Saraca asoca",
+    "category": "bark",
+    "class": "bark",
+    "plantPartUsed": "bark",
+    "commonNames": [
+      "ashoka"
+    ],
+    "region": "India and South Asia",
+    "summary": "Ashoka is positioned for traditional cycle-related support.",
+    "description": "It should be framed conservatively because traditional gynecologic use is much stronger than modern evidence.",
+    "mechanism": "Polyphenols support traditional cycle-related positioning.",
+    "mechanismTags": [
+      "traditional cycle support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "catechins",
+      "flavonoids"
+    ],
+    "topCompounds": [
+      "catechins"
+    ],
+    "markerCompounds": [
+      "catechins"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Avoid overextended reproductive-health claims."
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "frontendReadyFlag": "No",
+    "completenessPct": "0.55",
+    "priorityTier": "Medium",
+    "totalScore": "5",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1",
+    "sources": [
+      "Pass 125 curated expansion"
+    ]
+  },
+  {
+    "slug": "ashwagandha",
     "name": "Ashwagandha",
     "scientificName": "Withania somnifera",
     "latin": "Withania somnifera",
@@ -31,7 +540,7 @@
     "markerCompounds": [
       "withanolides"
     ],
-    "safetyNotes": "Short-term use appears safe; side effects include drowsiness and GI upset. Rare liver injury has been reported.",
+    "safetyNotes": "Short-term use appears safe; side effects include drowsiness and GI upset.",
     "interactions": [
       "May potentiate sedatives",
       "antihypertensives",
@@ -69,7 +578,265 @@
     ]
   },
   {
-    "slug": "black-cohosh-wb",
+    "slug": "astragalus",
+    "name": "Astragalus",
+    "scientificName": "Astragalus membranaceus",
+    "latin": "Astragalus membranaceus",
+    "category": "root",
+    "class": "root",
+    "plantPartUsed": "root",
+    "commonNames": [
+      "astragalus"
+    ],
+    "region": "China and East Asia",
+    "summary": "Astragalus is positioned for immune and fatigue-support use.",
+    "description": "It is best framed around astragalosides and polysaccharides.",
+    "mechanism": "Saponins and polysaccharides support immune and restorative positioning.",
+    "mechanismTags": [
+      "fatigue support",
+      "immune modulation"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "astragaloside IV",
+      "polysaccharides"
+    ],
+    "topCompounds": [
+      "astragaloside IV"
+    ],
+    "markerCompounds": [
+      "astragaloside IV"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution in autoimmune contexts."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "compound_count": "1",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "atractylodes",
+    "name": "Atractylodes",
+    "scientificName": "Atractylodes macrocephala",
+    "latin": "Atractylodes macrocephala",
+    "category": "rhizome",
+    "class": "rhizome",
+    "plantPartUsed": "rhizome",
+    "commonNames": [
+      "bai zhu"
+    ],
+    "region": "China and East Asia",
+    "summary": "Atractylodes is positioned for traditional digestive and restorative support.",
+    "description": "It is best framed as a digestive-tonic rhizome with traditional-system relevance.",
+    "mechanism": "Sesquiterpenes support digestive and restorative positioning.",
+    "mechanismTags": [
+      "digestive support",
+      "traditional restorative support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "atractylenolide I"
+    ],
+    "topCompounds": [
+      "atractylenolide I"
+    ],
+    "markerCompounds": [
+      "atractylenolide I"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Avoid overextended metabolic claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "compound_count": "1",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "bacopa",
+    "name": "Bacopa",
+    "scientificName": "Bacopa monnieri",
+    "latin": "Bacopa monnieri",
+    "category": "aerial parts",
+    "class": "aerial parts",
+    "plantPartUsed": "aerial parts",
+    "commonNames": [
+      "bacopa"
+    ],
+    "region": "India and tropical regions",
+    "summary": "Bacopa is positioned for cognitive and calming support.",
+    "description": "It is best framed around bacosides with slower-onset cognitive relevance.",
+    "mechanism": "Triterpene saponins support cognitive and calming positioning.",
+    "mechanismTags": [
+      "calming support",
+      "cognitive support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "bacoside A",
+      "bacopaside II"
+    ],
+    "topCompounds": [
+      "bacoside A"
+    ],
+    "markerCompounds": [
+      "bacoside A"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with GI sensitivity."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "compound_count": "1",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "banaba",
+    "name": "Banaba",
+    "scientificName": "Lagerstroemia speciosa",
+    "latin": "Lagerstroemia speciosa",
+    "category": "leaf",
+    "class": "leaf",
+    "plantPartUsed": "leaf",
+    "commonNames": [
+      "banaba"
+    ],
+    "region": "Southeast Asia",
+    "summary": "Banaba is positioned for metabolic and glycemic support.",
+    "description": "It is best framed conservatively because evidence quality and standardization vary across products.",
+    "mechanism": "Triterpene constituents are associated with glycemic-support positioning.",
+    "mechanismTags": [
+      "glycemic support",
+      "metabolic support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "corosolic acid"
+    ],
+    "topCompounds": [
+      "corosolic acid"
+    ],
+    "markerCompounds": [
+      "corosolic acid"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with glucose-lowering strategies."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "berberis",
+    "name": "Berberis",
+    "scientificName": "Berberis vulgaris",
+    "latin": "Berberis vulgaris",
+    "category": "root; bark",
+    "class": "root; bark",
+    "plantPartUsed": "root bark",
+    "commonNames": [
+      "barberry",
+      "berberis"
+    ],
+    "region": "Europe, North Africa, West Asia",
+    "summary": "Berberis is positioned for metabolic and antimicrobial support.",
+    "description": "It is best framed around berberine-bearing root bark with GI and medication-interaction caution.",
+    "mechanism": "AMPK and antimicrobial relevance are commonly cited positioning anchors.",
+    "mechanismTags": [
+      "antimicrobial support",
+      "metabolic support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "berberine",
+      "berbamine"
+    ],
+    "topCompounds": [
+      "berberine"
+    ],
+    "markerCompounds": [
+      "berberine"
+    ],
+    "safetyNotes": "Use caution in pregnancy, breastfeeding, and in those prone to GI upset.",
+    "interactions": [
+      "May interact with cytochrome-metabolized drugs",
+      "glucose-lowering agents",
+      "and anticoagulants."
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "completenessPct": "0.9",
+    "priorityTier": "High",
+    "totalScore": "3",
+    "compound_count": "0",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "bitter-melon",
+    "name": "Bitter Melon",
+    "scientificName": "Momordica charantia",
+    "latin": "Momordica charantia",
+    "category": "fruit",
+    "class": "fruit",
+    "plantPartUsed": "fruit",
+    "commonNames": [
+      "bitter melon",
+      "bitter gourd"
+    ],
+    "region": "Asia, Africa, Caribbean, tropics",
+    "summary": "Bitter melon is positioned for glucose and metabolic support.",
+    "description": "It is best framed as a food-medicine with hypoglycemia-aware caution.",
+    "mechanism": "Glucose-handling relevance is the core positioning feature.",
+    "mechanismTags": [
+      "glucose support",
+      "metabolic support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "charantin",
+      "polypeptide-p",
+      "cucurbitanes"
+    ],
+    "topCompounds": [
+      "charantin"
+    ],
+    "markerCompounds": [
+      "charantin"
+    ],
+    "safetyNotes": "Use caution in people prone to low blood sugar and during pregnancy.",
+    "interactions": [
+      "May add to glucose-lowering drugs and should be used cautiously with diabetes medications."
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "completenessPct": "0.9",
+    "priorityTier": "High",
+    "totalScore": "3",
+    "compound_count": "0",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "black-cohosh",
     "name": "Black Cohosh",
     "scientificName": "Actaea racemosa",
     "latin": "Actaea racemosa",
@@ -106,7 +873,7 @@
       "actein",
       "23-epi-26-deoxyactein"
     ],
-    "safetyNotes": "Generally well tolerated in short-term studies, but rare cases of liver injury have been reported. Product contamination or misidentification is a known issue.",
+    "safetyNotes": "Generally well tolerated in short-term studies, but rare cases of liver injury have been reported.",
     "interactions": [
       "Potential interactions with hepatotoxic drugs and with medications affecting estrogen or serotonergic pathways."
     ],
@@ -136,7 +903,1352 @@
     ]
   },
   {
-    "slug": "echinacea-purpurea-wb",
+    "slug": "black-pepper",
+    "name": "Black Pepper",
+    "scientificName": "Piper nigrum",
+    "latin": "Piper nigrum",
+    "category": "fruit",
+    "class": "fruit",
+    "plantPartUsed": "fruit",
+    "commonNames": [
+      "black pepper"
+    ],
+    "region": "India; cultivated globally",
+    "summary": "Black pepper is positioned for digestive and bioavailability-support use.",
+    "description": "It should be framed specifically around piperine and digestive relevance rather than as a stand-alone tonic.",
+    "mechanism": "Alkaloids support digestive and absorption-related positioning.",
+    "mechanismTags": [
+      "bioavailability support",
+      "digestive support",
+      "metabolic support"
+    ],
+    "evidenceLevel": "Unknown",
+    "activeCompounds": [
+      "piperine"
+    ],
+    "topCompounds": [
+      "piperine"
+    ],
+    "markerCompounds": [
+      "piperine"
+    ],
+    "safetyNotes": "Generally well tolerated; use caution with concentrated extracts.",
+    "interactions": [
+      "Use caution with drug-metabolism-sensitive contexts and tightly dosed stacks."
+    ],
+    "contraindications": [
+      "Use caution in reflux-sensitive contexts."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "bioavailability modulation",
+      "absorption enhancement",
+      "unclassified"
+    ],
+    "compound_count": "3",
+    "pathway_count": "3"
+  },
+  {
+    "slug": "blue-lotus",
+    "name": "Blue Lotus",
+    "scientificName": "Nymphaea caerulea",
+    "latin": "Nymphaea caerulea",
+    "category": "plant",
+    "class": "plant",
+    "plantPartUsed": "flower",
+    "commonNames": [
+      "Blue Lotus"
+    ],
+    "region": "global",
+    "summary": "Blue Lotus positioned for primary functional support.",
+    "description": "Conservative evidence framing applied.",
+    "mechanism": "Mechanistic activity supported by mixed evidence.",
+    "mechanismTags": [
+      "calming support",
+      "mood support",
+      "sleep support"
+    ],
+    "evidenceLevel": "Preclinical",
+    "activeCompounds": [
+      "aporphine alkaloids"
+    ],
+    "topCompounds": [
+      "nuciferine"
+    ],
+    "markerCompounds": [
+      "nuciferine"
+    ],
+    "safetyNotes": "Use caution with sedative-sensitive contexts and stacked calming formulas.",
+    "interactions": [
+      "May compound sedative effects in calming/sleep stacks."
+    ],
+    "contraindications": [
+      "Avoid high-sedation contexts without clear need."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "5",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "boldo",
+    "name": "Boldo",
+    "scientificName": "Peumus boldus",
+    "latin": "Peumus boldus",
+    "category": "leaf",
+    "class": "leaf",
+    "plantPartUsed": "leaf",
+    "commonNames": [
+      "boldo"
+    ],
+    "region": "South America",
+    "summary": "Boldo is positioned for digestive and hepatobiliary support.",
+    "description": "It is best framed as an aromatic bitter leaf botanical with modest human evidence.",
+    "mechanism": "Alkaloids and aromatic constituents support digestive and hepatobiliary positioning.",
+    "mechanismTags": [
+      "digestive support",
+      "hepatobiliary support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "boldine"
+    ],
+    "topCompounds": [
+      "boldine"
+    ],
+    "markerCompounds": [
+      "boldine"
+    ],
+    "safetyNotes": "Use cautiously in concentrated forms.",
+    "interactions": [
+      "Avoid with bile obstruction or excessive casual use."
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "frontendReadyFlag": "No",
+    "completenessPct": "0.55",
+    "priorityTier": "Medium",
+    "totalScore": "5",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1",
+    "sources": [
+      "Pass 125 curated expansion"
+    ]
+  },
+  {
+    "slug": "boswellia",
+    "name": "Boswellia",
+    "scientificName": "Boswellia serrata",
+    "latin": "Boswellia serrata",
+    "category": "resin",
+    "class": "resin",
+    "plantPartUsed": "gum resin",
+    "commonNames": [
+      "frankincense",
+      "boswellia"
+    ],
+    "region": "India and Northeast Africa",
+    "summary": "Boswellia is positioned for inflammatory and mobility support.",
+    "description": "It is best framed around boswellic acids with inflammatory-pathway relevance.",
+    "mechanism": "Boswellic acids are associated with 5-lipoxygenase and inflammatory signaling relevance.",
+    "mechanismTags": [
+      "anti-inflammatory",
+      "mobility support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "boswellic acids",
+      "AKBA"
+    ],
+    "topCompounds": [
+      "AKBA"
+    ],
+    "markerCompounds": [
+      "AKBA"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with GI sensitivity."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "compound_count": "1",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "bupleurum",
+    "name": "Bupleurum",
+    "scientificName": "Bupleurum chinense",
+    "latin": "Bupleurum chinense",
+    "category": "root",
+    "class": "root",
+    "plantPartUsed": "root",
+    "commonNames": [
+      "bupleurum"
+    ],
+    "region": "China and East Asia",
+    "summary": "Bupleurum is positioned for traditional liver and stress-support use.",
+    "description": "It should be framed conservatively because traditional-system context matters more than casual wellness claims.",
+    "mechanism": "Saponins support traditional hepatobiliary and stress-related positioning.",
+    "mechanismTags": [
+      "traditional liver support",
+      "traditional stress support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "saikosaponins"
+    ],
+    "topCompounds": [
+      "saikosaponin A"
+    ],
+    "markerCompounds": [
+      "saikosaponin A"
+    ],
+    "safetyNotes": "Use cautiously.",
+    "interactions": [
+      "Avoid overgeneralized mood claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "compound_count": "1",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "burdock",
+    "name": "Burdock",
+    "scientificName": "Arctium lappa",
+    "latin": "Arctium lappa",
+    "category": "root",
+    "class": "root",
+    "plantPartUsed": "root",
+    "commonNames": [
+      "burdock"
+    ],
+    "region": "Europe and Asia; cultivated broadly",
+    "summary": "Burdock root is positioned for traditional skin, digestive, and anti-inflammatory support.",
+    "description": "It is best framed as a traditional root botanical with modest modern evidence rather than a definitive detox herb.",
+    "mechanism": "Lignans and polyphenols are associated with antioxidant and anti-inflammatory positioning.",
+    "mechanismTags": [
+      "anti-inflammatory",
+      "traditional skin support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "arctiin",
+      "lignans"
+    ],
+    "topCompounds": [
+      "arctiin"
+    ],
+    "markerCompounds": [
+      "arctiin"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with daisy-family sensitivities."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "butterbur",
+    "name": "Butterbur",
+    "scientificName": "Petasites hybridus",
+    "latin": "Petasites hybridus",
+    "category": "plant",
+    "class": "plant",
+    "plantPartUsed": "root",
+    "commonNames": [
+      "butterbur",
+      "petasites",
+      "purple butterbur"
+    ],
+    "region": "Europe and parts of Asia and North America.",
+    "summary": "Butterbur (Petasites hybridus) is best framed narrowly for migraine and allergic-rhinitis contexts, not as a general tonic. Human data exist, but safety is the gate: only PA-free products should even be considered.",
+    "description": "Butterbur is a sesquiterpene-rich herb usually discussed around standardized root extracts. Petasin and isopetasin are the anchor constituents most often linked to migraine and allergic-rhinitis relevance. The commercial problem is safety, because pyrrolizidine alkaloids (PAs) can damage the liver and lungs and may be carcinogenic. Keep claims narrow and safety-forward.",
+    "mechanism": "Petasin and isopetasin are linked to butterbur's narrower migraine and allergy relevance; preclinical work suggests inhibition of TRPA1/TRPV1-mediated CGRP release with broader anti-inflammatory activity.",
+    "mechanismTags": [
+      "migraine support",
+      "anti-inflammatory",
+      "trpa1/trpv1 modulation",
+      "cgrp modulation"
+    ],
+    "evidenceLevel": "Limited human + preclinical",
+    "activeCompounds": [
+      "petasin",
+      "isopetasin",
+      "sesquiterpene esters"
+    ],
+    "topCompounds": [
+      "petasin",
+      "isopetasin"
+    ],
+    "markerCompounds": [
+      "petasin",
+      "isopetasin"
+    ],
+    "safetyNotes": "PA-containing butterbur products are unsafe.",
+    "interactions": [
+      "Discuss use before combining with other medicines. Keep extra caution around hepatotoxicity concerns and ragweed-family allergy cross-reactivity."
+    ],
+    "contraindications": [
+      "Pregnancy",
+      "breastfeeding",
+      "liver disease",
+      "known ragweed-family allergy",
+      "any non-PA-free product."
+    ],
+    "preparation": "Standardized PA-free root extract only; avoid casual raw/herbal use.",
+    "dosage": "Use only product-specific PA-free standardized extracts; do not generalize dose across unverified products.",
+    "publishStatus": "Ready with PA-free safety caveat",
+    "readinessFlag": "Validated - safety gated",
+    "completenessPct": "0.97",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "TRPA1",
+      "TRPV1",
+      "CGRP signaling"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1",
+    "sources": [
+      "https://www.nccih.nih.gov/health/butterbur",
+      "https://pubmed.ncbi.nlm.nih.gov/35427728/",
+      "https://pubmed.ncbi.nlm.nih.gov/33849430/"
+    ]
+  },
+  {
+    "slug": "cacao",
+    "name": "Cacao",
+    "scientificName": "Theobroma cacao",
+    "latin": "Theobroma cacao",
+    "category": "seed",
+    "class": "seed",
+    "plantPartUsed": "seed",
+    "commonNames": [
+      "cacao",
+      "cocoa"
+    ],
+    "region": "Tropical Americas; cultivated globally",
+    "summary": "Cacao is positioned for mood, circulation, and polyphenol support.",
+    "description": "It is best framed around flavanols and methylxanthines with stimulant awareness.",
+    "mechanism": "Polyphenol and methylxanthine relevance supports vascular and mood positioning.",
+    "mechanismTags": [
+      "circulation support",
+      "mood support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "theobromine",
+      "flavanols",
+      "catechins"
+    ],
+    "topCompounds": [
+      "theobromine"
+    ],
+    "markerCompounds": [
+      "theobromine"
+    ],
+    "safetyNotes": "Use caution in stimulant-sensitive users and with migraine triggers.",
+    "interactions": [
+      "May interact with stimulants and can add to caffeine-like effects."
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "completenessPct": "0.9",
+    "priorityTier": "High",
+    "totalScore": "3",
+    "compound_count": "0",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "calendula",
+    "name": "Calendula",
+    "scientificName": "Calendula officinalis",
+    "latin": "Calendula officinalis",
+    "category": "flower",
+    "class": "flower",
+    "plantPartUsed": "flower",
+    "commonNames": [
+      "calendula"
+    ],
+    "region": "Mediterranean; cultivated broadly",
+    "summary": "Calendula is a flower monograph positioned for topical soothing and traditional mucosal support.",
+    "description": "It is best framed around topical and tissue-soothing use rather than overextended systemic claims.",
+    "mechanism": "Triterpenes and flavonoids are associated with tissue-soothing and anti-inflammatory positioning.",
+    "mechanismTags": [
+      "anti-inflammatory",
+      "topical soothing support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "faradiol esters",
+      "flavonoids"
+    ],
+    "topCompounds": [
+      "faradiol"
+    ],
+    "markerCompounds": [
+      "faradiol"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with daisy-family sensitivities."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "caraway",
+    "name": "Caraway",
+    "scientificName": "Carum carvi",
+    "latin": "Carum carvi",
+    "category": "seed",
+    "class": "seed",
+    "plantPartUsed": "seed",
+    "commonNames": [
+      "caraway"
+    ],
+    "region": "Europe and Western Asia",
+    "summary": "Caraway is positioned for digestive and aromatic support.",
+    "description": "It is best framed as an aromatic seed with traditional GI relevance.",
+    "mechanism": "Volatile constituents support digestive and aromatic positioning.",
+    "mechanismTags": [
+      "aromatic support",
+      "digestive support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "carvone",
+      "limonene"
+    ],
+    "topCompounds": [
+      "carvone"
+    ],
+    "markerCompounds": [
+      "carvone"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with concentrated oil assumptions."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "cardamom",
+    "name": "Cardamom",
+    "scientificName": "Elettaria cardamomum",
+    "latin": "Elettaria cardamomum",
+    "category": "seed",
+    "class": "seed",
+    "plantPartUsed": "seed",
+    "commonNames": [
+      "cardamom"
+    ],
+    "region": "India and Guatemala; cultivated broadly",
+    "summary": "Cardamom is positioned for digestive and aromatic support.",
+    "description": "It is best framed as an aromatic culinary seed with modest translational evidence.",
+    "mechanism": "Volatiles support digestive and aromatic positioning.",
+    "mechanismTags": [
+      "aromatic support",
+      "digestive support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "1",
+      "8-cineole",
+      "terpinyl acetate"
+    ],
+    "topCompounds": [
+      "terpinyl acetate"
+    ],
+    "markerCompounds": [
+      "terpinyl acetate"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with concentrated essential-oil assumptions."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "carob",
+    "name": "Carob",
+    "scientificName": "Ceratonia siliqua",
+    "latin": "Ceratonia siliqua",
+    "category": "pod",
+    "class": "pod",
+    "plantPartUsed": "pod",
+    "commonNames": [
+      "carob"
+    ],
+    "region": "Mediterranean",
+    "summary": "Carob is positioned for digestive and metabolic support.",
+    "description": "It is best framed as a food-form legume pod with fiber and polyphenol relevance rather than strong pharmacologic action.",
+    "mechanism": "Inositol derivatives and polyphenols support metabolic and digestive positioning.",
+    "mechanismTags": [
+      "digestive support",
+      "metabolic support"
+    ],
+    "evidenceLevel": "Unknown",
+    "activeCompounds": [
+      "D-pinitol",
+      "polyphenols"
+    ],
+    "topCompounds": [
+      "D-pinitol"
+    ],
+    "markerCompounds": [
+      "D-pinitol"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with overextended glycemic claims."
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "frontendReadyFlag": "No",
+    "completenessPct": "0.55",
+    "priorityTier": "Medium",
+    "totalScore": "5",
+    "compound_count": "1",
+    "pathway_count": "0",
+    "sources": [
+      "Pass 125 curated expansion"
+    ]
+  },
+  {
+    "slug": "cassia-alata",
+    "name": "Cassia Alata",
+    "scientificName": "Senna alata",
+    "latin": "Senna alata",
+    "category": "botanical",
+    "class": "botanical",
+    "plantPartUsed": "varies",
+    "commonNames": [
+      "cassia alata"
+    ],
+    "summary": "Cassia Alata is an intake-stage monograph candidate linked to 2 internal compound records and pathway tags including MAPK pathway, NF-kB inhibition.",
+    "description": "Internal cross-linking supports Cassia Alata through compounds such as aloe-emodin, chrysophanol.",
+    "mechanism": "Internal workbook mapping currently connects this herb to MAPK pathway, NF-kB inhibition.",
+    "mechanismTags": [
+      "mapk pathway",
+      "nf-kb inhibition"
+    ],
+    "evidenceLevel": "Unknown",
+    "activeCompounds": [
+      "aloe-emodin",
+      "chrysophanol"
+    ],
+    "topCompounds": [
+      "aloe-emodin"
+    ],
+    "markerCompounds": [
+      "aloe-emodin"
+    ],
+    "safetyNotes": "Safety review required before publication.",
+    "interactions": [
+      "Interaction review required before publication."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "frontendReadyFlag": "No",
+    "completenessPct": "0.95",
+    "priorityTier": "High",
+    "totalScore": "6",
+    "compound_count": "0",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "celastrus-paniculatus",
+    "name": "Celastrus Paniculatus",
+    "scientificName": "Celastrus paniculatus",
+    "latin": "Celastrus paniculatus",
+    "category": "botanical",
+    "class": "botanical",
+    "plantPartUsed": "varies",
+    "commonNames": [
+      "celastrus paniculatus"
+    ],
+    "summary": "Celastrus Paniculatus is an intake-stage monograph candidate linked to 4 internal compound records in the current workbook.",
+    "description": "Internal cross-linking supports Celastrus Paniculatus through compounds such as beta-amyrin, celastrine, lupeol.",
+    "mechanism": "Current internal mapping is compound-linked, with pathway resolution still limited.",
+    "mechanismTags": [
+      "general or unknown targets"
+    ],
+    "evidenceLevel": "Unknown",
+    "activeCompounds": [
+      "beta-amyrin",
+      "celastrine",
+      "lupeol",
+      "celapanin"
+    ],
+    "topCompounds": [
+      "beta-amyrin"
+    ],
+    "markerCompounds": [
+      "beta-amyrin"
+    ],
+    "safetyNotes": "Safety review required before publication.",
+    "interactions": [
+      "Interaction review required before publication."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "frontendReadyFlag": "No",
+    "completenessPct": "0.95",
+    "priorityTier": "High",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "chaga",
+    "name": "Chaga",
+    "scientificName": "Inonotus obliquus",
+    "latin": "Inonotus obliquus",
+    "category": "sclerotia",
+    "class": "sclerotia",
+    "plantPartUsed": "sclerotia",
+    "commonNames": [
+      "chaga"
+    ],
+    "region": "Cold regions",
+    "summary": "Antioxidant fungus.",
+    "description": "Oxidative stress.",
+    "mechanism": "Nrf2",
+    "mechanismTags": [
+      "nrf2"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "betulinic acid"
+    ],
+    "topCompounds": [
+      "betulinic acid"
+    ],
+    "markerCompounds": [
+      "betulinic acid"
+    ],
+    "safetyNotes": "Safe.",
+    "interactions": [
+      "Oxalates"
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "completenessPct": "0.9",
+    "priorityTier": "High",
+    "totalScore": "3",
+    "compound_count": "0",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "chamomile",
+    "name": "Chamomile",
+    "scientificName": "Matricaria chamomilla",
+    "latin": "Matricaria chamomilla",
+    "category": "flower",
+    "class": "flower",
+    "plantPartUsed": "flower",
+    "commonNames": [
+      "chamomile"
+    ],
+    "region": "Europe; cultivated globally",
+    "summary": "Chamomile is a flower monograph positioned for calming, digestive, and anti-inflammatory support.",
+    "description": "It is best handled as a gentle calming botanical with broad traditional use and modest clinical depth.",
+    "mechanism": "Flavonoids and volatile constituents are associated with calming and digestive-support positioning.",
+    "mechanismTags": [
+      "anti-inflammatory",
+      "anxiolytic",
+      "sleep support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "apigenin"
+    ],
+    "topCompounds": [
+      "apigenin"
+    ],
+    "markerCompounds": [
+      "apigenin"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with ragweed-family allergy contexts."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified",
+      "GABA-A modulation",
+      "NF-kB inhibition",
+      "anxiolytic signaling",
+      "adrenergic signaling"
+    ],
+    "compound_count": "6",
+    "pathway_count": "5"
+  },
+  {
+    "slug": "cinnamon",
+    "name": "Cinnamon",
+    "scientificName": "Cinnamomum verum",
+    "latin": "Cinnamomum verum",
+    "category": "bark",
+    "class": "bark",
+    "plantPartUsed": "bark",
+    "commonNames": [
+      "cinnamon"
+    ],
+    "region": "South Asia; cultivated broadly",
+    "summary": "Cinnamon is a bark monograph positioned for glycemic and antimicrobial support.",
+    "description": "It is best framed conservatively because product form and species matter, especially around coumarin exposure in non-verum types.",
+    "mechanism": "Aromatic aldehydes and polyphenols are associated with glycemic and antimicrobial positioning.",
+    "mechanismTags": [
+      "antimicrobial support",
+      "glycemic support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "cinnamaldehyde",
+      "polyphenols"
+    ],
+    "topCompounds": [
+      "cinnamaldehyde"
+    ],
+    "markerCompounds": [
+      "cinnamaldehyde"
+    ],
+    "safetyNotes": "Generally well tolerated in culinary ranges.",
+    "interactions": [
+      "Use caution with concentrated extracts and coumarin-sensitive contexts."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "cissus",
+    "name": "Cissus",
+    "scientificName": "Cissus quadrangularis",
+    "latin": "Cissus quadrangularis",
+    "category": "stem",
+    "class": "stem",
+    "plantPartUsed": "stem",
+    "commonNames": [
+      "cissus"
+    ],
+    "region": "Africa and South Asia",
+    "summary": "Cissus is positioned for connective-tissue and recovery support.",
+    "description": "It is best framed conservatively because evidence is mixed and product positioning often outruns the data.",
+    "mechanism": "Constituents are associated with connective-tissue and recovery-adjacent positioning.",
+    "mechanismTags": [
+      "connective tissue support",
+      "recovery support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "ketosteroids",
+      "flavonoids"
+    ],
+    "topCompounds": [
+      "quadrangularin A"
+    ],
+    "markerCompounds": [
+      "quadrangularin A"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with aggressive performance claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "compound_count": "1",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "cistanche",
+    "name": "Cistanche",
+    "scientificName": "Cistanche deserticola",
+    "latin": "Cistanche deserticola",
+    "category": "stem",
+    "class": "stem",
+    "plantPartUsed": "stem",
+    "commonNames": [
+      "cistanche"
+    ],
+    "region": "China and Central Asia",
+    "summary": "Cistanche is positioned for traditional restorative and fatigue-support use.",
+    "description": "It should be framed conservatively because traditional-system use is broader than modern clinical depth.",
+    "mechanism": "Phenylethanoid glycosides support restorative and antioxidant positioning.",
+    "mechanismTags": [
+      "fatigue support",
+      "traditional restorative support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "echinacoside",
+      "acteoside"
+    ],
+    "topCompounds": [
+      "echinacoside"
+    ],
+    "markerCompounds": [
+      "echinacoside"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with exaggerated vitality claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "codonopsis",
+    "name": "Codonopsis",
+    "scientificName": "Codonopsis pilosula",
+    "latin": "Codonopsis pilosula",
+    "category": "root",
+    "class": "root",
+    "plantPartUsed": "root",
+    "commonNames": [
+      "codonopsis",
+      "dang shen"
+    ],
+    "region": "China and East Asia",
+    "summary": "Codonopsis is positioned for traditional restorative and fatigue-support use.",
+    "description": "It is best framed as a gentler tonic-style root with modest modern evidence.",
+    "mechanism": "Polysaccharides and glycosides support restorative and fatigue-support positioning.",
+    "mechanismTags": [
+      "fatigue support",
+      "traditional restorative support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "tangshenosides",
+      "polysaccharides"
+    ],
+    "topCompounds": [
+      "tangshenoside I"
+    ],
+    "markerCompounds": [
+      "tangshenoside I"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Avoid exaggerated adaptogen claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "compound_count": "1",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "coleus-forskohlii",
+    "name": "Coleus Forskohlii",
+    "scientificName": "Coleus forskohlii",
+    "latin": "Coleus forskohlii",
+    "category": "root",
+    "class": "root",
+    "plantPartUsed": "root",
+    "commonNames": [
+      "coleus forskohlii",
+      "forskolin"
+    ],
+    "region": "India and subtropical regions",
+    "summary": "Coleus forskohlii is positioned for cAMP-linked metabolic and vascular support.",
+    "description": "It is best framed around forskolin with blood-pressure and stimulant-stack caution.",
+    "mechanism": "Direct adenylate cyclase activation is the core proposed mechanism.",
+    "mechanismTags": [
+      "metabolic support",
+      "vascular support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "forskolin"
+    ],
+    "topCompounds": [
+      "forskolin"
+    ],
+    "markerCompounds": [
+      "forskolin"
+    ],
+    "safetyNotes": "Use caution with low blood pressure, bleeding risk, and GI sensitivity.",
+    "interactions": [
+      "May interact with antihypertensives",
+      "anticoagulants",
+      "bronchodilators",
+      "and stimulant stacks."
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "completenessPct": "0.9",
+    "priorityTier": "High",
+    "totalScore": "3",
+    "compound_count": "0",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "cordyceps",
+    "name": "Cordyceps",
+    "scientificName": "Cordyceps militaris",
+    "latin": "Cordyceps militaris",
+    "category": "fruiting body",
+    "class": "fruiting body",
+    "plantPartUsed": "fruiting body",
+    "commonNames": [
+      "cordyceps"
+    ],
+    "region": "Asia",
+    "summary": "Cordyceps (Cordyceps militaris) should be framed as a cultivated medicinal mushroom with broad preclinical pharmacology and more limited human-specific claims.",
+    "description": "Cordyceps militaris is most often discussed around cordycepin plus polysaccharides and related nucleosides. Commercial interest is high, but the evidence base is still strongest at the preclinical and cultivation/constituent level rather than for broad human outcome claims.",
+    "mechanism": "Cordycepin is a nucleoside analogue from C. militaris with anti-inflammatory and immunomodulatory signaling relevance in preclinical literature, including NF-kappaB, RIP2/caspase-1, Akt/GSK-3beta/p70S6K, TGF-beta/Smads, and Nrf2/HO-1 pathways.",
+    "mechanismTags": [
+      "immune modulation",
+      "anti-inflammatory",
+      "nf-kappab modulation",
+      "nrf2/ho-1",
+      "cordycepin"
+    ],
+    "evidenceLevel": "Preclinical + limited human",
+    "activeCompounds": [
+      "cordycepin",
+      "polysaccharides",
+      "adenosine"
+    ],
+    "topCompounds": [
+      "cordycepin"
+    ],
+    "markerCompounds": [
+      "cordycepin"
+    ],
+    "safetyNotes": "Commercial products vary by species identity, cultivation method, and cordycepin content.",
+    "interactions": [
+      "Avoid broad performance or disease claims",
+      "product-specific review matters more than generic mushroom hype."
+    ],
+    "preparation": "Fruiting-body powders/extracts and cultured mycelial products.",
+    "dosage": "Use formulation-specific ranges only; do not generalize across fruiting body, mycelium, and purified cordycepin products.",
+    "publishStatus": "Ready with claim restraint",
+    "readinessFlag": "Validated",
+    "completenessPct": "0.96",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "NF-kappaB",
+      "Nrf2/HO-1",
+      "RIP2/Caspase-1",
+      "Akt/GSK-3beta/p70S6K",
+      "TGF-beta/Smads"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1",
+    "sources": [
+      "https://pubmed.ncbi.nlm.nih.gov/34828915/",
+      "https://pubmed.ncbi.nlm.nih.gov/33090621/"
+    ]
+  },
+  {
+    "slug": "cranberry",
+    "name": "Cranberry",
+    "scientificName": "Vaccinium macrocarpon",
+    "latin": "Vaccinium macrocarpon",
+    "category": "berry",
+    "class": "berry",
+    "plantPartUsed": "fruit",
+    "commonNames": [
+      "cranberry"
+    ],
+    "region": "North America",
+    "summary": "Cranberry is positioned for urinary and antioxidant support.",
+    "description": "It is best framed around proanthocyanidin-rich urinary-support positioning rather than broad antimicrobial claims.",
+    "mechanism": "Polyphenols support urinary and antioxidant positioning.",
+    "mechanismTags": [
+      "antioxidant",
+      "urinary support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "A-type proanthocyanidins"
+    ],
+    "topCompounds": [
+      "A-type proanthocyanidins"
+    ],
+    "markerCompounds": [
+      "A-type proanthocyanidins"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with anticoagulant-sensitive contexts."
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "frontendReadyFlag": "No",
+    "completenessPct": "0.55",
+    "priorityTier": "Medium",
+    "totalScore": "5",
+    "compound_count": "1",
+    "pathway_count": "0",
+    "sources": [
+      "Pass 125 curated expansion"
+    ]
+  },
+  {
+    "slug": "curry-leaf",
+    "name": "Curry Leaf",
+    "scientificName": "Murraya koenigii",
+    "latin": "Murraya koenigii",
+    "category": "leaf",
+    "class": "leaf",
+    "plantPartUsed": "leaf",
+    "commonNames": [
+      "curry leaf"
+    ],
+    "region": "India and South Asia",
+    "summary": "Curry leaf is positioned for antioxidant and metabolic support.",
+    "description": "It is best framed as a culinary-medicinal leaf with food-form relevance.",
+    "mechanism": "Alkaloids and polyphenols support antioxidant and metabolic positioning.",
+    "mechanismTags": [
+      "antioxidant",
+      "metabolic support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "mahanimbine",
+      "carbazole alkaloids"
+    ],
+    "topCompounds": [
+      "mahanimbine"
+    ],
+    "markerCompounds": [
+      "mahanimbine"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Avoid overextended glycemic claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "damiana",
+    "name": "Damiana",
+    "scientificName": "Turnera diffusa",
+    "latin": "Turnera diffusa",
+    "category": "plant",
+    "class": "plant",
+    "plantPartUsed": "leaf",
+    "commonNames": [
+      "Damiana"
+    ],
+    "region": "global",
+    "summary": "Damiana positioned for primary functional support.",
+    "description": "Conservative evidence framing applied.",
+    "mechanism": "Mechanistic activity supported by mixed evidence.",
+    "mechanismTags": [
+      "calming support",
+      "libido support",
+      "mood support"
+    ],
+    "evidenceLevel": "Preclinical",
+    "activeCompounds": [
+      "flavonoids"
+    ],
+    "topCompounds": [
+      "apigenin"
+    ],
+    "markerCompounds": [
+      "apigenin"
+    ],
+    "safetyNotes": "General use caution; review stimulating vs calming stack context.",
+    "interactions": [
+      "Use caution in complex mood stacks."
+    ],
+    "contraindications": [
+      "Use caution in pregnancy-sensitive contexts."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "dandelion",
+    "name": "Dandelion",
+    "scientificName": "Taraxacum officinale",
+    "latin": "Taraxacum officinale",
+    "category": "leaf/root",
+    "class": "leaf/root",
+    "plantPartUsed": "leaf; root",
+    "commonNames": [
+      "dandelion"
+    ],
+    "region": "Europe, Asia, North America",
+    "summary": "Dandelion is positioned for digestive, hepatobiliary, and mild diuretic support.",
+    "description": "It is best framed as a traditional food-like bitter herb rather than a strong cleansing intervention.",
+    "mechanism": "Bitter and terpene-related constituents are associated with digestive and mild anti-inflammatory positioning.",
+    "mechanismTags": [
+      "digestive support",
+      "mild diuretic support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "taraxasterol",
+      "sesquiterpene lactones"
+    ],
+    "topCompounds": [
+      "taraxasterol"
+    ],
+    "markerCompounds": [
+      "taraxasterol"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with aggressive diuretic stacking or ragweed-family sensitivity."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "danshen",
+    "name": "Danshen",
+    "scientificName": "Salvia miltiorrhiza",
+    "latin": "Salvia miltiorrhiza",
+    "category": "root",
+    "class": "root",
+    "plantPartUsed": "root",
+    "commonNames": [
+      "danshen",
+      "red sage"
+    ],
+    "region": "China and East Asia",
+    "summary": "Danshen is positioned for cardiovascular and circulatory support.",
+    "description": "It is best framed around tanshinones and salvianolic acids with specific vascular-support positioning.",
+    "mechanism": "Diterpenes and phenolic acids support circulatory and antioxidant positioning.",
+    "mechanismTags": [
+      "cardiovascular support",
+      "vascular support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "tanshinone IIA",
+      "salvianolic acid B"
+    ],
+    "topCompounds": [
+      "tanshinone IIA"
+    ],
+    "markerCompounds": [
+      "tanshinone IIA"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with anticoagulant-sensitive contexts."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "compound_count": "1",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "dendrobium",
+    "name": "Dendrobium",
+    "scientificName": "Dendrobium officinale",
+    "latin": "Dendrobium officinale",
+    "category": "stem",
+    "class": "stem",
+    "plantPartUsed": "stem",
+    "commonNames": [
+      "dendrobium"
+    ],
+    "region": "China and East Asia",
+    "summary": "Dendrobium is positioned for traditional restorative and mucosal support.",
+    "description": "It should be framed conservatively because luxury-tonic narratives often exceed evidence depth.",
+    "mechanism": "Polysaccharides support restorative and mucosal positioning.",
+    "mechanismTags": [
+      "mucosal support",
+      "traditional restorative support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "polysaccharides",
+      "alkaloids"
+    ],
+    "topCompounds": [
+      "dendrobine"
+    ],
+    "markerCompounds": [
+      "dendrobine"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Avoid exaggerated anti-aging claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "dong-quai",
+    "name": "Dong Quai",
+    "scientificName": "Angelica sinensis",
+    "latin": "Angelica sinensis",
+    "category": "plant",
+    "class": "plant",
+    "plantPartUsed": "root",
+    "commonNames": [
+      "Dong Quai"
+    ],
+    "region": "global",
+    "summary": "Dong Quai positioned for primary functional support.",
+    "description": "Conservative evidence framing applied.",
+    "mechanism": "Mechanistic activity supported by mixed evidence.",
+    "mechanismTags": [
+      "circulation support",
+      "smooth muscle support",
+      "women's health"
+    ],
+    "evidenceLevel": "Preclinical",
+    "activeCompounds": [
+      "ferulic acid"
+    ],
+    "topCompounds": [
+      "ferulic acid"
+    ],
+    "markerCompounds": [
+      "ferulic acid"
+    ],
+    "safetyNotes": "Review interactions and contraindications.",
+    "interactions": [
+      "Use caution with anticoagulant-sensitive contexts."
+    ],
+    "contraindications": [
+      "Avoid pregnancy-sensitive contexts unless professionally guided."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "echinacea-purpurea",
     "name": "Echinacea Purpurea",
     "scientificName": "Echinacea purpurea",
     "latin": "Echinacea purpurea",
@@ -168,7 +2280,7 @@
     "markerCompounds": [
       "alkamides"
     ],
-    "safetyNotes": "Short‑term use of echinacea extracts appears safe for most adults. Reported side effects include digestive upset and rash; allergic reactions can occur, especially in individuals sensitive to plants in the Asteraceae family. Some children have developed rashes after echinacea use. Safety during pregnancy or breastfeeding is not established. There is conflicting evidence about whether echinacea alters the metabolism of drugs processed by the liver; theoretical interactions with immunosuppressants or caffeine have been proposed【246299874455786†L194-L213】.",
+    "safetyNotes": "Short‑term use of echinacea extracts appears safe for most adults.",
     "interactions": [
       "Echinacea may interact with immunosuppressant drugs by stimulating immune activity and could affect the pharmacokinetics of drugs metabolised by cytochrome P450 enzymes",
       "caution is advised when taken with hepatic substrates or caffeine."
@@ -192,6 +2304,391 @@
       "【246299874455786†L194-L213】",
       "【55003496660111†L75-L130】"
     ]
+  },
+  {
+    "slug": "elecampane",
+    "name": "Elecampane",
+    "scientificName": "Inula helenium",
+    "latin": "Inula helenium",
+    "category": "root",
+    "class": "root",
+    "plantPartUsed": "root",
+    "commonNames": [
+      "elecampane"
+    ],
+    "region": "Europe and Western Asia",
+    "summary": "Elecampane is positioned for traditional respiratory and digestive support.",
+    "description": "It is best framed as a bitter aromatic root with traditional bronchial relevance.",
+    "mechanism": "Sesquiterpene lactones support respiratory and bitter-digestive positioning.",
+    "mechanismTags": [
+      "digestive support",
+      "traditional respiratory support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "alantolactone",
+      "inulin"
+    ],
+    "topCompounds": [
+      "alantolactone"
+    ],
+    "markerCompounds": [
+      "alantolactone"
+    ],
+    "safetyNotes": "Use cautiously in concentrated forms.",
+    "interactions": [
+      "Use caution with ragweed-family sensitivity."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "eleuthero",
+    "name": "Eleuthero",
+    "scientificName": "Eleutherococcus senticosus",
+    "latin": "Eleutherococcus senticosus",
+    "category": "root",
+    "class": "root",
+    "plantPartUsed": "root",
+    "commonNames": [
+      "eleuthero"
+    ],
+    "region": "Asia",
+    "summary": "Adaptogen.",
+    "description": "Stress resilience.",
+    "mechanism": "HPA axis",
+    "mechanismTags": [
+      "hpa axis"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "eleutherosides"
+    ],
+    "topCompounds": [
+      "eleutherosides"
+    ],
+    "markerCompounds": [
+      "eleutherosides"
+    ],
+    "safetyNotes": "Safe.",
+    "interactions": [
+      "Generally safe"
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "completenessPct": "0.9",
+    "priorityTier": "High",
+    "totalScore": "3",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "epimedium",
+    "name": "Epimedium",
+    "scientificName": "Epimedium sagittatum",
+    "latin": "Epimedium sagittatum",
+    "category": "aerial parts",
+    "class": "aerial parts",
+    "plantPartUsed": "leaf",
+    "commonNames": [
+      "epimedium",
+      "horny goat weed"
+    ],
+    "region": "China and East Asia",
+    "summary": "Epimedium is better framed as a flavonoid-rich traditional-use herb with icariin-centered interest around sexual-function, bone, and nitric-oxide-linked signaling. Human evidence remains limited, so claims should stay moderate.",
+    "description": "Epimedium is represented here primarily through icariin and related prenylated flavonoids such as epimedin A, B, and C. The herb is commonly positioned for libido and circulation support, but a more disciplined framing keeps it in the traditional-use / limited-human-evidence tier. Mechanistic interest often centers on PDE-related signaling, endothelial nitric oxide activity, and broader bone-support and anti-inflammatory pathways observed in preclinical work.",
+    "mechanism": "Proposed mechanisms include PDE-related signaling, nitric-oxide-linked endothelial effects, and flavonoid-mediated bone and inflammatory pathway modulation. These mechanisms are directionally useful but should not be overstated beyond limited human confirmation.",
+    "mechanismTags": [
+      "circulation support",
+      "libido support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "icariin",
+      "epimedin A",
+      "epimedin B",
+      "epimedin C"
+    ],
+    "topCompounds": [
+      "icariin"
+    ],
+    "markerCompounds": [
+      "icariin"
+    ],
+    "safetyNotes": "Use caution in people with blood-pressure instability, hormone-sensitive conditions, or high sensitivity to activating supplements.",
+    "interactions": [
+      "May interact with antihypertensives",
+      "vasodilators",
+      "anticoagulants/antiplatelets",
+      "PDE-active drugs",
+      "and other agents that meaningfully affect cardiovascular tone."
+    ],
+    "contraindications": [
+      "Avoid aggressive recommendation in pregnancy",
+      "breastfeeding",
+      "unstable cardiovascular disease",
+      "active bleeding risk",
+      "or clinically significant hormone-sensitive conditions."
+    ],
+    "preparation": "Commonly appears as leaf extracts or blended formulas standardized around icariin content.",
+    "dosage": "Keep dosing product-specific and standardization-aware rather than inferring equivalence across raw herb and extract products.",
+    "qualityConcerns": "Extract standardization matters; icariin percentages vary meaningfully across products.",
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "completenessPct": "0.9",
+    "priorityTier": "High",
+    "totalScore": "3",
+    "pathwayTargets": [
+      "nitric oxide signaling",
+      "unclassified",
+      "PDE5-related signaling"
+    ],
+    "compound_count": "5",
+    "pathway_count": "3"
+  },
+  {
+    "slug": "eucalyptus",
+    "name": "Eucalyptus",
+    "scientificName": "Eucalyptus globulus",
+    "latin": "Eucalyptus globulus",
+    "category": "plant",
+    "class": "plant",
+    "plantPartUsed": "leaf",
+    "commonNames": [
+      "Eucalyptus"
+    ],
+    "region": "global",
+    "summary": "Eucalyptus positioned for primary functional support.",
+    "description": "Conservative evidence framing applied.",
+    "mechanism": "Mechanistic activity supported by mixed evidence.",
+    "mechanismTags": [
+      "anti-inflammatory",
+      "antimicrobial",
+      "respiratory support"
+    ],
+    "evidenceLevel": "Preclinical",
+    "activeCompounds": [
+      "eucalyptol",
+      "alpha-pinene",
+      "tannins"
+    ],
+    "topCompounds": [
+      "eucalyptol",
+      "alpha-pinene"
+    ],
+    "markerCompounds": [
+      "eucalyptol",
+      "alpha-pinene"
+    ],
+    "safetyNotes": "Review interactions and contraindications.",
+    "interactions": [
+      "May irritate when combined with strong volatile-oil protocols"
+    ],
+    "contraindications": [
+      "Use caution with young children and high-dose essential-oil contexts"
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "completenessPct": "0.9",
+    "priorityTier": "High",
+    "totalScore": "3",
+    "compound_count": "0",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "eucommia",
+    "name": "Eucommia",
+    "scientificName": "Eucommia ulmoides",
+    "latin": "Eucommia ulmoides",
+    "category": "bark/leaf",
+    "class": "bark/leaf",
+    "plantPartUsed": "bark; leaf",
+    "commonNames": [
+      "eucommia"
+    ],
+    "region": "China and East Asia",
+    "summary": "Eucommia is positioned for connective-tissue and cardiometabolic support.",
+    "description": "It is best framed conservatively because traditional tonic use is broader than modern evidence quality.",
+    "mechanism": "Iridoids and lignans support connective-tissue and metabolic positioning.",
+    "mechanismTags": [
+      "cardiometabolic support",
+      "connective tissue support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "geniposidic acid",
+      "lignans"
+    ],
+    "topCompounds": [
+      "geniposidic acid"
+    ],
+    "markerCompounds": [
+      "geniposidic acid"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Avoid overextended tonic claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "fennel",
+    "name": "Fennel",
+    "scientificName": "Foeniculum vulgare",
+    "latin": "Foeniculum vulgare",
+    "category": "seed",
+    "class": "seed",
+    "plantPartUsed": "seed",
+    "commonNames": [
+      "fennel"
+    ],
+    "region": "Mediterranean; cultivated globally",
+    "summary": "Fennel is a seed monograph positioned for digestive and antispasmodic support.",
+    "description": "It is best handled as an aromatic seed botanical with traditional GI-support use and modest mechanistic confidence.",
+    "mechanism": "Volatile constituents are associated with digestive soothing and antispasmodic positioning.",
+    "mechanismTags": [
+      "antispasmodic support",
+      "digestive support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "anethole",
+      "volatile oils"
+    ],
+    "topCompounds": [
+      "anethole"
+    ],
+    "markerCompounds": [
+      "anethole"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution in highly concentrated oil form."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "feverfew",
+    "name": "Feverfew",
+    "scientificName": "Tanacetum parthenium",
+    "latin": "Tanacetum parthenium",
+    "category": "plant",
+    "class": "plant",
+    "plantPartUsed": "leaf",
+    "commonNames": [
+      "Feverfew"
+    ],
+    "region": "global",
+    "summary": "Feverfew positioned for primary functional support.",
+    "description": "Conservative evidence framing applied.",
+    "mechanism": "Mechanistic activity supported by mixed evidence.",
+    "mechanismTags": [
+      "headache support",
+      "inflammation support",
+      "vascular modulation"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "parthenolide",
+      "flavonoids"
+    ],
+    "topCompounds": [
+      "parthenolide"
+    ],
+    "markerCompounds": [
+      "parthenolide"
+    ],
+    "safetyNotes": "Review interactions and contraindications.",
+    "interactions": [
+      "May interact with anticoagulant-sensitive contexts"
+    ],
+    "contraindications": [
+      "Use caution in pregnancy-sensitive and surgery-sensitive contexts"
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "galangal",
+    "name": "Galangal",
+    "scientificName": "Alpinia galanga",
+    "latin": "Alpinia galanga",
+    "category": "rhizome",
+    "class": "rhizome",
+    "plantPartUsed": "rhizome",
+    "commonNames": [
+      "galangal"
+    ],
+    "region": "Southeast Asia",
+    "summary": "Galangal is positioned for digestive and aromatic support.",
+    "description": "It is best framed as a culinary-medicinal rhizome with traditional GI relevance.",
+    "mechanism": "Flavonoids and volatiles support digestive and aromatic positioning.",
+    "mechanismTags": [
+      "aromatic support",
+      "digestive support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "galangin",
+      "volatile oils"
+    ],
+    "topCompounds": [
+      "galangin"
+    ],
+    "markerCompounds": [
+      "galangin"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Avoid overextended antimicrobial claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
   },
   {
     "slug": "garlic",
@@ -228,7 +2725,7 @@
     "markerCompounds": [
       "diallyl sulfide"
     ],
-    "safetyNotes": "Oral garlic preparations are generally safe when used for up to seven years; side effects include breath and body odour, abdominal pain, flatulence and nausea. Because garlic can inhibit platelet aggregation it may increase the risk of bleeding, especially when combined with anticoagulants or antiplatelet drugs. Raw garlic applied to the skin can cause severe irritation or burns. The safety of garlic supplements during pregnancy or breastfeeding is uncertain【945608786527328†L190-L207】.",
+    "safetyNotes": "Oral garlic preparations are generally safe when used for up to seven years; side effects include breath and body odour, abdominal pain, flatulence and nausea.",
     "interactions": [
       "Garlic may potentiate the effects of anticoagulant and antiplatelet drugs (e.g.",
       "warfarin",
@@ -258,7 +2755,52 @@
     ]
   },
   {
-    "slug": "ginger-wb",
+    "slug": "gastrodia",
+    "name": "Gastrodia",
+    "scientificName": "Gastrodia elata",
+    "latin": "Gastrodia elata",
+    "category": "rhizome",
+    "class": "rhizome",
+    "plantPartUsed": "rhizome",
+    "commonNames": [
+      "gastrodia",
+      "tian ma"
+    ],
+    "region": "China and East Asia",
+    "summary": "Gastrodia is positioned for traditional neurological and calming support.",
+    "description": "It should be framed conservatively because traditional neurologic use is broader than modern evidence.",
+    "mechanism": "Phenolic glycosides support traditional neurological and calming positioning.",
+    "mechanismTags": [
+      "calming support",
+      "traditional nervous-system support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "gastrodin"
+    ],
+    "topCompounds": [
+      "gastrodin"
+    ],
+    "markerCompounds": [
+      "gastrodin"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Avoid overstated neuroprotective claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "ginger",
     "name": "Ginger",
     "scientificName": "Zingiber officinale",
     "latin": "Zingiber officinale",
@@ -289,7 +2831,7 @@
     "markerCompounds": [
       "gingerol"
     ],
-    "safetyNotes": "Ginger is widely consumed as a food and supplement and is generally regarded as safe. Research suggests it may help with mild nausea and menstrual cramps. Reported side effects at high doses include abdominal discomfort, heartburn, diarrhoea and irritation of the mouth or throat【799387966105800†L29-L56】. Clinical studies using up to 1 000 mg/day of dried powdered extract report adverse event rates similar to placebo【739669106228210†L96-L133】. The safety of high‑dose ginger during pregnancy has not been conclusively established.",
+    "safetyNotes": "Ginger is widely consumed as a food and supplement and is generally regarded as safe.",
     "interactions": [
       "Ginger may increase the risk of bleeding when taken with anticoagulant or antiplatelet drugs and could lower blood glucose or blood pressure",
       "potentiating antidiabetic or antihypertensive medications."
@@ -321,7 +2863,7 @@
     ]
   },
   {
-    "slug": "ginkgo-biloba-wb",
+    "slug": "ginkgo-biloba",
     "name": "Ginkgo Biloba",
     "scientificName": "Ginkgo biloba",
     "latin": "Ginkgo biloba",
@@ -361,7 +2903,7 @@
       "ginkgolides",
       "bilobalide"
     ],
-    "safetyNotes": "Appears safe at recommended doses, but fresh seeds are toxic. May increase bleeding risk and lower seizure threshold.",
+    "safetyNotes": "Appears safe at recommended doses, but fresh seeds are toxic.",
     "interactions": [
       "May potentiate NSAIDs",
       "anticoagulants",
@@ -399,7 +2941,236 @@
     ]
   },
   {
-    "slug": "holy-basil-wb",
+    "slug": "gotu-kola",
+    "name": "Gotu Kola",
+    "scientificName": "Centella asiatica",
+    "latin": "Centella asiatica",
+    "category": "leaf",
+    "class": "leaf",
+    "plantPartUsed": "leaf",
+    "commonNames": [
+      "gotu kola"
+    ],
+    "region": "Global",
+    "summary": "Cognitive + vascular.",
+    "description": "NO support.",
+    "mechanism": "NO pathway",
+    "mechanismTags": [
+      "no"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "asiaticoside"
+    ],
+    "topCompounds": [
+      "asiaticoside"
+    ],
+    "markerCompounds": [
+      "asiaticoside"
+    ],
+    "safetyNotes": "Safe.",
+    "interactions": [
+      "Generally safe"
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "6",
+    "compound_count": "0",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "guarana",
+    "name": "Guarana",
+    "scientificName": "Paullinia cupana",
+    "latin": "Paullinia cupana",
+    "category": "plant",
+    "class": "plant",
+    "plantPartUsed": "seed",
+    "commonNames": [
+      "Guarana"
+    ],
+    "region": "global",
+    "summary": "Guarana positioned for primary functional support.",
+    "description": "Conservative evidence framing applied.",
+    "mechanism": "Mechanistic activity supported by mixed evidence.",
+    "mechanismTags": [
+      "cognition",
+      "energy support",
+      "metabolic support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "caffeine"
+    ],
+    "topCompounds": [
+      "caffeine"
+    ],
+    "markerCompounds": [
+      "caffeine"
+    ],
+    "safetyNotes": "Use caution with stimulant sensitivity, anxiety, or insomnia-prone contexts.",
+    "interactions": [
+      "May stack strongly with caffeine-heavy or stimulant-heavy formulas."
+    ],
+    "contraindications": [
+      "Use caution in uncontrolled blood pressure-sensitive contexts."
+    ],
+    "publishStatus": "Ready for QA",
+    "readinessFlag": "Ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "9",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "gudmar",
+    "name": "Gudmar",
+    "scientificName": "Gymnema sylvestre",
+    "latin": "Gymnema sylvestre",
+    "category": "leaf",
+    "class": "leaf",
+    "plantPartUsed": "leaf",
+    "commonNames": [
+      "gudmar"
+    ],
+    "region": "India and tropical Asia",
+    "summary": "Gudmar is positioned for glycemic and sweet-perception support.",
+    "description": "It should be framed consistently with gymnema while preserving alternate-name discoverability.",
+    "mechanism": "Triterpene saponins support glycemic and taste-modulation positioning.",
+    "mechanismTags": [
+      "glycemic support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "gymnemic acids"
+    ],
+    "topCompounds": [
+      "gymnemic acids"
+    ],
+    "markerCompounds": [
+      "gymnemic acids"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with glucose-lowering strategies."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "gymnema",
+    "name": "Gymnema",
+    "scientificName": "Gymnema sylvestre",
+    "latin": "Gymnema sylvestre",
+    "category": "leaf",
+    "class": "leaf",
+    "plantPartUsed": "leaf",
+    "commonNames": [
+      "gymnema"
+    ],
+    "region": "India and tropical Asia",
+    "summary": "Gymnema (Gymnema sylvestre) is best framed for sweet-perception and glycemic-support positioning, with mixed human and preclinical evidence rather than broad disease claims.",
+    "description": "Gymnema leaf is mainly anchored by gymnemic acids, a triterpene-glycoside cluster. The strongest mechanistic signal is sweet-taste suppression plus related effects on glucose handling, not generic wellness language. Keep human claims conservative and formulation-specific.",
+    "mechanism": "Gymnemic acids are triterpene glycosides that suppress sweet taste through human sweet-receptor signaling and have preclinical evidence for reducing intestinal glucose absorption.",
+    "mechanismTags": [
+      "glycemic support",
+      "sweet taste suppression",
+      "t1r2/t1r3 modulation",
+      "glucose absorption modulation"
+    ],
+    "evidenceLevel": "Mixed human + preclinical",
+    "activeCompounds": [
+      "gymnemic acids"
+    ],
+    "topCompounds": [
+      "gymnemic acids"
+    ],
+    "markerCompounds": [
+      "gymnemic acids"
+    ],
+    "safetyNotes": "Generally well tolerated, but products positioned for glucose support should be handled cautiously in people already using glucose-lowering strategies.",
+    "interactions": [
+      "Monitor carefully with antidiabetic drugs",
+      "insulin",
+      "or aggressive glucose-lowering stacks."
+    ],
+    "preparation": "Leaf powder, capsules, extracts, and sweet-blocking lozenges/mints.",
+    "dosage": "Use conservative product-specific extract ranges; sweet-blocking products are formulation dependent.",
+    "publishStatus": "Ready with glycemic caution",
+    "readinessFlag": "Validated",
+    "completenessPct": "0.97",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "T1R2/T1R3 sweet receptor",
+      "intestinal glucose transport"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1",
+    "sources": [
+      "https://pubmed.ncbi.nlm.nih.gov/31736747/",
+      "https://pubmed.ncbi.nlm.nih.gov/25056955/",
+      "https://pubmed.ncbi.nlm.nih.gov/9152931/"
+    ]
+  },
+  {
+    "slug": "hawthorn",
+    "name": "Hawthorn",
+    "scientificName": "Crataegus monogyna",
+    "latin": "Crataegus monogyna",
+    "category": "leaf/flower/berry",
+    "class": "leaf/flower/berry",
+    "plantPartUsed": "leaf; flower; fruit",
+    "commonNames": [
+      "hawthorn"
+    ],
+    "region": "Europe and cultivated globally",
+    "summary": "Hawthorn is positioned for cardiovascular and vascular support.",
+    "description": "It is best framed around procyanidins and flavonoids.",
+    "mechanism": "Polyphenols support endothelial and vascular relevance.",
+    "mechanismTags": [
+      "cardiovascular support",
+      "vascular support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "procyanidin B2",
+      "flavonoids"
+    ],
+    "topCompounds": [
+      "procyanidin B2"
+    ],
+    "markerCompounds": [
+      "procyanidin B2"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with cardiovascular medications."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "compound_count": "1",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "holy-basil",
     "name": "Holy Basil",
     "scientificName": "Ocimum tenuiflorum",
     "latin": "Ocimum tenuiflorum",
@@ -429,7 +3200,7 @@
       "eugenol",
       "ursolic acid"
     ],
-    "safetyNotes": "Generally safe; possible mild GI upset",
+    "safetyNotes": "Generally safe; possible mild GI upset.",
     "interactions": [
       "Anticoagulants",
       "antidiabetic drugs"
@@ -456,7 +3227,377 @@
     ]
   },
   {
-    "slug": "kava-wb",
+    "slug": "holy-basil-purple",
+    "name": "Holy Basil Purple",
+    "scientificName": "Ocimum tenuiflorum",
+    "latin": "Ocimum tenuiflorum",
+    "category": "leaf",
+    "class": "leaf",
+    "plantPartUsed": "leaf",
+    "commonNames": [
+      "Krishna tulsi"
+    ],
+    "region": "India and Southeast Asia",
+    "summary": "Purple holy basil is positioned for adaptogenic and antioxidant support.",
+    "description": "It should be framed similarly to tulsi while noting cultivar/form distinctions are secondary to constituent variability.",
+    "mechanism": "Polyphenols and volatiles support stress and antioxidant positioning.",
+    "mechanismTags": [
+      "adaptogenic support",
+      "antioxidant"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "eugenol",
+      "rosmarinic acid"
+    ],
+    "topCompounds": [
+      "eugenol"
+    ],
+    "markerCompounds": [
+      "eugenol"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with concentrated extract marketing claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "holy-basil-seed",
+    "name": "Holy Basil Seed",
+    "scientificName": "Ocimum tenuiflorum",
+    "latin": "Ocimum tenuiflorum",
+    "category": "seed",
+    "class": "seed",
+    "plantPartUsed": "seed",
+    "commonNames": [
+      "sabja",
+      "basil seed"
+    ],
+    "region": "India and Southeast Asia",
+    "summary": "Holy basil seed is positioned for demulcent and digestive support.",
+    "description": "It should be framed distinctly from holy basil leaf because fiber and mucilage drive different use-cases.",
+    "mechanism": "Demulcent fiber-rich chemistry supports digestive and soothing positioning.",
+    "mechanismTags": [
+      "demulcent support",
+      "digestive support"
+    ],
+    "evidenceLevel": "Unknown",
+    "activeCompounds": [
+      "mucilage",
+      "fiber"
+    ],
+    "topCompounds": [
+      "mucilage"
+    ],
+    "markerCompounds": [
+      "mucilage"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Separate from oral medications in concentrated use."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "compound_count": "1",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "hops",
+    "name": "Hops",
+    "scientificName": "Humulus lupulus",
+    "latin": "Humulus lupulus",
+    "category": "strobile",
+    "class": "strobile",
+    "plantPartUsed": "female cones",
+    "commonNames": [
+      "hops"
+    ],
+    "region": "Europe, Asia, North America",
+    "summary": "Hops is positioned for calming and sleep-support use.",
+    "description": "It is best framed around bitter-resin and prenylflavonoid chemistry with modest selected human evidence.",
+    "mechanism": "Bitter acids and prenylflavonoids support calming and anti-inflammatory positioning.",
+    "mechanismTags": [
+      "calming support",
+      "sleep support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "humulone",
+      "xanthohumol"
+    ],
+    "topCompounds": [
+      "humulone"
+    ],
+    "markerCompounds": [
+      "humulone"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with sedative stacking."
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "frontendReadyFlag": "No",
+    "completenessPct": "0.55",
+    "priorityTier": "Medium",
+    "totalScore": "5",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1",
+    "sources": [
+      "Pass 125 curated expansion"
+    ]
+  },
+  {
+    "slug": "houttuynia",
+    "name": "Houttuynia",
+    "scientificName": "Houttuynia cordata",
+    "latin": "Houttuynia cordata",
+    "category": "aerial parts",
+    "class": "aerial parts",
+    "plantPartUsed": "leaf; aerial parts",
+    "commonNames": [
+      "houttuynia"
+    ],
+    "region": "East and Southeast Asia",
+    "summary": "Houttuynia is positioned for traditional immune and respiratory support.",
+    "description": "It should be framed cautiously because strong folklore claims exceed the evidence.",
+    "mechanism": "Flavonoids and volatiles support traditional immune and respiratory positioning.",
+    "mechanismTags": [
+      "traditional immune support",
+      "traditional respiratory support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "quercitrin",
+      "volatile oils"
+    ],
+    "topCompounds": [
+      "quercitrin"
+    ],
+    "markerCompounds": [
+      "quercitrin"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Avoid exaggerated antiviral claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "isatis",
+    "name": "Isatis",
+    "scientificName": "Isatis tinctoria",
+    "latin": "Isatis tinctoria",
+    "category": "root/leaf",
+    "class": "root/leaf",
+    "plantPartUsed": "root; leaf",
+    "commonNames": [
+      "isatis",
+      "ban lan gen"
+    ],
+    "region": "China and Eurasia",
+    "summary": "Isatis is positioned for traditional immune and throat-support use.",
+    "description": "It is best framed as a traditional-use herb with limited modern clinical depth.",
+    "mechanism": "Indole derivatives support traditional immune-related positioning.",
+    "mechanismTags": [
+      "throat support",
+      "traditional immune support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "indirubin",
+      "tryptanthrin"
+    ],
+    "topCompounds": [
+      "tryptanthrin"
+    ],
+    "markerCompounds": [
+      "tryptanthrin"
+    ],
+    "safetyNotes": "Use cautiously.",
+    "interactions": [
+      "Avoid exaggerated infection-treatment claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "jatamansi",
+    "name": "Jatamansi",
+    "scientificName": "Nardostachys jatamansi",
+    "latin": "Nardostachys jatamansi",
+    "category": "rhizome",
+    "class": "rhizome",
+    "plantPartUsed": "rhizome",
+    "commonNames": [
+      "spikenard",
+      "jatamansi"
+    ],
+    "region": "Himalayan regions",
+    "summary": "Jatamansi is positioned for calming and traditional nervous-system support.",
+    "description": "It should be framed as a traditional aromatic rhizome with modest clinical depth.",
+    "mechanism": "Sesquiterpenes support calming and traditional nervous-system positioning.",
+    "mechanismTags": [
+      "calming support",
+      "traditional nervous-system support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "jatamansone"
+    ],
+    "topCompounds": [
+      "jatamansone"
+    ],
+    "markerCompounds": [
+      "jatamansone"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with sedative stacking."
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "frontendReadyFlag": "No",
+    "completenessPct": "0.55",
+    "priorityTier": "Medium",
+    "totalScore": "5",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1",
+    "sources": [
+      "Pass 125 curated expansion"
+    ]
+  },
+  {
+    "slug": "jujube",
+    "name": "Jujube",
+    "scientificName": "Ziziphus jujuba",
+    "latin": "Ziziphus jujuba",
+    "category": "fruit/seed",
+    "class": "fruit/seed",
+    "plantPartUsed": "fruit; seed",
+    "commonNames": [
+      "jujube",
+      "red date"
+    ],
+    "region": "China and cultivated broadly",
+    "summary": "Jujube is positioned for calming, nutritive, and traditional sleep-support use.",
+    "description": "It is best framed as a food-like fruit/seed botanical with gentle traditional positioning.",
+    "mechanism": "Saponins and flavonoids support calming and traditional sleep positioning.",
+    "mechanismTags": [
+      "calming support",
+      "nutritive support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "jujubosides",
+      "flavonoids"
+    ],
+    "topCompounds": [
+      "jujuboside A"
+    ],
+    "markerCompounds": [
+      "jujuboside A"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with sedative stacking."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "compound_count": "1",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "juniper",
+    "name": "Juniper",
+    "scientificName": "Juniperus communis",
+    "latin": "Juniperus communis",
+    "category": "berry/cone",
+    "class": "berry/cone",
+    "plantPartUsed": "berry",
+    "commonNames": [
+      "juniper berry"
+    ],
+    "region": "Europe, Asia, North America",
+    "summary": "Juniper is positioned for aromatic digestive and urinary support.",
+    "description": "It should be framed as an aromatic berry botanical with traditional GI and urinary relevance.",
+    "mechanism": "Volatile terpenes support digestive and aromatic positioning.",
+    "mechanismTags": [
+      "aromatic support",
+      "digestive support",
+      "urinary support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "alpha-pinene",
+      "terpenes"
+    ],
+    "topCompounds": [
+      "alpha-pinene"
+    ],
+    "markerCompounds": [
+      "alpha-pinene"
+    ],
+    "safetyNotes": "Use cautiously in concentrated forms.",
+    "interactions": [
+      "Avoid long-duration casual use."
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "frontendReadyFlag": "No",
+    "completenessPct": "0.55",
+    "priorityTier": "Medium",
+    "totalScore": "5",
+    "pathwayTargets": [
+      "adrenergic signaling"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1",
+    "sources": [
+      "Pass 125 curated expansion"
+    ]
+  },
+  {
+    "slug": "kava",
     "name": "Kava",
     "scientificName": "Piper methysticum",
     "latin": "Piper methysticum",
@@ -523,7 +3664,137 @@
     ]
   },
   {
-    "slug": "lemon-balm-wb",
+    "slug": "kuding-tea",
+    "name": "Kuding Tea",
+    "scientificName": "Ilex kudingcha",
+    "latin": "Ilex kudingcha",
+    "category": "leaf",
+    "class": "leaf",
+    "plantPartUsed": "leaf",
+    "commonNames": [
+      "kuding tea"
+    ],
+    "region": "China",
+    "summary": "Kuding tea is positioned for bitter antioxidant and cardiometabolic support.",
+    "description": "It should be framed as a bitter tea botanical with food-form relevance and modest modern evidence.",
+    "mechanism": "Bitters and polyphenols support antioxidant and metabolic positioning.",
+    "mechanismTags": [
+      "antioxidant",
+      "cardiometabolic support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "triterpenoid saponins",
+      "polyphenols"
+    ],
+    "topCompounds": [
+      "kudinlactone"
+    ],
+    "markerCompounds": [
+      "kudinlactone"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with strong bitterness and GI sensitivity."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "kudzu",
+    "name": "Kudzu",
+    "scientificName": "Pueraria lobata",
+    "latin": "Pueraria lobata",
+    "category": "plant",
+    "class": "plant",
+    "plantPartUsed": "root",
+    "commonNames": [
+      "Kudzu"
+    ],
+    "region": "global",
+    "summary": "Kudzu positioned for primary functional support.",
+    "description": "Conservative evidence framing applied.",
+    "mechanism": "Mechanistic activity supported by mixed evidence.",
+    "mechanismTags": [
+      "multi-domain"
+    ],
+    "evidenceLevel": "Unknown",
+    "activeCompounds": [
+      "isoflavones"
+    ],
+    "topCompounds": [
+      "puerarin"
+    ],
+    "markerCompounds": [
+      "puerarin"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution in stacked contexts."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "lavender",
+    "name": "Lavender",
+    "scientificName": "Lavandula angustifolia",
+    "latin": "Lavandula angustifolia",
+    "category": "flower",
+    "class": "flower",
+    "plantPartUsed": "flower",
+    "commonNames": [
+      "lavender"
+    ],
+    "region": "Mediterranean and cultivated globally",
+    "summary": "Lavender is positioned for calming and tension support.",
+    "description": "It is best framed around volatile oils with sedation-aware positioning.",
+    "mechanism": "GABAergic and calming relevance is commonly proposed for aroma and oral extract use.",
+    "mechanismTags": [
+      "calming support",
+      "tension support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "linalool",
+      "linalyl acetate"
+    ],
+    "topCompounds": [
+      "linalool"
+    ],
+    "markerCompounds": [
+      "linalool"
+    ],
+    "safetyNotes": "Can be sedating in some users.",
+    "interactions": [
+      "May add to sedative effects from CNS depressants."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "6",
+    "compound_count": "0",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "lemon-balm",
     "name": "Lemon Balm",
     "scientificName": "Melissa officinalis",
     "latin": "Melissa officinalis",
@@ -549,7 +3820,7 @@
     "markerCompounds": [
       "rosmarinic acid"
     ],
-    "safetyNotes": "Generally safe; mild sedation possible",
+    "safetyNotes": "Generally safe; mild sedation possible.",
     "interactions": [
       "Sedatives",
       "thyroid medications"
@@ -576,7 +3847,189 @@
     ]
   },
   {
-    "slug": "maca-wb",
+    "slug": "lemon-verbena",
+    "name": "Lemon Verbena",
+    "scientificName": "Aloysia citrodora",
+    "latin": "Aloysia citrodora",
+    "category": "leaf",
+    "class": "leaf",
+    "plantPartUsed": "leaf",
+    "commonNames": [
+      "lemon verbena"
+    ],
+    "region": "South America; cultivated broadly",
+    "summary": "Lemon verbena is positioned for calming and digestive support.",
+    "description": "It is best framed as a gentle aromatic botanical with modest evidence and pleasant tolerability.",
+    "mechanism": "Phenylpropanoid glycosides and aromatics are associated with calming and digestive positioning.",
+    "mechanismTags": [
+      "calming support",
+      "digestive support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "verbascoside",
+      "volatile oils"
+    ],
+    "topCompounds": [
+      "verbascoside"
+    ],
+    "markerCompounds": [
+      "verbascoside"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with concentrated essential-oil contexts."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "lemongrass",
+    "name": "Lemongrass",
+    "scientificName": "Cymbopogon citratus",
+    "latin": "Cymbopogon citratus",
+    "category": "leaf",
+    "class": "leaf",
+    "plantPartUsed": "leaf",
+    "commonNames": [
+      "lemongrass"
+    ],
+    "region": "Tropical Asia; cultivated globally",
+    "summary": "Lemongrass is positioned for digestive, calming, and aromatic support.",
+    "description": "It is best framed as an aromatic culinary-medicinal grass with modest clinical depth.",
+    "mechanism": "Volatile constituents support digestive and calming aromatic positioning.",
+    "mechanismTags": [
+      "aromatic support",
+      "calming support",
+      "digestive support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "citral",
+      "citronellal"
+    ],
+    "topCompounds": [
+      "citral"
+    ],
+    "markerCompounds": [
+      "citral"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with concentrated oil assumptions."
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "frontendReadyFlag": "No",
+    "completenessPct": "0.55",
+    "priorityTier": "Medium",
+    "totalScore": "5",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1",
+    "sources": [
+      "Pass 125 curated expansion"
+    ]
+  },
+  {
+    "slug": "longan",
+    "name": "Longan",
+    "scientificName": "Dimocarpus longan",
+    "latin": "Dimocarpus longan",
+    "category": "fruit/seed",
+    "class": "fruit/seed",
+    "plantPartUsed": "fruit; seed",
+    "commonNames": [
+      "longan"
+    ],
+    "region": "Southeast Asia",
+    "summary": "Longan is positioned for nutritive and traditional calming support.",
+    "description": "It should be framed as a food-like fruit botanical with modest modern evidence.",
+    "mechanism": "Polyphenols support antioxidant and nutritive positioning.",
+    "mechanismTags": [
+      "calming support",
+      "nutritive support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "polyphenols",
+      "gallic acid"
+    ],
+    "topCompounds": [
+      "gallic acid"
+    ],
+    "markerCompounds": [
+      "gallic acid"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Avoid overextended nootropic claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "luo-han-guo",
+    "name": "Luo Han Guo",
+    "scientificName": "Siraitia grosvenorii",
+    "latin": "Siraitia grosvenorii",
+    "category": "fruit",
+    "class": "fruit",
+    "plantPartUsed": "fruit",
+    "commonNames": [
+      "monk fruit",
+      "luo han guo"
+    ],
+    "region": "China",
+    "summary": "Luo Han Guo is positioned for throat and sweetener-adjacent support.",
+    "description": "It is best framed as a fruit botanical with sweet mogrosides and soothing traditional use.",
+    "mechanism": "Triterpene glycosides support sweetener and throat-soothing positioning.",
+    "mechanismTags": [
+      "sweetener-adjacent support",
+      "throat support"
+    ],
+    "evidenceLevel": "Unknown",
+    "activeCompounds": [
+      "mogrosides"
+    ],
+    "topCompounds": [
+      "mogroside V"
+    ],
+    "markerCompounds": [
+      "mogroside V"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Avoid overextended glycemic claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "compound_count": "1",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "maca",
     "name": "Maca",
     "scientificName": "Lepidium meyenii",
     "latin": "Lepidium meyenii",
@@ -603,7 +4056,7 @@
     "markerCompounds": [
       "macamides"
     ],
-    "safetyNotes": "Generally safe; mild GI upset possible",
+    "safetyNotes": "Generally safe; mild GI upset possible.",
     "interactions": [
       "Limited data"
     ],
@@ -625,6 +4078,146 @@
     "sources": [
       "PubMed",
       "NIH"
+    ]
+  },
+  {
+    "slug": "maitake-d-fraction",
+    "name": "Maitake D-Fraction",
+    "scientificName": "Grifola frondosa",
+    "latin": "Grifola frondosa",
+    "category": "extract",
+    "class": "extract",
+    "plantPartUsed": "fruiting body extract",
+    "commonNames": [
+      "maitake D-fraction"
+    ],
+    "region": "Japan; cultivated globally",
+    "summary": "Maitake D-fraction is positioned for immune-support use.",
+    "description": "It should be framed distinctly from whole maitake because extract-standardization claims can exceed the underlying evidence.",
+    "mechanism": "Beta-glucan-rich extracts support immune-modulating positioning.",
+    "mechanismTags": [
+      "immune modulation"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "beta-glucans"
+    ],
+    "topCompounds": [
+      "beta-glucans"
+    ],
+    "markerCompounds": [
+      "beta-glucans"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Avoid exaggerated oncology-treatment claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "mangosteen",
+    "name": "Mangosteen",
+    "scientificName": "Garcinia mangostana",
+    "latin": "Garcinia mangostana",
+    "category": "pericarp/fruit",
+    "class": "pericarp/fruit",
+    "plantPartUsed": "pericarp",
+    "commonNames": [
+      "mangosteen"
+    ],
+    "region": "Southeast Asia",
+    "summary": "Mangosteen is positioned for antioxidant and traditional wellness support.",
+    "description": "It should be framed conservatively because broad anti-inflammatory and disease claims outrun the evidence.",
+    "mechanism": "Xanthones support antioxidant and traditional-support positioning.",
+    "mechanismTags": [
+      "antioxidant",
+      "traditional wellness support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "alpha-mangostin",
+      "xanthones"
+    ],
+    "topCompounds": [
+      "alpha-mangostin"
+    ],
+    "markerCompounds": [
+      "alpha-mangostin"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with exaggerated anti-inflammatory claims."
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "frontendReadyFlag": "No",
+    "completenessPct": "0.55",
+    "priorityTier": "Medium",
+    "totalScore": "5",
+    "pathwayTargets": [
+      "adrenergic signaling"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1",
+    "sources": [
+      "Pass 125 curated expansion"
+    ]
+  },
+  {
+    "slug": "maral-root",
+    "name": "Maral Root",
+    "scientificName": "Rhaponticum carthamoides",
+    "latin": "Rhaponticum carthamoides",
+    "category": "root",
+    "class": "root",
+    "plantPartUsed": "root",
+    "commonNames": [
+      "maral root"
+    ],
+    "region": "Central Asia",
+    "summary": "Maral root is positioned for adaptogenic and performance-adjacent support.",
+    "description": "It is best framed carefully because ecdysteroid narratives often outpace evidence quality.",
+    "mechanism": "Ecdysteroids support adaptogenic and performance-adjacent positioning.",
+    "mechanismTags": [
+      "adaptogenic support",
+      "recovery support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "ecdysterone"
+    ],
+    "topCompounds": [
+      "ecdysterone"
+    ],
+    "markerCompounds": [
+      "ecdysterone"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with aggressive performance claims."
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "frontendReadyFlag": "No",
+    "completenessPct": "0.55",
+    "priorityTier": "Medium",
+    "totalScore": "5",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1",
+    "sources": [
+      "Pass 125 curated expansion"
     ]
   },
   {
@@ -684,7 +4277,712 @@
     ]
   },
   {
-    "slug": "peppermint-wb",
+    "slug": "moringa",
+    "name": "Moringa",
+    "scientificName": "Moringa oleifera",
+    "latin": "Moringa oleifera",
+    "category": "leaf/tree",
+    "class": "leaf/tree",
+    "plantPartUsed": "leaf; seed",
+    "commonNames": [
+      "moringa"
+    ],
+    "region": "India, Africa, tropical regions",
+    "summary": "Moringa is positioned for nutritive, antioxidant, and metabolic support.",
+    "description": "It is best framed as a nutrient-dense botanical with mixed translational evidence rather than as a universal superfood cure-all.",
+    "mechanism": "Glucosinolates and isothiocyanates support antioxidant and metabolic positioning.",
+    "mechanismTags": [
+      "antioxidant",
+      "metabolic support",
+      "nutritive support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "moringin",
+      "isothiocyanates"
+    ],
+    "topCompounds": [
+      "moringin"
+    ],
+    "markerCompounds": [
+      "moringin"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with concentrated extracts and glucose-lowering strategies."
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "frontendReadyFlag": "No",
+    "completenessPct": "0.55",
+    "priorityTier": "Medium",
+    "totalScore": "5",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1",
+    "sources": [
+      "Pass 125 curated expansion"
+    ]
+  },
+  {
+    "slug": "mucuna",
+    "name": "Mucuna",
+    "scientificName": "Mucuna pruriens",
+    "latin": "Mucuna pruriens",
+    "category": "seed",
+    "class": "seed",
+    "plantPartUsed": "seed",
+    "commonNames": [
+      "mucuna",
+      "velvet bean"
+    ],
+    "region": "India, tropical regions",
+    "summary": "Mucuna is positioned for dopamine-related and vitality support.",
+    "description": "It is best framed around L-DOPA-rich seeds with clear neurologic and stimulation-related caution.",
+    "mechanism": "Catecholamine precursor relevance through L-DOPA content.",
+    "mechanismTags": [
+      "dopamine support",
+      "vitality support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "L-DOPA",
+      "alkaloids"
+    ],
+    "topCompounds": [
+      "L-DOPA"
+    ],
+    "markerCompounds": [
+      "L-DOPA"
+    ],
+    "safetyNotes": "Use caution in psychiatric, cardiovascular, and dopaminergic contexts.",
+    "interactions": [
+      "May interact with MAOIs",
+      "dopaminergic drugs",
+      "stimulants",
+      "and antipsychotics."
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "completenessPct": "0.9",
+    "priorityTier": "High",
+    "totalScore": "3",
+    "compound_count": "0",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "mugwort",
+    "name": "Mugwort",
+    "scientificName": "Artemisia vulgaris",
+    "latin": "Artemisia vulgaris",
+    "category": "aerial parts",
+    "class": "aerial parts",
+    "plantPartUsed": "leaf; aerial parts",
+    "commonNames": [
+      "mugwort"
+    ],
+    "region": "Europe, Asia, North America",
+    "summary": "Mugwort is positioned for traditional digestive and cycle-related support.",
+    "description": "It is best framed conservatively because strong folklore and ritual associations often outrun clinical evidence.",
+    "mechanism": "Aromatic constituents drive much of the traditional positioning.",
+    "mechanismTags": [
+      "digestive support",
+      "traditional cycle support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "volatile oils",
+      "flavonoids"
+    ],
+    "topCompounds": [
+      "thujone"
+    ],
+    "markerCompounds": [
+      "thujone"
+    ],
+    "safetyNotes": "Use caution with concentrated preparations.",
+    "interactions": [
+      "Avoid during pregnancy."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "muira-puama",
+    "name": "Muira Puama",
+    "scientificName": "Ptychopetalum olacoides",
+    "latin": "Ptychopetalum olacoides",
+    "category": "bark/root",
+    "class": "bark/root",
+    "plantPartUsed": "bark; root",
+    "commonNames": [
+      "muira puama"
+    ],
+    "region": "Amazon basin",
+    "summary": "Muira puama is positioned for traditional vitality and stress-resilience support.",
+    "description": "It is best framed as a traditional Amazonian botanical with modest modern evidence.",
+    "mechanism": "Traditional use supports vitality and adaptogenic-adjacent positioning.",
+    "mechanismTags": [
+      "stress support",
+      "traditional vitality support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "sterols",
+      "terpenes"
+    ],
+    "topCompounds": [
+      "beta-sitosterol"
+    ],
+    "markerCompounds": [
+      "beta-sitosterol"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Avoid overextended neurocognitive claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "mulberry-leaf",
+    "name": "Mulberry Leaf",
+    "scientificName": "Morus alba",
+    "latin": "Morus alba",
+    "category": "leaf",
+    "class": "leaf",
+    "plantPartUsed": "leaf",
+    "commonNames": [
+      "mulberry leaf"
+    ],
+    "region": "China and cultivated broadly",
+    "summary": "Mulberry leaf is positioned for metabolic support, especially carbohydrate-handling contexts.",
+    "description": "It is best framed around alpha-glucosidase-adjacent positioning rather than generalized wellness language.",
+    "mechanism": "Iminosugars are associated with carbohydrate-handling support.",
+    "mechanismTags": [
+      "glycemic support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "1-deoxynojirimycin",
+      "flavonoids"
+    ],
+    "topCompounds": [
+      "1-deoxynojirimycin"
+    ],
+    "markerCompounds": [
+      "1-deoxynojirimycin"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with glucose-lowering strategies."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "myrtle",
+    "name": "Myrtle",
+    "scientificName": "Myrtus communis",
+    "latin": "Myrtus communis",
+    "category": "leaf",
+    "class": "leaf",
+    "plantPartUsed": "leaf",
+    "commonNames": [
+      "myrtle"
+    ],
+    "region": "Mediterranean",
+    "summary": "Myrtle is positioned for aromatic and antioxidant support.",
+    "description": "It is best framed as an aromatic Mediterranean leaf botanical with modest modern evidence.",
+    "mechanism": "Volatile constituents and polyphenols support aromatic and antioxidant positioning.",
+    "mechanismTags": [
+      "antioxidant",
+      "aromatic support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "myrtenyl acetate",
+      "myricetin"
+    ],
+    "topCompounds": [
+      "myrtenyl acetate"
+    ],
+    "markerCompounds": [
+      "myrtenyl acetate"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with concentrated oil assumptions."
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "frontendReadyFlag": "No",
+    "completenessPct": "0.55",
+    "priorityTier": "Medium",
+    "totalScore": "5",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1",
+    "sources": [
+      "Pass 125 curated expansion"
+    ]
+  },
+  {
+    "slug": "neem",
+    "name": "Neem",
+    "scientificName": "Azadirachta indica",
+    "latin": "Azadirachta indica",
+    "category": "leaf/seed",
+    "class": "leaf/seed",
+    "plantPartUsed": "leaf; seed",
+    "commonNames": [
+      "neem"
+    ],
+    "region": "India and South Asia",
+    "summary": "Neem is positioned for traditional skin, oral, and antimicrobial support.",
+    "description": "It should be framed carefully because topical, oral, and seed-oil contexts differ substantially in safety relevance.",
+    "mechanism": "Limonoids are associated with antimicrobial and traditional skin-support positioning.",
+    "mechanismTags": [
+      "antimicrobial support",
+      "traditional skin support"
+    ],
+    "evidenceLevel": "Preclinical",
+    "activeCompounds": [
+      "nimbin",
+      "azadirachtin"
+    ],
+    "topCompounds": [
+      "nimbin"
+    ],
+    "markerCompounds": [
+      "nimbin"
+    ],
+    "safetyNotes": "Use caution with concentrated internal use.",
+    "interactions": [
+      "Avoid overextending seed-oil safety assumptions to all forms."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "nettle-root",
+    "name": "Nettle Root",
+    "scientificName": "Urtica dioica",
+    "latin": "Urtica dioica",
+    "category": "root",
+    "class": "root",
+    "plantPartUsed": "root",
+    "commonNames": [
+      "nettle root"
+    ],
+    "region": "Europe, Asia, North America",
+    "summary": "Nettle root is positioned for urinary and men's-health support.",
+    "description": "It is best framed distinctly from nettle leaf.",
+    "mechanism": "Sterols and lignans support urinary positioning.",
+    "mechanismTags": [
+      "men's-health support",
+      "urinary support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "beta-sitosterol",
+      "lignans"
+    ],
+    "topCompounds": [
+      "beta-sitosterol"
+    ],
+    "markerCompounds": [
+      "beta-sitosterol"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with urinary medications."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "noni",
+    "name": "Noni",
+    "scientificName": "Morinda citrifolia",
+    "latin": "Morinda citrifolia",
+    "category": "fruit",
+    "class": "fruit",
+    "plantPartUsed": "fruit",
+    "commonNames": [
+      "noni"
+    ],
+    "region": "Pacific Islands; tropical regions",
+    "summary": "Noni is positioned for antioxidant and traditional wellness support.",
+    "description": "It should be framed conservatively because broad folk claims exceed the strength of modern evidence.",
+    "mechanism": "Anthraquinone-adjacent and iridoid chemistry support antioxidant and traditional-support positioning.",
+    "mechanismTags": [
+      "antioxidant",
+      "traditional wellness support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "damnacanthal",
+      "iridoids"
+    ],
+    "topCompounds": [
+      "damnacanthal"
+    ],
+    "markerCompounds": [
+      "damnacanthal"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with overgeneralized disease claims."
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "frontendReadyFlag": "No",
+    "completenessPct": "0.55",
+    "priorityTier": "Medium",
+    "totalScore": "5",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1",
+    "sources": [
+      "Pass 125 curated expansion"
+    ]
+  },
+  {
+    "slug": "notoginseng",
+    "name": "Notoginseng",
+    "scientificName": "Panax notoginseng",
+    "latin": "Panax notoginseng",
+    "category": "root",
+    "class": "root",
+    "plantPartUsed": "root",
+    "commonNames": [
+      "notoginseng",
+      "san qi"
+    ],
+    "region": "China",
+    "summary": "Notoginseng is positioned for circulatory and recovery support.",
+    "description": "It is best framed as a saponin-rich Panax relative with specific vascular-support positioning.",
+    "mechanism": "Saponins support vascular and recovery-related positioning.",
+    "mechanismTags": [
+      "recovery support",
+      "vascular support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "notoginsenoside R1",
+      "ginsenosides"
+    ],
+    "topCompounds": [
+      "notoginsenoside R1"
+    ],
+    "markerCompounds": [
+      "notoginsenoside R1"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with anticoagulant-sensitive contexts."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "compound_count": "1",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "oatstraw",
+    "name": "Oatstraw",
+    "scientificName": "Avena sativa",
+    "latin": "Avena sativa",
+    "category": "aerial parts",
+    "class": "aerial parts",
+    "plantPartUsed": "green tops; straw",
+    "commonNames": [
+      "oatstraw"
+    ],
+    "region": "Europe and cultivated globally",
+    "summary": "Oatstraw is positioned for nutritive and calming support.",
+    "description": "It is best framed as a gentle nutritive herb with limited high-signal clinical depth.",
+    "mechanism": "Polyphenols and nutritive positioning drive most use-cases.",
+    "mechanismTags": [
+      "calming support",
+      "nutritive support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "avenanthramides",
+      "minerals"
+    ],
+    "topCompounds": [
+      "avenanthramides"
+    ],
+    "markerCompounds": [
+      "avenanthramides"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with gluten cross-contact concerns depending on sourcing."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "ophiopogon",
+    "name": "Ophiopogon",
+    "scientificName": "Ophiopogon japonicus",
+    "latin": "Ophiopogon japonicus",
+    "category": "root tuber",
+    "class": "root tuber",
+    "plantPartUsed": "tuber",
+    "commonNames": [
+      "ophiopogon",
+      "mai men dong"
+    ],
+    "region": "China and East Asia",
+    "summary": "Ophiopogon is positioned for traditional demulcent and respiratory support.",
+    "description": "It is best framed as a moistening tonic-style root with traditional-system relevance.",
+    "mechanism": "Saponins support demulcent and traditional respiratory positioning.",
+    "mechanismTags": [
+      "demulcent support",
+      "traditional respiratory support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "ophiopogonins"
+    ],
+    "topCompounds": [
+      "ophiopogonin D"
+    ],
+    "markerCompounds": [
+      "ophiopogonin D"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Avoid overextended pulmonary claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "compound_count": "1",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "oregano",
+    "name": "Oregano",
+    "scientificName": "Origanum vulgare",
+    "latin": "Origanum vulgare",
+    "category": "plant",
+    "class": "plant",
+    "plantPartUsed": "leaf",
+    "commonNames": [
+      "Oregano"
+    ],
+    "region": "global",
+    "summary": "Oregano positioned for primary functional support.",
+    "description": "Conservative evidence framing applied.",
+    "mechanism": "Mechanistic activity supported by mixed evidence.",
+    "mechanismTags": [
+      "antimicrobial",
+      "digestive support",
+      "respiratory support"
+    ],
+    "evidenceLevel": "Preclinical",
+    "activeCompounds": [
+      "carvacrol",
+      "thymol",
+      "rosmarinic acid"
+    ],
+    "topCompounds": [
+      "carvacrol",
+      "thymol"
+    ],
+    "markerCompounds": [
+      "carvacrol",
+      "thymol"
+    ],
+    "safetyNotes": "General use caution; concentrated extracts can be irritating.",
+    "interactions": [
+      "May stack strongly with other antimicrobial concentrates"
+    ],
+    "contraindications": [
+      "Use caution with gastric irritation-sensitive contexts"
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "completenessPct": "0.9",
+    "priorityTier": "High",
+    "totalScore": "3",
+    "compound_count": "0",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "panax-ginseng",
+    "name": "Panax Ginseng",
+    "scientificName": "Panax ginseng",
+    "latin": "Panax ginseng",
+    "category": "root",
+    "class": "root",
+    "plantPartUsed": "root",
+    "commonNames": [
+      "ginseng"
+    ],
+    "region": "Asia",
+    "summary": "Adaptogenic root.",
+    "description": "Energy + stress.",
+    "mechanism": "AMPK modulation",
+    "mechanismTags": [
+      "ampk"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "ginsenosides"
+    ],
+    "topCompounds": [
+      "ginsenosides"
+    ],
+    "markerCompounds": [
+      "ginsenosides"
+    ],
+    "safetyNotes": "Safe.",
+    "interactions": [
+      "Stimulatory in high doses"
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "completenessPct": "0.9",
+    "priorityTier": "High",
+    "totalScore": "3",
+    "pathwayTargets": [
+      "cognitive modulation",
+      "unclassified",
+      "metabolic signaling",
+      "stress-response modulation",
+      "cholinergic modulation",
+      "neurotrophic signaling"
+    ],
+    "compound_count": "8",
+    "pathway_count": "8"
+  },
+  {
+    "slug": "passionflower",
+    "name": "Passionflower",
+    "scientificName": "Passiflora incarnata",
+    "latin": "Passiflora incarnata",
+    "category": "aerial",
+    "class": "aerial",
+    "plantPartUsed": "aerial",
+    "commonNames": [
+      "passionflower"
+    ],
+    "region": "Global",
+    "summary": "Passionflower (Passiflora incarnata) should be framed as a traditional calming and sleep-support herb, not a high-confidence receptor-specific anxiolytic.",
+    "description": "EMA supports passionflower for relief of mild mental stress and to aid sleep on the basis of long-standing traditional use. That is useful, but it is weaker than strong modern clinical efficacy. Keep the positioning around traditional calming use and avoid overclaiming a clean single-target GABA story.",
+    "mechanism": "Calming effects are plausibly related to flavonoid-rich extracts and GABAergic modulation hypotheses, but EMA's use-positioning rests on traditional use rather than strong clinical proof.",
+    "mechanismTags": [
+      "calming support",
+      "sleep support",
+      "traditional-use sedative",
+      "possible gabaergic modulation"
+    ],
+    "evidenceLevel": "Traditional use + limited clinical",
+    "activeCompounds": [
+      "chrysin"
+    ],
+    "topCompounds": [
+      "chrysin"
+    ],
+    "markerCompounds": [
+      "chrysin"
+    ],
+    "safetyNotes": "EMA reported no side effects at the time of assessment, but prudence still supports sedative-stacking caution.",
+    "interactions": [
+      "Use caution with alcohol",
+      "sedatives",
+      "or other CNS-depressant stacks."
+    ],
+    "contraindications": [
+      "Avoid casual daytime stacking when sedation would be a problem",
+      "keep use product-specific in pregnancy/breastfeeding contexts."
+    ],
+    "preparation": "Herbal tea and oral dry/liquid extracts from the aerial parts.",
+    "dosage": "Traditional oral tea/extract use in adults and adolescents over 12 only; follow product-monograph instructions.",
+    "publishStatus": "Ready",
+    "readinessFlag": "Validated",
+    "completenessPct": "0.97",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "traditional calming use",
+      "possible GABAergic signaling",
+      "no high-specificity target claim"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1",
+    "sources": [
+      "https://www.ema.europa.eu/en/medicines/herbal/passiflorae-herba",
+      "https://pubmed.ncbi.nlm.nih.gov/40872553/"
+    ]
+  },
+  {
+    "slug": "peppermint",
     "name": "Peppermint",
     "scientificName": "Mentha × piperita",
     "latin": "Mentha × piperita",
@@ -713,7 +5011,7 @@
     "markerCompounds": [
       "menthol"
     ],
-    "safetyNotes": "Menthol is generally regarded as safe. Enteric‑coated peppermint oil is well tolerated; the most common adverse effects reported in clinical trials are heartburn, nausea, abdominal pain and dry mouth【220193048567304†L45-L53】. High doses of minor constituents such as pulegone or menthofuran can cause hepatotoxicity in animals, but typical medicinal doses contain negligible amounts and no cases of human hepatotoxicity have been reported【271856535371736†L1296-L1354】. Peppermint oil should not be applied near the faces of infants or young children because menthol inhalation can cause serious adverse reactions【220193048567304†L45-L53】.",
+    "safetyNotes": "Menthol is generally regarded as safe.",
     "interactions": [
       "Peppermint oil may inhibit cytochrome P450 enzymes (e.g.",
       "CYP2A6 and UGT2B7) and could theoretically interact with drugs metabolised by these pathways."
@@ -744,7 +5042,478 @@
     ]
   },
   {
-    "slug": "rhodiola-rosea-wb",
+    "slug": "perilla",
+    "name": "Perilla",
+    "scientificName": "Perilla frutescens",
+    "latin": "Perilla frutescens",
+    "category": "leaf/seed",
+    "class": "leaf/seed",
+    "plantPartUsed": "leaf; seed",
+    "commonNames": [
+      "perilla",
+      "shiso"
+    ],
+    "region": "East Asia",
+    "summary": "Perilla is positioned for antioxidant, seasonal, and aromatic support.",
+    "description": "It is best framed as a culinary-medicinal herb with modest but relevant translational evidence.",
+    "mechanism": "Volatile and polyphenolic constituents support seasonal and aromatic positioning.",
+    "mechanismTags": [
+      "antioxidant",
+      "aromatic support",
+      "seasonal support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "perillaldehyde",
+      "rosmarinic acid"
+    ],
+    "topCompounds": [
+      "perillaldehyde"
+    ],
+    "markerCompounds": [
+      "perillaldehyde"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with concentrated oil assumptions."
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "frontendReadyFlag": "No",
+    "completenessPct": "0.55",
+    "priorityTier": "Medium",
+    "totalScore": "5",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1",
+    "sources": [
+      "Pass 125 curated expansion"
+    ]
+  },
+  {
+    "slug": "polygala",
+    "name": "Polygala",
+    "scientificName": "Polygala tenuifolia",
+    "latin": "Polygala tenuifolia",
+    "category": "root",
+    "class": "root",
+    "plantPartUsed": "root",
+    "commonNames": [
+      "yuan zhi",
+      "polygala"
+    ],
+    "region": "China and East Asia",
+    "summary": "Polygala is positioned for traditional cognitive and calming support.",
+    "description": "It is best framed as a traditional nootropic-style root with limited modern clinical depth.",
+    "mechanism": "Saponins support traditional cognitive and calming positioning.",
+    "mechanismTags": [
+      "calming support",
+      "traditional cognitive support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "tenuifolin",
+      "polygalasaponins"
+    ],
+    "topCompounds": [
+      "tenuifolin"
+    ],
+    "markerCompounds": [
+      "tenuifolin"
+    ],
+    "safetyNotes": "Use cautiously.",
+    "interactions": [
+      "Use caution with sedative stacking."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "pomegranate",
+    "name": "Pomegranate",
+    "scientificName": "Punica granatum",
+    "latin": "Punica granatum",
+    "category": "fruit rind/juice",
+    "class": "fruit rind/juice",
+    "plantPartUsed": "fruit; rind",
+    "commonNames": [
+      "pomegranate"
+    ],
+    "region": "Mediterranean to West Asia; cultivated globally",
+    "summary": "Pomegranate is positioned for vascular and antioxidant support.",
+    "description": "It is best framed as a polyphenol-rich fruit botanical with food-form relevance and moderate evidence.",
+    "mechanism": "Ellagitannins are associated with antioxidant and vascular-support positioning.",
+    "mechanismTags": [
+      "antioxidant",
+      "vascular support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "punicalagins",
+      "ellagic acid"
+    ],
+    "topCompounds": [
+      "punicalagins"
+    ],
+    "markerCompounds": [
+      "punicalagins"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with overgeneralized disease claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "poria",
+    "name": "Poria",
+    "scientificName": "Wolfiporia extensa",
+    "latin": "Wolfiporia extensa",
+    "category": "sclerotium",
+    "class": "sclerotium",
+    "plantPartUsed": "sclerotium",
+    "commonNames": [
+      "poria",
+      "fu ling"
+    ],
+    "region": "China and East Asia",
+    "summary": "Poria is positioned for traditional fluid-balance and calming support.",
+    "description": "It is best framed as a traditional medicinal fungus with modest modern clinical depth.",
+    "mechanism": "Triterpenes and polysaccharides support fluid-balance and calming positioning.",
+    "mechanismTags": [
+      "calming support",
+      "traditional fluid-balance support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "pachymic acid",
+      "polysaccharides"
+    ],
+    "topCompounds": [
+      "pachymic acid"
+    ],
+    "markerCompounds": [
+      "pachymic acid"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Avoid overextended diuretic claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "psyllium",
+    "name": "Psyllium",
+    "scientificName": "Plantago ovata",
+    "latin": "Plantago ovata",
+    "category": "seed husk",
+    "class": "seed husk",
+    "plantPartUsed": "seed husk",
+    "commonNames": [
+      "psyllium husk"
+    ],
+    "region": "India and cultivated globally",
+    "summary": "Psyllium (Plantago ovata husk) is a fiber-forward intervention with the strongest support for constipation and stool-softening, plus secondary support for cholesterol management.",
+    "description": "Psyllium is not a classic phytochemical-heavy herb; its value comes from gel-forming husk fiber. That makes it more of a functional-fiber tool than a general botanical tonic. Position it around bowel regularity, stool softening, and cautious cardiometabolic support.",
+    "mechanism": "Hydrophilic husk fiber forms a gel-like mass that increases stool water content and bulk, improves transit, and has modest cholesterol-lowering relevance.",
+    "mechanismTags": [
+      "bulk laxative",
+      "gi support",
+      "stool-softening",
+      "cholesterol support"
+    ],
+    "evidenceLevel": "Well-established use + human data",
+    "activeCompounds": [
+      "mucilage",
+      "arabinoxylans"
+    ],
+    "topCompounds": [
+      "mucilage"
+    ],
+    "markerCompounds": [
+      "mucilage"
+    ],
+    "safetyNotes": "Must be taken with plenty of liquid.",
+    "interactions": [
+      "Take away from other oral medicines. Do not take immediately before bed."
+    ],
+    "contraindications": [
+      "Bowel narrowing",
+      "swallowing difficulty",
+      "unexplained rectal bleeding",
+      "sudden bowel-habit change lasting more than 2 weeks."
+    ],
+    "preparation": "Seed-husk powder, granules, capsules, or sachets mixed with water.",
+    "dosage": "Always take with plenty of liquid; keep timing separated from other oral medicines.",
+    "publishStatus": "Ready",
+    "readinessFlag": "Validated",
+    "completenessPct": "0.98",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "gel-forming fiber",
+      "stool water retention",
+      "stool bulk",
+      "bile acid/cholesterol handling"
+    ],
+    "compound_count": "1",
+    "pathway_count": "0",
+    "sources": [
+      "https://www.ema.europa.eu/en/medicines/herbal/plantaginis-ovatae-seminis-tegumentum"
+    ]
+  },
+  {
+    "slug": "pueraria-mirifica",
+    "name": "Pueraria Mirifica",
+    "scientificName": "Pueraria mirifica",
+    "latin": "Pueraria mirifica",
+    "category": "root",
+    "class": "root",
+    "plantPartUsed": "root",
+    "commonNames": [
+      "pueraria mirifica"
+    ],
+    "region": "Thailand and Southeast Asia",
+    "summary": "Pueraria mirifica is positioned for phytoestrogen-focused support.",
+    "description": "It is best framed very cautiously due to potent estrogenic positioning.",
+    "mechanism": "Strong phytoestrogen relevance is the central positioning feature.",
+    "mechanismTags": [
+      "phytoestrogen support",
+      "women's-health support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "miroestrol",
+      "deoxymiroestrol"
+    ],
+    "topCompounds": [
+      "miroestrol"
+    ],
+    "markerCompounds": [
+      "miroestrol"
+    ],
+    "safetyNotes": "Use caution or avoid in hormone-sensitive conditions, pregnancy, and breastfeeding.",
+    "interactions": [
+      "May interact with hormonal therapies",
+      "contraceptives",
+      "and endocrine-active drugs."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "6",
+    "compound_count": "0",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "red-clover",
+    "name": "Red Clover",
+    "scientificName": "Trifolium pratense",
+    "latin": "Trifolium pratense",
+    "category": "flowering tops",
+    "class": "flowering tops",
+    "plantPartUsed": "flowering tops",
+    "commonNames": [
+      "red clover"
+    ],
+    "region": "Europe and Western Asia; cultivated broadly",
+    "summary": "Red clover is positioned for phytoestrogen-adjacent and traditional cycle-support use.",
+    "description": "It should be framed conservatively because endocrine-adjacent claims outrun the evidence in many product contexts.",
+    "mechanism": "Isoflavones are associated with phytoestrogen-adjacent positioning.",
+    "mechanismTags": [
+      "phytoestrogen-adjacent support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "isoflavones",
+      "genistein"
+    ],
+    "topCompounds": [
+      "genistein"
+    ],
+    "markerCompounds": [
+      "genistein"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution in hormone-sensitive contexts."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "rehmannia-prepared",
+    "name": "Rehmannia Prepared",
+    "scientificName": "Rehmannia glutinosa praeparata",
+    "latin": "Rehmannia glutinosa praeparata",
+    "category": "prepared root",
+    "class": "prepared root",
+    "plantPartUsed": "prepared root",
+    "commonNames": [
+      "prepared rehmannia",
+      "shu di huang"
+    ],
+    "region": "China and East Asia",
+    "summary": "Prepared rehmannia is positioned for traditional restorative support.",
+    "description": "It should be framed distinctly from raw rehmannia because processed-form use-cases differ materially.",
+    "mechanism": "Traditional preparation context supports restorative positioning.",
+    "mechanismTags": [
+      "traditional restorative support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "catalpol",
+      "rehmanniosides"
+    ],
+    "topCompounds": [
+      "catalpol"
+    ],
+    "markerCompounds": [
+      "catalpol"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Avoid conflating raw and prepared-form actions."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "reishi",
+    "name": "Reishi",
+    "scientificName": "Ganoderma lucidum",
+    "latin": "Ganoderma lucidum",
+    "category": "fruiting body",
+    "class": "fruiting body",
+    "plantPartUsed": "fruiting body",
+    "commonNames": [
+      "reishi"
+    ],
+    "region": "Global",
+    "summary": "Immune mushroom.",
+    "description": "Immune modulation.",
+    "mechanism": "NFkB",
+    "mechanismTags": [
+      "nfkb"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "triterpenes"
+    ],
+    "topCompounds": [
+      "triterpenes"
+    ],
+    "markerCompounds": [
+      "triterpenes"
+    ],
+    "safetyNotes": "Safe.",
+    "interactions": [
+      "Mild GI"
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "rhodiola",
+    "name": "Rhodiola",
+    "scientificName": "Rhodiola rosea",
+    "latin": "Rhodiola rosea",
+    "category": "root",
+    "class": "root",
+    "plantPartUsed": "root",
+    "commonNames": [
+      "rhodiola"
+    ],
+    "region": "Global",
+    "summary": "Stress resilience herb.",
+    "description": "Adaptogenic stress modulation.",
+    "mechanism": "HPA axis modulation",
+    "mechanismTags": [
+      "adaptogen",
+      "cognitive support",
+      "fatigue resistance"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "rosavins",
+      "salidroside"
+    ],
+    "topCompounds": [
+      "rosavins"
+    ],
+    "markerCompounds": [
+      "rosavins"
+    ],
+    "safetyNotes": "Safe.",
+    "interactions": [
+      "Dose dependent"
+    ],
+    "publishStatus": "Ready for QA",
+    "readinessFlag": "Ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "8",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "rhodiola-rosea",
     "name": "Rhodiola Rosea",
     "scientificName": "Rhodiola rosea",
     "latin": "Rhodiola rosea",
@@ -777,7 +5546,7 @@
       "rosavins",
       "salidroside"
     ],
-    "safetyNotes": "Generally well tolerated; possible dizziness, dry mouth, insomnia",
+    "safetyNotes": "Generally well tolerated; possible dizziness, dry mouth, insomnia.",
     "interactions": [
       "SSRIs",
       "MAOIs",
@@ -806,474 +5575,132 @@
     ]
   },
   {
-    "slug": "saw-palmetto",
-    "name": "Saw Palmetto",
-    "scientificName": "Serenoa repens",
-    "latin": "Serenoa repens",
-    "category": "berry extract",
-    "class": "berry extract",
-    "plantPartUsed": "berry",
-    "region": "Southeastern United States",
-    "summary": "Saw Palmetto (Serenoa repens) is a berry extract monograph focused on the berry used in herbal preparations. It is associated with Southeastern United States. 5-alpha-reductase inhibition; anti-androgenic effects. Generally safe; mild GI upset, headache.",
-    "description": "Saw Palmetto is represented here as a monograph-style entry centered on the berry. Key reported compounds include fatty acids; phytosterols (beta-sitosterol). Typical preparation forms: Berry extracts. 5-alpha-reductase inhibition; anti-androgenic effects. Interaction profile: Hormonal therapies, anticoagulants. Use caution or avoid in: Pregnancy.",
-    "mechanism": "5-alpha-reductase inhibition; anti-androgenic effects",
-    "mechanismTags": [
-      "anti-androgenic",
-      "hormonal"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "fatty acids",
-      "phytosterols (beta-sitosterol)"
-    ],
-    "topCompounds": [
-      "fatty acids",
-      "beta-sitosterol"
-    ],
-    "markerCompounds": [
-      "fatty acids",
-      "beta-sitosterol"
-    ],
-    "safetyNotes": "Generally safe; mild GI upset, headache",
-    "interactions": [
-      "Hormonal therapies",
-      "anticoagulants"
-    ],
-    "contraindications": [
-      "Pregnancy"
-    ],
-    "preparation": "Berry extracts",
-    "standardization": "Standardized to fatty acid content",
-    "publishStatus": "Ready for QA",
-    "readinessFlag": "Ready",
-    "frontendReadyFlag": "Yes",
-    "completenessPct": "0.928571429",
-    "priorityTier": "Medium",
-    "totalScore": "8",
-    "compound_count": "1",
-    "pathway_count": "0",
-    "sources": [
-      "NIH ODS",
-      "EMA"
-    ]
-  },
-  {
-    "slug": "st-johns-wort",
-    "name": "St Johns Wort",
-    "scientificName": "Hypericum perforatum",
-    "latin": "Hypericum perforatum",
-    "category": "herb",
-    "class": "herb",
-    "plantPartUsed": "flowering tops",
+    "slug": "rooibos",
+    "name": "Rooibos",
+    "scientificName": "Aspalathus linearis",
+    "latin": "Aspalathus linearis",
+    "category": "leaf",
+    "class": "leaf",
+    "plantPartUsed": "leaf",
     "commonNames": [
-      "St. John's wort",
-      "Hypericum",
-      "goatweed"
+      "rooibos",
+      "red bush"
     ],
-    "region": "Native to Europe and West Asia; naturalized in North America and other temperate regions.",
-    "summary": "St. John's wort (Hypericum perforatum) is a herb monograph focused on the flowering tops used in herbal preparations. It is associated with Native to Europe and West Asia; naturalized in North America and other temperate regions. Hyperforin and related compounds inhibit monoamine reuptake and affect TRPC6-linked neuroplasticity; additional monoamine oxidase and stress-pathway effects have been proposed. Can cause photosensitivity, GI upset, dizziness, insomnia, restlessness.",
-    "description": "St. John's wort is represented here as a monograph-style entry centered on the flowering tops. Key reported compounds include hyperforin; hypericin; pseudohypericin; quercetin; rutin; kaempferol. Typical preparation forms: Dried flowering tops or standardized extracts. Hyperforin and related compounds inhibit monoamine reuptake and affect TRPC6-linked neuroplasticity; additional monoamine oxidase and stress-pathway effects have been proposed. Interaction profile: Major interactions with antidepressants, oral contraceptives, cyclosporine, tacrolimus, HIV meds, anticancer drugs, warfarin, digoxin and others. Use caution or avoid in: Pregnancy, breastfeeding, bipolar disorder, concomitant prescription meds with CYP/P-gp liability.",
-    "mechanism": "Hyperforin and related compounds inhibit monoamine reuptake and affect TRPC6-linked neuroplasticity; additional monoamine oxidase and stress-pathway effects have been proposed.",
+    "region": "South Africa",
+    "summary": "Rooibos is positioned for gentle antioxidant and soothing support.",
+    "description": "It is best framed as a mild tea herb with low-intensity wellness positioning.",
+    "mechanism": "Polyphenol-linked antioxidant relevance supports mild positioning.",
     "mechanismTags": [
-      "dopaminergic",
-      "serotonergic"
+      "antioxidant support",
+      "soothing support"
     ],
     "evidenceLevel": "Human",
     "activeCompounds": [
-      "hyperforin",
-      "hypericin",
-      "pseudohypericin",
-      "quercetin",
-      "rutin",
-      "kaempferol"
+      "aspalathin",
+      "nothofagin",
+      "flavonoids"
     ],
     "topCompounds": [
-      "hyperforin",
-      "hypericin"
+      "aspalathin"
     ],
     "markerCompounds": [
-      "hyperforin",
-      "hypericin"
+      "aspalathin"
     ],
-    "safetyNotes": "Can cause photosensitivity, GI upset, dizziness, insomnia, restlessness. Strong inducer of CYP3A4 and P-gp.",
+    "safetyNotes": "Generally well tolerated.",
     "interactions": [
-      "Major interactions with antidepressants",
-      "oral contraceptives",
-      "cyclosporine",
-      "tacrolimus",
-      "HIV meds",
-      "anticancer drugs",
-      "warfarin",
-      "digoxin and others."
+      "No major interaction pattern is firmly established",
+      "use routine caution in polypharmacy."
     ],
-    "contraindications": [
-      "Pregnancy",
-      "breastfeeding",
-      "bipolar disorder",
-      "concomitant prescription meds with CYP/P-gp liability."
-    ],
-    "preparation": "Dried flowering tops or standardized extracts.",
-    "dosage": "300 mg extract three times daily",
-    "standardization": "Often 0.3% hypericin or 2–5% hyperforin.",
     "publishStatus": "Source review",
-    "readinessFlag": "Near ready",
-    "frontendReadyFlag": "No",
-    "completenessPct": "1",
+    "readinessFlag": "Needs work",
+    "completenessPct": "0.9",
     "priorityTier": "High",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1",
-    "sources": [
-      "Recovered from prior batch output in this conversation"
-    ]
+    "totalScore": "3",
+    "compound_count": "0",
+    "pathway_count": "0"
   },
   {
-    "slug": "turmeric-wb",
-    "name": "Turmeric",
-    "scientificName": "Curcuma longa",
-    "latin": "Curcuma longa",
-    "category": "rhizome",
-    "class": "rhizome",
-    "plantPartUsed": "unspecified",
+    "slug": "rose-hips",
+    "name": "Rose Hips",
+    "scientificName": "Rosa canina",
+    "latin": "Rosa canina",
+    "category": "fruit",
+    "class": "fruit",
+    "plantPartUsed": "fruit",
     "commonNames": [
-      "turmeric",
-      "Curcuma longa"
+      "rose hips"
     ],
-    "region": "Native to India and cultivated throughout the tropics; turmeric is not found in the wild and is grown as a domesticated plant【754431674042811†L224-L241】.",
-    "summary": "Turmeric (Curcuma longa) is a rhizome monograph focused on the unspecified used in herbal preparations. It is associated with Native to India and cultivated throughout the tropics; turmeric is not found in the wild and is grown as a domesticated plant【754431674042811†L224-L241】. The golden rhizomes of turmeric contain non‑volatile curcuminoids—curcumin (curcumin I), demethoxycurcumin (curcumin II) and bisdemethoxycurcumin (curcumin III)—as well as volatile mono‑ and sesquiterpenoids【768158627760254†L420-L432】【768158627760254†L442-L468】. Conventional oral preparations of turmeric or curcumin appear safe for up to 2–3 months.",
-    "description": "Turmeric is represented here as a monograph-style entry centered on the unspecified. Key reported compounds include curcumin; demethoxycurcumin; bisdemethoxycurcumin. Typical preparation forms: The rhizomes are boiled, dried and ground into powder used as a spice, dye and supplement. Extracts standardized for curcuminoid content are available as capsules or tablets. The golden rhizomes of turmeric contain non‑volatile curcuminoids—curcumin (curcumin I), demethoxycurcumin (curcumin II) and bisdemethoxycurcumin (curcumin III)—as well as volatile mono‑ and sesquiterpenoids【768158627760254†L420-L432】【768158627760254†L442-L468】. Curcumin and related curcuminoids exhibit antioxidant and anti‑inflammatory effects by modulating multiple molecular targets (e.g., NF‑κB, Nrf2, COX‑2). Most data are preclinical; human evidence is limited, so this mechanism should be considered proposed. Interaction profile: Curcumin may enhance the effects of anticoagulant, antiplatelet or antidiabetic drugs and could interact with drugs metabolized by cytochrome P450 enzymes; caution is advised. Use caution or avoid in: Avoid high‑dose turmeric supplements in people with gallbladder obstruction, bleeding disorders or those taking anticoagulant or antiplatelet medications. Use is not recommended during pregnancy or breastfeeding.",
-    "mechanism": "The golden rhizomes of turmeric contain non‑volatile curcuminoids—curcumin (curcumin I), demethoxycurcumin (curcumin II) and bisdemethoxycurcumin (curcumin III)—as well as volatile mono‑ and sesquiterpenoids【768158627760254†L420-L432】【768158627760254†L442-L468】. Curcumin and related curcuminoids exhibit antioxidant and anti‑inflammatory effects by modulating multiple molecular targets (e.g., NF‑κB, Nrf2, COX‑2). Most data are preclinical; human evidence is limited, so this mechanism should be considered proposed.",
+    "region": "Europe and temperate regions",
+    "summary": "Rose hips are positioned for antioxidant, nutritive, and joint-support use.",
+    "description": "They are best framed as polyphenol- and vitamin-rich fruit material with modest but relevant human evidence.",
+    "mechanism": "Polyphenols and ascorbate-rich fruit chemistry support antioxidant positioning.",
     "mechanismTags": [
-      "anti-inflammatory",
       "antioxidant",
-      "nf-kb modulation"
-    ],
-    "evidenceLevel": "Unknown",
-    "activeCompounds": [
-      "curcumin",
-      "demethoxycurcumin"
-    ],
-    "topCompounds": [
-      "curcumin"
-    ],
-    "markerCompounds": [
-      "curcumin"
-    ],
-    "safetyNotes": "Conventional oral preparations of turmeric or curcumin appear safe for up to 2–3 months. Reported adverse effects include nausea, vomiting, acid reflux, stomach upset, diarrhoea or constipation. Highly bioavailable curcumin products have been linked to liver damage in rare cases. The safety of turmeric supplements during pregnancy or breastfeeding is uncertain【628537290338832†L207-L223】.",
-    "interactions": [
-      "Curcumin may enhance the effects of anticoagulant",
-      "antiplatelet or antidiabetic drugs and could interact with drugs metabolized by cytochrome P450 enzymes",
-      "caution is advised."
-    ],
-    "contraindications": [
-      "Avoid high‑dose turmeric supplements in people with gallbladder obstruction",
-      "bleeding disorders or those taking anticoagulant or antiplatelet medications. Use is not recommended during pregnancy or breastfeeding."
-    ],
-    "preparation": "The rhizomes are boiled, dried and ground into powder used as a spice, dye and supplement. Extracts standardized for curcuminoid content are available as capsules or tablets.",
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "frontendReadyFlag": "No",
-    "completenessPct": "0.714285714",
-    "priorityTier": "Medium",
-    "totalScore": "6",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "6",
-    "pathway_count": "1",
-    "sources": [
-      "【768158627760254†L420-L432】",
-      "【768158627760254†L442-L468】",
-      "【628537290338832†L207-L223】",
-      "【754431674042811†L224-L241】"
-    ]
-  },
-  {
-    "slug": "valerian-wb",
-    "name": "Valerian",
-    "scientificName": "Valeriana officinalis",
-    "latin": "Valeriana officinalis",
-    "category": "herb",
-    "class": "herb",
-    "plantPartUsed": "root; rhizome",
-    "commonNames": [
-      "valerian",
-      "all-heal",
-      "garden heliotrope"
-    ],
-    "region": "Native to Europe and Asia; naturalized in North America and other temperate regions.",
-    "summary": "Valerian (Valeriana officinalis) is a herb monograph focused on the root; rhizome used in herbal preparations. It is associated with Native to Europe and Asia; naturalized in North America and other temperate regions. Valerenic acid derivatives modulate GABA-A signaling and may inhibit GABA breakdown. Short-term use appears safe; side effects include headache, GI upset, mental dullness, excitability, vivid dreams.",
-    "description": "Valerian is represented here as a monograph-style entry centered on the root; rhizome. Key reported compounds include valerenic acid; valerenol; valerenal; valepotriates (valtrate, isovaltrate); sesquiterpenoids. Typical preparation forms: Dried roots/rhizomes as teas, tinctures, or extracts. Valerenic acid derivatives modulate GABA-A signaling and may inhibit GABA breakdown. Interaction profile: May potentiate sedatives and alcohol. Use caution or avoid in: Pregnancy, breastfeeding, liver disease, concurrent CNS depressants.",
-    "mechanism": "Valerenic acid derivatives modulate GABA-A signaling and may inhibit GABA breakdown.",
-    "mechanismTags": [
-      "gaba modulation",
-      "sedative",
-      "sleep support"
+      "nutritive support"
     ],
     "evidenceLevel": "Human",
     "activeCompounds": [
-      "valerenic acid"
+      "trans-tiliroside",
+      "vitamin C"
     ],
     "topCompounds": [
-      "valerenic acid"
+      "trans-tiliroside"
     ],
     "markerCompounds": [
-      "valerenic acid"
+      "trans-tiliroside"
     ],
-    "safetyNotes": "Short-term use appears safe; side effects include headache, GI upset, mental dullness, excitability, vivid dreams. Rare liver injury reported.",
+    "safetyNotes": "Generally well tolerated.",
     "interactions": [
-      "May potentiate sedatives and alcohol."
+      "Use caution with overly concentrated extract claims."
     ],
-    "contraindications": [
-      "Pregnancy",
-      "breastfeeding",
-      "liver disease",
-      "concurrent CNS depressants."
-    ],
-    "preparation": "Dried roots/rhizomes as teas, tinctures, or extracts.",
-    "dosage": "300–600 mg extract",
     "publishStatus": "Source review",
-    "readinessFlag": "Near ready",
+    "readinessFlag": "Needs work",
     "frontendReadyFlag": "No",
-    "completenessPct": "0.928571429",
-    "priorityTier": "High",
-    "totalScore": "6",
+    "completenessPct": "0.55",
+    "priorityTier": "Medium",
+    "totalScore": "5",
     "pathwayTargets": [
       "unclassified"
     ],
     "compound_count": "1",
     "pathway_count": "1",
     "sources": [
-      "Recovered from prior batch output in this conversation"
+      "Pass 125 curated expansion"
     ]
   },
   {
-    "slug": "guarana-wb",
-    "name": "Guarana",
-    "scientificName": "Paullinia cupana",
-    "latin": "Paullinia cupana",
-    "category": "plant",
-    "class": "plant",
+    "slug": "roselle-seed",
+    "name": "Roselle Seed",
+    "scientificName": "Hibiscus sabdariffa",
+    "latin": "Hibiscus sabdariffa",
+    "category": "seed",
+    "class": "seed",
     "plantPartUsed": "seed",
     "commonNames": [
-      "Guarana"
+      "roselle seed"
     ],
-    "region": "global",
-    "summary": "Guarana positioned for primary functional support.",
-    "description": "Conservative evidence framing applied.",
-    "mechanism": "Mechanistic activity supported by mixed evidence.",
+    "region": "Africa and tropical regions",
+    "summary": "Roselle seed is positioned for nutritive and antioxidant support.",
+    "description": "It should be framed distinctly from hibiscus calyx because seed and calyx use-cases differ.",
+    "mechanism": "Seed lipids and antioxidants support nutritive positioning.",
     "mechanismTags": [
-      "cognition",
-      "energy support",
-      "metabolic support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "caffeine"
-    ],
-    "topCompounds": [
-      "caffeine"
-    ],
-    "markerCompounds": [
-      "caffeine"
-    ],
-    "safetyNotes": "Use caution with stimulant sensitivity, anxiety, or insomnia-prone contexts.",
-    "interactions": [
-      "May stack strongly with caffeine-heavy or stimulant-heavy formulas."
-    ],
-    "contraindications": [
-      "Use caution in uncontrolled blood pressure-sensitive contexts."
-    ],
-    "publishStatus": "Ready for QA",
-    "readinessFlag": "Ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "9",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "yerba-mate-wb",
-    "name": "Yerba Mate",
-    "scientificName": "Ilex paraguariensis",
-    "latin": "Ilex paraguariensis",
-    "category": "plant",
-    "class": "plant",
-    "plantPartUsed": "leaf",
-    "commonNames": [
-      "Yerba Mate"
-    ],
-    "region": "global",
-    "summary": "Yerba Mate positioned for primary functional support.",
-    "description": "Conservative evidence framing applied.",
-    "mechanism": "Mechanistic activity supported by mixed evidence.",
-    "mechanismTags": [
-      "cognition",
-      "energy support",
-      "metabolic support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "caffeine",
-      "polyphenols"
-    ],
-    "topCompounds": [
-      "caffeine"
-    ],
-    "markerCompounds": [
-      "caffeine"
-    ],
-    "safetyNotes": "Use caution with stimulant sensitivity or insomnia-prone contexts.",
-    "interactions": [
-      "May stack strongly with caffeine-heavy formulas."
-    ],
-    "contraindications": [
-      "Use caution in uncontrolled blood pressure-sensitive contexts."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "damiana-wb",
-    "name": "Damiana",
-    "scientificName": "Turnera diffusa",
-    "latin": "Turnera diffusa",
-    "category": "plant",
-    "class": "plant",
-    "plantPartUsed": "leaf",
-    "commonNames": [
-      "Damiana"
-    ],
-    "region": "global",
-    "summary": "Damiana positioned for primary functional support.",
-    "description": "Conservative evidence framing applied.",
-    "mechanism": "Mechanistic activity supported by mixed evidence.",
-    "mechanismTags": [
-      "calming support",
-      "libido support",
-      "mood support"
-    ],
-    "evidenceLevel": "Preclinical",
-    "activeCompounds": [
-      "flavonoids"
-    ],
-    "topCompounds": [
-      "apigenin"
-    ],
-    "markerCompounds": [
-      "apigenin"
-    ],
-    "safetyNotes": "General use caution; review stimulating vs calming stack context.",
-    "interactions": [
-      "Use caution in complex mood stacks."
-    ],
-    "contraindications": [
-      "Use caution in pregnancy-sensitive contexts."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "blue-lotus-wb",
-    "name": "Blue Lotus",
-    "scientificName": "Nymphaea caerulea",
-    "latin": "Nymphaea caerulea",
-    "category": "plant",
-    "class": "plant",
-    "plantPartUsed": "flower",
-    "commonNames": [
-      "Blue Lotus"
-    ],
-    "region": "global",
-    "summary": "Blue Lotus positioned for primary functional support.",
-    "description": "Conservative evidence framing applied.",
-    "mechanism": "Mechanistic activity supported by mixed evidence.",
-    "mechanismTags": [
-      "calming support",
-      "mood support",
-      "sleep support"
-    ],
-    "evidenceLevel": "Preclinical",
-    "activeCompounds": [
-      "aporphine alkaloids"
-    ],
-    "topCompounds": [
-      "nuciferine"
-    ],
-    "markerCompounds": [
-      "nuciferine"
-    ],
-    "safetyNotes": "Use caution with sedative-sensitive contexts and stacked calming formulas.",
-    "interactions": [
-      "May compound sedative effects in calming/sleep stacks."
-    ],
-    "contraindications": [
-      "Avoid high-sedation contexts without clear need."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "5",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "kudzu",
-    "name": "Kudzu",
-    "scientificName": "Pueraria lobata",
-    "latin": "Pueraria lobata",
-    "category": "plant",
-    "class": "plant",
-    "plantPartUsed": "root",
-    "commonNames": [
-      "Kudzu"
-    ],
-    "region": "global",
-    "summary": "Kudzu positioned for primary functional support.",
-    "description": "Conservative evidence framing applied.",
-    "mechanism": "Mechanistic activity supported by mixed evidence.",
-    "mechanismTags": [
-      "multi-domain"
+      "antioxidant",
+      "nutritive support"
     ],
     "evidenceLevel": "Unknown",
     "activeCompounds": [
-      "isoflavones"
+      "tocopherols",
+      "fatty acids"
     ],
     "topCompounds": [
-      "puerarin"
+      "tocopherols"
     ],
     "markerCompounds": [
-      "puerarin"
+      "tocopherols"
     ],
     "safetyNotes": "Generally well tolerated.",
     "interactions": [
-      "Use caution in stacked contexts."
+      "Avoid conflating seed with calyx evidence."
     ],
     "publishStatus": "Editorial polish",
     "readinessFlag": "Near ready",
@@ -1281,195 +5708,7 @@
     "priorityTier": "Medium",
     "totalScore": "7",
     "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "yarrow-wb",
-    "name": "Yarrow",
-    "scientificName": "Achillea millefolium",
-    "latin": "Achillea millefolium",
-    "category": "plant",
-    "class": "plant",
-    "plantPartUsed": "aerial",
-    "commonNames": [
-      "Yarrow"
-    ],
-    "region": "global",
-    "summary": "Yarrow positioned for primary functional support.",
-    "description": "Conservative evidence framing applied.",
-    "mechanism": "Mechanistic activity supported by mixed evidence.",
-    "mechanismTags": [
-      "anti-inflammatory",
-      "digestive support",
-      "women's health"
-    ],
-    "evidenceLevel": "Preclinical",
-    "activeCompounds": [
-      "flavonoids"
-    ],
-    "topCompounds": [
-      "apigenin"
-    ],
-    "markerCompounds": [
-      "apigenin"
-    ],
-    "safetyNotes": "Review interactions and contraindications.",
-    "interactions": [
-      "Use caution in anticoagulant-sensitive or complex women's health stacks."
-    ],
-    "contraindications": [
-      "Use caution in pregnancy-sensitive contexts."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "feverfew-wb",
-    "name": "Feverfew",
-    "scientificName": "Tanacetum parthenium",
-    "latin": "Tanacetum parthenium",
-    "category": "plant",
-    "class": "plant",
-    "plantPartUsed": "leaf",
-    "commonNames": [
-      "Feverfew"
-    ],
-    "region": "global",
-    "summary": "Feverfew positioned for primary functional support.",
-    "description": "Conservative evidence framing applied.",
-    "mechanism": "Mechanistic activity supported by mixed evidence.",
-    "mechanismTags": [
-      "headache support",
-      "inflammation support",
-      "vascular modulation"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "parthenolide",
-      "flavonoids"
-    ],
-    "topCompounds": [
-      "parthenolide"
-    ],
-    "markerCompounds": [
-      "parthenolide"
-    ],
-    "safetyNotes": "Review interactions and contraindications",
-    "interactions": [
-      "May interact with anticoagulant-sensitive contexts"
-    ],
-    "contraindications": [
-      "Use caution in pregnancy-sensitive and surgery-sensitive contexts"
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "butterbur",
-    "name": "Butterbur",
-    "scientificName": "Petasites hybridus",
-    "latin": "Petasites hybridus",
-    "category": "plant",
-    "class": "plant",
-    "plantPartUsed": "root",
-    "commonNames": [
-      "Butterbur"
-    ],
-    "region": "global",
-    "summary": "Butterbur positioned for primary functional support.",
-    "description": "Conservative evidence framing applied.",
-    "mechanism": "Mechanistic activity supported by mixed evidence.",
-    "mechanismTags": [
-      "multi-domain"
-    ],
-    "evidenceLevel": "Unknown",
-    "activeCompounds": [
-      "petasin"
-    ],
-    "topCompounds": [
-      "petasin"
-    ],
-    "markerCompounds": [
-      "petasin"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution in stacked contexts."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "dong-quai",
-    "name": "Dong Quai",
-    "scientificName": "Angelica sinensis",
-    "latin": "Angelica sinensis",
-    "category": "plant",
-    "class": "plant",
-    "plantPartUsed": "root",
-    "commonNames": [
-      "Dong Quai"
-    ],
-    "region": "global",
-    "summary": "Dong Quai positioned for primary functional support.",
-    "description": "Conservative evidence framing applied.",
-    "mechanism": "Mechanistic activity supported by mixed evidence.",
-    "mechanismTags": [
-      "circulation support",
-      "smooth muscle support",
-      "women's health"
-    ],
-    "evidenceLevel": "Preclinical",
-    "activeCompounds": [
-      "ferulic acid"
-    ],
-    "topCompounds": [
-      "ferulic acid"
-    ],
-    "markerCompounds": [
-      "ferulic acid"
-    ],
-    "safetyNotes": "Review interactions and contraindications.",
-    "interactions": [
-      "Use caution with anticoagulant-sensitive contexts."
-    ],
-    "contraindications": [
-      "Avoid pregnancy-sensitive contexts unless professionally guided."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
+      "oxidative stress reduction"
     ],
     "compound_count": "1",
     "pathway_count": "1"
@@ -1571,1517 +5810,171 @@
     "pathway_count": "1"
   },
   {
-    "slug": "thyme",
-    "name": "Thyme",
-    "scientificName": "Thymus vulgaris",
-    "latin": "Thymus vulgaris",
-    "category": "plant",
-    "class": "plant",
-    "plantPartUsed": "leaf",
-    "commonNames": [
-      "Thyme"
-    ],
-    "region": "global",
-    "summary": "Thyme positioned for primary functional support.",
-    "description": "Conservative evidence framing applied.",
-    "mechanism": "Mechanistic activity supported by mixed evidence.",
+    "slug": "saw-palmetto",
+    "name": "Saw Palmetto",
+    "scientificName": "Serenoa repens",
+    "latin": "Serenoa repens",
+    "category": "berry extract",
+    "class": "berry extract",
+    "plantPartUsed": "berry",
+    "region": "Southeastern United States",
+    "summary": "Saw Palmetto (Serenoa repens) is a berry extract monograph focused on the berry used in herbal preparations. It is associated with Southeastern United States. 5-alpha-reductase inhibition; anti-androgenic effects. Generally safe; mild GI upset, headache.",
+    "description": "Saw Palmetto is represented here as a monograph-style entry centered on the berry. Key reported compounds include fatty acids; phytosterols (beta-sitosterol). Typical preparation forms: Berry extracts. 5-alpha-reductase inhibition; anti-androgenic effects. Interaction profile: Hormonal therapies, anticoagulants. Use caution or avoid in: Pregnancy.",
+    "mechanism": "5-alpha-reductase inhibition; anti-androgenic effects",
     "mechanismTags": [
-      "antimicrobial",
-      "digestive support",
-      "respiratory support"
+      "anti-androgenic",
+      "hormonal"
     ],
-    "evidenceLevel": "Preclinical",
+    "evidenceLevel": "Human",
     "activeCompounds": [
-      "thymol"
+      "fatty acids",
+      "phytosterols (beta-sitosterol)"
     ],
     "topCompounds": [
-      "thymol"
+      "fatty acids",
+      "beta-sitosterol"
     ],
     "markerCompounds": [
-      "thymol"
+      "fatty acids",
+      "beta-sitosterol"
     ],
-    "safetyNotes": "Generally well tolerated; review concentrated oil use carefully.",
+    "safetyNotes": "Generally safe; mild GI upset, headache.",
     "interactions": [
-      "Use caution in stacks already heavy in potent essential-oil actives."
+      "Hormonal therapies",
+      "anticoagulants"
     ],
     "contraindications": [
-      "Use caution with highly sensitive GI contexts at concentrated intake."
+      "Pregnancy"
     ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
+    "preparation": "Berry extracts",
+    "standardization": "Standardized to fatty acid content",
+    "publishStatus": "Ready for QA",
+    "readinessFlag": "Ready",
+    "frontendReadyFlag": "Yes",
+    "completenessPct": "0.928571429",
     "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
+    "totalScore": "8",
     "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "oregano",
-    "name": "Oregano",
-    "scientificName": "Origanum vulgare",
-    "latin": "Origanum vulgare",
-    "category": "plant",
-    "class": "plant",
-    "plantPartUsed": "leaf",
-    "commonNames": [
-      "Oregano"
-    ],
-    "region": "global",
-    "summary": "Oregano positioned for primary functional support.",
-    "description": "Conservative evidence framing applied.",
-    "mechanism": "Mechanistic activity supported by mixed evidence.",
-    "mechanismTags": [
-      "antimicrobial",
-      "digestive support",
-      "respiratory support"
-    ],
-    "evidenceLevel": "Preclinical",
-    "activeCompounds": [
-      "carvacrol",
-      "thymol",
-      "rosmarinic acid"
-    ],
-    "topCompounds": [
-      "carvacrol",
-      "thymol"
-    ],
-    "markerCompounds": [
-      "carvacrol",
-      "thymol"
-    ],
-    "safetyNotes": "General use caution; concentrated extracts can be irritating",
-    "interactions": [
-      "May stack strongly with other antimicrobial concentrates"
-    ],
-    "contraindications": [
-      "Use caution with gastric irritation-sensitive contexts"
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "completenessPct": "0.9",
-    "priorityTier": "High",
-    "totalScore": "3",
-    "compound_count": "0",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "eucalyptus",
-    "name": "Eucalyptus",
-    "scientificName": "Eucalyptus globulus",
-    "latin": "Eucalyptus globulus",
-    "category": "plant",
-    "class": "plant",
-    "plantPartUsed": "leaf",
-    "commonNames": [
-      "Eucalyptus"
-    ],
-    "region": "global",
-    "summary": "Eucalyptus positioned for primary functional support.",
-    "description": "Conservative evidence framing applied.",
-    "mechanism": "Mechanistic activity supported by mixed evidence.",
-    "mechanismTags": [
-      "anti-inflammatory",
-      "antimicrobial",
-      "respiratory support"
-    ],
-    "evidenceLevel": "Preclinical",
-    "activeCompounds": [
-      "eucalyptol",
-      "alpha-pinene",
-      "tannins"
-    ],
-    "topCompounds": [
-      "eucalyptol",
-      "alpha-pinene"
-    ],
-    "markerCompounds": [
-      "eucalyptol",
-      "alpha-pinene"
-    ],
-    "safetyNotes": "Review interactions and contraindications",
-    "interactions": [
-      "May irritate when combined with strong volatile-oil protocols"
-    ],
-    "contraindications": [
-      "Use caution with young children and high-dose essential-oil contexts"
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "completenessPct": "0.9",
-    "priorityTier": "High",
-    "totalScore": "3",
-    "compound_count": "0",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "artichoke",
-    "name": "Artichoke",
-    "scientificName": "Cynara scolymus",
-    "latin": "Cynara scolymus",
-    "category": "leaf",
-    "class": "leaf",
-    "plantPartUsed": "leaf",
-    "commonNames": [
-      "artichoke leaf"
-    ],
-    "region": "Mediterranean; cultivated broadly",
-    "summary": "Artichoke is a leaf monograph positioned for hepatobiliary and digestive support.",
-    "description": "It is best framed around bitter-compound and phenolic support for digestion and bile-related positioning rather than broad detox claims.",
-    "mechanism": "Phenolic compounds are associated with choleretic and hepatometabolic-support positioning.",
-    "mechanismTags": [
-      "digestive support",
-      "hepatobiliary support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "cynarin",
-      "chlorogenic acid"
-    ],
-    "topCompounds": [
-      "cynarin"
-    ],
-    "markerCompounds": [
-      "cynarin"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Avoid with bile-duct obstruction or severe gallbladder issues."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "fennel",
-    "name": "Fennel",
-    "scientificName": "Foeniculum vulgare",
-    "latin": "Foeniculum vulgare",
-    "category": "seed",
-    "class": "seed",
-    "plantPartUsed": "seed",
-    "commonNames": [
-      "fennel"
-    ],
-    "region": "Mediterranean; cultivated globally",
-    "summary": "Fennel is a seed monograph positioned for digestive and antispasmodic support.",
-    "description": "It is best handled as an aromatic seed botanical with traditional GI-support use and modest mechanistic confidence.",
-    "mechanism": "Volatile constituents are associated with digestive soothing and antispasmodic positioning.",
-    "mechanismTags": [
-      "antispasmodic support",
-      "digestive support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "anethole",
-      "volatile oils"
-    ],
-    "topCompounds": [
-      "anethole"
-    ],
-    "markerCompounds": [
-      "anethole"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution in highly concentrated oil form."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "cinnamon",
-    "name": "Cinnamon",
-    "scientificName": "Cinnamomum verum",
-    "latin": "Cinnamomum verum",
-    "category": "bark",
-    "class": "bark",
-    "plantPartUsed": "bark",
-    "commonNames": [
-      "cinnamon"
-    ],
-    "region": "South Asia; cultivated broadly",
-    "summary": "Cinnamon is a bark monograph positioned for glycemic and antimicrobial support.",
-    "description": "It is best framed conservatively because product form and species matter, especially around coumarin exposure in non-verum types.",
-    "mechanism": "Aromatic aldehydes and polyphenols are associated with glycemic and antimicrobial positioning.",
-    "mechanismTags": [
-      "antimicrobial support",
-      "glycemic support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "cinnamaldehyde",
-      "polyphenols"
-    ],
-    "topCompounds": [
-      "cinnamaldehyde"
-    ],
-    "markerCompounds": [
-      "cinnamaldehyde"
-    ],
-    "safetyNotes": "Generally well tolerated in culinary ranges.",
-    "interactions": [
-      "Use caution with concentrated extracts and coumarin-sensitive contexts."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "dandelion",
-    "name": "Dandelion",
-    "scientificName": "Taraxacum officinale",
-    "latin": "Taraxacum officinale",
-    "category": "leaf/root",
-    "class": "leaf/root",
-    "plantPartUsed": "leaf; root",
-    "commonNames": [
-      "dandelion"
-    ],
-    "region": "Europe, Asia, North America",
-    "summary": "Dandelion is positioned for digestive, hepatobiliary, and mild diuretic support.",
-    "description": "It is best framed as a traditional food-like bitter herb rather than a strong cleansing intervention.",
-    "mechanism": "Bitter and terpene-related constituents are associated with digestive and mild anti-inflammatory positioning.",
-    "mechanismTags": [
-      "digestive support",
-      "mild diuretic support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "taraxasterol",
-      "sesquiterpene lactones"
-    ],
-    "topCompounds": [
-      "taraxasterol"
-    ],
-    "markerCompounds": [
-      "taraxasterol"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with aggressive diuretic stacking or ragweed-family sensitivity."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "burdock",
-    "name": "Burdock",
-    "scientificName": "Arctium lappa",
-    "latin": "Arctium lappa",
-    "category": "root",
-    "class": "root",
-    "plantPartUsed": "root",
-    "commonNames": [
-      "burdock"
-    ],
-    "region": "Europe and Asia; cultivated broadly",
-    "summary": "Burdock root is positioned for traditional skin, digestive, and anti-inflammatory support.",
-    "description": "It is best framed as a traditional root botanical with modest modern evidence rather than a definitive detox herb.",
-    "mechanism": "Lignans and polyphenols are associated with antioxidant and anti-inflammatory positioning.",
-    "mechanismTags": [
-      "anti-inflammatory",
-      "traditional skin support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "arctiin",
-      "lignans"
-    ],
-    "topCompounds": [
-      "arctiin"
-    ],
-    "markerCompounds": [
-      "arctiin"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with daisy-family sensitivities."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "chamomile-wb",
-    "name": "Chamomile",
-    "scientificName": "Matricaria chamomilla",
-    "latin": "Matricaria chamomilla",
-    "category": "flower",
-    "class": "flower",
-    "plantPartUsed": "flower",
-    "commonNames": [
-      "chamomile"
-    ],
-    "region": "Europe; cultivated globally",
-    "summary": "Chamomile is a flower monograph positioned for calming, digestive, and anti-inflammatory support.",
-    "description": "It is best handled as a gentle calming botanical with broad traditional use and modest clinical depth.",
-    "mechanism": "Flavonoids and volatile constituents are associated with calming and digestive-support positioning.",
-    "mechanismTags": [
-      "anti-inflammatory",
-      "anxiolytic",
-      "sleep support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "apigenin"
-    ],
-    "topCompounds": [
-      "apigenin"
-    ],
-    "markerCompounds": [
-      "apigenin"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with ragweed-family allergy contexts."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified",
-      "GABA-A modulation",
-      "NF-kB inhibition",
-      "anxiolytic signaling",
-      "adrenergic signaling"
-    ],
-    "compound_count": "6",
-    "pathway_count": "5"
-  },
-  {
-    "slug": "red-clover",
-    "name": "Red Clover",
-    "scientificName": "Trifolium pratense",
-    "latin": "Trifolium pratense",
-    "category": "flowering tops",
-    "class": "flowering tops",
-    "plantPartUsed": "flowering tops",
-    "commonNames": [
-      "red clover"
-    ],
-    "region": "Europe and Western Asia; cultivated broadly",
-    "summary": "Red clover is positioned for phytoestrogen-adjacent and traditional cycle-support use.",
-    "description": "It should be framed conservatively because endocrine-adjacent claims outrun the evidence in many product contexts.",
-    "mechanism": "Isoflavones are associated with phytoestrogen-adjacent positioning.",
-    "mechanismTags": [
-      "phytoestrogen-adjacent support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "isoflavones",
-      "genistein"
-    ],
-    "topCompounds": [
-      "genistein"
-    ],
-    "markerCompounds": [
-      "genistein"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution in hormone-sensitive contexts."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "oatstraw",
-    "name": "Oatstraw",
-    "scientificName": "Avena sativa",
-    "latin": "Avena sativa",
-    "category": "aerial parts",
-    "class": "aerial parts",
-    "plantPartUsed": "green tops; straw",
-    "commonNames": [
-      "oatstraw"
-    ],
-    "region": "Europe and cultivated globally",
-    "summary": "Oatstraw is positioned for nutritive and calming support.",
-    "description": "It is best framed as a gentle nutritive herb with limited high-signal clinical depth.",
-    "mechanism": "Polyphenols and nutritive positioning drive most use-cases.",
-    "mechanismTags": [
-      "calming support",
-      "nutritive support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "avenanthramides",
-      "minerals"
-    ],
-    "topCompounds": [
-      "avenanthramides"
-    ],
-    "markerCompounds": [
-      "avenanthramides"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with gluten cross-contact concerns depending on sourcing."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "calendula",
-    "name": "Calendula",
-    "scientificName": "Calendula officinalis",
-    "latin": "Calendula officinalis",
-    "category": "flower",
-    "class": "flower",
-    "plantPartUsed": "flower",
-    "commonNames": [
-      "calendula"
-    ],
-    "region": "Mediterranean; cultivated broadly",
-    "summary": "Calendula is a flower monograph positioned for topical soothing and traditional mucosal support.",
-    "description": "It is best framed around topical and tissue-soothing use rather than overextended systemic claims.",
-    "mechanism": "Triterpenes and flavonoids are associated with tissue-soothing and anti-inflammatory positioning.",
-    "mechanismTags": [
-      "anti-inflammatory",
-      "topical soothing support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "faradiol esters",
-      "flavonoids"
-    ],
-    "topCompounds": [
-      "faradiol"
-    ],
-    "markerCompounds": [
-      "faradiol"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with daisy-family sensitivities."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "pau-d-arco",
-    "name": "Pau d'Arco",
-    "scientificName": "Handroanthus impetiginosus",
-    "latin": "Handroanthus impetiginosus",
-    "category": "inner bark",
-    "class": "inner bark",
-    "plantPartUsed": "inner bark",
-    "commonNames": [
-      "pau d'arco"
-    ],
-    "region": "South America",
-    "summary": "Pau d'arco is positioned for traditional immune and antimicrobial support.",
-    "description": "It should be framed conservatively because popular claims often exceed the evidence and preparation differences matter.",
-    "mechanism": "Naphthoquinones are associated with antimicrobial and redox-related positioning in preclinical contexts.",
-    "mechanismTags": [
-      "antimicrobial support",
-      "traditional immune support"
-    ],
-    "evidenceLevel": "Preclinical",
-    "activeCompounds": [
-      "lapachol",
-      "naphthoquinones"
-    ],
-    "topCompounds": [
-      "lapachol"
-    ],
-    "markerCompounds": [
-      "lapachol"
-    ],
-    "safetyNotes": "Use conservatively; concentrated use may be irritating.",
-    "interactions": [
-      "Avoid exaggerated disease-treatment claims."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "gymnema",
-    "name": "Gymnema",
-    "scientificName": "Gymnema sylvestre",
-    "latin": "Gymnema sylvestre",
-    "category": "leaf",
-    "class": "leaf",
-    "plantPartUsed": "leaf",
-    "commonNames": [
-      "gymnema"
-    ],
-    "region": "India and tropical Asia",
-    "summary": "Gymnema is positioned for glycemic and sweet-perception support.",
-    "description": "It is best framed as a metabolic-support botanical with more specific use-cases than broad wellness claims.",
-    "mechanism": "Triterpene-related constituents are associated with glucose and sweet-taste positioning.",
-    "mechanismTags": [
-      "glycemic support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "gymnemic acids"
-    ],
-    "topCompounds": [
-      "gymnemic acids"
-    ],
-    "markerCompounds": [
-      "gymnemic acids"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with glucose-lowering strategies."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "banaba-wb",
-    "name": "Banaba",
-    "scientificName": "Lagerstroemia speciosa",
-    "latin": "Lagerstroemia speciosa",
-    "category": "leaf",
-    "class": "leaf",
-    "plantPartUsed": "leaf",
-    "commonNames": [
-      "banaba"
-    ],
-    "region": "Southeast Asia",
-    "summary": "Banaba is positioned for metabolic and glycemic support.",
-    "description": "It is best framed conservatively because evidence quality and standardization vary across products.",
-    "mechanism": "Triterpene constituents are associated with glycemic-support positioning.",
-    "mechanismTags": [
-      "glycemic support",
-      "metabolic support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "corosolic acid"
-    ],
-    "topCompounds": [
-      "corosolic acid"
-    ],
-    "markerCompounds": [
-      "corosolic acid"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with glucose-lowering strategies."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "mulberry-leaf-wb",
-    "name": "Mulberry Leaf",
-    "scientificName": "Morus alba",
-    "latin": "Morus alba",
-    "category": "leaf",
-    "class": "leaf",
-    "plantPartUsed": "leaf",
-    "commonNames": [
-      "mulberry leaf"
-    ],
-    "region": "China and cultivated broadly",
-    "summary": "Mulberry leaf is positioned for metabolic support, especially carbohydrate-handling contexts.",
-    "description": "It is best framed around alpha-glucosidase-adjacent positioning rather than generalized wellness language.",
-    "mechanism": "Iminosugars are associated with carbohydrate-handling support.",
-    "mechanismTags": [
-      "glycemic support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "1-deoxynojirimycin",
-      "flavonoids"
-    ],
-    "topCompounds": [
-      "1-deoxynojirimycin"
-    ],
-    "markerCompounds": [
-      "1-deoxynojirimycin"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with glucose-lowering strategies."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "neem",
-    "name": "Neem",
-    "scientificName": "Azadirachta indica",
-    "latin": "Azadirachta indica",
-    "category": "leaf/seed",
-    "class": "leaf/seed",
-    "plantPartUsed": "leaf; seed",
-    "commonNames": [
-      "neem"
-    ],
-    "region": "India and South Asia",
-    "summary": "Neem is positioned for traditional skin, oral, and antimicrobial support.",
-    "description": "It should be framed carefully because topical, oral, and seed-oil contexts differ substantially in safety relevance.",
-    "mechanism": "Limonoids are associated with antimicrobial and traditional skin-support positioning.",
-    "mechanismTags": [
-      "antimicrobial support",
-      "traditional skin support"
-    ],
-    "evidenceLevel": "Preclinical",
-    "activeCompounds": [
-      "nimbin",
-      "azadirachtin"
-    ],
-    "topCompounds": [
-      "nimbin"
-    ],
-    "markerCompounds": [
-      "nimbin"
-    ],
-    "safetyNotes": "Use caution with concentrated internal use.",
-    "interactions": [
-      "Avoid overextending seed-oil safety assumptions to all forms."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "mugwort-wb",
-    "name": "Mugwort",
-    "scientificName": "Artemisia vulgaris",
-    "latin": "Artemisia vulgaris",
-    "category": "aerial parts",
-    "class": "aerial parts",
-    "plantPartUsed": "leaf; aerial parts",
-    "commonNames": [
-      "mugwort"
-    ],
-    "region": "Europe, Asia, North America",
-    "summary": "Mugwort is positioned for traditional digestive and cycle-related support.",
-    "description": "It is best framed conservatively because strong folklore and ritual associations often outrun clinical evidence.",
-    "mechanism": "Aromatic constituents drive much of the traditional positioning.",
-    "mechanismTags": [
-      "digestive support",
-      "traditional cycle support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "volatile oils",
-      "flavonoids"
-    ],
-    "topCompounds": [
-      "thujone"
-    ],
-    "markerCompounds": [
-      "thujone"
-    ],
-    "safetyNotes": "Use caution with concentrated preparations.",
-    "interactions": [
-      "Avoid during pregnancy."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "lemon-verbena",
-    "name": "Lemon Verbena",
-    "scientificName": "Aloysia citrodora",
-    "latin": "Aloysia citrodora",
-    "category": "leaf",
-    "class": "leaf",
-    "plantPartUsed": "leaf",
-    "commonNames": [
-      "lemon verbena"
-    ],
-    "region": "South America; cultivated broadly",
-    "summary": "Lemon verbena is positioned for calming and digestive support.",
-    "description": "It is best framed as a gentle aromatic botanical with modest evidence and pleasant tolerability.",
-    "mechanism": "Phenylpropanoid glycosides and aromatics are associated with calming and digestive positioning.",
-    "mechanismTags": [
-      "calming support",
-      "digestive support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "verbascoside",
-      "volatile oils"
-    ],
-    "topCompounds": [
-      "verbascoside"
-    ],
-    "markerCompounds": [
-      "verbascoside"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with concentrated essential-oil contexts."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "milk-oats",
-    "name": "Milk Oats",
-    "scientificName": "Avena sativa",
-    "latin": "Avena sativa",
-    "category": "seed stage",
-    "class": "seed stage",
-    "plantPartUsed": "milky seed tops",
-    "commonNames": [
-      "milky oats",
-      "milk oats"
-    ],
-    "region": "Europe and cultivated globally",
-    "summary": "Milky oats are positioned for nutritive nervous-system support.",
-    "description": "They are best framed as a gentle traditional tonic rather than a strong acute intervention.",
-    "mechanism": "Traditional positioning centers on gentle nutritive support rather than a single strong mechanism.",
-    "mechanismTags": [
-      "calming support",
-      "nutritive support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "avenacosides",
-      "avenanthramides"
-    ],
-    "topCompounds": [
-      "avenacosides"
-    ],
-    "markerCompounds": [
-      "avenacosides"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with sourcing and gluten cross-contact concerns."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "cissus-wb",
-    "name": "Cissus",
-    "scientificName": "Cissus quadrangularis",
-    "latin": "Cissus quadrangularis",
-    "category": "stem",
-    "class": "stem",
-    "plantPartUsed": "stem",
-    "commonNames": [
-      "cissus"
-    ],
-    "region": "Africa and South Asia",
-    "summary": "Cissus is positioned for connective-tissue and recovery support.",
-    "description": "It is best framed conservatively because evidence is mixed and product positioning often outruns the data.",
-    "mechanism": "Constituents are associated with connective-tissue and recovery-adjacent positioning.",
-    "mechanismTags": [
-      "connective tissue support",
-      "recovery support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "ketosteroids",
-      "flavonoids"
-    ],
-    "topCompounds": [
-      "quadrangularin A"
-    ],
-    "markerCompounds": [
-      "quadrangularin A"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with aggressive performance claims."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "compound_count": "1",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "ashitaba-wb",
-    "name": "Ashitaba",
-    "scientificName": "Angelica keiskei",
-    "latin": "Angelica keiskei",
-    "category": "leaf/stem",
-    "class": "leaf/stem",
-    "plantPartUsed": "leaf; stem",
-    "commonNames": [
-      "ashitaba"
-    ],
-    "region": "Japan",
-    "summary": "Ashitaba is positioned for metabolic and antioxidant support.",
-    "description": "It is best framed around chalcone-rich chemistry with modest translational evidence.",
-    "mechanism": "Chalcones are associated with antioxidant and metabolic-support positioning.",
-    "mechanismTags": [
-      "antioxidant",
-      "metabolic support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "xanthoangelol",
-      "4-hydroxyderricin"
-    ],
-    "topCompounds": [
-      "4-hydroxyderricin"
-    ],
-    "markerCompounds": [
-      "4-hydroxyderricin"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with concentrated extract marketing claims."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "pomegranate",
-    "name": "Pomegranate",
-    "scientificName": "Punica granatum",
-    "latin": "Punica granatum",
-    "category": "fruit rind/juice",
-    "class": "fruit rind/juice",
-    "plantPartUsed": "fruit; rind",
-    "commonNames": [
-      "pomegranate"
-    ],
-    "region": "Mediterranean to West Asia; cultivated globally",
-    "summary": "Pomegranate is positioned for vascular and antioxidant support.",
-    "description": "It is best framed as a polyphenol-rich fruit botanical with food-form relevance and moderate evidence.",
-    "mechanism": "Ellagitannins are associated with antioxidant and vascular-support positioning.",
-    "mechanismTags": [
-      "antioxidant",
-      "vascular support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "punicalagins",
-      "ellagic acid"
-    ],
-    "topCompounds": [
-      "punicalagins"
-    ],
-    "markerCompounds": [
-      "punicalagins"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with overgeneralized disease claims."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "moringa",
-    "name": "Moringa",
-    "scientificName": "Moringa oleifera",
-    "latin": "Moringa oleifera",
-    "category": "leaf/tree",
-    "class": "leaf/tree",
-    "plantPartUsed": "leaf; seed",
-    "commonNames": [
-      "moringa"
-    ],
-    "region": "India, Africa, tropical regions",
-    "summary": "Moringa is positioned for nutritive, antioxidant, and metabolic support.",
-    "description": "It is best framed as a nutrient-dense botanical with mixed translational evidence rather than as a universal superfood cure-all.",
-    "mechanism": "Glucosinolates and isothiocyanates support antioxidant and metabolic positioning.",
-    "mechanismTags": [
-      "antioxidant",
-      "metabolic support",
-      "nutritive support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "moringin",
-      "isothiocyanates"
-    ],
-    "topCompounds": [
-      "moringin"
-    ],
-    "markerCompounds": [
-      "moringin"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with concentrated extracts and glucose-lowering strategies."
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "frontendReadyFlag": "No",
-    "completenessPct": "0.55",
-    "priorityTier": "Medium",
-    "totalScore": "5",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1",
+    "pathway_count": "0",
     "sources": [
-      "Pass 125 curated expansion"
+      "NIH ODS",
+      "EMA"
     ]
   },
   {
-    "slug": "arjuna-wb",
-    "name": "Arjuna",
-    "scientificName": "Terminalia arjuna",
-    "latin": "Terminalia arjuna",
-    "category": "bark",
-    "class": "bark",
-    "plantPartUsed": "bark",
-    "commonNames": [
-      "arjuna"
-    ],
-    "region": "India and South Asia",
-    "summary": "Arjuna is positioned for cardiovascular and vascular support.",
-    "description": "It is best framed around bark polyphenols and triterpenes with specific cardiotonic-support positioning.",
-    "mechanism": "Triterpenes and polyphenols support cardiovascular and antioxidant positioning.",
-    "mechanismTags": [
-      "cardiovascular support",
-      "vascular support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "arjunolic acid",
-      "triterpenes"
-    ],
-    "topCompounds": [
-      "arjunolic acid"
-    ],
-    "markerCompounds": [
-      "arjunolic acid"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with blood-pressure-lowering strategies."
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "frontendReadyFlag": "No",
-    "completenessPct": "0.55",
-    "priorityTier": "Medium",
-    "totalScore": "5",
-    "pathwayTargets": [
-      "cardiovascular signaling",
-      "unclassified"
-    ],
-    "compound_count": "2",
-    "pathway_count": "2",
-    "sources": [
-      "Pass 125 curated expansion"
-    ]
-  },
-  {
-    "slug": "noni",
-    "name": "Noni",
-    "scientificName": "Morinda citrifolia",
-    "latin": "Morinda citrifolia",
-    "category": "fruit",
-    "class": "fruit",
-    "plantPartUsed": "fruit",
-    "commonNames": [
-      "noni"
-    ],
-    "region": "Pacific Islands; tropical regions",
-    "summary": "Noni is positioned for antioxidant and traditional wellness support.",
-    "description": "It should be framed conservatively because broad folk claims exceed the strength of modern evidence.",
-    "mechanism": "Anthraquinone-adjacent and iridoid chemistry support antioxidant and traditional-support positioning.",
-    "mechanismTags": [
-      "antioxidant",
-      "traditional wellness support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "damnacanthal",
-      "iridoids"
-    ],
-    "topCompounds": [
-      "damnacanthal"
-    ],
-    "markerCompounds": [
-      "damnacanthal"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with overgeneralized disease claims."
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "frontendReadyFlag": "No",
-    "completenessPct": "0.55",
-    "priorityTier": "Medium",
-    "totalScore": "5",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1",
-    "sources": [
-      "Pass 125 curated expansion"
-    ]
-  },
-  {
-    "slug": "cranberry-wb",
-    "name": "Cranberry",
-    "scientificName": "Vaccinium macrocarpon",
-    "latin": "Vaccinium macrocarpon",
+    "slug": "schisandra",
+    "name": "Schisandra",
+    "scientificName": "Schisandra chinensis",
+    "latin": "Schisandra chinensis",
     "category": "berry",
     "class": "berry",
-    "plantPartUsed": "fruit",
-    "commonNames": [
-      "cranberry"
-    ],
-    "region": "North America",
-    "summary": "Cranberry is positioned for urinary and antioxidant support.",
-    "description": "It is best framed around proanthocyanidin-rich urinary-support positioning rather than broad antimicrobial claims.",
-    "mechanism": "Polyphenols support urinary and antioxidant positioning.",
-    "mechanismTags": [
-      "antioxidant",
-      "urinary support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "A-type proanthocyanidins"
-    ],
-    "topCompounds": [
-      "A-type proanthocyanidins"
-    ],
-    "markerCompounds": [
-      "A-type proanthocyanidins"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with anticoagulant-sensitive contexts."
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "frontendReadyFlag": "No",
-    "completenessPct": "0.55",
-    "priorityTier": "Medium",
-    "totalScore": "5",
-    "compound_count": "1",
-    "pathway_count": "0",
-    "sources": [
-      "Pass 125 curated expansion"
-    ]
-  },
-  {
-    "slug": "rose-hips",
-    "name": "Rose Hips",
-    "scientificName": "Rosa canina",
-    "latin": "Rosa canina",
-    "category": "fruit",
-    "class": "fruit",
-    "plantPartUsed": "fruit",
-    "commonNames": [
-      "rose hips"
-    ],
-    "region": "Europe and temperate regions",
-    "summary": "Rose hips are positioned for antioxidant, nutritive, and joint-support use.",
-    "description": "They are best framed as polyphenol- and vitamin-rich fruit material with modest but relevant human evidence.",
-    "mechanism": "Polyphenols and ascorbate-rich fruit chemistry support antioxidant positioning.",
-    "mechanismTags": [
-      "antioxidant",
-      "nutritive support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "trans-tiliroside",
-      "vitamin C"
-    ],
-    "topCompounds": [
-      "trans-tiliroside"
-    ],
-    "markerCompounds": [
-      "trans-tiliroside"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with overly concentrated extract claims."
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "frontendReadyFlag": "No",
-    "completenessPct": "0.55",
-    "priorityTier": "Medium",
-    "totalScore": "5",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1",
-    "sources": [
-      "Pass 125 curated expansion"
-    ]
-  },
-  {
-    "slug": "juniper",
-    "name": "Juniper",
-    "scientificName": "Juniperus communis",
-    "latin": "Juniperus communis",
-    "category": "berry/cone",
-    "class": "berry/cone",
     "plantPartUsed": "berry",
     "commonNames": [
-      "juniper berry"
+      "schisandra"
     ],
-    "region": "Europe, Asia, North America",
-    "summary": "Juniper is positioned for aromatic digestive and urinary support.",
-    "description": "It should be framed as an aromatic berry botanical with traditional GI and urinary relevance.",
-    "mechanism": "Volatile terpenes support digestive and aromatic positioning.",
+    "region": "Asia",
+    "summary": "Adaptogen.",
+    "description": "Liver + stress.",
+    "mechanism": "Nrf2",
     "mechanismTags": [
-      "aromatic support",
-      "digestive support",
-      "urinary support"
+      "nrf2"
     ],
     "evidenceLevel": "Human",
     "activeCompounds": [
-      "alpha-pinene",
-      "terpenes"
+      "gomisins"
     ],
     "topCompounds": [
-      "alpha-pinene"
+      "gomisins"
     ],
     "markerCompounds": [
-      "alpha-pinene"
+      "gomisins"
     ],
-    "safetyNotes": "Use cautiously in concentrated forms.",
+    "safetyNotes": "Safe.",
     "interactions": [
-      "Avoid long-duration casual use."
+      "Generally safe"
     ],
     "publishStatus": "Source review",
     "readinessFlag": "Needs work",
-    "frontendReadyFlag": "No",
-    "completenessPct": "0.55",
-    "priorityTier": "Medium",
-    "totalScore": "5",
-    "pathwayTargets": [
-      "adrenergic signaling"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1",
-    "sources": [
-      "Pass 125 curated expansion"
-    ]
+    "completenessPct": "0.9",
+    "priorityTier": "High",
+    "totalScore": "3",
+    "compound_count": "0",
+    "pathway_count": "0"
   },
   {
-    "slug": "myrtle-wb",
-    "name": "Myrtle",
-    "scientificName": "Myrtus communis",
-    "latin": "Myrtus communis",
-    "category": "leaf",
-    "class": "leaf",
-    "plantPartUsed": "leaf",
-    "commonNames": [
-      "myrtle"
-    ],
-    "region": "Mediterranean",
-    "summary": "Myrtle is positioned for aromatic and antioxidant support.",
-    "description": "It is best framed as an aromatic Mediterranean leaf botanical with modest modern evidence.",
-    "mechanism": "Volatile constituents and polyphenols support aromatic and antioxidant positioning.",
-    "mechanismTags": [
-      "antioxidant",
-      "aromatic support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "myrtenyl acetate",
-      "myricetin"
-    ],
-    "topCompounds": [
-      "myrtenyl acetate"
-    ],
-    "markerCompounds": [
-      "myrtenyl acetate"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with concentrated oil assumptions."
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "frontendReadyFlag": "No",
-    "completenessPct": "0.55",
-    "priorityTier": "Medium",
-    "totalScore": "5",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1",
-    "sources": [
-      "Pass 125 curated expansion"
-    ]
-  },
-  {
-    "slug": "acerola-wb",
-    "name": "Acerola",
-    "scientificName": "Malpighia emarginata",
-    "latin": "Malpighia emarginata",
+    "slug": "schisandra-berry",
+    "name": "Schisandra Berry",
+    "scientificName": "Schisandra chinensis",
+    "latin": "Schisandra chinensis",
     "category": "fruit",
     "class": "fruit",
     "plantPartUsed": "fruit",
     "commonNames": [
-      "acerola cherry"
+      "schisandra berry"
     ],
-    "region": "Caribbean; tropical Americas",
-    "summary": "Acerola is positioned for antioxidant and nutritive support.",
-    "description": "It is best framed as a vitamin-C-rich fruit botanical with food/supplement relevance.",
-    "mechanism": "Fruit polyphenols and vitamin content support antioxidant and nutritive positioning.",
+    "region": "China, Korea, Russia",
+    "summary": "Schisandra berry is positioned for adaptogenic and hepatoprotective support.",
+    "description": "It is best framed specifically around berry lignans and traditional stress-support positioning.",
+    "mechanism": "Lignans support adaptogenic and hepatoprotective positioning.",
     "mechanismTags": [
-      "antioxidant",
-      "nutritive support"
-    ],
-    "evidenceLevel": "Unknown",
-    "activeCompounds": [
-      "ascorbic acid",
-      "carotenoids"
-    ],
-    "topCompounds": [
-      "ascorbic acid"
-    ],
-    "markerCompounds": [
-      "ascorbic acid"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with overextended immune claims."
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "frontendReadyFlag": "No",
-    "completenessPct": "0.55",
-    "priorityTier": "Medium",
-    "totalScore": "5",
-    "compound_count": "1",
-    "pathway_count": "0",
-    "sources": [
-      "Pass 125 curated expansion"
-    ]
-  },
-  {
-    "slug": "mangosteen-wb",
-    "name": "Mangosteen",
-    "scientificName": "Garcinia mangostana",
-    "latin": "Garcinia mangostana",
-    "category": "pericarp/fruit",
-    "class": "pericarp/fruit",
-    "plantPartUsed": "pericarp",
-    "commonNames": [
-      "mangosteen"
-    ],
-    "region": "Southeast Asia",
-    "summary": "Mangosteen is positioned for antioxidant and traditional wellness support.",
-    "description": "It should be framed conservatively because broad anti-inflammatory and disease claims outrun the evidence.",
-    "mechanism": "Xanthones support antioxidant and traditional-support positioning.",
-    "mechanismTags": [
-      "antioxidant",
-      "traditional wellness support"
+      "adaptogenic support",
+      "hepatoprotective support"
     ],
     "evidenceLevel": "Human",
     "activeCompounds": [
-      "alpha-mangostin",
-      "xanthones"
+      "schisandrin",
+      "gomisin A"
     ],
     "topCompounds": [
-      "alpha-mangostin"
+      "gomisin A"
     ],
     "markerCompounds": [
-      "alpha-mangostin"
+      "gomisin A"
     ],
     "safetyNotes": "Generally well tolerated.",
     "interactions": [
-      "Use caution with exaggerated anti-inflammatory claims."
+      "Use caution with CYP-sensitive medication contexts."
     ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "frontendReadyFlag": "No",
-    "completenessPct": "0.55",
+    "publishStatus": "Ready for QA",
+    "readinessFlag": "Ready",
+    "completenessPct": "0.9",
     "priorityTier": "Medium",
-    "totalScore": "5",
-    "pathwayTargets": [
-      "adrenergic signaling"
-    ],
+    "totalScore": "8",
     "compound_count": "1",
-    "pathway_count": "1",
-    "sources": [
-      "Pass 125 curated expansion"
-    ]
+    "pathway_count": "0"
   },
   {
-    "slug": "boldo-wb",
-    "name": "Boldo",
-    "scientificName": "Peumus boldus",
-    "latin": "Peumus boldus",
-    "category": "leaf",
-    "class": "leaf",
-    "plantPartUsed": "leaf",
+    "slug": "shankhpushpi",
+    "name": "Shankhpushpi",
+    "scientificName": "Convolvulus pluricaulis",
+    "latin": "Convolvulus pluricaulis",
+    "category": "whole herb",
+    "class": "whole herb",
+    "plantPartUsed": "aerial parts",
     "commonNames": [
-      "boldo"
+      "shankhpushpi"
     ],
-    "region": "South America",
-    "summary": "Boldo is positioned for digestive and hepatobiliary support.",
-    "description": "It is best framed as an aromatic bitter leaf botanical with modest human evidence.",
-    "mechanism": "Alkaloids and aromatic constituents support digestive and hepatobiliary positioning.",
+    "region": "India and South Asia",
+    "summary": "Shankhpushpi is positioned for traditional cognitive and calming support.",
+    "description": "It is best framed as a traditional cognitive-support herb with limited modern clinical depth.",
+    "mechanism": "Traditional use centers on calming and cognitive-support positioning.",
     "mechanismTags": [
-      "digestive support",
-      "hepatobiliary support"
+      "calming support",
+      "traditional cognitive support"
     ],
     "evidenceLevel": "Human",
     "activeCompounds": [
-      "boldine"
+      "convolvine"
     ],
     "topCompounds": [
-      "boldine"
+      "convolvine"
     ],
     "markerCompounds": [
-      "boldine"
+      "convolvine"
     ],
-    "safetyNotes": "Use cautiously in concentrated forms.",
+    "safetyNotes": "Generally well tolerated.",
     "interactions": [
-      "Avoid with bile obstruction or excessive casual use."
+      "Avoid overstated nootropic claims."
     ],
     "publishStatus": "Source review",
     "readinessFlag": "Needs work",
@@ -3099,151 +5992,133 @@
     ]
   },
   {
-    "slug": "suma-wb",
-    "name": "Suma",
-    "scientificName": "Pfaffia paniculata",
-    "latin": "Pfaffia paniculata",
+    "slug": "shatavari",
+    "name": "Shatavari",
+    "scientificName": "Asparagus racemosus",
+    "latin": "Asparagus racemosus",
     "category": "root",
     "class": "root",
     "plantPartUsed": "root",
     "commonNames": [
-      "suma",
-      "Brazilian ginseng"
+      "shatavari"
     ],
-    "region": "South America",
-    "summary": "Suma is positioned for traditional adaptogenic and restorative support.",
-    "description": "It should be framed conservatively because traditional-use breadth exceeds evidence depth.",
-    "mechanism": "Saponins support traditional restorative and adaptogenic positioning.",
+    "region": "India and South Asia",
+    "summary": "Shatavari is positioned for soothing, women’s-health, and adaptogenic support.",
+    "description": "It is best framed around steroidal saponins with hormonal-context caution.",
+    "mechanism": "Demulcent and endocrine-modulating relevance is commonly proposed.",
     "mechanismTags": [
-      "adaptogenic support",
-      "traditional restorative support"
+      "soothing support",
+      "women's-health support"
     ],
     "evidenceLevel": "Human",
     "activeCompounds": [
-      "pfaffic acid",
+      "shatavarins",
       "saponins"
     ],
     "topCompounds": [
-      "pfaffic acid"
+      "shatavarin IV"
     ],
     "markerCompounds": [
-      "pfaffic acid"
+      "shatavarin IV"
     ],
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "Use caution in hormone-sensitive conditions.",
     "interactions": [
-      "Avoid overextended vitality claims."
+      "May interact with diuretics",
+      "hormone-modulating therapies",
+      "and glucose-lowering agents."
     ],
     "publishStatus": "Source review",
     "readinessFlag": "Needs work",
-    "frontendReadyFlag": "No",
-    "completenessPct": "0.55",
-    "priorityTier": "Medium",
-    "totalScore": "5",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1",
-    "sources": [
-      "Pass 125 curated expansion"
-    ]
+    "completenessPct": "0.9",
+    "priorityTier": "High",
+    "totalScore": "3",
+    "compound_count": "0",
+    "pathway_count": "0"
   },
   {
-    "slug": "maral-root-wb",
-    "name": "Maral Root",
-    "scientificName": "Rhaponticum carthamoides",
-    "latin": "Rhaponticum carthamoides",
+    "slug": "skullcap",
+    "name": "Skullcap",
+    "scientificName": "Scutellaria lateriflora",
+    "latin": "Scutellaria lateriflora",
+    "category": "aerial",
+    "class": "aerial",
+    "plantPartUsed": "aerial",
+    "commonNames": [
+      "skullcap"
+    ],
+    "region": "Global",
+    "summary": "Calming herb.",
+    "description": "GABAergic.",
+    "mechanism": "GABA modulation",
+    "mechanismTags": [
+      "gabaa"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "baicalin"
+    ],
+    "topCompounds": [
+      "baicalin"
+    ],
+    "markerCompounds": [
+      "baicalin"
+    ],
+    "safetyNotes": "Safe.",
+    "interactions": [
+      "Mild sedation"
+    ],
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "completenessPct": "0.9",
+    "priorityTier": "High",
+    "totalScore": "3",
+    "compound_count": "0",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "sophora-flavescens",
+    "name": "Sophora Flavescens",
+    "scientificName": "Sophora flavescens",
+    "latin": "Sophora flavescens",
     "category": "root",
     "class": "root",
     "plantPartUsed": "root",
     "commonNames": [
-      "maral root"
+      "ku shen"
     ],
-    "region": "Central Asia",
-    "summary": "Maral root is positioned for adaptogenic and performance-adjacent support.",
-    "description": "It is best framed carefully because ecdysteroid narratives often outpace evidence quality.",
-    "mechanism": "Ecdysteroids support adaptogenic and performance-adjacent positioning.",
+    "region": "China and East Asia",
+    "summary": "Sophora flavescens is positioned for traditional skin and GI support.",
+    "description": "It should be framed conservatively because alkaloid-rich roots can have stronger tolerability issues.",
+    "mechanism": "Alkaloids support traditional skin and GI-related positioning.",
     "mechanismTags": [
-      "adaptogenic support",
-      "recovery support"
+      "gi support",
+      "traditional skin support"
     ],
     "evidenceLevel": "Human",
     "activeCompounds": [
-      "ecdysterone"
+      "matrine",
+      "oxymatrine"
     ],
     "topCompounds": [
-      "ecdysterone"
+      "matrine"
     ],
     "markerCompounds": [
-      "ecdysterone"
+      "matrine"
     ],
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "Use cautiously.",
     "interactions": [
-      "Use caution with aggressive performance claims."
+      "Avoid overextended antimicrobial claims."
     ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "frontendReadyFlag": "No",
-    "completenessPct": "0.55",
+    "publishStatus": "Ready for QA",
+    "readinessFlag": "Ready",
+    "completenessPct": "0.9",
     "priorityTier": "Medium",
-    "totalScore": "5",
+    "totalScore": "8",
     "pathwayTargets": [
       "unclassified"
     ],
     "compound_count": "1",
-    "pathway_count": "1",
-    "sources": [
-      "Pass 125 curated expansion"
-    ]
-  },
-  {
-    "slug": "jatamansi",
-    "name": "Jatamansi",
-    "scientificName": "Nardostachys jatamansi",
-    "latin": "Nardostachys jatamansi",
-    "category": "rhizome",
-    "class": "rhizome",
-    "plantPartUsed": "rhizome",
-    "commonNames": [
-      "spikenard",
-      "jatamansi"
-    ],
-    "region": "Himalayan regions",
-    "summary": "Jatamansi is positioned for calming and traditional nervous-system support.",
-    "description": "It should be framed as a traditional aromatic rhizome with modest clinical depth.",
-    "mechanism": "Sesquiterpenes support calming and traditional nervous-system positioning.",
-    "mechanismTags": [
-      "calming support",
-      "traditional nervous-system support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "jatamansone"
-    ],
-    "topCompounds": [
-      "jatamansone"
-    ],
-    "markerCompounds": [
-      "jatamansone"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with sedative stacking."
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "frontendReadyFlag": "No",
-    "completenessPct": "0.55",
-    "priorityTier": "Medium",
-    "totalScore": "5",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1",
-    "sources": [
-      "Pass 125 curated expansion"
-    ]
+    "pathway_count": "1"
   },
   {
     "slug": "soursop",
@@ -3295,2021 +6170,127 @@
     ]
   },
   {
-    "slug": "ashoka-wb",
-    "name": "Ashoka",
-    "scientificName": "Saraca asoca",
-    "latin": "Saraca asoca",
-    "category": "bark",
-    "class": "bark",
-    "plantPartUsed": "bark",
+    "slug": "st-johns-wort",
+    "name": "St Johns Wort",
+    "scientificName": "Hypericum perforatum",
+    "latin": "Hypericum perforatum",
+    "category": "herb",
+    "class": "herb",
+    "plantPartUsed": "flowering tops",
     "commonNames": [
-      "ashoka"
+      "St. John's wort",
+      "Hypericum",
+      "goatweed"
     ],
-    "region": "India and South Asia",
-    "summary": "Ashoka is positioned for traditional cycle-related support.",
-    "description": "It should be framed conservatively because traditional gynecologic use is much stronger than modern evidence.",
-    "mechanism": "Polyphenols support traditional cycle-related positioning.",
+    "region": "Native to Europe and West Asia; naturalized in North America and other temperate regions.",
+    "summary": "St. John's wort (Hypericum perforatum) is a herb monograph focused on the flowering tops used in herbal preparations. It is associated with Native to Europe and West Asia; naturalized in North America and other temperate regions. Hyperforin and related compounds inhibit monoamine reuptake and affect TRPC6-linked neuroplasticity; additional monoamine oxidase and stress-pathway effects have been proposed. Can cause photosensitivity, GI upset, dizziness, insomnia, restlessness.",
+    "description": "St. John's wort is represented here as a monograph-style entry centered on the flowering tops. Key reported compounds include hyperforin; hypericin; pseudohypericin; quercetin; rutin; kaempferol. Typical preparation forms: Dried flowering tops or standardized extracts. Hyperforin and related compounds inhibit monoamine reuptake and affect TRPC6-linked neuroplasticity; additional monoamine oxidase and stress-pathway effects have been proposed. Interaction profile: Major interactions with antidepressants, oral contraceptives, cyclosporine, tacrolimus, HIV meds, anticancer drugs, warfarin, digoxin and others. Use caution or avoid in: Pregnancy, breastfeeding, bipolar disorder, concomitant prescription meds with CYP/P-gp liability.",
+    "mechanism": "Hyperforin and related compounds inhibit monoamine reuptake and affect TRPC6-linked neuroplasticity; additional monoamine oxidase and stress-pathway effects have been proposed.",
     "mechanismTags": [
-      "traditional cycle support"
+      "dopaminergic",
+      "serotonergic"
     ],
     "evidenceLevel": "Human",
     "activeCompounds": [
-      "catechins",
-      "flavonoids"
+      "hyperforin",
+      "hypericin",
+      "pseudohypericin",
+      "quercetin",
+      "rutin",
+      "kaempferol"
     ],
     "topCompounds": [
-      "catechins"
+      "hyperforin",
+      "hypericin"
     ],
     "markerCompounds": [
-      "catechins"
+      "hyperforin",
+      "hypericin"
     ],
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "Can cause photosensitivity, GI upset, dizziness, insomnia, restlessness.",
     "interactions": [
-      "Avoid overextended reproductive-health claims."
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "frontendReadyFlag": "No",
-    "completenessPct": "0.55",
-    "priorityTier": "Medium",
-    "totalScore": "5",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1",
-    "sources": [
-      "Pass 125 curated expansion"
-    ]
-  },
-  {
-    "slug": "shankhpushpi-wb",
-    "name": "Shankhpushpi",
-    "scientificName": "Convolvulus pluricaulis",
-    "latin": "Convolvulus pluricaulis",
-    "category": "whole herb",
-    "class": "whole herb",
-    "plantPartUsed": "aerial parts",
-    "commonNames": [
-      "shankhpushpi"
-    ],
-    "region": "India and South Asia",
-    "summary": "Shankhpushpi is positioned for traditional cognitive and calming support.",
-    "description": "It is best framed as a traditional cognitive-support herb with limited modern clinical depth.",
-    "mechanism": "Traditional use centers on calming and cognitive-support positioning.",
-    "mechanismTags": [
-      "calming support",
-      "traditional cognitive support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "convolvine"
-    ],
-    "topCompounds": [
-      "convolvine"
-    ],
-    "markerCompounds": [
-      "convolvine"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Avoid overstated nootropic claims."
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "frontendReadyFlag": "No",
-    "completenessPct": "0.55",
-    "priorityTier": "Medium",
-    "totalScore": "5",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1",
-    "sources": [
-      "Pass 125 curated expansion"
-    ]
-  },
-  {
-    "slug": "hops-wb",
-    "name": "Hops",
-    "scientificName": "Humulus lupulus",
-    "latin": "Humulus lupulus",
-    "category": "strobile",
-    "class": "strobile",
-    "plantPartUsed": "female cones",
-    "commonNames": [
-      "hops"
-    ],
-    "region": "Europe, Asia, North America",
-    "summary": "Hops is positioned for calming and sleep-support use.",
-    "description": "It is best framed around bitter-resin and prenylflavonoid chemistry with modest selected human evidence.",
-    "mechanism": "Bitter acids and prenylflavonoids support calming and anti-inflammatory positioning.",
-    "mechanismTags": [
-      "calming support",
-      "sleep support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "humulone",
-      "xanthohumol"
-    ],
-    "topCompounds": [
-      "humulone"
-    ],
-    "markerCompounds": [
-      "humulone"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with sedative stacking."
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "frontendReadyFlag": "No",
-    "completenessPct": "0.55",
-    "priorityTier": "Medium",
-    "totalScore": "5",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1",
-    "sources": [
-      "Pass 125 curated expansion"
-    ]
-  },
-  {
-    "slug": "lemongrass",
-    "name": "Lemongrass",
-    "scientificName": "Cymbopogon citratus",
-    "latin": "Cymbopogon citratus",
-    "category": "leaf",
-    "class": "leaf",
-    "plantPartUsed": "leaf",
-    "commonNames": [
-      "lemongrass"
-    ],
-    "region": "Tropical Asia; cultivated globally",
-    "summary": "Lemongrass is positioned for digestive, calming, and aromatic support.",
-    "description": "It is best framed as an aromatic culinary-medicinal grass with modest clinical depth.",
-    "mechanism": "Volatile constituents support digestive and calming aromatic positioning.",
-    "mechanismTags": [
-      "aromatic support",
-      "calming support",
-      "digestive support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "citral",
-      "citronellal"
-    ],
-    "topCompounds": [
-      "citral"
-    ],
-    "markerCompounds": [
-      "citral"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with concentrated oil assumptions."
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "frontendReadyFlag": "No",
-    "completenessPct": "0.55",
-    "priorityTier": "Medium",
-    "totalScore": "5",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1",
-    "sources": [
-      "Pass 125 curated expansion"
-    ]
-  },
-  {
-    "slug": "perilla",
-    "name": "Perilla",
-    "scientificName": "Perilla frutescens",
-    "latin": "Perilla frutescens",
-    "category": "leaf/seed",
-    "class": "leaf/seed",
-    "plantPartUsed": "leaf; seed",
-    "commonNames": [
-      "perilla",
-      "shiso"
-    ],
-    "region": "East Asia",
-    "summary": "Perilla is positioned for antioxidant, seasonal, and aromatic support.",
-    "description": "It is best framed as a culinary-medicinal herb with modest but relevant translational evidence.",
-    "mechanism": "Volatile and polyphenolic constituents support seasonal and aromatic positioning.",
-    "mechanismTags": [
-      "antioxidant",
-      "aromatic support",
-      "seasonal support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "perillaldehyde",
-      "rosmarinic acid"
-    ],
-    "topCompounds": [
-      "perillaldehyde"
-    ],
-    "markerCompounds": [
-      "perillaldehyde"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with concentrated oil assumptions."
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "frontendReadyFlag": "No",
-    "completenessPct": "0.55",
-    "priorityTier": "Medium",
-    "totalScore": "5",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1",
-    "sources": [
-      "Pass 125 curated expansion"
-    ]
-  },
-  {
-    "slug": "carob-wb",
-    "name": "Carob",
-    "scientificName": "Ceratonia siliqua",
-    "latin": "Ceratonia siliqua",
-    "category": "pod",
-    "class": "pod",
-    "plantPartUsed": "pod",
-    "commonNames": [
-      "carob"
-    ],
-    "region": "Mediterranean",
-    "summary": "Carob is positioned for digestive and metabolic support.",
-    "description": "It is best framed as a food-form legume pod with fiber and polyphenol relevance rather than strong pharmacologic action.",
-    "mechanism": "Inositol derivatives and polyphenols support metabolic and digestive positioning.",
-    "mechanismTags": [
-      "digestive support",
-      "metabolic support"
-    ],
-    "evidenceLevel": "Unknown",
-    "activeCompounds": [
-      "D-pinitol",
-      "polyphenols"
-    ],
-    "topCompounds": [
-      "D-pinitol"
-    ],
-    "markerCompounds": [
-      "D-pinitol"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with overextended glycemic claims."
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "frontendReadyFlag": "No",
-    "completenessPct": "0.55",
-    "priorityTier": "Medium",
-    "totalScore": "5",
-    "compound_count": "1",
-    "pathway_count": "0",
-    "sources": [
-      "Pass 125 curated expansion"
-    ]
-  },
-  {
-    "slug": "danshen",
-    "name": "Danshen",
-    "scientificName": "Salvia miltiorrhiza",
-    "latin": "Salvia miltiorrhiza",
-    "category": "root",
-    "class": "root",
-    "plantPartUsed": "root",
-    "commonNames": [
-      "danshen",
-      "red sage"
-    ],
-    "region": "China and East Asia",
-    "summary": "Danshen is positioned for cardiovascular and circulatory support.",
-    "description": "It is best framed around tanshinones and salvianolic acids with specific vascular-support positioning.",
-    "mechanism": "Diterpenes and phenolic acids support circulatory and antioxidant positioning.",
-    "mechanismTags": [
-      "cardiovascular support",
-      "vascular support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "tanshinone IIA",
-      "salvianolic acid B"
-    ],
-    "topCompounds": [
-      "tanshinone IIA"
-    ],
-    "markerCompounds": [
-      "tanshinone IIA"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with anticoagulant-sensitive contexts."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "compound_count": "1",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "eucommia-wb",
-    "name": "Eucommia",
-    "scientificName": "Eucommia ulmoides",
-    "latin": "Eucommia ulmoides",
-    "category": "bark/leaf",
-    "class": "bark/leaf",
-    "plantPartUsed": "bark; leaf",
-    "commonNames": [
-      "eucommia"
-    ],
-    "region": "China and East Asia",
-    "summary": "Eucommia is positioned for connective-tissue and cardiometabolic support.",
-    "description": "It is best framed conservatively because traditional tonic use is broader than modern evidence quality.",
-    "mechanism": "Iridoids and lignans support connective-tissue and metabolic positioning.",
-    "mechanismTags": [
-      "cardiometabolic support",
-      "connective tissue support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "geniposidic acid",
-      "lignans"
-    ],
-    "topCompounds": [
-      "geniposidic acid"
-    ],
-    "markerCompounds": [
-      "geniposidic acid"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Avoid overextended tonic claims."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "cistanche-wb",
-    "name": "Cistanche",
-    "scientificName": "Cistanche deserticola",
-    "latin": "Cistanche deserticola",
-    "category": "stem",
-    "class": "stem",
-    "plantPartUsed": "stem",
-    "commonNames": [
-      "cistanche"
-    ],
-    "region": "China and Central Asia",
-    "summary": "Cistanche is positioned for traditional restorative and fatigue-support use.",
-    "description": "It should be framed conservatively because traditional-system use is broader than modern clinical depth.",
-    "mechanism": "Phenylethanoid glycosides support restorative and antioxidant positioning.",
-    "mechanismTags": [
-      "fatigue support",
-      "traditional restorative support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "echinacoside",
-      "acteoside"
-    ],
-    "topCompounds": [
-      "echinacoside"
-    ],
-    "markerCompounds": [
-      "echinacoside"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with exaggerated vitality claims."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "jujube-wb",
-    "name": "Jujube",
-    "scientificName": "Ziziphus jujuba",
-    "latin": "Ziziphus jujuba",
-    "category": "fruit/seed",
-    "class": "fruit/seed",
-    "plantPartUsed": "fruit; seed",
-    "commonNames": [
-      "jujube",
-      "red date"
-    ],
-    "region": "China and cultivated broadly",
-    "summary": "Jujube is positioned for calming, nutritive, and traditional sleep-support use.",
-    "description": "It is best framed as a food-like fruit/seed botanical with gentle traditional positioning.",
-    "mechanism": "Saponins and flavonoids support calming and traditional sleep positioning.",
-    "mechanismTags": [
-      "calming support",
-      "nutritive support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "jujubosides",
-      "flavonoids"
-    ],
-    "topCompounds": [
-      "jujuboside A"
-    ],
-    "markerCompounds": [
-      "jujuboside A"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with sedative stacking."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "compound_count": "1",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "longan-wb",
-    "name": "Longan",
-    "scientificName": "Dimocarpus longan",
-    "latin": "Dimocarpus longan",
-    "category": "fruit/seed",
-    "class": "fruit/seed",
-    "plantPartUsed": "fruit; seed",
-    "commonNames": [
-      "longan"
-    ],
-    "region": "Southeast Asia",
-    "summary": "Longan is positioned for nutritive and traditional calming support.",
-    "description": "It should be framed as a food-like fruit botanical with modest modern evidence.",
-    "mechanism": "Polyphenols support antioxidant and nutritive positioning.",
-    "mechanismTags": [
-      "calming support",
-      "nutritive support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "polyphenols",
-      "gallic acid"
-    ],
-    "topCompounds": [
-      "gallic acid"
-    ],
-    "markerCompounds": [
-      "gallic acid"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Avoid overextended nootropic claims."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "polygala",
-    "name": "Polygala",
-    "scientificName": "Polygala tenuifolia",
-    "latin": "Polygala tenuifolia",
-    "category": "root",
-    "class": "root",
-    "plantPartUsed": "root",
-    "commonNames": [
-      "yuan zhi",
-      "polygala"
-    ],
-    "region": "China and East Asia",
-    "summary": "Polygala is positioned for traditional cognitive and calming support.",
-    "description": "It is best framed as a traditional nootropic-style root with limited modern clinical depth.",
-    "mechanism": "Saponins support traditional cognitive and calming positioning.",
-    "mechanismTags": [
-      "calming support",
-      "traditional cognitive support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "tenuifolin",
-      "polygalasaponins"
-    ],
-    "topCompounds": [
-      "tenuifolin"
-    ],
-    "markerCompounds": [
-      "tenuifolin"
-    ],
-    "safetyNotes": "Use cautiously.",
-    "interactions": [
-      "Use caution with sedative stacking."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "gastrodia",
-    "name": "Gastrodia",
-    "scientificName": "Gastrodia elata",
-    "latin": "Gastrodia elata",
-    "category": "rhizome",
-    "class": "rhizome",
-    "plantPartUsed": "rhizome",
-    "commonNames": [
-      "gastrodia",
-      "tian ma"
-    ],
-    "region": "China and East Asia",
-    "summary": "Gastrodia is positioned for traditional neurological and calming support.",
-    "description": "It should be framed conservatively because traditional neurologic use is broader than modern evidence.",
-    "mechanism": "Phenolic glycosides support traditional neurological and calming positioning.",
-    "mechanismTags": [
-      "calming support",
-      "traditional nervous-system support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "gastrodin"
-    ],
-    "topCompounds": [
-      "gastrodin"
-    ],
-    "markerCompounds": [
-      "gastrodin"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Avoid overstated neuroprotective claims."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "white-peony-wb",
-    "name": "White Peony",
-    "scientificName": "Paeonia lactiflora",
-    "latin": "Paeonia lactiflora",
-    "category": "root",
-    "class": "root",
-    "plantPartUsed": "root",
-    "commonNames": [
-      "white peony"
-    ],
-    "region": "China and East Asia",
-    "summary": "White peony is positioned for traditional cycle-related and calming support.",
-    "description": "It is best framed as a paeoniflorin-rich root with traditional-system relevance.",
-    "mechanism": "Monoterpene glycosides support traditional cycle and calming positioning.",
-    "mechanismTags": [
-      "calming support",
-      "traditional cycle support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "paeoniflorin"
-    ],
-    "topCompounds": [
-      "paeoniflorin"
-    ],
-    "markerCompounds": [
-      "paeoniflorin"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with anticoagulant-sensitive contexts."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "bupleurum",
-    "name": "Bupleurum",
-    "scientificName": "Bupleurum chinense",
-    "latin": "Bupleurum chinense",
-    "category": "root",
-    "class": "root",
-    "plantPartUsed": "root",
-    "commonNames": [
-      "bupleurum"
-    ],
-    "region": "China and East Asia",
-    "summary": "Bupleurum is positioned for traditional liver and stress-support use.",
-    "description": "It should be framed conservatively because traditional-system context matters more than casual wellness claims.",
-    "mechanism": "Saponins support traditional hepatobiliary and stress-related positioning.",
-    "mechanismTags": [
-      "traditional liver support",
-      "traditional stress support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "saikosaponins"
-    ],
-    "topCompounds": [
-      "saikosaponin A"
-    ],
-    "markerCompounds": [
-      "saikosaponin A"
-    ],
-    "safetyNotes": "Use cautiously.",
-    "interactions": [
-      "Avoid overgeneralized mood claims."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "compound_count": "1",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "codonopsis-wb",
-    "name": "Codonopsis",
-    "scientificName": "Codonopsis pilosula",
-    "latin": "Codonopsis pilosula",
-    "category": "root",
-    "class": "root",
-    "plantPartUsed": "root",
-    "commonNames": [
-      "codonopsis",
-      "dang shen"
-    ],
-    "region": "China and East Asia",
-    "summary": "Codonopsis is positioned for traditional restorative and fatigue-support use.",
-    "description": "It is best framed as a gentler tonic-style root with modest modern evidence.",
-    "mechanism": "Polysaccharides and glycosides support restorative and fatigue-support positioning.",
-    "mechanismTags": [
-      "fatigue support",
-      "traditional restorative support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "tangshenosides",
-      "polysaccharides"
-    ],
-    "topCompounds": [
-      "tangshenoside I"
-    ],
-    "markerCompounds": [
-      "tangshenoside I"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Avoid exaggerated adaptogen claims."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "compound_count": "1",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "dendrobium",
-    "name": "Dendrobium",
-    "scientificName": "Dendrobium officinale",
-    "latin": "Dendrobium officinale",
-    "category": "stem",
-    "class": "stem",
-    "plantPartUsed": "stem",
-    "commonNames": [
-      "dendrobium"
-    ],
-    "region": "China and East Asia",
-    "summary": "Dendrobium is positioned for traditional restorative and mucosal support.",
-    "description": "It should be framed conservatively because luxury-tonic narratives often exceed evidence depth.",
-    "mechanism": "Polysaccharides support restorative and mucosal positioning.",
-    "mechanismTags": [
-      "mucosal support",
-      "traditional restorative support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "polysaccharides",
-      "alkaloids"
-    ],
-    "topCompounds": [
-      "dendrobine"
-    ],
-    "markerCompounds": [
-      "dendrobine"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Avoid exaggerated anti-aging claims."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "ophiopogon-wb",
-    "name": "Ophiopogon",
-    "scientificName": "Ophiopogon japonicus",
-    "latin": "Ophiopogon japonicus",
-    "category": "root tuber",
-    "class": "root tuber",
-    "plantPartUsed": "tuber",
-    "commonNames": [
-      "ophiopogon",
-      "mai men dong"
-    ],
-    "region": "China and East Asia",
-    "summary": "Ophiopogon is positioned for traditional demulcent and respiratory support.",
-    "description": "It is best framed as a moistening tonic-style root with traditional-system relevance.",
-    "mechanism": "Saponins support demulcent and traditional respiratory positioning.",
-    "mechanismTags": [
-      "demulcent support",
-      "traditional respiratory support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "ophiopogonins"
-    ],
-    "topCompounds": [
-      "ophiopogonin D"
-    ],
-    "markerCompounds": [
-      "ophiopogonin D"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Avoid overextended pulmonary claims."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "compound_count": "1",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "houttuynia-wb",
-    "name": "Houttuynia",
-    "scientificName": "Houttuynia cordata",
-    "latin": "Houttuynia cordata",
-    "category": "aerial parts",
-    "class": "aerial parts",
-    "plantPartUsed": "leaf; aerial parts",
-    "commonNames": [
-      "houttuynia"
-    ],
-    "region": "East and Southeast Asia",
-    "summary": "Houttuynia is positioned for traditional immune and respiratory support.",
-    "description": "It should be framed cautiously because strong folklore claims exceed the evidence.",
-    "mechanism": "Flavonoids and volatiles support traditional immune and respiratory positioning.",
-    "mechanismTags": [
-      "traditional immune support",
-      "traditional respiratory support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "quercitrin",
-      "volatile oils"
-    ],
-    "topCompounds": [
-      "quercitrin"
-    ],
-    "markerCompounds": [
-      "quercitrin"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Avoid exaggerated antiviral claims."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "isatis-wb",
-    "name": "Isatis",
-    "scientificName": "Isatis tinctoria",
-    "latin": "Isatis tinctoria",
-    "category": "root/leaf",
-    "class": "root/leaf",
-    "plantPartUsed": "root; leaf",
-    "commonNames": [
-      "isatis",
-      "ban lan gen"
-    ],
-    "region": "China and Eurasia",
-    "summary": "Isatis is positioned for traditional immune and throat-support use.",
-    "description": "It is best framed as a traditional-use herb with limited modern clinical depth.",
-    "mechanism": "Indole derivatives support traditional immune-related positioning.",
-    "mechanismTags": [
-      "throat support",
-      "traditional immune support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "indirubin",
-      "tryptanthrin"
-    ],
-    "topCompounds": [
-      "tryptanthrin"
-    ],
-    "markerCompounds": [
-      "tryptanthrin"
-    ],
-    "safetyNotes": "Use cautiously.",
-    "interactions": [
-      "Avoid exaggerated infection-treatment claims."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "sophora-flavescens-wb",
-    "name": "Sophora Flavescens",
-    "scientificName": "Sophora flavescens",
-    "latin": "Sophora flavescens",
-    "category": "root",
-    "class": "root",
-    "plantPartUsed": "root",
-    "commonNames": [
-      "ku shen"
-    ],
-    "region": "China and East Asia",
-    "summary": "Sophora flavescens is positioned for traditional skin and GI support.",
-    "description": "It should be framed conservatively because alkaloid-rich roots can have stronger tolerability issues.",
-    "mechanism": "Alkaloids support traditional skin and GI-related positioning.",
-    "mechanismTags": [
-      "gi support",
-      "traditional skin support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "matrine",
-      "oxymatrine"
-    ],
-    "topCompounds": [
-      "matrine"
-    ],
-    "markerCompounds": [
-      "matrine"
-    ],
-    "safetyNotes": "Use cautiously.",
-    "interactions": [
-      "Avoid overextended antimicrobial claims."
-    ],
-    "publishStatus": "Ready for QA",
-    "readinessFlag": "Ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "8",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "notoginseng-wb",
-    "name": "Notoginseng",
-    "scientificName": "Panax notoginseng",
-    "latin": "Panax notoginseng",
-    "category": "root",
-    "class": "root",
-    "plantPartUsed": "root",
-    "commonNames": [
-      "notoginseng",
-      "san qi"
-    ],
-    "region": "China",
-    "summary": "Notoginseng is positioned for circulatory and recovery support.",
-    "description": "It is best framed as a saponin-rich Panax relative with specific vascular-support positioning.",
-    "mechanism": "Saponins support vascular and recovery-related positioning.",
-    "mechanismTags": [
-      "recovery support",
-      "vascular support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "notoginsenoside R1",
-      "ginsenosides"
-    ],
-    "topCompounds": [
-      "notoginsenoside R1"
-    ],
-    "markerCompounds": [
-      "notoginsenoside R1"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with anticoagulant-sensitive contexts."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "compound_count": "1",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "luo-han-guo-wb",
-    "name": "Luo Han Guo",
-    "scientificName": "Siraitia grosvenorii",
-    "latin": "Siraitia grosvenorii",
-    "category": "fruit",
-    "class": "fruit",
-    "plantPartUsed": "fruit",
-    "commonNames": [
-      "monk fruit",
-      "luo han guo"
-    ],
-    "region": "China",
-    "summary": "Luo Han Guo is positioned for throat and sweetener-adjacent support.",
-    "description": "It is best framed as a fruit botanical with sweet mogrosides and soothing traditional use.",
-    "mechanism": "Triterpene glycosides support sweetener and throat-soothing positioning.",
-    "mechanismTags": [
-      "sweetener-adjacent support",
-      "throat support"
-    ],
-    "evidenceLevel": "Unknown",
-    "activeCompounds": [
-      "mogrosides"
-    ],
-    "topCompounds": [
-      "mogroside V"
-    ],
-    "markerCompounds": [
-      "mogroside V"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Avoid overextended glycemic claims."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "compound_count": "1",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "kuding-tea-wb",
-    "name": "Kuding Tea",
-    "scientificName": "Ilex kudingcha",
-    "latin": "Ilex kudingcha",
-    "category": "leaf",
-    "class": "leaf",
-    "plantPartUsed": "leaf",
-    "commonNames": [
-      "kuding tea"
-    ],
-    "region": "China",
-    "summary": "Kuding tea is positioned for bitter antioxidant and cardiometabolic support.",
-    "description": "It should be framed as a bitter tea botanical with food-form relevance and modest modern evidence.",
-    "mechanism": "Bitters and polyphenols support antioxidant and metabolic positioning.",
-    "mechanismTags": [
-      "antioxidant",
-      "cardiometabolic support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "triterpenoid saponins",
-      "polyphenols"
-    ],
-    "topCompounds": [
-      "kudinlactone"
-    ],
-    "markerCompounds": [
-      "kudinlactone"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with strong bitterness and GI sensitivity."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "atractylodes",
-    "name": "Atractylodes",
-    "scientificName": "Atractylodes macrocephala",
-    "latin": "Atractylodes macrocephala",
-    "category": "rhizome",
-    "class": "rhizome",
-    "plantPartUsed": "rhizome",
-    "commonNames": [
-      "bai zhu"
-    ],
-    "region": "China and East Asia",
-    "summary": "Atractylodes is positioned for traditional digestive and restorative support.",
-    "description": "It is best framed as a digestive-tonic rhizome with traditional-system relevance.",
-    "mechanism": "Sesquiterpenes support digestive and restorative positioning.",
-    "mechanismTags": [
-      "digestive support",
-      "traditional restorative support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "atractylenolide I"
-    ],
-    "topCompounds": [
-      "atractylenolide I"
-    ],
-    "markerCompounds": [
-      "atractylenolide I"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Avoid overextended metabolic claims."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "compound_count": "1",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "schisandra-berry",
-    "name": "Schisandra Berry",
-    "scientificName": "Schisandra chinensis",
-    "latin": "Schisandra chinensis",
-    "category": "fruit",
-    "class": "fruit",
-    "plantPartUsed": "fruit",
-    "commonNames": [
-      "schisandra berry"
-    ],
-    "region": "China, Korea, Russia",
-    "summary": "Schisandra berry is positioned for adaptogenic and hepatoprotective support.",
-    "description": "It is best framed specifically around berry lignans and traditional stress-support positioning.",
-    "mechanism": "Lignans support adaptogenic and hepatoprotective positioning.",
-    "mechanismTags": [
-      "adaptogenic support",
-      "hepatoprotective support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "schisandrin",
-      "gomisin A"
-    ],
-    "topCompounds": [
-      "gomisin A"
-    ],
-    "markerCompounds": [
-      "gomisin A"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with CYP-sensitive medication contexts."
-    ],
-    "publishStatus": "Ready for QA",
-    "readinessFlag": "Ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "8",
-    "compound_count": "1",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "catuba",
-    "name": "Catuba",
-    "scientificName": "Erythroxylum catuaba",
-    "latin": "Erythroxylum catuaba",
-    "category": "bark",
-    "class": "bark",
-    "plantPartUsed": "bark",
-    "commonNames": [
-      "catuaba"
-    ],
-    "region": "Brazil",
-    "summary": "Catuaba is positioned for traditional mood, libido, and vitality support.",
-    "description": "It should be framed conservatively because traditional aphrodisiac narratives exceed modern evidence depth.",
-    "mechanism": "Traditional use and alkaloid-rich chemistry support vitality and mood-adjacent positioning.",
-    "mechanismTags": [
-      "mood support",
-      "traditional vitality support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "alkaloids",
-      "flavonoids"
-    ],
-    "topCompounds": [
-      "catuabine"
-    ],
-    "markerCompounds": [
-      "catuabine"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Avoid exaggerated sexual-performance claims."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "compound_count": "1",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "muira-puama-wb",
-    "name": "Muira Puama",
-    "scientificName": "Ptychopetalum olacoides",
-    "latin": "Ptychopetalum olacoides",
-    "category": "bark/root",
-    "class": "bark/root",
-    "plantPartUsed": "bark; root",
-    "commonNames": [
-      "muira puama"
-    ],
-    "region": "Amazon basin",
-    "summary": "Muira puama is positioned for traditional vitality and stress-resilience support.",
-    "description": "It is best framed as a traditional Amazonian botanical with modest modern evidence.",
-    "mechanism": "Traditional use supports vitality and adaptogenic-adjacent positioning.",
-    "mechanismTags": [
-      "stress support",
-      "traditional vitality support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "sterols",
-      "terpenes"
-    ],
-    "topCompounds": [
-      "beta-sitosterol"
-    ],
-    "markerCompounds": [
-      "beta-sitosterol"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Avoid overextended neurocognitive claims."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "maitake-d-fraction-wb",
-    "name": "Maitake D-Fraction",
-    "scientificName": "Grifola frondosa",
-    "latin": "Grifola frondosa",
-    "category": "extract",
-    "class": "extract",
-    "plantPartUsed": "fruiting body extract",
-    "commonNames": [
-      "maitake D-fraction"
-    ],
-    "region": "Japan; cultivated globally",
-    "summary": "Maitake D-fraction is positioned for immune-support use.",
-    "description": "It should be framed distinctly from whole maitake because extract-standardization claims can exceed the underlying evidence.",
-    "mechanism": "Beta-glucan-rich extracts support immune-modulating positioning.",
-    "mechanismTags": [
-      "immune modulation"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "beta-glucans"
-    ],
-    "topCompounds": [
-      "beta-glucans"
-    ],
-    "markerCompounds": [
-      "beta-glucans"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Avoid exaggerated oncology-treatment claims."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "poria",
-    "name": "Poria",
-    "scientificName": "Wolfiporia extensa",
-    "latin": "Wolfiporia extensa",
-    "category": "sclerotium",
-    "class": "sclerotium",
-    "plantPartUsed": "sclerotium",
-    "commonNames": [
-      "poria",
-      "fu ling"
-    ],
-    "region": "China and East Asia",
-    "summary": "Poria is positioned for traditional fluid-balance and calming support.",
-    "description": "It is best framed as a traditional medicinal fungus with modest modern clinical depth.",
-    "mechanism": "Triterpenes and polysaccharides support fluid-balance and calming positioning.",
-    "mechanismTags": [
-      "calming support",
-      "traditional fluid-balance support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "pachymic acid",
-      "polysaccharides"
-    ],
-    "topCompounds": [
-      "pachymic acid"
-    ],
-    "markerCompounds": [
-      "pachymic acid"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Avoid overextended diuretic claims."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "rehmannia-prepared-wb",
-    "name": "Rehmannia Prepared",
-    "scientificName": "Rehmannia glutinosa praeparata",
-    "latin": "Rehmannia glutinosa praeparata",
-    "category": "prepared root",
-    "class": "prepared root",
-    "plantPartUsed": "prepared root",
-    "commonNames": [
-      "prepared rehmannia",
-      "shu di huang"
-    ],
-    "region": "China and East Asia",
-    "summary": "Prepared rehmannia is positioned for traditional restorative support.",
-    "description": "It should be framed distinctly from raw rehmannia because processed-form use-cases differ materially.",
-    "mechanism": "Traditional preparation context supports restorative positioning.",
-    "mechanismTags": [
-      "traditional restorative support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "catalpol",
-      "rehmanniosides"
-    ],
-    "topCompounds": [
-      "catalpol"
-    ],
-    "markerCompounds": [
-      "catalpol"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Avoid conflating raw and prepared-form actions."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "agarikon-wb",
-    "name": "Agarikon",
-    "scientificName": "Fomitopsis officinalis",
-    "latin": "Fomitopsis officinalis",
-    "category": "fruiting body",
-    "class": "fruiting body",
-    "plantPartUsed": "fruiting body",
-    "commonNames": [
-      "agarikon"
-    ],
-    "region": "Europe, Asia, North America",
-    "summary": "Agarikon is positioned for traditional immune and respiratory support.",
-    "description": "It should be framed modestly because traditional use is much stronger than modern evidence.",
-    "mechanism": "Traditional fungal use and polysaccharides support immune-support positioning.",
-    "mechanismTags": [
-      "respiratory support",
-      "traditional immune support"
-    ],
-    "evidenceLevel": "Preclinical",
-    "activeCompounds": [
-      "agaric acid",
-      "polysaccharides"
-    ],
-    "topCompounds": [
-      "agaric acid"
-    ],
-    "markerCompounds": [
-      "agaric acid"
-    ],
-    "safetyNotes": "Use cautiously.",
-    "interactions": [
-      "Avoid exaggerated antimicrobial claims."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "elecampane",
-    "name": "Elecampane",
-    "scientificName": "Inula helenium",
-    "latin": "Inula helenium",
-    "category": "root",
-    "class": "root",
-    "plantPartUsed": "root",
-    "commonNames": [
-      "elecampane"
-    ],
-    "region": "Europe and Western Asia",
-    "summary": "Elecampane is positioned for traditional respiratory and digestive support.",
-    "description": "It is best framed as a bitter aromatic root with traditional bronchial relevance.",
-    "mechanism": "Sesquiterpene lactones support respiratory and bitter-digestive positioning.",
-    "mechanismTags": [
-      "digestive support",
-      "traditional respiratory support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "alantolactone",
-      "inulin"
-    ],
-    "topCompounds": [
-      "alantolactone"
-    ],
-    "markerCompounds": [
-      "alantolactone"
-    ],
-    "safetyNotes": "Use cautiously in concentrated forms.",
-    "interactions": [
-      "Use caution with ragweed-family sensitivity."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "angelica-root",
-    "name": "Angelica Root",
-    "scientificName": "Angelica archangelica",
-    "latin": "Angelica archangelica",
-    "category": "root",
-    "class": "root",
-    "plantPartUsed": "root",
-    "commonNames": [
-      "angelica root"
-    ],
-    "region": "Northern Europe",
-    "summary": "Angelica root is positioned for aromatic digestive and traditional cycle-related support.",
-    "description": "It should be framed carefully because furanocoumarin context matters for some use cases.",
-    "mechanism": "Aromatic compounds support digestive and traditional positioning.",
-    "mechanismTags": [
-      "digestive support",
-      "traditional cycle support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "angelicin",
-      "essential oils"
-    ],
-    "topCompounds": [
-      "angelicin"
-    ],
-    "markerCompounds": [
-      "angelicin"
-    ],
-    "safetyNotes": "Use cautiously.",
-    "interactions": [
-      "Use caution with photosensitivity-related contexts."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "galangal",
-    "name": "Galangal",
-    "scientificName": "Alpinia galanga",
-    "latin": "Alpinia galanga",
-    "category": "rhizome",
-    "class": "rhizome",
-    "plantPartUsed": "rhizome",
-    "commonNames": [
-      "galangal"
-    ],
-    "region": "Southeast Asia",
-    "summary": "Galangal is positioned for digestive and aromatic support.",
-    "description": "It is best framed as a culinary-medicinal rhizome with traditional GI relevance.",
-    "mechanism": "Flavonoids and volatiles support digestive and aromatic positioning.",
-    "mechanismTags": [
-      "aromatic support",
-      "digestive support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "galangin",
-      "volatile oils"
-    ],
-    "topCompounds": [
-      "galangin"
-    ],
-    "markerCompounds": [
-      "galangin"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Avoid overextended antimicrobial claims."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "black-pepper-wb",
-    "name": "Black Pepper",
-    "scientificName": "Piper nigrum",
-    "latin": "Piper nigrum",
-    "category": "fruit",
-    "class": "fruit",
-    "plantPartUsed": "fruit",
-    "commonNames": [
-      "black pepper"
-    ],
-    "region": "India; cultivated globally",
-    "summary": "Black pepper is positioned for digestive and bioavailability-support use.",
-    "description": "It should be framed specifically around piperine and digestive relevance rather than as a stand-alone tonic.",
-    "mechanism": "Alkaloids support digestive and absorption-related positioning.",
-    "mechanismTags": [
-      "bioavailability support",
-      "digestive support",
-      "metabolic support"
-    ],
-    "evidenceLevel": "Unknown",
-    "activeCompounds": [
-      "piperine"
-    ],
-    "topCompounds": [
-      "piperine"
-    ],
-    "markerCompounds": [
-      "piperine"
-    ],
-    "safetyNotes": "Generally well tolerated; use caution with concentrated extracts.",
-    "interactions": [
-      "Use caution with drug-metabolism-sensitive contexts and tightly dosed stacks."
+      "Major interactions with antidepressants",
+      "oral contraceptives",
+      "cyclosporine",
+      "tacrolimus",
+      "HIV meds",
+      "anticancer drugs",
+      "warfarin",
+      "digoxin and others."
     ],
     "contraindications": [
-      "Use caution in reflux-sensitive contexts."
+      "Pregnancy",
+      "breastfeeding",
+      "bipolar disorder",
+      "concomitant prescription meds with CYP/P-gp liability."
     ],
-    "publishStatus": "Editorial polish",
+    "preparation": "Dried flowering tops or standardized extracts.",
+    "dosage": "300 mg extract three times daily",
+    "standardization": "Often 0.3% hypericin or 2–5% hyperforin.",
+    "publishStatus": "Source review",
     "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "bioavailability modulation",
-      "absorption enhancement",
-      "unclassified"
-    ],
-    "compound_count": "3",
-    "pathway_count": "3"
-  },
-  {
-    "slug": "cardamom-wb",
-    "name": "Cardamom",
-    "scientificName": "Elettaria cardamomum",
-    "latin": "Elettaria cardamomum",
-    "category": "seed",
-    "class": "seed",
-    "plantPartUsed": "seed",
-    "commonNames": [
-      "cardamom"
-    ],
-    "region": "India and Guatemala; cultivated broadly",
-    "summary": "Cardamom is positioned for digestive and aromatic support.",
-    "description": "It is best framed as an aromatic culinary seed with modest translational evidence.",
-    "mechanism": "Volatiles support digestive and aromatic positioning.",
-    "mechanismTags": [
-      "aromatic support",
-      "digestive support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "1",
-      "8-cineole",
-      "terpinyl acetate"
-    ],
-    "topCompounds": [
-      "terpinyl acetate"
-    ],
-    "markerCompounds": [
-      "terpinyl acetate"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with concentrated essential-oil assumptions."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
+    "frontendReadyFlag": "No",
+    "completenessPct": "1",
+    "priorityTier": "High",
     "totalScore": "7",
     "pathwayTargets": [
       "unclassified"
     ],
     "compound_count": "1",
-    "pathway_count": "1"
+    "pathway_count": "1",
+    "sources": [
+      "Recovered from prior batch output in this conversation"
+    ]
   },
   {
-    "slug": "holy-basil-seed",
-    "name": "Holy Basil Seed",
-    "scientificName": "Ocimum tenuiflorum",
-    "latin": "Ocimum tenuiflorum",
-    "category": "seed",
-    "class": "seed",
-    "plantPartUsed": "seed",
+    "slug": "suma",
+    "name": "Suma",
+    "scientificName": "Pfaffia paniculata",
+    "latin": "Pfaffia paniculata",
+    "category": "root",
+    "class": "root",
+    "plantPartUsed": "root",
     "commonNames": [
-      "sabja",
-      "basil seed"
+      "suma",
+      "Brazilian ginseng"
     ],
-    "region": "India and Southeast Asia",
-    "summary": "Holy basil seed is positioned for demulcent and digestive support.",
-    "description": "It should be framed distinctly from holy basil leaf because fiber and mucilage drive different use-cases.",
-    "mechanism": "Demulcent fiber-rich chemistry supports digestive and soothing positioning.",
-    "mechanismTags": [
-      "demulcent support",
-      "digestive support"
-    ],
-    "evidenceLevel": "Unknown",
-    "activeCompounds": [
-      "mucilage",
-      "fiber"
-    ],
-    "topCompounds": [
-      "mucilage"
-    ],
-    "markerCompounds": [
-      "mucilage"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Separate from oral medications in concentrated use."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "compound_count": "1",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "psyllium",
-    "name": "Psyllium",
-    "scientificName": "Plantago ovata",
-    "latin": "Plantago ovata",
-    "category": "seed husk",
-    "class": "seed husk",
-    "plantPartUsed": "seed husk",
-    "commonNames": [
-      "psyllium husk"
-    ],
-    "region": "India and cultivated globally",
-    "summary": "Psyllium is positioned for fiber, GI, and metabolic support.",
-    "description": "It is best framed as a functional-fiber intervention more than a classic phytochemical-heavy herb.",
-    "mechanism": "Gel-forming fibers support GI and metabolic positioning.",
-    "mechanismTags": [
-      "gi support",
-      "metabolic support"
-    ],
-    "evidenceLevel": "Unknown",
-    "activeCompounds": [
-      "mucilage",
-      "arabinoxylans"
-    ],
-    "topCompounds": [
-      "mucilage"
-    ],
-    "markerCompounds": [
-      "mucilage"
-    ],
-    "safetyNotes": "Generally well tolerated with sufficient fluids.",
-    "interactions": [
-      "Separate from oral medications."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "compound_count": "1",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "caraway-wb",
-    "name": "Caraway",
-    "scientificName": "Carum carvi",
-    "latin": "Carum carvi",
-    "category": "seed",
-    "class": "seed",
-    "plantPartUsed": "seed",
-    "commonNames": [
-      "caraway"
-    ],
-    "region": "Europe and Western Asia",
-    "summary": "Caraway is positioned for digestive and aromatic support.",
-    "description": "It is best framed as an aromatic seed with traditional GI relevance.",
-    "mechanism": "Volatile constituents support digestive and aromatic positioning.",
-    "mechanismTags": [
-      "aromatic support",
-      "digestive support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "carvone",
-      "limonene"
-    ],
-    "topCompounds": [
-      "carvone"
-    ],
-    "markerCompounds": [
-      "carvone"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with concentrated oil assumptions."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "ajwain-wb",
-    "name": "Ajwain",
-    "scientificName": "Trachyspermum ammi",
-    "latin": "Trachyspermum ammi",
-    "category": "seed",
-    "class": "seed",
-    "plantPartUsed": "seed",
-    "commonNames": [
-      "ajwain"
-    ],
-    "region": "India and South Asia",
-    "summary": "Ajwain is positioned for digestive and aromatic support.",
-    "description": "It is best framed as a culinary-medicinal seed with strong traditional GI positioning.",
-    "mechanism": "Aromatic phenols support digestive and antimicrobial-adjacent positioning.",
-    "mechanismTags": [
-      "aromatic support",
-      "digestive support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "thymol"
-    ],
-    "topCompounds": [
-      "thymol"
-    ],
-    "markerCompounds": [
-      "thymol"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Avoid overextended antimicrobial claims."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "3",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "holy-basil-purple",
-    "name": "Holy Basil Purple",
-    "scientificName": "Ocimum tenuiflorum",
-    "latin": "Ocimum tenuiflorum",
-    "category": "leaf",
-    "class": "leaf",
-    "plantPartUsed": "leaf",
-    "commonNames": [
-      "Krishna tulsi"
-    ],
-    "region": "India and Southeast Asia",
-    "summary": "Purple holy basil is positioned for adaptogenic and antioxidant support.",
-    "description": "It should be framed similarly to tulsi while noting cultivar/form distinctions are secondary to constituent variability.",
-    "mechanism": "Polyphenols and volatiles support stress and antioxidant positioning.",
+    "region": "South America",
+    "summary": "Suma is positioned for traditional adaptogenic and restorative support.",
+    "description": "It should be framed conservatively because traditional-use breadth exceeds evidence depth.",
+    "mechanism": "Saponins support traditional restorative and adaptogenic positioning.",
     "mechanismTags": [
       "adaptogenic support",
-      "antioxidant"
+      "traditional restorative support"
     ],
     "evidenceLevel": "Human",
     "activeCompounds": [
-      "eugenol",
-      "rosmarinic acid"
+      "pfaffic acid",
+      "saponins"
     ],
     "topCompounds": [
-      "eugenol"
+      "pfaffic acid"
     ],
     "markerCompounds": [
-      "eugenol"
+      "pfaffic acid"
     ],
     "safetyNotes": "Generally well tolerated.",
     "interactions": [
-      "Use caution with concentrated extract marketing claims."
+      "Avoid overextended vitality claims."
     ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
+    "publishStatus": "Source review",
+    "readinessFlag": "Needs work",
+    "frontendReadyFlag": "No",
+    "completenessPct": "0.55",
     "priorityTier": "Medium",
-    "totalScore": "7",
+    "totalScore": "5",
     "pathwayTargets": [
       "unclassified"
     ],
     "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "curry-leaf-wb",
-    "name": "Curry Leaf",
-    "scientificName": "Murraya koenigii",
-    "latin": "Murraya koenigii",
-    "category": "leaf",
-    "class": "leaf",
-    "plantPartUsed": "leaf",
-    "commonNames": [
-      "curry leaf"
-    ],
-    "region": "India and South Asia",
-    "summary": "Curry leaf is positioned for antioxidant and metabolic support.",
-    "description": "It is best framed as a culinary-medicinal leaf with food-form relevance.",
-    "mechanism": "Alkaloids and polyphenols support antioxidant and metabolic positioning.",
-    "mechanismTags": [
-      "antioxidant",
-      "metabolic support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "mahanimbine",
-      "carbazole alkaloids"
-    ],
-    "topCompounds": [
-      "mahanimbine"
-    ],
-    "markerCompounds": [
-      "mahanimbine"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Avoid overextended glycemic claims."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "gudmar",
-    "name": "Gudmar",
-    "scientificName": "Gymnema sylvestre",
-    "latin": "Gymnema sylvestre",
-    "category": "leaf",
-    "class": "leaf",
-    "plantPartUsed": "leaf",
-    "commonNames": [
-      "gudmar"
-    ],
-    "region": "India and tropical Asia",
-    "summary": "Gudmar is positioned for glycemic and sweet-perception support.",
-    "description": "It should be framed consistently with gymnema while preserving alternate-name discoverability.",
-    "mechanism": "Triterpene saponins support glycemic and taste-modulation positioning.",
-    "mechanismTags": [
-      "glycemic support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "gymnemic acids"
-    ],
-    "topCompounds": [
-      "gymnemic acids"
-    ],
-    "markerCompounds": [
-      "gymnemic acids"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with glucose-lowering strategies."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "roselle-seed",
-    "name": "Roselle Seed",
-    "scientificName": "Hibiscus sabdariffa",
-    "latin": "Hibiscus sabdariffa",
-    "category": "seed",
-    "class": "seed",
-    "plantPartUsed": "seed",
-    "commonNames": [
-      "roselle seed"
-    ],
-    "region": "Africa and tropical regions",
-    "summary": "Roselle seed is positioned for nutritive and antioxidant support.",
-    "description": "It should be framed distinctly from hibiscus calyx because seed and calyx use-cases differ.",
-    "mechanism": "Seed lipids and antioxidants support nutritive positioning.",
-    "mechanismTags": [
-      "antioxidant",
-      "nutritive support"
-    ],
-    "evidenceLevel": "Unknown",
-    "activeCompounds": [
-      "tocopherols",
-      "fatty acids"
-    ],
-    "topCompounds": [
-      "tocopherols"
-    ],
-    "markerCompounds": [
-      "tocopherols"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Avoid conflating seed with calyx evidence."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "oxidative stress reduction"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
+    "pathway_count": "1",
+    "sources": [
+      "Pass 125 curated expansion"
+    ]
   },
   {
     "slug": "tamarind",
@@ -5357,465 +6338,41 @@
     "pathway_count": "1"
   },
   {
-    "slug": "rhodiola-wb",
-    "name": "Rhodiola",
-    "scientificName": "Rhodiola rosea",
-    "latin": "Rhodiola rosea",
-    "category": "root",
-    "class": "root",
-    "plantPartUsed": "root",
-    "commonNames": [
-      "rhodiola"
-    ],
-    "region": "Global",
-    "summary": "Stress resilience herb.",
-    "description": "Adaptogenic stress modulation.",
-    "mechanism": "HPA axis modulation",
-    "mechanismTags": [
-      "adaptogen",
-      "cognitive support",
-      "fatigue resistance"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "rosavins",
-      "salidroside"
-    ],
-    "topCompounds": [
-      "rosavins"
-    ],
-    "markerCompounds": [
-      "rosavins"
-    ],
-    "safetyNotes": "Safe",
-    "interactions": [
-      "Dose dependent"
-    ],
-    "publishStatus": "Ready for QA",
-    "readinessFlag": "Ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "8",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "cordyceps",
-    "name": "Cordyceps",
-    "scientificName": "Cordyceps militaris",
-    "latin": "Cordyceps militaris",
-    "category": "fruiting body",
-    "class": "fruiting body",
-    "plantPartUsed": "fruiting body",
-    "commonNames": [
-      "cordyceps"
-    ],
-    "region": "Asia",
-    "summary": "Energy-support fungus.",
-    "description": "ATP / mitochondrial support.",
-    "mechanism": "AMPK signaling",
-    "mechanismTags": [
-      "ampk"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "cordycepin"
-    ],
-    "topCompounds": [
-      "cordycepin"
-    ],
-    "markerCompounds": [
-      "cordycepin"
-    ],
-    "safetyNotes": "Safe",
-    "interactions": [
-      "Generally well tolerated"
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "lion-s-mane-wb",
-    "name": "Lion's Mane",
-    "scientificName": "Hericium erinaceus",
-    "latin": "Hericium erinaceus",
-    "category": "fruiting body",
-    "class": "fruiting body",
-    "plantPartUsed": "fruiting body",
-    "commonNames": [
-      "lions mane"
-    ],
-    "region": "Global",
-    "summary": "Neurotrophic mushroom.",
-    "description": "NGF stimulation.",
-    "mechanism": "Neurogenesis",
-    "mechanismTags": [
-      "ngf"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "hericenones",
-      "erinacines"
-    ],
-    "topCompounds": [
-      "hericenones",
-      "erinacines"
-    ],
-    "markerCompounds": [
-      "hericenones",
-      "erinacines"
-    ],
-    "safetyNotes": "Safe",
-    "interactions": [
-      "Mild GI possible"
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "compound_count": "1",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "panax-ginseng-wb",
-    "name": "Panax Ginseng",
-    "scientificName": "Panax ginseng",
-    "latin": "Panax ginseng",
-    "category": "root",
-    "class": "root",
-    "plantPartUsed": "root",
-    "commonNames": [
-      "ginseng"
-    ],
-    "region": "Asia",
-    "summary": "Adaptogenic root.",
-    "description": "Energy + stress.",
-    "mechanism": "AMPK modulation",
-    "mechanismTags": [
-      "ampk"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "ginsenosides"
-    ],
-    "topCompounds": [
-      "ginsenosides"
-    ],
-    "markerCompounds": [
-      "ginsenosides"
-    ],
-    "safetyNotes": "Safe",
-    "interactions": [
-      "Stimulatory in high doses"
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "completenessPct": "0.9",
-    "priorityTier": "High",
-    "totalScore": "3",
-    "pathwayTargets": [
-      "cognitive modulation",
-      "unclassified",
-      "metabolic signaling",
-      "stress-response modulation",
-      "cholinergic modulation",
-      "neurotrophic signaling"
-    ],
-    "compound_count": "8",
-    "pathway_count": "8"
-  },
-  {
-    "slug": "passionflower-wb",
-    "name": "Passionflower",
-    "scientificName": "Passiflora incarnata",
-    "latin": "Passiflora incarnata",
-    "category": "aerial",
-    "class": "aerial",
-    "plantPartUsed": "aerial",
-    "commonNames": [
-      "passionflower"
-    ],
-    "region": "Global",
-    "summary": "Calming herb.",
-    "description": "GABA support.",
-    "mechanism": "GABA modulation",
-    "mechanismTags": [
-      "gabaa"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "chrysin"
-    ],
-    "topCompounds": [
-      "chrysin"
-    ],
-    "markerCompounds": [
-      "chrysin"
-    ],
-    "safetyNotes": "Safe",
-    "interactions": [
-      "Sedation possible"
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "yohimbe-wb",
-    "name": "Yohimbe",
-    "scientificName": "Pausinystalia johimbe",
-    "latin": "Pausinystalia johimbe",
-    "category": "bark",
-    "class": "bark",
-    "plantPartUsed": "bark",
-    "commonNames": [
-      "yohimbe"
-    ],
-    "region": "Africa",
-    "summary": "Stimulant bark.",
-    "description": "Adrenergic activity.",
-    "mechanism": "Adrenergic",
-    "mechanismTags": [
-      "alpha2"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "yohimbine"
-    ],
-    "topCompounds": [
-      "yohimbine"
-    ],
-    "markerCompounds": [
-      "yohimbine"
-    ],
-    "safetyNotes": "Risk",
-    "interactions": [
-      "High BP risk"
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "completenessPct": "0.9",
-    "priorityTier": "High",
-    "totalScore": "3",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "skullcap-wb",
-    "name": "Skullcap",
-    "scientificName": "Scutellaria lateriflora",
-    "latin": "Scutellaria lateriflora",
-    "category": "aerial",
-    "class": "aerial",
-    "plantPartUsed": "aerial",
-    "commonNames": [
-      "skullcap"
-    ],
-    "region": "Global",
-    "summary": "Calming herb.",
-    "description": "GABAergic.",
-    "mechanism": "GABA modulation",
-    "mechanismTags": [
-      "gabaa"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "baicalin"
-    ],
-    "topCompounds": [
-      "baicalin"
-    ],
-    "markerCompounds": [
-      "baicalin"
-    ],
-    "safetyNotes": "Safe",
-    "interactions": [
-      "Mild sedation"
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "completenessPct": "0.9",
-    "priorityTier": "High",
-    "totalScore": "3",
-    "compound_count": "0",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "eleuthero",
-    "name": "Eleuthero",
-    "scientificName": "Eleutherococcus senticosus",
-    "latin": "Eleutherococcus senticosus",
-    "category": "root",
-    "class": "root",
-    "plantPartUsed": "root",
-    "commonNames": [
-      "eleuthero"
-    ],
-    "region": "Asia",
-    "summary": "Adaptogen.",
-    "description": "Stress resilience.",
-    "mechanism": "HPA axis",
-    "mechanismTags": [
-      "hpa axis"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "eleutherosides"
-    ],
-    "topCompounds": [
-      "eleutherosides"
-    ],
-    "markerCompounds": [
-      "eleutherosides"
-    ],
-    "safetyNotes": "Safe",
-    "interactions": [
-      "Generally safe"
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "completenessPct": "0.9",
-    "priorityTier": "High",
-    "totalScore": "3",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "gotu-kola-wb",
-    "name": "Gotu Kola",
-    "scientificName": "Centella asiatica",
-    "latin": "Centella asiatica",
-    "category": "leaf",
-    "class": "leaf",
+    "slug": "thyme",
+    "name": "Thyme",
+    "scientificName": "Thymus vulgaris",
+    "latin": "Thymus vulgaris",
+    "category": "plant",
+    "class": "plant",
     "plantPartUsed": "leaf",
     "commonNames": [
-      "gotu kola"
+      "Thyme"
     ],
-    "region": "Global",
-    "summary": "Cognitive + vascular.",
-    "description": "NO support.",
-    "mechanism": "NO pathway",
+    "region": "global",
+    "summary": "Thyme positioned for primary functional support.",
+    "description": "Conservative evidence framing applied.",
+    "mechanism": "Mechanistic activity supported by mixed evidence.",
     "mechanismTags": [
-      "no"
+      "antimicrobial",
+      "digestive support",
+      "respiratory support"
     ],
-    "evidenceLevel": "Human",
+    "evidenceLevel": "Preclinical",
     "activeCompounds": [
-      "asiaticoside"
+      "thymol"
     ],
     "topCompounds": [
-      "asiaticoside"
+      "thymol"
     ],
     "markerCompounds": [
-      "asiaticoside"
+      "thymol"
     ],
-    "safetyNotes": "Safe",
+    "safetyNotes": "Generally well tolerated; review concentrated oil use carefully.",
     "interactions": [
-      "Generally safe"
+      "Use caution in stacks already heavy in potent essential-oil actives."
     ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "6",
-    "compound_count": "0",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "schisandra",
-    "name": "Schisandra",
-    "scientificName": "Schisandra chinensis",
-    "latin": "Schisandra chinensis",
-    "category": "berry",
-    "class": "berry",
-    "plantPartUsed": "berry",
-    "commonNames": [
-      "schisandra"
-    ],
-    "region": "Asia",
-    "summary": "Adaptogen.",
-    "description": "Liver + stress.",
-    "mechanism": "Nrf2",
-    "mechanismTags": [
-      "nrf2"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "gomisins"
-    ],
-    "topCompounds": [
-      "gomisins"
-    ],
-    "markerCompounds": [
-      "gomisins"
-    ],
-    "safetyNotes": "Safe",
-    "interactions": [
-      "Generally safe"
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "completenessPct": "0.9",
-    "priorityTier": "High",
-    "totalScore": "3",
-    "compound_count": "0",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "reishi",
-    "name": "Reishi",
-    "scientificName": "Ganoderma lucidum",
-    "latin": "Ganoderma lucidum",
-    "category": "fruiting body",
-    "class": "fruiting body",
-    "plantPartUsed": "fruiting body",
-    "commonNames": [
-      "reishi"
-    ],
-    "region": "Global",
-    "summary": "Immune mushroom.",
-    "description": "Immune modulation.",
-    "mechanism": "NFkB",
-    "mechanismTags": [
-      "nfkb"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "triterpenes"
-    ],
-    "topCompounds": [
-      "triterpenes"
-    ],
-    "markerCompounds": [
-      "triterpenes"
-    ],
-    "safetyNotes": "Safe",
-    "interactions": [
-      "Mild GI"
+    "contraindications": [
+      "Use caution with highly sensitive GI contexts at concentrated intake."
     ],
     "publishStatus": "Editorial polish",
     "readinessFlag": "Near ready",
@@ -5829,398 +6386,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "chaga",
-    "name": "Chaga",
-    "scientificName": "Inonotus obliquus",
-    "latin": "Inonotus obliquus",
-    "category": "sclerotia",
-    "class": "sclerotia",
-    "plantPartUsed": "sclerotia",
-    "commonNames": [
-      "chaga"
-    ],
-    "region": "Cold regions",
-    "summary": "Antioxidant fungus.",
-    "description": "Oxidative stress.",
-    "mechanism": "Nrf2",
-    "mechanismTags": [
-      "nrf2"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "betulinic acid"
-    ],
-    "topCompounds": [
-      "betulinic acid"
-    ],
-    "markerCompounds": [
-      "betulinic acid"
-    ],
-    "safetyNotes": "Safe",
-    "interactions": [
-      "Oxalates"
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "completenessPct": "0.9",
-    "priorityTier": "High",
-    "totalScore": "3",
-    "compound_count": "0",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "turkey-tail-wb",
-    "name": "Turkey Tail",
-    "scientificName": "Trametes versicolor",
-    "latin": "Trametes versicolor",
-    "category": "fruiting body",
-    "class": "fruiting body",
-    "plantPartUsed": "fruiting body",
-    "commonNames": [
-      "turkey tail"
-    ],
-    "region": "Global",
-    "summary": "Immune fungus.",
-    "description": "Immune modulation.",
-    "mechanism": "immune signaling",
-    "mechanismTags": [
-      "nfkb"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "PSK"
-    ],
-    "topCompounds": [
-      "PSK"
-    ],
-    "markerCompounds": [
-      "PSK"
-    ],
-    "safetyNotes": "Safe",
-    "interactions": [
-      "Generally safe"
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "compound_count": "1",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "boswellia",
-    "name": "Boswellia",
-    "scientificName": "Boswellia serrata",
-    "latin": "Boswellia serrata",
-    "category": "resin",
-    "class": "resin",
-    "plantPartUsed": "gum resin",
-    "commonNames": [
-      "frankincense",
-      "boswellia"
-    ],
-    "region": "India and Northeast Africa",
-    "summary": "Boswellia is positioned for inflammatory and mobility support.",
-    "description": "It is best framed around boswellic acids with inflammatory-pathway relevance.",
-    "mechanism": "Boswellic acids are associated with 5-lipoxygenase and inflammatory signaling relevance.",
-    "mechanismTags": [
-      "anti-inflammatory",
-      "mobility support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "boswellic acids",
-      "AKBA"
-    ],
-    "topCompounds": [
-      "AKBA"
-    ],
-    "markerCompounds": [
-      "AKBA"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with GI sensitivity."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "compound_count": "1",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "hawthorn",
-    "name": "Hawthorn",
-    "scientificName": "Crataegus monogyna",
-    "latin": "Crataegus monogyna",
-    "category": "leaf/flower/berry",
-    "class": "leaf/flower/berry",
-    "plantPartUsed": "leaf; flower; fruit",
-    "commonNames": [
-      "hawthorn"
-    ],
-    "region": "Europe and cultivated globally",
-    "summary": "Hawthorn is positioned for cardiovascular and vascular support.",
-    "description": "It is best framed around procyanidins and flavonoids.",
-    "mechanism": "Polyphenols support endothelial and vascular relevance.",
-    "mechanismTags": [
-      "cardiovascular support",
-      "vascular support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "procyanidin B2",
-      "flavonoids"
-    ],
-    "topCompounds": [
-      "procyanidin B2"
-    ],
-    "markerCompounds": [
-      "procyanidin B2"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with cardiovascular medications."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "compound_count": "1",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "astragalus",
-    "name": "Astragalus",
-    "scientificName": "Astragalus membranaceus",
-    "latin": "Astragalus membranaceus",
-    "category": "root",
-    "class": "root",
-    "plantPartUsed": "root",
-    "commonNames": [
-      "astragalus"
-    ],
-    "region": "China and East Asia",
-    "summary": "Astragalus is positioned for immune and fatigue-support use.",
-    "description": "It is best framed around astragalosides and polysaccharides.",
-    "mechanism": "Saponins and polysaccharides support immune and restorative positioning.",
-    "mechanismTags": [
-      "fatigue support",
-      "immune modulation"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "astragaloside IV",
-      "polysaccharides"
-    ],
-    "topCompounds": [
-      "astragaloside IV"
-    ],
-    "markerCompounds": [
-      "astragaloside IV"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution in autoimmune contexts."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "compound_count": "1",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "nettle-root",
-    "name": "Nettle Root",
-    "scientificName": "Urtica dioica",
-    "latin": "Urtica dioica",
-    "category": "root",
-    "class": "root",
-    "plantPartUsed": "root",
-    "commonNames": [
-      "nettle root"
-    ],
-    "region": "Europe, Asia, North America",
-    "summary": "Nettle root is positioned for urinary and men's-health support.",
-    "description": "It is best framed distinctly from nettle leaf.",
-    "mechanism": "Sterols and lignans support urinary positioning.",
-    "mechanismTags": [
-      "men's-health support",
-      "urinary support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "beta-sitosterol",
-      "lignans"
-    ],
-    "topCompounds": [
-      "beta-sitosterol"
-    ],
-    "markerCompounds": [
-      "beta-sitosterol"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with urinary medications."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "bacopa-wb",
-    "name": "Bacopa",
-    "scientificName": "Bacopa monnieri",
-    "latin": "Bacopa monnieri",
-    "category": "aerial parts",
-    "class": "aerial parts",
-    "plantPartUsed": "aerial parts",
-    "commonNames": [
-      "bacopa"
-    ],
-    "region": "India and tropical regions",
-    "summary": "Bacopa is positioned for cognitive and calming support.",
-    "description": "It is best framed around bacosides with slower-onset cognitive relevance.",
-    "mechanism": "Triterpene saponins support cognitive and calming positioning.",
-    "mechanismTags": [
-      "calming support",
-      "cognitive support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "bacoside A",
-      "bacopaside II"
-    ],
-    "topCompounds": [
-      "bacoside A"
-    ],
-    "markerCompounds": [
-      "bacoside A"
-    ],
-    "safetyNotes": "Generally well tolerated.",
-    "interactions": [
-      "Use caution with GI sensitivity."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "7",
-    "compound_count": "1",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "mucuna",
-    "name": "Mucuna",
-    "scientificName": "Mucuna pruriens",
-    "latin": "Mucuna pruriens",
-    "category": "seed",
-    "class": "seed",
-    "plantPartUsed": "seed",
-    "commonNames": [
-      "mucuna",
-      "velvet bean"
-    ],
-    "region": "India, tropical regions",
-    "summary": "Mucuna is positioned for dopamine-related and vitality support.",
-    "description": "It is best framed around L-DOPA-rich seeds with clear neurologic and stimulation-related caution.",
-    "mechanism": "Catecholamine precursor relevance through L-DOPA content.",
-    "mechanismTags": [
-      "dopamine support",
-      "vitality support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "L-DOPA",
-      "alkaloids"
-    ],
-    "topCompounds": [
-      "L-DOPA"
-    ],
-    "markerCompounds": [
-      "L-DOPA"
-    ],
-    "safetyNotes": "Use caution in psychiatric, cardiovascular, and dopaminergic contexts.",
-    "interactions": [
-      "May interact with MAOIs",
-      "dopaminergic drugs",
-      "stimulants",
-      "and antipsychotics."
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "completenessPct": "0.9",
-    "priorityTier": "High",
-    "totalScore": "3",
-    "compound_count": "0",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "epimedium",
-    "name": "Epimedium",
-    "scientificName": "Epimedium sagittatum",
-    "latin": "Epimedium sagittatum",
-    "category": "aerial parts",
-    "class": "aerial parts",
-    "plantPartUsed": "leaf",
-    "commonNames": [
-      "epimedium",
-      "horny goat weed"
-    ],
-    "region": "China and East Asia",
-    "summary": "Epimedium is positioned for libido and circulation support.",
-    "description": "It is best framed around icariin and broader flavonoid content with stimulant and cardiovascular caution.",
-    "mechanism": "PDE-related and nitric-oxide-linked relevance is commonly proposed.",
-    "mechanismTags": [
-      "circulation support",
-      "libido support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "icariin",
-      "flavonoids"
-    ],
-    "topCompounds": [
-      "icariin"
-    ],
-    "markerCompounds": [
-      "icariin"
-    ],
-    "safetyNotes": "Use caution with blood pressure instability and overstimulation.",
-    "interactions": [
-      "May interact with antihypertensives",
-      "vasodilators",
-      "stimulants",
-      "and anticoagulants."
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "completenessPct": "0.9",
-    "priorityTier": "High",
-    "totalScore": "3",
-    "pathwayTargets": [
-      "nitric oxide signaling",
-      "unclassified",
-      "PDE5-related signaling"
-    ],
-    "compound_count": "5",
-    "pathway_count": "3"
-  },
-  {
-    "slug": "tongkat-ali-wb",
+    "slug": "tongkat-ali",
     "name": "Tongkat Ali",
     "scientificName": "Eurycoma longifolia",
     "latin": "Eurycoma longifolia",
@@ -6265,184 +6431,548 @@
     "pathway_count": "0"
   },
   {
-    "slug": "shatavari",
-    "name": "Shatavari",
-    "scientificName": "Asparagus racemosus",
-    "latin": "Asparagus racemosus",
-    "category": "root",
-    "class": "root",
-    "plantPartUsed": "root",
+    "slug": "turkey-tail",
+    "name": "Turkey Tail",
+    "scientificName": "Trametes versicolor",
+    "latin": "Trametes versicolor",
+    "category": "fruiting body",
+    "class": "fruiting body",
+    "plantPartUsed": "fruiting body",
     "commonNames": [
-      "shatavari"
+      "turkey tail"
     ],
-    "region": "India and South Asia",
-    "summary": "Shatavari is positioned for soothing, women’s-health, and adaptogenic support.",
-    "description": "It is best framed around steroidal saponins with hormonal-context caution.",
-    "mechanism": "Demulcent and endocrine-modulating relevance is commonly proposed.",
+    "region": "Global",
+    "summary": "Immune fungus.",
+    "description": "Immune modulation.",
+    "mechanism": "immune signaling",
     "mechanismTags": [
-      "soothing support",
-      "women's-health support"
+      "nfkb"
     ],
     "evidenceLevel": "Human",
     "activeCompounds": [
-      "shatavarins",
-      "saponins"
+      "PSK"
     ],
     "topCompounds": [
-      "shatavarin IV"
+      "PSK"
     ],
     "markerCompounds": [
-      "shatavarin IV"
+      "PSK"
     ],
-    "safetyNotes": "Use caution in hormone-sensitive conditions.",
+    "safetyNotes": "Safe.",
     "interactions": [
-      "May interact with diuretics",
-      "hormone-modulating therapies",
-      "and glucose-lowering agents."
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "completenessPct": "0.9",
-    "priorityTier": "High",
-    "totalScore": "3",
-    "compound_count": "0",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "pueraria-mirifica-wb",
-    "name": "Pueraria Mirifica",
-    "scientificName": "Pueraria mirifica",
-    "latin": "Pueraria mirifica",
-    "category": "root",
-    "class": "root",
-    "plantPartUsed": "root",
-    "commonNames": [
-      "pueraria mirifica"
-    ],
-    "region": "Thailand and Southeast Asia",
-    "summary": "Pueraria mirifica is positioned for phytoestrogen-focused support.",
-    "description": "It is best framed very cautiously due to potent estrogenic positioning.",
-    "mechanism": "Strong phytoestrogen relevance is the central positioning feature.",
-    "mechanismTags": [
-      "phytoestrogen support",
-      "women's-health support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "miroestrol",
-      "deoxymiroestrol"
-    ],
-    "topCompounds": [
-      "miroestrol"
-    ],
-    "markerCompounds": [
-      "miroestrol"
-    ],
-    "safetyNotes": "Use caution or avoid in hormone-sensitive conditions, pregnancy, and breastfeeding.",
-    "interactions": [
-      "May interact with hormonal therapies",
-      "contraceptives",
-      "and endocrine-active drugs."
+      "Generally safe"
     ],
     "publishStatus": "Editorial polish",
     "readinessFlag": "Near ready",
     "completenessPct": "0.9",
     "priorityTier": "Medium",
-    "totalScore": "6",
-    "compound_count": "0",
+    "totalScore": "7",
+    "compound_count": "1",
     "pathway_count": "0"
   },
   {
-    "slug": "cacao",
-    "name": "Cacao",
-    "scientificName": "Theobroma cacao",
-    "latin": "Theobroma cacao",
-    "category": "seed",
-    "class": "seed",
-    "plantPartUsed": "seed",
+    "slug": "turmeric",
+    "name": "Turmeric",
+    "scientificName": "Curcuma longa",
+    "latin": "Curcuma longa",
+    "category": "rhizome",
+    "class": "rhizome",
+    "plantPartUsed": "unspecified",
     "commonNames": [
-      "cacao",
-      "cocoa"
+      "turmeric",
+      "Curcuma longa"
     ],
-    "region": "Tropical Americas; cultivated globally",
-    "summary": "Cacao is positioned for mood, circulation, and polyphenol support.",
-    "description": "It is best framed around flavanols and methylxanthines with stimulant awareness.",
-    "mechanism": "Polyphenol and methylxanthine relevance supports vascular and mood positioning.",
+    "region": "Native to India and cultivated throughout the tropics; turmeric is not found in the wild and is grown as a domesticated plant【754431674042811†L224-L241】.",
+    "summary": "Turmeric (Curcuma longa) is a rhizome monograph focused on the unspecified used in herbal preparations. It is associated with Native to India and cultivated throughout the tropics; turmeric is not found in the wild and is grown as a domesticated plant【754431674042811†L224-L241】. The golden rhizomes of turmeric contain non‑volatile curcuminoids—curcumin (curcumin I), demethoxycurcumin (curcumin II) and bisdemethoxycurcumin (curcumin III)—as well as volatile mono‑ and sesquiterpenoids【768158627760254†L420-L432】【768158627760254†L442-L468】. Conventional oral preparations of turmeric or curcumin appear safe for up to 2–3 months.",
+    "description": "Turmeric is represented here as a monograph-style entry centered on the unspecified. Key reported compounds include curcumin; demethoxycurcumin; bisdemethoxycurcumin. Typical preparation forms: The rhizomes are boiled, dried and ground into powder used as a spice, dye and supplement. Extracts standardized for curcuminoid content are available as capsules or tablets. The golden rhizomes of turmeric contain non‑volatile curcuminoids—curcumin (curcumin I), demethoxycurcumin (curcumin II) and bisdemethoxycurcumin (curcumin III)—as well as volatile mono‑ and sesquiterpenoids【768158627760254†L420-L432】【768158627760254†L442-L468】. Curcumin and related curcuminoids exhibit antioxidant and anti‑inflammatory effects by modulating multiple molecular targets (e.g., NF‑κB, Nrf2, COX‑2). Most data are preclinical; human evidence is limited, so this mechanism should be considered proposed. Interaction profile: Curcumin may enhance the effects of anticoagulant, antiplatelet or antidiabetic drugs and could interact with drugs metabolized by cytochrome P450 enzymes; caution is advised. Use caution or avoid in: Avoid high‑dose turmeric supplements in people with gallbladder obstruction, bleeding disorders or those taking anticoagulant or antiplatelet medications. Use is not recommended during pregnancy or breastfeeding.",
+    "mechanism": "The golden rhizomes of turmeric contain non‑volatile curcuminoids—curcumin (curcumin I), demethoxycurcumin (curcumin II) and bisdemethoxycurcumin (curcumin III)—as well as volatile mono‑ and sesquiterpenoids【768158627760254†L420-L432】【768158627760254†L442-L468】. Curcumin and related curcuminoids exhibit antioxidant and anti‑inflammatory effects by modulating multiple molecular targets (e.g., NF‑κB, Nrf2, COX‑2). Most data are preclinical; human evidence is limited, so this mechanism should be considered proposed.",
     "mechanismTags": [
-      "circulation support",
-      "mood support"
+      "anti-inflammatory",
+      "antioxidant",
+      "nf-kb modulation"
     ],
-    "evidenceLevel": "Human",
+    "evidenceLevel": "Unknown",
     "activeCompounds": [
-      "theobromine",
-      "flavanols",
-      "catechins"
+      "curcumin",
+      "demethoxycurcumin"
     ],
     "topCompounds": [
-      "theobromine"
+      "curcumin"
     ],
     "markerCompounds": [
-      "theobromine"
+      "curcumin"
     ],
-    "safetyNotes": "Use caution in stimulant-sensitive users and with migraine triggers.",
+    "safetyNotes": "Conventional oral preparations of turmeric or curcumin appear safe for up to 2–3 months.",
     "interactions": [
-      "May interact with stimulants and can add to caffeine-like effects."
+      "Curcumin may enhance the effects of anticoagulant",
+      "antiplatelet or antidiabetic drugs and could interact with drugs metabolized by cytochrome P450 enzymes",
+      "caution is advised."
     ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "completenessPct": "0.9",
-    "priorityTier": "High",
-    "totalScore": "3",
-    "compound_count": "0",
-    "pathway_count": "0"
+    "contraindications": [
+      "Avoid high‑dose turmeric supplements in people with gallbladder obstruction",
+      "bleeding disorders or those taking anticoagulant or antiplatelet medications. Use is not recommended during pregnancy or breastfeeding."
+    ],
+    "preparation": "The rhizomes are boiled, dried and ground into powder used as a spice, dye and supplement. Extracts standardized for curcuminoid content are available as capsules or tablets.",
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "frontendReadyFlag": "No",
+    "completenessPct": "0.714285714",
+    "priorityTier": "Medium",
+    "totalScore": "6",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "6",
+    "pathway_count": "1",
+    "sources": [
+      "【768158627760254†L420-L432】",
+      "【768158627760254†L442-L468】",
+      "【628537290338832†L207-L223】",
+      "【754431674042811†L224-L241】"
+    ]
   },
   {
-    "slug": "rooibos-wb",
-    "name": "Rooibos",
-    "scientificName": "Aspalathus linearis",
-    "latin": "Aspalathus linearis",
-    "category": "leaf",
-    "class": "leaf",
-    "plantPartUsed": "leaf",
+    "slug": "valerian",
+    "name": "Valerian",
+    "scientificName": "Valeriana officinalis",
+    "latin": "Valeriana officinalis",
+    "category": "herb",
+    "class": "herb",
+    "plantPartUsed": "root; rhizome",
     "commonNames": [
-      "rooibos",
-      "red bush"
+      "valerian",
+      "all-heal",
+      "garden heliotrope"
     ],
-    "region": "South Africa",
-    "summary": "Rooibos is positioned for gentle antioxidant and soothing support.",
-    "description": "It is best framed as a mild tea herb with low-intensity wellness positioning.",
-    "mechanism": "Polyphenol-linked antioxidant relevance supports mild positioning.",
+    "region": "Native to Europe and Asia; naturalized in North America and other temperate regions.",
+    "summary": "Valerian (Valeriana officinalis) is a herb monograph focused on the root; rhizome used in herbal preparations. It is associated with Native to Europe and Asia; naturalized in North America and other temperate regions. Valerenic acid derivatives modulate GABA-A signaling and may inhibit GABA breakdown. Short-term use appears safe; side effects include headache, GI upset, mental dullness, excitability, vivid dreams.",
+    "description": "Valerian is represented here as a monograph-style entry centered on the root; rhizome. Key reported compounds include valerenic acid; valerenol; valerenal; valepotriates (valtrate, isovaltrate); sesquiterpenoids. Typical preparation forms: Dried roots/rhizomes as teas, tinctures, or extracts. Valerenic acid derivatives modulate GABA-A signaling and may inhibit GABA breakdown. Interaction profile: May potentiate sedatives and alcohol. Use caution or avoid in: Pregnancy, breastfeeding, liver disease, concurrent CNS depressants.",
+    "mechanism": "Valerenic acid derivatives modulate GABA-A signaling and may inhibit GABA breakdown.",
     "mechanismTags": [
-      "antioxidant support",
-      "soothing support"
+      "gaba modulation",
+      "sedative",
+      "sleep support"
     ],
     "evidenceLevel": "Human",
     "activeCompounds": [
-      "aspalathin",
-      "nothofagin",
-      "flavonoids"
+      "valerenic acid"
     ],
     "topCompounds": [
-      "aspalathin"
+      "valerenic acid"
     ],
     "markerCompounds": [
-      "aspalathin"
+      "valerenic acid"
+    ],
+    "safetyNotes": "Short-term use appears safe; side effects include headache, GI upset, mental dullness, excitability, vivid dreams.",
+    "interactions": [
+      "May potentiate sedatives and alcohol."
+    ],
+    "contraindications": [
+      "Pregnancy",
+      "breastfeeding",
+      "liver disease",
+      "concurrent CNS depressants."
+    ],
+    "preparation": "Dried roots/rhizomes as teas, tinctures, or extracts.",
+    "dosage": "300–600 mg extract",
+    "publishStatus": "Source review",
+    "readinessFlag": "Near ready",
+    "frontendReadyFlag": "No",
+    "completenessPct": "0.928571429",
+    "priorityTier": "High",
+    "totalScore": "6",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1",
+    "sources": [
+      "Recovered from prior batch output in this conversation"
+    ]
+  },
+  {
+    "slug": "white-peony",
+    "name": "White Peony",
+    "scientificName": "Paeonia lactiflora",
+    "latin": "Paeonia lactiflora",
+    "category": "root",
+    "class": "root",
+    "plantPartUsed": "root",
+    "commonNames": [
+      "white peony"
+    ],
+    "region": "China and East Asia",
+    "summary": "White peony is positioned for traditional cycle-related and calming support.",
+    "description": "It is best framed as a paeoniflorin-rich root with traditional-system relevance.",
+    "mechanism": "Monoterpene glycosides support traditional cycle and calming positioning.",
+    "mechanismTags": [
+      "calming support",
+      "traditional cycle support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "paeoniflorin"
+    ],
+    "topCompounds": [
+      "paeoniflorin"
+    ],
+    "markerCompounds": [
+      "paeoniflorin"
     ],
     "safetyNotes": "Generally well tolerated.",
     "interactions": [
-      "No major interaction pattern is firmly established",
-      "use routine caution in polypharmacy."
+      "Use caution with anticoagulant-sensitive contexts."
     ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "yarrow",
+    "name": "Yarrow",
+    "scientificName": "Achillea millefolium",
+    "latin": "Achillea millefolium",
+    "category": "plant",
+    "class": "plant",
+    "plantPartUsed": "aerial",
+    "commonNames": [
+      "Yarrow"
+    ],
+    "region": "global",
+    "summary": "Yarrow positioned for primary functional support.",
+    "description": "Conservative evidence framing applied.",
+    "mechanism": "Mechanistic activity supported by mixed evidence.",
+    "mechanismTags": [
+      "anti-inflammatory",
+      "digestive support",
+      "women's health"
+    ],
+    "evidenceLevel": "Preclinical",
+    "activeCompounds": [
+      "flavonoids"
+    ],
+    "topCompounds": [
+      "apigenin"
+    ],
+    "markerCompounds": [
+      "apigenin"
+    ],
+    "safetyNotes": "Review interactions and contraindications.",
+    "interactions": [
+      "Use caution in anticoagulant-sensitive or complex women's health stacks."
+    ],
+    "contraindications": [
+      "Use caution in pregnancy-sensitive contexts."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "yerba-mate",
+    "name": "Yerba Mate",
+    "scientificName": "Ilex paraguariensis",
+    "latin": "Ilex paraguariensis",
+    "category": "plant",
+    "class": "plant",
+    "plantPartUsed": "leaf",
+    "commonNames": [
+      "Yerba Mate"
+    ],
+    "region": "global",
+    "summary": "Yerba Mate positioned for primary functional support.",
+    "description": "Conservative evidence framing applied.",
+    "mechanism": "Mechanistic activity supported by mixed evidence.",
+    "mechanismTags": [
+      "cognition",
+      "energy support",
+      "metabolic support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "caffeine",
+      "polyphenols"
+    ],
+    "topCompounds": [
+      "caffeine"
+    ],
+    "markerCompounds": [
+      "caffeine"
+    ],
+    "safetyNotes": "Use caution with stimulant sensitivity or insomnia-prone contexts.",
+    "interactions": [
+      "May stack strongly with caffeine-heavy formulas."
+    ],
+    "contraindications": [
+      "Use caution in uncontrolled blood pressure-sensitive contexts."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "yohimbe",
+    "name": "Yohimbe",
+    "scientificName": "Pausinystalia johimbe",
+    "latin": "Pausinystalia johimbe",
+    "category": "bark",
+    "class": "bark",
+    "plantPartUsed": "bark",
+    "commonNames": [
+      "yohimbe"
+    ],
+    "region": "Africa",
+    "summary": "Yohimbe is best handled as a high-risk stimulant bark centered on yohimbine rather than as a broadly wellness-friendly herb. Its profile fits narrow, caution-heavy use where adrenergic stimulation and psychiatric/cardiovascular risk must be foregrounded.",
+    "description": "Yohimbe is represented here as a bark-derived monograph anchored to yohimbine, an alpha-2 adrenergic antagonist with sympathomimetic effects. The herb is more appropriately framed around safety review than routine recommendation. Potential effects include increased alertness and sexual-function relevance, but tolerability can be poor and adverse effects may include anxiety, tachycardia, blood-pressure elevation, agitation, insomnia, and gastrointestinal distress. Use should be conservative and exclusion-heavy in people with cardiovascular, psychiatric, seizure, renal, or hepatic vulnerability.",
+    "mechanism": "Primary relevance is adrenergic: alpha-2 adrenergic antagonism may increase sympathetic output and catecholamine release. This can explain stimulant, cardiovascular, and sexual-function effects, but also the higher burden of adverse reactions.",
+    "mechanismTags": [
+      "alpha2"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "yohimbine",
+      "rauwolscine"
+    ],
+    "topCompounds": [
+      "yohimbine"
+    ],
+    "markerCompounds": [
+      "yohimbine"
+    ],
+    "safetyNotes": "High-caution herb.",
+    "interactions": [
+      "May interact adversely with stimulants",
+      "antidepressants",
+      "MAOI-like agents",
+      "antihypertensives",
+      "vasopressors",
+      "and other products affecting blood pressure",
+      "heart rate",
+      "or mood."
+    ],
+    "contraindications": [
+      "Avoid in pregnancy",
+      "breastfeeding",
+      "cardiovascular disease",
+      "uncontrolled blood pressure",
+      "panic/anxiety disorders",
+      "bipolar-spectrum illness",
+      "seizure disorders",
+      "and significant renal or hepatic disease."
+    ],
+    "preparation": "Best treated as a standardized-extract / isolated-alkaloid caution case rather than a casual whole-bark recommendation.",
+    "dosage": "Do not treat legacy folk-use dosing as routine guidance; dose review should be product-specific and safety-led.",
+    "qualityConcerns": "High variability risk across bark products; alkaloid content and tolerability may be inconsistent.",
     "publishStatus": "Source review",
     "readinessFlag": "Needs work",
     "completenessPct": "0.9",
     "priorityTier": "High",
     "totalScore": "3",
-    "compound_count": "0",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "pau-darco",
+    "name": "Pau d'Arco",
+    "scientificName": "Handroanthus impetiginosus",
+    "latin": "Handroanthus impetiginosus",
+    "category": "inner bark",
+    "class": "inner bark",
+    "plantPartUsed": "inner bark",
+    "commonNames": [
+      "pau d'arco"
+    ],
+    "region": "South America",
+    "summary": "Pau d'arco is positioned for traditional immune and antimicrobial support.",
+    "description": "It should be framed conservatively because popular claims often exceed the evidence and preparation differences matter.",
+    "mechanism": "Naphthoquinones are associated with antimicrobial and redox-related positioning in preclinical contexts.",
+    "mechanismTags": [
+      "antimicrobial support",
+      "traditional immune support"
+    ],
+    "evidenceLevel": "Preclinical",
+    "activeCompounds": [
+      "lapachol",
+      "naphthoquinones"
+    ],
+    "topCompounds": [
+      "lapachol"
+    ],
+    "markerCompounds": [
+      "lapachol"
+    ],
+    "safetyNotes": "Use conservatively; concentrated use may be irritating.",
+    "interactions": [
+      "Avoid exaggerated disease-treatment claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "milky-oats",
+    "name": "Milk Oats",
+    "scientificName": "Avena sativa",
+    "latin": "Avena sativa",
+    "category": "seed stage",
+    "class": "seed stage",
+    "plantPartUsed": "milky seed tops",
+    "commonNames": [
+      "milky oats",
+      "milk oats"
+    ],
+    "region": "Europe and cultivated globally",
+    "summary": "Milky oats are positioned for nutritive nervous-system support.",
+    "description": "They are best framed as a gentle traditional tonic rather than a strong acute intervention.",
+    "mechanism": "Traditional positioning centers on gentle nutritive support rather than a single strong mechanism.",
+    "mechanismTags": [
+      "calming support",
+      "nutritive support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "avenacosides",
+      "avenanthramides"
+    ],
+    "topCompounds": [
+      "avenacosides"
+    ],
+    "markerCompounds": [
+      "avenacosides"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with sourcing and gluten cross-contact concerns."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "pathwayTargets": [
+      "unclassified"
+    ],
+    "compound_count": "1",
+    "pathway_count": "1"
+  },
+  {
+    "slug": "catuaba",
+    "name": "Catuba",
+    "scientificName": "Erythroxylum catuaba",
+    "latin": "Erythroxylum catuaba",
+    "category": "bark",
+    "class": "bark",
+    "plantPartUsed": "bark",
+    "commonNames": [
+      "catuaba"
+    ],
+    "region": "Brazil",
+    "summary": "Catuaba is positioned for traditional mood, libido, and vitality support.",
+    "description": "It should be framed conservatively because traditional aphrodisiac narratives exceed modern evidence depth.",
+    "mechanism": "Traditional use and alkaloid-rich chemistry support vitality and mood-adjacent positioning.",
+    "mechanismTags": [
+      "mood support",
+      "traditional vitality support"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "alkaloids",
+      "flavonoids"
+    ],
+    "topCompounds": [
+      "catuabine"
+    ],
+    "markerCompounds": [
+      "catuabine"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Avoid exaggerated sexual-performance claims."
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "compound_count": "1",
     "pathway_count": "0"
   },
   {
-    "slug": "cat-s-claw",
+    "slug": "lions-mane",
+    "name": "Lion's Mane",
+    "scientificName": "Hericium erinaceus",
+    "latin": "Hericium erinaceus",
+    "category": "fruiting body",
+    "class": "fruiting body",
+    "plantPartUsed": "fruiting body",
+    "commonNames": [
+      "lions mane"
+    ],
+    "region": "Global",
+    "summary": "Neurotrophic mushroom.",
+    "description": "NGF stimulation.",
+    "mechanism": "Neurogenesis",
+    "mechanismTags": [
+      "ngf"
+    ],
+    "evidenceLevel": "Human",
+    "activeCompounds": [
+      "hericenones",
+      "erinacines"
+    ],
+    "topCompounds": [
+      "hericenones",
+      "erinacines"
+    ],
+    "markerCompounds": [
+      "hericenones",
+      "erinacines"
+    ],
+    "safetyNotes": "Safe",
+    "interactions": [
+      "Mild GI possible"
+    ],
+    "publishStatus": "Editorial polish",
+    "readinessFlag": "Near ready",
+    "completenessPct": "0.9",
+    "priorityTier": "Medium",
+    "totalScore": "7",
+    "compound_count": "1",
+    "pathway_count": "0"
+  },
+  {
+    "slug": "cats-claw",
     "name": "Cat's Claw",
     "scientificName": "Uncaria tomentosa",
     "latin": "Uncaria tomentosa",
@@ -6487,370 +7017,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "lavender-wb",
-    "name": "Lavender",
-    "scientificName": "Lavandula angustifolia",
-    "latin": "Lavandula angustifolia",
-    "category": "flower",
-    "class": "flower",
-    "plantPartUsed": "flower",
-    "commonNames": [
-      "lavender"
-    ],
-    "region": "Mediterranean and cultivated globally",
-    "summary": "Lavender is positioned for calming and tension support.",
-    "description": "It is best framed around volatile oils with sedation-aware positioning.",
-    "mechanism": "GABAergic and calming relevance is commonly proposed for aroma and oral extract use.",
-    "mechanismTags": [
-      "calming support",
-      "tension support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "linalool",
-      "linalyl acetate"
-    ],
-    "topCompounds": [
-      "linalool"
-    ],
-    "markerCompounds": [
-      "linalool"
-    ],
-    "safetyNotes": "Can be sedating in some users.",
-    "interactions": [
-      "May add to sedative effects from CNS depressants."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "completenessPct": "0.9",
-    "priorityTier": "Medium",
-    "totalScore": "6",
-    "compound_count": "0",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "berberis",
-    "name": "Berberis",
-    "scientificName": "Berberis vulgaris",
-    "latin": "Berberis vulgaris",
-    "category": "root; bark",
-    "class": "root; bark",
-    "plantPartUsed": "root bark",
-    "commonNames": [
-      "barberry",
-      "berberis"
-    ],
-    "region": "Europe, North Africa, West Asia",
-    "summary": "Berberis is positioned for metabolic and antimicrobial support.",
-    "description": "It is best framed around berberine-bearing root bark with GI and medication-interaction caution.",
-    "mechanism": "AMPK and antimicrobial relevance are commonly cited positioning anchors.",
-    "mechanismTags": [
-      "antimicrobial support",
-      "metabolic support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "berberine",
-      "berbamine"
-    ],
-    "topCompounds": [
-      "berberine"
-    ],
-    "markerCompounds": [
-      "berberine"
-    ],
-    "safetyNotes": "Use caution in pregnancy, breastfeeding, and in those prone to GI upset.",
-    "interactions": [
-      "May interact with cytochrome-metabolized drugs",
-      "glucose-lowering agents",
-      "and anticoagulants."
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "completenessPct": "0.9",
-    "priorityTier": "High",
-    "totalScore": "3",
-    "compound_count": "0",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "bitter-melon",
-    "name": "Bitter Melon",
-    "scientificName": "Momordica charantia",
-    "latin": "Momordica charantia",
-    "category": "fruit",
-    "class": "fruit",
-    "plantPartUsed": "fruit",
-    "commonNames": [
-      "bitter melon",
-      "bitter gourd"
-    ],
-    "region": "Asia, Africa, Caribbean, tropics",
-    "summary": "Bitter melon is positioned for glucose and metabolic support.",
-    "description": "It is best framed as a food-medicine with hypoglycemia-aware caution.",
-    "mechanism": "Glucose-handling relevance is the core positioning feature.",
-    "mechanismTags": [
-      "glucose support",
-      "metabolic support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "charantin",
-      "polypeptide-p",
-      "cucurbitanes"
-    ],
-    "topCompounds": [
-      "charantin"
-    ],
-    "markerCompounds": [
-      "charantin"
-    ],
-    "safetyNotes": "Use caution in people prone to low blood sugar and during pregnancy.",
-    "interactions": [
-      "May add to glucose-lowering drugs and should be used cautiously with diabetes medications."
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "completenessPct": "0.9",
-    "priorityTier": "High",
-    "totalScore": "3",
-    "compound_count": "0",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "coleus-forskohlii",
-    "name": "Coleus Forskohlii",
-    "scientificName": "Coleus forskohlii",
-    "latin": "Coleus forskohlii",
-    "category": "root",
-    "class": "root",
-    "plantPartUsed": "root",
-    "commonNames": [
-      "coleus forskohlii",
-      "forskolin"
-    ],
-    "region": "India and subtropical regions",
-    "summary": "Coleus forskohlii is positioned for cAMP-linked metabolic and vascular support.",
-    "description": "It is best framed around forskolin with blood-pressure and stimulant-stack caution.",
-    "mechanism": "Direct adenylate cyclase activation is the core proposed mechanism.",
-    "mechanismTags": [
-      "metabolic support",
-      "vascular support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "forskolin"
-    ],
-    "topCompounds": [
-      "forskolin"
-    ],
-    "markerCompounds": [
-      "forskolin"
-    ],
-    "safetyNotes": "Use caution with low blood pressure, bleeding risk, and GI sensitivity.",
-    "interactions": [
-      "May interact with antihypertensives",
-      "anticoagulants",
-      "bronchodilators",
-      "and stimulant stacks."
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "completenessPct": "0.9",
-    "priorityTier": "High",
-    "totalScore": "3",
-    "compound_count": "0",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "aloe-vera-wb",
-    "name": "Aloe Vera",
-    "scientificName": "Aloe vera",
-    "latin": "Aloe vera",
-    "category": "botanical",
-    "class": "botanical",
-    "plantPartUsed": "varies",
-    "commonNames": [
-      "aloe vera"
-    ],
-    "summary": "Aloe Vera is an intake-stage monograph candidate linked to 1 internal compound records in the current workbook.",
-    "description": "Internal cross-linking supports Aloe Vera through compounds such as aloin.",
-    "mechanism": "Current internal mapping is compound-linked, with pathway resolution still limited.",
-    "mechanismTags": [
-      "anti-inflammatory",
-      "demulcent",
-      "digestive support"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "acemannan",
-      "aloe-emodin",
-      "aloin"
-    ],
-    "topCompounds": [
-      "acemannan",
-      "aloe-emodin"
-    ],
-    "markerCompounds": [
-      "acemannan",
-      "aloe-emodin"
-    ],
-    "safetyNotes": "General use caution; distinguish inner gel from latex-rich stimulant-laxative fractions",
-    "interactions": [
-      "May amplify laxative-heavy or glucose-lowering contexts"
-    ],
-    "contraindications": [
-      "Use caution with diarrhea-prone or pregnancy-sensitive contexts when latex fractions are relevant"
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "frontendReadyFlag": "No",
-    "completenessPct": "0.95",
-    "priorityTier": "High",
-    "totalScore": "4",
-    "compound_count": "0",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "american-ginseng-wb",
-    "name": "American Ginseng",
-    "scientificName": "Panax quinquefolius",
-    "latin": "Panax quinquefolius",
-    "category": "botanical",
-    "class": "botanical",
-    "plantPartUsed": "varies",
-    "commonNames": [
-      "american ginseng"
-    ],
-    "summary": "American Ginseng is an intake-stage monograph candidate linked to 3 internal compound records and pathway tags including gabaergic_modulation, inflammatory_pathway_modulation.",
-    "description": "Internal cross-linking supports American Ginseng through compounds such as ginsenosides (including rb1, rg1), rb2.",
-    "mechanism": "Internal workbook mapping currently connects this herb to gabaergic_modulation, inflammatory_pathway_modulation.",
-    "mechanismTags": [
-      "gabaergic_modulation",
-      "inflammatory_pathway_modulation"
-    ],
-    "evidenceLevel": "Unknown",
-    "activeCompounds": [
-      "ginsenosides (including rb1",
-      "rg1)",
-      "rb2"
-    ],
-    "topCompounds": [
-      "ginsenosides (including rb1"
-    ],
-    "markerCompounds": [
-      "ginsenosides (including rb1"
-    ],
-    "safetyNotes": "Safety review required before publication.",
-    "interactions": [
-      "Interaction review required before publication."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "frontendReadyFlag": "No",
-    "completenessPct": "0.95",
-    "priorityTier": "High",
-    "totalScore": "6",
-    "compound_count": "0",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "artemisia-annua-wb",
-    "name": "Artemisia Annua",
-    "scientificName": "Artemisia annua",
-    "latin": "Artemisia annua",
-    "category": "botanical",
-    "class": "botanical",
-    "plantPartUsed": "varies",
-    "commonNames": [
-      "artemisia annua"
-    ],
-    "summary": "Artemisia Annua is an intake-stage monograph candidate linked to 1 internal compound records in the current workbook.",
-    "description": "Internal cross-linking supports Artemisia Annua through compounds such as artemisinin.",
-    "mechanism": "Current internal mapping is compound-linked, with pathway resolution still limited.",
-    "mechanismTags": [
-      "antimicrobial",
-      "immune support",
-      "oxidative stress modulation"
-    ],
-    "evidenceLevel": "Human",
-    "activeCompounds": [
-      "artemisinin",
-      "arteannuin B",
-      "chrysosplenetin"
-    ],
-    "topCompounds": [
-      "artemisinin",
-      "arteannuin B"
-    ],
-    "markerCompounds": [
-      "artemisinin",
-      "arteannuin B"
-    ],
-    "safetyNotes": "Review interactions and contraindications",
-    "interactions": [
-      "May interact with liver-metabolized stacks and intensive antimicrobial protocols"
-    ],
-    "contraindications": [
-      "Avoid pregnancy-sensitive contexts without stronger review"
-    ],
-    "publishStatus": "Source review",
-    "readinessFlag": "Needs work",
-    "frontendReadyFlag": "No",
-    "completenessPct": "0.95",
-    "priorityTier": "High",
-    "totalScore": "4",
-    "compound_count": "0",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "celastrus-paniculatus-wb",
-    "name": "Celastrus Paniculatus",
-    "scientificName": "Celastrus paniculatus",
-    "latin": "Celastrus paniculatus",
-    "category": "botanical",
-    "class": "botanical",
-    "plantPartUsed": "varies",
-    "commonNames": [
-      "celastrus paniculatus"
-    ],
-    "summary": "Celastrus Paniculatus is an intake-stage monograph candidate linked to 4 internal compound records in the current workbook.",
-    "description": "Internal cross-linking supports Celastrus Paniculatus through compounds such as beta-amyrin, celastrine, lupeol.",
-    "mechanism": "Current internal mapping is compound-linked, with pathway resolution still limited.",
-    "mechanismTags": [
-      "general or unknown targets"
-    ],
-    "evidenceLevel": "Unknown",
-    "activeCompounds": [
-      "beta-amyrin",
-      "celastrine",
-      "lupeol",
-      "celapanin"
-    ],
-    "topCompounds": [
-      "beta-amyrin"
-    ],
-    "markerCompounds": [
-      "beta-amyrin"
-    ],
-    "safetyNotes": "Safety review required before publication.",
-    "interactions": [
-      "Interaction review required before publication."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "frontendReadyFlag": "No",
-    "completenessPct": "0.95",
-    "priorityTier": "High",
-    "totalScore": "7",
-    "pathwayTargets": [
-      "unclassified"
-    ],
-    "compound_count": "1",
-    "pathway_count": "1"
-  },
-  {
-    "slug": "calamus-wb",
+    "slug": "acorus-calamus",
     "name": "Calamus",
     "scientificName": "Acorus calamus",
     "latin": "Acorus calamus",
@@ -6894,7 +7061,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "cayenne",
+    "slug": "capsicum-annuum",
     "name": "Cayenne",
     "scientificName": "Capsicum annuum",
     "latin": "Capsicum annuum",
@@ -6937,7 +7104,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "corydalis",
+    "slug": "corydalis-yanhusuo",
     "name": "Corydalis",
     "scientificName": "Corydalis yanhusuo",
     "latin": "Corydalis yanhusuo",
@@ -6985,7 +7152,7 @@
     "pathway_count": "3"
   },
   {
-    "slug": "chinese-skullcap",
+    "slug": "scutellaria-baicalensis",
     "name": "Chinese Skullcap",
     "scientificName": "Scutellaria baicalensis",
     "latin": "Scutellaria baicalensis",
@@ -7034,7 +7201,7 @@
     "pathway_count": "3"
   },
   {
-    "slug": "phellodendron",
+    "slug": "phellodendron-amurense",
     "name": "Phellodendron",
     "scientificName": "Phellodendron amurense",
     "latin": "Phellodendron amurense",
@@ -7078,7 +7245,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "coptis",
+    "slug": "coptis-chinensis",
     "name": "Coptis",
     "scientificName": "Coptis chinensis",
     "latin": "Coptis chinensis",
@@ -7122,7 +7289,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "saffron",
+    "slug": "crocus-sativus",
     "name": "Saffron",
     "scientificName": "Crocus sativus",
     "latin": "Crocus sativus",
@@ -7165,7 +7332,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "papaya-leaf",
+    "slug": "carica-papaya",
     "name": "Papaya Leaf",
     "scientificName": "Carica papaya",
     "latin": "Carica papaya",
@@ -7208,7 +7375,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "kanna-wb",
+    "slug": "sceletium-tortuosum",
     "name": "Kanna",
     "scientificName": "Sceletium tortuosum",
     "latin": "Sceletium tortuosum",
@@ -7251,7 +7418,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "green-tea",
+    "slug": "camellia-sinensis",
     "name": "Green Tea",
     "scientificName": "Camellia sinensis",
     "latin": "Camellia sinensis",
@@ -7304,7 +7471,7 @@
     "pathway_count": "9"
   },
   {
-    "slug": "goldenseal",
+    "slug": "hydrastis-canadensis",
     "name": "Goldenseal",
     "scientificName": "Hydrastis canadensis",
     "latin": "Hydrastis canadensis",
@@ -7347,7 +7514,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "salacia",
+    "slug": "salacia-reticulata",
     "name": "Salacia",
     "scientificName": "Salacia reticulata",
     "latin": "Salacia reticulata",
@@ -7389,7 +7556,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "chuanxiong",
+    "slug": "ligusticum-chuanxiong",
     "name": "Chuanxiong",
     "scientificName": "Ligusticum chuanxiong",
     "latin": "Ligusticum chuanxiong",
@@ -7438,7 +7605,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "fingerroot",
+    "slug": "boesenbergia-rotunda",
     "name": "Fingerroot",
     "scientificName": "Boesenbergia rotunda",
     "latin": "Boesenbergia rotunda",
@@ -7480,7 +7647,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "wormwood-wb",
+    "slug": "artemisia-absinthium",
     "name": "Wormwood",
     "scientificName": "Artemisia absinthium",
     "latin": "Artemisia absinthium",
@@ -7522,7 +7689,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "horse-chestnut",
+    "slug": "aesculus-hippocastanum",
     "name": "Horse Chestnut",
     "scientificName": "Aesculus hippocastanum",
     "latin": "Aesculus hippocastanum",
@@ -7570,7 +7737,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "bael",
+    "slug": "aegle-marmelos",
     "name": "Bael",
     "scientificName": "Aegle marmelos",
     "latin": "Aegle marmelos",
@@ -7612,7 +7779,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "guayusa-wb",
+    "slug": "ilex-guayusa",
     "name": "Guayusa",
     "scientificName": "Ilex guayusa",
     "latin": "Ilex guayusa",
@@ -7656,7 +7823,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "honeysuckle",
+    "slug": "lonicera-japonica",
     "name": "Honeysuckle",
     "scientificName": "Lonicera japonica",
     "latin": "Lonicera japonica",
@@ -7698,49 +7865,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "cassia-alata-wb",
-    "name": "Cassia Alata",
-    "scientificName": "Senna alata",
-    "latin": "Senna alata",
-    "category": "botanical",
-    "class": "botanical",
-    "plantPartUsed": "varies",
-    "commonNames": [
-      "cassia alata"
-    ],
-    "summary": "Cassia Alata is an intake-stage monograph candidate linked to 2 internal compound records and pathway tags including MAPK pathway, NF-kB inhibition.",
-    "description": "Internal cross-linking supports Cassia Alata through compounds such as aloe-emodin, chrysophanol.",
-    "mechanism": "Internal workbook mapping currently connects this herb to MAPK pathway, NF-kB inhibition.",
-    "mechanismTags": [
-      "mapk pathway",
-      "nf-kb inhibition"
-    ],
-    "evidenceLevel": "Unknown",
-    "activeCompounds": [
-      "aloe-emodin",
-      "chrysophanol"
-    ],
-    "topCompounds": [
-      "aloe-emodin"
-    ],
-    "markerCompounds": [
-      "aloe-emodin"
-    ],
-    "safetyNotes": "Safety review required before publication.",
-    "interactions": [
-      "Interaction review required before publication."
-    ],
-    "publishStatus": "Editorial polish",
-    "readinessFlag": "Near ready",
-    "frontendReadyFlag": "No",
-    "completenessPct": "0.95",
-    "priorityTier": "High",
-    "totalScore": "6",
-    "compound_count": "0",
-    "pathway_count": "0"
-  },
-  {
-    "slug": "american-yellow-lotus-wb",
+    "slug": "nelumbo-lutea",
     "name": "American Yellow Lotus",
     "scientificName": "Nelumbo lutea",
     "latin": "Nelumbo lutea",
@@ -7783,7 +7908,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "anise-hyssop",
+    "slug": "agastache-foeniculum",
     "name": "Anise Hyssop",
     "scientificName": "Agastache foeniculum",
     "latin": "Agastache foeniculum",
@@ -7825,7 +7950,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "marshmallow",
+    "slug": "althaea-officinalis",
     "name": "Marshmallow",
     "scientificName": "Althaea officinalis",
     "latin": "Althaea officinalis",
@@ -7872,7 +7997,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "licorice",
+    "slug": "glycyrrhiza-glabra",
     "name": "Licorice",
     "scientificName": "Glycyrrhiza glabra",
     "latin": "Glycyrrhiza glabra",
@@ -7912,7 +8037,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "elderberry",
+    "slug": "sambucus-nigra",
     "name": "Elderberry",
     "scientificName": "Sambucus nigra",
     "latin": "Sambucus nigra",
@@ -7961,7 +8086,7 @@
     "pathway_count": "0"
   },
   {
-    "slug": "punarnava",
+    "slug": "boerhavia-diffusa",
     "name": "Punarnava",
     "scientificName": "Boerhavia diffusa",
     "latin": "Boerhavia diffusa",
@@ -8013,7 +8138,7 @@
     "pathway_count": "1"
   },
   {
-    "slug": "coffee-cherry",
+    "slug": "coffee",
     "name": "Coffee Cherry",
     "scientificName": "Coffea arabica",
     "latin": "Coffea arabica",


### PR DESCRIPTION
### Motivation

- Produce deterministic, site-facing JSON exports from the workbook (herbs, compounds, herb↔compound map) using the updated workbook export pipeline while preserving stable slugs, deduping arrays, and stripping invalid/empty values. 

### Description

- Re-ran the workbook export and updated the three site-facing outputs: `public/data/workbook-herbs.json`, `public/data/workbook-compounds.json`, and `public/data/workbook-herb-compound-map.json` using `Site Export Herbs` and `Site Export Compounds` (with legacy fallbacks) and normalized header mappings. 
- Export logic applies slug normalization, de-duplication (`dedupeBy`), array normalization, and `removeEmptyValues` to strip invalid/empty junk prior to writing JSON files. 
- Merged primary-sheet rows with legacy fallback rows and normalized multi-value fields (semicolon/comma delimited) to keep exports deterministic and stable. 
- Committed regenerated files containing updated content, slug/id normalization, and many compound/herb content corrections and enrichments.

### Testing

- Commands run and results: executed `node scripts/export-workbook-to-json.mjs` which completed successfully and printed `[export] workbook-herbs.json: 172 records written`, `[export] workbook-compounds.json: 631 records written`, and `[export] workbook-herb-compound-map.json: 222 records written`; follow-up `git add` + `git commit` completed for the three files. 
- Changed-file list: `public/data/workbook-herbs.json`, `public/data/workbook-compounds.json`, and `public/data/workbook-herb-compound-map.json` were updated and committed. 
- Key diffs / notable normalization: many compound slugs were normalized (removal of legacy `-wb` suffixes), several compound and herb records contain enriched `mechanism`, `mechanismTags`, `pathwayTargets`, `confidence`/`evidence` fields, and new deduping/cleanup removed empty/object noise across records. 
- Diagnostics and follow-ups: exporter flagged `Site Export Compounds` missing required `compoundName` column causing `630` rows to be skipped (diagnostic: `Site Export Compounds: missing required columns => compoundName`), and `Herb Compound Map V3` deduped/skipped `5` rows; recommended next steps are to fix the workbook `Site Export Compounds` sheet (restore `compoundName` header/data), re-run `node scripts/export-workbook-to-json.mjs` and validate the compound-layer coverage before any downstream publication or frontend integration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd2e8c634c83238080ee9605256a76)