### PR TITLE
Extend Tailwind config with accent palette, animations, shadows, and safelist

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -2,8 +2,48 @@
 module.exports = {
   darkMode: 'class',
   content: ['./index.html', './src/**/*.{ts,tsx,js,jsx,mdx}'],
+  safelist: ['animate-pulse-slow', 'shadow-glow-teal', 'shadow-glow-violet'],
   theme: {
     extend: {
+      colors: {
+        accent: 'var(--accent-teal)',
+        teal: {
+          DEFAULT: '#0ECFB3',
+          50: '#f0fdfb',
+          100: '#ccfbf1',
+          200: '#99f6e4',
+          300: '#5eead4',
+          400: '#2dd4bf',
+          500: '#14b8a6',
+          600: '#0d9488',
+          700: '#0f766e',
+          800: '#115e59',
+          900: '#042e28',
+        },
+        violet: {
+          DEFAULT: '#7B5CF5',
+        },
+      },
+      animation: {
+        'pulse-slow': 'pulse 4s cubic-bezier(0.4,0,0.6,1) infinite',
+        'fade-in': 'fadeIn 0.3s ease-out',
+        'slide-up': 'slideUp 0.35s cubic-bezier(0.16,1,0.3,1)',
+      },
+      keyframes: {
+        fadeIn: {
+          from: { opacity: '0' },
+          to: { opacity: '1' },
+        },
+        slideUp: {
+          from: { opacity: '0', transform: 'translateY(12px)' },
+          to: { opacity: '1', transform: 'translateY(0)' },
+        },
+      },
+      boxShadow: {
+        'glow-teal': '0 0 24px rgba(14,207,179,0.25)',
+        'glow-violet': '0 0 24px rgba(123,92,245,0.25)',
+        card: '0 1px 3px rgba(0,0,0,0.4), 0 8px 24px rgba(0,0,0,0.25)',
+      },
       fontFamily: {
         display: ['DM Serif Display', 'Georgia', 'serif'],
         body: ['Instrument Sans', 'system-ui', 'sans-serif'],


### PR DESCRIPTION
### Motivation
- Add brand color tokens, motion utilities, and shadows to support new UI components and interactive states across the site. 
- Ensure runtime theming via CSS variables (for `accent`) and prevent purge removal of new animation/shadow utilities.

### Description
- Added a top-level `safelist` with `['animate-pulse-slow', 'shadow-glow-teal', 'shadow-glow-violet']` to preserve utilities during purge. 
- Extended `theme.extend.colors` to include `accent: 'var(--accent-teal)'`, a full `teal` scale (`DEFAULT`, `50`–`900`), and `violet.DEFAULT` in `tailwind.config.ts`. 
- Added custom `animation` entries (`pulse-slow`, `fade-in`, `slide-up`) and corresponding `keyframes` (`fadeIn`, `slideUp`). 
- Added `boxShadow` tokens `glow-teal`, `glow-violet`, and `card`, and left existing `fontFamily` settings intact.

### Testing
- Verified the config is valid with `node -e "const fs=require('fs'); new Function(fs.readFileSync('tailwind.config.ts','utf8')); console.log('tailwind config syntax ok')"` which succeeded. 
- Ran a full site build with `npm run build`, which completed successfully (build produced warnings about large chunks but finished). 
- Pre-commit checks (including `eslint` on staged TS files) executed during the change workflow and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3b2db99cc8323b46b68e2135b8ef0)