### PR TITLE
Harden workbook-first pipeline and isolate legacy fallback

### DIFF
--- a/scripts/build-publication-manifest-from-workbook.mjs
+++ b/scripts/build-publication-manifest-from-workbook.mjs
@@ -50,18 +50,13 @@ function toSlugMap(records) {
   return map
 }
 
-function isHerbEligible(workbookHerb, legacyHerb) {
+function isHerbEligible(workbookHerb) {
   const frontendReady = String(workbookHerb?.frontendReadyFlag ?? '').trim() === 'Yes'
   const ready = String(workbookHerb?.readinessFlag ?? '').trim() === 'Ready'
   const nearReady = String(workbookHerb?.readinessFlag ?? '').trim() === 'Near ready'
   const completenessPct = parsePercent(workbookHerb?.completenessPct)
   const nearReadyWithCoverage = nearReady && completenessPct >= 60
-
-  const legacyDescription = hasNonEmptyText(legacyHerb?.description)
-  const legacyCompounds = Array.isArray(legacyHerb?.activeCompounds) ? legacyHerb.activeCompounds.length > 0 : false
-  const legacyCovered = Boolean(legacyHerb) && legacyDescription && legacyCompounds
-
-  return frontendReady || ready || nearReadyWithCoverage || legacyCovered
+  return frontendReady || ready || nearReadyWithCoverage
 }
 
 function isCompoundEligible(compound) {
@@ -84,15 +79,12 @@ function run() {
   const previousCompounds = Array.isArray(previousManifest?.entities?.compounds) ? previousManifest.entities.compounds : []
 
   const workbookHerbs = readJsonArray('workbook-herbs.json')
-  const legacyHerbs = readJsonArray('herbs.json')
   const workbookCompounds = readJsonArray('workbook-compounds.json')
 
   const workbookHerbsBySlug = toSlugMap(workbookHerbs)
-  const legacyHerbsBySlug = toSlugMap(legacyHerbs)
-
-  const allHerbSlugs = [...new Set([...workbookHerbsBySlug.keys(), ...legacyHerbsBySlug.keys()])]
+  const allHerbSlugs = [...new Set([...workbookHerbsBySlug.keys()])]
   const eligibleHerbs = allHerbSlugs
-    .filter(slug => isHerbEligible(workbookHerbsBySlug.get(slug), legacyHerbsBySlug.get(slug)))
+    .filter(slug => isHerbEligible(workbookHerbsBySlug.get(slug)))
     .sort((a, b) => a.localeCompare(b))
 
   const eligibleCompounds = workbookCompounds
@@ -104,7 +96,7 @@ function run() {
 
   const manifest = {
     generatedAt: new Date().toISOString(),
-    source: 'workbook+legacy',
+    source: 'workbook',
     entities: {
       herbs: eligibleHerbs,
       compounds: uniqueEligibleCompounds,
@@ -124,7 +116,7 @@ function run() {
     stdio: 'inherit',
   })
 
-  console.log('[publication-manifest] source=workbook+legacy')
+  console.log('[publication-manifest] source=workbook')
   console.log(`[publication-manifest] herbs before=${previousHerbs.length} after=${eligibleHerbs.length} delta=${eligibleHerbs.length - previousHerbs.length}`)
   console.log(`[publication-manifest] compounds before=${previousCompounds.length} after=${uniqueEligibleCompounds.length} delta=${uniqueEligibleCompounds.length - previousCompounds.length}`)
   console.log(`[publication-manifest] totals herbs=${allHerbSlugs.length} compounds=${workbookCompounds.length}`)

--- a/scripts/export-workbook-to-json.mjs
+++ b/scripts/export-workbook-to-json.mjs
@@ -57,6 +57,12 @@ function createDiagnostics() {
   }
 }
 
+function parseArgs(argv) {
+  return {
+    allowLegacyFallback: argv.includes('--allow-legacy-fallback'),
+  }
+}
+
 function toCleanString(value) {
   const cleaned = normalizeWorkbookCell(value)
   if (cleaned === '') return ''
@@ -183,40 +189,40 @@ function readSheetRows(workbook, sheetName, diagnostics, { optional = false } = 
   return nonEmptyRows
 }
 
-function mergePrimaryRowsWithFallback(primaryRows, fallbackRows, getKey) {
-  const fallbackByKey = new Map()
-  for (const row of fallbackRows) {
-    const key = toCleanString(getKey(row))
-    if (!key || fallbackByKey.has(key)) continue
-    fallbackByKey.set(key, row)
+function rowsByPrimaryWithOptionalFallback({ primaryRows, fallbackRows, getKey, allowLegacyFallback, entityType }) {
+  if (!allowLegacyFallback) {
+    return { rows: primaryRows, fallbackUsage: [] }
   }
 
-  const matchedFallbackKeys = new Set()
-  const mergedRows = []
-  for (const row of primaryRows) {
-    const key = toCleanString(getKey(row))
-    const fallback = key ? fallbackByKey.get(key) : null
-    if (key && fallback) matchedFallbackKeys.add(key)
-    mergedRows.push({ ...(fallback || {}), ...row })
-  }
+  const primaryKeys = new Set(primaryRows.map(row => toCleanString(getKey(row)).toLowerCase()).filter(Boolean))
+  const fallbackUsage = []
+  const rows = [...primaryRows]
 
   for (const row of fallbackRows) {
-    const key = toCleanString(getKey(row))
-    if (primaryRows.length > 0 && key && matchedFallbackKeys.has(key)) continue
-    mergedRows.push(row)
+    const key = toCleanString(getKey(row)).toLowerCase()
+    if (!key || primaryKeys.has(key)) continue
+    rows.push(row)
+    fallbackUsage.push({
+      entityType,
+      key,
+      reason: 'missing_site_export_alignment',
+      sourceSheet: entityType === 'herb' ? LEGACY_HERB_SHEET : LEGACY_COMPOUND_SHEET,
+    })
   }
 
-  return mergedRows
+  return { rows, fallbackUsage }
 }
 
-function exportHerbs(workbook, diagnostics) {
+function exportHerbs(workbook, diagnostics, options) {
   const primaryRows = readSheetRows(workbook, PRIMARY_HERB_SHEET, diagnostics, { optional: true })
   const fallbackRows = readSheetRows(workbook, LEGACY_HERB_SHEET, diagnostics)
-  const rows = mergePrimaryRowsWithFallback(
+  const { rows, fallbackUsage } = rowsByPrimaryWithOptionalFallback({
     primaryRows,
     fallbackRows,
-    row => firstMeaningful(row.slug, row.herbSlug, row.name ? slugify(row.name) : '')
-  )
+    getKey: row => firstMeaningful(row.slug, row.herbSlug, row.name ? slugify(row.name) : ''),
+    allowLegacyFallback: options.allowLegacyFallback,
+    entityType: 'herb',
+  })
 
   const records = rows
     .map(row => ({
@@ -270,17 +276,19 @@ function exportHerbs(workbook, diagnostics) {
     return removeEmptyValues(withNormalizedSlug)
   })
   diagnostics.sheets[PRIMARY_HERB_SHEET].skippedRows += records.length - deduped.length
-  return deduped
+  return { records: deduped, fallbackUsage }
 }
 
-function exportCompounds(workbook, diagnostics) {
+function exportCompounds(workbook, diagnostics, options) {
   const primaryRows = readSheetRows(workbook, PRIMARY_COMPOUND_SHEET, diagnostics, { optional: true })
   const fallbackRows = readSheetRows(workbook, LEGACY_COMPOUND_SHEET, diagnostics)
-  const rows = mergePrimaryRowsWithFallback(
+  const { rows, fallbackUsage } = rowsByPrimaryWithOptionalFallback({
     primaryRows,
     fallbackRows,
-    row => firstMeaningful(row.canonicalCompoundId, row.compoundName, row.canonicalCompoundName)
-  )
+    getKey: row => firstMeaningful(row.canonicalCompoundId, row.compoundName, row.canonicalCompoundName),
+    allowLegacyFallback: options.allowLegacyFallback,
+    entityType: 'compound',
+  })
 
   const records = rows.map(row => ({
     id: cleanScalar(row.canonicalCompoundId) || slugify(row.compoundName || row.canonicalCompoundName || row.Compound),
@@ -323,7 +331,7 @@ function exportCompounds(workbook, diagnostics) {
     return removeEmptyValues(cleaned)
   })
   diagnostics.sheets[PRIMARY_COMPOUND_SHEET].skippedRows += records.length - deduped.length
-  return deduped
+  return { records: deduped, fallbackUsage }
 }
 
 function exportHerbCompoundMap(workbook, diagnostics) {
@@ -400,7 +408,15 @@ function writeJson(filename, records) {
   console.log(`[export] ${filename}: ${records.length} records written`)
 }
 
+function writeReportJson(relativePath, records) {
+  const outputPath = path.join(repoRoot, relativePath)
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true })
+  fs.writeFileSync(outputPath, `${JSON.stringify(records, null, 2)}\n`)
+  console.log(`[export] ${relativePath}: ${records.length} records written`)
+}
+
 function main() {
+  const options = parseArgs(process.argv.slice(2))
   const diagnostics = createDiagnostics()
   const workbook = XLSX.readFile(workbookPath, { sheets: EXPORT_WORKBOOK_SHEETS })
   const ignoredSheets = workbook.SheetNames.filter(sheetName => !EXPORT_WORKBOOK_SHEETS.includes(sheetName))
@@ -411,10 +427,18 @@ function main() {
     }
   }
 
-  writeJson('workbook-herbs.json', exportHerbs(workbook, diagnostics))
-  writeJson('workbook-compounds.json', exportCompounds(workbook, diagnostics))
+  const herbsExport = exportHerbs(workbook, diagnostics, options)
+  const compoundsExport = exportCompounds(workbook, diagnostics, options)
+  const fallbackUsage = [...herbsExport.fallbackUsage, ...compoundsExport.fallbackUsage]
+
+  writeJson('workbook-herbs.json', herbsExport.records)
+  writeJson('workbook-compounds.json', compoundsExport.records)
   writeJson('workbook-herb-compound-map.json', exportHerbCompoundMap(workbook, diagnostics))
   writeJson('workbook-goal-bundles.json', exportGoalBundles(workbook, diagnostics))
+  writeReportJson('reports/workbook-fallback-usage.json', fallbackUsage)
+  if (options.allowLegacyFallback) {
+    console.warn(`[export] legacy fallback enabled via --allow-legacy-fallback. fallback rows used=${fallbackUsage.length}`)
+  }
 
   console.log(
     `[export][diagnostics] ignored non-target sheets: ${ignoredSheets.length > 0 ? ignoredSheets.join(', ') : '(none)'}`

--- a/scripts/import-xlsx-monographs.mjs
+++ b/scripts/import-xlsx-monographs.mjs
@@ -90,6 +90,7 @@ const COMPOUND_EXPLICIT_ALIASES = {
 function parseArgs(argv) {
   return {
     dryRun: argv.includes('--dry-run'),
+    allowLegacyFallback: argv.includes('--allow-legacy-fallback'),
   }
 }
 
@@ -489,30 +490,38 @@ function parseSheet(workbook, sheetName, diagnostics, { optional = false } = {})
   })
 }
 
-function mergePrimaryRowsWithFallback(primaryRows, fallbackRows, getKey) {
+function rowsByPrimaryWithOptionalFallback({ primaryRows, fallbackRows, getKey, allowLegacyFallback, entityType }) {
+  if (!allowLegacyFallback) {
+    return { rows: primaryRows, fallbackUsage: [] }
+  }
+
   const fallbackByKey = new Map()
   for (const row of fallbackRows) {
-    const key = cleanText(getKey(row))
+    const key = cleanText(getKey(row)).toLowerCase()
     if (!key || fallbackByKey.has(key)) continue
     fallbackByKey.set(key, row)
   }
 
-  const matchedKeys = new Set()
-  const mergedRows = []
-  for (const row of primaryRows) {
-    const key = cleanText(getKey(row))
-    const fallback = key ? fallbackByKey.get(key) : null
-    if (key && fallback) matchedKeys.add(key)
-    mergedRows.push({ ...(fallback || {}), ...row })
+  const primaryKeys = new Set(
+    primaryRows
+      .map((row) => cleanText(getKey(row)).toLowerCase())
+      .filter(Boolean)
+  )
+  const fallbackUsage = []
+  const rows = [...primaryRows]
+
+  for (const [key, row] of fallbackByKey.entries()) {
+    if (primaryKeys.has(key)) continue
+    rows.push(row)
+    fallbackUsage.push({
+      entityType,
+      key,
+      reason: 'missing_site_export_alignment',
+      sourceSheet: entityType === 'herb' ? LEGACY_HERB_SHEET : LEGACY_COMPOUND_SHEET,
+    })
   }
 
-  for (const row of fallbackRows) {
-    const key = cleanText(getKey(row))
-    if (primaryRows.length > 0 && key && matchedKeys.has(key)) continue
-    mergedRows.push(row)
-  }
-
-  return mergedRows
+  return { rows, fallbackUsage }
 }
 
 function slugify(value) {
@@ -616,28 +625,6 @@ function resolveHerbRetry(herbIndex, row) {
   for (const normalizedName of herbNormalizationVariants(row.name)) {
     const nameMatch = herbIndex.byNormalizedName.get(normalizedName)
     if (nameMatch) return { herb: nameMatch, matchType: 'normalized-name' }
-  }
-
-  const commonNames = splitSemicolonDelimited(row.commonNames)
-  for (const commonName of commonNames) {
-    for (const normalizedCommon of herbNormalizationVariants(commonName)) {
-      const commonMatch = herbIndex.byNormalizedCommonName.get(normalizedCommon)
-      if (commonMatch) return { herb: commonMatch, matchType: 'alias-common' }
-    }
-  }
-
-  const aliasCandidates = dedupeStrings([
-    ...splitSemicolonDelimited(row.aliases),
-    cleanText(row.scientificName),
-    cleanText(row.name),
-    HERB_EXPLICIT_ALIASES[normalizeLookupBase(row.slug)] || '',
-    HERB_EXPLICIT_ALIASES[normalizeLookupBase(row.name)] || '',
-  ])
-  for (const alias of aliasCandidates) {
-    for (const normalizedAlias of herbNormalizationVariants(alias)) {
-      const aliasMatch = herbIndex.byNormalizedAlias.get(normalizedAlias)
-      if (aliasMatch) return { herb: aliasMatch, matchType: 'alias-common' }
-    }
   }
 
   return { herb: null, matchType: 'unmatched' }
@@ -770,11 +757,7 @@ function resolveCompoundPrimary(compoundIndex, row) {
 }
 
 function resolveCompoundRetry(compoundIndex, row) {
-  const nameCandidates = [
-    cleanText(row.compoundName),
-    cleanText(row.canonicalCompoundName),
-    COMPOUND_EXPLICIT_ALIASES[normalizeLookupBase(row.compoundName)] || '',
-  ]
+  const nameCandidates = [cleanText(row.compoundName), cleanText(row.canonicalCompoundName)]
   for (const candidate of nameCandidates) {
     for (const normalizedName of compoundNormalizationVariants(candidate)) {
       const nameMatch = compoundIndex.byNormalizedCompoundName.get(normalizedName)
@@ -1034,19 +1017,23 @@ function main() {
   diagnostics.ignoredSheets = workbook.SheetNames.filter(sheetName => !TARGET_WORKBOOK_SHEETS.includes(sheetName))
   const primaryHerbRows = parseSheet(workbook, PRIMARY_HERB_SHEET, diagnostics, { optional: true })
   const fallbackHerbRows = parseSheet(workbook, LEGACY_HERB_SHEET, diagnostics)
-  const herbRows = mergePrimaryRowsWithFallback(
-    primaryHerbRows,
-    fallbackHerbRows,
-    row => cleanText(row.slug || row.herbSlug || row.name)
-  )
+  const { rows: herbRows, fallbackUsage: herbFallbackUsage } = rowsByPrimaryWithOptionalFallback({
+    primaryRows: primaryHerbRows,
+    fallbackRows: fallbackHerbRows,
+    getKey: row => cleanText(row.slug || row.herbSlug || row.name),
+    allowLegacyFallback: options.allowLegacyFallback,
+    entityType: 'herb',
+  })
 
   const primaryCompoundRows = parseSheet(workbook, PRIMARY_COMPOUND_SHEET, diagnostics, { optional: true })
   const fallbackCompoundRows = parseSheet(workbook, LEGACY_COMPOUND_SHEET, diagnostics)
-  const compoundRows = mergePrimaryRowsWithFallback(
-    primaryCompoundRows,
-    fallbackCompoundRows,
-    row => cleanText(row.canonicalCompoundId || row.compoundName || row.canonicalCompoundName)
-  )
+  const { rows: compoundRows, fallbackUsage: compoundFallbackUsage } = rowsByPrimaryWithOptionalFallback({
+    primaryRows: primaryCompoundRows,
+    fallbackRows: fallbackCompoundRows,
+    getKey: row => cleanText(row.canonicalCompoundId || row.compoundName || row.canonicalCompoundName),
+    allowLegacyFallback: options.allowLegacyFallback,
+    entityType: 'compound',
+  })
   parseSheet(workbook, 'Herb Compound Map V3', diagnostics)
   parseSheet(workbook, 'Production Export V1', diagnostics, { optional: OPTIONAL_WORKBOOK_SHEETS.has('Production Export V1') })
 
@@ -1065,8 +1052,8 @@ function main() {
     herbs: {},
     compounds: {},
   }
-  const herbMatchTypeCounts = { slug: 0, identityMap: 0, normalizedName: 0, aliasCommon: 0, fallback: 0, unmatched: 0 }
-  const compoundMatchTypeCounts = { canonicalName: 0, identityMap: 0, normalizedName: 0, fallback: 0, unmatched: 0 }
+  const herbMatchTypeCounts = { slug: 0, normalizedName: 0, unmatched: 0 }
+  const compoundMatchTypeCounts = { canonicalName: 0, normalizedName: 0, unmatched: 0 }
   const identityDebug = {
     herbs: { hits: [], misses: [] },
     compounds: { hits: [], misses: [] },
@@ -1096,10 +1083,10 @@ function main() {
     ? JSON.parse(fs.readFileSync(unmatchedCompoundsReportPath, 'utf8')).length
     : null
 
-  const herbIdentitySampleKeys = [...herbIdentityMap.keys()].slice(0, 5)
-  const compoundIdentitySampleKeys = [...compoundIdentityMap.keys()].slice(0, 5)
-  console.log(`[import-xlsx-monographs] identity map loaded: data/identity/herb-identity-map.json entries=${herbIdentityMap.size}, sample keys=${JSON.stringify(herbIdentitySampleKeys)}`)
-  console.log(`[import-xlsx-monographs] identity map loaded: data/identity/compound-identity-map.json entries=${compoundIdentityMap.size}, sample keys=${JSON.stringify(compoundIdentitySampleKeys)}`)
+  const totalFallbackUsage = herbFallbackUsage.length + compoundFallbackUsage.length
+  if (options.allowLegacyFallback) {
+    console.warn(`[import-xlsx-monographs] legacy fallback enabled via --allow-legacy-fallback. fallback rows used=${totalFallbackUsage}`)
+  }
 
   const herbPrimaryUnmatchedRows = []
   for (const row of herbRows) {
@@ -1127,44 +1114,6 @@ function main() {
   }
 
   for (const row of herbPrimaryUnmatchedRows) {
-    const herbIdentityKey = chooseBestIdentityKey([
-      row.name,
-      row.scientificName,
-      row.slug,
-    ])
-    const mappedHerbSlug = herbIdentityMap.get(herbIdentityKey)
-    const mappedHerb = resolveMappedHerb(herbIndex, mappedHerbSlug)
-    if (mappedHerb) {
-      if (identityDebug.herbs.hits.length < 10) {
-        identityDebug.herbs.hits.push({
-          identityKey: herbIdentityKey,
-          mappedValue: mappedHerbSlug,
-          resolvedHerbSlug: cleanText(mappedHerb.slug),
-          rowName: cleanText(row.name),
-        })
-      }
-      herbMatchTypeCounts.identityMap += 1
-      const patched = patchHerb(mappedHerb, row, fieldPatchCounts.herbs)
-      const payload = {
-        rowSlug: cleanText(row.slug),
-        rowName: cleanText(row.name),
-        herbSlug: cleanText(mappedHerb.slug),
-        herbName: cleanText(mappedHerb.name),
-        matchType: 'identity-map',
-        identityKey: herbIdentityKey,
-      }
-      if (patched) herbLog.matchedAndPatched.push(payload)
-      else herbLog.matchedNoChange.push(payload)
-      continue
-    }
-    if (identityDebug.herbs.misses.length < 10) {
-      identityDebug.herbs.misses.push({
-        identityKey: herbIdentityKey,
-        mappedValue: mappedHerbSlug || null,
-        rowName: cleanText(row.name),
-      })
-    }
-
     const { herb, matchType } = resolveHerbRetry(herbIndex, row)
     if (!herb) {
       herbLog.unmatched.push({
@@ -1175,8 +1124,6 @@ function main() {
       continue
     }
     if (matchType === 'normalized-name') herbMatchTypeCounts.normalizedName += 1
-    else if (matchType === 'alias-common') herbMatchTypeCounts.aliasCommon += 1
-    else herbMatchTypeCounts.fallback += 1
     const patched = patchHerb(herb, row, fieldPatchCounts.herbs)
     const payload = {
       rowSlug: cleanText(row.slug),
@@ -1223,47 +1170,6 @@ function main() {
   }
 
   for (const row of compoundPrimaryUnmatchedRows) {
-    const compoundIdentityKey = chooseBestIdentityKey([
-      row.canonicalCompoundName,
-      row.compoundName,
-      row.canonicalCompoundId,
-    ])
-    const mappedCompoundId = compoundIdentityMap.get(compoundIdentityKey)
-    const mappedCompound = resolveMappedCompound(compoundIndex, compounds, mappedCompoundId)
-    if (mappedCompound) {
-      if (identityDebug.compounds.hits.length < 10) {
-        identityDebug.compounds.hits.push({
-          identityKey: compoundIdentityKey,
-          mappedValue: mappedCompoundId,
-          resolvedCompoundId: cleanText(mappedCompound.canonicalCompoundId || mappedCompound.id || mappedCompound.slug),
-          rowCompoundName: cleanText(row.compoundName || row.canonicalCompoundName),
-        })
-      }
-      const compoundKey = cleanText(mappedCompound.canonicalCompoundId || mappedCompound.id || mappedCompound.slug).toLowerCase()
-      if (compoundKey && matchedCompoundSlugs.has(compoundKey)) continue
-      if (compoundKey) matchedCompoundSlugs.add(compoundKey)
-      compoundMatchTypeCounts.identityMap += 1
-      const patched = patchCompound(mappedCompound, row, reservedCanonicalIds, fieldPatchCounts.compounds)
-      const payload = {
-        rowCompoundId: cleanText(row.canonicalCompoundId),
-        rowCompoundName: cleanText(row.compoundName),
-        compoundId: cleanText(mappedCompound.id),
-        compoundName: cleanText(mappedCompound.name),
-        matchType: 'identity-map',
-        identityKey: compoundIdentityKey,
-      }
-      if (patched) compoundLog.matchedAndPatched.push(payload)
-      else compoundLog.matchedNoChange.push(payload)
-      continue
-    }
-    if (identityDebug.compounds.misses.length < 10) {
-      identityDebug.compounds.misses.push({
-        identityKey: compoundIdentityKey,
-        mappedValue: mappedCompoundId || null,
-        rowCompoundName: cleanText(row.compoundName || row.canonicalCompoundName),
-      })
-    }
-
     const { compound, matchType } = resolveCompoundRetry(compoundIndex, row)
     if (!compound) {
       compoundLog.unmatched.push({
@@ -1279,7 +1185,6 @@ function main() {
     if (compoundKey) matchedCompoundSlugs.add(compoundKey)
 
     if (matchType === 'normalized-name') compoundMatchTypeCounts.normalizedName += 1
-    else compoundMatchTypeCounts.fallback += 1
     const patched = patchCompound(compound, row, reservedCanonicalIds, fieldPatchCounts.compounds)
     const payload = {
       rowCompoundId: cleanText(row.canonicalCompoundId),
@@ -1296,6 +1201,8 @@ function main() {
   ensureReportsDir()
   writeJson(unmatchedHerbsReportPath, herbLog.unmatched)
   writeJson(unmatchedCompoundsReportPath, compoundLog.unmatched)
+  const fallbackUsageReportPath = path.join(reportsDir, 'workbook-fallback-usage.json')
+  writeJson(fallbackUsageReportPath, [...herbFallbackUsage, ...compoundFallbackUsage])
   const identityMapSuggestions = {
     generatedAt: new Date().toISOString(),
     herbs: buildIdentityMapSuggestions({
@@ -1324,12 +1231,9 @@ function main() {
     `[import-xlsx-monographs] ignored non-target sheets: ${diagnostics.ignoredSheets.length > 0 ? diagnostics.ignoredSheets.join(', ') : '(none)'}`
   )
   console.log(`[import-xlsx-monographs] rows read => herbs: ${herbRows.length}, compounds: ${compoundRows.length}`)
-  console.log(`[import-xlsx-monographs] herb matches => matched via slug: ${herbMatchTypeCounts.slug}, matched via identity map: ${herbMatchTypeCounts.identityMap}, matched via normalized name: ${herbMatchTypeCounts.normalizedName}, matched via alias/commonNames: ${herbMatchTypeCounts.aliasCommon}, matched via fallback: ${herbMatchTypeCounts.fallback}, remaining unmatched: ${herbMatchTypeCounts.unmatched}`)
-  console.log(`[import-xlsx-monographs] compound matches => matched via canonical: ${compoundMatchTypeCounts.canonicalName}, matched via identity map: ${compoundMatchTypeCounts.identityMap}, matched via normalized: ${compoundMatchTypeCounts.normalizedName}, matched via fallback: ${compoundMatchTypeCounts.fallback}, remaining unmatched: ${compoundMatchTypeCounts.unmatched}`)
-  console.log(`[import-xlsx-monographs] identity map herb hit samples: ${JSON.stringify(identityDebug.herbs.hits)}`)
-  console.log(`[import-xlsx-monographs] identity map herb miss samples: ${JSON.stringify(identityDebug.herbs.misses)}`)
-  console.log(`[import-xlsx-monographs] identity map compound hit samples: ${JSON.stringify(identityDebug.compounds.hits)}`)
-  console.log(`[import-xlsx-monographs] identity map compound miss samples: ${JSON.stringify(identityDebug.compounds.misses)}`)
+  console.log(`[import-xlsx-monographs] herb matches => matched via slug: ${herbMatchTypeCounts.slug}, matched via normalized name: ${herbMatchTypeCounts.normalizedName}, remaining unmatched: ${herbMatchTypeCounts.unmatched}`)
+  console.log(`[import-xlsx-monographs] compound matches => matched via canonical: ${compoundMatchTypeCounts.canonicalName}, matched via normalized: ${compoundMatchTypeCounts.normalizedName}, remaining unmatched: ${compoundMatchTypeCounts.unmatched}`)
+  console.log(`[import-xlsx-monographs] fallback usage count: ${totalFallbackUsage}`)
   if (previousUnmatchedHerbsCount !== null) {
     const herbDelta = previousUnmatchedHerbsCount - herbLog.unmatched.length
     const herbPct = previousUnmatchedHerbsCount > 0 ? ((herbDelta / previousUnmatchedHerbsCount) * 100).toFixed(2) : '0.00'
@@ -1360,6 +1264,7 @@ function main() {
   console.log(`[import-xlsx-monographs] compound field patch counts: ${JSON.stringify(fieldPatchCounts.compounds)}`)
   console.log(`[import-xlsx-monographs] unmatched herb report: ${path.relative(repoRoot, unmatchedHerbsReportPath)}`)
   console.log(`[import-xlsx-monographs] unmatched compound report: ${path.relative(repoRoot, unmatchedCompoundsReportPath)}`)
+  console.log(`[import-xlsx-monographs] fallback usage report: ${path.relative(repoRoot, fallbackUsageReportPath)}`)
   console.log(`[import-xlsx-monographs] identity map suggestions: ${path.relative(repoRoot, identityMapSuggestionsPath)}`)
   console.log(`[import-xlsx-monographs] unmatched herbs: ${JSON.stringify(herbLog.unmatched)}`)
   console.log(`[import-xlsx-monographs] unmatched compounds: ${JSON.stringify(compoundLog.unmatched)}`)

--- a/scripts/verify-workbook-import-reconciliation.mjs
+++ b/scripts/verify-workbook-import-reconciliation.mjs
@@ -11,9 +11,11 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const repoRoot = path.resolve(__dirname, '..')
 const workbookPath = resolveWorkbookPath(repoRoot)
-const REQUIRED_WORKBOOK_SHEETS = ['Herb Monographs', 'Compound Master V3']
+const REQUIRED_WORKBOOK_SHEETS = ['Site Export Herbs', 'Site Export Compounds']
 const herbsPath = path.join(repoRoot, 'public', 'data', 'herbs.json')
 const compoundsPath = path.join(repoRoot, 'public', 'data', 'compounds.json')
+const workbookHerbsPath = path.join(repoRoot, 'public', 'data', 'workbook-herbs.json')
+const workbookCompoundsPath = path.join(repoRoot, 'public', 'data', 'workbook-compounds.json')
 
 function clean(value) {
   return String(value ?? '').trim().toLowerCase()
@@ -53,7 +55,20 @@ function baselineCounts() {
     if (hit) compoundMatches += 1
   }
 
-  return { herbRows: herbRows.length, herbMatches, compoundRows: compoundRows.length, compoundMatches }
+  const missingRequiredHerbFields = herbRows
+    .map((row, index) => ({
+      row: index + 2,
+      missing: ['name', 'hero', 'coreInsight'].filter((field) => !String(row[field] ?? '').trim()),
+    }))
+    .filter((entry) => entry.missing.length > 0)
+
+  return {
+    herbRows: herbRows.length,
+    herbMatches,
+    compoundRows: compoundRows.length,
+    compoundMatches,
+    missingRequiredHerbFields,
+  }
 }
 
 function runDryImport() {
@@ -78,6 +93,13 @@ function runDryImport() {
   }
 }
 
+function runWorkbookExport() {
+  execFileSync('node', ['scripts/export-workbook-to-json.mjs'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+}
+
 function assert(condition, message) {
   if (!condition) {
     throw new Error(`[verify-workbook-import-reconciliation] ${message}`)
@@ -85,11 +107,32 @@ function assert(condition, message) {
 }
 
 function main() {
+  runWorkbookExport()
   const baseline = baselineCounts()
   const reconciled = runDryImport()
+  const workbookHerbs = JSON.parse(fs.readFileSync(workbookHerbsPath, 'utf8'))
+  const workbookCompounds = JSON.parse(fs.readFileSync(workbookCompoundsPath, 'utf8'))
 
-  assert(reconciled.herbMatched >= baseline.herbMatches, 'Herb reconciliation reduced match coverage.')
-  assert(reconciled.compoundMatched > baseline.compoundMatches, 'Compound reconciliation did not improve match coverage.')
+  assert(reconciled.herbMatched <= baseline.herbRows, 'Suspicious over-matching detected for herbs.')
+  assert(reconciled.compoundMatched <= baseline.compoundRows, 'Suspicious over-matching detected for compounds.')
+  assert(baseline.herbRows > 0, 'Site Export Herbs has zero rows.')
+  assert(baseline.compoundRows > 0, 'Site Export Compounds has zero rows.')
+  assert(Array.isArray(workbookHerbs) && workbookHerbs.length > 0, 'workbook-herbs.json export is empty.')
+  assert(Array.isArray(workbookCompounds) && workbookCompounds.length > 0, 'workbook-compounds.json export is empty.')
+  assert(baseline.herbRows >= workbookHerbs.length, 'Workbook herb row count must be >= exported herb count.')
+  assert(baseline.compoundRows >= workbookCompounds.length, 'Workbook compound row count must be >= exported compound count.')
+  assert(baseline.missingRequiredHerbFields.length === 0, `Missing required Site Export Herbs fields: ${JSON.stringify(baseline.missingRequiredHerbFields.slice(0, 10))}`)
+
+  const duplicateHerbSlugs = workbookHerbs
+    .map(item => String(item?.slug ?? '').trim().toLowerCase())
+    .filter(Boolean)
+    .filter((slug, index, arr) => arr.indexOf(slug) !== index)
+  const duplicateCompoundSlugs = workbookCompounds
+    .map(item => String(item?.slug ?? item?.id ?? '').trim().toLowerCase())
+    .filter(Boolean)
+    .filter((slug, index, arr) => arr.indexOf(slug) !== index)
+  assert(duplicateHerbSlugs.length === 0, `Duplicate herb slugs in workbook export: ${JSON.stringify([...new Set(duplicateHerbSlugs)].slice(0, 10))}`)
+  assert(duplicateCompoundSlugs.length === 0, `Duplicate compound slugs in workbook export: ${JSON.stringify([...new Set(duplicateCompoundSlugs)].slice(0, 10))}`)
 
   const unmatchedHerbsReport = path.join(repoRoot, 'reports', 'workbook-unmatched-herbs.json')
   const unmatchedCompoundsReport = path.join(repoRoot, 'reports', 'workbook-unmatched-compounds.json')

--- a/src/lib/compound-data.ts
+++ b/src/lib/compound-data.ts
@@ -100,26 +100,7 @@ let compoundsSummaryPromise: Promise<CompoundSummaryRecord[]> | null = null
 let canonicalCompoundsSummaryPromise: Promise<CompoundSummaryRecord[]> | null = null
 let workbookCompoundsPromise: Promise<Record<string, unknown>[]> | null = null
 const compoundDetailPromiseBySlug = new Map<string, Promise<CompoundRecord | null>>()
-
-function isPresent(value: unknown): boolean {
-  if (value == null) return false
-  if (typeof value === 'string') return value.trim().length > 0
-  if (Array.isArray(value)) return value.length > 0
-  return true
-}
-
-function mergeCompoundSummaryRows(
-  existing: CompoundSummaryRecord,
-  workbook: CompoundSummaryRecord,
-): CompoundSummaryRecord {
-  const merged: CompoundSummaryRecord = { ...existing }
-  for (const [key, value] of Object.entries(workbook)) {
-    if (!isPresent(merged[key as keyof CompoundSummaryRecord]) && isPresent(value)) {
-      ;(merged as Record<string, unknown>)[key] = value
-    }
-  }
-  return merged
-}
+const ENABLE_LEGACY_SUMMARY_FALLBACK = import.meta.env.VITE_ENABLE_LEGACY_SUMMARY_FALLBACK === 'true'
 
 function normalizeSlugCandidate(value: string): string {
   return value
@@ -375,39 +356,23 @@ export function isRenderableCompound(raw: Record<string, unknown>): boolean {
 
 export async function loadCompoundSummaryData(): Promise<CompoundSummaryRecord[]> {
   if (!compoundsSummaryPromise) {
-    compoundsSummaryPromise = Promise.all([
-      fetch('/data/compounds-summary.json', { cache: 'no-store' }).then(response => {
-        if (!response.ok) throw new Error('Failed to load /data/compounds-summary.json')
+    compoundsSummaryPromise = fetch('/data/workbook-compounds.json', { cache: 'no-store' })
+      .then(response => {
+        if (!response.ok) throw new Error('Failed to load /data/workbook-compounds.json')
         return response.json()
-      }),
-      fetch('/data/workbook-compounds.json', { cache: 'no-store' })
-        .then(response => {
-          if (!response.ok) throw new Error('Failed to load /data/workbook-compounds.json')
+      })
+      .then(async workbookPayload => {
+        const workbookRows = Array.isArray(workbookPayload) ? workbookPayload : []
+        if (workbookRows.length > 0 || !ENABLE_LEGACY_SUMMARY_FALLBACK) {
+          return workbookRows.map(row => normalizeCompoundSummary(row as Record<string, unknown>)).filter(row => Boolean(row.slug))
+        }
+
+        const legacySummaryPayload = await fetch('/data/compounds-summary.json', { cache: 'no-store' }).then(response => {
+          if (!response.ok) throw new Error('Failed to load /data/compounds-summary.json')
           return response.json()
         })
-        .catch(() => []),
-    ])
-      .then(([summaryPayload, workbookPayload]) => {
-        const summaryRows = Array.isArray(summaryPayload) ? summaryPayload : []
-        const workbookRows = Array.isArray(workbookPayload) ? workbookPayload : []
-        const mergedBySlug = new Map<string, CompoundSummaryRecord>()
-
-        summaryRows
-          .map(row => normalizeCompoundSummary(row as Record<string, unknown>))
-          .forEach(row => {
-            if (!row.slug) return
-            mergedBySlug.set(row.slug, row)
-          })
-
-        workbookRows
-          .map(row => normalizeCompoundSummary(row as Record<string, unknown>))
-          .forEach(row => {
-            if (!row.slug) return
-            const existing = mergedBySlug.get(row.slug)
-            mergedBySlug.set(row.slug, existing ? mergeCompoundSummaryRows(existing, row) : row)
-          })
-
-        return Array.from(mergedBySlug.values())
+        const summaryRows = Array.isArray(legacySummaryPayload) ? legacySummaryPayload : []
+        return summaryRows.map(row => normalizeCompoundSummary(row as Record<string, unknown>)).filter(row => Boolean(row.slug))
       })
       .catch(error => {
         compoundsSummaryPromise = null

--- a/src/lib/herb-data.ts
+++ b/src/lib/herb-data.ts
@@ -79,23 +79,7 @@ let herbSummariesPromise: Promise<HerbSummary[]> | null = null
 let canonicalHerbSummariesPromise: Promise<HerbSummary[]> | null = null
 let workbookHerbsPromise: Promise<Record<string, unknown>[]> | null = null
 const herbDetailPromiseBySlug = new Map<string, Promise<Herb | null>>()
-
-function isPresent(value: unknown): boolean {
-  if (value == null) return false
-  if (typeof value === 'string') return value.trim().length > 0
-  if (Array.isArray(value)) return value.length > 0
-  return true
-}
-
-function mergeHerbSummaryRows(existing: HerbSummary, workbook: HerbSummary): HerbSummary {
-  const merged: HerbSummary = { ...existing }
-  for (const [key, value] of Object.entries(workbook)) {
-    if (!isPresent(merged[key]) && isPresent(value)) {
-      merged[key] = value
-    }
-  }
-  return merged
-}
+const ENABLE_LEGACY_SUMMARY_FALLBACK = import.meta.env.VITE_ENABLE_LEGACY_SUMMARY_FALLBACK === 'true'
 
 function normalizeSlugCandidate(value: string): string {
   return value
@@ -464,39 +448,23 @@ export function isRenderableHerbRow(raw: Record<string, unknown>): boolean {
 
 export async function loadHerbSummaryData(): Promise<HerbSummary[]> {
   if (!herbSummariesPromise) {
-    herbSummariesPromise = Promise.all([
-      fetch('/data/herbs-summary.json', { cache: 'no-store' }).then(response => {
-        if (!response.ok) throw new Error('Failed to load /data/herbs-summary.json')
+    herbSummariesPromise = fetch('/data/workbook-herbs.json', { cache: 'no-store' })
+      .then(response => {
+        if (!response.ok) throw new Error('Failed to load /data/workbook-herbs.json')
         return response.json()
-      }),
-      fetch('/data/workbook-herbs.json', { cache: 'no-store' })
-        .then(response => {
-          if (!response.ok) throw new Error('Failed to load /data/workbook-herbs.json')
+      })
+      .then(async workbookPayload => {
+        const workbookRows = Array.isArray(workbookPayload) ? workbookPayload : []
+        if (workbookRows.length > 0 || !ENABLE_LEGACY_SUMMARY_FALLBACK) {
+          return workbookRows.map(row => normalizeHerbSummaryRow(row as Record<string, unknown>)).filter(row => Boolean(row.slug))
+        }
+
+        const legacySummaryPayload = await fetch('/data/herbs-summary.json', { cache: 'no-store' }).then(response => {
+          if (!response.ok) throw new Error('Failed to load /data/herbs-summary.json')
           return response.json()
         })
-        .catch(() => []),
-    ])
-      .then(([summaryPayload, workbookPayload]) => {
-        const summaryRows = Array.isArray(summaryPayload) ? summaryPayload : []
-        const workbookRows = Array.isArray(workbookPayload) ? workbookPayload : []
-        const mergedBySlug = new Map<string, HerbSummary>()
-
-        summaryRows
-          .map(row => normalizeHerbSummaryRow(row as Record<string, unknown>))
-          .forEach(row => {
-            if (!row.slug) return
-            mergedBySlug.set(row.slug, row)
-          })
-
-        workbookRows
-          .map(row => normalizeHerbSummaryRow(row as Record<string, unknown>))
-          .forEach(row => {
-            if (!row.slug) return
-            const existing = mergedBySlug.get(row.slug)
-            mergedBySlug.set(row.slug, existing ? mergeHerbSummaryRows(existing, row) : row)
-          })
-
-        return Array.from(mergedBySlug.values())
+        const summaryRows = Array.isArray(legacySummaryPayload) ? legacySummaryPayload : []
+        return summaryRows.map(row => normalizeHerbSummaryRow(row as Record<string, unknown>)).filter(row => Boolean(row.slug))
       })
       .catch(error => {
         herbSummariesPromise = null


### PR DESCRIPTION
### Motivation
- Enforce the workbook (Site Export sheets) as the single source of truth for site-facing herbs/compounds and remove quiet legacy merges. 
- Make legacy data usage explicit, measurable, and opt-in so alignment gaps are visible and can be remediated. 
- Tighten matching rules to avoid silent overmatching and ensure build-time verification fails on suspicious or incomplete exports. 

### Description
- Importer: updated `scripts/import-xlsx-monographs.mjs` to require workbook-first rows, added `--allow-legacy-fallback` opt-in flag, removed silent identity-map/alias fallback match paths, enforce slug/normalized-name matching only, and emit fallback usage entries to `reports/workbook-fallback-usage.json` while still writing unmatched rows to `reports/workbook-unmatched-herbs.json` and `reports/workbook-unmatched-compounds.json`. 
- Exporter: updated `scripts/export-workbook-to-json.mjs` to treat Site Export sheets as primary, gate legacy row inclusion behind `--allow-legacy-fallback`, return structured export payloads, and write a dedicated fallback usage report. 
- Verifier: hardened `scripts/verify-workbook-import-reconciliation.mjs` to run the workbook export, verify workbook sheet counts >= exported counts, check for duplicate slugs, require non-empty workbook exports, require `name`, `hero`, and `coreInsight` presence on Site Export Herbs rows, and fail fast on violations. 
- Publication manifest and loaders: `scripts/build-publication-manifest-from-workbook.mjs` now sources only workbook exports (`source: 'workbook'`) and `src/lib/herb-data.ts` / `src/lib/compound-data.ts` now prefer `workbook-*` summary JSONs, with legacy summary fallback gated by `VITE_ENABLE_LEGACY_SUMMARY_FALLBACK=true`. 

### Testing
- Static checks: `node --check` was run against `scripts/import-xlsx-monographs.mjs`, `scripts/export-workbook-to-json.mjs`, `scripts/verify-workbook-import-reconciliation.mjs`, `scripts/build-publication-manifest-from-workbook.mjs`, `src/lib/herb-data.ts`, and `src/lib/compound-data.ts` and all passed. 
- Functional runs: `node scripts/import-xlsx-monographs.mjs --dry-run` produced import diagnostics (herbs read/compound read counts and unmatched lists) and wrote unmatched reports; `node scripts/export-workbook-to-json.mjs` produced workbook export outputs and a fallback usage report (current workbook produced zero strict workbook herb/compound records due to alignment gaps). 
- Reconciliation: `node scripts/verify-workbook-import-reconciliation.mjs` was executed; it runs the export and then enforces the new strict checks and currently fails as designed against the present workbook because Site Export Compounds lack the expected `compoundName` alignment and `workbook-herbs.json` is empty under strict mode. 
- Full build: `npm run build` was executed and completed (the build run exercises the pipeline end-to-end and surfaced the current workbook alignment issues which must be addressed or temporarily allowed via `--allow-legacy-fallback`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd3ef802b48323a60aafca925c051c)