### PR TITLE
Revamp frontend visuals with immersive neon background and upgraded UI surfaces

### DIFF
--- a/src/components/CompoundCard.tsx
+++ b/src/components/CompoundCard.tsx
@@ -82,18 +82,19 @@ export default function CompoundCard({ compound }: { compound: CompoundWithRefs 
     <motion.article
       whileHover={{ scale: 1.003 }}
       title={compound.herbsFound.map(h => h.name).join(', ')}
-      className='ds-card relative flex h-full flex-col gap-2 rounded-xl border-white/12 bg-white/[0.02] p-3 text-left'
+      className='neo-card fade-in-surface ds-card relative flex h-full flex-col gap-2.5 rounded-xl border-white/12 p-3.5 text-left'
     >
+      <div aria-hidden className='pointer-events-none absolute -bottom-10 -left-8 h-20 w-20 rounded-full bg-cyan-300/10 blur-2xl' />
       <h2
         title={isTitleTruncated ? compound.name : undefined}
         className='line-clamp-2 min-h-[2.2rem] break-all text-[0.95rem] font-semibold leading-tight text-white sm:text-base'
       >
         {title}
       </h2>
-      <p className='line-clamp-2 text-xs leading-[1.35] text-white/72'>{summary}</p>
+      <p className='line-clamp-2 text-xs leading-[1.45] text-white/76'>{summary}</p>
       <div className='flex flex-wrap gap-1'>
-        <span className='ds-pill'>{normalizeChip(confidence)}</span>
-        {primaryEffects[0] && <span className='ds-pill'>{primaryEffects[0]}</span>}
+        <span className='ds-pill neo-pill'>{normalizeChip(confidence)}</span>
+        {primaryEffects[0] && <span className='ds-pill neo-pill'>{primaryEffects[0]}</span>}
       </div>
       <p className='line-clamp-1 text-[11px] text-white/56'>{sourceLine}</p>
       <div className='mt-auto' />

--- a/src/components/CosmicBackground.tsx
+++ b/src/components/CosmicBackground.tsx
@@ -7,6 +7,7 @@ export default function CosmicBackground({ animated = true }: CosmicBackgroundPr
     <div aria-hidden className={`cosmic-background ${animated ? 'is-animated' : 'is-static'}`}>
       <div className='cosmic-layer cosmic-base' />
       <div className='cosmic-layer cosmic-vignette' />
+      <div className='cosmic-layer cosmic-noise' />
     </div>
   )
 }

--- a/src/components/HerbCard.tsx
+++ b/src/components/HerbCard.tsx
@@ -56,8 +56,9 @@ function HerbCard({
 
   return (
     <Card
-      className={`ds-card relative flex h-full flex-col border-white/12 bg-white/[0.02] ${compact ? 'gap-1.5 p-2.5' : 'gap-2 p-3'}`}
+      className={`neo-card fade-in-surface ds-card relative flex h-full flex-col border-white/12 ${compact ? 'gap-2 p-2.5' : 'gap-2.5 p-3.5'}`}
     >
+      <div aria-hidden className='pointer-events-none absolute -right-10 -top-14 h-24 w-24 rounded-full bg-fuchsia-400/10 blur-2xl' />
       <header>
         <h2
           title={isTitleTruncated ? name : undefined}
@@ -67,7 +68,17 @@ function HerbCard({
         </h2>
       </header>
 
-      <p className='line-clamp-2 text-xs leading-[1.35] text-white/72'>{summaryText}</p>
+      <p className='line-clamp-2 text-xs leading-[1.45] text-white/78'>{summaryText}</p>
+
+      {mergedTags.length > 0 && (
+        <div className='flex flex-wrap gap-1'>
+          {mergedTags.slice(0, 2).map(tag => (
+            <span key={tag} className='ds-pill neo-pill'>
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
 
       <div className='flex items-center justify-between gap-2 text-[11px] text-white/58'>
         <div className='truncate'>
@@ -94,7 +105,7 @@ function HerbCard({
       <footer className='mt-auto pt-0.5'>
         <Link
           to={detailUrl}
-          className='inline-flex min-h-7 items-center rounded-md border border-white/15 bg-white/[0.03] px-2 py-1 text-[11px] font-medium text-white/78 transition hover:border-cyan-300/45 hover:text-white'
+          className='inline-flex min-h-7 items-center rounded-md border border-white/15 bg-white/[0.03] px-2 py-1 text-[11px] font-medium text-white/78 transition duration-300 hover:border-cyan-300/45 hover:text-white'
         >
           View details
         </Link>

--- a/src/index.css
+++ b/src/index.css
@@ -46,7 +46,7 @@ body {
   line-height: 1.55;
   letter-spacing: 0;
   overscroll-behavior-y: none;
-  background: #05070a;
+  background: #060711;
   @apply antialiased;
 }
 
@@ -121,7 +121,65 @@ a:hover {
   .ds-card-paper,
   .ds-card-tight,
   .ds-card-lg {
-    @apply rounded-xl border border-white/10 bg-white/[0.02] shadow-none;
+    @apply rounded-xl border border-white/10 bg-white/[0.03] shadow-none;
+    backdrop-filter: blur(8px);
+  }
+
+  .neo-card {
+    position: relative;
+    overflow: hidden;
+    border: 1px solid rgba(174, 210, 255, 0.2);
+    background:
+      linear-gradient(160deg, rgba(127, 93, 255, 0.08), rgba(0, 229, 255, 0.03) 34%, rgba(255, 88, 227, 0.05)),
+      rgba(255, 255, 255, 0.03);
+    box-shadow:
+      0 1px 0 rgba(255, 255, 255, 0.12) inset,
+      0 20px 48px -36px rgba(126, 71, 255, 0.65),
+      0 24px 42px -40px rgba(1, 194, 255, 0.6);
+    transition: transform 260ms ease, border-color 240ms ease, box-shadow 260ms ease, background 260ms ease;
+  }
+
+  .neo-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: linear-gradient(130deg, rgba(147, 51, 234, 0.14), rgba(34, 211, 238, 0.06), transparent 58%);
+    opacity: 0.58;
+    transition: opacity 260ms ease;
+  }
+
+  .neo-card:hover {
+    transform: translateY(-2px) scale(1.01);
+    border-color: rgba(87, 238, 255, 0.5);
+    box-shadow:
+      0 0 0 1px rgba(103, 232, 249, 0.18),
+      0 18px 44px -28px rgba(87, 238, 255, 0.5),
+      0 24px 54px -30px rgba(216, 73, 255, 0.42);
+  }
+
+  .neo-card:hover::before {
+    opacity: 0.82;
+  }
+
+  .neo-pill {
+    border-color: rgba(134, 239, 255, 0.32);
+    background: linear-gradient(140deg, rgba(34, 211, 238, 0.12), rgba(236, 72, 153, 0.11));
+    color: rgba(232, 248, 255, 0.92);
+  }
+
+  .detail-panel {
+    @apply rounded-2xl border p-4;
+    border-color: rgba(255, 255, 255, 0.12);
+    background:
+      linear-gradient(170deg, rgba(123, 97, 255, 0.07), rgba(0, 186, 255, 0.03) 46%, rgba(255, 255, 255, 0.02)),
+      rgba(5, 8, 18, 0.42);
+    backdrop-filter: blur(10px);
+    box-shadow: 0 12px 34px -26px rgba(0, 0, 0, 0.8);
+  }
+
+  .fade-in-surface {
+    animation: fade-surface 320ms ease both;
   }
 
   .ds-card {
@@ -228,4 +286,15 @@ a:hover {
 
 .no-scrollbar::-webkit-scrollbar {
   display: none;
+}
+
+@keyframes fade-surface {
+  from {
+    opacity: 0;
+    transform: translateY(5px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }

--- a/src/pages/CompoundDetail.tsx
+++ b/src/pages/CompoundDetail.tsx
@@ -65,7 +65,7 @@ const ISSUE_TEMPLATE_URL =
 
 function Section({ title, children }: { title: string; children: ReactNode }) {
   return (
-    <section className='border-white/8 mt-6 border-t pt-5'>
+    <section className='detail-panel fade-in-surface mt-6'>
       <h2 className='mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-white/50'>
         {title}
       </h2>
@@ -568,18 +568,18 @@ export default function CompoundDetail() {
             </p>
           )}
           <div className='mt-4 grid gap-3 sm:grid-cols-3'>
-            <section className='rounded-lg border border-white/10 bg-black/20 p-3'>
+            <section className='detail-panel rounded-lg p-3'>
               <h2 className='text-[11px] font-semibold uppercase tracking-[0.14em] text-white/56'>Why it matters</h2>
               <p className='mt-1 text-xs text-white/80'>
                 {whyItMatters || 'Tracked for mechanism context and potential outcomes.'}
               </p>
             </section>
-            <section className='rounded-lg border border-white/10 bg-black/20 p-3'>
-              <h2 className='text-[11px] font-semibold uppercase tracking-[0.14em] text-white/56'>Key effects</h2>
+            <section className='detail-panel rounded-lg p-3'>
+              <h2 className='text-[11px] font-semibold uppercase tracking-[0.16em] text-white/62'>Key effects</h2>
               <div className='mt-1 flex flex-wrap gap-1.5'>
                 {topEffects.length > 0 ? (
                   topEffects.map(effect => (
-                    <span key={`top-effect-${effect}`} className='ds-pill text-[11px]'>
+                    <span key={`top-effect-${effect}`} className='ds-pill neo-pill text-[11px]'>
                       {effect}
                     </span>
                   ))
@@ -588,7 +588,7 @@ export default function CompoundDetail() {
                 )}
               </div>
             </section>
-            <section className='rounded-lg border border-white/10 bg-black/20 p-3'>
+            <section className='detail-panel rounded-lg p-3'>
               <h2 className='text-[11px] font-semibold uppercase tracking-[0.14em] text-white/56'>Where it appears</h2>
               <p className='mt-1 text-xs text-white/80'>
                 {whereAppears.join(', ') || 'Related herbs listed below.'}
@@ -640,7 +640,7 @@ export default function CompoundDetail() {
             {primaryEffects.map(effect => (
               <span
                 key={effect}
-                className='rounded-full border border-cyan-300/30 bg-cyan-500/10 px-2.5 py-1 text-xs text-cyan-100'
+                className='neo-pill rounded-full border px-2.5 py-1 text-xs'
               >
                 {effect}
               </span>
@@ -666,7 +666,7 @@ export default function CompoundDetail() {
         {pharmacokinetics && <Section title='Pharmacokinetics'>{pharmacokinetics}</Section>}
 
         {pathwayTargets.length > 0 && (
-          <section className='border-white/8 mt-6 border-t pt-5'>
+          <section className='detail-panel fade-in-surface mt-6'>
             <Collapse title='Pathway Targets'>
               <div className='flex flex-wrap gap-2 text-sm text-white/85'>
                 {pathwayTargets.map(target => (
@@ -680,7 +680,7 @@ export default function CompoundDetail() {
         )}
 
         {compoundTherapeuticUses.length > 0 && (
-          <section className='border-white/8 mt-6 border-t pt-5'>
+          <section className='detail-panel fade-in-surface mt-6'>
             <Collapse title='Traditional & Therapeutic Use'>
               <div className='text-sm leading-relaxed text-white/85'>
                 <ListSection items={compoundTherapeuticUses} maxVisible={6} />
@@ -694,7 +694,7 @@ export default function CompoundDetail() {
           compoundInteractions.length > 0 ||
           compoundSideEffects.length > 0 ||
           uniqueDrugInteractionItems.length > 0) && (
-          <section id='governed-safety-interactions' className='border-white/8 mt-6 border-t pt-5'>
+          <section id='governed-safety-interactions' className='detail-panel fade-in-surface mt-6'>
             <Collapse title='Safety Notes'>
               <div className='space-y-4 text-sm leading-relaxed text-white/85'>
                 {compoundContraindications.length > 0 && (
@@ -732,7 +732,7 @@ export default function CompoundDetail() {
 
         {/* Found in */}
         {foundInHerbLinks.length > 0 && (
-          <section id='related-herbs' className='border-white/8 mt-6 border-t pt-5'>
+          <section id='related-herbs' className='detail-panel fade-in-surface mt-6'>
             <Collapse title={`Found In (${foundInHerbLinks.length})`}>
               <div className='space-y-4 text-sm leading-relaxed text-white/85'>
                 {linkedHerbCards.length > 0 && (
@@ -770,7 +770,7 @@ export default function CompoundDetail() {
         )}
 
         {relatedCollections.length > 0 && (
-          <section className='border-white/8 mt-6 border-t pt-5'>
+          <section className='detail-panel fade-in-surface mt-6'>
             <Collapse title='Compare in Related Collections'>
               <div className='space-y-2 text-sm text-white/85'>
                 <p className='text-xs text-white/65'>
@@ -804,7 +804,7 @@ export default function CompoundDetail() {
         {governedResearch && governedFaq && governedRelatedQuestions && (
           <>
             {showRawDebug && compound.rawData && (
-              <section className='rounded-2xl border border-amber-200/20 bg-black/20 p-4'>
+              <section className='detail-panel rounded-2xl border-amber-200/30 p-4'>
                 <h2 className='text-[11px] font-semibold uppercase tracking-[0.14em] text-amber-100/80'>
                   Debug raw data
                 </h2>
@@ -1040,7 +1040,7 @@ export default function CompoundDetail() {
         {compound.duration && <Section title='Duration'>{compound.duration}</Section>}
         {/* Sources */}
         {(compound.sources.length > 0 || workbookSources.length > 0) && (
-          <section className='border-white/8 mt-6 border-t pt-5'>
+          <section className='detail-panel fade-in-surface mt-6'>
             <Collapse title='Sources'>
               <ol className='list-decimal space-y-1 pl-5 text-sm leading-relaxed text-white/85'>
                 {compound.sources.map((source, index) => (

--- a/src/pages/Compounds.tsx
+++ b/src/pages/Compounds.tsx
@@ -278,20 +278,20 @@ export default function CompoundsPage() {
             ].slice(0, 2)
 
             return (
-              <article key={compound.id} className='ds-card flex h-full flex-col gap-1.5 rounded-lg p-3'>
+              <article key={compound.id} className='neo-card fade-in-surface ds-card flex h-full flex-col gap-2 rounded-lg p-3.5'>
                 <h2
                   title={compound.name}
                   className='line-clamp-2 min-h-[2.2rem] break-all text-[0.95rem] font-semibold leading-tight text-white sm:text-base'
                 >
                   {title}
                 </h2>
-                <p className='line-clamp-1 text-xs leading-[1.35] text-white/72'>{summarize({ description: compound.curatedData?.summary || '', effects: compound.curatedData?.keyEffects || [] })}</p>
+                <p className='line-clamp-1 text-xs leading-[1.45] text-white/78'>{summarize({ description: compound.curatedData?.summary || '', effects: compound.curatedData?.keyEffects || [] })}</p>
                 {chips.length > 0 && (
                   <div className='flex flex-wrap gap-1'>
                     {chips.map(chip => (
                       <span
                         key={`${compound.id}-${chip.label}`}
-                        className='ds-pill'
+                        className='ds-pill neo-pill'
                       >
                         {chip.label}
                       </span>
@@ -305,7 +305,7 @@ export default function CompoundsPage() {
                 </span>
                 <Link
                   to={`/compounds/${compound.slug}`}
-                  className='mt-auto inline-flex w-fit items-center rounded-md border border-white/15 bg-white/[0.03] px-2 py-1 text-[11px] font-medium text-white/80 transition hover:border-cyan-300/45 hover:text-white'
+                  className='mt-auto inline-flex w-fit items-center rounded-md border border-white/15 bg-white/[0.03] px-2 py-1 text-[11px] font-medium text-white/80 transition duration-300 hover:border-cyan-300/45 hover:text-white'
                 >
                   View context page
                 </Link>

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -105,7 +105,7 @@ function DisclosureSection({ title, defaultOpen = false, children }: DisclosureP
   const [open, setOpen] = useState(defaultOpen)
 
   return (
-    <section className='rounded-2xl border border-white/10 bg-white/[0.02]'>
+    <section className='detail-panel fade-in-surface'>
       <button
         type='button'
         className='flex w-full items-center justify-between px-4 py-3 text-left'
@@ -290,7 +290,7 @@ export default function HerbDetail() {
           <ul>{safetyNotes.map(note => <li key={`static-safety-${note}`}>{note}</li>)}</ul>
         </div>
 
-        <header className='rounded-2xl border border-white/10 bg-white/[0.03] p-4 sm:p-4'>
+        <header className='detail-panel fade-in-surface p-4 sm:p-5'>
           <h1 className='text-3xl font-semibold sm:text-4xl'>{herbName}</h1>
           {scientificName && <p className='mt-1 text-sm italic text-white/55'>{scientificName}</p>}
           {!descriptionIsPlaceholder && (
@@ -298,13 +298,13 @@ export default function HerbDetail() {
           )}
 
           <section className='mt-3'>
-            <h2 className='text-xs font-semibold uppercase tracking-[0.14em] text-white/58'>Key effects</h2>
+            <h2 className='text-xs font-semibold uppercase tracking-[0.16em] text-white/62'>Key effects</h2>
             <div className='mt-2 flex flex-wrap gap-2'>
               {keyEffects.length > 0 ? (
                 keyEffects.map(effect => (
                   <span
                     key={effect}
-                    className='rounded-full border border-cyan-300/30 bg-cyan-500/10 px-2.5 py-1 text-xs text-cyan-100'
+                    className='neo-pill rounded-full border px-2.5 py-1 text-xs'
                   >
                     {effect}
                   </span>
@@ -315,12 +315,12 @@ export default function HerbDetail() {
             </div>
           </section>
 
-          <div className='mt-3 inline-flex rounded-full border border-white/20 bg-white/5 px-2.5 py-1 text-xs text-white/80'>
+          <div className='mt-3 inline-flex rounded-full border border-white/20 bg-white/5 px-2.5 py-1 text-xs text-white/84'>
             Evidence strength: {confidenceLabel}
           </div>
         </header>
 
-        <section className='rounded-2xl border border-white/10 bg-white/[0.02] p-4'>
+        <section className='detail-panel fade-in-surface p-4 sm:p-5'>
           <h2 className='text-sm font-semibold uppercase tracking-[0.16em] text-white/85'>Use case</h2>
           <ul className='mt-2 list-disc space-y-1 pl-5 text-sm text-white/85'>
             {useCasePoints.slice(0, 3).map(point => (
@@ -352,7 +352,7 @@ export default function HerbDetail() {
         </DisclosureSection>
 
         {coreInsight && coreInsight !== summary && (
-          <section className='rounded-2xl border border-white/10 bg-white/[0.02] p-4'>
+          <section className='detail-panel fade-in-surface p-4 sm:p-5'>
             <h2 className='text-sm font-semibold uppercase tracking-[0.16em] text-white/85'>Core insight</h2>
             <p className='mt-2 text-sm leading-relaxed text-white/85'>{coreInsight}</p>
           </section>

--- a/src/pages/Herbs.tsx
+++ b/src/pages/Herbs.tsx
@@ -312,19 +312,19 @@ export default function HerbsPage() {
           {visibleHerbs.map((herb, index) => (
             <article
               key={herb.slug || herb.id || `${herb.common}-${index}`}
-              className='flex h-full flex-col rounded-lg border border-white/12 bg-white/[0.02] p-3'
+              className='neo-card fade-in-surface flex h-full flex-col rounded-lg border border-white/12 p-3.5 transition duration-300'
             >
               <h2 className='text-base font-semibold text-white'>
                 {toTitleCase(String(herb.common || herb.scientific || herb.name || 'Herb'))}
               </h2>
-              <p className='mt-1 line-clamp-1 text-xs text-white/72'>
+              <p className='mt-1 line-clamp-1 text-xs text-white/78'>
                 {cleanSummary(String((herb.curatedData as Record<string, unknown> | undefined)?.summary || ''), String(herb.common || herb.name || ''))}
               </p>
               <div className='mt-2 flex flex-wrap gap-1'>
                 {getKeyEffects(herb).map(effect => (
                   <span
                     key={`${herb.slug}-${effect}`}
-                    className='inline-flex rounded-full border border-cyan-300/28 bg-cyan-500/10 px-2 py-0.5 text-[10px] text-cyan-100'
+                    className='neo-pill inline-flex rounded-full border px-2 py-0.5 text-[10px]'
                   >
                     {effect}
                   </span>
@@ -342,7 +342,7 @@ export default function HerbsPage() {
                           slugify(String(herb.common || herb.scientific || herb.name || '')),
                         )}`
                   }
-                  className='inline-flex items-center rounded-md border border-white/15 bg-white/[0.03] px-2 py-1 text-[11px] font-medium text-white/80 transition hover:border-cyan-300/45 hover:text-white'
+                  className='inline-flex items-center rounded-md border border-white/15 bg-white/[0.03] px-2 py-1 text-[11px] font-medium text-white/80 transition duration-300 hover:border-cyan-300/45 hover:text-white'
                 >
                   View decision page
                 </Link>

--- a/src/styles/galaxy.css
+++ b/src/styles/galaxy.css
@@ -4,7 +4,10 @@
   z-index: 0;
   pointer-events: none;
   overflow: hidden;
-  background: #05070a;
+  background:
+    radial-gradient(120% 120% at 12% 12%, rgba(104, 87, 255, 0.2), transparent 56%),
+    radial-gradient(90% 100% at 88% 78%, rgba(0, 217, 255, 0.12), transparent 62%),
+    linear-gradient(170deg, #060711 0%, #09071a 42%, #05070d 100%);
 }
 
 .cosmic-layer {
@@ -13,7 +16,37 @@
 }
 
 .cosmic-base {
-  background: #05070a;
+  background:
+    radial-gradient(75% 65% at 30% 30%, rgba(130, 80, 255, 0.14), transparent 66%),
+    radial-gradient(80% 60% at 72% 74%, rgba(255, 70, 214, 0.1), transparent 74%);
+  filter: blur(2px) saturate(115%);
+}
+
+.cosmic-base::before,
+.cosmic-base::after {
+  content: '';
+  position: absolute;
+  border-radius: 999px;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.cosmic-base::before {
+  width: 58vw;
+  height: 58vw;
+  left: -12vw;
+  top: -18vw;
+  background: radial-gradient(circle, rgba(84, 255, 240, 0.16) 0%, rgba(84, 255, 240, 0) 72%);
+  filter: blur(20px);
+}
+
+.cosmic-base::after {
+  width: 54vw;
+  height: 54vw;
+  right: -10vw;
+  bottom: -20vw;
+  background: radial-gradient(circle, rgba(216, 73, 255, 0.16) 0%, rgba(216, 73, 255, 0) 70%);
+  filter: blur(28px);
 }
 
 .cosmic-aurora,
@@ -23,4 +56,58 @@
 
 .cosmic-vignette {
   background: radial-gradient(110% 90% at 50% 48%, rgba(5, 7, 10, 0) 58%, rgba(2, 4, 8, 0.64) 100%);
+}
+
+.cosmic-layer.cosmic-noise {
+  opacity: 0.07;
+  background-image:
+    radial-gradient(rgba(255, 255, 255, 0.18) 0.6px, transparent 0.6px),
+    radial-gradient(rgba(255, 255, 255, 0.14) 0.6px, transparent 0.6px);
+  background-size: 3px 3px, 5px 5px;
+  background-position: 0 0, 1px 2px;
+}
+
+.cosmic-background.is-animated .cosmic-base {
+  animation: cosmic-drift 26s ease-in-out infinite alternate;
+}
+
+.cosmic-background.is-animated .cosmic-base::before {
+  animation: glow-float-a 24s ease-in-out infinite alternate;
+}
+
+.cosmic-background.is-animated .cosmic-base::after {
+  animation: glow-float-b 28s ease-in-out infinite alternate;
+}
+
+@keyframes cosmic-drift {
+  0% {
+    transform: scale(1) translate3d(0, 0, 0);
+    filter: blur(2px) saturate(108%);
+  }
+  100% {
+    transform: scale(1.04) translate3d(0, -1.5%, 0);
+    filter: blur(3px) saturate(128%);
+  }
+}
+
+@keyframes glow-float-a {
+  0% {
+    transform: translate3d(0, 0, 0);
+    opacity: 0.55;
+  }
+  100% {
+    transform: translate3d(6vw, 3vh, 0) scale(1.06);
+    opacity: 0.84;
+  }
+}
+
+@keyframes glow-float-b {
+  0% {
+    transform: translate3d(0, 0, 0);
+    opacity: 0.48;
+  }
+  100% {
+    transform: translate3d(-7vw, -4vh, 0) scale(1.04);
+    opacity: 0.78;
+  }
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -7,15 +7,18 @@
   --font-mono: 'DM Mono', 'Fira Code', monospace;
   --radius: 0.75rem;
 
-  --accent-h: 186;
-  --accent-s: 62%;
-  --accent-l: 50%;
+  --accent-h: 190;
+  --accent-s: 88%;
+  --accent-l: 58%;
   --accent: hsl(var(--accent-h) var(--accent-s) var(--accent-l));
 
-  --bg: 220 25% 4%;
-  --surface: 215 22% 8%;
-  --card: 215 20% 11%;
-  --text: 210 22% 96%;
+  --accent-magenta: 312 84% 64%;
+  --primary-violet: 252 74% 62%;
+
+  --bg: 244 40% 6%;
+  --surface: 238 30% 11%;
+  --card: 234 24% 14%;
+  --text: 220 26% 94%;
   --fg: 210 22% 96%;
   --mute: 210 10% 64%;
   --muted: 210 10% 64%;


### PR DESCRIPTION
### Motivation
- Move the site away from a flat, generic look toward a dark, immersive, slightly psychedelic but readable UI without touching backend logic or data schemas. 
- Provide a consistent visual system (background, cards, detail panels, micro-interactions) so index and detail surfaces read as a unified design language.

### Description
- Implemented an animated, layered background with slow color drift, radial glow blobs and a subtle noise overlay in `src/styles/galaxy.css` and wired the extra noise layer in `src/components/CosmicBackground.tsx`.
- Added reusable surface primitives and motion utilities (`.neo-card`, `.neo-pill`, `.detail-panel`, `.fade-in-surface`) and tuned card/detail surface blurs and hover behavior in `src/index.css` and theme color tokens in `src/styles/theme.css`.
- Upgraded card components and browse grids to use the new surface styles and micro-interactions with small visual accent elements in `src/components/HerbCard.tsx`, `src/components/CompoundCard.tsx`, `src/pages/Herbs.tsx`, and `src/pages/Compounds.tsx`.
- Reworked detail page surfaces and disclosure sections for clearer hierarchy and breathing room by replacing several card wrappers with `detail-panel` and applying improved typography/spacing in `src/pages/HerbDetail.tsx` and `src/pages/CompoundDetail.tsx`.

### Testing
- Ran `npm run build` which completed successfully and includes the repository prebuild/postbuild checks and prerender verification (`prerender-static`, sitemap, publishing, and structured-data smoke checks).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd50e6a4cc8323832f9e40a81aac54)