### PR TITLE
Prioritize workbook-curated card/detail content with legacy fallback

### DIFF
--- a/src/components/CompoundCard.tsx
+++ b/src/components/CompoundCard.tsx
@@ -4,6 +4,7 @@ import { buildCardSummary } from '@/lib/summary'
 import { extractPrimaryEffects } from '@/utils/extractPrimaryEffects'
 import { calculateCompoundConfidence } from '@/utils/calculateConfidence'
 import { formatBrowseTitle } from '@/utils/titleDisplay'
+import { cleanEffectChips, sanitizeSummaryText } from '@/lib/sanitize'
 
 interface HerbRef {
   name: string
@@ -16,6 +17,10 @@ export interface CompoundWithRefs extends Compound {
 }
 
 function getMechanism(compound: CompoundWithRefs): string {
+  const rawRecord = compound.rawData as Record<string, unknown> | undefined
+  const workbookMechanism = String(rawRecord?.mechanisms || rawRecord?.mechanism || '').trim()
+  if (workbookMechanism) return workbookMechanism
+
   if (typeof compound.mechanism === 'string' && compound.mechanism.trim()) {
     return compound.mechanism
   }
@@ -24,27 +29,50 @@ function getMechanism(compound: CompoundWithRefs): string {
   return typeof legacyMechanism === 'string' ? legacyMechanism : ''
 }
 
+function getWorkbookHero(compound: CompoundWithRefs): string {
+  const rawRecord = compound.rawData as Record<string, unknown> | undefined
+  return sanitizeSummaryText(
+    rawRecord?.hero || rawRecord?.coreInsight || compound.curatedData?.summary || compound.description || '',
+    1,
+  )
+}
+
+function normalizeChip(value: string): string {
+  return value
+    .replace(/[.,/#!$%^&*;:{}=\-_`~()]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
 export default function CompoundCard({ compound }: { compound: CompoundWithRefs }) {
   const mechanism = getMechanism(compound)
-  const effects = Array.isArray(compound.effects) ? compound.effects : []
+  const workbookEffects = cleanEffectChips(
+    (compound.rawData as Record<string, unknown> | undefined)?.effects ||
+      compound.curatedData?.keyEffects ||
+      compound.effects ||
+      [],
+    4,
+  )
+  const effects = Array.isArray(workbookEffects) ? workbookEffects : []
   const confidence = calculateCompoundConfidence({
     mechanism,
     effects,
     compounds: compound.herbsFound.map(h => h.name),
   })
-  const primaryEffects = extractPrimaryEffects(effects, 2)
+  const primaryEffects = extractPrimaryEffects(effects, 2).map(normalizeChip).filter(Boolean)
   const visibleHerbs = compound.herbsFound.slice(0, 2)
   const hiddenHerbCount = Math.max(compound.herbsFound.length - visibleHerbs.length, 0)
   const title = formatBrowseTitle(compound.name, 60)
   const isTitleTruncated = title !== compound.name
-  const summary =
+  const summary = getWorkbookHero(compound) ||
     buildCardSummary({
       effects,
       mechanism,
       description: compound.description,
       activeCompounds: compound.herbsFound.map(h => h.name),
       maxLen: 120,
-    })?.trim() || 'Summary coming soon.'
+    })?.trim() ||
+    'Summary coming soon.'
   const sourceLine =
     visibleHerbs.length > 0
       ? `Found in ${visibleHerbs.map(h => h.name).join(', ')}${hiddenHerbCount > 0 ? ` +${hiddenHerbCount}` : ''}`
@@ -64,7 +92,7 @@ export default function CompoundCard({ compound }: { compound: CompoundWithRefs 
       </h2>
       <p className='line-clamp-2 text-xs leading-[1.35] text-white/72'>{summary}</p>
       <div className='flex flex-wrap gap-1'>
-        <span className='ds-pill'>{confidence}</span>
+        <span className='ds-pill'>{normalizeChip(confidence)}</span>
         {primaryEffects[0] && <span className='ds-pill'>{primaryEffects[0]}</span>}
       </div>
       <p className='line-clamp-1 text-[11px] text-white/56'>{sourceLine}</p>

--- a/src/components/HerbCard.tsx
+++ b/src/components/HerbCard.tsx
@@ -9,6 +9,9 @@ interface HerbCardProps {
   summary: string
   tags?: string[]
   mechanismTags?: string[]
+  hero?: string
+  effects?: string[]
+  coreInsight?: string
   compound_count?: number
   evidence_tier?: string
   evidenceLevel?: string
@@ -16,25 +19,40 @@ interface HerbCardProps {
   compact?: boolean
 }
 
+function normalizeChip(value: string): string {
+  return value
+    .replace(/[.,/#!$%^&*;:{}=\-_`~()]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
 function HerbCard({
   name,
   summary,
   tags = [],
   mechanismTags = [],
+  hero,
+  effects = [],
+  coreInsight,
   compound_count,
   evidence_tier,
   evidenceLevel,
   detailUrl,
   compact = false,
 }: HerbCardProps) {
-  const mergedTags = Array.from(new Set([...tags, ...mechanismTags].filter(Boolean)))
+  const mergedTags = Array.from(new Set([...effects, ...tags, ...mechanismTags].filter(Boolean)))
+    .map(tag => normalizeChip(String(tag)))
+    .filter(Boolean)
   const primaryTag = mergedTags[0]
   const hasCompoundCount = typeof compound_count === 'number' && compound_count > 0
   const title = formatBrowseTitle(name, 60)
   const isTitleTruncated = title !== name
-  const summaryText = summary?.trim() || 'Overview coming soon.'
+  const summaryText = hero?.trim() || coreInsight?.trim() || summary?.trim() || 'Overview coming soon.'
 
-  const chipItems = [evidence_tier || evidenceLevel || '', primaryTag || ''].filter(Boolean).slice(0, 2)
+  const chipItems = [evidence_tier || evidenceLevel || '', primaryTag || '']
+    .map(chip => normalizeChip(String(chip)))
+    .filter(Boolean)
+    .slice(0, 2)
 
   return (
     <Card

--- a/src/pages/CompoundDetail.tsx
+++ b/src/pages/CompoundDetail.tsx
@@ -130,6 +130,18 @@ function normalizeTextValue(value: unknown): string {
   return String(value || '').trim()
 }
 
+function readRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : {}
+}
+
+function readWorkbookText(record: Record<string, unknown>, ...keys: string[]): string {
+  for (const key of keys) {
+    const value = normalizeTextValue(record[key])
+    if (value) return value
+  }
+  return ''
+}
+
 function splitPipeList(value: unknown): string[] {
   if (Array.isArray(value)) {
     return value.map(item => normalizeTextValue(item)).filter(Boolean)
@@ -194,6 +206,9 @@ export default function CompoundDetail() {
   }
 
   const compoundRecord = compound as unknown as Record<string, unknown>
+  const rawRecord = readRecord(compound.rawData)
+  const contextRecord = readRecord(rawRecord.context)
+  const safetyRecord = readRecord(rawRecord.safety)
   const name =
     normalizeTextValue(compoundRecord.compoundName) ||
     normalizeTextValue(compoundRecord.name) ||
@@ -205,17 +220,34 @@ export default function CompoundDetail() {
   const workbookSources = uniqueNormalizedList(splitPipeList(compoundRecord.sourceUrls))
   const relatedHerbSlugs = uniqueNormalizedList(splitClean(compoundRecord.relatedHerbSlugs))
   const curatedData = compound.curatedData
-  const compoundEffects = cleanEffectChips(curatedData.keyEffects, 12)
+  const compoundEffects = cleanEffectChips(rawRecord.effects || curatedData.keyEffects || compound.effects, 12)
   const compoundContraindications = uniqueNormalizedList(compound.contraindications)
   const compoundSideEffects = uniqueNormalizedList(compound.sideEffects)
   const compoundTherapeuticUses = uniqueNormalizedList(compound.therapeuticUses)
   const compoundInteractions = uniqueNormalizedList(compound.interactions)
-  const compoundDescription = sanitizeSummaryText(curatedData.summary, 2)
-  const compoundMechanism = sanitizeReadableText(curatedData.mechanism)
+  const heroSummary = sanitizeSummaryText(
+    readWorkbookText(rawRecord, 'hero', 'summary', 'description') || curatedData.summary,
+    2,
+  )
+  const coreInsight = sanitizeSummaryText(
+    readWorkbookText(rawRecord, 'coreInsight', 'whyItMatters', 'overview') || curatedData.whyItMatters,
+    1,
+  )
+  const contextSummary = sanitizeSummaryText(
+    readWorkbookText(contextRecord, 'summary', 'overview', 'notes') || readWorkbookText(rawRecord, 'context'),
+    2,
+  )
+  const compoundDescription = heroSummary
+  const compoundMechanism = sanitizeReadableText(
+    readWorkbookText(rawRecord, 'mechanisms', 'mechanism') || curatedData.mechanism,
+  )
+  const workbookSafety = uniqueNormalizedList(
+    splitClean(safetyRecord.notes || safetyRecord.summary || safetyRecord.caution || rawRecord.safety),
+  )
   const drugInteractions = normalizeTextValue(compoundRecord.drugInteractions)
   const uniqueDrugInteractionItems = Array.from(
     new Map(
-      [...compoundInteractions, ...(drugInteractions ? [sanitizeReadableText(drugInteractions)] : [])]
+      [...workbookSafety, ...compoundInteractions, ...(drugInteractions ? [sanitizeReadableText(drugInteractions)] : [])]
         .map(item => normalizeTextValue(item))
         .filter(Boolean)
         .map(item => [normalizeKey(item), item]),
@@ -244,7 +276,8 @@ export default function CompoundDetail() {
     })
   })
 
-  const whyItMatters = sanitizeSummaryText(curatedData.whyItMatters || compoundEffects.slice(0, 2).join(' + '), 1)
+  const whyItMatters = coreInsight ||
+    sanitizeSummaryText(curatedData.whyItMatters || compoundEffects.slice(0, 2).join(' + '), 1)
   const premiumDetails = [
     { title: 'Identity', value: compound.identity },
     {
@@ -425,7 +458,7 @@ export default function CompoundDetail() {
   })
   const governedReviewFreshness = buildGovernedReviewFreshness(governedResearch)
   const topSummary = sanitizeSummaryText(
-    governedIntro.whatItIs || governedIntro.commonUse || compoundDescription || compoundMechanism,
+    compoundDescription || coreInsight || governedIntro.whatItIs || governedIntro.commonUse || compoundMechanism,
     1,
   )
   const topEffects = primaryEffects.slice(0, 4)
@@ -606,6 +639,10 @@ export default function CompoundDetail() {
         )}
 
         {compoundMechanism && <Section title='Mechanism of Action'>{compoundMechanism}</Section>}
+
+        {contextSummary && contextSummary !== topSummary && (
+          <Section title='Context'>{contextSummary}</Section>
+        )}
 
         {compoundEffects.length > 0 && (
           <Section title='Effects'>

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -41,6 +41,18 @@ function splitTextList(value: unknown): string[] {
     .filter(Boolean)
 }
 
+function readRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : {}
+}
+
+function readWorkbookText(raw: Record<string, unknown>, ...keys: string[]): string {
+  for (const key of keys) {
+    const value = String(raw[key] || '').trim()
+    if (value) return value
+  }
+  return ''
+}
+
 function toEvidenceStrengthLabel(value: string) {
   const normalized = String(value || '').trim().toLowerCase()
   if (!normalized) return 'Limited'
@@ -150,14 +162,29 @@ export default function HerbDetail() {
   const herbName = toTitleCase(herb.commonName || herb.common || herb.name || herb.slug)
   const scientificName = String(herb.scientific || herb.latinName || '').trim()
   const curatedData = herb.curatedData
-  const description = String(curatedData.summary || '').trim()
+  const rawRecord = readRecord(herb.rawData)
+  const contextRecord = readRecord(rawRecord.context)
+  const safetyRecord = readRecord(rawRecord.safety)
+  const description = readWorkbookText(rawRecord, 'hero', 'summary', 'description') || String(curatedData.summary || '').trim()
   const descriptionIsPlaceholder = isPlaceholder(description, herbName)
   const summary = sanitizeSummaryText(description, 2)
+  const coreInsight = sanitizeSummaryText(
+    readWorkbookText(rawRecord, 'coreInsight', 'overview', 'whyItMatters') || curatedData.whyItMatters,
+    1,
+  )
 
-  const effects = dedupePresentationList(splitTextList(curatedData.keyEffects), 8).map(toTitleCase)
+  const effects = dedupePresentationList(
+    splitTextList(rawRecord.effects || rawRecord.keyEffects || curatedData.keyEffects),
+    8,
+  ).map(toTitleCase)
   const keyEffects = effects.slice(0, 4)
   const activeCompounds = dedupePresentationList(splitTextList(herb.activeCompounds || herb.compounds), 10)
-  const mechanism = String(curatedData.mechanism || '').trim()
+  const mechanism =
+    readWorkbookText(rawRecord, 'mechanisms', 'mechanism') || String(curatedData.mechanism || '').trim()
+  const contextSummary = sanitizeSummaryText(
+    readWorkbookText(contextRecord, 'summary', 'overview', 'notes') || readWorkbookText(rawRecord, 'context'),
+    2,
+  )
   const dosage = String(herb.dosage || '').trim()
   const duration = String(herb.duration || '').trim()
   const preparation = String(herb.preparation || '').trim()
@@ -165,7 +192,14 @@ export default function HerbDetail() {
   const contraindications = splitTextList(herb.contraindications)
   const interactions = splitTextList(herb.interactions)
   const sideEffects = splitTextList(herb.sideeffects || herb.sideEffects)
-  const safety = splitTextList((herb as Record<string, unknown>).safetyNotes || (herb as Record<string, unknown>).safety)
+  const safety = splitTextList(
+    safetyRecord.notes ||
+      safetyRecord.summary ||
+      safetyRecord.caution ||
+      rawRecord.safety ||
+      (herb as Record<string, unknown>).safetyNotes ||
+      (herb as Record<string, unknown>).safety,
+  )
 
   const safetyNotes = dedupePresentationList([
     ...contraindications,
@@ -182,6 +216,7 @@ export default function HerbDetail() {
   const sources = toSources(herb.sources)
   const confidenceLabel = toEvidenceStrengthLabel(String(herb.evidenceLevel || herb.confidence || 'Limited'))
   const useCasePoints = [
+    contextSummary || coreInsight,
     effects[0] ? `Best for ${effects[0].toLowerCase()} goals when you want a gentler herbal option.` : '',
     effects[1] ? `May also support ${effects[1].toLowerCase()} depending on preparation and dose.` : '',
     confidenceLabel === 'Traditional'
@@ -248,7 +283,7 @@ export default function HerbDetail() {
       <article className='space-y-3'>
         <div className='sr-only' aria-hidden='true'>
           <h1>{herbName}</h1>
-          <p>{curatedData.summary}</p>
+          <p>{summary}</p>
           <ul>{safetyNotes.map(note => <li key={`static-safety-${note}`}>{note}</li>)}</ul>
         </div>
 
@@ -313,15 +348,28 @@ export default function HerbDetail() {
           )}
         </DisclosureSection>
 
+        {coreInsight && coreInsight !== summary && (
+          <section className='rounded-2xl border border-white/10 bg-white/[0.02] p-4'>
+            <h2 className='text-sm font-semibold uppercase tracking-[0.16em] text-white/85'>Core insight</h2>
+            <p className='mt-2 text-sm leading-relaxed text-white/85'>{coreInsight}</p>
+          </section>
+        )}
+
         {!descriptionIsPlaceholder && (
           <DisclosureSection title='Full Description'>
-            <p>{curatedData.summary}</p>
+            <p>{summary}</p>
           </DisclosureSection>
         )}
 
         <DisclosureSection title='Mechanism of Action'>
           <p>{mechanism || 'Mechanism notes are being expanded.'}</p>
         </DisclosureSection>
+
+        {contextSummary && contextSummary !== summary && (
+          <DisclosureSection title='Context'>
+            <p>{contextSummary}</p>
+          </DisclosureSection>
+        )}
 
         <DisclosureSection title='Dosage & Usage'>
           <ul className='list-disc space-y-1 pl-5'>


### PR DESCRIPTION
### Motivation
- Surface workbook-exported, curator-reviewed text (hero, key effects, core insight, mechanisms, safety, context) across cards and detail pages while preserving existing legacy fallbacks and route behavior.
- Avoid rendering raw legacy text when workbook-curated fields exist and prevent duplicate/repeated sections in detail pages.

### Description
- Prefer workbook fields first by reading `rawData`/workbook keys (`hero`, `coreInsight`, `effects`, `mechanisms`, `context`, `safety.*`) and fall back to curated/legacy fields when missing, and suppress repeated sections when content duplicates the main summary.
- Normalize and de-duplicate effect/chip labels (punctuation removed, compact) and prefer workbook-driven chips for herb and compound cards to keep cards compact and scannable.
- Files changed: `src/components/HerbCard.tsx`, `src/components/CompoundCard.tsx`, `src/pages/HerbDetail.tsx`, `src/pages/CompoundDetail.tsx` which implement workbook-first reads, chip normalization, and non-duplicative Core Insight/Context rendering.

### Testing
- Ran the production compile step with `npm run build:compile`, which completed successfully (Vite production build passed). 
- Pre-commit lint/`lint-staged` hooks ran during the change and `eslint --max-warnings=0` passed for the touched TSX files.
- No automated unit tests were modified; the build and static verification steps passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd31101f7883238e0d4e455a1950ca)