### PR TITLE
Update workbook resolver default path

### DIFF
--- a/scripts/workbook-source.mjs
+++ b/scripts/workbook-source.mjs
@@ -1,11 +1,16 @@
 import path from 'node:path'
 
-const DEFAULT_WORKBOOK_RELATIVE_PATH = 'data-sources/thehippiescientist_icariin_epimedium_brevicornum_unlock.xlsx'
+const DEFAULT_WORKBOOK_RELATIVE_PATH = 'data-sources/herb_monograph_master.xlsx'
 
 export function resolveWorkbookPath(rootDir, { envPath = process.env.HERB_XLSX_PATH } = {}) {
+  let resolvedPath
+
   if (typeof envPath === 'string' && envPath.trim()) {
-    return path.resolve(rootDir, envPath.trim())
+    resolvedPath = path.resolve(rootDir, envPath.trim())
+  } else {
+    resolvedPath = path.resolve(rootDir, DEFAULT_WORKBOOK_RELATIVE_PATH)
   }
 
-  return path.resolve(rootDir, DEFAULT_WORKBOOK_RELATIVE_PATH)
+  console.log(`[workbook-source] Resolved workbook path: ${resolvedPath}`)
+  return resolvedPath
 }


### PR DESCRIPTION
### Motivation
- Replace the legacy default workbook with the new master workbook while preserving existing environment override behavior and making the resolved path explicit at runtime.

### Description
- Updated `scripts/workbook-source.mjs` to set `DEFAULT_WORKBOOK_RELATIVE_PATH` to `data-sources/herb_monograph_master.xlsx`, preserved the `HERB_XLSX_PATH`/`envPath` override precedence, refactored to compute a single `resolvedPath`, and added a `console.log` that prints the chosen path before returning it (changed file: `scripts/workbook-source.mjs`).

### Testing
- Executed `node --input-type=module -e "import { resolveWorkbookPath } from './scripts/workbook-source.mjs'; resolveWorkbookPath(process.cwd());"` and `node --input-type=module -e "import { resolveWorkbookPath } from './scripts/workbook-source.mjs'; resolveWorkbookPath(process.cwd(), { envPath: 'custom/path.xlsx' });"` which logged the expected default and overridden resolved paths, and a `git commit` of the change completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e536fa54c4832383433ef41fbb8ca9)