### PR TITLE
Adjust glass and panel surfaces for stronger contrast

### DIFF
--- a/src/styles/glass.css
+++ b/src/styles/glass.css
@@ -58,16 +58,18 @@
 }
 
 .glass-card {
-  backdrop-filter: blur(24px);
-  -webkit-backdrop-filter: blur(24px);
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid var(--border-default);
+  backdrop-filter: blur(28px);
+  -webkit-backdrop-filter: blur(28px);
+  background: rgba(10, 11, 18, 0.75);
+  border: 1px solid rgba(255, 255, 255, 0.14);
   box-shadow: var(--shadow-card), var(--shadow-glow-teal);
 }
 
 .neo-card {
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px solid var(--border-subtle);
+  background: rgba(10, 11, 18, 0.72);
+  border: 1px solid rgba(255, 255, 255, 0.10);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
   border-radius: var(--radius);
   transition: transform var(--duration-base) var(--ease-out-expo), border-color var(--duration-base) var(--ease-out-expo);
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -51,8 +51,8 @@
   }
 
   .premium-panel {
-    background: rgba(255, 255, 255, 0.04);
-    border: 1px solid var(--border-default);
+    background: rgba(8, 9, 16, 0.80);
+    border: 1px solid rgba(255, 255, 255, 0.12);
     border-radius: var(--radius-lg);
     backdrop-filter: blur(24px);
     -webkit-backdrop-filter: blur(24px);
@@ -60,8 +60,8 @@
   }
 
   .browse-shell {
-    background: rgba(14, 207, 179, 0.04);
-    border: 1px solid var(--border-default);
+    background: rgba(8, 12, 16, 0.78);
+    border: 1px solid rgba(14, 207, 179, 0.12);
     border-radius: var(--radius-lg);
     backdrop-filter: blur(24px);
     -webkit-backdrop-filter: blur(24px);


### PR DESCRIPTION
### Motivation
- Make card and panel surfaces read as clearly distinct elevated surfaces over varied page backgrounds by increasing opacity and tuning blur and border strength.
- Preserve existing visual language (blur, rounded radii, shadows) while improving contrast and legibility for `.glass-card`, `.neo-card`, `.premium-panel`, and `.browse-shell`.

### Description
- In `src/styles/glass.css` updated `.glass-card` to `background: rgba(10, 11, 18, 0.75)`, `backdrop-filter: blur(28px)` (and `-webkit-` variant), and `border: 1px solid rgba(255, 255, 255, 0.14)` to increase separation from page backgrounds.
- In `src/styles/glass.css` updated `.neo-card` to `background: rgba(10, 11, 18, 0.72)`, `border: 1px solid rgba(255, 255, 255, 0.10)`, and added `backdrop-filter: blur(16px)` plus `-webkit-backdrop-filter` for consistent glass effect.
- In `src/styles/global.css` updated `.premium-panel` to `background: rgba(8, 9, 16, 0.80)` with `border: 1px solid rgba(255, 255, 255, 0.12)` while retaining `blur(24px)`.
- In `src/styles/global.css` updated `.browse-shell` to `background: rgba(8, 12, 16, 0.78)` with `border: 1px solid rgba(14, 207, 179, 0.12)` while retaining `blur(24px)`.

### Testing
- Verified edits by inspecting file contents and diffs using `sed`/`nl` and a scripted replacement via `python`, and confirmed the requested RGBA and blur values are present; these checks succeeded.
- No automated build or visual screenshot tests were run in this change; this is a CSS-only visual update and should be validated in-browser during review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3bacbf84c8323a7ed79c5cf90eb3f)