### PR TITLE
Implementation schema cleanup: remove runtime legacy herb field fallbacks

### DIFF
--- a/src/components/AdvancedSearch.tsx
+++ b/src/components/AdvancedSearch.tsx
@@ -6,7 +6,7 @@ export type AdvancedHerb = {
   scientific?: string
   effects?: string
   tags?: string[]
-  compounds?: string[]
+  activeCompounds?: string[]
   contraindications?: string[] | string
   interactions?: string[] | string
   intensity?: string | number | null
@@ -122,7 +122,7 @@ export default function AdvancedSearch({
         herb.effects,
         (herb as Record<string, unknown>).description,
         (herb.tags || []).join(' '),
-        (herb.compounds || []).join(' '),
+        (herb.activeCompounds || []).join(' '),
       ]
       const haystack = norm(fields.join(' '))
       if (query && !haystack.includes(query)) return false

--- a/src/components/CompoundCard.tsx
+++ b/src/components/CompoundCard.tsx
@@ -27,8 +27,7 @@ function getMechanism(compound: CompoundWithRefs): string {
     return compound.mechanism
   }
 
-  const legacyMechanism = (compound as Record<string, unknown>).mechanismOfAction
-  return typeof legacyMechanism === 'string' ? legacyMechanism : ''
+  return ''
 }
 
 function getWorkbookHero(compound: CompoundWithRefs): string {

--- a/src/components/EntityDatabasePage.tsx
+++ b/src/components/EntityDatabasePage.tsx
@@ -110,17 +110,13 @@ export default function EntityDatabasePage({
       const regions = [item.region, ...(item.regiontags || [])].filter(Boolean)
       regions.forEach(entry => regionSet.add(String(entry)))
 
-      const mechanisms = String(item.mechanism || (item as any).mechanismOfAction || '')
+      const mechanisms = String(item.mechanism || '')
         .split(/[;|]/)
         .map(entry => entry.trim())
         .filter(Boolean)
       mechanisms.forEach(entry => mechanismSet.add(entry))
 
-      const compounds = [
-        ...((item as any).activeCompounds || []),
-        ...(item.active_compounds || []),
-        ...(item.compounds || []),
-      ]
+      const compounds = [...((item as any).activeCompounds || [])]
         .map(entry => String(entry).trim())
         .filter(Boolean)
       compounds.forEach(entry => activeCompoundSet.add(entry))
@@ -134,7 +130,7 @@ export default function EntityDatabasePage({
       ].filter(Boolean)
       interactions.forEach(entry => interactionSet.add(String(entry)))
 
-      const legalValues = [item.legalStatus, item.legalstatus, item.legal].filter(Boolean)
+      const legalValues = [item.legalStatus].filter(Boolean)
       legalValues.forEach(entry => legalSet.add(String(entry)))
 
       const categories = [
@@ -205,19 +201,13 @@ export default function EntityDatabasePage({
       }
 
       if (mechanismFilter.length > 0) {
-        const mechanism = String(
-          item.mechanism || (item as any).mechanismOfAction || ''
-        ).toLowerCase()
+        const mechanism = String(item.mechanism || '').toLowerCase()
         const hasAny = mechanismFilter.some(entry => mechanism.includes(entry.toLowerCase()))
         if (!hasAny) return false
       }
 
       if (compoundFilter.length > 0) {
-        const compounds = [
-          ...((item as any).activeCompounds || []),
-          ...(item.active_compounds || []),
-          ...(item.compounds || []),
-        ]
+        const compounds = [...((item as any).activeCompounds || [])]
           .join(' ')
           .toLowerCase()
         const hasAny = compoundFilter.some(entry => compounds.includes(entry.toLowerCase()))
@@ -233,7 +223,7 @@ export default function EntityDatabasePage({
       }
 
       if (legalFilter.length > 0) {
-        const legal = String(item.legalStatus || item.legalstatus || item.legal || '').toLowerCase()
+        const legal = String(item.legalStatus || '').toLowerCase()
         const hasAny = legalFilter.some(entry => legal.includes(entry.toLowerCase()))
         if (!hasAny) return false
       }

--- a/src/components/HerbList.tsx
+++ b/src/components/HerbList.tsx
@@ -61,8 +61,8 @@ const HerbList: React.FC<Props> = ({
                     effects: h.effects,
                     mechanism: h.mechanism,
                     description: h.description,
-                    activeCompounds: h.compounds,
-                    therapeuticUses: h.therapeuticUses,
+                    activeCompounds: h.activeCompounds,
+                    therapeuticUses: h.traditionalUses,
                     maxLen: 130,
                   }) || 'Learn more about this herb and its potential uses.'
                 }

--- a/src/hooks/useHerbs.ts
+++ b/src/hooks/useHerbs.ts
@@ -26,7 +26,7 @@ export function useHerbs(): Herb[] {
       const missing: string[] = []
       if (!h.description) missing.push('description')
       if (!h.mechanism) missing.push('mechanism')
-      if (!(Array.isArray(h.compounds) && h.compounds.length)) missing.push('compounds')
+      if (!(Array.isArray(h.activeCompounds) && h.activeCompounds.length)) missing.push('activeCompounds')
       if (missing.length) {
         recordDevMessage('warning', `${herbName(h)} missing: ${missing.join(', ')}`)
       }

--- a/src/lib/herb-data.ts
+++ b/src/lib/herb-data.ts
@@ -225,33 +225,29 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
   const { data } = sanitizeHerbRecord(raw, { debug: import.meta.env.DEV })
   const context = readContextRecord(data)
   const safetyRecord = readSafetyRecord(data)
-  const common = cleanText(data.common ?? data.commonName ?? data.name) || ''
-  const scientific =
-    cleanText(data.scientific ?? data.latin ?? data.latinName ?? data.scientificName) || ''
+  const common = cleanText(data.name) || ''
+  const scientific = cleanText(data.scientificName) || ''
   const slug = String(data.slug || data.id || slugify(common || scientific || ''))
     .trim()
     .toLowerCase()
 
-  const primaryActions = splitClean(data.primaryActions ?? data.actions ?? data.effects ?? data.benefits)
+  const primaryActions = splitClean(data.primaryActions ?? data.effects)
   const contraindications = splitClean(data.contraindications)
   const interactions = splitClean(data.interactions)
-  const sideeffects = splitClean(data.sideEffects ?? data.sideeffects)
+  const sideeffects = splitClean(data.sideEffects)
   const safetyNotes = normalizeSafetyNotes(
     safetyRecord.caution,
     safetyRecord.notes,
     safetyRecord.summary,
     data.safetyNotes,
-    data.safety,
     data.contraindications,
     data.interactions,
-    data.sideEffects ?? data.sideeffects,
+    data.sideEffects,
   )
   const rawInteractionTags = splitClean(data.interactionTags)
   const rawInteractionNotes = splitClean(data.interactionNotes)
-  const traditionalUses = splitClean(data.traditionalUses ?? data.therapeuticUses)
-  const activeCompounds = splitClean(
-    data.activeCompounds ?? data.active_compounds ?? data.compounds,
-  )
+  const traditionalUses = splitClean(data.traditionalUses)
+  const activeCompounds = splitClean(data.activeCompounds)
   const sources = normalizeSources(data.sources)
   const researchEnrichment = normalizeResearchEnrichment(data.researchEnrichment)
   const productRecommendations = normalizeProductRecommendations(data.productRecommendations)
@@ -265,8 +261,6 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
   const mechanisms = normalizeMechanisms(
     data.mechanisms,
     data.mechanism,
-    data.mechanismOfAction,
-    data.pathwayTargets,
   )
   const mechanism = mechanisms.join('; ')
   const description =
@@ -274,9 +268,9 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
   const duration = cleanText(data.duration) || ''
   const dosage = cleanText(data.dosage) || ''
   const preparation = cleanText(data.preparation) || ''
-  const legalStatus = cleanText(data.legalStatus ?? data.legalstatus) || ''
+  const legalStatus = cleanText(data.legalStatus) || ''
   const region = cleanText(data.region) || ''
-  const category = cleanText(data.class ?? data.category) || ''
+  const category = cleanText(data.category) || ''
   const intensity = cleanText(data.intensity) || ''
   const relatedEntities = splitClean(data.relatedEntities ?? context.foundIn)
   const relatedCompounds = splitClean(data.relatedCompounds ?? context.relatedCompounds)
@@ -287,10 +281,8 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
       .filter(Boolean),
   )
   const identity = cleanText(data.identity) || ''
-  const categoryUseContext = cleanText(data.categoryUseContext ?? data.category_use_context) || ''
-  const evidenceLevel =
-    cleanText(data.evidenceLevel ?? data.evidence_level ?? safetyRecord.evidence ?? safetyRecord.confidence) ||
-    ''
+  const categoryUseContext = cleanText(data.categoryUseContext) || ''
+  const evidenceLevel = cleanText(data.evidenceLevel ?? safetyRecord.evidence ?? safetyRecord.confidence) || ''
   const benefits = splitClean(data.benefits ?? data.effects)
 
   return {
@@ -302,7 +294,7 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
     scientific,
     description,
     category,
-    class: cleanText(data.class) || '',
+    class: '',
     intensity,
     region,
     primaryActions,
@@ -321,8 +313,6 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
     preparation,
     sideeffects,
     activeCompounds,
-    compounds: activeCompounds,
-    active_compounds: activeCompounds,
     legalStatus,
     identity,
     categoryUseContext,
@@ -339,7 +329,7 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
       summary: description,
       description,
       whyItMatters: cleanText(data.whyItMatters ?? data.coreInsight ?? data.overview) || description,
-      primaryEffects: splitClean(data.primary_effects ?? data.primaryEffects ?? data.keyEffects ?? primaryActions),
+      primaryEffects: splitClean(data.primaryEffects ?? data.keyEffects ?? primaryActions),
       effects: primaryActions,
       contraindications,
       interactions,
@@ -357,13 +347,11 @@ function normalizeHerbSummaryRow(raw: Record<string, unknown>): HerbSummary {
   const slug = String(raw.slug || '')
     .trim()
     .toLowerCase()
-  const common = cleanText(raw.common ?? raw.commonName ?? raw.name) || ''
-  const scientific = cleanText(raw.scientific ?? raw.latin ?? raw.scientificName) || ''
-  const primaryActions = splitClean(
-    raw.primaryActions ?? raw.actions ?? raw.effects ?? raw.benefits,
-  )
-  const mechanisms = normalizeMechanisms(raw.mechanisms, raw.mechanism, raw.mechanismOfAction, raw.pathwayTargets)
-  const activeCompounds = splitClean(raw.activeCompounds ?? raw.compounds)
+  const common = cleanText(raw.name) || ''
+  const scientific = cleanText(raw.scientificName) || ''
+  const primaryActions = splitClean(raw.primaryActions ?? raw.effects)
+  const mechanisms = normalizeMechanisms(raw.mechanisms, raw.mechanism)
+  const activeCompounds = splitClean(raw.activeCompounds)
   const confidence = String(raw.confidence || '').toLowerCase()
   const confidenceLevel: Herb['confidence'] =
     confidence === 'high' || confidence === 'medium' ? confidence : 'low'
@@ -375,7 +363,7 @@ function normalizeHerbSummaryRow(raw: Record<string, unknown>): HerbSummary {
     common,
     scientific,
     category: cleanText(raw.category) || '',
-    class: cleanText(raw.class) || '',
+    class: '',
     confidence: confidenceLevel,
     summaryShort: cleanText(raw.summaryShort ?? raw.description ?? raw.summary ?? raw.hero ?? raw.coreInsight) || '',
     description: cleanText(raw.description ?? raw.summaryShort ?? raw.summary ?? raw.hero ?? raw.coreInsight) || '',
@@ -384,32 +372,19 @@ function normalizeHerbSummaryRow(raw: Record<string, unknown>): HerbSummary {
     mechanism: cleanText(raw.mechanism ?? mechanisms.join('; ')) || '',
     effects: primaryActions,
     activeCompounds,
-    compounds: activeCompounds,
     safetyNotes: cleanText(raw.safetyNotes ?? safetyRecord.summary ?? safetyRecord.caution) || '',
-    traditionalUses: splitClean(raw.traditionalUses ?? raw.therapeuticUses),
+    traditionalUses: splitClean(raw.traditionalUses),
     evidenceLevel: cleanText(raw.evidenceLevel ?? raw.confidence) || '',
     relatedHerbs: splitClean(raw.relatedHerbs),
     interactionTags: splitClean(raw.interactionTags),
     interactionNotes: splitClean(raw.interactionNotes),
     interactions: splitClean(raw.interactions),
     contraindications: splitClean(raw.contraindications),
-    mechanismOfAction: cleanText(raw.mechanismOfAction) || '',
     safety: cleanText(raw.safety ?? safetyRecord.caution ?? safetyRecord.summary) || '',
     sideEffects: cleanText(raw.sideEffects) || '',
     toxicity: cleanText(raw.toxicity) || '',
     tags: splitClean(raw.tags),
     region: cleanText(raw.region ?? context.region) || '',
-    legalstatus: cleanText(raw.legalstatus) || '',
-    commonName: cleanText(raw.commonName) || '',
-    activeConstituents: Array.isArray(raw.activeConstituents)
-      ? raw.activeConstituents
-          .map(entry =>
-            entry && typeof entry === 'object' && 'name' in entry
-              ? { name: cleanText((entry as { name?: unknown }).name) }
-              : null,
-          )
-          .filter((entry): entry is { name: string } => Boolean(entry?.name))
-      : undefined,
     sourceCount: Number.isFinite(Number(raw.sourceCount)) ? Number(raw.sourceCount) : undefined,
     hasInteractionData: Boolean(raw.hasInteractionData),
     hasEvidenceNotes: Boolean(raw.hasEvidenceNotes),

--- a/src/pages/HerbBlender.tsx
+++ b/src/pages/HerbBlender.tsx
@@ -167,8 +167,8 @@ export default function HerbBlender() {
                     effects: h.effects,
                     mechanism: h.mechanism,
                     description: h.description,
-                    activeCompounds: h.compounds,
-                    therapeuticUses: h.therapeuticUses,
+                    activeCompounds: h.activeCompounds,
+                    therapeuticUses: h.traditionalUses,
                     maxLen: 130,
                   }) || 'Learn more about this herb and its potential uses.'
                 }

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -29,7 +29,7 @@ export default function NotFound() {
           h.scientific,
           h.effects,
           (h.tags || []).join(' '),
-          (h.compounds || []).join(' '),
+          (h.activeCompounds || []).join(' '),
         ]
           .join(' ')
           .toLowerCase()


### PR DESCRIPTION
### Motivation
- Remove lingering runtime references and conditional fallbacks for obsolete herb/compound field names so pages/components render from the canonical schema only.
- Simplify rendering and filtering logic to reduce accidental dependency on legacy workbook shapes while keeping ingestion/exporter compatibility where necessary.
- Confine legacy compatibility to the exporter layer so runtime code can be cleaner and easier to reason about.

### Description
- Updated runtime normalization in `src/lib/herb-data.ts` to read canonical fields (`name`, `scientificName`, `activeCompounds`, `traditionalUses`, `legalStatus`, `mechanism`) and removed re-emission of legacy aliases and fallback reads. Files changed: `src/lib/herb-data.ts`, `src/components/EntityDatabasePage.tsx`, `src/components/HerbList.tsx`, `src/pages/HerbBlender.tsx`, `src/components/AdvancedSearch.tsx`, `src/pages/NotFound.tsx`, `src/hooks/useHerbs.ts`, and `src/components/CompoundCard.tsx`.
- Removed conditional branches and rendering fallbacks that referenced obsolete keys such as `commonName`, `scientific`/`latin*`, `active_compounds`/`compounds`, `therapeuticUses`, `mechanismOfAction`, and `legalstatus` in the touched runtime paths. (See `src/lib/herb-data.ts` and `src/components/EntityDatabasePage.tsx`.)
- Updated consumers to rely on canonical fields: herb cards/search blades now use `activeCompounds` and `traditionalUses`, dev diagnostics check for `activeCompounds`, and compound card mechanism fallback to `mechanismOfAction` was removed.
- Kept exporter/import compatibility logic intact (legacy workbook fallbacks and `--allow-legacy-fallback` behavior remain in `scripts/export-workbook-to-json.mjs`) so ingestion still supports older column names while runtime uses the permanent schema.

### Testing
- Ran the site build and compilation with `npm run build:compile` which completed successfully with no compile errors and prerender/verification steps passing. 
- Prebuild/data scripts ran as part of the build (workbook export and ingestion hooks), and the build reported successful prerender and publishing/verifications.
- All modified TypeScript/TSX files passed the repository pre-commit linting hooks during commit.
- No automated tests were added or changed in this pass; build+prerender validation succeeded.

Manual review items
- A follow-up repo-wide sweep is recommended because utility/reporting/discovery helpers still reference legacy keys in some places (e.g., `mechanismOfAction`, `compounds`) that were not changed in this focused pass.
- Decide when to remove remaining workbook legacy aliases from the exporter entirely (currently preserved intentionally for ingestion compatibility).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d0ccb1fc832388b1408f0e6b03c6)