### PR TITLE
Polish filter & search UI component styling

### DIFF
--- a/src/components/TagFilterBar.tsx
+++ b/src/components/TagFilterBar.tsx
@@ -41,7 +41,7 @@ export default function TagFilterBar({ allTags, activeTags, onToggleTag }: Props
       variants={containerVariants}
       initial='hidden'
       animate='visible'
-      className='no-scrollbar flex gap-2 overflow-x-auto py-2'
+      className='scrollbar-none flex gap-2 overflow-x-auto py-2'
     >
       {allTags.map(tag => {
         const active = activeTags.includes(tag)
@@ -59,7 +59,7 @@ export default function TagFilterBar({ allTags, activeTags, onToggleTag }: Props
                 : { scale: 1, boxShadow: 'none' }
             }
             transition={{ type: 'spring', stiffness: 220, damping: 12 }}
-            className={`ds-pill whitespace-nowrap transition-colors duration-300 ${active ? 'bg-emerald-700/70 text-white ring-2 ring-emerald-400 dark:bg-emerald-800' : 'bg-black/70 text-white/70 dark:bg-gray-800 dark:text-gray-200'}`}
+            className={`whitespace-nowrap rounded-full border px-3 py-1.5 text-xs font-medium transition-all duration-150 ${active ? 'border-[var(--accent-teal)]/40 bg-[var(--accent-teal)]/8 text-[var(--accent-teal)]' : 'border-white/12 bg-transparent text-white/55 hover:border-white/24 hover:text-white/80'}`}
           >
             {decodeTag(tag)}
           </motion.button>
@@ -72,7 +72,7 @@ export default function TagFilterBar({ allTags, activeTags, onToggleTag }: Props
           whileTap={{ scale: 0.9 }}
           whileHover={{ scale: 1.08 }}
           transition={{ type: 'spring', stiffness: 220, damping: 12 }}
-          className='ds-pill whitespace-nowrap bg-rose-700/70 text-white transition-colors duration-300 dark:bg-rose-800'
+          className='whitespace-nowrap rounded-full border border-white/12 bg-transparent px-3 py-1.5 text-xs font-medium text-white/55 transition-all duration-150 hover:border-white/24 hover:text-white/80'
         >
           Clear Filters
         </motion.button>

--- a/src/components/filters/EffectFilter.tsx
+++ b/src/components/filters/EffectFilter.tsx
@@ -59,10 +59,10 @@ export default function EffectFilter({ options, selected, onToggle }: EffectFilt
               key={effect}
               type='button'
               onClick={() => onToggle(effect)}
-              className={`rounded-full border px-2.5 py-1 text-xs transition ${
+              className={`rounded-full border px-3 py-1.5 text-xs font-medium transition-all duration-150 ${
                 active
-                  ? 'border-cyan-300/55 bg-cyan-500/18 text-cyan-100'
-                  : 'border-white/20 bg-white/[0.02] text-white/80 hover:bg-white/[0.08]'
+                  ? 'border-[var(--accent-teal)]/40 bg-[var(--accent-teal)]/8 text-[var(--accent-teal)]'
+                  : 'border-white/12 bg-transparent text-white/55 hover:border-white/24 hover:text-white/80'
               }`}
             >
               {effect}

--- a/src/components/filters/SearchBar.tsx
+++ b/src/components/filters/SearchBar.tsx
@@ -16,21 +16,36 @@ export default function SearchBar({ value, onChange, placeholder, className = ''
     <div className={`sticky top-2 z-20 ${className}`}>
       <div className='browse-shell p-3'>
         <div className='section-label mb-1 px-1'>Search archive</div>
-        <div className='flex items-center gap-2'>
+        <div className='relative'>
+          <svg
+            xmlns='http://www.w3.org/2000/svg'
+            viewBox='0 0 24 24'
+            fill='none'
+            stroke='currentColor'
+            strokeWidth='2'
+            strokeLinecap='round'
+            strokeLinejoin='round'
+            aria-hidden='true'
+            className='pointer-events-none absolute left-3.5 top-1/2 size-[15px] -translate-y-1/2 text-white/40'
+          >
+            <circle cx='11' cy='11' r='8' />
+            <path d='m21 21-4.3-4.3' />
+          </svg>
           <input
             value={value}
             onChange={handleChange}
             placeholder={placeholder}
-            className='w-full rounded-xl border border-white/20 bg-white/[0.03] px-3 py-2.5 text-sm text-white placeholder:text-white/45 focus:outline-none focus:ring-2 focus:ring-cyan-400/40'
+            className='h-11 w-full rounded-xl border border-white/12 bg-white/5 px-4 pl-10 text-sm text-white placeholder:text-white/35 transition-colors focus:border-[var(--accent-teal)]/50 focus:outline-none focus:ring-0'
             aria-label='Search entries'
           />
           {value && (
             <button
               type='button'
-              className='btn-secondary px-3 py-2 text-xs'
+              className='absolute right-3 top-1/2 -translate-y-1/2 text-white/40 transition-colors hover:text-white'
               onClick={() => onChange('')}
+              aria-label='Clear search'
             >
-              Clear
+              ×
             </button>
           )}
         </div>

--- a/src/components/filters/SortSelect.tsx
+++ b/src/components/filters/SortSelect.tsx
@@ -12,7 +12,7 @@ export default function SortSelect({ value, onChange }: SortSelectProps) {
       <select
         value={value}
         onChange={event => onChange(event.target.value as SortFilter)}
-        className='w-full rounded-xl border border-white/20 bg-black/30 px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-violet-400/35'
+        className='h-11 w-full appearance-none rounded-xl border border-white/12 bg-white/5 bg-[url("data:image/svg+xml,%3Csvg%20xmlns%3D%27http%3A//www.w3.org/2000/svg%27%20viewBox%3D%270%200%2020%2020%27%20fill%3D%27none%27%3E%3Cpath%20d%3D%27M5%207.5L10%2012.5L15%207.5%27%20stroke%3D%27rgba%28255%2C255%2C255%2C0.55%29%27%20stroke-width%3D%271.75%27%20stroke-linecap%3D%27round%27%20stroke-linejoin%3D%27round%27/%3E%3C/svg%3E")] bg-[right_0.85rem_center] bg-[length:15px_15px] bg-no-repeat px-4 pr-10 text-sm text-white/80 transition-colors focus:border-[var(--accent-teal)]/50 focus:outline-none focus:ring-0'
       >
         <option value='browse_quality'>Best quality (default)</option>
         <option value='az'>A–Z</option>


### PR DESCRIPTION
### Motivation
- Refresh the visual styling of the browse filters and search UI so the inputs, select, and filter chips share a consistent polished appearance. 
- Apply updated spacing, borders, background, hover, and focus states while keeping all component logic, state, handlers, and props unchanged. 
- Make tag/effect chips and the horizontal tag bar visually consistent and keyboard/interaction-friendly.

### Description
- Updated classNames in `src/components/filters/SearchBar.tsx` to implement a full-width `h-11` rounded input, inset 15px search icon (absolute left), `pl-10` spacing, and an absolute clear `×` button when a value is present while preserving handlers. 
- Updated `src/components/filters/SortSelect.tsx` to use `appearance-none`, `h-11` input-shell styling, matching border/background/focus states, and a custom SVG chevron via `background-image`. 
- Updated `src/components/filters/EffectFilter.tsx` to use chip classes `text-xs font-medium px-3 py-1.5 rounded-full border transition-all duration-150` with the requested active (`border-[var(--accent-teal)]/40 bg-[var(--accent-teal)]/8 text-[var(--accent-teal)]`) and default (`border-white/12 bg-transparent text-white/55 hover:border-white/24 hover:text-white/80`) states. 
- Updated `src/components/TagFilterBar.tsx` to enable horizontal scrolling with hidden scrollbar (`scrollbar-none`), and unified tag chip classes to match the `EffectFilter` active/inactive styles while preserving motion/animation behavior.

### Testing
- Ran `npm run build:compile` and the Vite build completed successfully. 
- Pre-commit checks (lint-staged / `eslint` via the commit hook) passed during the commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e390c00fa88323875dda9de8a1e0fa)