### PR TITLE
Align herb runtime normalization to permanent monograph schema

### DIFF
--- a/src/hooks/useFilteredHerbs.ts
+++ b/src/hooks/useFilteredHerbs.ts
@@ -41,7 +41,6 @@ export function useFilteredHerbs(herbs: Herb[], options: Options = {}) {
           { name: 'common', weight: 0.8 },
           { name: 'nameNorm', weight: 0.7 },
           { name: 'scientific', weight: 0.7 },
-          { name: 'scientificname', weight: 0.6 },
           { name: 'compounds', weight: 0.5 },
           { name: 'tags', weight: 0.4 },
         ],

--- a/src/lib/herb-data.ts
+++ b/src/lib/herb-data.ts
@@ -199,32 +199,8 @@ function normalizeProductRecommendations(value: unknown): ProductRecommendation[
     .slice(0, 2)
 }
 
-function readContextRecord(data: Record<string, unknown>): Record<string, unknown> {
-  const context = data.context
-  if (typeof context === 'string') {
-    const trimmed = context.trim()
-    if (!trimmed) return {}
-    try {
-      const parsed = JSON.parse(trimmed)
-      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
-        ? (parsed as Record<string, unknown>)
-        : {}
-    } catch {
-      return {}
-    }
-  }
-  return context && typeof context === 'object' ? (context as Record<string, unknown>) : {}
-}
-
-function readSafetyRecord(data: Record<string, unknown>): Record<string, unknown> {
-  const safety = data.safety
-  return safety && typeof safety === 'object' ? (safety as Record<string, unknown>) : {}
-}
-
 function normalizeHerbRow(raw: Record<string, unknown>): Herb {
   const { data } = sanitizeHerbRecord(raw, { debug: import.meta.env.DEV })
-  const context = readContextRecord(data)
-  const safetyRecord = readSafetyRecord(data)
   const common = cleanText(data.name) || ''
   const scientific = cleanText(data.scientificName) || ''
   const slug = String(data.slug || data.id || slugify(common || scientific || ''))
@@ -236,9 +212,6 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
   const interactions = splitClean(data.interactions)
   const sideeffects = splitClean(data.sideEffects)
   const safetyNotes = normalizeSafetyNotes(
-    safetyRecord.caution,
-    safetyRecord.notes,
-    safetyRecord.summary,
     data.safetyNotes,
     data.contraindications,
     data.interactions,
@@ -263,8 +236,7 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
     data.mechanism,
   )
   const mechanism = mechanisms.join('; ')
-  const description =
-    cleanText(data.description ?? data.summary ?? data.hero ?? data.intro ?? data.coreInsight) || ''
+  const description = cleanText(data.description ?? data.summary) || ''
   const duration = cleanText(data.duration) || ''
   const dosage = cleanText(data.dosage) || ''
   const preparation = cleanText(data.preparation) || ''
@@ -272,8 +244,8 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
   const region = cleanText(data.region) || ''
   const category = cleanText(data.category) || ''
   const intensity = cleanText(data.intensity) || ''
-  const relatedEntities = splitClean(data.relatedEntities ?? context.foundIn)
-  const relatedCompounds = splitClean(data.relatedCompounds ?? context.relatedCompounds)
+  const relatedEntities = splitClean(data.relatedEntities)
+  const relatedCompounds = splitClean(data.relatedCompounds)
   const relatedHerbs = splitClean(data.relatedHerbs).concat(
     relatedEntities
       .filter(entry => entry.toLowerCase().startsWith('herb:'))
@@ -282,7 +254,7 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
   )
   const identity = cleanText(data.identity) || ''
   const categoryUseContext = cleanText(data.categoryUseContext) || ''
-  const evidenceLevel = cleanText(data.evidenceLevel ?? safetyRecord.evidence ?? safetyRecord.confidence) || ''
+  const evidenceLevel = cleanText(data.evidenceLevel) || ''
   const benefits = splitClean(data.benefits ?? data.effects)
 
   return {
@@ -328,8 +300,8 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
       name: common || scientific || slug,
       summary: description,
       description,
-      whyItMatters: cleanText(data.whyItMatters ?? data.coreInsight ?? data.overview) || description,
-      primaryEffects: splitClean(data.primaryEffects ?? data.keyEffects ?? primaryActions),
+      whyItMatters: cleanText(data.whyItMatters) || description,
+      primaryEffects: splitClean(data.primaryEffects ?? primaryActions),
       effects: primaryActions,
       contraindications,
       interactions,
@@ -342,8 +314,6 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
 }
 
 function normalizeHerbSummaryRow(raw: Record<string, unknown>): HerbSummary {
-  const context = readContextRecord(raw)
-  const safetyRecord = readSafetyRecord(raw)
   const slug = String(raw.slug || '')
     .trim()
     .toLowerCase()
@@ -365,14 +335,14 @@ function normalizeHerbSummaryRow(raw: Record<string, unknown>): HerbSummary {
     category: cleanText(raw.category) || '',
     class: '',
     confidence: confidenceLevel,
-    summaryShort: cleanText(raw.summaryShort ?? raw.description ?? raw.summary ?? raw.hero ?? raw.coreInsight) || '',
-    description: cleanText(raw.description ?? raw.summaryShort ?? raw.summary ?? raw.hero ?? raw.coreInsight) || '',
+    summaryShort: cleanText(raw.summaryShort ?? raw.description ?? raw.summary) || '',
+    description: cleanText(raw.description ?? raw.summaryShort ?? raw.summary) || '',
     primaryActions,
     mechanisms,
     mechanism: cleanText(raw.mechanism ?? mechanisms.join('; ')) || '',
     effects: primaryActions,
     activeCompounds,
-    safetyNotes: cleanText(raw.safetyNotes ?? safetyRecord.summary ?? safetyRecord.caution) || '',
+    safetyNotes: cleanText(raw.safetyNotes) || '',
     traditionalUses: splitClean(raw.traditionalUses),
     evidenceLevel: cleanText(raw.evidenceLevel ?? raw.confidence) || '',
     relatedHerbs: splitClean(raw.relatedHerbs),
@@ -380,11 +350,11 @@ function normalizeHerbSummaryRow(raw: Record<string, unknown>): HerbSummary {
     interactionNotes: splitClean(raw.interactionNotes),
     interactions: splitClean(raw.interactions),
     contraindications: splitClean(raw.contraindications),
-    safety: cleanText(raw.safety ?? safetyRecord.caution ?? safetyRecord.summary) || '',
+    safety: cleanText(raw.safety) || '',
     sideEffects: cleanText(raw.sideEffects) || '',
     toxicity: cleanText(raw.toxicity) || '',
     tags: splitClean(raw.tags),
-    region: cleanText(raw.region ?? context.region) || '',
+    region: cleanText(raw.region) || '',
     sourceCount: Number.isFinite(Number(raw.sourceCount)) ? Number(raw.sourceCount) : undefined,
     hasInteractionData: Boolean(raw.hasInteractionData),
     hasEvidenceNotes: Boolean(raw.hasEvidenceNotes),

--- a/src/lib/workbookRender.ts
+++ b/src/lib/workbookRender.ts
@@ -35,7 +35,7 @@ export function resolveHeroSummary(
   input: Record<string, unknown> | undefined | null,
   maxSentences = 1,
 ): string {
-  const summary = sanitizeSummaryText(input?.hero || input?.summary || input?.description || '', maxSentences)
+  const summary = sanitizeSummaryText(input?.summary || input?.description || '', maxSentences)
   return isJunk(summary) ? '' : summary
 }
 
@@ -43,6 +43,6 @@ export function resolveCoreInsight(
   input: Record<string, unknown> | undefined | null,
   maxSentences = 1,
 ): string {
-  const insight = sanitizeSummaryText(input?.coreInsight || input?.overview || input?.whyItMatters || '', maxSentences)
+  const insight = sanitizeSummaryText(input?.whyItMatters || '', maxSentences)
   return isJunk(insight) ? '' : insight
 }


### PR DESCRIPTION
### Motivation
- Final alignment pass to remove legacy exporter/front-end drift after schema replacement and UI refactors so runtime herb rows match the permanent monograph schema and trust‑first UI expectations.
- Remove redundant compatibility shims that caused the frontend to consume multiple legacy text aliases and wrapper objects, reducing complexity and accidental copy fallbacks.
- Keep minimal, intentional compatibility for safety/operational continuity while making the normalization and summary paths stricter.

### Description
- Normalized herb row and summary loading to read permanent runtime fields directly and removed legacy wrapper-parsing and fallback aliases by updating `src/lib/herb-data.ts` to stop reading `context.*` and `safety.*`, and to prefer `description`/`summary`/`safetyNotes`/`evidenceLevel`/`related*` directly. (file changed: `src/lib/herb-data.ts`).
- Tightened summary resolution by changing `resolveHeroSummary` to no longer read `hero`, and `resolveCoreInsight` to only use `whyItMatters`, removing `coreInsight`/`overview` fallbacks (file changed: `src/lib/workbookRender.ts`).
- Removed a stale Fuse search key `scientificname` from the herb index search config to match emitted runtime keys (file changed: `src/hooks/useFilteredHerbs.ts`).
- Compatibility retained: dual keys for profile state (`profile_status`/`profileStatus`) and summary quality (`summary_quality`/`summaryQuality`) and back-compat loader aliases such as `loadHerbData` remain unchanged to avoid operational breakage.

### Testing
- Changed files: `src/lib/herb-data.ts`, `src/lib/workbookRender.ts`, `src/hooks/useFilteredHerbs.ts`.
- Commands run: `npm run prebuild:validate`, `npm run verify:redirects`, and `npm run build` (build executed during audit); all checks passed in this environment and the build completed successfully.
- Verification results: `prebuild:validate` ✔ herb dataset valid, `verify:redirects` ✔ redirects OK, full `npm run build` ✔ produced expected artifacts and prerender verification reports during the audit run.
- Risks / follow-ups: manual review recommended for remaining workbook-era copy fallbacks (e.g. `readWorkbookText` usage in `HerbDetail`) and plan to later collapse dual-key parsing once all producers emit canonical field names.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4f52cd484832385ab87335f1170cb)