### PR TITLE
Add reusable render guard for herb & compound detail pages

### DIFF
--- a/src/__tests__/renderGuard.test.ts
+++ b/src/__tests__/renderGuard.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { buildUniqueDetailCopy, sanitizeRenderChips, sanitizeRenderList } from '@/lib/renderGuard'
+
+describe('renderGuard', () => {
+  it('dedupes list values and drops broken fragments', () => {
+    expect(sanitizeRenderList(['focus', 'Focus', 'nan', 'an', ''])).toEqual(['focus'])
+  })
+
+  it('strips trailing punctuation from chips and dedupes', () => {
+    expect(sanitizeRenderChips(['anti-inflammatory...', 'anti-inflammatory;', 'focus!!'], 5)).toEqual([
+      'anti-inflammatory',
+      'focus',
+    ])
+  })
+
+  it('collapses repeated section meaning', () => {
+    expect(
+      buildUniqueDetailCopy({
+        hero: 'Supports calm and sleep quality.',
+        overview: 'Supports calm and sleep quality',
+        context: 'Used when stress drives poor sleep.',
+        mechanism: 'Used when stress drives poor sleep',
+      }),
+    ).toEqual({
+      hero: 'Supports calm and sleep quality.',
+      overview: '',
+      context: 'Used when stress drives poor sleep.',
+      mechanism: '',
+    })
+  })
+})

--- a/src/lib/renderGuard.ts
+++ b/src/lib/renderGuard.ts
@@ -1,0 +1,96 @@
+import { dedupePresentationList, normalizePresentationLabel, sanitizeReadableText, splitClean } from '@/lib/sanitize'
+
+type UniqueCopyInput = {
+  hero?: unknown
+  overview?: unknown
+  context?: unknown
+  mechanism?: unknown
+}
+
+type UniqueCopyOutput = {
+  hero: string
+  overview: string
+  context: string
+  mechanism: string
+}
+
+function normalizeMeaningKey(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[.,;:!?()[\]{}'"`]/g, ' ')
+    .replace(/\b(?:the|a|an|and|or|for|of|to|with|from|in|on|by|it|this|that)\b/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function stripChipTrailingPunctuation(value: string): string {
+  return value.replace(/[\s.,;:!?-]+$/g, '').trim()
+}
+
+function isBrokenFragment(value: string): boolean {
+  if (!value) return true
+  if (value.length < 3) return true
+  if (!/[a-z]/i.test(value)) return true
+  if (/^[^a-z]+$/i.test(value)) return true
+  if (/^(effect|effects|mechanism|overview|context)$/i.test(value)) return true
+  return false
+}
+
+/**
+ * Shared render guard for list-like UI values.
+ * - Splits string/array content
+ * - Removes broken fragments
+ * - Deduplicates near-identical entries
+ */
+export function sanitizeRenderList(value: unknown, maxItems = 8): string[] {
+  return dedupePresentationList(splitClean(value), maxItems).filter(item => !isBrokenFragment(item))
+}
+
+/**
+ * Shared guard for pill/chip content.
+ * - Reuses list sanitization
+ * - Strips trailing punctuation artefacts ("focus..." => "focus")
+ */
+export function sanitizeRenderChips(value: unknown, maxItems = 8): string[] {
+  const seen = new Set<string>()
+  const output: string[] = []
+
+  sanitizeRenderList(value, maxItems * 2).forEach(item => {
+    const normalized = normalizePresentationLabel(stripChipTrailingPunctuation(item))
+    const key = normalizeMeaningKey(normalized)
+    if (!normalized || isBrokenFragment(normalized) || !key || seen.has(key)) return
+    seen.add(key)
+    output.push(normalized)
+  })
+
+  return output.slice(0, Math.max(0, maxItems))
+}
+
+/**
+ * Ensures hero/overview/context/mechanism each keep a distinct purpose.
+ * Duplicate meaning is collapsed to the earliest section priority:
+ * hero -> overview -> context -> mechanism.
+ */
+export function buildUniqueDetailCopy(input: UniqueCopyInput): UniqueCopyOutput {
+  const ordered: Array<keyof UniqueCopyOutput> = ['hero', 'overview', 'context', 'mechanism']
+  const cleaned: UniqueCopyOutput = {
+    hero: sanitizeReadableText(input.hero),
+    overview: sanitizeReadableText(input.overview),
+    context: sanitizeReadableText(input.context),
+    mechanism: sanitizeReadableText(input.mechanism),
+  }
+
+  const acceptedKeys = new Set<string>()
+  ordered.forEach(sectionKey => {
+    const value = cleaned[sectionKey]
+    if (!value) return
+    const meaning = normalizeMeaningKey(value)
+    if (!meaning || acceptedKeys.has(meaning)) {
+      cleaned[sectionKey] = ''
+      return
+    }
+    acceptedKeys.add(meaning)
+  })
+
+  return cleaned
+}

--- a/src/pages/CompoundDetail.tsx
+++ b/src/pages/CompoundDetail.tsx
@@ -11,6 +11,7 @@ import {
   splitClean,
   uniqueNormalizedList,
 } from '@/lib/sanitize'
+import { buildUniqueDetailCopy, sanitizeRenderChips, sanitizeRenderList } from '@/lib/renderGuard'
 import { pickNonEmptyKeys } from '@/lib/nonEmptyFields'
 import { calculateCompoundConfidence } from '@/utils/calculateConfidence'
 import { getCompoundDataCompleteness } from '@/utils/getDataCompleteness'
@@ -216,42 +217,51 @@ export default function CompoundDetail() {
     'Unknown compound'
   const evidence = sanitizeReadableText(compoundRecord.evidence)
   const pharmacokinetics = sanitizeReadableText(compoundRecord.pharmacokinetics)
-  const pathwayTargets = uniqueNormalizedList(splitClean(compoundRecord.pathwayTargets))
-  const workbookSources = uniqueNormalizedList(splitPipeList(compoundRecord.sourceUrls))
+  const pathwayTargets = sanitizeRenderList(splitClean(compoundRecord.pathwayTargets))
+  const workbookSources = sanitizeRenderList(splitPipeList(compoundRecord.sourceUrls))
   const relatedHerbSlugs = uniqueNormalizedList(splitClean(compoundRecord.relatedHerbSlugs))
   const curatedData = compound.curatedData
-  const compoundEffects = cleanEffectChips(rawRecord.effects || curatedData.keyEffects || compound.effects, 12)
-  const compoundContraindications = uniqueNormalizedList(compound.contraindications)
-  const compoundSideEffects = uniqueNormalizedList(compound.sideEffects)
-  const compoundTherapeuticUses = uniqueNormalizedList(compound.therapeuticUses)
-  const compoundInteractions = uniqueNormalizedList(compound.interactions)
+  const compoundEffects = sanitizeRenderChips(
+    cleanEffectChips(rawRecord.effects || curatedData.keyEffects || compound.effects, 12),
+    12,
+  )
+  const compoundContraindications = sanitizeRenderList(compound.contraindications)
+  const compoundSideEffects = sanitizeRenderList(compound.sideEffects)
+  const compoundTherapeuticUses = sanitizeRenderList(compound.therapeuticUses)
+  const compoundInteractions = sanitizeRenderList(compound.interactions)
   const heroSummary = sanitizeSummaryText(
     readWorkbookText(rawRecord, 'hero', 'summary', 'description') || curatedData.summary,
     2,
   )
-  const coreInsight = sanitizeSummaryText(
-    readWorkbookText(rawRecord, 'coreInsight', 'whyItMatters', 'overview') || curatedData.whyItMatters,
-    1,
-  )
-  const contextSummary = sanitizeSummaryText(
-    readWorkbookText(contextRecord, 'summary', 'overview', 'notes') || readWorkbookText(rawRecord, 'context'),
-    2,
-  )
-  const compoundDescription = heroSummary
-  const compoundMechanism = sanitizeReadableText(
-    readWorkbookText(rawRecord, 'mechanisms', 'mechanism') || curatedData.mechanism,
-  )
-  const workbookSafety = uniqueNormalizedList(
+  const uniqueCopy = buildUniqueDetailCopy({
+    hero: heroSummary,
+    overview: sanitizeSummaryText(
+      readWorkbookText(rawRecord, 'coreInsight', 'whyItMatters', 'overview') || curatedData.whyItMatters,
+      1,
+    ),
+    context: sanitizeSummaryText(
+      readWorkbookText(contextRecord, 'summary', 'overview', 'notes') || readWorkbookText(rawRecord, 'context'),
+      2,
+    ),
+    mechanism: sanitizeReadableText(readWorkbookText(rawRecord, 'mechanisms', 'mechanism') || curatedData.mechanism),
+  })
+  const coreInsight = uniqueCopy.overview
+  const contextSummary = uniqueCopy.context
+  const compoundDescription = uniqueCopy.hero
+  const compoundMechanism = uniqueCopy.mechanism
+  const workbookSafety = sanitizeRenderList(
     splitClean(safetyRecord.notes || safetyRecord.summary || safetyRecord.caution || rawRecord.safety),
   )
   const drugInteractions = normalizeTextValue(compoundRecord.drugInteractions)
-  const uniqueDrugInteractionItems = Array.from(
-    new Map(
-      [...workbookSafety, ...compoundInteractions, ...(drugInteractions ? [sanitizeReadableText(drugInteractions)] : [])]
-        .map(item => normalizeTextValue(item))
-        .filter(Boolean)
-        .map(item => [normalizeKey(item), item]),
-    ).values(),
+  const uniqueDrugInteractionItems = sanitizeRenderList(
+    Array.from(
+      new Map(
+        [...workbookSafety, ...compoundInteractions, ...(drugInteractions ? [sanitizeReadableText(drugInteractions)] : [])]
+          .map(item => normalizeTextValue(item))
+          .filter(Boolean)
+          .map(item => [normalizeKey(item), item]),
+      ).values(),
+    ),
   )
 
   const linkedHerbs = mapRelatedHerbsForCompound(compound, herbs)

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -5,11 +5,8 @@ import { Link, useLocation, useParams } from 'react-router-dom'
 import Meta from '@/components/Meta'
 import { useCompoundDataState } from '@/lib/compound-data'
 import { useHerbDataState, useHerbDetailState } from '@/lib/herb-data'
-import {
-  dedupePresentationList,
-  normalizePresentationLabel,
-  sanitizeSummaryText,
-} from '@/lib/sanitize'
+import { dedupePresentationList, normalizePresentationLabel, sanitizeReadableText, sanitizeSummaryText } from '@/lib/sanitize'
+import { buildUniqueDetailCopy, sanitizeRenderChips, sanitizeRenderList } from '@/lib/renderGuard'
 import { HerbDetailSkeleton } from '@/components/skeletons/DetailSkeletons'
 import { SITE_URL, breadcrumbJsonLd, herbJsonLd } from '@/lib/seo'
 import { shouldShowRawDebug } from '@/lib/semanticCompression'
@@ -168,23 +165,29 @@ export default function HerbDetail() {
   const description = readWorkbookText(rawRecord, 'hero', 'summary', 'description') || String(curatedData.summary || '').trim()
   const descriptionIsPlaceholder = isPlaceholder(description, herbName)
   const summary = sanitizeSummaryText(description, 2)
-  const coreInsight = sanitizeSummaryText(
-    readWorkbookText(rawRecord, 'coreInsight', 'overview', 'whyItMatters') || curatedData.whyItMatters,
-    1,
-  )
+  const fullDescription = sanitizeReadableText(description)
+  const uniqueCopy = buildUniqueDetailCopy({
+    hero: summary,
+    overview: sanitizeSummaryText(
+      readWorkbookText(rawRecord, 'coreInsight', 'overview', 'whyItMatters') || curatedData.whyItMatters,
+      1,
+    ),
+    context: sanitizeSummaryText(
+      readWorkbookText(contextRecord, 'summary', 'overview', 'notes') || readWorkbookText(rawRecord, 'context'),
+      2,
+    ),
+    mechanism: readWorkbookText(rawRecord, 'mechanisms', 'mechanism') || String(curatedData.mechanism || '').trim(),
+  })
+  const coreInsight = uniqueCopy.overview
 
-  const effects = dedupePresentationList(
-    splitTextList(rawRecord.effects || rawRecord.keyEffects || curatedData.keyEffects),
+  const effects = sanitizeRenderChips(
+    dedupePresentationList(splitTextList(rawRecord.effects || rawRecord.keyEffects || curatedData.keyEffects), 8),
     8,
   ).map(toTitleCase)
   const keyEffects = effects.slice(0, 4)
-  const activeCompounds = dedupePresentationList(splitTextList(herb.activeCompounds || herb.compounds), 10)
-  const mechanism =
-    readWorkbookText(rawRecord, 'mechanisms', 'mechanism') || String(curatedData.mechanism || '').trim()
-  const contextSummary = sanitizeSummaryText(
-    readWorkbookText(contextRecord, 'summary', 'overview', 'notes') || readWorkbookText(rawRecord, 'context'),
-    2,
-  )
+  const activeCompounds = sanitizeRenderList(splitTextList(herb.activeCompounds || herb.compounds), 10)
+  const mechanism = uniqueCopy.mechanism
+  const contextSummary = uniqueCopy.context
   const dosage = String(herb.dosage || '').trim()
   const duration = String(herb.duration || '').trim()
   const preparation = String(herb.preparation || '').trim()
@@ -355,9 +358,9 @@ export default function HerbDetail() {
           </section>
         )}
 
-        {!descriptionIsPlaceholder && (
+        {!descriptionIsPlaceholder && fullDescription && fullDescription !== summary && (
           <DisclosureSection title='Full Description'>
-            <p>{summary}</p>
+            <p>{fullDescription}</p>
           </DisclosureSection>
         )}
 


### PR DESCRIPTION
### Motivation
- Prevent low-quality, duplicate, or malformed workbook content from reaching the UI by adding a small reusable pre-render sanitation layer that does not modify workbook data.
- Ensure each detail section (hero / overview / context / mechanism) has a unique purpose and avoid surface-level repetition in the rendered pages.

### Description
- Add a shared guard `src/lib/renderGuard.ts` exposing `sanitizeRenderList`, `sanitizeRenderChips`, and `buildUniqueDetailCopy` that implement dedupe, broken-fragment filtering, trailing-punctuation stripping, and semantic-collapse (hero → overview → context → mechanism).
- Wire the guard into herb and compound detail renderers in `src/pages/HerbDetail.tsx` and `src/pages/CompoundDetail.tsx`, sanitizing effects/chips, lists, safety/interaction arrays, pathway targets, and section copy; also render the herb "Full Description" only when it adds content beyond the hero summary.
- Add focused unit tests in `src/__tests__/renderGuard.test.ts` that exercise list dedupe + broken fragment removal, chip punctuation stripping, and repeated-section collapse behavior.
- Files changed: `src/lib/renderGuard.ts`, `src/pages/HerbDetail.tsx`, `src/pages/CompoundDetail.tsx`, `src/__tests__/renderGuard.test.ts`.

### Testing
- `npm run lint -- src/lib/renderGuard.ts src/pages/HerbDetail.tsx src/pages/CompoundDetail.tsx src/__tests__/renderGuard.test.ts` succeeded against the modified files.
- `npx vitest run src/__tests__/renderGuard.test.ts` was attempted but the repo environment failed to resolve `vitest/config`, causing the test runner to error outside of the new test file logic.
- `npm run build` completed successfully in the verification run and the build output was inspected (generated data artifacts were cleaned up before committing).
- Commit performed: added guard, integrated pages, and included tests (commit message: "Add shared render guard for herb and compound detail content").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd33c06810832390bd7d18485a7e1b)