### PR TITLE
Clean dark high-contrast theme: remove glow/gradients and simplify surfaces

### DIFF
--- a/src/components/CardShell.tsx
+++ b/src/components/CardShell.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { motion } from '@/lib/motion'
 
 interface Props {
   children: React.ReactNode
@@ -7,12 +6,11 @@ interface Props {
 }
 
 const CardShell: React.FC<Props> = ({ children, className }) => (
-  <motion.div
-    whileHover={{ scale: 1.05 }}
-    className={`glass-card focus-within:shadow-glow relative rounded-lg bg-gradient-to-br from-white/5 to-white/10 p-4 ${className ?? ''}`}
+  <div
+    className={`relative rounded-[var(--radius-lg)] border border-[var(--border-default)] bg-[var(--surface-2)] p-4 ${className ?? ''}`}
   >
     {children}
-  </motion.div>
+  </div>
 )
 
 export default CardShell

--- a/src/components/SiteLayout.tsx
+++ b/src/components/SiteLayout.tsx
@@ -1,5 +1,4 @@
 import { PropsWithChildren } from 'react'
-import CosmicBackground from './CosmicBackground'
 
 type SiteLayoutProps = PropsWithChildren<{
   ambientEnabled?: boolean
@@ -8,7 +7,6 @@ type SiteLayoutProps = PropsWithChildren<{
 export default function SiteLayout({ children }: SiteLayoutProps) {
   return (
     <div className='relative isolate min-h-svh overflow-x-hidden bg-[var(--bg)]'>
-      <CosmicBackground animated={false} />
       <div className='relative z-10 flex min-h-svh flex-col'>{children}</div>
     </div>
   )

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -15,8 +15,10 @@ type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
 const variantClasses: Record<ButtonVariant, string> = {
   primary: 'btn-primary',
   secondary: 'btn-secondary',
-  ghost: 'border border-[var(--border-default)] bg-transparent text-[var(--text-secondary)] hover:text-[var(--text-primary)]',
-  danger: 'border border-[var(--accent-danger)]/40 bg-[var(--accent-danger)]/14 text-[var(--accent-danger)] hover:bg-[var(--accent-danger)]/20',
+  ghost:
+    'border border-[var(--border-default)] bg-[var(--surface-1)] text-[var(--text-secondary)] hover:border-[var(--border-strong)] hover:text-[var(--text-primary)]',
+  danger:
+    'border border-[var(--accent-danger)]/50 bg-[var(--accent-danger)]/12 text-[var(--text-primary)] hover:bg-[var(--accent-danger)]/18',
 }
 
 const sizeClasses: Record<ButtonSize, string> = {
@@ -51,7 +53,7 @@ export function Button({
     <MotionButton
       whileTap={{ scale: 0.99 }}
       disabled={isDisabled}
-      className={`inline-flex items-center justify-center gap-2 rounded-lg font-medium transition-colors ${variantClasses[variant]} ${sizeClasses[size]} ${loading ? 'cursor-not-allowed opacity-60' : ''} ${className}`.trim()}
+      className={`inline-flex items-center justify-center gap-2 rounded-md font-medium transition-colors ${variantClasses[variant]} ${sizeClasses[size]} ${loading ? 'cursor-not-allowed opacity-60' : ''} ${className}`.trim()}
       {...props}
     >
       {loading && <Spinner />}

--- a/src/index.css
+++ b/src/index.css
@@ -2,9 +2,7 @@
 @import './styles/tokens.css';
 @import './styles/tags.css';
 @import './styles/clamp.css';
-@import './styles/glass.css';
 @import './styles/melt.css';
-@import './styles/galaxy.css';
 @import './styles/global.css';
 
 @tailwind base;
@@ -67,7 +65,7 @@ svg {
 }
 
 a {
-  color: color-mix(in oklab, var(--accent) 82%, white 18%);
+  color: color-mix(in oklab, var(--accent) 78%, white 22%);
   text-decoration: none;
   transition: color 0.15s ease;
 }
@@ -79,7 +77,7 @@ a:hover {
 
 @layer components {
   .container-page {
-    @apply mx-auto w-full max-w-5xl px-4 sm:px-6;
+    @apply mx-auto w-full max-w-6xl px-4 sm:px-6 lg:px-8;
   }
 
   .ds-section {
@@ -101,11 +99,11 @@ a:hover {
   }
 
   .ds-card {
-    @apply p-3;
+    @apply p-4;
   }
 
   .ds-card-lg {
-    @apply p-4;
+    @apply p-5;
     background: var(--surface-3);
   }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -71,7 +71,7 @@
     align-items: center;
     justify-content: center;
     gap: 0.5rem;
-    padding: 0.62rem 1.1rem;
+    padding: 0.7rem 1.1rem;
     border-radius: var(--radius);
     border: 1px solid;
     font-weight: 600;
@@ -81,13 +81,13 @@
   }
 
   .btn-primary {
-    border-color: color-mix(in oklab, var(--accent-primary) 55%, var(--border-default));
-    background: var(--accent-primary);
-    color: #08101d;
+    border-color: color-mix(in oklab, var(--accent-primary) 45%, var(--border-default));
+    background: color-mix(in oklab, var(--accent-primary) 72%, #0d1522 28%);
+    color: var(--text-primary);
   }
 
   .btn-primary:hover {
-    background: color-mix(in oklab, var(--accent-primary) 88%, white 12%);
+    background: color-mix(in oklab, var(--accent-primary) 82%, #0d1522 18%);
   }
 
   .btn-secondary {
@@ -97,7 +97,7 @@
   }
 
   .btn-secondary:hover {
-    border-color: color-mix(in oklab, var(--accent-primary) 35%, var(--border-default));
+    border-color: var(--border-strong);
     color: var(--text-primary);
     background: var(--surface-2);
   }
@@ -174,6 +174,7 @@
     border-color: var(--border-default);
     background: var(--surface-2);
     backdrop-filter: none;
+    -webkit-backdrop-filter: none;
   }
   .glass-pill {
     @apply backdrop-glass rounded-full;

--- a/src/styles/melt.css
+++ b/src/styles/melt.css
@@ -7,12 +7,10 @@
   width: min(96vw, 720px);
   padding: 12px;
   border-radius: 16px;
-  background: rgba(12, 12, 14, 0.72);
-  border: 1px solid rgba(255, 255, 255, 0.16);
-  backdrop-filter: saturate(130%) blur(10px);
-  -webkit-backdrop-filter: saturate(130%) blur(10px);
+  background: var(--surface-2);
+  border: 1px solid var(--border-default);
   z-index: 60;
-  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
+  box-shadow: none;
 }
 
 .melt-row {
@@ -24,8 +22,8 @@
 
 .chip {
   appearance: none;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--border-default);
+  background: var(--surface-1);
   height: 38px;
   padding: 0 14px;
   border-radius: 999px;
@@ -35,8 +33,8 @@
 }
 
 .chip--active {
-  background: rgba(70, 220, 200, 0.22);
-  border-color: rgba(70, 220, 200, 0.55);
+  background: color-mix(in oklab, var(--accent-primary) 16%, var(--surface-1));
+  border-color: color-mix(in oklab, var(--accent-primary) 35%, var(--border-default));
 }
 
 /* Ensure header never overflows horizontally */

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -17,20 +17,20 @@
     --duration-base: 200ms;
 
     /* trust-first dark system */
-    --bg: #0b1220;
-    --surface-1: #111a2a;
-    --surface-2: #162133;
-    --surface-3: #1b283b;
-    --surface-4: #223149;
+    --bg: #0a0c0f;
+    --surface-1: #12161c;
+    --surface-2: #181d24;
+    --surface-3: #202631;
+    --surface-4: #2a3140;
 
-    --text-primary: #eef4ff;
-    --text-secondary: #c3cddd;
-    --text-muted: #8d99ad;
-    --text-disabled: #667186;
+    --text-primary: #f3f5f7;
+    --text-secondary: #d8dde5;
+    --text-muted: #a8b1bf;
+    --text-disabled: #6e7786;
 
-    --border-subtle: rgb(154 171 196 / 16%);
-    --border-default: rgb(154 171 196 / 24%);
-    --border-strong: rgb(154 171 196 / 34%);
+    --border-subtle: rgb(175 189 209 / 18%);
+    --border-default: rgb(175 189 209 / 28%);
+    --border-strong: rgb(175 189 209 / 40%);
 
     --accent-primary: #77a7ff;
     --accent-secondary: #95b7ff;
@@ -38,8 +38,8 @@
     --accent-success: #5fc59c;
     --accent-danger: #f08a8a;
 
-    --shadow-card: 0 1px 2px rgb(0 0 0 / 36%), 0 8px 20px rgb(0 0 0 / 22%);
-    --shadow-elevated: 0 14px 30px rgb(0 0 0 / 28%);
+    --shadow-card: none;
+    --shadow-elevated: none;
 
     --accent-h: 217;
     --accent-s: 92%;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -22,7 +22,7 @@ module.exports = {
         },
       },
       boxShadow: {
-        card: '0 1px 2px rgba(0,0,0,0.35), 0 6px 18px rgba(0,0,0,0.22)',
+        card: 'none',
       },
       fontFamily: {
         body: ['Inter', 'Instrument Sans', 'system-ui', 'sans-serif'],


### PR DESCRIPTION
### Motivation
- Replace noisy, low-contrast, and decorative visuals (glows, gradients, nebula/aurora, glass blur) with a clean, high-contrast dark-only baseline. 
- Improve readability and consistency across shared UI primitives (cards, buttons, chips, popovers) by using simple surfaces, borders, and readable typography. 
- Standardize spacing and component defaults so pages render on a neutral dark backdrop without ambient visual noise.

### Description
- Removed ambient/cosmic background rendering and related decorative stylesheet imports by updating `src/components/SiteLayout.tsx` and the index stylesheet imports in `src/index.css` to eliminate `CosmicBackground`, `galaxy.css`, and `glass.css` from the main bundle. 
- Tightened theme tokens in `src/styles/theme.css` to a neutral dark palette with stronger `--text-*` and `--border-*` contrast and disabled elevated card shadows (`--shadow-card` / `--shadow-elevated`). 
- Eliminated glass/blur/backdrop-filter and heavy shadows from melt/popover and chip styles in `src/styles/melt.css` and removed related backdrop filters in `src/styles/global.css`. 
- Simplified shared card and popup surfaces by replacing gradient/glow `CardShell` with a bordered dark surface in `src/components/CardShell.tsx` and normalized button variants in `src/components/ui/Button.tsx` to use solid surfaces, clearer borders, and consistent radii. 
- Adjusted layout and spacing defaults (container width and `ds-card`/`ds-card-lg` padding) in `src/index.css` and `src/styles/global.css` and disabled Tailwind `boxShadow.card` in `tailwind.config.ts` so components default to flat surfaces.

### Testing
- Ran the production compile step with `npm run build:compile`, which completed successfully. 
- Ran a full site build via `npm run build` (pre/post build tasks executed) and the build + prerender verification steps completed without errors. 
- Linting/format hooks executed as part of the staged-file checks and returned clean results during the commit flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5315f7c6883239d794b450c272fd9)