### PR TITLE
Cleanup herb/compound schema fallbacks in loaders and detail pages

### DIFF
--- a/src/lib/compound-data.ts
+++ b/src/lib/compound-data.ts
@@ -108,9 +108,7 @@ function normalizeEnrichmentSummary(value: unknown): PublishSafeEnrichmentSummar
 
 let compoundsSummaryPromise: Promise<CompoundSummaryRecord[]> | null = null
 let canonicalCompoundsSummaryPromise: Promise<CompoundSummaryRecord[]> | null = null
-let workbookCompoundsPromise: Promise<Record<string, unknown>[]> | null = null
 const compoundDetailPromiseBySlug = new Map<string, Promise<CompoundRecord | null>>()
-const ENABLE_LEGACY_SUMMARY_FALLBACK = import.meta.env.VITE_ENABLE_LEGACY_SUMMARY_FALLBACK === 'true'
 
 function normalizeSlugCandidate(value: string): string {
   return value
@@ -119,23 +117,6 @@ function normalizeSlugCandidate(value: string): string {
     .toLowerCase()
     .replace(/\band\b/g, '')
     .replace(/[^a-z0-9]+/g, '')
-}
-
-function loadWorkbookCompoundRows(): Promise<Record<string, unknown>[]> {
-  if (!workbookCompoundsPromise) {
-    workbookCompoundsPromise = fetch('/data/workbook-compounds.json', { cache: 'no-store' })
-      .then(response => {
-        if (!response.ok) throw new Error('Failed to load /data/workbook-compounds.json')
-        return response.json()
-      })
-      .then(payload => (Array.isArray(payload) ? (payload as Record<string, unknown>[]) : []))
-      .catch(error => {
-        workbookCompoundsPromise = null
-        throw error
-      })
-  }
-
-  return workbookCompoundsPromise
 }
 
 function loadCanonicalCompoundSummaryRows(): Promise<CompoundSummaryRecord[]> {
@@ -156,43 +137,6 @@ function loadCanonicalCompoundSummaryRows(): Promise<CompoundSummaryRecord[]> {
   }
 
   return canonicalCompoundsSummaryPromise
-}
-
-async function loadWorkbookCompoundDetailBySlug(slug: string): Promise<CompoundRecord | null> {
-  const needle = normalizeSlugCandidate(slug)
-  if (!needle) return null
-
-  const workbookRows = await loadWorkbookCompoundRows().catch(() => [])
-  const match = workbookRows.find(row => {
-    const record = row as Record<string, unknown>
-    const aliases = splitClean(record.aliases)
-    const candidates = [
-      String(record.slug || ''),
-      String(record.id || ''),
-      String(record.name || ''),
-      String(record.compoundName || ''),
-      String(record.canonicalCompoundId || ''),
-      String(record.canonicalCompoundName || ''),
-      ...aliases,
-    ]
-    return candidates.some(candidate => normalizeSlugCandidate(candidate) === needle)
-  })
-
-  if (!match) return null
-  return normalizeCompound(match)
-}
-
-async function resolveCompoundDetailSlug(slug: string): Promise<string | null> {
-  const needle = normalizeSlugCandidate(slug)
-  if (!needle) return null
-
-  const summaries = await loadCompoundSummaryData()
-  const match = summaries.find(item => {
-    const candidates = [item.slug, item.id, item.name, ...item.aliases]
-    return candidates.some(candidate => normalizeSlugCandidate(candidate) === needle)
-  })
-
-  return match?.slug || null
 }
 
 async function resolveCanonicalCompoundDetailSlug(slug: string): Promise<string | null> {
@@ -394,23 +338,14 @@ export function isRenderableCompound(raw: Record<string, unknown>): boolean {
 
 export async function loadCompoundSummaryData(): Promise<CompoundSummaryRecord[]> {
   if (!compoundsSummaryPromise) {
-    compoundsSummaryPromise = fetch('/data/workbook-compounds.json', { cache: 'no-store' })
+    compoundsSummaryPromise = fetch('/data/compounds-summary.json', { cache: 'no-store' })
       .then(response => {
-        if (!response.ok) throw new Error('Failed to load /data/workbook-compounds.json')
+        if (!response.ok) throw new Error('Failed to load /data/compounds-summary.json')
         return response.json()
       })
-      .then(async workbookPayload => {
-        const workbookRows = Array.isArray(workbookPayload) ? workbookPayload : []
-        if (workbookRows.length > 0 || !ENABLE_LEGACY_SUMMARY_FALLBACK) {
-          return workbookRows.map(row => normalizeCompoundSummary(row as Record<string, unknown>)).filter(row => Boolean(row.slug))
-        }
-
-        const legacySummaryPayload = await fetch('/data/compounds-summary.json', { cache: 'no-store' }).then(response => {
-          if (!response.ok) throw new Error('Failed to load /data/compounds-summary.json')
-          return response.json()
-        })
-        const summaryRows = Array.isArray(legacySummaryPayload) ? legacySummaryPayload : []
-        return summaryRows.map(row => normalizeCompoundSummary(row as Record<string, unknown>)).filter(row => Boolean(row.slug))
+      .then(payload => {
+        const rows = Array.isArray(payload) ? payload : []
+        return rows.map(row => normalizeCompoundSummary(row as Record<string, unknown>)).filter(row => Boolean(row.slug))
       })
       .catch(error => {
         compoundsSummaryPromise = null
@@ -430,21 +365,16 @@ export async function loadCompoundDetailBySlug(slug: string): Promise<CompoundRe
 
   const request = resolveCanonicalCompoundDetailSlug(slugKey)
     .then(async resolvedCanonicalSlug => {
-      if (resolvedCanonicalSlug) {
-        const canonicalResponse = await fetch(
-          `/data/compounds-detail/${encodeURIComponent(resolvedCanonicalSlug)}.json`,
-          { cache: 'no-store' },
-        )
-        if (canonicalResponse.ok) {
-          return canonicalResponse.json()
-        }
-        if (canonicalResponse.status !== 404) {
-          throw new Error(`Failed to load /data/compounds-detail/${resolvedCanonicalSlug}.json`)
-        }
+      if (!resolvedCanonicalSlug) return null
+      const canonicalResponse = await fetch(
+        `/data/compounds-detail/${encodeURIComponent(resolvedCanonicalSlug)}.json`,
+        { cache: 'no-store' },
+      )
+      if (canonicalResponse.ok) {
+        return canonicalResponse.json()
       }
-
-      const resolvedSlug = await resolveCompoundDetailSlug(slugKey)
-      return loadWorkbookCompoundDetailBySlug(resolvedSlug || slugKey)
+      if (canonicalResponse.status === 404) return null
+      throw new Error(`Failed to load /data/compounds-detail/${resolvedCanonicalSlug}.json`)
     })
     .then(payload => {
       if (!payload || typeof payload !== 'object') return null

--- a/src/lib/herb-data.ts
+++ b/src/lib/herb-data.ts
@@ -81,9 +81,7 @@ function normalizeEnrichmentSummary(value: unknown): PublishSafeEnrichmentSummar
 
 let herbSummariesPromise: Promise<HerbSummary[]> | null = null
 let canonicalHerbSummariesPromise: Promise<HerbSummary[]> | null = null
-let workbookHerbsPromise: Promise<Record<string, unknown>[]> | null = null
 const herbDetailPromiseBySlug = new Map<string, Promise<Herb | null>>()
-const ENABLE_LEGACY_SUMMARY_FALLBACK = import.meta.env.VITE_ENABLE_LEGACY_SUMMARY_FALLBACK === 'true'
 
 function normalizeSlugCandidate(value: string): string {
   return value
@@ -92,23 +90,6 @@ function normalizeSlugCandidate(value: string): string {
     .toLowerCase()
     .replace(/\band\b/g, '')
     .replace(/[^a-z0-9]+/g, '')
-}
-
-function loadWorkbookHerbRows(): Promise<Record<string, unknown>[]> {
-  if (!workbookHerbsPromise) {
-    workbookHerbsPromise = fetch('/data/workbook-herbs.json', { cache: 'no-store' })
-      .then(response => {
-        if (!response.ok) throw new Error('Failed to load /data/workbook-herbs.json')
-        return response.json()
-      })
-      .then(payload => (Array.isArray(payload) ? (payload as Record<string, unknown>[]) : []))
-      .catch(error => {
-        workbookHerbsPromise = null
-        throw error
-      })
-  }
-
-  return workbookHerbsPromise
 }
 
 function loadCanonicalHerbSummaryRows(): Promise<HerbSummary[]> {
@@ -129,52 +110,6 @@ function loadCanonicalHerbSummaryRows(): Promise<HerbSummary[]> {
   }
 
   return canonicalHerbSummariesPromise
-}
-
-async function loadWorkbookHerbDetailBySlug(slug: string): Promise<Herb | null> {
-  const needle = normalizeSlugCandidate(slug)
-  if (!needle) return null
-
-  const workbookRows = await loadWorkbookHerbRows().catch(() => [])
-  const match = workbookRows.find(row => {
-    const record = row as Record<string, unknown>
-    const aliases = splitClean(record.aliases)
-    const candidates = [
-      String(record.slug || ''),
-      String(record.id || ''),
-      String(record.common || ''),
-      String(record.name || ''),
-      String(record.commonName || ''),
-      String(record.scientific || ''),
-      String(record.scientificName || ''),
-      String(record.latin || ''),
-      ...aliases,
-    ]
-    return candidates.some(candidate => normalizeSlugCandidate(candidate) === needle)
-  })
-
-  if (!match) return null
-  return normalizeHerbRow(match)
-}
-
-async function resolveHerbDetailSlug(slug: string): Promise<string | null> {
-  const needle = normalizeSlugCandidate(slug)
-  if (!needle) return null
-
-  const summaries = await loadHerbSummaryData()
-  const match = summaries.find(item => {
-    const candidates = [
-      item.slug,
-      item.id,
-      item.common,
-      item.scientific,
-      item.name,
-      ...item.aliases,
-    ]
-    return candidates.some(candidate => normalizeSlugCandidate(candidate) === needle)
-  })
-
-  return match?.slug || null
 }
 
 async function resolveCanonicalHerbDetailSlug(slug: string): Promise<string | null> {
@@ -492,23 +427,14 @@ export function isRenderableHerbRow(raw: Record<string, unknown>): boolean {
 
 export async function loadHerbSummaryData(): Promise<HerbSummary[]> {
   if (!herbSummariesPromise) {
-    herbSummariesPromise = fetch('/data/workbook-herbs.json', { cache: 'no-store' })
+    herbSummariesPromise = fetch('/data/herbs-summary.json', { cache: 'no-store' })
       .then(response => {
-        if (!response.ok) throw new Error('Failed to load /data/workbook-herbs.json')
+        if (!response.ok) throw new Error('Failed to load /data/herbs-summary.json')
         return response.json()
       })
-      .then(async workbookPayload => {
-        const workbookRows = Array.isArray(workbookPayload) ? workbookPayload : []
-        if (workbookRows.length > 0 || !ENABLE_LEGACY_SUMMARY_FALLBACK) {
-          return workbookRows.map(row => normalizeHerbSummaryRow(row as Record<string, unknown>)).filter(row => Boolean(row.slug))
-        }
-
-        const legacySummaryPayload = await fetch('/data/herbs-summary.json', { cache: 'no-store' }).then(response => {
-          if (!response.ok) throw new Error('Failed to load /data/herbs-summary.json')
-          return response.json()
-        })
-        const summaryRows = Array.isArray(legacySummaryPayload) ? legacySummaryPayload : []
-        return summaryRows.map(row => normalizeHerbSummaryRow(row as Record<string, unknown>)).filter(row => Boolean(row.slug))
+      .then(payload => {
+        const rows = Array.isArray(payload) ? payload : []
+        return rows.map(row => normalizeHerbSummaryRow(row as Record<string, unknown>)).filter(row => Boolean(row.slug))
       })
       .catch(error => {
         herbSummariesPromise = null
@@ -528,21 +454,16 @@ export async function loadHerbDetailBySlug(slug: string): Promise<Herb | null> {
 
   const request = resolveCanonicalHerbDetailSlug(slugKey)
     .then(async resolvedCanonicalSlug => {
-      if (resolvedCanonicalSlug) {
-        const canonicalResponse = await fetch(
-          `/data/herbs-detail/${encodeURIComponent(resolvedCanonicalSlug)}.json`,
-          { cache: 'no-store' },
-        )
-        if (canonicalResponse.ok) {
-          return canonicalResponse.json()
-        }
-        if (canonicalResponse.status !== 404) {
-          throw new Error(`Failed to load /data/herbs-detail/${resolvedCanonicalSlug}.json`)
-        }
+      if (!resolvedCanonicalSlug) return null
+      const canonicalResponse = await fetch(
+        `/data/herbs-detail/${encodeURIComponent(resolvedCanonicalSlug)}.json`,
+        { cache: 'no-store' },
+      )
+      if (canonicalResponse.ok) {
+        return canonicalResponse.json()
       }
-
-      const resolvedSlug = await resolveHerbDetailSlug(slugKey)
-      return loadWorkbookHerbDetailBySlug(resolvedSlug || slugKey)
+      if (canonicalResponse.status === 404) return null
+      throw new Error(`Failed to load /data/herbs-detail/${resolvedCanonicalSlug}.json`)
     })
     .then(payload => {
       if (!payload || typeof payload !== 'object') return null

--- a/src/pages/CompoundDetail.tsx
+++ b/src/pages/CompoundDetail.tsx
@@ -9,7 +9,6 @@ import {
   sanitizeReadableText,
   sanitizeSummaryText,
   splitClean,
-  uniqueNormalizedList,
 } from '@/lib/sanitize'
 import { buildUniqueDetailCopy, sanitizeRenderChips, sanitizeRenderList } from '@/lib/renderGuard'
 import { normalizeTagList } from '@/lib/tagNormalization'
@@ -166,21 +165,6 @@ function readWorkbookText(record: Record<string, unknown>, ...keys: string[]): s
   return ''
 }
 
-function splitPipeList(value: unknown): string[] {
-  return normalizeTagList(
-    Array.isArray(value) ? value : normalizeTextValue(value).split('|'),
-    { caseStyle: 'none', minLength: 1, maxItems: 50 },
-  )
-}
-
-function toTitleCase(value: string): string {
-  return value
-    .replace(/[-_]+/g, ' ')
-    .trim()
-    .replace(/\s+/g, ' ')
-    .replace(/\b\w/g, letter => letter.toUpperCase())
-}
-
 function buildSourceLabel(rawUrl: string, fallbackTitle: string) {
   const title = normalizeTextValue(fallbackTitle)
   const genericTitle = !title || /^(source|link|reference|article|study)$/i.test(title)
@@ -197,18 +181,7 @@ export default function CompoundDetail() {
   const location = useLocation()
   const showRawDebug = shouldShowRawDebug(location.search)
   const { compounds, isLoading: isCompoundsLoading } = useCompoundDataState()
-  const slugNeedle = normalizeKey(slug)
-  const detailLookupSlug =
-    compounds.find(item => {
-      const record = item as unknown as Record<string, unknown>
-      const candidates = [
-        item.slug,
-        item.id,
-        normalizeTextValue(record.canonicalCompoundId),
-      ]
-      return candidates.some(candidate => normalizeKey(String(candidate || '')) === slugNeedle)
-    })?.slug || slug
-  const { compound, isLoading: isCompoundLoading } = useCompoundDetailState(detailLookupSlug)
+  const { compound, isLoading: isCompoundLoading } = useCompoundDetailState(slug)
   const { herbs, isLoading: isHerbLoading } = useHerbDataState()
 
   if (isCompoundLoading || isCompoundsLoading || isHerbLoading) {
@@ -233,19 +206,13 @@ export default function CompoundDetail() {
   const profileStatus = getProfileStatus(rawRecord)
   const summaryQuality = getSummaryQuality(rawRecord)
   const isMinimalProfile = profileStatus === 'minimal'
-  const name =
-    normalizeTextValue(compoundRecord.compoundName) ||
-    normalizeTextValue(compoundRecord.name) ||
-    normalizeTextValue(compoundRecord.id) ||
-    'Unknown compound'
+  const name = normalizeTextValue(compound.name) || normalizeTextValue(compound.id) || 'Unknown compound'
   const evidence = sanitizeReadableText(compoundRecord.evidence)
   const pharmacokinetics = sanitizeReadableText(compoundRecord.pharmacokinetics)
-  const pathwayTargets = sanitizeRenderList(splitClean(compound.pathways || compoundRecord.pathwayTargets))
-  const workbookSources = sanitizeRenderList(splitPipeList(compoundRecord.sourceUrls))
-  const relatedHerbSlugs = uniqueNormalizedList(splitClean(compound.foundIn || compoundRecord.relatedHerbSlugs))
+  const pathwayTargets = sanitizeRenderList(splitClean(compound.pathways))
   const curatedData = compound.curatedData
   const compoundEffects = sanitizeRenderChips(
-    cleanEffectChips((compound as Record<string, unknown>).primaryActions || rawRecord.primaryActions || curatedData.keyEffects || compound.effects, 12),
+    cleanEffectChips(compound.effects || curatedData.keyEffects, 12),
     12,
   )
   const compoundContraindications = sanitizeRenderList(compound.contraindications)
@@ -268,7 +235,7 @@ export default function CompoundDetail() {
     ),
     mechanism: sanitizeReadableText(
       splitClean(compound.mechanisms).join('; ') ||
-      readWorkbookText(rawRecord, 'mechanisms', 'mechanism') ||
+      readWorkbookText(rawRecord, 'mechanism') ||
       curatedData.mechanism,
     ),
   })
@@ -280,12 +247,11 @@ export default function CompoundDetail() {
     splitClean(safetyRecord.notes || safetyRecord.summary || safetyRecord.caution || rawRecord.safety),
     8,
   )
-  const drugInteractions = normalizeTextValue(compoundRecord.drugInteractions)
   const uniqueDrugInteractionItems = sanitizeRenderList(
     normalizeTagList(
       Array.from(
         new Map(
-          [...workbookSafety, ...compoundInteractions, ...(drugInteractions ? [sanitizeReadableText(drugInteractions)] : [])]
+          [...workbookSafety, ...compoundInteractions]
             .map(item => normalizeTextValue(item))
             .filter(Boolean)
             .map(item => [normalizeKey(item), item]),
@@ -366,14 +332,6 @@ export default function CompoundDetail() {
       to: `/herbs/${encodeURIComponent(herb.slug)}`,
     })),
     ...premiumRelatedHerbs,
-    ...relatedHerbSlugs.map(entry => {
-      const normalized = herbByKey.get(normalizeKey(entry))
-      const resolvedSlug = normalized?.slug || entry
-      return {
-        label: normalized?.label || toTitleCase(entry),
-        to: `/herbs/${encodeURIComponent(resolvedSlug)}`,
-      }
-    }),
   ])
   const relatedCompoundLinks = dedupeRelatedLinks(premiumRelatedCompounds)
   const relationGroups = [

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -162,8 +162,8 @@ export default function HerbDetail() {
     )
   }
 
-  const herbName = toTitleCase(herb.commonName || herb.common || herb.name || herb.slug)
-  const scientificName = String(herb.scientific || herb.latinName || '').trim()
+  const herbName = toTitleCase(herb.name || herb.slug)
+  const scientificName = String(herb.scientificName || herb.scientific || '').trim()
   const curatedData = herb.curatedData
   const rawRecord = readRecord(herb.rawData)
   const contextRecord = readRecord(rawRecord.context)
@@ -187,21 +187,21 @@ export default function HerbDetail() {
       2,
     ),
     mechanism:
-      splitTextList((herb as Record<string, unknown>).mechanisms).join('; ') ||
-      readWorkbookText(rawRecord, 'mechanisms', 'mechanism') ||
+      splitTextList(herb.mechanisms).join('; ') ||
+      readWorkbookText(rawRecord, 'mechanism') ||
       String(curatedData.mechanism || '').trim(),
   })
   const coreInsight = uniqueCopy.overview
 
   const primaryActions = sanitizeRenderChips(
     dedupePresentationList(
-      splitTextList((herb as Record<string, unknown>).primaryActions || rawRecord.primaryActions || curatedData.keyEffects),
+      splitTextList(herb.primaryActions || curatedData.keyEffects),
       8,
     ),
     8,
   )
   const keyEffects = primaryActions.slice(0, 4)
-  const activeCompounds = sanitizeRenderList(splitTextList(herb.activeCompounds || herb.compounds), 10)
+  const activeCompounds = sanitizeRenderList(splitTextList(herb.activeCompounds), 10)
   const mechanism = uniqueCopy.mechanism
   const contextSummary = uniqueCopy.context
   const dosage = String(herb.dosage || '').trim()
@@ -210,14 +210,12 @@ export default function HerbDetail() {
   const standardization = String(herb.standardization || '').trim()
   const contraindications = splitTextList(herb.contraindications)
   const interactions = splitTextList(herb.interactions)
-  const sideEffects = splitTextList(herb.sideeffects || herb.sideEffects)
+  const sideEffects = splitTextList(herb.sideEffects)
   const safety = splitTextList(
     safetyRecord.notes ||
       safetyRecord.summary ||
       safetyRecord.caution ||
-      rawRecord.safety ||
-      (herb as Record<string, unknown>).safetyNotes ||
-      (herb as Record<string, unknown>).safety,
+      herb.safetyNotes,
   )
 
   const rawSafetyNotes = dedupePresentationList([
@@ -246,7 +244,7 @@ export default function HerbDetail() {
     priorityWarning ? `Use caution: ${priorityWarning}.` : 'Avoid if safety context, medications, or medical status are unclear.',
   ].filter(Boolean)
   const pagePath = `/herbs/${herb.slug}`
-  const relatedHerbSlugs = splitTextList((herb as Record<string, unknown>).relatedHerbs)
+  const relatedHerbSlugs = splitTextList(herb.relatedHerbs)
   const relatedHerbs = herbs
     .filter(item => item.slug && item.slug !== herb.slug && (relatedHerbSlugs.length === 0 || relatedHerbSlugs.includes(item.slug)))
     .slice(0, 4)


### PR DESCRIPTION
### Motivation
- Remove remaining runtime fallbacks to workbook fields so pages render from the permanent canonical schema and canonical detail payloads. 
- Simplify Herb and Compound detail components to rely on the permanent field names only and eliminate conditional rendering for obsolete aliases. 
- Keep minimal compatibility at the ingestion/export layer and surface any manual-review items for data entries that relied on removed runtime fallbacks. 

### Description
- Loaders: replaced workbook-summary/detail fallbacks with direct canonical payload resolution in `src/lib/herb-data.ts` and `src/lib/compound-data.ts`, removing the workbook row loaders and legacy-summary branch logic. Files changed: `src/lib/herb-data.ts`, `src/lib/compound-data.ts`. 
- Pages/components: simplified rendering in `src/pages/HerbDetail.tsx` and `src/pages/CompoundDetail.tsx` to use permanent schema fields (e.g., `name`, `scientificName`, `mechanism`, `primaryActions`, `activeCompounds`, `sideEffects`, `safetyNotes`, `effects`, `pathways`) and removed many obsolete conditional fallbacks and lookups. Files changed: `src/pages/HerbDetail.tsx`, `src/pages/CompoundDetail.tsx`. 
- Dead fields removed from runtime/page logic: `canonicalCompoundId`, `compoundName`, `sourceUrls`, `relatedHerbSlugs`, `drugInteractions`, raw `primaryActions` fallback, and various herb-level alias fallbacks such as `commonName`, `latinName`, `active_compounds`/`compounds`, `sideeffects`, and in-page ad-hoc `safety` fallbacks. 
- Remaining compatibility shims: canonical slug resolution still tolerates aliases/aliases lists when resolving which canonical detail file to fetch, normalizers in loader/normalization functions still accept some legacy input key variants to support ingestion, and `loadHerbData()` alias is preserved. 
- Manual review list: verify sample herb and compound routes that previously relied on workbook-only fields for content quality; decide whether to further trim normalizer aliasing once canonical data is confirmed; optionally remove remaining raw `compoundRecord` raw-field usages (`evidence`, `pharmacokinetics`) if those are deprecated upstream. 

### Testing
- Ran `npm run build` which executed prebuild, build, prerender and postbuild verification flows and completed successfully. 
- Ran `npm run build:compile` (vite build) after edits and it completed successfully without runtime errors. 
- Verification: prerender and editorial verification steps in the build pipeline passed during the runs (build/prerender reports were generated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3f609040c83239ae1874d9aefc03a)