### PR TITLE
Polish compounds UI: clean tag labels and enhance card visuals

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -56,7 +56,11 @@ body::before {
   inset: 0;
   pointer-events: none;
   z-index: 1;
-  background: radial-gradient(120% 90% at 50% 46%, rgba(5, 7, 10, 0) 58%, rgba(2, 4, 7, 0.52) 100%);
+  background:
+    radial-gradient(80% 58% at 26% 14%, rgba(109, 88, 255, 0.11), rgba(109, 88, 255, 0) 68%),
+    radial-gradient(70% 64% at 82% 88%, rgba(27, 214, 255, 0.08), rgba(27, 214, 255, 0) 72%),
+    radial-gradient(120% 90% at 50% 46%, rgba(5, 7, 10, 0) 58%, rgba(2, 4, 7, 0.54) 100%);
+  animation: ambient-shift 22s ease-in-out infinite alternate;
 }
 
 .prerender-content.sr-only {
@@ -128,14 +132,21 @@ a:hover {
   .neo-card {
     position: relative;
     overflow: hidden;
-    border: 1px solid rgba(174, 210, 255, 0.2);
+    border: 1px solid rgba(174, 210, 255, 0.24);
     background:
-      linear-gradient(160deg, rgba(127, 93, 255, 0.08), rgba(0, 229, 255, 0.03) 34%, rgba(255, 88, 227, 0.05)),
+      linear-gradient(
+        164deg,
+        rgba(127, 93, 255, 0.12),
+        rgba(0, 229, 255, 0.055) 36%,
+        rgba(255, 88, 227, 0.08)
+      ),
       rgba(255, 255, 255, 0.03);
     box-shadow:
-      0 1px 0 rgba(255, 255, 255, 0.12) inset,
-      0 20px 48px -36px rgba(126, 71, 255, 0.65),
-      0 24px 42px -40px rgba(1, 194, 255, 0.6);
+      0 1px 0 rgba(255, 255, 255, 0.14) inset,
+      inset 0 10px 20px -18px rgba(228, 239, 255, 0.28),
+      0 0 0 1px rgba(160, 232, 255, 0.06),
+      0 24px 58px -42px rgba(126, 71, 255, 0.62),
+      0 24px 50px -40px rgba(1, 194, 255, 0.54);
     transition: transform 260ms ease, border-color 240ms ease, box-shadow 260ms ease, background 260ms ease;
   }
 
@@ -145,17 +156,18 @@ a:hover {
     inset: 0;
     pointer-events: none;
     background: linear-gradient(130deg, rgba(147, 51, 234, 0.14), rgba(34, 211, 238, 0.06), transparent 58%);
-    opacity: 0.58;
+    opacity: 0.62;
     transition: opacity 260ms ease;
   }
 
   .neo-card:hover {
-    transform: translateY(-2px) scale(1.01);
-    border-color: rgba(87, 238, 255, 0.5);
+    transform: translateY(-2px) scale(1.016);
+    border-color: rgba(87, 238, 255, 0.56);
     box-shadow:
-      0 0 0 1px rgba(103, 232, 249, 0.18),
-      0 18px 44px -28px rgba(87, 238, 255, 0.5),
-      0 24px 54px -30px rgba(216, 73, 255, 0.42);
+      0 0 0 1px rgba(103, 232, 249, 0.2),
+      inset 0 10px 20px -18px rgba(236, 245, 255, 0.3),
+      0 18px 44px -28px rgba(87, 238, 255, 0.56),
+      0 28px 64px -32px rgba(216, 73, 255, 0.5);
   }
 
   .neo-card:hover::before {
@@ -163,9 +175,19 @@ a:hover {
   }
 
   .neo-pill {
-    border-color: rgba(134, 239, 255, 0.32);
-    background: linear-gradient(140deg, rgba(34, 211, 238, 0.12), rgba(236, 72, 153, 0.11));
-    color: rgba(232, 248, 255, 0.92);
+    border-color: rgba(134, 239, 255, 0.42);
+    background: linear-gradient(140deg, rgba(34, 211, 238, 0.18), rgba(168, 85, 247, 0.16));
+    color: rgba(238, 250, 255, 0.98);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.16), 0 0 12px rgba(91, 224, 255, 0.18);
+  }
+
+  .compound-context-link {
+    box-shadow: 0 0 0 rgba(88, 233, 255, 0);
+  }
+
+  .compound-context-link:hover {
+    background: rgba(255, 255, 255, 0.08);
+    box-shadow: 0 0 18px rgba(88, 233, 255, 0.22);
   }
 
   .detail-panel {
@@ -296,5 +318,16 @@ a:hover {
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+@keyframes ambient-shift {
+  0% {
+    filter: saturate(100%) hue-rotate(0deg);
+    opacity: 0.95;
+  }
+  100% {
+    filter: saturate(112%) hue-rotate(8deg);
+    opacity: 1;
   }
 }

--- a/src/pages/Compounds.tsx
+++ b/src/pages/Compounds.tsx
@@ -54,6 +54,34 @@ function getStatusTag(level: ConfidenceLevel) {
   return 'Limited evidence'
 }
 
+function formatChipLabel(value: string) {
+  const trimmed = String(value || '').trim()
+  if (!trimmed) return ''
+
+  let decoded = trimmed
+  if (
+    (decoded.startsWith('["') && decoded.endsWith('"]')) ||
+    (decoded.startsWith("['") && decoded.endsWith("']"))
+  ) {
+    try {
+      const parsed = JSON.parse(decoded.replace(/'/g, '"'))
+      decoded = Array.isArray(parsed) ? String(parsed[0] || '') : decoded
+    } catch {
+      decoded = decoded.replace(/^\[+|\]+$/g, '')
+    }
+  }
+
+  const normalized = decoded
+    .replace(/^\[+|\]+$/g, '')
+    .replace(/^['"]+|['"]+$/g, '')
+    .replace(/\s*-\s*/g, '-')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  if (!normalized) return ''
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1)
+}
+
 export default function CompoundsPage() {
   const INITIAL_RESULTS = 18
   const LOAD_MORE_STEP = 18
@@ -275,19 +303,27 @@ export default function CompoundsPage() {
                       : []),
                   ]
                 : []),
-            ].slice(0, 2)
+            ]
+              .map(chip => ({ ...chip, label: formatChipLabel(chip.label) }))
+              .filter(chip => Boolean(chip.label))
+              .slice(0, 2)
 
             return (
-              <article key={compound.id} className='neo-card fade-in-surface ds-card flex h-full flex-col gap-2 rounded-lg p-3.5'>
+              <article key={compound.id} className='neo-card fade-in-surface ds-card flex h-full flex-col gap-2.5 rounded-lg p-4'>
                 <h2
                   title={compound.name}
-                  className='line-clamp-2 min-h-[2.2rem] break-all text-[0.95rem] font-semibold leading-tight text-white sm:text-base'
+                  className='line-clamp-2 min-h-[2.4rem] break-all text-[1.04rem] font-semibold leading-tight text-white sm:text-[1.12rem]'
                 >
                   {title}
                 </h2>
-                <p className='line-clamp-1 text-xs leading-[1.45] text-white/78'>{summarize({ description: compound.curatedData?.summary || '', effects: compound.curatedData?.keyEffects || [] })}</p>
+                <p className='line-clamp-2 text-[0.74rem] leading-[1.5] text-white/72'>
+                  {summarize({
+                    description: compound.curatedData?.summary || '',
+                    effects: compound.curatedData?.keyEffects || [],
+                  })}
+                </p>
                 {chips.length > 0 && (
-                  <div className='flex flex-wrap gap-1'>
+                  <div className='flex flex-wrap gap-1.5'>
                     {chips.map(chip => (
                       <span
                         key={`${compound.id}-${chip.label}`}
@@ -299,13 +335,13 @@ export default function CompoundsPage() {
                   </div>
                 )}
                 <span
-                  className={`mt-1 inline-flex w-fit rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-[0.08em] ${confidenceBadgeClass(confidence)}`}
+                  className={`mt-1 inline-flex w-fit rounded-full border px-2 py-0.5 text-[9px] uppercase tracking-[0.11em] ${confidenceBadgeClass(confidence)}`}
                 >
                   {getStatusTag(confidence)}
                 </span>
                 <Link
                   to={`/compounds/${compound.slug}`}
-                  className='mt-auto inline-flex w-fit items-center rounded-md border border-white/15 bg-white/[0.03] px-2 py-1 text-[11px] font-medium text-white/80 transition duration-300 hover:border-cyan-300/45 hover:text-white'
+                  className='compound-context-link mt-auto inline-flex w-fit items-center rounded-md border border-white/20 bg-white/[0.04] px-2.5 py-1 text-[11px] font-medium text-white/82 transition duration-500 hover:border-cyan-200/75 hover:text-white'
                 >
                   View context page
                 </Link>


### PR DESCRIPTION
### Motivation
- Improve visual quality and perceived polish of compound cards without changing layout or data.
- Prevent raw JSON-like tag strings from surfacing in the UI and make tags readable and consistent.
- Add subtle, restrained motion and depth to make the interface feel premium while remaining accessible.

### Description
- Normalize and format chip/tag labels before rendering (strip brackets/quotes, parse simple JSON arrays, normalize hyphens, capitalize) in `src/pages/Compounds.tsx`.
- Increase card visual depth and hover affordance via richer gradients, subtle inner glow and tuned box-shadows, and a slight scale on hover in `src/index.css` using existing `.neo-card` rules.
- Refresh tag pill styling to a brighter cyan/violet tint with soft glow and small inset highlight by updating `.neo-pill` styles in `src/index.css`.
- Improve typography hierarchy and spacing for compound cards and refine the "View context page" button hover/timing with a gentle glow by updating `src/pages/Compounds.tsx` and adding `.compound-context-link` in `src/index.css`.

### Testing
- Ran production compilation with `npm run build:compile` and the build completed successfully with only existing non-blocking warnings.
- Pre-commit hooks (including `eslint --max-warnings=0` for staged TS/TSX files) were executed as part of the commit and passed.
- No runtime errors surfaced during the build and prerender steps that ran as part of the build pipeline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd5dde3708832392ca29cb21bf2481)