### PR TITLE
Harden tag sanitization against trailing period tokens

### DIFF
--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -24,6 +24,8 @@ const JUNK_PATTERNS: RegExp[] = [
 
 const JUNK_WHOLE_VALUE: RegExp[] = [
   /^[\s;,.|nan]+$/i,
+  /^\.$/,
+  /^[.\s]+$/,
   /^no direct/i,
   /^contextual inference/i,
   /^\[object\s+object\]$/i,

--- a/src/lib/tagNormalization.ts
+++ b/src/lib/tagNormalization.ts
@@ -56,6 +56,7 @@ function cleanTagToken(token: string): string {
     .replace(COLLAPSE_PUNCTUATION, '$1')
     .replace(/^[\s"'`,.[{(]+/, '')
     .replace(/[\s"'`,.\])}]+$/, '')
+    .replace(/\.+$/, '')
     .replace(/\s+/g, ' ')
     .trim()
 }
@@ -84,6 +85,7 @@ export function normalizeTagList(value: unknown, options: NormalizeTagOptions = 
     .flatMap(entry => parseTagSegments(entry))
     .map(entry => cleanTagToken(entry))
     .filter(entry => isRenderableTag(entry, minLength))
+    .filter(token => !token.endsWith('.'))
     .forEach(entry => {
       const cased = applyCaseStyle(entry, caseStyle)
       const key = cased.toLowerCase()


### PR DESCRIPTION
### Motivation
- Trailing periods in tag tokens sometimes passed through the existing cleanup chain, producing tags like `Adaptogen.` or `...` that should be removed or treated as junk. 
- Add an explicit strip and a defensive filter plus whole-value junk patterns to ensure such tokens are not rendered.

### Description
- Added an explicit trailing-period removal step to `cleanTagToken` by inserting `.replace(/\.+$/, '')` in `src/lib/tagNormalization.ts` to strip any sequence of terminal dots. 
- Added a defensive filter `.filter(token => !token.endsWith('.'))` to `normalizeTagList` in `src/lib/tagNormalization.ts` to drop tokens that still end with a dot after cleaning. 
- Expanded `JUNK_WHOLE_VALUE` in `src/lib/sanitize.ts` with `^\.$` and `^[.\s]+$` to treat a lone period and dot/space-only values as whole-value junk.

### Testing
- Ran `npm run build:compile` (Vite production build) and the build completed successfully with no compile errors. 
- Pre-commit lint checks (`eslint --max-warnings=0`) ran as part of the staged-file hooks and passed. 
- Changed files: `src/lib/tagNormalization.ts` and `src/lib/sanitize.ts`, and the build artifacts were validated during the compile step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3bd387a3883238462838c58bedee8)