### PR TITLE
Align herb/compound frontend with permanent public schema

### DIFF
--- a/src/lib/compound-data.ts
+++ b/src/lib/compound-data.ts
@@ -15,38 +15,40 @@ export type CompoundRecord = {
   id: string
   slug: string
   name: string
+  summary: string
   description: string
   className: string
   category: string
   compoundClass: string
-  intensity: string
+  primaryActions: string[]
   mechanisms: string[]
   targets: string[]
   pathways: string[]
+  foundIn: string[]
+  bioavailability: string
+  safetyNotes: string
+  evidenceLevel: string
+  relatedCompounds: string[]
   mechanism: string
-  activeCompounds: string[]
   effects: string[]
-  therapeuticUses: string[]
-  contraindications: string[]
+  herbs: string[]
   interactions: string[]
+  contraindications: string[]
+  interactionTags?: string[]
+  interactionNotes?: string[]
+  therapeuticUses: string[]
+  sideEffects: string[]
   dosage: string
   duration: string
   region: string
   preparation: string
   legalStatus: string
-  sideEffects: string[]
-  interactionTags?: string[]
-  interactionNotes?: string[]
-  foundIn: string[]
-  herbs: string[]
   sources: SourceRef[]
   lastUpdated: string
   confidence: ConfidenceLevel
   identity: string
   categoryUseContext: string
-  evidenceLevel: string
   relatedEntities: string[]
-  relatedCompounds: string[]
   linkedHerbs: string[]
   researchEnrichment?: ResearchEnrichment
   researchEnrichmentSummary?: PublishSafeEnrichmentSummary
@@ -61,11 +63,13 @@ export type CompoundSummaryRecord = {
   id: string
   slug: string
   name: string
+  summary: string
   summaryShort: string
   description: string
   className: string
   category: string
   compoundClass: string
+  primaryActions: string[]
   mechanisms: string[]
   targets: string[]
   pathways: string[]
@@ -232,11 +236,13 @@ function normalizeCompound(raw: Record<string, unknown>): CompoundRecord {
     id: String(data.id || slug),
     slug,
     name,
+    summary: cleanText(data.summary ?? data.description ?? data.hero ?? data.intro ?? data.coreInsight) || '',
     description:
       cleanText(data.description ?? data.summary ?? data.hero ?? data.intro ?? data.coreInsight) || '',
     className: cleanText(data.class ?? data.type ?? data.className ?? data.compoundClass) || '',
     category: cleanText(data.category ?? data.class ?? data.type ?? data.className ?? data.compoundClass) || '',
     compoundClass: cleanText(data.compoundClass ?? data.class ?? data.className ?? data.type) || '',
+    primaryActions,
     mechanisms,
     targets,
     pathways,
@@ -265,6 +271,8 @@ function normalizeCompound(raw: Record<string, unknown>): CompoundRecord {
     relatedCompounds,
     compounds,
     linkedHerbs,
+    bioavailability: cleanText(data.bioavailability ?? data.absorption ?? data.pkSummary) || '',
+    safetyNotes: splitClean(data.safetyNotes ?? safetyRecord.notes ?? safetyRecord.summary ?? safetyRecord.caution).join('; '),
     confidence: calculateCompoundConfidence({ mechanism, effects: primaryActions, compounds: foundIn }),
     sources,
     researchEnrichment: researchEnrichment || undefined,
@@ -307,11 +315,13 @@ function normalizeCompoundSummary(raw: Record<string, unknown>): CompoundSummary
       .trim()
       .toLowerCase(),
     name: cleanText(raw.name) || '',
+    summary: cleanText(raw.summary ?? raw.description ?? raw.summaryShort ?? raw.hero ?? raw.coreInsight) || '',
     summaryShort: cleanText(raw.summaryShort ?? raw.description ?? raw.summary ?? raw.hero ?? raw.coreInsight) || '',
     description: cleanText(raw.description ?? raw.summaryShort ?? raw.summary ?? raw.hero ?? raw.coreInsight) || '',
     className: cleanText(raw.className ?? raw.compoundClass) || '',
     category: cleanText(raw.category ?? raw.className ?? raw.compoundClass) || '',
     compoundClass: cleanText(raw.compoundClass ?? raw.className ?? raw.category) || '',
+    primaryActions: effects,
     mechanisms,
     targets,
     pathways,

--- a/src/lib/compoundHerbRelations.ts
+++ b/src/lib/compoundHerbRelations.ts
@@ -6,7 +6,7 @@ export type RelatedHerb = {
   name: string
   descriptor: string
   confidence?: Herb['confidence']
-  effects?: string[]
+  primaryActions?: string[]
 }
 
 function normalizeKey(value: unknown) {
@@ -20,10 +20,12 @@ function pickHerbName(herb: Herb) {
 }
 
 function pickDescriptor(herb: Herb) {
-  const effects = Array.isArray(herb.effects)
-    ? herb.effects.filter(effect => typeof effect === 'string' && effect.trim())
-    : []
-  if (effects.length > 0) return effects[0]
+  const primaryActions = Array.isArray(herb.primaryActions)
+    ? herb.primaryActions.filter(effect => typeof effect === 'string' && effect.trim())
+    : Array.isArray(herb.effects)
+      ? herb.effects.filter(effect => typeof effect === 'string' && effect.trim())
+      : []
+  if (primaryActions.length > 0) return primaryActions[0]
 
   const description = String(herb.description || '').trim()
   if (description.length > 0) return description.slice(0, 80)
@@ -54,7 +56,11 @@ export function mapRelatedHerbsForCompound(compound: CompoundRecord, herbs: Herb
           name: pickHerbName(existing),
           descriptor: pickDescriptor(existing),
           confidence: existing.confidence,
-          effects: Array.isArray(existing.effects) ? existing.effects : [],
+          primaryActions: Array.isArray(existing.primaryActions)
+            ? existing.primaryActions
+            : Array.isArray(existing.effects)
+              ? existing.effects
+              : [],
         } satisfies RelatedHerb
       }
       
@@ -78,7 +84,11 @@ export function mapRelatedHerbsForCompound(compound: CompoundRecord, herbs: Herb
       name: pickHerbName(herb),
       descriptor: pickDescriptor(herb),
       confidence: herb.confidence,
-      effects: Array.isArray(herb.effects) ? herb.effects : [],
+      primaryActions: Array.isArray(herb.primaryActions)
+        ? herb.primaryActions
+        : Array.isArray(herb.effects)
+          ? herb.effects
+          : [],
     }))
 
   const merged = new Map<string, RelatedHerb>()

--- a/src/lib/herb-data.ts
+++ b/src/lib/herb-data.ts
@@ -25,16 +25,16 @@ export type HerbSummary = {
   summaryShort: string
   description: string
   primaryActions: string[]
-  primaryEffects?: string[]
   mechanisms: string[]
   activeCompounds: string[]
-  compounds: string[]
+  safetyNotes?: string
+  traditionalUses?: string[]
+  evidenceLevel?: string
+  relatedHerbs?: string[]
   interactionTags: string[]
   interactionNotes?: string[]
   interactions?: string[] | string
   contraindications?: string[] | string
-  traditionalUses?: string[]
-  relatedHerbs?: string[]
   relatedCompounds?: string[]
   mechanism?: string
   effects?: string[]
@@ -232,9 +232,7 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
     .trim()
     .toLowerCase()
 
-  const primaryActions = splitClean(
-    data.primaryActions ?? data.actions ?? data.effects ?? data.keyEffects ?? data.benefits,
-  )
+  const primaryActions = splitClean(data.primaryActions ?? data.actions ?? data.effects ?? data.benefits)
   const contraindications = splitClean(data.contraindications)
   const interactions = splitClean(data.interactions)
   const sideeffects = splitClean(data.sideEffects ?? data.sideeffects)
@@ -362,7 +360,7 @@ function normalizeHerbSummaryRow(raw: Record<string, unknown>): HerbSummary {
   const common = cleanText(raw.common ?? raw.commonName ?? raw.name) || ''
   const scientific = cleanText(raw.scientific ?? raw.latin ?? raw.scientificName) || ''
   const primaryActions = splitClean(
-    raw.primaryActions ?? raw.actions ?? raw.effects ?? raw.keyEffects ?? raw.benefits,
+    raw.primaryActions ?? raw.actions ?? raw.effects ?? raw.benefits,
   )
   const mechanisms = normalizeMechanisms(raw.mechanisms, raw.mechanism, raw.mechanismOfAction, raw.pathwayTargets)
   const activeCompounds = splitClean(raw.activeCompounds ?? raw.compounds)
@@ -385,9 +383,12 @@ function normalizeHerbSummaryRow(raw: Record<string, unknown>): HerbSummary {
     mechanisms,
     mechanism: cleanText(raw.mechanism ?? mechanisms.join('; ')) || '',
     effects: primaryActions,
-    primaryEffects: splitClean(raw.primary_effects ?? raw.primaryEffects ?? raw.keyEffects ?? primaryActions).slice(0, 4),
     activeCompounds,
     compounds: activeCompounds,
+    safetyNotes: cleanText(raw.safetyNotes ?? safetyRecord.summary ?? safetyRecord.caution) || '',
+    traditionalUses: splitClean(raw.traditionalUses ?? raw.therapeuticUses),
+    evidenceLevel: cleanText(raw.evidenceLevel ?? raw.confidence) || '',
+    relatedHerbs: splitClean(raw.relatedHerbs),
     interactionTags: splitClean(raw.interactionTags),
     interactionNotes: splitClean(raw.interactionNotes),
     interactions: splitClean(raw.interactions),

--- a/src/pages/CompoundDetail.tsx
+++ b/src/pages/CompoundDetail.tsx
@@ -212,7 +212,7 @@ export default function CompoundDetail() {
   const pathwayTargets = sanitizeRenderList(splitClean(compound.pathways))
   const curatedData = compound.curatedData
   const compoundEffects = sanitizeRenderChips(
-    cleanEffectChips(compound.effects || curatedData.keyEffects, 12),
+    cleanEffectChips(compound.primaryActions || compound.effects || curatedData.keyEffects, 12),
     12,
   )
   const compoundContraindications = sanitizeRenderList(compound.contraindications)
@@ -220,7 +220,7 @@ export default function CompoundDetail() {
   const compoundTherapeuticUses = sanitizeRenderList(compound.therapeuticUses)
   const compoundInteractions = sanitizeRenderList(compound.interactions)
   const heroSummary = sanitizeSummaryText(
-    readWorkbookText(rawRecord, 'hero', 'summary', 'description') || curatedData.summary,
+    compound.summary || compound.description || curatedData.summary,
     2,
   )
   const uniqueCopy = buildUniqueDetailCopy({
@@ -235,7 +235,7 @@ export default function CompoundDetail() {
     ),
     mechanism: sanitizeReadableText(
       splitClean(compound.mechanisms).join('; ') ||
-      readWorkbookText(rawRecord, 'mechanism') ||
+      compound.mechanism ||
       curatedData.mechanism,
     ),
   })
@@ -483,7 +483,7 @@ export default function CompoundDetail() {
 
   // Derive a display class — category only if it's meaningful
   const displayClass =
-    compound.className || (compound.category !== 'Uncategorized' ? compound.category : '')
+    compound.compoundClass || compound.className || (compound.category !== 'Uncategorized' ? compound.category : '')
   const compoundEffectsMetaText = Array.isArray(compoundEffects)
     ? compoundEffects.join(', ').slice(0, 155)
     : ''
@@ -521,7 +521,7 @@ export default function CompoundDetail() {
             name,
             slug: compound.slug,
             description: compoundMetaDescription,
-            category: compound.category,
+            category: compound.compoundClass || compound.category,
             breadcrumbId,
             governedSummary: compound.researchEnrichmentSummary,
           }),

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -172,7 +172,7 @@ export default function HerbDetail() {
   const summaryQuality = getSummaryQuality(rawRecord)
   const isMinimalProfile = profileStatus === 'minimal'
   const showSummaryRegion = shouldRenderSummary(profileStatus, summaryQuality)
-  const description = readWorkbookText(rawRecord, 'hero', 'summary', 'description') || String(curatedData.summary || '').trim()
+  const description = String(herb.summary || herb.description || '').trim() || String(curatedData.summary || '').trim()
   const descriptionIsPlaceholder = isPlaceholder(description, herbName)
   const summary = sanitizeSummaryText(description, 2)
   const fullDescription = sanitizeReadableText(description)
@@ -188,7 +188,7 @@ export default function HerbDetail() {
     ),
     mechanism:
       splitTextList(herb.mechanisms).join('; ') ||
-      readWorkbookText(rawRecord, 'mechanism') ||
+      String(herb.mechanism || '').trim() ||
       String(curatedData.mechanism || '').trim(),
   })
   const coreInsight = uniqueCopy.overview
@@ -254,7 +254,7 @@ export default function HerbDetail() {
     }))
 
   const compoundIndex = new Map(compounds.map(compound => [String(compound.name || '').toLowerCase(), compound]))
-  const relatedCompounds = activeCompounds
+  const relatedCompounds = [...activeCompounds, ...splitTextList(herb.relatedCompounds)]
     .map(name => {
       const match = compoundIndex.get(name.toLowerCase())
       if (!match?.slug) return null

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,8 @@ export type Herb = {
   legalstatusClean?: string | null
   schedule?: string
   description?: string
+  primaryActions?: string[]
+  mechanisms?: string[]
   effects?: string[] | string
   effectsSummary?: string | null
   mechanism?: string
@@ -39,6 +41,8 @@ export type Herb = {
   activeConstituents?: { name: string }[]
   preparations?: string[]
   preparation?: string | null
+  traditionalUses?: string[]
+  relatedHerbs?: string[]
   preparationsText?: string
   interactions?: string[] | string
   interactionsText?: string

--- a/src/types/compound.ts
+++ b/src/types/compound.ts
@@ -21,6 +21,17 @@ export type CanonicalCompound = {
 
 export type CompoundRecord = {
   name: string
+  slug?: string
+  summary?: string
+  description?: string
+  compoundClass?: string
+  primaryActions?: string[]
+  mechanisms?: string[]
+  targets?: string[]
+  pathways?: string[]
+  foundIn?: string[]
+  bioavailability?: string
+  safetyNotes?: string
   category?: string
   mechanism?: string
   effects?: string[]
@@ -38,7 +49,6 @@ export type CompoundRecord = {
   linkedHerbs?: string[]
   researchEnrichment?: ResearchEnrichment
   researchEnrichmentSummary?: PublishSafeEnrichmentSummary
-  foundIn?: string[]
   [key: string]: unknown
 }
 

--- a/src/types/herb.ts
+++ b/src/types/herb.ts
@@ -32,6 +32,8 @@ export type HerbRecord = {
   // Content
   summary?: string
   description?: string
+  primaryActions?: string[]
+  mechanisms?: string[]
   mechanism?: string
   mechanismTags?: string[]
   evidenceLevel?: string
@@ -41,6 +43,8 @@ export type HerbRecord = {
   interactions?: string[] | string
   contraindications?: string[] | string
   preparation?: string | null
+  traditionalUses?: string[]
+  relatedHerbs?: string[]
   dosage?: string
   standardization?: string
   qualityConcerns?: string

--- a/src/utils/getSeoLandingResults.ts
+++ b/src/utils/getSeoLandingResults.ts
@@ -25,7 +25,7 @@ function scoreHerbCompleteness(herb: Herb): number {
   const count = [
     herb.description,
     herb.mechanism || herb.mechanismOfAction || herb.mechanismofaction,
-    herb.effects,
+    herb.primaryActions ?? herb.effects,
     herb.active_compounds,
     herb.compounds,
     herb.safety,
@@ -38,9 +38,8 @@ function scoreCompoundCompleteness(compound: CompoundRecord): number {
   const count = [
     compound.description,
     compound.mechanism,
-    compound.effects,
-    compound.activeCompounds,
-    compound.herbs,
+    compound.primaryActions ?? compound.effects,
+    compound.foundIn,
     compound.legalStatus,
   ].filter(value => splitClean(value).length > 0 || normalizeText(value).length > 0).length
 
@@ -56,15 +55,15 @@ function getHerbConfidence(herb: Herb): string {
 function getCompoundConfidence(compound: CompoundRecord): string {
   return calculateCompoundConfidence({
     mechanism: compound.mechanism,
-    effects: compound.effects,
-    compounds: compound.activeCompounds,
+    effects: compound.primaryActions ?? compound.effects,
+    compounds: compound.foundIn,
   })
 }
 
 function herbHasSparseData(herb: Herb): boolean {
   const essentialFields = [
     herb.description,
-    herb.effects,
+    herb.primaryActions ?? herb.effects,
     herb.mechanism || herb.mechanismOfAction || herb.mechanismofaction,
   ]
 
@@ -73,7 +72,7 @@ function herbHasSparseData(herb: Herb): boolean {
 }
 
 function compoundHasSparseData(compound: CompoundRecord): boolean {
-  const essentialFields = [compound.description, compound.effects, compound.mechanism]
+  const essentialFields = [compound.description, compound.primaryActions ?? compound.effects, compound.mechanism]
   const present = essentialFields.filter(
     value => splitClean(value).length > 0 || normalizeText(value).length > 0
   ).length
@@ -95,7 +94,7 @@ function matchesHerb(config: SeoLandingConfig, herb: Herb): boolean {
     ...(Array.isArray(herb.categories) ? herb.categories : []),
     String((herb as Record<string, unknown>).class ?? ''),
   ]
-  const effectFields = [herb.effects, herb.effectsSummary, herb.tags]
+  const effectFields = [herb.primaryActions ?? herb.effects, herb.effectsSummary, herb.tags]
   const compoundFields = [
     herb.activeCompounds,
     herb.active_compounds,
@@ -123,9 +122,9 @@ function matchesHerb(config: SeoLandingConfig, herb: Herb): boolean {
 function matchesCompound(config: SeoLandingConfig, compound: CompoundRecord): boolean {
   const target = normalizeText(config.target)
 
-  const effectFields = [compound.effects, compound.description]
-  const classFields = [compound.className, compound.category]
-  const compoundRefFields = [compound.name, compound.activeCompounds]
+  const effectFields = [compound.primaryActions ?? compound.effects, compound.description]
+  const classFields = [compound.compoundClass, compound.className, compound.category]
+  const compoundRefFields = [compound.name, compound.foundIn]
 
   if (config.kind === 'effect') {
     return effectFields.some(field => isNeedleMatch(field, target))


### PR DESCRIPTION
### Motivation
- Move frontend consumption to the new permanent herb/compound schema (canonical fields like `primaryActions`, `mechanisms`, `foundIn`, `compoundClass`, `bioavailability`, `safetyNotes`, `related*`) and remove reliance on legacy “effects/actions/benefits” fallbacks while preserving minimal loader-level compatibility.

### Description
- Normalize loaders to emit the permanent schema as canonical output and map legacy fields into those canonical fields in the ingestion layer (`src/lib/herb-data.ts`, `src/lib/compound-data.ts`).
- Update frontend consumers to prefer canonical fields for rendering and metadata (detail pages and cards), including `HerbDetail` and `CompoundDetail` preferring `summary`, `primaryActions`, `mechanisms`, and `compoundClass` where applicable (`src/pages/HerbDetail.tsx`, `src/pages/CompoundDetail.tsx`).
- Update related-entity mapping and SEO/landing logic to use canonical fields (`primaryActions`, `compoundClass`, `foundIn`) and adjust related-herb mapping to expose `primaryActions` (`src/lib/compoundHerbRelations.ts`, `src/utils/getSeoLandingResults.ts`).
- Extend TypeScript types to include permanent-schema fields used by frontend consumers and normalizers (`src/types.ts`, `src/types/herb.ts`, `src/types/compound.ts`).
- Files changed: `src/lib/herb-data.ts`, `src/lib/compound-data.ts`, `src/pages/HerbDetail.tsx`, `src/pages/CompoundDetail.tsx`, `src/lib/compoundHerbRelations.ts`, `src/utils/getSeoLandingResults.ts`, `src/types.ts`, `src/types/herb.ts`, `src/types/compound.ts`.

### Testing
- Ran `npm run build:compile` and the production compile step completed successfully (vite build output reported success). 
- Pre-commit hooks / `lint-staged` ran `eslint --max-warnings=0` during commit and passed. 
- Summary: build and lint checks passed locally; no unit test failures were produced during this focused schema/front-end alignment pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4ced928448323ba32c0503012dc42)