### PR TITLE
Align herb and compound normalization to permanent public schema

### DIFF
--- a/src/hooks/useHerbs.ts
+++ b/src/hooks/useHerbs.ts
@@ -25,7 +25,7 @@ export function useHerbs(): Herb[] {
     herbList.forEach(h => {
       const missing: string[] = []
       if (!h.description) missing.push('description')
-      if (!h.mechanism) missing.push('mechanism')
+      if (!(Array.isArray(h.mechanisms) && h.mechanisms.length) && !h.mechanism) missing.push('mechanisms')
       if (!(Array.isArray(h.activeCompounds) && h.activeCompounds.length)) missing.push('activeCompounds')
       if (missing.length) {
         recordDevMessage('warning', `${herbName(h)} missing: ${missing.join(', ')}`)

--- a/src/lib/compound-data.ts
+++ b/src/lib/compound-data.ts
@@ -203,13 +203,15 @@ function normalizeCompound(raw: Record<string, unknown>): CompoundRecord {
   const safetyRecord = readSafetyRecord(data)
   const name = cleanText(data.name ?? data.commonName ?? data.id) || ''
   const slug = String(data.slug || slugify(name))
-  const primaryActions = splitClean(data.primaryActions ?? data.effects ?? data.actions ?? data.benefits ?? data.keyEffects)
+  const primaryActions = splitClean(
+    data.primaryActions ?? data.effects ?? data.actions ?? data.benefits ?? data.keyEffects,
+  )
   const foundIn = splitClean(
-    data.associatedHerbs ?? data.foundInHerbs ?? data.herbs ?? data.foundIn ?? context.foundIn,
+    data.foundIn ?? data.herbs ?? data.associatedHerbs ?? data.foundInHerbs ?? context.foundIn,
   )
   const mechanisms = splitClean(data.mechanisms ?? data.mechanism ?? data.mechanismOfAction)
-  const targets = splitClean(data.targets ?? data.mechanismTargets)
-  const pathways = splitClean(data.pathways ?? data.pathwayTargets)
+  const targets = splitClean(data.targets ?? data.mechanismTargets ?? context.targets)
+  const pathways = splitClean(data.pathways ?? data.pathwayTargets ?? context.pathways)
   const mechanism = cleanText(data.mechanism ?? mechanisms.join('; ') ?? data.mechanismOfAction) || ''
   const researchEnrichment = normalizeResearchEnrichment(data.researchEnrichment)
   const rawInteractionTags = splitClean(data.interactionTags)
@@ -225,7 +227,7 @@ function normalizeCompound(raw: Record<string, unknown>): CompoundRecord {
   const evidenceLevel =
     cleanText(data.evidenceLevel ?? data.evidence_level ?? safetyRecord.evidence ?? safetyRecord.confidence) ||
     ''
-  const relatedEntities = splitClean(data.relatedEntities ?? context.foundIn)
+  const relatedEntities = splitClean(data.relatedEntities)
   const relatedCompounds = splitClean(data.relatedCompounds ?? context.relatedCompounds)
   const linkedHerbs = splitClean(data.linkedHerbs)
   const compounds = splitClean(data.compounds ?? data.relatedCompounds)
@@ -300,7 +302,9 @@ function normalizeCompound(raw: Record<string, unknown>): CompoundRecord {
 
 function normalizeCompoundSummary(raw: Record<string, unknown>): CompoundSummaryRecord {
   const context = readContextRecord(raw)
-  const effects = splitClean(raw.primaryActions ?? raw.effects ?? raw.actions ?? raw.benefits ?? raw.keyEffects)
+  const effects = splitClean(
+    raw.primaryActions ?? raw.effects ?? raw.actions ?? raw.benefits ?? raw.keyEffects,
+  )
   const foundIn = splitClean(raw.foundIn ?? raw.herbs ?? context.foundIn)
   const mechanisms = splitClean(raw.mechanisms ?? raw.mechanism ?? raw.mechanismOfAction)
   const targets = splitClean(raw.targets ?? raw.mechanismTargets)

--- a/src/lib/herb-data.ts
+++ b/src/lib/herb-data.ts
@@ -207,7 +207,9 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
     .trim()
     .toLowerCase()
 
-  const primaryActions = splitClean(data.primaryActions ?? data.effects)
+  const primaryActions = splitClean(
+    data.primaryActions ?? data.effects ?? data.actions ?? data.benefits,
+  )
   const contraindications = splitClean(data.contraindications)
   const interactions = splitClean(data.interactions)
   const sideeffects = splitClean(data.sideEffects)
@@ -219,7 +221,7 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
   )
   const rawInteractionTags = splitClean(data.interactionTags)
   const rawInteractionNotes = splitClean(data.interactionNotes)
-  const traditionalUses = splitClean(data.traditionalUses)
+  const traditionalUses = splitClean(data.traditionalUses ?? data.traditionalUse)
   const activeCompounds = splitClean(data.activeCompounds)
   const sources = normalizeSources(data.sources)
   const researchEnrichment = normalizeResearchEnrichment(data.researchEnrichment)
@@ -231,10 +233,7 @@ function normalizeHerbRow(raw: Record<string, unknown>): Herb {
     seed: seededInteraction,
   })
 
-  const mechanisms = normalizeMechanisms(
-    data.mechanisms,
-    data.mechanism,
-  )
+  const mechanisms = normalizeMechanisms(data.mechanisms, data.mechanism, data.mechanismOfAction)
   const mechanism = mechanisms.join('; ')
   const description = cleanText(data.description ?? data.summary) || ''
   const duration = cleanText(data.duration) || ''

--- a/src/utils/filterCompounds.ts
+++ b/src/utils/filterCompounds.ts
@@ -15,9 +15,9 @@ function getConfidenceRank(level: string) {
 
 function getCompoundConfidence(compound: CompoundSummaryRecord) {
   return calculateCompoundConfidence({
-    mechanism: compound.mechanism,
-    effects: asStringArray(compound.effects),
-    compounds: asStringArray(compound.herbs),
+    mechanism: asStringArray(compound.mechanisms).join('; ') || compound.mechanism,
+    effects: asStringArray(compound.primaryActions ?? compound.effects),
+    compounds: asStringArray(compound.foundIn ?? compound.herbs),
   })
 }
 
@@ -49,9 +49,9 @@ export function filterCompounds(
   const searched = searchEntries(compounds, filters.query, compound => ({
     name: compound.name,
     type: compound.category || compound.className,
-    mechanism: compound.mechanism,
-    effects: asStringArray(compound.effects),
-    activeCompounds: asStringArray(compound.herbs),
+    mechanism: asStringArray(compound.mechanisms).join('; ') || compound.mechanism,
+    effects: asStringArray(compound.primaryActions ?? compound.effects),
+    activeCompounds: asStringArray(compound.foundIn ?? compound.herbs),
     contraindications: [],
     safety: [],
   })).map(result => result.entry)
@@ -60,7 +60,9 @@ export function filterCompounds(
   const typeNeedle = normalizeText(filters.type)
 
   const filtered = searched.filter(compound => {
-    const effects = asStringArray(compound.effects).map(effect => normalizeText(effect))
+    const effects = asStringArray(compound.primaryActions ?? compound.effects).map(effect =>
+      normalizeText(effect),
+    )
     const confidence = getCompoundConfidence(compound)
     const category = normalizeText(compound.category || compound.className)
 
@@ -86,9 +88,9 @@ export function filterCompounds(
         name: compound.name,
         summary: compound.summaryShort || compound.description,
         description: compound.description,
-        mechanism: compound.mechanism,
-        effects: asStringArray(compound.effects),
-        associations: asStringArray(compound.herbs),
+        mechanism: asStringArray(compound.mechanisms).join('; ') || compound.mechanism,
+        effects: asStringArray(compound.primaryActions ?? compound.effects),
+        associations: asStringArray(compound.foundIn ?? compound.herbs),
         sourceCount: compound.sourceCount,
         hasEvidence: Boolean(compound.researchEnrichmentSummary?.evidenceLabel),
         confidenceLevel: getCompoundConfidence(compound),
@@ -144,7 +146,9 @@ export function filterCompounds(
       (browseQuality.assessments.get(a)?.rankScore ?? 0)
     if (rankScoreDiff !== 0) return rankScoreDiff
 
-    const effectCountDiff = asStringArray(b.effects).length - asStringArray(a.effects).length
+    const effectCountDiff =
+      asStringArray(b.primaryActions ?? b.effects).length -
+      asStringArray(a.primaryActions ?? a.effects).length
     if (effectCountDiff !== 0) return effectCountDiff
 
     return a.name.localeCompare(b.name)

--- a/src/utils/filterHerbs.ts
+++ b/src/utils/filterHerbs.ts
@@ -43,8 +43,8 @@ export function filterHerbs(herbs: Herb[], filters: EntryFilterState): Herb[] {
   const searched = searchEntries(herbs, filters.query, herb => ({
     name: herb.common || herb.name || herb.scientific || herb.slug,
     type: String((herb as Record<string, unknown>).class || herb.category || ''),
-    mechanism: herb.mechanism || herb.mechanismOfAction || herb.mechanismofaction,
-    effects: asStringArray(herb.effects),
+    mechanism: asStringArray(herb.mechanisms).join('; ') || herb.mechanism || herb.mechanismOfAction || herb.mechanismofaction,
+    effects: asStringArray(herb.primaryActions ?? herb.effects),
     activeCompounds: asStringArray(herb.activeCompounds || herb.active_compounds || herb.compounds),
     contraindications: asStringArray(herb.contraindications),
     safety: asStringArray(herb.safety),
@@ -54,7 +54,9 @@ export function filterHerbs(herbs: Herb[], filters: EntryFilterState): Herb[] {
   const typeNeedle = normalizeText(filters.type)
 
   const filtered = searched.filter(herb => {
-    const herbEffects = asStringArray(herb.effects).map(effect => normalizeText(effect))
+    const herbEffects = asStringArray(herb.primaryActions ?? herb.effects).map(effect =>
+      normalizeText(effect),
+    )
     const confidence = getHerbConfidence(herb)
     const herbType = normalizeText(
       String((herb as Record<string, unknown>).class || herb.category || ''),
@@ -81,8 +83,9 @@ export function filterHerbs(herbs: Herb[], filters: EntryFilterState): Herb[] {
         name: herb.common || herb.name || herb.scientific || herb.slug,
         summary: herb.summaryShort || herb.description,
         description: herb.description,
-        mechanism: herb.mechanism || herb.mechanismOfAction,
-        effects: asStringArray(herb.effects),
+        mechanism:
+          asStringArray(herb.mechanisms).join('; ') || herb.mechanism || herb.mechanismOfAction,
+        effects: asStringArray(herb.primaryActions ?? herb.effects),
         associations: asStringArray(herb.activeCompounds || herb.active_compounds || herb.compounds),
         sourceCount: (herb as Record<string, unknown>).sourceCount,
         hasEvidence: Boolean(herb.researchEnrichmentSummary?.evidenceLabel),
@@ -141,7 +144,9 @@ export function filterHerbs(herbs: Herb[], filters: EntryFilterState): Herb[] {
       (browseQuality.assessments.get(a)?.rankScore ?? 0)
     if (rankScoreDiff !== 0) return rankScoreDiff
 
-    const effectCountDiff = asStringArray(b.effects).length - asStringArray(a.effects).length
+    const effectCountDiff =
+      asStringArray(b.primaryActions ?? b.effects).length -
+      asStringArray(a.primaryActions ?? a.effects).length
     if (effectCountDiff !== 0) return effectCountDiff
 
     return String(a.common || a.name || a.scientific || '').localeCompare(

--- a/src/utils/getSeoLandingResults.ts
+++ b/src/utils/getSeoLandingResults.ts
@@ -24,7 +24,7 @@ function confidenceRank(level: string): number {
 function scoreHerbCompleteness(herb: Herb): number {
   const count = [
     herb.description,
-    herb.mechanism || herb.mechanismOfAction || herb.mechanismofaction,
+    splitClean(herb.mechanisms).join('; ') || herb.mechanism || herb.mechanismOfAction || herb.mechanismofaction,
     herb.primaryActions ?? herb.effects,
     herb.active_compounds,
     herb.compounds,
@@ -37,9 +37,9 @@ function scoreHerbCompleteness(herb: Herb): number {
 function scoreCompoundCompleteness(compound: CompoundRecord): number {
   const count = [
     compound.description,
-    compound.mechanism,
+    splitClean(compound.mechanisms).join('; ') || compound.mechanism,
     compound.primaryActions ?? compound.effects,
-    compound.foundIn,
+    compound.foundIn ?? compound.herbs,
     compound.legalStatus,
   ].filter(value => splitClean(value).length > 0 || normalizeText(value).length > 0).length
 
@@ -54,9 +54,9 @@ function getHerbConfidence(herb: Herb): string {
 
 function getCompoundConfidence(compound: CompoundRecord): string {
   return calculateCompoundConfidence({
-    mechanism: compound.mechanism,
+    mechanism: splitClean(compound.mechanisms).join('; ') || compound.mechanism,
     effects: compound.primaryActions ?? compound.effects,
-    compounds: compound.foundIn,
+    compounds: compound.foundIn ?? compound.herbs,
   })
 }
 
@@ -64,7 +64,7 @@ function herbHasSparseData(herb: Herb): boolean {
   const essentialFields = [
     herb.description,
     herb.primaryActions ?? herb.effects,
-    herb.mechanism || herb.mechanismOfAction || herb.mechanismofaction,
+    splitClean(herb.mechanisms).join('; ') || herb.mechanism || herb.mechanismOfAction || herb.mechanismofaction,
   ]
 
   const present = essentialFields.filter(value => normalizeText(value).length > 0).length
@@ -72,7 +72,11 @@ function herbHasSparseData(herb: Herb): boolean {
 }
 
 function compoundHasSparseData(compound: CompoundRecord): boolean {
-  const essentialFields = [compound.description, compound.primaryActions ?? compound.effects, compound.mechanism]
+  const essentialFields = [
+    compound.description,
+    compound.primaryActions ?? compound.effects,
+    splitClean(compound.mechanisms).join('; ') || compound.mechanism,
+  ]
   const present = essentialFields.filter(
     value => splitClean(value).length > 0 || normalizeText(value).length > 0
   ).length
@@ -124,7 +128,7 @@ function matchesCompound(config: SeoLandingConfig, compound: CompoundRecord): bo
 
   const effectFields = [compound.primaryActions ?? compound.effects, compound.description]
   const classFields = [compound.compoundClass, compound.className, compound.category]
-  const compoundRefFields = [compound.name, compound.foundIn]
+  const compoundRefFields = [compound.name, compound.foundIn ?? compound.herbs]
 
   if (config.kind === 'effect') {
     return effectFields.some(field => isNeedleMatch(field, target))

--- a/src/utils/sanitizeData.ts
+++ b/src/utils/sanitizeData.ts
@@ -43,9 +43,9 @@ const FIELD_ALIASES: Record<SanitizedEntityKind, Record<string, string>> = {
     compounds: 'activeCompounds',
   },
   compound: {
-    foundIn: 'herbs',
-    foundInHerbs: 'herbs',
-    associatedHerbs: 'herbs',
+    herbs: 'foundIn',
+    foundInHerbs: 'foundIn',
+    associatedHerbs: 'foundIn',
     type: 'className',
     class: 'className',
     mechanismOfAction: 'mechanism',
@@ -150,8 +150,8 @@ function reportIssues(kind: SanitizedEntityKind, data: Record<string, unknown>):
     issues.push('Invalid display name')
   }
 
-  if (kind === 'compound' && normalizeToArray(data.herbs).length === 0) {
-    issues.push('No linked herbs')
+  if (kind === 'compound' && normalizeToArray(data.foundIn).length === 0) {
+    issues.push('No foundIn links')
   }
 
   return issues


### PR DESCRIPTION
### Motivation

- Enforce the permanent public schema for Herb and Compound records across ingestion, normalization, and UI consumers to reduce ambiguity and drift. 
- Make canonical fields the primary source (`primaryActions`, `mechanisms`, `targets`, `pathways`, `foundIn`) while preserving minimal read-time compatibility for legacy payloads. 
- Keep changes minimal and scoped to normalization, sanitizer aliases, filtering, SEO scoring, and a small dev-diagnostic update.

### Description

- Canonical normalization: prioritize permanent fields in loaders and normalizers so `primaryActions` is used instead of `effects/actions/benefits`, `mechanisms` aggregates mixed mechanism inputs, and `foundIn` is the canonical compound→herb relationship field. Files updated: `src/lib/herb-data.ts`, `src/lib/compound-data.ts`, `src/utils/sanitizeData.ts`.
- Consumer updates: updated downstream consumers and ranking logic to prefer canonical fields with narrow fallbacks; changes in `src/utils/filterHerbs.ts`, `src/utils/filterCompounds.ts`, and `src/utils/getSeoLandingResults.ts` ensure search, filtering, and SEO scoring use canonical fields first.
- Compatibility mappings: sanitizer aliases were adjusted so legacy arrays (`herbs`, `foundInHerbs`, `associatedHerbs`) map into `foundIn`; herb aliases keep `effects/actions/benefits -> primaryActions`; `mechanismOfAction` and `traditionalUse` read into `mechanisms` and `traditionalUses` respectively. (Minimal compatibility only; no inventing new fields.)
- Dev diagnostics: updated `src/hooks/useHerbs.ts` to warn when canonical `mechanisms` is missing (instead of only legacy `mechanism`).
- Files changed: `src/utils/sanitizeData.ts`, `src/lib/herb-data.ts`, `src/lib/compound-data.ts`, `src/utils/filterHerbs.ts`, `src/utils/filterCompounds.ts`, `src/utils/getSeoLandingResults.ts`, `src/hooks/useHerbs.ts`.

### Testing

- Ran `npm run build` (includes prebuild data tasks and site build) which completed successfully in this environment. 
- Ran `npm run build:compile` (Vite production compile) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e52aaf62108323bfab38034762996c)