### PR TITLE
Refactor homepage into trust-first scientific reference layout

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,91 +1,38 @@
-import { motion, useReducedMotion } from '@/lib/motion'
 import HeroCTA from './HeroCTA'
 
 export default function Hero() {
-  const reduceMotion = useReducedMotion()
-
-  const staggerVariants = {
-    hidden: {},
-    show: {
-      transition: {
-        staggerChildren: 0.1,
-      },
-    },
-  }
-
-  const childVariants = {
-    hidden: { opacity: 0, y: 10 },
-    show: {
-      opacity: 1,
-      y: 0,
-      transition: { duration: 0.4, ease: [0.22, 1, 0.36, 1] },
-    },
-  }
-
   return (
-    <div className='relative mx-auto mt-2 max-w-6xl px-4 pb-6 pt-10 sm:mt-4 sm:px-6 sm:pb-10 sm:pt-16'>
-      <div className="relative before:pointer-events-none before:absolute before:inset-0 before:rounded-[1.75rem] before:bg-[conic-gradient(from_180deg_at_50%_50%,rgba(14,207,179,0.22)_0deg,rgba(167,139,250,0.2)_130deg,rgba(14,207,179,0.08)_260deg,rgba(14,207,179,0.22)_360deg)] before:opacity-70 before:[mask:linear-gradient(#fff_0_0)_content-box,linear-gradient(#fff_0_0)] before:[mask-composite:xor] before:p-px before:animate-[spin_18s_linear_infinite]">
-        <section className='premium-panel relative overflow-hidden rounded-[1.75rem] px-5 py-7 sm:px-10 sm:py-12'>
-          <div className='pointer-events-none absolute -left-12 -top-12 h-72 w-72 rounded-full bg-violet-500/15 blur-[80px] animate-[pulse_4s_ease-in-out_infinite]' />
-          <div className='pointer-events-none absolute -bottom-16 -right-8 h-64 w-64 rounded-full bg-teal-400/12 blur-[64px]' />
-
-          <motion.div
-            initial={reduceMotion ? undefined : { opacity: 0, y: 14 }}
-            animate={reduceMotion ? undefined : { opacity: 1, y: 0 }}
-            transition={reduceMotion ? undefined : { duration: 0.45, ease: [0.22, 1, 0.36, 1] }}
-            className='relative grid gap-8 lg:grid-cols-[1fr_auto] lg:items-end'
-          >
-            <motion.div
-              className='space-y-5'
-              variants={staggerVariants}
-              initial={reduceMotion ? undefined : 'hidden'}
-              animate={reduceMotion ? undefined : 'show'}
+    <div className='mx-auto mt-2 max-w-6xl px-4 pb-4 pt-8 sm:mt-4 sm:px-6 sm:pb-8 sm:pt-12'>
+      <section className='premium-panel rounded-3xl px-5 py-8 sm:px-10 sm:py-10'>
+        <div className='grid gap-7 lg:grid-cols-[1fr_auto] lg:items-end'>
+          <div className='space-y-4'>
+            <p className='section-label'>The Hippie Scientist · Science-first reference</p>
+            <h1
+              className='tracking-tight text-white'
+              style={{
+                fontFamily: 'var(--font-display)',
+                fontSize: 'clamp(2.25rem, 5.2vw, 4.3rem)',
+                lineHeight: 0.95,
+              }}
             >
-              <motion.p variants={childVariants} className='section-label'>
-                The Hippie Scientist · Research Archive
-              </motion.p>
-              <motion.h1
-                variants={childVariants}
-                className='tracking-tight text-white'
-                style={{
-                  fontFamily: 'var(--font-display)',
-                  fontSize: 'clamp(2.6rem, 5.5vw, 5rem)',
-                  lineHeight: 0.92,
-                }}
-              >
-                Precision-first field guide for{' '}
-                <span
-                  className='text-[var(--accent-teal)]'
-                  style={{ textShadow: '0 0 32px rgba(14,207,179,0.4)' }}
-                >
-                  psychoactive botanicals
-                </span>
-              </motion.h1>
-              <motion.p variants={childVariants} className='max-w-xl text-base leading-relaxed text-white/70 sm:text-lg'>
-                Evidence-weighted herb and compound profiles with safety framing, mechanism context,
-                and practical decision tools for careful exploration.
-              </motion.p>
-              <motion.div variants={childVariants}>
-                <HeroCTA />
-              </motion.div>
-            </motion.div>
+              Evidence-first herb and compound reference
+            </h1>
+            <p className='max-w-2xl text-sm leading-relaxed text-white/74 sm:text-base'>
+              Browse herbs, compounds, and mechanism signals in one place with transparent confidence framing and safety context.
+            </p>
+            <HeroCTA />
+          </div>
 
-            <motion.div
-              variants={reduceMotion ? undefined : childVariants}
-              initial={reduceMotion ? undefined : 'hidden'}
-              animate={reduceMotion ? undefined : 'show'}
-              transition={reduceMotion ? undefined : { delay: 0.1 }}
-              className='browse-shell relative border-0 border-l-2 border-l-[var(--accent-teal)]/30 bg-transparent p-4 pl-5 shadow-none sm:p-5 sm:pl-6 lg:max-w-[300px]'
-            >
-              <p className='section-label'>Live Archive</p>
-              <div className='mt-3 space-y-2 text-sm text-white/85'>
-                <p>Herbs, compounds, interactions, and blend scenarios.</p>
-                <p className='text-white/62'>Built for responsible decisions, not hype cycles.</p>
-              </div>
-            </motion.div>
-          </motion.div>
-        </section>
-      </div>
+          <aside className='browse-shell border border-white/12 bg-white/[0.02] p-4 sm:p-5 lg:max-w-[320px]'>
+            <p className='section-label'>How to use this archive</p>
+            <ul className='mt-3 space-y-2 text-sm text-white/80'>
+              <li>Start with a herb or compound profile.</li>
+              <li>Cross-check mechanism clues against source quality.</li>
+              <li>Review safety cautions and interactions before decisions.</li>
+            </ul>
+          </aside>
+        </div>
+      </section>
     </div>
   )
 }

--- a/src/components/HeroCTA.tsx
+++ b/src/components/HeroCTA.tsx
@@ -7,20 +7,20 @@ export default function HeroCTA() {
   return (
     <div className='w-full space-y-3'>
       <div className='flex flex-col gap-2 sm:flex-row'>
-        <a href='#effect-search' className={`${baseButtonClasses} btn-primary`}>
-          Start Effect Search
-        </a>
-        <Link to='/herbs' className={`${baseButtonClasses} btn-secondary`}>
-          Browse Archive
+        <Link to='/herbs' className={`${baseButtonClasses} btn-primary`}>
+          Browse herbs
+        </Link>
+        <Link to='/compounds' className={`${baseButtonClasses} btn-secondary`}>
+          Browse compounds
         </Link>
       </div>
       <div className='flex flex-wrap gap-3 text-xs text-white/62'>
-        <Link to='/interactions' className='transition hover:text-white'>
-          Interaction Checker
-        </Link>
+        <a href='#mechanism-explorer' className='transition hover:text-white'>
+          Mechanism explorer
+        </a>
         <span>•</span>
-        <Link to='/build' className='transition hover:text-white'>
-          Blend Builder
+        <Link to='/interactions' className='transition hover:text-white'>
+          Interaction checker
         </Link>
       </div>
     </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,66 +1,68 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import Meta from '../components/Meta'
-import EmailCapture from '@/components/EmailCapture'
 import Hero from '@/components/Hero'
-import EffectExplorer from '@/components/EffectExplorer'
 import { getHomepageData, type HomepageFeaturedItem } from '@/lib/homepage-data'
-import { useRecentlyViewed, useSavedItems } from '@/lib/growth'
-import { readStorage } from '@/utils/storageState'
-import GuideDownloadCard from '@/components/GuideDownloadCard'
-import { FEATURED_COLLECTION_SLUGS, SEO_COLLECTIONS } from '@/data/seoCollections'
 import { organizationJsonLd, websiteJsonLd } from '@/lib/seo'
 import { trackHomepageEntityClick } from '@/lib/contentJourneyTracking'
 
-type RecentBlend = {
-  id: string
-  intent: 'sleep' | 'focus' | 'relaxation'
-  herbSlugs: string[]
-  createdAt: string
+type MechanismTopic = {
+  label: string
+  query: string
+  description: string
 }
 
-type RecentInteractionCheck = {
-  id: string
-  checkedAt: string
-  herbSlugs: string[]
-  warningCount: number
+const MECHANISM_TOPICS: MechanismTopic[] = [
+  { label: 'GABA signaling', query: 'gaba', description: 'Sedative and anxiolytic pathways.' },
+  { label: 'Serotonin signaling', query: 'serotonin', description: 'Mood, perception, and regulation pathways.' },
+  { label: 'Dopamine signaling', query: 'dopamine', description: 'Motivation and reward-associated pathways.' },
+  { label: 'Cholinergic pathways', query: 'acetylcholine', description: 'Attention, memory, and cognitive signaling.' },
+]
+
+function conciseBlurb(value: string, fallback: string) {
+  const normalized = String(value || '')
+    .replace(/\s+/g, ' ')
+    .trim()
+  if (!normalized) return fallback
+  if (normalized.length <= 145) return normalized
+  return `${normalized.slice(0, 142).trimEnd()}...`
 }
 
-const RECENT_STACKS_KEY = 'ths:recent-herb-stacks'
-const INTERACTION_HISTORY_KEY = 'ths:interaction-check-history'
+function countMechanismMatches(records: Array<{ mechanism?: string }>, query: string) {
+  const needle = query.toLowerCase()
+  return records.filter(entry => String(entry.mechanism || '').toLowerCase().includes(needle)).length
+}
+
+function entityHref(item: HomepageFeaturedItem) {
+  return item.kind === 'herb' ? `/herbs/${item.slug}` : `/compounds/${item.slug}`
+}
 
 export default function Home() {
   const homepageData = useMemo(() => getHomepageData(), [])
-  const [featured] = useState<HomepageFeaturedItem[]>(homepageData.featured)
-  const [curated] = useState<HomepageFeaturedItem[]>(homepageData.curated)
-  const { items } = useSavedItems()
-  const recent = useRecentlyViewed()
-  const [recentBlends, setRecentBlends] = useState<RecentBlend[]>([])
-  const [recentChecks, setRecentChecks] = useState<RecentInteractionCheck[]>([])
-
-  useEffect(() => {
-    setRecentBlends(readStorage<RecentBlend[]>(RECENT_STACKS_KEY, []))
-    setRecentChecks(readStorage<RecentInteractionCheck[]>(INTERACTION_HISTORY_KEY, []))
-  }, [])
-
-  const dailyDiscovery = useMemo(() => featured[0] ?? null, [featured])
-  const featuredCollections = useMemo(
+  const generatedDateLabel = useMemo(
     () =>
-      FEATURED_COLLECTION_SLUGS.map(slug =>
-        SEO_COLLECTIONS.find(collection => collection.slug === slug)
-      ).filter((collection): collection is (typeof SEO_COLLECTIONS)[number] => Boolean(collection)),
-    []
+      new Date(homepageData.generatedAt).toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      }),
+    [homepageData.generatedAt],
   )
-  const recentHerbs = useMemo(
-    () => recent.filter(item => item.type === 'herb').slice(0, 12),
-    [recent]
+
+  const featuredHerbs = useMemo(
+    () => homepageData.featured.filter(item => item.kind === 'herb').slice(0, 3),
+    [homepageData.featured],
+  )
+  const featuredCompounds = useMemo(
+    () => homepageData.featured.filter(item => item.kind === 'compound').slice(0, 3),
+    [homepageData.featured],
   )
 
   return (
     <>
       <Meta
-        title='The Hippie Scientist — Mindful Exploration of Psychoactive Herbs'
-        description='Science-based harm-reduction research on psychoactive herbs and plant compounds. Browse 100+ herbs, check interactions, build blends, and read independent field notes.'
+        title='The Hippie Scientist — Science-first Herb & Compound Reference'
+        description='Science-first herb and compound reference with mechanism context, confidence framing, and safety notes.'
         path='/'
         pageType='website'
         jsonLd={[websiteJsonLd(), organizationJsonLd()]}
@@ -68,161 +70,171 @@ export default function Home() {
 
       <Hero />
 
-      <section className='container mx-auto max-w-6xl px-4 py-10 sm:px-6 sm:py-16'>
-        <div className='grid gap-4 md:grid-cols-[1.35fr_1fr]'>
-          <div className='premium-panel p-5 sm:p-6'>
-            <p className='section-label'>Immediate next step</p>
-            <h2 className='mt-3 text-2xl font-semibold text-white sm:text-3xl'>Where to start</h2>
-            <p className='mt-3 max-w-2xl text-sm text-white/74 sm:text-base'>
-              Search by outcome first, then pressure-test safety using interactions and full context pages before experimenting.
-            </p>
-            <div className='mt-5 flex flex-wrap gap-2.5'>
-              <a href='#effect-search' className='btn-primary'>Open Effect Search</a>
-              <Link to='/interactions' className='btn-secondary'>Run Interaction Check</Link>
-            </div>
-          </div>
-
-          <div className='browse-shell p-5 sm:p-6'>
-            <p className='section-label'>Knowledge scope</p>
-            <nav aria-label='Site stats' className='mt-3 grid grid-cols-1 gap-2.5'>
-              <Link
-                to='/herbs'
-                className='group flex items-center gap-3 rounded-xl border border-white/12 bg-white/[0.035] px-4 py-3 text-sm text-white/85 transition-all duration-200 hover:border-white/24 hover:bg-white/[0.07]'
-                aria-label={`${homepageData.counts.herbs} psychoactive herbs`}
-              >
-                <span className='font-mono text-base font-medium tabular-nums text-amber-300'>{homepageData.counts.herbs}+</span>
-                <span className='leading-tight text-white/82'>psychoactive herbs</span>
-                <span aria-hidden className='ml-auto text-white/55 transition group-hover:text-white/85'>
-                  →
-                </span>
-              </Link>
-              <Link
-                to='/compounds'
-                className='group flex items-center gap-3 rounded-xl border border-white/12 bg-white/[0.035] px-4 py-3 text-sm text-white/85 transition-all duration-200 hover:border-white/24 hover:bg-white/[0.07]'
-                aria-label={`${homepageData.counts.compounds} active compounds`}
-              >
-                <span className='font-mono text-base font-medium tabular-nums text-amber-300'>{homepageData.counts.compounds}+</span>
-                <span className='leading-tight text-white/82'>active compounds</span>
-                <span aria-hidden className='ml-auto text-white/55 transition group-hover:text-white/85'>
-                  →
-                </span>
-              </Link>
-              <Link
-                to='/blog'
-                className='group flex items-center gap-3 rounded-xl border border-white/12 bg-white/[0.035] px-4 py-3 text-sm text-white/85 transition-all duration-200 hover:border-white/24 hover:bg-white/[0.07]'
-                aria-label={`${homepageData.counts.articles} research notes`}
-              >
-                <span className='font-mono text-base font-medium tabular-nums text-amber-300'>{homepageData.counts.articles}+</span>
-                <span className='leading-tight text-white/82'>research notes</span>
-                <span aria-hidden className='ml-auto text-white/55 transition group-hover:text-white/85'>
-                  →
-                </span>
-              </Link>
-            </nav>
-          </div>
+      <section className='container mx-auto max-w-6xl px-4 py-8 sm:px-6 sm:py-10'>
+        <p className='section-label'>Browse entry points</p>
+        <div className='mt-4 grid gap-3 sm:grid-cols-2 xl:grid-cols-4'>
+          <Link to='/herbs' className='premium-panel p-4 transition-colors hover:border-white/20'>
+            <p className='section-label'>Herbs</p>
+            <p className='mt-2 text-2xl font-semibold text-amber-200'>{homepageData.counts.herbs}</p>
+            <p className='mt-2 text-sm text-white/72'>Browse herb profiles with effects, confidence, and safety context.</p>
+          </Link>
+          <Link to='/compounds' className='premium-panel p-4 transition-colors hover:border-white/20'>
+            <p className='section-label'>Compounds</p>
+            <p className='mt-2 text-2xl font-semibold text-amber-200'>{homepageData.counts.compounds}</p>
+            <p className='mt-2 text-sm text-white/72'>Review compound mechanisms, linked herbs, and risk notes.</p>
+          </Link>
+          <Link to='/herbs?query=mechanism' className='premium-panel p-4 transition-colors hover:border-white/20'>
+            <p className='section-label'>Mechanisms</p>
+            <p className='mt-2 text-2xl font-semibold text-amber-200'>Explore</p>
+            <p className='mt-2 text-sm text-white/72'>Search mechanism language across herb entries and follow links to details.</p>
+          </Link>
+          <Link to='/blog' className='premium-panel p-4 transition-colors hover:border-white/20'>
+            <p className='section-label'>Notebook</p>
+            <p className='mt-2 text-2xl font-semibold text-amber-200'>{homepageData.counts.articles}</p>
+            <p className='mt-2 text-sm text-white/72'>Read research notebooks documenting assumptions, caveats, and updates.</p>
+          </Link>
         </div>
       </section>
 
-      <EffectExplorer herbs={homepageData.effectExplorerHerbs} />
+      <section className='container mx-auto max-w-6xl px-4 pb-8 sm:px-6'>
+        <div className='browse-shell p-4 sm:p-5'>
+          <p className='section-label'>Trust strip</p>
+          <div className='mt-3 grid gap-2 md:grid-cols-3'>
+            {homepageData.trustBadges.slice(0, 3).map(badge => (
+              <p key={badge} className='rounded-xl border border-white/12 bg-white/[0.02] px-3 py-2 text-sm text-white/76'>
+                {badge}
+              </p>
+            ))}
+          </div>
+          <p className='mt-3 text-xs text-white/55'>Homepage data snapshot: {generatedDateLabel}</p>
+        </div>
+      </section>
 
-      <section className='container mx-auto max-w-6xl px-4 py-10 sm:px-6'>
-        <p className='section-label'>Editor curation</p>
-        <h2 className='font-display mb-6 text-2xl text-white sm:text-3xl'>Editor&apos;s Picks</h2>
-        <div className='lux-grid sm:grid-cols-2 lg:grid-cols-3'>
-          {curated.slice(0, 3).map(item => (
+      <section className='container mx-auto max-w-6xl px-4 py-8 sm:px-6'>
+        <div className='mb-4 flex items-end justify-between gap-3'>
+          <div>
+            <p className='section-label'>Featured herbs</p>
+            <h2 className='mt-1 text-2xl text-white'>Herb profiles to start with</h2>
+          </div>
+          <Link to='/herbs' className='text-sm text-cyan-200 hover:text-cyan-100'>
+            View all herbs →
+          </Link>
+        </div>
+        <div className='grid gap-3 md:grid-cols-3'>
+          {featuredHerbs.map(item => (
             <Link
-              key={`starter-${item.kind}-${item.slug}`}
-              to={item.kind === 'herb' ? `/herbs/${item.slug}` : `/compounds/${item.slug}`}
-              className='premium-panel block h-full p-5 transition-all duration-200 hover:-translate-y-0.5 hover:border-white/20'
+              key={item.slug}
+              to={entityHref(item)}
+              className='premium-panel flex h-full flex-col p-4 transition-colors hover:border-white/20'
               onClick={() =>
                 trackHomepageEntityClick({
                   targetType: item.kind,
                   targetSlug: item.slug,
-                  placement: 'popular_paths_starter_profile',
+                  placement: 'featured_herbs',
                 })
               }
             >
-              <p className='section-label'>{item.kind} spotlight</p>
-              <h3 className='mt-2 text-xl font-semibold text-white'>{item.name}</h3>
-              <p className='mt-3 line-clamp-3 text-sm text-white/74'>{item.blurb}</p>
-              <p className='mt-4 text-xs tracking-[0.14em] text-cyan-200/80 uppercase'>{item.qualityBadge}</p>
+              <p className='section-label'>{item.qualityBadge}</p>
+              <h3 className='mt-2 text-lg font-semibold text-white'>{item.name}</h3>
+              <p className='mt-2 text-sm text-white/73'>{conciseBlurb(item.blurb, 'Open profile for mechanism and safety notes.')}</p>
+              <span className='mt-4 text-xs text-cyan-200'>Open herb profile →</span>
             </Link>
           ))}
         </div>
       </section>
 
-      {dailyDiscovery && (
-        <section className='container mx-auto max-w-6xl px-4 pb-8 sm:px-6'>
-          <div className='premium-panel p-6 sm:p-8'>
-            <p className='section-label'>Today&apos;s discovery</p>
-            <h2 className='mt-3 text-3xl text-white sm:text-4xl'>{dailyDiscovery.name}</h2>
-            <p className='mt-3 max-w-3xl text-sm text-white/78 sm:text-base'>{dailyDiscovery.blurb}</p>
-            <div className='mt-5 flex flex-wrap gap-2'>
-              <Link
-                to={dailyDiscovery.kind === 'herb' ? `/herbs/${dailyDiscovery.slug}` : `/compounds/${dailyDiscovery.slug}`}
-                className='btn-primary'
-              >
-                Read full breakdown
-              </Link>
-              <span className='ds-pill'>{dailyDiscovery.qualityBadge}</span>
-            </div>
+      <section className='container mx-auto max-w-6xl px-4 py-2 sm:px-6 sm:py-4'>
+        <div className='mb-4 flex items-end justify-between gap-3'>
+          <div>
+            <p className='section-label'>Featured compounds</p>
+            <h2 className='mt-1 text-2xl text-white'>Compound entries from the archive</h2>
           </div>
-        </section>
-      )}
-
-      <section className='container mx-auto max-w-6xl px-4 py-4 sm:px-6'>
-        <GuideDownloadCard
-          eyebrow='Safety download'
-          title='Unknown Compound Survival Guide'
-          description='Get a practical framework for unknown or uncertain compounds, including a decision tree and stop/go checks.'
-          buttonText='Download the Free Guide'
-          fileUrl='/downloads/unknown-compound-survival-guide.pdf'
-          footer={<Link to='/guides/unknown-compound-survival-guide' className='text-cyan-200 hover:text-cyan-100'>See full guide overview →</Link>}
-        />
-      </section>
-
-      <section className='container mx-auto max-w-6xl px-4 py-10 sm:px-6'>
-        <h2 className='font-display mb-6 text-2xl text-white sm:text-3xl'>Browse Collections</h2>
-        <div className='grid gap-4 sm:grid-cols-2'>
-          {featuredCollections.map(collection => (
+          <Link to='/compounds' className='text-sm text-cyan-200 hover:text-cyan-100'>
+            View all compounds →
+          </Link>
+        </div>
+        <div className='grid gap-3 md:grid-cols-3'>
+          {featuredCompounds.map(item => (
             <Link
-              key={collection.slug}
-              to={`/collections/${collection.slug}`}
-              className='neo-card block p-4 text-sm font-medium text-white/88 transition-colors hover:text-white'
+              key={item.slug}
+              to={entityHref(item)}
+              className='premium-panel flex h-full flex-col p-4 transition-colors hover:border-white/20'
+              onClick={() =>
+                trackHomepageEntityClick({
+                  targetType: item.kind,
+                  targetSlug: item.slug,
+                  placement: 'featured_compounds',
+                })
+              }
             >
-              {collection.title}
+              <p className='section-label'>{item.qualityBadge}</p>
+              <h3 className='mt-2 text-lg font-semibold text-white'>{item.name}</h3>
+              <p className='mt-2 text-sm text-white/73'>{conciseBlurb(item.blurb, 'Open profile for source-backed mechanism context.')}</p>
+              <span className='mt-4 text-xs text-cyan-200'>Open compound profile →</span>
             </Link>
           ))}
         </div>
       </section>
 
-      {items.length > 0 && (
-        <section className='container mx-auto max-w-6xl px-4 pb-8 sm:px-6'>
-          <p className='section-label'>Recently Viewed</p>
-          <div className='mt-3 flex gap-2 overflow-x-auto pb-1'>
-            {recentHerbs.map(item => (
+      <section id='mechanism-explorer' className='container mx-auto max-w-6xl px-4 py-10 sm:px-6'>
+        <p className='section-label'>Mechanism explorer</p>
+        <h2 className='mt-1 text-2xl text-white'>Start from pathway-level questions</h2>
+        <p className='mt-2 max-w-3xl text-sm text-white/73'>
+          Jump into mechanism-related terms found in current herb records. Use these as a first pass, then validate on full profile pages.
+        </p>
+        <div className='mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4'>
+          {MECHANISM_TOPICS.map(topic => {
+            const matchCount = countMechanismMatches(homepageData.effectExplorerHerbs, topic.query)
+            return (
               <Link
-                key={`${item.type}-${item.slug}`}
-                to={item.href}
-                className='shrink-0 rounded-full border border-white/12 bg-white/[0.035] px-3 py-1.5 text-xs font-medium text-white/85 transition-colors hover:border-white/24 hover:text-white'
+                key={topic.query}
+                to={`/herbs?query=${encodeURIComponent(topic.query)}`}
+                className='browse-shell p-4 transition-colors hover:border-white/20'
               >
-                {item.title}
+                <p className='text-sm font-semibold text-white'>{topic.label}</p>
+                <p className='mt-1 text-xs text-white/64'>{topic.description}</p>
+                <p className='mt-3 text-xs text-amber-200'>{matchCount} herb records mention this term</p>
               </Link>
-            ))}
-          </div>
-          {(recentBlends.length > 0 || recentChecks.length > 0) && (
-            <p className='mt-3 text-xs text-white/48'>
-              Also tracked: {recentBlends.length} recent blends and {recentChecks.length} interaction checks.
-            </p>
-          )}
-        </section>
-      )}
+            )
+          })}
+        </div>
+      </section>
 
-      <EmailCapture
-        title='Get one new herb insight per day'
-        subtitle='Day 1: beginner blend guide. Day 2+: a short daily herb or compound insight with a direct link back to the full breakdown.'
-        buttonLabel='Start daily insights'
-      />
+      <section className='container mx-auto max-w-6xl px-4 pb-8 sm:px-6'>
+        <div className='premium-panel p-5 sm:p-6'>
+          <p className='section-label'>Research notebook</p>
+          <h2 className='mt-2 text-2xl text-white'>How the archive evolves</h2>
+          <p className='mt-3 max-w-3xl text-sm text-white/74'>
+            The research notebook tracks data updates, pipeline changes, and evidence caveats so readers can audit why entries changed.
+          </p>
+          <div className='mt-4 flex flex-wrap gap-2.5'>
+            <Link to='/blog' className='btn-secondary'>
+              Open research notebook
+            </Link>
+            <Link to='/data-report' className='btn-secondary'>
+              View data report
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className='container mx-auto max-w-6xl px-4 pb-12 sm:px-6'>
+        <div className='browse-shell p-5 sm:p-6'>
+          <p className='section-label'>Methodology</p>
+          <h2 className='mt-2 text-2xl text-white'>How confidence and safety framing work</h2>
+          <p className='mt-3 max-w-3xl text-sm text-white/74'>
+            Read the methodology before acting on any entry. Confidence labels are evidence framing, not treatment recommendations.
+          </p>
+          <div className='mt-4 flex flex-wrap gap-2.5'>
+            <Link to='/methodology' className='btn-primary'>
+              Read methodology
+            </Link>
+            <Link to='/interactions' className='btn-secondary'>
+              Run interaction check
+            </Link>
+          </div>
+        </div>
+      </section>
     </>
   )
 }


### PR DESCRIPTION
### Motivation
- Replace a noisy, marketing-forward homepage with a calm, trust-first front door that immediately communicates a science-first herb/compound reference and clear browse paths. 
- Preserve the permanent schema and rely only on already-generated homepage payload fields (no schema changes). 

### Description
- Rebuilt the homepage to the requested hierarchy: Hero → Browse entry points → Trust strip → Featured herbs → Featured compounds → Mechanism explorer → Research notebook → Methodology, implemented in `src/pages/Home.tsx`. 
- Simplified the hero by removing animated gradients/motion and sharpening copy, and added a concise “how to use” aside in `src/components/Hero.tsx`. 
- Updated CTAs in `src/components/HeroCTA.tsx` to route to `'/herbs'`, `'/compounds'`, the mechanism explorer anchor, and the interaction checker. 
- Removed or simplified noisy sections (effect explorer embed, editor picks/daily discovery, guide download card, collections grid, recently viewed, and email capture) and added lightweight mechanism topic entry points that count matches against `effectExplorerHerbs[].mechanism` from the generated homepage payload. 
- Files changed: `src/pages/Home.tsx`, `src/components/Hero.tsx`, `src/components/HeroCTA.tsx`.

### Testing
- Ran the build/compile: `npm run build:compile`, which completed successfully (Vite build + prerender steps passed) with non-blocking bundle-size warnings. 
- Pre-commit hooks and linting ran during commit and `eslint --max-warnings=0` passed for the touched files. 
- Verified that the homepage uses only existing generated data fields (`counts`, `trustBadges`, `featured`, `effectExplorerHerbs`, `generatedAt`) and that no JSON/schema files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4d5a8cef08323bdca1cec9d18fa28)