### PR TITLE
Workbook-driven rendering: profile_status/summary_quality/primary_effects gating

### DIFF
--- a/src/components/CompoundCard.tsx
+++ b/src/components/CompoundCard.tsx
@@ -6,6 +6,7 @@ import { calculateCompoundConfidence } from '@/utils/calculateConfidence'
 import { formatBrowseTitle } from '@/utils/titleDisplay'
 import { cleanEffectChips, sanitizeSummaryText } from '@/lib/sanitize'
 import { normalizeTagList } from '@/lib/tagNormalization'
+import { getPrimaryEffects, getProfileStatus, getSummaryQuality, resolveHeroSummary, shouldRenderSummary } from '@/lib/workbookRender'
 
 interface HerbRef {
   name: string
@@ -41,8 +42,13 @@ function getWorkbookHero(compound: CompoundWithRefs): string {
 
 export default function CompoundCard({ compound }: { compound: CompoundWithRefs }) {
   const mechanism = getMechanism(compound)
+  const rawRecord = (compound.rawData as Record<string, unknown> | undefined) || {}
+  const profileStatus = getProfileStatus(rawRecord)
+  const summaryQuality = getSummaryQuality(rawRecord)
+  const isMinimal = profileStatus === 'minimal'
+  const showSummary = shouldRenderSummary(profileStatus, summaryQuality)
   const workbookEffects = cleanEffectChips(
-    (compound.rawData as Record<string, unknown> | undefined)?.effects ||
+    rawRecord.effects ||
       compound.curatedData?.keyEffects ||
       compound.effects ||
       [],
@@ -54,20 +60,26 @@ export default function CompoundCard({ compound }: { compound: CompoundWithRefs 
     effects,
     compounds: compound.herbsFound.map(h => h.name),
   })
-  const primaryEffects = normalizeTagList(extractPrimaryEffects(effects, 2), { caseStyle: 'title', maxItems: 2 })
+  const primaryEffects = normalizeTagList(
+    getPrimaryEffects(rawRecord, 2).length ? getPrimaryEffects(rawRecord, 2) : extractPrimaryEffects(effects, 2),
+    { caseStyle: 'title', maxItems: 2 },
+  )
   const visibleHerbs = compound.herbsFound.slice(0, 2)
   const hiddenHerbCount = Math.max(compound.herbsFound.length - visibleHerbs.length, 0)
   const title = formatBrowseTitle(compound.name, 60)
   const isTitleTruncated = title !== compound.name
-  const summary = getWorkbookHero(compound) ||
-    buildCardSummary({
-      effects,
-      mechanism,
-      description: compound.description,
-      activeCompounds: compound.herbsFound.map(h => h.name),
-      maxLen: 120,
-    })?.trim() ||
-    'Summary coming soon.'
+  const summary =
+    resolveHeroSummary(rawRecord, 1) ||
+    getWorkbookHero(compound) ||
+    (summaryQuality === 'strong'
+      ? buildCardSummary({
+          effects,
+          mechanism,
+          description: compound.description,
+          activeCompounds: compound.herbsFound.map(h => h.name),
+          maxLen: 120,
+        })?.trim()
+      : '')
   const sourceLine =
     visibleHerbs.length > 0
       ? `Found in ${visibleHerbs.map(h => h.name).join(', ')}${hiddenHerbCount > 0 ? ` +${hiddenHerbCount}` : ''}`
@@ -86,12 +98,12 @@ export default function CompoundCard({ compound }: { compound: CompoundWithRefs 
       >
         {title}
       </h2>
-      <p className='line-clamp-2 text-xs leading-[1.45] text-white/76'>{summary}</p>
+      {showSummary && summary ? <p className='line-clamp-2 text-xs leading-[1.45] text-white/76'>{summary}</p> : null}
       <div className='flex flex-wrap gap-1'>
         <span className='ds-pill neo-pill'>{normalizeTagList(confidence, { caseStyle: 'title', maxItems: 1 })[0] || confidence}</span>
         {primaryEffects[0] && <span className='ds-pill neo-pill'>{primaryEffects[0]}</span>}
       </div>
-      <p className='line-clamp-1 text-[11px] text-white/56'>{sourceLine}</p>
+      {!isMinimal && <p className='line-clamp-1 text-[11px] text-white/56'>{sourceLine}</p>}
       <div className='mt-auto' />
     </motion.article>
   )

--- a/src/components/EntityDatabasePage.tsx
+++ b/src/components/EntityDatabasePage.tsx
@@ -11,7 +11,6 @@ import type { Herb } from '@/types'
 import { trackEvent } from '@/lib/growth'
 import { CTA } from '@/lib/cta'
 import { buildCardSummary } from '@/lib/summary'
-import { extractPrimaryEffects } from '@/utils/extractPrimaryEffects'
 import { hasVal } from '@/lib/pretty'
 import { slugify } from '@/lib/slug'
 
@@ -544,7 +543,7 @@ export default function EntityDatabasePage({
 
         <section className='ds-section grid gap-4 pb-8 md:grid-cols-2'>
           {filtered.map((item, index) => (
-            <HerbCard
+              <HerbCard
               key={item.slug ?? item.id ?? `${kind}-${index}`}
               name={String(item.common || item.scientific || item.name || 'Herb')}
               summary={
@@ -555,7 +554,13 @@ export default function EntityDatabasePage({
                   maxLen: 130,
                 }) || 'Learn more about this herb and its potential uses.'
               }
-              tags={extractPrimaryEffects(Array.isArray(item.curatedData?.keyEffects) ? item.curatedData.keyEffects : [], 2)}
+              primary_effects={Array.isArray((item as Record<string, unknown>).primary_effects)
+                ? ((item as Record<string, unknown>).primary_effects as string[])
+                : Array.isArray((item as Record<string, unknown>).primaryEffects)
+                  ? ((item as Record<string, unknown>).primaryEffects as string[])
+                  : []}
+              profile_status={String((item as Record<string, unknown>).profile_status || (item as Record<string, unknown>).profileStatus || '')}
+              summary_quality={String((item as Record<string, unknown>).summary_quality || (item as Record<string, unknown>).summaryQuality || '')}
               detailUrl={
                 hasVal(item.slug)
                   ? `${kind === 'compound' ? '/compounds' : '/herbs'}/${encodeURIComponent(String(item.slug))}`

--- a/src/components/HerbCard.tsx
+++ b/src/components/HerbCard.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 import Card from './ui/Card'
 import { formatBrowseTitle } from '@/utils/titleDisplay'
 import { normalizeTagList } from '@/lib/tagNormalization'
+import { getProfileStatus, getSummaryQuality, shouldRenderSummary } from '@/lib/workbookRender'
 
 interface HerbCardProps {
   name: string
@@ -18,6 +19,9 @@ interface HerbCardProps {
   evidenceLevel?: string
   detailUrl: string
   compact?: boolean
+  profile_status?: string
+  summary_quality?: string
+  primary_effects?: string[]
 }
 
 function HerbCard({
@@ -33,13 +37,22 @@ function HerbCard({
   evidenceLevel,
   detailUrl,
   compact = false,
+  profile_status,
+  summary_quality,
+  primary_effects = [],
 }: HerbCardProps) {
-  const mergedTags = normalizeTagList([...effects, ...tags, ...mechanismTags], { caseStyle: 'title', maxItems: 6 })
-  const primaryTag = mergedTags[0]
+  const profileStatus = getProfileStatus({ profile_status })
+  const summaryQuality = getSummaryQuality({ summary_quality })
+  const showSummary = shouldRenderSummary(profileStatus, summaryQuality)
+  const isMinimal = profileStatus === 'minimal'
+  const isPartial = profileStatus === 'partial'
+  const pills = normalizeTagList(primary_effects, { caseStyle: 'title', maxItems: 2 })
+  const fallbackTags = normalizeTagList([...tags, ...mechanismTags], { caseStyle: 'title', maxItems: 2 })
+  const primaryTag = pills[0] || fallbackTags[0]
   const hasCompoundCount = typeof compound_count === 'number' && compound_count > 0
   const title = formatBrowseTitle(name, 60)
   const isTitleTruncated = title !== name
-  const summaryText = hero?.trim() || coreInsight?.trim() || summary?.trim() || 'Overview coming soon.'
+  const summaryText = hero?.trim() || summary?.trim() || (summaryQuality === 'strong' ? coreInsight?.trim() : '')
 
   const chipItems = normalizeTagList([evidence_tier || evidenceLevel || '', primaryTag || ''], {
     caseStyle: 'title',
@@ -60,11 +73,13 @@ function HerbCard({
         </h2>
       </header>
 
-      <p className='line-clamp-2 text-xs leading-[1.45] text-white/78'>{summaryText}</p>
+      {showSummary && summaryText ? (
+        <p className='line-clamp-2 text-xs leading-[1.45] text-white/78'>{summaryText}</p>
+      ) : null}
 
-      {mergedTags.length > 0 && (
+      {pills.length > 0 && (
         <div className='flex flex-wrap gap-1'>
-          {mergedTags.slice(0, 2).map(tag => (
+          {pills.map(tag => (
             <span key={tag} className='ds-pill neo-pill'>
               {tag}
             </span>
@@ -74,13 +89,15 @@ function HerbCard({
 
       <div className='flex items-center justify-between gap-2 text-[11px] text-white/58'>
         <div className='truncate'>
-          {hasCompoundCount ? (
+          {isMinimal ? (
+            <span>Minimal profile</span>
+          ) : hasCompoundCount ? (
             <span className='inline-flex items-center gap-1'>
               <FlaskConical className='h-3 w-3' aria-hidden='true' />
               {compound_count} compounds
             </span>
           ) : (
-            <span>Profile</span>
+            <span>{isPartial ? 'Partial profile' : 'Profile'}</span>
           )}
         </div>
         {chipItems.length > 0 && (

--- a/src/components/HerbList.tsx
+++ b/src/components/HerbList.tsx
@@ -3,7 +3,6 @@ import { AnimatePresence, motion } from '@/lib/motion'
 import type { Herb } from '../types'
 import HerbCard from './HerbCard'
 import { buildCardSummary } from '@/lib/summary'
-import { extractPrimaryEffects } from '@/utils/extractPrimaryEffects'
 import { hasVal } from '@/lib/pretty'
 import { slugify } from '@/lib/slug'
 
@@ -67,7 +66,13 @@ const HerbList: React.FC<Props> = ({
                     maxLen: 130,
                   }) || 'Learn more about this herb and its potential uses.'
                 }
-                tags={extractPrimaryEffects(Array.isArray(h.effects) ? h.effects : [], 2)}
+                primary_effects={Array.isArray((h as Record<string, unknown>).primary_effects)
+                  ? ((h as Record<string, unknown>).primary_effects as string[])
+                  : Array.isArray((h as Record<string, unknown>).primaryEffects)
+                    ? ((h as Record<string, unknown>).primaryEffects as string[])
+                    : []}
+                profile_status={String((h as Record<string, unknown>).profile_status || (h as Record<string, unknown>).profileStatus || '')}
+                summary_quality={String((h as Record<string, unknown>).summary_quality || (h as Record<string, unknown>).summaryQuality || '')}
                 detailUrl={
                   hasVal(h.slug)
                     ? `/herbs/${encodeURIComponent(String(h.slug))}`

--- a/src/lib/compound-data.ts
+++ b/src/lib/compound-data.ts
@@ -219,6 +219,18 @@ function normalizeSources(value: unknown): SourceRef[] {
 
 function readContextRecord(data: Record<string, unknown>): Record<string, unknown> {
   const context = data.context
+  if (typeof context === 'string') {
+    const trimmed = context.trim()
+    if (!trimmed) return {}
+    try {
+      const parsed = JSON.parse(trimmed)
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : {}
+    } catch {
+      return {}
+    }
+  }
   return context && typeof context === 'object' ? (context as Record<string, unknown>) : {}
 }
 
@@ -237,7 +249,7 @@ function normalizeCompound(raw: Record<string, unknown>): CompoundRecord {
   const herbs = splitClean(
     data.associatedHerbs ?? data.foundInHerbs ?? data.herbs ?? data.foundIn ?? context.foundIn,
   )
-  const mechanism = cleanText(data.mechanism ?? data.mechanisms ?? data.mechanismOfAction) || ''
+  const mechanism = cleanText(data.mechanism ?? splitClean(data.mechanisms).join('; ') ?? data.mechanismOfAction) || ''
   const researchEnrichment = normalizeResearchEnrichment(data.researchEnrichment)
   const rawInteractionTags = splitClean(data.interactionTags)
   const rawInteractionNotes = splitClean(data.interactionNotes)
@@ -304,7 +316,7 @@ function normalizeCompound(raw: Record<string, unknown>): CompoundRecord {
       description:
         cleanText(data.description ?? data.summary ?? data.hero ?? data.intro ?? data.coreInsight) || '',
       whyItMatters: cleanText(data.whyItMatters ?? data.coreInsight ?? data.overview) || '',
-      primaryEffects: splitClean(data.primaryEffects ?? data.keyEffects ?? effects),
+      primaryEffects: splitClean(data.primary_effects ?? data.primaryEffects ?? data.keyEffects ?? effects),
       effects,
       contraindications: splitClean(data.contraindications),
       interactions: splitClean(data.interactions),
@@ -334,9 +346,9 @@ function normalizeCompoundSummary(raw: Record<string, unknown>): CompoundSummary
     description: cleanText(raw.description ?? raw.summaryShort ?? raw.summary ?? raw.hero ?? raw.coreInsight) || '',
     className: cleanText(raw.className) || '',
     category: cleanText(raw.category ?? raw.className) || '',
-    mechanism: cleanText(raw.mechanism ?? raw.mechanisms) || '',
+    mechanism: cleanText(raw.mechanism ?? splitClean(raw.mechanisms).join('; ')) || '',
     effects,
-    primaryEffects: splitClean(raw.primaryEffects ?? raw.keyEffects ?? effects).slice(0, 4),
+    primaryEffects: splitClean(raw.primary_effects ?? raw.primaryEffects ?? raw.keyEffects ?? effects).slice(0, 4),
     herbs,
     confidence: confidence === 'high' || confidence === 'medium' ? confidence : 'low',
     hasInteractionData: Boolean(raw.hasInteractionData),

--- a/src/lib/herb-data.ts
+++ b/src/lib/herb-data.ts
@@ -256,6 +256,18 @@ function normalizeProductRecommendations(value: unknown): ProductRecommendation[
 
 function readContextRecord(data: Record<string, unknown>): Record<string, unknown> {
   const context = data.context
+  if (typeof context === 'string') {
+    const trimmed = context.trim()
+    if (!trimmed) return {}
+    try {
+      const parsed = JSON.parse(trimmed)
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : {}
+    } catch {
+      return {}
+    }
+  }
   return context && typeof context === 'object' ? (context as Record<string, unknown>) : {}
 }
 
@@ -305,7 +317,7 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
     seed: seededInteraction,
   })
 
-  const mechanism = cleanText(data.mechanism ?? data.mechanisms ?? data.mechanismOfAction) || ''
+  const mechanism = cleanText(data.mechanism ?? splitClean(data.mechanisms).join('; ') ?? data.mechanismOfAction) || ''
   const description =
     cleanText(data.description ?? data.summary ?? data.hero ?? data.intro ?? data.coreInsight) || ''
   const duration = cleanText(data.duration) || ''
@@ -367,7 +379,7 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
       summary: description,
       description,
       whyItMatters: cleanText(data.whyItMatters ?? data.coreInsight ?? data.overview) || description,
-      primaryEffects: splitClean(data.primaryEffects ?? data.keyEffects ?? effects),
+      primaryEffects: splitClean(data.primary_effects ?? data.primaryEffects ?? data.keyEffects ?? effects),
       effects,
       contraindications,
       interactions,
@@ -404,9 +416,9 @@ function normalizeHerbSummaryRow(raw: Record<string, unknown>): HerbSummary {
     confidence: confidenceLevel,
     summaryShort: cleanText(raw.summaryShort ?? raw.description ?? raw.summary ?? raw.hero ?? raw.coreInsight) || '',
     description: cleanText(raw.description ?? raw.summaryShort ?? raw.summary ?? raw.hero ?? raw.coreInsight) || '',
-    mechanism: cleanText(raw.mechanism ?? raw.mechanisms) || '',
+    mechanism: cleanText(raw.mechanism ?? splitClean(raw.mechanisms).join('; ')) || '',
     effects,
-    primaryEffects: splitClean(raw.primaryEffects ?? raw.keyEffects ?? effects).slice(0, 4),
+    primaryEffects: splitClean(raw.primary_effects ?? raw.primaryEffects ?? raw.keyEffects ?? effects).slice(0, 4),
     activeCompounds,
     compounds: activeCompounds,
     interactionTags: splitClean(raw.interactionTags),

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -108,6 +108,18 @@ export function splitClean(value: unknown): string[] {
   if (Array.isArray(value)) return cleanList(value)
 
   if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return []
+
+    if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+      try {
+        const parsed = JSON.parse(trimmed)
+        return Array.isArray(parsed) ? cleanList(parsed) : []
+      } catch {
+        return []
+      }
+    }
+
     const parts = value
       .split(/[\n,;|]/)
       .map(part => part.trim())

--- a/src/lib/workbookRender.ts
+++ b/src/lib/workbookRender.ts
@@ -1,0 +1,46 @@
+import { cleanEffectChips, sanitizeSummaryText, splitClean } from '@/lib/sanitize'
+
+export type ProfileStatus = 'complete' | 'partial' | 'minimal'
+export type SummaryQuality = 'strong' | 'weak' | 'none'
+
+function normalizeStatus(value: unknown): string {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+}
+
+export function getProfileStatus(input: Record<string, unknown> | undefined | null): ProfileStatus {
+  const status = normalizeStatus(input?.profile_status ?? input?.profileStatus)
+  if (status === 'minimal' || status === 'partial' || status === 'complete') return status
+  return 'complete'
+}
+
+export function getSummaryQuality(input: Record<string, unknown> | undefined | null): SummaryQuality {
+  const quality = normalizeStatus(input?.summary_quality ?? input?.summaryQuality)
+  if (quality === 'none' || quality === 'weak' || quality === 'strong') return quality
+  return 'strong'
+}
+
+export function getPrimaryEffects(input: Record<string, unknown> | undefined | null, maxItems = 4): string[] {
+  return cleanEffectChips(splitClean(input?.primary_effects ?? input?.primaryEffects), maxItems)
+}
+
+export function shouldRenderSummary(profileStatus: ProfileStatus, summaryQuality: SummaryQuality): boolean {
+  if (summaryQuality === 'none') return false
+  if (profileStatus === 'minimal') return false
+  return true
+}
+
+export function resolveHeroSummary(
+  input: Record<string, unknown> | undefined | null,
+  maxSentences = 1,
+): string {
+  return sanitizeSummaryText(input?.hero || input?.summary || input?.description || '', maxSentences)
+}
+
+export function resolveCoreInsight(
+  input: Record<string, unknown> | undefined | null,
+  maxSentences = 1,
+): string {
+  return sanitizeSummaryText(input?.coreInsight || input?.overview || input?.whyItMatters || '', maxSentences)
+}

--- a/src/pages/CompoundDetail.tsx
+++ b/src/pages/CompoundDetail.tsx
@@ -16,7 +16,6 @@ import { normalizeTagList } from '@/lib/tagNormalization'
 import { pickNonEmptyKeys } from '@/lib/nonEmptyFields'
 import { calculateCompoundConfidence } from '@/utils/calculateConfidence'
 import { getCompoundDataCompleteness } from '@/utils/getDataCompleteness'
-import { extractPrimaryEffects } from '@/utils/extractPrimaryEffects'
 import { CompoundDetailSkeleton } from '@/components/skeletons/DetailSkeletons'
 import { mapRelatedHerbsForCompound } from '@/lib/compoundHerbRelations'
 import HerbCard from '@/components/HerbCard'
@@ -53,6 +52,7 @@ import { buildFallbackCompoundIntro, buildGovernedDetailIntro } from '@/lib/gove
 import { resolveGovernedCtaDecision } from '@/lib/governedCta'
 import { buildGovernedReviewFreshness } from '@/lib/governedReviewFreshness'
 import { shouldShowRawDebug } from '@/lib/semanticCompression'
+import { getPrimaryEffects, getProfileStatus, getSummaryQuality, shouldRenderSummary } from '@/lib/workbookRender'
 import {
   trackDetailBuilderClick,
   trackCtaSlotImpression,
@@ -133,6 +133,18 @@ function normalizeTextValue(value: unknown): string {
 }
 
 function readRecord(value: unknown): Record<string, unknown> {
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return {}
+    try {
+      const parsed = JSON.parse(trimmed)
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : {}
+    } catch {
+      return {}
+    }
+  }
   return value && typeof value === 'object' ? (value as Record<string, unknown>) : {}
 }
 
@@ -208,6 +220,9 @@ export default function CompoundDetail() {
   const rawRecord = readRecord(compound.rawData)
   const contextRecord = readRecord(rawRecord.context)
   const safetyRecord = readRecord(rawRecord.safety)
+  const profileStatus = getProfileStatus(rawRecord)
+  const summaryQuality = getSummaryQuality(rawRecord)
+  const isMinimalProfile = profileStatus === 'minimal'
   const name =
     normalizeTextValue(compoundRecord.compoundName) ||
     normalizeTextValue(compoundRecord.name) ||
@@ -362,7 +377,7 @@ export default function CompoundDetail() {
     herbs: compound.herbs,
   })
 
-  const primaryEffects = cleanEffectChips(extractPrimaryEffects(compoundEffects, 8), 5)
+  const primaryEffects = cleanEffectChips(getPrimaryEffects(rawRecord, 5), 5)
 
   const sourceCount = compound.sources.length
   const cautionCount = countCautionSignals({
@@ -564,18 +579,18 @@ export default function CompoundDetail() {
           <div className='flex flex-wrap items-start justify-between gap-3'>
             <h1 className='text-3xl font-semibold leading-tight'>{name}</h1>
           </div>
-          {topSummary && (
+          {shouldRenderSummary(profileStatus, summaryQuality) && topSummary && (
             <p className='mt-3 max-w-3xl text-sm leading-relaxed text-white/80'>
               {topSummary}
             </p>
           )}
           <div className='mt-4 grid gap-3 sm:grid-cols-3'>
-            <section className='detail-panel rounded-lg p-3'>
+            {!isMinimalProfile && <section className='detail-panel rounded-lg p-3'>
               <h2 className='text-[11px] font-semibold uppercase tracking-[0.14em] text-white/56'>Why it matters</h2>
               <p className='mt-1 text-xs text-white/80'>
                 {whyItMatters || 'Tracked for mechanism context and potential outcomes.'}
               </p>
-            </section>
+            </section>}
             <section className='detail-panel rounded-lg p-3'>
               <h2 className='text-[11px] font-semibold uppercase tracking-[0.16em] text-white/62'>Key effects</h2>
               <div className='mt-1 flex flex-wrap gap-1.5'>
@@ -585,17 +600,15 @@ export default function CompoundDetail() {
                       {effect}
                     </span>
                   ))
-                ) : (
-                  <p className='text-xs text-white/80'>Effects being reviewed.</p>
-                )}
+                ) : null}
               </div>
             </section>
-            <section className='detail-panel rounded-lg p-3'>
+            {!isMinimalProfile && <section className='detail-panel rounded-lg p-3'>
               <h2 className='text-[11px] font-semibold uppercase tracking-[0.14em] text-white/56'>Where it appears</h2>
               <p className='mt-1 text-xs text-white/80'>
                 {whereAppears.join(', ') || 'Related herbs listed below.'}
               </p>
-            </section>
+            </section>}
           </div>
           {(confidence || sourceCount > 0 || cautionCount > 0) && (
             <div className='mt-3 flex flex-wrap gap-1.5'>
@@ -625,7 +638,7 @@ export default function CompoundDetail() {
         </header>
 
         {/* Core fields — only render when value is present */}
-        {compoundDescription && compoundDescription !== topSummary && (
+        {!isMinimalProfile && compoundDescription && compoundDescription !== topSummary && (
           <Section title='Overview'>
             {compoundDescription}
             {displayClass && (
@@ -650,9 +663,9 @@ export default function CompoundDetail() {
           </div>
         )}
 
-        {compoundMechanism && <Section title='Mechanism of Action'>{compoundMechanism}</Section>}
+        {!isMinimalProfile && compoundMechanism && <Section title='Mechanism of Action'>{compoundMechanism}</Section>}
 
-        {contextSummary && contextSummary !== topSummary && (
+        {!isMinimalProfile && contextSummary && contextSummary !== topSummary && (
           <Section title='Context'>{contextSummary}</Section>
         )}
 
@@ -665,9 +678,9 @@ export default function CompoundDetail() {
         <PremiumDataSection details={premiumDetails} relationGroups={relationGroups} />
 
 
-        {pharmacokinetics && <Section title='Pharmacokinetics'>{pharmacokinetics}</Section>}
+        {!isMinimalProfile && pharmacokinetics && <Section title='Pharmacokinetics'>{pharmacokinetics}</Section>}
 
-        {pathwayTargets.length > 0 && (
+        {!isMinimalProfile && pathwayTargets.length > 0 && (
           <section className='browse-shell fade-in-surface mt-6 p-4 sm:p-5'>
             <Collapse title='Pathway Targets'>
               <div className='flex flex-wrap gap-2 text-sm text-white/85'>
@@ -681,7 +694,7 @@ export default function CompoundDetail() {
           </section>
         )}
 
-        {compoundTherapeuticUses.length > 0 && (
+        {!isMinimalProfile && compoundTherapeuticUses.length > 0 && (
           <section className='browse-shell fade-in-surface mt-6 p-4 sm:p-5'>
             <Collapse title='Traditional & Therapeutic Use'>
               <div className='text-sm leading-relaxed text-white/85'>
@@ -692,7 +705,7 @@ export default function CompoundDetail() {
         )}
 
         {/* Safety */}
-        {(compoundContraindications.length > 0 ||
+        {!isMinimalProfile && (compoundContraindications.length > 0 ||
           compoundInteractions.length > 0 ||
           compoundSideEffects.length > 0 ||
           uniqueDrugInteractionItems.length > 0) && (
@@ -733,7 +746,7 @@ export default function CompoundDetail() {
         )}
 
         {/* Found in */}
-        {foundInHerbLinks.length > 0 && (
+        {!isMinimalProfile && foundInHerbLinks.length > 0 && (
           <section id='related-herbs' className='detail-panel fade-in-surface mt-6'>
             <Collapse title={`Found In (${foundInHerbLinks.length})`}>
               <div className='space-y-4 text-sm leading-relaxed text-white/85'>
@@ -744,7 +757,13 @@ export default function CompoundDetail() {
                         key={herb.slug}
                         name={herb.name}
                         summary={herb.descriptor || 'Learn more about this herb and its potential uses.'}
-                        tags={extractPrimaryEffects(herb.effects, 2)}
+                        primary_effects={Array.isArray((herb as Record<string, unknown>).primary_effects)
+                          ? ((herb as Record<string, unknown>).primary_effects as string[])
+                          : Array.isArray((herb as Record<string, unknown>).primaryEffects)
+                            ? ((herb as Record<string, unknown>).primaryEffects as string[])
+                            : []}
+                        profile_status={String((herb as Record<string, unknown>).profile_status || (herb as Record<string, unknown>).profileStatus || '')}
+                        summary_quality={String((herb as Record<string, unknown>).summary_quality || (herb as Record<string, unknown>).summaryQuality || '')}
                         detailUrl={`/herbs/${encodeURIComponent(herb.slug)}`}
                       />
                     ))}
@@ -771,7 +790,7 @@ export default function CompoundDetail() {
           </section>
         )}
 
-        {relatedCollections.length > 0 && (
+        {!isMinimalProfile && relatedCollections.length > 0 && (
           <section className='browse-shell fade-in-surface mt-6 p-4 sm:p-5'>
             <Collapse title='Compare in Related Collections'>
               <div className='space-y-2 text-sm text-white/85'>
@@ -803,7 +822,7 @@ export default function CompoundDetail() {
           </section>
         )}
 
-        {governedResearch && governedFaq && governedRelatedQuestions && (
+        {!isMinimalProfile && governedResearch && governedFaq && governedRelatedQuestions && (
           <>
             {showRawDebug && compound.rawData && (
               <section className='detail-panel rounded-2xl border-amber-200/30 p-4'>

--- a/src/pages/Compounds.tsx
+++ b/src/pages/Compounds.tsx
@@ -19,6 +19,7 @@ import type { EnrichmentFilter } from '@/types/enrichmentDiscovery'
 import { trackGovernedEvent } from '@/lib/governedAnalytics'
 import { formatBrowseTitle } from '@/utils/titleDisplay'
 import { cleanEffectChips, sanitizeSummaryText } from '@/lib/sanitize'
+import { getPrimaryEffects, getProfileStatus, getSummaryQuality, resolveCoreInsight, resolveHeroSummary, shouldRenderSummary } from '@/lib/workbookRender'
 
 const ENRICHMENT_FILTER_OPTIONS: Array<{ value: EnrichmentFilter; label: string }> = [
   { value: 'all', label: 'All research states' },
@@ -38,12 +39,14 @@ function confidenceBadgeClass(level: ConfidenceLevel) {
   return 'border-rose-300/35 bg-rose-500/10 text-rose-100/90'
 }
 
-function summarize(compound: { description: string; effects: string[] }) {
-  const cleanedDescription = sanitizeSummaryText(compound.description, 1)
-  if (cleanedDescription) return cleanedDescription
-  const chipFallback = cleanEffectChips(compound.effects, 2)
-  if (chipFallback.length) return chipFallback.join(' · ')
-  return 'Profile in progress.'
+function summarize(compound: Record<string, unknown>) {
+  const profileStatus = getProfileStatus(compound)
+  const summaryQuality = getSummaryQuality(compound)
+  if (!shouldRenderSummary(profileStatus, summaryQuality)) return ''
+  const hero = sanitizeSummaryText(resolveHeroSummary(compound, 1), 1)
+  if (hero) return hero
+  if (summaryQuality === 'strong') return sanitizeSummaryText(resolveCoreInsight(compound, 1), 1)
+  return ''
 }
 
 function getStatusTag(level: ConfidenceLevel) {
@@ -130,8 +133,20 @@ export default function CompoundsPage() {
       ) : (
         <section className='grid gap-3 sm:grid-cols-2 lg:grid-cols-3'>
           {visibleCompounds.map(compound => {
+            const rawCompound = (compound.rawData as Record<string, unknown> | undefined) || {}
             const confidence = compound.confidence ?? calculateCompoundConfidence({ mechanism: compound.mechanism, effects: compound.effects, compounds: compound.herbs })
-            const primaryEffects = cleanEffectChips(extractPrimaryEffects(compound.curatedData?.keyEffects || compound.effects, 8), 2)
+            const primaryEffects = cleanEffectChips(
+              getPrimaryEffects(rawCompound, 2).length
+                ? getPrimaryEffects(rawCompound, 2)
+                : extractPrimaryEffects(compound.curatedData?.keyEffects || compound.effects, 8),
+              2,
+            )
+            const profileStatus = getProfileStatus(rawCompound)
+            const summary = summarize({
+              ...rawCompound,
+              description: compound.curatedData?.summary || compound.description || '',
+              effects: compound.curatedData?.keyEffects || compound.effects || [],
+            })
 
             const title = formatBrowseTitle(compound.name, 58)
             const chips = [
@@ -148,13 +163,14 @@ export default function CompoundsPage() {
               <article key={compound.id} className='premium-panel fade-in-surface flex h-full flex-col gap-2.5 p-4'>
                 <p className='section-label'>Compound profile</p>
                 <h2 title={compound.name} className='line-clamp-2 min-h-[2.4rem] text-xl leading-tight text-white'>{title}</h2>
-                <p className='line-clamp-3 text-sm leading-[1.5] text-white/72'>
-                  {summarize({ description: compound.curatedData?.summary || '', effects: compound.curatedData?.keyEffects || [] })}
-                </p>
+                {summary && <p className='line-clamp-3 text-sm leading-[1.5] text-white/72'>{summary}</p>}
                 {chips.length > 0 && (
                   <div className='flex flex-wrap gap-1.5'>
                     {chips.map(chip => <span key={`${compound.id}-${chip.label}`} className='ds-pill neo-pill'>{chip.label}</span>)}
                   </div>
+                )}
+                {profileStatus === 'minimal' && (
+                  <span className='mt-1 text-[10px] uppercase tracking-[0.11em] text-white/60'>Minimal profile</span>
                 )}
                 <span className={`mt-1 inline-flex w-fit rounded-full border px-2 py-0.5 text-[9px] uppercase tracking-[0.11em] ${confidenceBadgeClass(confidence)}`}>
                   {getStatusTag(confidence)}

--- a/src/pages/HerbBlender.tsx
+++ b/src/pages/HerbBlender.tsx
@@ -10,7 +10,6 @@ import { useLocalStorage } from '../hooks/useLocalStorage'
 import { herbName, splitField } from '../utils/herb'
 import Meta from '../components/Meta'
 import { buildCardSummary } from '@/lib/summary'
-import { extractPrimaryEffects } from '@/utils/extractPrimaryEffects'
 import { hasVal } from '@/lib/pretty'
 import { slugify } from '@/lib/slug'
 
@@ -173,7 +172,13 @@ export default function HerbBlender() {
                     maxLen: 130,
                   }) || 'Learn more about this herb and its potential uses.'
                 }
-                tags={extractPrimaryEffects(Array.isArray(h.effects) ? h.effects : [], 2)}
+                primary_effects={Array.isArray((h as Record<string, unknown>).primary_effects)
+                  ? ((h as Record<string, unknown>).primary_effects as string[])
+                  : Array.isArray((h as Record<string, unknown>).primaryEffects)
+                    ? ((h as Record<string, unknown>).primaryEffects as string[])
+                    : []}
+                profile_status={String((h as Record<string, unknown>).profile_status || (h as Record<string, unknown>).profileStatus || '')}
+                summary_quality={String((h as Record<string, unknown>).summary_quality || (h as Record<string, unknown>).summaryQuality || '')}
                 detailUrl={
                   hasVal(h.slug)
                     ? `/herbs/${encodeURIComponent(String(h.slug))}`

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -11,6 +11,7 @@ import { normalizeTagList } from '@/lib/tagNormalization'
 import { HerbDetailSkeleton } from '@/components/skeletons/DetailSkeletons'
 import { SITE_URL, breadcrumbJsonLd, herbJsonLd } from '@/lib/seo'
 import { shouldShowRawDebug } from '@/lib/semanticCompression'
+import { getPrimaryEffects, getProfileStatus, getSummaryQuality, shouldRenderSummary } from '@/lib/workbookRender'
 
 type SourceRef = { title: string; url: string; note?: string }
 
@@ -32,6 +33,18 @@ function splitTextList(value: unknown): string[] {
 }
 
 function readRecord(value: unknown): Record<string, unknown> {
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return {}
+    try {
+      const parsed = JSON.parse(trimmed)
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? (parsed as Record<string, unknown>)
+        : {}
+    } catch {
+      return {}
+    }
+  }
   return value && typeof value === 'object' ? (value as Record<string, unknown>) : {}
 }
 
@@ -155,6 +168,10 @@ export default function HerbDetail() {
   const rawRecord = readRecord(herb.rawData)
   const contextRecord = readRecord(rawRecord.context)
   const safetyRecord = readRecord(rawRecord.safety)
+  const profileStatus = getProfileStatus(rawRecord)
+  const summaryQuality = getSummaryQuality(rawRecord)
+  const isMinimalProfile = profileStatus === 'minimal'
+  const showSummaryRegion = shouldRenderSummary(profileStatus, summaryQuality)
   const description = readWorkbookText(rawRecord, 'hero', 'summary', 'description') || String(curatedData.summary || '').trim()
   const descriptionIsPlaceholder = isPlaceholder(description, herbName)
   const summary = sanitizeSummaryText(description, 2)
@@ -177,7 +194,7 @@ export default function HerbDetail() {
     dedupePresentationList(splitTextList(rawRecord.effects || rawRecord.keyEffects || curatedData.keyEffects), 8),
     8,
   )
-  const keyEffects = effects.slice(0, 4)
+  const keyEffects = getPrimaryEffects(rawRecord, 4)
   const activeCompounds = sanitizeRenderList(splitTextList(herb.activeCompounds || herb.compounds), 10)
   const mechanism = uniqueCopy.mechanism
   const contextSummary = uniqueCopy.context
@@ -286,7 +303,7 @@ export default function HerbDetail() {
         <header className='premium-panel fade-in-surface p-5 sm:p-7'>
           <p className='section-label'>Herb profile</p><h1 className='mt-2 text-4xl font-semibold sm:text-5xl'>{herbName}</h1>
           {scientificName && <p className='mt-1 text-sm italic text-white/55'>{scientificName}</p>}
-          {!descriptionIsPlaceholder && (
+          {showSummaryRegion && !descriptionIsPlaceholder && (
             <p className='mt-3 max-w-3xl text-sm leading-relaxed text-white/80'>{summary}</p>
           )}
 
@@ -302,9 +319,7 @@ export default function HerbDetail() {
                     {effect}
                   </span>
                 ))
-              ) : (
-                <span className='text-sm text-white/65'>Effects being reviewed.</span>
-              )}
+              ) : null}
             </div>
           </section>
 
@@ -313,14 +328,14 @@ export default function HerbDetail() {
           </div>
         </header>
 
-        <section className='browse-shell fade-in-surface p-5 sm:p-6'>
+        {!isMinimalProfile && <section className='browse-shell fade-in-surface p-5 sm:p-6'>
           <h2 className='section-label text-white/82'>Use case framework</h2>
           <ul className='mt-2 list-disc space-y-1 pl-5 text-sm text-white/85'>
             {useCasePoints.slice(0, 3).map(point => (
               <li key={point}>{point}</li>
             ))}
           </ul>
-        </section>
+        </section>}
 
         {safetyNotes.length > 0 && (
           <DisclosureSection title='Safety & Interactions' defaultOpen={Boolean(priorityWarning)}>
@@ -332,7 +347,7 @@ export default function HerbDetail() {
           </DisclosureSection>
         )}
 
-        <DisclosureSection title='Active Compounds' defaultOpen>
+        {!isMinimalProfile && <DisclosureSection title='Active Compounds' defaultOpen>
           {activeCompounds.length > 0 ? (
             <ul className='list-disc space-y-1 pl-5'>
               {activeCompounds.map(compound => (
@@ -342,42 +357,41 @@ export default function HerbDetail() {
           ) : (
             <p>Compound list is being expanded.</p>
           )}
-        </DisclosureSection>
+        </DisclosureSection>}
 
-        {coreInsight && coreInsight !== summary && (
+        {!isMinimalProfile && summaryQuality === 'strong' && coreInsight && coreInsight !== summary && (
           <section className='browse-shell fade-in-surface p-5 sm:p-6'>
             <h2 className='text-sm font-semibold uppercase tracking-[0.16em] text-white/85'>Core insight</h2>
             <p className='mt-2 text-sm leading-relaxed text-white/85'>{coreInsight}</p>
           </section>
         )}
 
-        {!descriptionIsPlaceholder && fullDescription && fullDescription !== summary && (
+        {!isMinimalProfile && !descriptionIsPlaceholder && fullDescription && fullDescription !== summary && (
           <DisclosureSection title='Full Description'>
             <p>{fullDescription}</p>
           </DisclosureSection>
         )}
 
-        <DisclosureSection title='Mechanism of Action'>
-          <p>{mechanism || 'Mechanism notes are being expanded.'}</p>
-        </DisclosureSection>
+        {!isMinimalProfile && mechanism && (
+          <DisclosureSection title='Mechanism of Action'>
+            <p>{mechanism}</p>
+          </DisclosureSection>
+        )}
 
-        {contextSummary && contextSummary !== summary && (
+        {!isMinimalProfile && contextSummary && contextSummary !== summary && (
           <DisclosureSection title='Context'>
             <p>{contextSummary}</p>
           </DisclosureSection>
         )}
 
-        <DisclosureSection title='Dosage & Usage'>
+        {!isMinimalProfile && (dosage || duration || preparation || standardization) && <DisclosureSection title='Dosage & Usage'>
           <ul className='list-disc space-y-1 pl-5'>
             {dosage && <li>Dosage: {dosage}</li>}
             {duration && <li>Duration: {duration}</li>}
             {preparation && <li>Preparation: {preparation}</li>}
             {standardization && <li>Standardization: {standardization}</li>}
-            {!dosage && !duration && !preparation && !standardization && (
-              <li>Dosage guidance is still being reviewed.</li>
-            )}
           </ul>
-        </DisclosureSection>
+        </DisclosureSection>}
 
         <DisclosureSection title='Research & Sources'>
           {sources.length > 0 ? (
@@ -400,9 +414,7 @@ export default function HerbDetail() {
                 </li>
               ))}
             </ol>
-          ) : (
-            <p>Primary source citations are being added.</p>
-          )}
+          ) : null}
         </DisclosureSection>
 
         {showRawDebug && herb.rawData && (
@@ -413,7 +425,7 @@ export default function HerbDetail() {
           </DisclosureSection>
         )}
 
-        <DisclosureSection title='Related Herbs & Compounds'>
+        {!isMinimalProfile && <DisclosureSection title='Related Herbs & Compounds'>
           <div className='space-y-3'>
             {relatedHerbs.length > 0 && (
               <div>
@@ -439,11 +451,8 @@ export default function HerbDetail() {
                 </div>
               </div>
             )}
-            {relatedHerbs.length === 0 && relatedCompounds.length === 0 && (
-              <p>Related entities will appear here as coverage expands.</p>
-            )}
           </div>
-        </DisclosureSection>
+        </DisclosureSection>}
       </article>
     </main>
   )

--- a/src/pages/HerbGoalPage.tsx
+++ b/src/pages/HerbGoalPage.tsx
@@ -6,9 +6,9 @@ import { useGoalBundles } from '@/hooks/useGoalBundles'
 import {
   buildEffectCollectionFeed,
   EFFECT_COLLECTION_CONFIGS,
-  effectCollectionChips,
   type EffectCollectionIntent,
 } from '@/utils/effectCollections'
+import { getPrimaryEffects, getProfileStatus, getSummaryQuality, resolveHeroSummary, shouldRenderSummary } from '@/lib/workbookRender'
 
 const COLLECTION_ORDER: EffectCollectionIntent[] = ['sleep', 'focus', 'relaxation']
 
@@ -97,6 +97,12 @@ export default function HerbGoalPage() {
         <ol className='mt-3 space-y-3'>
           {ranked.map(item => {
             const slug = String(item.herb.slug || '').trim()
+            const rawHerb = (item.herb.rawData as Record<string, unknown> | undefined) || (item.herb as unknown as Record<string, unknown>)
+            const profileStatus = getProfileStatus(rawHerb)
+            const summaryQuality = getSummaryQuality(rawHerb)
+            const showSummary = shouldRenderSummary(profileStatus, summaryQuality)
+            const summary = resolveHeroSummary(rawHerb, 1) || (summaryQuality === 'strong' ? item.summary : '')
+            const primaryEffects = getPrimaryEffects(rawHerb, profileStatus === 'minimal' ? 1 : 3)
             return (
               <li
                 key={slug || item.rank}
@@ -126,13 +132,13 @@ export default function HerbGoalPage() {
                   </span>
                 </div>
 
-                <p className='mt-2 text-sm text-white/80'>{item.summary}</p>
+                {showSummary && summary && <p className='mt-2 text-sm text-white/80'>{summary}</p>}
                 <p className='mt-2 text-xs text-white/65'>
                   Matched effects: {item.matchedEffects.slice(0, 3).join(', ') || config.query}
                 </p>
 
                 <div className='mt-2 flex flex-wrap gap-1.5'>
-                  {effectCollectionChips(item.herb).map(effect => (
+                  {primaryEffects.map(effect => (
                     <span
                       key={`${slug}-${effect}`}
                       className='rounded-full border border-violet-300/35 bg-violet-500/15 px-2.5 py-1 text-[11px] text-violet-100'

--- a/src/pages/Herbs.tsx
+++ b/src/pages/Herbs.tsx
@@ -20,6 +20,7 @@ import { trackGovernedEvent } from '@/lib/governedAnalytics'
 import { slugify } from '@/lib/slug'
 import { dedupePresentationList, sanitizeSummaryText } from '@/lib/sanitize'
 import { Link } from 'react-router-dom'
+import { getPrimaryEffects, getProfileStatus, getSummaryQuality, resolveCoreInsight, resolveHeroSummary, shouldRenderSummary } from '@/lib/workbookRender'
 
 function isPlaceholder(text: string, herbName = ''): boolean {
   const value = String(text || '').trim().toLowerCase()
@@ -33,26 +34,20 @@ const toTitleCase = (value: string) => String(value || '').trim().toLowerCase().
 
 const cleanSummary = (value: string, herbName = '') => {
   const normalized = sanitizeSummaryText(value, 2)
-  if (!normalized || isPlaceholder(normalized, herbName)) return 'Profile in progress'
+  if (!normalized || isPlaceholder(normalized, herbName)) return ''
   if (normalized.length <= 130) return normalized
   return `${normalized.slice(0, 127).trimEnd()}...`
 }
 
 const getKeyEffects = (herb: Record<string, unknown>) =>
-  dedupePresentationList(
-    Array.isArray((herb.curatedData as Record<string, unknown> | undefined)?.keyEffects)
-      ? ((herb.curatedData as Record<string, unknown>).keyEffects as string[])
-      : Array.isArray(herb.primaryEffects)
-        ? herb.primaryEffects
-        : Array.isArray(herb.effects)
-          ? herb.effects
-          : [],
-    3,
-  )
+  dedupePresentationList(getPrimaryEffects(herb, 3), 3)
     .map(toTitleCase)
     .slice(0, 3)
 
 const getStatusTag = (herb: Record<string, unknown>) => {
+  const status = getProfileStatus(herb)
+  if (status === 'minimal') return 'Minimal profile'
+  if (status === 'partial') return 'Partial profile'
   const tier = String(herb.qualityTier || herb.evidenceLevel || '').toLowerCase()
   if (tier.includes('strong') || tier.includes('high')) return 'Well documented'
   if (tier.includes('medium') || tier.includes('moderate')) return 'Moderate evidence'
@@ -160,11 +155,23 @@ export default function HerbsPage() {
         <section className='grid gap-3 sm:grid-cols-2 lg:grid-cols-3'>
           {visibleHerbs.map((herb, index) => (
             <article key={herb.slug || herb.id || `${herb.common}-${index}`} className='premium-panel fade-in-surface flex h-full flex-col p-4'>
+              {(() => {
+                const rawHerb = herb as unknown as Record<string, unknown>
+                const profileStatus = getProfileStatus(rawHerb)
+                const summaryQuality = getSummaryQuality(rawHerb)
+                const hero = cleanSummary(resolveHeroSummary(rawHerb, 2), String(herb.common || herb.name || ''))
+                const coreInsight = cleanSummary(resolveCoreInsight(rawHerb, 1), String(herb.common || herb.name || ''))
+                const summary = hero || (summaryQuality === 'strong' ? coreInsight : '')
+                const keyEffects = getKeyEffects(rawHerb)
+                const showSummary = shouldRenderSummary(profileStatus, summaryQuality) && Boolean(summary)
+                const chips = profileStatus === 'minimal' ? keyEffects.slice(0, 1) : keyEffects
+                return (
+                  <>
               <p className='section-label'>{getStatusTag(herb)}</p>
               <h2 className='mt-2 text-xl leading-tight text-white'>{toTitleCase(String(herb.common || herb.scientific || herb.name || 'Herb'))}</h2>
-              <p className='mt-2 line-clamp-3 text-sm text-white/75'>{cleanSummary(String((herb.curatedData as Record<string, unknown> | undefined)?.summary || ''), String(herb.common || herb.name || ''))}</p>
+              {showSummary && <p className='mt-2 line-clamp-3 text-sm text-white/75'>{summary}</p>}
               <div className='mt-3 flex flex-wrap gap-1.5'>
-                {getKeyEffects(herb).map(effect => (
+                {chips.map(effect => (
                   <span key={`${herb.slug}-${effect}`} className='neo-pill inline-flex rounded-full border px-2 py-0.5 text-[10px]'>{effect}</span>
                 ))}
               </div>
@@ -176,6 +183,9 @@ export default function HerbsPage() {
                   View decision page
                 </Link>
               </div>
+                  </>
+                )
+              })()}
             </article>
           ))}
         </section>


### PR DESCRIPTION
### Motivation
- Drive frontend card/detail/search rendering from workbook-export fields (`profile_status`, `summary_quality`, `primary_effects`) so workbook-first content controls density and summaries while preserving existing backend/export contracts and avoiding legacy fallbacks.

### Description
- Add a shared workbook render helper `src/lib/workbookRender.ts` that normalizes `profile_status` and `summary_quality`, exposes `getPrimaryEffects`, and provides summary/hero resolution and summary gating helpers, and update `src/lib/sanitize.ts` to safely parse serialized array strings (invalid/empty JSON arrays become `[]`).
- Update workbook normalizers to be robust to workbook-export shapes and stringified `context` objects, and to read workbook-first fields for `primary_effects`, `mechanisms`, `context.foundIn`, and `context.relatedCompounds` in `src/lib/herb-data.ts` and `src/lib/compound-data.ts`.
- Implement profile-density and summary-quality behavior across the UI so cards and result lists use `primary_effects` for pills, card density follows `profile_status` (`complete`/`partial`/`minimal`), and summary rendering follows `summary_quality` (`strong`/`weak`/`none`), applying changes to card components and browse/detail pages (see key files changed below).
- Propagate the new props at callsites so linked surfaces (entity DB, blender, related-herb cards, lists) respect workbook-driven pills and gating without falling back to legacy “placeholder” copy.

### Testing
- Built and linted: ran `npm run build:compile` and `npm run lint` which completed successfully, and also executed `npm run build` during verification (data regeneration side-effects were intentionally discarded before commit); no automated test failures were reported.
- Verified prerender/build steps completed and site compile succeeded during verification, and `eslint` passed with zero reported errors in the changed files.
- Files changed: `src/lib/workbookRender.ts`, `src/lib/sanitize.ts`, `src/lib/herb-data.ts`, `src/lib/compound-data.ts`, `src/components/HerbCard.tsx`, `src/components/CompoundCard.tsx`, `src/components/HerbList.tsx`, `src/components/EntityDatabasePage.tsx`, `src/pages/Herbs.tsx`, `src/pages/Compounds.tsx`, `src/pages/HerbGoalPage.tsx`, `src/pages/HerbDetail.tsx`, `src/pages/CompoundDetail.tsx`, and `src/pages/HerbBlender.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddabd9708c8323a5281835e004731f)