### PR TITLE
Overhaul loading and skeleton UI components

### DIFF
--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -1,40 +1,15 @@
 import React from 'react'
-import { motion } from '@/lib/motion'
 
 export const LoadingScreen: React.FC = () => {
   return (
     <div
-      className='bg-cosmic-gradient fixed inset-0 z-50 flex items-center justify-center'
+      className='fixed inset-0 z-50 flex items-center justify-center bg-[#07080F]'
       role='status'
       aria-live='polite'
     >
       <div className='text-center'>
-        <motion.div
-          className='bg-psychedelic-gradient mx-auto mb-4 flex h-24 w-24 items-center justify-center rounded-full'
-          animate={{
-            rotate: 360,
-            boxShadow: [
-              '0 0 20px rgba(139, 92, 246, 0.5)',
-              '0 0 40px rgba(236, 72, 153, 0.8)',
-              '0 0 20px rgba(139, 92, 246, 0.5)',
-            ],
-          }}
-          transition={{
-            rotate: { duration: 2, repeat: Infinity, ease: 'linear' },
-            boxShadow: { duration: 2, repeat: Infinity, ease: 'easeInOut' },
-          }}
-        >
-          <span className='text-2xl font-bold text-white'>HS</span>
-        </motion.div>
-
-        <motion.h2
-          className='font-display text-2xl font-bold text-white'
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          transition={{ duration: 1, repeat: Infinity, repeatType: 'reverse' }}
-        >
-          Loading...
-        </motion.h2>
+        <h2 className='font-display text-2xl italic text-white/80'>Hippie Scientist</h2>
+        <div className='mx-auto mt-4 h-0.5 w-24 animate-pulse rounded-full bg-[var(--accent-teal)]' />
         <span className='sr-only'>Loading content, please wait</span>
       </div>
     </div>

--- a/src/components/LoadingSpinner.tsx
+++ b/src/components/LoadingSpinner.tsx
@@ -1,36 +1,37 @@
 import React from 'react'
-import { motion } from '@/lib/motion'
 
-const LoadingSpinner: React.FC = () => {
+type LoadingSpinnerSize = 'sm' | 'md' | 'lg'
+
+const spinnerSizeMap: Record<LoadingSpinnerSize, number> = {
+  sm: 16,
+  md: 24,
+  lg: 40,
+}
+
+const LoadingSpinner: React.FC<{ size?: LoadingSpinnerSize }> = ({ size = 'md' }) => {
+  const spinnerSize = spinnerSizeMap[size]
+
   return (
-    <div className='bg-cosmic-forest flex min-h-screen items-center justify-center'>
-      <motion.div
-        className='flex flex-col items-center space-y-4'
-        initial={{ opacity: 0, scale: 0.8 }}
-        animate={{ opacity: 1, scale: 1 }}
-        transition={{ duration: 0.5 }}
-      >
-        <div className='relative'>
-          <motion.div
-            className='border-lichen h-16 w-16 rounded-full border-4 border-t-transparent'
-            animate={{ rotate: 360 }}
-            transition={{ duration: 1, repeat: Infinity, ease: 'linear' }}
-          />
-          <motion.div
-            className='absolute inset-0 h-16 w-16 rounded-full border-4 border-white/20 border-b-transparent'
-            animate={{ rotate: -360 }}
-            transition={{ duration: 1.5, repeat: Infinity, ease: 'linear' }}
-          />
-        </div>
-        <motion.p
-          className='text-lg font-medium text-white'
-          animate={{ opacity: [0.5, 1, 0.5] }}
-          transition={{ duration: 2, repeat: Infinity }}
-        >
-          Loading...
-        </motion.p>
-      </motion.div>
-    </div>
+    <svg
+      className='animate-spin'
+      width={spinnerSize}
+      height={spinnerSize}
+      viewBox='0 0 24 24'
+      fill='none'
+      role='status'
+      aria-label='Loading'
+    >
+      <circle
+        cx='12'
+        cy='12'
+        r='10'
+        stroke='var(--accent-teal)'
+        strokeWidth='2'
+        strokeLinecap='round'
+        strokeDasharray='56'
+        strokeDashoffset='18'
+      />
+    </svg>
   )
 }
 

--- a/src/components/skeletons/DetailSkeletons.tsx
+++ b/src/components/skeletons/DetailSkeletons.tsx
@@ -1,115 +1,130 @@
-import Skeleton from '@/components/ui/Skeleton'
+const skeletonBaseClass =
+  'rounded bg-white/6 animate-[shimmer_1.8s_ease-in-out_infinite] [background-size:200%_100%] [background-image:linear-gradient(90deg,transparent_25%,rgba(255,255,255,0.06)_50%,transparent_75%)]'
+
+function ShimmerStyles() {
+  return (
+    <style>
+      {`@keyframes shimmer { from { background-position: -200% 0 } to { background-position: 200% 0 } }`}
+    </style>
+  )
+}
+
+function SkeletonBlock({ className = '' }: { className?: string }) {
+  return <div className={`${skeletonBaseClass} ${className}`.trim()} />
+}
 
 function SkeletonPill({ className = '' }: { className?: string }) {
-  return <Skeleton className={`h-7 rounded-full ${className}`.trim()} />
+  return <SkeletonBlock className={`h-7 rounded-full ${className}`.trim()} />
 }
 
 export function HerbDetailSkeleton() {
   return (
-    <main className='container mx-auto max-w-4xl px-4 py-8 text-white' aria-busy='true'>
-      <Skeleton className='h-10 w-40 rounded-xl' />
+    <>
+      <ShimmerStyles />
+      <main className='container mx-auto max-w-4xl px-4 py-8 text-white' aria-busy='true'>
+        <article className='ds-card-lg space-y-8'>
+          <header className='space-y-3'>
+            <SkeletonBlock className='h-10 w-2/3' />
+            <SkeletonBlock className='h-4 w-1/3' />
+          </header>
 
-      <article className='ds-card-lg mt-4 space-y-6'>
-        <header className='space-y-4'>
-          <div className='space-y-3'>
-            <Skeleton className='h-10 w-2/3' />
-            <Skeleton className='h-4 w-1/3' />
-          </div>
-          <Skeleton className='h-16 rounded-2xl' />
-        </header>
+          <section className='space-y-4'>
+            <SkeletonBlock className='h-5 w-24' />
+            <SkeletonBlock className='h-24 w-full rounded-xl' />
+          </section>
 
-        <div className='flex flex-wrap gap-2'>
-          <SkeletonPill className='w-24' />
-          <SkeletonPill className='w-28' />
-          <SkeletonPill className='w-20' />
-        </div>
+          <section className='space-y-4'>
+            <SkeletonBlock className='h-5 w-28' />
+            <SkeletonBlock className='h-20 w-full rounded-xl' />
+          </section>
 
-        <div className='space-y-3'>
-          <Skeleton className='h-4 w-24' />
-          <Skeleton className='h-4 w-full' />
-          <Skeleton className='h-4 w-11/12' />
-          <Skeleton className='h-4 w-10/12' />
-        </div>
-
-        <div className='space-y-3 border-t border-white/10 pt-5'>
-          <Skeleton className='h-4 w-32' />
-          <div className='flex flex-wrap gap-2'>
-            <SkeletonPill className='w-28' />
-            <SkeletonPill className='w-32' />
-            <SkeletonPill className='w-24' />
-          </div>
-        </div>
-      </article>
-    </main>
+          <section className='space-y-4'>
+            <SkeletonBlock className='h-5 w-20' />
+            <SkeletonBlock className='h-28 w-full rounded-xl' />
+          </section>
+        </article>
+      </main>
+    </>
   )
+}
+
+export function CardSkeleton() {
+  return <SkeletonBlock className='h-32 w-full rounded-xl' />
 }
 
 export function CompoundDetailSkeleton() {
   return (
-    <main className='container mx-auto max-w-4xl px-4 py-8 text-white' aria-busy='true'>
-      <Skeleton className='h-10 w-44 rounded-xl' />
+    <>
+      <ShimmerStyles />
+      <main className='container mx-auto max-w-4xl px-4 py-8 text-white' aria-busy='true'>
+        <article className='ds-card-lg space-y-6'>
+          <header className='space-y-4'>
+            <div className='flex items-start justify-between gap-3'>
+              <SkeletonBlock className='h-10 w-2/3' />
+              <SkeletonPill className='w-28' />
+            </div>
+            <SkeletonBlock className='h-14 rounded-2xl' />
+          </header>
 
-      <article className='ds-card-lg mt-4 space-y-6'>
-        <header className='space-y-4'>
-          <div className='flex items-start justify-between gap-3'>
-            <Skeleton className='h-10 w-2/3' />
-            <SkeletonPill className='w-28' />
+          <div className='flex flex-wrap gap-2'>
+            <SkeletonPill className='w-24' />
+            <SkeletonPill className='w-20' />
+            <SkeletonPill className='w-24' />
           </div>
-          <Skeleton className='h-14 rounded-2xl' />
-        </header>
 
-        <div className='flex flex-wrap gap-2'>
-          <SkeletonPill className='w-24' />
-          <SkeletonPill className='w-20' />
-          <SkeletonPill className='w-24' />
-        </div>
+          <div className='space-y-3'>
+            <SkeletonBlock className='h-4 w-24' />
+            <SkeletonBlock className='h-4 w-full' />
+            <SkeletonBlock className='h-4 w-11/12' />
+          </div>
 
-        <div className='space-y-3'>
-          <Skeleton className='h-4 w-24' />
-          <Skeleton className='h-4 w-full' />
-          <Skeleton className='h-4 w-11/12' />
-        </div>
-
-        <div className='space-y-3 border-t border-white/10 pt-5'>
-          <Skeleton className='h-4 w-32' />
-          <Skeleton className='h-10 w-full rounded-xl' />
-          <Skeleton className='h-10 w-5/6 rounded-xl' />
-        </div>
-      </article>
-    </main>
+          <div className='space-y-3 border-t border-white/10 pt-5'>
+            <SkeletonBlock className='h-4 w-32' />
+            <SkeletonBlock className='h-10 w-full rounded-xl' />
+            <SkeletonBlock className='h-10 w-5/6 rounded-xl' />
+          </div>
+        </article>
+      </main>
+    </>
   )
 }
 
 export function InteractionReportSkeleton() {
   return (
-    <section
-      className='space-y-4 rounded-2xl border border-white/10 bg-black/25 p-5'
-      aria-busy='true'
-      aria-live='polite'
-    >
-      <Skeleton className='h-7 w-56' />
-      <Skeleton className='h-4 w-11/12' />
-      <div className='space-y-2'>
-        <Skeleton className='h-14 rounded-xl' />
-        <Skeleton className='h-14 rounded-xl' />
-      </div>
-    </section>
+    <>
+      <ShimmerStyles />
+      <section
+        className='space-y-4 rounded-2xl border border-white/10 bg-black/25 p-5'
+        aria-busy='true'
+        aria-live='polite'
+      >
+        <SkeletonBlock className='h-7 w-56' />
+        <SkeletonBlock className='h-4 w-11/12' />
+        <div className='space-y-2'>
+          <SkeletonBlock className='h-14 rounded-xl' />
+          <SkeletonBlock className='h-14 rounded-xl' />
+        </div>
+      </section>
+    </>
   )
 }
 
 export function LearningPanelSkeleton() {
   return (
-    <div className='space-y-4' aria-busy='true' aria-live='polite'>
-      <div className='flex flex-wrap gap-2'>
-        <SkeletonPill className='w-28' />
-        <SkeletonPill className='w-24' />
-        <SkeletonPill className='w-32' />
+    <>
+      <ShimmerStyles />
+      <div className='space-y-4' aria-busy='true' aria-live='polite'>
+        <div className='flex flex-wrap gap-2'>
+          <SkeletonPill className='w-28' />
+          <SkeletonPill className='w-24' />
+          <SkeletonPill className='w-32' />
+        </div>
+        <SkeletonBlock className='h-48 rounded-2xl' />
+        <div className='space-y-2'>
+          <SkeletonBlock className='h-4 w-full' />
+          <SkeletonBlock className='h-4 w-10/12' />
+        </div>
       </div>
-      <Skeleton className='h-48 rounded-2xl' />
-      <div className='space-y-2'>
-        <Skeleton className='h-4 w-full' />
-        <Skeleton className='h-4 w-10/12' />
-      </div>
-    </div>
+    </>
   )
 }


### PR DESCRIPTION
### Motivation

- Simplify and standardize the app loading experience by replacing motion-heavy/particle effects with a minimal, accessible full-page overlay and subtle branding treatment.
- Provide a small reusable spinner component for inline use with explicit size variants to avoid coupling spinner visuals to a fullscreen wrapper.
- Replace pulsing `animate-pulse` skeletons with a shimmer treatment to better communicate loading of larger, structured detail pages.

### Description

- Replaced `LoadingScreen` with a minimal full-page overlay using `fixed inset-0 z-50 bg-[#07080F]` and centered site name in `font-display italic text-2xl text-white/80` with a subtle pulsing teal bar beneath it, and removed all motion/particle visuals (`src/components/LoadingScreen.tsx`).
- Rebuilt `LoadingSpinner` as a lightweight SVG circle spinner that uses `stroke='var(--accent-teal)'`, `strokeWidth=2`, `animate-spin`, and a `size` prop with variants `sm` (16px), `md` (24px default), and `lg` (40px) (`src/components/LoadingSpinner.tsx`).
- Updated `DetailSkeletons` to introduce a shimmer animation via `@keyframes shimmer`, a `skeletonBaseClass` with the requested gradient/background-size/animation, and primitive components `SkeletonBlock` and `SkeletonPill`; refactored `HerbDetailSkeleton` to the requested hero row + three body rows and added `CardSkeleton` (`src/components/skeletons/DetailSkeletons.tsx`).
- Changes are scoped to the three component files only and follow existing Tailwind patterns used in the project.

### Testing

- Ran `npm run build:compile` which completed successfully (production build passed).
- Pre-commit hooks ran `eslint --max-warnings=0` on staged TS/TSX files during commit and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3ab6e17148323981f984faa0a5e62)