### PR TITLE
Filter workbook placeholder summaries and suppress duplicate section bodies

### DIFF
--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -38,6 +38,11 @@ const JUNK_WHOLE_VALUE: RegExp[] = [
   /^data pending$/i,
   /^n\/?a$/i,
   /^none$/i,
+  /^.{0,120} appears in records as a compound reported in/i,
+  /^.{0,120} appears in records/i,
+  /currently mentions/i,
+  /source coverage is limited and still developing/i,
+  /^related herbs listed below\.?$/i,
 ]
 
 const NUMERIC_ONLY = /^\d+(?:[\s.,/-]\d+)*$/

--- a/src/lib/workbookRender.ts
+++ b/src/lib/workbookRender.ts
@@ -1,4 +1,4 @@
-import { cleanEffectChips, sanitizeSummaryText, splitClean } from '@/lib/sanitize'
+import { cleanEffectChips, isJunk, sanitizeSummaryText, splitClean } from '@/lib/sanitize'
 
 export type ProfileStatus = 'complete' | 'partial' | 'minimal'
 export type SummaryQuality = 'strong' | 'weak' | 'none'
@@ -35,12 +35,14 @@ export function resolveHeroSummary(
   input: Record<string, unknown> | undefined | null,
   maxSentences = 1,
 ): string {
-  return sanitizeSummaryText(input?.hero || input?.summary || input?.description || '', maxSentences)
+  const summary = sanitizeSummaryText(input?.hero || input?.summary || input?.description || '', maxSentences)
+  return isJunk(summary) ? '' : summary
 }
 
 export function resolveCoreInsight(
   input: Record<string, unknown> | undefined | null,
   maxSentences = 1,
 ): string {
-  return sanitizeSummaryText(input?.coreInsight || input?.overview || input?.whyItMatters || '', maxSentences)
+  const insight = sanitizeSummaryText(input?.coreInsight || input?.overview || input?.whyItMatters || '', maxSentences)
+  return isJunk(insight) ? '' : insight
 }

--- a/src/pages/CompoundDetail.tsx
+++ b/src/pages/CompoundDetail.tsx
@@ -132,6 +132,16 @@ function normalizeTextValue(value: unknown): string {
   return String(value || '').trim()
 }
 
+function createSectionBodyTracker() {
+  const renderedBodies = new Set<string>()
+  return (value: unknown): string => {
+    const body = normalizeTextValue(value)
+    if (!body || renderedBodies.has(body)) return ''
+    renderedBodies.add(body)
+    return body
+  }
+}
+
 function readRecord(value: unknown): Record<string, unknown> {
   if (typeof value === 'string') {
     const trimmed = value.trim()
@@ -305,6 +315,18 @@ export default function CompoundDetail() {
 
   const whyItMatters = coreInsight ||
     sanitizeSummaryText(curatedData.whyItMatters || compoundEffects.slice(0, 2).join(' + '), 1)
+  const consumeSectionBody = createSectionBodyTracker()
+  const whyItMattersBody = !isMinimalProfile
+    ? consumeSectionBody(whyItMatters || 'Tracked for mechanism context and potential outcomes.')
+    : ''
+  const overviewBody = !isMinimalProfile && compoundDescription !== topSummary
+    ? consumeSectionBody(compoundDescription)
+    : ''
+  const mechanismBody = !isMinimalProfile ? consumeSectionBody(compoundMechanism) : ''
+  const contextBody = !isMinimalProfile && contextSummary !== topSummary ? consumeSectionBody(contextSummary) : ''
+  const pharmacokineticsBody = !isMinimalProfile ? consumeSectionBody(pharmacokinetics) : ''
+  const dosageBody = consumeSectionBody(compound.dosage)
+  const durationBody = consumeSectionBody(compound.duration)
   const premiumDetails = [
     { title: 'Identity', value: compound.identity },
     {
@@ -585,10 +607,10 @@ export default function CompoundDetail() {
             </p>
           )}
           <div className='mt-4 grid gap-3 sm:grid-cols-3'>
-            {!isMinimalProfile && <section className='detail-panel rounded-lg p-3'>
+            {whyItMattersBody && <section className='detail-panel rounded-lg p-3'>
               <h2 className='text-[11px] font-semibold uppercase tracking-[0.14em] text-white/56'>Why it matters</h2>
               <p className='mt-1 text-xs text-white/80'>
-                {whyItMatters || 'Tracked for mechanism context and potential outcomes.'}
+                {whyItMattersBody}
               </p>
             </section>}
             <section className='detail-panel rounded-lg p-3'>
@@ -638,9 +660,9 @@ export default function CompoundDetail() {
         </header>
 
         {/* Core fields — only render when value is present */}
-        {!isMinimalProfile && compoundDescription && compoundDescription !== topSummary && (
+        {overviewBody && (
           <Section title='Overview'>
-            {compoundDescription}
+            {overviewBody}
             {displayClass && (
               <p className='mt-3 label-specimen'>
                 Category: {displayClass}
@@ -663,10 +685,10 @@ export default function CompoundDetail() {
           </div>
         )}
 
-        {!isMinimalProfile && compoundMechanism && <Section title='Mechanism of Action'>{compoundMechanism}</Section>}
+        {mechanismBody && <Section title='Mechanism of Action'>{mechanismBody}</Section>}
 
-        {!isMinimalProfile && contextSummary && contextSummary !== topSummary && (
-          <Section title='Context'>{contextSummary}</Section>
+        {contextBody && (
+          <Section title='Context'>{contextBody}</Section>
         )}
 
         {compoundEffects.length > 0 && (
@@ -678,7 +700,7 @@ export default function CompoundDetail() {
         <PremiumDataSection details={premiumDetails} relationGroups={relationGroups} />
 
 
-        {!isMinimalProfile && pharmacokinetics && <Section title='Pharmacokinetics'>{pharmacokinetics}</Section>}
+        {pharmacokineticsBody && <Section title='Pharmacokinetics'>{pharmacokineticsBody}</Section>}
 
         {!isMinimalProfile && pathwayTargets.length > 0 && (
           <section className='browse-shell fade-in-surface mt-6 p-4 sm:p-5'>
@@ -1057,8 +1079,8 @@ export default function CompoundDetail() {
         </section>
 
         {/* Practical info */}
-        {compound.dosage && <Section title='Dosage'>{compound.dosage}</Section>}
-        {compound.duration && <Section title='Duration'>{compound.duration}</Section>}
+        {dosageBody && <Section title='Dosage'>{dosageBody}</Section>}
+        {durationBody && <Section title='Duration'>{durationBody}</Section>}
         {/* Sources */}
         {(compound.sources.length > 0 || workbookSources.length > 0) && (
           <section className='browse-shell fade-in-surface mt-6 p-4 sm:p-5'>


### PR DESCRIPTION
### Motivation
- Workbook-derived hero/overview/core-insight text was falling back to a common auto-generated placeholder template (e.g. "[name] appears in records as a compound reported in [herb] and...") and being rendered as real content.
- The same placeholder text was appearing in multiple consecutive sections, producing duplicated copy on the compound detail page.

### Description
- Add whole-value junk regexes to `JUNK_WHOLE_VALUE` in `src/lib/sanitize.ts` to catch phrases like `appears in records`, `appears in records as a compound reported in`, `currently mentions`, `source coverage is limited and still developing`, and `Related herbs listed below.`.
- Guard workbook summaries by passing sanitized results through `isJunk()` in `src/lib/workbookRender.ts` and return an empty string when the summary/insight is still junk.
- Implement per-render duplicate section-body suppression in `src/pages/CompoundDetail.tsx` via `createSectionBodyTracker()` and route section bodies (Why it matters, Overview, Mechanism, Context, Pharmacokinetics, Dosage, Duration) through it so identical bodies render only once.
- Files changed: `src/lib/sanitize.ts`, `src/lib/workbookRender.ts`, `src/pages/CompoundDetail.tsx`.

### Testing
- Ran `npm run build`, which completed successfully including compile and postbuild checks (pass).
- Pre-commit hooks ran `eslint --max-warnings=0` on staged files during commit and passed (pass).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3bdde4b388323b1bb9b4a440a82d8)