### PR TITLE
Standardize core UI primitives for pagination, breadcrumb, badge, and button

### DIFF
--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { motion } from '@/lib/motion'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 
 interface Props {
   currentPage: number
@@ -7,52 +7,72 @@ interface Props {
   onPageChange: (page: number) => void
 }
 
+const baseButtonClasses =
+  'inline-flex h-9 w-9 items-center justify-center rounded-lg border border-white/12 bg-transparent text-sm font-medium text-white/60 transition-all hover:bg-white/8 hover:text-white disabled:cursor-not-allowed disabled:opacity-40'
+
+const activePageClasses = 'border-[var(--accent-teal)]/40 bg-[var(--accent-teal)]/10 text-[var(--accent-teal)]'
+
 const Pagination: React.FC<Props> = ({ currentPage, totalPages, onPageChange }) => {
   const getPages = () => {
     if (totalPages <= 7) return Array.from({ length: totalPages }, (_, i) => i + 1)
+
     const pages: (number | string)[] = [1]
     const start = Math.max(2, currentPage - 1)
     const end = Math.min(totalPages - 1, currentPage + 1)
+
     if (start > 2) pages.push('…')
     for (let i = start; i <= end; i++) pages.push(i)
     if (end < totalPages - 1) pages.push('…')
+
     pages.push(totalPages)
     return pages
   }
+
   const pages = getPages()
+
   return (
-    <div className='mx-auto mb-8 mt-4 flex flex-wrap justify-center gap-2'>
+    <div className='mx-auto mb-8 mt-4 flex flex-wrap items-center justify-center gap-2'>
       <button
         type='button'
+        aria-label='Previous page'
         disabled={currentPage === 1}
         onClick={() => onPageChange(currentPage - 1)}
-        className='rounded px-2 py-1 text-sm text-white/70 disabled:opacity-40'
+        className={baseButtonClasses}
       >
-        Prev
+        <ChevronLeft size={16} />
       </button>
+
       {pages.map((p, i) =>
         typeof p === 'number' ? (
-          <motion.button
-            whileHover={{ scale: 1.1 }}
+          <button
             key={p}
+            type='button'
+            aria-label={`Go to page ${p}`}
+            aria-current={p === currentPage ? 'page' : undefined}
             onClick={() => onPageChange(p)}
-            className={`w-8 rounded px-2 py-1 text-center text-sm ${p === currentPage ? 'bg-white/15 text-white' : 'text-white/70'}`}
+            className={`${baseButtonClasses} ${p === currentPage ? activePageClasses : ''}`.trim()}
           >
             {p}
-          </motion.button>
+          </button>
         ) : (
-          <span key={`ellipsis-${i}`} className='w-8 px-2 py-1 text-center text-white/60'>
+          <span
+            key={`ellipsis-${i}`}
+            aria-hidden='true'
+            className='inline-flex h-9 w-9 items-center justify-center text-sm font-medium text-white/40'
+          >
             {p}
           </span>
         )
       )}
+
       <button
         type='button'
+        aria-label='Next page'
         disabled={currentPage === totalPages}
         onClick={() => onPageChange(currentPage + 1)}
-        className='rounded px-2 py-1 text-sm text-white/70 disabled:opacity-40'
+        className={baseButtonClasses}
       >
-        Next
+        <ChevronRight size={16} />
       </button>
     </div>
   )

--- a/src/components/navigation/BreadcrumbTrail.tsx
+++ b/src/components/navigation/BreadcrumbTrail.tsx
@@ -14,23 +14,26 @@ export default function BreadcrumbTrail({ items, className = '' }: BreadcrumbTra
   if (!items.length) return null
 
   return (
-    <nav
-      aria-label='Breadcrumb'
-      className={`mb-3 rounded-xl border border-white/10 bg-white/[0.03] px-3 py-2 text-xs text-white/70 ${className}`.trim()}
-    >
-      <ol className='flex flex-wrap items-center gap-1.5'>
+    <nav aria-label='Breadcrumb' className={className.trim()}>
+      <ol className='flex flex-wrap items-center'>
         {items.map((item, index) => {
           const isLast = index === items.length - 1
+
           return (
-            <li key={`${item.label}-${index}`} className='inline-flex items-center gap-1.5'>
+            <li key={`${item.label}-${index}`} className='inline-flex items-center'>
               {item.to && !isLast ? (
-                <Link to={item.to} className='hover:text-white'>
+                <Link to={item.to} className='text-xs text-white/45 transition-colors hover:text-white/80'>
                   {item.label}
                 </Link>
               ) : (
-                <span className={isLast ? 'text-white/90' : ''}>{item.label}</span>
+                <span className='text-xs font-medium text-white/80'>{item.label}</span>
               )}
-              {!isLast && <span aria-hidden='true'>/</span>}
+
+              {!isLast && (
+                <span aria-hidden='true' className='mx-1.5 text-white/25'>
+                  /
+                </span>
+              )}
             </li>
           )
         })}

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -1,15 +1,26 @@
-import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, ReactNode } from 'react'
+
+type BadgeVariant = 'default' | 'teal' | 'amber' | 'violet'
 
 type BadgeProps = ComponentPropsWithoutRef<'span'> & {
-  children: ReactNode;
-  className?: string;
-};
+  children: ReactNode
+  variant?: BadgeVariant
+  className?: string
+}
 
-export default function Badge({ children, className = '', ...props }: BadgeProps) {
-  const classes = className ? `badge ${className}` : 'badge';
+const variantClasses: Record<BadgeVariant, string> = {
+  default: 'bg-white/8 text-white/55 border-white/16',
+  teal: 'bg-[var(--accent-teal)]/10 text-[var(--accent-teal)]/70 border-[var(--accent-teal)]/20',
+  amber: 'bg-amber-400/10 text-amber-300/70 border-amber-400/20',
+  violet: 'bg-violet-400/10 text-violet-300/70 border-violet-400/20',
+}
+
+const sizeClasses = 'rounded-full border px-2 py-0.5 text-[0.7rem] font-medium'
+
+export default function Badge({ children, variant = 'default', className = '', ...props }: BadgeProps) {
   return (
-    <span className={classes} {...props}>
+    <span className={`${sizeClasses} ${variantClasses[variant]} ${className}`.trim()} {...props}>
       {children}
     </span>
-  );
+  )
 }

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,30 +1,61 @@
-import type { ReactNode } from 'react'
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
 import { motion } from '@/lib/motion'
-import type { HTMLMotionProps } from '@/lib/motion'
 
-const variantClasses: Record<'default' | 'primary' | 'secondary' | 'ghost', string> = {
-  default: 'btn',
-  primary: 'btn btn-primary',
-  secondary: 'btn btn-secondary',
-  ghost: 'btn btn-ghost',
+type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger'
+type ButtonSize = 'sm' | 'md' | 'lg'
+
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  children: ReactNode
+  variant?: ButtonVariant
+  size?: ButtonSize
+  loading?: boolean
+  className?: string
 }
 
-type ButtonProps = {
-  children: ReactNode
-  variant?: 'default' | 'primary' | 'secondary' | 'ghost'
-  className?: string
-} & Omit<HTMLMotionProps<'button'>, 'children' | 'className'>
+const variantClasses: Record<ButtonVariant, string> = {
+  primary: 'btn-primary',
+  secondary: 'btn-secondary',
+  ghost: 'border border-transparent bg-transparent text-white/65 hover:text-white',
+  danger: 'border border-red-500/30 bg-red-500/15 text-red-400 hover:bg-red-500/20',
+}
+
+const sizeClasses: Record<ButtonSize, string> = {
+  sm: 'px-3 py-1.5 text-xs',
+  md: 'px-4 py-2 text-sm',
+  lg: 'px-5 py-2.5 text-base',
+}
 
 const MotionButton = motion.button
 
-export function Button({ children, variant = 'default', className = '', ...props }: ButtonProps) {
+function Spinner() {
+  return (
+    <span
+      aria-hidden='true'
+      className='inline-block h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-r-transparent'
+    />
+  )
+}
+
+export function Button({
+  children,
+  variant = 'primary',
+  size = 'md',
+  loading = false,
+  disabled,
+  className = '',
+  ...props
+}: ButtonProps) {
+  const isDisabled = disabled || loading
+
   return (
     <MotionButton
       whileTap={{ scale: 0.985 }}
-      whileHover={{ y: -1, scale: 1.005 }}
-      className={`${variantClasses[variant]} ${className}`.trim()}
+      whileHover={isDisabled ? undefined : { y: -1, scale: 1.005 }}
+      disabled={isDisabled}
+      className={`inline-flex items-center justify-center gap-2 rounded-lg font-medium transition-all ${variantClasses[variant]} ${sizeClasses[size]} ${loading ? 'cursor-not-allowed opacity-60' : ''} ${className}`.trim()}
       {...props}
     >
+      {loading && <Spinner />}
       {children}
     </MotionButton>
   )


### PR DESCRIPTION
### Motivation
- Provide consistent visual and interaction primitives across the site by standardizing pagination, breadcrumb, badge, and button components. 
- Make variant, size, and loading affordances explicit so other components can reuse a predictable API and CSS tokens.

### Description
- Pagination: replaced ad-hoc buttons with a shared 9x9 rounded button primitive, added `ChevronLeft`/`ChevronRight` icons, `aria` labels and an active-page accent class (`--accent-teal`).
- BreadcrumbTrail: standardized item typography and hover colors, rendered the current page as non-link, and added a styled separator (`/`) with `text-white/25 mx-1.5` spacing.
- Badge: introduced a typed `variant` API (`default`, `teal`, `amber`, `violet`) and unified compact sizing/border tokens (`rounded-full border px-2 py-0.5 text-[0.7rem] font-medium`).
- Button: added explicit `variant` (`primary`, `secondary`, `ghost`, `danger`) and `size` (`sm`, `md`, `lg`) options, a `loading` state that shows an inline spinner, and a disabled affordance that suppresses hover animation and applies `opacity-60 cursor-not-allowed`.

### Testing
- Files and key diffs: changed `src/components/Pagination.tsx`, `src/components/navigation/BreadcrumbTrail.tsx`, `src/components/ui/Badge.tsx`, and `src/components/ui/Button.tsx` with the summaries above reflecting unified classes, new variant APIs, and added accessibility attributes. 
- Commands run: `cat AGENTS.md`, inspected component sources, ran `npm run build:compile`, and committed the changes (pre-commit hook executed `eslint --max-warnings=0`).
- Verification results: `npm run build:compile` completed successfully and the pre-commit lint step passed during commit (commit created: `3f993ec`).
- Risks / follow-ups: full `npm run build` was avoided to prevent repository data-refresh side effects, a visual QA pass in a browser is recommended (screenshot tooling unavailable here), and a brief review of usages of `.btn-primary` / `.btn-secondary` elsewhere is advised to ensure consistent appearance site-wide.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3971113a08323b515603f6d5e9bac)