### PR TITLE
Unify Entity and Compound cards with HerbCard styling

### DIFF
--- a/src/components/CompoundCard.tsx
+++ b/src/components/CompoundCard.tsx
@@ -89,9 +89,12 @@ export default function CompoundCard({ compound }: { compound: CompoundWithRefs 
     <motion.article
       whileHover={{ scale: 1.003 }}
       title={compound.herbsFound.map(h => h.name).join(', ')}
-      className='neo-card fade-in-surface ds-card relative flex h-full flex-col gap-2.5 rounded-xl border-white/12 p-3.5 text-left'
+      className='group relative flex h-full flex-col gap-2.5 rounded-[var(--radius-lg)] border border-white/8 bg-white/[0.03] p-4 text-left transition-all duration-200 hover:-translate-y-0.5 hover:border-white/16 hover:bg-white/[0.055] hover:shadow-[0_8px_32px_rgba(0,0,0,0.4)]'
     >
-      <div aria-hidden className='pointer-events-none absolute -bottom-10 -left-8 h-20 w-20 rounded-full bg-cyan-300/10 blur-2xl' />
+      <div
+        aria-hidden
+        className='pointer-events-none absolute inset-0 rounded-[var(--radius-lg)] opacity-0 transition-opacity duration-300 group-hover:opacity-100 shadow-[inset_0_0_0_1px_rgba(14,207,179,0.12)]'
+      />
       <h2
         title={isTitleTruncated ? compound.name : undefined}
         className='line-clamp-2 min-h-[2.2rem] break-all text-[0.95rem] font-semibold leading-tight text-white sm:text-base'
@@ -100,8 +103,14 @@ export default function CompoundCard({ compound }: { compound: CompoundWithRefs 
       </h2>
       {showSummary && summary ? <p className='line-clamp-2 text-xs leading-[1.45] text-white/76'>{summary}</p> : null}
       <div className='flex flex-wrap gap-1'>
-        <span className='ds-pill neo-pill'>{normalizeTagList(confidence, { caseStyle: 'title', maxItems: 1 })[0] || confidence}</span>
-        {primaryEffects[0] && <span className='ds-pill neo-pill'>{primaryEffects[0]}</span>}
+        <span className='inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-2 py-0.5 text-[0.68rem] font-medium text-white/55'>
+          {normalizeTagList(confidence, { caseStyle: 'title', maxItems: 1 })[0] || confidence}
+        </span>
+        {primaryEffects[0] && (
+          <span className='inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-2 py-0.5 text-[0.68rem] font-medium text-white/55'>
+            {primaryEffects[0]}
+          </span>
+        )}
       </div>
       {!isMinimal && <p className='line-clamp-1 text-[11px] text-white/56'>{sourceLine}</p>}
       <div className='mt-auto' />

--- a/src/components/EntityCard.tsx
+++ b/src/components/EntityCard.tsx
@@ -8,7 +8,11 @@ export default function EntityCard({ e }: { e: Entity }) {
   })
 
   return (
-    <article className='ds-card-lg ds-stack'>
+    <article className='group relative flex h-full flex-col gap-2.5 rounded-[var(--radius-lg)] border border-white/8 bg-white/[0.03] p-4 transition-all duration-200 hover:-translate-y-0.5 hover:border-white/16 hover:bg-white/[0.055] hover:shadow-[0_8px_32px_rgba(0,0,0,0.4)]'>
+      <div
+        aria-hidden
+        className='pointer-events-none absolute inset-0 rounded-[var(--radius-lg)] opacity-0 transition-opacity duration-300 group-hover:opacity-100 shadow-[inset_0_0_0_1px_rgba(14,207,179,0.12)]'
+      />
       <h3 className='text-xl font-semibold text-white md:text-2xl'>
         {e.commonName ?? e.latinName}
       </h3>
@@ -17,7 +21,10 @@ export default function EntityCard({ e }: { e: Entity }) {
       {e.tags?.length ? (
         <div className='mt-4 flex flex-wrap gap-2'>
           {e.tags.slice(0, 4).map(tag => (
-            <span key={tag} className='ds-pill'>
+            <span
+              key={tag}
+              className='inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-2 py-0.5 text-[0.68rem] font-medium text-white/55'
+            >
               {tag}
             </span>
           ))}


### PR DESCRIPTION
### Motivation
- Align the visual language of `EntityCard` and `CompoundCard` with the existing `HerbCard` design so cards look consistent across the app and reuse the same hover/outline/chip language.

### Description
- Replaced both card roots with the HerbCard-style container classes (`group`, `rounded-[var(--radius-lg)]`, `border border-white/8`, `bg-white/[0.03]`, `p-4`, hover translate/border/bg/shadow, and transition classes). 
- Added the same inset hover glow overlay element to both components (`absolute inset-0 rounded-[var(--radius-lg)] opacity-0 transition-opacity duration-300 group-hover:opacity-100 shadow-[inset_0_0_0_1px_rgba(14,207,179,0.12)]`).
- Standardized chip/badge markup in both files to the shared chip class (`inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-2 py-0.5 text-[0.68rem] font-medium text-white/55`) and replaced the prior `ds-pill` / `neo-pill` usages.
- Preserved all existing component props and rendering logic; compound/display titles remain `font-semibold` and no data/prop shape changes were introduced; molecular-formula monospace and mechanism/pathway color were not added here because the components do not render those fields differently currently (can be applied where those labels are rendered in a follow-up if desired).

### Testing
- Ran `npm run build` which completed successfully.
- Pre-commit lint-staged ran `eslint --max-warnings=0` on the changed TSX files and passed.
- Changed files: `src/components/EntityCard.tsx`, `src/components/CompoundCard.tsx`.
- Key diffs: card root className stacks updated to match `HerbCard`, inset hover glow `div` added to both, and pill elements replaced with the standardized chip classes.
- Verification: build ✅, lint ✅.
- Follow-up: apply `text-[var(--accent-teal)]/70` to any mechanism/pathway label and `font-mono` to rendered molecular formula when those fields are present in the markup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e389a111488323b3befa9c5b5ac8a1)