### PR TITLE
fix: ensure unique slugs in deduped entity output

### DIFF
--- a/scripts/dedupe-entities.mjs
+++ b/scripts/dedupe-entities.mjs
@@ -354,6 +354,29 @@ function dedupeDataset(config) {
     return left.localeCompare(right)
   })
 
+  const usedSlugs = new Set()
+  for (const record of deduped) {
+    const originalSlug = text(record.slug)
+    if (!originalSlug) continue
+    if (!usedSlugs.has(originalSlug)) {
+      usedSlugs.add(originalSlug)
+      continue
+    }
+
+    let suffix = 2
+    let candidateSlug = `${originalSlug}-${suffix}`
+    while (usedSlugs.has(candidateSlug)) {
+      suffix += 1
+      candidateSlug = `${originalSlug}-${suffix}`
+    }
+
+    record.slug = candidateSlug
+    if (text(record.id) === originalSlug) {
+      record.id = candidateSlug
+    }
+    usedSlugs.add(candidateSlug)
+  }
+
   stats.after = deduped.length
 
   return {


### PR DESCRIPTION
### Motivation
- Workbook-driven rebuilds produced duplicate herb slugs (route-collision risk), so the dedupe output must guarantee unique slugs.

### Description
- Add a uniqueness pass to `scripts/dedupe-entities.mjs` that suffixes duplicate slugs with `-2`, `-3`, etc., and updates `id` when it matched the old slug; only `scripts/dedupe-entities.mjs` was modified.

### Testing
- Executed `npm ci`, `npm run build`, `npm run verify:workbook-import`, `npm run verify:redirects`, `npm run verify:governed-ux`, and ad-hoc Node checks for duplicate herb slugs, all of which passed and the post-fix duplicate-slug check returned zero duplicates, while `npm run data:refresh+build` failed due to missing local CSV inputs (expected in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd364132088323afe3844f71f7bd6a)