### PR TITLE
Update workbook exporter to require new master sheets

### DIFF
--- a/scripts/export-workbook-to-json.mjs
+++ b/scripts/export-workbook-to-json.mjs
@@ -17,12 +17,12 @@ const __dirname = path.dirname(__filename)
 const repoRoot = path.resolve(__dirname, '..')
 const workbookPath = resolveWorkbookPath(repoRoot)
 const dataDir = path.join(repoRoot, 'public', 'data')
-const SHEET_MAP = {
-  herbs: ['Herb Master'],
-  compounds: ['Compound Master'],
-  herbCompoundMap: ['Herb Compound Map'],
+const REQUIRED_WORKBOOK_SHEETS = {
+  herbs: 'Herb Master',
+  compounds: 'Compound Master',
+  herbCompoundMap: 'Herb Compound Map',
 }
-const REQUIRED_SHEET_KEYS = ['herbs', 'compounds', 'herbCompoundMap']
+const REQUIRED_SHEET_KEYS = Object.keys(REQUIRED_WORKBOOK_SHEETS)
 const RESOLVED_REQUIRED_COLUMNS = {
   herbs: ['name'],
   compounds: ['compoundName'],
@@ -30,7 +30,7 @@ const RESOLVED_REQUIRED_COLUMNS = {
 }
 const LEGACY_GOAL_BUNDLE_SHEET = 'Production Export V1'
 const EXPORT_WORKBOOK_SHEETS = [
-  ...REQUIRED_SHEET_KEYS.flatMap(sheetKey => SHEET_MAP[sheetKey]),
+  ...REQUIRED_SHEET_KEYS.map(sheetKey => REQUIRED_WORKBOOK_SHEETS[sheetKey]),
   LEGACY_GOAL_BUNDLE_SHEET,
 ]
 const OPTIONAL_WORKBOOK_SHEETS = new Set(['Production Export V1'])
@@ -57,15 +57,12 @@ function createDiagnostics() {
 function resolveWorkbookSheets(workbook) {
   const resolvedSheets = {}
   for (const sheetKey of REQUIRED_SHEET_KEYS) {
-    const candidates = SHEET_MAP[sheetKey]
-    const resolvedName = candidates.find(sheetName => Boolean(workbook.Sheets[sheetName]))
-    if (!resolvedName) {
-      throw new Error(
-        `[export] Missing required sheet for "${sheetKey}". Expected one of: ${candidates.join(', ')}`
-      )
+    const requiredSheetName = REQUIRED_WORKBOOK_SHEETS[sheetKey]
+    if (!workbook.Sheets[requiredSheetName]) {
+      throw new Error(`[export] Missing required sheet "${requiredSheetName}" for "${sheetKey}".`)
     }
-    resolvedSheets[sheetKey] = resolvedName
-    console.log(`[export][sheets] ${sheetKey}: ${resolvedName}`)
+    resolvedSheets[sheetKey] = requiredSheetName
+    console.log(`[export][sheets] ${sheetKey}: ${requiredSheetName}`)
   }
   return resolvedSheets
 }


### PR DESCRIPTION
### Motivation
- The exporter should target the explicit new workbook tabs `Herb Master`, `Compound Master`, and `Herb Compound Map` and fail fast if those exact sheets are missing to match the updated workbook layout.
- Preserve downstream JSON output contracts so that quality gate, publication, and sitemap consumers are not broken by the change.

### Description
- Replaced the previous candidate-based `SHEET_MAP` with an exact `REQUIRED_WORKBOOK_SHEETS` mapping and derived `REQUIRED_SHEET_KEYS` from its keys.
- Updated `EXPORT_WORKBOOK_SHEETS` construction to read required sheet names from `REQUIRED_WORKBOOK_SHEETS` instead of flattening candidate arrays.
- Simplified `resolveWorkbookSheets()` to validate the presence of each exact required sheet name and throw a clear error when a required sheet is missing, while leaving record-shaping and output file paths unchanged.

### Testing
- Ran `node scripts/export-workbook-to-json.mjs` which completed successfully and generated the expected outputs including `public/data/workbook-herbs.json`, `public/data/workbook-compounds.json`, and `public/data/workbook-herb-compound-map.json`.
- Commit pre-commit hooks executed `eslint` as part of the automated checks and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e53b9f33088323b7dfbda140a0d2c2)