### PR TITLE
Remove legacy schema fallbacks from runtime entity rendering and filters

### DIFF
--- a/src/components/EntityCard.tsx
+++ b/src/components/EntityCard.tsx
@@ -14,9 +14,9 @@ export default function EntityCard({ e }: { e: Entity }) {
         className='pointer-events-none absolute inset-0 rounded-[var(--radius-lg)] opacity-0 transition-opacity duration-300 group-hover:opacity-100 shadow-[inset_0_0_0_1px_rgba(14,207,179,0.12)]'
       />
       <h3 className='text-xl font-semibold text-white md:text-2xl'>
-        {e.commonName ?? e.latinName}
+        {e.name}
       </h3>
-      {e.commonName && <p className='mt-1 italic text-white/60'>{e.latinName}</p>}
+      {e.scientificName && <p className='mt-1 italic text-white/60'>{e.scientificName}</p>}
       <p className='mt-3 text-white/80'>{summary}</p>
       {e.tags?.length ? (
         <div className='mt-4 flex flex-wrap gap-2'>

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -10,8 +10,8 @@ type Intensity = 'MILD' | 'MODERATE' | 'STRONG'
 export type Entity = {
   id: string
   kind: 'herb' | 'compound'
-  commonName?: string
-  latinName: string
+  name: string
+  scientificName?: string
   summary?: string
   description?: string
   tags?: string[]
@@ -67,30 +67,23 @@ function toEntity(item: unknown, kind: 'herb' | 'compound'): Entity | null {
   const record = asRecord(item)
   if (!record) return null
 
-  const commonName = isNonEmptyString(record.commonName)
-    ? record.commonName
-    : isNonEmptyString(record.common)
-      ? record.common
-      : isNonEmptyString(record.name)
-        ? record.name
-        : undefined
-  const latinName = isNonEmptyString(record.latinName)
-    ? record.latinName
+  const name = isNonEmptyString(record.common)
+    ? record.common
+    : isNonEmptyString(record.name)
+      ? record.name
+      : null
+  if (!name) return null
+  const scientificName = isNonEmptyString(record.scientificName)
+    ? record.scientificName
     : isNonEmptyString(record.scientific)
       ? record.scientific
-      : isNonEmptyString(record.scientificName)
-        ? record.scientificName
-        : isNonEmptyString(commonName)
-          ? commonName
-          : null
-
-  if (!latinName) return null
+      : undefined
 
   const id = isNonEmptyString(record.id)
     ? record.id
     : isNonEmptyString(record.slug)
       ? record.slug
-      : latinName
+      : name
 
   const summary = isNonEmptyString(record.summary)
     ? record.summary
@@ -101,8 +94,8 @@ function toEntity(item: unknown, kind: 'herb' | 'compound'): Entity | null {
   return {
     id,
     kind,
-    commonName,
-    latinName,
+    name,
+    scientificName,
     summary,
     description: isNonEmptyString(record.description) ? record.description : undefined,
     tags: asStringArray(record.tags),

--- a/src/utils/effectSearch.ts
+++ b/src/utils/effectSearch.ts
@@ -123,9 +123,7 @@ export function rankHerbsByEffect(herbs: Herb[], query: string): RankedEffectHer
       const multiEffectScore = matchedEffects.length * 18
       const fuzzyMatchScore = Math.max(fuzzyMatches, 0) * 6
 
-      const compounds = asStringArray(
-        herb.activeCompounds || herb.active_compounds || herb.compounds || herb.compoundsDetailed
-      )
+      const compounds = asStringArray(herb.activeCompounds)
       const compoundSupportCount = compounds.length
       const compoundStrength = Math.min(compoundSupportCount, 6) * 5
 

--- a/src/utils/extractFilterOptions.ts
+++ b/src/utils/extractFilterOptions.ts
@@ -39,11 +39,11 @@ export function extractFilterOptions(input: { herbs?: Herb[]; compounds?: Compou
   const compoundEffects = (input.compounds || []).flatMap(compound => splitList(compound.effects))
 
   const classes = (input.herbs || [])
-    .map(herb => String((herb as Record<string, unknown>).class || herb.category || '').trim())
+    .map(herb => String(herb.category || '').trim())
     .filter(Boolean)
 
   const categories = (input.compounds || [])
-    .map(compound => String((compound.category || compound.className || '').trim()))
+    .map(compound => String((compound.category || compound.compoundClass || '').trim()))
     .filter(Boolean)
 
   return {

--- a/src/utils/filterCompounds.ts
+++ b/src/utils/filterCompounds.ts
@@ -17,7 +17,7 @@ function getCompoundConfidence(compound: CompoundSummaryRecord) {
   return calculateCompoundConfidence({
     mechanism: asStringArray(compound.mechanisms).join('; ') || compound.mechanism,
     effects: asStringArray(compound.primaryActions ?? compound.effects),
-    compounds: asStringArray(compound.foundIn ?? compound.herbs),
+    compounds: asStringArray(compound.foundIn),
   })
 }
 
@@ -48,10 +48,10 @@ export function filterCompounds(
 ): CompoundSummaryRecord[] {
   const searched = searchEntries(compounds, filters.query, compound => ({
     name: compound.name,
-    type: compound.category || compound.className,
+    type: compound.category || compound.compoundClass,
     mechanism: asStringArray(compound.mechanisms).join('; ') || compound.mechanism,
     effects: asStringArray(compound.primaryActions ?? compound.effects),
-    activeCompounds: asStringArray(compound.foundIn ?? compound.herbs),
+    activeCompounds: asStringArray(compound.foundIn),
     contraindications: [],
     safety: [],
   })).map(result => result.entry)
@@ -64,7 +64,7 @@ export function filterCompounds(
       normalizeText(effect),
     )
     const confidence = getCompoundConfidence(compound)
-    const category = normalizeText(compound.category || compound.className)
+    const category = normalizeText(compound.category || compound.compoundClass)
 
     if (effectNeedles.length > 0) {
       const hasAllEffects = effectNeedles.every(effect =>
@@ -90,7 +90,7 @@ export function filterCompounds(
         description: compound.description,
         mechanism: asStringArray(compound.mechanisms).join('; ') || compound.mechanism,
         effects: asStringArray(compound.primaryActions ?? compound.effects),
-        associations: asStringArray(compound.foundIn ?? compound.herbs),
+        associations: asStringArray(compound.foundIn),
         sourceCount: compound.sourceCount,
         hasEvidence: Boolean(compound.researchEnrichmentSummary?.evidenceLabel),
         confidenceLevel: getCompoundConfidence(compound),

--- a/src/utils/filterHerbs.ts
+++ b/src/utils/filterHerbs.ts
@@ -42,10 +42,10 @@ function getFreshnessRank(herb: Herb) {
 export function filterHerbs(herbs: Herb[], filters: EntryFilterState): Herb[] {
   const searched = searchEntries(herbs, filters.query, herb => ({
     name: herb.common || herb.name || herb.scientific || herb.slug,
-    type: String((herb as Record<string, unknown>).class || herb.category || ''),
-    mechanism: asStringArray(herb.mechanisms).join('; ') || herb.mechanism || herb.mechanismOfAction || herb.mechanismofaction,
+    type: String(herb.category || ''),
+    mechanism: asStringArray(herb.mechanisms).join('; ') || herb.mechanism,
     effects: asStringArray(herb.primaryActions ?? herb.effects),
-    activeCompounds: asStringArray(herb.activeCompounds || herb.active_compounds || herb.compounds),
+    activeCompounds: asStringArray(herb.activeCompounds),
     contraindications: asStringArray(herb.contraindications),
     safety: asStringArray(herb.safety),
   })).map(result => result.entry)
@@ -58,9 +58,7 @@ export function filterHerbs(herbs: Herb[], filters: EntryFilterState): Herb[] {
       normalizeText(effect),
     )
     const confidence = getHerbConfidence(herb)
-    const herbType = normalizeText(
-      String((herb as Record<string, unknown>).class || herb.category || ''),
-    )
+    const herbType = normalizeText(String(herb.category || ''))
 
     if (effectNeedles.length > 0) {
       const hasAllEffects = effectNeedles.every(effect =>
@@ -83,10 +81,9 @@ export function filterHerbs(herbs: Herb[], filters: EntryFilterState): Herb[] {
         name: herb.common || herb.name || herb.scientific || herb.slug,
         summary: herb.summaryShort || herb.description,
         description: herb.description,
-        mechanism:
-          asStringArray(herb.mechanisms).join('; ') || herb.mechanism || herb.mechanismOfAction,
+        mechanism: asStringArray(herb.mechanisms).join('; ') || herb.mechanism,
         effects: asStringArray(herb.primaryActions ?? herb.effects),
-        associations: asStringArray(herb.activeCompounds || herb.active_compounds || herb.compounds),
+        associations: asStringArray(herb.activeCompounds),
         sourceCount: (herb as Record<string, unknown>).sourceCount,
         hasEvidence: Boolean(herb.researchEnrichmentSummary?.evidenceLabel),
         confidenceLevel: getHerbConfidence(herb),

--- a/src/utils/getDataCompleteness.ts
+++ b/src/utils/getDataCompleteness.ts
@@ -46,11 +46,9 @@ function countPresent(flags: boolean[]): number {
 }
 
 export function getHerbDataCompleteness(entry: Record<string, unknown>): HerbCompleteness {
-  const mechanism = entry.mechanism ?? entry.mechanismOfAction ?? entry.mechanismofaction
+  const mechanism = entry.mechanism
   const effects = toStringList(entry.effects)
-  const activeCompounds = toStringList(
-    entry.activeCompounds ?? entry.active_compounds ?? entry.compounds
-  )
+  const activeCompounds = toStringList(entry.activeCompounds)
   const contraindications = toStringList(entry.contraindications)
 
   const hasMechanism = isNonEmptyString(mechanism)
@@ -78,12 +76,10 @@ export function getHerbDataCompleteness(entry: Record<string, unknown>): HerbCom
 }
 
 export function getCompoundDataCompleteness(entry: Record<string, unknown>): CompoundCompleteness {
-  const mechanism = entry.mechanism ?? entry.mechanismOfAction
+  const mechanism = entry.mechanism
   const effects = toStringList(entry.effects)
   const safety = toStringList(entry.contraindications ?? entry.interactions ?? entry.safety)
-  const herbs = toStringList(
-    entry.herbs ?? entry.associatedHerbs ?? entry.foundInHerbs ?? entry.foundIn
-  )
+  const herbs = toStringList(entry.foundIn)
 
   const hasMechanism = isNonEmptyString(mechanism)
   const hasEffects = effects.length > 0

--- a/src/utils/getSeoLandingResults.ts
+++ b/src/utils/getSeoLandingResults.ts
@@ -24,10 +24,9 @@ function confidenceRank(level: string): number {
 function scoreHerbCompleteness(herb: Herb): number {
   const count = [
     herb.description,
-    splitClean(herb.mechanisms).join('; ') || herb.mechanism || herb.mechanismOfAction || herb.mechanismofaction,
+    splitClean(herb.mechanisms).join('; ') || herb.mechanism,
     herb.primaryActions ?? herb.effects,
-    herb.active_compounds,
-    herb.compounds,
+    herb.activeCompounds,
     herb.safety,
   ].filter(value => splitClean(value).length > 0 || normalizeText(value).length > 0).length
 
@@ -39,7 +38,7 @@ function scoreCompoundCompleteness(compound: CompoundRecord): number {
     compound.description,
     splitClean(compound.mechanisms).join('; ') || compound.mechanism,
     compound.primaryActions ?? compound.effects,
-    compound.foundIn ?? compound.herbs,
+    compound.foundIn,
     compound.legalStatus,
   ].filter(value => splitClean(value).length > 0 || normalizeText(value).length > 0).length
 
@@ -56,7 +55,7 @@ function getCompoundConfidence(compound: CompoundRecord): string {
   return calculateCompoundConfidence({
     mechanism: splitClean(compound.mechanisms).join('; ') || compound.mechanism,
     effects: compound.primaryActions ?? compound.effects,
-    compounds: compound.foundIn ?? compound.herbs,
+    compounds: compound.foundIn,
   })
 }
 
@@ -64,7 +63,7 @@ function herbHasSparseData(herb: Herb): boolean {
   const essentialFields = [
     herb.description,
     herb.primaryActions ?? herb.effects,
-    splitClean(herb.mechanisms).join('; ') || herb.mechanism || herb.mechanismOfAction || herb.mechanismofaction,
+    splitClean(herb.mechanisms).join('; ') || herb.mechanism,
   ]
 
   const present = essentialFields.filter(value => normalizeText(value).length > 0).length
@@ -96,15 +95,11 @@ function matchesHerb(config: SeoLandingConfig, herb: Herb): boolean {
     herb.category,
     herb.category_label,
     ...(Array.isArray(herb.categories) ? herb.categories : []),
-    String((herb as Record<string, unknown>).class ?? ''),
   ]
   const effectFields = [herb.primaryActions ?? herb.effects, herb.effectsSummary, herb.tags]
   const compoundFields = [
     herb.activeCompounds,
-    herb.active_compounds,
     herb.activeconstituents,
-    herb.compounds,
-    herb.compoundsDetailed,
     herb.activeConstituents?.map(item => item.name),
   ]
 
@@ -127,8 +122,8 @@ function matchesCompound(config: SeoLandingConfig, compound: CompoundRecord): bo
   const target = normalizeText(config.target)
 
   const effectFields = [compound.primaryActions ?? compound.effects, compound.description]
-  const classFields = [compound.compoundClass, compound.className, compound.category]
-  const compoundRefFields = [compound.name, compound.foundIn ?? compound.herbs]
+  const classFields = [compound.compoundClass, compound.category]
+  const compoundRefFields = [compound.name, compound.foundIn]
 
   if (config.kind === 'effect') {
     return effectFields.some(field => isNeedleMatch(field, target))
@@ -164,8 +159,8 @@ export function getSeoLandingResults(
         const completenessDiff = scoreHerbCompleteness(b) - scoreHerbCompleteness(a)
         if (completenessDiff !== 0) return completenessDiff
 
-        const aName = String(a.common || a.name || a.scientific || a.slug || '')
-        const bName = String(b.common || b.name || b.scientific || b.slug || '')
+        const aName = String(a.common || a.name || a.slug || '')
+        const bName = String(b.common || b.name || b.slug || '')
         return aName.localeCompare(bName)
       })
 

--- a/src/utils/herb.ts
+++ b/src/utils/herb.ts
@@ -5,13 +5,9 @@ export function herbName(herb: Partial<Herb> | null | undefined): string {
   if (typeof herb.common === 'string' && herb.common.trim()) return herb.common.trim()
   if (typeof herb.name === 'string' && herb.name.trim()) return herb.name.trim()
   if (typeof herb.nameNorm === 'string' && herb.nameNorm.trim()) return herb.nameNorm.trim()
-  if (typeof (herb as any).commonName === 'string' && (herb as any).commonName.trim())
-    return (herb as any).commonName.trim()
   if (typeof herb.commonnames === 'string' && herb.commonnames.trim())
     return herb.commonnames.trim()
   if (typeof herb.scientific === 'string' && herb.scientific.trim()) return herb.scientific.trim()
-  if (typeof herb.scientificname === 'string' && herb.scientificname.trim())
-    return herb.scientificname.trim()
   return (herb.id as string) || ''
 }
 


### PR DESCRIPTION
### Motivation
- Remove leftover reads and fallback logic for obsolete herb/compound schema fields so runtime UI relies only on the new canonical schema.
- Simplify entity rendering and filtering to expose upstream data issues instead of silently masking missing fields with legacy aliases.
- Keep only minimal loader-side normalization/shims where necessary to avoid breaking ingestion but stop masking missing current-schema fields in the UI.

### Description
- Key changes across runtime code: updated `src/components/EntityCard.tsx`, `src/lib/data.ts`, and utilities under `src/utils/` to stop reading legacy aliases and to use canonical fields (`name`, `scientificName`, `activeCompounds`, `foundIn`, `category`/`compoundClass`) only; files changed: `src/components/EntityCard.tsx`, `src/lib/data.ts`, `src/utils/herb.ts`, `src/utils/filterHerbs.ts`, `src/utils/filterCompounds.ts`, `src/utils/getDataCompleteness.ts`, `src/utils/effectSearch.ts`, `src/utils/extractFilterOptions.ts`, `src/utils/getSeoLandingResults.ts`.
- Dead fields removed from runtime reads and fallbacks: herb-side `commonName`, `scientificname`, `class` (fallback reads), `mechanismOfAction`, `mechanismofaction`, `active_compounds`, `compounds`, `compoundsDetailed`; compound-side `herbs`, `className`, `associatedHerbs`, `foundInHerbs`.
- Remaining shims: loader/normalization logic (e.g., `normalizeCompound` and data-loading paths) still map some older importer fields into canonical fields to preserve ingestion tolerance, but runtime rendering and filters no longer rely on those aliases.
- Manual review items: confirm upstream exporters produce `activeCompounds` for herbs and `foundIn` for compounds, validate `category` vs `compoundClass` consistency for compound filters, and consider a follow-up pass to remove legacy aliases from non-runtime modules if desired.

### Testing
- Built the app with `npm run build`, which completed successfully and produced prerendered routes and build artifacts (build: pass).
- Ran redirects verification with `npm run verify:redirects`, which returned OK for the dist redirects manifest (redirects: pass).
- Build-time verification scripts executed during the build (prerender/verify-prerender/verify-publishing/structured-data checks) reported success as part of the `npm run build` run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e52c4dd1a483239a12cebb2beb0087)