### PR TITLE
Bridge workbook export fields into existing herb/compound UI models

### DIFF
--- a/src/lib/compound-data.ts
+++ b/src/lib/compound-data.ts
@@ -236,13 +236,27 @@ function normalizeSources(value: unknown): SourceRef[] {
     .filter((item): item is SourceRef => Boolean(item))
 }
 
+function readContextRecord(data: Record<string, unknown>): Record<string, unknown> {
+  const context = data.context
+  return context && typeof context === 'object' ? (context as Record<string, unknown>) : {}
+}
+
+function readSafetyRecord(data: Record<string, unknown>): Record<string, unknown> {
+  const safety = data.safety
+  return safety && typeof safety === 'object' ? (safety as Record<string, unknown>) : {}
+}
+
 function normalizeCompound(raw: Record<string, unknown>): CompoundRecord {
   const { data } = sanitizeCompoundRecord(raw, { debug: import.meta.env.DEV })
+  const context = readContextRecord(data)
+  const safetyRecord = readSafetyRecord(data)
   const name = cleanText(data.name ?? data.commonName ?? data.id) || ''
   const slug = String(data.slug || slugify(name))
-  const effects = splitClean(data.effects)
-  const herbs = splitClean(data.associatedHerbs ?? data.foundInHerbs ?? data.herbs ?? data.foundIn)
-  const mechanism = cleanText(data.mechanism ?? data.mechanismOfAction) || ''
+  const effects = splitClean(data.effects ?? data.keyEffects)
+  const herbs = splitClean(
+    data.associatedHerbs ?? data.foundInHerbs ?? data.herbs ?? data.foundIn ?? context.foundIn,
+  )
+  const mechanism = cleanText(data.mechanism ?? data.mechanisms ?? data.mechanismOfAction) || ''
   const researchEnrichment = normalizeResearchEnrichment(data.researchEnrichment)
   const rawInteractionTags = splitClean(data.interactionTags)
   const rawInteractionNotes = splitClean(data.interactionNotes)
@@ -254,9 +268,11 @@ function normalizeCompound(raw: Record<string, unknown>): CompoundRecord {
   })
   const identity = cleanText(data.identity) || ''
   const categoryUseContext = cleanText(data.categoryUseContext ?? data.category_use_context) || ''
-  const evidenceLevel = cleanText(data.evidenceLevel ?? data.evidence_level) || ''
-  const relatedEntities = splitClean(data.relatedEntities)
-  const relatedCompounds = splitClean(data.relatedCompounds)
+  const evidenceLevel =
+    cleanText(data.evidenceLevel ?? data.evidence_level ?? safetyRecord.evidence ?? safetyRecord.confidence) ||
+    ''
+  const relatedEntities = splitClean(data.relatedEntities ?? context.foundIn)
+  const relatedCompounds = splitClean(data.relatedCompounds ?? context.relatedCompounds)
   const linkedHerbs = splitClean(data.linkedHerbs)
   const compounds = splitClean(data.compounds ?? data.relatedCompounds)
   const benefits = splitClean(data.benefits ?? data.effects)
@@ -266,7 +282,8 @@ function normalizeCompound(raw: Record<string, unknown>): CompoundRecord {
     id: String(data.id || slug),
     slug,
     name,
-    description: cleanText(data.description ?? data.summary) || '',
+    description:
+      cleanText(data.description ?? data.summary ?? data.hero ?? data.intro ?? data.coreInsight) || '',
     className: cleanText(data.class ?? data.type ?? data.className) || '',
     category: cleanText(data.category ?? data.class ?? data.type ?? data.className) || '',
     intensity: cleanText(data.intensity) || '',
@@ -301,15 +318,17 @@ function normalizeCompound(raw: Record<string, unknown>): CompoundRecord {
     lastUpdated: String(data.lastUpdated || data.updatedAt || '').trim(),
     curatedData: getCuratedData({
       name,
-      summary: cleanText(data.summary) || cleanText(data.description) || '',
-      description: cleanText(data.description ?? data.summary) || '',
-      whyItMatters: cleanText(data.whyItMatters) || '',
-      primaryEffects: splitClean(data.primaryEffects ?? effects),
+      summary:
+        cleanText(data.summary ?? data.description ?? data.hero ?? data.intro ?? data.coreInsight) || '',
+      description:
+        cleanText(data.description ?? data.summary ?? data.hero ?? data.intro ?? data.coreInsight) || '',
+      whyItMatters: cleanText(data.whyItMatters ?? data.coreInsight ?? data.overview) || '',
+      primaryEffects: splitClean(data.primaryEffects ?? data.keyEffects ?? effects),
       effects,
       contraindications: splitClean(data.contraindications),
       interactions: splitClean(data.interactions),
       sideEffects: splitClean(data.sideEffects),
-      safety: splitClean(data.safety),
+      safety: splitClean(data.safety ?? safetyRecord.caution ?? safetyRecord.notes ?? safetyRecord.summary),
       mechanism,
     }),
     rawData: data as Record<string, unknown>,
@@ -317,8 +336,9 @@ function normalizeCompound(raw: Record<string, unknown>): CompoundRecord {
 }
 
 function normalizeCompoundSummary(raw: Record<string, unknown>): CompoundSummaryRecord {
-  const effects = splitClean(raw.effects)
-  const herbs = splitClean(raw.herbs)
+  const context = readContextRecord(raw)
+  const effects = splitClean(raw.effects ?? raw.keyEffects)
+  const herbs = splitClean(raw.herbs ?? raw.foundIn ?? context.foundIn)
   const confidence = String(raw.confidence || '')
     .trim()
     .toLowerCase()
@@ -329,13 +349,13 @@ function normalizeCompoundSummary(raw: Record<string, unknown>): CompoundSummary
       .trim()
       .toLowerCase(),
     name: cleanText(raw.name) || '',
-    summaryShort: cleanText(raw.summaryShort ?? raw.description) || '',
-    description: cleanText(raw.description ?? raw.summaryShort) || '',
+    summaryShort: cleanText(raw.summaryShort ?? raw.description ?? raw.summary ?? raw.hero ?? raw.coreInsight) || '',
+    description: cleanText(raw.description ?? raw.summaryShort ?? raw.summary ?? raw.hero ?? raw.coreInsight) || '',
     className: cleanText(raw.className) || '',
     category: cleanText(raw.category ?? raw.className) || '',
-    mechanism: cleanText(raw.mechanism) || '',
+    mechanism: cleanText(raw.mechanism ?? raw.mechanisms) || '',
     effects,
-    primaryEffects: splitClean(raw.primaryEffects ?? effects).slice(0, 4),
+    primaryEffects: splitClean(raw.primaryEffects ?? raw.keyEffects ?? effects).slice(0, 4),
     herbs,
     confidence: confidence === 'high' || confidence === 'medium' ? confidence : 'low',
     hasInteractionData: Boolean(raw.hasInteractionData),

--- a/src/lib/herb-data.ts
+++ b/src/lib/herb-data.ts
@@ -270,8 +270,20 @@ function normalizeProductRecommendations(value: unknown): ProductRecommendation[
     .slice(0, 2)
 }
 
+function readContextRecord(data: Record<string, unknown>): Record<string, unknown> {
+  const context = data.context
+  return context && typeof context === 'object' ? (context as Record<string, unknown>) : {}
+}
+
+function readSafetyRecord(data: Record<string, unknown>): Record<string, unknown> {
+  const safety = data.safety
+  return safety && typeof safety === 'object' ? (safety as Record<string, unknown>) : {}
+}
+
 function normalizeHerbRow(raw: Record<string, unknown>): Herb {
   const { data } = sanitizeHerbRecord(raw, { debug: import.meta.env.DEV })
+  const context = readContextRecord(data)
+  const safetyRecord = readSafetyRecord(data)
   const common = cleanText(data.common ?? data.commonName ?? data.name) || ''
   const scientific =
     cleanText(data.scientific ?? data.latin ?? data.latinName ?? data.scientificName) || ''
@@ -279,11 +291,14 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
     .trim()
     .toLowerCase()
 
-  const effects = splitClean(data.effects)
+  const effects = splitClean(data.effects ?? data.keyEffects)
   const contraindications = splitClean(data.contraindications)
   const interactions = splitClean(data.interactions)
   const sideeffects = splitClean(data.sideEffects ?? data.sideeffects)
   const safetyNotes = normalizeSafetyNotes(
+    safetyRecord.caution,
+    safetyRecord.notes,
+    safetyRecord.summary,
     data.safetyNotes,
     data.safety,
     data.contraindications,
@@ -306,8 +321,9 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
     seed: seededInteraction,
   })
 
-  const mechanism = cleanText(data.mechanism ?? data.mechanismOfAction) || ''
-  const description = cleanText(data.description ?? data.summary) || ''
+  const mechanism = cleanText(data.mechanism ?? data.mechanisms ?? data.mechanismOfAction) || ''
+  const description =
+    cleanText(data.description ?? data.summary ?? data.hero ?? data.intro ?? data.coreInsight) || ''
   const duration = cleanText(data.duration) || ''
   const dosage = cleanText(data.dosage) || ''
   const preparation = cleanText(data.preparation) || ''
@@ -315,11 +331,13 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
   const region = cleanText(data.region) || ''
   const category = cleanText(data.class ?? data.category) || ''
   const intensity = cleanText(data.intensity) || ''
-  const relatedEntities = splitClean(data.relatedEntities)
-  const relatedCompounds = splitClean(data.relatedCompounds)
+  const relatedEntities = splitClean(data.relatedEntities ?? context.foundIn)
+  const relatedCompounds = splitClean(data.relatedCompounds ?? context.relatedCompounds)
   const identity = cleanText(data.identity) || ''
   const categoryUseContext = cleanText(data.categoryUseContext ?? data.category_use_context) || ''
-  const evidenceLevel = cleanText(data.evidenceLevel ?? data.evidence_level) || ''
+  const evidenceLevel =
+    cleanText(data.evidenceLevel ?? data.evidence_level ?? safetyRecord.evidence ?? safetyRecord.confidence) ||
+    ''
   const benefits = splitClean(data.benefits ?? data.effects)
 
   return {
@@ -364,8 +382,8 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
       name: common || scientific || slug,
       summary: description,
       description,
-      whyItMatters: cleanText(data.whyItMatters) || description,
-      primaryEffects: splitClean(data.primaryEffects ?? effects),
+      whyItMatters: cleanText(data.whyItMatters ?? data.coreInsight ?? data.overview) || description,
+      primaryEffects: splitClean(data.primaryEffects ?? data.keyEffects ?? effects),
       effects,
       contraindications,
       interactions,
@@ -378,12 +396,14 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
 }
 
 function normalizeHerbSummaryRow(raw: Record<string, unknown>): HerbSummary {
+  const context = readContextRecord(raw)
+  const safetyRecord = readSafetyRecord(raw)
   const slug = String(raw.slug || '')
     .trim()
     .toLowerCase()
   const common = cleanText(raw.common ?? raw.commonName ?? raw.name) || ''
   const scientific = cleanText(raw.scientific ?? raw.latin ?? raw.scientificName) || ''
-  const effects = splitClean(raw.effects)
+  const effects = splitClean(raw.effects ?? raw.keyEffects)
   const activeCompounds = splitClean(raw.activeCompounds ?? raw.compounds)
   const confidence = String(raw.confidence || '').toLowerCase()
   const confidenceLevel: Herb['confidence'] =
@@ -398,11 +418,11 @@ function normalizeHerbSummaryRow(raw: Record<string, unknown>): HerbSummary {
     category: cleanText(raw.category) || '',
     class: cleanText(raw.class) || '',
     confidence: confidenceLevel,
-    summaryShort: cleanText(raw.summaryShort ?? raw.description) || '',
-    description: cleanText(raw.description ?? raw.summaryShort) || '',
-    mechanism: cleanText(raw.mechanism) || '',
+    summaryShort: cleanText(raw.summaryShort ?? raw.description ?? raw.summary ?? raw.hero ?? raw.coreInsight) || '',
+    description: cleanText(raw.description ?? raw.summaryShort ?? raw.summary ?? raw.hero ?? raw.coreInsight) || '',
+    mechanism: cleanText(raw.mechanism ?? raw.mechanisms) || '',
     effects,
-    primaryEffects: splitClean(raw.primaryEffects ?? effects).slice(0, 4),
+    primaryEffects: splitClean(raw.primaryEffects ?? raw.keyEffects ?? effects).slice(0, 4),
     activeCompounds,
     compounds: activeCompounds,
     interactionTags: splitClean(raw.interactionTags),
@@ -410,11 +430,11 @@ function normalizeHerbSummaryRow(raw: Record<string, unknown>): HerbSummary {
     interactions: splitClean(raw.interactions),
     contraindications: splitClean(raw.contraindications),
     mechanismOfAction: cleanText(raw.mechanismOfAction) || '',
-    safety: cleanText(raw.safety) || '',
+    safety: cleanText(raw.safety ?? safetyRecord.caution ?? safetyRecord.summary) || '',
     sideEffects: cleanText(raw.sideEffects) || '',
     toxicity: cleanText(raw.toxicity) || '',
     tags: splitClean(raw.tags),
-    region: cleanText(raw.region) || '',
+    region: cleanText(raw.region ?? context.region) || '',
     legalstatus: cleanText(raw.legalstatus) || '',
     commonName: cleanText(raw.commonName) || '',
     activeConstituents: Array.isArray(raw.activeConstituents)


### PR DESCRIPTION
### Motivation
- Map workbook-export shapes into the exact frontend shape the detail pages expect without changing UI models or rendering behavior. 
- Accept additional workbook fields (`hero`, `coreInsight`, `mechanisms`, `keyEffects`, nested `context`/`safety`) as fallbacks so editorial exports can feed the site.
- Preserve backward compatibility and avoid duplicate meaning by only using workbook-derived values when canonical fields are missing.

### Description
- Updated adapters in `src/lib/herb-data.ts` and `src/lib/compound-data.ts` to add lightweight bridge logic and safe readers for nested workbook objects (`context`, `safety`).
- Added helpers `readContextRecord` and `readSafetyRecord` and used them to populate fallback fields used by the UI (detail + summary normalizers).
- Implemented these specific mapping fallbacks: `hero`/`intro`/`coreInsight` → `summary`/`description`, `effects`/`keyEffects` → `effects` & `primaryEffects`, `mechanisms` → `mechanism`, `context.foundIn` → `relatedEntities`/`herbs`, `context.relatedCompounds` → `relatedCompounds`, and `safety.{caution,notes,summary}` → safety lists with `safety.{evidence,confidence}` → evidence/evidenceLevel.
- Preserved existing precedence: canonical/legacy fields (e.g., `description`, `mechanism`, `effects`) remain primary and workbook fields are used only as fallbacks to avoid double-rendering of the same concept.
- Files changed: `src/lib/herb-data.ts`, `src/lib/compound-data.ts`.

### Testing
- Ran production build with `npm run build`, which completed and produced the prerendered output (build + prerender checks passed).
- Ran repository test command `npm run test -- --run src/__tests__/sanitizeData.test.ts src/__tests__/trust.test.ts`, which is a no-op in this repo and exited successfully (`No tests specified`).
- Committed changes with message `Add workbook bridge mapping for herb and compound detail fields` after lint hooks; commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd2fece2c483238d6d0de4b1e9e3dd)