### PR TITLE
Run workbook export/import integration refresh

### DIFF
--- a/public/data/compounds.json
+++ b/public/data/compounds.json
@@ -1021,7 +1021,7 @@
     "name": "Alpha-asarone",
     "herbs": [
       "acorus americanus",
-      "nan"
+      "calamus"
     ],
     "effects": [
       "No direct effects data. Contextual inference:",
@@ -1148,7 +1148,7 @@
     "name": "apigenin",
     "herbs": [
       "alchemilla vulgaris",
-      "nan"
+      "chamomile"
     ],
     "effects": [
       "Uterine tonic",
@@ -1386,7 +1386,8 @@
   {
     "name": "Astragalin",
     "herbs": [
-      "desmodium adscendens"
+      "desmodium adscendens",
+      "astragalus-membranaceus"
     ],
     "effects": [
       "No direct effects data. Contextual inference: Used to treat asthma",
@@ -1400,7 +1401,10 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "astragalin"
+    "slug": "astragalin",
+    "canonicalCompoundId": "astragalin",
+    "id": "astragalin",
+    "compoundName": "Astragalin"
   },
   {
     "name": "Atropine",
@@ -1499,8 +1503,9 @@
   {
     "name": "Baicalin",
     "herbs": [
-      "nan",
-      "scutellaria lateriflora"
+      "scutellaria lateriflora",
+      "skullcap",
+      "scutellaria-baicalensis"
     ],
     "effects": [
       "Mild sedation",
@@ -1713,7 +1718,8 @@
   {
     "name": "Boldine",
     "herbs": [
-      "peumus boldus"
+      "peumus boldus",
+      "boldo"
     ],
     "effects": [
       "No direct effects data. Contextual inference:",
@@ -1767,7 +1773,7 @@
   {
     "name": "Boswellic acids",
     "herbs": [
-      "nan"
+      "boswellia-serrata"
     ],
     "effects": [
       "Joint pain relief",
@@ -1779,7 +1785,10 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "boswellic-acids"
+    "slug": "boswellic-acids",
+    "canonicalCompoundId": "boswellic-acid",
+    "id": "boswellic-acid",
+    "compoundName": "Boswellic acid"
   },
   {
     "name": "budmunchiamines L1-L6",
@@ -1911,7 +1920,9 @@
   {
     "name": "caffeic acid",
     "herbs": [
-      "alchemilla vulgaris"
+      "alchemilla vulgaris",
+      "echinacea-purpurea",
+      "coffee"
     ],
     "effects": [
       "Uterine tonic",
@@ -1947,9 +1958,10 @@
   {
     "name": "Caffeine",
     "herbs": [
-      "nan",
       "yerba mate",
-      "camellia sinensis"
+      "camellia sinensis",
+      "ilex-paraguariensis",
+      "guayusa"
     ],
     "effects": [
       "Mental alertness",
@@ -2260,7 +2272,7 @@
   {
     "name": "carvacrol",
     "herbs": [
-      "nan"
+      "ajwain"
     ],
     "effects": [
       "Stress relief",
@@ -2311,7 +2323,8 @@
     "name": "catechin",
     "herbs": [
       "agrimonia eupatoria",
-      "alchemilla vulgaris"
+      "alchemilla vulgaris",
+      "camellia-sinensis"
     ],
     "effects": [
       "Astringent",
@@ -2353,7 +2366,7 @@
     "herbs": [
       "albizia lebbeck",
       "byrsonima crassifolia",
-      "nan"
+      "ashoka"
     ],
     "effects": [
       "Used in Ayurveda for asthma",
@@ -2548,7 +2561,8 @@
   {
     "name": "Chamazulene",
     "herbs": [
-      "nan"
+      "chamomile",
+      "matricaria-chamomilla"
     ],
     "effects": [
       "Anti-inflammatory",
@@ -2576,7 +2590,9 @@
   {
     "name": "Chlorogenic acid",
     "herbs": [
-      "yerba mate"
+      "yerba mate",
+      "coffee",
+      "coffea-arabica"
     ],
     "effects": [
       "No direct effects data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... No direct mechanismofaction data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... Consumed as a social and energizing herbal tea throughout South America.. Consumed as a social and energizing herbal tea throughout South America."
@@ -3504,8 +3520,8 @@
   {
     "name": "elemicin",
     "herbs": [
-      "nan",
-      "myristica fragrans"
+      "myristica fragrans",
+      "myristica-fragrans"
     ],
     "effects": [
       "Euphoria",
@@ -3534,7 +3550,10 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "elemicin"
+    "slug": "elemicin",
+    "canonicalCompoundId": "elemicin",
+    "id": "elemicin",
+    "compoundName": "Elemicin"
   },
   {
     "name": "ellagic acid",
@@ -4077,7 +4096,7 @@
   {
     "name": "Eucalyptol",
     "herbs": [
-      "nan"
+      "peppermint"
     ],
     "effects": [
       "Clarity",
@@ -4104,9 +4123,11 @@
   {
     "name": "eugenol",
     "herbs": [
-      "nan",
       "pimenta dioica",
-      "tynanthus panurensis"
+      "tynanthus panurensis",
+      "holy-basil",
+      "calamus",
+      "syzygium-aromaticum"
     ],
     "effects": [
       "Euphoria",
@@ -4186,8 +4207,8 @@
     "name": "Farnesol",
     "herbs": [
       "linden",
-      "nan",
-      "Silver Linden"
+      "Silver Linden",
+      "matricaria-chamomilla"
     ],
     "effects": [
       "No direct effects data. Contextual inference: Used as a calming tea for sleep",
@@ -4213,7 +4234,10 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "farnesol"
+    "slug": "farnesol",
+    "canonicalCompoundId": "farnesol",
+    "id": "farnesol",
+    "compoundName": "Farnesol"
   },
   {
     "name": "fatty acids",
@@ -4245,7 +4269,8 @@
   {
     "name": "ferulic acid",
     "herbs": [
-      "adenostoma fasciculatum"
+      "adenostoma fasciculatum",
+      "angelica-sinensis"
     ],
     "effects": [
       "Traditional uses include skin and respiratory conditions",
@@ -4662,7 +4687,7 @@
     "name": "gallic acid",
     "herbs": [
       "alchemilla vulgaris",
-      "nan"
+      "longan"
     ],
     "effects": [
       "Uterine tonic",
@@ -4951,7 +4976,7 @@
   {
     "name": "harmaline)",
     "herbs": [
-      "nan"
+      "peganum-harmala"
     ],
     "effects": [
       "Intense stimulation",
@@ -5074,8 +5099,8 @@
   {
     "name": "harmine",
     "herbs": [
-      "nan",
-      "banisteriopsis caapi"
+      "banisteriopsis caapi",
+      "peganum-harmala"
     ],
     "effects": [
       "Altered perception",
@@ -5207,7 +5232,8 @@
   {
     "name": "Huperzine A",
     "herbs": [
-      "huperzia serrata"
+      "huperzia serrata",
+      "huperzia-serrata"
     ],
     "effects": [
       "No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine"
@@ -5398,8 +5424,8 @@
   {
     "name": "Ibogaine",
     "herbs": [
-      "nan",
-      "tabernanthe iboga"
+      "tabernanthe iboga",
+      "tabernanthe-iboga"
     ],
     "effects": [
       "Intense visions",
@@ -5766,7 +5792,8 @@
   {
     "name": "isorhamnetin",
     "herbs": [
-      "aerva lanata"
+      "aerva lanata",
+      "ginkgo-biloba"
     ],
     "effects": [
       "Diuretic",
@@ -5903,7 +5930,8 @@
       "aerva lanata",
       "albizia lebbeck",
       "alchemilla vulgaris",
-      "linden"
+      "linden",
+      "ginkgo-biloba"
     ],
     "effects": [
       "Diuretic",
@@ -5984,7 +6012,8 @@
   {
     "name": "Kavalactones (kavain",
     "herbs": [
-      "nan"
+      "kava",
+      "piper-methysticum"
     ],
     "effects": [
       "Euphoria",
@@ -6339,7 +6368,7 @@
     "name": "limonene",
     "herbs": [
       "acorus tatarinowii",
-      "nan"
+      "peppermint"
     ],
     "effects": [
       "CNS stimulant",
@@ -6412,8 +6441,9 @@
     "name": "linalool",
     "herbs": [
       "acorus tatarinowii",
-      "nan",
-      "Silver Linden"
+      "Silver Linden",
+      "lavender",
+      "lavandula-angustifolia"
     ],
     "effects": [
       "CNS stimulant",
@@ -7169,7 +7199,7 @@
   {
     "name": "mesembrenone",
     "herbs": [
-      "nan"
+      "kanna"
     ],
     "effects": [
       "Euphoria",
@@ -7210,8 +7240,7 @@
   {
     "name": "Mesembrine",
     "herbs": [
-      "kanna",
-      "nan"
+      "kanna"
     ],
     "effects": [
       "No direct effects data. Contextual inference:",
@@ -7315,7 +7344,8 @@
   {
     "name": "methyl eugenol",
     "herbs": [
-      "acorus tatarinowii"
+      "acorus tatarinowii",
+      "holy-basil"
     ],
     "effects": [
       "CNS stimulant",
@@ -7335,12 +7365,14 @@
     "category": null,
     "sources": [
       {
-        "note": "Inferred from scientific name:",
-        "url": ""
+        "note": "Inferred from scientific name:"
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "methyl-eugenol"
+    "slug": "methyl-eugenol",
+    "canonicalCompoundId": "methyleugenol",
+    "id": "methyleugenol",
+    "compoundName": "methyl eugenol"
   },
   {
     "name": "methyl grevillate",
@@ -7429,7 +7461,7 @@
   {
     "name": "methysticin",
     "herbs": [
-      "nan"
+      "piper-methysticum"
     ],
     "effects": [
       "Euphoria",
@@ -7692,8 +7724,8 @@
   {
     "name": "Myristicin",
     "herbs": [
-      "nan",
-      "myristica fragrans"
+      "myristica fragrans",
+      "myristica-fragrans"
     ],
     "effects": [
       "Euphoria",
@@ -8007,8 +8039,8 @@
   {
     "name": "Nicotine",
     "herbs": [
-      "nan",
-      "nicotiana rustica"
+      "nicotiana rustica",
+      "nicotiana-tabacum"
     ],
     "effects": [
       "Stimulation",
@@ -8236,8 +8268,9 @@
     "name": "Nuciferine",
     "herbs": [
       "blue lotus",
-      "nan",
-      "nelumbo nucifera"
+      "nelumbo nucifera",
+      "damiana",
+      "blue-lotus"
     ],
     "effects": [
       "No direct effects data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... No direct mechanismofaction data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... Used ceremonially in Ancient Egypt for euphoria and vision enhancement.. Used ceremonially in Ancient Egypt for euphoria and vision enhancement.",
@@ -8438,12 +8471,14 @@
     "category": null,
     "sources": [
       {
-        "note": "Inferred from scientific name:",
-        "url": ""
+        "note": "Inferred from scientific name:"
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "oleanolic-acid"
+    "slug": "oleanolic-acid",
+    "canonicalCompoundId": "oleanolic-acid",
+    "id": "oleanolic-acid",
+    "compoundName": "Oleanolic acid"
   },
   {
     "name": "other saponins",
@@ -8787,8 +8822,8 @@
   {
     "name": "Petasin",
     "herbs": [
-      "nan",
-      "petasites hybridus"
+      "petasites hybridus",
+      "yarrow"
     ],
     "effects": [
       "Mild sedation",
@@ -9255,7 +9290,8 @@
   {
     "name": "Quercetin",
     "herbs": [
-      "nan"
+      "ginkgo-biloba",
+      "hypericum-perforatum"
     ],
     "effects": [
       "mast-cell modulation",
@@ -9318,7 +9354,8 @@
   {
     "name": "quercitrin",
     "herbs": [
-      "albizia julibrissin"
+      "albizia julibrissin",
+      "houttuynia"
     ],
     "effects": [
       "No direct effects data. Contextual inference:",
@@ -9346,9 +9383,11 @@
   {
     "name": "rosmarinic acid",
     "herbs": [
-      "nan",
       "perilla frutescens",
-      "salvia apiana"
+      "salvia apiana",
+      "lemon-balm",
+      "rosmarinus-officinalis",
+      "holy-basil"
     ],
     "effects": [
       "Mild sedation",
@@ -9762,7 +9801,7 @@
   {
     "name": "scopoletin",
     "herbs": [
-      "nan"
+      "morinda-citrifolia"
     ],
     "effects": [
       "Relaxation",
@@ -10823,7 +10862,8 @@
       "artemisia abrotanum",
       "artemisia absinthium",
       "artemisia ludoviciana",
-      "nan"
+      "mugwort",
+      "artemisia-absinthium"
     ],
     "effects": [
       "No direct effects data. Contextual inference: Used in ritual",
@@ -10872,8 +10912,8 @@
   {
     "name": "thymol",
     "herbs": [
-      "nan",
-      "thymus vulgaris"
+      "thymus vulgaris",
+      "ajwain"
     ],
     "effects": [
       "Mild sedation",
@@ -11166,7 +11206,7 @@
     "name": "umbelliferone",
     "herbs": [
       "adenostoma fasciculatum",
-      "nan"
+      "angelica-archangelica"
     ],
     "effects": [
       "Traditional uses include skin and respiratory conditions",
@@ -11240,7 +11280,8 @@
   {
     "name": "ursolic acid",
     "herbs": [
-      "nan"
+      "holy-basil",
+      "ocimum-sanctum"
     ],
     "effects": [
       "Stress relief",
@@ -11289,7 +11330,8 @@
   {
     "name": "Valerenic acid",
     "herbs": [
-      "nan"
+      "valerian",
+      "valeriana-officinalis"
     ],
     "effects": [
       "Sedation",
@@ -11361,7 +11403,8 @@
     "name": "vasicine",
     "herbs": [
       "adhatoda vasica",
-      "justicia adhatoda"
+      "justicia adhatoda",
+      "justicia-adhatoda"
     ],
     "effects": [
       "No direct effects data. Contextual inference:",
@@ -11689,7 +11732,8 @@
   {
     "name": "wogonin",
     "herbs": [
-      "nan"
+      "skullcap",
+      "scutellaria-baicalensis"
     ],
     "effects": [
       "Mild sedation",
@@ -11745,7 +11789,7 @@
   {
     "name": "yangonin)",
     "herbs": [
-      "nan"
+      "piper-methysticum"
     ],
     "effects": [
       "Euphoria",
@@ -11775,7 +11819,8 @@
   {
     "name": "Yohimbine",
     "herbs": [
-      "nan"
+      "yohimbe",
+      "pausinystalia-yohimbe"
     ],
     "effects": [
       "Stimulation",

--- a/public/data/herbs.json
+++ b/public/data/herbs.json
@@ -1574,7 +1574,9 @@
     "activeCompounds": [
       "acemannan",
       "aloe-emodin",
-      "aloin"
+      "aloin",
+      "Emodin",
+      "Rhein"
     ],
     "effects": [
       "Laxative",
@@ -1954,7 +1956,10 @@
     "activeCompounds": [
       "ginsenosides (including rb1",
       "rg1)",
-      "rb2"
+      "rb2",
+      "Ginsenoside Rb1",
+      "Ginsenoside Rg1",
+      "Ginsenoside Rg3"
     ],
     "effects": [
       "No direct effects data. Contextual inference:",
@@ -2373,7 +2378,10 @@
     "class": null,
     "intensity": "No direct intensity data. Contextual inference: Antipyretic, anti-inflammatory, and antidiabetic; used in tcm. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Antipyretic, anti-inflammatory, and antidiabetic; used in TCM. No direct region data. Contextual inference: Antipyretic, anti-inflammatory, and antidiabetic; used in tcm. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Antipyretic, anti-inflammatory, and antidiabetic; used in TCM. none. ; nan; nan. ; nan; nan",
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "Timosaponin AIII",
+      "Mangiferin aglycone"
+    ],
     "effects": [
       "Antipyretic",
       "anti-inflammatory",
@@ -2402,8 +2410,7 @@
         "title": "Inferred from scientific name:"
       },
       {
-        "note": "Inferred from scientific name:",
-        "url": ""
+        "note": "Inferred from scientific name:"
       }
     ],
     "lastUpdated": "2026-03-21",
@@ -2436,6 +2443,9 @@
     "sideEffects": [
       "allergic rash or itching in sensitive individuals",
       "mild gastrointestinal upset (nausea, cramping, or loose stool)"
+    ],
+    "aliases": [
+      "Anemarrhena asphodeloides"
     ]
   },
   {
@@ -2488,7 +2498,8 @@
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
     "activeCompounds": [
       "angelicin",
-      "essential oils"
+      "essential oils",
+      "umbelliferone"
     ],
     "effects": [
       "Carminative",
@@ -2558,7 +2569,10 @@
     "intensity": "No direct intensity data. Contextual inference: Blood tonic, hormone modulator, menstrual regulator. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Blood tonic, hormone modulator, menstrual regulator. No direct region data. Contextual inference: Blood tonic, hormone modulator, menstrual regulator. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Blood tonic, hormone modulator, menstrual regulator. none. ; nan; nan. ; nan; nan",
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
     "activeCompounds": [
-      "ferulic acid"
+      "Ferulic acid",
+      "Ligustilide",
+      "Senkyunolide A",
+      "Butylidenephthalide"
     ],
     "effects": [
       "Blood tonic",
@@ -3704,7 +3718,8 @@
     "activeCompounds": [
       "alpha-thujone",
       "absinthin",
-      "beta-thujone"
+      "beta-thujone",
+      "Thujone"
     ],
     "effects": [
       "No direct effects data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... No direct mechanismofaction data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... Used in absinthe and traditional medicine for digestion and stimulation.. Used in absinthe and traditional medicine for digestion and stimulation."
@@ -4363,7 +4378,10 @@
     "intensity": "No direct intensity data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "mechanism": "Withanolides are thought to mediate adaptogenic and neuroprotective effects by modulating HPA-axis signaling, NF-κB, Nrf2 and GABAergic pathways.",
     "activeCompounds": [
-      "withanolides"
+      "withanolides",
+      "Withaferin A",
+      "Withanolide A",
+      "withanoside IV"
     ],
     "effects": [
       "No direct effects data. Contextual inference:",
@@ -4627,8 +4645,10 @@
     "intensity": "No direct intensity data. Contextual inference: Immunostimulant, adaptogen, antiviral. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Immunostimulant, adaptogen, antiviral. No direct region data. Contextual inference: Immunostimulant, adaptogen, antiviral. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Immunostimulant, adaptogen, antiviral. none. ; nan; nan. ; nan; nan",
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
     "activeCompounds": [
-      "astragaloside IV",
-      "polysaccharides"
+      "Astragaloside IV",
+      "Calycosin",
+      "Formononetin",
+      "Astragalin"
     ],
     "effects": [
       "Immunostimulant",
@@ -4701,7 +4721,9 @@
     "intensity": "No direct intensity data. Contextual inference: Tonic for spleen and digestion in tcm. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Tonic for spleen and digestion in TCM. No direct region data. Contextual inference: Tonic for spleen and digestion in tcm. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Tonic for spleen and digestion in TCM. none. ; nan; nan. ; nan; nan",
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
     "activeCompounds": [
-      "atractylenolide I"
+      "Atractylenolide I",
+      "Atractylenolide II",
+      "Atractylenolide III"
     ],
     "effects": [
       "Tonic for spleen and digestion in TCM"
@@ -5125,7 +5147,7 @@
     ],
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "description": "; nan; nan.",
+    "description": "Bacopa monnieri lean herb row for high-speed phytochemical ingestion.",
     "dosage": [
       "No direct dosage data. Contextual inference:",
       "nan.. No direct mechanismofaction data. Contextual inference:",
@@ -5148,6 +5170,9 @@
     "sideEffects": [
       "mild gastrointestinal upset (nausea, cramping, or loose stool)",
       "headache (more likely with higher intake)"
+    ],
+    "aliases": [
+      "Bacopa monnieri"
     ]
   },
   {
@@ -6275,8 +6300,11 @@
     "intensity": "No direct intensity data. Contextual inference: Anti-inflammatory, analgesic, arthritic support. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Anti-inflammatory, analgesic, arthritic support. No direct region data. Contextual inference: Anti-inflammatory, analgesic, arthritic support. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Anti-inflammatory, analgesic, arthritic support. none. ; nan; nan. ; nan; nan",
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
     "activeCompounds": [
-      "boswellic acids",
-      "AKBA"
+      "Boswellic acid",
+      "Acetyl-beta-boswellic acid",
+      "11-keto-beta-boswellic acid",
+      "Acetyl-11-keto-beta-boswellic acid",
+      "Boswellic acids"
     ],
     "effects": [
       "Anti-inflammatory",
@@ -6873,7 +6901,11 @@
     "class": null,
     "intensity": "No direct intensity data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "mechanism": "No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "eugenol",
+      "alpha-asarone",
+      "beta-asarone"
+    ],
     "effects": [
       "No direct effects data. Contextual inference:",
       "nan.. No direct mechanismofaction data. Contextual inference:",
@@ -6893,7 +6925,7 @@
     ],
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "description": "; nan; nan.",
+    "description": "Internal cross-linking supports Calamus through compounds such as eugenol, alpha-asarone, beta-asarone.",
     "dosage": [
       "No direct dosage data. Contextual inference:",
       "nan.. No direct mechanismofaction data. Contextual inference:",
@@ -6916,6 +6948,9 @@
     "sideEffects": [
       "allergic rash or itching in sensitive individuals",
       "mild gastrointestinal upset (nausea, cramping, or loose stool)"
+    ],
+    "aliases": [
+      "Calamus"
     ]
   },
   {
@@ -8803,7 +8838,12 @@
     "class": null,
     "intensity": "mild",
     "mechanism": "No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "Asiatic acid",
+      "Madecassic acid",
+      "Asiaticoside",
+      "Madecassoside"
+    ],
     "effects": [
       "No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine",
       "Cognitive enhancer",
@@ -8835,7 +8875,7 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "description": "Folk medicine.",
+    "description": "Centella asiatica contains Asiatic acid and is linked here to PI3K/Akt modulation.",
     "dosage": [
       "No direct dosage data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. No direct region data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. Folk medicine. Folk medicine"
     ],
@@ -8853,7 +8893,10 @@
       "anxiety."
     ],
     "traditionalUse": "Folk medicine",
-    "slug": "centella-asiatica"
+    "slug": "centella-asiatica",
+    "aliases": [
+      "Centella asiatica"
+    ]
   },
   {
     "name": "cephaelis ipecacuanha",
@@ -9135,7 +9178,8 @@
     "intensity": "mild",
     "mechanism": "No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan",
     "activeCompounds": [
-      "apigenin"
+      "apigenin",
+      "Chamazulene"
     ],
     "effects": [
       "No direct effects data. Contextual inference:",
@@ -9408,7 +9452,9 @@
     "class": null,
     "intensity": "mild",
     "mechanism": "No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "Esculetin"
+    ],
     "effects": [
       "No direct effects data. Contextual inference:",
       "nan.. No direct mechanismofaction data. Contextual inference:",
@@ -9429,7 +9475,7 @@
     ],
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "description": "; nan; nan.",
+    "description": "Cichorium intybus lean monograph row enriched in bulk mode.",
     "dosage": [
       "No direct dosage data. Contextual inference:",
       "nan.. No direct mechanismofaction data. Contextual inference:",
@@ -9452,6 +9498,9 @@
     "sideEffects": [
       "dry mouth",
       "allergic rash or itching in sensitive individuals"
+    ],
+    "aliases": [
+      "Cichorium intybus"
     ]
   },
   {
@@ -10050,7 +10099,11 @@
     "class": null,
     "intensity": "No direct intensity data. Contextual inference: Aphrodisiac, antipruritic, antifungal. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Aphrodisiac, antipruritic, antifungal. No direct region data. Contextual inference: Aphrodisiac, antipruritic, antifungal. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Aphrodisiac, antipruritic, antifungal. none. ; nan; nan. ; nan; nan",
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "Osthole",
+      "Imperatorin",
+      "Isoimperatorin"
+    ],
     "effects": [
       "Aphrodisiac",
       "antipruritic",
@@ -10075,8 +10128,7 @@
         "title": "Inferred from scientific name:"
       },
       {
-        "note": "Inferred from scientific name:",
-        "url": ""
+        "note": "Inferred from scientific name:"
       }
     ],
     "lastUpdated": "2026-03-21",
@@ -10097,7 +10149,10 @@
       "Possible skin irritation",
       "avoid during pregnancy due to uterine stimulation"
     ],
-    "slug": "cnidium-monnieri"
+    "slug": "cnidium-monnieri",
+    "aliases": [
+      "Cnidium monnieri"
+    ]
   },
   {
     "name": "coca",
@@ -10329,7 +10384,9 @@
     "class": null,
     "intensity": "No direct intensity data. Contextual inference: Stimulant, cognitive enhancer, antioxidant. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Stimulant, cognitive enhancer, antioxidant. No direct region data. Contextual inference: Stimulant, cognitive enhancer, antioxidant. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Stimulant, cognitive enhancer, antioxidant. none. ; nan; nan. ; nan; nan",
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "Chlorogenic acid"
+    ],
     "effects": [
       "Stimulant",
       "cognitive enhancer",
@@ -10398,7 +10455,9 @@
       "caffeine",
       "trigonelline",
       "cafestol",
-      "kahweol"
+      "kahweol",
+      "Chlorogenic acid",
+      "caffeic acid"
     ],
     "effects": [
       "No direct effects data. Contextual inference:",
@@ -11374,7 +11433,10 @@
     "class": null,
     "intensity": "No direct intensity data. Contextual inference: Astringent, kidney and liver tonic, antioxidant. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Astringent, kidney and liver tonic, antioxidant. No direct region data. Contextual inference: Astringent, kidney and liver tonic, antioxidant. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Astringent, kidney and liver tonic, antioxidant. none. ; nan; nan. ; nan; nan",
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "Loganin",
+      "Morroniside"
+    ],
     "effects": [
       "Astringent",
       "kidney and liver tonic",
@@ -11398,8 +11460,7 @@
         "title": "Inferred from scientific name:"
       },
       {
-        "note": "Inferred from scientific name:",
-        "url": ""
+        "note": "Inferred from scientific name:"
       }
     ],
     "lastUpdated": "2026-03-21",
@@ -11427,7 +11488,10 @@
       "Generally safe",
       "may cause mild GI upset or dizziness in sensitive individuals"
     ],
-    "slug": "cornus-officinalis"
+    "slug": "cornus-officinalis",
+    "aliases": [
+      "Cornus officinalis"
+    ]
   },
   {
     "name": "corydalis cava",
@@ -11859,7 +11923,10 @@
     "class": null,
     "intensity": "No direct intensity data. Contextual inference: Anti-inflammatory, antioxidant, liver protective. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Anti-inflammatory, antioxidant, liver protective. No direct region data. Contextual inference: Anti-inflammatory, antioxidant, liver protective. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Anti-inflammatory, antioxidant, liver protective. none. ; nan; nan. ; nan; nan",
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "Demethoxycurcumin",
+      "Bisdemethoxycurcumin"
+    ],
     "effects": [
       "Anti-inflammatory",
       "antioxidant",
@@ -11888,8 +11955,7 @@
         "title": "Inferred from scientific name:"
       },
       {
-        "note": "Inferred from scientific name:",
-        "url": ""
+        "note": "Inferred from scientific name:"
       }
     ],
     "lastUpdated": "2026-03-21",
@@ -11912,7 +11978,10 @@
       "or diarrhea",
       "gallbladder stimulation noted"
     ],
-    "slug": "curcuma-longa"
+    "slug": "curcuma-longa",
+    "aliases": [
+      "Curcuma longa"
+    ]
   },
   {
     "name": "cymbopogon citratus",
@@ -12352,7 +12421,8 @@
     "mechanism": "No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan",
     "activeCompounds": [
       "flavonoids",
-      "apigenin"
+      "apigenin",
+      "Nuciferine"
     ],
     "effects": [
       "No direct effects data. Contextual inference:",
@@ -16118,12 +16188,17 @@
     "intensity": "mild",
     "mechanism": "The standardized leaf extract (EGb 761) contains terpene lactones and flavone glycosides that modulate multiple neurotransmitter systems and platelet-activating factor pathways.",
     "activeCompounds": [
-      "ginkgolides A, B, C, J",
+      "ginkgolides A",
+      "B",
+      "C",
+      "J",
       "bilobalide",
       "ginkgetin",
       "bilobetin",
       "sciadopitysin",
-      "ginkgolides"
+      "Quercetin",
+      "Kaempferol",
+      "isorhamnetin"
     ],
     "effects": [
       "No direct effects data. Contextual inference:",
@@ -16296,7 +16371,8 @@
     "intensity": "No direct intensity data. Contextual inference: Anti-inflammatory, expectorant, adrenal support. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Anti-inflammatory, expectorant, adrenal support. No direct region data. Contextual inference: Anti-inflammatory, expectorant, adrenal support. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Anti-inflammatory, expectorant, adrenal support. none. ; nan; nan. ; nan; nan",
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
     "activeCompounds": [
-      "glycyrrhizin"
+      "Glycyrrhizin",
+      "Glycyrrhetinic acid"
     ],
     "effects": [
       "Anti-inflammatory",
@@ -16756,7 +16832,10 @@
     "class": null,
     "intensity": "mild",
     "mechanism": "No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "caffeine",
+      "theobromine"
+    ],
     "effects": [
       "No direct effects data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
@@ -16793,7 +16872,10 @@
     "region": "No direct region data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine",
     "therapeuticUses": "Energy, focus, lucid dreaming support",
     "traditionalUse": "Used in ritual, dreaming or folk medicine",
-    "slug": "guayusa"
+    "slug": "guayusa",
+    "aliases": [
+      "Guayusa"
+    ]
   },
   {
     "name": "gymnema sylvestre",
@@ -16976,7 +17058,9 @@
     "class": null,
     "intensity": "No direct intensity data. Contextual inference: Anti-inflammatory, analgesic, osteoarthritis relief. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Anti-inflammatory, analgesic, osteoarthritis relief. No direct region data. Contextual inference: Anti-inflammatory, analgesic, osteoarthritis relief. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Anti-inflammatory, analgesic, osteoarthritis relief. none. ; nan; nan. ; nan; nan",
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "Harpagoside"
+    ],
     "effects": [
       "Anti-inflammatory",
       "analgesic",
@@ -17003,8 +17087,7 @@
         "title": "Inferred from scientific name:"
       },
       {
-        "note": "Inferred from scientific name:",
-        "url": ""
+        "note": "Inferred from scientific name:"
       }
     ],
     "lastUpdated": "2026-03-21",
@@ -17034,7 +17117,10 @@
       "diarrhea",
       "caution with ulcers and anticoagulants"
     ],
-    "slug": "harpagophytum-procumbens"
+    "slug": "harpagophytum-procumbens",
+    "aliases": [
+      "Harpagophytum procumbens"
+    ]
   },
   {
     "name": "hawaiian baby woodrose",
@@ -17685,7 +17771,8 @@
     "activeCompounds": [
       "eugenol",
       "ursolic acid",
-      "rosmarinic acid"
+      "rosmarinic acid",
+      "methyl eugenol"
     ],
     "effects": [
       "No direct effects data. Contextual inference: Used in ritual",
@@ -18004,7 +18091,8 @@
     "intensity": "mild",
     "mechanism": "No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine",
     "activeCompounds": [
-      "Huperzine A"
+      "Huperzine A",
+      "Huperzine B"
     ],
     "effects": [
       "No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine"
@@ -18019,7 +18107,7 @@
     ],
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "description": "Folk medicine.",
+    "description": "Huperzia serrata contains Huperzine A and is linked here to acetylcholinesterase inhibition.",
     "dosage": [
       "No direct dosage data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. No direct region data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. Folk medicine. Folk medicine"
     ],
@@ -18037,6 +18125,9 @@
     "sideEffects": [
       "May cause gastrointestinal upset (nausea, cramping, or diarrhea).",
       "Possible headache, dizziness, or allergic skin reaction in sensitive users."
+    ],
+    "aliases": [
+      "Huperzia serrata"
     ]
   },
   {
@@ -18399,7 +18490,9 @@
     "class": null,
     "intensity": "No direct intensity data. Contextual inference: Stimulant; rich in caffeine and theobromine (yerba mate). Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Stimulant; rich in caffeine and theobromine (yerba mate). No direct region data. Contextual inference: Stimulant; rich in caffeine and theobromine (yerba mate). Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Stimulant; rich in caffeine and theobromine (yerba mate). none. ; nan; nan. ; nan; nan",
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "Caffeine"
+    ],
     "effects": [
       "Stimulant",
       "rich in caffeine and theobromine (yerba mate)",
@@ -19465,7 +19558,10 @@
     "intensity": "mild",
     "mechanism": "No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan",
     "activeCompounds": [
-      "Mesembrine"
+      "mesembrenone",
+      "mesembranol",
+      "mesembrine",
+      "mesembrenol"
     ],
     "effects": [
       "No direct effects data. Contextual inference:",
@@ -19487,7 +19583,7 @@
     ],
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "description": "; nan; nan.",
+    "description": "Internal cross-linking supports Kanna through compounds such as mesembrenone, mesembranol, mesembrine.",
     "dosage": [
       "No direct dosage data. Contextual inference:",
       "nan.. No direct mechanismofaction data. Contextual inference:",
@@ -19510,6 +19606,9 @@
     "sideEffects": [
       "May cause gastrointestinal upset (nausea, cramping, or diarrhea).",
       "Possible headache, dizziness, or allergic skin reaction in sensitive users."
+    ],
+    "aliases": [
+      "Kanna"
     ]
   },
   {
@@ -19526,7 +19625,8 @@
       "yangonin",
       "desmethoxyyangonin",
       "flavokavain A/B/C",
-      "total kavalactones"
+      "total kavalactones",
+      "Kavalactones (kavain"
     ],
     "effects": [
       "No direct effects data. Contextual inference:",
@@ -20043,7 +20143,9 @@
     "class": null,
     "intensity": "No direct intensity data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "mechanism": "No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "Linalool"
+    ],
     "effects": [
       "No direct effects data. Contextual inference:",
       "nan.. No direct mechanismofaction data. Contextual inference:",
@@ -20082,7 +20184,7 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "description": "; nan; nan.",
+    "description": "Lean bulk ingestion row for Lavandula angustifolia. Key active compounds include Linalool.",
     "dosage": [
       "No direct dosage data. Contextual inference:",
       "nan.. No direct mechanismofaction data. Contextual inference:",
@@ -20105,7 +20207,10 @@
       "calming effects."
     ],
     "traditionalUse": "; nan; nan",
-    "slug": "lavandula-angustifolia"
+    "slug": "lavandula-angustifolia",
+    "aliases": [
+      "Lavandula angustifolia"
+    ]
   },
   {
     "name": "ledum palustre",
@@ -21068,7 +21173,9 @@
     "class": null,
     "intensity": "moderate",
     "mechanism": "No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "Lobeline"
+    ],
     "effects": [
       "No direct effects data. Contextual inference:",
       "nan.. No direct mechanismofaction data. Contextual inference:",
@@ -21089,7 +21196,7 @@
     ],
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "description": "; nan; nan.",
+    "description": "Lobelia inflata contains Lobeline and is linked here to nicotinic acetylcholine receptor modulation.",
     "dosage": [
       "No direct dosage data. Contextual inference:",
       "nan.. No direct mechanismofaction data. Contextual inference:",
@@ -21112,6 +21219,9 @@
     "sideEffects": [
       "May cause gastrointestinal upset (nausea, cramping, or diarrhea).",
       "Possible headache, dizziness, or allergic skin reaction in sensitive users."
+    ],
+    "aliases": [
+      "Lobelia inflata"
     ]
   },
   {
@@ -22213,7 +22323,11 @@
     "class": null,
     "intensity": "No direct intensity data. Contextual inference: Calming, anti-inflammatory, digestive support. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Calming, anti-inflammatory, digestive support. No direct region data. Contextual inference: Calming, anti-inflammatory, digestive support. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Calming, anti-inflammatory, digestive support. none. ; nan; nan. ; nan; nan",
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "Farnesol",
+      "Bisabolol",
+      "Chamazulene"
+    ],
     "effects": [
       "Calming",
       "anti-inflammatory",
@@ -22240,8 +22354,7 @@
         "title": "Inferred from scientific name:"
       },
       {
-        "note": "Inferred from scientific name:",
-        "url": ""
+        "note": "Inferred from scientific name:"
       }
     ],
     "lastUpdated": "2026-03-21",
@@ -22264,7 +22377,10 @@
       "especially in Asteraceae",
       "sensitive individuals"
     ],
-    "slug": "matricaria-chamomilla"
+    "slug": "matricaria-chamomilla",
+    "aliases": [
+      "Matricaria chamomilla"
+    ]
   },
   {
     "name": "melaleuca alternifolia",
@@ -23276,7 +23392,8 @@
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
     "activeCompounds": [
       "damnacanthal",
-      "iridoids"
+      "iridoids",
+      "scopoletin"
     ],
     "effects": [
       "Immune support",
@@ -31702,7 +31819,10 @@
     "class": null,
     "intensity": "No direct intensity data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "mechanism": "No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "Anatabine",
+      "Nicotine"
+    ],
     "effects": [
       "No direct effects data. Contextual inference:",
       "nan.. No direct mechanismofaction data. Contextual inference:",
@@ -31720,7 +31840,7 @@
     ],
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "description": "; nan; nan.",
+    "description": "Nicotiana tabacum contains Anatabine and is linked here to nicotinic acetylcholine receptor modulation.",
     "dosage": [
       "No direct dosage data. Contextual inference:",
       "nan.. No direct mechanismofaction data. Contextual inference:",
@@ -31736,7 +31856,10 @@
     "region": "No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan",
     "therapeuticUses": "Traditional ritual use, appetite suppression",
     "traditionalUse": "; nan; nan",
-    "slug": "nicotiana-tabacum"
+    "slug": "nicotiana-tabacum",
+    "aliases": [
+      "Nicotiana tabacum"
+    ]
   },
   {
     "name": "nigella sativa",
@@ -31744,7 +31867,9 @@
     "class": null,
     "intensity": "No direct intensity data. Contextual inference: Anti-inflammatory, antioxidant, immune modulating. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Anti-inflammatory, antioxidant, immune modulating. No direct region data. Contextual inference: Anti-inflammatory, antioxidant, immune modulating. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Anti-inflammatory, antioxidant, immune modulating. none. ; nan; nan. ; nan; nan",
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "Thymoquinone"
+    ],
     "effects": [
       "Anti-inflammatory",
       "antioxidant",
@@ -31772,8 +31897,7 @@
         "title": "Inferred from scientific name:"
       },
       {
-        "note": "Inferred from scientific name:",
-        "url": ""
+        "note": "Inferred from scientific name:"
       }
     ],
     "lastUpdated": "2026-03-21",
@@ -31795,7 +31919,10 @@
       "allergic reactions",
       "avoid high doses in pregnancy"
     ],
-    "slug": "nigella-sativa"
+    "slug": "nigella-sativa",
+    "aliases": [
+      "Nigella sativa"
+    ]
   },
   {
     "name": "nymphaea ampla",
@@ -32239,7 +32366,9 @@
     "intensity": "No direct intensity data. Contextual inference: Adaptogen, energy booster, cognitive enhancer. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Adaptogen, energy booster, cognitive enhancer. No direct region data. Contextual inference: Adaptogen, energy booster, cognitive enhancer. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Adaptogen, energy booster, cognitive enhancer. none. ; nan; nan. ; nan; nan",
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
     "activeCompounds": [
-      "ginsenosides"
+      "Ginsenoside Rb1",
+      "Ginsenoside Rg1",
+      "Ginsenoside Rg3"
     ],
     "effects": [
       "Adaptogen",
@@ -32452,7 +32581,7 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "description": "; nan; nan.",
+    "description": "EMA supports passionflower for relief of mild mental stress and to aid sleep on the basis of long-standing traditional use. That is useful, but it is weaker than strong modern clinical efficacy. Keep the positioning around traditional calming use and avoid overclaiming a clean single-target GABA story.",
     "dosage": [
       "No direct dosage data. Contextual inference:",
       "nan.. No direct mechanismofaction data. Contextual inference:",
@@ -32550,7 +32679,9 @@
     "class": null,
     "intensity": "moderate",
     "mechanism": "No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "Yohimbine"
+    ],
     "effects": [
       "No direct effects data. Contextual inference:",
       "nan.. No direct mechanismofaction data. Contextual inference:",
@@ -32858,7 +32989,9 @@
     "intensity": "mild",
     "mechanism": "Peppermint oil contains more than 80 constituents; menthol is the main bioactive component. Menthol acts as a smooth‑muscle relaxant by blocking L‑type calcium channels and activating transient receptor potential channels (TRPM8 and TRPA1). These actions underlie the spasmolytic and analgesic properties of peppermint oil. Peppermint oil also has antimicrobial, antiviral and anti‑inflammatory effects.",
     "activeCompounds": [
-      "menthol"
+      "menthol",
+      "Eucalyptol",
+      "limonene"
     ],
     "effects": [
       "May reduce IBS abdominal pain and global symptom burden",
@@ -33737,7 +33870,9 @@
     "class": null,
     "intensity": "No direct intensity data. Contextual inference: Anti-inflammatory, wound healing, demulcent. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Anti-inflammatory, wound healing, demulcent. No direct region data. Contextual inference: Anti-inflammatory, wound healing, demulcent. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Anti-inflammatory, wound healing, demulcent. none. ; nan; nan. ; nan; nan",
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "Aucubin"
+    ],
     "effects": [
       "Anti-inflammatory",
       "wound healing",
@@ -33764,8 +33899,7 @@
         "title": "Inferred from scientific name:"
       },
       {
-        "note": "Inferred from scientific name:",
-        "url": ""
+        "note": "Inferred from scientific name:"
       }
     ],
     "lastUpdated": "2026-03-21",
@@ -33786,7 +33920,10 @@
       "Generally safe",
       "rare allergic skin reactions"
     ],
-    "slug": "plantago-major"
+    "slug": "plantago-major",
+    "aliases": [
+      "Plantago major"
+    ]
   },
   {
     "name": "podophyllum peltatum",
@@ -35165,7 +35302,10 @@
     "class": null,
     "intensity": "No direct intensity data. Contextual inference: Laxative, digestive aid, antimicrobial. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Laxative, digestive aid, antimicrobial. No direct region data. Contextual inference: Laxative, digestive aid, antimicrobial. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Laxative, digestive aid, antimicrobial. none. ; nan; nan. ; nan; nan",
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "Emodin",
+      "Rhein"
+    ],
     "effects": [
       "Laxative",
       "digestive aid",
@@ -35191,8 +35331,7 @@
         "title": "Inferred from scientific name:"
       },
       {
-        "note": "Inferred from scientific name:",
-        "url": ""
+        "note": "Inferred from scientific name:"
       }
     ],
     "lastUpdated": "2026-03-21",
@@ -35214,7 +35353,10 @@
       "abdominal cramps",
       "electrolyte imbalance"
     ],
-    "slug": "rheum-palmatum"
+    "slug": "rheum-palmatum",
+    "aliases": [
+      "Rheum palmatum"
+    ]
   },
   {
     "name": "rhizophora mangle",
@@ -37236,7 +37378,9 @@
     "class": null,
     "intensity": "No direct intensity data. Contextual inference: Antioxidant and anti-aging effects; traditional chinese medicine. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Antioxidant and anti-aging effects; traditional Chinese medicine. No direct region data. Contextual inference: Antioxidant and anti-aging effects; traditional chinese medicine. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Antioxidant and anti-aging effects; traditional Chinese medicine. none. ; nan; nan. ; nan; nan",
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "ginkgetin"
+    ],
     "effects": [
       "Antioxidant and anti-aging effects",
       "traditional Chinese medicine",
@@ -37261,8 +37405,7 @@
         "title": "Inferred from scientific name:"
       },
       {
-        "note": "Inferred from scientific name:",
-        "url": ""
+        "note": "Inferred from scientific name:"
       }
     ],
     "lastUpdated": "2026-03-21",
@@ -37293,6 +37436,9 @@
     "sideEffects": [
       "mild gastrointestinal upset (nausea, cramping, or loose stool)",
       "allergic rash or itching in sensitive individuals"
+    ],
+    "aliases": [
+      "Selaginella tamariscina"
     ]
   },
   {
@@ -38345,7 +38491,9 @@
     "class": null,
     "intensity": "No direct intensity data. Contextual inference: Traditionally used in chinese medicine for inflammation and pain relief. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Traditionally used in Chinese medicine for inflammation and pain relief. No direct region data. Contextual inference: Traditionally used in chinese medicine for inflammation and pain relief. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Traditionally used in Chinese medicine for inflammation and pain relief. none. ; nan; nan. ; nan; nan",
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "Cepharanthine"
+    ],
     "effects": [
       "Traditionally used in Chinese medicine for inflammation and pain relief"
     ],
@@ -38365,8 +38513,7 @@
         "title": "Inferred from scientific name:"
       },
       {
-        "note": "Inferred from scientific name:",
-        "url": ""
+        "note": "Inferred from scientific name:"
       }
     ],
     "lastUpdated": "2026-03-21",
@@ -38394,6 +38541,9 @@
     "sideEffects": [
       "mild gastrointestinal upset (nausea, cramping, or loose stool)",
       "allergic rash or itching in sensitive individuals"
+    ],
+    "aliases": [
+      "Stephania cepharantha"
     ]
   },
   {
@@ -38402,7 +38552,9 @@
     "class": null,
     "intensity": "No direct intensity data. Contextual inference: Anti-inflammatory, antihypertensive, used in tcm. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Anti-inflammatory, antihypertensive, used in TCM. No direct region data. Contextual inference: Anti-inflammatory, antihypertensive, used in tcm. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Anti-inflammatory, antihypertensive, used in TCM. none. ; nan; nan. ; nan; nan",
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "Tetrandrine"
+    ],
     "effects": [
       "Anti-inflammatory",
       "antihypertensive",
@@ -38429,8 +38581,7 @@
         "title": "Inferred from scientific name:"
       },
       {
-        "note": "Inferred from scientific name:",
-        "url": ""
+        "note": "Inferred from scientific name:"
       }
     ],
     "lastUpdated": "2026-03-21",
@@ -38460,7 +38611,10 @@
       "dizziness",
       "GI effects"
     ],
-    "slug": "stephania-tetrandra"
+    "slug": "stephania-tetrandra",
+    "aliases": [
+      "Stephania tetrandra"
+    ]
   },
   {
     "name": "sweet acacia",
@@ -38790,7 +38944,9 @@
     "class": null,
     "intensity": "No direct intensity data. Contextual inference: Antiseptic, analgesic (especially dental), antioxidant. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Antiseptic, analgesic (especially dental), antioxidant. No direct region data. Contextual inference: Antiseptic, analgesic (especially dental), antioxidant. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Antiseptic, analgesic (especially dental), antioxidant. none. ; nan; nan. ; nan; nan",
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "Eugenol"
+    ],
     "effects": [
       "Antiseptic",
       "analgesic (especially dental)",
@@ -38814,8 +38970,7 @@
         "title": "Inferred from scientific name:"
       },
       {
-        "note": "Inferred from scientific name:",
-        "url": ""
+        "note": "Inferred from scientific name:"
       }
     ],
     "lastUpdated": "2026-03-21",
@@ -38843,7 +38998,10 @@
       "Allergic reactions",
       "clove oil may cause mucosal irritation"
     ],
-    "slug": "syzygium-aromaticum"
+    "slug": "syzygium-aromaticum",
+    "aliases": [
+      "Syzygium aromaticum"
+    ]
   },
   {
     "name": "tabebuia impetiginosa",
@@ -41650,6 +41808,9 @@
       "mild gastrointestinal upset (nausea, cramping, or loose stool)",
       "headache (more likely with higher intake)",
       "allergic rash or itching in sensitive individuals"
+    ],
+    "aliases": [
+      "Verbena officinalis"
     ]
   },
   {
@@ -42665,7 +42826,11 @@
     "class": null,
     "intensity": "mild",
     "mechanism": "No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "alpha-thujone",
+      "absinthin",
+      "beta-thujone"
+    ],
     "effects": [
       "No direct effects data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
@@ -42689,7 +42854,7 @@
     ],
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "description": "Used in ritual, dreaming or folk medicine.",
+    "description": "Internal cross-linking supports Wormwood through compounds such as alpha-thujone, absinthin, beta-thujone.",
     "dosage": [
       "No direct dosage data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
@@ -42714,6 +42879,9 @@
       "mild gastrointestinal upset (nausea, cramping, or loose stool)",
       "headache (more likely with higher intake)",
       "allergic rash or itching in sensitive individuals"
+    ],
+    "aliases": [
+      "Wormwood"
     ]
   },
   {
@@ -42786,7 +42954,8 @@
     "mechanism": "No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan",
     "activeCompounds": [
       "flavonoids",
-      "apigenin"
+      "apigenin",
+      "Petasin"
     ],
     "effects": [
       "No direct effects data. Contextual inference:",
@@ -42970,7 +43139,8 @@
     "intensity": "moderate",
     "mechanism": "No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan",
     "activeCompounds": [
-      "yohimbine"
+      "yohimbine",
+      "rauwolscine"
     ],
     "effects": [
       "No direct effects data. Contextual inference:",
@@ -42983,21 +43153,14 @@
       "Use caution with prescription medications and chronic conditions; monitor for intolerance.",
       "discontinue if hypersensitivity or allergic symptoms occur"
     ],
-    "safetyNotes": [
-      "caution",
-      "No direct toxicity data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan. No direct effects data. Contextual inference:",
-      "nan."
-    ],
+    "safetyNotes": "High-caution herb. Prioritize cardiovascular and psychiatric risk review. Avoid escalation framing, avoid use in people prone to panic, hypertension, arrhythmia, or seizure, and avoid positioning as a routine tonic.",
     "sources": [
       {
         "title": "Internal workbook cross-link"
       }
     ],
     "lastUpdated": "2026-03-21",
-    "description": "; nan; nan.",
+    "description": "Yohimbe is represented here as a bark-derived monograph anchored to yohimbine, an alpha-2 adrenergic antagonist with sympathomimetic effects. The herb is more appropriately framed around safety review than routine recommendation. Potential effects include increased alertness and sexual-function relevance, but tolerability can be poor and adverse effects may include anxiety, tachycardia, blood-pressure elevation, agitation, insomnia, and gastrointestinal distress. Use should be conservative and exclusion-heavy in people with cardiovascular, psychiatric, seizure, renal, or hepatic vulnerability.",
     "dosage": [
       "No direct dosage data. Contextual inference:",
       "nan.. No direct mechanismofaction data. Contextual inference:",
@@ -44198,7 +44361,8 @@
     "activeCompounds": [
       "caffeine",
       "theanine",
-      "catechins (egcg)"
+      "catechins (egcg)",
+      "catechin"
     ],
     "effects": [
       "No direct effects data. Contextual inference:",
@@ -45081,7 +45245,8 @@
     "intensity": "No direct intensity data. Contextual inference: Cognitive enhancer, anxiolytic, wound healing; triterpenes improve circulation. Boosts collagen synthesis, modulates gaba and blood flow.. ; nan; nan.. Boosts collagen synthesis, modulates GABA and blood flow.. Cognitive enhancer, anxiolytic, wound healing; triterpenes improve circulation. No direct region data. Contextual inference: Cognitive enhancer, anxiolytic, wound healing; triterpenes improve circulation. Boosts collagen synthesis, modulates gaba and blood flow.. ; nan; nan.. Boosts collagen synthesis, modulates GABA and blood flow.. Cognitive enhancer, anxiolytic, wound healing; triterpenes improve circulation. ; nan; nan. ; nan; nan",
     "mechanism": "Boosts collagen synthesis, modulates GABA and blood flow.",
     "activeCompounds": [
-      "asiaticoside"
+      "asiaticoside",
+      "Madecassoside"
     ],
     "effects": [
       "Cognitive enhancer",
@@ -46084,7 +46249,10 @@
       "headache (more likely with higher intake)",
       "allergic rash or itching in sensitive individuals"
     ],
-    "slug": "myristica-fragrans"
+    "slug": "myristica-fragrans",
+    "aliases": [
+      "Myristica fragrans"
+    ]
   },
   {
     "name": "nelumbo nucifera",
@@ -46125,7 +46293,10 @@
       "headache (more likely with higher intake)",
       "allergic rash or itching in sensitive individuals"
     ],
-    "slug": "nelumbo-nucifera"
+    "slug": "nelumbo-nucifera",
+    "aliases": [
+      "Nelumbo nucifera"
+    ]
   },
   {
     "name": "nepeta cataria",
@@ -46305,7 +46476,9 @@
     "class": null,
     "intensity": "No direct intensity data. Contextual inference: Adaptogen, anti-stress, immune support. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Adaptogen, anti-stress, immune support. No direct region data. Contextual inference: Adaptogen, anti-stress, immune support. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Adaptogen, anti-stress, immune support. none. ; nan; nan. ; nan; nan",
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "Ursolic acid"
+    ],
     "effects": [
       "Adaptogen",
       "anti",
@@ -46316,8 +46489,7 @@
     "safetyNotes": [],
     "sources": [
       {
-        "note": "Inferred from scientific name:",
-        "url": ""
+        "note": "Inferred from scientific name:"
       }
     ],
     "lastUpdated": "2026-03-21",
@@ -46338,7 +46510,10 @@
       "drowsiness",
       "caution with anticoagulants"
     ],
-    "slug": "ocimum-sanctum"
+    "slug": "ocimum-sanctum",
+    "aliases": [
+      "Ocimum sanctum"
+    ]
   },
   {
     "name": "papaver somniferum",
@@ -46517,7 +46692,10 @@
     "class": null,
     "intensity": "No direct intensity data. Contextual inference: Mao inhibitor, antispasmodic, psychoactive. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. MAO inhibitor, antispasmodic, psychoactive. No direct region data. Contextual inference: Mao inhibitor, antispasmodic, psychoactive. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. MAO inhibitor, antispasmodic, psychoactive. none. ; nan; nan. ; nan; nan",
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "harmine",
+      "harmaline)"
+    ],
     "effects": [
       "MAO inhibitor",
       "antispasmodic",
@@ -46724,7 +46902,14 @@
     "class": null,
     "intensity": "moderate",
     "mechanism": "No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "Kavalactones",
+      "Kavain",
+      "Yangonin",
+      "Methysticin",
+      "Kavalactones (kavain",
+      "yangonin)"
+    ],
     "effects": [
       "No direct effects data. Contextual inference:",
       "nan.. No direct mechanismofaction data. Contextual inference:",
@@ -46756,13 +46941,16 @@
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "legalStatus": "restricted",
     "interactions": [],
-    "description": "; nan; nan.",
+    "description": "Piper methysticum contains Kavalactones and is linked here to GABA-A modulation.",
     "sideEffects": [
       "mild gastrointestinal upset (nausea, cramping, or loose stool)",
       "headache (more likely with higher intake)",
       "allergic rash or itching in sensitive individuals"
     ],
-    "slug": "piper-methysticum"
+    "slug": "piper-methysticum",
+    "aliases": [
+      "Piper methysticum"
+    ]
   },
   {
     "name": "pituri",
@@ -47528,7 +47716,9 @@
     "intensity": "No direct intensity data. Contextual inference: Nervine, anxiolytic, anti-inflammatory; used for insomnia and anxiety. Flavonoids modulate gaba receptors; offers calming and anxiolytic effects.. ; nan; nan.. Flavonoids modulate GABA receptors; offers calming and anxiolytic effects.. Nervine, anxiolytic, anti-inflammatory; used for insomnia and anxiety. No direct region data. Contextual inference: Nervine, anxiolytic, anti-inflammatory; used for insomnia and anxiety. Flavonoids modulate gaba receptors; offers calming and anxiolytic effects.. ; nan; nan.. Flavonoids modulate GABA receptors; offers calming and anxiolytic effects.. Nervine, anxiolytic, anti-inflammatory; used for insomnia and anxiety. ; nan; nan. ; nan; nan",
     "mechanism": "Flavonoids modulate GABA receptors; offers calming and anxiolytic effects.",
     "activeCompounds": [
-      "baicalin"
+      "baicalin",
+      "Baicalein",
+      "Wogonin"
     ],
     "effects": [
       "Nervine",
@@ -48177,7 +48367,11 @@
     "class": null,
     "intensity": "No direct intensity data. Contextual inference: Sedative, anxiolytic, sleep aid. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Sedative, anxiolytic, sleep aid. No direct region data. Contextual inference: Sedative, anxiolytic, sleep aid. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Sedative, anxiolytic, sleep aid. none. ; nan; nan. ; nan; nan",
     "mechanism": "Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.",
-    "activeCompounds": [],
+    "activeCompounds": [
+      "Valerenic acid",
+      "Valerenol",
+      "Valepotriates"
+    ],
     "effects": [
       "Sedative",
       "anxiolytic",
@@ -48187,8 +48381,7 @@
     "safetyNotes": [],
     "sources": [
       {
-        "note": "Inferred from scientific name:",
-        "url": ""
+        "note": "Inferred from scientific name:"
       }
     ],
     "lastUpdated": "2026-03-21",
@@ -48210,7 +48403,10 @@
       "vivid dreams",
       "avoid with sedatives"
     ],
-    "slug": "valeriana-officinalis"
+    "slug": "valeriana-officinalis",
+    "aliases": [
+      "Valeriana officinalis"
+    ]
   },
   {
     "name": "virola calophylla",
@@ -49668,7 +49864,8 @@
       "ajwain"
     ],
     "activeCompounds": [
-      "thymol"
+      "thymol",
+      "carvacrol"
     ],
     "interactions": [
       "Avoid overextended antimicrobial claims."

--- a/public/data/workbook-compounds.json
+++ b/public/data/workbook-compounds.json
@@ -1,1421 +1,17 @@
 [
   {
-    "id": "1-8-cineole",
-    "slug": "1-8-cineole",
-    "canonicalCompoundId": "1-8-cineole",
-    "name": "1,8-cineole",
-    "compoundName": "1,8-cineole",
-    "canonicalCompoundName": "1,8-cineole",
-    "hero": "Defines a key pharmacological signal attributed to 1,8-cineole in herbal extracts.",
-    "coreInsight": "1,8-cineole matters most when bronchodilation support is used as the primary readout. That makes it more informative than a generic monoterpene oxide label.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[\"bronchodilation support\"]"
-    ]
-  },
-  {
-    "id": "1-deoxynojirimycin",
-    "slug": "1-deoxynojirimycin",
-    "canonicalCompoundId": "1-deoxynojirimycin",
-    "name": "1-deoxynojirimycin",
-    "compoundName": "1-deoxynojirimycin",
-    "canonicalCompoundName": "1-deoxynojirimycin",
-    "hero": "Helps define why Mulberry Leaf extracts perform differently in formulation.",
-    "coreInsight": "1-deoxynojirimycin becomes more valuable when Mulberry Leaf is standardized by named actives rather than total extract mass.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[\"glucose absorption modulation\"]"
-    ]
-  },
-  {
-    "id": "11-keto-beta-boswellic-acid",
-    "slug": "11-keto-beta-boswellic-acid",
-    "canonicalCompoundId": "11-keto-beta-boswellic-acid",
-    "name": "11-keto-beta-boswellic acid",
-    "compoundName": "11-keto-beta-boswellic acid",
-    "canonicalCompoundName": "11-keto-beta-boswellic acid",
-    "hero": "Defines a key pharmacological signal attributed to 11-keto-beta-boswellic acid in herbal extracts.",
-    "coreInsight": "11-keto-beta-boswellic acid remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[\"5-lipoxygenase inhibition\"",
-      "\"leukotriene suppression\"]"
-    ]
-  },
-  {
-    "id": "23-epi-26-deoxyactein",
-    "slug": "23-epi-26-deoxyactein",
-    "canonicalCompoundId": "23-epi-26-deoxyactein",
-    "name": "23-epi-26-deoxyactein",
-    "compoundName": "23-epi-26-deoxyactein",
-    "canonicalCompoundName": "23-epi-26-deoxyactein",
-    "hero": "Distinguishes 23-epi-26-deoxyactein from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "23-epi-26-deoxyactein matters because it can be ranked directly against triterpene glycosides (actein, 23-epi-26-deoxyactein) and related neighbors during compound prioritization.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[\"nitric oxide modulation\"",
-      "\"serotonin modulation\"",
-      "\"hormone modulation\"]"
-    ]
-  },
-  {
-    "id": "4-hydroxyderricin",
-    "slug": "4-hydroxyderricin",
-    "canonicalCompoundId": "4-hydroxyderricin",
-    "name": "4-hydroxyderricin",
-    "compoundName": "4-hydroxyderricin",
-    "canonicalCompoundName": "4-hydroxyderricin",
-    "hero": "Defines a key pharmacological signal attributed to 4-hydroxyderricin in herbal extracts.",
-    "coreInsight": "4-hydroxyderricin remains provisional because the evidence behind Ashitaba does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"NF-κB modulation\"]"
-    ]
-  },
-  {
-    "id": "5-hydroxytryptophan-5-htp",
-    "slug": "5-hydroxytryptophan-5-htp",
-    "canonicalCompoundId": "5-hydroxytryptophan-5-htp",
-    "name": "5-hydroxytryptophan (5-HTP)",
-    "compoundName": "5-hydroxytryptophan (5-HTP)",
-    "canonicalCompoundName": "5-hydroxytryptophan (5-HTP)",
-    "hero": "Defines a key pharmacological signal attributed to 5-hydroxytryptophan (5-htp) in herbal extracts.",
-    "coreInsight": "5-hydroxytryptophan (5-HTP) stays provisional because the evidence behind Griffonia simplicifolia does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[\"serotonin modulation\"]"
-    ]
-  },
-  {
-    "id": "5-meo-dmt",
-    "slug": "5-meo-dmt",
-    "canonicalCompoundId": "5-meo-dmt",
-    "name": "5-meo-dmt",
-    "compoundName": "5-meo-dmt",
-    "canonicalCompoundName": "5-meo-dmt",
-    "hero": "Defines a key pharmacological signal attributed to 5-meo-dmt in herbal extracts.",
-    "coreInsight": "5-meo-dmt matters most when serotonin modulation is used as the primary readout. That makes it more informative than a generic alkaloid label.",
-    "effects": [
-      "[\"hallucinogenic\"",
-      "\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[\"serotonin modulation\"]"
-    ]
-  },
-  {
-    "id": "6-gingerol",
-    "slug": "6-gingerol",
-    "canonicalCompoundId": "6-gingerol",
-    "name": "6-Gingerol",
-    "compoundName": "6-Gingerol",
-    "canonicalCompoundName": "6-Gingerol",
-    "hero": "Defines a key pharmacological signal attributed to 6-gingerol in herbal extracts.",
-    "coreInsight": "6-Gingerol matters most when gastrointestinal modulation is used as the primary readout. That makes it more informative than a generic Anti-inflammatory; GI modulation label.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[\"gastrointestinal modulation\"",
-      "\"inflammatory signaling modulation\"]"
-    ]
-  },
-  {
-    "id": "6-shogaol",
-    "slug": "6-shogaol",
-    "canonicalCompoundId": "6-shogaol",
-    "name": "6-Shogaol",
-    "compoundName": "6-Shogaol",
-    "canonicalCompoundName": "6-Shogaol",
-    "hero": "Drives anti-inflammatory and antioxidant activity within Zingiber officinale chemistry.",
-    "coreInsight": "For Zingiber officinale, 6-Shogaol is most useful as a direct anti-inflammatory signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"gastrointestinal modulation\"",
-      "\"inflammatory signaling modulation\"]"
-    ]
-  },
-  {
-    "id": "7-hydroxymitragynine",
-    "slug": "7-hydroxymitragynine",
-    "canonicalCompoundId": "7-hydroxymitragynine",
-    "name": "7-hydroxymitragynine",
-    "compoundName": "7-hydroxymitragynine",
-    "canonicalCompoundName": "7-hydroxymitragynine",
-    "hero": "Defines a key pharmacological signal attributed to 7-hydroxymitragynine in herbal extracts.",
-    "coreInsight": "7-hydroxymitragynine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antidepressant\"",
-      "\"analgesic\"",
-      "\"stimulant\"]"
-    ],
-    "mechanisms": [
-      "[\"serotonin modulation\"",
-      "\"opioid receptor modulation\"]"
-    ]
-  },
-  {
-    "id": "8-cineole",
-    "slug": "8-cineole",
-    "canonicalCompoundId": "8-cineole",
-    "name": "8-cineole",
-    "compoundName": "8-cineole",
-    "canonicalCompoundName": "8-cineole",
-    "hero": "Distinguishes 8-cineole from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "8-cineole matters because it can be ranked directly against terpinyl acetate and related neighbors during compound prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "a-type-proanthocyanidins",
-    "slug": "a-type-proanthocyanidins",
-    "canonicalCompoundId": "a-type-proanthocyanidins",
-    "name": "a-type proanthocyanidins",
-    "compoundName": "a-type proanthocyanidins",
-    "canonicalCompoundName": "a-type proanthocyanidins",
-    "hero": "Defines a key pharmacological signal attributed to a-type proanthocyanidins in herbal extracts.",
-    "coreInsight": "a-type proanthocyanidins remains provisional because the evidence behind Cranberry does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"diuretic\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "absinthin",
-    "slug": "absinthin",
-    "canonicalCompoundId": "absinthin",
-    "name": "absinthin",
-    "compoundName": "absinthin",
-    "canonicalCompoundName": "absinthin",
-    "hero": "Defines a key pharmacological signal attributed to absinthin in herbal extracts.",
-    "coreInsight": "absinthin stays provisional because the evidence behind Wormwood does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"]"
-    ]
-  },
-  {
-    "id": "acetyl-11-keto-beta-boswellic-acid",
-    "slug": "acetyl-11-keto-beta-boswellic-acid",
-    "canonicalCompoundId": "acetyl-11-keto-beta-boswellic-acid",
-    "name": "acetyl-11-keto-beta-boswellic acid",
-    "compoundName": "acetyl-11-keto-beta-boswellic acid",
-    "canonicalCompoundName": "acetyl-11-keto-beta-boswellic acid",
-    "hero": "Delivers 5-lipoxygenase inhibition in acetyl-11-keto-beta-boswellic acid.",
-    "coreInsight": "acetyl-11-keto-beta-boswellic acid matters most when 5-lipoxygenase inhibition is used as the primary readout. That makes it more informative than a generic acetyl-11-keto-beta-boswellic acid (akba) label.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[\"5-lipoxygenase inhibition\"",
-      "\"leukotriene suppression\"]"
-    ]
-  },
-  {
-    "id": "acetyl-beta-boswellic-acid",
-    "slug": "acetyl-beta-boswellic-acid",
-    "canonicalCompoundId": "acetyl-beta-boswellic-acid",
-    "name": "acetyl-beta-boswellic acid",
-    "compoundName": "acetyl-beta-boswellic acid",
-    "canonicalCompoundName": "acetyl-beta-boswellic acid",
-    "hero": "Carries 5-lipoxygenase inhibition in acetyl-beta-boswellic acid.",
-    "coreInsight": "acetyl-beta-boswellic acid matters most when 5-lipoxygenase inhibition is used as the primary readout. That makes it more informative than a generic organic acid label.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[\"5-lipoxygenase inhibition\"",
-      "\"leukotriene suppression\"]"
-    ]
-  },
-  {
-    "id": "acetyl-l-carnitine",
-    "slug": "acetyl-l-carnitine",
-    "canonicalCompoundId": "acetyl-l-carnitine",
-    "name": "acetyl-l-carnitine",
-    "compoundName": "acetyl-l-carnitine",
-    "canonicalCompoundName": "acetyl-l-carnitine",
-    "hero": "Defines a key pharmacological signal attributed to acetyl-l-carnitine in herbal extracts.",
-    "coreInsight": "acetyl-l-carnitine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[\"mitochondrial support\"]"
-    ]
-  },
-  {
-    "id": "aconitine",
-    "slug": "aconitine",
-    "canonicalCompoundId": "aconitine",
-    "name": "aconitine",
-    "compoundName": "aconitine",
-    "canonicalCompoundName": "aconitine",
-    "hero": "Defines a key pharmacological signal attributed to aconitine in herbal extracts.",
-    "coreInsight": "aconitine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "actein",
-    "slug": "actein",
-    "canonicalCompoundId": "actein",
-    "name": "Actein",
-    "compoundName": "Actein",
-    "canonicalCompoundName": "Actein",
-    "hero": "Distinguishes Actein from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Actein matters because it can be ranked directly against triterpene glycosides (actein, 23-epi-26-deoxyactein) and related neighbors during compound prioritization.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[\"NF-kB inhibition\"",
-      "\"nitric oxide modulation\"",
-      "\"serotonin modulation\"",
-      "\"hormone modulation\"]"
-    ]
-  },
-  {
-    "id": "acteoside",
-    "slug": "acteoside",
-    "canonicalCompoundId": "acteoside",
-    "name": "acteoside",
-    "compoundName": "acteoside",
-    "canonicalCompoundName": "acteoside",
-    "hero": "Defines a key pharmacological signal attributed to acteoside in herbal extracts.",
-    "coreInsight": "acteoside remains provisional because the evidence behind Cistanche does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "adenosine",
-    "slug": "adenosine",
-    "canonicalCompoundId": "adenosine",
-    "name": "adenosine",
-    "compoundName": "adenosine",
-    "canonicalCompoundName": "adenosine",
-    "hero": "Defines a key pharmacological signal attributed to adenosine in herbal extracts.",
-    "coreInsight": "adenosine stays provisional because the evidence behind Cordyceps does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "aegeline",
-    "slug": "aegeline",
-    "canonicalCompoundId": "aegeline",
-    "name": "aegeline",
-    "compoundName": "aegeline",
-    "canonicalCompoundName": "aegeline",
-    "hero": "Acts as a recognizable chemical marker within Bael.",
-    "coreInsight": "Within Bael, aegeline helps define the plant’s chemistry alongside markers such as marmelosin.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "aescin",
-    "slug": "aescin",
-    "canonicalCompoundId": "aescin",
-    "name": "aescin",
-    "compoundName": "aescin",
-    "canonicalCompoundName": "aescin",
-    "hero": "Helps define why Horse Chestnut extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, aescin helps separate Horse Chestnut extracts from adjacent markers such as aesculin. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "aesculin",
-    "slug": "aesculin",
-    "canonicalCompoundId": "aesculin",
-    "name": "aesculin",
-    "compoundName": "aesculin",
-    "canonicalCompoundName": "aesculin",
-    "hero": "Helps define why Horse Chestnut extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, aesculin helps separate Horse Chestnut extracts from adjacent markers such as aescin. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "agaric-acid",
-    "slug": "agaric-acid",
-    "canonicalCompoundId": "agaric-acid",
-    "name": "agaric acid",
-    "compoundName": "agaric acid",
-    "canonicalCompoundName": "agaric acid",
-    "hero": "Helps define why Agarikon extracts perform differently in formulation.",
-    "coreInsight": "agaric acid becomes more valuable when Agarikon is standardized by named actives rather than total extract mass.",
-    "effects": [
-      "[\"immunomodulatory\"]"
-    ],
-    "mechanisms": [
-      "[\"immune signaling modulation\"]"
-    ]
-  },
-  {
-    "id": "agnuside",
-    "slug": "agnuside",
-    "canonicalCompoundId": "agnuside",
-    "name": "agnuside",
-    "compoundName": "agnuside",
-    "canonicalCompoundName": "agnuside",
-    "hero": "Defines a key pharmacological signal attributed to agnuside in herbal extracts.",
-    "coreInsight": "Agnuside remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "agrimoniin",
-    "slug": "agrimoniin",
-    "canonicalCompoundId": "agrimoniin",
-    "name": "agrimoniin",
-    "compoundName": "agrimoniin",
-    "canonicalCompoundName": "agrimoniin",
-    "hero": "Defines a key pharmacological signal attributed to agrimoniin in herbal extracts.",
-    "coreInsight": "agrimoniin remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "ajmaline",
-    "slug": "ajmaline",
-    "canonicalCompoundId": "ajmaline",
-    "name": "ajmaline",
-    "compoundName": "ajmaline",
-    "canonicalCompoundName": "ajmaline",
-    "hero": "Defines a key pharmacological signal attributed to ajmaline in herbal extracts.",
-    "coreInsight": "ajmaline stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "ajoene",
-    "slug": "ajoene",
-    "canonicalCompoundId": "ajoene",
-    "name": "ajoene",
-    "compoundName": "ajoene",
-    "canonicalCompoundName": "ajoene",
-    "hero": "Acts as a recognizable chemical marker within Garlic.",
-    "coreInsight": "Within Garlic, ajoene helps define the plant’s chemistry alongside markers such as diallyl sulfide.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "akba",
-    "slug": "akba",
-    "canonicalCompoundId": "akba",
-    "name": "akba",
-    "compoundName": "akba",
-    "canonicalCompoundName": "akba",
-    "hero": "Helps define why Boswellia extracts perform differently in formulation.",
-    "coreInsight": "akba becomes more valuable when Boswellia is standardized by named actives rather than total extract mass.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "akuammine",
-    "slug": "akuammine",
-    "canonicalCompoundId": "akuammine",
-    "name": "Akuammine",
-    "compoundName": "Akuammine",
-    "canonicalCompoundName": "Akuammine",
-    "hero": "Delivers analgesic activity within Picralima nitida chemistry.",
-    "coreInsight": "For Picralima nitida, Akuammine is most useful as a direct analgesic signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"analgesic\"]"
-    ],
-    "mechanisms": [
-      "[\"analgesic signaling\"",
-      "\"opioid receptor modulation\"]"
-    ]
-  },
-  {
-    "id": "alangine",
-    "slug": "alangine",
-    "canonicalCompoundId": "alangine",
-    "name": "alangine",
-    "compoundName": "alangine",
-    "canonicalCompoundName": "alangine",
-    "hero": "Defines a key pharmacological signal attributed to alangine in herbal extracts.",
-    "coreInsight": "alangine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "alantolactone",
-    "slug": "alantolactone",
-    "canonicalCompoundId": "alantolactone",
-    "name": "alantolactone",
-    "compoundName": "alantolactone",
-    "canonicalCompoundName": "alantolactone",
-    "hero": "Distinguishes alantolactone from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Alantolactone matters because it can be ranked directly against inulin and related neighbors during compound prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "alchorneine",
-    "slug": "alchorneine",
-    "canonicalCompoundId": "alchorneine",
-    "name": "alchorneine",
-    "compoundName": "alchorneine",
-    "canonicalCompoundName": "alchorneine",
-    "hero": "Defines a key pharmacological signal attributed to alchorneine in herbal extracts.",
-    "coreInsight": "alchorneine remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "allantoin",
-    "slug": "allantoin",
-    "canonicalCompoundId": "allantoin",
-    "name": "allantoin",
-    "compoundName": "allantoin",
-    "canonicalCompoundName": "allantoin",
-    "hero": "Defines a key pharmacological signal attributed to allantoin in herbal extracts.",
-    "coreInsight": "allantoin stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "allicin",
-    "slug": "allicin",
-    "canonicalCompoundId": "allicin",
-    "name": "allicin",
-    "compoundName": "allicin",
-    "canonicalCompoundName": "allicin",
-    "hero": "Defines a key pharmacological signal attributed to allicin in herbal extracts.",
-    "coreInsight": "allicin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "allyl-isothiocyanate",
-    "slug": "allyl-isothiocyanate",
-    "canonicalCompoundId": "allyl-isothiocyanate",
-    "name": "allyl isothiocyanate",
-    "compoundName": "allyl isothiocyanate",
-    "canonicalCompoundName": "allyl isothiocyanate",
-    "hero": "Defines a key pharmacological signal attributed to allyl isothiocyanate in herbal extracts.",
-    "coreInsight": "allyl isothiocyanate remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "aloe-emodin",
-    "slug": "aloe-emodin",
-    "canonicalCompoundId": "aloe-emodin",
-    "name": "aloe-emodin",
-    "compoundName": "aloe-emodin",
-    "canonicalCompoundName": "aloe-emodin",
-    "hero": "Defines anti-inflammatory activity within Aloe Vera chemistry.",
-    "coreInsight": "For Aloe Vera, aloe-emodin is most useful as a direct anti-inflammatory signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[\"NF-kB inhibition\"",
-      "\"NF-kB modulation\"",
-      "\"NF-κB modulation\"]"
-    ]
-  },
-  {
-    "id": "aloin",
-    "slug": "aloin",
-    "canonicalCompoundId": "aloin",
-    "name": "aloin",
-    "compoundName": "aloin",
-    "canonicalCompoundName": "aloin",
-    "hero": "Helps define why Aloe Vera extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, aloin helps separate Aloe Vera extracts from adjacent markers such as aloe-emodin. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "alpha-asarone",
-    "slug": "alpha-asarone",
-    "canonicalCompoundId": "alpha-asarone",
-    "name": "alpha-asarone",
-    "compoundName": "alpha-asarone",
-    "canonicalCompoundName": "alpha-asarone",
-    "hero": "Distinguishes alpha-asarone from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Alpha-asarone matters because it can be ranked directly against beta-asarone and related neighbors during compound prioritization.",
-    "effects": [
-      "[\"stimulant\"]"
-    ],
-    "mechanisms": [
-      "[\"adrenergic signaling\"]"
-    ]
-  },
-  {
-    "id": "alpha-bisabolol",
-    "slug": "alpha-bisabolol",
-    "canonicalCompoundId": "alpha-bisabolol",
-    "name": "alpha-bisabolol",
-    "compoundName": "alpha-bisabolol",
-    "canonicalCompoundName": "alpha-bisabolol",
-    "hero": "Defines a key pharmacological signal attributed to alpha-bisabolol in herbal extracts.",
-    "coreInsight": "alpha-bisabolol remains provisional because the evidence behind Chamomile does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antispasmodic\"",
-      "\"muscle-relaxant\"",
-      "\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"",
-      "\"adrenergic signaling\"]"
-    ]
-  },
-  {
-    "id": "alpha-gpc-l-alpha-glycerylphosphorylcholine",
-    "slug": "alpha-gpc-l-alpha-glycerylphosphorylcholine",
-    "canonicalCompoundId": "alpha-gpc-l-alpha-glycerylphosphorylcholine",
-    "name": "alpha-gpc l-alpha-glycerylphosphorylcholine",
-    "compoundName": "alpha-gpc l-alpha-glycerylphosphorylcholine",
-    "canonicalCompoundName": "alpha-gpc l-alpha-glycerylphosphorylcholine",
-    "hero": "Defines a key pharmacological signal attributed to alpha-gpc l-alpha-glycerylphosphorylcholine in herbal extracts.",
-    "coreInsight": "alpha-gpc l-alpha-glycerylphosphorylcholine stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"nootropic\"",
-      "\"stimulant\"]"
-    ],
-    "mechanisms": [
-      "[\"adrenergic signaling\"]"
-    ]
-  },
-  {
-    "id": "alpha-mangostin",
-    "slug": "alpha-mangostin",
-    "canonicalCompoundId": "alpha-mangostin",
-    "name": "alpha-mangostin",
-    "compoundName": "alpha-mangostin",
-    "canonicalCompoundName": "alpha-mangostin",
-    "hero": "Acts as a recognizable chemical marker within Mangosteen.",
-    "coreInsight": "Within Mangosteen, alpha-mangostin serves mainly as a phytochemical marker that sharpens chemical identity.",
-    "effects": [
-      "[\"antioxidant\"",
-      "\"stimulant\"]"
-    ],
-    "mechanisms": [
-      "[\"adrenergic signaling\"]"
-    ]
-  },
-  {
-    "id": "alpha-pinene",
-    "slug": "alpha-pinene",
-    "canonicalCompoundId": "alpha-pinene",
-    "name": "alpha-pinene",
-    "compoundName": "alpha-pinene",
-    "canonicalCompoundName": "alpha-pinene",
-    "hero": "Defines a key pharmacological signal attributed to alpha-pinene in herbal extracts.",
-    "coreInsight": "alpha-pinene matters most when adrenergic signaling is used as the primary readout. That makes it more informative than a generic terpenes label.",
-    "effects": [
-      "[\"stimulant\"]"
-    ],
-    "mechanisms": [
-      "[\"adrenergic signaling\"]"
-    ]
-  },
-  {
-    "id": "alpha-terpineol",
-    "slug": "alpha-terpineol",
-    "canonicalCompoundId": "alpha-terpineol",
-    "name": "alpha-terpineol",
-    "compoundName": "alpha-terpineol",
-    "canonicalCompoundName": "alpha-terpineol",
-    "hero": "Sharpens stimulant activity at the compound level.",
-    "coreInsight": "alpha-terpineol is most useful when a formulation needs a direct stimulant signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"stimulant\"]"
-    ],
-    "mechanisms": [
-      "[\"adrenergic signaling\"]"
-    ]
-  },
-  {
-    "id": "alpha-thujone",
-    "slug": "alpha-thujone",
-    "canonicalCompoundId": "alpha-thujone",
-    "name": "alpha-thujone",
-    "compoundName": "alpha-thujone",
-    "canonicalCompoundName": "alpha-thujone",
-    "hero": "Helps define why Wormwood extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, alpha-thujone helps separate Wormwood extracts from adjacent markers such as absinthin. That improves standardization decisions.",
-    "effects": [
-      "[\"anxiolytic\"",
-      "\"stimulant\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"",
-      "\"adrenergic signaling\"]"
-    ]
-  },
-  {
-    "id": "amarogentin",
-    "slug": "amarogentin",
-    "canonicalCompoundId": "amarogentin",
-    "name": "amarogentin",
-    "compoundName": "amarogentin",
-    "canonicalCompoundName": "amarogentin",
-    "hero": "Defines a key pharmacological signal attributed to amarogentin in herbal extracts.",
-    "coreInsight": "Amarogentin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "amentoflavone",
-    "slug": "amentoflavone",
-    "canonicalCompoundId": "amentoflavone",
-    "name": "amentoflavone",
-    "compoundName": "amentoflavone",
-    "canonicalCompoundName": "amentoflavone",
-    "hero": "Defines a key pharmacological signal attributed to amentoflavone in herbal extracts.",
-    "coreInsight": "amentoflavone remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "anabasine",
-    "slug": "anabasine",
-    "canonicalCompoundId": "anabasine",
-    "name": "anabasine",
-    "compoundName": "anabasine",
-    "canonicalCompoundName": "anabasine",
-    "hero": "Defines a key pharmacological signal attributed to anabasine in herbal extracts.",
-    "coreInsight": "anabasine stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"nootropic\"]"
-    ],
-    "mechanisms": [
-      "[\"dopamine modulation\"]"
-    ]
-  },
-  {
-    "id": "andrographolide",
-    "slug": "andrographolide",
-    "canonicalCompoundId": "andrographolide",
-    "name": "Andrographolide",
-    "compoundName": "Andrographolide",
-    "canonicalCompoundName": "Andrographolide",
-    "hero": "Acts as a recognizable chemical marker within Andrographis paniculata.",
-    "coreInsight": "Within Andrographis paniculata, Andrographolide serves mainly as a phytochemical marker that sharpens chemical identity.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[\"NF-kB inhibition\"",
-      "\"inflammatory signaling modulation\"",
-      "\"NF-kB modulation\"",
-      "\"NF-κB modulation\"]"
-    ]
-  },
-  {
-    "id": "anethole",
-    "slug": "anethole",
-    "canonicalCompoundId": "anethole",
-    "name": "anethole",
-    "compoundName": "anethole",
-    "canonicalCompoundName": "anethole",
-    "hero": "Helps define why Fennel extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, anethole helps separate Fennel extracts from adjacent markers such as estragole. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "angelicin",
-    "slug": "angelicin",
-    "canonicalCompoundId": "angelicin",
-    "name": "angelicin",
-    "compoundName": "angelicin",
-    "canonicalCompoundName": "angelicin",
-    "hero": "Helps define why Angelica Root extracts perform differently in formulation.",
-    "coreInsight": "angelicin becomes more valuable when Angelica Root is standardized by named actives rather than total extract mass.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "anisomelic-acid",
-    "slug": "anisomelic-acid",
-    "canonicalCompoundId": "anisomelic-acid",
-    "name": "anisomelic acid",
-    "compoundName": "anisomelic acid",
-    "canonicalCompoundName": "anisomelic acid",
-    "hero": "Defines a key pharmacological signal attributed to anisomelic acid in herbal extracts.",
-    "coreInsight": "anisomelic acid remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "annonacin",
-    "slug": "annonacin",
-    "canonicalCompoundId": "annonacin",
-    "name": "annonacin",
-    "compoundName": "annonacin",
-    "canonicalCompoundName": "annonacin",
-    "hero": "Defines a key pharmacological signal attributed to annonacin in herbal extracts.",
-    "coreInsight": "Annonacin remains provisional because the evidence behind soursop does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "anonaine",
-    "slug": "anonaine",
-    "canonicalCompoundId": "anonaine",
-    "name": "anonaine",
-    "compoundName": "anonaine",
-    "canonicalCompoundName": "anonaine",
-    "hero": "Defines a key pharmacological signal attributed to anonaine in herbal extracts.",
-    "coreInsight": "anonaine remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "anthocyanins-delphinidin",
-    "slug": "anthocyanins-delphinidin",
-    "canonicalCompoundId": "anthocyanins-delphinidin",
-    "name": "anthocyanins delphinidin",
-    "compoundName": "anthocyanins delphinidin",
-    "canonicalCompoundName": "anthocyanins delphinidin",
-    "hero": "Defines a key pharmacological signal attributed to anthocyanins delphinidin in herbal extracts.",
-    "coreInsight": "anthocyanins delphinidin stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "apigenin",
-    "slug": "apigenin",
-    "canonicalCompoundId": "apigenin",
-    "name": "Apigenin",
-    "compoundName": "Apigenin",
-    "canonicalCompoundName": "Apigenin",
-    "hero": "Acts as a recognizable chemical marker within Chamomile.",
-    "coreInsight": "Within Chamomile, Apigenin helps define the plant’s chemistry alongside markers such as alpha-bisabolol.",
-    "effects": [
-      "[\"anxiolytic\"",
-      "\"anti-inflammatory\"",
-      "\"antispasmodic\"",
-      "\"muscle-relaxant\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"",
-      "\"NF-kB inhibition\"",
-      "\"anxiolytic signaling\"",
-      "\"NF-kB modulation\"]"
-    ]
-  },
-  {
-    "id": "apomorphine",
-    "slug": "apomorphine",
-    "canonicalCompoundId": "apomorphine",
-    "name": "apomorphine",
-    "compoundName": "apomorphine",
-    "canonicalCompoundName": "apomorphine",
-    "hero": "Defines a key pharmacological signal attributed to apomorphine in herbal extracts.",
-    "coreInsight": "apomorphine matters most when dopamine modulation is used as the primary readout. That makes it more informative than a generic other label.",
-    "effects": [
-      "[\"sedative\"]"
-    ],
-    "mechanisms": [
-      "[\"dopamine modulation\"]"
-    ]
-  },
-  {
-    "id": "arabinoxylans",
-    "slug": "arabinoxylans",
-    "canonicalCompoundId": "arabinoxylans",
-    "name": "arabinoxylans",
-    "compoundName": "arabinoxylans",
-    "canonicalCompoundName": "arabinoxylans",
-    "hero": "Helps define why Psyllium extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, arabinoxylans helps separate Psyllium extracts from adjacent markers such as mucilage. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[\"gastrointestinal modulation\"]"
-    ]
-  },
-  {
-    "id": "arbutin",
-    "slug": "arbutin",
-    "canonicalCompoundId": "arbutin",
-    "name": "arbutin",
-    "compoundName": "arbutin",
-    "canonicalCompoundName": "arbutin",
-    "hero": "Defines a key pharmacological signal attributed to arbutin in herbal extracts.",
-    "coreInsight": "arbutin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "arctiin",
-    "slug": "arctiin",
-    "canonicalCompoundId": "arctiin",
-    "name": "arctiin",
-    "compoundName": "arctiin",
-    "canonicalCompoundName": "arctiin",
-    "hero": "Defines a key pharmacological signal attributed to arctiin in herbal extracts.",
-    "coreInsight": "Arctiin remains provisional because the evidence behind burdock does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "arecaidine",
-    "slug": "arecaidine",
-    "canonicalCompoundId": "arecaidine",
-    "name": "arecaidine",
-    "compoundName": "arecaidine",
-    "canonicalCompoundName": "arecaidine",
-    "hero": "Defines a key pharmacological signal attributed to arecaidine in herbal extracts.",
-    "coreInsight": "arecaidine remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "arecoline",
-    "slug": "arecoline",
-    "canonicalCompoundId": "arecoline",
-    "name": "arecoline",
-    "compoundName": "arecoline",
-    "canonicalCompoundName": "arecoline",
-    "hero": "Defines a key pharmacological signal attributed to arecoline in herbal extracts.",
-    "coreInsight": "arecoline stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "arjunetin",
-    "slug": "arjunetin",
-    "canonicalCompoundId": "arjunetin",
-    "name": "Arjunetin",
-    "compoundName": "Arjunetin",
-    "canonicalCompoundName": "Arjunetin",
-    "hero": "Acts as a recognizable chemical marker within Arjuna.",
-    "coreInsight": "Within Arjuna, Arjunetin helps define the plant’s chemistry alongside markers such as arjunolic acid.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "arjungenin",
-    "slug": "arjungenin",
-    "canonicalCompoundId": "arjungenin",
-    "name": "Arjungenin",
-    "compoundName": "Arjungenin",
-    "canonicalCompoundName": "Arjungenin",
-    "hero": "Focuses oxidative stress reduction in Arjungenin.",
-    "coreInsight": "Arjungenin matters most when oxidative stress reduction is used as the primary readout. That makes it more informative than a generic Triterpenoid label.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "arjunic-acid",
-    "slug": "arjunic-acid",
-    "canonicalCompoundId": "arjunic-acid",
-    "name": "Arjunic acid",
-    "compoundName": "Arjunic acid",
-    "canonicalCompoundName": "Arjunic acid",
-    "hero": "Helps define why Arjuna extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, Arjunic acid helps separate Arjuna extracts from adjacent markers such as arjunolic acid. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[\"cardiovascular signaling\"]"
-    ]
-  },
-  {
-    "id": "arjunolic-acid",
-    "slug": "arjunolic-acid",
-    "canonicalCompoundId": "arjunolic-acid",
-    "name": "arjunolic acid",
-    "compoundName": "arjunolic acid",
-    "canonicalCompoundName": "arjunolic acid",
-    "hero": "Helps define why Arjuna extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, arjunolic acid helps separate Arjuna extracts from adjacent markers such as Arjunic acid. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "armepavine",
-    "slug": "armepavine",
-    "canonicalCompoundId": "armepavine",
-    "name": "armepavine",
-    "compoundName": "armepavine",
-    "canonicalCompoundName": "armepavine",
-    "hero": "Distinguishes armepavine from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Armepavine matters because it can be ranked directly against n-methylasimilobine and related neighbors during compound prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "artemisinin",
-    "slug": "artemisinin",
-    "canonicalCompoundId": "artemisinin",
-    "name": "artemisinin",
-    "compoundName": "artemisinin",
-    "canonicalCompoundName": "artemisinin",
-    "hero": "Defines a key pharmacological signal attributed to artemisinin in herbal extracts.",
-    "coreInsight": "artemisinin remains provisional because the evidence behind Artemisia Annua does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "asclepiadin",
-    "slug": "asclepiadin",
-    "canonicalCompoundId": "asclepiadin",
-    "name": "asclepiadin",
-    "compoundName": "asclepiadin",
-    "canonicalCompoundName": "asclepiadin",
-    "hero": "Defines a key pharmacological signal attributed to asclepiadin in herbal extracts.",
-    "coreInsight": "asclepiadin stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "ashwagandha-withanolides",
-    "slug": "ashwagandha-withanolides",
-    "canonicalCompoundId": "ashwagandha-withanolides",
-    "name": "ashwagandha withanolides",
-    "compoundName": "ashwagandha withanolides",
-    "canonicalCompoundName": "ashwagandha withanolides",
-    "hero": "Delivers gaba-a modulation in ashwagandha withanolides.",
-    "coreInsight": "ashwagandha withanolides matters most when gaba-a modulation is used as the primary readout. That makes it more informative than a generic ashwagandha (withanolides) label.",
-    "effects": [
-      "[\"adaptogenic\"",
-      "\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"",
-      "\"HPA-axis modulation\"]"
-    ]
-  },
-  {
-    "id": "asiatic-acid",
-    "slug": "asiatic-acid",
-    "canonicalCompoundId": "asiatic-acid",
-    "name": "asiatic acid",
-    "compoundName": "asiatic acid",
-    "canonicalCompoundName": "asiatic acid",
-    "hero": "Defines a key pharmacological signal attributed to asiatic acid in herbal extracts.",
-    "coreInsight": "asiatic acid remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "asiaticoside",
-    "slug": "asiaticoside",
-    "canonicalCompoundId": "asiaticoside",
-    "name": "asiaticoside",
-    "compoundName": "asiaticoside",
-    "canonicalCompoundName": "asiaticoside",
-    "hero": "Helps define why Gotu Kola extracts perform differently in formulation.",
-    "coreInsight": "asiaticoside becomes more valuable when Gotu Kola is standardized by named actives rather than total extract mass.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "asperuloside",
-    "slug": "asperuloside",
-    "canonicalCompoundId": "asperuloside",
-    "name": "asperuloside",
-    "compoundName": "asperuloside",
-    "canonicalCompoundName": "asperuloside",
-    "hero": "Defines a key pharmacological signal attributed to asperuloside in herbal extracts.",
-    "coreInsight": "asperuloside remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "aspidospermine",
-    "slug": "aspidospermine",
-    "canonicalCompoundId": "aspidospermine",
-    "name": "aspidospermine",
-    "compoundName": "aspidospermine",
-    "canonicalCompoundName": "aspidospermine",
-    "hero": "Defines a key pharmacological signal attributed to aspidospermine in herbal extracts.",
-    "coreInsight": "Aspidospermine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "astragaloside-iv",
-    "slug": "astragaloside-iv",
-    "canonicalCompoundId": "astragaloside-iv",
-    "name": "astragaloside iv",
-    "compoundName": "astragaloside iv",
-    "canonicalCompoundName": "astragaloside iv",
-    "hero": "Defines a key pharmacological signal attributed to astragaloside iv in herbal extracts.",
-    "coreInsight": "astragaloside iv remains provisional because the evidence behind Astragalus does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "atractylenolide-i",
-    "slug": "atractylenolide-i",
-    "canonicalCompoundId": "atractylenolide-i",
-    "name": "atractylenolide i",
-    "compoundName": "atractylenolide i",
-    "canonicalCompoundName": "atractylenolide i",
-    "hero": "Defines a key pharmacological signal attributed to atractylenolide i in herbal extracts.",
-    "coreInsight": "atractylenolide i stays provisional because the evidence behind Atractylodes does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "atractylenolide-ii",
-    "slug": "atractylenolide-ii",
-    "canonicalCompoundId": "atractylenolide-ii",
-    "name": "atractylenolide ii",
-    "compoundName": "atractylenolide ii",
-    "canonicalCompoundName": "atractylenolide ii",
-    "hero": "Defines a key pharmacological signal attributed to atractylenolide ii in herbal extracts.",
-    "coreInsight": "atractylenolide ii remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "atractylenolide-iii",
-    "slug": "atractylenolide-iii",
-    "canonicalCompoundId": "atractylenolide-iii",
-    "name": "atractylenolide iii",
-    "compoundName": "atractylenolide iii",
-    "canonicalCompoundName": "atractylenolide iii",
-    "hero": "Defines a key pharmacological signal attributed to atractylenolide iii in herbal extracts.",
-    "coreInsight": "atractylenolide iii remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "atractylon",
-    "slug": "atractylon",
-    "canonicalCompoundId": "atractylon",
-    "name": "atractylon",
-    "compoundName": "atractylon",
-    "canonicalCompoundName": "atractylon",
-    "hero": "Defines a key pharmacological signal attributed to atractylon in herbal extracts.",
-    "coreInsight": "atractylon remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "atropine",
-    "slug": "atropine",
-    "canonicalCompoundId": "atropine",
-    "name": "atropine",
-    "compoundName": "atropine",
-    "canonicalCompoundName": "atropine",
-    "hero": "Defines a key pharmacological signal attributed to atropine in herbal extracts.",
-    "coreInsight": "atropine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"nootropic\"]"
-    ],
-    "mechanisms": [
-      "[\"cholinergic modulation\"]"
-    ]
-  },
-  {
-    "id": "aucubin",
-    "slug": "aucubin",
-    "canonicalCompoundId": "aucubin",
-    "name": "aucubin",
-    "compoundName": "aucubin",
-    "canonicalCompoundName": "aucubin",
-    "hero": "Defines a key pharmacological signal attributed to aucubin in herbal extracts.",
-    "coreInsight": "Aucubin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "avenacosides",
-    "slug": "avenacosides",
-    "canonicalCompoundId": "avenacosides",
-    "name": "avenacosides",
-    "compoundName": "avenacosides",
-    "canonicalCompoundName": "avenacosides",
-    "hero": "Defines a key pharmacological signal attributed to avenacosides in herbal extracts.",
-    "coreInsight": "avenacosides remains provisional because the evidence behind Milk Oats does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "avenanthramides",
-    "slug": "avenanthramides",
-    "canonicalCompoundId": "avenanthramides",
-    "name": "avenanthramides",
-    "compoundName": "avenanthramides",
-    "canonicalCompoundName": "avenanthramides",
-    "hero": "Defines a key pharmacological signal attributed to avenanthramides in herbal extracts.",
-    "coreInsight": "avenanthramides stays provisional because the evidence behind Oatstraw does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "azadirachtin",
-    "slug": "azadirachtin",
-    "canonicalCompoundId": "azadirachtin",
-    "name": "azadirachtin",
-    "compoundName": "azadirachtin",
-    "canonicalCompoundName": "azadirachtin",
-    "hero": "Acts as a recognizable chemical marker within Neem.",
-    "coreInsight": "Within Neem, azadirachtin helps define the plant’s chemistry alongside markers such as nimbin.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "bacopaside-ii",
-    "slug": "bacopaside-ii",
-    "canonicalCompoundId": "bacopaside-ii",
-    "name": "bacopaside ii",
-    "compoundName": "bacopaside ii",
-    "canonicalCompoundName": "bacopaside ii",
-    "hero": "Defines neuroprotective and hepatoprotective activity within Bacopa chemistry.",
-    "coreInsight": "For Bacopa, bacopaside ii is most useful as a direct neuroprotective signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"neuroprotective\"",
-      "\"hepatoprotective\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "bacoside-a",
-    "slug": "bacoside-a",
-    "canonicalCompoundId": "bacoside-a",
-    "name": "bacoside a",
-    "compoundName": "bacoside a",
-    "canonicalCompoundName": "bacoside a",
-    "hero": "Delivers nootropic activity within Bacopa chemistry.",
-    "coreInsight": "For Bacopa, bacoside a is most useful as a direct nootropic signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"nootropic\"]"
-    ],
-    "mechanisms": [
-      "[]"
+    "id": "baicalin",
+    "slug": "baicalin",
+    "canonicalCompoundId": "baicalin",
+    "name": "Baicalin",
+    "compoundName": "Baicalin",
+    "canonicalCompoundName": "Baicalin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
@@ -1425,628 +21,42 @@
     "name": "Baicalein",
     "compoundName": "Baicalein",
     "canonicalCompoundName": "Baicalein",
-    "hero": "Helps define why Chinese Skullcap extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, Baicalein helps separate Chinese Skullcap extracts from adjacent markers such as Baicalin. That improves standardization decisions.",
-    "effects": [
-      "[\"anxiolytic\"",
-      "\"anti-inflammatory\"",
-      "\"neuroprotective\"",
-      "\"hepatoprotective\"]"
-    ],
     "mechanisms": [
-      "[\"NF-kB inhibition\"",
-      "\"neuroprotective signaling\"",
-      "\"GABA-A modulation\"",
-      "\"NF-kB modulation\"]"
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
-    "id": "baicalin",
-    "slug": "baicalin",
-    "canonicalCompoundId": "baicalin",
-    "name": "Baicalin",
-    "compoundName": "Baicalin",
-    "canonicalCompoundName": "Baicalin",
-    "hero": "Distinguishes Baicalin from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Baicalin matters because it can be ranked directly against baicalein and related neighbors during compound prioritization.",
-    "effects": [
-      "[\"anxiolytic\"",
-      "\"anti-inflammatory\"",
-      "\"neuroprotective\"",
-      "\"hepatoprotective\"]"
-    ],
+    "id": "wogonin",
+    "slug": "wogonin",
+    "canonicalCompoundId": "wogonin",
+    "name": "Wogonin",
+    "compoundName": "Wogonin",
+    "canonicalCompoundName": "Wogonin",
     "mechanisms": [
-      "[\"NF-kB inhibition\"",
-      "\"neuroprotective signaling\"",
-      "\"GABA-A modulation\"",
-      "\"NF-kB modulation\"]"
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
-    "id": "benzyl-benzoate",
-    "slug": "benzyl-benzoate",
-    "canonicalCompoundId": "benzyl-benzoate",
-    "name": "benzyl benzoate",
-    "compoundName": "benzyl benzoate",
-    "canonicalCompoundName": "benzyl benzoate",
-    "hero": "Defines a key pharmacological signal attributed to benzyl benzoate in herbal extracts.",
-    "coreInsight": "benzyl benzoate remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
+    "id": "thymoquinone",
+    "slug": "thymoquinone",
+    "canonicalCompoundId": "thymoquinone",
+    "name": "Thymoquinone",
+    "compoundName": "Thymoquinone",
+    "canonicalCompoundName": "Thymoquinone",
     "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "benzyl-isothiocyanate",
-    "slug": "benzyl-isothiocyanate",
-    "canonicalCompoundId": "benzyl-isothiocyanate",
-    "name": "benzyl isothiocyanate",
-    "compoundName": "benzyl isothiocyanate",
-    "canonicalCompoundName": "benzyl isothiocyanate",
-    "hero": "Defines a key pharmacological signal attributed to benzyl isothiocyanate in herbal extracts.",
-    "coreInsight": "benzyl isothiocyanate stays provisional because the evidence behind Papaya Leaf does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[]"
+      "NF-κB inhibition",
+      "Nrf2 activation"
     ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "berbamine",
-    "slug": "berbamine",
-    "canonicalCompoundId": "berbamine",
-    "name": "berbamine",
-    "compoundName": "berbamine",
-    "canonicalCompoundName": "berbamine",
-    "hero": "Acts as a recognizable chemical marker within Berberis.",
-    "coreInsight": "Within Berberis, berbamine helps define the plant’s chemistry alongside markers such as berberine.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "berberine",
-    "slug": "berberine",
-    "canonicalCompoundId": "berberine",
-    "name": "berberine",
-    "compoundName": "berberine",
-    "canonicalCompoundName": "berberine",
-    "hero": "Defines a key pharmacological signal attributed to berberine in herbal extracts.",
-    "coreInsight": "berberine matters most when mitochondrial support is used as the primary readout. That makes it more informative than a generic alkaloid label.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[\"mitochondrial support\"]"
-    ]
-  },
-  {
-    "id": "beta-amyrin",
-    "slug": "beta-amyrin",
-    "canonicalCompoundId": "beta-amyrin",
-    "name": "beta-amyrin",
-    "compoundName": "beta-amyrin",
-    "canonicalCompoundName": "beta-amyrin",
-    "hero": "Helps define why Celastrus Paniculatus extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, beta-amyrin helps separate Celastrus Paniculatus extracts from adjacent markers such as celapanin. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "beta-asarone",
-    "slug": "beta-asarone",
-    "canonicalCompoundId": "beta-asarone",
-    "name": "beta-asarone",
-    "compoundName": "beta-asarone",
-    "canonicalCompoundName": "beta-asarone",
-    "hero": "Helps define why Calamus extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, beta-asarone helps separate Calamus extracts from adjacent markers such as alpha-asarone. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "beta-asarone-low-levels",
-    "slug": "beta-asarone-low-levels",
-    "canonicalCompoundId": "beta-asarone-low-levels",
-    "name": "beta-asarone low levels",
-    "compoundName": "beta-asarone low levels",
-    "canonicalCompoundName": "beta-asarone low levels",
-    "hero": "Defines a key pharmacological signal attributed to beta-asarone low levels in herbal extracts.",
-    "coreInsight": "Beta-asarone low levels remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "beta-boswellic-acid",
-    "slug": "beta-boswellic-acid",
-    "canonicalCompoundId": "beta-boswellic-acid",
-    "name": "beta-boswellic acid",
-    "compoundName": "beta-boswellic acid",
-    "canonicalCompoundName": "beta-boswellic acid",
-    "hero": "Defines a key pharmacological signal attributed to beta-boswellic acid in herbal extracts.",
-    "coreInsight": "beta-boswellic acid remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[\"5-lipoxygenase inhibition\"",
-      "\"leukotriene suppression\"]"
-    ]
-  },
-  {
-    "id": "beta-caryophyllene",
-    "slug": "beta-caryophyllene",
-    "canonicalCompoundId": "beta-caryophyllene",
-    "name": "beta-caryophyllene",
-    "compoundName": "beta-caryophyllene",
-    "canonicalCompoundName": "beta-caryophyllene",
-    "hero": "Defines a key pharmacological signal attributed to beta-caryophyllene in herbal extracts.",
-    "coreInsight": "beta-caryophyllene stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "beta-glucans",
-    "slug": "beta-glucans",
-    "canonicalCompoundId": "beta-glucans",
-    "name": "beta-glucans",
-    "compoundName": "beta-glucans",
-    "canonicalCompoundName": "beta-glucans",
-    "hero": "Acts as a recognizable chemical marker within Maitake D-Fraction.",
-    "coreInsight": "Within Maitake D-Fraction, beta-glucans serves mainly as a phytochemical marker that sharpens chemical identity.",
-    "effects": [
-      "[\"immunomodulatory\"]"
-    ],
-    "mechanisms": [
-      "[\"immune signaling modulation\"]"
-    ]
-  },
-  {
-    "id": "beta-lapachone",
-    "slug": "beta-lapachone",
-    "canonicalCompoundId": "beta-lapachone",
-    "name": "beta-lapachone",
-    "compoundName": "beta-lapachone",
-    "canonicalCompoundName": "beta-lapachone",
-    "hero": "Defines a key pharmacological signal attributed to beta-lapachone in herbal extracts.",
-    "coreInsight": "beta-lapachone remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "beta-sitosterol",
-    "slug": "beta-sitosterol",
-    "canonicalCompoundId": "beta-sitosterol",
-    "name": "beta-sitosterol",
-    "compoundName": "beta-sitosterol",
-    "canonicalCompoundName": "beta-sitosterol",
-    "hero": "Sharpens anti-inflammatory and diuretic activity within Muira Puama chemistry.",
-    "coreInsight": "For Muira Puama, beta-sitosterol is most useful as a direct anti-inflammatory signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"diuretic\"]"
-    ],
-    "mechanisms": [
-      "[\"androgen signaling modulation\"]"
-    ]
-  },
-  {
-    "id": "beta-thujone",
-    "slug": "beta-thujone",
-    "canonicalCompoundId": "beta-thujone",
-    "name": "beta-thujone",
-    "compoundName": "beta-thujone",
-    "canonicalCompoundName": "beta-thujone",
-    "hero": "Helps define why Wormwood extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, beta-thujone helps separate Wormwood extracts from adjacent markers such as absinthin. That improves standardization decisions.",
-    "effects": [
-      "[\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"]"
-    ]
-  },
-  {
-    "id": "betulinic-acid",
-    "slug": "betulinic-acid",
-    "canonicalCompoundId": "betulinic-acid",
-    "name": "betulinic acid",
-    "compoundName": "betulinic acid",
-    "canonicalCompoundName": "betulinic acid",
-    "hero": "Defines a key pharmacological signal attributed to betulinic acid in herbal extracts.",
-    "coreInsight": "Betulinic acid remains provisional because the evidence behind chaga does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "bilobalide",
-    "slug": "bilobalide",
-    "canonicalCompoundId": "bilobalide",
-    "name": "Bilobalide",
-    "compoundName": "Bilobalide",
-    "canonicalCompoundName": "Bilobalide",
-    "hero": "Defines a key pharmacological signal attributed to bilobalide in herbal extracts.",
-    "coreInsight": "Bilobalide remains provisional because the evidence behind Ginkgo Biloba does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"neuroprotective\"",
-      "\"hepatoprotective\"",
-      "\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[\"neuroprotective signaling\"",
-      "\"GABA-A modulation\"]"
-    ]
-  },
-  {
-    "id": "bilobetin",
-    "slug": "bilobetin",
-    "canonicalCompoundId": "bilobetin",
-    "name": "bilobetin",
-    "compoundName": "bilobetin",
-    "canonicalCompoundName": "bilobetin",
-    "hero": "Defines a key pharmacological signal attributed to bilobetin in herbal extracts.",
-    "coreInsight": "bilobetin stays provisional because the evidence behind Ginkgo Biloba does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "bisabolol",
-    "slug": "bisabolol",
-    "canonicalCompoundId": "bisabolol",
-    "name": "bisabolol",
-    "compoundName": "bisabolol",
-    "canonicalCompoundName": "bisabolol",
-    "hero": "Defines a key pharmacological signal attributed to bisabolol in herbal extracts.",
-    "coreInsight": "bisabolol remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "bisdemethoxycurcumin",
-    "slug": "bisdemethoxycurcumin",
-    "canonicalCompoundId": "bisdemethoxycurcumin",
-    "name": "Bisdemethoxycurcumin",
-    "compoundName": "Bisdemethoxycurcumin",
-    "canonicalCompoundName": "Bisdemethoxycurcumin",
-    "hero": "Anchors anti-inflammatory activity within Turmeric chemistry.",
-    "coreInsight": "For Turmeric, Bisdemethoxycurcumin is most useful as a direct anti-inflammatory signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "boldine",
-    "slug": "boldine",
-    "canonicalCompoundId": "boldine",
-    "name": "boldine",
-    "compoundName": "boldine",
-    "canonicalCompoundName": "boldine",
-    "hero": "Helps define why Boldo extracts perform differently in formulation.",
-    "coreInsight": "boldine becomes more valuable when Boldo is standardized by named actives rather than total extract mass.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "bonducin",
-    "slug": "bonducin",
-    "canonicalCompoundId": "bonducin",
-    "name": "bonducin",
-    "compoundName": "bonducin",
-    "canonicalCompoundName": "bonducin",
-    "hero": "Defines a key pharmacological signal attributed to bonducin in herbal extracts.",
-    "coreInsight": "bonducin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "brunfelsamidine",
-    "slug": "brunfelsamidine",
-    "canonicalCompoundId": "brunfelsamidine",
-    "name": "brunfelsamidine",
-    "compoundName": "brunfelsamidine",
-    "canonicalCompoundName": "brunfelsamidine",
-    "hero": "Defines a key pharmacological signal attributed to brunfelsamidine in herbal extracts.",
-    "coreInsight": "Brunfelsamidine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "bryonin",
-    "slug": "bryonin",
-    "canonicalCompoundId": "bryonin",
-    "name": "bryonin",
-    "compoundName": "bryonin",
-    "canonicalCompoundName": "bryonin",
-    "hero": "Defines a key pharmacological signal attributed to bryonin in herbal extracts.",
-    "coreInsight": "bryonin remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "bufotenin",
-    "slug": "bufotenin",
-    "canonicalCompoundId": "bufotenin",
-    "name": "bufotenin",
-    "compoundName": "bufotenin",
-    "canonicalCompoundName": "bufotenin",
-    "hero": "Defines a key pharmacological signal attributed to bufotenin in herbal extracts.",
-    "coreInsight": "bufotenin stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"hallucinogenic\"",
-      "\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[\"serotonin modulation\"]"
-    ]
-  },
-  {
-    "id": "bulbocapnine",
-    "slug": "bulbocapnine",
-    "canonicalCompoundId": "bulbocapnine",
-    "name": "bulbocapnine",
-    "compoundName": "bulbocapnine",
-    "canonicalCompoundName": "bulbocapnine",
-    "hero": "Defines a key pharmacological signal attributed to bulbocapnine in herbal extracts.",
-    "coreInsight": "bulbocapnine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "buphanidrine",
-    "slug": "buphanidrine",
-    "canonicalCompoundId": "buphanidrine",
-    "name": "buphanidrine",
-    "compoundName": "buphanidrine",
-    "canonicalCompoundName": "buphanidrine",
-    "hero": "Defines a key pharmacological signal attributed to buphanidrine in herbal extracts.",
-    "coreInsight": "buphanidrine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "cafestol",
-    "slug": "cafestol",
-    "canonicalCompoundId": "cafestol",
-    "name": "cafestol",
-    "compoundName": "cafestol",
-    "canonicalCompoundName": "cafestol",
-    "hero": "Anchors stimulant and antioxidant activity within Coffee Cherry chemistry.",
-    "coreInsight": "For Coffee Cherry, cafestol is most useful as a direct stimulant signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"stimulant\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "caffeic-acid",
-    "slug": "caffeic-acid",
-    "canonicalCompoundId": "caffeic-acid",
-    "name": "caffeic acid",
-    "compoundName": "caffeic acid",
-    "canonicalCompoundName": "caffeic acid",
-    "hero": "Helps define why Black Cohosh extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, caffeic acid helps separate Black Cohosh extracts from adjacent markers such as Cimicifugoside. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "caffeine",
-    "slug": "caffeine",
-    "canonicalCompoundId": "caffeine",
-    "name": "Caffeine",
-    "compoundName": "Caffeine",
-    "canonicalCompoundName": "Caffeine",
-    "hero": "Distinguishes Caffeine from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Caffeine matters because it can be ranked directly against theanine and related neighbors during compound prioritization.",
-    "effects": [
-      "[\"stimulant\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"adenosine A1 antagonism\"",
-      "\"adenosine A2A antagonism\"",
-      "\"stimulant CNS signaling\"]"
-    ]
-  },
-  {
-    "id": "calotropin",
-    "slug": "calotropin",
-    "canonicalCompoundId": "calotropin",
-    "name": "calotropin",
-    "compoundName": "calotropin",
-    "canonicalCompoundName": "calotropin",
-    "hero": "Defines a key pharmacological signal attributed to calotropin in herbal extracts.",
-    "coreInsight": "calotropin remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "camphor",
-    "slug": "camphor",
-    "canonicalCompoundId": "camphor",
-    "name": "camphor",
-    "compoundName": "camphor",
-    "canonicalCompoundName": "camphor",
-    "hero": "Defines a key pharmacological signal attributed to camphor in herbal extracts.",
-    "coreInsight": "camphor stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "cannabidiol",
-    "slug": "cannabidiol",
-    "canonicalCompoundId": "cannabidiol",
-    "name": "cannabidiol",
-    "compoundName": "cannabidiol",
-    "canonicalCompoundName": "cannabidiol",
-    "hero": "Defines a key pharmacological signal attributed to cannabidiol in herbal extracts.",
-    "coreInsight": "cannabidiol remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "capsaicin",
-    "slug": "capsaicin",
-    "canonicalCompoundId": "capsaicin",
-    "name": "capsaicin",
-    "compoundName": "capsaicin",
-    "canonicalCompoundName": "capsaicin",
-    "hero": "Defines a key pharmacological signal attributed to capsaicin in herbal extracts.",
-    "coreInsight": "capsaicin matters most when trpv1 modulation is used as the primary readout. That makes it more informative than a generic capsaicinoid label.",
-    "effects": [
-      "[\"analgesic\"]"
-    ],
-    "mechanisms": [
-      "[\"TRPV1 modulation\"]"
-    ]
-  },
-  {
-    "id": "capsanthin",
-    "slug": "capsanthin",
-    "canonicalCompoundId": "capsanthin",
-    "name": "capsanthin",
-    "compoundName": "capsanthin",
-    "canonicalCompoundName": "capsanthin",
-    "hero": "Drives analgesic activity within Cayenne chemistry.",
-    "coreInsight": "For Cayenne, capsanthin is most useful as a direct analgesic signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"analgesic\"]"
-    ],
-    "mechanisms": [
-      "[\"TRPV1 modulation\"]"
-    ]
-  },
-  {
-    "id": "capsorubin",
-    "slug": "capsorubin",
-    "canonicalCompoundId": "capsorubin",
-    "name": "capsorubin",
-    "compoundName": "capsorubin",
-    "canonicalCompoundName": "capsorubin",
-    "hero": "Helps define why Cayenne extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, capsorubin helps separate Cayenne extracts from adjacent markers such as capsaicin. That improves standardization decisions.",
-    "effects": [
-      "[\"analgesic\"]"
-    ],
-    "mechanisms": [
-      "[\"TRPV1 modulation\"]"
-    ]
-  },
-  {
-    "id": "cardanol",
-    "slug": "cardanol",
-    "canonicalCompoundId": "cardanol",
-    "name": "cardanol",
-    "compoundName": "cardanol",
-    "canonicalCompoundName": "cardanol",
-    "hero": "Defines a key pharmacological signal attributed to cardanol in herbal extracts.",
-    "coreInsight": "Cardanol remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "cardol",
-    "slug": "cardol",
-    "canonicalCompoundId": "cardol",
-    "name": "cardol",
-    "compoundName": "cardol",
-    "canonicalCompoundName": "cardol",
-    "hero": "Defines a key pharmacological signal attributed to cardol in herbal extracts.",
-    "coreInsight": "cardol remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
@@ -2056,1814 +66,162 @@
     "name": "Carnosic acid",
     "compoundName": "Carnosic acid",
     "canonicalCompoundName": "Carnosic acid",
-    "hero": "Defines a key pharmacological signal attributed to carnosic acid in herbal extracts.",
-    "coreInsight": "Carnosic acid stays provisional because the evidence behind Rosmarinus officinalis does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"neuroprotective\"",
-      "\"antioxidant\"",
-      "\"adaptogenic\"",
-      "\"hepatoprotective\"]"
-    ],
     "mechanisms": [
-      "[\"neuroprotective signaling\"]"
+      "Nrf2 activation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
-    "id": "carnosol",
-    "slug": "carnosol",
-    "canonicalCompoundId": "carnosol",
-    "name": "Carnosol",
-    "compoundName": "Carnosol",
-    "canonicalCompoundName": "Carnosol",
-    "hero": "Acts as a recognizable chemical marker within Rosmarinus officinalis.",
-    "coreInsight": "Within Rosmarinus officinalis, Carnosol helps define the plant’s chemistry alongside markers such as Rosmarinic acid.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"",
-      "\"adaptogenic\"]"
-    ],
+    "id": "oleuropein",
+    "slug": "oleuropein",
+    "canonicalCompoundId": "oleuropein",
+    "name": "Oleuropein",
+    "compoundName": "Oleuropein",
+    "canonicalCompoundName": "Oleuropein",
     "mechanisms": [
-      "[\"NF-kB inhibition\"",
-      "\"NF-kB modulation\"",
-      "\"NF-κB modulation\"]"
+      "NF-κB inhibition",
+      "AMPK activation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
-    "id": "carpaine",
-    "slug": "carpaine",
-    "canonicalCompoundId": "carpaine",
-    "name": "carpaine",
-    "compoundName": "carpaine",
-    "canonicalCompoundName": "carpaine",
-    "hero": "Carries analgesic activity within Papaya Leaf chemistry.",
-    "coreInsight": "For Papaya Leaf, carpaine is most useful as a direct analgesic signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"analgesic\"]"
-    ],
+    "id": "hydroxytyrosol",
+    "slug": "hydroxytyrosol",
+    "canonicalCompoundId": "hydroxytyrosol",
+    "name": "Hydroxytyrosol",
+    "compoundName": "Hydroxytyrosol",
+    "canonicalCompoundName": "Hydroxytyrosol",
     "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "carvacrol",
-    "slug": "carvacrol",
-    "canonicalCompoundId": "carvacrol",
-    "name": "carvacrol",
-    "compoundName": "carvacrol",
-    "canonicalCompoundName": "carvacrol",
-    "hero": "Focuses anti-inflammatory and analgesic activity within Ajwain chemistry.",
-    "coreInsight": "For Ajwain, carvacrol is most useful as a direct anti-inflammatory signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"analgesic\"",
-      "\"antioxidant\"]"
+      "Nrf2 activation",
+      "PI3K/Akt modulation"
     ],
-    "mechanisms": [
-      "[\"TRPA1 modulation\"]"
-    ]
-  },
-  {
-    "id": "carvone",
-    "slug": "carvone",
-    "canonicalCompoundId": "carvone",
-    "name": "carvone",
-    "compoundName": "carvone",
-    "canonicalCompoundName": "carvone",
-    "hero": "Helps define why Caraway extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, carvone helps separate Caraway extracts from adjacent markers such as limonene. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "casimiroedine",
-    "slug": "casimiroedine",
-    "canonicalCompoundId": "casimiroedine",
-    "name": "casimiroedine",
-    "compoundName": "casimiroedine",
-    "canonicalCompoundName": "casimiroedine",
-    "hero": "Defines a key pharmacological signal attributed to casimiroedine in herbal extracts.",
-    "coreInsight": "Casimiroedine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "casticin",
-    "slug": "casticin",
-    "canonicalCompoundId": "casticin",
-    "name": "casticin",
-    "compoundName": "casticin",
-    "canonicalCompoundName": "casticin",
-    "hero": "Defines a key pharmacological signal attributed to casticin in herbal extracts.",
-    "coreInsight": "casticin remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "catalpol",
-    "slug": "catalpol",
-    "canonicalCompoundId": "catalpol",
-    "name": "catalpol",
-    "compoundName": "catalpol",
-    "canonicalCompoundName": "catalpol",
-    "hero": "Defines a key pharmacological signal attributed to catalpol in herbal extracts.",
-    "coreInsight": "catalpol stays provisional because the evidence behind Rehmannia Prepared does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"neuroprotective\"",
-      "\"hepatoprotective\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "catechin",
-    "slug": "catechin",
-    "canonicalCompoundId": "catechin",
-    "name": "Catechin",
-    "compoundName": "Catechin",
-    "canonicalCompoundName": "Catechin",
-    "hero": "Acts as a recognizable chemical marker within Green Tea.",
-    "coreInsight": "Within Green Tea, Catechin helps define the plant’s chemistry alongside markers such as Caffeine.",
-    "effects": [
-      "[\"antioxidant\"",
-      "\"adaptogenic\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "catechins",
-    "slug": "catechins",
-    "canonicalCompoundId": "catechins",
-    "name": "catechins",
-    "compoundName": "catechins",
-    "canonicalCompoundName": "catechins",
-    "hero": "Delivers antioxidant activity within Ashoka chemistry.",
-    "coreInsight": "For Ashoka, catechins is most useful as a direct antioxidant signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "cathine",
-    "slug": "cathine",
-    "canonicalCompoundId": "cathine",
-    "name": "cathine",
-    "compoundName": "cathine",
-    "canonicalCompoundName": "cathine",
-    "hero": "Defines a key pharmacological signal attributed to cathine in herbal extracts.",
-    "coreInsight": "cathine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "cathinone",
-    "slug": "cathinone",
-    "canonicalCompoundId": "cathinone",
-    "name": "cathinone",
-    "compoundName": "cathinone",
-    "canonicalCompoundName": "cathinone",
-    "hero": "Defines a key pharmacological signal attributed to cathinone in herbal extracts.",
-    "coreInsight": "cathinone remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "cbd",
-    "slug": "cbd",
-    "canonicalCompoundId": "cbd",
-    "name": "cbd",
-    "compoundName": "cbd",
-    "canonicalCompoundName": "cbd",
-    "hero": "Defines a key pharmacological signal attributed to cbd in herbal extracts.",
-    "coreInsight": "Cbd remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[\"endocannabinoid modulation\"]"
-    ]
-  },
-  {
-    "id": "celapagin",
-    "slug": "celapagin",
-    "canonicalCompoundId": "celapagin",
-    "name": "celapagin",
-    "compoundName": "celapagin",
-    "canonicalCompoundName": "celapagin",
-    "hero": "Defines a key pharmacological signal attributed to celapagin in herbal extracts.",
-    "coreInsight": "celapagin remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "celapanin",
-    "slug": "celapanin",
-    "canonicalCompoundId": "celapanin",
-    "name": "celapanin",
-    "compoundName": "celapanin",
-    "canonicalCompoundName": "celapanin",
-    "hero": "Defines a key pharmacological signal attributed to celapanin in herbal extracts.",
-    "coreInsight": "celapanin stays provisional because the evidence behind Celastrus Paniculatus does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "celastrine",
-    "slug": "celastrine",
-    "canonicalCompoundId": "celastrine",
-    "name": "Celastrine",
-    "compoundName": "Celastrine",
-    "canonicalCompoundName": "Celastrine",
-    "hero": "Acts as a recognizable chemical marker within Celastrus paniculatus.",
-    "coreInsight": "Within Celastrus paniculatus, Celastrine helps define the plant’s chemistry alongside markers such as beta-amyrin.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "cephaeline",
-    "slug": "cephaeline",
-    "canonicalCompoundId": "cephaeline",
-    "name": "cephaeline",
-    "compoundName": "cephaeline",
-    "canonicalCompoundName": "cephaeline",
-    "hero": "Defines a key pharmacological signal attributed to cephaeline in herbal extracts.",
-    "coreInsight": "cephaeline remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "cepharanthine",
-    "slug": "cepharanthine",
-    "canonicalCompoundId": "cepharanthine",
-    "name": "cepharanthine",
-    "compoundName": "cepharanthine",
-    "canonicalCompoundName": "cepharanthine",
-    "hero": "Delivers diuretic activity at the compound level.",
-    "coreInsight": "cepharanthine is most useful when a formulation needs a direct diuretic signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"diuretic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "chamazulene",
-    "slug": "chamazulene",
-    "canonicalCompoundId": "chamazulene",
-    "name": "chamazulene",
-    "compoundName": "chamazulene",
-    "canonicalCompoundName": "chamazulene",
-    "hero": "Helps define why Chamomile extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, chamazulene helps separate Chamomile extracts from adjacent markers such as Apigenin. That improves standardization decisions.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antispasmodic\"",
-      "\"muscle-relaxant\"",
-      "\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"]"
-    ]
-  },
-  {
-    "id": "charantin",
-    "slug": "charantin",
-    "canonicalCompoundId": "charantin",
-    "name": "charantin",
-    "compoundName": "charantin",
-    "canonicalCompoundName": "charantin",
-    "hero": "Distinguishes charantin from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Charantin matters because it can be ranked directly against polypeptide-p and related neighbors during compound prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "chavicine",
-    "slug": "chavicine",
-    "canonicalCompoundId": "chavicine",
-    "name": "Chavicine",
-    "compoundName": "Chavicine",
-    "canonicalCompoundName": "Chavicine",
-    "hero": "Defines a key pharmacological signal attributed to chavicine in herbal extracts.",
-    "coreInsight": "Chavicine remains provisional because the evidence behind Black Pepper does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"stimulant\"]"
-    ],
-    "mechanisms": [
-      "[\"bioavailability modulation\"]"
-    ]
-  },
-  {
-    "id": "chavicol",
-    "slug": "chavicol",
-    "canonicalCompoundId": "chavicol",
-    "name": "chavicol",
-    "compoundName": "chavicol",
-    "canonicalCompoundName": "chavicol",
-    "hero": "Defines a key pharmacological signal attributed to chavicol in herbal extracts.",
-    "coreInsight": "chavicol stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "chelerythrine",
-    "slug": "chelerythrine",
-    "canonicalCompoundId": "chelerythrine",
-    "name": "chelerythrine",
-    "compoundName": "chelerythrine",
-    "canonicalCompoundName": "chelerythrine",
-    "hero": "Defines a key pharmacological signal attributed to chelerythrine in herbal extracts.",
-    "coreInsight": "chelerythrine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "chelidonine",
-    "slug": "chelidonine",
-    "canonicalCompoundId": "chelidonine",
-    "name": "chelidonine",
-    "compoundName": "chelidonine",
-    "canonicalCompoundName": "chelidonine",
-    "hero": "Defines a key pharmacological signal attributed to chelidonine in herbal extracts.",
-    "coreInsight": "chelidonine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "chicoric-acid",
-    "slug": "chicoric-acid",
-    "canonicalCompoundId": "chicoric-acid",
-    "name": "chicoric acid",
-    "compoundName": "chicoric acid",
-    "canonicalCompoundName": "chicoric acid",
-    "hero": "Helps define why Echinacea Purpurea extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, chicoric acid helps separate Echinacea Purpurea extracts from adjacent markers such as alkamides. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "chlorogenic-acid",
-    "slug": "chlorogenic-acid",
-    "canonicalCompoundId": "chlorogenic-acid",
-    "name": "chlorogenic acid",
-    "compoundName": "chlorogenic acid",
-    "canonicalCompoundName": "chlorogenic acid",
-    "hero": "Helps define why Artichoke extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, chlorogenic acid helps separate Artichoke extracts from adjacent markers such as cynarin. That improves standardization decisions.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "choline",
-    "slug": "choline",
-    "canonicalCompoundId": "choline",
-    "name": "choline",
-    "compoundName": "choline",
-    "canonicalCompoundName": "choline",
-    "hero": "Defines a key pharmacological signal attributed to choline in herbal extracts.",
-    "coreInsight": "Choline remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"nootropic\"]"
-    ],
-    "mechanisms": [
-      "[\"cholinergic modulation\"]"
-    ]
-  },
-  {
-    "id": "chrysin",
-    "slug": "chrysin",
-    "canonicalCompoundId": "chrysin",
-    "name": "chrysin",
-    "compoundName": "chrysin",
-    "canonicalCompoundName": "chrysin",
-    "hero": "Defines a key pharmacological signal attributed to chrysin in herbal extracts.",
-    "coreInsight": "chrysin remains provisional because the evidence behind Passionflower does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"",
-      "\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[\"possible GABAergic signaling\"",
-      "\"GABA-A modulation\"]"
-    ]
-  },
-  {
-    "id": "chrysoeriol",
-    "slug": "chrysoeriol",
-    "canonicalCompoundId": "chrysoeriol",
-    "name": "chrysoeriol",
-    "compoundName": "chrysoeriol",
-    "canonicalCompoundName": "chrysoeriol",
-    "hero": "Defines a key pharmacological signal attributed to chrysoeriol in herbal extracts.",
-    "coreInsight": "chrysoeriol stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "chrysophanol",
-    "slug": "chrysophanol",
-    "canonicalCompoundId": "chrysophanol",
-    "name": "chrysophanol",
-    "compoundName": "chrysophanol",
-    "canonicalCompoundName": "chrysophanol",
-    "hero": "Acts as a recognizable chemical marker within Cassia Alata.",
-    "coreInsight": "Within Cassia Alata, chrysophanol helps define the plant’s chemistry alongside markers such as aloe-emodin.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "chymopapain",
-    "slug": "chymopapain",
-    "canonicalCompoundId": "chymopapain",
-    "name": "chymopapain",
-    "compoundName": "chymopapain",
-    "canonicalCompoundName": "chymopapain",
-    "hero": "Concentrates analgesic activity within Papaya Leaf chemistry.",
-    "coreInsight": "For Papaya Leaf, chymopapain is most useful as a direct analgesic signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"analgesic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "cimicifugoside",
-    "slug": "cimicifugoside",
-    "canonicalCompoundId": "cimicifugoside",
-    "name": "Cimicifugoside",
-    "compoundName": "Cimicifugoside",
-    "canonicalCompoundName": "Cimicifugoside",
-    "hero": "Sharpens anti-inflammatory and antidepressant activity within Black Cohosh chemistry.",
-    "coreInsight": "For Black Cohosh, Cimicifugoside is most useful as a direct anti-inflammatory signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[\"serotonin modulation\"",
-      "\"hormone modulation\"",
-      "\"inflammatory signaling modulation\"]"
-    ]
-  },
-  {
-    "id": "cimifugoside",
-    "slug": "cimifugoside",
-    "canonicalCompoundId": "cimifugoside",
-    "name": "cimifugoside",
-    "compoundName": "cimifugoside",
-    "canonicalCompoundName": "cimifugoside",
-    "hero": "Helps define why Black Cohosh extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, cimifugoside helps separate Black Cohosh extracts from adjacent markers such as triterpene glycosides (actein, 23-epi-26-deoxyactein). That improves standardization decisions.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "cineole",
-    "slug": "cineole",
-    "canonicalCompoundId": "cineole",
-    "name": "cineole",
-    "compoundName": "cineole",
-    "canonicalCompoundName": "cineole",
-    "hero": "Distinguishes cineole from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Cineole matters because it can be ranked directly against terpinyl acetate and related neighbors during compound prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "cinnamaldehyde",
-    "slug": "cinnamaldehyde",
-    "canonicalCompoundId": "cinnamaldehyde",
-    "name": "cinnamaldehyde",
-    "compoundName": "cinnamaldehyde",
-    "canonicalCompoundName": "cinnamaldehyde",
-    "hero": "Defines a key pharmacological signal attributed to cinnamaldehyde in herbal extracts.",
-    "coreInsight": "cinnamaldehyde remains provisional because the evidence behind Cinnamon does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "cinnamoylcocaine",
-    "slug": "cinnamoylcocaine",
-    "canonicalCompoundId": "cinnamoylcocaine",
-    "name": "cinnamoylcocaine",
-    "compoundName": "cinnamoylcocaine",
-    "canonicalCompoundName": "cinnamoylcocaine",
-    "hero": "Defines a key pharmacological signal attributed to cinnamoylcocaine in herbal extracts.",
-    "coreInsight": "cinnamoylcocaine stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "cis-cinnamoylcocaine",
-    "slug": "cis-cinnamoylcocaine",
-    "canonicalCompoundId": "cis-cinnamoylcocaine",
-    "name": "cis-cinnamoylcocaine",
-    "compoundName": "cis-cinnamoylcocaine",
-    "canonicalCompoundName": "cis-cinnamoylcocaine",
-    "hero": "Defines a key pharmacological signal attributed to cis-cinnamoylcocaine in herbal extracts.",
-    "coreInsight": "cis-cinnamoylcocaine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "citicoline-cdp-choline",
-    "slug": "citicoline-cdp-choline",
-    "canonicalCompoundId": "citicoline-cdp-choline",
-    "name": "citicoline cdp-choline",
-    "compoundName": "citicoline cdp-choline",
-    "canonicalCompoundName": "citicoline cdp-choline",
-    "hero": "Anchors cholinergic modulation in citicoline cdp-choline.",
-    "coreInsight": "citicoline cdp-choline matters most when cholinergic modulation is used as the primary readout. That makes it more informative than a generic citicoline (CDP-choline) label.",
-    "effects": [
-      "[\"nootropic\"]"
-    ],
-    "mechanisms": [
-      "[\"cholinergic modulation\"]"
-    ]
-  },
-  {
-    "id": "citral",
-    "slug": "citral",
-    "canonicalCompoundId": "citral",
-    "name": "citral",
-    "compoundName": "citral",
-    "canonicalCompoundName": "citral",
-    "hero": "Concentrates anti-inflammatory and analgesic activity within Lemongrass chemistry.",
-    "coreInsight": "For Lemongrass, citral is most useful as a direct anti-inflammatory signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"analgesic\"",
-      "\"immunomodulatory\"]"
-    ],
-    "mechanisms": [
-      "[\"immune signaling modulation\"]"
-    ]
-  },
-  {
-    "id": "citric-acid",
-    "slug": "citric-acid",
-    "canonicalCompoundId": "citric-acid",
-    "name": "citric acid",
-    "compoundName": "citric acid",
-    "canonicalCompoundName": "citric acid",
-    "hero": "Defines a key pharmacological signal attributed to citric acid in herbal extracts.",
-    "coreInsight": "citric acid remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "citronellal",
-    "slug": "citronellal",
-    "canonicalCompoundId": "citronellal",
-    "name": "citronellal",
-    "compoundName": "citronellal",
-    "canonicalCompoundName": "citronellal",
-    "hero": "Distinguishes citronellal from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Citronellal matters because it can be ranked directly against citral and related neighbors during compound prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "cocaine",
-    "slug": "cocaine",
-    "canonicalCompoundId": "cocaine",
-    "name": "cocaine",
-    "compoundName": "cocaine",
-    "canonicalCompoundName": "cocaine",
-    "hero": "Defines a key pharmacological signal attributed to cocaine in herbal extracts.",
-    "coreInsight": "cocaine remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "codeine",
-    "slug": "codeine",
-    "canonicalCompoundId": "codeine",
-    "name": "codeine",
-    "compoundName": "codeine",
-    "canonicalCompoundName": "codeine",
-    "hero": "Defines a key pharmacological signal attributed to codeine in herbal extracts.",
-    "coreInsight": "codeine stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "columbamine",
-    "slug": "columbamine",
-    "canonicalCompoundId": "columbamine",
-    "name": "columbamine",
-    "compoundName": "columbamine",
-    "canonicalCompoundName": "columbamine",
-    "hero": "Defines a key pharmacological signal attributed to columbamine in herbal extracts.",
-    "coreInsight": "columbamine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "conhydrine",
-    "slug": "conhydrine",
-    "canonicalCompoundId": "conhydrine",
-    "name": "conhydrine",
-    "compoundName": "conhydrine",
-    "canonicalCompoundName": "conhydrine",
-    "hero": "Defines a key pharmacological signal attributed to conhydrine in herbal extracts.",
-    "coreInsight": "conhydrine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "coniine",
-    "slug": "coniine",
-    "canonicalCompoundId": "coniine",
-    "name": "coniine",
-    "compoundName": "coniine",
-    "canonicalCompoundName": "coniine",
-    "hero": "Defines a key pharmacological signal attributed to coniine in herbal extracts.",
-    "coreInsight": "coniine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "convallatoxin",
-    "slug": "convallatoxin",
-    "canonicalCompoundId": "convallatoxin",
-    "name": "convallatoxin",
-    "compoundName": "convallatoxin",
-    "canonicalCompoundName": "convallatoxin",
-    "hero": "Defines a key pharmacological signal attributed to convallatoxin in herbal extracts.",
-    "coreInsight": "convallatoxin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "convalloside-cardiac-glycosides",
-    "slug": "convalloside-cardiac-glycosides",
-    "canonicalCompoundId": "convalloside-cardiac-glycosides",
-    "name": "convalloside cardiac glycosides",
-    "compoundName": "convalloside cardiac glycosides",
-    "canonicalCompoundName": "convalloside cardiac glycosides",
-    "hero": "Defines a key pharmacological signal attributed to convalloside cardiac glycosides in herbal extracts.",
-    "coreInsight": "Convalloside cardiac glycosides remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "convolvine",
-    "slug": "convolvine",
-    "canonicalCompoundId": "convolvine",
-    "name": "convolvine",
-    "compoundName": "convolvine",
-    "canonicalCompoundName": "convolvine",
-    "hero": "Defines a key pharmacological signal attributed to convolvine in herbal extracts.",
-    "coreInsight": "convolvine remains provisional because the evidence behind Shankhpushpi does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"nootropic\"",
-      "\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "copalic-acid",
-    "slug": "copalic-acid",
-    "canonicalCompoundId": "copalic-acid",
-    "name": "copalic acid",
-    "compoundName": "copalic acid",
-    "canonicalCompoundName": "copalic acid",
-    "hero": "Defines a key pharmacological signal attributed to copalic acid in herbal extracts.",
-    "coreInsight": "copalic acid stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "coptisine",
-    "slug": "coptisine",
-    "canonicalCompoundId": "coptisine",
-    "name": "coptisine",
-    "compoundName": "coptisine",
-    "canonicalCompoundName": "coptisine",
-    "hero": "Acts as a recognizable chemical marker within Coptis.",
-    "coreInsight": "Within Coptis, coptisine helps define the plant’s chemistry alongside markers such as berberine.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "cordycepin",
-    "slug": "cordycepin",
-    "canonicalCompoundId": "cordycepin",
-    "name": "cordycepin",
-    "compoundName": "cordycepin",
-    "canonicalCompoundName": "cordycepin",
-    "hero": "Defines a key pharmacological signal attributed to cordycepin in herbal extracts.",
-    "coreInsight": "cordycepin matters most when immune modulation is used as the primary readout. That makes it more informative than a generic nucleoside analogue label.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"immunomodulatory\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"immune modulation\"",
-      "\"NF-kappaB modulation\"",
-      "\"Nrf2 activation\"",
-      "\"immune signaling modulation\"]"
-    ]
-  },
-  {
-    "id": "coronaridine",
-    "slug": "coronaridine",
-    "canonicalCompoundId": "coronaridine",
-    "name": "coronaridine",
-    "compoundName": "coronaridine",
-    "canonicalCompoundName": "coronaridine",
-    "hero": "Defines a key pharmacological signal attributed to coronaridine in herbal extracts.",
-    "coreInsight": "coronaridine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "corosolic-acid",
-    "slug": "corosolic-acid",
-    "canonicalCompoundId": "corosolic-acid",
-    "name": "corosolic acid",
-    "compoundName": "corosolic acid",
-    "canonicalCompoundName": "corosolic acid",
-    "hero": "Helps define why Banaba extracts perform differently in formulation.",
-    "coreInsight": "corosolic acid becomes more valuable when Banaba is standardized by named actives rather than total extract mass.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "corydaline",
-    "slug": "corydaline",
-    "canonicalCompoundId": "corydaline",
-    "name": "corydaline",
-    "compoundName": "corydaline",
-    "canonicalCompoundName": "corydaline",
-    "hero": "Distinguishes corydaline from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Corydaline matters because it can be ranked directly against dehydrocorybulbine and related neighbors during compound prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "crocetin",
-    "slug": "crocetin",
-    "canonicalCompoundId": "crocetin",
-    "name": "crocetin",
-    "compoundName": "crocetin",
-    "canonicalCompoundName": "crocetin",
-    "hero": "Defines a key pharmacological signal attributed to crocetin in herbal extracts.",
-    "coreInsight": "crocetin remains provisional because the evidence behind Saffron does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
     "id": "crocin",
     "slug": "crocin",
     "canonicalCompoundId": "crocin",
-    "name": "crocin",
-    "compoundName": "crocin",
-    "canonicalCompoundName": "crocin",
-    "hero": "Defines a key pharmacological signal attributed to crocin in herbal extracts.",
-    "coreInsight": "crocin stays provisional because the evidence behind Saffron does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[]"
-    ],
+    "name": "Crocin",
+    "compoundName": "Crocin",
+    "canonicalCompoundName": "Crocin",
     "mechanisms": [
-      "[]"
+      "PI3K/Akt modulation",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
-    "id": "cryogenine-vertine",
-    "slug": "cryogenine-vertine",
-    "canonicalCompoundId": "cryogenine-vertine",
-    "name": "cryogenine vertine",
-    "compoundName": "cryogenine vertine",
-    "canonicalCompoundName": "cryogenine vertine",
-    "hero": "Delivers anti-inflammatory and antispasmodic activity at the compound level.",
-    "coreInsight": "cryogenine vertine is most useful when a formulation needs a direct anti-inflammatory signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antispasmodic\"",
-      "\"muscle-relaxant\"]"
-    ],
+    "id": "crocetin",
+    "slug": "crocetin",
+    "canonicalCompoundId": "crocetin",
+    "name": "Crocetin",
+    "compoundName": "Crocetin",
+    "canonicalCompoundName": "Crocetin",
     "mechanisms": [
-      "[]"
+      "PI3K/Akt modulation",
+      "Nrf2 activation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
-    "id": "curcumin",
-    "slug": "curcumin",
-    "canonicalCompoundId": "curcumin",
-    "name": "curcumin",
-    "compoundName": "curcumin",
-    "canonicalCompoundName": "curcumin",
-    "hero": "Defines a key pharmacological signal attributed to curcumin in herbal extracts.",
-    "coreInsight": "curcumin matters most when nf-kb inhibition is used as the primary readout. That makes it more informative than a generic phenolic label.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"]"
-    ],
+    "id": "silibinin",
+    "slug": "silibinin",
+    "canonicalCompoundId": "silibinin",
+    "name": "Silibinin",
+    "compoundName": "Silibinin",
+    "canonicalCompoundName": "Silibinin",
     "mechanisms": [
-      "[\"NF-kB inhibition\"",
-      "\"NF-kB modulation\"",
-      "\"NF-κB modulation\"]"
+      "STAT3 inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
-    "id": "curcuminoids",
-    "slug": "curcuminoids",
-    "canonicalCompoundId": "curcuminoids",
-    "name": "curcuminoids",
-    "compoundName": "curcuminoids",
-    "canonicalCompoundName": "curcuminoids",
-    "hero": "Focuses anti-inflammatory and antioxidant activity at the compound level.",
-    "coreInsight": "curcuminoids is most useful when a formulation needs a direct anti-inflammatory signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"]"
-    ],
+    "id": "glycyrrhizin",
+    "slug": "glycyrrhizin",
+    "canonicalCompoundId": "glycyrrhizin",
+    "name": "Glycyrrhizin",
+    "compoundName": "Glycyrrhizin",
+    "canonicalCompoundName": "Glycyrrhizin",
     "mechanisms": [
-      "[\"NF-kB inhibition\"",
-      "\"COX inhibition\"",
-      "\"NF-kB modulation\"",
-      "\"NF-κB modulation\"]"
-    ]
-  },
-  {
-    "id": "curcuminoids-curcumin",
-    "slug": "curcuminoids-curcumin",
-    "canonicalCompoundId": "curcuminoids-curcumin",
-    "name": "curcuminoids curcumin",
-    "compoundName": "curcuminoids curcumin",
-    "canonicalCompoundName": "curcuminoids curcumin",
-    "hero": "Defines a key pharmacological signal attributed to curcuminoids curcumin in herbal extracts.",
-    "coreInsight": "curcuminoids curcumin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
+      "HMGB1 inhibition",
+      "NF-κB inhibition"
     ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "cuscohygrine",
-    "slug": "cuscohygrine",
-    "canonicalCompoundId": "cuscohygrine",
-    "name": "cuscohygrine",
-    "compoundName": "cuscohygrine",
-    "canonicalCompoundName": "cuscohygrine",
-    "hero": "Defines a key pharmacological signal attributed to cuscohygrine in herbal extracts.",
-    "coreInsight": "Cuscohygrine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "cyanidin",
-    "slug": "cyanidin",
-    "canonicalCompoundId": "cyanidin",
-    "name": "cyanidin",
-    "compoundName": "cyanidin",
-    "canonicalCompoundName": "cyanidin",
-    "hero": "Defines a key pharmacological signal attributed to cyanidin in herbal extracts.",
-    "coreInsight": "cyanidin remains provisional because the evidence behind Elderberry does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "cynarin",
-    "slug": "cynarin",
-    "canonicalCompoundId": "cynarin",
-    "name": "cynarin",
-    "compoundName": "cynarin",
-    "canonicalCompoundName": "cynarin",
-    "hero": "Defines a key pharmacological signal attributed to cynarin in herbal extracts.",
-    "coreInsight": "cynarin stays provisional because the evidence behind Artichoke does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "cyperene",
-    "slug": "cyperene",
-    "canonicalCompoundId": "cyperene",
-    "name": "cyperene",
-    "compoundName": "cyperene",
-    "canonicalCompoundName": "cyperene",
-    "hero": "Defines antioxidant activity at the compound level.",
-    "coreInsight": "cyperene is most useful when a formulation needs a direct antioxidant signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "d-pinitol",
-    "slug": "d-pinitol",
-    "canonicalCompoundId": "d-pinitol",
-    "name": "d-pinitol",
-    "compoundName": "d-pinitol",
-    "canonicalCompoundName": "d-pinitol",
-    "hero": "Helps define why Carob extracts perform differently in formulation.",
-    "coreInsight": "d-pinitol becomes more valuable when Carob is standardized by named actives rather than total extract mass.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "daidzein",
-    "slug": "daidzein",
-    "canonicalCompoundId": "daidzein",
-    "name": "daidzein",
-    "compoundName": "daidzein",
-    "canonicalCompoundName": "daidzein",
-    "hero": "Defines a key pharmacological signal attributed to daidzein in herbal extracts.",
-    "coreInsight": "daidzein remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "damnacanthal",
-    "slug": "damnacanthal",
-    "canonicalCompoundId": "damnacanthal",
-    "name": "damnacanthal",
-    "compoundName": "damnacanthal",
-    "canonicalCompoundName": "damnacanthal",
-    "hero": "Helps define why Noni extracts perform differently in formulation.",
-    "coreInsight": "damnacanthal becomes more valuable when Noni is standardized by named actives rather than total extract mass.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "dehydrocorybulbine",
-    "slug": "dehydrocorybulbine",
-    "canonicalCompoundId": "dehydrocorybulbine",
-    "name": "Dehydrocorybulbine",
-    "compoundName": "Dehydrocorybulbine",
-    "canonicalCompoundName": "Dehydrocorybulbine",
-    "hero": "Distinguishes Dehydrocorybulbine from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Dehydrocorybulbine matters because it can be ranked directly against corydaline and related neighbors during compound prioritization.",
-    "effects": [
-      "[\"analgesic\"]"
-    ],
-    "mechanisms": [
-      "[\"dopamine modulation\"",
-      "\"analgesic signaling\"]"
-    ]
-  },
-  {
-    "id": "dehydrocorydalmine",
-    "slug": "dehydrocorydalmine",
-    "canonicalCompoundId": "dehydrocorydalmine",
-    "name": "dehydrocorydalmine",
-    "compoundName": "dehydrocorydalmine",
-    "canonicalCompoundName": "dehydrocorydalmine",
-    "hero": "Defines a key pharmacological signal attributed to dehydrocorydalmine in herbal extracts.",
-    "coreInsight": "dehydrocorydalmine remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "demethoxycurcumin",
-    "slug": "demethoxycurcumin",
-    "canonicalCompoundId": "demethoxycurcumin",
-    "name": "Demethoxycurcumin",
-    "compoundName": "Demethoxycurcumin",
-    "canonicalCompoundName": "Demethoxycurcumin",
-    "hero": "Defines a key pharmacological signal attributed to demethoxycurcumin in herbal extracts.",
-    "coreInsight": "Demethoxycurcumin stays provisional because the evidence behind Turmeric does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "dendrobine",
-    "slug": "dendrobine",
-    "canonicalCompoundId": "dendrobine",
-    "name": "dendrobine",
-    "compoundName": "dendrobine",
-    "canonicalCompoundName": "dendrobine",
-    "hero": "Acts as a recognizable chemical marker within Dendrobium.",
-    "coreInsight": "Within Dendrobium, dendrobine serves mainly as a phytochemical marker that sharpens chemical identity.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "deoxymiroestrol",
-    "slug": "deoxymiroestrol",
-    "canonicalCompoundId": "deoxymiroestrol",
-    "name": "deoxymiroestrol",
-    "compoundName": "deoxymiroestrol",
-    "canonicalCompoundName": "deoxymiroestrol",
-    "hero": "Helps define why Pueraria Mirifica extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, deoxymiroestrol helps separate Pueraria Mirifica extracts from adjacent markers such as miroestrol. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "desmethoxyyangonin",
-    "slug": "desmethoxyyangonin",
-    "canonicalCompoundId": "desmethoxyyangonin",
-    "name": "desmethoxyyangonin",
-    "compoundName": "desmethoxyyangonin",
-    "canonicalCompoundName": "desmethoxyyangonin",
-    "hero": "Delivers anxiolytic activity within Kava chemistry.",
-    "coreInsight": "For Kava, desmethoxyyangonin is most useful as a direct anxiolytic signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"",
-      "\"calcium channel modulation\"",
-      "\"dopamine modulation\"]"
-    ]
-  },
-  {
-    "id": "desmethylicaritin",
-    "slug": "desmethylicaritin",
-    "canonicalCompoundId": "desmethylicaritin",
-    "name": "Desmethylicaritin",
-    "compoundName": "Desmethylicaritin",
-    "canonicalCompoundName": "Desmethylicaritin",
-    "hero": "Helps define why Epimedium extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, Desmethylicaritin helps separate Epimedium extracts from adjacent markers such as Icariin. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "diallyl-disulfide",
-    "slug": "diallyl-disulfide",
-    "canonicalCompoundId": "diallyl-disulfide",
-    "name": "diallyl disulfide",
-    "compoundName": "diallyl disulfide",
-    "canonicalCompoundName": "diallyl disulfide",
-    "hero": "Distinguishes diallyl disulfide from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Diallyl disulfide matters because it can be ranked directly against diallyl sulfide and related neighbors during compound prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "diallyl-sulfide",
-    "slug": "diallyl-sulfide",
-    "canonicalCompoundId": "diallyl-sulfide",
-    "name": "diallyl sulfide",
-    "compoundName": "diallyl sulfide",
-    "canonicalCompoundName": "diallyl sulfide",
-    "hero": "Defines a key pharmacological signal attributed to diallyl sulfide in herbal extracts.",
-    "coreInsight": "diallyl sulfide remains provisional because the evidence behind Garlic does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "diallyl-trisulfide",
-    "slug": "diallyl-trisulfide",
-    "canonicalCompoundId": "diallyl-trisulfide",
-    "name": "diallyl trisulfide",
-    "compoundName": "diallyl trisulfide",
-    "canonicalCompoundName": "diallyl trisulfide",
-    "hero": "Defines a key pharmacological signal attributed to diallyl trisulfide in herbal extracts.",
-    "coreInsight": "diallyl trisulfide stays provisional because the evidence behind Garlic does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "dibenzyl-trisulfide",
-    "slug": "dibenzyl-trisulfide",
-    "canonicalCompoundId": "dibenzyl-trisulfide",
-    "name": "dibenzyl trisulfide",
-    "compoundName": "dibenzyl trisulfide",
-    "canonicalCompoundName": "dibenzyl trisulfide",
-    "hero": "Defines a key pharmacological signal attributed to dibenzyl trisulfide in herbal extracts.",
-    "coreInsight": "dibenzyl trisulfide remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "digitoxin",
-    "slug": "digitoxin",
-    "canonicalCompoundId": "digitoxin",
-    "name": "digitoxin",
-    "compoundName": "digitoxin",
-    "canonicalCompoundName": "digitoxin",
-    "hero": "Defines a key pharmacological signal attributed to digitoxin in herbal extracts.",
-    "coreInsight": "digitoxin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "digoxin",
-    "slug": "digoxin",
-    "canonicalCompoundId": "digoxin",
-    "name": "digoxin",
-    "compoundName": "digoxin",
-    "canonicalCompoundName": "digoxin",
-    "hero": "Defines a key pharmacological signal attributed to digoxin in herbal extracts.",
-    "coreInsight": "digoxin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "dihydrocapsaicin",
-    "slug": "dihydrocapsaicin",
-    "canonicalCompoundId": "dihydrocapsaicin",
-    "name": "dihydrocapsaicin",
-    "compoundName": "dihydrocapsaicin",
-    "canonicalCompoundName": "dihydrocapsaicin",
-    "hero": "Helps define why Cayenne extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, dihydrocapsaicin helps separate Cayenne extracts from adjacent markers such as capsaicin. That improves standardization decisions.",
-    "effects": [
-      "[\"analgesic\"]"
-    ],
-    "mechanisms": [
-      "[\"TRPV1 modulation\"]"
-    ]
-  },
-  {
-    "id": "dihydrohelenalin",
-    "slug": "dihydrohelenalin",
-    "canonicalCompoundId": "dihydrohelenalin",
-    "name": "dihydrohelenalin",
-    "compoundName": "dihydrohelenalin",
-    "canonicalCompoundName": "dihydrohelenalin",
-    "hero": "Defines a key pharmacological signal attributed to dihydrohelenalin in herbal extracts.",
-    "coreInsight": "Dihydrohelenalin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "dihydrokavain",
-    "slug": "dihydrokavain",
-    "canonicalCompoundId": "dihydrokavain",
-    "name": "dihydrokavain",
-    "compoundName": "dihydrokavain",
-    "canonicalCompoundName": "dihydrokavain",
-    "hero": "Defines a key pharmacological signal attributed to dihydrokavain in herbal extracts.",
-    "coreInsight": "dihydrokavain remains provisional because the evidence behind Kava does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"anxiolytic\"",
-      "\"sedative\"",
-      "\"muscle-relaxant\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"",
-      "\"calcium channel modulation\"",
-      "\"dopamine modulation\"]"
-    ]
-  },
-  {
-    "id": "dihydromethysticin",
-    "slug": "dihydromethysticin",
-    "canonicalCompoundId": "dihydromethysticin",
-    "name": "dihydromethysticin",
-    "compoundName": "dihydromethysticin",
-    "canonicalCompoundName": "dihydromethysticin",
-    "hero": "Defines a key pharmacological signal attributed to dihydromethysticin in herbal extracts.",
-    "coreInsight": "dihydromethysticin stays provisional because the evidence behind Kava does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"",
-      "\"calcium channel modulation\"",
-      "\"dopamine modulation\"]"
-    ]
-  },
-  {
-    "id": "dillapiole",
-    "slug": "dillapiole",
-    "canonicalCompoundId": "dillapiole",
-    "name": "dillapiole",
-    "compoundName": "dillapiole",
-    "canonicalCompoundName": "dillapiole",
-    "hero": "Defines a key pharmacological signal attributed to dillapiole in herbal extracts.",
-    "coreInsight": "dillapiole remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "dmt",
-    "slug": "dmt",
-    "canonicalCompoundId": "dmt",
-    "name": "dmt",
-    "compoundName": "dmt",
-    "canonicalCompoundName": "dmt",
-    "hero": "Defines a key pharmacological signal attributed to dmt in herbal extracts.",
-    "coreInsight": "dmt matters most when serotonin modulation is used as the primary readout. That makes it more informative than a generic alkaloid label.",
-    "effects": [
-      "[\"hallucinogenic\"",
-      "\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[\"serotonin modulation\"]"
-    ]
-  },
-  {
-    "id": "dopamine",
-    "slug": "dopamine",
-    "canonicalCompoundId": "dopamine",
-    "name": "Dopamine",
-    "compoundName": "Dopamine",
-    "canonicalCompoundName": "Dopamine",
-    "hero": "Sharpens stimulant and euphoric activity within Mucuna pruriens chemistry.",
-    "coreInsight": "For Mucuna pruriens, Dopamine is most useful as a direct stimulant signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"stimulant\"",
-      "\"euphoric\"]"
-    ],
-    "mechanisms": [
-      "[\"dopamine modulation\"]"
-    ]
-  },
-  {
-    "id": "ecdysterone",
-    "slug": "ecdysterone",
-    "canonicalCompoundId": "ecdysterone",
-    "name": "ecdysterone",
-    "compoundName": "ecdysterone",
-    "canonicalCompoundName": "ecdysterone",
-    "hero": "Helps define why Maral Root extracts perform differently in formulation.",
-    "coreInsight": "ecdysterone becomes more valuable when Maral Root is standardized by named actives rather than total extract mass.",
-    "effects": [
-      "[\"adaptogenic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "ecg",
-    "slug": "ecg",
-    "canonicalCompoundId": "ecg",
-    "name": "ECG",
-    "compoundName": "ECG",
-    "canonicalCompoundName": "ECG",
-    "hero": "Distinguishes ECG from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Ecg matters because it can be ranked directly against caffeine and related neighbors during compound prioritization.",
-    "effects": [
-      "[\"antioxidant\"",
-      "\"adaptogenic\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "echinacoside",
-    "slug": "echinacoside",
-    "canonicalCompoundId": "echinacoside",
-    "name": "echinacoside",
-    "compoundName": "echinacoside",
-    "canonicalCompoundName": "echinacoside",
-    "hero": "Defines a key pharmacological signal attributed to echinacoside in herbal extracts.",
-    "coreInsight": "echinacoside remains provisional because the evidence behind Cistanche does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "ecliptine",
-    "slug": "ecliptine",
-    "canonicalCompoundId": "ecliptine",
-    "name": "ecliptine",
-    "compoundName": "ecliptine",
-    "canonicalCompoundName": "ecliptine",
-    "hero": "Defines a key pharmacological signal attributed to ecliptine in herbal extracts.",
-    "coreInsight": "ecliptine stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "egcg",
-    "slug": "egcg",
-    "canonicalCompoundId": "egcg",
-    "name": "EGCG",
-    "compoundName": "EGCG",
-    "canonicalCompoundName": "EGCG",
-    "hero": "Acts as a recognizable chemical marker within Green Tea.",
-    "coreInsight": "Within Green Tea, EGCG helps define the plant’s chemistry alongside markers such as Caffeine.",
-    "effects": [
-      "[\"antioxidant\"",
-      "\"adaptogenic\"]"
-    ],
-    "mechanisms": [
-      "[\"AMPK activation\"]"
-    ]
-  },
-  {
-    "id": "eleutherosides",
-    "slug": "eleutherosides",
-    "canonicalCompoundId": "eleutherosides",
-    "name": "eleutherosides",
-    "compoundName": "eleutherosides",
-    "canonicalCompoundName": "eleutherosides",
-    "hero": "Anchors adaptogenic and antioxidant activity within Eleuthero chemistry.",
-    "coreInsight": "For Eleuthero, eleutherosides is most useful as a direct adaptogenic signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"adaptogenic\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "ellagic-acid",
-    "slug": "ellagic-acid",
-    "canonicalCompoundId": "ellagic-acid",
-    "name": "ellagic acid",
-    "compoundName": "ellagic acid",
-    "canonicalCompoundName": "ellagic acid",
-    "hero": "Concentrates anti-inflammatory and antioxidant activity within Pomegranate chemistry.",
-    "coreInsight": "For Pomegranate, ellagic acid is most useful as a direct anti-inflammatory signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"Antioxidant and anti-inflammatory signaling\"]"
-    ]
-  },
-  {
-    "id": "emetine",
-    "slug": "emetine",
-    "canonicalCompoundId": "emetine",
-    "name": "emetine",
-    "compoundName": "emetine",
-    "canonicalCompoundName": "emetine",
-    "hero": "Defines a key pharmacological signal attributed to emetine in herbal extracts.",
-    "coreInsight": "emetine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
     "id": "emodin",
     "slug": "emodin",
     "canonicalCompoundId": "emodin",
-    "name": "emodin",
-    "compoundName": "emodin",
-    "canonicalCompoundName": "emodin",
-    "hero": "Distinguishes emodin from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Emodin matters because it can be ranked directly against aloe-emodin and related neighbors during compound prioritization.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
+    "name": "Emodin",
+    "compoundName": "Emodin",
+    "canonicalCompoundName": "Emodin",
     "mechanisms": [
-      "[\"NF-kB inhibition\"",
-      "\"NF-kB modulation\"",
-      "\"NF-κB modulation\"]"
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
-    "id": "ephedrine",
-    "slug": "ephedrine",
-    "canonicalCompoundId": "ephedrine",
-    "name": "ephedrine",
-    "compoundName": "ephedrine",
-    "canonicalCompoundName": "ephedrine",
-    "hero": "Defines a key pharmacological signal attributed to ephedrine in herbal extracts.",
-    "coreInsight": "ephedrine remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"stimulant\"]"
-    ],
+    "id": "rhein",
+    "slug": "rhein",
+    "canonicalCompoundId": "rhein",
+    "name": "Rhein",
+    "compoundName": "Rhein",
+    "canonicalCompoundName": "Rhein",
     "mechanisms": [
-      "[\"adrenergic modulation\"]"
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
-    "id": "epicatechin",
-    "slug": "epicatechin",
-    "canonicalCompoundId": "epicatechin",
-    "name": "Epicatechin",
-    "compoundName": "Epicatechin",
-    "canonicalCompoundName": "Epicatechin",
-    "hero": "Defines a key pharmacological signal attributed to epicatechin in herbal extracts.",
-    "coreInsight": "Epicatechin stays provisional because the evidence behind Green Tea does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[]"
-    ],
+    "id": "schisandrin",
+    "slug": "schisandrin",
+    "canonicalCompoundId": "schisandrin",
+    "name": "Schisandrin",
+    "compoundName": "Schisandrin",
+    "canonicalCompoundName": "Schisandrin",
     "mechanisms": [
-      "[]"
+      "Nrf2 activation",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
-    "id": "epimedin-a",
-    "slug": "epimedin-a",
-    "canonicalCompoundId": "epimedin-a",
-    "name": "Epimedin A",
-    "compoundName": "Epimedin A",
-    "canonicalCompoundName": "Epimedin A",
-    "hero": "Acts as a recognizable chemical marker within Epimedium.",
-    "coreInsight": "Within Epimedium, Epimedin A helps define the plant’s chemistry alongside markers such as Icariin.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"]"
-    ],
+    "id": "celastrol",
+    "slug": "celastrol",
+    "canonicalCompoundId": "celastrol",
+    "name": "Celastrol",
+    "compoundName": "Celastrol",
+    "canonicalCompoundName": "Celastrol",
     "mechanisms": [
-      "[\"nitric oxide modulation\"]"
-    ]
-  },
-  {
-    "id": "epimedin-b",
-    "slug": "epimedin-b",
-    "canonicalCompoundId": "epimedin-b",
-    "name": "Epimedin B",
-    "compoundName": "Epimedin B",
-    "canonicalCompoundName": "Epimedin B",
-    "hero": "Drives nitric oxide modulation in Epimedin B.",
-    "coreInsight": "Epimedin B matters most when nitric oxide modulation is used as the primary readout. That makes it more informative than a generic Flavonoid label.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"]"
+      "HSP90 inhibition",
+      "NF-κB inhibition"
     ],
-    "mechanisms": [
-      "[\"nitric oxide modulation\"]"
-    ]
-  },
-  {
-    "id": "epimedin-c",
-    "slug": "epimedin-c",
-    "canonicalCompoundId": "epimedin-c",
-    "name": "Epimedin C",
-    "compoundName": "Epimedin C",
-    "canonicalCompoundName": "Epimedin C",
-    "hero": "Anchors anti-inflammatory and antioxidant activity within Epimedium chemistry.",
-    "coreInsight": "For Epimedium, Epimedin C is most useful as a direct anti-inflammatory signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"nitric oxide modulation\"]"
-    ]
-  },
-  {
-    "id": "ergine",
-    "slug": "ergine",
-    "canonicalCompoundId": "ergine",
-    "name": "ergine",
-    "compoundName": "ergine",
-    "canonicalCompoundName": "ergine",
-    "hero": "Defines a key pharmacological signal attributed to ergine in herbal extracts.",
-    "coreInsight": "ergine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "erinacines",
-    "slug": "erinacines",
-    "canonicalCompoundId": "erinacines",
-    "name": "erinacines",
-    "compoundName": "erinacines",
-    "canonicalCompoundName": "erinacines",
-    "hero": "Distinguishes erinacines from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Erinacines matters because it can be ranked directly against hericenone c and related neighbors during compound prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "eryngial",
-    "slug": "eryngial",
-    "canonicalCompoundId": "eryngial",
-    "name": "eryngial",
-    "compoundName": "eryngial",
-    "canonicalCompoundName": "eryngial",
-    "hero": "Defines a key pharmacological signal attributed to eryngial in herbal extracts.",
-    "coreInsight": "eryngial remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "esculetin",
-    "slug": "esculetin",
-    "canonicalCompoundId": "esculetin",
-    "name": "esculetin",
-    "compoundName": "esculetin",
-    "canonicalCompoundName": "esculetin",
-    "hero": "Defines a key pharmacological signal attributed to esculetin in herbal extracts.",
-    "coreInsight": "esculetin stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "estragole",
-    "slug": "estragole",
-    "canonicalCompoundId": "estragole",
-    "name": "estragole",
-    "compoundName": "estragole",
-    "canonicalCompoundName": "estragole",
-    "hero": "Acts as a recognizable chemical marker within Anise Hyssop.",
-    "coreInsight": "Within Anise Hyssop, estragole helps define the plant’s chemistry alongside markers such as anethole.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "ethyl-cinnamate",
-    "slug": "ethyl-cinnamate",
-    "canonicalCompoundId": "ethyl-cinnamate",
-    "name": "ethyl cinnamate",
-    "compoundName": "ethyl cinnamate",
-    "canonicalCompoundName": "ethyl cinnamate",
-    "hero": "Defines a key pharmacological signal attributed to ethyl cinnamate in herbal extracts.",
-    "coreInsight": "ethyl cinnamate remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "eucalyptol",
-    "slug": "eucalyptol",
-    "canonicalCompoundId": "eucalyptol",
-    "name": "eucalyptol",
-    "compoundName": "eucalyptol",
-    "canonicalCompoundName": "eucalyptol",
-    "hero": "Helps define why Thyme extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, eucalyptol helps separate Thyme extracts from adjacent markers such as thymol. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "eucalyptol-cineole",
-    "slug": "eucalyptol-cineole",
-    "canonicalCompoundId": "eucalyptol-cineole",
-    "name": "eucalyptol cineole",
-    "compoundName": "eucalyptol cineole",
-    "canonicalCompoundName": "eucalyptol cineole",
-    "hero": "Defines a key pharmacological signal attributed to eucalyptol cineole in herbal extracts.",
-    "coreInsight": "eucalyptol cineole remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
@@ -3873,750 +231,285 @@
     "name": "Eugenol",
     "compoundName": "Eugenol",
     "canonicalCompoundName": "Eugenol",
-    "hero": "Distinguishes Eugenol from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Eugenol matters because it can be ranked directly against ursolic acid and related neighbors during compound prioritization.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"analgesic\"",
-      "\"antimicrobial\"",
-      "\"adaptogenic\"]"
-    ],
     "mechanisms": [
-      "[\"TRPV1 modulation\"]"
+      "COX inhibition",
+      "TRP channel modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
-    "id": "eurycomanone",
-    "slug": "eurycomanone",
-    "canonicalCompoundId": "eurycomanone",
-    "name": "eurycomanone",
-    "compoundName": "eurycomanone",
-    "canonicalCompoundName": "eurycomanone",
-    "hero": "Defines a key pharmacological signal attributed to eurycomanone in herbal extracts.",
-    "coreInsight": "eurycomanone remains provisional because the evidence behind Tongkat Ali does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[]"
-    ],
+    "id": "linalool",
+    "slug": "linalool",
+    "canonicalCompoundId": "linalool",
+    "name": "Linalool",
+    "compoundName": "Linalool",
+    "canonicalCompoundName": "Linalool",
     "mechanisms": [
-      "[]"
+      "GABA-A modulation",
+      "voltage-gated calcium channel modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
-    "id": "evodiamine",
-    "slug": "evodiamine",
-    "canonicalCompoundId": "evodiamine",
-    "name": "evodiamine",
-    "compoundName": "evodiamine",
-    "canonicalCompoundName": "evodiamine",
-    "hero": "Defines a key pharmacological signal attributed to evodiamine in herbal extracts.",
-    "coreInsight": "evodiamine stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
+    "id": "saikosaponin-a",
+    "slug": "saikosaponin-a",
+    "canonicalCompoundId": "saikosaponin-a",
+    "name": "Saikosaponin A",
+    "compoundName": "Saikosaponin A",
+    "canonicalCompoundName": "Saikosaponin A",
     "mechanisms": [
-      "[]"
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
-    "id": "fangchinoline",
-    "slug": "fangchinoline",
-    "canonicalCompoundId": "fangchinoline",
-    "name": "fangchinoline",
-    "compoundName": "fangchinoline",
-    "canonicalCompoundName": "fangchinoline",
-    "hero": "Defines a key pharmacological signal attributed to fangchinoline in herbal extracts.",
-    "coreInsight": "fangchinoline remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
+    "id": "curcumin",
+    "slug": "curcumin",
+    "canonicalCompoundId": "curcumin",
+    "name": "Curcumin",
+    "compoundName": "Curcumin",
+    "canonicalCompoundName": "Curcumin",
     "mechanisms": [
-      "[]"
+      "NF-κB inhibition",
+      "Nrf2 activation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
-    "id": "faradiol",
-    "slug": "faradiol",
-    "canonicalCompoundId": "faradiol",
-    "name": "faradiol",
-    "compoundName": "faradiol",
-    "canonicalCompoundName": "faradiol",
-    "hero": "Carries anti-inflammatory activity within Calendula chemistry.",
-    "coreInsight": "For Calendula, faradiol is most useful as a direct anti-inflammatory signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
+    "id": "hesperidin",
+    "slug": "hesperidin",
+    "canonicalCompoundId": "hesperidin",
+    "name": "Hesperidin",
+    "compoundName": "Hesperidin",
+    "canonicalCompoundName": "Hesperidin",
     "mechanisms": [
-      "[]"
+      "PI3K/Akt modulation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
-    "id": "faradiol-esters",
-    "slug": "faradiol-esters",
-    "canonicalCompoundId": "faradiol-esters",
-    "name": "faradiol esters",
-    "compoundName": "faradiol esters",
-    "canonicalCompoundName": "faradiol esters",
-    "hero": "Focuses anti-inflammatory activity within Calendula chemistry.",
-    "coreInsight": "For Calendula, faradiol esters is most useful as a direct anti-inflammatory signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
+    "id": "berberine",
+    "slug": "berberine",
+    "canonicalCompoundId": "berberine",
+    "name": "Berberine",
+    "compoundName": "Berberine",
+    "canonicalCompoundName": "Berberine",
     "mechanisms": [
-      "[]"
+      "AMPK activation",
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "PubMed",
+      "review literature"
     ]
   },
   {
-    "id": "febrifugine",
-    "slug": "febrifugine",
-    "canonicalCompoundId": "febrifugine",
-    "name": "febrifugine",
-    "compoundName": "febrifugine",
-    "canonicalCompoundName": "febrifugine",
-    "hero": "Defines a key pharmacological signal attributed to febrifugine in herbal extracts.",
-    "coreInsight": "febrifugine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
+    "id": "palmatine",
+    "slug": "palmatine",
+    "canonicalCompoundId": "palmatine",
+    "name": "Palmatine",
+    "compoundName": "Palmatine",
+    "canonicalCompoundName": "Palmatine",
     "mechanisms": [
-      "[]"
+      "AMPK activation",
+      "MAPK pathway modulation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "PubMed",
+      "review literature"
     ]
   },
   {
-    "id": "fenchone",
-    "slug": "fenchone",
-    "canonicalCompoundId": "fenchone",
-    "name": "fenchone",
-    "compoundName": "fenchone",
-    "canonicalCompoundName": "fenchone",
-    "hero": "Defines a key pharmacological signal attributed to fenchone in herbal extracts.",
-    "coreInsight": "Fenchone remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
+    "id": "jatrorrhizine",
+    "slug": "jatrorrhizine",
+    "canonicalCompoundId": "jatrorrhizine",
+    "name": "Jatrorrhizine",
+    "compoundName": "Jatrorrhizine",
+    "canonicalCompoundName": "Jatrorrhizine",
     "mechanisms": [
-      "[]"
+      "AMPK activation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "PubMed",
+      "review literature"
     ]
   },
   {
-    "id": "ferulenol",
-    "slug": "ferulenol",
-    "canonicalCompoundId": "ferulenol",
-    "name": "ferulenol",
-    "compoundName": "ferulenol",
-    "canonicalCompoundName": "ferulenol",
-    "hero": "Defines a key pharmacological signal attributed to ferulenol in herbal extracts.",
-    "coreInsight": "ferulenol remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
+    "id": "columbamine",
+    "slug": "columbamine",
+    "canonicalCompoundId": "columbamine",
+    "name": "Columbamine",
+    "compoundName": "Columbamine",
+    "canonicalCompoundName": "Columbamine",
     "mechanisms": [
-      "[]"
+      "AMPK activation",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "PubMed",
+      "review literature"
     ]
   },
   {
-    "id": "ferulic-acid",
-    "slug": "ferulic-acid",
-    "canonicalCompoundId": "ferulic-acid",
-    "name": "ferulic acid",
-    "compoundName": "ferulic acid",
-    "canonicalCompoundName": "ferulic acid",
-    "hero": "Defines a key pharmacological signal attributed to ferulic acid in herbal extracts.",
-    "coreInsight": "ferulic acid stays provisional because the evidence behind Chuanxiong does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[]"
-    ],
+    "id": "andrographolide",
+    "slug": "andrographolide",
+    "canonicalCompoundId": "andrographolide",
+    "name": "Andrographolide",
+    "compoundName": "Andrographolide",
+    "canonicalCompoundName": "Andrographolide",
     "mechanisms": [
-      "[]"
+      "NF-κB inhibition",
+      "JAK/STAT modulation",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "PubMed",
+      "review literature"
     ]
   },
   {
-    "id": "flavokavain-a",
-    "slug": "flavokavain-a",
-    "canonicalCompoundId": "flavokavain-a",
-    "name": "flavokavain a",
-    "compoundName": "flavokavain a",
-    "canonicalCompoundName": "flavokavain a",
-    "hero": "Acts as a recognizable chemical marker within Kava.",
-    "coreInsight": "Within Kava, flavokavain a helps define the plant’s chemistry alongside markers such as kavain.",
-    "effects": [
-      "[\"anxiolytic\"",
-      "\"sedative\"",
-      "\"muscle-relaxant\"",
-      "\"antioxidant\"]"
-    ],
+    "id": "neoandrographolide",
+    "slug": "neoandrographolide",
+    "canonicalCompoundId": "neoandrographolide",
+    "name": "Neoandrographolide",
+    "compoundName": "Neoandrographolide",
+    "canonicalCompoundName": "Neoandrographolide",
     "mechanisms": [
-      "[\"apoptosis modulation\"",
-      "\"GABA-A modulation\"",
-      "\"sodium channel inhibition\"",
-      "\"calcium channel modulation\"]"
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "PubMed",
+      "review literature"
     ]
   },
   {
-    "id": "flavokavain-b",
-    "slug": "flavokavain-b",
-    "canonicalCompoundId": "flavokavain-b",
-    "name": "flavokavain b",
-    "compoundName": "flavokavain b",
-    "canonicalCompoundName": "flavokavain b",
-    "hero": "Delivers apoptosis modulation in flavokavain b.",
-    "coreInsight": "flavokavain b matters most when apoptosis modulation is used as the primary readout. That makes it more informative than a generic chalcone label.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"anxiolytic\"",
-      "\"antioxidant\"]"
-    ],
+    "id": "gymnemic-acid",
+    "slug": "gymnemic-acid",
+    "canonicalCompoundId": "gymnemic-acid",
+    "name": "Gymnemic acid",
+    "compoundName": "Gymnemic acid",
+    "canonicalCompoundName": "Gymnemic acid",
     "mechanisms": [
-      "[\"apoptosis modulation\"",
-      "\"GABA-A modulation\"",
-      "\"sodium channel inhibition\"",
-      "\"calcium channel modulation\"]"
+      "glucose absorption modulation",
+      "AMPK activation"
+    ],
+    "foundIn": [
+      "PubMed",
+      "review literature"
     ]
   },
   {
-    "id": "flavokavain-c",
-    "slug": "flavokavain-c",
-    "canonicalCompoundId": "flavokavain-c",
-    "name": "flavokavain c",
-    "compoundName": "flavokavain c",
-    "canonicalCompoundName": "flavokavain c",
-    "hero": "Carries anti-inflammatory and anxiolytic activity at the compound level.",
-    "coreInsight": "flavokavain c is most useful when a formulation needs a direct anti-inflammatory signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"anxiolytic\"",
-      "\"antioxidant\"]"
-    ],
+    "id": "charantin",
+    "slug": "charantin",
+    "canonicalCompoundId": "charantin",
+    "name": "Charantin",
+    "compoundName": "Charantin",
+    "canonicalCompoundName": "Charantin",
     "mechanisms": [
-      "[\"GABA-A modulation\"",
-      "\"sodium channel inhibition\"",
-      "\"calcium channel modulation\"",
-      "\"dopamine modulation\"]"
+      "AMPK activation",
+      "GLUT4 translocation modulation"
+    ],
+    "foundIn": [
+      "PubMed",
+      "review literature"
     ]
   },
   {
-    "id": "formononetin",
-    "slug": "formononetin",
-    "canonicalCompoundId": "formononetin",
-    "name": "formononetin",
-    "compoundName": "formononetin",
-    "canonicalCompoundName": "formononetin",
-    "hero": "Defines a key pharmacological signal attributed to formononetin in herbal extracts.",
-    "coreInsight": "formononetin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
+    "id": "momordicoside-k",
+    "slug": "momordicoside-k",
+    "canonicalCompoundId": "momordicoside-k",
+    "name": "Momordicoside K",
+    "compoundName": "Momordicoside K",
+    "canonicalCompoundName": "Momordicoside K",
     "mechanisms": [
-      "[]"
+      "AMPK activation",
+      "PPARγ activation"
+    ],
+    "foundIn": [
+      "PubMed",
+      "review literature"
     ]
   },
   {
-    "id": "fraxin",
-    "slug": "fraxin",
-    "canonicalCompoundId": "fraxin",
-    "name": "fraxin",
-    "compoundName": "fraxin",
-    "canonicalCompoundName": "fraxin",
-    "hero": "Defines a key pharmacological signal attributed to fraxin in herbal extracts.",
-    "coreInsight": "Fraxin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
+    "id": "diosgenin",
+    "slug": "diosgenin",
+    "canonicalCompoundId": "diosgenin",
+    "name": "Diosgenin",
+    "compoundName": "Diosgenin",
+    "canonicalCompoundName": "Diosgenin",
     "mechanisms": [
-      "[]"
+      "PI3K/Akt modulation",
+      "PPARγ activation"
+    ],
+    "foundIn": [
+      "PubMed",
+      "review literature"
     ]
   },
   {
-    "id": "fucoidan",
-    "slug": "fucoidan",
-    "canonicalCompoundId": "fucoidan",
-    "name": "fucoidan",
-    "compoundName": "fucoidan",
-    "canonicalCompoundName": "fucoidan",
-    "hero": "Defines a key pharmacological signal attributed to fucoidan in herbal extracts.",
-    "coreInsight": "fucoidan remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
+    "id": "protodioscin",
+    "slug": "protodioscin",
+    "canonicalCompoundId": "protodioscin",
+    "name": "Protodioscin",
+    "compoundName": "Protodioscin",
+    "canonicalCompoundName": "Protodioscin",
     "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "fukinolic-acid",
-    "slug": "fukinolic-acid",
-    "canonicalCompoundId": "fukinolic-acid",
-    "name": "Fukinolic acid",
-    "compoundName": "Fukinolic acid",
-    "canonicalCompoundName": "Fukinolic acid",
-    "hero": "Defines a key pharmacological signal attributed to fukinolic acid in herbal extracts.",
-    "coreInsight": "Fukinolic acid stays provisional because the evidence behind Black Cohosh does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"]"
+      "NO signaling modulation",
+      "PI3K/Akt modulation"
     ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "galangin",
-    "slug": "galangin",
-    "canonicalCompoundId": "galangin",
-    "name": "galangin",
-    "compoundName": "galangin",
-    "canonicalCompoundName": "galangin",
-    "hero": "Acts as a recognizable chemical marker within Galangal.",
-    "coreInsight": "Within Galangal, galangin serves mainly as a phytochemical marker that sharpens chemical identity.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "gallic-acid",
-    "slug": "gallic-acid",
-    "canonicalCompoundId": "gallic-acid",
-    "name": "gallic acid",
-    "compoundName": "gallic acid",
-    "canonicalCompoundName": "gallic acid",
-    "hero": "Helps define why Longan extracts perform differently in formulation.",
-    "coreInsight": "gallic acid becomes more valuable when Longan is standardized by named actives rather than total extract mass.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "gamma-aminobutyric-acid",
-    "slug": "gamma-aminobutyric-acid",
-    "canonicalCompoundId": "gamma-aminobutyric-acid",
-    "name": "gamma-aminobutyric acid",
-    "compoundName": "gamma-aminobutyric acid",
-    "canonicalCompoundName": "gamma-aminobutyric acid",
-    "hero": "Delivers anxiolytic activity at the compound level.",
-    "coreInsight": "gamma-aminobutyric acid is most useful when a formulation needs a direct anxiolytic signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"]"
-    ]
-  },
-  {
-    "id": "gamma-linolenic-acid",
-    "slug": "gamma-linolenic-acid",
-    "canonicalCompoundId": "gamma-linolenic-acid",
-    "name": "gamma-linolenic acid",
-    "compoundName": "gamma-linolenic acid",
-    "canonicalCompoundName": "gamma-linolenic acid",
-    "hero": "Defines a key pharmacological signal attributed to gamma-linolenic acid in herbal extracts.",
-    "coreInsight": "gamma-linolenic acid remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "gastrodin",
-    "slug": "gastrodin",
-    "canonicalCompoundId": "gastrodin",
-    "name": "gastrodin",
-    "compoundName": "gastrodin",
-    "canonicalCompoundName": "gastrodin",
-    "hero": "Defines a key pharmacological signal attributed to gastrodin in herbal extracts.",
-    "coreInsight": "Gastrodin remains provisional because the evidence behind gastrodia does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"anxiolytic\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "gelsedine",
-    "slug": "gelsedine",
-    "canonicalCompoundId": "gelsedine",
-    "name": "gelsedine",
-    "compoundName": "gelsedine",
-    "canonicalCompoundName": "gelsedine",
-    "hero": "Requires tighter safety interpretation than many adjacent plant compounds.",
-    "coreInsight": "gelsedine needs separate risk review because safety constraints can change its value in formulation.",
-    "effects": [
-      "[\"analgesic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "gelsemicine",
-    "slug": "gelsemicine",
-    "canonicalCompoundId": "gelsemicine",
-    "name": "gelsemicine",
-    "compoundName": "gelsemicine",
-    "canonicalCompoundName": "gelsemicine",
-    "hero": "Defines a key pharmacological signal attributed to gelsemicine in herbal extracts.",
-    "coreInsight": "gelsemicine stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"analgesic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "gelsemine",
-    "slug": "gelsemine",
-    "canonicalCompoundId": "gelsemine",
-    "name": "gelsemine",
-    "compoundName": "gelsemine",
-    "canonicalCompoundName": "gelsemine",
-    "hero": "Concentrates analgesic activity at the compound level.",
-    "coreInsight": "gelsemine is most useful when a formulation needs a direct analgesic signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"analgesic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "gelseminine",
-    "slug": "gelseminine",
-    "canonicalCompoundId": "gelseminine",
-    "name": "gelseminine",
-    "compoundName": "gelseminine",
-    "canonicalCompoundName": "gelseminine",
-    "hero": "Sharpens analgesic activity at the compound level.",
-    "coreInsight": "gelseminine is most useful when a formulation needs a direct analgesic signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"analgesic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "gelseverine",
-    "slug": "gelseverine",
-    "canonicalCompoundId": "gelseverine",
-    "name": "gelseverine",
-    "compoundName": "gelseverine",
-    "canonicalCompoundName": "gelseverine",
-    "hero": "Defines analgesic activity at the compound level.",
-    "coreInsight": "gelseverine is most useful when a formulation needs a direct analgesic signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"analgesic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "geniposide",
-    "slug": "geniposide",
-    "canonicalCompoundId": "geniposide",
-    "name": "geniposide",
-    "compoundName": "geniposide",
-    "canonicalCompoundName": "geniposide",
-    "hero": "Defines a key pharmacological signal attributed to geniposide in herbal extracts.",
-    "coreInsight": "geniposide remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "geniposidic-acid",
-    "slug": "geniposidic-acid",
-    "canonicalCompoundId": "geniposidic-acid",
-    "name": "geniposidic acid",
-    "compoundName": "geniposidic acid",
-    "canonicalCompoundName": "geniposidic acid",
-    "hero": "Requires tighter safety interpretation than many adjacent plant compounds.",
-    "coreInsight": "Geniposidic acid needs separate risk review because safety constraints can change its value in formulation.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "genistein",
-    "slug": "genistein",
-    "canonicalCompoundId": "genistein",
-    "name": "genistein",
-    "compoundName": "genistein",
-    "canonicalCompoundName": "genistein",
-    "hero": "Defines a key pharmacological signal attributed to genistein in herbal extracts.",
-    "coreInsight": "genistein remains provisional because the evidence behind Red Clover does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"estrogen receptor modulation\"]"
-    ]
-  },
-  {
-    "id": "gentiopicroside",
-    "slug": "gentiopicroside",
-    "canonicalCompoundId": "gentiopicroside",
-    "name": "gentiopicroside",
-    "compoundName": "gentiopicroside",
-    "canonicalCompoundName": "gentiopicroside",
-    "hero": "Defines a key pharmacological signal attributed to gentiopicroside in herbal extracts.",
-    "coreInsight": "gentiopicroside stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "geranial",
-    "slug": "geranial",
-    "canonicalCompoundId": "geranial",
-    "name": "geranial",
-    "compoundName": "geranial",
-    "canonicalCompoundName": "geranial",
-    "hero": "Anchors antioxidant activity at the compound level.",
-    "coreInsight": "geranial is most useful when a formulation needs a direct antioxidant signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "geraniin",
-    "slug": "geraniin",
-    "canonicalCompoundId": "geraniin",
-    "name": "geraniin",
-    "compoundName": "geraniin",
-    "canonicalCompoundName": "geraniin",
-    "hero": "Concentrates antioxidant activity at the compound level.",
-    "coreInsight": "geraniin is most useful when a formulation needs a direct antioxidant signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "geraniol",
-    "slug": "geraniol",
-    "canonicalCompoundId": "geraniol",
-    "name": "geraniol",
-    "compoundName": "geraniol",
-    "canonicalCompoundName": "geraniol",
-    "hero": "Sharpens antioxidant activity at the compound level.",
-    "coreInsight": "geraniol is most useful when a formulation needs a direct antioxidant signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "ginkgetin",
-    "slug": "ginkgetin",
-    "canonicalCompoundId": "ginkgetin",
-    "name": "ginkgetin",
-    "compoundName": "ginkgetin",
-    "canonicalCompoundName": "ginkgetin",
-    "hero": "Helps define why Ginkgo Biloba extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, ginkgetin helps separate Ginkgo Biloba extracts from adjacent markers such as Isorhamnetin. That improves standardization decisions.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"COX inhibition\"",
-      "\"5-lipoxygenase inhibition\"]"
-    ]
-  },
-  {
-    "id": "ginkgo-biloba-ginkgolides",
-    "slug": "ginkgo-biloba-ginkgolides",
-    "canonicalCompoundId": "ginkgo-biloba-ginkgolides",
-    "name": "ginkgo biloba ginkgolides",
-    "compoundName": "ginkgo biloba ginkgolides",
-    "canonicalCompoundName": "ginkgo biloba ginkgolides",
-    "hero": "Defines a key pharmacological signal attributed to ginkgo biloba ginkgolides in herbal extracts.",
-    "coreInsight": "Ginkgo biloba ginkgolides remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[\"Platelet-activating factor (PAF) antagonism\"]"
-    ]
-  },
-  {
-    "id": "ginkgolide-a",
-    "slug": "ginkgolide-a",
-    "canonicalCompoundId": "ginkgolide-a",
-    "name": "Ginkgolide A",
-    "compoundName": "Ginkgolide A",
-    "canonicalCompoundName": "Ginkgolide A",
-    "hero": "Defines a key pharmacological signal attributed to ginkgolide a in herbal extracts.",
-    "coreInsight": "Ginkgolide A remains provisional because the evidence behind Ginkgo Biloba does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "ginkgolide-b",
-    "slug": "ginkgolide-b",
-    "canonicalCompoundId": "ginkgolide-b",
-    "name": "Ginkgolide B",
-    "compoundName": "Ginkgolide B",
-    "canonicalCompoundName": "Ginkgolide B",
-    "hero": "Defines a key pharmacological signal attributed to ginkgolide b in herbal extracts.",
-    "coreInsight": "Ginkgolide B stays provisional because the evidence behind Ginkgo Biloba does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[\"PAF antagonism\"",
-      "\"vascular signaling\"]"
-    ]
-  },
-  {
-    "id": "ginkgolide-c",
-    "slug": "ginkgolide-c",
-    "canonicalCompoundId": "ginkgolide-c",
-    "name": "Ginkgolide C",
-    "compoundName": "Ginkgolide C",
-    "canonicalCompoundName": "Ginkgolide C",
-    "hero": "Acts as a recognizable chemical marker within Ginkgo Biloba.",
-    "coreInsight": "Within Ginkgo Biloba, Ginkgolide C helps define the plant’s chemistry alongside markers such as ginkgolides A, B, C, J.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "ginkgolide-j",
-    "slug": "ginkgolide-j",
-    "canonicalCompoundId": "ginkgolide-j",
-    "name": "ginkgolide j",
-    "compoundName": "ginkgolide j",
-    "canonicalCompoundName": "ginkgolide j",
-    "hero": "Defines a key pharmacological signal attributed to ginkgolide j in herbal extracts.",
-    "coreInsight": "ginkgolide j remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
+    "foundIn": [
+      "PubMed",
+      "review literature"
     ]
   },
   {
     "id": "ginsenoside-rb1",
     "slug": "ginsenoside-rb1",
     "canonicalCompoundId": "ginsenoside-rb1",
-    "name": "Ginsenoside RB1",
-    "compoundName": "Ginsenoside RB1",
-    "canonicalCompoundName": "Ginsenoside RB1",
-    "hero": "Concentrates nootropic activity within Panax Ginseng chemistry.",
-    "coreInsight": "For Panax Ginseng, Ginsenoside RB1 is most useful as a direct nootropic signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"nootropic\"]"
-    ],
+    "name": "Ginsenoside Rb1",
+    "compoundName": "Ginsenoside Rb1",
+    "canonicalCompoundName": "Ginsenoside Rb1",
     "mechanisms": [
-      "[\"cholinergic modulation\"",
-      "\"cognitive modulation\"]"
-    ]
-  },
-  {
-    "id": "ginsenoside-rd",
-    "slug": "ginsenoside-rd",
-    "canonicalCompoundId": "ginsenoside-rd",
-    "name": "Ginsenoside Rd",
-    "compoundName": "Ginsenoside Rd",
-    "canonicalCompoundName": "Ginsenoside Rd",
-    "hero": "Helps define why Panax Ginseng extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, Ginsenoside Rd helps separate Panax Ginseng extracts from adjacent markers such as Ginsenoside RG1. That improves standardization decisions.",
-    "effects": [
-      "[\"neuroprotective\"",
-      "\"hepatoprotective\"]"
+      "PI3K/Akt modulation",
+      "cholinergic modulation",
+      "Nrf2 activation"
     ],
-    "mechanisms": [
-      "[\"neuroprotective signaling\"]"
-    ]
-  },
-  {
-    "id": "ginsenoside-re",
-    "slug": "ginsenoside-re",
-    "canonicalCompoundId": "ginsenoside-re",
-    "name": "Ginsenoside Re",
-    "compoundName": "Ginsenoside Re",
-    "canonicalCompoundName": "Ginsenoside Re",
-    "hero": "Distinguishes Ginsenoside Re from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Ginsenoside re matters because it can be ranked directly against ginsenoside rg1 and related neighbors during compound prioritization.",
-    "effects": [
-      "[\"adaptogenic\"]"
-    ],
-    "mechanisms": [
-      "[\"metabolic signaling\"",
-      "\"stress-response modulation\"",
-      "\"cortisol modulation\"]"
-    ]
-  },
-  {
-    "id": "ginsenoside-rf",
-    "slug": "ginsenoside-rf",
-    "canonicalCompoundId": "ginsenoside-rf",
-    "name": "Ginsenoside Rf",
-    "compoundName": "Ginsenoside Rf",
-    "canonicalCompoundName": "Ginsenoside Rf",
-    "hero": "Defines a key pharmacological signal attributed to ginsenoside rf in herbal extracts.",
-    "coreInsight": "Ginsenoside Rf remains provisional because the evidence behind Panax Ginseng does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"nootropic\"",
-      "\"adaptogenic\"]"
-    ],
-    "mechanisms": [
-      "[\"stress-response modulation\"",
-      "\"cognitive modulation\"]"
+    "foundIn": [
+      "PubMed",
+      "review literature"
     ]
   },
   {
     "id": "ginsenoside-rg1",
     "slug": "ginsenoside-rg1",
     "canonicalCompoundId": "ginsenoside-rg1",
-    "name": "Ginsenoside RG1",
-    "compoundName": "Ginsenoside RG1",
-    "canonicalCompoundName": "Ginsenoside RG1",
-    "hero": "Defines a key pharmacological signal attributed to ginsenoside rg1 in herbal extracts.",
-    "coreInsight": "Ginsenoside RG1 stays provisional because the evidence behind Panax Ginseng does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"nootropic\"",
-      "\"neuroprotective\"",
-      "\"hepatoprotective\"]"
-    ],
+    "name": "Ginsenoside Rg1",
+    "compoundName": "Ginsenoside Rg1",
+    "canonicalCompoundName": "Ginsenoside Rg1",
     "mechanisms": [
-      "[\"cognitive modulation\"",
-      "\"neurotrophic signaling\"]"
+      "PI3K/Akt modulation",
+      "NO signaling modulation",
+      "Nrf2 activation"
+    ],
+    "foundIn": [
+      "PubMed",
+      "review literature"
     ]
   },
   {
@@ -4626,5138 +519,14 @@
     "name": "Ginsenoside Rg3",
     "compoundName": "Ginsenoside Rg3",
     "canonicalCompoundName": "Ginsenoside Rg3",
-    "hero": "Acts as a recognizable chemical marker within Panax Ginseng.",
-    "coreInsight": "Within Panax Ginseng, Ginsenoside Rg3 helps define the plant’s chemistry alongside markers such as Ginsenoside RG1.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[\"NF-kB inhibition\"",
-      "\"metabolic signaling\"",
-      "\"NF-kB modulation\"",
-      "\"NF-κB modulation\"]"
-    ]
-  },
-  {
-    "id": "ginsenosides-including-rb1",
-    "slug": "ginsenosides-including-rb1",
-    "canonicalCompoundId": "ginsenosides-including-rb1",
-    "name": "ginsenosides including rb1",
-    "compoundName": "ginsenosides including rb1",
-    "canonicalCompoundName": "ginsenosides including rb1",
-    "hero": "Helps define why American Ginseng extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, ginsenosides including rb1 helps separate American Ginseng extracts from adjacent markers such as rb2. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "ginsenosides-rb1",
-    "slug": "ginsenosides-rb1",
-    "canonicalCompoundId": "ginsenosides-rb1",
-    "name": "ginsenosides rb1",
-    "compoundName": "ginsenosides rb1",
-    "canonicalCompoundName": "ginsenosides rb1",
-    "hero": "Defines a key pharmacological signal attributed to ginsenosides rb1 in herbal extracts.",
-    "coreInsight": "ginsenosides rb1 remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "gitoxin",
-    "slug": "gitoxin",
-    "canonicalCompoundId": "gitoxin",
-    "name": "gitoxin",
-    "compoundName": "gitoxin",
-    "canonicalCompoundName": "gitoxin",
-    "hero": "Defines a key pharmacological signal attributed to gitoxin in herbal extracts.",
-    "coreInsight": "gitoxin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "glycyrrhizin",
-    "slug": "glycyrrhizin",
-    "canonicalCompoundId": "glycyrrhizin",
-    "name": "glycyrrhizin",
-    "compoundName": "glycyrrhizin",
-    "canonicalCompoundName": "glycyrrhizin",
-    "hero": "Defines a key pharmacological signal attributed to glycyrrhizin in herbal extracts.",
-    "coreInsight": "Glycyrrhizin remains provisional because the evidence behind licorice does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "gomisin",
-    "slug": "gomisin",
-    "canonicalCompoundId": "gomisin",
-    "name": "gomisin",
-    "compoundName": "gomisin",
-    "canonicalCompoundName": "gomisin",
-    "hero": "Defines a key pharmacological signal attributed to gomisin in herbal extracts.",
-    "coreInsight": "gomisin remains provisional because the evidence behind Schisandra Berry does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "gomisin-a",
-    "slug": "gomisin-a",
-    "canonicalCompoundId": "gomisin-a",
-    "name": "gomisin a",
-    "compoundName": "gomisin a",
-    "canonicalCompoundName": "gomisin a",
-    "hero": "Defines a key pharmacological signal attributed to gomisin a in herbal extracts.",
-    "coreInsight": "gomisin a stays provisional because the evidence behind Schisandra does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"adaptogenic\"",
-      "\"hepatoprotective\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "gramine",
-    "slug": "gramine",
-    "canonicalCompoundId": "gramine",
-    "name": "gramine",
-    "compoundName": "gramine",
-    "canonicalCompoundName": "gramine",
-    "hero": "Defines a key pharmacological signal attributed to gramine in herbal extracts.",
-    "coreInsight": "gramine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "grindelic-acid",
-    "slug": "grindelic-acid",
-    "canonicalCompoundId": "grindelic-acid",
-    "name": "grindelic acid",
-    "compoundName": "grindelic acid",
-    "canonicalCompoundName": "grindelic acid",
-    "hero": "Focuses antioxidant activity at the compound level.",
-    "coreInsight": "grindelic acid is most useful when a formulation needs a direct antioxidant signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "gurmarin",
-    "slug": "gurmarin",
-    "canonicalCompoundId": "gurmarin",
-    "name": "gurmarin",
-    "compoundName": "gurmarin",
-    "canonicalCompoundName": "gurmarin",
-    "hero": "Defines a key pharmacological signal attributed to gurmarin in herbal extracts.",
-    "coreInsight": "gurmarin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[\"glucose absorption modulation\"]"
-    ]
-  },
-  {
-    "id": "guvacine",
-    "slug": "guvacine",
-    "canonicalCompoundId": "guvacine",
-    "name": "guvacine",
-    "compoundName": "guvacine",
-    "canonicalCompoundName": "guvacine",
-    "hero": "Defines a key pharmacological signal attributed to guvacine in herbal extracts.",
-    "coreInsight": "guvacine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "guvacoline",
-    "slug": "guvacoline",
-    "canonicalCompoundId": "guvacoline",
-    "name": "guvacoline",
-    "compoundName": "guvacoline",
-    "canonicalCompoundName": "guvacoline",
-    "hero": "Defines a key pharmacological signal attributed to guvacoline in herbal extracts.",
-    "coreInsight": "Guvacoline remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "gymnemic-acids",
-    "slug": "gymnemic-acids",
-    "canonicalCompoundId": "gymnemic-acids",
-    "name": "gymnemic acids",
-    "compoundName": "gymnemic acids",
-    "canonicalCompoundName": "gymnemic acids",
-    "hero": "Defines a key pharmacological signal attributed to gymnemic acids in herbal extracts.",
-    "coreInsight": "gymnemic acids remains provisional because the evidence behind Gudmar does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[\"sweet taste suppression\"",
-      "\"T1R2/T1R3 modulation\"",
-      "\"glucose absorption modulation\"]"
-    ]
-  },
-  {
-    "id": "gypenosides-dammarane-type-saponins",
-    "slug": "gypenosides-dammarane-type-saponins",
-    "canonicalCompoundId": "gypenosides-dammarane-type-saponins",
-    "name": "gypenosides dammarane-type saponins",
-    "compoundName": "gypenosides dammarane-type saponins",
-    "canonicalCompoundName": "gypenosides dammarane-type saponins",
-    "hero": "Defines a key pharmacological signal attributed to gypenosides dammarane-type saponins in herbal extracts.",
-    "coreInsight": "gypenosides dammarane-type saponins stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"immunomodulatory\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "harmaline",
-    "slug": "harmaline",
-    "canonicalCompoundId": "harmaline",
-    "name": "Harmaline",
-    "compoundName": "Harmaline",
-    "canonicalCompoundName": "Harmaline",
-    "hero": "Acts as a recognizable chemical marker within Peganum harmala.",
-    "coreInsight": "Within Peganum harmala, Harmaline helps define the plant’s chemistry alongside markers such as Harmine.",
-    "effects": [
-      "[\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[\"serotonin modulation\"",
-      "\"MAO-A inhibition\"]"
-    ]
-  },
-  {
-    "id": "harmalol",
-    "slug": "harmalol",
-    "canonicalCompoundId": "harmalol",
-    "name": "harmalol",
-    "compoundName": "harmalol",
-    "canonicalCompoundName": "harmalol",
-    "hero": "Defines a key pharmacological signal attributed to harmalol in herbal extracts.",
-    "coreInsight": "harmalol remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "harmine",
-    "slug": "harmine",
-    "canonicalCompoundId": "harmine",
-    "name": "Harmine",
-    "compoundName": "Harmine",
-    "canonicalCompoundName": "Harmine",
-    "hero": "Focuses antidepressant activity within Peganum harmala chemistry.",
-    "coreInsight": "For Peganum harmala, Harmine is most useful as a direct antidepressant signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[\"serotonin modulation\"",
-      "\"MAO-A inhibition\"]"
-    ]
-  },
-  {
-    "id": "harpagoside",
-    "slug": "harpagoside",
-    "canonicalCompoundId": "harpagoside",
-    "name": "harpagoside",
-    "compoundName": "harpagoside",
-    "canonicalCompoundName": "harpagoside",
-    "hero": "Defines a key pharmacological signal attributed to harpagoside in herbal extracts.",
-    "coreInsight": "harpagoside remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "helenalin",
-    "slug": "helenalin",
-    "canonicalCompoundId": "helenalin",
-    "name": "helenalin",
-    "compoundName": "helenalin",
-    "canonicalCompoundName": "helenalin",
-    "hero": "Defines a key pharmacological signal attributed to helenalin in herbal extracts.",
-    "coreInsight": "Helenalin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "hericenone-c",
-    "slug": "hericenone-c",
-    "canonicalCompoundId": "hericenone-c",
-    "name": "hericenone c",
-    "compoundName": "hericenone c",
-    "canonicalCompoundName": "hericenone c",
-    "hero": "Defines a key pharmacological signal attributed to hericenone c in herbal extracts.",
-    "coreInsight": "hericenone c remains provisional because the evidence behind Lion's Mane does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "hericenones",
-    "slug": "hericenones",
-    "canonicalCompoundId": "hericenones",
-    "name": "hericenones",
-    "compoundName": "hericenones",
-    "canonicalCompoundName": "hericenones",
-    "hero": "Defines a key pharmacological signal attributed to hericenones in herbal extracts.",
-    "coreInsight": "hericenones stays provisional because the evidence behind Lion's Mane does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "hesperidin",
-    "slug": "hesperidin",
-    "canonicalCompoundId": "hesperidin",
-    "name": "hesperidin",
-    "compoundName": "hesperidin",
-    "canonicalCompoundName": "hesperidin",
-    "hero": "Defines modulates inflammatory cytokine signaling in hesperidin.",
-    "coreInsight": "hesperidin matters most when modulates inflammatory cytokine signaling is used as the primary readout. That makes it more informative than a generic flavonoid label.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"immunomodulatory\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"Modulates inflammatory cytokine signaling\"",
-      "\"immune signaling modulation\"]"
-    ]
-  },
-  {
-    "id": "hibiscus-acid",
-    "slug": "hibiscus-acid",
-    "canonicalCompoundId": "hibiscus-acid",
-    "name": "hibiscus acid",
-    "compoundName": "hibiscus acid",
-    "canonicalCompoundName": "hibiscus acid",
-    "hero": "Delivers oxidative stress reduction in hibiscus acid.",
-    "coreInsight": "hibiscus acid matters most when oxidative stress reduction is used as the primary readout. That makes it more informative than a generic organic acid label.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "hinokiflavone",
-    "slug": "hinokiflavone",
-    "canonicalCompoundId": "hinokiflavone",
-    "name": "hinokiflavone",
-    "compoundName": "hinokiflavone",
-    "canonicalCompoundName": "hinokiflavone",
-    "hero": "Carries antioxidant activity at the compound level.",
-    "coreInsight": "hinokiflavone is most useful when a formulation needs a direct antioxidant signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "histamine",
-    "slug": "histamine",
-    "canonicalCompoundId": "histamine",
-    "name": "histamine",
-    "compoundName": "histamine",
-    "canonicalCompoundName": "histamine",
-    "hero": "Defines a key pharmacological signal attributed to histamine in herbal extracts.",
-    "coreInsight": "histamine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "humulone",
-    "slug": "humulone",
-    "canonicalCompoundId": "humulone",
-    "name": "humulone",
-    "compoundName": "humulone",
-    "canonicalCompoundName": "humulone",
-    "hero": "Distinguishes humulone from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Humulone matters because it can be ranked directly against xanthohumol and related neighbors during compound prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "huperzine-a",
-    "slug": "huperzine-a",
-    "canonicalCompoundId": "huperzine-a",
-    "name": "huperzine a",
-    "compoundName": "huperzine a",
-    "canonicalCompoundName": "huperzine a",
-    "hero": "Defines a key pharmacological signal attributed to huperzine a in herbal extracts.",
-    "coreInsight": "huperzine a remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"nootropic\"]"
-    ],
-    "mechanisms": [
-      "[\"acetylcholinesterase inhibition\"]"
-    ]
-  },
-  {
-    "id": "hydrastine",
-    "slug": "hydrastine",
-    "canonicalCompoundId": "hydrastine",
-    "name": "hydrastine",
-    "compoundName": "hydrastine",
-    "canonicalCompoundName": "hydrastine",
-    "hero": "Defines a key pharmacological signal attributed to hydrastine in herbal extracts.",
-    "coreInsight": "hydrastine stays provisional because the evidence behind Goldenseal does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "hydroxy-alpha-sanshool",
-    "slug": "hydroxy-alpha-sanshool",
-    "canonicalCompoundId": "hydroxy-alpha-sanshool",
-    "name": "hydroxy-alpha-sanshool",
-    "compoundName": "hydroxy-alpha-sanshool",
-    "canonicalCompoundName": "hydroxy-alpha-sanshool",
-    "hero": "Defines a key pharmacological signal attributed to hydroxy-alpha-sanshool in herbal extracts.",
-    "coreInsight": "hydroxy-alpha-sanshool matters most when adrenergic signaling is used as the primary readout. That makes it more informative than a generic other label.",
-    "effects": [
-      "[\"stimulant\"]"
-    ],
-    "mechanisms": [
-      "[\"adrenergic signaling\"]"
-    ]
-  },
-  {
-    "id": "hydroxy-beta-sanshool",
-    "slug": "hydroxy-beta-sanshool",
-    "canonicalCompoundId": "hydroxy-beta-sanshool",
-    "name": "hydroxy-beta-sanshool",
-    "compoundName": "hydroxy-beta-sanshool",
-    "canonicalCompoundName": "hydroxy-beta-sanshool",
-    "hero": "Defines a key pharmacological signal attributed to hydroxy-beta-sanshool in herbal extracts.",
-    "coreInsight": "hydroxy-beta-sanshool remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "hydroxycitric-acid",
-    "slug": "hydroxycitric-acid",
-    "canonicalCompoundId": "hydroxycitric-acid",
-    "name": "hydroxycitric acid",
-    "compoundName": "hydroxycitric acid",
-    "canonicalCompoundName": "hydroxycitric acid",
-    "hero": "Defines a key pharmacological signal attributed to hydroxycitric acid in herbal extracts.",
-    "coreInsight": "hydroxycitric acid remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "hydroxytyrosol",
-    "slug": "hydroxytyrosol",
-    "canonicalCompoundId": "hydroxytyrosol",
-    "name": "hydroxytyrosol",
-    "compoundName": "hydroxytyrosol",
-    "canonicalCompoundName": "hydroxytyrosol",
-    "hero": "Helps define why 3 extracts perform differently in formulation.",
-    "coreInsight": "hydroxytyrosol becomes more valuable when 3 is standardized by named actives rather than total extract mass.",
-    "effects": [
-      "[\"antioxidant\"",
-      "\"adaptogenic\"",
-      "\"anti-inflammatory\"",
-      "\"hepatoprotective\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "hydroxytyrosol-acetate",
-    "slug": "hydroxytyrosol-acetate",
-    "canonicalCompoundId": "hydroxytyrosol-acetate",
-    "name": "hydroxytyrosol acetate",
-    "compoundName": "hydroxytyrosol acetate",
-    "canonicalCompoundName": "hydroxytyrosol acetate",
-    "hero": "Defines a key pharmacological signal attributed to hydroxytyrosol acetate in herbal extracts.",
-    "coreInsight": "Hydroxytyrosol acetate remains provisional because the evidence behind 2-(3 does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"antioxidant\"",
-      "\"hepatoprotective\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "hyoscyamine",
-    "slug": "hyoscyamine",
-    "canonicalCompoundId": "hyoscyamine",
-    "name": "hyoscyamine",
-    "compoundName": "hyoscyamine",
-    "canonicalCompoundName": "hyoscyamine",
-    "hero": "Defines a key pharmacological signal attributed to hyoscyamine in herbal extracts.",
-    "coreInsight": "hyoscyamine remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"nootropic\"]"
-    ],
-    "mechanisms": [
-      "[\"cholinergic modulation\"]"
-    ]
-  },
-  {
-    "id": "hypaconitine",
-    "slug": "hypaconitine",
-    "canonicalCompoundId": "hypaconitine",
-    "name": "hypaconitine",
-    "compoundName": "hypaconitine",
-    "canonicalCompoundName": "hypaconitine",
-    "hero": "Defines a key pharmacological signal attributed to hypaconitine in herbal extracts.",
-    "coreInsight": "hypaconitine stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "hyperforin",
-    "slug": "hyperforin",
-    "canonicalCompoundId": "hyperforin",
-    "name": "Hyperforin",
-    "compoundName": "Hyperforin",
-    "canonicalCompoundName": "Hyperforin",
-    "hero": "Acts as a recognizable chemical marker within Hypericum perforatum.",
-    "coreInsight": "Within Hypericum perforatum, Hyperforin helps define the plant’s chemistry alongside markers such as Hypericin.",
-    "effects": [
-      "[\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[\"antidepressant signaling\"",
-      "\"monoamine reuptake modulation\"]"
-    ]
-  },
-  {
-    "id": "hypericin",
-    "slug": "hypericin",
-    "canonicalCompoundId": "hypericin",
-    "name": "Hypericin",
-    "compoundName": "Hypericin",
-    "canonicalCompoundName": "Hypericin",
-    "hero": "Defines a key pharmacological signal attributed to hypericin in herbal extracts.",
-    "coreInsight": "Hypericin matters most when antidepressant signaling is used as the primary readout. That makes it more informative than a generic Naphthodianthrone label.",
-    "effects": [
-      "[\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[\"antidepressant signaling\"]"
-    ]
-  },
-  {
-    "id": "ibogaine",
-    "slug": "ibogaine",
-    "canonicalCompoundId": "ibogaine",
-    "name": "Ibogaine",
-    "compoundName": "Ibogaine",
-    "canonicalCompoundName": "Ibogaine",
-    "hero": "Defines analgesic and stimulant activity within Tabernanthe iboga chemistry.",
-    "coreInsight": "For Tabernanthe iboga, Ibogaine is most useful as a direct analgesic signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"analgesic\"",
-      "\"stimulant\"",
-      "\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[\"Ibogaine exhibits NMDA receptor antagonism\"",
-      "\"and monoamine transporter modulation.\"",
-      "\"NMDA antagonism\"",
-      "\"opioid modulation\"]"
-    ]
-  },
-  {
-    "id": "ibotenic-acid",
-    "slug": "ibotenic-acid",
-    "canonicalCompoundId": "ibotenic-acid",
-    "name": "ibotenic acid",
-    "compoundName": "ibotenic acid",
-    "canonicalCompoundName": "ibotenic acid",
-    "hero": "Defines a key pharmacological signal attributed to ibotenic acid in herbal extracts.",
-    "coreInsight": "ibotenic acid remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"]"
-    ]
-  },
-  {
-    "id": "icariin",
-    "slug": "icariin",
-    "canonicalCompoundId": "icariin",
-    "name": "Icariin",
-    "compoundName": "Icariin",
-    "canonicalCompoundName": "Icariin",
-    "hero": "Distinguishes Icariin from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Icariin matters because it can be ranked directly against epimedin a and related neighbors during compound prioritization.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"PDE-related signaling\"",
-      "\"nitric oxide modulation\"",
-      "\"bone signaling\"",
-      "\"pde5-related signaling\"]"
-    ]
-  },
-  {
-    "id": "icaritin",
-    "slug": "icaritin",
-    "canonicalCompoundId": "icaritin",
-    "name": "Icaritin",
-    "compoundName": "Icaritin",
-    "canonicalCompoundName": "Icaritin",
-    "hero": "Defines a key pharmacological signal attributed to icaritin in herbal extracts.",
-    "coreInsight": "Icaritin remains provisional because the evidence behind Epimedium does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "imperatorin",
-    "slug": "imperatorin",
-    "canonicalCompoundId": "imperatorin",
-    "name": "imperatorin",
-    "compoundName": "imperatorin",
-    "canonicalCompoundName": "imperatorin",
-    "hero": "Defines a key pharmacological signal attributed to imperatorin in herbal extracts.",
-    "coreInsight": "imperatorin stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "indirubin",
-    "slug": "indirubin",
-    "canonicalCompoundId": "indirubin",
-    "name": "indirubin",
-    "compoundName": "indirubin",
-    "canonicalCompoundName": "indirubin",
-    "hero": "Acts as a recognizable chemical marker within Isatis.",
-    "coreInsight": "Within Isatis, indirubin helps define the plant’s chemistry alongside markers such as tryptanthrin.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "inotodiol",
-    "slug": "inotodiol",
-    "canonicalCompoundId": "inotodiol",
-    "name": "inotodiol",
-    "compoundName": "inotodiol",
-    "canonicalCompoundName": "inotodiol",
-    "hero": "Defines a key pharmacological signal attributed to inotodiol in herbal extracts.",
-    "coreInsight": "inotodiol remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "inulin",
-    "slug": "inulin",
-    "canonicalCompoundId": "inulin",
-    "name": "inulin",
-    "compoundName": "inulin",
-    "canonicalCompoundName": "inulin",
-    "hero": "Helps define why Elecampane extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, inulin helps separate Elecampane extracts from adjacent markers such as alantolactone. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "iodine",
-    "slug": "iodine",
-    "canonicalCompoundId": "iodine",
-    "name": "iodine",
-    "compoundName": "iodine",
-    "canonicalCompoundName": "iodine",
-    "hero": "Defines a key pharmacological signal attributed to iodine in herbal extracts.",
-    "coreInsight": "iodine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "iridin",
-    "slug": "iridin",
-    "canonicalCompoundId": "iridin",
-    "name": "iridin",
-    "compoundName": "iridin",
-    "canonicalCompoundName": "iridin",
-    "hero": "Defines a key pharmacological signal attributed to iridin in herbal extracts.",
-    "coreInsight": "Iridin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "isocorypalmine",
-    "slug": "isocorypalmine",
-    "canonicalCompoundId": "isocorypalmine",
-    "name": "isocorypalmine",
-    "compoundName": "isocorypalmine",
-    "canonicalCompoundName": "isocorypalmine",
-    "hero": "Defines a key pharmacological signal attributed to isocorypalmine in herbal extracts.",
-    "coreInsight": "isocorypalmine remains provisional because the evidence behind Corydalacts as does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "isoergine",
-    "slug": "isoergine",
-    "canonicalCompoundId": "isoergine",
-    "name": "isoergine",
-    "compoundName": "isoergine",
-    "canonicalCompoundName": "isoergine",
-    "hero": "Defines a key pharmacological signal attributed to isoergine in herbal extracts.",
-    "coreInsight": "isoergine stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "isofebrifugine",
-    "slug": "isofebrifugine",
-    "canonicalCompoundId": "isofebrifugine",
-    "name": "isofebrifugine",
-    "compoundName": "isofebrifugine",
-    "canonicalCompoundName": "isofebrifugine",
-    "hero": "Defines a key pharmacological signal attributed to isofebrifugine in herbal extracts.",
-    "coreInsight": "isofebrifugine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "isoferulic-acid",
-    "slug": "isoferulic-acid",
-    "canonicalCompoundId": "isoferulic-acid",
-    "name": "Isoferulic acid",
-    "compoundName": "Isoferulic acid",
-    "canonicalCompoundName": "Isoferulic acid",
-    "hero": "Anchors inflammatory signaling modulation in Isoferulic acid.",
-    "coreInsight": "Isoferulic acid matters most when inflammatory signaling modulation is used as the primary readout. That makes it more informative than a generic Phenolic acid label.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"",
-      "\"adaptogenic\"]"
-    ],
-    "mechanisms": [
-      "[\"inflammatory signaling modulation\"]"
-    ]
-  },
-  {
-    "id": "isoflavones-genistein",
-    "slug": "isoflavones-genistein",
-    "canonicalCompoundId": "isoflavones-genistein",
-    "name": "isoflavones genistein",
-    "compoundName": "isoflavones genistein",
-    "canonicalCompoundName": "isoflavones genistein",
-    "hero": "Helps define why Red Clover extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, isoflavones genistein helps separate Red Clover extracts from adjacent markers such as genistein. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "isomenthone",
-    "slug": "isomenthone",
-    "canonicalCompoundId": "isomenthone",
-    "name": "isomenthone",
-    "compoundName": "isomenthone",
-    "canonicalCompoundName": "isomenthone",
-    "hero": "Defines a key pharmacological signal attributed to isomenthone in herbal extracts.",
-    "coreInsight": "isomenthone remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "isomitraphylline",
-    "slug": "isomitraphylline",
-    "canonicalCompoundId": "isomitraphylline",
-    "name": "isomitraphylline",
-    "compoundName": "isomitraphylline",
-    "canonicalCompoundName": "isomitraphylline",
-    "hero": "Defines a key pharmacological signal attributed to isomitraphylline in herbal extracts.",
-    "coreInsight": "Isomitraphylline remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "isopetasin",
-    "slug": "isopetasin",
-    "canonicalCompoundId": "isopetasin",
-    "name": "isopetasin",
-    "compoundName": "isopetasin",
-    "canonicalCompoundName": "isopetasin",
-    "hero": "Defines a key pharmacological signal attributed to isopetasin in herbal extracts.",
-    "coreInsight": "isopetasin remains provisional because the evidence behind Butterbur does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"",
-      "\"analgesic\"]"
-    ],
-    "mechanisms": [
-      "[\"TRPV1 modulation\"",
-      "\"TRPA1 modulation\"",
-      "\"CGRP modulation\"",
-      "\"CGRP signaling\"]"
-    ]
-  },
-  {
-    "id": "isorhamnetin",
-    "slug": "isorhamnetin",
-    "canonicalCompoundId": "isorhamnetin",
-    "name": "Isorhamnetin",
-    "compoundName": "Isorhamnetin",
-    "canonicalCompoundName": "Isorhamnetin",
-    "hero": "Defines a key pharmacological signal attributed to isorhamnetin in herbal extracts.",
-    "coreInsight": "Isorhamnetin stays provisional because the evidence behind Ginkgo Biloba does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"antioxidant\"",
-      "\"adaptogenic\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "isosilybin-a",
-    "slug": "isosilybin-a",
-    "canonicalCompoundId": "isosilybin-a",
-    "name": "isosilybin a",
-    "compoundName": "isosilybin a",
-    "canonicalCompoundName": "isosilybin a",
-    "hero": "Focuses anti-inflammatory and hepatoprotective activity at the compound level.",
-    "coreInsight": "isosilybin a is most useful when a formulation needs a direct anti-inflammatory signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"hepatoprotective\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "isosilybin-b",
-    "slug": "isosilybin-b",
-    "canonicalCompoundId": "isosilybin-b",
-    "name": "isosilybin b",
-    "compoundName": "isosilybin b",
-    "canonicalCompoundName": "isosilybin b",
-    "hero": "Drives anti-inflammatory and hepatoprotective activity at the compound level.",
-    "coreInsight": "isosilybin b is most useful when a formulation needs a direct anti-inflammatory signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"hepatoprotective\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "isosilychristin",
-    "slug": "isosilychristin",
-    "canonicalCompoundId": "isosilychristin",
-    "name": "isosilychristin",
-    "compoundName": "isosilychristin",
-    "canonicalCompoundName": "isosilychristin",
-    "hero": "Anchors antioxidant and hepatoprotective activity at the compound level.",
-    "coreInsight": "isosilychristin is most useful when a formulation needs a direct antioxidant signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"antioxidant\"",
-      "\"hepatoprotective\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "isovaleric-acid",
-    "slug": "isovaleric-acid",
-    "canonicalCompoundId": "isovaleric-acid",
-    "name": "isovaleric acid",
-    "compoundName": "isovaleric acid",
-    "canonicalCompoundName": "isovaleric acid",
-    "hero": "Defines a key pharmacological signal attributed to isovaleric acid in herbal extracts.",
-    "coreInsight": "isovaleric acid remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "isovaltrate",
-    "slug": "isovaltrate",
-    "canonicalCompoundId": "isovaltrate",
-    "name": "isovaltrate",
-    "compoundName": "isovaltrate",
-    "canonicalCompoundName": "isovaltrate",
-    "hero": "Defines a key pharmacological signal attributed to isovaltrate in herbal extracts.",
-    "coreInsight": "Isovaltrate remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "jatamansone",
-    "slug": "jatamansone",
-    "canonicalCompoundId": "jatamansone",
-    "name": "jatamansone",
-    "compoundName": "jatamansone",
-    "canonicalCompoundName": "jatamansone",
-    "hero": "Defines a key pharmacological signal attributed to jatamansone in herbal extracts.",
-    "coreInsight": "jatamansone remains provisional because the evidence behind Jatamansi does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "jatrorrhizine",
-    "slug": "jatrorrhizine",
-    "canonicalCompoundId": "jatrorrhizine",
-    "name": "jatrorrhizine",
-    "compoundName": "jatrorrhizine",
-    "canonicalCompoundName": "jatrorrhizine",
-    "hero": "Defines a key pharmacological signal attributed to jatrorrhizine in herbal extracts.",
-    "coreInsight": "jatrorrhizine stays provisional because the evidence behind Phellodendron does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "juglone",
-    "slug": "juglone",
-    "canonicalCompoundId": "juglone",
-    "name": "juglone",
-    "compoundName": "juglone",
-    "canonicalCompoundName": "juglone",
-    "hero": "Defines a key pharmacological signal attributed to juglone in herbal extracts.",
-    "coreInsight": "juglone remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "jujuboside-a",
-    "slug": "jujuboside-a",
-    "canonicalCompoundId": "jujuboside-a",
-    "name": "jujuboside a",
-    "compoundName": "jujuboside a",
-    "canonicalCompoundName": "jujuboside a",
-    "hero": "Focuses sedative and anxiolytic activity within Jujube chemistry.",
-    "coreInsight": "For Jujube, jujuboside a is most useful as a direct sedative signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"sedative\"",
-      "\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "kaempferol",
-    "slug": "kaempferol",
-    "canonicalCompoundId": "kaempferol",
-    "name": "Kaempferol",
-    "compoundName": "Kaempferol",
-    "canonicalCompoundName": "Kaempferol",
-    "hero": "Drives anti-inflammatory and antioxidant activity within Ginkgo Biloba chemistry.",
-    "coreInsight": "For Ginkgo Biloba, Kaempferol is most useful as a direct anti-inflammatory signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"",
-      "\"adaptogenic\"]"
-    ],
-    "mechanisms": [
-      "[\"NF-kB inhibition\"",
-      "\"NF-kB modulation\"",
-      "\"NF-κB modulation\"]"
-    ]
-  },
-  {
-    "id": "kahweol",
-    "slug": "kahweol",
-    "canonicalCompoundId": "kahweol",
-    "name": "kahweol",
-    "compoundName": "kahweol",
-    "canonicalCompoundName": "kahweol",
-    "hero": "Helps define why Coffee Cherry extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, kahweol helps separate Coffee Cherry extracts from adjacent markers such as cafestol. That improves standardization decisions.",
-    "effects": [
-      "[\"stimulant\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "kava-kavalactones",
-    "slug": "kava-kavalactones",
-    "canonicalCompoundId": "kava-kavalactones",
-    "name": "kava kavalactones",
-    "compoundName": "kava kavalactones",
-    "canonicalCompoundName": "kava kavalactones",
-    "hero": "Defines a key pharmacological signal attributed to kava kavalactones in herbal extracts.",
-    "coreInsight": "Kava kavalactones remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"anxiolytic\"",
-      "\"sedative\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"]"
-    ]
-  },
-  {
-    "id": "kavain",
-    "slug": "kavain",
-    "canonicalCompoundId": "kavain",
-    "name": "kavain",
-    "compoundName": "kavain",
-    "canonicalCompoundName": "kavain",
-    "hero": "Defines a key pharmacological signal attributed to kavain in herbal extracts.",
-    "coreInsight": "kavain remains provisional because the evidence behind Kava does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"anxiolytic\"",
-      "\"sedative\"",
-      "\"muscle-relaxant\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"",
-      "\"calcium channel modulation\"",
-      "\"dopamine modulation\"]"
-    ]
-  },
-  {
-    "id": "kotalanol",
-    "slug": "kotalanol",
-    "canonicalCompoundId": "kotalanol",
-    "name": "kotalanol",
-    "compoundName": "kotalanol",
-    "canonicalCompoundName": "kotalanol",
-    "hero": "Defines a key pharmacological signal attributed to kotalanol in herbal extracts.",
-    "coreInsight": "kotalanol stays provisional because the evidence behind Salacia does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "kudinlactone",
-    "slug": "kudinlactone",
-    "canonicalCompoundId": "kudinlactone",
-    "name": "kudinlactone",
-    "compoundName": "kudinlactone",
-    "canonicalCompoundName": "kudinlactone",
-    "hero": "Acts as a recognizable chemical marker within Kuding Tea.",
-    "coreInsight": "Within Kuding Tea, kudinlactone serves mainly as a phytochemical marker that sharpens chemical identity.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "kurarinone",
-    "slug": "kurarinone",
-    "canonicalCompoundId": "kurarinone",
-    "name": "kurarinone",
-    "compoundName": "kurarinone",
-    "canonicalCompoundName": "kurarinone",
-    "hero": "Defines a key pharmacological signal attributed to kurarinone in herbal extracts.",
-    "coreInsight": "kurarinone remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "kutkoside",
-    "slug": "kutkoside",
-    "canonicalCompoundId": "kutkoside",
-    "name": "kutkoside",
-    "compoundName": "kutkoside",
-    "canonicalCompoundName": "kutkoside",
-    "hero": "Defines a key pharmacological signal attributed to kutkoside in herbal extracts.",
-    "coreInsight": "kutkoside remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "l-phenylalanine",
-    "slug": "l-phenylalanine",
-    "canonicalCompoundId": "l-phenylalanine",
-    "name": "l-phenylalanine",
-    "compoundName": "l-phenylalanine",
-    "canonicalCompoundName": "l-phenylalanine",
-    "hero": "Defines a key pharmacological signal attributed to l-phenylalanine in herbal extracts.",
-    "coreInsight": "l-phenylalanine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"stimulant\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"hormone modulation\"]"
-    ]
-  },
-  {
-    "id": "l-theanine",
-    "slug": "l-theanine",
-    "canonicalCompoundId": "l-theanine",
-    "name": "l-theanine",
-    "compoundName": "l-theanine",
-    "canonicalCompoundName": "l-theanine",
-    "hero": "Defines a key pharmacological signal attributed to l-theanine in herbal extracts.",
-    "coreInsight": "L-theanine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"anxiolytic\"",
-      "\"adaptogenic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "l-tryptophan",
-    "slug": "l-tryptophan",
-    "canonicalCompoundId": "l-tryptophan",
-    "name": "l-tryptophan",
-    "compoundName": "l-tryptophan",
-    "canonicalCompoundName": "l-tryptophan",
-    "hero": "Defines a key pharmacological signal attributed to l-tryptophan in herbal extracts.",
-    "coreInsight": "l-tryptophan remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[\"serotonin modulation\"]"
-    ]
-  },
-  {
-    "id": "l-tyrosine",
-    "slug": "l-tyrosine",
-    "canonicalCompoundId": "l-tyrosine",
-    "name": "l-tyrosine",
-    "compoundName": "l-tyrosine",
-    "canonicalCompoundName": "l-tyrosine",
-    "hero": "Defines a key pharmacological signal attributed to l-tyrosine in herbal extracts.",
-    "coreInsight": "l-tyrosine stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"stimulant\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"hormone modulation\"]"
-    ]
-  },
-  {
-    "id": "lactucin",
-    "slug": "lactucin",
-    "canonicalCompoundId": "lactucin",
-    "name": "lactucin",
-    "compoundName": "lactucin",
-    "canonicalCompoundName": "lactucin",
-    "hero": "Defines a key pharmacological signal attributed to lactucin in herbal extracts.",
-    "coreInsight": "lactucin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "lactucopicrin",
-    "slug": "lactucopicrin",
-    "canonicalCompoundId": "lactucopicrin",
-    "name": "lactucopicrin",
-    "compoundName": "lactucopicrin",
-    "canonicalCompoundName": "lactucopicrin",
-    "hero": "Defines a key pharmacological signal attributed to lactucopicrin in herbal extracts.",
-    "coreInsight": "lactucopicrin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "lapachol",
-    "slug": "lapachol",
-    "canonicalCompoundId": "lapachol",
-    "name": "lapachol",
-    "compoundName": "lapachol",
-    "canonicalCompoundName": "lapachol",
-    "hero": "Helps define why Pau d'Arco extracts perform differently in formulation.",
-    "coreInsight": "lapachol becomes more valuable when Pau d'Arco is standardized by named actives rather than total extract mass.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "ledol",
-    "slug": "ledol",
-    "canonicalCompoundId": "ledol",
-    "name": "ledol",
-    "compoundName": "ledol",
-    "canonicalCompoundName": "ledol",
-    "hero": "Defines a key pharmacological signal attributed to ledol in herbal extracts.",
-    "coreInsight": "ledol remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "leonurine",
-    "slug": "leonurine",
-    "canonicalCompoundId": "leonurine",
-    "name": "leonurine",
-    "compoundName": "leonurine",
-    "canonicalCompoundName": "leonurine",
-    "hero": "Defines a key pharmacological signal attributed to leonurine in herbal extracts.",
-    "coreInsight": "Leonurine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"diuretic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "ligustilide",
-    "slug": "ligustilide",
-    "canonicalCompoundId": "ligustilide",
-    "name": "ligustilide",
-    "compoundName": "ligustilide",
-    "canonicalCompoundName": "ligustilide",
-    "hero": "Defines a key pharmacological signal attributed to ligustilide in herbal extracts.",
-    "coreInsight": "ligustilide remains provisional because the evidence behind Chuanxiong does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "limonene",
-    "slug": "limonene",
-    "canonicalCompoundId": "limonene",
-    "name": "limonene",
-    "compoundName": "limonene",
-    "canonicalCompoundName": "limonene",
-    "hero": "Defines a key pharmacological signal attributed to limonene in herbal extracts.",
-    "coreInsight": "limonene stays provisional because the evidence behind Anise Hyssop does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[\"endocannabinoid modulation\"]"
-    ]
-  },
-  {
-    "id": "linalool",
-    "slug": "linalool",
-    "canonicalCompoundId": "linalool",
-    "name": "linalool",
-    "compoundName": "linalool",
-    "canonicalCompoundName": "linalool",
-    "hero": "Acts as a recognizable chemical marker within Lavender.",
-    "coreInsight": "Within Lavender, linalool helps define the plant’s chemistry alongside markers such as linalyl acetate.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "linalyl-acetate",
-    "slug": "linalyl-acetate",
-    "canonicalCompoundId": "linalyl-acetate",
-    "name": "linalyl acetate",
-    "compoundName": "linalyl acetate",
-    "canonicalCompoundName": "linalyl acetate",
-    "hero": "Helps define why Lavender extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, linalyl acetate helps separate Lavender extracts from adjacent markers such as linalool. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "linoleic-acid",
-    "slug": "linoleic-acid",
-    "canonicalCompoundId": "linoleic-acid",
-    "name": "linoleic acid",
-    "compoundName": "linoleic acid",
-    "canonicalCompoundName": "linoleic acid",
-    "hero": "Defines a key pharmacological signal attributed to linoleic acid in herbal extracts.",
-    "coreInsight": "linoleic acid remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "lithospermic-acid",
-    "slug": "lithospermic-acid",
-    "canonicalCompoundId": "lithospermic-acid",
-    "name": "lithospermic acid",
-    "compoundName": "lithospermic acid",
-    "canonicalCompoundName": "lithospermic acid",
-    "hero": "Defines a key pharmacological signal attributed to lithospermic acid in herbal extracts.",
-    "coreInsight": "lithospermic acid remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "lobelanidine",
-    "slug": "lobelanidine",
-    "canonicalCompoundId": "lobelanidine",
-    "name": "lobelanidine",
-    "compoundName": "lobelanidine",
-    "canonicalCompoundName": "lobelanidine",
-    "hero": "Defines a key pharmacological signal attributed to lobelanidine in herbal extracts.",
-    "coreInsight": "Lobelanidine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"nootropic\"]"
-    ],
-    "mechanisms": [
-      "[\"dopamine modulation\"]"
-    ]
-  },
-  {
-    "id": "lobeline",
-    "slug": "lobeline",
-    "canonicalCompoundId": "lobeline",
-    "name": "lobeline",
-    "compoundName": "lobeline",
-    "canonicalCompoundName": "lobeline",
-    "hero": "Defines a key pharmacological signal attributed to lobeline in herbal extracts.",
-    "coreInsight": "lobeline remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"nootropic\"]"
-    ],
-    "mechanisms": [
-      "[\"dopamine modulation\"]"
-    ]
-  },
-  {
-    "id": "loganin",
-    "slug": "loganin",
-    "canonicalCompoundId": "loganin",
-    "name": "loganin",
-    "compoundName": "loganin",
-    "canonicalCompoundName": "loganin",
-    "hero": "Defines a key pharmacological signal attributed to loganin in herbal extracts.",
-    "coreInsight": "loganin stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "lsa",
-    "slug": "lsa",
-    "canonicalCompoundId": "lsa",
-    "name": "lsa",
-    "compoundName": "lsa",
-    "canonicalCompoundName": "lsa",
-    "hero": "Defines a key pharmacological signal attributed to lsa in herbal extracts.",
-    "coreInsight": "lsa matters most when serotonin modulation is used as the primary readout. That makes it more informative than a generic other label.",
-    "effects": [
-      "[\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[\"serotonin modulation\"]"
-    ]
-  },
-  {
-    "id": "lsd-ergoline-derivative",
-    "slug": "lsd-ergoline-derivative",
-    "canonicalCompoundId": "lsd-ergoline-derivative",
-    "name": "lsd ergoline derivative",
-    "compoundName": "lsd ergoline derivative",
-    "canonicalCompoundName": "lsd ergoline derivative",
-    "hero": "Sharpens dopamine modulation in lsd ergoline derivative.",
-    "coreInsight": "lsd ergoline derivative matters most when dopamine modulation is used as the primary readout. That makes it more informative than a generic lsd (ergoline derivative) label.",
-    "effects": [
-      "[\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[\"dopamine modulation\"",
-      "\"serotonin modulation\"]"
-    ]
-  },
-  {
-    "id": "lupeol",
-    "slug": "lupeol",
-    "canonicalCompoundId": "lupeol",
-    "name": "lupeol",
-    "compoundName": "lupeol",
-    "canonicalCompoundName": "lupeol",
-    "hero": "Helps define why Celastrus Paniculatus extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, lupeol helps separate Celastrus Paniculatus extracts from adjacent markers such as beta-amyrin. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "lupulone",
-    "slug": "lupulone",
-    "canonicalCompoundId": "lupulone",
-    "name": "lupulone",
-    "compoundName": "lupulone",
-    "canonicalCompoundName": "lupulone",
-    "hero": "Defines a key pharmacological signal attributed to lupulone in herbal extracts.",
-    "coreInsight": "lupulone remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "luteolin",
-    "slug": "luteolin",
-    "canonicalCompoundId": "luteolin",
-    "name": "Luteolin",
-    "compoundName": "Luteolin",
-    "canonicalCompoundName": "Luteolin",
-    "hero": "Distinguishes Luteolin from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Luteolin matters because it can be ranked directly against chlorogenic acid and related neighbors during compound prioritization.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"NF-kB inhibition\"",
-      "\"NF-kB modulation\"",
-      "\"NF-κB modulation\"]"
-    ]
-  },
-  {
-    "id": "lycopene",
-    "slug": "lycopene",
-    "canonicalCompoundId": "lycopene",
-    "name": "lycopene",
-    "compoundName": "lycopene",
-    "canonicalCompoundName": "lycopene",
-    "hero": "Defines a key pharmacological signal attributed to lycopene in herbal extracts.",
-    "coreInsight": "lycopene remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "lycopodine",
-    "slug": "lycopodine",
-    "canonicalCompoundId": "lycopodine",
-    "name": "lycopodine",
-    "compoundName": "lycopodine",
-    "canonicalCompoundName": "lycopodine",
-    "hero": "Defines a key pharmacological signal attributed to lycopodine in herbal extracts.",
-    "coreInsight": "lycopodine stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "lycorine",
-    "slug": "lycorine",
-    "canonicalCompoundId": "lycorine",
-    "name": "lycorine",
-    "compoundName": "lycorine",
-    "canonicalCompoundName": "lycorine",
-    "hero": "Defines a key pharmacological signal attributed to lycorine in herbal extracts.",
-    "coreInsight": "lycorine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "lythrine",
-    "slug": "lythrine",
-    "canonicalCompoundId": "lythrine",
-    "name": "lythrine",
-    "compoundName": "lythrine",
-    "canonicalCompoundName": "lythrine",
-    "hero": "Defines a key pharmacological signal attributed to lythrine in herbal extracts.",
-    "coreInsight": "lythrine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "macaenes",
-    "slug": "macaenes",
-    "canonicalCompoundId": "macaenes",
-    "name": "macaenes",
-    "compoundName": "macaenes",
-    "canonicalCompoundName": "macaenes",
-    "hero": "Helps define why Maca extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, macaenes helps separate Maca extracts from adjacent markers such as macamides. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "macamides",
-    "slug": "macamides",
-    "canonicalCompoundId": "macamides",
-    "name": "macamides",
-    "compoundName": "macamides",
-    "canonicalCompoundName": "macamides",
-    "hero": "Helps define why Maca extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, macamides helps separate Maca extracts from adjacent markers such as macaenes. That improves standardization decisions.",
-    "effects": [
-      "[\"stimulant\"]"
-    ],
-    "mechanisms": [
-      "[\"endocannabinoid modulation\"]"
-    ]
-  },
-  {
-    "id": "madecassic-acid",
-    "slug": "madecassic-acid",
-    "canonicalCompoundId": "madecassic-acid",
-    "name": "madecassic acid",
-    "compoundName": "madecassic acid",
-    "canonicalCompoundName": "madecassic acid",
-    "hero": "Defines a key pharmacological signal attributed to madecassic acid in herbal extracts.",
-    "coreInsight": "Madecassic acid remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "madecassoside",
-    "slug": "madecassoside",
-    "canonicalCompoundId": "madecassoside",
-    "name": "madecassoside",
-    "compoundName": "madecassoside",
-    "canonicalCompoundName": "madecassoside",
-    "hero": "Defines a key pharmacological signal attributed to madecassoside in herbal extracts.",
-    "coreInsight": "madecassoside remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "magnesium",
-    "slug": "magnesium",
-    "canonicalCompoundId": "magnesium",
-    "name": "magnesium",
-    "compoundName": "magnesium",
-    "canonicalCompoundName": "magnesium",
-    "hero": "Defines a key pharmacological signal attributed to magnesium in herbal extracts.",
-    "coreInsight": "magnesium stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"stimulant\"",
-      "\"muscle-relaxant\"",
-      "\"antioxidant\"",
-      "\"antispasmodic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "mahanimbine",
-    "slug": "mahanimbine",
-    "canonicalCompoundId": "mahanimbine",
-    "name": "mahanimbine",
-    "compoundName": "mahanimbine",
-    "canonicalCompoundName": "mahanimbine",
-    "hero": "Acts as a recognizable chemical marker within Curry Leaf.",
-    "coreInsight": "Within Curry Leaf, mahanimbine serves mainly as a phytochemical marker that sharpens chemical identity.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "maltol",
-    "slug": "maltol",
-    "canonicalCompoundId": "maltol",
-    "name": "maltol",
-    "compoundName": "maltol",
-    "canonicalCompoundName": "maltol",
-    "hero": "Anchors antioxidant activity at the compound level.",
-    "coreInsight": "maltol is most useful when a formulation needs a direct antioxidant signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "mangiferin",
-    "slug": "mangiferin",
-    "canonicalCompoundId": "mangiferin",
-    "name": "mangiferin",
-    "compoundName": "mangiferin",
-    "canonicalCompoundName": "mangiferin",
-    "hero": "Helps define why Salacia extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, mangiferin helps separate Salacia extracts from adjacent markers such as kotalanol. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "marmelosin",
-    "slug": "marmelosin",
-    "canonicalCompoundId": "marmelosin",
-    "name": "marmelosin",
-    "compoundName": "marmelosin",
-    "canonicalCompoundName": "marmelosin",
-    "hero": "Helps define why Bael extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, marmelosin helps separate Bael extracts from adjacent markers such as aegeline. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "matrine",
-    "slug": "matrine",
-    "canonicalCompoundId": "matrine",
-    "name": "matrine",
-    "compoundName": "matrine",
-    "canonicalCompoundName": "matrine",
-    "hero": "Distinguishes matrine from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Matrine matters because it can be ranked directly against oxymatrine and related neighbors during compound prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "melatonin",
-    "slug": "melatonin",
-    "canonicalCompoundId": "melatonin",
-    "name": "melatonin",
-    "compoundName": "melatonin",
-    "canonicalCompoundName": "melatonin",
-    "hero": "Defines a key pharmacological signal attributed to melatonin in herbal extracts.",
-    "coreInsight": "melatonin remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"sedative\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "menthofuran",
-    "slug": "menthofuran",
-    "canonicalCompoundId": "menthofuran",
-    "name": "menthofuran",
-    "compoundName": "menthofuran",
-    "canonicalCompoundName": "menthofuran",
-    "hero": "Defines a key pharmacological signal attributed to menthofuran in herbal extracts.",
-    "coreInsight": "menthofuran stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "menthol",
-    "slug": "menthol",
-    "canonicalCompoundId": "menthol",
-    "name": "menthol",
-    "compoundName": "menthol",
-    "canonicalCompoundName": "menthol",
-    "hero": "Acts as a recognizable chemical marker within Peppermint.",
-    "coreInsight": "Within Peppermint, menthol helps define the plant’s chemistry alongside markers such as l‑menthol.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "menthone",
-    "slug": "menthone",
-    "canonicalCompoundId": "menthone",
-    "name": "menthone",
-    "compoundName": "menthone",
-    "canonicalCompoundName": "menthone",
-    "hero": "Drives antioxidant activity at the compound level.",
-    "coreInsight": "menthone is most useful when a formulation needs a direct antioxidant signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "menthyl-acetate",
-    "slug": "menthyl-acetate",
-    "canonicalCompoundId": "menthyl-acetate",
-    "name": "menthyl acetate",
-    "compoundName": "menthyl acetate",
-    "canonicalCompoundName": "menthyl acetate",
-    "hero": "Defines a key pharmacological signal attributed to menthyl acetate in herbal extracts.",
-    "coreInsight": "menthyl acetate remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "mesaconitine",
-    "slug": "mesaconitine",
-    "canonicalCompoundId": "mesaconitine",
-    "name": "mesaconitine",
-    "compoundName": "mesaconitine",
-    "canonicalCompoundName": "mesaconitine",
-    "hero": "Defines a key pharmacological signal attributed to mesaconitine in herbal extracts.",
-    "coreInsight": "mesaconitine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "mescaline",
-    "slug": "mescaline",
-    "canonicalCompoundId": "mescaline",
-    "name": "mescaline",
-    "compoundName": "mescaline",
-    "canonicalCompoundName": "mescaline",
-    "hero": "Defines a key pharmacological signal attributed to mescaline in herbal extracts.",
-    "coreInsight": "Mescaline remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"hallucinogenic\"",
-      "\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[\"serotonin modulation\"]"
-    ]
-  },
-  {
-    "id": "mescaline-derivative",
-    "slug": "mescaline-derivative",
-    "canonicalCompoundId": "mescaline-derivative",
-    "name": "mescaline derivative",
-    "compoundName": "mescaline derivative",
-    "canonicalCompoundName": "mescaline derivative",
-    "hero": "Defines a key pharmacological signal attributed to mescaline derivative in herbal extracts.",
-    "coreInsight": "mescaline derivative remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"hallucinogenic\"",
-      "\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[\"dopamine modulation\"",
-      "\"serotonin modulation\"]"
-    ]
-  },
-  {
-    "id": "mesembranol",
-    "slug": "mesembranol",
-    "canonicalCompoundId": "mesembranol",
-    "name": "mesembranol",
-    "compoundName": "mesembranol",
-    "canonicalCompoundName": "mesembranol",
-    "hero": "Defines a key pharmacological signal attributed to mesembranol in herbal extracts.",
-    "coreInsight": "mesembranol stays provisional because the evidence behind Kanna does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "mesembrenol",
-    "slug": "mesembrenol",
-    "canonicalCompoundId": "mesembrenol",
-    "name": "mesembrenol",
-    "compoundName": "mesembrenol",
-    "canonicalCompoundName": "mesembrenol",
-    "hero": "Acts as a recognizable chemical marker within Kanna.",
-    "coreInsight": "Within Kanna, mesembrenol helps define the plant’s chemistry alongside markers such as mesembranol.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "mesembrenone",
-    "slug": "mesembrenone",
-    "canonicalCompoundId": "mesembrenone",
-    "name": "mesembrenone",
-    "compoundName": "mesembrenone",
-    "canonicalCompoundName": "mesembrenone",
-    "hero": "Helps define why Kanna extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, mesembrenone helps separate Kanna extracts from adjacent markers such as mesembranol. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "mesembrine",
-    "slug": "mesembrine",
-    "canonicalCompoundId": "mesembrine",
-    "name": "mesembrine",
-    "compoundName": "mesembrine",
-    "canonicalCompoundName": "mesembrine",
-    "hero": "Helps define why Kanna extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, mesembrine helps separate Kanna extracts from adjacent markers such as mesembranol. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "methyl-salicylate",
-    "slug": "methyl-salicylate",
-    "canonicalCompoundId": "methyl-salicylate",
-    "name": "methyl salicylate",
-    "compoundName": "methyl salicylate",
-    "canonicalCompoundName": "methyl salicylate",
-    "hero": "Defines a key pharmacological signal attributed to methyl salicylate in herbal extracts.",
-    "coreInsight": "methyl salicylate remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "methysticin",
-    "slug": "methysticin",
-    "canonicalCompoundId": "methysticin",
-    "name": "methysticin",
-    "compoundName": "methysticin",
-    "canonicalCompoundName": "methysticin",
-    "hero": "Distinguishes methysticin from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Methysticin matters because it can be ranked directly against kavain and related neighbors during compound prioritization.",
-    "effects": [
-      "[\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"",
-      "\"calcium channel modulation\"",
-      "\"dopamine modulation\"]"
-    ]
-  },
-  {
-    "id": "miroestrol",
-    "slug": "miroestrol",
-    "canonicalCompoundId": "miroestrol",
-    "name": "miroestrol",
-    "compoundName": "miroestrol",
-    "canonicalCompoundName": "miroestrol",
-    "hero": "Defines a key pharmacological signal attributed to miroestrol in herbal extracts.",
-    "coreInsight": "miroestrol remains provisional because the evidence behind Pueraria Mirifica does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "mitragynine",
-    "slug": "mitragynine",
-    "canonicalCompoundId": "mitragynine",
-    "name": "mitragynine",
-    "compoundName": "mitragynine",
-    "canonicalCompoundName": "mitragynine",
-    "hero": "Defines a key pharmacological signal attributed to mitragynine in herbal extracts.",
-    "coreInsight": "mitragynine stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antidepressant\"",
-      "\"analgesic\"",
-      "\"stimulant\"]"
-    ],
-    "mechanisms": [
-      "[\"serotonin modulation\"",
-      "\"opioid receptor modulation\"]"
-    ]
-  },
-  {
-    "id": "mitrajavine",
-    "slug": "mitrajavine",
-    "canonicalCompoundId": "mitrajavine",
-    "name": "mitrajavine",
-    "compoundName": "mitrajavine",
-    "canonicalCompoundName": "mitrajavine",
-    "hero": "Defines a key pharmacological signal attributed to mitrajavine in herbal extracts.",
-    "coreInsight": "mitrajavine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "mitraphylline",
-    "slug": "mitraphylline",
-    "canonicalCompoundId": "mitraphylline",
-    "name": "mitraphylline",
-    "compoundName": "mitraphylline",
-    "canonicalCompoundName": "mitraphylline",
-    "hero": "Helps define why Cat's Claw extracts perform differently in formulation.",
-    "coreInsight": "mitraphylline becomes more valuable when Cat's Claw is standardized by named actives rather than total extract mass.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "mogroside-v",
-    "slug": "mogroside-v",
-    "canonicalCompoundId": "mogroside-v",
-    "name": "mogroside v",
-    "compoundName": "mogroside v",
-    "canonicalCompoundName": "mogroside v",
-    "hero": "Focuses antioxidant activity within Luo Han Guo chemistry.",
-    "coreInsight": "For Luo Han Guo, mogroside v is most useful as a direct antioxidant signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "mogrosides",
-    "slug": "mogrosides",
-    "canonicalCompoundId": "mogrosides",
-    "name": "mogrosides",
-    "compoundName": "mogrosides",
-    "canonicalCompoundName": "mogrosides",
-    "hero": "Helps define why Luo Han Guo extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, mogrosides helps separate Luo Han Guo extracts from adjacent markers such as mogroside v. That improves standardization decisions.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "moringin",
-    "slug": "moringin",
-    "canonicalCompoundId": "moringin",
-    "name": "moringin",
-    "compoundName": "moringin",
-    "canonicalCompoundName": "moringin",
-    "hero": "Defines a key pharmacological signal attributed to moringin in herbal extracts.",
-    "coreInsight": "Moringin remains provisional because the evidence behind moringa does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "morphine",
-    "slug": "morphine",
-    "canonicalCompoundId": "morphine",
-    "name": "morphine",
-    "compoundName": "morphine",
-    "canonicalCompoundName": "morphine",
-    "hero": "Defines a key pharmacological signal attributed to morphine in herbal extracts.",
-    "coreInsight": "morphine remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "morroniside",
-    "slug": "morroniside",
-    "canonicalCompoundId": "morroniside",
-    "name": "morroniside",
-    "compoundName": "morroniside",
-    "canonicalCompoundName": "morroniside",
-    "hero": "Defines a key pharmacological signal attributed to morroniside in herbal extracts.",
-    "coreInsight": "morroniside stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "muscimol",
-    "slug": "muscimol",
-    "canonicalCompoundId": "muscimol",
-    "name": "muscimol",
-    "compoundName": "muscimol",
-    "canonicalCompoundName": "muscimol",
-    "hero": "Defines a key pharmacological signal attributed to muscimol in herbal extracts.",
-    "coreInsight": "muscimol matters most when gaba-a modulation is used as the primary readout. That makes it more informative than a generic other label.",
-    "effects": [
-      "[\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"]"
-    ]
-  },
-  {
-    "id": "myo-inositol",
-    "slug": "myo-inositol",
-    "canonicalCompoundId": "myo-inositol",
-    "name": "myo-inositol",
-    "compoundName": "myo-inositol",
-    "canonicalCompoundName": "myo-inositol",
-    "hero": "Defines a key pharmacological signal attributed to myo-inositol in herbal extracts.",
-    "coreInsight": "myo-inositol remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "myrcene",
-    "slug": "myrcene",
-    "canonicalCompoundId": "myrcene",
-    "name": "myrcene",
-    "compoundName": "myrcene",
-    "canonicalCompoundName": "myrcene",
-    "hero": "Defines a key pharmacological signal attributed to myrcene in herbal extracts.",
-    "coreInsight": "myrcene remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "myricetin",
-    "slug": "myricetin",
-    "canonicalCompoundId": "myricetin",
-    "name": "myricetin",
-    "compoundName": "myricetin",
-    "canonicalCompoundName": "myricetin",
-    "hero": "Helps define why Myrtle extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, myricetin helps separate Myrtle extracts from adjacent markers such as myrtenyl acetate. That improves standardization decisions.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "myristicin",
-    "slug": "myristicin",
-    "canonicalCompoundId": "myristicin",
-    "name": "myristicin",
-    "compoundName": "myristicin",
-    "canonicalCompoundName": "myristicin",
-    "hero": "Defines a key pharmacological signal attributed to myristicin in herbal extracts.",
-    "coreInsight": "Myristicin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "myrtenyl-acetate",
-    "slug": "myrtenyl-acetate",
-    "canonicalCompoundId": "myrtenyl-acetate",
-    "name": "myrtenyl acetate",
-    "compoundName": "myrtenyl acetate",
-    "canonicalCompoundName": "myrtenyl acetate",
-    "hero": "Defines a key pharmacological signal attributed to myrtenyl acetate in herbal extracts.",
-    "coreInsight": "myrtenyl acetate remains provisional because the evidence behind Myrtle does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "n-acetyl-l-tyrosine",
-    "slug": "n-acetyl-l-tyrosine",
-    "canonicalCompoundId": "n-acetyl-l-tyrosine",
-    "name": "n-acetyl-l-tyrosine",
-    "compoundName": "n-acetyl-l-tyrosine",
-    "canonicalCompoundName": "n-acetyl-l-tyrosine",
-    "hero": "Defines a key pharmacological signal attributed to n-acetyl-l-tyrosine in herbal extracts.",
-    "coreInsight": "n-acetyl-l-tyrosine stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"stimulant\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "n-acetylcysteine",
-    "slug": "n-acetylcysteine",
-    "canonicalCompoundId": "n-acetylcysteine",
-    "name": "n-acetylcysteine",
-    "compoundName": "n-acetylcysteine",
-    "canonicalCompoundName": "n-acetylcysteine",
-    "hero": "Defines a key pharmacological signal attributed to n-acetylcysteine in herbal extracts.",
-    "coreInsight": "n-acetylcysteine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "n-dimethylhistamine",
-    "slug": "n-dimethylhistamine",
-    "canonicalCompoundId": "n-dimethylhistamine",
-    "name": "n-dimethylhistamine",
-    "compoundName": "n-dimethylhistamine",
-    "canonicalCompoundName": "n-dimethylhistamine",
-    "hero": "Defines a key pharmacological signal attributed to n-dimethylhistamine in herbal extracts.",
-    "coreInsight": "n-dimethylhistamine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "n-dimethyltryptamine",
-    "slug": "n-dimethyltryptamine",
-    "canonicalCompoundId": "n-dimethyltryptamine",
-    "name": "n-dimethyltryptamine",
-    "compoundName": "n-dimethyltryptamine",
-    "canonicalCompoundName": "n-dimethyltryptamine",
-    "hero": "Delivers hallucinogenic and antidepressant activity at the compound level.",
-    "coreInsight": "n-dimethyltryptamine is most useful when a formulation needs a direct hallucinogenic signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"hallucinogenic\"",
-      "\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[\"serotonin modulation\"]"
-    ]
-  },
-  {
-    "id": "n-methylasimilobine",
-    "slug": "n-methylasimilobine",
-    "canonicalCompoundId": "n-methylasimilobine",
-    "name": "n-methylasimilobine",
-    "compoundName": "n-methylasimilobine",
-    "canonicalCompoundName": "n-methylasimilobine",
-    "hero": "Helps define why American Yellow Lotus extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, n-methylasimilobine helps separate American Yellow Lotus extracts from adjacent markers such as armepavine. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "n-methyltryptamine",
-    "slug": "n-methyltryptamine",
-    "canonicalCompoundId": "n-methyltryptamine",
-    "name": "n-methyltryptamine",
-    "compoundName": "n-methyltryptamine",
-    "canonicalCompoundName": "n-methyltryptamine",
-    "hero": "Defines a key pharmacological signal attributed to n-methyltryptamine in herbal extracts.",
-    "coreInsight": "N-methyltryptamine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"hallucinogenic\"",
-      "\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[\"serotonin modulation\"]"
-    ]
-  },
-  {
-    "id": "n-monomethylhistamine",
-    "slug": "n-monomethylhistamine",
-    "canonicalCompoundId": "n-monomethylhistamine",
-    "name": "n-monomethylhistamine",
-    "compoundName": "n-monomethylhistamine",
-    "canonicalCompoundName": "n-monomethylhistamine",
-    "hero": "Defines a key pharmacological signal attributed to n-monomethylhistamine in herbal extracts.",
-    "coreInsight": "n-monomethylhistamine remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "neoquassin",
-    "slug": "neoquassin",
-    "canonicalCompoundId": "neoquassin",
-    "name": "neoquassin",
-    "compoundName": "neoquassin",
-    "canonicalCompoundName": "neoquassin",
-    "hero": "Defines a key pharmacological signal attributed to neoquassin in herbal extracts.",
-    "coreInsight": "neoquassin stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "neral",
-    "slug": "neral",
-    "canonicalCompoundId": "neral",
-    "name": "neral",
-    "compoundName": "neral",
-    "canonicalCompoundName": "neral",
-    "hero": "Concentrates antioxidant activity at the compound level.",
-    "coreInsight": "neral is most useful when a formulation needs a direct antioxidant signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "neriine",
-    "slug": "neriine",
-    "canonicalCompoundId": "neriine",
-    "name": "neriine",
-    "compoundName": "neriine",
-    "canonicalCompoundName": "neriine",
-    "hero": "Defines a key pharmacological signal attributed to neriine in herbal extracts.",
-    "coreInsight": "neriine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "nesodine",
-    "slug": "nesodine",
-    "canonicalCompoundId": "nesodine",
-    "name": "nesodine",
-    "compoundName": "nesodine",
-    "canonicalCompoundName": "nesodine",
-    "hero": "Defines a key pharmacological signal attributed to nesodine in herbal extracts.",
-    "coreInsight": "nesodine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "niacin",
-    "slug": "niacin",
-    "canonicalCompoundId": "niacin",
-    "name": "niacin",
-    "compoundName": "niacin",
-    "canonicalCompoundName": "niacin",
-    "hero": "Defines a key pharmacological signal attributed to niacin in herbal extracts.",
-    "coreInsight": "niacin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "nicotine",
-    "slug": "nicotine",
-    "canonicalCompoundId": "nicotine",
-    "name": "nicotine",
-    "compoundName": "nicotine",
-    "canonicalCompoundName": "nicotine",
-    "hero": "Defines a key pharmacological signal attributed to nicotine in herbal extracts.",
-    "coreInsight": "Nicotine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"nootropic\"]"
-    ],
-    "mechanisms": [
-      "[\"dopamine modulation\"]"
-    ]
-  },
-  {
-    "id": "nicotinic-acid",
-    "slug": "nicotinic-acid",
-    "canonicalCompoundId": "nicotinic-acid",
-    "name": "Nicotinic acid",
-    "compoundName": "Nicotinic acid",
-    "canonicalCompoundName": "Nicotinic acid",
-    "hero": "Defines a key pharmacological signal attributed to nicotinic acid in herbal extracts.",
-    "coreInsight": "Nicotinic acid remains provisional because the evidence behind Mucuna pruriens does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "nigellone",
-    "slug": "nigellone",
-    "canonicalCompoundId": "nigellone",
-    "name": "nigellone",
-    "compoundName": "nigellone",
-    "canonicalCompoundName": "nigellone",
-    "hero": "Defines a key pharmacological signal attributed to nigellone in herbal extracts.",
-    "coreInsight": "nigellone stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "nimbin",
-    "slug": "nimbin",
-    "canonicalCompoundId": "nimbin",
-    "name": "nimbin",
-    "compoundName": "nimbin",
-    "canonicalCompoundName": "nimbin",
-    "hero": "Acts as a recognizable chemical marker within Neem.",
-    "coreInsight": "Within Neem, nimbin helps define the plant’s chemistry alongside markers such as azadirachtin.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "nordihydrocapsaicin",
-    "slug": "nordihydrocapsaicin",
-    "canonicalCompoundId": "nordihydrocapsaicin",
-    "name": "nordihydrocapsaicin",
-    "compoundName": "nordihydrocapsaicin",
-    "canonicalCompoundName": "nordihydrocapsaicin",
-    "hero": "Defines a key pharmacological signal attributed to nordihydrocapsaicin in herbal extracts.",
-    "coreInsight": "nordihydrocapsaicin matters most when trpv1 modulation is used as the primary readout. That makes it more informative than a generic other label.",
-    "effects": [
-      "[\"analgesic\"]"
-    ],
-    "mechanisms": [
-      "[\"TRPV1 modulation\"]"
-    ]
-  },
-  {
-    "id": "norephedrine",
-    "slug": "norephedrine",
-    "canonicalCompoundId": "norephedrine",
-    "name": "norephedrine",
-    "compoundName": "norephedrine",
-    "canonicalCompoundName": "norephedrine",
-    "hero": "Defines a key pharmacological signal attributed to norephedrine in herbal extracts.",
-    "coreInsight": "norephedrine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "nornicotine",
-    "slug": "nornicotine",
-    "canonicalCompoundId": "nornicotine",
-    "name": "nornicotine",
-    "compoundName": "nornicotine",
-    "canonicalCompoundName": "nornicotine",
-    "hero": "Defines a key pharmacological signal attributed to nornicotine in herbal extracts.",
-    "coreInsight": "nornicotine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"nootropic\"]"
-    ],
-    "mechanisms": [
-      "[\"dopamine modulation\"]"
-    ]
-  },
-  {
-    "id": "notoginsenoside-r1",
-    "slug": "notoginsenoside-r1",
-    "canonicalCompoundId": "notoginsenoside-r1",
-    "name": "notoginsenoside r1",
-    "compoundName": "notoginsenoside r1",
-    "canonicalCompoundName": "notoginsenoside r1",
-    "hero": "Defines a key pharmacological signal attributed to notoginsenoside r1 in herbal extracts.",
-    "coreInsight": "Notoginsenoside r1 remains provisional because the evidence behind notoginseng does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "nuciferine",
-    "slug": "nuciferine",
-    "canonicalCompoundId": "nuciferine",
-    "name": "nuciferine",
-    "compoundName": "nuciferine",
-    "canonicalCompoundName": "nuciferine",
-    "hero": "Requires tighter safety interpretation than many adjacent plant compounds.",
-    "coreInsight": "nuciferine needs separate risk review because safety constraints can change its value in formulation.",
-    "effects": [
-      "[\"sedative\"]"
-    ],
-    "mechanisms": [
-      "[\"dopamine modulation\"]"
-    ]
-  },
-  {
-    "id": "oleandrin",
-    "slug": "oleandrin",
-    "canonicalCompoundId": "oleandrin",
-    "name": "oleandrin",
-    "compoundName": "oleandrin",
-    "canonicalCompoundName": "oleandrin",
-    "hero": "Defines a key pharmacological signal attributed to oleandrin in herbal extracts.",
-    "coreInsight": "oleandrin stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "omega-3-fatty-acids",
-    "slug": "omega-3-fatty-acids",
-    "canonicalCompoundId": "omega-3-fatty-acids",
-    "name": "omega-3 fatty acids",
-    "compoundName": "omega-3 fatty acids",
-    "canonicalCompoundName": "omega-3 fatty acids",
-    "hero": "Drives hepatoprotective activity at the compound level.",
-    "coreInsight": "omega-3 fatty acids is most useful when a formulation needs a direct hepatoprotective signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"hepatoprotective\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "ophiopogonin-d",
-    "slug": "ophiopogonin-d",
-    "canonicalCompoundId": "ophiopogonin-d",
-    "name": "ophiopogonin d",
-    "compoundName": "ophiopogonin d",
-    "canonicalCompoundName": "ophiopogonin d",
-    "hero": "Helps define why Ophiopogon extracts perform differently in formulation.",
-    "coreInsight": "ophiopogonin d becomes more valuable when Ophiopogon is standardized by named actives rather than total extract mass.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "osthole",
-    "slug": "osthole",
-    "canonicalCompoundId": "osthole",
-    "name": "osthole",
-    "compoundName": "osthole",
-    "canonicalCompoundName": "osthole",
-    "hero": "Defines a key pharmacological signal attributed to osthole in herbal extracts.",
-    "coreInsight": "osthole remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "oxyacanthine",
-    "slug": "oxyacanthine",
-    "canonicalCompoundId": "oxyacanthine",
-    "name": "oxyacanthine",
-    "compoundName": "oxyacanthine",
-    "canonicalCompoundName": "oxyacanthine",
-    "hero": "Defines a key pharmacological signal attributed to oxyacanthine in herbal extracts.",
-    "coreInsight": "oxyacanthine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "oxyberberine",
-    "slug": "oxyberberine",
-    "canonicalCompoundId": "oxyberberine",
-    "name": "oxyberberine",
-    "compoundName": "oxyberberine",
-    "canonicalCompoundName": "oxyberberine",
-    "hero": "Defines a key pharmacological signal attributed to oxyberberine in herbal extracts.",
-    "coreInsight": "Oxyberberine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "oxymatrine",
-    "slug": "oxymatrine",
-    "canonicalCompoundId": "oxymatrine",
-    "name": "oxymatrine",
-    "compoundName": "oxymatrine",
-    "canonicalCompoundName": "oxymatrine",
-    "hero": "Defines a key pharmacological signal attributed to oxymatrine in herbal extracts.",
-    "coreInsight": "oxymatrine remains provisional because the evidence behind Sophora Flavescens does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "pachymic-acid",
-    "slug": "pachymic-acid",
-    "canonicalCompoundId": "pachymic-acid",
-    "name": "pachymic acid",
-    "compoundName": "pachymic acid",
-    "canonicalCompoundName": "pachymic acid",
-    "hero": "Defines a key pharmacological signal attributed to pachymic acid in herbal extracts.",
-    "coreInsight": "pachymic acid stays provisional because the evidence behind Poria does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "paeoniflorin",
-    "slug": "paeoniflorin",
-    "canonicalCompoundId": "paeoniflorin",
-    "name": "paeoniflorin",
-    "compoundName": "paeoniflorin",
-    "canonicalCompoundName": "paeoniflorin",
-    "hero": "Acts as a recognizable chemical marker within White Peony.",
-    "coreInsight": "Within White Peony, paeoniflorin serves mainly as a phytochemical marker that sharpens chemical identity.",
-    "effects": [
-      "[\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "palmatine",
-    "slug": "palmatine",
-    "canonicalCompoundId": "palmatine",
-    "name": "palmatine",
-    "compoundName": "palmatine",
-    "canonicalCompoundName": "palmatine",
-    "hero": "Helps define why Coptis extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, palmatine helps separate Coptis extracts from adjacent markers such as berberine. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "palustrol",
-    "slug": "palustrol",
-    "canonicalCompoundId": "palustrol",
-    "name": "palustrol",
-    "compoundName": "palustrol",
-    "canonicalCompoundName": "palustrol",
-    "hero": "Defines a key pharmacological signal attributed to palustrol in herbal extracts.",
-    "coreInsight": "palustrol remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "panduratin-a",
-    "slug": "panduratin-a",
-    "canonicalCompoundId": "panduratin-a",
-    "name": "panduratin a",
-    "compoundName": "panduratin a",
-    "canonicalCompoundName": "panduratin a",
-    "hero": "Helps define why Fingerroot extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, panduratin a helps separate Fingerroot extracts from adjacent markers such as pinocembrin. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "paniculatin",
-    "slug": "paniculatin",
-    "canonicalCompoundId": "paniculatin",
-    "name": "paniculatin",
-    "compoundName": "paniculatin",
-    "canonicalCompoundName": "paniculatin",
-    "hero": "Defines a key pharmacological signal attributed to paniculatin in herbal extracts.",
-    "coreInsight": "Paniculatin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "papain",
-    "slug": "papain",
-    "canonicalCompoundId": "papain",
-    "name": "papain",
-    "compoundName": "papain",
-    "canonicalCompoundName": "papain",
-    "hero": "Defines a key pharmacological signal attributed to papain in herbal extracts.",
-    "coreInsight": "papain remains provisional because the evidence behind Papaya Leaf does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"analgesic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "parthenolide",
-    "slug": "parthenolide",
-    "canonicalCompoundId": "parthenolide",
-    "name": "parthenolide",
-    "compoundName": "parthenolide",
-    "canonicalCompoundName": "parthenolide",
-    "hero": "Defines a key pharmacological signal attributed to parthenolide in herbal extracts.",
-    "coreInsight": "parthenolide stays provisional because the evidence behind Kudzu does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "pectin",
-    "slug": "pectin",
-    "canonicalCompoundId": "pectin",
-    "name": "pectin",
-    "compoundName": "pectin",
-    "canonicalCompoundName": "pectin",
-    "hero": "Acts as a recognizable chemical marker within Marshmallow.",
-    "coreInsight": "Within Marshmallow, pectin serves mainly as a phytochemical marker that sharpens chemical identity.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "pellucidin-a",
-    "slug": "pellucidin-a",
-    "canonicalCompoundId": "pellucidin-a",
-    "name": "pellucidin a",
-    "compoundName": "pellucidin a",
-    "canonicalCompoundName": "pellucidin a",
-    "hero": "Focuses antioxidant activity at the compound level.",
-    "coreInsight": "pellucidin a is most useful when a formulation needs a direct antioxidant signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "perillaldehyde",
-    "slug": "perillaldehyde",
-    "canonicalCompoundId": "perillaldehyde",
-    "name": "perillaldehyde",
-    "compoundName": "perillaldehyde",
-    "canonicalCompoundName": "perillaldehyde",
-    "hero": "Helps define why Perilla extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, perillaldehyde helps separate Perilla extracts from adjacent markers such as Rosmarinic acid. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "peruvoside",
-    "slug": "peruvoside",
-    "canonicalCompoundId": "peruvoside",
-    "name": "peruvoside",
-    "compoundName": "peruvoside",
-    "canonicalCompoundName": "peruvoside",
-    "hero": "Defines a key pharmacological signal attributed to peruvoside in herbal extracts.",
-    "coreInsight": "peruvoside remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "petasin",
-    "slug": "petasin",
-    "canonicalCompoundId": "petasin",
-    "name": "petasin",
-    "compoundName": "petasin",
-    "canonicalCompoundName": "petasin",
-    "hero": "Distinguishes petasin from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Petasin matters because it can be ranked directly against isopetasin and related neighbors during compound prioritization.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"",
-      "\"analgesic\"]"
-    ],
-    "mechanisms": [
-      "[\"TRPV1 modulation\"",
-      "\"TRPA1 modulation\"",
-      "\"CGRP modulation\"",
-      "\"CGRP signaling\"]"
-    ]
-  },
-  {
-    "id": "pfaffic-acid",
-    "slug": "pfaffic-acid",
-    "canonicalCompoundId": "pfaffic-acid",
-    "name": "pfaffic acid",
-    "compoundName": "pfaffic acid",
-    "canonicalCompoundName": "pfaffic acid",
-    "hero": "Defines a key pharmacological signal attributed to pfaffic acid in herbal extracts.",
-    "coreInsight": "pfaffic acid remains provisional because the evidence behind Suma does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "phosphatidylserine",
-    "slug": "phosphatidylserine",
-    "canonicalCompoundId": "phosphatidylserine",
-    "name": "phosphatidylserine",
-    "compoundName": "phosphatidylserine",
-    "canonicalCompoundName": "phosphatidylserine",
-    "hero": "Defines a key pharmacological signal attributed to phosphatidylserine in herbal extracts.",
-    "coreInsight": "phosphatidylserine stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"adaptogenic\"",
-      "\"neuroprotective\"]"
-    ],
-    "mechanisms": [
-      "[\"apoptosis modulation\"]"
-    ]
-  },
-  {
-    "id": "phyllanthin",
-    "slug": "phyllanthin",
-    "canonicalCompoundId": "phyllanthin",
-    "name": "Phyllanthin",
-    "compoundName": "Phyllanthin",
-    "canonicalCompoundName": "Phyllanthin",
-    "hero": "Acts as a recognizable chemical marker within Phyllanthus amarus.",
-    "coreInsight": "Within Phyllanthus amarus, Phyllanthin serves mainly as a phytochemical marker that sharpens chemical identity.",
-    "effects": [
-      "[\"hepatoprotective\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "picrocrocin",
-    "slug": "picrocrocin",
-    "canonicalCompoundId": "picrocrocin",
-    "name": "picrocrocin",
-    "compoundName": "picrocrocin",
-    "canonicalCompoundName": "picrocrocin",
-    "hero": "Helps define why Saffron extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, picrocrocin helps separate Saffron extracts from adjacent markers such as crocetin. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
     "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "pinene",
-    "slug": "pinene",
-    "canonicalCompoundId": "pinene",
-    "name": "pinene",
-    "compoundName": "pinene",
-    "canonicalCompoundName": "pinene",
-    "hero": "Helps define why Eucalyptus extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, pinene helps separate Eucalyptus extracts from adjacent markers such as alpha-pinene. That improves standardization decisions.",
-    "effects": [
-      "[]"
+      "NF-κB inhibition",
+      "PI3K/Akt modulation",
+      "VEGF signaling inhibition"
     ],
-    "mechanisms": [
-      "[\"endocannabinoid modulation\"]"
-    ]
-  },
-  {
-    "id": "pinocembrin",
-    "slug": "pinocembrin",
-    "canonicalCompoundId": "pinocembrin",
-    "name": "pinocembrin",
-    "compoundName": "pinocembrin",
-    "canonicalCompoundName": "pinocembrin",
-    "hero": "Helps define why Fingerroot extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, pinocembrin helps separate Fingerroot extracts from adjacent markers such as panduratin a. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "pinostrobin",
-    "slug": "pinostrobin",
-    "canonicalCompoundId": "pinostrobin",
-    "name": "pinostrobin",
-    "compoundName": "pinostrobin",
-    "canonicalCompoundName": "pinostrobin",
-    "hero": "Distinguishes pinostrobin from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Pinostrobin matters because it can be ranked directly against panduratin a and related neighbors during compound prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "piperine",
-    "slug": "piperine",
-    "canonicalCompoundId": "piperine",
-    "name": "Piperine",
-    "compoundName": "Piperine",
-    "canonicalCompoundName": "Piperine",
-    "hero": "Defines a key pharmacological signal attributed to piperine in herbal extracts.",
-    "coreInsight": "Piperine remains provisional because the evidence behind Black Pepper does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"stimulant\"]"
-    ],
-    "mechanisms": [
-      "[\"bioavailability modulation\"]"
-    ]
-  },
-  {
-    "id": "podophyllotoxin",
-    "slug": "podophyllotoxin",
-    "canonicalCompoundId": "podophyllotoxin",
-    "name": "podophyllotoxin",
-    "compoundName": "podophyllotoxin",
-    "canonicalCompoundName": "podophyllotoxin",
-    "hero": "Defines a key pharmacological signal attributed to podophyllotoxin in herbal extracts.",
-    "coreInsight": "podophyllotoxin stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "polygodial",
-    "slug": "polygodial",
-    "canonicalCompoundId": "polygodial",
-    "name": "polygodial",
-    "compoundName": "polygodial",
-    "canonicalCompoundName": "polygodial",
-    "hero": "Defines antioxidant activity at the compound level.",
-    "coreInsight": "polygodial is most useful when a formulation needs a direct antioxidant signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "polypeptide-p",
-    "slug": "polypeptide-p",
-    "canonicalCompoundId": "polypeptide-p",
-    "name": "polypeptide-p",
-    "compoundName": "polypeptide-p",
-    "canonicalCompoundName": "polypeptide-p",
-    "hero": "Helps define why Bitter Melon extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, polypeptide-p helps separate Bitter Melon extracts from adjacent markers such as charantin. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "pristimerin",
-    "slug": "pristimerin",
-    "canonicalCompoundId": "pristimerin",
-    "name": "pristimerin",
-    "compoundName": "pristimerin",
-    "canonicalCompoundName": "pristimerin",
-    "hero": "Defines a key pharmacological signal attributed to pristimerin in herbal extracts.",
-    "coreInsight": "pristimerin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "probiotics",
-    "slug": "probiotics",
-    "canonicalCompoundId": "probiotics",
-    "name": "probiotics",
-    "compoundName": "probiotics",
-    "canonicalCompoundName": "probiotics",
-    "hero": "Defines a key pharmacological signal attributed to probiotics in herbal extracts.",
-    "coreInsight": "probiotics remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"immunomodulatory\"]"
-    ],
-    "mechanisms": [
-      "[\"immune modulation\"]"
-    ]
-  },
-  {
-    "id": "procyanidin-b2",
-    "slug": "procyanidin-b2",
-    "canonicalCompoundId": "procyanidin-b2",
-    "name": "procyanidin b2",
-    "compoundName": "procyanidin b2",
-    "canonicalCompoundName": "procyanidin b2",
-    "hero": "Defines a key pharmacological signal attributed to procyanidin b2 in herbal extracts.",
-    "coreInsight": "Procyanidin b2 remains provisional because the evidence behind hawthorn does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "protoanemonin",
-    "slug": "protoanemonin",
-    "canonicalCompoundId": "protoanemonin",
-    "name": "protoanemonin",
-    "compoundName": "protoanemonin",
-    "canonicalCompoundName": "protoanemonin",
-    "hero": "Defines a key pharmacological signal attributed to protoanemonin in herbal extracts.",
-    "coreInsight": "protoanemonin remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "protopine",
-    "slug": "protopine",
-    "canonicalCompoundId": "protopine",
-    "name": "protopine",
-    "compoundName": "protopine",
-    "canonicalCompoundName": "protopine",
-    "hero": "Defines a key pharmacological signal attributed to protopine in herbal extracts.",
-    "coreInsight": "protopine stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "pseudoephedrine",
-    "slug": "pseudoephedrine",
-    "canonicalCompoundId": "pseudoephedrine",
-    "name": "pseudoephedrine",
-    "compoundName": "pseudoephedrine",
-    "canonicalCompoundName": "pseudoephedrine",
-    "hero": "Defines a key pharmacological signal attributed to pseudoephedrine in herbal extracts.",
-    "coreInsight": "pseudoephedrine matters most when adrenergic modulation is used as the primary readout. That makes it more informative than a generic other label.",
-    "effects": [
-      "[\"stimulant\"]"
-    ],
-    "mechanisms": [
-      "[\"adrenergic modulation\"]"
-    ]
-  },
-  {
-    "id": "pseudohypericin",
-    "slug": "pseudohypericin",
-    "canonicalCompoundId": "pseudohypericin",
-    "name": "pseudohypericin",
-    "compoundName": "pseudohypericin",
-    "canonicalCompoundName": "pseudohypericin",
-    "hero": "Defines antimicrobial activity within St Johns Wort chemistry.",
-    "coreInsight": "For St Johns Wort, pseudohypericin is most useful as a direct antimicrobial signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"antimicrobial\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "psilocin",
-    "slug": "psilocin",
-    "canonicalCompoundId": "psilocin",
-    "name": "psilocin",
-    "compoundName": "psilocin",
-    "canonicalCompoundName": "psilocin",
-    "hero": "Defines a key pharmacological signal attributed to psilocin in herbal extracts.",
-    "coreInsight": "psilocin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "psilocybin",
-    "slug": "psilocybin",
-    "canonicalCompoundId": "psilocybin",
-    "name": "psilocybin",
-    "compoundName": "psilocybin",
-    "canonicalCompoundName": "psilocybin",
-    "hero": "Defines a key pharmacological signal attributed to psilocybin in herbal extracts.",
-    "coreInsight": "psilocybin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"hallucinogenic\"",
-      "\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[\"serotonin modulation\"]"
-    ]
-  },
-  {
-    "id": "psk",
-    "slug": "psk",
-    "canonicalCompoundId": "psk",
-    "name": "psk",
-    "compoundName": "psk",
-    "canonicalCompoundName": "psk",
-    "hero": "Defines a key pharmacological signal attributed to psk in herbal extracts.",
-    "coreInsight": "Psk remains provisional because the evidence behind turkey tail does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"immunomodulatory\"]"
-    ],
-    "mechanisms": [
-      "[\"immune signaling modulation\"]"
-    ]
-  },
-  {
-    "id": "puerarin",
-    "slug": "puerarin",
-    "canonicalCompoundId": "puerarin",
-    "name": "puerarin",
-    "compoundName": "puerarin",
-    "canonicalCompoundName": "puerarin",
-    "hero": "Defines a key pharmacological signal attributed to puerarin in herbal extracts.",
-    "coreInsight": "puerarin remains provisional because the evidence behind Blue Lotus does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "pulegone",
-    "slug": "pulegone",
-    "canonicalCompoundId": "pulegone",
-    "name": "pulegone",
-    "compoundName": "pulegone",
-    "canonicalCompoundName": "pulegone",
-    "hero": "Defines a key pharmacological signal attributed to pulegone in herbal extracts.",
-    "coreInsight": "pulegone stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "punarnavine",
-    "slug": "punarnavine",
-    "canonicalCompoundId": "punarnavine",
-    "name": "Punarnavine",
-    "compoundName": "Punarnavine",
-    "canonicalCompoundName": "Punarnavine",
-    "hero": "Acts as a recognizable chemical marker within Boerhavia diffusa.",
-    "coreInsight": "Within Boerhavia diffusa, Punarnavine helps define the plant’s chemistry alongside markers such as Quercetin.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "punicalagins",
-    "slug": "punicalagins",
-    "canonicalCompoundId": "punicalagins",
-    "name": "punicalagins",
-    "compoundName": "punicalagins",
-    "canonicalCompoundName": "punicalagins",
-    "hero": "Sharpens oxidative stress reduction in punicalagins.",
-    "coreInsight": "punicalagins matters most when oxidative stress reduction is used as the primary readout. That makes it more informative than a generic ellagitannins label.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "pyridoxine",
-    "slug": "pyridoxine",
-    "canonicalCompoundId": "pyridoxine",
-    "name": "pyridoxine",
-    "compoundName": "pyridoxine",
-    "canonicalCompoundName": "pyridoxine",
-    "hero": "Defines a key pharmacological signal attributed to pyridoxine in herbal extracts.",
-    "coreInsight": "pyridoxine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "quadrangularin-a",
-    "slug": "quadrangularin-a",
-    "canonicalCompoundId": "quadrangularin-a",
-    "name": "quadrangularin a",
-    "compoundName": "quadrangularin a",
-    "canonicalCompoundName": "quadrangularin a",
-    "hero": "Helps define why Cissus extracts perform differently in formulation.",
-    "coreInsight": "quadrangularin a becomes more valuable when Cissus is standardized by named actives rather than total extract mass.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "quassin",
-    "slug": "quassin",
-    "canonicalCompoundId": "quassin",
-    "name": "quassin",
-    "compoundName": "quassin",
-    "canonicalCompoundName": "quassin",
-    "hero": "Defines a key pharmacological signal attributed to quassin in herbal extracts.",
-    "coreInsight": "Quassin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "quebrachine",
-    "slug": "quebrachine",
-    "canonicalCompoundId": "quebrachine",
-    "name": "quebrachine",
-    "compoundName": "quebrachine",
-    "canonicalCompoundName": "quebrachine",
-    "hero": "Defines a key pharmacological signal attributed to quebrachine in herbal extracts.",
-    "coreInsight": "quebrachine remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "quercetin",
-    "slug": "quercetin",
-    "canonicalCompoundId": "quercetin",
-    "name": "Quercetin",
-    "compoundName": "Quercetin",
-    "canonicalCompoundName": "Quercetin",
-    "hero": "Defines a key pharmacological signal attributed to quercetin in herbal extracts.",
-    "coreInsight": "Quercetin stays provisional because the evidence behind Ginkgo Biloba does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"",
-      "\"adaptogenic\"]"
-    ],
-    "mechanisms": [
-      "[\"NF-kB inhibition\"",
-      "\"mast-cell modulation\"",
-      "\"NF-kB modulation\"",
-      "\"NF-κB modulation\"]"
-    ]
-  },
-  {
-    "id": "quercitrin",
-    "slug": "quercitrin",
-    "canonicalCompoundId": "quercitrin",
-    "name": "quercitrin",
-    "compoundName": "quercitrin",
-    "canonicalCompoundName": "quercitrin",
-    "hero": "Acts as a recognizable chemical marker within Houttuynia.",
-    "coreInsight": "Within Houttuynia, quercitrin serves mainly as a phytochemical marker that sharpens chemical identity.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "rb2",
-    "slug": "rb2",
-    "canonicalCompoundId": "rb2",
-    "name": "rb2",
-    "compoundName": "rb2",
-    "canonicalCompoundName": "rb2",
-    "hero": "Helps define why American Ginseng extracts perform differently in formulation.",
-    "coreInsight": "rb2 becomes more valuable when American Ginseng is standardized by named actives rather than total extract mass.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "reserpine",
-    "slug": "reserpine",
-    "canonicalCompoundId": "reserpine",
-    "name": "reserpine",
-    "compoundName": "reserpine",
-    "canonicalCompoundName": "reserpine",
-    "hero": "Defines a key pharmacological signal attributed to reserpine in herbal extracts.",
-    "coreInsight": "reserpine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "resveratrol",
-    "slug": "resveratrol",
-    "canonicalCompoundId": "resveratrol",
-    "name": "Resveratrol",
-    "compoundName": "Resveratrol",
-    "canonicalCompoundName": "Resveratrol",
-    "hero": "Helps define why Polygonum cuspidatum extracts perform differently in formulation.",
-    "coreInsight": "Resveratrol becomes more valuable when Polygonum cuspidatum is standardized by named actives rather than total extract mass.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"",
-      "\"adaptogenic\"]"
-    ],
-    "mechanisms": [
-      "[\"NF-kB inhibition\"",
-      "\"AMPK activation\"",
-      "\"SIRT1-associated signaling\"",
-      "\"NF-kB modulation\"]"
-    ]
-  },
-  {
-    "id": "rhodiola-salidroside-rosavin",
-    "slug": "rhodiola-salidroside-rosavin",
-    "canonicalCompoundId": "rhodiola-salidroside-rosavin",
-    "name": "rhodiola salidroside rosavin",
-    "compoundName": "rhodiola salidroside rosavin",
-    "canonicalCompoundName": "rhodiola salidroside rosavin",
-    "hero": "Defines a key pharmacological signal attributed to rhodiola salidroside rosavin in herbal extracts.",
-    "coreInsight": "Rhodiola salidroside rosavin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"adaptogenic\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "rhodiosin",
-    "slug": "rhodiosin",
-    "canonicalCompoundId": "rhodiosin",
-    "name": "rhodiosin",
-    "compoundName": "rhodiosin",
-    "canonicalCompoundName": "rhodiosin",
-    "hero": "Defines a key pharmacological signal attributed to rhodiosin in herbal extracts.",
-    "coreInsight": "rhodiosin remains provisional because the evidence behind Rhodiola does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "riboflavin",
-    "slug": "riboflavin",
-    "canonicalCompoundId": "riboflavin",
-    "name": "riboflavin",
-    "compoundName": "riboflavin",
-    "canonicalCompoundName": "riboflavin",
-    "hero": "Defines a key pharmacological signal attributed to riboflavin in herbal extracts.",
-    "coreInsight": "riboflavin stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"stimulant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "ricin",
-    "slug": "ricin",
-    "canonicalCompoundId": "ricin",
-    "name": "ricin",
-    "compoundName": "ricin",
-    "canonicalCompoundName": "ricin",
-    "hero": "Defines a key pharmacological signal attributed to ricin in herbal extracts.",
-    "coreInsight": "ricin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "ricinoleic-acid",
-    "slug": "ricinoleic-acid",
-    "canonicalCompoundId": "ricinoleic-acid",
-    "name": "ricinoleic acid",
-    "compoundName": "ricinoleic acid",
-    "canonicalCompoundName": "ricinoleic acid",
-    "hero": "Defines a key pharmacological signal attributed to ricinoleic acid in herbal extracts.",
-    "coreInsight": "ricinoleic acid remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "roemerine",
-    "slug": "roemerine",
-    "canonicalCompoundId": "roemerine",
-    "name": "roemerine",
-    "compoundName": "roemerine",
-    "canonicalCompoundName": "roemerine",
-    "hero": "Helps define why American Yellow Lotus extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, roemerine helps separate American Yellow Lotus extracts from adjacent markers such as armepavine. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "rosarin",
-    "slug": "rosarin",
-    "canonicalCompoundId": "rosarin",
-    "name": "Rosarin",
-    "compoundName": "Rosarin",
-    "canonicalCompoundName": "Rosarin",
-    "hero": "Helps define why Rhodiola extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, Rosarin helps separate Rhodiola extracts from adjacent markers such as Salidroside. That improves standardization decisions.",
-    "effects": [
-      "[\"antioxidant\"",
-      "\"adaptogenic\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "rosavin",
-    "slug": "rosavin",
-    "canonicalCompoundId": "rosavin",
-    "name": "Rosavin",
-    "compoundName": "Rosavin",
-    "canonicalCompoundName": "Rosavin",
-    "hero": "Distinguishes Rosavin from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Rosavin matters because it can be ranked directly against salidroside and related neighbors during compound prioritization.",
-    "effects": [
-      "[\"adaptogenic\"",
-      "\"antidepressant\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"Adaptogenic and stress-response modulation\"]"
-    ]
-  },
-  {
-    "id": "rosin",
-    "slug": "rosin",
-    "canonicalCompoundId": "rosin",
-    "name": "Rosin",
-    "compoundName": "Rosin",
-    "canonicalCompoundName": "Rosin",
-    "hero": "Defines a key pharmacological signal attributed to rosin in herbal extracts.",
-    "coreInsight": "Rosin remains provisional because the evidence behind Rhodiola does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"antioxidant\"",
-      "\"adaptogenic\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "rosiridin",
-    "slug": "rosiridin",
-    "canonicalCompoundId": "rosiridin",
-    "name": "rosiridin",
-    "compoundName": "rosiridin",
-    "canonicalCompoundName": "rosiridin",
-    "hero": "Defines a key pharmacological signal attributed to rosiridin in herbal extracts.",
-    "coreInsight": "rosiridin stays provisional because the evidence behind Rhodiola does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"adaptogenic\"",
-      "\"antidepressant\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"MAO inhibition\"]"
-    ]
-  },
-  {
-    "id": "rosmarinic-acid",
-    "slug": "rosmarinic-acid",
-    "canonicalCompoundId": "rosmarinic-acid",
-    "name": "Rosmarinic acid",
-    "compoundName": "Rosmarinic acid",
-    "canonicalCompoundName": "Rosmarinic acid",
-    "hero": "Acts as a recognizable chemical marker within Holy Basil.",
-    "coreInsight": "Within Holy Basil, Rosmarinic acid helps define the plant’s chemistry alongside markers such as Eugenol.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"",
-      "\"adaptogenic\"",
-      "\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[\"COX inhibition\"",
-      "\"GABA-A modulation\"",
-      "\"NF-kB inhibition\"",
-      "\"Antioxidant and anti-inflammatory signaling\"]"
-    ]
-  },
-  {
-    "id": "rutaecarpine",
-    "slug": "rutaecarpine",
-    "canonicalCompoundId": "rutaecarpine",
-    "name": "rutaecarpine",
-    "compoundName": "rutaecarpine",
-    "canonicalCompoundName": "rutaecarpine",
-    "hero": "Defines a key pharmacological signal attributed to rutaecarpine in herbal extracts.",
-    "coreInsight": "rutaecarpine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "rutin",
-    "slug": "rutin",
-    "canonicalCompoundId": "rutin",
-    "name": "rutin",
-    "compoundName": "rutin",
-    "canonicalCompoundName": "rutin",
-    "hero": "Helps define why Elderberry extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, rutin helps separate Elderberry extracts from adjacent markers such as Hyperforin. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "s-adenosyl-l-methionine",
-    "slug": "s-adenosyl-l-methionine",
-    "canonicalCompoundId": "s-adenosyl-l-methionine",
-    "name": "s-adenosyl-l-methionine",
-    "compoundName": "s-adenosyl-l-methionine",
-    "canonicalCompoundName": "s-adenosyl-l-methionine",
-    "hero": "Defines a key pharmacological signal attributed to s-adenosyl-l-methionine in herbal extracts.",
-    "coreInsight": "s-adenosyl-l-methionine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "s-allyl-cysteine",
-    "slug": "s-allyl-cysteine",
-    "canonicalCompoundId": "s-allyl-cysteine",
-    "name": "s-allyl-cysteine",
-    "compoundName": "s-allyl-cysteine",
-    "canonicalCompoundName": "s-allyl-cysteine",
-    "hero": "Distinguishes s-allyl-cysteine from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "S-allyl-cysteine matters because it can be ranked directly against diallyl sulfide and related neighbors during compound prioritization.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "safranal",
-    "slug": "safranal",
-    "canonicalCompoundId": "safranal",
-    "name": "safranal",
-    "compoundName": "safranal",
-    "canonicalCompoundName": "safranal",
-    "hero": "Defines a key pharmacological signal attributed to safranal in herbal extracts.",
-    "coreInsight": "safranal remains provisional because the evidence behind Saffron does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "safrole",
-    "slug": "safrole",
-    "canonicalCompoundId": "safrole",
-    "name": "safrole",
-    "compoundName": "safrole",
-    "canonicalCompoundName": "safrole",
-    "hero": "Defines a key pharmacological signal attributed to safrole in herbal extracts.",
-    "coreInsight": "safrole stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "saikosaponin-a",
-    "slug": "saikosaponin-a",
-    "canonicalCompoundId": "saikosaponin-a",
-    "name": "saikosaponin a",
-    "compoundName": "saikosaponin a",
-    "canonicalCompoundName": "saikosaponin a",
-    "hero": "Acts as a recognizable chemical marker within Bupleurum.",
-    "coreInsight": "Within Bupleurum, saikosaponin a serves mainly as a phytochemical marker that sharpens chemical identity.",
-    "effects": [
-      "[\"adaptogenic\"",
-      "\"hepatoprotective\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "salacinol",
-    "slug": "salacinol",
-    "canonicalCompoundId": "salacinol",
-    "name": "salacinol",
-    "compoundName": "salacinol",
-    "canonicalCompoundName": "salacinol",
-    "hero": "Helps define why Salacia extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, salacinol helps separate Salacia extracts from adjacent markers such as kotalanol. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "salicin",
-    "slug": "salicin",
-    "canonicalCompoundId": "salicin",
-    "name": "salicin",
-    "compoundName": "salicin",
-    "canonicalCompoundName": "salicin",
-    "hero": "Drives antioxidant activity at the compound level.",
-    "coreInsight": "salicin is most useful when a formulation needs a direct antioxidant signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "salicylic-acid",
-    "slug": "salicylic-acid",
-    "canonicalCompoundId": "salicylic-acid",
-    "name": "salicylic acid",
-    "compoundName": "salicylic acid",
-    "canonicalCompoundName": "salicylic acid",
-    "hero": "Defines a key pharmacological signal attributed to salicylic acid in herbal extracts.",
-    "coreInsight": "salicylic acid remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "salidroside",
-    "slug": "salidroside",
-    "canonicalCompoundId": "salidroside",
-    "name": "Salidroside",
-    "compoundName": "Salidroside",
-    "canonicalCompoundName": "Salidroside",
-    "hero": "Distinguishes Salidroside from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Salidroside matters because it can be ranked directly against rosavin and related neighbors during compound prioritization.",
-    "effects": [
-      "[\"neuroprotective\"",
-      "\"adaptogenic\"",
-      "\"antioxidant\"",
-      "\"hepatoprotective\"]"
-    ],
-    "mechanisms": [
-      "[\"Nrf2 activation\"",
-      "\"Neuroprotective and adaptogenic signaling\"]"
-    ]
-  },
-  {
-    "id": "salvianolic-acid-b",
-    "slug": "salvianolic-acid-b",
-    "canonicalCompoundId": "salvianolic-acid-b",
-    "name": "Salvianolic acid B",
-    "compoundName": "Salvianolic acid B",
-    "canonicalCompoundName": "Salvianolic acid B",
-    "hero": "Defines a key pharmacological signal attributed to salvianolic acid b in herbal extracts.",
-    "coreInsight": "Salvianolic acid B remains provisional because the evidence behind Salvia miltiorrhiza does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"antioxidant\"",
-      "\"adaptogenic\"",
-      "\"hepatoprotective\"]"
-    ],
-    "mechanisms": [
-      "[\"vascular signaling\"]"
-    ]
-  },
-  {
-    "id": "salvinorin-a",
-    "slug": "salvinorin-a",
-    "canonicalCompoundId": "salvinorin-a",
-    "name": "salvinorin a",
-    "compoundName": "salvinorin a",
-    "canonicalCompoundName": "salvinorin a",
-    "hero": "Defines a key pharmacological signal attributed to salvinorin a in herbal extracts.",
-    "coreInsight": "salvinorin a stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"hallucinogenic\"]"
-    ],
-    "mechanisms": [
-      "[\"opioid receptor modulation\"]"
-    ]
-  },
-  {
-    "id": "sambunigrin",
-    "slug": "sambunigrin",
-    "canonicalCompoundId": "sambunigrin",
-    "name": "sambunigrin",
-    "compoundName": "sambunigrin",
-    "canonicalCompoundName": "sambunigrin",
-    "hero": "Delivers antioxidant activity at the compound level.",
-    "coreInsight": "sambunigrin is most useful when a formulation needs a direct antioxidant signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "sanguinarine",
-    "slug": "sanguinarine",
-    "canonicalCompoundId": "sanguinarine",
-    "name": "sanguinarine",
-    "compoundName": "sanguinarine",
-    "canonicalCompoundName": "sanguinarine",
-    "hero": "Defines a key pharmacological signal attributed to sanguinarine in herbal extracts.",
-    "coreInsight": "sanguinarine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "saponins-hederacoside",
-    "slug": "saponins-hederacoside",
-    "canonicalCompoundId": "saponins-hederacoside",
-    "name": "saponins hederacoside",
-    "compoundName": "saponins hederacoside",
-    "canonicalCompoundName": "saponins hederacoside",
-    "hero": "Focuses immunomodulatory and antioxidant activity at the compound level.",
-    "coreInsight": "saponins hederacoside is most useful when a formulation needs a direct immunomodulatory signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"immunomodulatory\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "sarsaponin",
-    "slug": "sarsaponin",
-    "canonicalCompoundId": "sarsaponin",
-    "name": "sarsaponin",
-    "compoundName": "sarsaponin",
-    "canonicalCompoundName": "sarsaponin",
-    "hero": "Defines a key pharmacological signal attributed to sarsaponin in herbal extracts.",
-    "coreInsight": "sarsaponin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"immunomodulatory\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "schisandrin",
-    "slug": "schisandrin",
-    "canonicalCompoundId": "schisandrin",
-    "name": "schisandrin",
-    "compoundName": "schisandrin",
-    "canonicalCompoundName": "schisandrin",
-    "hero": "Distinguishes schisandrin from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Schisandrin matters because it can be ranked directly against gomisin a and related neighbors during compound prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "sciadopitysin",
-    "slug": "sciadopitysin",
-    "canonicalCompoundId": "sciadopitysin",
-    "name": "sciadopitysin",
-    "compoundName": "sciadopitysin",
-    "canonicalCompoundName": "sciadopitysin",
-    "hero": "Defines a key pharmacological signal attributed to sciadopitysin in herbal extracts.",
-    "coreInsight": "sciadopitysin remains provisional because the evidence behind Ginkgo Biloba does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "scopadulcic-acid",
-    "slug": "scopadulcic-acid",
-    "canonicalCompoundId": "scopadulcic-acid",
-    "name": "scopadulcic acid",
-    "compoundName": "scopadulcic acid",
-    "canonicalCompoundName": "scopadulcic acid",
-    "hero": "Defines a key pharmacological signal attributed to scopadulcic acid in herbal extracts.",
-    "coreInsight": "scopadulcic acid stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "scoparin",
-    "slug": "scoparin",
-    "canonicalCompoundId": "scoparin",
-    "name": "scoparin",
-    "compoundName": "scoparin",
-    "canonicalCompoundName": "scoparin",
-    "hero": "Defines antioxidant activity at the compound level.",
-    "coreInsight": "scoparin is most useful when a formulation needs a direct antioxidant signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "scopolamine",
-    "slug": "scopolamine",
-    "canonicalCompoundId": "scopolamine",
-    "name": "scopolamine",
-    "compoundName": "scopolamine",
-    "canonicalCompoundName": "scopolamine",
-    "hero": "Defines a key pharmacological signal attributed to scopolamine in herbal extracts.",
-    "coreInsight": "scopolamine matters most when cholinergic modulation is used as the primary readout. That makes it more informative than a generic alkaloid label.",
-    "effects": [
-      "[\"nootropic\"]"
-    ],
-    "mechanisms": [
-      "[\"cholinergic modulation\"]"
-    ]
-  },
-  {
-    "id": "scopoletin",
-    "slug": "scopoletin",
-    "canonicalCompoundId": "scopoletin",
-    "name": "scopoletin",
-    "compoundName": "scopoletin",
-    "canonicalCompoundName": "scopoletin",
-    "hero": "Defines a key pharmacological signal attributed to scopoletin in herbal extracts.",
-    "coreInsight": "scopoletin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "scutellarin",
-    "slug": "scutellarin",
-    "canonicalCompoundId": "scutellarin",
-    "name": "scutellarin",
-    "compoundName": "scutellarin",
-    "canonicalCompoundName": "scutellarin",
-    "hero": "Helps define why Skullcap extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, scutellarin helps separate Skullcap extracts from adjacent markers such as Baicalin. That improves standardization decisions.",
-    "effects": [
-      "[\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"]"
-    ]
-  },
-  {
-    "id": "selenium",
-    "slug": "selenium",
-    "canonicalCompoundId": "selenium",
-    "name": "selenium",
-    "compoundName": "selenium",
-    "canonicalCompoundName": "selenium",
-    "hero": "Defines a key pharmacological signal attributed to selenium in herbal extracts.",
-    "coreInsight": "Selenium remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antioxidant\"",
-      "\"hepatoprotective\"]"
-    ],
-    "mechanisms": [
-      "[\"hormone modulation\"]"
-    ]
-  },
-  {
-    "id": "sempervirine",
-    "slug": "sempervirine",
-    "canonicalCompoundId": "sempervirine",
-    "name": "sempervirine",
-    "compoundName": "sempervirine",
-    "canonicalCompoundName": "sempervirine",
-    "hero": "Requires tighter safety interpretation than many adjacent plant compounds.",
-    "coreInsight": "sempervirine needs separate risk review because safety constraints can change its value in formulation.",
-    "effects": [
-      "[\"analgesic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "serotonin",
-    "slug": "serotonin",
-    "canonicalCompoundId": "serotonin",
-    "name": "serotonin",
-    "compoundName": "serotonin",
-    "canonicalCompoundName": "serotonin",
-    "hero": "Defines a key pharmacological signal attributed to serotonin in herbal extracts.",
-    "coreInsight": "serotonin stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antidepressant\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"serotonin modulation\"]"
-    ]
-  },
-  {
-    "id": "serpentine",
-    "slug": "serpentine",
-    "canonicalCompoundId": "serpentine",
-    "name": "serpentine",
-    "compoundName": "serpentine",
-    "canonicalCompoundName": "serpentine",
-    "hero": "Defines a key pharmacological signal attributed to serpentine in herbal extracts.",
-    "coreInsight": "serpentine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "silica",
-    "slug": "silica",
-    "canonicalCompoundId": "silica",
-    "name": "silica",
-    "compoundName": "silica",
-    "canonicalCompoundName": "silica",
-    "hero": "Defines antioxidant activity at the compound level.",
-    "coreInsight": "silica is most useful when a formulation needs a direct antioxidant signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "silybin-a",
-    "slug": "silybin-a",
-    "canonicalCompoundId": "silybin-a",
-    "name": "silybin a",
-    "compoundName": "silybin a",
-    "canonicalCompoundName": "silybin a",
-    "hero": "Delivers anti-inflammatory and antioxidant activity within silibinin A chemistry.",
-    "coreInsight": "For silibinin A, silybin a is most useful as a direct anti-inflammatory signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"",
-      "\"hepatoprotective\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "silybin-b",
-    "slug": "silybin-b",
-    "canonicalCompoundId": "silybin-b",
-    "name": "silybin b",
-    "compoundName": "silybin b",
-    "canonicalCompoundName": "silybin b",
-    "hero": "Helps define why silibinin B extracts perform differently in formulation.",
-    "coreInsight": "silybin b becomes more valuable when silibinin B is standardized by named actives rather than total extract mass.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"",
-      "\"hepatoprotective\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "silychristin",
-    "slug": "silychristin",
-    "canonicalCompoundId": "silychristin",
-    "name": "silychristin",
-    "compoundName": "silychristin",
-    "canonicalCompoundName": "silychristin",
-    "hero": "Defines a key pharmacological signal attributed to silychristin in herbal extracts.",
-    "coreInsight": "Silychristin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "silydianin",
-    "slug": "silydianin",
-    "canonicalCompoundId": "silydianin",
-    "name": "silydianin",
-    "compoundName": "silydianin",
-    "canonicalCompoundName": "silydianin",
-    "hero": "Defines a key pharmacological signal attributed to silydianin in herbal extracts.",
-    "coreInsight": "silydianin remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "silymarin",
-    "slug": "silymarin",
-    "canonicalCompoundId": "silymarin",
-    "name": "silymarin",
-    "compoundName": "silymarin",
-    "canonicalCompoundName": "silymarin",
-    "hero": "Defines a key pharmacological signal attributed to silymarin in herbal extracts.",
-    "coreInsight": "silymarin stays provisional because the evidence behind Milk Thistle does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"antioxidant\"",
-      "\"hepatoprotective\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "silymarin-silibinin",
-    "slug": "silymarin-silibinin",
-    "canonicalCompoundId": "silymarin-silibinin",
-    "name": "silymarin silibinin",
-    "compoundName": "silymarin silibinin",
-    "canonicalCompoundName": "silymarin silibinin",
-    "hero": "Defines a key pharmacological signal attributed to silymarin silibinin in herbal extracts.",
-    "coreInsight": "silymarin silibinin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "sinigrin",
-    "slug": "sinigrin",
-    "canonicalCompoundId": "sinigrin",
-    "name": "sinigrin",
-    "compoundName": "sinigrin",
-    "canonicalCompoundName": "sinigrin",
-    "hero": "Defines a key pharmacological signal attributed to sinigrin in herbal extracts.",
-    "coreInsight": "sinigrin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "sitoindoside-ix",
-    "slug": "sitoindoside-ix",
-    "canonicalCompoundId": "sitoindoside-ix",
-    "name": "sitoindoside ix",
-    "compoundName": "sitoindoside ix",
-    "canonicalCompoundName": "sitoindoside ix",
-    "hero": "Defines neuroprotective and immunomodulatory activity within 27-O-beta-D-glucopyranosyl withaferin A chemistry.",
-    "coreInsight": "For 27-O-beta-D-glucopyranosyl withaferin A, sitoindoside ix is most useful as a direct neuroprotective signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"neuroprotective\"",
-      "\"immunomodulatory\"",
-      "\"hepatoprotective\"]"
-    ],
-    "mechanisms": [
-      "[\"immune signaling modulation\"]"
-    ]
-  },
-  {
-    "id": "sitoindoside-x",
-    "slug": "sitoindoside-x",
-    "canonicalCompoundId": "sitoindoside-x",
-    "name": "sitoindoside x",
-    "compoundName": "sitoindoside x",
-    "canonicalCompoundName": "sitoindoside x",
-    "hero": "Defines a key pharmacological signal attributed to sitoindoside x in herbal extracts.",
-    "coreInsight": "sitoindoside x remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"neuroprotective\"",
-      "\"adaptogenic\"",
-      "\"hepatoprotective\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "skimmianine",
-    "slug": "skimmianine",
-    "canonicalCompoundId": "skimmianine",
-    "name": "skimmianine",
-    "compoundName": "skimmianine",
-    "canonicalCompoundName": "skimmianine",
-    "hero": "Distinguishes skimmianine from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Skimmianine matters because it can be ranked directly against aegeline and related neighbors during compound prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "solamargine",
-    "slug": "solamargine",
-    "canonicalCompoundId": "solamargine",
-    "name": "solamargine",
-    "compoundName": "solamargine",
-    "canonicalCompoundName": "solamargine",
-    "hero": "Defines a key pharmacological signal attributed to solamargine in herbal extracts.",
-    "coreInsight": "solamargine remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "solanine",
-    "slug": "solanine",
-    "canonicalCompoundId": "solanine",
-    "name": "solanine",
-    "compoundName": "solanine",
-    "canonicalCompoundName": "solanine",
-    "hero": "Defines a key pharmacological signal attributed to solanine in herbal extracts.",
-    "coreInsight": "solanine stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "spilanthol",
-    "slug": "spilanthol",
-    "canonicalCompoundId": "spilanthol",
-    "name": "spilanthol",
-    "compoundName": "spilanthol",
-    "canonicalCompoundName": "spilanthol",
-    "hero": "Defines a key pharmacological signal attributed to spilanthol in herbal extracts.",
-    "coreInsight": "spilanthol remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "stachydrine",
-    "slug": "stachydrine",
-    "canonicalCompoundId": "stachydrine",
-    "name": "stachydrine",
-    "compoundName": "stachydrine",
-    "canonicalCompoundName": "stachydrine",
-    "hero": "Defines a key pharmacological signal attributed to stachydrine in herbal extracts.",
-    "coreInsight": "stachydrine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "sulforaphane",
-    "slug": "sulforaphane",
-    "canonicalCompoundId": "sulforaphane",
-    "name": "sulforaphane",
-    "compoundName": "sulforaphane",
-    "canonicalCompoundName": "sulforaphane",
-    "hero": "Sharpens antioxidant activity at the compound level.",
-    "coreInsight": "sulforaphane is most useful when a formulation needs a direct antioxidant signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"Nrf2 activation\"]"
-    ]
-  },
-  {
-    "id": "swertiamarin",
-    "slug": "swertiamarin",
-    "canonicalCompoundId": "swertiamarin",
-    "name": "swertiamarin",
-    "compoundName": "swertiamarin",
-    "canonicalCompoundName": "swertiamarin",
-    "hero": "Defines a key pharmacological signal attributed to swertiamarin in herbal extracts.",
-    "coreInsight": "swertiamarin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "synephrine",
-    "slug": "synephrine",
-    "canonicalCompoundId": "synephrine",
-    "name": "synephrine",
-    "compoundName": "synephrine",
-    "canonicalCompoundName": "synephrine",
-    "hero": "Defines a key pharmacological signal attributed to synephrine in herbal extracts.",
-    "coreInsight": "Synephrine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "tangshenoside-i",
-    "slug": "tangshenoside-i",
-    "canonicalCompoundId": "tangshenoside-i",
-    "name": "tangshenoside i",
-    "compoundName": "tangshenoside i",
-    "canonicalCompoundName": "tangshenoside i",
-    "hero": "Defines a key pharmacological signal attributed to tangshenoside i in herbal extracts.",
-    "coreInsight": "tangshenoside i remains provisional because the evidence behind Codonopsacts as does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"stimulant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "tanshinone-iia",
-    "slug": "tanshinone-iia",
-    "canonicalCompoundId": "tanshinone-iia",
-    "name": "Tanshinone IIA",
-    "compoundName": "Tanshinone IIA",
-    "canonicalCompoundName": "Tanshinone IIA",
-    "hero": "Defines a key pharmacological signal attributed to tanshinone iia in herbal extracts.",
-    "coreInsight": "Tanshinone IIA stays provisional because the evidence behind Danshen does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[\"NF-kB inhibition\"",
-      "\"cardiovascular signaling\"",
-      "\"NF-kB modulation\"",
-      "\"NF-κB modulation\"]"
-    ]
-  },
-  {
-    "id": "taraxasterol",
-    "slug": "taraxasterol",
-    "canonicalCompoundId": "taraxasterol",
-    "name": "taraxasterol",
-    "compoundName": "taraxasterol",
-    "canonicalCompoundName": "taraxasterol",
-    "hero": "Acts as a recognizable chemical marker within Dandelion.",
-    "coreInsight": "Within Dandelion, taraxasterol serves mainly as a phytochemical marker that sharpens chemical identity.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "tartaric-acid",
-    "slug": "tartaric-acid",
-    "canonicalCompoundId": "tartaric-acid",
-    "name": "tartaric acid",
-    "compoundName": "tartaric acid",
-    "canonicalCompoundName": "tartaric acid",
-    "hero": "Helps define why Tamarind extracts perform differently in formulation.",
-    "coreInsight": "tartaric acid becomes more valuable when Tamarind is standardized by named actives rather than total extract mass.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "taspine",
-    "slug": "taspine",
-    "canonicalCompoundId": "taspine",
-    "name": "taspine",
-    "compoundName": "taspine",
-    "canonicalCompoundName": "taspine",
-    "hero": "Defines a key pharmacological signal attributed to taspine in herbal extracts.",
-    "coreInsight": "taspine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "taurine",
-    "slug": "taurine",
-    "canonicalCompoundId": "taurine",
-    "name": "taurine",
-    "compoundName": "taurine",
-    "canonicalCompoundName": "taurine",
-    "hero": "Defines a key pharmacological signal attributed to taurine in herbal extracts.",
-    "coreInsight": "taurine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"diuretic\"",
-      "\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"]"
-    ]
-  },
-  {
-    "id": "tenuifolin",
-    "slug": "tenuifolin",
-    "canonicalCompoundId": "tenuifolin",
-    "name": "tenuifolin",
-    "compoundName": "tenuifolin",
-    "canonicalCompoundName": "tenuifolin",
-    "hero": "Defines a key pharmacological signal attributed to tenuifolin in herbal extracts.",
-    "coreInsight": "Tenuifolin remains provisional because the evidence behind polygala does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"nootropic\"",
-      "\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "tephrosin",
-    "slug": "tephrosin",
-    "canonicalCompoundId": "tephrosin",
-    "name": "tephrosin",
-    "compoundName": "tephrosin",
-    "canonicalCompoundName": "tephrosin",
-    "hero": "Defines a key pharmacological signal attributed to tephrosin in herbal extracts.",
-    "coreInsight": "tephrosin remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "terpinen-4-ol",
-    "slug": "terpinen-4-ol",
-    "canonicalCompoundId": "terpinen-4-ol",
-    "name": "terpinen-4-ol",
-    "compoundName": "terpinen-4-ol",
-    "canonicalCompoundName": "terpinen-4-ol",
-    "hero": "Defines a key pharmacological signal attributed to terpinen-4-ol in herbal extracts.",
-    "coreInsight": "terpinen-4-ol stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "terpinyl-acetate",
-    "slug": "terpinyl-acetate",
-    "canonicalCompoundId": "terpinyl-acetate",
-    "name": "terpinyl acetate",
-    "compoundName": "terpinyl acetate",
-    "canonicalCompoundName": "terpinyl acetate",
-    "hero": "Acts as a recognizable chemical marker within Cardamom.",
-    "coreInsight": "Within Cardamom, terpinyl acetate helps define the plant’s chemistry alongside markers such as 8-cineole.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "tetrahydroharmine",
-    "slug": "tetrahydroharmine",
-    "canonicalCompoundId": "tetrahydroharmine",
-    "name": "tetrahydroharmine",
-    "compoundName": "tetrahydroharmine",
-    "canonicalCompoundName": "tetrahydroharmine",
-    "hero": "Defines a key pharmacological signal attributed to tetrahydroharmine in herbal extracts.",
-    "coreInsight": "tetrahydroharmine matters most when serotonin modulation is used as the primary readout. That makes it more informative than a generic other label.",
-    "effects": [
-      "[\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[\"serotonin modulation\"]"
-    ]
-  },
-  {
-    "id": "tetrahydropalmatine",
-    "slug": "tetrahydropalmatine",
-    "canonicalCompoundId": "tetrahydropalmatine",
-    "name": "tetrahydropalmatine",
-    "compoundName": "tetrahydropalmatine",
-    "canonicalCompoundName": "tetrahydropalmatine",
-    "hero": "Helps define why Corydalis extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, tetrahydropalmatine helps separate Corydalis extracts from adjacent markers such as corydaline. That improves standardization decisions.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "tetramethylpyrazine",
-    "slug": "tetramethylpyrazine",
-    "canonicalCompoundId": "tetramethylpyrazine",
-    "name": "tetramethylpyrazine",
-    "compoundName": "tetramethylpyrazine",
-    "canonicalCompoundName": "tetramethylpyrazine",
-    "hero": "Defines a key pharmacological signal attributed to tetramethylpyrazine in herbal extracts.",
-    "coreInsight": "tetramethylpyrazine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "tetrandrine",
-    "slug": "tetrandrine",
-    "canonicalCompoundId": "tetrandrine",
-    "name": "tetrandrine",
-    "compoundName": "tetrandrine",
-    "canonicalCompoundName": "tetrandrine",
-    "hero": "Defines a key pharmacological signal attributed to tetrandrine in herbal extracts.",
-    "coreInsight": "Tetrandrine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"diuretic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "thc",
-    "slug": "thc",
-    "canonicalCompoundId": "thc",
-    "name": "thc",
-    "compoundName": "thc",
-    "canonicalCompoundName": "thc",
-    "hero": "Defines a key pharmacological signal attributed to thc in herbal extracts.",
-    "coreInsight": "thc remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[\"endocannabinoid modulation\"]"
-    ]
-  },
-  {
-    "id": "theanine",
-    "slug": "theanine",
-    "canonicalCompoundId": "theanine",
-    "name": "Theanine",
-    "compoundName": "Theanine",
-    "canonicalCompoundName": "Theanine",
-    "hero": "Defines a key pharmacological signal attributed to theanine in herbal extracts.",
-    "coreInsight": "Theanine stays provisional because the evidence behind Green Tea does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"",
-      "\"calming CNS signaling\"",
-      "\"glutamatergic modulation\"]"
-    ]
-  },
-  {
-    "id": "thebaine",
-    "slug": "thebaine",
-    "canonicalCompoundId": "thebaine",
-    "name": "thebaine",
-    "compoundName": "thebaine",
-    "canonicalCompoundName": "thebaine",
-    "hero": "Defines a key pharmacological signal attributed to thebaine in herbal extracts.",
-    "coreInsight": "thebaine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "theobromine",
-    "slug": "theobromine",
-    "canonicalCompoundId": "theobromine",
-    "name": "theobromine",
-    "compoundName": "theobromine",
-    "canonicalCompoundName": "theobromine",
-    "hero": "Focuses oxidative stress reduction in theobromine.",
-    "coreInsight": "theobromine matters most when oxidative stress reduction is used as the primary readout. That makes it more informative than a generic tannins label.",
-    "effects": [
-      "[\"stimulant\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "theophylline",
-    "slug": "theophylline",
-    "canonicalCompoundId": "theophylline",
-    "name": "theophylline",
-    "compoundName": "theophylline",
-    "canonicalCompoundName": "theophylline",
-    "hero": "Drives stimulant and antioxidant activity within Guarana chemistry.",
-    "coreInsight": "For Guarana, theophylline is most useful as a direct stimulant signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"stimulant\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "thevetin-a",
-    "slug": "thevetin-a",
-    "canonicalCompoundId": "thevetin-a",
-    "name": "thevetin a",
-    "compoundName": "thevetin a",
-    "canonicalCompoundName": "thevetin a",
-    "hero": "Defines a key pharmacological signal attributed to thevetin a in herbal extracts.",
-    "coreInsight": "thevetin a remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "thevetin-b",
-    "slug": "thevetin-b",
-    "canonicalCompoundId": "thevetin-b",
-    "name": "thevetin b",
-    "compoundName": "thevetin b",
-    "canonicalCompoundName": "thevetin b",
-    "hero": "Defines a key pharmacological signal attributed to thevetin b in herbal extracts.",
-    "coreInsight": "Thevetin b remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "thujone",
-    "slug": "thujone",
-    "canonicalCompoundId": "thujone",
-    "name": "thujone",
-    "compoundName": "thujone",
-    "canonicalCompoundName": "thujone",
-    "hero": "Defines a key pharmacological signal attributed to thujone in herbal extracts.",
-    "coreInsight": "thujone remains provisional because the evidence behind Mugwort does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "thymol",
-    "slug": "thymol",
-    "canonicalCompoundId": "thymol",
-    "name": "thymol",
-    "compoundName": "thymol",
-    "canonicalCompoundName": "thymol",
-    "hero": "Defines a key pharmacological signal attributed to thymol in herbal extracts.",
-    "coreInsight": "thymol stays provisional because the evidence behind Ajwain does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "thymoquinone",
-    "slug": "thymoquinone",
-    "canonicalCompoundId": "thymoquinone",
-    "name": "thymoquinone",
-    "compoundName": "thymoquinone",
-    "canonicalCompoundName": "thymoquinone",
-    "hero": "Defines a key pharmacological signal attributed to thymoquinone in herbal extracts.",
-    "coreInsight": "thymoquinone remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "timosaponin-aiii",
-    "slug": "timosaponin-aiii",
-    "canonicalCompoundId": "timosaponin-aiii",
-    "name": "timosaponin aiii",
-    "compoundName": "timosaponin aiii",
-    "canonicalCompoundName": "timosaponin aiii",
-    "hero": "Carries immunomodulatory activity at the compound level.",
-    "coreInsight": "timosaponin aiii is most useful when a formulation needs a direct immunomodulatory signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"immunomodulatory\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "tocopherols",
-    "slug": "tocopherols",
-    "canonicalCompoundId": "tocopherols",
-    "name": "tocopherols",
-    "compoundName": "tocopherols",
-    "canonicalCompoundName": "tocopherols",
-    "hero": "Focuses antioxidant and adaptogenic activity within Roselle Seed chemistry.",
-    "coreInsight": "For Roselle Seed, tocopherols is most useful as a direct antioxidant signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"antioxidant\"",
-      "\"adaptogenic\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "trans-cinnamoylcocaine",
-    "slug": "trans-cinnamoylcocaine",
-    "canonicalCompoundId": "trans-cinnamoylcocaine",
-    "name": "trans-cinnamoylcocaine",
-    "compoundName": "trans-cinnamoylcocaine",
-    "canonicalCompoundName": "trans-cinnamoylcocaine",
-    "hero": "Defines a key pharmacological signal attributed to trans-cinnamoylcocaine in herbal extracts.",
-    "coreInsight": "trans-cinnamoylcocaine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "trans-tiliroside",
-    "slug": "trans-tiliroside",
-    "canonicalCompoundId": "trans-tiliroside",
-    "name": "trans-tiliroside",
-    "compoundName": "trans-tiliroside",
-    "canonicalCompoundName": "trans-tiliroside",
-    "hero": "Distinguishes trans-tiliroside from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Trans-tiliroside matters because it can be ranked directly against vitamin c and related neighbors during compound prioritization.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "triandrin",
-    "slug": "triandrin",
-    "canonicalCompoundId": "triandrin",
-    "name": "triandrin",
-    "compoundName": "triandrin",
-    "canonicalCompoundName": "triandrin",
-    "hero": "Defines a key pharmacological signal attributed to triandrin in herbal extracts.",
-    "coreInsight": "triandrin remains provisional because the evidence behind (E)-triandrin does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"adaptogenic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "trigonelline",
-    "slug": "trigonelline",
-    "canonicalCompoundId": "trigonelline",
-    "name": "trigonelline",
-    "compoundName": "trigonelline",
-    "canonicalCompoundName": "trigonelline",
-    "hero": "Defines a key pharmacological signal attributed to trigonelline in herbal extracts.",
-    "coreInsight": "trigonelline stays provisional because the evidence behind Coffee Cherry does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"stimulant\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "triketones-leptospermone",
-    "slug": "triketones-leptospermone",
-    "canonicalCompoundId": "triketones-leptospermone",
-    "name": "triketones leptospermone",
-    "compoundName": "triketones leptospermone",
-    "canonicalCompoundName": "triketones leptospermone",
-    "hero": "Defines a key pharmacological signal attributed to triketones leptospermone in herbal extracts.",
-    "coreInsight": "triketones leptospermone remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "tropacocaine",
-    "slug": "tropacocaine",
-    "canonicalCompoundId": "tropacocaine",
-    "name": "tropacocaine",
-    "compoundName": "tropacocaine",
-    "canonicalCompoundName": "tropacocaine",
-    "hero": "Defines a key pharmacological signal attributed to tropacocaine in herbal extracts.",
-    "coreInsight": "tropacocaine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "tryptamine",
-    "slug": "tryptamine",
-    "canonicalCompoundId": "tryptamine",
-    "name": "tryptamine",
-    "compoundName": "tryptamine",
-    "canonicalCompoundName": "tryptamine",
-    "hero": "Carries hallucinogenic and antidepressant activity at the compound level.",
-    "coreInsight": "tryptamine is most useful when a formulation needs a direct hallucinogenic signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"hallucinogenic\"",
-      "\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[\"serotonin modulation\"]"
-    ]
-  },
-  {
-    "id": "tryptanthrin",
-    "slug": "tryptanthrin",
-    "canonicalCompoundId": "tryptanthrin",
-    "name": "tryptanthrin",
-    "compoundName": "tryptanthrin",
-    "canonicalCompoundName": "tryptanthrin",
-    "hero": "Helps define why Isatis extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, tryptanthrin helps separate Isatis extracts from adjacent markers such as indirubin. That improves standardization decisions.",
-    "effects": [
-      "[\"immunomodulatory\"]"
-    ],
-    "mechanisms": [
-      "[\"immune signaling modulation\"]"
-    ]
-  },
-  {
-    "id": "turmerone",
-    "slug": "turmerone",
-    "canonicalCompoundId": "turmerone",
-    "name": "turmerone",
-    "compoundName": "turmerone",
-    "canonicalCompoundName": "turmerone",
-    "hero": "Defines a key pharmacological signal attributed to turmerone in herbal extracts.",
-    "coreInsight": "Turmerone remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "tussilagone",
-    "slug": "tussilagone",
-    "canonicalCompoundId": "tussilagone",
-    "name": "tussilagone",
-    "compoundName": "tussilagone",
-    "canonicalCompoundName": "tussilagone",
-    "hero": "Defines a key pharmacological signal attributed to tussilagone in herbal extracts.",
-    "coreInsight": "tussilagone remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "tylophorine",
-    "slug": "tylophorine",
-    "canonicalCompoundId": "tylophorine",
-    "name": "tylophorine",
-    "compoundName": "tylophorine",
-    "canonicalCompoundName": "tylophorine",
-    "hero": "Defines a key pharmacological signal attributed to tylophorine in herbal extracts.",
-    "coreInsight": "tylophorine stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "tyrosol",
-    "slug": "tyrosol",
-    "canonicalCompoundId": "tyrosol",
-    "name": "Tyrosol",
-    "compoundName": "Tyrosol",
-    "canonicalCompoundName": "Tyrosol",
-    "hero": "Acts as a recognizable chemical marker within 2-(4-hydroxyphenyl)ethanol.",
-    "coreInsight": "Within 2-(4-hydroxyphenyl)ethanol, Tyrosol helps define the plant’s chemistry alongside markers such as Salidroside.",
-    "effects": [
-      "[\"antioxidant\"",
-      "\"hepatoprotective\"]"
-    ],
-    "mechanisms": [
-      "[\"Nrf2 activation\"]"
-    ]
-  },
-  {
-    "id": "umbelliferone",
-    "slug": "umbelliferone",
-    "canonicalCompoundId": "umbelliferone",
-    "name": "umbelliferone",
-    "compoundName": "umbelliferone",
-    "canonicalCompoundName": "umbelliferone",
-    "hero": "Defines a key pharmacological signal attributed to umbelliferone in herbal extracts.",
-    "coreInsight": "umbelliferone remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "umckalin",
-    "slug": "umckalin",
-    "canonicalCompoundId": "umckalin",
-    "name": "umckalin",
-    "compoundName": "umckalin",
-    "canonicalCompoundName": "umckalin",
-    "hero": "Delivers antioxidant activity at the compound level.",
-    "coreInsight": "umckalin is most useful when a formulation needs a direct antioxidant signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "unresolved-herb-level-entry",
-    "slug": "unresolved-herb-level-entry",
-    "canonicalCompoundId": "unresolved-herb-level-entry",
-    "name": "unresolved herb level entry",
-    "compoundName": "unresolved herb level entry",
-    "canonicalCompoundName": "unresolved herb level entry",
-    "hero": "Defines a key pharmacological signal attributed to unresolved herb level entry in herbal extracts.",
-    "coreInsight": "unresolved herb level entry remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress reduction\"]"
-    ]
-  },
-  {
-    "id": "uridine-monophosphate",
-    "slug": "uridine-monophosphate",
-    "canonicalCompoundId": "uridine-monophosphate",
-    "name": "uridine monophosphate",
-    "compoundName": "uridine monophosphate",
-    "canonicalCompoundName": "uridine monophosphate",
-    "hero": "Defines a key pharmacological signal attributed to uridine monophosphate in herbal extracts.",
-    "coreInsight": "Uridine monophosphate remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"nootropic\"]"
-    ],
-    "mechanisms": [
-      "[]"
+    "foundIn": [
+      "PubMed",
+      "review literature"
     ]
   },
   {
@@ -9767,325 +536,82 @@
     "name": "Ursolic acid",
     "compoundName": "Ursolic acid",
     "canonicalCompoundName": "Ursolic acid",
-    "hero": "Defines a key pharmacological signal attributed to ursolic acid in herbal extracts.",
-    "coreInsight": "Ursolic acid remains provisional because the evidence behind Holy Basil does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"adaptogenic\"",
-      "\"muscle-relaxant\"",
-      "\"antispasmodic\"]"
-    ],
     "mechanisms": [
-      "[\"NF-kB inhibition\"",
-      "\"AMPK activation\"",
-      "\"NF-kB modulation\"",
-      "\"NF-κB modulation\"]"
+      "NF-κB inhibition",
+      "STAT3 inhibition",
+      "AMPK activation",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "PubMed",
+      "review literature"
     ]
   },
   {
-    "id": "uscharin",
-    "slug": "uscharin",
-    "canonicalCompoundId": "uscharin",
-    "name": "uscharin",
-    "compoundName": "uscharin",
-    "canonicalCompoundName": "uscharin",
-    "hero": "Defines a key pharmacological signal attributed to uscharin in herbal extracts.",
-    "coreInsight": "uscharin stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
+    "id": "oleanolic-acid",
+    "slug": "oleanolic-acid",
+    "canonicalCompoundId": "oleanolic-acid",
+    "name": "Oleanolic acid",
+    "compoundName": "Oleanolic acid",
+    "canonicalCompoundName": "Oleanolic acid",
     "mechanisms": [
-      "[]"
+      "Nrf2 activation",
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "PubMed",
+      "review literature"
     ]
   },
   {
-    "id": "usnic-acid",
-    "slug": "usnic-acid",
-    "canonicalCompoundId": "usnic-acid",
-    "name": "usnic acid",
-    "compoundName": "usnic acid",
-    "canonicalCompoundName": "usnic acid",
-    "hero": "Defines a key pharmacological signal attributed to usnic acid in herbal extracts.",
-    "coreInsight": "usnic acid remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
+    "id": "asiaticoside",
+    "slug": "asiaticoside",
+    "canonicalCompoundId": "asiaticoside",
+    "name": "Asiaticoside",
+    "compoundName": "Asiaticoside",
+    "canonicalCompoundName": "Asiaticoside",
     "mechanisms": [
-      "[]"
+      "TGF-β signaling modulation",
+      "MAPK pathway modulation",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "PubMed",
+      "review literature"
     ]
   },
   {
-    "id": "valeranone",
-    "slug": "valeranone",
-    "canonicalCompoundId": "valeranone",
-    "name": "valeranone",
-    "compoundName": "valeranone",
-    "canonicalCompoundName": "valeranone",
-    "hero": "Defines a key pharmacological signal attributed to valeranone in herbal extracts.",
-    "coreInsight": "valeranone remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
+    "id": "madecassoside",
+    "slug": "madecassoside",
+    "canonicalCompoundId": "madecassoside",
+    "name": "Madecassoside",
+    "compoundName": "Madecassoside",
+    "canonicalCompoundName": "Madecassoside",
     "mechanisms": [
-      "[]"
+      "NF-κB inhibition",
+      "TGF-β signaling modulation",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "PubMed",
+      "review literature"
     ]
   },
   {
-    "id": "valerenal",
-    "slug": "valerenal",
-    "canonicalCompoundId": "valerenal",
-    "name": "valerenal",
-    "compoundName": "valerenal",
-    "canonicalCompoundName": "valerenal",
-    "hero": "Defines a key pharmacological signal attributed to valerenal in herbal extracts.",
-    "coreInsight": "valerenal remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
+    "id": "bacoside-a",
+    "slug": "bacoside-a",
+    "canonicalCompoundId": "bacoside-a",
+    "name": "Bacoside A",
+    "compoundName": "Bacoside A",
+    "canonicalCompoundName": "Bacoside A",
     "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "valerenic-acid",
-    "slug": "valerenic-acid",
-    "canonicalCompoundId": "valerenic-acid",
-    "name": "valerenic acid",
-    "compoundName": "valerenic acid",
-    "canonicalCompoundName": "valerenic acid",
-    "hero": "Helps define why Valerian extracts perform differently in formulation.",
-    "coreInsight": "valerenic acid becomes more valuable when Valerian is standardized by named actives rather than total extract mass.",
-    "effects": [
-      "[\"anxiolytic\"]"
+      "cholinergic modulation",
+      "ERK pathway modulation"
     ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"]"
-    ]
-  },
-  {
-    "id": "valerenol",
-    "slug": "valerenol",
-    "canonicalCompoundId": "valerenol",
-    "name": "valerenol",
-    "compoundName": "valerenol",
-    "canonicalCompoundName": "valerenol",
-    "hero": "Defines a key pharmacological signal attributed to valerenol in herbal extracts.",
-    "coreInsight": "Valerenol remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"]"
-    ]
-  },
-  {
-    "id": "valerian-valerenic-acid",
-    "slug": "valerian-valerenic-acid",
-    "canonicalCompoundId": "valerian-valerenic-acid",
-    "name": "valerian valerenic acid",
-    "compoundName": "valerian valerenic acid",
-    "canonicalCompoundName": "valerian valerenic acid",
-    "hero": "Defines a key pharmacological signal attributed to valerian valerenic acid in herbal extracts.",
-    "coreInsight": "valerian valerenic acid remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"]"
-    ]
-  },
-  {
-    "id": "valtrate",
-    "slug": "valtrate",
-    "canonicalCompoundId": "valtrate",
-    "name": "valtrate",
-    "compoundName": "valtrate",
-    "canonicalCompoundName": "valtrate",
-    "hero": "Defines a key pharmacological signal attributed to valtrate in herbal extracts.",
-    "coreInsight": "valtrate stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "vanillin",
-    "slug": "vanillin",
-    "canonicalCompoundId": "vanillin",
-    "name": "vanillin",
-    "compoundName": "vanillin",
-    "canonicalCompoundName": "vanillin",
-    "hero": "Defines a key pharmacological signal attributed to vanillin in herbal extracts.",
-    "coreInsight": "vanillin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "vasicine",
-    "slug": "vasicine",
-    "canonicalCompoundId": "vasicine",
-    "name": "Vasicine",
-    "compoundName": "Vasicine",
-    "canonicalCompoundName": "Vasicine",
-    "hero": "Defines a key pharmacological signal attributed to vasicine in herbal extracts.",
-    "coreInsight": "Vasicine matters most when bronchodilation support is used as the primary readout. That makes it more informative than a generic Alkaloid label.",
-    "effects": [
-      "[\"antispasmodic\"",
-      "\"stimulant\"]"
-    ],
-    "mechanisms": [
-      "[\"bronchodilation support\"]"
-    ]
-  },
-  {
-    "id": "vasicinone",
-    "slug": "vasicinone",
-    "canonicalCompoundId": "vasicinone",
-    "name": "vasicinone",
-    "compoundName": "vasicinone",
-    "canonicalCompoundName": "vasicinone",
-    "hero": "Defines a key pharmacological signal attributed to vasicinone in herbal extracts.",
-    "coreInsight": "vasicinone remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "verbascoside",
-    "slug": "verbascoside",
-    "canonicalCompoundId": "verbascoside",
-    "name": "verbascoside",
-    "compoundName": "verbascoside",
-    "canonicalCompoundName": "verbascoside",
-    "hero": "Helps define why Lemon Verbena extracts perform differently in formulation.",
-    "coreInsight": "verbascoside becomes more valuable when Lemon Verbena is standardized by named actives rather than total extract mass.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "vicine",
-    "slug": "vicine",
-    "canonicalCompoundId": "vicine",
-    "name": "vicine",
-    "compoundName": "vicine",
-    "canonicalCompoundName": "vicine",
-    "hero": "Defines a key pharmacological signal attributed to vicine in herbal extracts.",
-    "coreInsight": "Vicine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "vincamine",
-    "slug": "vincamine",
-    "canonicalCompoundId": "vincamine",
-    "name": "vincamine",
-    "compoundName": "vincamine",
-    "canonicalCompoundName": "vincamine",
-    "hero": "Defines a key pharmacological signal attributed to vincamine in herbal extracts.",
-    "coreInsight": "vincamine remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "viscotoxin",
-    "slug": "viscotoxin",
-    "canonicalCompoundId": "viscotoxin",
-    "name": "viscotoxin",
-    "compoundName": "viscotoxin",
-    "canonicalCompoundName": "viscotoxin",
-    "hero": "Defines a key pharmacological signal attributed to viscotoxin in herbal extracts.",
-    "coreInsight": "viscotoxin stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "vitamin-c",
-    "slug": "vitamin-c",
-    "canonicalCompoundId": "vitamin-c",
-    "name": "vitamin c",
-    "compoundName": "vitamin c",
-    "canonicalCompoundName": "vitamin c",
-    "hero": "Acts as a recognizable chemical marker within Rose Hips.",
-    "coreInsight": "Within Rose Hips, vitamin c helps define the plant’s chemistry alongside markers such as trans-tiliroside.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ]
-  },
-  {
-    "id": "vitamin-d",
-    "slug": "vitamin-d",
-    "canonicalCompoundId": "vitamin-d",
-    "name": "vitamin d",
-    "compoundName": "vitamin d",
-    "canonicalCompoundName": "vitamin d",
-    "hero": "Anchors after metabolic activation in vitamin d.",
-    "coreInsight": "vitamin d matters most when after metabolic activation is used as the primary readout. That makes it more informative than a generic secosteroid label.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[\"After metabolic activation\"]"
-    ]
-  },
-  {
-    "id": "vitexin",
-    "slug": "vitexin",
-    "canonicalCompoundId": "vitexin",
-    "name": "vitexin",
-    "compoundName": "vitexin",
-    "canonicalCompoundName": "vitexin",
-    "hero": "Concentrates anxiolytic activity at the compound level.",
-    "coreInsight": "vitexin is most useful when a formulation needs a direct anxiolytic signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"",
-      "\"mild MAO-A inhibition proposed.\"]"
-    ]
-  },
-  {
-    "id": "voacangine",
-    "slug": "voacangine",
-    "canonicalCompoundId": "voacangine",
-    "name": "voacangine",
-    "compoundName": "voacangine",
-    "canonicalCompoundName": "voacangine",
-    "hero": "Defines a key pharmacological signal attributed to voacangine in herbal extracts.",
-    "coreInsight": "voacangine remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
+    "foundIn": [
+      "PubMed",
+      "review literature"
     ]
   },
   {
@@ -10095,18 +621,14 @@
     "name": "Withaferin A",
     "compoundName": "Withaferin A",
     "canonicalCompoundName": "Withaferin A",
-    "hero": "Distinguishes Withaferin A from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Withaferin a matters because it can be ranked directly against withanolide a and related neighbors during compound prioritization.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"muscle-relaxant\"",
-      "\"hepatoprotective\"]"
-    ],
     "mechanisms": [
-      "[\"HSP90 modulation\"",
-      "\"vimentin modulation\"",
-      "\"IKKbeta modulation\"",
-      "\"NF-kB inhibition\"]"
+      "NF-κB inhibition",
+      "HSP90 inhibition",
+      "apoptosis pathway modulation"
+    ],
+    "foundIn": [
+      "PubMed",
+      "review literature"
     ]
   },
   {
@@ -10116,287 +638,3098 @@
     "name": "Withanolide A",
     "compoundName": "Withanolide A",
     "canonicalCompoundName": "Withanolide A",
-    "hero": "Defines a key pharmacological signal attributed to withanolide a in herbal extracts.",
-    "coreInsight": "Withanolide A remains provisional because the evidence behind Ashwagandha does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"neuroprotective\"",
-      "\"adaptogenic\"",
-      "\"anti-inflammatory\"",
-      "\"antioxidant\"]"
-    ],
     "mechanisms": [
-      "[\"neuroprotective signaling\"",
-      "\"stress-response modulation\"]"
+      "PI3K/Akt modulation",
+      "cholinergic modulation"
+    ],
+    "foundIn": [
+      "PubMed",
+      "review literature"
     ]
   },
   {
-    "id": "withanolide-d",
-    "slug": "withanolide-d",
-    "canonicalCompoundId": "withanolide-d",
-    "name": "withanolide d",
-    "compoundName": "withanolide d",
-    "canonicalCompoundName": "withanolide d",
-    "hero": "Defines a key pharmacological signal attributed to withanolide d in herbal extracts.",
-    "coreInsight": "withanolide d stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"adaptogenic\"",
-      "\"anti-inflammatory\"]"
-    ],
+    "id": "piperlongumine",
+    "slug": "piperlongumine",
+    "canonicalCompoundId": "piperlongumine",
+    "name": "Piperlongumine",
+    "compoundName": "Piperlongumine",
+    "canonicalCompoundName": "Piperlongumine",
     "mechanisms": [
-      "[]"
+      "ROS-mediated signaling modulation",
+      "STAT3 inhibition",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "PubMed",
+      "review literature"
     ]
   },
   {
-    "id": "withanolides-withaferin-a",
-    "slug": "withanolides-withaferin-a",
-    "canonicalCompoundId": "withanolides-withaferin-a",
-    "name": "withanolides withaferin a",
-    "compoundName": "withanolides withaferin a",
-    "canonicalCompoundName": "withanolides withaferin a",
-    "hero": "Focuses adaptogenic and anti-inflammatory activity at the compound level.",
-    "coreInsight": "withanolides withaferin a is most useful when a formulation needs a direct adaptogenic signal instead of broad phytochemical coverage.",
-    "effects": [
-      "[\"adaptogenic\"",
-      "\"anti-inflammatory\"]"
-    ],
+    "id": "quercetin",
+    "slug": "quercetin",
+    "canonicalCompoundId": "quercetin",
+    "name": "Quercetin",
+    "compoundName": "Quercetin",
+    "canonicalCompoundName": "Quercetin",
     "mechanisms": [
-      "[]"
+      "NF-κB inhibition",
+      "PI3K/Akt modulation",
+      "Nrf2 activation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
-    "id": "withanone",
-    "slug": "withanone",
-    "canonicalCompoundId": "withanone",
-    "name": "withanone",
-    "compoundName": "withanone",
-    "canonicalCompoundName": "withanone",
-    "hero": "Drives adaptogenic and nootropic activity within WTHN chemistry.",
-    "coreInsight": "For WTHN, withanone is most useful as a direct adaptogenic signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"adaptogenic\"",
-      "\"nootropic\"]"
-    ],
+    "id": "kaempferol",
+    "slug": "kaempferol",
+    "canonicalCompoundId": "kaempferol",
+    "name": "Kaempferol",
+    "compoundName": "Kaempferol",
+    "canonicalCompoundName": "Kaempferol",
     "mechanisms": [
-      "[]"
+      "PI3K/Akt modulation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
-    "id": "withanoside-iv",
-    "slug": "withanoside-iv",
-    "canonicalCompoundId": "withanoside-iv",
-    "name": "Withanoside IV",
-    "compoundName": "Withanoside IV",
-    "canonicalCompoundName": "Withanoside IV",
-    "hero": "Anchors neuroprotective and hepatoprotective activity within Ashwagandha chemistry.",
-    "coreInsight": "For Ashwagandha, Withanoside IV is most useful as a direct neuroprotective signal rather than a diffuse whole-herb claim.",
-    "effects": [
-      "[\"neuroprotective\"",
-      "\"hepatoprotective\"]"
-    ],
+    "id": "myricetin",
+    "slug": "myricetin",
+    "canonicalCompoundId": "myricetin",
+    "name": "Myricetin",
+    "compoundName": "Myricetin",
+    "canonicalCompoundName": "Myricetin",
     "mechanisms": [
-      "[]"
+      "MAPK pathway modulation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
-    "id": "withanoside-v",
-    "slug": "withanoside-v",
-    "canonicalCompoundId": "withanoside-v",
-    "name": "Withanoside V",
-    "compoundName": "Withanoside V",
-    "canonicalCompoundName": "Withanoside V",
-    "hero": "Helps define why Ashwagandha extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, Withanoside V helps separate Ashwagandha extracts from adjacent markers such as Withaferin A. That improves standardization decisions.",
-    "effects": [
-      "[\"neuroprotective\"",
-      "\"adaptogenic\"",
-      "\"hepatoprotective\"]"
-    ],
+    "id": "apigenin",
+    "slug": "apigenin",
+    "canonicalCompoundId": "apigenin",
+    "name": "Apigenin",
+    "compoundName": "Apigenin",
+    "canonicalCompoundName": "Apigenin",
     "mechanisms": [
-      "[]"
+      "GABA-A modulation",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
-    "id": "wogonin",
-    "slug": "wogonin",
-    "canonicalCompoundId": "wogonin",
-    "name": "wogonin",
-    "compoundName": "wogonin",
-    "canonicalCompoundName": "wogonin",
-    "hero": "Distinguishes wogonin from broader phytochemical classes through a more specific activity signal.",
-    "coreInsight": "Wogonin matters because it can be ranked directly against baicalin and related neighbors during compound prioritization.",
-    "effects": [
-      "[\"anxiolytic\"]"
-    ],
+    "id": "luteolin",
+    "slug": "luteolin",
+    "canonicalCompoundId": "luteolin",
+    "name": "Luteolin",
+    "compoundName": "Luteolin",
+    "canonicalCompoundName": "Luteolin",
     "mechanisms": [
-      "[\"GABA-A modulation\"]"
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
-    "id": "wogonoside",
-    "slug": "wogonoside",
-    "canonicalCompoundId": "wogonoside",
-    "name": "Wogonoside",
-    "compoundName": "Wogonoside",
-    "canonicalCompoundName": "Wogonoside",
-    "hero": "Defines a key pharmacological signal attributed to wogonoside in herbal extracts.",
-    "coreInsight": "Wogonoside remains provisional because the evidence behind Chinese Skullcap does not support stronger confidence for thacts as compound yet.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"]"
-    ],
+    "id": "naringenin",
+    "slug": "naringenin",
+    "canonicalCompoundId": "naringenin",
+    "name": "Naringenin",
+    "compoundName": "Naringenin",
+    "canonicalCompoundName": "Naringenin",
     "mechanisms": [
-      "[\"NF-kB inhibition\"",
-      "\"NF-kB modulation\"",
-      "\"NF-κB modulation\"]"
+      "AMPK activation",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
-    "id": "xanthoangelol",
-    "slug": "xanthoangelol",
-    "canonicalCompoundId": "xanthoangelol",
-    "name": "xanthoangelol",
-    "compoundName": "xanthoangelol",
-    "canonicalCompoundName": "xanthoangelol",
-    "hero": "Defines a key pharmacological signal attributed to xanthoangelol in herbal extracts.",
-    "coreInsight": "xanthoangelol stays provisional because the evidence behind Ashitaba does not support stronger confidence for this compound yet.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"]"
-    ],
+    "id": "naringin",
+    "slug": "naringin",
+    "canonicalCompoundId": "naringin",
+    "name": "Naringin",
+    "compoundName": "Naringin",
+    "canonicalCompoundName": "Naringin",
     "mechanisms": [
-      "[\"NF-κB modulation\"]"
+      "AMPK activation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
-    "id": "xanthohumol",
-    "slug": "xanthohumol",
-    "canonicalCompoundId": "xanthohumol",
-    "name": "xanthohumol",
-    "compoundName": "xanthohumol",
-    "canonicalCompoundName": "xanthohumol",
-    "hero": "Acts as a recognizable chemical marker within Hops.",
-    "coreInsight": "Within Hops, xanthohumol helps define the plant’s chemistry alongside markers such as humulone.",
-    "effects": [
-      "[]"
-    ],
+    "id": "rutin",
+    "slug": "rutin",
+    "canonicalCompoundId": "rutin",
+    "name": "Rutin",
+    "compoundName": "Rutin",
+    "canonicalCompoundName": "Rutin",
     "mechanisms": [
-      "[]"
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
-    "id": "xanthotoxol",
-    "slug": "xanthotoxol",
-    "canonicalCompoundId": "xanthotoxol",
-    "name": "xanthotoxol",
-    "compoundName": "xanthotoxol",
-    "canonicalCompoundName": "xanthotoxol",
-    "hero": "Defines a key pharmacological signal attributed to xanthotoxol in herbal extracts.",
-    "coreInsight": "xanthotoxol remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
+    "id": "catechin",
+    "slug": "catechin",
+    "canonicalCompoundId": "catechin",
+    "name": "Catechin",
+    "compoundName": "Catechin",
+    "canonicalCompoundName": "Catechin",
     "mechanisms": [
-      "[]"
+      "AMPK activation",
+      "Nrf2 activation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
     ]
   },
   {
-    "id": "xanthumin",
-    "slug": "xanthumin",
-    "canonicalCompoundId": "xanthumin",
-    "name": "xanthumin",
-    "compoundName": "xanthumin",
-    "canonicalCompoundName": "xanthumin",
-    "hero": "Defines a key pharmacological signal attributed to xanthumin in herbal extracts.",
-    "coreInsight": "xanthumin remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
+    "id": "epicatechin",
+    "slug": "epicatechin",
+    "canonicalCompoundId": "epicatechin",
+    "name": "Epicatechin",
+    "compoundName": "Epicatechin",
+    "canonicalCompoundName": "Epicatechin",
     "mechanisms": [
-      "[]"
+      "PI3K/Akt modulation",
+      "eNOS activation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "epigallocatechin-gallate-egcg",
+    "slug": "epigallocatechin-gallate-egcg",
+    "canonicalCompoundId": "epigallocatechin-gallate-egcg",
+    "name": "Epigallocatechin gallate (EGCG)",
+    "compoundName": "Epigallocatechin gallate (EGCG)",
+    "canonicalCompoundName": "Epigallocatechin gallate (EGCG)",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "theaflavin",
+    "slug": "theaflavin",
+    "canonicalCompoundId": "theaflavin",
+    "name": "Theaflavin",
+    "compoundName": "Theaflavin",
+    "canonicalCompoundName": "Theaflavin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "thearubigin",
+    "slug": "thearubigin",
+    "canonicalCompoundId": "thearubigin",
+    "name": "Thearubigin",
+    "compoundName": "Thearubigin",
+    "canonicalCompoundName": "Thearubigin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "Nrf2 activation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "resveratrol",
+    "slug": "resveratrol",
+    "canonicalCompoundId": "resveratrol",
+    "name": "Resveratrol",
+    "compoundName": "Resveratrol",
+    "canonicalCompoundName": "Resveratrol",
+    "mechanisms": [
+      "SIRT1 activation",
+      "AMPK activation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "pterostilbene",
+    "slug": "pterostilbene",
+    "canonicalCompoundId": "pterostilbene",
+    "name": "Pterostilbene",
+    "compoundName": "Pterostilbene",
+    "canonicalCompoundName": "Pterostilbene",
+    "mechanisms": [
+      "AMPK activation",
+      "PPAR activation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "genistein",
+    "slug": "genistein",
+    "canonicalCompoundId": "genistein",
+    "name": "Genistein",
+    "compoundName": "Genistein",
+    "canonicalCompoundName": "Genistein",
+    "mechanisms": [
+      "estrogen receptor modulation",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "daidzein",
+    "slug": "daidzein",
+    "canonicalCompoundId": "daidzein",
+    "name": "Daidzein",
+    "compoundName": "Daidzein",
+    "canonicalCompoundName": "Daidzein",
+    "mechanisms": [
+      "estrogen receptor modulation",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "formononetin",
+    "slug": "formononetin",
+    "canonicalCompoundId": "formononetin",
+    "name": "Formononetin",
+    "compoundName": "Formononetin",
+    "canonicalCompoundName": "Formononetin",
+    "mechanisms": [
+      "estrogen receptor modulation",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "biochanin-a",
+    "slug": "biochanin-a",
+    "canonicalCompoundId": "biochanin-a",
+    "name": "Biochanin A",
+    "compoundName": "Biochanin A",
+    "canonicalCompoundName": "Biochanin A",
+    "mechanisms": [
+      "estrogen receptor modulation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "ellagic-acid",
+    "slug": "ellagic-acid",
+    "canonicalCompoundId": "ellagic-acid",
+    "name": "Ellagic acid",
+    "compoundName": "Ellagic acid",
+    "canonicalCompoundName": "Ellagic acid",
+    "mechanisms": [
+      "Nrf2 activation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "gallic-acid",
+    "slug": "gallic-acid",
+    "canonicalCompoundId": "gallic-acid",
+    "name": "Gallic acid",
+    "compoundName": "Gallic acid",
+    "canonicalCompoundName": "Gallic acid",
+    "mechanisms": [
+      "MAPK pathway modulation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "ferulic-acid",
+    "slug": "ferulic-acid",
+    "canonicalCompoundId": "ferulic-acid",
+    "name": "Ferulic acid",
+    "compoundName": "Ferulic acid",
+    "canonicalCompoundName": "Ferulic acid",
+    "mechanisms": [
+      "Nrf2 activation",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "chlorogenic-acid",
+    "slug": "chlorogenic-acid",
+    "canonicalCompoundId": "chlorogenic-acid",
+    "name": "Chlorogenic acid",
+    "compoundName": "Chlorogenic acid",
+    "canonicalCompoundName": "Chlorogenic acid",
+    "mechanisms": [
+      "AMPK activation",
+      "glucose metabolism modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "caffeic-acid",
+    "slug": "caffeic-acid",
+    "canonicalCompoundId": "caffeic-acid",
+    "name": "Caffeic acid",
+    "compoundName": "Caffeic acid",
+    "canonicalCompoundName": "Caffeic acid",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "osthole",
+    "slug": "osthole",
+    "canonicalCompoundId": "osthole",
+    "name": "Osthole",
+    "compoundName": "Osthole",
+    "canonicalCompoundName": "Osthole",
+    "mechanisms": [
+      "PDE4 inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "imperatorin",
+    "slug": "imperatorin",
+    "canonicalCompoundId": "imperatorin",
+    "name": "Imperatorin",
+    "compoundName": "Imperatorin",
+    "canonicalCompoundName": "Imperatorin",
+    "mechanisms": [
+      "acetylcholinesterase inhibition",
+      "voltage-gated calcium channel modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "isoimperatorin",
+    "slug": "isoimperatorin",
+    "canonicalCompoundId": "isoimperatorin",
+    "name": "Isoimperatorin",
+    "compoundName": "Isoimperatorin",
+    "canonicalCompoundName": "Isoimperatorin",
+    "mechanisms": [
+      "acetylcholinesterase inhibition",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "psoralen",
+    "slug": "psoralen",
+    "canonicalCompoundId": "psoralen",
+    "name": "Psoralen",
+    "compoundName": "Psoralen",
+    "canonicalCompoundName": "Psoralen",
+    "mechanisms": [
+      "estrogen receptor modulation",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "angelicin",
+    "slug": "angelicin",
+    "canonicalCompoundId": "angelicin",
+    "name": "Angelicin",
+    "compoundName": "Angelicin",
+    "canonicalCompoundName": "Angelicin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "bergapten",
+    "slug": "bergapten",
+    "canonicalCompoundId": "bergapten",
+    "name": "Bergapten",
+    "compoundName": "Bergapten",
+    "canonicalCompoundName": "Bergapten",
+    "mechanisms": [
+      "MAPK pathway modulation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "scopoletin",
+    "slug": "scopoletin",
+    "canonicalCompoundId": "scopoletin",
+    "name": "Scopoletin",
+    "compoundName": "Scopoletin",
+    "canonicalCompoundName": "Scopoletin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "voltage-gated calcium channel modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "esculetin",
+    "slug": "esculetin",
+    "canonicalCompoundId": "esculetin",
+    "name": "Esculetin",
+    "compoundName": "Esculetin",
+    "canonicalCompoundName": "Esculetin",
+    "mechanisms": [
+      "5-lipoxygenase inhibition",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "fraxetin",
+    "slug": "fraxetin",
+    "canonicalCompoundId": "fraxetin",
+    "name": "Fraxetin",
+    "compoundName": "Fraxetin",
+    "canonicalCompoundName": "Fraxetin",
+    "mechanisms": [
+      "Nrf2 activation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "umbelliferone",
+    "slug": "umbelliferone",
+    "canonicalCompoundId": "umbelliferone",
+    "name": "Umbelliferone",
+    "compoundName": "Umbelliferone",
+    "canonicalCompoundName": "Umbelliferone",
+    "mechanisms": [
+      "Nrf2 activation",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "daphnetin",
+    "slug": "daphnetin",
+    "canonicalCompoundId": "daphnetin",
+    "name": "Daphnetin",
+    "compoundName": "Daphnetin",
+    "canonicalCompoundName": "Daphnetin",
+    "mechanisms": [
+      "JAK/STAT inhibition",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "matrine",
+    "slug": "matrine",
+    "canonicalCompoundId": "matrine",
+    "name": "Matrine",
+    "compoundName": "Matrine",
+    "canonicalCompoundName": "Matrine",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "oxymatrine",
+    "slug": "oxymatrine",
+    "canonicalCompoundId": "oxymatrine",
+    "name": "Oxymatrine",
+    "compoundName": "Oxymatrine",
+    "canonicalCompoundName": "Oxymatrine",
+    "mechanisms": [
+      "TGF-β signaling modulation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "tetrandrine",
+    "slug": "tetrandrine",
+    "canonicalCompoundId": "tetrandrine",
+    "name": "Tetrandrine",
+    "compoundName": "Tetrandrine",
+    "canonicalCompoundName": "Tetrandrine",
+    "mechanisms": [
+      "voltage-gated calcium channel modulation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "cepharanthine",
+    "slug": "cepharanthine",
+    "canonicalCompoundId": "cepharanthine",
+    "name": "Cepharanthine",
+    "compoundName": "Cepharanthine",
+    "canonicalCompoundName": "Cepharanthine",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "magnoflorine",
+    "slug": "magnoflorine",
+    "canonicalCompoundId": "magnoflorine",
+    "name": "Magnoflorine",
+    "compoundName": "Magnoflorine",
+    "canonicalCompoundName": "Magnoflorine",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "ligustilide",
+    "slug": "ligustilide",
+    "canonicalCompoundId": "ligustilide",
+    "name": "Ligustilide",
+    "compoundName": "Ligustilide",
+    "canonicalCompoundName": "Ligustilide",
+    "mechanisms": [
+      "voltage-gated calcium channel modulation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "senkyunolide-a",
+    "slug": "senkyunolide-a",
+    "canonicalCompoundId": "senkyunolide-a",
+    "name": "Senkyunolide A",
+    "compoundName": "Senkyunolide A",
+    "canonicalCompoundName": "Senkyunolide A",
+    "mechanisms": [
+      "MAPK pathway modulation",
+      "voltage-gated calcium channel modulation"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "butylidenephthalide",
+    "slug": "butylidenephthalide",
+    "canonicalCompoundId": "butylidenephthalide",
+    "name": "Butylidenephthalide",
+    "compoundName": "Butylidenephthalide",
+    "canonicalCompoundName": "Butylidenephthalide",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "xanthotoxin",
+    "slug": "xanthotoxin",
+    "canonicalCompoundId": "xanthotoxin",
+    "name": "Xanthotoxin",
+    "compoundName": "Xanthotoxin",
+    "canonicalCompoundName": "Xanthotoxin",
+    "mechanisms": [
+      "MAPK pathway modulation",
+      "PDE inhibition"
+    ],
+    "foundIn": [
+      "bulk-ingestion-fast-pass"
+    ]
+  },
+  {
+    "id": "boswellic-acid",
+    "slug": "boswellic-acid",
+    "canonicalCompoundId": "boswellic-acid",
+    "name": "Boswellic acid",
+    "compoundName": "Boswellic acid",
+    "canonicalCompoundName": "Boswellic acid",
+    "mechanisms": [
+      "5-lipoxygenase inhibition",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "Boswellia serrata"
+    ]
+  },
+  {
+    "id": "acetyl-beta-boswellic-acid",
+    "slug": "acetyl-beta-boswellic-acid",
+    "canonicalCompoundId": "acetyl-beta-boswellic-acid",
+    "name": "Acetyl-beta-boswellic acid",
+    "compoundName": "Acetyl-beta-boswellic acid",
+    "canonicalCompoundName": "Acetyl-beta-boswellic acid",
+    "mechanisms": [
+      "5-lipoxygenase inhibition",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "Boswellia serrata"
+    ]
+  },
+  {
+    "id": "11-keto-beta-boswellic-acid",
+    "slug": "11-keto-beta-boswellic-acid",
+    "canonicalCompoundId": "11-keto-beta-boswellic-acid",
+    "name": "11-keto-beta-boswellic acid",
+    "compoundName": "11-keto-beta-boswellic acid",
+    "canonicalCompoundName": "11-keto-beta-boswellic acid",
+    "mechanisms": [
+      "5-lipoxygenase inhibition",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "Boswellia serrata"
+    ]
+  },
+  {
+    "id": "acetyl-11-keto-beta-boswellic-acid",
+    "slug": "acetyl-11-keto-beta-boswellic-acid",
+    "canonicalCompoundId": "acetyl-11-keto-beta-boswellic-acid",
+    "name": "Acetyl-11-keto-beta-boswellic acid",
+    "compoundName": "Acetyl-11-keto-beta-boswellic acid",
+    "canonicalCompoundName": "Acetyl-11-keto-beta-boswellic acid",
+    "mechanisms": [
+      "5-lipoxygenase inhibition",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "Boswellia",
+      "Boswellia carterii",
+      "Boswellia serrata"
+    ]
+  },
+  {
+    "id": "valerenic-acid",
+    "slug": "valerenic-acid",
+    "canonicalCompoundId": "valerenic-acid",
+    "name": "Valerenic acid",
+    "compoundName": "Valerenic acid",
+    "canonicalCompoundName": "Valerenic acid",
+    "mechanisms": [
+      "GABA-A modulation",
+      "voltage-gated calcium channel modulation"
+    ],
+    "foundIn": [
+      "Valerian",
+      "Valeriana officinalis"
+    ]
+  },
+  {
+    "id": "valerenol",
+    "slug": "valerenol",
+    "canonicalCompoundId": "valerenol",
+    "name": "Valerenol",
+    "compoundName": "Valerenol",
+    "canonicalCompoundName": "Valerenol",
+    "mechanisms": [
+      "GABA-A modulation"
+    ],
+    "foundIn": [
+      "Valeriana officinalis"
+    ]
+  },
+  {
+    "id": "kavalactones",
+    "slug": "kavalactones",
+    "canonicalCompoundId": "kavalactones",
+    "name": "Kavalactones",
+    "compoundName": "Kavalactones",
+    "canonicalCompoundName": "Kavalactones",
+    "mechanisms": [
+      "GABA-A modulation",
+      "voltage-gated sodium channel modulation"
+    ],
+    "foundIn": [
+      "Piper methysticum"
+    ]
+  },
+  {
+    "id": "kavain",
+    "slug": "kavain",
+    "canonicalCompoundId": "kavain",
+    "name": "Kavain",
+    "compoundName": "Kavain",
+    "canonicalCompoundName": "Kavain",
+    "mechanisms": [
+      "GABA-A modulation",
+      "voltage-gated sodium channel modulation"
+    ],
+    "foundIn": [
+      "Kava",
+      "Piper methysticum"
     ]
   },
   {
     "id": "yangonin",
     "slug": "yangonin",
     "canonicalCompoundId": "yangonin",
-    "name": "yangonin",
-    "compoundName": "yangonin",
-    "canonicalCompoundName": "yangonin",
-    "hero": "Helps define why Kava extracts perform differently in formulation.",
-    "coreInsight": "In formulation work, yangonin helps separate Kava extracts from adjacent markers such as kavain. That improves standardization decisions.",
-    "effects": [
-      "[\"anxiolytic\"]"
-    ],
+    "name": "Yangonin",
+    "compoundName": "Yangonin",
+    "canonicalCompoundName": "Yangonin",
     "mechanisms": [
-      "[\"GABA-A modulation\"",
-      "\"calcium channel modulation\"",
-      "\"dopamine modulation\"]"
+      "CB1 receptor modulation",
+      "MAO-B inhibition"
+    ],
+    "foundIn": [
+      "Piper methysticum"
     ]
   },
   {
-    "id": "yohimbine",
-    "slug": "yohimbine",
-    "canonicalCompoundId": "yohimbine",
-    "name": "Yohimbine",
-    "compoundName": "Yohimbine",
-    "canonicalCompoundName": "Yohimbine",
-    "hero": "Requires tighter safety interpretation than many adjacent plant compounds.",
-    "coreInsight": "Yohimbine needs separate risk review before it is used as a lead marker. can amplify anxiety, blood-pressure instability, tachycardia, and overstimulation; not appropriate as a casual wellness compound.",
-    "effects": [
-      "[\"stimulant\"]"
-    ],
+    "id": "methysticin",
+    "slug": "methysticin",
+    "canonicalCompoundId": "methysticin",
+    "name": "Methysticin",
+    "compoundName": "Methysticin",
+    "canonicalCompoundName": "Methysticin",
     "mechanisms": [
-      "[\"adrenergic signaling\"",
-      "\"alpha-2 adrenergic antagonism\"]"
+      "GABA-A modulation",
+      "MAO-B inhibition"
+    ],
+    "foundIn": [
+      "Piper methysticum"
     ]
   },
   {
-    "id": "zerumbone",
-    "slug": "zerumbone",
-    "canonicalCompoundId": "zerumbone",
-    "name": "zerumbone",
-    "compoundName": "zerumbone",
-    "canonicalCompoundName": "zerumbone",
-    "hero": "Defines a key pharmacological signal attributed to zerumbone in herbal extracts.",
-    "coreInsight": "zerumbone remains provisional because its evidence base acts as still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"immunomodulatory\"]"
-    ],
+    "id": "valepotriates",
+    "slug": "valepotriates",
+    "canonicalCompoundId": "valepotriates",
+    "name": "Valepotriates",
+    "compoundName": "Valepotriates",
+    "canonicalCompoundName": "Valepotriates",
     "mechanisms": [
-      "[\"immune signaling modulation\"]"
+      "GABA-A modulation",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "Valeriana officinalis"
     ]
   },
   {
-    "id": "zinc",
-    "slug": "zinc",
-    "canonicalCompoundId": "zinc",
-    "name": "zinc",
-    "compoundName": "zinc",
-    "canonicalCompoundName": "zinc",
-    "hero": "Defines a key pharmacological signal attributed to zinc in herbal extracts.",
-    "coreInsight": "zinc stays provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
+    "id": "hyperforin",
+    "slug": "hyperforin",
+    "canonicalCompoundId": "hyperforin",
+    "name": "Hyperforin",
+    "compoundName": "Hyperforin",
+    "canonicalCompoundName": "Hyperforin",
     "mechanisms": [
-      "[]"
+      "TRPC6 channel modulation",
+      "monoamine reuptake inhibition"
+    ],
+    "foundIn": [
+      "St Johns Wort",
+      "Hypericum perforatum"
     ]
   },
   {
-    "id": "zingerone",
-    "slug": "zingerone",
-    "canonicalCompoundId": "zingerone",
-    "name": "zingerone",
-    "compoundName": "zingerone",
-    "canonicalCompoundName": "zingerone",
-    "hero": "Defines a key pharmacological signal attributed to zingerone in herbal extracts.",
-    "coreInsight": "zingerone remains provisional because its evidence base is still too thin for higher-confidence prioritization.",
-    "effects": [
-      "[]"
-    ],
+    "id": "hypericin",
+    "slug": "hypericin",
+    "canonicalCompoundId": "hypericin",
+    "name": "Hypericin",
+    "compoundName": "Hypericin",
+    "canonicalCompoundName": "Hypericin",
     "mechanisms": [
-      "[]"
+      "PKC modulation",
+      "apoptosis pathway modulation (caspase activation)"
+    ],
+    "foundIn": [
+      "Hypericum perforatum",
+      "St Johns Wort"
+    ]
+  },
+  {
+    "id": "aucubin",
+    "slug": "aucubin",
+    "canonicalCompoundId": "aucubin",
+    "name": "Aucubin",
+    "compoundName": "Aucubin",
+    "canonicalCompoundName": "Aucubin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "Plantago major"
+    ]
+  },
+  {
+    "id": "catalpol",
+    "slug": "catalpol",
+    "canonicalCompoundId": "catalpol",
+    "name": "Catalpol",
+    "compoundName": "Catalpol",
+    "canonicalCompoundName": "Catalpol",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "AMPK activation"
+    ],
+    "foundIn": [
+      "Rehmannia Prepared",
+      "Rehmannia glutinosa"
+    ]
+  },
+  {
+    "id": "harpagoside",
+    "slug": "harpagoside",
+    "canonicalCompoundId": "harpagoside",
+    "name": "Harpagoside",
+    "compoundName": "Harpagoside",
+    "canonicalCompoundName": "Harpagoside",
+    "mechanisms": [
+      "COX inhibition",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "Harpagophytum procumbens"
+    ]
+  },
+  {
+    "id": "loganin",
+    "slug": "loganin",
+    "canonicalCompoundId": "loganin",
+    "name": "Loganin",
+    "compoundName": "Loganin",
+    "canonicalCompoundName": "Loganin",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "Nrf2 activation"
+    ],
+    "foundIn": [
+      "Cornus officinalis"
+    ]
+  },
+  {
+    "id": "morroniside",
+    "slug": "morroniside",
+    "canonicalCompoundId": "morroniside",
+    "name": "Morroniside",
+    "compoundName": "Morroniside",
+    "canonicalCompoundName": "Morroniside",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "Nrf2 activation"
+    ],
+    "foundIn": [
+      "Cornus officinalis"
+    ]
+  },
+  {
+    "id": "oleocanthal",
+    "slug": "oleocanthal",
+    "canonicalCompoundId": "oleocanthal",
+    "name": "Oleocanthal",
+    "compoundName": "Oleocanthal",
+    "canonicalCompoundName": "Oleocanthal",
+    "mechanisms": [
+      "COX inhibition",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "Olea europaea"
+    ]
+  },
+  {
+    "id": "oleacein",
+    "slug": "oleacein",
+    "canonicalCompoundId": "oleacein",
+    "name": "Oleacein",
+    "compoundName": "Oleacein",
+    "canonicalCompoundName": "Oleacein",
+    "mechanisms": [
+      "Nrf2 activation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "Olea europaea"
+    ]
+  },
+  {
+    "id": "rosavin",
+    "slug": "rosavin",
+    "canonicalCompoundId": "rosavin",
+    "name": "Rosavin",
+    "compoundName": "Rosavin",
+    "canonicalCompoundName": "Rosavin",
+    "mechanisms": [
+      "AMPK activation",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "Rhodiola Rosea",
+      "Rhodiola"
+    ]
+  },
+  {
+    "id": "rosarin",
+    "slug": "rosarin",
+    "canonicalCompoundId": "rosarin",
+    "name": "Rosarin",
+    "compoundName": "Rosarin",
+    "canonicalCompoundName": "Rosarin",
+    "mechanisms": [
+      "AMPK activation",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "Rhodiola",
+      "Rhodiola Rosea"
+    ]
+  },
+  {
+    "id": "rosin",
+    "slug": "rosin",
+    "canonicalCompoundId": "rosin",
+    "name": "Rosin",
+    "compoundName": "Rosin",
+    "canonicalCompoundName": "Rosin",
+    "mechanisms": [
+      "AMPK activation",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "Rhodiola",
+      "Rhodiola Rosea"
+    ]
+  },
+  {
+    "id": "salidroside",
+    "slug": "salidroside",
+    "canonicalCompoundId": "salidroside",
+    "name": "Salidroside",
+    "compoundName": "Salidroside",
+    "canonicalCompoundName": "Salidroside",
+    "mechanisms": [
+      "AMPK activation",
+      "PI3K/Akt modulation",
+      "Nrf2 activation"
+    ],
+    "foundIn": [
+      "Rhodiola",
+      "Rhodiola Rosea"
+    ]
+  },
+  {
+    "id": "tyrosol",
+    "slug": "tyrosol",
+    "canonicalCompoundId": "tyrosol",
+    "name": "Tyrosol",
+    "compoundName": "Tyrosol",
+    "canonicalCompoundName": "Tyrosol",
+    "mechanisms": [
+      "Nrf2 activation",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "Rhodiola",
+      "Rhodiola Rosea"
+    ]
+  },
+  {
+    "id": "echinacoside",
+    "slug": "echinacoside",
+    "canonicalCompoundId": "echinacoside",
+    "name": "Echinacoside",
+    "compoundName": "Echinacoside",
+    "canonicalCompoundName": "Echinacoside",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "Nrf2 activation"
+    ],
+    "foundIn": [
+      "Cistanche",
+      "Echinacea Purpurea",
+      "Cistanche deserticola"
+    ]
+  },
+  {
+    "id": "acteoside",
+    "slug": "acteoside",
+    "canonicalCompoundId": "acteoside",
+    "name": "Acteoside",
+    "compoundName": "Acteoside",
+    "canonicalCompoundName": "Acteoside",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "Verbena officinalis"
+    ]
+  },
+  {
+    "id": "verbascoside",
+    "slug": "verbascoside",
+    "canonicalCompoundId": "verbascoside",
+    "name": "Verbascoside",
+    "compoundName": "Verbascoside",
+    "canonicalCompoundName": "Verbascoside",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "Lemon Verbena",
+      "Plantago lanceolata"
+    ]
+  },
+  {
+    "id": "forskolin",
+    "slug": "forskolin",
+    "canonicalCompoundId": "forskolin",
+    "name": "Forskolin",
+    "compoundName": "Forskolin",
+    "canonicalCompoundName": "Forskolin",
+    "mechanisms": [
+      "adenylyl cyclase activation",
+      "cAMP signaling"
+    ],
+    "foundIn": [
+      "Coleus forskohlii"
+    ]
+  },
+  {
+    "id": "bacoside-b",
+    "slug": "bacoside-b",
+    "canonicalCompoundId": "bacoside-b",
+    "name": "Bacoside B",
+    "compoundName": "Bacoside B",
+    "canonicalCompoundName": "Bacoside B",
+    "mechanisms": [
+      "cholinergic modulation",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "Bacopa monnieri"
+    ]
+  },
+  {
+    "id": "glycyrrhetinic-acid",
+    "slug": "glycyrrhetinic-acid",
+    "canonicalCompoundId": "glycyrrhetinic-acid",
+    "name": "Glycyrrhetinic acid",
+    "compoundName": "Glycyrrhetinic acid",
+    "canonicalCompoundName": "Glycyrrhetinic acid",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "HMGB1 inhibition"
+    ],
+    "foundIn": [
+      "Glycyrrhiza glabra"
+    ]
+  },
+  {
+    "id": "shikonin",
+    "slug": "shikonin",
+    "canonicalCompoundId": "shikonin",
+    "name": "Shikonin",
+    "compoundName": "Shikonin",
+    "canonicalCompoundName": "Shikonin",
+    "mechanisms": [
+      "PKM2 inhibition",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "Lithospermum erythrorhizon"
+    ]
+  },
+  {
+    "id": "acetylshikonin",
+    "slug": "acetylshikonin",
+    "canonicalCompoundId": "acetylshikonin",
+    "name": "Acetylshikonin",
+    "compoundName": "Acetylshikonin",
+    "canonicalCompoundName": "Acetylshikonin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "apoptosis pathway modulation (caspase activation)"
+    ],
+    "foundIn": [
+      "Lithospermum erythrorhizon"
+    ]
+  },
+  {
+    "id": "plumbagin",
+    "slug": "plumbagin",
+    "canonicalCompoundId": "plumbagin",
+    "name": "Plumbagin",
+    "compoundName": "Plumbagin",
+    "canonicalCompoundName": "Plumbagin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "STAT3 inhibition",
+      "ROS-mediated signaling modulation"
+    ],
+    "foundIn": [
+      "Plumbago zeylanica"
+    ]
+  },
+  {
+    "id": "lawsone",
+    "slug": "lawsone",
+    "canonicalCompoundId": "lawsone",
+    "name": "Lawsone",
+    "compoundName": "Lawsone",
+    "canonicalCompoundName": "Lawsone",
+    "mechanisms": [
+      "MAPK pathway modulation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "Lawsonia inermis"
+    ]
+  },
+  {
+    "id": "embelin",
+    "slug": "embelin",
+    "canonicalCompoundId": "embelin",
+    "name": "Embelin",
+    "compoundName": "Embelin",
+    "canonicalCompoundName": "Embelin",
+    "mechanisms": [
+      "XIAP inhibition",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "Embelia ribes"
+    ]
+  },
+  {
+    "id": "thujone",
+    "slug": "thujone",
+    "canonicalCompoundId": "thujone",
+    "name": "Thujone",
+    "compoundName": "Thujone",
+    "canonicalCompoundName": "Thujone",
+    "mechanisms": [
+      "GABA-A receptor antagonism",
+      "TRP channel modulation"
+    ],
+    "foundIn": [
+      "Mugwort",
+      "Sage",
+      "Artemisia absinthium"
+    ]
+  },
+  {
+    "id": "artemisinin",
+    "slug": "artemisinin",
+    "canonicalCompoundId": "artemisinin",
+    "name": "Artemisinin",
+    "compoundName": "Artemisinin",
+    "canonicalCompoundName": "Artemisinin",
+    "mechanisms": [
+      "ROS-mediated signaling modulation",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "Artemisia annua"
+    ]
+  },
+  {
+    "id": "artesunate",
+    "slug": "artesunate",
+    "canonicalCompoundId": "artesunate",
+    "name": "Artesunate",
+    "compoundName": "Artesunate",
+    "canonicalCompoundName": "Artesunate",
+    "mechanisms": [
+      "ROS-mediated signaling modulation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "Artemisia annua"
+    ]
+  },
+  {
+    "id": "artemisinin-b",
+    "slug": "artemisinin-b",
+    "canonicalCompoundId": "artemisinin-b",
+    "name": "Artemisinin B",
+    "compoundName": "Artemisinin B",
+    "canonicalCompoundName": "Artemisinin B",
+    "mechanisms": [
+      "ROS-mediated signaling modulation",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "Artemisia annua"
+    ]
+  },
+  {
+    "id": "astragaloside-iv",
+    "slug": "astragaloside-iv",
+    "canonicalCompoundId": "astragaloside-iv",
+    "name": "Astragaloside IV",
+    "compoundName": "Astragaloside IV",
+    "canonicalCompoundName": "Astragaloside IV",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "AMPK activation",
+      "TGF-β signaling modulation"
+    ],
+    "foundIn": [
+      "Astragalus",
+      "Astragalus membranaceus"
+    ]
+  },
+  {
+    "id": "calycosin",
+    "slug": "calycosin",
+    "canonicalCompoundId": "calycosin",
+    "name": "Calycosin",
+    "compoundName": "Calycosin",
+    "canonicalCompoundName": "Calycosin",
+    "mechanisms": [
+      "estrogen receptor modulation",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "Astragalus",
+      "Red Clover",
+      "Astragalus membranaceus"
+    ]
+  },
+  {
+    "id": "astragalin",
+    "slug": "astragalin",
+    "canonicalCompoundId": "astragalin",
+    "name": "Astragalin",
+    "compoundName": "Astragalin",
+    "canonicalCompoundName": "Astragalin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "Astragalus membranaceus"
+    ]
+  },
+  {
+    "id": "puerarin",
+    "slug": "puerarin",
+    "canonicalCompoundId": "puerarin",
+    "name": "Puerarin",
+    "compoundName": "Puerarin",
+    "canonicalCompoundName": "Puerarin",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "AMPK activation",
+      "estrogen receptor modulation"
+    ],
+    "foundIn": [
+      "Blue Lotus",
+      "Kudzu",
+      "Pueraria lobata"
+    ]
+  },
+  {
+    "id": "daidzin",
+    "slug": "daidzin",
+    "canonicalCompoundId": "daidzin",
+    "name": "Daidzin",
+    "compoundName": "Daidzin",
+    "canonicalCompoundName": "Daidzin",
+    "mechanisms": [
+      "estrogen receptor modulation",
+      "glucose absorption modulation"
+    ],
+    "foundIn": [
+      "Kudzu",
+      "Pueraria Mirifica",
+      "Pueraria lobata"
+    ]
+  },
+  {
+    "id": "ononin",
+    "slug": "ononin",
+    "canonicalCompoundId": "ononin",
+    "name": "Ononin",
+    "compoundName": "Ononin",
+    "canonicalCompoundName": "Ononin",
+    "mechanisms": [
+      "estrogen receptor modulation",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "Red Clover",
+      "Kudzu",
+      "Pueraria lobata"
+    ]
+  },
+  {
+    "id": "mangiferin",
+    "slug": "mangiferin",
+    "canonicalCompoundId": "mangiferin",
+    "name": "Mangiferin",
+    "compoundName": "Mangiferin",
+    "canonicalCompoundName": "Mangiferin",
+    "mechanisms": [
+      "AMPK activation",
+      "Nrf2 activation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "Mangifera indica"
+    ]
+  },
+  {
+    "id": "mangostin",
+    "slug": "mangostin",
+    "canonicalCompoundId": "mangostin",
+    "name": "Mangostin",
+    "compoundName": "Mangostin",
+    "canonicalCompoundName": "Mangostin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "PI3K/Akt modulation",
+      "apoptosis pathway modulation (caspase activation)"
+    ],
+    "foundIn": [
+      "Garcinia mangostana"
+    ]
+  },
+  {
+    "id": "alpha-mangostin",
+    "slug": "alpha-mangostin",
+    "canonicalCompoundId": "alpha-mangostin",
+    "name": "Alpha-mangostin",
+    "compoundName": "Alpha-mangostin",
+    "canonicalCompoundName": "Alpha-mangostin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "apoptosis pathway modulation (caspase activation)",
+      "STAT3 inhibition"
+    ],
+    "foundIn": [
+      "Mangosteen",
+      "Garcinia mangostana"
+    ]
+  },
+  {
+    "id": "garcinol",
+    "slug": "garcinol",
+    "canonicalCompoundId": "garcinol",
+    "name": "Garcinol",
+    "compoundName": "Garcinol",
+    "canonicalCompoundName": "Garcinol",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "HAT inhibition",
+      "STAT3 inhibition"
+    ],
+    "foundIn": [
+      "Garcinia indica"
+    ]
+  },
+  {
+    "id": "curcumol",
+    "slug": "curcumol",
+    "canonicalCompoundId": "curcumol",
+    "name": "Curcumol",
+    "compoundName": "Curcumol",
+    "canonicalCompoundName": "Curcumol",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "Curcuma zedoaria"
+    ]
+  },
+  {
+    "id": "curdione",
+    "slug": "curdione",
+    "canonicalCompoundId": "curdione",
+    "name": "Curdione",
+    "compoundName": "Curdione",
+    "canonicalCompoundName": "Curdione",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "apoptosis pathway modulation (caspase activation)"
+    ],
+    "foundIn": [
+      "Curcuma zedoaria"
+    ]
+  },
+  {
+    "id": "demethoxycurcumin",
+    "slug": "demethoxycurcumin",
+    "canonicalCompoundId": "demethoxycurcumin",
+    "name": "Demethoxycurcumin",
+    "compoundName": "Demethoxycurcumin",
+    "canonicalCompoundName": "Demethoxycurcumin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "Nrf2 activation"
+    ],
+    "foundIn": [
+      "Turmeric",
+      "Curcuma longa"
+    ]
+  },
+  {
+    "id": "bisdemethoxycurcumin",
+    "slug": "bisdemethoxycurcumin",
+    "canonicalCompoundId": "bisdemethoxycurcumin",
+    "name": "Bisdemethoxycurcumin",
+    "compoundName": "Bisdemethoxycurcumin",
+    "canonicalCompoundName": "Bisdemethoxycurcumin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "Nrf2 activation"
+    ],
+    "foundIn": [
+      "Turmeric",
+      "Curcuma longa"
+    ]
+  },
+  {
+    "id": "paeoniflorin",
+    "slug": "paeoniflorin",
+    "canonicalCompoundId": "paeoniflorin",
+    "name": "Paeoniflorin",
+    "compoundName": "Paeoniflorin",
+    "canonicalCompoundName": "Paeoniflorin",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "White Peony",
+      "Paeonia lactiflora"
+    ]
+  },
+  {
+    "id": "albiflorin",
+    "slug": "albiflorin",
+    "canonicalCompoundId": "albiflorin",
+    "name": "Albiflorin",
+    "compoundName": "Albiflorin",
+    "canonicalCompoundName": "Albiflorin",
+    "mechanisms": [
+      "MAPK pathway modulation",
+      "monoamine reuptake inhibition"
+    ],
+    "foundIn": [
+      "Paeonia lactiflora"
+    ]
+  },
+  {
+    "id": "paeonol",
+    "slug": "paeonol",
+    "canonicalCompoundId": "paeonol",
+    "name": "Paeonol",
+    "compoundName": "Paeonol",
+    "canonicalCompoundName": "Paeonol",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "Nrf2 activation"
+    ],
+    "foundIn": [
+      "Paeonia suffruticosa"
+    ]
+  },
+  {
+    "id": "timosaponin-aiii",
+    "slug": "timosaponin-aiii",
+    "canonicalCompoundId": "timosaponin-aiii",
+    "name": "Timosaponin AIII",
+    "compoundName": "Timosaponin AIII",
+    "canonicalCompoundName": "Timosaponin AIII",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "apoptosis pathway modulation (caspase activation)"
+    ],
+    "foundIn": [
+      "Anemarrhena asphodeloides"
+    ]
+  },
+  {
+    "id": "mangiferin-aglycone",
+    "slug": "mangiferin-aglycone",
+    "canonicalCompoundId": "mangiferin-aglycone",
+    "name": "Mangiferin aglycone",
+    "compoundName": "Mangiferin aglycone",
+    "canonicalCompoundName": "Mangiferin aglycone",
+    "mechanisms": [
+      "AMPK activation",
+      "Nrf2 activation"
+    ],
+    "foundIn": [
+      "Anemarrhena asphodeloides"
+    ]
+  },
+  {
+    "id": "lobeline",
+    "slug": "lobeline",
+    "canonicalCompoundId": "lobeline",
+    "name": "Lobeline",
+    "compoundName": "Lobeline",
+    "canonicalCompoundName": "Lobeline",
+    "mechanisms": [
+      "nicotinic acetylcholine receptor modulation",
+      "dopamine transporter modulation"
+    ],
+    "foundIn": [
+      "Lobelia inflata"
+    ]
+  },
+  {
+    "id": "huperzine-a",
+    "slug": "huperzine-a",
+    "canonicalCompoundId": "huperzine-a",
+    "name": "Huperzine A",
+    "compoundName": "Huperzine A",
+    "canonicalCompoundName": "Huperzine A",
+    "mechanisms": [
+      "acetylcholinesterase inhibition",
+      "NMDA receptor modulation"
+    ],
+    "foundIn": [
+      "Huperzia serrata"
+    ]
+  },
+  {
+    "id": "huperzine-b",
+    "slug": "huperzine-b",
+    "canonicalCompoundId": "huperzine-b",
+    "name": "Huperzine B",
+    "compoundName": "Huperzine B",
+    "canonicalCompoundName": "Huperzine B",
+    "mechanisms": [
+      "acetylcholinesterase inhibition",
+      "NMDA receptor modulation"
+    ],
+    "foundIn": [
+      "Huperzia serrata"
+    ]
+  },
+  {
+    "id": "anatabine",
+    "slug": "anatabine",
+    "canonicalCompoundId": "anatabine",
+    "name": "Anatabine",
+    "compoundName": "Anatabine",
+    "canonicalCompoundName": "Anatabine",
+    "mechanisms": [
+      "nicotinic acetylcholine receptor modulation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "Nicotiana tabacum"
+    ]
+  },
+  {
+    "id": "anabasine",
+    "slug": "anabasine",
+    "canonicalCompoundId": "anabasine",
+    "name": "Anabasine",
+    "compoundName": "Anabasine",
+    "canonicalCompoundName": "Anabasine",
+    "mechanisms": [
+      "nicotinic acetylcholine receptor modulation"
+    ],
+    "foundIn": [
+      "Nicotiana glauca"
+    ]
+  },
+  {
+    "id": "nicotine",
+    "slug": "nicotine",
+    "canonicalCompoundId": "nicotine",
+    "name": "Nicotine",
+    "compoundName": "Nicotine",
+    "canonicalCompoundName": "Nicotine",
+    "mechanisms": [
+      "nicotinic acetylcholine receptor agonism",
+      "dopamine release modulation"
+    ],
+    "foundIn": [
+      "Nicotiana tabacum"
+    ]
+  },
+  {
+    "id": "beta-caryophyllene",
+    "slug": "beta-caryophyllene",
+    "canonicalCompoundId": "beta-caryophyllene",
+    "name": "Beta-caryophyllene",
+    "compoundName": "Beta-caryophyllene",
+    "canonicalCompoundName": "Beta-caryophyllene",
+    "mechanisms": [
+      "CB2 receptor agonism",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "Piper nigrum"
+    ]
+  },
+  {
+    "id": "caryophyllene-oxide",
+    "slug": "caryophyllene-oxide",
+    "canonicalCompoundId": "caryophyllene-oxide",
+    "name": "Caryophyllene oxide",
+    "compoundName": "Caryophyllene oxide",
+    "canonicalCompoundName": "Caryophyllene oxide",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "apoptosis pathway modulation (caspase activation)"
+    ],
+    "foundIn": [
+      "Piper nigrum"
+    ]
+  },
+  {
+    "id": "nerolidol",
+    "slug": "nerolidol",
+    "canonicalCompoundId": "nerolidol",
+    "name": "Nerolidol",
+    "compoundName": "Nerolidol",
+    "canonicalCompoundName": "Nerolidol",
+    "mechanisms": [
+      "GABA-A modulation",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "Cymbopogon citratus"
+    ]
+  },
+  {
+    "id": "farnesol",
+    "slug": "farnesol",
+    "canonicalCompoundId": "farnesol",
+    "name": "Farnesol",
+    "compoundName": "Farnesol",
+    "canonicalCompoundName": "Farnesol",
+    "mechanisms": [
+      "PPAR activation",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "Matricaria chamomilla"
+    ]
+  },
+  {
+    "id": "bisabolol",
+    "slug": "bisabolol",
+    "canonicalCompoundId": "bisabolol",
+    "name": "Bisabolol",
+    "compoundName": "Bisabolol",
+    "canonicalCompoundName": "Bisabolol",
+    "mechanisms": [
+      "COX inhibition",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "Matricaria chamomilla"
+    ]
+  },
+  {
+    "id": "chamazulene",
+    "slug": "chamazulene",
+    "canonicalCompoundId": "chamazulene",
+    "name": "Chamazulene",
+    "compoundName": "Chamazulene",
+    "canonicalCompoundName": "Chamazulene",
+    "mechanisms": [
+      "COX inhibition",
+      "leukotriene pathway modulation"
+    ],
+    "foundIn": [
+      "Chamomile",
+      "Matricaria chamomilla"
+    ]
+  },
+  {
+    "id": "atractylenolide-i",
+    "slug": "atractylenolide-i",
+    "canonicalCompoundId": "atractylenolide-i",
+    "name": "Atractylenolide I",
+    "compoundName": "Atractylenolide I",
+    "canonicalCompoundName": "Atractylenolide I",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "Atractylodes",
+      "Atractylodes macrocephala"
+    ]
+  },
+  {
+    "id": "atractylenolide-ii",
+    "slug": "atractylenolide-ii",
+    "canonicalCompoundId": "atractylenolide-ii",
+    "name": "Atractylenolide II",
+    "compoundName": "Atractylenolide II",
+    "canonicalCompoundName": "Atractylenolide II",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "Atractylodes macrocephala"
+    ]
+  },
+  {
+    "id": "atractylenolide-iii",
+    "slug": "atractylenolide-iii",
+    "canonicalCompoundId": "atractylenolide-iii",
+    "name": "Atractylenolide III",
+    "compoundName": "Atractylenolide III",
+    "canonicalCompoundName": "Atractylenolide III",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "Atractylodes macrocephala"
+    ]
+  },
+  {
+    "id": "beta-elemene",
+    "slug": "beta-elemene",
+    "canonicalCompoundId": "beta-elemene",
+    "name": "Beta-elemene",
+    "compoundName": "Beta-elemene",
+    "canonicalCompoundName": "Beta-elemene",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "apoptosis pathway modulation (caspase activation)"
+    ],
+    "foundIn": [
+      "Curcuma wenyujin"
+    ]
+  },
+  {
+    "id": "elemicin",
+    "slug": "elemicin",
+    "canonicalCompoundId": "elemicin",
+    "name": "Elemicin",
+    "compoundName": "Elemicin",
+    "canonicalCompoundName": "Elemicin",
+    "mechanisms": [
+      "monoamine oxidase inhibition",
+      "TRP channel modulation"
+    ],
+    "foundIn": [
+      "Myristica fragrans"
+    ]
+  },
+  {
+    "id": "myristicin",
+    "slug": "myristicin",
+    "canonicalCompoundId": "myristicin",
+    "name": "Myristicin",
+    "compoundName": "Myristicin",
+    "canonicalCompoundName": "Myristicin",
+    "mechanisms": [
+      "monoamine oxidase inhibition",
+      "acetylcholinesterase inhibition"
+    ],
+    "foundIn": [
+      "Myristica fragrans"
+    ]
+  },
+  {
+    "id": "safrole",
+    "slug": "safrole",
+    "canonicalCompoundId": "safrole",
+    "name": "Safrole",
+    "compoundName": "Safrole",
+    "canonicalCompoundName": "Safrole",
+    "mechanisms": [
+      "TRP channel modulation",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "Ocotea odorifera"
+    ]
+  },
+  {
+    "id": "methyleugenol",
+    "slug": "methyleugenol",
+    "canonicalCompoundId": "methyleugenol",
+    "name": "Methyleugenol",
+    "compoundName": "Methyleugenol",
+    "canonicalCompoundName": "Methyleugenol",
+    "mechanisms": [
+      "TRP channel modulation",
+      "GABA-A modulation"
+    ],
+    "foundIn": [
+      "Ocimum basilicum"
+    ]
+  },
+  {
+    "id": "asiatic-acid",
+    "slug": "asiatic-acid",
+    "canonicalCompoundId": "asiatic-acid",
+    "name": "Asiatic acid",
+    "compoundName": "Asiatic acid",
+    "canonicalCompoundName": "Asiatic acid",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "TGF-β signaling modulation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "Centella asiatica"
+    ]
+  },
+  {
+    "id": "madecassic-acid",
+    "slug": "madecassic-acid",
+    "canonicalCompoundId": "madecassic-acid",
+    "name": "Madecassic acid",
+    "compoundName": "Madecassic acid",
+    "canonicalCompoundName": "Madecassic acid",
+    "mechanisms": [
+      "TGF-β signaling modulation",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "Centella asiatica"
+    ]
+  },
+  {
+    "id": "gymnemagenin",
+    "slug": "gymnemagenin",
+    "canonicalCompoundId": "gymnemagenin",
+    "name": "Gymnemagenin",
+    "compoundName": "Gymnemagenin",
+    "canonicalCompoundName": "Gymnemagenin",
+    "mechanisms": [
+      "glucose absorption modulation",
+      "AMPK activation"
+    ],
+    "foundIn": [
+      "Gymnema sylvestre"
+    ]
+  },
+  {
+    "id": "gurmarin",
+    "slug": "gurmarin",
+    "canonicalCompoundId": "gurmarin",
+    "name": "Gurmarin",
+    "compoundName": "Gurmarin",
+    "canonicalCompoundName": "Gurmarin",
+    "mechanisms": [
+      "sweet taste receptor modulation",
+      "glucose absorption modulation"
+    ],
+    "foundIn": [
+      "Gymnema sylvestre"
+    ]
+  },
+  {
+    "id": "corosolic-acid",
+    "slug": "corosolic-acid",
+    "canonicalCompoundId": "corosolic-acid",
+    "name": "Corosolic acid",
+    "compoundName": "Corosolic acid",
+    "canonicalCompoundName": "Corosolic acid",
+    "mechanisms": [
+      "AMPK activation",
+      "GLUT4 translocation modulation"
+    ],
+    "foundIn": [
+      "Banaba",
+      "Lagerstroemia speciosa"
+    ]
+  },
+  {
+    "id": "lagerstroemin",
+    "slug": "lagerstroemin",
+    "canonicalCompoundId": "lagerstroemin",
+    "name": "Lagerstroemin",
+    "compoundName": "Lagerstroemin",
+    "canonicalCompoundName": "Lagerstroemin",
+    "mechanisms": [
+      "PPAR activation",
+      "glucose uptake modulation"
+    ],
+    "foundIn": [
+      "Lagerstroemia speciosa"
+    ]
+  },
+  {
+    "id": "mulberroside-a",
+    "slug": "mulberroside-a",
+    "canonicalCompoundId": "mulberroside-a",
+    "name": "Mulberroside A",
+    "compoundName": "Mulberroside A",
+    "canonicalCompoundName": "Mulberroside A",
+    "mechanisms": [
+      "glucose absorption modulation",
+      "alpha-glucosidase inhibition"
+    ],
+    "foundIn": [
+      "Morus alba"
+    ]
+  },
+  {
+    "id": "oxyresveratrol",
+    "slug": "oxyresveratrol",
+    "canonicalCompoundId": "oxyresveratrol",
+    "name": "Oxyresveratrol",
+    "compoundName": "Oxyresveratrol",
+    "canonicalCompoundName": "Oxyresveratrol",
+    "mechanisms": [
+      "alpha-glucosidase inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "Morus alba"
+    ]
+  },
+  {
+    "id": "morin",
+    "slug": "morin",
+    "canonicalCompoundId": "morin",
+    "name": "Morin",
+    "compoundName": "Morin",
+    "canonicalCompoundName": "Morin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "Morus alba"
+    ]
+  },
+  {
+    "id": "deoxyelephantopin",
+    "slug": "deoxyelephantopin",
+    "canonicalCompoundId": "deoxyelephantopin",
+    "name": "Deoxyelephantopin",
+    "compoundName": "Deoxyelephantopin",
+    "canonicalCompoundName": "Deoxyelephantopin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "STAT3 inhibition",
+      "apoptosis pathway modulation (caspase activation)"
+    ],
+    "foundIn": [
+      "Elephantopus scaber"
+    ]
+  },
+  {
+    "id": "elephantopin",
+    "slug": "elephantopin",
+    "canonicalCompoundId": "elephantopin",
+    "name": "Elephantopin",
+    "compoundName": "Elephantopin",
+    "canonicalCompoundName": "Elephantopin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "Elephantopus scaber"
+    ]
+  },
+  {
+    "id": "guggulsterone",
+    "slug": "guggulsterone",
+    "canonicalCompoundId": "guggulsterone",
+    "name": "Guggulsterone",
+    "compoundName": "Guggulsterone",
+    "canonicalCompoundName": "Guggulsterone",
+    "mechanisms": [
+      "FXR antagonism",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "Commiphora mukul"
+    ]
+  },
+  {
+    "id": "commipheric-acid",
+    "slug": "commipheric-acid",
+    "canonicalCompoundId": "commipheric-acid",
+    "name": "Commipheric acid",
+    "compoundName": "Commipheric acid",
+    "canonicalCompoundName": "Commipheric acid",
+    "mechanisms": [
+      "PPAR activation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "Commiphora mukul"
+    ]
+  },
+  {
+    "id": "beta-sitosterol",
+    "slug": "beta-sitosterol",
+    "canonicalCompoundId": "beta-sitosterol",
+    "name": "Beta-sitosterol",
+    "compoundName": "Beta-sitosterol",
+    "canonicalCompoundName": "Beta-sitosterol",
+    "mechanisms": [
+      "PPAR activation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "Muira Puama",
+      "Nettle Root",
+      "Saw Palmetto",
+      "Serenoa repens"
+    ]
+  },
+  {
+    "id": "stigmasterol",
+    "slug": "stigmasterol",
+    "canonicalCompoundId": "stigmasterol",
+    "name": "Stigmasterol",
+    "compoundName": "Stigmasterol",
+    "canonicalCompoundName": "Stigmasterol",
+    "mechanisms": [
+      "PPAR activation",
+      "MAPK pathway modulation"
+    ],
+    "foundIn": [
+      "Serenoa repens"
+    ]
+  },
+  {
+    "id": "ajoene",
+    "slug": "ajoene",
+    "canonicalCompoundId": "ajoene",
+    "name": "ajoene",
+    "compoundName": "ajoene",
+    "canonicalCompoundName": "ajoene",
+    "mechanisms": [
+      "platelet aggregation inhibition",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "lean-bulk-pass-010"
+    ]
+  },
+  {
+    "id": "acemannan",
+    "slug": "acemannan",
+    "canonicalCompoundId": "acemannan",
+    "name": "acemannan",
+    "compoundName": "acemannan",
+    "canonicalCompoundName": "acemannan",
+    "mechanisms": [
+      "TLR4 modulation",
+      "NF-κB modulation"
+    ],
+    "foundIn": [
+      "lean-bulk-pass-010"
+    ]
+  },
+  {
+    "id": "aescin",
+    "slug": "aescin",
+    "canonicalCompoundId": "aescin",
+    "name": "aescin",
+    "compoundName": "aescin",
+    "canonicalCompoundName": "aescin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "endothelial barrier modulation"
+    ],
+    "foundIn": [
+      "lean-bulk-pass-010"
+    ]
+  },
+  {
+    "id": "alpha-asarone",
+    "slug": "alpha-asarone",
+    "canonicalCompoundId": "alpha-asarone",
+    "name": "alpha-asarone",
+    "compoundName": "alpha-asarone",
+    "canonicalCompoundName": "alpha-asarone",
+    "mechanisms": [
+      "GABA-A modulation",
+      "acetylcholinesterase inhibition"
+    ],
+    "foundIn": [
+      "lean-bulk-pass-010"
+    ]
+  },
+  {
+    "id": "aspalathin",
+    "slug": "aspalathin",
+    "canonicalCompoundId": "aspalathin",
+    "name": "aspalathin",
+    "compoundName": "aspalathin",
+    "canonicalCompoundName": "aspalathin",
+    "mechanisms": [
+      "AMPK activation",
+      "Nrf2 activation"
+    ],
+    "foundIn": [
+      "lean-bulk-pass-010"
+    ]
+  },
+  {
+    "id": "bacopaside-ii",
+    "slug": "bacopaside-ii",
+    "canonicalCompoundId": "bacopaside-ii",
+    "name": "bacopaside II",
+    "compoundName": "bacopaside II",
+    "canonicalCompoundName": "bacopaside II",
+    "mechanisms": [
+      "MARK4 inhibition",
+      "cholinergic modulation"
+    ],
+    "foundIn": [
+      "lean-bulk-pass-010"
+    ]
+  },
+  {
+    "id": "berbamine",
+    "slug": "berbamine",
+    "canonicalCompoundId": "berbamine",
+    "name": "berbamine",
+    "compoundName": "berbamine",
+    "canonicalCompoundName": "berbamine",
+    "mechanisms": [
+      "JAK/STAT inhibition",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "lean-bulk-pass-010"
+    ]
+  },
+  {
+    "id": "betulinic-acid",
+    "slug": "betulinic-acid",
+    "canonicalCompoundId": "betulinic-acid",
+    "name": "betulinic acid",
+    "compoundName": "betulinic acid",
+    "canonicalCompoundName": "betulinic acid",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "apoptosis pathway modulation"
+    ],
+    "foundIn": [
+      "lean-bulk-pass-010"
+    ]
+  },
+  {
+    "id": "bilobetin",
+    "slug": "bilobetin",
+    "canonicalCompoundId": "bilobetin",
+    "name": "bilobetin",
+    "compoundName": "bilobetin",
+    "canonicalCompoundName": "bilobetin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK modulation"
+    ],
+    "foundIn": [
+      "lean-bulk-pass-010"
+    ]
+  },
+  {
+    "id": "cafestol",
+    "slug": "cafestol",
+    "canonicalCompoundId": "cafestol",
+    "name": "cafestol",
+    "compoundName": "cafestol",
+    "canonicalCompoundName": "cafestol",
+    "mechanisms": [
+      "Nrf2 activation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "lean-bulk-pass-010"
+    ]
+  },
+  {
+    "id": "chicoric-acid",
+    "slug": "chicoric-acid",
+    "canonicalCompoundId": "chicoric-acid",
+    "name": "chicoric acid",
+    "compoundName": "chicoric acid",
+    "canonicalCompoundName": "chicoric acid",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK modulation"
+    ],
+    "foundIn": [
+      "lean-bulk-pass-010"
+    ]
+  },
+  {
+    "id": "citronellal",
+    "slug": "citronellal",
+    "canonicalCompoundId": "citronellal",
+    "name": "citronellal",
+    "compoundName": "citronellal",
+    "canonicalCompoundName": "citronellal",
+    "mechanisms": [
+      "TRPA1 modulation",
+      "sensory ion-channel modulation"
+    ],
+    "foundIn": [
+      "lean-bulk-pass-010"
+    ]
+  },
+  {
+    "id": "coptisine",
+    "slug": "coptisine",
+    "canonicalCompoundId": "coptisine",
+    "name": "coptisine",
+    "compoundName": "coptisine",
+    "canonicalCompoundName": "coptisine",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-κB inhibition",
+      "MAPK modulation"
+    ],
+    "foundIn": [
+      "lean-bulk-pass-010"
+    ]
+  },
+  {
+    "id": "deoxymiroestrol",
+    "slug": "deoxymiroestrol",
+    "canonicalCompoundId": "deoxymiroestrol",
+    "name": "deoxymiroestrol",
+    "compoundName": "deoxymiroestrol",
+    "canonicalCompoundName": "deoxymiroestrol",
+    "mechanisms": [
+      "estrogen receptor modulation"
+    ],
+    "foundIn": [
+      "lean-bulk-pass-010"
+    ]
+  },
+  {
+    "id": "desmethoxyyangonin",
+    "slug": "desmethoxyyangonin",
+    "canonicalCompoundId": "desmethoxyyangonin",
+    "name": "desmethoxyyangonin",
+    "compoundName": "desmethoxyyangonin",
+    "canonicalCompoundName": "desmethoxyyangonin",
+    "mechanisms": [
+      "MAO-B inhibition",
+      "GABA-A modulation"
+    ],
+    "foundIn": [
+      "lean-bulk-pass-010"
+    ]
+  },
+  {
+    "id": "dihydrokavain",
+    "slug": "dihydrokavain",
+    "canonicalCompoundId": "dihydrokavain",
+    "name": "dihydrokavain",
+    "compoundName": "dihydrokavain",
+    "canonicalCompoundName": "dihydrokavain",
+    "mechanisms": [
+      "GABA-A modulation"
+    ],
+    "foundIn": [
+      "lean-bulk-pass-010"
+    ]
+  },
+  {
+    "id": "dihydromethysticin",
+    "slug": "dihydromethysticin",
+    "canonicalCompoundId": "dihydromethysticin",
+    "name": "dihydromethysticin",
+    "compoundName": "dihydromethysticin",
+    "canonicalCompoundName": "dihydromethysticin",
+    "mechanisms": [
+      "GABA-A modulation",
+      "MAO-B inhibition"
+    ],
+    "foundIn": [
+      "lean-bulk-pass-010"
+    ]
+  },
+  {
+    "id": "erinacines",
+    "slug": "erinacines",
+    "canonicalCompoundId": "erinacines",
+    "name": "erinacines",
+    "compoundName": "erinacines",
+    "canonicalCompoundName": "erinacines",
+    "mechanisms": [
+      "NGF induction",
+      "ERK/CREB pathway modulation"
+    ],
+    "foundIn": [
+      "lean-bulk-pass-010"
+    ]
+  },
+  {
+    "id": "hericenones",
+    "slug": "hericenones",
+    "canonicalCompoundId": "hericenones",
+    "name": "hericenones",
+    "compoundName": "hericenones",
+    "canonicalCompoundName": "hericenones",
+    "mechanisms": [
+      "NGF induction",
+      "ERK/CREB pathway modulation"
+    ],
+    "foundIn": [
+      "lean-bulk-pass-010"
+    ]
+  },
+  {
+    "id": "indirubin",
+    "slug": "indirubin",
+    "canonicalCompoundId": "indirubin",
+    "name": "indirubin",
+    "compoundName": "indirubin",
+    "canonicalCompoundName": "indirubin",
+    "mechanisms": [
+      "CDK inhibition",
+      "STAT3 inhibition"
+    ],
+    "foundIn": [
+      "lean-bulk-pass-010"
+    ]
+  },
+  {
+    "id": "kahweol",
+    "slug": "kahweol",
+    "canonicalCompoundId": "kahweol",
+    "name": "kahweol",
+    "compoundName": "kahweol",
+    "canonicalCompoundName": "kahweol",
+    "mechanisms": [
+      "Nrf2 activation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "lean-bulk-pass-010"
+    ]
+  },
+  {
+    "id": "kotalanol",
+    "slug": "kotalanol",
+    "canonicalCompoundId": "kotalanol",
+    "name": "kotalanol",
+    "compoundName": "kotalanol",
+    "canonicalCompoundName": "kotalanol",
+    "mechanisms": [
+      "alpha-glucosidase inhibition"
+    ],
+    "foundIn": [
+      "lean-bulk-pass-010"
+    ]
+  },
+  {
+    "id": "mesembrine",
+    "slug": "mesembrine",
+    "canonicalCompoundId": "mesembrine",
+    "name": "mesembrine",
+    "compoundName": "mesembrine",
+    "canonicalCompoundName": "mesembrine",
+    "mechanisms": [
+      "serotonin reuptake inhibition",
+      "PDE4 inhibition"
+    ],
+    "foundIn": [
+      "lean-bulk-pass-010"
+    ]
+  },
+  {
+    "id": "mesembrenone",
+    "slug": "mesembrenone",
+    "canonicalCompoundId": "mesembrenone",
+    "name": "mesembrenone",
+    "compoundName": "mesembrenone",
+    "canonicalCompoundName": "mesembrenone",
+    "mechanisms": [
+      "serotonin reuptake inhibition",
+      "PDE4 inhibition"
+    ],
+    "foundIn": [
+      "lean-bulk-pass-010"
+    ]
+  },
+  {
+    "id": "arjunolic-acid",
+    "slug": "arjunolic-acid",
+    "canonicalCompoundId": "arjunolic-acid",
+    "name": "arjunolic acid",
+    "compoundName": "arjunolic acid",
+    "canonicalCompoundName": "arjunolic acid",
+    "mechanisms": [
+      "PPAR activation",
+      "NF-κB inhibition"
+    ],
+    "foundIn": [
+      "Arjuna",
+      "Terminalia arjuna"
+    ]
+  },
+  {
+    "id": "columbin",
+    "slug": "columbin",
+    "canonicalCompoundId": "columbin",
+    "name": "columbin",
+    "compoundName": "columbin",
+    "canonicalCompoundName": "columbin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK modulation"
+    ],
+    "foundIn": [
+      "Tinospora cordifolia"
+    ]
+  },
+  {
+    "id": "cryptotanshinone",
+    "slug": "cryptotanshinone",
+    "canonicalCompoundId": "cryptotanshinone",
+    "name": "cryptotanshinone",
+    "compoundName": "cryptotanshinone",
+    "canonicalCompoundName": "cryptotanshinone",
+    "mechanisms": [
+      "STAT3 inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "foundIn": [
+      "Salvia miltiorrhiza"
+    ]
+  },
+  {
+    "id": "galangin",
+    "slug": "galangin",
+    "canonicalCompoundId": "galangin",
+    "name": "galangin",
+    "compoundName": "galangin",
+    "canonicalCompoundName": "galangin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK modulation"
+    ],
+    "foundIn": [
+      "Galangal",
+      "Alpinia officinarum"
+    ]
+  },
+  {
+    "id": "ginkgolide-b",
+    "slug": "ginkgolide-b",
+    "canonicalCompoundId": "ginkgolide-b",
+    "name": "ginkgolide B",
+    "compoundName": "ginkgolide B",
+    "canonicalCompoundName": "ginkgolide B",
+    "mechanisms": [
+      "PAF receptor antagonism",
+      "neuroprotection"
+    ],
+    "foundIn": [
+      "Ginkgo Biloba"
+    ]
+  },
+  {
+    "id": "honokiol",
+    "slug": "honokiol",
+    "canonicalCompoundId": "honokiol",
+    "name": "honokiol",
+    "compoundName": "honokiol",
+    "canonicalCompoundName": "honokiol",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "GABA-A modulation"
+    ],
+    "foundIn": [
+      "Magnolia officinalis"
+    ]
+  },
+  {
+    "id": "magnolol",
+    "slug": "magnolol",
+    "canonicalCompoundId": "magnolol",
+    "name": "magnolol",
+    "compoundName": "magnolol",
+    "canonicalCompoundName": "magnolol",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "GABA-A modulation"
+    ],
+    "foundIn": [
+      "Magnolia officinalis"
+    ]
+  },
+  {
+    "id": "piperine",
+    "slug": "piperine",
+    "canonicalCompoundId": "piperine",
+    "name": "piperine",
+    "compoundName": "piperine",
+    "canonicalCompoundName": "piperine",
+    "mechanisms": [
+      "TRPV1 activation",
+      "CYP3A4 inhibition"
+    ],
+    "foundIn": [
+      "Black Pepper",
+      "Piper longum",
+      "Piper nigrum"
+    ]
+  },
+  {
+    "id": "rosmarinic-acid",
+    "slug": "rosmarinic-acid",
+    "canonicalCompoundId": "rosmarinic-acid",
+    "name": "rosmarinic acid",
+    "compoundName": "rosmarinic acid",
+    "canonicalCompoundName": "rosmarinic acid",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "complement inhibition"
+    ],
+    "foundIn": [
+      "Lemon Balm",
+      "Rosmarinus officinalis",
+      "Holy Basil"
+    ]
+  },
+  {
+    "id": "safranal",
+    "slug": "safranal",
+    "canonicalCompoundId": "safranal",
+    "name": "safranal",
+    "compoundName": "safranal",
+    "canonicalCompoundName": "safranal",
+    "mechanisms": [
+      "GABA-A modulation",
+      "NMDA modulation"
+    ],
+    "foundIn": [
+      "Saffron"
+    ]
+  },
+  {
+    "id": "theanine",
+    "slug": "theanine",
+    "canonicalCompoundId": "theanine",
+    "name": "theanine",
+    "compoundName": "theanine",
+    "canonicalCompoundName": "theanine",
+    "mechanisms": [
+      "glutamate receptor modulation",
+      "GABA upregulation"
+    ],
+    "targets": [
+      "Glutamate receptors",
+      "GABA-related signaling"
+    ],
+    "pathways": [
+      "glutamatergic signaling",
+      "GABAergic signaling"
+    ],
+    "foundIn": [
+      "Green Tea"
+    ],
+    "bioavailability": "Readily absorbed orally and crosses the blood-brain barrier."
+  },
+  {
+    "id": "cinnamaldehyde",
+    "slug": "cinnamaldehyde",
+    "canonicalCompoundId": "cinnamaldehyde",
+    "name": "cinnamaldehyde",
+    "compoundName": "cinnamaldehyde",
+    "canonicalCompoundName": "cinnamaldehyde",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "TRPA1",
+      "inflammatory enzymes"
+    ],
+    "pathways": [
+      "AMPK",
+      "NF-κB",
+      "TRPA1-linked signaling"
+    ],
+    "foundIn": [
+      "Cinnamon"
+    ],
+    "bioavailability": "Volatile and reactive; whole-bark preparations differ from isolated compound exposure."
+  },
+  {
+    "id": "trigonelline",
+    "slug": "trigonelline",
+    "canonicalCompoundId": "trigonelline",
+    "name": "trigonelline",
+    "compoundName": "trigonelline",
+    "canonicalCompoundName": "trigonelline",
+    "mechanisms": [
+      "Nrf2 activation",
+      "glucose metabolism modulation"
+    ],
+    "foundIn": [
+      "Coffee",
+      "Fenugreek"
+    ]
+  },
+  {
+    "id": "withanoside-iv",
+    "slug": "withanoside-iv",
+    "canonicalCompoundId": "withanoside-iv",
+    "name": "withanoside IV",
+    "compoundName": "withanoside IV",
+    "canonicalCompoundName": "withanoside IV",
+    "mechanisms": [
+      "BDNF upregulation",
+      "neurite outgrowth promotion"
+    ],
+    "targets": [
+      "Neurotrophic signaling nodes",
+      "cholinergic systems"
+    ],
+    "pathways": [
+      "BDNF-linked signaling",
+      "neurite outgrowth pathways"
+    ],
+    "foundIn": [
+      "Ashwagandha"
+    ],
+    "bioavailability": "Usually consumed within root extracts rather than as an isolated compound."
+  },
+  {
+    "id": "schisandrin-b",
+    "slug": "schisandrin-b",
+    "canonicalCompoundId": "schisandrin-b",
+    "name": "schisandrin B",
+    "compoundName": "schisandrin B",
+    "canonicalCompoundName": "schisandrin B",
+    "mechanisms": [
+      "Nrf2 activation",
+      "mitochondrial protection"
+    ],
+    "targets": [
+      "Mitochondrial redox systems",
+      "antioxidant enzymes"
+    ],
+    "pathways": [
+      "Nrf2",
+      "mitochondrial stress response"
+    ],
+    "foundIn": [
+      "Schisandra"
+    ],
+    "bioavailability": "Lipophilic lignan with better delivery in whole extracts than isolated dry powder."
+  },
+  {
+    "id": "eleutheroside-b",
+    "slug": "eleutheroside-b",
+    "canonicalCompoundId": "eleutheroside-b",
+    "name": "eleutheroside B",
+    "compoundName": "eleutheroside B",
+    "canonicalCompoundName": "eleutheroside B",
+    "mechanisms": [
+      "HPA-axis modulation",
+      "immune modulation"
+    ],
+    "foundIn": [
+      "Eleuthero"
+    ]
+  },
+  {
+    "id": "eleutheroside-e",
+    "slug": "eleutheroside-e",
+    "canonicalCompoundId": "eleutheroside-e",
+    "name": "eleutheroside E",
+    "compoundName": "eleutheroside E",
+    "canonicalCompoundName": "eleutheroside E",
+    "mechanisms": [
+      "AMPK activation",
+      "stress response modulation"
+    ],
+    "foundIn": [
+      "Eleuthero"
+    ]
+  },
+  {
+    "id": "punicalagin",
+    "slug": "punicalagin",
+    "canonicalCompoundId": "punicalagin",
+    "name": "punicalagin",
+    "compoundName": "punicalagin",
+    "canonicalCompoundName": "punicalagin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "ellagitannin-mediated antioxidant signaling"
+    ],
+    "targets": [
+      "Inflammatory mediators",
+      "redox-sensitive enzymes"
+    ],
+    "pathways": [
+      "NF-κB",
+      "oxidative stress response"
+    ],
+    "foundIn": [
+      "Pomegranate"
+    ],
+    "bioavailability": "Parent compound is transformed extensively; downstream urolithin formation varies by microbiome."
+  },
+  {
+    "id": "carnosol",
+    "slug": "carnosol",
+    "canonicalCompoundId": "carnosol",
+    "name": "carnosol",
+    "compoundName": "carnosol",
+    "canonicalCompoundName": "carnosol",
+    "mechanisms": [
+      "Nrf2 activation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "Keap1-sensitive redox targets",
+      "STAT3-related signaling"
+    ],
+    "pathways": [
+      "Nrf2",
+      "NF-κB",
+      "STAT3"
+    ],
+    "foundIn": [
+      "Rosmarinus officinalis",
+      "Rosemary"
+    ],
+    "bioavailability": "Lipophilic compound; best delivered in extracts or fat-containing preparations."
+  },
+  {
+    "id": "glucomoringin",
+    "slug": "glucomoringin",
+    "canonicalCompoundId": "glucomoringin",
+    "name": "glucomoringin",
+    "compoundName": "glucomoringin",
+    "canonicalCompoundName": "glucomoringin",
+    "mechanisms": [
+      "Nrf2 activation",
+      "isothiocyanate signaling"
+    ],
+    "targets": [
+      "Phase II detox enzymes",
+      "electrophile sensors"
+    ],
+    "pathways": [
+      "Nrf2",
+      "phase II detox response"
+    ],
+    "foundIn": [
+      "Moringa"
+    ],
+    "bioavailability": "Bioactivity depends on conversion to isothiocyanates after processing or digestion."
+  },
+  {
+    "id": "methyl-eugenol",
+    "slug": "methyl-eugenol",
+    "canonicalCompoundId": "methyl-eugenol",
+    "name": "methyl eugenol",
+    "compoundName": "methyl eugenol",
+    "canonicalCompoundName": "methyl eugenol",
+    "mechanisms": [
+      "TRPA1 modulation",
+      "voltage-gated channel modulation"
+    ],
+    "foundIn": [
+      "Holy Basil"
+    ]
+  },
+  {
+    "id": "anethole",
+    "slug": "anethole",
+    "canonicalCompoundId": "anethole",
+    "name": "anethole",
+    "compoundName": "anethole",
+    "canonicalCompoundName": "anethole",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "smooth muscle relaxation"
+    ],
+    "foundIn": [
+      "Fennel",
+      "Anise Hyssop"
+    ]
+  },
+  {
+    "id": "carvacrol",
+    "slug": "carvacrol",
+    "canonicalCompoundId": "carvacrol",
+    "name": "carvacrol",
+    "compoundName": "carvacrol",
+    "canonicalCompoundName": "carvacrol",
+    "mechanisms": [
+      "TRPA1 activation",
+      "membrane disruption"
+    ],
+    "targets": [
+      "TRPA1",
+      "membrane lipids"
+    ],
+    "pathways": [
+      "TRPA1-related signaling",
+      "membrane stress response"
+    ],
+    "foundIn": [
+      "Sage",
+      "Ajwain",
+      "Oregano",
+      "Thyme"
+    ],
+    "bioavailability": "Lipophilic volatile; delivery varies substantially by extract type."
+  },
+  {
+    "id": "thymol",
+    "slug": "thymol",
+    "canonicalCompoundId": "thymol",
+    "name": "thymol",
+    "compoundName": "thymol",
+    "canonicalCompoundName": "thymol",
+    "mechanisms": [
+      "GABA-A modulation",
+      "membrane disruption"
+    ],
+    "targets": [
+      "GABA-A-related sites",
+      "membrane targets"
+    ],
+    "pathways": [
+      "GABAergic signaling",
+      "TRPA1-related sensory signaling"
+    ],
+    "foundIn": [
+      "Rosemary",
+      "Ajwain",
+      "Thyme",
+      "Oregano"
+    ],
+    "bioavailability": "Volatile constituent; concentrated essential oil exposure is stronger than culinary intake."
+  },
+  {
+    "id": "silybin",
+    "slug": "silybin",
+    "canonicalCompoundId": "silybin",
+    "name": "silybin",
+    "compoundName": "silybin",
+    "canonicalCompoundName": "silybin",
+    "mechanisms": [
+      "Nrf2 activation",
+      "TGF-β modulation"
+    ],
+    "targets": [
+      "TGF-β-related nodes",
+      "antioxidant enzymes"
+    ],
+    "pathways": [
+      "Nrf2",
+      "TGF-β"
+    ],
+    "foundIn": [
+      "Milk Thistle"
+    ],
+    "bioavailability": "Poor water solubility; phospholipid complexes can improve absorption."
+  },
+  {
+    "id": "silychristin",
+    "slug": "silychristin",
+    "canonicalCompoundId": "silychristin",
+    "name": "silychristin",
+    "compoundName": "silychristin",
+    "canonicalCompoundName": "silychristin",
+    "mechanisms": [
+      "Nrf2 activation",
+      "ABC transporter modulation"
+    ],
+    "foundIn": [
+      "Milk Thistle"
+    ]
+  },
+  {
+    "id": "silydianin",
+    "slug": "silydianin",
+    "canonicalCompoundId": "silydianin",
+    "name": "silydianin",
+    "compoundName": "silydianin",
+    "canonicalCompoundName": "silydianin",
+    "mechanisms": [
+      "Nrf2 activation",
+      "hepatocyte protection"
+    ],
+    "foundIn": [
+      "Milk Thistle"
+    ]
+  },
+  {
+    "id": "epigallocatechin",
+    "slug": "epigallocatechin",
+    "canonicalCompoundId": "epigallocatechin",
+    "name": "epigallocatechin",
+    "compoundName": "epigallocatechin",
+    "canonicalCompoundName": "epigallocatechin",
+    "mechanisms": [
+      "Nrf2 activation",
+      "MAPK modulation"
+    ],
+    "foundIn": [
+      "Green Tea"
+    ]
+  },
+  {
+    "id": "epicatechin-gallate",
+    "slug": "epicatechin-gallate",
+    "canonicalCompoundId": "epicatechin-gallate",
+    "name": "epicatechin gallate",
+    "compoundName": "epicatechin gallate",
+    "canonicalCompoundName": "epicatechin gallate",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK modulation"
+    ],
+    "targets": [
+      "Inflammatory kinases",
+      "redox-active enzymes"
+    ],
+    "pathways": [
+      "NF-κB",
+      "MAPK"
+    ],
+    "foundIn": [
+      "Green Tea"
+    ],
+    "bioavailability": "Part of the tea catechin pool; stability and absorption depend on preparation."
+  },
+  {
+    "id": "epigallocatechin-gallate",
+    "slug": "epigallocatechin-gallate",
+    "canonicalCompoundId": "epigallocatechin-gallate",
+    "name": "epigallocatechin gallate",
+    "compoundName": "epigallocatechin gallate",
+    "canonicalCompoundName": "epigallocatechin gallate",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-κB inhibition",
+      "EGFR modulation"
+    ],
+    "targets": [
+      "AMPK",
+      "EGFR",
+      "IKK complex"
+    ],
+    "pathways": [
+      "AMPK",
+      "NF-κB",
+      "MAPK"
+    ],
+    "foundIn": [
+      "Green Tea"
+    ],
+    "bioavailability": "Oral absorption is limited; exposure improves with repeated intake and formulation support."
+  },
+  {
+    "id": "gallocatechin",
+    "slug": "gallocatechin",
+    "canonicalCompoundId": "gallocatechin",
+    "name": "gallocatechin",
+    "compoundName": "gallocatechin",
+    "canonicalCompoundName": "gallocatechin",
+    "mechanisms": [
+      "Nrf2 activation",
+      "MAPK modulation"
+    ],
+    "foundIn": [
+      "Green Tea"
     ]
   }
 ]

--- a/public/data/workbook-herb-compound-map.json
+++ b/public/data/workbook-herb-compound-map.json
@@ -1,2966 +1,1442 @@
 [
   {
-    "herbSlug": "ashwagandha",
-    "herbName": "Ashwagandha",
-    "rawCompound": "Withaferin A",
-    "normalizedAtom": "withaferin a",
-    "canonicalCompoundId": "withaferin-a",
-    "canonicalCompoundName": "Withaferin A",
-    "v3MatchType": "exact-normalized",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "anti-inflammatory",
-      "multi-target signaling modulation"
-    ],
-    "pathwayTargets": [
-      "HSP90",
-      "vimentin",
-      "IKKbeta",
-      "NF-kappaB",
-      "EMT-related signaling"
-    ]
+    "herbSlug": "withaferin-a",
+    "herbName": "Withaferin A"
   },
   {
-    "herbSlug": "black-cohosh",
-    "herbName": "Black Cohosh",
-    "rawCompound": "triterpene glycosides (actein, 23-epi-26-deoxyactein)",
-    "normalizedAtom": "triterpene glycosides actein 23 epi 26 deoxyactein",
-    "canonicalCompoundId": "triterpene-glycosides-actein-23-epi-26-deoxyactein",
-    "canonicalCompoundName": "triterpene glycosides (actein, 23-epi-26-deoxyactein)",
-    "v3MatchType": "exact-normalized",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "anti-inflammatory",
-      "multi-target signaling modulation"
-    ],
-    "pathwayTargets": [
-      "NF-kB",
-      "calcium signaling",
-      "nitric oxide"
-    ]
+    "herbSlug": "triterpene-glycosides-actein-23-epi-26-deoxyactein",
+    "herbName": "triterpene glycosides (actein, 23-epi-26-deoxyactein)"
   },
   {
-    "herbSlug": "echinacea-purpurea",
-    "herbName": "Echinacea Purpurea",
-    "rawCompound": "alkamides",
-    "normalizedAtom": "alkamides",
-    "canonicalCompoundId": "alkamides",
-    "canonicalCompoundName": "alkamides",
-    "v3MatchType": "no-master-match",
-    "mappingTier": "broad-class-retained"
+    "herbSlug": "alkamides",
+    "herbName": "alkamides"
   },
   {
-    "herbSlug": "garlic",
-    "herbName": "Garlic",
-    "rawCompound": "diallyl sulfide",
-    "normalizedAtom": "diallyl sulfide",
-    "canonicalCompoundId": "diallyl-sulfide",
-    "canonicalCompoundName": "diallyl sulfide",
-    "v3MatchType": "exact-normalized",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "detoxification",
-      "metabolic modulation"
-    ],
-    "pathwayTargets": [
-      "CYP450 modulation",
-      "antioxidant pathways"
-    ]
+    "herbSlug": "diallyl-sulfide",
+    "herbName": "diallyl sulfide"
   },
   {
-    "herbSlug": "ginger",
-    "herbName": "Ginger",
-    "rawCompound": "6-Gingerol",
-    "normalizedAtom": "6 gingerol",
-    "canonicalCompoundId": "6-gingerol",
-    "canonicalCompoundName": "6-Gingerol",
-    "v3MatchType": "exact-normalized",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "COX/NF-kB inhibition"
-    ],
-    "pathwayTargets": [
-      "inflammatory_pathway_modulation"
-    ]
+    "herbSlug": "6-gingerol",
+    "herbName": "6-Gingerol"
   },
   {
-    "herbSlug": "ginkgo-biloba",
-    "herbName": "Ginkgo Biloba",
-    "rawCompound": "ginkgolides A, B, C, J",
-    "normalizedAtom": "ginkgolides a b c j",
-    "canonicalCompoundId": "ginkgolides-a-b-c-j",
-    "canonicalCompoundName": "ginkgolides A, B, C, J",
-    "v3MatchType": "exact-normalized",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "PAF receptor antagonism",
-      "neuroactive ion-channel modulation"
-    ],
-    "pathwayTargets": [
-      "PAFR",
-      "glycine receptor chloride channel"
-    ]
+    "herbSlug": "ginkgolides-a-b-c-j",
+    "herbName": "ginkgolides A, B, C, J"
   },
   {
-    "herbSlug": "holy-basil",
-    "herbName": "Holy Basil",
-    "rawCompound": "Eugenol",
-    "normalizedAtom": "eugenol",
-    "canonicalCompoundId": "eugenol",
-    "canonicalCompoundName": "Eugenol",
-    "v3MatchType": "exact-normalized",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "anti-inflammatory",
-      "analgesic",
-      "antimicrobial"
-    ],
-    "pathwayTargets": [
-      "COX",
-      "prostaglandins",
-      "TRPV1"
-    ]
+    "herbSlug": "eugenol",
+    "herbName": "Eugenol"
   },
   {
-    "herbSlug": "kava",
-    "herbName": "Kava",
-    "rawCompound": "kavain",
-    "normalizedAtom": "kavain",
-    "canonicalCompoundId": "kavain",
-    "canonicalCompoundName": "kavain",
-    "v3MatchType": "exact-normalized",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "GABAergic modulation",
-      "multi-target signaling modulation"
-    ],
-    "pathwayTargets": [
-      "dopaminergic_modulation",
-      "gabaergic_modulation"
-    ]
+    "herbSlug": "kavain",
+    "herbName": "kavain"
   },
   {
-    "herbSlug": "lemon-balm",
-    "herbName": "Lemon Balm",
-    "rawCompound": "Rosmarinic acid",
-    "normalizedAtom": "rosmarinic acid",
-    "canonicalCompoundId": "rosmarinic-acid",
-    "canonicalCompoundName": "Rosmarinic acid",
-    "v3MatchType": "exact-normalized",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "anti-inflammatory",
-      "antioxidant",
-      "gabaergic modulation"
-    ],
-    "pathwayTargets": [
-      "COX",
-      "LOX",
-      "reactive oxygen species",
-      "GABA metabolism"
-    ]
+    "herbSlug": "rosmarinic-acid",
+    "herbName": "Rosmarinic acid"
   },
   {
-    "herbSlug": "maca",
-    "herbName": "Maca",
-    "rawCompound": "macamides",
-    "normalizedAtom": "macamides",
-    "canonicalCompoundId": "macamides",
-    "canonicalCompoundName": "macamides",
-    "v3MatchType": "no-master-match",
-    "mappingTier": "broad-class-retained"
+    "herbSlug": "macamides",
+    "herbName": "macamides"
   },
   {
-    "herbSlug": "milk-thistle",
-    "herbName": "Milk Thistle",
-    "rawCompound": "silybin A/B",
-    "normalizedAtom": "silybin a b",
-    "canonicalCompoundId": "silybin-a-b",
-    "canonicalCompoundName": "silybin A/B",
-    "v3MatchType": "exact-normalized",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "anti-inflammatory",
-      "antioxidant",
-      "hepatoprotective",
-      "redox modulation"
-    ],
-    "pathwayTargets": [
-      "Nrf2-associated signaling",
-      "NF-kappaB",
-      "oxidative-stress signaling"
-    ]
+    "herbSlug": "silybin-a-b",
+    "herbName": "silybin A/B"
   },
   {
-    "herbSlug": "peppermint",
-    "herbName": "Peppermint",
-    "rawCompound": "l‑menthol",
-    "normalizedAtom": "l menthol",
-    "canonicalCompoundId": "l-menthol",
-    "canonicalCompoundName": "l‑menthol",
-    "v3MatchType": "exact-normalized",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "multi-target signaling modulation"
-    ],
-    "pathwayTargets": [
-      "TRPM8 agonism",
-      "general or unknown targets"
-    ]
+    "herbSlug": "l-menthol",
+    "herbName": "l‐menthol"
   },
   {
-    "herbSlug": "rhodiola-rosea",
-    "herbName": "Rhodiola Rosea",
-    "rawCompound": "Rosavin",
-    "normalizedAtom": "rosavin",
-    "canonicalCompoundId": "rosavin",
-    "canonicalCompoundName": "Rosavin",
-    "v3MatchType": "exact-normalized",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "adaptogen",
-      "serotonergic",
-      "dopaminergic"
-    ],
-    "pathwayTargets": [
-      "HPA-axis modulation",
-      "monoamine signaling"
-    ]
+    "herbSlug": "rosavin",
+    "herbName": "Rosavin"
   },
   {
-    "herbSlug": "saw-palmetto",
-    "herbName": "Saw Palmetto",
-    "rawCompound": "fatty acids",
-    "normalizedAtom": "fatty acids",
-    "canonicalCompoundId": "fatty-acids",
-    "canonicalCompoundName": "fatty acids",
-    "v3MatchType": "no-master-match",
-    "mappingTier": "broad-class-retained"
+    "herbSlug": "fatty-acids",
+    "herbName": "fatty acids"
   },
   {
-    "herbSlug": "st-johns-wort",
-    "herbName": "St Johns Wort",
-    "rawCompound": "Hyperforin",
-    "normalizedAtom": "hyperforin",
-    "canonicalCompoundId": "hyperforin",
-    "canonicalCompoundName": "Hyperforin",
-    "v3MatchType": "exact-normalized",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "monoamine reuptake modulation",
-      "neuroplasticity modulation",
-      "enzyme induction relevance"
-    ],
-    "pathwayTargets": [
-      "TRPC6",
-      "serotonin/norepinephrine/dopamine reuptake-related pathways",
-      "CYP3A4 induction",
-      "P-glycoprotein induction"
-    ]
+    "herbSlug": "hyperforin",
+    "herbName": "Hyperforin"
   },
   {
-    "herbSlug": "turmeric",
-    "herbName": "Turmeric",
-    "rawCompound": "Demethoxycurcumin",
-    "normalizedAtom": "demethoxycurcumin",
-    "canonicalCompoundId": "demethoxycurcumin",
-    "canonicalCompoundName": "Demethoxycurcumin",
-    "v3MatchType": "exact-normalized",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "inflammatory_pathway_modulation",
-      "oxidative_stress_modulation"
-    ],
-    "pathwayTargets": [
-      "NFkB",
-      "oxidative-stress signaling"
-    ]
-  },
-  {
-    "herbSlug": "valerian",
-    "herbName": "Valerian",
-    "rawCompound": "valerenic acid",
-    "normalizedAtom": "valerenic acid",
-    "canonicalCompoundId": "valerenic-acid",
-    "canonicalCompoundName": "valerenic acid",
-    "v3MatchType": "exact-normalized",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "GABAergic modulation",
-      "multi-target signaling modulation"
-    ],
-    "pathwayTargets": [
-      "gabaergic_modulation",
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "guarana",
-    "herbName": "Guarana",
-    "rawCompound": "Caffeine",
-    "normalizedAtom": "caffeine",
-    "canonicalCompoundId": "caffeine",
-    "canonicalCompoundName": "Caffeine",
-    "v3MatchType": "exact",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "multi-domain"
-    ],
-    "pathwayTargets": [
-      "unknown"
-    ]
-  },
-  {
-    "herbSlug": "yerba-mate",
-    "herbName": "Yerba Mate",
-    "rawCompound": "Apigenin",
-    "normalizedAtom": "apigenin",
-    "canonicalCompoundId": "apigenin",
-    "canonicalCompoundName": "Apigenin",
-    "v3MatchType": "exact",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "multi-domain"
-    ],
-    "pathwayTargets": [
-      "unknown"
-    ]
-  },
-  {
-    "herbSlug": "damiana",
-    "herbName": "Damiana",
-    "rawCompound": "nuciferine",
-    "normalizedAtom": "nuciferine",
-    "canonicalCompoundId": "nuciferine",
-    "canonicalCompoundName": "nuciferine",
-    "v3MatchType": "exact",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "multi-domain"
-    ],
-    "pathwayTargets": [
-      "unknown"
-    ]
-  },
-  {
-    "herbSlug": "blue-lotus",
-    "herbName": "Blue Lotus",
-    "rawCompound": "puerarin",
-    "normalizedAtom": "puerarin",
-    "canonicalCompoundId": "puerarin",
-    "canonicalCompoundName": "puerarin",
-    "v3MatchType": "exact",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "multi-domain"
-    ],
-    "pathwayTargets": [
-      "unknown"
-    ]
-  },
-  {
-    "herbSlug": "kudzu",
-    "herbName": "Kudzu",
-    "rawCompound": "parthenolide",
-    "normalizedAtom": "parthenolide",
-    "canonicalCompoundId": "parthenolide",
-    "canonicalCompoundName": "parthenolide",
-    "v3MatchType": "exact",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "multi-domain"
-    ],
-    "pathwayTargets": [
-      "unknown"
-    ]
-  },
-  {
-    "herbSlug": "yarrow",
-    "herbName": "Yarrow",
-    "rawCompound": "petasin",
-    "normalizedAtom": "petasin",
-    "canonicalCompoundId": "petasin",
-    "canonicalCompoundName": "petasin",
-    "v3MatchType": "exact",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "multi-domain"
-    ],
-    "pathwayTargets": [
-      "unknown"
-    ]
-  },
-  {
-    "herbSlug": "feverfew",
-    "herbName": "Feverfew",
-    "rawCompound": "Actein",
-    "normalizedAtom": "actein",
-    "canonicalCompoundId": "actein",
-    "canonicalCompoundName": "Actein",
-    "v3MatchType": "exact",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "multi-domain"
-    ],
-    "pathwayTargets": [
-      "unknown"
-    ]
-  },
-  {
-    "herbSlug": "butterbur",
-    "herbName": "Butterbur",
-    "rawCompound": "petasin",
-    "normalizedAtom": "petasin",
-    "canonicalCompoundId": "petasin",
-    "canonicalCompoundName": "petasin",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "migraine support",
-      "anti-inflammatory",
-      "TRPA1/TRPV1 modulation",
-      "CGRP modulation"
-    ],
-    "pathwayTargets": [
-      "TRPA1",
-      "TRPV1",
-      "CGRP signaling"
-    ]
-  },
-  {
-    "herbSlug": "dong-quai",
-    "herbName": "Dong Quai",
-    "rawCompound": "curcumin",
-    "normalizedAtom": "curcumin",
-    "canonicalCompoundId": "curcumin",
-    "canonicalCompoundName": "curcumin",
-    "v3MatchType": "exact",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "multi-domain"
-    ],
-    "pathwayTargets": [
-      "unknown"
-    ]
-  },
-  {
-    "herbSlug": "rosemary",
-    "herbName": "Rosemary",
-    "rawCompound": "thymol",
-    "normalizedAtom": "thymol",
-    "canonicalCompoundId": "thymol",
-    "canonicalCompoundName": "thymol",
-    "v3MatchType": "exact",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "multi-domain"
-    ],
-    "pathwayTargets": [
-      "unknown"
-    ]
-  },
-  {
-    "herbSlug": "sage",
-    "herbName": "Sage",
-    "rawCompound": "carvacrol",
-    "normalizedAtom": "carvacrol",
-    "canonicalCompoundId": "carvacrol",
-    "canonicalCompoundName": "carvacrol",
-    "v3MatchType": "exact",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "multi-domain"
-    ],
-    "pathwayTargets": [
-      "unknown"
-    ]
-  },
-  {
-    "herbSlug": "thyme",
-    "herbName": "Thyme",
-    "rawCompound": "eucalyptol",
-    "normalizedAtom": "eucalyptol",
-    "canonicalCompoundId": "eucalyptol",
-    "canonicalCompoundName": "eucalyptol",
-    "v3MatchType": "exact",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "multi-domain"
-    ],
-    "pathwayTargets": [
-      "unknown"
-    ]
-  },
-  {
-    "herbSlug": "artichoke",
-    "herbName": "Artichoke",
-    "rawCompound": "cynarin",
-    "normalizedAtom": "cynarin",
-    "canonicalCompoundId": "cynarin",
-    "canonicalCompoundName": "cynarin",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "digestive support",
-      "hepatobiliary support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "fennel",
-    "herbName": "Fennel",
-    "rawCompound": "anethole",
-    "normalizedAtom": "anethole",
-    "canonicalCompoundId": "anethole",
-    "canonicalCompoundName": "anethole",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "digestive support",
-      "antispasmodic support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "cinnamon",
-    "herbName": "Cinnamon",
-    "rawCompound": "cinnamaldehyde",
-    "normalizedAtom": "cinnamaldehyde",
-    "canonicalCompoundId": "cinnamaldehyde",
-    "canonicalCompoundName": "cinnamaldehyde",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "glycemic support",
-      "antimicrobial support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "dandelion",
-    "herbName": "Dandelion",
-    "rawCompound": "taraxasterol",
-    "normalizedAtom": "taraxasterol",
-    "canonicalCompoundId": "taraxasterol",
-    "canonicalCompoundName": "taraxasterol",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "digestive support",
-      "mild diuretic support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "burdock",
-    "herbName": "Burdock",
-    "rawCompound": "arctiin",
-    "normalizedAtom": "arctiin",
-    "canonicalCompoundId": "arctiin",
-    "canonicalCompoundName": "arctiin",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "traditional skin support",
-      "anti-inflammatory"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "chamomile",
-    "herbName": "Chamomile",
-    "rawCompound": "Apigenin",
-    "normalizedAtom": "apigenin",
-    "canonicalCompoundId": "apigenin",
-    "canonicalCompoundName": "Apigenin",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "calming support",
-      "digestive support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "red-clover",
-    "herbName": "Red Clover",
-    "rawCompound": "genistein",
-    "normalizedAtom": "genistein",
-    "canonicalCompoundId": "genistein",
-    "canonicalCompoundName": "genistein",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "phytoestrogen-adjacent support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "oatstraw",
-    "herbName": "Oatstraw",
-    "rawCompound": "avenanthramides",
-    "normalizedAtom": "avenanthramides",
-    "canonicalCompoundId": "avenanthramides",
-    "canonicalCompoundName": "avenanthramides",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "nutritive support",
-      "calming support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "calendula",
-    "herbName": "Calendula",
-    "rawCompound": "faradiol",
-    "normalizedAtom": "faradiol",
-    "canonicalCompoundId": "faradiol",
-    "canonicalCompoundName": "faradiol",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "topical soothing support",
-      "anti-inflammatory"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "pau-darco",
-    "herbName": "Pau d'Arco",
-    "rawCompound": "lapachol",
-    "normalizedAtom": "lapachol",
-    "canonicalCompoundId": "lapachol",
-    "canonicalCompoundName": "lapachol",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "traditional immune support",
-      "antimicrobial support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "gymnema",
-    "herbName": "Gymnema",
-    "rawCompound": "gymnemic acids",
-    "normalizedAtom": "gymnemic acids",
-    "canonicalCompoundId": "gymnemic-acids",
-    "canonicalCompoundName": "gymnemic acids",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "glycemic support",
-      "sweet taste suppression",
-      "T1R2/T1R3 modulation"
-    ],
-    "pathwayTargets": [
-      "T1R2/T1R3 sweet receptor",
-      "intestinal glucose transport"
-    ]
-  },
-  {
-    "herbSlug": "banaba",
-    "herbName": "Banaba",
-    "rawCompound": "corosolic acid",
-    "normalizedAtom": "corosolic acid",
-    "canonicalCompoundId": "corosolic-acid",
-    "canonicalCompoundName": "corosolic acid",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "glycemic support",
-      "metabolic support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "mulberry-leaf",
-    "herbName": "Mulberry Leaf",
-    "rawCompound": "1-deoxynojirimycin",
-    "normalizedAtom": "1 deoxynojirimycin",
-    "canonicalCompoundId": "1-deoxynojirimycin",
-    "canonicalCompoundName": "1-deoxynojirimycin",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "glycemic support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "neem",
-    "herbName": "Neem",
-    "rawCompound": "nimbin",
-    "normalizedAtom": "nimbin",
-    "canonicalCompoundId": "nimbin",
-    "canonicalCompoundName": "nimbin",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "traditional skin support",
-      "antimicrobial support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "mugwort",
-    "herbName": "Mugwort",
-    "rawCompound": "thujone",
-    "normalizedAtom": "thujone",
-    "canonicalCompoundId": "thujone",
-    "canonicalCompoundName": "thujone",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "digestive support",
-      "traditional cycle support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "lemon-verbena",
-    "herbName": "Lemon Verbena",
-    "rawCompound": "verbascoside",
-    "normalizedAtom": "verbascoside",
-    "canonicalCompoundId": "verbascoside",
-    "canonicalCompoundName": "verbascoside",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "calming support",
-      "digestive support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "milky-oats",
-    "herbName": "Milk Oats",
-    "rawCompound": "avenacosides",
-    "normalizedAtom": "avenacosides",
-    "canonicalCompoundId": "avenacosides",
-    "canonicalCompoundName": "avenacosides",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "nutritive support",
-      "calming support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "cissus",
-    "herbName": "Cissus",
-    "rawCompound": "quadrangularin a",
-    "normalizedAtom": "quadrangularin a",
-    "canonicalCompoundId": "quadrangularin-a",
-    "canonicalCompoundName": "quadrangularin a",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "connective tissue support",
-      "recovery support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "ashitaba",
-    "herbName": "Ashitaba",
-    "rawCompound": "4-hydroxyderricin",
-    "normalizedAtom": "4 hydroxyderricin",
-    "canonicalCompoundId": "4-hydroxyderricin",
-    "canonicalCompoundName": "4-hydroxyderricin",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "metabolic support",
-      "antioxidant"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "pomegranate",
-    "herbName": "Pomegranate",
-    "rawCompound": "punicalagins",
-    "normalizedAtom": "punicalagins",
-    "canonicalCompoundId": "punicalagins",
-    "canonicalCompoundName": "punicalagins",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "vascular support",
-      "antioxidant"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "moringa",
-    "herbName": "Moringa",
-    "rawCompound": "moringin",
-    "normalizedAtom": "moringin",
-    "canonicalCompoundId": "moringin",
-    "canonicalCompoundName": "moringin",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "nutritive support",
-      "antioxidant",
-      "metabolic support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "arjuna",
-    "herbName": "Arjuna",
-    "rawCompound": "arjunolic acid",
-    "normalizedAtom": "arjunolic acid",
-    "canonicalCompoundId": "arjunolic-acid",
-    "canonicalCompoundName": "arjunolic acid",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "cardiovascular support",
-      "vascular support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "noni",
-    "herbName": "Noni",
-    "rawCompound": "damnacanthal",
-    "normalizedAtom": "damnacanthal",
-    "canonicalCompoundId": "damnacanthal",
-    "canonicalCompoundName": "damnacanthal",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "traditional wellness support",
-      "antioxidant"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "cranberry",
-    "herbName": "Cranberry",
-    "rawCompound": "a-type proanthocyanidins",
-    "normalizedAtom": "a type proanthocyanidins",
-    "canonicalCompoundId": "a-type-proanthocyanidins",
-    "canonicalCompoundName": "a-type proanthocyanidins",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "urinary support",
-      "antioxidant"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "rose-hips",
-    "herbName": "Rose Hips",
-    "rawCompound": "trans-tiliroside",
-    "normalizedAtom": "trans tiliroside",
-    "canonicalCompoundId": "trans-tiliroside",
-    "canonicalCompoundName": "trans-tiliroside",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "antioxidant",
-      "nutritive support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "juniper",
-    "herbName": "Juniper",
-    "rawCompound": "alpha-pinene",
-    "normalizedAtom": "alpha pinene",
-    "canonicalCompoundId": "alpha-pinene",
-    "canonicalCompoundName": "alpha-pinene",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "digestive support",
-      "urinary support",
-      "aromatic support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "myrtle",
-    "herbName": "Myrtle",
-    "rawCompound": "myrtenyl acetate",
-    "normalizedAtom": "myrtenyl acetate",
-    "canonicalCompoundId": "myrtenyl-acetate",
-    "canonicalCompoundName": "myrtenyl acetate",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "aromatic support",
-      "antioxidant"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "acerola",
-    "herbName": "Acerola",
-    "rawCompound": "ascorbic acid",
-    "normalizedAtom": "ascorbic acid",
-    "canonicalCompoundId": "ascorbic-acid",
-    "canonicalCompoundName": "ascorbic acid",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "antioxidant",
-      "nutritive support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "mangosteen",
-    "herbName": "Mangosteen",
-    "rawCompound": "alpha-mangostin",
-    "normalizedAtom": "alpha mangostin",
-    "canonicalCompoundId": "alpha-mangostin",
-    "canonicalCompoundName": "alpha-mangostin",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "antioxidant",
-      "traditional wellness support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "boldo",
-    "herbName": "Boldo",
-    "rawCompound": "boldine",
-    "normalizedAtom": "boldine",
-    "canonicalCompoundId": "boldine",
-    "canonicalCompoundName": "boldine",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "digestive support",
-      "hepatobiliary support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "suma",
-    "herbName": "Suma",
-    "rawCompound": "pfaffic acid",
-    "normalizedAtom": "pfaffic acid",
-    "canonicalCompoundId": "pfaffic-acid",
-    "canonicalCompoundName": "pfaffic acid",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "traditional restorative support",
-      "adaptogenic support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "maral-root",
-    "herbName": "Maral Root",
-    "rawCompound": "ecdysterone",
-    "normalizedAtom": "ecdysterone",
-    "canonicalCompoundId": "ecdysterone",
-    "canonicalCompoundName": "ecdysterone",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "adaptogenic support",
-      "recovery support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "jatamansi",
-    "herbName": "Jatamansi",
-    "rawCompound": "jatamansone",
-    "normalizedAtom": "jatamansone",
-    "canonicalCompoundId": "jatamansone",
-    "canonicalCompoundName": "jatamansone",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "calming support",
-      "traditional nervous-system support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "soursop",
-    "herbName": "Soursop",
-    "rawCompound": "annonacin",
-    "normalizedAtom": "annonacin",
-    "canonicalCompoundId": "annonacin",
-    "canonicalCompoundName": "annonacin",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "traditional wellness support",
-      "antioxidant"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "ashoka",
-    "herbName": "Ashoka",
-    "rawCompound": "catechins",
-    "normalizedAtom": "catechins",
-    "canonicalCompoundId": "catechins",
-    "canonicalCompoundName": "catechins",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "traditional cycle support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "shankhpushpi",
-    "herbName": "Shankhpushpi",
-    "rawCompound": "convolvine",
-    "normalizedAtom": "convolvine",
-    "canonicalCompoundId": "convolvine",
-    "canonicalCompoundName": "convolvine",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "traditional cognitive support",
-      "calming support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "hops",
-    "herbName": "Hops",
-    "rawCompound": "humulone",
-    "normalizedAtom": "humulone",
-    "canonicalCompoundId": "humulone",
-    "canonicalCompoundName": "humulone",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "calming support",
-      "sleep support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "lemongrass",
-    "herbName": "Lemongrass",
-    "rawCompound": "citral",
-    "normalizedAtom": "citral",
-    "canonicalCompoundId": "citral",
-    "canonicalCompoundName": "citral",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "digestive support",
-      "calming support",
-      "aromatic support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "perilla",
-    "herbName": "Perilla",
-    "rawCompound": "perillaldehyde",
-    "normalizedAtom": "perillaldehyde",
-    "canonicalCompoundId": "perillaldehyde",
-    "canonicalCompoundName": "perillaldehyde",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "seasonal support",
-      "antioxidant",
-      "aromatic support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "carob",
-    "herbName": "Carob",
-    "rawCompound": "d-pinitol",
-    "normalizedAtom": "d pinitol",
-    "canonicalCompoundId": "d-pinitol",
-    "canonicalCompoundName": "d-pinitol",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "digestive support",
-      "metabolic support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "danshen",
-    "herbName": "Danshen",
-    "rawCompound": "Tanshinone IIA",
-    "normalizedAtom": "tanshinone iia",
-    "canonicalCompoundId": "tanshinone-iia",
-    "canonicalCompoundName": "Tanshinone IIA",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "cardiovascular support",
-      "vascular support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "eucommia",
-    "herbName": "Eucommia",
-    "rawCompound": "geniposidic acid",
-    "normalizedAtom": "geniposidic acid",
-    "canonicalCompoundId": "geniposidic-acid",
-    "canonicalCompoundName": "geniposidic acid",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "connective tissue support",
-      "cardiometabolic support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "cistanche",
-    "herbName": "Cistanche",
-    "rawCompound": "echinacoside",
-    "normalizedAtom": "echinacoside",
-    "canonicalCompoundId": "echinacoside",
-    "canonicalCompoundName": "echinacoside",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "traditional restorative support",
-      "fatigue support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "jujube",
-    "herbName": "Jujube",
-    "rawCompound": "jujuboside a",
-    "normalizedAtom": "jujuboside a",
-    "canonicalCompoundId": "jujuboside-a",
-    "canonicalCompoundName": "jujuboside a",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "calming support",
-      "nutritive support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "longan",
-    "herbName": "Longan",
-    "rawCompound": "gallic acid",
-    "normalizedAtom": "gallic acid",
-    "canonicalCompoundId": "gallic-acid",
-    "canonicalCompoundName": "gallic acid",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "nutritive support",
-      "calming support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "polygala",
-    "herbName": "Polygala",
-    "rawCompound": "tenuifolin",
-    "normalizedAtom": "tenuifolin",
-    "canonicalCompoundId": "tenuifolin",
-    "canonicalCompoundName": "tenuifolin",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "traditional cognitive support",
-      "calming support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "gastrodia",
-    "herbName": "Gastrodia",
-    "rawCompound": "gastrodin",
-    "normalizedAtom": "gastrodin",
-    "canonicalCompoundId": "gastrodin",
-    "canonicalCompoundName": "gastrodin",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "traditional nervous-system support",
-      "calming support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "white-peony",
-    "herbName": "White Peony",
-    "rawCompound": "paeoniflorin",
-    "normalizedAtom": "paeoniflorin",
-    "canonicalCompoundId": "paeoniflorin",
-    "canonicalCompoundName": "paeoniflorin",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "traditional cycle support",
-      "calming support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "bupleurum",
-    "herbName": "Bupleurum",
-    "rawCompound": "saikosaponin a",
-    "normalizedAtom": "saikosaponin a",
-    "canonicalCompoundId": "saikosaponin-a",
-    "canonicalCompoundName": "saikosaponin a",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "traditional liver support",
-      "traditional stress support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "codonopsis",
-    "herbName": "Codonopsis",
-    "rawCompound": "tangshenoside i",
-    "normalizedAtom": "tangshenoside i",
-    "canonicalCompoundId": "tangshenoside-i",
-    "canonicalCompoundName": "tangshenoside i",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "traditional restorative support",
-      "fatigue support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "dendrobium",
-    "herbName": "Dendrobium",
-    "rawCompound": "dendrobine",
-    "normalizedAtom": "dendrobine",
-    "canonicalCompoundId": "dendrobine",
-    "canonicalCompoundName": "dendrobine",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "traditional restorative support",
-      "mucosal support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "ophiopogon",
-    "herbName": "Ophiopogon",
-    "rawCompound": "ophiopogonin d",
-    "normalizedAtom": "ophiopogonin d",
-    "canonicalCompoundId": "ophiopogonin-d",
-    "canonicalCompoundName": "ophiopogonin d",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "demulcent support",
-      "traditional respiratory support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "houttuynia",
-    "herbName": "Houttuynia",
-    "rawCompound": "quercitrin",
-    "normalizedAtom": "quercitrin",
-    "canonicalCompoundId": "quercitrin",
-    "canonicalCompoundName": "quercitrin",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "traditional immune support",
-      "traditional respiratory support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "isatis",
-    "herbName": "Isatis",
-    "rawCompound": "tryptanthrin",
-    "normalizedAtom": "tryptanthrin",
-    "canonicalCompoundId": "tryptanthrin",
-    "canonicalCompoundName": "tryptanthrin",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "traditional immune support",
-      "throat support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "sophora-flavescens",
-    "herbName": "Sophora Flavescens",
-    "rawCompound": "matrine",
-    "normalizedAtom": "matrine",
-    "canonicalCompoundId": "matrine",
-    "canonicalCompoundName": "matrine",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "traditional skin support",
-      "GI support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "notoginseng",
-    "herbName": "Notoginseng",
-    "rawCompound": "notoginsenoside r1",
-    "normalizedAtom": "notoginsenoside r1",
-    "canonicalCompoundId": "notoginsenoside-r1",
-    "canonicalCompoundName": "notoginsenoside r1",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "vascular support",
-      "recovery support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "luo-han-guo",
-    "herbName": "Luo Han Guo",
-    "rawCompound": "mogroside v",
-    "normalizedAtom": "mogroside v",
-    "canonicalCompoundId": "mogroside-v",
-    "canonicalCompoundName": "mogroside v",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "throat support",
-      "sweetener-adjacent support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "kuding-tea",
-    "herbName": "Kuding Tea",
-    "rawCompound": "kudinlactone",
-    "normalizedAtom": "kudinlactone",
-    "canonicalCompoundId": "kudinlactone",
-    "canonicalCompoundName": "kudinlactone",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "antioxidant",
-      "cardiometabolic support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "atractylodes",
-    "herbName": "Atractylodes",
-    "rawCompound": "atractylenolide i",
-    "normalizedAtom": "atractylenolide i",
-    "canonicalCompoundId": "atractylenolide-i",
-    "canonicalCompoundName": "atractylenolide i",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "digestive support",
-      "traditional restorative support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "schisandra-berry",
-    "herbName": "Schisandra Berry",
-    "rawCompound": "gomisin a",
-    "normalizedAtom": "gomisin a",
-    "canonicalCompoundId": "gomisin-a",
-    "canonicalCompoundName": "gomisin a",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "adaptogenic support",
-      "hepatoprotective support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "catuaba",
-    "herbName": "Catuaba",
-    "rawCompound": "catuabine",
-    "normalizedAtom": "catuabine",
-    "canonicalCompoundId": "catuabine",
-    "canonicalCompoundName": "catuabine",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "traditional vitality support",
-      "mood support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "muira-puama",
-    "herbName": "Muira Puama",
-    "rawCompound": "beta-sitosterol",
-    "normalizedAtom": "beta sitosterol",
-    "canonicalCompoundId": "beta-sitosterol",
-    "canonicalCompoundName": "beta-sitosterol",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "traditional vitality support",
-      "stress support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "maitake-d-fraction",
-    "herbName": "Maitake D-Fraction",
-    "rawCompound": "beta-glucans",
-    "normalizedAtom": "beta glucans",
-    "canonicalCompoundId": "beta-glucans",
-    "canonicalCompoundName": "beta-glucans",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "immune modulation"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "poria",
-    "herbName": "Poria",
-    "rawCompound": "pachymic acid",
-    "normalizedAtom": "pachymic acid",
-    "canonicalCompoundId": "pachymic-acid",
-    "canonicalCompoundName": "pachymic acid",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "traditional fluid-balance support",
-      "calming support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "rehmannia-prepared",
-    "herbName": "Rehmannia Prepared",
-    "rawCompound": "catalpol",
-    "normalizedAtom": "catalpol",
-    "canonicalCompoundId": "catalpol",
-    "canonicalCompoundName": "catalpol",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "traditional restorative support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "agarikon",
-    "herbName": "Agarikon",
-    "rawCompound": "agaric acid",
-    "normalizedAtom": "agaric acid",
-    "canonicalCompoundId": "agaric-acid",
-    "canonicalCompoundName": "agaric acid",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "traditional immune support",
-      "respiratory support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "elecampane",
-    "herbName": "Elecampane",
-    "rawCompound": "alantolactone",
-    "normalizedAtom": "alantolactone",
-    "canonicalCompoundId": "alantolactone",
-    "canonicalCompoundName": "alantolactone",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "traditional respiratory support",
-      "digestive support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "angelica-root",
-    "herbName": "Angelica Root",
-    "rawCompound": "angelicin",
-    "normalizedAtom": "angelicin",
-    "canonicalCompoundId": "angelicin",
-    "canonicalCompoundName": "angelicin",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "digestive support",
-      "traditional cycle support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "galangal",
-    "herbName": "Galangal",
-    "rawCompound": "galangin",
-    "normalizedAtom": "galangin",
-    "canonicalCompoundId": "galangin",
-    "canonicalCompoundName": "galangin",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "digestive support",
-      "aromatic support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "black-pepper",
-    "herbName": "Black Pepper",
-    "rawCompound": "Piperine",
-    "normalizedAtom": "piperine",
-    "canonicalCompoundId": "piperine",
-    "canonicalCompoundName": "Piperine",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "digestive support",
-      "bioavailability support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "cardamom",
-    "herbName": "Cardamom",
-    "rawCompound": "terpinyl acetate",
-    "normalizedAtom": "terpinyl acetate",
-    "canonicalCompoundId": "terpinyl-acetate",
-    "canonicalCompoundName": "terpinyl acetate",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "digestive support",
-      "aromatic support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "holy-basil-seed",
-    "herbName": "Holy Basil Seed",
-    "rawCompound": "mucilage",
-    "normalizedAtom": "mucilage",
-    "canonicalCompoundId": "mucilage",
-    "canonicalCompoundName": "mucilage",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "demulcent support",
-      "digestive support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "psyllium",
-    "herbName": "Psyllium",
-    "rawCompound": "mucilage",
-    "normalizedAtom": "mucilage",
-    "canonicalCompoundId": "mucilage",
-    "canonicalCompoundName": "mucilage",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "bulk laxative",
-      "GI support",
-      "cholesterol support"
-    ],
-    "pathwayTargets": [
-      "gel-forming fiber",
-      "stool water retention",
-      "stool bulk"
-    ]
-  },
-  {
-    "herbSlug": "caraway",
-    "herbName": "Caraway",
-    "rawCompound": "carvone",
-    "normalizedAtom": "carvone",
-    "canonicalCompoundId": "carvone",
-    "canonicalCompoundName": "carvone",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "digestive support",
-      "aromatic support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "ajwain",
-    "herbName": "Ajwain",
-    "rawCompound": "thymol",
-    "normalizedAtom": "thymol",
-    "canonicalCompoundId": "thymol",
-    "canonicalCompoundName": "thymol",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "digestive support",
-      "aromatic support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "holy-basil-purple",
-    "herbName": "Holy Basil Purple",
-    "rawCompound": "Eugenol",
-    "normalizedAtom": "eugenol",
-    "canonicalCompoundId": "eugenol",
-    "canonicalCompoundName": "Eugenol",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "adaptogenic support",
-      "antioxidant"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "curry-leaf",
-    "herbName": "Curry Leaf",
-    "rawCompound": "mahanimbine",
-    "normalizedAtom": "mahanimbine",
-    "canonicalCompoundId": "mahanimbine",
-    "canonicalCompoundName": "mahanimbine",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "antioxidant",
-      "metabolic support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "gudmar",
-    "herbName": "Gudmar",
-    "rawCompound": "gymnemic acids",
-    "normalizedAtom": "gymnemic acids",
-    "canonicalCompoundId": "gymnemic-acids",
-    "canonicalCompoundName": "gymnemic acids",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "glycemic support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "roselle-seed",
-    "herbName": "Roselle Seed",
-    "rawCompound": "tocopherols",
-    "normalizedAtom": "tocopherols",
-    "canonicalCompoundId": "tocopherols",
-    "canonicalCompoundName": "tocopherols",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "nutritive support",
-      "antioxidant"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "tamarind",
-    "herbName": "Tamarind",
-    "rawCompound": "tartaric acid",
-    "normalizedAtom": "tartaric acid",
-    "canonicalCompoundId": "tartaric-acid",
-    "canonicalCompoundName": "tartaric acid",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "digestive support",
-      "antioxidant"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "boswellia",
-    "herbName": "Boswellia",
-    "rawCompound": "akba",
-    "normalizedAtom": "akba",
-    "canonicalCompoundId": "akba",
-    "canonicalCompoundName": "akba",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "anti-inflammatory",
-      "mobility support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "hawthorn",
-    "herbName": "Hawthorn",
-    "rawCompound": "procyanidin b2",
-    "normalizedAtom": "procyanidin b2",
-    "canonicalCompoundId": "procyanidin-b2",
-    "canonicalCompoundName": "procyanidin b2",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "cardiovascular support",
-      "vascular support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "astragalus",
-    "herbName": "Astragalus",
-    "rawCompound": "astragaloside iv",
-    "normalizedAtom": "astragaloside iv",
-    "canonicalCompoundId": "astragaloside-iv",
-    "canonicalCompoundName": "astragaloside iv",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "immune modulation",
-      "fatigue support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "nettle-root",
-    "herbName": "Nettle Root",
-    "rawCompound": "beta-sitosterol",
-    "normalizedAtom": "beta sitosterol",
-    "canonicalCompoundId": "beta-sitosterol",
-    "canonicalCompoundName": "beta-sitosterol",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "urinary support",
-      "men's-health support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "rhodiola",
-    "herbName": "Rhodiola",
-    "rawCompound": "Salidroside",
-    "normalizedAtom": "salidroside",
-    "canonicalCompoundId": "salidroside",
-    "canonicalCompoundName": "Salidroside",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "adaptogenic support",
-      "fatigue support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "bacopa",
-    "herbName": "Bacopa",
-    "rawCompound": "bacoside a",
-    "normalizedAtom": "bacoside a",
-    "canonicalCompoundId": "bacoside-a",
-    "canonicalCompoundName": "bacoside a",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "cognitive support",
-      "calming support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "passionflower",
-    "herbName": "Passionflower",
-    "rawCompound": "chrysin",
-    "normalizedAtom": "chrysin",
-    "canonicalCompoundId": "chrysin",
-    "canonicalCompoundName": "chrysin",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "calming support",
-      "sleep support",
-      "traditional-use sedative"
-    ],
-    "pathwayTargets": [
-      "possible GABAergic signaling",
-      "low target specificity"
-    ]
-  },
-  {
-    "herbSlug": "cordyceps",
-    "herbName": "Cordyceps",
-    "rawCompound": "cordycepin",
-    "normalizedAtom": "cordycepin",
-    "canonicalCompoundId": "cordycepin",
-    "canonicalCompoundName": "cordycepin",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "immune modulation",
-      "anti-inflammatory",
-      "NF-kappaB modulation"
-    ],
-    "pathwayTargets": [
-      "NF-kappaB",
-      "Nrf2/HO-1",
-      "RIP2/Caspase-1"
-    ]
-  },
-  {
-    "herbSlug": "lions-mane",
-    "herbName": "Lion's Mane",
-    "rawCompound": "hericenone c",
-    "normalizedAtom": "hericenone c",
-    "canonicalCompoundId": "hericenone-c",
-    "canonicalCompoundName": "hericenone c",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "neurocognitive support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "reishi",
-    "herbName": "Reishi",
-    "rawCompound": "beta-glucans",
-    "normalizedAtom": "beta glucans",
-    "canonicalCompoundId": "beta-glucans",
-    "canonicalCompoundName": "beta-glucans",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "immune modulation",
-      "calming support"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "turkey-tail",
-    "herbName": "Turkey Tail",
-    "rawCompound": "psk",
-    "normalizedAtom": "psk",
-    "canonicalCompoundId": "psk",
-    "canonicalCompoundName": "psk",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "immune modulation"
-    ],
-    "pathwayTargets": [
-      "general or unknown targets"
-    ]
-  },
-  {
-    "herbSlug": "corydalis-yanhusuo",
-    "herbName": "Dehydrocorybulbine"
-  },
-  {
-    "herbSlug": "picralima-nitida",
-    "herbName": "Akuammine"
-  },
-  {
-    "herbSlug": "peganum-harmala",
-    "herbName": "Harmine"
-  },
-  {
-    "herbSlug": "andrographis-paniculata",
-    "herbName": "Andrographolide"
-  },
-  {
-    "herbSlug": "phyllanthus-amarus",
-    "herbName": "Phyllanthin"
-  },
-  {
-    "herbSlug": "justicia-adhatoda",
-    "herbName": "Vasicine"
-  },
-  {
-    "herbSlug": "tabernanthe-iboga",
-    "herbName": "Ibogaine"
-  },
-  {
-    "herbSlug": "boerhavia-diffusa",
-    "herbName": "Punarnavine"
-  },
-  {
-    "herbSlug": "celastrus-paniculatus",
-    "herbName": "Celastrine"
-  },
-  {
-    "herbSlug": "epimedium",
-    "herbName": "Epimedium",
-    "rawCompound": "Icariin",
-    "normalizedAtom": "icariin",
-    "canonicalCompoundId": "icariin",
-    "canonicalCompoundName": "Icariin",
-    "v3MatchType": "exact-normalized",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "PDE-related signaling",
-      "nitric oxide signaling"
-    ],
-    "pathwayTargets": [
-      "eNOS/NO signaling",
-      "PDE-related signaling"
-    ]
-  },
-  {
-    "herbSlug": "yohimbe",
-    "herbName": "Yohimbe",
-    "rawCompound": "Yohimbine",
-    "normalizedAtom": "yohimbine",
-    "canonicalCompoundId": "yohimbine",
-    "canonicalCompoundName": "Yohimbine",
-    "v3MatchType": "exact-normalized",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "adrenergic signaling",
-      "alpha-2 adrenergic antagonism"
-    ],
-    "pathwayTargets": [
-      "alpha-2 adrenergic receptor antagonism"
-    ]
-  },
-  {
-    "herbSlug": "eleuthero",
-    "herbName": "Eleuthero",
-    "rawCompound": "eleutherosides",
-    "normalizedAtom": "eleutherosides",
-    "canonicalCompoundId": "eleutherosides",
-    "canonicalCompoundName": "eleutherosides",
-    "v3MatchType": "exact-normalized",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "adaptogen",
-      "stress-response modulation"
-    ],
-    "pathwayTargets": [
-      "HPA-axis-related signaling (broad/preclinical)"
-    ]
-  },
-  {
-    "herbSlug": "salvia-miltiorrhiza",
-    "herbName": "Tanshinone IIA"
-  },
-  {
-    "herbSlug": "epimedium",
-    "herbName": "Icariin",
-    "mechanismTags": [
-      "flavonoid activity",
-      "nitric oxide signaling"
-    ]
-  },
-  {
-    "herbSlug": "pausinystalia-yohimbe",
-    "herbName": "Yohimbine"
-  },
-  {
-    "herbSlug": "mucuna-pruriens",
-    "herbName": "Dopamine"
-  },
-  {
-    "herbSlug": "curcuma-longa",
+    "herbSlug": "demethoxycurcumin",
     "herbName": "Demethoxycurcumin"
   },
   {
-    "herbSlug": "camellia-sinensis",
+    "herbSlug": "valerenic-acid",
+    "herbName": "valerenic acid"
+  },
+  {
+    "herbSlug": "caffeine",
+    "herbName": "Caffeine"
+  },
+  {
+    "herbSlug": "apigenin",
+    "herbName": "Apigenin"
+  },
+  {
+    "herbSlug": "nuciferine",
+    "herbName": "nuciferine"
+  },
+  {
+    "herbSlug": "puerarin",
+    "herbName": "puerarin"
+  },
+  {
+    "herbSlug": "parthenolide",
+    "herbName": "parthenolide"
+  },
+  {
+    "herbSlug": "petasin",
+    "herbName": "petasin"
+  },
+  {
+    "herbSlug": "actein",
+    "herbName": "Actein"
+  },
+  {
+    "herbSlug": "curcumin",
+    "herbName": "curcumin"
+  },
+  {
+    "herbSlug": "thymol",
+    "herbName": "thymol"
+  },
+  {
+    "herbSlug": "carvacrol",
+    "herbName": "carvacrol"
+  },
+  {
+    "herbSlug": "eucalyptol",
+    "herbName": "eucalyptol"
+  },
+  {
+    "herbSlug": "cynarin",
+    "herbName": "cynarin"
+  },
+  {
+    "herbSlug": "anethole",
+    "herbName": "anethole"
+  },
+  {
+    "herbSlug": "cinnamaldehyde",
+    "herbName": "cinnamaldehyde"
+  },
+  {
+    "herbSlug": "taraxasterol",
+    "herbName": "taraxasterol"
+  },
+  {
+    "herbSlug": "arctiin",
+    "herbName": "arctiin"
+  },
+  {
+    "herbSlug": "genistein",
+    "herbName": "genistein"
+  },
+  {
+    "herbSlug": "avenanthramides",
+    "herbName": "avenanthramides"
+  },
+  {
+    "herbSlug": "faradiol",
+    "herbName": "faradiol"
+  },
+  {
+    "herbSlug": "lapachol",
+    "herbName": "lapachol"
+  },
+  {
+    "herbSlug": "gymnemic-acids",
+    "herbName": "gymnemic acids"
+  },
+  {
+    "herbSlug": "corosolic-acid",
+    "herbName": "corosolic acid"
+  },
+  {
+    "herbSlug": "1-deoxynojirimycin",
+    "herbName": "1-deoxynojirimycin"
+  },
+  {
+    "herbSlug": "nimbin",
+    "herbName": "nimbin"
+  },
+  {
+    "herbSlug": "thujone",
+    "herbName": "thujone"
+  },
+  {
+    "herbSlug": "verbascoside",
+    "herbName": "verbascoside"
+  },
+  {
+    "herbSlug": "avenacosides",
+    "herbName": "avenacosides"
+  },
+  {
+    "herbSlug": "quadrangularin-a",
+    "herbName": "quadrangularin a"
+  },
+  {
+    "herbSlug": "4-hydroxyderricin",
+    "herbName": "4-hydroxyderricin"
+  },
+  {
+    "herbSlug": "punicalagins",
+    "herbName": "punicalagins"
+  },
+  {
+    "herbSlug": "moringin",
+    "herbName": "moringin"
+  },
+  {
+    "herbSlug": "arjunolic-acid",
+    "herbName": "arjunolic acid"
+  },
+  {
+    "herbSlug": "damnacanthal",
+    "herbName": "damnacanthal"
+  },
+  {
+    "herbSlug": "a-type-proanthocyanidins",
+    "herbName": "a-type proanthocyanidins"
+  },
+  {
+    "herbSlug": "trans-tiliroside",
+    "herbName": "trans-tiliroside"
+  },
+  {
+    "herbSlug": "alpha-pinene",
+    "herbName": "alpha-pinene"
+  },
+  {
+    "herbSlug": "myrtenyl-acetate",
+    "herbName": "myrtenyl acetate"
+  },
+  {
+    "herbSlug": "ascorbic-acid",
+    "herbName": "ascorbic acid"
+  },
+  {
+    "herbSlug": "alpha-mangostin",
+    "herbName": "alpha-mangostin"
+  },
+  {
+    "herbSlug": "boldine",
+    "herbName": "boldine"
+  },
+  {
+    "herbSlug": "pfaffic-acid",
+    "herbName": "pfaffic acid"
+  },
+  {
+    "herbSlug": "ecdysterone",
+    "herbName": "ecdysterone"
+  },
+  {
+    "herbSlug": "jatamansone",
+    "herbName": "jatamansone"
+  },
+  {
+    "herbSlug": "annonacin",
+    "herbName": "annonacin"
+  },
+  {
+    "herbSlug": "catechins",
+    "herbName": "catechins"
+  },
+  {
+    "herbSlug": "convolvine",
+    "herbName": "convolvine"
+  },
+  {
+    "herbSlug": "humulone",
+    "herbName": "humulone"
+  },
+  {
+    "herbSlug": "citral",
+    "herbName": "citral"
+  },
+  {
+    "herbSlug": "perillaldehyde",
+    "herbName": "perillaldehyde"
+  },
+  {
+    "herbSlug": "d-pinitol",
+    "herbName": "d-pinitol"
+  },
+  {
+    "herbSlug": "tanshinone-iia",
+    "herbName": "Tanshinone IIA"
+  },
+  {
+    "herbSlug": "geniposidic-acid",
+    "herbName": "geniposidic acid"
+  },
+  {
+    "herbSlug": "echinacoside",
+    "herbName": "echinacoside"
+  },
+  {
+    "herbSlug": "jujuboside-a",
+    "herbName": "jujuboside a"
+  },
+  {
+    "herbSlug": "gallic-acid",
+    "herbName": "gallic acid"
+  },
+  {
+    "herbSlug": "tenuifolin",
+    "herbName": "tenuifolin"
+  },
+  {
+    "herbSlug": "gastrodin",
+    "herbName": "gastrodin"
+  },
+  {
+    "herbSlug": "paeoniflorin",
+    "herbName": "paeoniflorin"
+  },
+  {
+    "herbSlug": "saikosaponin-a",
+    "herbName": "saikosaponin a"
+  },
+  {
+    "herbSlug": "tangshenoside-i",
+    "herbName": "tangshenoside i"
+  },
+  {
+    "herbSlug": "dendrobine",
+    "herbName": "dendrobine"
+  },
+  {
+    "herbSlug": "ophiopogonin-d",
+    "herbName": "ophiopogonin d"
+  },
+  {
+    "herbSlug": "quercitrin",
+    "herbName": "quercitrin"
+  },
+  {
+    "herbSlug": "tryptanthrin",
+    "herbName": "tryptanthrin"
+  },
+  {
+    "herbSlug": "matrine",
+    "herbName": "matrine"
+  },
+  {
+    "herbSlug": "notoginsenoside-r1",
+    "herbName": "notoginsenoside r1"
+  },
+  {
+    "herbSlug": "mogroside-v",
+    "herbName": "mogroside v"
+  },
+  {
+    "herbSlug": "kudinlactone",
+    "herbName": "kudinlactone"
+  },
+  {
+    "herbSlug": "atractylenolide-i",
+    "herbName": "atractylenolide i"
+  },
+  {
+    "herbSlug": "gomisin-a",
+    "herbName": "gomisin a"
+  },
+  {
+    "herbSlug": "catuabine",
+    "herbName": "catuabine"
+  },
+  {
+    "herbSlug": "beta-sitosterol",
+    "herbName": "beta-sitosterol"
+  },
+  {
+    "herbSlug": "beta-glucans",
+    "herbName": "beta-glucans"
+  },
+  {
+    "herbSlug": "pachymic-acid",
+    "herbName": "pachymic acid"
+  },
+  {
+    "herbSlug": "catalpol",
+    "herbName": "catalpol"
+  },
+  {
+    "herbSlug": "agaric-acid",
+    "herbName": "agaric acid"
+  },
+  {
+    "herbSlug": "alantolactone",
+    "herbName": "alantolactone"
+  },
+  {
+    "herbSlug": "angelicin",
+    "herbName": "angelicin"
+  },
+  {
+    "herbSlug": "galangin",
+    "herbName": "galangin"
+  },
+  {
+    "herbSlug": "piperine",
+    "herbName": "Piperine"
+  },
+  {
+    "herbSlug": "terpinyl-acetate",
+    "herbName": "terpinyl acetate"
+  },
+  {
+    "herbSlug": "mucilage",
+    "herbName": "mucilage"
+  },
+  {
+    "herbSlug": "carvone",
+    "herbName": "carvone"
+  },
+  {
+    "herbSlug": "mahanimbine",
+    "herbName": "mahanimbine"
+  },
+  {
+    "herbSlug": "tocopherols",
+    "herbName": "tocopherols"
+  },
+  {
+    "herbSlug": "tartaric-acid",
+    "herbName": "tartaric acid"
+  },
+  {
+    "herbSlug": "akba",
+    "herbName": "akba"
+  },
+  {
+    "herbSlug": "procyanidin-b2",
+    "herbName": "procyanidin b2"
+  },
+  {
+    "herbSlug": "astragaloside-iv",
+    "herbName": "astragaloside iv"
+  },
+  {
+    "herbSlug": "salidroside",
+    "herbName": "Salidroside"
+  },
+  {
+    "herbSlug": "bacoside-a",
+    "herbName": "bacoside a"
+  },
+  {
+    "herbSlug": "chrysin",
+    "herbName": "chrysin"
+  },
+  {
+    "herbSlug": "cordycepin",
+    "herbName": "cordycepin"
+  },
+  {
+    "herbSlug": "hericenone-c",
+    "herbName": "hericenone c"
+  },
+  {
+    "herbSlug": "psk",
+    "herbName": "psk"
+  },
+  {
+    "herbSlug": "icariin",
+    "herbName": "Icariin"
+  },
+  {
+    "herbSlug": "yohimbine",
+    "herbName": "Yohimbine"
+  },
+  {
+    "herbSlug": "eleutherosides",
+    "herbName": "eleutherosides"
+  },
+  {
+    "herbSlug": "bisdemethoxycurcumin",
+    "herbName": "Bisdemethoxycurcumin"
+  },
+  {
+    "herbSlug": "theanine",
     "herbName": "Theanine"
   },
   {
-    "herbSlug": "hypericum-perforatum",
+    "herbSlug": "hypericin",
     "herbName": "Hypericin"
   },
   {
-    "herbSlug": "ginkgo-biloba",
+    "herbSlug": "ginkgolide-b",
     "herbName": "Ginkgolide B"
   },
   {
-    "herbSlug": "panax-ginseng",
-    "herbName": "Ginsenoside Rg1"
+    "herbSlug": "bilobalide",
+    "herbName": "Bilobalide"
   },
   {
-    "herbSlug": "withania-somnifera",
+    "herbSlug": "ginsenoside-rg1",
+    "herbName": "Ginsenoside RG1"
+  },
+  {
+    "herbSlug": "ginsenoside-rb1",
+    "herbName": "Ginsenoside RB1"
+  },
+  {
+    "herbSlug": "withanolide-a",
     "herbName": "Withanolide A"
   },
   {
-    "herbSlug": "turmeric",
-    "herbName": "Turmeric",
-    "rawCompound": "curcumin",
-    "normalizedAtom": "curcumin",
-    "canonicalCompoundId": "curcumin",
-    "canonicalCompoundName": "curcumin"
+    "herbSlug": "harmine",
+    "herbName": "Harmine"
   },
   {
-    "herbSlug": "turmeric",
-    "herbName": "Turmeric",
-    "rawCompound": "Bisdemethoxycurcumin",
-    "normalizedAtom": "bisdemethoxycurcumin",
-    "canonicalCompoundId": "bisdemethoxycurcumin",
-    "canonicalCompoundName": "Bisdemethoxycurcumin"
+    "herbSlug": "harmaline",
+    "herbName": "Harmaline"
   },
   {
-    "herbSlug": "green-tea",
-    "herbName": "Green Tea",
-    "rawCompound": "Caffeine",
-    "normalizedAtom": "caffeine",
-    "canonicalCompoundId": "caffeine",
-    "canonicalCompoundName": "Caffeine"
+    "herbSlug": "salvianolic-acid-b",
+    "herbName": "Salvianolic acid B"
   },
   {
-    "herbSlug": "green-tea",
-    "herbName": "Green Tea",
-    "rawCompound": "Theanine",
-    "normalizedAtom": "theanine",
-    "canonicalCompoundId": "theanine",
-    "canonicalCompoundName": "Theanine"
+    "herbSlug": "vasicine",
+    "herbName": "Vasicine"
   },
   {
-    "herbSlug": "hypericum-perforatum",
-    "herbName": "Hypericum perforatum",
-    "rawCompound": "Hypericin",
-    "normalizedAtom": "hypericin",
-    "canonicalCompoundId": "hypericin",
-    "canonicalCompoundName": "Hypericin"
+    "herbSlug": "ibogaine",
+    "herbName": "Ibogaine"
   },
   {
-    "herbSlug": "hypericum-perforatum",
-    "herbName": "Hypericum perforatum",
-    "rawCompound": "Hyperforin",
-    "normalizedAtom": "hyperforin",
-    "canonicalCompoundId": "hyperforin",
-    "canonicalCompoundName": "Hyperforin"
+    "herbSlug": "akuammine",
+    "herbName": "Akuammine"
   },
   {
-    "herbSlug": "ginkgo-biloba",
-    "herbName": "Ginkgo Biloba",
-    "rawCompound": "Ginkgolide B",
-    "normalizedAtom": "ginkgolide b",
-    "canonicalCompoundId": "ginkgolide-b",
-    "canonicalCompoundName": "Ginkgolide B"
+    "herbSlug": "dehydrocorybulbine",
+    "herbName": "Dehydrocorybulbine"
   },
   {
-    "herbSlug": "ginkgo-biloba",
-    "herbName": "Ginkgo Biloba",
-    "rawCompound": "Bilobalide",
-    "normalizedAtom": "bilobalide",
-    "canonicalCompoundId": "bilobalide",
-    "canonicalCompoundName": "Bilobalide"
+    "herbSlug": "andrographolide",
+    "herbName": "Andrographolide"
   },
   {
-    "herbSlug": "panax-ginseng",
-    "herbName": "Panax Ginseng",
-    "rawCompound": "Ginsenoside RG1",
-    "normalizedAtom": "ginsenoside rg1",
-    "canonicalCompoundId": "ginsenoside-rg1",
-    "canonicalCompoundName": "Ginsenoside RG1"
+    "herbSlug": "phyllanthin",
+    "herbName": "Phyllanthin"
   },
   {
-    "herbSlug": "panax-ginseng",
-    "herbName": "Panax Ginseng",
-    "rawCompound": "Ginsenoside RB1",
-    "normalizedAtom": "ginsenoside rb1",
-    "canonicalCompoundId": "ginsenoside-rb1",
-    "canonicalCompoundName": "Ginsenoside RB1"
+    "herbSlug": "l-dopa",
+    "herbName": "L-DOPA"
   },
   {
-    "herbSlug": "ashwagandha",
-    "herbName": "Ashwagandha",
-    "rawCompound": "Withanolide A",
-    "normalizedAtom": "withanolide a",
-    "canonicalCompoundId": "withanolide-a",
-    "canonicalCompoundName": "Withanolide A"
+    "herbSlug": "dopamine",
+    "herbName": "Dopamine"
   },
   {
-    "herbSlug": "peganum-harmala",
-    "herbName": "Peganum harmala",
-    "rawCompound": "Harmine",
-    "normalizedAtom": "harmine",
-    "canonicalCompoundId": "harmine",
-    "canonicalCompoundName": "Harmine"
+    "herbSlug": "resveratrol",
+    "herbName": "Resveratrol"
   },
   {
-    "herbSlug": "peganum-harmala",
-    "herbName": "Peganum harmala",
-    "rawCompound": "Harmaline",
-    "normalizedAtom": "harmaline",
-    "canonicalCompoundId": "harmaline",
-    "canonicalCompoundName": "Harmaline"
+    "herbSlug": "quercetin",
+    "herbName": "Quercetin"
   },
   {
-    "herbSlug": "salvia-miltiorrhiza",
-    "herbName": "Salvia miltiorrhiza",
-    "rawCompound": "Tanshinone IIA",
-    "normalizedAtom": "tanshinone iia",
-    "canonicalCompoundId": "tanshinone-iia",
-    "canonicalCompoundName": "Tanshinone IIA"
+    "herbSlug": "baicalin",
+    "herbName": "Baicalin"
   },
   {
-    "herbSlug": "salvia-miltiorrhiza",
-    "herbName": "Salvia miltiorrhiza",
-    "rawCompound": "Salvianolic acid B",
-    "normalizedAtom": "salvianolic acid b",
-    "canonicalCompoundId": "salvianolic-acid-b",
-    "canonicalCompoundName": "Salvianolic acid B"
+    "herbSlug": "baicalein",
+    "herbName": "Baicalein"
   },
   {
-    "herbSlug": "justicia-adhatoda",
-    "herbName": "Justicia adhatoda",
-    "rawCompound": "Vasicine",
-    "normalizedAtom": "vasicine",
-    "canonicalCompoundId": "vasicine",
-    "canonicalCompoundName": "Vasicine"
+    "herbSlug": "carnosic-acid",
+    "herbName": "Carnosic acid"
   },
   {
-    "herbSlug": "tabernanthe-iboga",
-    "herbName": "Tabernanthe iboga",
-    "rawCompound": "Ibogaine",
-    "normalizedAtom": "ibogaine",
-    "canonicalCompoundId": "ibogaine",
-    "canonicalCompoundName": "Ibogaine"
+    "herbSlug": "carnosol",
+    "herbName": "Carnosol"
   },
   {
-    "herbSlug": "picralima-nitida",
-    "herbName": "Picralima nitida",
-    "rawCompound": "Akuammine",
-    "normalizedAtom": "akuammine",
-    "canonicalCompoundId": "akuammine",
-    "canonicalCompoundName": "Akuammine"
+    "herbSlug": "6-shogaol",
+    "herbName": "6-Shogaol"
   },
   {
-    "herbSlug": "corydalis-yanhusuo",
-    "herbName": "Corydalis yanhusuo",
-    "rawCompound": "Dehydrocorybulbine",
-    "normalizedAtom": "dehydrocorybulbine",
-    "canonicalCompoundId": "dehydrocorybulbine",
-    "canonicalCompoundName": "Dehydrocorybulbine"
+    "herbSlug": "ginsenoside-rg3",
+    "herbName": "Ginsenoside Rg3"
   },
   {
-    "herbSlug": "andrographis-paniculata",
-    "herbName": "Andrographis paniculata",
-    "rawCompound": "Andrographolide",
-    "normalizedAtom": "andrographolide",
-    "canonicalCompoundId": "andrographolide",
-    "canonicalCompoundName": "Andrographolide"
+    "herbSlug": "kaempferol",
+    "herbName": "Kaempferol"
   },
   {
-    "herbSlug": "phyllanthus-amarus",
-    "herbName": "Phyllanthus amarus",
-    "rawCompound": "Phyllanthin",
-    "normalizedAtom": "phyllanthin",
-    "canonicalCompoundId": "phyllanthin",
-    "canonicalCompoundName": "Phyllanthin"
+    "herbSlug": "isorhamnetin",
+    "herbName": "Isorhamnetin"
   },
   {
-    "herbSlug": "mucuna-pruriens",
-    "herbName": "Mucuna pruriens",
-    "rawCompound": "L-DOPA",
-    "normalizedAtom": "l dopa",
-    "canonicalCompoundId": "l-dopa",
-    "canonicalCompoundName": "L-DOPA"
+    "herbSlug": "ginsenoside-re",
+    "herbName": "Ginsenoside Re"
   },
   {
-    "herbSlug": "mucuna-pruriens",
-    "herbName": "Mucuna pruriens",
-    "rawCompound": "Dopamine",
-    "normalizedAtom": "dopamine",
-    "canonicalCompoundId": "dopamine",
-    "canonicalCompoundName": "Dopamine"
+    "herbSlug": "ginsenoside-rd",
+    "herbName": "Ginsenoside Rd"
   },
   {
-    "herbSlug": "pausinystalia-yohimbe",
-    "herbName": "Pausinystalia yohimbe",
-    "rawCompound": "Yohimbine",
-    "normalizedAtom": "yohimbine",
-    "canonicalCompoundId": "yohimbine",
-    "canonicalCompoundName": "Yohimbine"
+    "herbSlug": "ginsenoside-rf",
+    "herbName": "Ginsenoside Rf"
   },
   {
-    "herbSlug": "polygonum-cuspidatum",
-    "herbName": "Polygonum cuspidatum",
-    "rawCompound": "Resveratrol",
-    "normalizedAtom": "resveratrol",
-    "canonicalCompoundId": "resveratrol",
-    "canonicalCompoundName": "Resveratrol"
+    "herbSlug": "wogonin",
+    "herbName": "wogonin"
   },
   {
-    "herbSlug": "green-tea",
-    "herbName": "Green Tea",
-    "rawCompound": "Quercetin",
-    "normalizedAtom": "quercetin",
-    "canonicalCompoundId": "quercetin",
-    "canonicalCompoundName": "Quercetin"
+    "herbSlug": "wogonoside",
+    "herbName": "Wogonoside"
   },
   {
-    "herbSlug": "ginkgo-biloba",
-    "herbName": "Ginkgo Biloba",
-    "rawCompound": "Quercetin",
-    "normalizedAtom": "quercetin",
-    "canonicalCompoundId": "quercetin",
-    "canonicalCompoundName": "Quercetin"
+    "herbSlug": "alpha-bisabolol",
+    "herbName": "alpha-bisabolol"
   },
   {
-    "herbSlug": "hypericum-perforatum",
-    "herbName": "Hypericum perforatum",
-    "rawCompound": "Quercetin",
-    "normalizedAtom": "quercetin",
-    "canonicalCompoundId": "quercetin",
-    "canonicalCompoundName": "Quercetin"
+    "herbSlug": "chamazulene",
+    "herbName": "chamazulene"
   },
   {
-    "herbSlug": "petroselinum-crispum",
-    "herbName": "Petroselinum crispum",
-    "rawCompound": "Apigenin",
-    "normalizedAtom": "apigenin",
-    "canonicalCompoundId": "apigenin",
-    "canonicalCompoundName": "Apigenin"
+    "herbSlug": "epimedin-a",
+    "herbName": "Epimedin A"
   },
   {
-    "herbSlug": "vitis-vinifera",
-    "herbName": "Vitis vinifera",
-    "rawCompound": "Resveratrol",
-    "normalizedAtom": "resveratrol",
-    "canonicalCompoundId": "resveratrol",
-    "canonicalCompoundName": "Resveratrol"
+    "herbSlug": "epimedin-b",
+    "herbName": "Epimedin B"
   },
   {
-    "herbSlug": "ilex-paraguariensis",
-    "herbName": "Ilex paraguariensis",
-    "rawCompound": "Caffeine",
-    "normalizedAtom": "caffeine",
-    "canonicalCompoundId": "caffeine",
-    "canonicalCompoundName": "Caffeine"
+    "herbSlug": "epimedin-c",
+    "herbName": "Epimedin C"
   },
   {
-    "herbSlug": "rosmarinus-officinalis",
-    "herbName": "Rosmarinus officinalis",
-    "rawCompound": "Rosmarinic acid",
-    "normalizedAtom": "rosmarinic acid",
-    "canonicalCompoundId": "rosmarinic-acid",
-    "canonicalCompoundName": "Rosmarinic acid"
+    "herbSlug": "egcg",
+    "herbName": "EGCG"
   },
   {
-    "herbSlug": "chinese-skullcap",
-    "herbName": "Chinese Skullcap",
-    "rawCompound": "Baicalin",
-    "normalizedAtom": "baicalin",
-    "canonicalCompoundId": "baicalin",
-    "canonicalCompoundName": "Baicalin"
+    "herbSlug": "ecg",
+    "herbName": "ECG"
   },
   {
-    "herbSlug": "zingiber-officinale",
-    "herbName": "Zingiber officinale",
-    "rawCompound": "6-Gingerol",
-    "normalizedAtom": "6 gingerol",
-    "canonicalCompoundId": "6-gingerol",
-    "canonicalCompoundName": "6-Gingerol"
+    "herbSlug": "catechin",
+    "herbName": "Catechin"
   },
   {
-    "herbSlug": "chinese-skullcap",
-    "herbName": "Chinese Skullcap",
-    "rawCompound": "Baicalein",
-    "normalizedAtom": "baicalein",
-    "canonicalCompoundId": "baicalein",
-    "canonicalCompoundName": "Baicalein"
+    "herbSlug": "chavicine",
+    "herbName": "Chavicine"
   },
   {
-    "herbSlug": "rosmarinus-officinalis",
-    "herbName": "Rosmarinus officinalis",
-    "rawCompound": "Carnosic acid",
-    "normalizedAtom": "carnosic acid",
-    "canonicalCompoundId": "carnosic-acid",
-    "canonicalCompoundName": "Carnosic acid"
+    "herbSlug": "apomorphine",
+    "herbName": "apomorphine"
   },
   {
-    "herbSlug": "rosmarinus-officinalis",
-    "herbName": "Rosmarinus officinalis",
-    "rawCompound": "Carnosol",
-    "normalizedAtom": "carnosol",
-    "canonicalCompoundId": "carnosol",
-    "canonicalCompoundName": "Carnosol"
+    "herbSlug": "cimicifugoside",
+    "herbName": "Cimicifugoside"
   },
   {
-    "herbSlug": "zingiber-officinale",
-    "herbName": "Zingiber officinale",
-    "rawCompound": "6-Shogaol",
-    "normalizedAtom": "6 shogaol",
-    "canonicalCompoundId": "6-shogaol",
-    "canonicalCompoundName": "6-Shogaol"
+    "herbSlug": "isoferulic-acid",
+    "herbName": "Isoferulic acid"
   },
   {
-    "herbSlug": "panax-ginseng",
-    "herbName": "Panax Ginseng",
-    "rawCompound": "Ginsenoside Rg3",
-    "normalizedAtom": "ginsenoside rg3",
-    "canonicalCompoundId": "ginsenoside-rg3",
-    "canonicalCompoundName": "Ginsenoside Rg3"
+    "herbSlug": "arjunic-acid",
+    "herbName": "Arjunic acid"
   },
   {
-    "herbSlug": "ginkgo-biloba",
-    "herbName": "Ginkgo Biloba",
-    "rawCompound": "Kaempferol",
-    "normalizedAtom": "kaempferol",
-    "canonicalCompoundId": "kaempferol",
-    "canonicalCompoundName": "Kaempferol"
+    "herbSlug": "ursolic-acid",
+    "herbName": "Ursolic acid"
   },
   {
-    "herbSlug": "ginkgo-biloba",
-    "herbName": "Ginkgo Biloba",
-    "rawCompound": "Isorhamnetin",
-    "normalizedAtom": "isorhamnetin",
-    "canonicalCompoundId": "isorhamnetin",
-    "canonicalCompoundName": "Isorhamnetin"
+    "herbSlug": "rosarin",
+    "herbName": "Rosarin"
   },
   {
-    "herbSlug": "panax-ginseng",
-    "herbName": "Panax Ginseng",
-    "rawCompound": "Ginsenoside Re",
-    "normalizedAtom": "ginsenoside re",
-    "canonicalCompoundId": "ginsenoside-re",
-    "canonicalCompoundName": "Ginsenoside Re"
+    "herbSlug": "rosin",
+    "herbName": "Rosin"
   },
   {
-    "herbSlug": "panax-ginseng",
-    "herbName": "Panax Ginseng",
-    "rawCompound": "Ginsenoside Rd",
-    "normalizedAtom": "ginsenoside rd",
-    "canonicalCompoundId": "ginsenoside-rd",
-    "canonicalCompoundName": "Ginsenoside Rd"
+    "herbSlug": "tyrosol",
+    "herbName": "Tyrosol"
   },
   {
-    "herbSlug": "panax-ginseng",
-    "herbName": "Panax Ginseng",
-    "rawCompound": "Ginsenoside Rf",
-    "normalizedAtom": "ginsenoside rf",
-    "canonicalCompoundId": "ginsenoside-rf",
-    "canonicalCompoundName": "Ginsenoside Rf",
-    "v3MatchType": "pass13-real-sweep",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "stress-response modulation",
-      "cognitive modulation"
-    ],
-    "pathwayTargets": [
-      "stress-response modulation",
-      "cognitive modulation"
-    ]
+    "herbSlug": "arjungenin",
+    "herbName": "Arjungenin"
   },
   {
-    "herbSlug": "scutellaria-baicalensis",
-    "herbName": "Chinese Skullcap",
-    "rawCompound": "wogonin",
-    "normalizedAtom": "wogonin",
-    "canonicalCompoundId": "wogonin",
-    "canonicalCompoundName": "wogonin",
-    "v3MatchType": "pass13-real-sweep",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "NF-kB inhibition",
-      "neuroprotective signaling"
-    ],
-    "pathwayTargets": [
-      "NF-kB inhibition",
-      "neuroprotective signaling"
-    ]
+    "herbSlug": "arjunetin",
+    "herbName": "Arjunetin"
   },
   {
-    "herbSlug": "scutellaria-baicalensis",
-    "herbName": "Chinese Skullcap",
-    "rawCompound": "Wogonoside",
-    "normalizedAtom": "wogonoside",
-    "canonicalCompoundId": "wogonoside",
-    "canonicalCompoundName": "Wogonoside",
-    "v3MatchType": "pass13-real-sweep",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "NF-kB inhibition"
-    ],
-    "pathwayTargets": [
-      "NF-kB inhibition"
-    ]
+    "herbSlug": "23-epi-26-deoxyactein",
+    "herbName": "23-epi-26-deoxyactein"
   },
   {
-    "herbSlug": "chamomile",
-    "herbName": "Chamomile",
-    "rawCompound": "alpha-bisabolol",
-    "normalizedAtom": "alpha bisabolol",
-    "canonicalCompoundId": "alpha-bisabolol",
-    "canonicalCompoundName": "alpha-bisabolol",
-    "v3MatchType": "pass13-real-sweep",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "anti-inflammatory signaling",
-      "calming CNS signaling"
-    ],
-    "pathwayTargets": [
-      "anti-inflammatory signaling",
-      "calming CNS signaling"
-    ]
+    "herbSlug": "fukinolic-acid",
+    "herbName": "Fukinolic acid"
   },
   {
-    "herbSlug": "chamomile",
-    "herbName": "Chamomile",
-    "rawCompound": "chamazulene",
-    "normalizedAtom": "chamazulene",
-    "canonicalCompoundId": "chamazulene",
-    "canonicalCompoundName": "chamazulene",
-    "v3MatchType": "pass13-real-sweep",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "anti-inflammatory signaling"
-    ],
-    "pathwayTargets": [
-      "anti-inflammatory signaling"
-    ]
+    "herbSlug": "withanoside-iv",
+    "herbName": "Withanoside IV"
   },
   {
-    "herbSlug": "epimedium",
-    "herbName": "Epimedium",
-    "rawCompound": "Epimedin A",
-    "normalizedAtom": "epimedin a",
-    "canonicalCompoundId": "epimedin-a",
-    "canonicalCompoundName": "Epimedin A",
-    "v3MatchType": "pass13-real-sweep",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "flavonoid activity",
-      "nitric oxide signaling"
-    ],
-    "pathwayTargets": [
-      "nitric oxide signaling"
-    ]
+    "herbSlug": "withanoside-v",
+    "herbName": "Withanoside V"
   },
   {
-    "herbSlug": "epimedium",
-    "herbName": "Epimedium",
-    "rawCompound": "Epimedin B",
-    "normalizedAtom": "epimedin b",
-    "canonicalCompoundId": "epimedin-b",
-    "canonicalCompoundName": "Epimedin B",
-    "v3MatchType": "pass13-real-sweep",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "flavonoid activity",
-      "nitric oxide signaling"
-    ],
-    "pathwayTargets": [
-      "nitric oxide signaling"
-    ]
+    "herbSlug": "icaritin",
+    "herbName": "Icaritin"
   },
   {
-    "herbSlug": "epimedium",
-    "herbName": "Epimedium",
-    "rawCompound": "Epimedin C",
-    "normalizedAtom": "epimedin c",
-    "canonicalCompoundId": "epimedin-c",
-    "canonicalCompoundName": "Epimedin C",
-    "v3MatchType": "pass13-real-sweep",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "flavonoid activity",
-      "nitric oxide signaling"
-    ],
-    "pathwayTargets": [
-      "nitric oxide signaling"
-    ]
+    "herbSlug": "desmethylicaritin",
+    "herbName": "Desmethylicaritin"
   },
   {
-    "herbSlug": "camellia-sinensis",
-    "herbName": "Green Tea",
-    "rawCompound": "EGCG",
-    "normalizedAtom": "egcg",
-    "canonicalCompoundId": "egcg",
-    "canonicalCompoundName": "EGCG",
-    "v3MatchType": "pass13-real-sweep",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "oxidative stress reduction",
-      "AMPK activation"
-    ],
-    "pathwayTargets": [
-      "oxidative stress reduction",
-      "AMPK activation"
-    ]
+    "herbSlug": "isopetasin",
+    "herbName": "isopetasin"
   },
   {
-    "herbSlug": "camellia-sinensis",
-    "herbName": "Green Tea",
-    "rawCompound": "ECG",
-    "normalizedAtom": "ecg",
-    "canonicalCompoundId": "ecg",
-    "canonicalCompoundName": "ECG",
-    "v3MatchType": "pass13-real-sweep",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "oxidative stress reduction"
-    ],
-    "pathwayTargets": [
-      "oxidative stress reduction"
-    ]
+    "herbSlug": "berberine",
+    "herbName": "berberine"
   },
   {
-    "herbSlug": "camellia-sinensis",
-    "herbName": "Green Tea",
-    "rawCompound": "Catechin",
-    "normalizedAtom": "catechin",
-    "canonicalCompoundId": "catechin",
-    "canonicalCompoundName": "Catechin",
-    "v3MatchType": "pass13-real-sweep",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "oxidative stress reduction"
-    ],
-    "pathwayTargets": [
-      "oxidative stress reduction"
-    ]
+    "herbSlug": "palmatine",
+    "herbName": "palmatine"
   },
   {
-    "herbSlug": "black-pepper",
-    "herbName": "Black Pepper",
-    "rawCompound": "Chavicine",
-    "normalizedAtom": "chavicine",
-    "canonicalCompoundId": "chavicine",
-    "canonicalCompoundName": "Chavicine",
-    "v3MatchType": "pass13-real-sweep",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "bioavailability modulation"
-    ],
-    "pathwayTargets": [
-      "bioavailability modulation"
-    ]
+    "herbSlug": "1-8-cineole",
+    "herbName": "1,8-cineole"
   },
   {
-    "herbSlug": "blue-lotus",
-    "herbName": "Blue Lotus",
-    "rawCompound": "nuciferine",
-    "normalizedAtom": "nuciferine",
-    "canonicalCompoundId": "nuciferine",
-    "canonicalCompoundName": "nuciferine",
-    "v3MatchType": "pass13-real-sweep",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "dopamine signaling",
-      "calming CNS signaling"
-    ],
-    "pathwayTargets": [
-      "dopamine signaling",
-      "calming CNS signaling"
-    ]
+    "herbSlug": "limonene",
+    "herbName": "limonene"
   },
   {
-    "herbSlug": "blue-lotus",
-    "herbName": "Blue Lotus",
-    "rawCompound": "apomorphine",
-    "normalizedAtom": "apomorphine",
-    "canonicalCompoundId": "apomorphine",
-    "canonicalCompoundName": "apomorphine",
-    "v3MatchType": "pass13-real-sweep",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "dopamine signaling"
-    ],
-    "pathwayTargets": [
-      "dopamine signaling"
-    ]
+    "herbSlug": "acetyl-11-keto-beta-boswellic-acid",
+    "herbName": "acetyl-11-keto-beta-boswellic acid"
   },
   {
-    "herbSlug": "black-cohosh",
-    "herbName": "Black Cohosh",
-    "rawCompound": "Cimicifugoside",
-    "normalizedAtom": "cimicifugoside",
-    "canonicalCompoundId": "cimicifugoside",
-    "canonicalCompoundName": "Cimicifugoside",
-    "v3MatchType": "pass13-real-sweep",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "serotonergic signaling",
-      "anti-inflammatory signaling"
-    ],
-    "pathwayTargets": [
-      "serotonergic signaling",
-      "anti-inflammatory signaling"
-    ]
+    "herbSlug": "ginkgetin",
+    "herbName": "ginkgetin"
   },
   {
-    "herbSlug": "black-cohosh",
-    "herbName": "Black Cohosh",
-    "rawCompound": "Isoferulic acid",
-    "normalizedAtom": "isoferulic acid",
-    "canonicalCompoundId": "isoferulic-acid",
-    "canonicalCompoundName": "Isoferulic acid",
-    "v3MatchType": "pass13-real-sweep",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "oxidative stress reduction",
-      "anti-inflammatory signaling"
-    ],
-    "pathwayTargets": [
-      "oxidative stress reduction",
-      "anti-inflammatory signaling"
-    ]
+    "herbSlug": "capsanthin",
+    "herbName": "capsanthin"
   },
   {
-    "herbSlug": "arjuna",
-    "herbName": "Arjuna",
-    "rawCompound": "Arjunic acid",
-    "normalizedAtom": "arjunic acid",
-    "canonicalCompoundId": "arjunic-acid",
-    "canonicalCompoundName": "Arjunic acid",
-    "v3MatchType": "pass13-real-sweep",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "cardiovascular signaling"
-    ],
-    "pathwayTargets": [
-      "cardiovascular signaling"
-    ]
+    "herbSlug": "capsorubin",
+    "herbName": "capsorubin"
   },
   {
-    "herbSlug": "ajwain",
-    "herbName": "Ajwain",
-    "rawCompound": "carvacrol",
-    "normalizedAtom": "carvacrol",
-    "canonicalCompoundId": "carvacrol",
-    "canonicalCompoundName": "carvacrol",
-    "v3MatchType": "pass13-real-sweep",
-    "mappingTier": "master-linked",
-    "mechanismTags": [
-      "gastrointestinal modulation",
-      "antimicrobial signaling"
-    ],
-    "pathwayTargets": [
-      "gastrointestinal modulation",
-      "antimicrobial signaling"
-    ]
+    "herbSlug": "dihydrocapsaicin",
+    "herbName": "dihydrocapsaicin"
   },
   {
-    "herbSlug": "ginkgo-biloba",
-    "herbName": "Ginkgolide A"
+    "herbSlug": "biochanin-a",
+    "herbName": "biochanin A"
   },
   {
-    "herbSlug": "panax-ginseng",
-    "herbName": "Ginsenoside Rg1"
+    "herbSlug": "calycosin",
+    "herbName": "calycosin"
   },
   {
-    "herbSlug": "green-tea",
+    "herbSlug": "coumestrol",
+    "herbName": "coumestrol"
+  },
+  {
+    "herbSlug": "daidzin",
+    "herbName": "daidzin"
+  },
+  {
+    "herbSlug": "ononin",
+    "herbName": "ononin"
+  },
+  {
+    "herbSlug": "capsaicin",
+    "herbName": "capsaicin"
+  },
+  {
+    "herbSlug": "sulforaphane",
+    "herbName": "sulforaphane"
+  },
+  {
+    "herbSlug": "thymoquinone",
+    "herbName": "Thymoquinone"
+  },
+  {
+    "herbSlug": "oleuropein",
+    "herbName": "Oleuropein"
+  },
+  {
+    "herbSlug": "hydroxytyrosol",
+    "herbName": "Hydroxytyrosol"
+  },
+  {
+    "herbSlug": "crocin",
+    "herbName": "Crocin"
+  },
+  {
+    "herbSlug": "crocetin",
+    "herbName": "Crocetin"
+  },
+  {
+    "herbSlug": "silibinin",
+    "herbName": "Silibinin"
+  },
+  {
+    "herbSlug": "glycyrrhizin",
+    "herbName": "Glycyrrhizin"
+  },
+  {
+    "herbSlug": "emodin",
+    "herbName": "Emodin"
+  },
+  {
+    "herbSlug": "rhein",
+    "herbName": "Rhein"
+  },
+  {
+    "herbSlug": "schisandrin",
+    "herbName": "Schisandrin"
+  },
+  {
+    "herbSlug": "celastrol",
+    "herbName": "Celastrol"
+  },
+  {
+    "herbSlug": "linalool",
+    "herbName": "Linalool"
+  },
+  {
+    "herbSlug": "hesperidin",
+    "herbName": "Hesperidin"
+  },
+  {
+    "herbSlug": "jatrorrhizine",
+    "herbName": "Jatrorrhizine"
+  },
+  {
+    "herbSlug": "columbamine",
+    "herbName": "Columbamine"
+  },
+  {
+    "herbSlug": "neoandrographolide",
+    "herbName": "Neoandrographolide"
+  },
+  {
+    "herbSlug": "gymnemic-acid",
+    "herbName": "Gymnemic acid"
+  },
+  {
+    "herbSlug": "charantin",
+    "herbName": "Charantin"
+  },
+  {
+    "herbSlug": "momordicoside-k",
+    "herbName": "Momordicoside K"
+  },
+  {
+    "herbSlug": "diosgenin",
+    "herbName": "Diosgenin"
+  },
+  {
+    "herbSlug": "protodioscin",
+    "herbName": "Protodioscin"
+  },
+  {
+    "herbSlug": "oleanolic-acid",
+    "herbName": "Oleanolic acid"
+  },
+  {
+    "herbSlug": "asiaticoside",
+    "herbName": "Asiaticoside"
+  },
+  {
+    "herbSlug": "madecassoside",
+    "herbName": "Madecassoside"
+  },
+  {
+    "herbSlug": "piperlongumine",
+    "herbName": "Piperlongumine"
+  },
+  {
+    "herbSlug": "myricetin",
+    "herbName": "Myricetin"
+  },
+  {
+    "herbSlug": "luteolin",
+    "herbName": "Luteolin"
+  },
+  {
+    "herbSlug": "naringenin",
+    "herbName": "Naringenin"
+  },
+  {
+    "herbSlug": "naringin",
+    "herbName": "Naringin"
+  },
+  {
+    "herbSlug": "rutin",
+    "herbName": "Rutin"
+  },
+  {
+    "herbSlug": "epicatechin",
     "herbName": "Epicatechin"
   },
   {
-    "herbName": "Holy Basil",
-    "rawCompound": "Ursolic acid",
-    "normalizedAtom": "ursolic acid",
-    "canonicalCompoundId": "ursolic-acid",
-    "canonicalCompoundName": "Ursolic acid"
+    "herbSlug": "epigallocatechin-gallate-egcg",
+    "herbName": "Epigallocatechin gallate (EGCG)"
   },
   {
-    "herbName": "Holy Basil",
-    "rawCompound": "Rosmarinic acid",
-    "normalizedAtom": "rosmarinic acid",
-    "canonicalCompoundId": "rosmarinic-acid",
-    "canonicalCompoundName": "Rosmarinic acid"
+    "herbSlug": "theaflavin",
+    "herbName": "Theaflavin"
   },
   {
-    "herbName": "Rhodiola",
-    "rawCompound": "Rosavin",
-    "normalizedAtom": "rosavin",
-    "canonicalCompoundId": "rosavin",
-    "canonicalCompoundName": "Rosavin"
+    "herbSlug": "thearubigin",
+    "herbName": "Thearubigin"
   },
   {
-    "herbName": "Rhodiola",
-    "rawCompound": "Rosarin",
-    "normalizedAtom": "rosarin",
-    "canonicalCompoundId": "rosarin",
-    "canonicalCompoundName": "Rosarin"
+    "herbSlug": "pterostilbene",
+    "herbName": "Pterostilbene"
   },
   {
-    "herbName": "Rhodiola",
-    "rawCompound": "Rosin",
-    "normalizedAtom": "rosin",
-    "canonicalCompoundId": "rosin",
-    "canonicalCompoundName": "Rosin"
+    "herbSlug": "daidzein",
+    "herbName": "Daidzein"
   },
   {
-    "herbName": "Rhodiola",
-    "rawCompound": "Tyrosol",
-    "normalizedAtom": "tyrosol",
-    "canonicalCompoundId": "tyrosol",
-    "canonicalCompoundName": "Tyrosol"
+    "herbSlug": "formononetin",
+    "herbName": "Formononetin"
   },
   {
-    "herbName": "Arjuna",
-    "rawCompound": "Arjungenin",
-    "normalizedAtom": "arjungenin",
-    "canonicalCompoundId": "arjungenin",
-    "canonicalCompoundName": "Arjungenin"
+    "herbSlug": "ellagic-acid",
+    "herbName": "Ellagic acid"
   },
   {
-    "herbName": "Arjuna",
-    "rawCompound": "Arjunetin",
-    "normalizedAtom": "arjunetin",
-    "canonicalCompoundId": "arjunetin",
-    "canonicalCompoundName": "Arjunetin"
+    "herbSlug": "ferulic-acid",
+    "herbName": "Ferulic acid"
   },
   {
-    "herbName": "Black Cohosh",
-    "rawCompound": "Actein",
-    "normalizedAtom": "actein",
-    "canonicalCompoundId": "actein",
-    "canonicalCompoundName": "Actein"
+    "herbSlug": "chlorogenic-acid",
+    "herbName": "Chlorogenic acid"
   },
   {
-    "herbName": "Black Cohosh",
-    "rawCompound": "23-epi-26-deoxyactein",
-    "normalizedAtom": "23 epi 26 deoxyactein",
-    "canonicalCompoundId": "23-epi-26-deoxyactein",
-    "canonicalCompoundName": "23-epi-26-deoxyactein"
+    "herbSlug": "caffeic-acid",
+    "herbName": "Caffeic acid"
   },
   {
-    "herbName": "Black Cohosh",
-    "rawCompound": "Fukinolic acid",
-    "normalizedAtom": "fukinolic acid",
-    "canonicalCompoundId": "fukinolic-acid",
-    "canonicalCompoundName": "Fukinolic acid"
+    "herbSlug": "osthole",
+    "herbName": "Osthole"
   },
   {
-    "herbName": "Ashwagandha",
-    "rawCompound": "Withanoside IV",
-    "normalizedAtom": "withanoside iv",
-    "canonicalCompoundId": "withanoside-iv",
-    "canonicalCompoundName": "Withanoside IV"
+    "herbSlug": "imperatorin",
+    "herbName": "Imperatorin"
   },
   {
-    "herbName": "Ashwagandha",
-    "rawCompound": "Withanoside V",
-    "normalizedAtom": "withanoside v",
-    "canonicalCompoundId": "withanoside-v",
-    "canonicalCompoundName": "Withanoside V"
+    "herbSlug": "isoimperatorin",
+    "herbName": "Isoimperatorin"
   },
   {
-    "herbName": "Epimedium",
-    "normalizedAtom": "icaritin",
-    "canonicalCompoundId": "icaritin",
-    "canonicalCompoundName": "Icaritin"
+    "herbSlug": "psoralen",
+    "herbName": "Psoralen"
   },
   {
-    "herbName": "Epimedium",
-    "normalizedAtom": "desmethylicaritin",
-    "canonicalCompoundId": "desmethylicaritin",
-    "canonicalCompoundName": "Desmethylicaritin"
+    "herbSlug": "bergapten",
+    "herbName": "Bergapten"
   },
   {
-    "herbSlug": "butterbur",
-    "herbName": "Butterbur",
-    "rawCompound": "isopetasin",
-    "normalizedAtom": "isopetasin",
-    "canonicalCompoundId": "isopetasin",
-    "canonicalCompoundName": "isopetasin",
-    "v3MatchType": "exact_canonical_id",
-    "mappingTier": "specific",
-    "mechanismTags": [
-      "migraine support",
-      "anti-inflammatory",
-      "TRPA1/TRPV1 modulation",
-      "CGRP modulation"
-    ],
-    "pathwayTargets": [
-      "TRPA1",
-      "TRPV1",
-      "CGRP signaling"
-    ]
+    "herbSlug": "scopoletin",
+    "herbName": "Scopoletin"
+  },
+  {
+    "herbSlug": "esculetin",
+    "herbName": "Esculetin"
+  },
+  {
+    "herbSlug": "fraxetin",
+    "herbName": "Fraxetin"
+  },
+  {
+    "herbSlug": "umbelliferone",
+    "herbName": "Umbelliferone"
+  },
+  {
+    "herbSlug": "daphnetin",
+    "herbName": "Daphnetin"
+  },
+  {
+    "herbSlug": "oxymatrine",
+    "herbName": "Oxymatrine"
+  },
+  {
+    "herbSlug": "tetrandrine",
+    "herbName": "Tetrandrine"
+  },
+  {
+    "herbSlug": "cepharanthine",
+    "herbName": "Cepharanthine"
+  },
+  {
+    "herbSlug": "magnoflorine",
+    "herbName": "Magnoflorine"
+  },
+  {
+    "herbSlug": "ligustilide",
+    "herbName": "Ligustilide"
+  },
+  {
+    "herbSlug": "senkyunolide-a",
+    "herbName": "Senkyunolide A"
+  },
+  {
+    "herbSlug": "butylidenephthalide",
+    "herbName": "Butylidenephthalide"
+  },
+  {
+    "herbSlug": "xanthotoxin",
+    "herbName": "Xanthotoxin"
+  },
+  {
+    "herbSlug": "boswellic-acid",
+    "herbName": "Boswellic acid"
+  },
+  {
+    "herbSlug": "acetyl-beta-boswellic-acid",
+    "herbName": "Acetyl-beta-boswellic acid"
+  },
+  {
+    "herbSlug": "11-keto-beta-boswellic-acid",
+    "herbName": "11-keto-beta-boswellic acid"
+  },
+  {
+    "herbSlug": "valerenol",
+    "herbName": "Valerenol"
+  },
+  {
+    "herbSlug": "kavalactones",
+    "herbName": "Kavalactones"
+  },
+  {
+    "herbSlug": "yangonin",
+    "herbName": "Yangonin"
+  },
+  {
+    "herbSlug": "methysticin",
+    "herbName": "Methysticin"
+  },
+  {
+    "herbSlug": "valepotriates",
+    "herbName": "Valepotriates"
+  },
+  {
+    "herbSlug": "aucubin",
+    "herbName": "Aucubin"
+  },
+  {
+    "herbSlug": "harpagoside",
+    "herbName": "Harpagoside"
+  },
+  {
+    "herbSlug": "loganin",
+    "herbName": "Loganin"
+  },
+  {
+    "herbSlug": "morroniside",
+    "herbName": "Morroniside"
+  },
+  {
+    "herbSlug": "oleocanthal",
+    "herbName": "Oleocanthal"
+  },
+  {
+    "herbSlug": "oleacein",
+    "herbName": "Oleacein"
+  },
+  {
+    "herbSlug": "acteoside",
+    "herbName": "Acteoside"
+  },
+  {
+    "herbSlug": "forskolin",
+    "herbName": "Forskolin"
+  },
+  {
+    "herbSlug": "bacoside-b",
+    "herbName": "Bacoside B"
+  },
+  {
+    "herbSlug": "glycyrrhetinic-acid",
+    "herbName": "Glycyrrhetinic acid"
+  },
+  {
+    "herbSlug": "shikonin",
+    "herbName": "Shikonin"
+  },
+  {
+    "herbSlug": "acetylshikonin",
+    "herbName": "Acetylshikonin"
+  },
+  {
+    "herbSlug": "plumbagin",
+    "herbName": "Plumbagin"
+  },
+  {
+    "herbSlug": "lawsone",
+    "herbName": "Lawsone"
+  },
+  {
+    "herbSlug": "embelin",
+    "herbName": "Embelin"
+  },
+  {
+    "herbSlug": "artemisinin",
+    "herbName": "Artemisinin"
+  },
+  {
+    "herbSlug": "artesunate",
+    "herbName": "Artesunate"
+  },
+  {
+    "herbSlug": "artemisinin-b",
+    "herbName": "Artemisinin B"
+  },
+  {
+    "herbSlug": "astragalin",
+    "herbName": "Astragalin"
+  },
+  {
+    "herbSlug": "mangiferin",
+    "herbName": "Mangiferin"
+  },
+  {
+    "herbSlug": "mangostin",
+    "herbName": "Mangostin"
+  },
+  {
+    "herbSlug": "garcinol",
+    "herbName": "Garcinol"
+  },
+  {
+    "herbSlug": "curcumol",
+    "herbName": "Curcumol"
+  },
+  {
+    "herbSlug": "curdione",
+    "herbName": "Curdione"
+  },
+  {
+    "herbSlug": "albiflorin",
+    "herbName": "Albiflorin"
+  },
+  {
+    "herbSlug": "paeonol",
+    "herbName": "Paeonol"
+  },
+  {
+    "herbSlug": "timosaponin-aiii",
+    "herbName": "Timosaponin AIII"
+  },
+  {
+    "herbSlug": "mangiferin-aglycone",
+    "herbName": "Mangiferin aglycone"
+  },
+  {
+    "herbSlug": "lobeline",
+    "herbName": "Lobeline"
+  },
+  {
+    "herbSlug": "huperzine-a",
+    "herbName": "Huperzine A"
+  },
+  {
+    "herbSlug": "huperzine-b",
+    "herbName": "Huperzine B"
+  },
+  {
+    "herbSlug": "anatabine",
+    "herbName": "Anatabine"
+  },
+  {
+    "herbSlug": "anabasine",
+    "herbName": "Anabasine"
+  },
+  {
+    "herbSlug": "nicotine",
+    "herbName": "Nicotine"
+  },
+  {
+    "herbSlug": "beta-caryophyllene",
+    "herbName": "Beta-caryophyllene"
+  },
+  {
+    "herbSlug": "caryophyllene-oxide",
+    "herbName": "Caryophyllene oxide"
+  },
+  {
+    "herbSlug": "nerolidol",
+    "herbName": "Nerolidol"
+  },
+  {
+    "herbSlug": "farnesol",
+    "herbName": "Farnesol"
+  },
+  {
+    "herbSlug": "bisabolol",
+    "herbName": "Bisabolol"
+  },
+  {
+    "herbSlug": "atractylenolide-ii",
+    "herbName": "Atractylenolide II"
+  },
+  {
+    "herbSlug": "atractylenolide-iii",
+    "herbName": "Atractylenolide III"
+  },
+  {
+    "herbSlug": "beta-elemene",
+    "herbName": "Beta-elemene"
+  },
+  {
+    "herbSlug": "elemicin",
+    "herbName": "Elemicin"
+  },
+  {
+    "herbSlug": "myristicin",
+    "herbName": "Myristicin"
+  },
+  {
+    "herbSlug": "safrole",
+    "herbName": "Safrole"
+  },
+  {
+    "herbSlug": "methyleugenol",
+    "herbName": "Methyleugenol"
+  },
+  {
+    "herbSlug": "asiatic-acid",
+    "herbName": "Asiatic acid"
+  },
+  {
+    "herbSlug": "madecassic-acid",
+    "herbName": "Madecassic acid"
+  },
+  {
+    "herbSlug": "gymnemagenin",
+    "herbName": "Gymnemagenin"
+  },
+  {
+    "herbSlug": "gurmarin",
+    "herbName": "Gurmarin"
+  },
+  {
+    "herbSlug": "lagerstroemin",
+    "herbName": "Lagerstroemin"
+  },
+  {
+    "herbSlug": "mulberroside-a",
+    "herbName": "Mulberroside A"
+  },
+  {
+    "herbSlug": "oxyresveratrol",
+    "herbName": "Oxyresveratrol"
+  },
+  {
+    "herbSlug": "morin",
+    "herbName": "Morin"
+  },
+  {
+    "herbSlug": "deoxyelephantopin",
+    "herbName": "Deoxyelephantopin"
+  },
+  {
+    "herbSlug": "elephantopin",
+    "herbName": "Elephantopin"
+  },
+  {
+    "herbSlug": "guggulsterone",
+    "herbName": "Guggulsterone"
+  },
+  {
+    "herbSlug": "commipheric-acid",
+    "herbName": "Commipheric acid"
+  },
+  {
+    "herbSlug": "stigmasterol",
+    "herbName": "Stigmasterol"
+  },
+  {
+    "herbSlug": "ajoene",
+    "herbName": "ajoene"
+  },
+  {
+    "herbSlug": "acemannan",
+    "herbName": "acemannan"
+  },
+  {
+    "herbSlug": "aescin",
+    "herbName": "aescin"
+  },
+  {
+    "herbSlug": "alpha-asarone",
+    "herbName": "alpha-asarone"
+  },
+  {
+    "herbSlug": "aspalathin",
+    "herbName": "aspalathin"
+  },
+  {
+    "herbSlug": "bacopaside-ii",
+    "herbName": "bacopaside II"
+  },
+  {
+    "herbSlug": "berbamine",
+    "herbName": "berbamine"
+  },
+  {
+    "herbSlug": "betulinic-acid",
+    "herbName": "betulinic acid"
+  },
+  {
+    "herbSlug": "bilobetin",
+    "herbName": "bilobetin"
+  },
+  {
+    "herbSlug": "cafestol",
+    "herbName": "cafestol"
+  },
+  {
+    "herbSlug": "chicoric-acid",
+    "herbName": "chicoric acid"
+  },
+  {
+    "herbSlug": "citronellal",
+    "herbName": "citronellal"
+  },
+  {
+    "herbSlug": "coptisine",
+    "herbName": "coptisine"
+  },
+  {
+    "herbSlug": "deoxymiroestrol",
+    "herbName": "deoxymiroestrol"
+  },
+  {
+    "herbSlug": "desmethoxyyangonin",
+    "herbName": "desmethoxyyangonin"
+  },
+  {
+    "herbSlug": "dihydrokavain",
+    "herbName": "dihydrokavain"
+  },
+  {
+    "herbSlug": "dihydromethysticin",
+    "herbName": "dihydromethysticin"
+  },
+  {
+    "herbSlug": "erinacines",
+    "herbName": "erinacines"
+  },
+  {
+    "herbSlug": "hericenones",
+    "herbName": "hericenones"
+  },
+  {
+    "herbSlug": "indirubin",
+    "herbName": "indirubin"
+  },
+  {
+    "herbSlug": "kahweol",
+    "herbName": "kahweol"
+  },
+  {
+    "herbSlug": "kotalanol",
+    "herbName": "kotalanol"
+  },
+  {
+    "herbSlug": "mesembrine",
+    "herbName": "mesembrine"
+  },
+  {
+    "herbSlug": "mesembrenone",
+    "herbName": "mesembrenone"
+  },
+  {
+    "herbSlug": "columbin",
+    "herbName": "columbin"
+  },
+  {
+    "herbSlug": "cryptotanshinone",
+    "herbName": "cryptotanshinone"
+  },
+  {
+    "herbSlug": "honokiol",
+    "herbName": "honokiol"
+  },
+  {
+    "herbSlug": "magnolol",
+    "herbName": "magnolol"
+  },
+  {
+    "herbSlug": "safranal",
+    "herbName": "safranal"
+  },
+  {
+    "herbSlug": "trigonelline",
+    "herbName": "trigonelline"
+  },
+  {
+    "herbSlug": "schisandrin-b",
+    "herbName": "schisandrin B"
+  },
+  {
+    "herbSlug": "eleutheroside-b",
+    "herbName": "eleutheroside B"
+  },
+  {
+    "herbSlug": "eleutheroside-e",
+    "herbName": "eleutheroside E"
+  },
+  {
+    "herbSlug": "punicalagin",
+    "herbName": "punicalagin"
+  },
+  {
+    "herbSlug": "glucomoringin",
+    "herbName": "glucomoringin"
+  },
+  {
+    "herbSlug": "methyl-eugenol",
+    "herbName": "methyl eugenol"
+  },
+  {
+    "herbSlug": "silybin",
+    "herbName": "silybin"
+  },
+  {
+    "herbSlug": "silychristin",
+    "herbName": "silychristin"
+  },
+  {
+    "herbSlug": "silydianin",
+    "herbName": "silydianin"
+  },
+  {
+    "herbSlug": "epigallocatechin",
+    "herbName": "epigallocatechin"
+  },
+  {
+    "herbSlug": "epicatechin-gallate",
+    "herbName": "epicatechin gallate"
+  },
+  {
+    "herbSlug": "epigallocatechin-gallate",
+    "herbName": "epigallocatechin gallate"
+  },
+  {
+    "herbSlug": "gallocatechin",
+    "herbName": "gallocatechin"
   }
 ]

--- a/public/data/workbook-herbs.json
+++ b/public/data/workbook-herbs.json
@@ -1,2426 +1,4337 @@
 [
   {
-    "slug": "acerola",
-    "name": "Acerola",
-    "hero": "Used for antioxidant support, with ascorbic acid serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to ascorbic acid rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "agarikon",
-    "name": "Agarikon",
-    "hero": "Used for immunomodulatory support, with agaric acid serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to agaric acid rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"immunomodulatory\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Use cautiously."
-  },
-  {
-    "slug": "ajwain",
-    "name": "Ajwain",
-    "hero": "Used for antimicrobial support, with thymol serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to thymol and carvacrol rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"antimicrobial\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "aloe-vera",
-    "name": "Aloe Vera",
-    "hero": "Used for anti-inflammatory support, with acemannan and aloe-emodin serving as key marker compounds.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "General use caution; distinguish inner gel from latex-rich stimulant-laxative fractions."
-  },
-  {
-    "slug": "american-ginseng",
-    "name": "American Ginseng",
-    "hero": "Used for anti-inflammatory support, with ginsenosides (including rb1 serving as key marker compound.",
-    "coreInsight": "Its value comes from a clearer mechanism readout than a generic traditional-use label. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"",
-      "\"NF-kB inhibition\"]"
-    ],
-    "safetyNotes": "Safety review required before publication."
-  },
-  {
-    "slug": "american-yellow-lotus",
-    "name": "American Yellow Lotus",
-    "hero": "Defined by nuciferine as key marker compound, with activity centered on dopamine modulation.",
-    "coreInsight": "Its value comes from a clearer mechanism readout than a generic traditional-use label. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[\"dopamine modulation\"]"
-    ],
-    "safetyNotes": "Safety review required before publication."
-  },
-  {
-    "slug": "angelica-root",
-    "name": "Angelica Root",
-    "hero": "Standardized around angelicin to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to angelicin rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Use cautiously."
-  },
-  {
-    "slug": "anise-hyssop",
-    "name": "Anise Hyssop",
-    "hero": "Defined by limonene as key marker compound, with activity centered on endocannabinoid modulation.",
-    "coreInsight": "Its value comes from a clearer mechanism readout than a generic traditional-use label. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[\"endocannabinoid modulation\"]"
-    ],
-    "safetyNotes": "Safety review required before publication."
-  },
-  {
-    "slug": "arjuna",
-    "name": "Arjuna",
-    "hero": "Used for antioxidant support, with arjunolic acid serving as key marker compound.",
-    "coreInsight": "It matters because arjunolic acid and Arjunic acid help explain cardiovascular signaling in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"cardiovascular signaling\"]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "artemisia-annua",
-    "name": "Artemisia Annua",
-    "hero": "Used for antimicrobial and antioxidant support, with artemisinin and arteannuin B serving as key marker compounds.",
-    "coreInsight": "Its value comes from a clearer mechanism readout than a generic traditional-use label. Evidence is limited.",
-    "effects": [
-      "[\"antimicrobial\"",
-      "\"antioxidant\"",
-      "\"immunomodulatory\"",
-      "\"adaptogenic\"]"
-    ],
-    "mechanisms": [
-      "[\"oxidative stress modulation\"",
-      "\"cortisol modulation\"]"
-    ],
-    "safetyNotes": "Review interactions and contraindications."
-  },
-  {
-    "slug": "artichoke",
-    "name": "Artichoke",
-    "hero": "Standardized around cynarin to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to cynarin rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "ashitaba",
-    "name": "Ashitaba",
-    "hero": "Used for antioxidant support, with 4-hydroxyderricin serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to 4-hydroxyderricin rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "ashoka",
-    "name": "Ashoka",
-    "hero": "Standardized around catechins to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to catechins rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
     "slug": "ashwagandha",
     "name": "Ashwagandha",
-    "hero": "Used for anti-inflammatory and neuroprotective support, with withanolides serving as key marker compound.",
-    "coreInsight": "It matters because Withaferin A and Withanolide A help explain cortisol modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"neuroprotective\"",
-      "\"adaptogenic\"",
-      "\"sedative\"]"
+    "primaryActions": [
+      "Stress response support",
+      "neurotrophic support",
+      "inflammatory modulation"
     ],
     "mechanisms": [
-      "[\"cortisol modulation\"",
-      "\"Nrf2 activation\"",
-      "\"NF-kB inhibition\"",
-      "\"GABA-A modulation\"]"
+      "adaptogen",
+      "stress modulation",
+      "cortisol regulation",
+      "NF-κB inhibition",
+      "HSP90 inhibition",
+      "apoptosis pathway modulation",
+      "PI3K/Akt modulation",
+      "cholinergic modulation",
+      "BDNF upregulation",
+      "neurite outgrowth promotion"
     ],
-    "safetyNotes": "Short-term use appears safe; side effects include drowsiness and GI upset."
-  },
-  {
-    "slug": "astragalus",
-    "name": "Astragalus",
-    "hero": "Used for immunomodulatory and stimulant support, with astragaloside IV serving as key marker compound.",
-    "coreInsight": "It matters because astragaloside iv help explain immune modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"immunomodulatory\"",
-      "\"stimulant\"]"
+    "description": "Ashwagandha centers on the root. Key reported compounds include withaferin A; withanolide D; withanolide A; withanoside IV; sitoindosides; alkaloids. Typical preparation forms: Root powders and standardized extracts. Withanolides are thought to mediate adaptogenic and neuroprotective effects by modulating HPA-axis signaling, NF-κB, Nrf2 and GABAergic pathways. Interaction profile: May potentiate sedatives, antihypertensives, antidiabetics, thyroid hormones, and immunosuppressants. Use caution or avoid in: Pregnancy, breastfeeding, autoimmune disease, thyroid disorders, liver disease.",
+    "activeCompounds": [
+      "withanolides",
+      "Withaferin A",
+      "Withanolide A",
+      "withanoside IV"
     ],
-    "mechanisms": [
-      "[\"immune modulation\"]"
+    "safetyNotes": "Short-term use appears safe; side effects include drowsiness and GI upset. Rare liver injury has been reported.",
+    "interactions": [
+      "Use caution with sedatives",
+      "thyroid-active therapy",
+      "or immunomodulators."
     ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "atractylodes",
-    "name": "Atractylodes",
-    "hero": "Standardized around atractylenolide I to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to atractylenolide i rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "bacopa",
-    "name": "Bacopa",
-    "hero": "Used for nootropic and anxiolytic support, with bacoside A serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to bacoside a rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"nootropic\"",
-      "\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "bael",
-    "name": "Bael",
-    "hero": "Standardized around skimmianine to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Safety review required before publication."
-  },
-  {
-    "slug": "banaba",
-    "name": "Banaba",
-    "hero": "Standardized around corosolic acid to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to corosolic acid rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "berberis",
-    "name": "Berberis",
-    "hero": "Used for antimicrobial support, with berberine serving as key marker compound.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[\"antimicrobial\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Use caution in pregnancy, breastfeeding, and in those prone to GI upset."
-  },
-  {
-    "slug": "bitter-melon",
-    "name": "Bitter Melon",
-    "hero": "Standardized around charantin to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Use caution in people prone to low blood sugar and during pregnancy."
+    "preparation": "Root powder and extracts are most common; higher-extract products shift compound ratios."
   },
   {
     "slug": "black-cohosh",
     "name": "Black Cohosh",
-    "hero": "Used for anti-inflammatory and antioxidant support, with actein and 23-epi-26-deoxyactein serving as key marker compounds.",
-    "coreInsight": "It matters because triterpene glycosides (actein, 23-epi-26-deoxyactein) and Cimicifugoside help explain serotonin modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"",
-      "\"nootropic\"",
-      "\"adaptogenic\"]"
-    ],
     "mechanisms": [
-      "[\"serotonin modulation\"",
-      "\"hormone modulation\"",
-      "\"selective estrogen receptor modulation\"]"
-    ],
-    "safetyNotes": "Generally well tolerated in short-term studies, but rare cases of liver injury have been reported."
-  },
-  {
-    "slug": "black-pepper",
-    "name": "Black Pepper",
-    "hero": "Defined by piperine as key marker compound, with activity centered on bioavailability modulation.",
-    "coreInsight": "It matters because Piperine and Chavicine help explain bioavailability modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[\"bioavailability modulation\"]"
-    ],
-    "safetyNotes": "Generally well tolerated; use caution with concentrated extracts."
-  },
-  {
-    "slug": "blue-lotus",
-    "name": "Blue Lotus",
-    "hero": "Used for sedative and anxiolytic support, with nuciferine serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to puerarin and nuciferine rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"sedative\"",
-      "\"anxiolytic\"",
-      "\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Use caution with sedative-sensitive contexts and stacked calming formulas."
-  },
-  {
-    "slug": "boldo",
-    "name": "Boldo",
-    "hero": "Standardized around boldine to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to boldine rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Use cautiously in concentrated forms."
-  },
-  {
-    "slug": "boswellia",
-    "name": "Boswellia",
-    "hero": "Used for anti-inflammatory support, with AKBA serving as key marker compound.",
-    "coreInsight": "It matters because akba help explain 5-lipoxygenase inhibition in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[\"5-lipoxygenase inhibition\"]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "bupleurum",
-    "name": "Bupleurum",
-    "hero": "Used for adaptogenic and hepatoprotective support, with saikosaponin A serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to saikosaponin a rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"adaptogenic\"",
-      "\"hepatoprotective\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Use cautiously."
-  },
-  {
-    "slug": "burdock",
-    "name": "Burdock",
-    "hero": "Used for anti-inflammatory and antioxidant support, with arctiin serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to arctiin rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "butterbur",
-    "name": "Butterbur",
-    "hero": "Used for anti-inflammatory and antioxidant support, with petasin and isopetasin serving as key marker compounds.",
-    "coreInsight": "It matters because petasin and isopetasin help explain tRPV1 modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"",
-      "\"hepatoprotective\"]"
-    ],
-    "mechanisms": [
-      "[\"TRPV1 modulation\"",
-      "\"TRPA1 modulation\"",
-      "\"CGRP modulation\"",
-      "\"cgrp modulation\"",
-      "\"CGRP signaling\"]"
-    ],
-    "safetyNotes": "PA-containing butterbur products are unsafe."
-  },
-  {
-    "slug": "cacao",
-    "name": "Cacao",
-    "hero": "Used for stimulant and antidepressant support, with theobromine serving as key marker compound.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[\"stimulant\"",
-      "\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Use caution in stimulant-sensitive users and with migraine triggers."
-  },
-  {
-    "slug": "calamus",
-    "name": "Calamus",
-    "hero": "Used for anti-inflammatory support, with eugenol serving as key marker compound.",
-    "coreInsight": "Its value comes from a clearer mechanism readout than a generic traditional-use label. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"",
-      "\"NF-kB inhibition\"",
-      "\"PLCγ2-PKC pathway inhibition\"",
-      "\"plcγ2-pkc pathway inhibition\"",
-      "\"PLCγ2-PKC pathway inhibition.\"]"
-    ],
-    "safetyNotes": "Safety review required before publication."
-  },
-  {
-    "slug": "calendula",
-    "name": "Calendula",
-    "hero": "Used for anti-inflammatory support, with faradiol serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to faradiol rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "caraway",
-    "name": "Caraway",
-    "hero": "Standardized around carvone to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to carvone rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "cardamom",
-    "name": "Cardamom",
-    "hero": "Standardized around terpinyl acetate to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to terpinyl acetate rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "carob",
-    "name": "Carob",
-    "hero": "Standardized around D-pinitol to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to d-pinitol rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "cassia-alata",
-    "name": "Cassia Alata",
-    "hero": "Used for anti-inflammatory support, with aloe-emodin serving as key marker compound.",
-    "coreInsight": "Its value comes from a clearer mechanism readout than a generic traditional-use label. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[\"NF-kB inhibition\"",
-      "\"NF-kB modulation\"]"
-    ],
-    "safetyNotes": "Safety review required before publication."
-  },
-  {
-    "slug": "cat-s-claw",
-    "name": "Cat's Claw",
-    "hero": "Used for immunomodulatory and anti-inflammatory support, with mitraphylline serving as key marker compound.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[\"immunomodulatory\"",
-      "\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Use caution or avoid in autoimmune disease, transplant settings, pregnancy, and breastfeeding."
-  },
-  {
-    "slug": "catuba",
-    "name": "Catuba",
-    "hero": "Used for antidepressant support, with catuabine serving as key marker compound.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "cayenne",
-    "name": "Cayenne",
-    "hero": "Defined by capsaicin as key marker compound, with activity centered on tRPV1 modulation.",
-    "coreInsight": "Its value comes from a clearer mechanism readout than a generic traditional-use label. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[\"TRPV1 modulation\"]"
-    ],
-    "safetyNotes": "Safety review required before publication."
-  },
-  {
-    "slug": "celastrus-paniculatus",
-    "name": "Celastrus Paniculatus",
-    "hero": "Standardized around beta-amyrin to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to Celastrine rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Safety review required before publication."
-  },
-  {
-    "slug": "chaga",
-    "name": "Chaga",
-    "hero": "Used for antioxidant and adaptogenic support, with betulinic acid serving as key marker compound.",
-    "coreInsight": "Its value comes from a clearer mechanism readout than a generic traditional-use label. Evidence is limited.",
-    "effects": [
-      "[\"antioxidant\"",
-      "\"adaptogenic\"]"
-    ],
-    "mechanisms": [
-      "[\"Nrf2 activation\"]"
-    ],
-    "safetyNotes": "Safe."
-  },
-  {
-    "slug": "chamomile",
-    "name": "Chamomile",
-    "hero": "Used for anxiolytic and sedative support, with apigenin serving as key marker compound.",
-    "coreInsight": "It matters because Apigenin and alpha-bisabolol help explain gABA-A modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"anxiolytic\"",
-      "\"sedative\"",
-      "\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"",
-      "\"NF-kB inhibition\"",
-      "\"anxiolytic signaling\"",
-      "\"adrenergic signaling\"]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "chinese-skullcap",
-    "name": "Chinese Skullcap",
-    "hero": "Used for anti-inflammatory and neuroprotective support, with baicalein serving as key marker compound.",
-    "coreInsight": "It matters because Baicalin and Baicalein help explain gABA-A modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"neuroprotective\"",
-      "\"nootropic\"",
-      "\"hepatoprotective\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"",
-      "\"LOX inhibition\"",
-      "\"NF-kB inhibition\"",
-      "\"lox inhibition\"]"
-    ],
-    "safetyNotes": "Safety review required before publication."
-  },
-  {
-    "slug": "chuanxiong",
-    "name": "Chuanxiong",
-    "hero": "Standardized around ligustilide and ferulic acid to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Review interactions and contraindications."
-  },
-  {
-    "slug": "cinnamon",
-    "name": "Cinnamon",
-    "hero": "Used for antimicrobial support, with cinnamaldehyde serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to cinnamaldehyde rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"antimicrobial\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated in culinary ranges."
-  },
-  {
-    "slug": "cissus",
-    "name": "Cissus",
-    "hero": "Used for anti-inflammatory support, with quadrangularin A serving as key marker compound.",
-    "coreInsight": "It matters because quadrangularin a help explain nF-kB inhibition in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[\"NF-kB inhibition\"",
-      "\"COX inhibition\"]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "cistanche",
-    "name": "Cistanche",
-    "hero": "Used for stimulant and antioxidant support, with echinacoside serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to echinacoside rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"stimulant\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "codonopsis",
-    "name": "Codonopsis",
-    "hero": "Used for stimulant support, with tangshenoside I serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to tangshenoside i rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"stimulant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "coffee-cherry",
-    "name": "Coffee Cherry",
-    "hero": "Defined by caffeine as key marker compound, with activity centered on adenosine antagonism.",
-    "coreInsight": "Its value comes from a clearer mechanism readout than a generic traditional-use label. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[\"adenosine antagonism\"",
-      "\"dopamine modulation\"]"
-    ],
-    "safetyNotes": "Safety review required before publication."
-  },
-  {
-    "slug": "coleus-forskohlii",
-    "name": "Coleus Forskohlii",
-    "hero": "Used for stimulant support, with forskolin serving as key marker compound.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[\"stimulant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Use caution with low blood pressure, bleeding risk, and GI sensitivity."
-  },
-  {
-    "slug": "coptis",
-    "name": "Coptis",
-    "hero": "Used for anti-inflammatory support, with berberine serving as key marker compound.",
-    "coreInsight": "Its value comes from a clearer mechanism readout than a generic traditional-use label. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[\"AMPK activation\"",
-      "\"NF-kB inhibition\"",
-      "\"mitochondrial complex I inhibition\"",
-      "\"ampk activation\"",
-      "\"mitochondrial complex i inhibition\"",
-      "\"mitochondrial complex I inhibition.\"]"
-    ],
-    "safetyNotes": "Safety review required before publication."
-  },
-  {
-    "slug": "cordyceps",
-    "name": "Cordyceps",
-    "hero": "Used for anti-inflammatory and immunomodulatory support, with cordycepin serving as key marker compound.",
-    "coreInsight": "It matters because cordycepin help explain immune modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"immunomodulatory\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"immune modulation\"",
-      "\"NF-kappaB modulation\"",
-      "\"Nrf2 activation\"",
-      "\"nf-kappab modulation\"]"
-    ],
-    "safetyNotes": "Commercial products vary by species identity, cultivation method, and cordycepin content."
-  },
-  {
-    "slug": "corydalis",
-    "name": "Corydalis",
-    "hero": "Used for analgesic support, with corydaline serving as key marker compound.",
-    "coreInsight": "Its value comes from a clearer mechanism readout than a generic traditional-use label. Evidence is limited.",
-    "effects": [
-      "[\"analgesic\"]"
-    ],
-    "mechanisms": [
-      "[\"dopamine modulation\"",
-      "\"analgesic signaling\"]"
-    ],
-    "safetyNotes": "Safety review required before publication."
-  },
-  {
-    "slug": "cranberry",
-    "name": "Cranberry",
-    "hero": "Used for antimicrobial and antioxidant support, with A-type proanthocyanidins serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to a-type proanthocyanidins rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"antimicrobial\"",
-      "\"antioxidant\"",
-      "\"diuretic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "curry-leaf",
-    "name": "Curry Leaf",
-    "hero": "Used for antioxidant support, with mahanimbine serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to mahanimbine rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "damiana",
-    "name": "Damiana",
-    "hero": "Used for anxiolytic and antidepressant support, with apigenin serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to nuciferine rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"anxiolytic\"",
-      "\"antidepressant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "General use caution; review stimulating vs calming stack context."
-  },
-  {
-    "slug": "dandelion",
-    "name": "Dandelion",
-    "hero": "Used for diuretic and anti-inflammatory support, with taraxasterol serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to taraxasterol rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"diuretic\"",
-      "\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "danshen",
-    "name": "Danshen",
-    "hero": "Used for antioxidant support, with tanshinone IIA serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to Tanshinone IIA rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "dendrobium",
-    "name": "Dendrobium",
-    "hero": "Standardized around dendrobine to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to dendrobine rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "dong-quai",
-    "name": "Dong Quai",
-    "hero": "Used for muscle-relaxant and antispasmodic support, with ferulic acid serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to curcumin rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"muscle-relaxant\"",
-      "\"antispasmodic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Review interactions and contraindications."
+      "serotonergic",
+      "anti-inflammatory",
+      "hormonal"
+    ],
+    "description": "Black Cohosh centers on the root; rhizome. Key reported compounds include triterpene glycosides (actein, 23-epi-26-deoxyactein); cimifugoside; caffeic acid derivatives; fukinolic acid. Typical preparation forms: Root and rhizome used in standardized extracts, capsules, tablets, and tinctures. Proposed mechanism based on preclinical and limited clinical data: black cohosh may act through serotonergic pathways, selective estrogen receptor modulation, and anti-inflammatory signaling rather than as a classical estrogen. Interaction profile: Potential interactions with hepatotoxic drugs and with medications affecting estrogen or serotonergic pathways. Use caution or avoid in: Avoid in pregnancy and breastfeeding. Use caution in liver disease or hormone-sensitive conditions.",
+    "activeCompounds": [
+      "triterpene glycosides (actein",
+      "23-epi-26-deoxyactein)",
+      "cimifugoside",
+      "caffeic acid derivatives",
+      "fukinolic acid"
+    ],
+    "safetyNotes": "Generally well tolerated in short-term studies, but rare cases of liver injury have been reported. Product contamination or misidentification is a known issue."
   },
   {
     "slug": "echinacea-purpurea",
     "name": "Echinacea Purpurea",
-    "hero": "Used for immunomodulatory and anti-inflammatory support, with alkamides serving as key marker compound.",
-    "coreInsight": "It matters because alkamides help explain immune signaling modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"immunomodulatory\"",
-      "\"anti-inflammatory\"",
-      "\"nootropic\"",
-      "\"hepatoprotective\"]"
-    ],
     "mechanisms": [
-      "[\"immune signaling modulation\"]"
+      "immunomodulatory",
+      "NF-κB inhibition",
+      "MAPK pathway modulation",
+      "MAPK modulation"
     ],
-    "safetyNotes": "Short‑term use of echinacea extracts appears safe for most adults."
+    "description": "Echinacea Purpurea centers on the unspecified. Key reported compounds include alkamides; chicoric acid; echinacoside; caffeic acid; cynarin. Typical preparation forms: Medicinal products use the roots and aerial parts in teas, juices, tinctures and standardized extracts. Roots, leaves and flowers of Echinacea purpurea contain mixtures of lipophilic alkamides and hydrophilic caffeic acid derivatives such as chicoric acid and echinacoside, along with polysaccharides and glycoproteins【880087072039746†L166-L200】【840476591578855†L240-L305】. These constituents stimulate immune function by enhancing phagocytosis, activating fibroblasts and respiratory burst activity, and modulating nitric‐oxide and cytokine production via cannabinoid type‐2 receptors【880087072039746†L215-L243】. They also inhibit cyclo‐oxygenase and lipoxygenase enzymes. Most mechanistic data are from cell and animal studies; human evidence is limited. Interaction profile: Echinacea may interact with immunosuppressant drugs by stimulating immune activity and could affect the pharmacokinetics of drugs metabolised by cytochrome P450 enzymes; caution is advised when taken with hepatic substrates or caffeine. Use caution or avoid in: Individuals with autoimmune disorders or allergies to ragweed and other Asteraceae plants should avoid echinacea. Use during pregnancy or breastfeeding is not recommended. People taking immunosuppressant drugs should avoid echinacea due to potential antagonism.",
+    "activeCompounds": [
+      "alkamides",
+      "chicoric acid",
+      "echinacoside",
+      "caffeic acid",
+      "cynarin"
+    ],
+    "safetyNotes": "Short‐term use of echinacea extracts appears safe for most adults. Reported side effects include digestive upset and rash; allergic reactions can occur, especially in individuals sensitive to plants in the Asteraceae family. Some children have developed rashes after echinacea use. Safety during pregnancy or breastfeeding is not established. There is conflicting evidence about whether echinacea alters the metabolism of drugs processed by the liver; theoretical interactions with immunosuppressants or caffeine have been proposed【246299874455786†L194-L213】."
   },
   {
-    "slug": "elderberry",
-    "name": "Elderberry",
-    "hero": "Used for antioxidant and immunomodulatory support, with cyanidin and rutin serving as key marker compounds.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[\"antioxidant\"",
-      "\"immunomodulatory\"]"
-    ],
+    "slug": "garlic",
+    "name": "Garlic",
     "mechanisms": [
-      "[]"
+      "anti-inflammatory",
+      "antioxidant",
+      "immunomodulatory",
+      "platelet aggregation inhibition",
+      "NF-κB inhibition"
     ],
-    "safetyNotes": "General use caution; use properly prepared material only."
+    "description": "Garlic centers on the unspecified. Key reported compounds include diallyl sulfide; diallyl disulfide; diallyl trisulfide; ajoene; S‐allyl‐cysteine. Typical preparation forms: Fresh or dried bulbs are used as food and in remedies. Commercial supplements include aged garlic extracts, oils and powders standardized for organosulfur content. Garlic bulbs contain organosulfur compounds such as diallyl sulfide, diallyl disulfide, diallyl trisulfide, ajoene and S‐allyl‐cysteine. These constituents exert antioxidant, anti‐inflammatory and immunomodulatory effects in vitro and in animal models by scavenging free radicals and modulating inflammatory pathways. Human evidence is limited, so this should be regarded as a proposed mechanism based on preclinical data. Interaction profile: Garlic may potentiate the effects of anticoagulant and antiplatelet drugs (e.g., warfarin, aspirin) and should be discontinued before surgery. It may also enhance the effects of antihypertensive or antidiabetic medicines. Use caution or avoid in: People with bleeding disorders, those taking anticoagulant or antiplatelet drugs and individuals scheduled for surgery should avoid high‐dose garlic supplements. Because safety during pregnancy and breastfeeding has not been established, garlic supplements are not recommended in these populations.",
+    "activeCompounds": [
+      "diallyl sulfide",
+      "diallyl disulfide",
+      "diallyl trisulfide",
+      "ajoene",
+      "S‐allyl‐cysteine"
+    ],
+    "safetyNotes": "Oral garlic preparations are generally safe when used for up to seven years; side effects include breath and body odour, abdominal pain, flatulence and nausea. Because garlic can inhibit platelet aggregation it may increase the risk of bleeding, especially when combined with anticoagulants or antiplatelet drugs. Raw garlic applied to the skin can cause severe irritation or burns. The safety of garlic supplements during pregnancy or breastfeeding is uncertain【945608786527328†L190-L207】."
   },
   {
-    "slug": "elecampane",
-    "name": "Elecampane",
-    "hero": "Standardized around alantolactone to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to alantolactone rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
+    "slug": "ginger",
+    "name": "Ginger",
     "mechanisms": [
-      "[]"
+      "anti-inflammatory",
+      "digestive support",
+      "nausea modulation"
     ],
-    "safetyNotes": "Use cautiously in concentrated forms."
+    "description": "Ginger centers on the unspecified. Key reported compounds include [6]-gingerol; shogaols; zingerone; paradols. Typical preparation forms: The rhizome is used fresh, dried, pickled, preserved, candied or powdered. Supplements include encapsulated dried powders and extracts【418916103730052†L176-L189】. Ginger rhizomes contain phenolic constituents such as gingerols, shogaols, zingerone and paradols. These compounds modulate immune‐cell function and regulate signalling pathways including nuclear factor‐κB, MAPK and PI3K/Akt/mTOR, and they can activate AMP‐activated protein kinase (AMPK), NRF2, HO‐1 and PPARγ【69571933386645†L153-L169】【69571933386645†L240-L249】. Through these mechanisms ginger exhibits anti‐inflammatory, antioxidant and neuroprotective effects. Interaction profile: Ginger may increase the risk of bleeding when taken with anticoagulant or antiplatelet drugs and could lower blood glucose or blood pressure, potentiating antidiabetic or antihypertensive medications. Use caution or avoid in: Use cautiously in pregnancy, gallstone disease or bleeding disorders. Discontinue before surgery and avoid high‐dose supplements when taking anticoagulants.",
+    "activeCompounds": [
+      "gingerol",
+      "shogaol"
+    ],
+    "safetyNotes": "Ginger is widely consumed as a food and supplement and is generally regarded as safe. Research suggests it may help with mild nausea and menstrual cramps. Reported side effects at high doses include abdominal discomfort, heartburn, diarrhoea and irritation of the mouth or throat【799387966105800†L29-L56】. Clinical studies using up to 1 000 mg/day of dried powdered extract report adverse event rates similar to placebo【739669106228210†L96-L133】. The safety of high‐dose ginger during pregnancy has not been conclusively established."
   },
   {
-    "slug": "eleuthero",
-    "name": "Eleuthero",
-    "hero": "Used for adaptogenic support, with eleutherosides serving as key marker compound.",
-    "coreInsight": "It matters because eleutherosides help explain hPA-axis modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"adaptogenic\"]"
-    ],
+    "slug": "ginkgo-biloba",
+    "name": "Ginkgo Biloba",
     "mechanisms": [
-      "[\"HPA-axis modulation\"]"
+      "dopaminergic",
+      "serotonergic",
+      "cholinergic",
+      "antioxidant",
+      "NF-κB inhibition",
+      "PI3K/Akt modulation",
+      "Nrf2 activation",
+      "MAPK modulation"
     ],
-    "safetyNotes": "Safe."
+    "description": "Ginkgo Biloba centers on the leaf. Key reported compounds include ginkgolides A, B, C, J; bilobalide; ginkgetin; bilobetin; sciadopitysin. Typical preparation forms: Standardized leaf extract (EGb 761). The standardized leaf extract (EGb 761) contains terpene lactones and flavone glycosides that modulate multiple neurotransmitter systems and platelet-activating factor pathways. Interaction profile: May potentiate NSAIDs, anticoagulants, antiplatelets, and interact with antidepressants and antidiabetic drugs. Use caution or avoid in: Pregnancy, breastfeeding, bleeding disorders, epilepsy, planned surgery.",
+    "activeCompounds": [
+      "ginkgolides A",
+      "B",
+      "C",
+      "J",
+      "bilobalide",
+      "ginkgetin",
+      "bilobetin",
+      "sciadopitysin",
+      "Quercetin",
+      "Kaempferol"
+    ],
+    "safetyNotes": "Appears safe at recommended doses, but fresh seeds are toxic. May increase bleeding risk and lower seizure threshold."
   },
   {
-    "slug": "epimedium",
-    "name": "Epimedium",
-    "hero": "Used for anti-inflammatory support, with icariin serving as key marker compound.",
-    "coreInsight": "It matters because Icariin and Epimedin A help explain pDE-related signaling in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
+    "slug": "holy-basil",
+    "name": "Holy Basil",
     "mechanisms": [
-      "[\"PDE-related signaling\"",
-      "\"nitric oxide modulation\"",
-      "\"NF-kB inhibition\"",
-      "\"PDE5-related signaling\"]"
+      "adaptogen",
+      "anti-inflammatory",
+      "antioxidant",
+      "COX inhibition",
+      "TRP channel modulation",
+      "NF-κB inhibition",
+      "STAT3 inhibition",
+      "AMPK activation",
+      "TRPA1 modulation",
+      "voltage-gated channel modulation"
     ],
-    "safetyNotes": "Use caution in people with blood-pressure instability, hormone-sensitive conditions, or high sensitivity to activating supplements."
+    "description": "Holy Basil centers on the leaf; aerial parts. Key reported compounds include eugenol; ursolic acid; rosmarinic acid. Typical preparation forms: Leaf extracts, teas. Adaptogenic; anti-inflammatory; modulates cortisol and stress pathways. Interaction profile: Anticoagulants, antidiabetic drugs. Use caution or avoid in: Pregnancy (limited data).",
+    "activeCompounds": [
+      "eugenol",
+      "ursolic acid",
+      "rosmarinic acid",
+      "methyl eugenol"
+    ],
+    "safetyNotes": "Generally safe; possible mild GI upset"
   },
   {
-    "slug": "eucalyptus",
-    "name": "Eucalyptus",
-    "hero": "Used for anti-inflammatory and antimicrobial support, with eucalyptol and alpha-pinene serving as key marker compounds.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antimicrobial\"]"
+    "slug": "kava",
+    "name": "Kava",
+    "mechanisms": [
+      "gabaergic",
+      "MAO-B inhibition",
+      "GABA-A modulation"
+    ],
+    "description": "Kava centers on the root; rhizome. Key reported compounds include kavain; dihydrokavain; methysticin; dihydromethysticin; yangonin; desmethoxyyangonin; flavokavain A/B/C. Typical preparation forms: Traditional aqueous root beverage; modern standardized root extracts. Kavalactones modulate GABA-A receptors and ion channels, producing anxiolytic and sedative effects without classical benzodiazepine-site binding. Interaction profile: Additive sedation with CNS depressants and alcohol; possible hepatic enzyme interactions. Use caution or avoid in: Liver disease, pregnancy, breastfeeding, concurrent CNS depressants or hepatotoxic drugs.",
+    "activeCompounds": [
+      "kavain",
+      "dihydrokavain",
+      "methysticin",
+      "dihydromethysticin",
+      "yangonin",
+      "desmethoxyyangonin",
+      "flavokavain A/B/C"
+    ],
+    "safetyNotes": "Rare but serious liver injury has been reported, especially with nontraditional extracts or concurrent alcohol/hepatotoxic drug use."
+  },
+  {
+    "slug": "lemon-balm",
+    "name": "Lemon Balm",
+    "mechanisms": [
+      "anxiolytic",
+      "antiviral",
+      "calming"
+    ],
+    "description": "Lemon Balm centers on the leaf; aerial parts. Key reported compounds include rosmarinic acid; citral; citronellal; linalool; flavonoids. Typical preparation forms: Leaf extracts, teas, tinctures. GABAergic (GABA transaminase inhibition); mild cholinergic activity. Interaction profile: Sedatives, thyroid medications. Use caution or avoid in: Hypothyroidism (caution).",
+    "activeCompounds": [
+      "rosmarinic acid"
+    ],
+    "safetyNotes": "Generally safe; mild sedation possible"
+  },
+  {
+    "slug": "maca",
+    "name": "Maca",
+    "mechanisms": [
+      "adaptogen",
+      "hormonal"
+    ],
+    "description": "Maca centers on the root; hypocotyl. Key reported compounds include macamides; macaenes; glucosinolates. Typical preparation forms: Dried root powder, extracts. May influence endocrine signaling and energy metabolism (unclear mechanism). Interaction profile: Limited data. Use caution or avoid in: Hormone-sensitive conditions (caution).",
+    "activeCompounds": [
+      "macamides",
+      "macaenes",
+      "glucosinolates"
+    ],
+    "safetyNotes": "Generally safe; mild GI upset possible"
+  },
+  {
+    "slug": "milk-thistle",
+    "name": "Milk Thistle",
+    "primaryActions": [
+      "Hepatocyte protection",
+      "antioxidant response support",
+      "antifibrotic signaling"
     ],
     "mechanisms": [
-      "[]"
+      "liver support",
+      "antioxidant",
+      "hepatoprotection",
+      "STAT3 inhibition",
+      "NF-κB inhibition",
+      "PI3K/Akt modulation",
+      "Nrf2 activation",
+      "TGF-β modulation",
+      "ABC transporter modulation",
+      "hepatocyte protection"
+    ],
+    "description": "Milk Thistle centers on the seed; fruit. Key reported compounds include silybin A/B; isosilybin A/B; silychristin; silydianin; isosilychristin. Typical preparation forms: Seed/fruit extracts standardized to silymarin. Silymarin flavonolignans exhibit antioxidant, anti-inflammatory and antifibrotic activity relevant to hepatoprotection. Interaction profile: Possible CYP2C9/CYP3A4 interaction risk; may affect warfarin and some other drugs. Use caution or avoid in: Asteraceae allergy; caution in pregnancy/breastfeeding.",
+    "activeCompounds": [
+      "silymarin",
+      "Silibinin",
+      "silybin",
+      "silychristin",
+      "silydianin"
+    ],
+    "safetyNotes": "Generally well tolerated; mild GI side effects and occasional allergic reactions.",
+    "interactions": [
+      "May affect drug transport and metabolism in susceptible users."
+    ],
+    "preparation": "Seed extract is more practical than whole seed; standardized silymarin products are common."
+  },
+  {
+    "slug": "peppermint",
+    "name": "Peppermint",
+    "mechanisms": [
+      "digestive support",
+      "smooth muscle relaxation"
+    ],
+    "description": "Peppermint centers on the unspecified. Key reported compounds include l‐menthol; l‐menthone; isomenthone; menthyl acetate; 1,8‐cineole (eucalyptol); menthofuran; limonene. Typical preparation forms: Leaves and flowering tops are used fresh or dried to make teas and flavourings. Medicinal products include enteric‐coated capsules of peppermint oil and topical preparations. Peppermint oil contains more than 80 constituents; menthol is the main bioactive component. Menthol acts as a smooth‐muscle relaxant by blocking L‐type calcium channels and activating transient receptor potential channels (TRPM8 and TRPA1). These actions underlie the spasmolytic and analgesic properties of peppermint oil. Peppermint oil also has antimicrobial, antiviral and anti‐inflammatory effects【271856535371736†L224-L289】【271856535371736†L312-L333】. Interaction profile: Peppermint oil may inhibit cytochrome P450 enzymes (e.g., CYP2A6 and UGT2B7) and could theoretically interact with drugs metabolised by these pathways. Use caution or avoid in: Avoid in infants and young children, and in people with gastro‐oesophageal reflux disease or bile duct obstruction. Use cautiously in those taking hepatotoxic drugs due to potential pulegone/menthofuran toxicity.",
+    "activeCompounds": [
+      "menthol"
+    ],
+    "safetyNotes": "Menthol is generally regarded as safe. Enteric‐coated peppermint oil is well tolerated; the most common adverse effects reported in clinical trials are heartburn, nausea, abdominal pain and dry mouth【220193048567304†L45-L53】. High doses of minor constituents such as pulegone or menthofuran can cause hepatotoxicity in animals, but typical medicinal doses contain negligible amounts and no cases of human hepatotoxicity have been reported【271856535371736†L1296-L1354】. Peppermint oil should not be applied near the faces of infants or young children because menthol inhalation can cause serious adverse reactions【220193048567304†L45-L53】."
+  },
+  {
+    "slug": "rhodiola-rosea",
+    "name": "Rhodiola Rosea",
+    "mechanisms": [
+      "adaptogen",
+      "serotonergic",
+      "dopaminergic",
+      "antioxidant"
+    ],
+    "description": "Rhodiola Rosea centers on the root. Key reported compounds include rosavin; rosarin; rosin; salidroside; tyrosol. Typical preparation forms: Standardized root extracts. Adaptogen; modulates HPA axis; influences serotonin, dopamine, norepinephrine; antioxidant. Interaction profile: SSRIs, MAOIs, stimulants. Use caution or avoid in: Bipolar disorder; avoid high doses before sleep.",
+    "activeCompounds": [
+      "rosavin",
+      "rosarin",
+      "rosin",
+      "salidroside",
+      "tyrosol"
+    ],
+    "safetyNotes": "Generally well tolerated; possible dizziness; dry mouth; insomnia"
+  },
+  {
+    "slug": "saw-palmetto",
+    "name": "Saw Palmetto",
+    "mechanisms": [
+      "hormonal",
+      "anti-androgenic"
+    ],
+    "description": "Saw Palmetto centers on the berry. Key reported compounds include fatty acids; phytosterols (beta-sitosterol). Typical preparation forms: Berry extracts. 5-alpha-reductase inhibition; anti-androgenic effects. Interaction profile: Hormonal therapies, anticoagulants. Use caution or avoid in: Pregnancy.",
+    "activeCompounds": [
+      "fatty acids",
+      "phytosterols (beta-sitosterol)"
+    ],
+    "safetyNotes": "Generally safe; mild GI upset; headache"
+  },
+  {
+    "slug": "st-johns-wort",
+    "name": "St Johns Wort",
+    "mechanisms": [
+      "serotonergic",
+      "dopaminergic",
+      "NF-κB inhibition",
+      "PI3K/Akt modulation",
+      "Nrf2 activation"
+    ],
+    "description": "St. John's wort centers on the flowering tops. Key reported compounds include hyperforin; hypericin; pseudohypericin; quercetin; rutin; kaempferol. Typical preparation forms: Dried flowering tops or standardized extracts. Hyperforin and related compounds inhibit monoamine reuptake and affect TRPC6-linked neuroplasticity; additional monoamine oxidase and stress-pathway effects have been proposed. Interaction profile: Major interactions with antidepressants, oral contraceptives, cyclosporine, tacrolimus, HIV meds, anticancer drugs, warfarin, digoxin and others. Use caution or avoid in: Pregnancy, breastfeeding, bipolar disorder, concomitant prescription meds with CYP/P-gp liability.",
+    "activeCompounds": [
+      "hyperforin",
+      "hypericin",
+      "pseudohypericin",
+      "quercetin",
+      "rutin",
+      "kaempferol"
+    ],
+    "safetyNotes": "Can cause photosensitivity, GI upset, dizziness, insomnia, restlessness. Strong inducer of CYP3A4 and P-gp."
+  },
+  {
+    "slug": "turmeric",
+    "name": "Turmeric",
+    "mechanisms": [
+      "anti-inflammatory",
+      "antioxidant",
+      "nf-kb modulation",
+      "NF-κB inhibition",
+      "Nrf2 activation"
+    ],
+    "description": "Turmeric centers on the unspecified. Key reported compounds include curcumin; demethoxycurcumin; bisdemethoxycurcumin. Typical preparation forms: The rhizomes are boiled, dried and ground into powder used as a spice, dye and supplement. Extracts standardized for curcuminoid content are available as capsules or tablets. The golden rhizomes of turmeric contain non‐volatile curcuminoids-curcumin (curcumin I), demethoxycurcumin (curcumin II) and bisdemethoxycurcumin (curcumin III)-as well as volatile mono‐ and sesquiterpenoids【768158627760254†L420-L432】【768158627760254†L442-L468】. Curcumin and related curcuminoids exhibit antioxidant and anti‐inflammatory effects by modulating multiple molecular targets (e.g., NF‐κB, Nrf2, COX‐2). Most data are preclinical; human evidence is limited, so this mechanism should be considered proposed. Interaction profile: Curcumin may enhance the effects of anticoagulant, antiplatelet or antidiabetic drugs and could interact with drugs metabolized by cytochrome P450 enzymes; caution is advised. Use caution or avoid in: Avoid high‐dose turmeric supplements in people with gallbladder obstruction, bleeding disorders or those taking anticoagulant or antiplatelet medications. Use is not recommended during pregnancy or breastfeeding.",
+    "activeCompounds": [
+      "curcumin",
+      "demethoxycurcumin"
+    ],
+    "safetyNotes": "Conventional oral preparations of turmeric or curcumin appear safe for up to 2-3 months. Reported adverse effects include nausea, vomiting, acid reflux, stomach upset, diarrhoea or constipation. Highly bioavailable curcumin products have been linked to liver damage in rare cases. The safety of turmeric supplements during pregnancy or breastfeeding is uncertain【628537290338832†L207-L223】."
+  },
+  {
+    "slug": "valerian",
+    "name": "Valerian",
+    "mechanisms": [
+      "sedative",
+      "sleep support",
+      "gaba modulation"
+    ],
+    "description": "Valerian centers on the root; rhizome. Key reported compounds include valerenic acid; valerenol; valerenal; valepotriates (valtrate, isovaltrate); sesquiterpenoids. Typical preparation forms: Dried roots/rhizomes as teas, tinctures, or extracts. Valerenic acid derivatives modulate GABA-A signaling and may inhibit GABA breakdown. Interaction profile: May potentiate sedatives and alcohol. Use caution or avoid in: Pregnancy, breastfeeding, liver disease, concurrent CNS depressants.",
+    "activeCompounds": [
+      "valerenic acid"
+    ],
+    "safetyNotes": "Short-term use appears safe; side effects include headache, GI upset, mental dullness, excitability, vivid dreams. Rare liver injury reported."
+  },
+  {
+    "slug": "guarana",
+    "name": "Guarana",
+    "mechanisms": [
+      "energy support",
+      "cognition",
+      "metabolic support"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "activeCompounds": [
+      "caffeine"
+    ],
+    "safetyNotes": "Use caution with stimulant sensitivity, anxiety, or insomnia-prone contexts."
+  },
+  {
+    "slug": "yerba-mate",
+    "name": "Yerba Mate",
+    "mechanisms": [
+      "energy support",
+      "cognition",
+      "metabolic support"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "activeCompounds": [
+      "caffeine",
+      "polyphenols"
+    ],
+    "safetyNotes": "Use caution with stimulant sensitivity or insomnia-prone contexts."
+  },
+  {
+    "slug": "damiana",
+    "name": "Damiana",
+    "mechanisms": [
+      "mood support",
+      "calming support",
+      "libido support"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "activeCompounds": [
+      "flavonoids"
+    ],
+    "safetyNotes": "General use caution; review stimulating vs calming stack context."
+  },
+  {
+    "slug": "blue-lotus",
+    "name": "Blue Lotus",
+    "mechanisms": [
+      "calming support",
+      "mood support",
+      "sleep support"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "activeCompounds": [
+      "aporphine alkaloids"
+    ],
+    "safetyNotes": "Use caution with sedative-sensitive contexts and stacked calming formulas."
+  },
+  {
+    "slug": "kudzu",
+    "name": "Kudzu",
+    "mechanisms": [
+      "multi-domain"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "activeCompounds": [
+      "isoflavones"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "yarrow",
+    "name": "Yarrow",
+    "mechanisms": [
+      "digestive support",
+      "anti-inflammatory",
+      "women's health"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "activeCompounds": [
+      "flavonoids"
     ],
     "safetyNotes": "Review interactions and contraindications."
   },
   {
-    "slug": "eucommia",
-    "name": "Eucommia",
-    "hero": "Standardized around geniposidic acid to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to geniposidic acid rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
+    "slug": "feverfew",
+    "name": "Feverfew",
+    "mechanisms": [
+      "inflammation support",
+      "headache support",
+      "vascular modulation"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "activeCompounds": [
+      "parthenolide",
+      "flavonoids"
+    ],
+    "safetyNotes": "Review interactions and contraindications"
+  },
+  {
+    "slug": "butterbur",
+    "name": "Butterbur",
+    "mechanisms": [
+      "migraine support",
+      "anti-inflammatory",
+      "TRPA1/TRPV1 modulation",
+      "CGRP modulation"
+    ],
+    "description": "Butterbur is a sesquiterpene-rich herb usually discussed around standardized root extracts. Petasin and isopetasin are the anchor constituents most often linked to migraine and allergic-rhinitis relevance. The commercial problem is safety, because pyrrolizidine alkaloids (PAs) can damage the liver and lungs and may be carcinogenic. Keep claims narrow and safety-forward.",
+    "activeCompounds": [
+      "petasin",
+      "isopetasin",
+      "sesquiterpene esters"
+    ],
+    "safetyNotes": "PA-containing butterbur products are unsafe. Only PA-free products should be considered, and even then rare liver injury has been reported. Use caution with ragweed-family allergy."
+  },
+  {
+    "slug": "dong-quai",
+    "name": "Dong Quai",
+    "mechanisms": [
+      "circulation support",
+      "women's health",
+      "smooth muscle support"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "activeCompounds": [
+      "ferulic acid"
+    ],
+    "safetyNotes": "Review interactions and contraindications."
+  },
+  {
+    "slug": "rosemary",
+    "name": "Rosemary",
+    "primaryActions": [
+      "Nrf2 support",
+      "inflammatory pathway control",
+      "cognitive and digestive support"
     ],
     "mechanisms": [
-      "[]"
+      "cognition",
+      "antioxidant",
+      "digestive support",
+      "Nrf2 activation",
+      "NF-κB inhibition",
+      "STAT3 inhibition",
+      "AMPK activation",
+      "PI3K/Akt modulation"
+    ],
+    "description": "Conservative evidence framing applied. Lean bulk enrichment added: Carnosic acid.",
+    "activeCompounds": [
+      "rosmarinic acid",
+      "Carnosic acid",
+      "Ursolic acid",
+      "Oleanolic acid",
+      "carnosol"
+    ],
+    "safetyNotes": "Generally well tolerated; review concentrated extract use.",
+    "interactions": [
+      "Caution with concentrated extracts alongside anticoagulants."
+    ],
+    "preparation": "Leaf infusion for mild use; extracts provide higher diterpene exposure."
+  },
+  {
+    "slug": "sage",
+    "name": "Sage",
+    "mechanisms": [
+      "cognition",
+      "digestive support",
+      "antioxidant",
+      "Nrf2 activation",
+      "NF-κB inhibition",
+      "STAT3 inhibition",
+      "AMPK activation",
+      "PI3K/Akt modulation"
+    ],
+    "description": "Conservative evidence framing applied. Lean bulk enrichment added: Carnosic acid.",
+    "activeCompounds": [
+      "thujone",
+      "Carnosic acid",
+      "Ursolic acid",
+      "Oleanolic acid"
+    ],
+    "safetyNotes": "Generally well tolerated; review concentrated extract use."
+  },
+  {
+    "slug": "thyme",
+    "name": "Thyme",
+    "mechanisms": [
+      "respiratory support",
+      "antimicrobial",
+      "digestive support",
+      "NF-κB inhibition",
+      "MAPK pathway modulation",
+      "TRPA1 activation",
+      "membrane disruption",
+      "GABA-A modulation"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "activeCompounds": [
+      "thymol",
+      "Luteolin",
+      "carvacrol"
+    ],
+    "safetyNotes": "Generally well tolerated; review concentrated oil use carefully."
+  },
+  {
+    "slug": "oregano",
+    "name": "Oregano",
+    "mechanisms": [
+      "antimicrobial",
+      "digestive support",
+      "respiratory support",
+      "TRPA1 activation",
+      "membrane disruption",
+      "GABA-A modulation"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "activeCompounds": [
+      "carvacrol",
+      "thymol",
+      "rosmarinic acid"
+    ],
+    "safetyNotes": "General use caution; concentrated extracts can be irritating"
+  },
+  {
+    "slug": "eucalyptus",
+    "name": "Eucalyptus",
+    "mechanisms": [
+      "respiratory support",
+      "antimicrobial",
+      "anti-inflammatory"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "activeCompounds": [
+      "eucalyptol",
+      "alpha-pinene",
+      "tannins"
+    ],
+    "safetyNotes": "Review interactions and contraindications"
+  },
+  {
+    "slug": "artichoke",
+    "name": "Artichoke",
+    "mechanisms": [
+      "digestive support",
+      "hepatobiliary support",
+      "NF-κB inhibition",
+      "MAPK pathway modulation",
+      "AMPK activation",
+      "glucose metabolism modulation"
+    ],
+    "description": "It is best framed around bitter-compound and phenolic support for digestion and bile-related positioning rather than broad detox claims.",
+    "activeCompounds": [
+      "cynarin",
+      "chlorogenic acid",
+      "Luteolin"
     ],
     "safetyNotes": "Generally well tolerated."
   },
   {
     "slug": "fennel",
     "name": "Fennel",
-    "hero": "Used for antispasmodic and muscle-relaxant support, with anethole serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to anethole rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"antispasmodic\"",
-      "\"muscle-relaxant\"]"
+    "primaryActions": [
+      "Digestive support",
+      "smooth muscle relaxation",
+      "aromatic carminative action"
     ],
     "mechanisms": [
-      "[]"
+      "digestive support",
+      "antispasmodic support",
+      "NF-κB inhibition",
+      "smooth muscle relaxation"
+    ],
+    "description": "It is best handled as an aromatic seed botanical with traditional GI-support use and modest mechanistic confidence.",
+    "activeCompounds": [
+      "anethole",
+      "volatile oils"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Possible estrogenic interaction concerns with concentrated use."
+    ],
+    "preparation": "Tea or crushed seed is traditional; extracts concentrate volatile constituents."
+  },
+  {
+    "slug": "cinnamon",
+    "name": "Cinnamon",
+    "primaryActions": [
+      "Metabolic support",
+      "inflammatory control",
+      "sensory channel activity"
+    ],
+    "mechanisms": [
+      "glycemic support",
+      "antimicrobial support",
+      "AMPK activation",
+      "NF-κB inhibition"
+    ],
+    "description": "It is best framed conservatively because product form and species matter, especially around coumarin exposure in non-verum types.",
+    "activeCompounds": [
+      "cinnamaldehyde",
+      "polyphenols"
+    ],
+    "safetyNotes": "Generally well tolerated in culinary ranges.",
+    "interactions": [
+      "Use caution with anticoagulants and glucose-lowering therapy."
+    ],
+    "preparation": "Bark powder or extract; species matters for coumarin exposure."
+  },
+  {
+    "slug": "dandelion",
+    "name": "Dandelion",
+    "mechanisms": [
+      "digestive support",
+      "mild diuretic support"
+    ],
+    "description": "It is best framed as a traditional food-like bitter herb rather than a strong cleansing intervention.",
+    "activeCompounds": [
+      "taraxasterol",
+      "sesquiterpene lactones"
     ],
     "safetyNotes": "Generally well tolerated."
   },
   {
-    "slug": "feverfew",
-    "name": "Feverfew",
-    "hero": "Used for anti-inflammatory support, with parthenolide serving as key marker compound.",
-    "coreInsight": "It matters because Actein help explain vascular modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
+    "slug": "burdock",
+    "name": "Burdock",
     "mechanisms": [
-      "[\"vascular modulation\"]"
+      "traditional skin support",
+      "anti-inflammatory"
     ],
-    "safetyNotes": "Review interactions and contraindications."
-  },
-  {
-    "slug": "fingerroot",
-    "name": "Fingerroot",
-    "hero": "Standardized around pinostrobin to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Safety review required before publication."
-  },
-  {
-    "slug": "galangal",
-    "name": "Galangal",
-    "hero": "Standardized around galangin to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to galangin rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
+    "description": "It is best framed as a traditional root botanical with modest modern evidence rather than a definitive detox herb.",
+    "activeCompounds": [
+      "arctiin",
+      "lignans"
     ],
     "safetyNotes": "Generally well tolerated."
   },
   {
-    "slug": "garlic",
-    "name": "Garlic",
-    "hero": "Used for anti-inflammatory and analgesic support, with diallyl sulfide serving as key marker compound.",
-    "coreInsight": "It matters because diallyl sulfide help explain immune signaling modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"analgesic\"",
-      "\"antioxidant\"",
-      "\"immunomodulatory\"]"
-    ],
+    "slug": "chamomile",
+    "name": "Chamomile",
     "mechanisms": [
-      "[\"immune signaling modulation\"]"
+      "anxiolytic",
+      "sleep support",
+      "anti-inflammatory",
+      "GABA-A modulation",
+      "PI3K/Akt modulation"
     ],
-    "safetyNotes": "Oral garlic preparations are generally safe when used for up to seven years; side effects include breath and body odour, abdominal pain, flatulence and nausea."
-  },
-  {
-    "slug": "gastrodia",
-    "name": "Gastrodia",
-    "hero": "Used for anxiolytic support, with gastrodin serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to gastrodin rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[]"
+    "description": "It is best handled as a gentle calming botanical with broad traditional use and modest clinical depth.",
+    "activeCompounds": [
+      "apigenin"
     ],
     "safetyNotes": "Generally well tolerated."
   },
   {
-    "slug": "ginger",
-    "name": "Ginger",
-    "hero": "Used for anti-inflammatory and neuroprotective support, with gingerol serving as key marker compound.",
-    "coreInsight": "It matters because 6-Gingerol help explain nrf2 activation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"neuroprotective\"",
-      "\"antioxidant\"",
-      "\"immunomodulatory\"]"
-    ],
+    "slug": "red-clover",
+    "name": "Red Clover",
     "mechanisms": [
-      "[\"Nrf2 activation\"]"
-    ],
-    "safetyNotes": "Ginger is widely consumed as a food and supplement and is generally regarded as safe."
-  },
-  {
-    "slug": "ginkgo-biloba",
-    "name": "Ginkgo Biloba",
-    "hero": "Used for anti-inflammatory and neuroprotective support, with ginkgolides and bilobalide serving as key marker compounds.",
-    "coreInsight": "It matters because ginkgolides A, B, C, J and Ginkgolide B help explain dopamine modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"neuroprotective\"",
-      "\"antioxidant\"",
-      "\"nootropic\"]"
-    ],
-    "mechanisms": [
-      "[\"dopamine modulation\"",
-      "\"serotonin modulation\"",
-      "\"cholinergic modulation\"",
-      "\"NF-kB inhibition\"",
-      "\"PAF antagonism\"]"
-    ],
-    "safetyNotes": "Appears safe at recommended doses, but fresh seeds are toxic."
-  },
-  {
-    "slug": "goldenseal",
-    "name": "Goldenseal",
-    "hero": "Used for anti-inflammatory support, with berberine serving as key marker compound.",
-    "coreInsight": "Its value comes from a clearer mechanism readout than a generic traditional-use label. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[\"AMPK activation\"",
-      "\"NF-kB inhibition\"",
-      "\"mitochondrial complex I inhibition\"",
-      "\"ampk activation\"",
-      "\"mitochondrial complex i inhibition\"",
-      "\"mitochondrial complex I inhibition.\"]"
-    ],
-    "safetyNotes": "Safety review required before publication."
-  },
-  {
-    "slug": "gotu-kola",
-    "name": "Gotu Kola",
-    "hero": "Used for nootropic support, with asiaticoside serving as key marker compound.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[\"nootropic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Safe."
-  },
-  {
-    "slug": "green-tea",
-    "name": "Green Tea",
-    "hero": "Used for adaptogenic and stimulant support, with caffeine serving as key marker compound.",
-    "coreInsight": "It matters because Caffeine and Theanine help explain adenosine antagonism in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"adaptogenic\"",
-      "\"stimulant\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"adenosine antagonism\"",
-      "\"dopamine modulation\"",
-      "\"adenosine A1 antagonism\"",
-      "\"adenosine A2A antagonism\"",
-      "\"stimulant CNS signaling\"",
-      "\"AMPK activation\"]"
-    ],
-    "safetyNotes": "Safety review required before publication."
-  },
-  {
-    "slug": "guarana",
-    "name": "Guarana",
-    "hero": "Used for stimulant and nootropic support, with caffeine serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to Caffeine rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"stimulant\"",
-      "\"nootropic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Use caution with stimulant sensitivity, anxiety, or insomnia-prone contexts."
-  },
-  {
-    "slug": "guayusa",
-    "name": "Guayusa",
-    "hero": "Defined by caffeine as key marker compound, with activity centered on adenosine antagonism.",
-    "coreInsight": "Its value comes from a clearer mechanism readout than a generic traditional-use label. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[\"adenosine antagonism\"",
-      "\"dopamine modulation\"]"
-    ],
-    "safetyNotes": "Safety review required before publication."
-  },
-  {
-    "slug": "gudmar",
-    "name": "Gudmar",
-    "hero": "Standardized around gymnemic acids to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to gymnemic acids rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "gymnema",
-    "name": "Gymnema",
-    "hero": "Defined by gymnemic acids as key marker compound, with activity centered on sweet taste suppression.",
-    "coreInsight": "It matters because gymnemic acids help explain sweet taste suppression in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[\"sweet taste suppression\"",
-      "\"T1R2/T1R3 modulation\"",
-      "\"glucose absorption modulation\"",
-      "\"t1r2/t1r3 modulation\"]"
-    ],
-    "safetyNotes": "Generally well tolerated, but products positioned for glucose support should be handled cautiously in people already using glucose-lowering strategies."
-  },
-  {
-    "slug": "hawthorn",
-    "name": "Hawthorn",
-    "hero": "Standardized around procyanidin B2 to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to procyanidin b2 rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "holy-basil",
-    "name": "Holy Basil",
-    "hero": "Used for anti-inflammatory and antioxidant support, with eugenol and ursolic acid serving as key marker compounds.",
-    "coreInsight": "It matters because Eugenol and Ursolic acid help explain cortisol modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"",
-      "\"adaptogenic\"",
-      "\"nootropic\"]"
-    ],
-    "mechanisms": [
-      "[\"cortisol modulation\"]"
-    ],
-    "safetyNotes": "Generally safe; possible mild GI upset."
-  },
-  {
-    "slug": "holy-basil-purple",
-    "name": "Holy Basil Purple",
-    "hero": "Used for antioxidant and adaptogenic support, with eugenol serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to Eugenol rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"antioxidant\"",
-      "\"adaptogenic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "holy-basil-seed",
-    "name": "Holy Basil Seed",
-    "hero": "Standardized around mucilage to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to mucilage rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "honeysuckle",
-    "name": "Honeysuckle",
-    "hero": "Used for anti-inflammatory support, with luteolin serving as key marker compound.",
-    "coreInsight": "Its value comes from a clearer mechanism readout than a generic traditional-use label. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[\"MAPK pathway inhibition\"",
-      "\"NF-kB inhibition\"",
-      "\"mapk pathway inhibition\"",
-      "\"NF-kB modulation\"]"
-    ],
-    "safetyNotes": "Safety review required before publication."
-  },
-  {
-    "slug": "hops",
-    "name": "Hops",
-    "hero": "Used for sedative and anxiolytic support, with humulone serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to humulone rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"sedative\"",
-      "\"anxiolytic\"",
-      "\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "horse-chestnut",
-    "name": "Horse Chestnut",
-    "hero": "Used for anti-inflammatory support, with aescin and aesculin serving as key marker compounds.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Review interactions and contraindications."
-  },
-  {
-    "slug": "houttuynia",
-    "name": "Houttuynia",
-    "hero": "Used for immunomodulatory support, with quercitrin serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to quercitrin rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"immunomodulatory\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "isatis",
-    "name": "Isatis",
-    "hero": "Used for immunomodulatory support, with tryptanthrin serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to tryptanthrin rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"immunomodulatory\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Use cautiously."
-  },
-  {
-    "slug": "jatamansi",
-    "name": "Jatamansi",
-    "hero": "Used for anxiolytic support, with jatamansone serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to jatamansone rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "jujube",
-    "name": "Jujube",
-    "hero": "Used for sedative and anxiolytic support, with jujuboside A serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to jujuboside a rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"sedative\"",
-      "\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "juniper",
-    "name": "Juniper",
-    "hero": "Used for diuretic support, with alpha-pinene serving as key marker compound.",
-    "coreInsight": "It matters because alpha-pinene help explain adrenergic signaling in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"diuretic\"]"
-    ],
-    "mechanisms": [
-      "[\"adrenergic signaling\"]"
-    ],
-    "safetyNotes": "Use cautiously in concentrated forms."
-  },
-  {
-    "slug": "kanna",
-    "name": "Kanna",
-    "hero": "Standardized around mesembrenone to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Safety review required before publication."
-  },
-  {
-    "slug": "kava",
-    "name": "Kava",
-    "hero": "Used for anxiolytic and sedative support, with total kavalactones serving as key marker compound.",
-    "coreInsight": "It matters because kavain help explain gABA-A modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"anxiolytic\"",
-      "\"sedative\"",
-      "\"nootropic\"",
-      "\"hepatoprotective\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"]"
-    ],
-    "safetyNotes": "Rare but serious liver injury has been reported, especially with nontraditional extracts or concurrent alcohol/hepatotoxic drug use."
-  },
-  {
-    "slug": "kuding-tea",
-    "name": "Kuding Tea",
-    "hero": "Used for antioxidant support, with kudinlactone serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to kudinlactone rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "kudzu",
-    "name": "Kudzu",
-    "hero": "Standardized around puerarin to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to parthenolide rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "lavender",
-    "name": "Lavender",
-    "hero": "Used for sedative and anxiolytic support, with linalool serving as key marker compound.",
-    "coreInsight": "Its value comes from a clearer mechanism readout than a generic traditional-use label. Evidence is limited.",
-    "effects": [
-      "[\"sedative\"",
-      "\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"]"
-    ],
-    "safetyNotes": "Can be sedating in some users."
-  },
-  {
-    "slug": "lemon-balm",
-    "name": "Lemon Balm",
-    "hero": "Used for anxiolytic and sedative support, with rosmarinic acid serving as key marker compound.",
-    "coreInsight": "It matters because Rosmarinic acid help explain gABA-A modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"anxiolytic\"",
-      "\"sedative\"",
-      "\"antimicrobial\"",
-      "\"nootropic\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"",
-      "\"cholinergic modulation\"]"
-    ],
-    "safetyNotes": "Generally safe; mild sedation possible."
-  },
-  {
-    "slug": "lemon-verbena",
-    "name": "Lemon Verbena",
-    "hero": "Used for anxiolytic support, with verbascoside serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to verbascoside rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "lemongrass",
-    "name": "Lemongrass",
-    "hero": "Used for anxiolytic support, with citral serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to citral rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "licorice",
-    "name": "Licorice",
-    "hero": "Standardized around glycyrrhizin to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Safety review required before publication."
-  },
-  {
-    "slug": "lion-s-mane",
-    "name": "Lion's Mane",
-    "hero": "Standardized around hericenones and erinacines to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to hericenone c rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Safe."
-  },
-  {
-    "slug": "longan",
-    "name": "Longan",
-    "hero": "Used for anxiolytic and antioxidant support, with gallic acid serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to gallic acid rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"anxiolytic\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "luo-han-guo",
-    "name": "Luo Han Guo",
-    "hero": "Standardized around mogroside V to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to mogroside v rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "maca",
-    "name": "Maca",
-    "hero": "Used for stimulant and adaptogenic support, with macamides serving as key marker compound.",
-    "coreInsight": "It matters because macamides help explain hormone modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"stimulant\"",
-      "\"adaptogenic\"",
-      "\"nootropic\"]"
-    ],
-    "mechanisms": [
-      "[\"hormone modulation\"]"
-    ],
-    "safetyNotes": "Generally safe; mild GI upset possible."
-  },
-  {
-    "slug": "maitake-d-fraction",
-    "name": "Maitake D-Fraction",
-    "hero": "Used for immunomodulatory support, with beta-glucans serving as key marker compound.",
-    "coreInsight": "It matters because beta-glucans help explain immune modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"immunomodulatory\"]"
-    ],
-    "mechanisms": [
-      "[\"immune modulation\"]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "mangosteen",
-    "name": "Mangosteen",
-    "hero": "Used for anti-inflammatory and antioxidant support, with alpha-mangostin serving as key marker compound.",
-    "coreInsight": "It matters because alpha-mangostin help explain adrenergic signaling in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[\"adrenergic signaling\"]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "maral-root",
-    "name": "Maral Root",
-    "hero": "Used for adaptogenic support, with ecdysterone serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to ecdysterone rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"adaptogenic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "marshmallow",
-    "name": "Marshmallow",
-    "hero": "Standardized around mucilage polysaccharides to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "General use caution; separate from medications when timing matters."
-  },
-  {
-    "slug": "milk-oats",
-    "name": "Milk Oats",
-    "hero": "Used for anxiolytic support, with avenacosides serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to avenacosides rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"anxiolytic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "milk-thistle",
-    "name": "Milk Thistle",
-    "hero": "Used for anti-inflammatory and antioxidant support, with silymarin serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to silybin A/B rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"",
-      "\"hepatoprotective\"",
-      "\"nootropic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated; mild GI side effects and occasional allergic reactions."
-  },
-  {
-    "slug": "moringa",
-    "name": "Moringa",
-    "hero": "Used for antioxidant support, with moringin serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to moringin rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "mucuna",
-    "name": "Mucuna",
-    "hero": "Defined by L-DOPA as key marker compound, with activity centered on dopamine modulation.",
-    "coreInsight": "Its value comes from a clearer mechanism readout than a generic traditional-use label. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[\"dopamine modulation\"]"
-    ],
-    "safetyNotes": "Use caution in psychiatric, cardiovascular, and dopaminergic contexts."
-  },
-  {
-    "slug": "mugwort",
-    "name": "Mugwort",
-    "hero": "Standardized around thujone to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to thujone rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Use caution with concentrated preparations."
-  },
-  {
-    "slug": "muira-puama",
-    "name": "Muira Puama",
-    "hero": "Used for adaptogenic support, with beta-sitosterol serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to beta-sitosterol rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"adaptogenic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "mulberry-leaf",
-    "name": "Mulberry Leaf",
-    "hero": "Defined by 1-deoxynojirimycin as key marker compound, with activity centered on glucose absorption modulation.",
-    "coreInsight": "It matters because 1-deoxynojirimycin help explain glucose absorption modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[\"glucose absorption modulation\"]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "myrtle",
-    "name": "Myrtle",
-    "hero": "Used for antioxidant support, with myrtenyl acetate serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to myrtenyl acetate rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "neem",
-    "name": "Neem",
-    "hero": "Used for antimicrobial support, with nimbin serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to nimbin rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"antimicrobial\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Use caution with concentrated internal use."
-  },
-  {
-    "slug": "nettle-root",
-    "name": "Nettle Root",
-    "hero": "Used for diuretic support, with beta-sitosterol serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to beta-sitosterol rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"diuretic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "noni",
-    "name": "Noni",
-    "hero": "Used for antioxidant support, with damnacanthal serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to damnacanthal rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "notoginseng",
-    "name": "Notoginseng",
-    "hero": "Used for anti-inflammatory support, with notoginsenoside R1 serving as key marker compound.",
-    "coreInsight": "It matters because notoginsenoside r1 help explain nF-kB inhibition in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[\"NF-kB inhibition\"",
-      "\"COX inhibition\"]"
+      "phytoestrogen-adjacent support",
+      "estrogen receptor modulation",
+      "PI3K/Akt modulation",
+      "MAPK pathway modulation",
+      "NF-κB inhibition"
+    ],
+    "description": "It should be framed conservatively because endocrine-adjacent claims outrun the evidence in many product contexts.",
+    "activeCompounds": [
+      "isoflavones",
+      "genistein",
+      "Daidzein",
+      "Formononetin",
+      "Biochanin A"
     ],
     "safetyNotes": "Generally well tolerated."
   },
   {
     "slug": "oatstraw",
     "name": "Oatstraw",
-    "hero": "Used for anxiolytic support, with avenanthramides serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to avenanthramides rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"anxiolytic\"]"
-    ],
     "mechanisms": [
-      "[]"
+      "nutritive support",
+      "calming support"
+    ],
+    "description": "It is best framed as a gentle nutritive herb with limited high-signal clinical depth.",
+    "activeCompounds": [
+      "avenanthramides",
+      "minerals"
     ],
     "safetyNotes": "Generally well tolerated."
   },
   {
-    "slug": "ophiopogon",
-    "name": "Ophiopogon",
-    "hero": "Standardized around ophiopogonin D to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to ophiopogonin d rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
+    "slug": "calendula",
+    "name": "Calendula",
     "mechanisms": [
-      "[]"
+      "topical soothing support",
+      "anti-inflammatory"
+    ],
+    "description": "It is best framed around topical and tissue-soothing use rather than overextended systemic claims.",
+    "activeCompounds": [
+      "faradiol esters",
+      "flavonoids"
     ],
     "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "oregano",
-    "name": "Oregano",
-    "hero": "Used for antimicrobial support, with carvacrol and thymol serving as key marker compounds.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[\"antimicrobial\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "General use caution; concentrated extracts can be irritating."
-  },
-  {
-    "slug": "panax-ginseng",
-    "name": "Panax Ginseng",
-    "hero": "Used for stimulant and adaptogenic support, with ginsenosides serving as key marker compound.",
-    "coreInsight": "It matters because Ginsenoside RG1 and Ginsenoside RB1 help explain aMPK modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"stimulant\"",
-      "\"adaptogenic\"",
-      "\"nootropic\"]"
-    ],
-    "mechanisms": [
-      "[\"AMPK modulation\"",
-      "\"cognitive modulation\"",
-      "\"metabolic signaling\"",
-      "\"stress-response modulation\"",
-      "\"cholinergic modulation\"",
-      "\"neurotrophic signaling\"]"
-    ],
-    "safetyNotes": "Safe."
-  },
-  {
-    "slug": "papaya-leaf",
-    "name": "Papaya Leaf",
-    "hero": "Used for analgesic support, with carpaine serving as key marker compound.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[\"analgesic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Safety review required before publication."
-  },
-  {
-    "slug": "passionflower",
-    "name": "Passionflower",
-    "hero": "Used for anxiolytic and sedative support, with chrysin serving as key marker compound.",
-    "coreInsight": "It matters because chrysin help explain gABA-A modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"anxiolytic\"",
-      "\"sedative\"",
-      "\"adaptogenic\"]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"",
-      "\"possible GABAergic signaling\"]"
-    ],
-    "safetyNotes": "EMA reported no side effects at the time of assessment, but prudence still supports sedative-stacking caution."
   },
   {
     "slug": "pau-d-arco",
     "name": "Pau d'Arco",
-    "hero": "Used for antimicrobial and immunomodulatory support, with lapachol serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to lapachol rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"antimicrobial\"",
-      "\"immunomodulatory\"]"
-    ],
     "mechanisms": [
-      "[]"
+      "traditional immune support",
+      "antimicrobial support"
+    ],
+    "description": "It should be framed conservatively because popular claims often exceed the evidence and preparation differences matter.",
+    "activeCompounds": [
+      "lapachol",
+      "naphthoquinones"
     ],
     "safetyNotes": "Use conservatively; concentrated use may be irritating."
   },
   {
-    "slug": "peppermint",
-    "name": "Peppermint",
-    "hero": "Used for anti-inflammatory and analgesic support, with menthol serving as key marker compound.",
-    "coreInsight": "It matters because l‑menthol help explain tRPA1 modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"analgesic\"",
-      "\"antimicrobial\"",
-      "\"muscle-relaxant\"]"
-    ],
+    "slug": "gymnema",
+    "name": "Gymnema",
     "mechanisms": [
-      "[\"TRPA1 modulation\"",
-      "\"calcium channel modulation\"]"
+      "glycemic support",
+      "sweet taste suppression",
+      "T1R2/T1R3 modulation",
+      "glucose absorption modulation",
+      "AMPK activation"
     ],
-    "safetyNotes": "Menthol is generally regarded as safe."
+    "description": "Gymnema leaf is mainly anchored by gymnemic acids, a triterpene-glycoside cluster. The strongest mechanistic signal is sweet-taste suppression plus related effects on glucose handling, not generic wellness language. Keep human claims conservative and formulation-specific.",
+    "activeCompounds": [
+      "gymnemic acids",
+      "Gymnemic acid"
+    ],
+    "safetyNotes": "Generally well tolerated, but products positioned for glucose support should be handled cautiously in people already using glucose-lowering strategies."
   },
   {
-    "slug": "perilla",
-    "name": "Perilla",
-    "hero": "Used for antioxidant support, with perillaldehyde serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to perillaldehyde rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
+    "slug": "banaba",
+    "name": "Banaba",
     "mechanisms": [
-      "[]"
+      "glycemic support",
+      "metabolic support"
+    ],
+    "description": "It is best framed conservatively because evidence quality and standardization vary across products.",
+    "activeCompounds": [
+      "corosolic acid"
     ],
     "safetyNotes": "Generally well tolerated."
   },
   {
-    "slug": "phellodendron",
-    "name": "Phellodendron",
-    "hero": "Used for anti-inflammatory support, with berberine serving as key marker compound.",
-    "coreInsight": "Its value comes from a clearer mechanism readout than a generic traditional-use label. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
+    "slug": "mulberry-leaf",
+    "name": "Mulberry Leaf",
     "mechanisms": [
-      "[\"AMPK activation\"",
-      "\"NF-kB inhibition\"",
-      "\"mitochondrial complex I inhibition\"",
-      "\"ampk activation\"",
-      "\"mitochondrial complex i inhibition\"",
-      "\"mitochondrial complex I inhibition.\"]"
+      "glycemic support"
     ],
-    "safetyNotes": "Safety review required before publication."
+    "description": "It is best framed around alpha-glucosidase-adjacent positioning rather than generalized wellness language.",
+    "activeCompounds": [
+      "1-deoxynojirimycin",
+      "flavonoids"
+    ],
+    "safetyNotes": "Generally well tolerated."
   },
   {
-    "slug": "polygala",
-    "name": "Polygala",
-    "hero": "Used for nootropic and anxiolytic support, with tenuifolin serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to tenuifolin rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"nootropic\"",
-      "\"anxiolytic\"]"
-    ],
+    "slug": "neem",
+    "name": "Neem",
     "mechanisms": [
-      "[]"
+      "traditional skin support",
+      "antimicrobial support"
     ],
-    "safetyNotes": "Use cautiously."
+    "description": "It should be framed carefully because topical, oral, and seed-oil contexts differ substantially in safety relevance.",
+    "activeCompounds": [
+      "nimbin",
+      "azadirachtin"
+    ],
+    "safetyNotes": "Use caution with concentrated internal use."
+  },
+  {
+    "slug": "mugwort",
+    "name": "Mugwort",
+    "mechanisms": [
+      "digestive support",
+      "traditional cycle support"
+    ],
+    "description": "It is best framed conservatively because strong folklore and ritual associations often outrun clinical evidence.",
+    "activeCompounds": [
+      "volatile oils",
+      "flavonoids"
+    ],
+    "safetyNotes": "Use caution with concentrated preparations."
+  },
+  {
+    "slug": "lemon-verbena",
+    "name": "Lemon Verbena",
+    "mechanisms": [
+      "calming support",
+      "digestive support"
+    ],
+    "description": "It is best framed as a gentle aromatic botanical with modest evidence and pleasant tolerability.",
+    "activeCompounds": [
+      "verbascoside",
+      "volatile oils"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "milk-oats",
+    "name": "Milk Oats",
+    "mechanisms": [
+      "nutritive support",
+      "calming support"
+    ],
+    "description": "They are best framed as a gentle traditional tonic rather than a strong acute intervention.",
+    "activeCompounds": [
+      "avenacosides",
+      "avenanthramides"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "cissus",
+    "name": "Cissus",
+    "mechanisms": [
+      "connective tissue support",
+      "recovery support"
+    ],
+    "description": "It is best framed conservatively because evidence is mixed and product positioning often outruns the data.",
+    "activeCompounds": [
+      "ketosteroids",
+      "flavonoids"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "ashitaba",
+    "name": "Ashitaba",
+    "mechanisms": [
+      "metabolic support",
+      "antioxidant"
+    ],
+    "description": "It is best framed around chalcone-rich chemistry with modest translational evidence.",
+    "activeCompounds": [
+      "xanthoangelol",
+      "4-hydroxyderricin"
+    ],
+    "safetyNotes": "Generally well tolerated."
   },
   {
     "slug": "pomegranate",
     "name": "Pomegranate",
-    "hero": "Used for antioxidant support, with punicalagins serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to punicalagins rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"antioxidant\"]"
+    "primaryActions": [
+      "Inflammatory control",
+      "tannin-rich antioxidant activity",
+      "vascular support"
     ],
     "mechanisms": [
-      "[]"
+      "vascular support",
+      "antioxidant",
+      "Nrf2 activation",
+      "NF-κB inhibition",
+      "MAPK pathway modulation",
+      "ellagitannin-mediated antioxidant signaling"
+    ],
+    "description": "It is best framed as a polyphenol-rich fruit botanical with food-form relevance and moderate evidence.",
+    "activeCompounds": [
+      "punicalagins",
+      "ellagic acid",
+      "Gallic acid",
+      "punicalagin"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Polyphenol-rich extracts may alter drug metabolism in some contexts."
+    ],
+    "preparation": "Juice and rind extracts differ substantially in tannin density."
+  },
+  {
+    "slug": "moringa",
+    "name": "Moringa",
+    "primaryActions": [
+      "Phase II detox support",
+      "redox signaling",
+      "nutrient-dense tonic use"
+    ],
+    "mechanisms": [
+      "nutritive support",
+      "antioxidant",
+      "metabolic support",
+      "Nrf2 activation",
+      "isothiocyanate signaling"
+    ],
+    "description": "It is best framed as a nutrient-dense botanical with mixed translational evidence rather than as a universal superfood cure-all.",
+    "activeCompounds": [
+      "moringin",
+      "isothiocyanates",
+      "glucomoringin"
+    ],
+    "safetyNotes": "Generally well tolerated.",
+    "interactions": [
+      "Use caution with glucose-lowering therapy when using concentrated extracts."
+    ],
+    "preparation": "Leaf powder is common; myrosinase-active processing changes glucosinolate conversion."
+  },
+  {
+    "slug": "arjuna",
+    "name": "Arjuna",
+    "mechanisms": [
+      "cardiovascular support",
+      "vascular support"
+    ],
+    "description": "It is best framed around bark polyphenols and triterpenes with specific cardiotonic-support positioning.",
+    "activeCompounds": [
+      "arjunolic acid",
+      "triterpenes"
     ],
     "safetyNotes": "Generally well tolerated."
   },
   {
-    "slug": "poria",
-    "name": "Poria",
-    "hero": "Used for anxiolytic support, with pachymic acid serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to pachymic acid rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"anxiolytic\"]"
-    ],
+    "slug": "noni",
+    "name": "Noni",
     "mechanisms": [
-      "[]"
+      "traditional wellness support",
+      "antioxidant"
+    ],
+    "description": "It should be framed conservatively because broad folk claims exceed the strength of modern evidence.",
+    "activeCompounds": [
+      "damnacanthal",
+      "iridoids"
     ],
     "safetyNotes": "Generally well tolerated."
   },
   {
-    "slug": "psyllium",
-    "name": "Psyllium",
-    "hero": "Standardized around mucilage to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to mucilage rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
+    "slug": "cranberry",
+    "name": "Cranberry",
     "mechanisms": [
-      "[]"
+      "urinary support",
+      "antioxidant"
     ],
-    "safetyNotes": "Must be taken with plenty of liquid."
-  },
-  {
-    "slug": "pueraria-mirifica",
-    "name": "Pueraria Mirifica",
-    "hero": "Used for nootropic support, with miroestrol serving as key marker compound.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[\"nootropic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Use caution or avoid in hormone-sensitive conditions, pregnancy, and breastfeeding."
-  },
-  {
-    "slug": "punarnava",
-    "name": "Punarnava",
-    "hero": "Used for anti-inflammatory and diuretic support, with boeravinones and punarnavine serving as key marker compounds.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"diuretic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "General use caution."
-  },
-  {
-    "slug": "red-clover",
-    "name": "Red Clover",
-    "hero": "Standardized around genistein to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to genistein rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "rehmannia-prepared",
-    "name": "Rehmannia Prepared",
-    "hero": "Standardized around catalpol to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to catalpol rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "reishi",
-    "name": "Reishi",
-    "hero": "Used for anti-inflammatory and immunomodulatory support, with triterpenes serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to beta-glucans rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"immunomodulatory\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Safe."
-  },
-  {
-    "slug": "rhodiola",
-    "name": "Rhodiola",
-    "hero": "Used for nootropic and adaptogenic support, with rosavins serving as key marker compound.",
-    "coreInsight": "It matters because Salidroside and Rosavin help explain hPA axis modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"nootropic\"",
-      "\"adaptogenic\"",
-      "\"stimulant\"]"
-    ],
-    "mechanisms": [
-      "[\"HPA axis modulation\"",
-      "\"HPA-axis modulation\"]"
-    ],
-    "safetyNotes": "Safe."
-  },
-  {
-    "slug": "rhodiola-rosea",
-    "name": "Rhodiola Rosea",
-    "hero": "Used for sedative and antioxidant support, with rosavins and salidroside serving as key marker compounds.",
-    "coreInsight": "It matters because Rosavin help explain serotonin modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"sedative\"",
-      "\"antioxidant\"",
-      "\"adaptogenic\"",
-      "\"stimulant\"]"
-    ],
-    "mechanisms": [
-      "[\"serotonin modulation\"",
-      "\"dopamine modulation\"",
-      "\"HPA-axis modulation\"]"
-    ],
-    "safetyNotes": "Generally well tolerated; possible dizziness, dry mouth, insomnia."
-  },
-  {
-    "slug": "rooibos",
-    "name": "Rooibos",
-    "hero": "Used for antioxidant support, with aspalathin serving as key marker compound.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
-    "mechanisms": [
-      "[]"
+    "description": "It is best framed around proanthocyanidin-rich urinary-support positioning rather than broad antimicrobial claims.",
+    "activeCompounds": [
+      "A-type proanthocyanidins"
     ],
     "safetyNotes": "Generally well tolerated."
   },
   {
     "slug": "rose-hips",
     "name": "Rose Hips",
-    "hero": "Used for antioxidant support, with trans-tiliroside serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to trans-tiliroside rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
     "mechanisms": [
-      "[]"
+      "antioxidant",
+      "nutritive support"
+    ],
+    "description": "They are best framed as polyphenol- and vitamin-rich fruit material with modest but relevant human evidence.",
+    "activeCompounds": [
+      "trans-tiliroside",
+      "vitamin C"
     ],
     "safetyNotes": "Generally well tolerated."
   },
   {
-    "slug": "roselle-seed",
-    "name": "Roselle Seed",
-    "hero": "Used for antioxidant and adaptogenic support, with tocopherols serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to tocopherols rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"antioxidant\"",
-      "\"adaptogenic\"]"
-    ],
+    "slug": "juniper",
+    "name": "Juniper",
     "mechanisms": [
-      "[]"
+      "digestive support",
+      "urinary support",
+      "aromatic support"
+    ],
+    "description": "It should be framed as an aromatic berry botanical with traditional GI and urinary relevance.",
+    "activeCompounds": [
+      "alpha-pinene",
+      "terpenes"
+    ],
+    "safetyNotes": "Use cautiously in concentrated forms."
+  },
+  {
+    "slug": "myrtle",
+    "name": "Myrtle",
+    "mechanisms": [
+      "aromatic support",
+      "antioxidant"
+    ],
+    "description": "It is best framed as an aromatic Mediterranean leaf botanical with modest modern evidence.",
+    "activeCompounds": [
+      "myrtenyl acetate",
+      "myricetin"
     ],
     "safetyNotes": "Generally well tolerated."
   },
   {
-    "slug": "rosemary",
-    "name": "Rosemary",
-    "hero": "Used for antioxidant and nootropic support, with rosmarinic acid serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to thymol rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"antioxidant\"",
-      "\"nootropic\"]"
-    ],
+    "slug": "acerola",
+    "name": "Acerola",
     "mechanisms": [
-      "[]"
+      "antioxidant",
+      "nutritive support"
     ],
-    "safetyNotes": "Generally well tolerated; review concentrated extract use."
+    "description": "It is best framed as a vitamin-C-rich fruit botanical with food/supplement relevance.",
+    "activeCompounds": [
+      "ascorbic acid",
+      "carotenoids"
+    ],
+    "safetyNotes": "Generally well tolerated."
   },
   {
-    "slug": "saffron",
-    "name": "Saffron",
-    "hero": "Standardized around picrocrocin to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
+    "slug": "mangosteen",
+    "name": "Mangosteen",
     "mechanisms": [
-      "[]"
+      "antioxidant",
+      "traditional wellness support"
     ],
-    "safetyNotes": "Safety review required before publication."
+    "description": "It should be framed conservatively because broad anti-inflammatory and disease claims outrun the evidence.",
+    "activeCompounds": [
+      "alpha-mangostin",
+      "xanthones"
+    ],
+    "safetyNotes": "Generally well tolerated."
   },
   {
-    "slug": "sage",
-    "name": "Sage",
-    "hero": "Used for antioxidant and nootropic support, with thujone serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to carvacrol rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"antioxidant\"",
-      "\"nootropic\"]"
-    ],
+    "slug": "boldo",
+    "name": "Boldo",
     "mechanisms": [
-      "[]"
+      "digestive support",
+      "hepatobiliary support"
     ],
-    "safetyNotes": "Generally well tolerated; review concentrated extract use."
+    "description": "It is best framed as an aromatic bitter leaf botanical with modest human evidence.",
+    "activeCompounds": [
+      "boldine"
+    ],
+    "safetyNotes": "Use cautiously in concentrated forms."
   },
   {
-    "slug": "salacia",
-    "name": "Salacia",
-    "hero": "Standardized around mangiferin to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
+    "slug": "suma",
+    "name": "Suma",
     "mechanisms": [
-      "[]"
+      "traditional restorative support",
+      "adaptogenic support"
     ],
-    "safetyNotes": "Safety review required before publication."
+    "description": "It should be framed conservatively because traditional-use breadth exceeds evidence depth.",
+    "activeCompounds": [
+      "pfaffic acid",
+      "saponins"
+    ],
+    "safetyNotes": "Generally well tolerated."
   },
   {
-    "slug": "saw-palmetto",
-    "name": "Saw Palmetto",
-    "hero": "Used for nootropic support, with fatty acids and beta-sitosterol serving as key marker compounds.",
-    "coreInsight": "It matters because fatty acids help explain hormone modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"nootropic\"]"
-    ],
+    "slug": "maral-root",
+    "name": "Maral Root",
     "mechanisms": [
-      "[\"hormone modulation\"",
-      "\"5-alpha-reductase inhibition\"]"
+      "adaptogenic support",
+      "recovery support"
     ],
-    "safetyNotes": "Generally safe; mild GI upset, headache."
+    "description": "It is best framed carefully because ecdysteroid narratives often outpace evidence quality.",
+    "activeCompounds": [
+      "ecdysterone"
+    ],
+    "safetyNotes": "Generally well tolerated."
   },
   {
-    "slug": "schisandra",
-    "name": "Schisandra",
-    "hero": "Used for adaptogenic and antioxidant support, with gomisins serving as key marker compound.",
-    "coreInsight": "Its value comes from a clearer mechanism readout than a generic traditional-use label. Evidence is limited.",
-    "effects": [
-      "[\"adaptogenic\"",
-      "\"antioxidant\"",
-      "\"hepatoprotective\"]"
-    ],
+    "slug": "jatamansi",
+    "name": "Jatamansi",
     "mechanisms": [
-      "[\"Nrf2 activation\"]"
+      "calming support",
+      "traditional nervous-system support"
     ],
-    "safetyNotes": "Safe."
+    "description": "It should be framed as a traditional aromatic rhizome with modest clinical depth.",
+    "activeCompounds": [
+      "jatamansone"
+    ],
+    "safetyNotes": "Generally well tolerated."
   },
   {
-    "slug": "schisandra-berry",
-    "name": "Schisandra Berry",
-    "hero": "Used for adaptogenic and hepatoprotective support, with gomisin A serving as key marker compound.",
-    "coreInsight": "It matters because gomisin a help explain cortisol modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"adaptogenic\"",
-      "\"hepatoprotective\"]"
-    ],
+    "slug": "soursop",
+    "name": "Soursop",
     "mechanisms": [
-      "[\"cortisol modulation\"]"
+      "traditional wellness support",
+      "antioxidant"
+    ],
+    "description": "It must be framed carefully because anticancer folklore claims greatly exceed evidence and safety certainty.",
+    "activeCompounds": [
+      "annonacin"
+    ],
+    "safetyNotes": "Use cautiously."
+  },
+  {
+    "slug": "ashoka",
+    "name": "Ashoka",
+    "mechanisms": [
+      "traditional cycle support"
+    ],
+    "description": "It should be framed conservatively because traditional gynecologic use is much stronger than modern evidence.",
+    "activeCompounds": [
+      "catechins",
+      "flavonoids"
     ],
     "safetyNotes": "Generally well tolerated."
   },
   {
     "slug": "shankhpushpi",
     "name": "Shankhpushpi",
-    "hero": "Used for nootropic and anxiolytic support, with convolvine serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to convolvine rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"nootropic\"",
-      "\"anxiolytic\"]"
-    ],
     "mechanisms": [
-      "[]"
+      "traditional cognitive support",
+      "calming support"
+    ],
+    "description": "It is best framed as a traditional cognitive-support herb with limited modern clinical depth.",
+    "activeCompounds": [
+      "convolvine"
     ],
     "safetyNotes": "Generally well tolerated."
   },
   {
-    "slug": "shatavari",
-    "name": "Shatavari",
-    "hero": "Used for adaptogenic support, with shatavarin IV serving as key marker compound.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[\"adaptogenic\"]"
-    ],
+    "slug": "hops",
+    "name": "Hops",
     "mechanisms": [
-      "[]"
+      "calming support",
+      "sleep support"
     ],
-    "safetyNotes": "Use caution in hormone-sensitive conditions."
+    "description": "It is best framed around bitter-resin and prenylflavonoid chemistry with modest selected human evidence.",
+    "activeCompounds": [
+      "humulone",
+      "xanthohumol"
+    ],
+    "safetyNotes": "Generally well tolerated."
   },
   {
-    "slug": "skullcap",
-    "name": "Skullcap",
-    "hero": "Used for anxiolytic support, with baicalin serving as key marker compound.",
-    "coreInsight": "Its value comes from a clearer mechanism readout than a generic traditional-use label. Evidence is limited.",
-    "effects": [
-      "[\"anxiolytic\"]"
-    ],
+    "slug": "lemongrass",
+    "name": "Lemongrass",
     "mechanisms": [
-      "[\"GABA-A modulation\"]"
+      "digestive support",
+      "calming support",
+      "aromatic support",
+      "TRPA1 modulation",
+      "sensory ion-channel modulation"
     ],
-    "safetyNotes": "Safe."
+    "description": "It is best framed as an aromatic culinary-medicinal grass with modest clinical depth.",
+    "activeCompounds": [
+      "citral",
+      "citronellal"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "perilla",
+    "name": "Perilla",
+    "mechanisms": [
+      "seasonal support",
+      "antioxidant",
+      "aromatic support"
+    ],
+    "description": "It is best framed as a culinary-medicinal herb with modest but relevant translational evidence.",
+    "activeCompounds": [
+      "perillaldehyde",
+      "rosmarinic acid"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "carob",
+    "name": "Carob",
+    "mechanisms": [
+      "digestive support",
+      "metabolic support"
+    ],
+    "description": "It is best framed as a food-form legume pod with fiber and polyphenol relevance rather than strong pharmacologic action.",
+    "activeCompounds": [
+      "D-pinitol",
+      "polyphenols"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "danshen",
+    "name": "Danshen",
+    "mechanisms": [
+      "cardiovascular support",
+      "vascular support"
+    ],
+    "description": "It is best framed around tanshinones and salvianolic acids with specific vascular-support positioning.",
+    "activeCompounds": [
+      "tanshinone IIA",
+      "salvianolic acid B"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "eucommia",
+    "name": "Eucommia",
+    "mechanisms": [
+      "connective tissue support",
+      "cardiometabolic support"
+    ],
+    "description": "It is best framed conservatively because traditional tonic use is broader than modern evidence quality.",
+    "activeCompounds": [
+      "geniposidic acid",
+      "lignans"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "cistanche",
+    "name": "Cistanche",
+    "mechanisms": [
+      "traditional restorative support",
+      "fatigue support"
+    ],
+    "description": "It should be framed conservatively because traditional-system use is broader than modern clinical depth.",
+    "activeCompounds": [
+      "echinacoside",
+      "acteoside"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "jujube",
+    "name": "Jujube",
+    "mechanisms": [
+      "calming support",
+      "nutritive support"
+    ],
+    "description": "It is best framed as a food-like fruit/seed botanical with gentle traditional positioning.",
+    "activeCompounds": [
+      "jujubosides",
+      "flavonoids"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "longan",
+    "name": "Longan",
+    "mechanisms": [
+      "nutritive support",
+      "calming support"
+    ],
+    "description": "It should be framed as a food-like fruit botanical with modest modern evidence.",
+    "activeCompounds": [
+      "polyphenols",
+      "gallic acid"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "polygala",
+    "name": "Polygala",
+    "mechanisms": [
+      "traditional cognitive support",
+      "calming support"
+    ],
+    "description": "It is best framed as a traditional nootropic-style root with limited modern clinical depth.",
+    "activeCompounds": [
+      "tenuifolin",
+      "polygalasaponins"
+    ],
+    "safetyNotes": "Use cautiously."
+  },
+  {
+    "slug": "gastrodia",
+    "name": "Gastrodia",
+    "mechanisms": [
+      "traditional nervous-system support",
+      "calming support"
+    ],
+    "description": "It should be framed conservatively because traditional neurologic use is broader than modern evidence.",
+    "activeCompounds": [
+      "gastrodin"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "white-peony",
+    "name": "White Peony",
+    "mechanisms": [
+      "traditional cycle support",
+      "calming support"
+    ],
+    "description": "It is best framed as a paeoniflorin-rich root with traditional-system relevance.",
+    "activeCompounds": [
+      "paeoniflorin"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "bupleurum",
+    "name": "Bupleurum",
+    "mechanisms": [
+      "traditional liver support",
+      "traditional stress support",
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "description": "It should be framed conservatively because traditional-system context matters more than casual wellness claims.",
+    "activeCompounds": [
+      "saikosaponins",
+      "Saikosaponin A"
+    ],
+    "safetyNotes": "Use cautiously."
+  },
+  {
+    "slug": "codonopsis",
+    "name": "Codonopsis",
+    "mechanisms": [
+      "traditional restorative support",
+      "fatigue support"
+    ],
+    "description": "It is best framed as a gentler tonic-style root with modest modern evidence.",
+    "activeCompounds": [
+      "tangshenosides",
+      "polysaccharides"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "dendrobium",
+    "name": "Dendrobium",
+    "mechanisms": [
+      "traditional restorative support",
+      "mucosal support"
+    ],
+    "description": "It should be framed conservatively because luxury-tonic narratives often exceed evidence depth.",
+    "activeCompounds": [
+      "polysaccharides",
+      "alkaloids"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "ophiopogon",
+    "name": "Ophiopogon",
+    "mechanisms": [
+      "demulcent support",
+      "traditional respiratory support"
+    ],
+    "description": "It is best framed as a moistening tonic-style root with traditional-system relevance.",
+    "activeCompounds": [
+      "ophiopogonins"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "houttuynia",
+    "name": "Houttuynia",
+    "mechanisms": [
+      "traditional immune support",
+      "traditional respiratory support"
+    ],
+    "description": "It should be framed cautiously because strong folklore claims exceed the evidence.",
+    "activeCompounds": [
+      "quercitrin",
+      "volatile oils"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "isatis",
+    "name": "Isatis",
+    "mechanisms": [
+      "traditional immune support",
+      "throat support",
+      "CDK inhibition",
+      "STAT3 inhibition"
+    ],
+    "description": "It is best framed as a traditional-use herb with limited modern clinical depth.",
+    "activeCompounds": [
+      "indirubin",
+      "tryptanthrin"
+    ],
+    "safetyNotes": "Use cautiously."
   },
   {
     "slug": "sophora-flavescens",
     "name": "Sophora Flavescens",
-    "hero": "Standardized around matrine to keep herbal identity and extract comparison consistent.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to matrine rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
     "mechanisms": [
-      "[]"
+      "traditional skin support",
+      "GI support"
+    ],
+    "description": "It should be framed conservatively because alkaloid-rich roots can have stronger tolerability issues.",
+    "activeCompounds": [
+      "matrine",
+      "oxymatrine"
     ],
     "safetyNotes": "Use cautiously."
   },
   {
-    "slug": "soursop",
-    "name": "Soursop",
-    "hero": "Used for antioxidant support, with annonacin serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to annonacin rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
+    "slug": "notoginseng",
+    "name": "Notoginseng",
     "mechanisms": [
-      "[]"
+      "vascular support",
+      "recovery support"
+    ],
+    "description": "It is best framed as a saponin-rich Panax relative with specific vascular-support positioning.",
+    "activeCompounds": [
+      "notoginsenoside R1",
+      "ginsenosides"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "luo-han-guo",
+    "name": "Luo Han Guo",
+    "mechanisms": [
+      "throat support",
+      "sweetener-adjacent support"
+    ],
+    "description": "It is best framed as a fruit botanical with sweet mogrosides and soothing traditional use.",
+    "activeCompounds": [
+      "mogrosides"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "kuding-tea",
+    "name": "Kuding Tea",
+    "mechanisms": [
+      "antioxidant",
+      "cardiometabolic support"
+    ],
+    "description": "It should be framed as a bitter tea botanical with food-form relevance and modest modern evidence.",
+    "activeCompounds": [
+      "triterpenoid saponins",
+      "polyphenols"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "atractylodes",
+    "name": "Atractylodes",
+    "mechanisms": [
+      "digestive support",
+      "traditional restorative support"
+    ],
+    "description": "It is best framed as a digestive-tonic rhizome with traditional-system relevance.",
+    "activeCompounds": [
+      "atractylenolide I"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "schisandra-berry",
+    "name": "Schisandra Berry",
+    "mechanisms": [
+      "adaptogenic support",
+      "hepatoprotective support"
+    ],
+    "description": "It is best framed specifically around berry lignans and traditional stress-support positioning.",
+    "activeCompounds": [
+      "schisandrin",
+      "gomisin A"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "catuba",
+    "name": "Catuba",
+    "mechanisms": [
+      "traditional vitality support",
+      "mood support"
+    ],
+    "description": "It should be framed conservatively because traditional aphrodisiac narratives exceed modern evidence depth.",
+    "activeCompounds": [
+      "alkaloids",
+      "flavonoids"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "muira-puama",
+    "name": "Muira Puama",
+    "mechanisms": [
+      "traditional vitality support",
+      "stress support"
+    ],
+    "description": "It is best framed as a traditional Amazonian botanical with modest modern evidence.",
+    "activeCompounds": [
+      "sterols",
+      "terpenes"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "maitake-d-fraction",
+    "name": "Maitake D-Fraction",
+    "mechanisms": [
+      "immune modulation"
+    ],
+    "description": "It should be framed distinctly from whole maitake because extract-standardization claims can exceed the underlying evidence.",
+    "activeCompounds": [
+      "beta-glucans"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "poria",
+    "name": "Poria",
+    "mechanisms": [
+      "traditional fluid-balance support",
+      "calming support"
+    ],
+    "description": "It is best framed as a traditional medicinal fungus with modest modern clinical depth.",
+    "activeCompounds": [
+      "pachymic acid",
+      "polysaccharides"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "rehmannia-prepared",
+    "name": "Rehmannia Prepared",
+    "mechanisms": [
+      "traditional restorative support"
+    ],
+    "description": "It should be framed distinctly from raw rehmannia because processed-form use-cases differ materially.",
+    "activeCompounds": [
+      "catalpol",
+      "rehmanniosides"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "agarikon",
+    "name": "Agarikon",
+    "mechanisms": [
+      "traditional immune support",
+      "respiratory support"
+    ],
+    "description": "It should be framed modestly because traditional use is much stronger than modern evidence.",
+    "activeCompounds": [
+      "agaric acid",
+      "polysaccharides"
     ],
     "safetyNotes": "Use cautiously."
   },
   {
-    "slug": "st-johns-wort",
-    "name": "St Johns Wort",
-    "hero": "Used for adaptogenic and sedative support, with hyperforin and hypericin serving as key marker compounds.",
-    "coreInsight": "It matters because Hyperforin help explain serotonin modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"adaptogenic\"",
-      "\"sedative\"",
-      "\"antidepressant\"",
-      "\"nootropic\"]"
-    ],
+    "slug": "elecampane",
+    "name": "Elecampane",
     "mechanisms": [
-      "[\"serotonin modulation\"",
-      "\"dopamine modulation\"]"
+      "traditional respiratory support",
+      "digestive support"
     ],
-    "safetyNotes": "Can cause photosensitivity, GI upset, dizziness, insomnia, restlessness."
+    "description": "It is best framed as a bitter aromatic root with traditional bronchial relevance.",
+    "activeCompounds": [
+      "alantolactone",
+      "inulin"
+    ],
+    "safetyNotes": "Use cautiously in concentrated forms."
   },
   {
-    "slug": "suma",
-    "name": "Suma",
-    "hero": "Used for adaptogenic support, with pfaffic acid serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to pfaffic acid rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"adaptogenic\"]"
-    ],
+    "slug": "angelica-root",
+    "name": "Angelica Root",
     "mechanisms": [
-      "[]"
+      "digestive support",
+      "traditional cycle support"
+    ],
+    "description": "It should be framed carefully because furanocoumarin context matters for some use cases.",
+    "activeCompounds": [
+      "angelicin",
+      "essential oils"
+    ],
+    "safetyNotes": "Use cautiously."
+  },
+  {
+    "slug": "galangal",
+    "name": "Galangal",
+    "mechanisms": [
+      "digestive support",
+      "aromatic support"
+    ],
+    "description": "It is best framed as a culinary-medicinal rhizome with traditional GI relevance.",
+    "activeCompounds": [
+      "galangin",
+      "volatile oils"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "black-pepper",
+    "name": "Black Pepper",
+    "mechanisms": [
+      "digestive support",
+      "bioavailability support",
+      "metabolic support"
+    ],
+    "description": "It should be framed specifically around piperine and digestive relevance rather than as a stand-alone tonic.",
+    "activeCompounds": [
+      "piperine"
+    ],
+    "safetyNotes": "Generally well tolerated; use caution with concentrated extracts."
+  },
+  {
+    "slug": "cardamom",
+    "name": "Cardamom",
+    "mechanisms": [
+      "digestive support",
+      "aromatic support"
+    ],
+    "description": "It is best framed as an aromatic culinary seed with modest translational evidence.",
+    "activeCompounds": [
+      "1",
+      "8-cineole",
+      "terpinyl acetate"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "holy-basil-seed",
+    "name": "Holy Basil Seed",
+    "mechanisms": [
+      "demulcent support",
+      "digestive support"
+    ],
+    "description": "It should be framed distinctly from holy basil leaf because fiber and mucilage drive different use-cases.",
+    "activeCompounds": [
+      "mucilage",
+      "fiber"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "psyllium",
+    "name": "Psyllium",
+    "mechanisms": [
+      "bulk laxative",
+      "GI support",
+      "stool-softening",
+      "cholesterol support"
+    ],
+    "description": "Psyllium is not a classic phytochemical-heavy herb; its value comes from gel-forming husk fiber. That makes it more of a functional-fiber tool than a general botanical tonic. Position it around bowel regularity, stool softening, and cautious cardiometabolic support.",
+    "activeCompounds": [
+      "mucilage",
+      "arabinoxylans"
+    ],
+    "safetyNotes": "Must be taken with plenty of liquid. Without enough fluid there is a risk of choking or bowel obstruction; allergy is also possible."
+  },
+  {
+    "slug": "caraway",
+    "name": "Caraway",
+    "mechanisms": [
+      "digestive support",
+      "aromatic support"
+    ],
+    "description": "It is best framed as an aromatic seed with traditional GI relevance.",
+    "activeCompounds": [
+      "carvone",
+      "limonene"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "ajwain",
+    "name": "Ajwain",
+    "mechanisms": [
+      "digestive support",
+      "aromatic support"
+    ],
+    "description": "It is best framed as a culinary-medicinal seed with strong traditional GI positioning.",
+    "activeCompounds": [
+      "thymol"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "holy-basil-purple",
+    "name": "Holy Basil Purple",
+    "mechanisms": [
+      "adaptogenic support",
+      "antioxidant"
+    ],
+    "description": "It should be framed similarly to tulsi while noting cultivar/form distinctions are secondary to constituent variability.",
+    "activeCompounds": [
+      "eugenol",
+      "rosmarinic acid"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "curry-leaf",
+    "name": "Curry Leaf",
+    "mechanisms": [
+      "antioxidant",
+      "metabolic support"
+    ],
+    "description": "It is best framed as a culinary-medicinal leaf with food-form relevance.",
+    "activeCompounds": [
+      "mahanimbine",
+      "carbazole alkaloids"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "gudmar",
+    "name": "Gudmar",
+    "mechanisms": [
+      "glycemic support"
+    ],
+    "description": "It should be framed consistently with gymnema while preserving alternate-name discoverability.",
+    "activeCompounds": [
+      "gymnemic acids"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "roselle-seed",
+    "name": "Roselle Seed",
+    "mechanisms": [
+      "nutritive support",
+      "antioxidant"
+    ],
+    "description": "It should be framed distinctly from hibiscus calyx because seed and calyx use-cases differ.",
+    "activeCompounds": [
+      "tocopherols",
+      "fatty acids"
     ],
     "safetyNotes": "Generally well tolerated."
   },
   {
     "slug": "tamarind",
     "name": "Tamarind",
-    "hero": "Used for antioxidant support, with tartaric acid serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to tartaric acid rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"antioxidant\"]"
-    ],
     "mechanisms": [
-      "[]"
+      "digestive support",
+      "antioxidant"
+    ],
+    "description": "It is best framed as a food-form fruit with digestive and polyphenol relevance.",
+    "activeCompounds": [
+      "tartaric acid",
+      "polyphenols"
     ],
     "safetyNotes": "Generally well tolerated."
   },
   {
-    "slug": "thyme",
-    "name": "Thyme",
-    "hero": "Used for antimicrobial support, with thymol serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to eucalyptol rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"antimicrobial\"]"
-    ],
+    "slug": "rhodiola",
+    "name": "Rhodiola",
     "mechanisms": [
-      "[]"
+      "adaptogen",
+      "fatigue resistance",
+      "cognitive support"
     ],
-    "safetyNotes": "Generally well tolerated; review concentrated oil use carefully."
+    "description": "Adaptogenic stress modulation.",
+    "activeCompounds": [
+      "rosavins",
+      "salidroside"
+    ],
+    "safetyNotes": "Safe"
   },
   {
-    "slug": "tongkat-ali",
-    "name": "Tongkat Ali",
-    "hero": "Used for adaptogenic support, with eurycomanone serving as key marker compound.",
-    "coreInsight": "It remains relevant when safety limits and evidence strength are reviewed together. Evidence is limited.",
-    "effects": [
-      "[\"adaptogenic\"]"
-    ],
+    "slug": "cordyceps",
+    "name": "Cordyceps",
     "mechanisms": [
-      "[]"
+      "immune modulation",
+      "anti-inflammatory",
+      "NF-kappaB modulation",
+      "Nrf2/HO-1",
+      "cordycepin"
     ],
-    "safetyNotes": "May be activating and is not ideal for anxiety-prone or sleep-fragile users."
+    "description": "Cordyceps militaris is most often discussed around cordycepin plus polysaccharides and related nucleosides. Commercial interest is high, but the evidence base is still strongest at the preclinical and cultivation/constituent level rather than for broad human outcome claims.",
+    "activeCompounds": [
+      "cordycepin",
+      "polysaccharides",
+      "adenosine"
+    ],
+    "safetyNotes": "Commercial products vary by species identity, cultivation method, and cordycepin content. Keep benefit claims conservative unless tied to a specific studied product."
   },
   {
-    "slug": "turkey-tail",
-    "name": "Turkey Tail",
-    "hero": "Used for anti-inflammatory and immunomodulatory support, with PSK serving as key marker compound.",
-    "coreInsight": "It matters because psk help explain immune signaling in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"immunomodulatory\"]"
-    ],
+    "slug": "lion-s-mane",
+    "name": "Lion's Mane",
     "mechanisms": [
-      "[\"immune signaling\"",
-      "\"immune signaling modulation\"]"
+      "NGF",
+      "NGF induction",
+      "ERK/CREB pathway modulation"
     ],
-    "safetyNotes": "Safe."
+    "description": "NGF stimulation.",
+    "activeCompounds": [
+      "hericenones",
+      "erinacines"
+    ],
+    "safetyNotes": "Safe"
   },
   {
-    "slug": "turmeric",
-    "name": "Turmeric",
-    "hero": "Used for anti-inflammatory and antioxidant support, with curcumin serving as key marker compound.",
-    "coreInsight": "It matters because Demethoxycurcumin and curcumin help explain nF-kB inhibition in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"",
-      "\"antioxidant\"",
-      "\"nootropic\"]"
-    ],
+    "slug": "panax-ginseng",
+    "name": "Panax Ginseng",
     "mechanisms": [
-      "[\"NF-kB inhibition\"",
-      "\"COX inhibition\"",
-      "\"Nrf2 activation\"",
-      "\"NF-kB modulation\"]"
+      "AMPK"
     ],
-    "safetyNotes": "Conventional oral preparations of turmeric or curcumin appear safe for up to 2–3 months."
+    "description": "Energy + stress.",
+    "activeCompounds": [
+      "ginsenosides"
+    ],
+    "safetyNotes": "Safe"
   },
   {
-    "slug": "valerian",
-    "name": "Valerian",
-    "hero": "Used for sedative and nootropic support, with valerenic acid serving as key marker compound.",
-    "coreInsight": "It matters because valerenic acid help explain gABA-A modulation in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"sedative\"",
-      "\"nootropic\"",
-      "\"hepatoprotective\"]"
-    ],
+    "slug": "passionflower",
+    "name": "Passionflower",
     "mechanisms": [
-      "[\"GABA-A modulation\"]"
+      "calming support",
+      "sleep support",
+      "traditional-use sedative",
+      "possible GABAergic modulation"
     ],
-    "safetyNotes": "Short-term use appears safe; side effects include headache, GI upset, mental dullness, excitability, vivid dreams."
-  },
-  {
-    "slug": "white-peony",
-    "name": "White Peony",
-    "hero": "Used for anxiolytic support, with paeoniflorin serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to paeoniflorin rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"anxiolytic\"]"
+    "description": "EMA supports passionflower for relief of mild mental stress and to aid sleep on the basis of long-standing traditional use. That is useful, but it is weaker than strong modern clinical efficacy. Keep the positioning around traditional calming use and avoid overclaiming a clean single-target GABA story.",
+    "activeCompounds": [
+      "chrysin"
     ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Generally well tolerated."
-  },
-  {
-    "slug": "wormwood",
-    "name": "Wormwood",
-    "hero": "Defined by alpha-thujone as key marker compound, with activity centered on gABA-A modulation.",
-    "coreInsight": "Its value comes from a clearer mechanism readout than a generic traditional-use label. Evidence is limited.",
-    "effects": [
-      "[]"
-    ],
-    "mechanisms": [
-      "[\"GABA-A modulation\"]"
-    ],
-    "safetyNotes": "Safety review required before publication."
-  },
-  {
-    "slug": "yarrow",
-    "name": "Yarrow",
-    "hero": "Used for anti-inflammatory support, with apigenin serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to petasin rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"anti-inflammatory\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Review interactions and contraindications."
-  },
-  {
-    "slug": "yerba-mate",
-    "name": "Yerba Mate",
-    "hero": "Used for stimulant and nootropic support, with caffeine serving as key marker compound.",
-    "coreInsight": "It is most useful when formulation decisions stay anchored to Apigenin rather than broad herb claims. Evidence is limited.",
-    "effects": [
-      "[\"stimulant\"",
-      "\"nootropic\"]"
-    ],
-    "mechanisms": [
-      "[]"
-    ],
-    "safetyNotes": "Use caution with stimulant sensitivity or insomnia-prone contexts."
+    "safetyNotes": "EMA reported no side effects at the time of assessment, but prudence still supports sedative-stacking caution."
   },
   {
     "slug": "yohimbe",
     "name": "Yohimbe",
-    "hero": "Used for anxiolytic and stimulant support, with yohimbine serving as key marker compound.",
-    "coreInsight": "It matters because Yohimbine help explain adrenergic signaling in a way that is useful for product positioning. Evidence is limited.",
-    "effects": [
-      "[\"anxiolytic\"",
-      "\"stimulant\"",
-      "\"adaptogenic\"",
-      "\"hepatoprotective\"]"
+    "mechanisms": [
+      "adrenergic signaling",
+      "alpha-2 adrenergic antagonism",
+      "stimulant activity",
+      "sexual function"
+    ],
+    "description": "Yohimbe is represented here as a bark-derived monograph anchored to yohimbine, an alpha-2 adrenergic antagonist with sympathomimetic effects. The herb is more appropriately framed around safety review than routine recommendation. Potential effects include increased alertness and sexual-function relevance, but tolerability can be poor and adverse effects may include anxiety, tachycardia, blood-pressure elevation, agitation, insomnia, and gastrointestinal distress. Use should be conservative and exclusion-heavy in people with cardiovascular, psychiatric, seizure, renal, or hepatic vulnerability.",
+    "activeCompounds": [
+      "yohimbine",
+      "rauwolscine"
+    ],
+    "safetyNotes": "High-caution herb. Prioritize cardiovascular and psychiatric risk review. Avoid escalation framing, avoid use in people prone to panic, hypertension, arrhythmia, or seizure, and avoid positioning as a routine tonic."
+  },
+  {
+    "slug": "skullcap",
+    "name": "Skullcap",
+    "mechanisms": [
+      "GABAA",
+      "NF-κB inhibition",
+      "PI3K/Akt modulation",
+      "COX inhibition",
+      "MAPK pathway modulation"
+    ],
+    "description": "GABAergic.",
+    "activeCompounds": [
+      "baicalin",
+      "Baicalein",
+      "Wogonin"
+    ],
+    "safetyNotes": "Safe"
+  },
+  {
+    "slug": "eleuthero",
+    "name": "Eleuthero",
+    "primaryActions": [
+      "Stress adaptation",
+      "endurance support",
+      "immune modulation"
     ],
     "mechanisms": [
-      "[\"adrenergic signaling\"",
-      "\"alpha-2 adrenergic antagonism\"]"
+      "HPA axis",
+      "HPA-axis modulation",
+      "immune modulation",
+      "AMPK activation",
+      "stress response modulation"
     ],
-    "safetyNotes": "High-caution herb."
+    "description": "Stress resilience.",
+    "activeCompounds": [
+      "eleutherosides",
+      "eleutheroside B",
+      "eleutheroside E"
+    ],
+    "safetyNotes": "Safe",
+    "interactions": [
+      "Use caution with stimulants or blood pressure-active agents."
+    ],
+    "preparation": "Root decoction or extract; standardized eleutheroside products are common."
+  },
+  {
+    "slug": "gotu-kola",
+    "name": "Gotu Kola",
+    "mechanisms": [
+      "NO",
+      "TGF-β signaling modulation",
+      "MAPK pathway modulation",
+      "NF-κB inhibition"
+    ],
+    "description": "NO support.",
+    "activeCompounds": [
+      "asiaticoside",
+      "Madecassoside"
+    ],
+    "safetyNotes": "Safe"
+  },
+  {
+    "slug": "schisandra",
+    "name": "Schisandra",
+    "primaryActions": [
+      "Stress adaptation",
+      "hepatic support",
+      "mitochondrial resilience"
+    ],
+    "mechanisms": [
+      "Nrf2",
+      "Nrf2 activation",
+      "PI3K/Akt modulation",
+      "mitochondrial protection"
+    ],
+    "description": "Liver + stress.",
+    "activeCompounds": [
+      "gomisins",
+      "Schisandrin",
+      "schisandrin B"
+    ],
+    "safetyNotes": "Safe",
+    "interactions": [
+      "Potential interactions with CYP-metabolized drugs."
+    ],
+    "preparation": "Berry decoction or extract; concentrated lignan extracts provide stronger exposure."
+  },
+  {
+    "slug": "reishi",
+    "name": "Reishi",
+    "mechanisms": [
+      "NFkB"
+    ],
+    "description": "Immune modulation.",
+    "activeCompounds": [
+      "triterpenes"
+    ],
+    "safetyNotes": "Safe"
+  },
+  {
+    "slug": "chaga",
+    "name": "Chaga",
+    "mechanisms": [
+      "Nrf2",
+      "NF-κB inhibition",
+      "apoptosis pathway modulation"
+    ],
+    "description": "Oxidative stress.",
+    "activeCompounds": [
+      "betulinic acid"
+    ],
+    "safetyNotes": "Safe"
+  },
+  {
+    "slug": "turkey-tail",
+    "name": "Turkey Tail",
+    "mechanisms": [
+      "NFkB"
+    ],
+    "description": "Immune modulation.",
+    "activeCompounds": [
+      "PSK"
+    ],
+    "safetyNotes": "Safe"
+  },
+  {
+    "slug": "boswellia",
+    "name": "Boswellia",
+    "mechanisms": [
+      "anti-inflammatory",
+      "mobility support"
+    ],
+    "description": "It is best framed around boswellic acids with inflammatory-pathway relevance.",
+    "activeCompounds": [
+      "boswellic acids",
+      "AKBA",
+      "acetyl-11-keto-beta-boswellic acid"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "hawthorn",
+    "name": "Hawthorn",
+    "mechanisms": [
+      "cardiovascular support",
+      "vascular support",
+      "Nrf2 activation",
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "description": "It is best framed around procyanidins and flavonoids.",
+    "activeCompounds": [
+      "procyanidin B2",
+      "flavonoids",
+      "Oleanolic acid"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "astragalus",
+    "name": "Astragalus",
+    "mechanisms": [
+      "immune modulation",
+      "fatigue support",
+      "estrogen receptor modulation",
+      "PI3K/Akt modulation"
+    ],
+    "description": "It is best framed around astragalosides and polysaccharides.",
+    "activeCompounds": [
+      "astragaloside IV",
+      "polysaccharides",
+      "Formononetin"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "nettle-root",
+    "name": "Nettle Root",
+    "mechanisms": [
+      "urinary support",
+      "men's-health support"
+    ],
+    "description": "It is best framed distinctly from nettle leaf.",
+    "activeCompounds": [
+      "beta-sitosterol",
+      "lignans"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "bacopa",
+    "name": "Bacopa",
+    "mechanisms": [
+      "cognitive support",
+      "calming support",
+      "MARK4 inhibition",
+      "cholinergic modulation"
+    ],
+    "description": "It is best framed around bacosides with slower-onset cognitive relevance.",
+    "activeCompounds": [
+      "bacoside A",
+      "bacopaside II"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "mucuna",
+    "name": "Mucuna",
+    "mechanisms": [
+      "dopamine support",
+      "vitality support"
+    ],
+    "description": "It is best framed around L-DOPA-rich seeds with clear neurologic and stimulation-related caution.",
+    "activeCompounds": [
+      "L-DOPA",
+      "alkaloids"
+    ],
+    "safetyNotes": "Use caution in psychiatric, cardiovascular, and dopaminergic contexts."
+  },
+  {
+    "slug": "epimedium",
+    "name": "Epimedium",
+    "mechanisms": [
+      "PDE-related signaling",
+      "nitric oxide signaling",
+      "sexual function",
+      "bone support",
+      "flavonoid activity"
+    ],
+    "description": "Epimedium is represented here primarily through icariin and related prenylated flavonoids such as epimedin A, B, and C. The herb is commonly positioned for libido and circulation support, but a more disciplined framing keeps it in the traditional-use / limited-human-evidence tier. Mechanistic interest often centers on PDE-related signaling, endothelial nitric oxide activity, and broader bone-support and anti-inflammatory pathways observed in preclinical work.",
+    "activeCompounds": [
+      "icariin",
+      "epimedin A",
+      "epimedin B",
+      "epimedin C"
+    ],
+    "safetyNotes": "Use caution in people with blood-pressure instability, hormone-sensitive conditions, or high sensitivity to activating supplements. Keep positioning moderate rather than performance-driven."
+  },
+  {
+    "slug": "tongkat-ali",
+    "name": "Tongkat Ali",
+    "mechanisms": [
+      "vitality support",
+      "stress support"
+    ],
+    "description": "It is best framed as a bitter root extract with endocrine and stimulation-related caution.",
+    "activeCompounds": [
+      "eurycomanone",
+      "quassinoids"
+    ],
+    "safetyNotes": "May be activating and is not ideal for anxiety-prone or sleep-fragile users."
+  },
+  {
+    "slug": "shatavari",
+    "name": "Shatavari",
+    "mechanisms": [
+      "women's-health support",
+      "soothing support"
+    ],
+    "description": "It is best framed around steroidal saponins with hormonal-context caution.",
+    "activeCompounds": [
+      "shatavarins",
+      "saponins"
+    ],
+    "safetyNotes": "Use caution in hormone-sensitive conditions."
+  },
+  {
+    "slug": "pueraria-mirifica",
+    "name": "Pueraria Mirifica",
+    "mechanisms": [
+      "phytoestrogen support",
+      "women's-health support",
+      "estrogen receptor modulation"
+    ],
+    "description": "It is best framed very cautiously due to potent estrogenic positioning.",
+    "activeCompounds": [
+      "miroestrol",
+      "deoxymiroestrol"
+    ],
+    "safetyNotes": "Use caution or avoid in hormone-sensitive conditions, pregnancy, and breastfeeding."
+  },
+  {
+    "slug": "cacao",
+    "name": "Cacao",
+    "mechanisms": [
+      "mood support",
+      "circulation support",
+      "AMPK activation",
+      "Nrf2 activation",
+      "PI3K/Akt modulation",
+      "eNOS activation"
+    ],
+    "description": "It is best framed around flavanols and methylxanthines with stimulant awareness.",
+    "activeCompounds": [
+      "theobromine",
+      "flavanols",
+      "catechins",
+      "Catechin",
+      "Epicatechin"
+    ],
+    "safetyNotes": "Use caution in stimulant-sensitive users and with migraine triggers."
+  },
+  {
+    "slug": "rooibos",
+    "name": "Rooibos",
+    "mechanisms": [
+      "antioxidant support",
+      "soothing support",
+      "AMPK activation",
+      "Nrf2 activation"
+    ],
+    "description": "It is best framed as a mild tea herb with low-intensity wellness positioning.",
+    "activeCompounds": [
+      "aspalathin",
+      "nothofagin",
+      "flavonoids"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "cat-s-claw",
+    "name": "Cat's Claw",
+    "mechanisms": [
+      "immune support",
+      "inflammatory support"
+    ],
+    "description": "It is best framed around oxindole alkaloids with autoimmune and transplant-related caution.",
+    "activeCompounds": [
+      "oxindole alkaloids",
+      "quinovic acid glycosides"
+    ],
+    "safetyNotes": "Use caution or avoid in autoimmune disease, transplant settings, pregnancy, and breastfeeding."
+  },
+  {
+    "slug": "lavender",
+    "name": "Lavender",
+    "mechanisms": [
+      "calming support",
+      "tension support",
+      "GABA-A modulation",
+      "voltage-gated calcium channel modulation"
+    ],
+    "description": "It is best framed around volatile oils with sedation-aware positioning.",
+    "activeCompounds": [
+      "linalool",
+      "linalyl acetate"
+    ],
+    "safetyNotes": "Can be sedating in some users."
+  },
+  {
+    "slug": "berberis",
+    "name": "Berberis",
+    "mechanisms": [
+      "metabolic support",
+      "antimicrobial support",
+      "JAK/STAT inhibition",
+      "NF-κB inhibition"
+    ],
+    "description": "It is best framed around berberine-bearing root bark with GI and medication-interaction caution.",
+    "activeCompounds": [
+      "berberine",
+      "berbamine"
+    ],
+    "safetyNotes": "Use caution in pregnancy, breastfeeding, and in those prone to GI upset."
+  },
+  {
+    "slug": "bitter-melon",
+    "name": "Bitter Melon",
+    "mechanisms": [
+      "glucose support",
+      "metabolic support",
+      "AMPK activation",
+      "GLUT4 translocation modulation",
+      "PPARγ activation"
+    ],
+    "description": "It is best framed as a food-medicine with hypoglycemia-aware caution.",
+    "activeCompounds": [
+      "charantin",
+      "polypeptide-p",
+      "cucurbitanes",
+      "Momordicoside K"
+    ],
+    "safetyNotes": "Use caution in people prone to low blood sugar and during pregnancy."
+  },
+  {
+    "slug": "coleus-forskohlii",
+    "name": "Coleus Forskohlii",
+    "mechanisms": [
+      "metabolic support",
+      "vascular support"
+    ],
+    "description": "It is best framed around forskolin with blood-pressure and stimulant-stack caution.",
+    "activeCompounds": [
+      "forskolin"
+    ],
+    "safetyNotes": "Use caution with low blood pressure, bleeding risk, and GI sensitivity."
+  },
+  {
+    "slug": "aloe-vera",
+    "name": "Aloe Vera",
+    "mechanisms": [
+      "demulcent",
+      "digestive support",
+      "anti-inflammatory",
+      "NF-κB inhibition",
+      "PI3K/Akt modulation",
+      "MAPK pathway modulation",
+      "TLR4 modulation",
+      "NF-κB modulation"
+    ],
+    "description": "Internal cross-linking supports Aloe Vera through compounds such as aloin.",
+    "activeCompounds": [
+      "acemannan",
+      "aloe-emodin",
+      "aloin",
+      "Emodin",
+      "Rhein"
+    ],
+    "safetyNotes": "General use caution; distinguish inner gel from latex-rich stimulant-laxative fractions"
+  },
+  {
+    "slug": "american-ginseng",
+    "name": "American Ginseng",
+    "mechanisms": [
+      "cholinergic modulation",
+      "gabaergic_modulation",
+      "inflammatory_pathway_modulation",
+      "PI3K/Akt modulation",
+      "Nrf2 activation",
+      "NO signaling modulation",
+      "NF-κB inhibition",
+      "VEGF signaling inhibition"
+    ],
+    "description": "Internal cross-linking supports American Ginseng through compounds such as ginsenosides (including rb1, rg1), rb2.",
+    "activeCompounds": [
+      "ginsenosides (including rb1",
+      "rg1)",
+      "rb2",
+      "Ginsenoside Rb1",
+      "Ginsenoside Rg1",
+      "Ginsenoside Rg3"
+    ],
+    "safetyNotes": "Safety review required before publication."
+  },
+  {
+    "slug": "artemisia-annua",
+    "name": "Artemisia Annua",
+    "mechanisms": [
+      "immune support",
+      "antimicrobial",
+      "oxidative stress modulation"
+    ],
+    "description": "Internal cross-linking supports Artemisia Annua through compounds such as artemisinin.",
+    "activeCompounds": [
+      "artemisinin",
+      "arteannuin B",
+      "chrysosplenetin"
+    ],
+    "safetyNotes": "Review interactions and contraindications"
+  },
+  {
+    "slug": "celastrus-paniculatus",
+    "name": "Celastrus Paniculatus",
+    "mechanisms": [
+      "general or unknown targets"
+    ],
+    "description": "Internal cross-linking supports Celastrus Paniculatus through compounds such as beta-amyrin, celastrine, lupeol.",
+    "activeCompounds": [
+      "beta-amyrin",
+      "celastrine",
+      "lupeol",
+      "celapanin"
+    ],
+    "safetyNotes": "Safety review required before publication."
+  },
+  {
+    "slug": "calamus",
+    "name": "Calamus",
+    "mechanisms": [
+      "gabaergic_modulation",
+      "NF-kB pathway inhibition",
+      "PLCγ2-PKC pathway inhibition",
+      "GABA-A modulation",
+      "acetylcholinesterase inhibition"
+    ],
+    "description": "Internal cross-linking supports Calamus through compounds such as eugenol, alpha-asarone, beta-asarone.",
+    "activeCompounds": [
+      "eugenol",
+      "alpha-asarone",
+      "beta-asarone"
+    ],
+    "safetyNotes": "Safety review required before publication."
+  },
+  {
+    "slug": "cayenne",
+    "name": "Cayenne",
+    "mechanisms": [
+      "TRPV1 activation"
+    ],
+    "description": "Internal cross-linking supports Cayenne through compounds such as capsaicin, capsorubin, dihydrocapsaicin.",
+    "activeCompounds": [
+      "capsaicin",
+      "capsorubin",
+      "dihydrocapsaicin",
+      "capsanthin"
+    ],
+    "safetyNotes": "Safety review required before publication."
+  },
+  {
+    "slug": "corydalis",
+    "name": "Corydalis",
+    "mechanisms": [
+      "dopaminergic_modulation"
+    ],
+    "description": "Internal cross-linking supports Corydalis through compounds such as corydaline, isocorypalmine, dehydrocorybulbine.",
+    "activeCompounds": [
+      "corydaline",
+      "isocorypalmine",
+      "dehydrocorybulbine",
+      "tetrahydropalmatine"
+    ],
+    "safetyNotes": "Safety review required before publication."
+  },
+  {
+    "slug": "chinese-skullcap",
+    "name": "Chinese Skullcap",
+    "mechanisms": [
+      "gabaergic_modulation",
+      "LOX inhibition",
+      "NF-kB inhibition"
+    ],
+    "description": "Internal cross-linking supports Chinese Skullcap through compounds such as baicalein, baicalin, wogonin.",
+    "activeCompounds": [
+      "baicalein",
+      "baicalin",
+      "wogonin"
+    ],
+    "safetyNotes": "Safety review required before publication."
+  },
+  {
+    "slug": "phellodendron",
+    "name": "Phellodendron",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-kB pathway inhibition",
+      "mitochondrial complex I inhibition"
+    ],
+    "description": "Internal cross-linking supports Phellodendron through compounds such as berberine, jatrorrhizine, palmatine.",
+    "activeCompounds": [
+      "berberine",
+      "jatrorrhizine",
+      "palmatine"
+    ],
+    "safetyNotes": "Safety review required before publication."
+  },
+  {
+    "slug": "coptis",
+    "name": "Coptis",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-kB pathway inhibition",
+      "mitochondrial complex I inhibition",
+      "NF-κB inhibition",
+      "MAPK modulation"
+    ],
+    "description": "Internal cross-linking supports Coptis through compounds such as berberine, palmatine, coptisine.",
+    "activeCompounds": [
+      "berberine",
+      "palmatine",
+      "coptisine"
+    ],
+    "safetyNotes": "Safety review required before publication."
+  },
+  {
+    "slug": "saffron",
+    "name": "Saffron",
+    "primaryActions": [
+      "Neuroactive support",
+      "mood-related signaling",
+      "antioxidant effects"
+    ],
+    "mechanisms": [
+      "general or unknown targets",
+      "PI3K/Akt modulation",
+      "NF-κB inhibition",
+      "PPAR activation",
+      "GABA-A modulation",
+      "NMDA modulation"
+    ],
+    "description": "Internal cross-linking supports Saffron through compounds such as picrocrocin, crocin, safranal.",
+    "activeCompounds": [
+      "picrocrocin",
+      "crocin",
+      "safranal",
+      "crocetin"
+    ],
+    "safetyNotes": "Safety review required before publication.",
+    "interactions": [
+      "Use caution with serotonergic medications and anticoagulants."
+    ],
+    "preparation": "Threads or standardized extract; aroma-rich preparations emphasize safranal exposure."
+  },
+  {
+    "slug": "papaya-leaf",
+    "name": "Papaya Leaf",
+    "mechanisms": [
+      "general or unknown targets"
+    ],
+    "description": "Internal cross-linking supports Papaya Leaf through compounds such as carpaine, papain, benzyl isothiocyanate.",
+    "activeCompounds": [
+      "carpaine",
+      "papain",
+      "benzyl isothiocyanate",
+      "chymopapain"
+    ],
+    "safetyNotes": "Safety review required before publication."
+  },
+  {
+    "slug": "kanna",
+    "name": "Kanna",
+    "mechanisms": [
+      "general or unknown targets",
+      "serotonin reuptake inhibition",
+      "PDE4 inhibition"
+    ],
+    "description": "Internal cross-linking supports Kanna through compounds such as mesembrenone, mesembranol, mesembrine.",
+    "activeCompounds": [
+      "mesembrenone",
+      "mesembranol",
+      "mesembrine",
+      "mesembrenol"
+    ],
+    "safetyNotes": "Safety review required before publication."
+  },
+  {
+    "slug": "green-tea",
+    "name": "Green Tea",
+    "primaryActions": [
+      "AMPK support",
+      "inflammatory signaling control",
+      "redox modulation"
+    ],
+    "mechanisms": [
+      "adenosine_antagonism",
+      "ADORA1",
+      "ADORA2A (adenosine receptors)",
+      "dopaminergic_modulation",
+      "MAPK pathway modulation",
+      "NF-κB inhibition",
+      "AMPK activation",
+      "Nrf2 activation",
+      "PI3K/Akt modulation",
+      "eNOS activation",
+      "glutamate receptor modulation",
+      "GABA upregulation",
+      "MAPK modulation",
+      "EGFR modulation"
+    ],
+    "description": "Internal cross-linking supports Green Tea through compounds such as caffeine, theanine, catechins (egcg).",
+    "activeCompounds": [
+      "caffeine",
+      "theanine",
+      "catechins (egcg)",
+      "Myricetin",
+      "Catechin",
+      "Epicatechin",
+      "Epigallocatechin gallate (EGCG)",
+      "Gallic acid",
+      "epigallocatechin",
+      "epicatechin gallate",
+      "epigallocatechin gallate",
+      "gallocatechin"
+    ],
+    "safetyNotes": "Safety review required before publication.",
+    "interactions": [
+      "May interact with stimulants and iron absorption timing."
+    ],
+    "preparation": "Infusion or standardized extract; lower-temperature steeping preserves catechins and theanine balance."
+  },
+  {
+    "slug": "goldenseal",
+    "name": "Goldenseal",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-kB pathway inhibition",
+      "mitochondrial complex I inhibition",
+      "NF-κB inhibition",
+      "PI3K/Akt modulation",
+      "MAPK pathway modulation"
+    ],
+    "description": "Internal cross-linking supports Goldenseal through compounds such as berberine, hydrastine.",
+    "activeCompounds": [
+      "berberine",
+      "hydrastine",
+      "Palmatine",
+      "Jatrorrhizine"
+    ],
+    "safetyNotes": "Safety review required before publication."
+  },
+  {
+    "slug": "salacia",
+    "name": "Salacia",
+    "mechanisms": [
+      "general or unknown targets",
+      "alpha-glucosidase inhibition"
+    ],
+    "description": "Internal cross-linking supports Salacia through compounds such as mangiferin, kotalanol, salacinol.",
+    "activeCompounds": [
+      "mangiferin",
+      "kotalanol",
+      "salacinol"
+    ],
+    "safetyNotes": "Safety review required before publication."
+  },
+  {
+    "slug": "chuanxiong",
+    "name": "Chuanxiong",
+    "mechanisms": [
+      "circulatory support",
+      "cardiovascular support",
+      "headache support"
+    ],
+    "description": "Internal cross-linking supports Chuanxiong through compounds such as ligustilide, ferulic acid, tetramethylpyrazine.",
+    "activeCompounds": [
+      "ligustilide",
+      "ferulic acid",
+      "senkyunolide"
+    ],
+    "safetyNotes": "Review interactions and contraindications"
+  },
+  {
+    "slug": "fingerroot",
+    "name": "Fingerroot",
+    "mechanisms": [
+      "general or unknown targets"
+    ],
+    "description": "Internal cross-linking supports Fingerroot through compounds such as pinostrobin, pinocembrin, panduratin a.",
+    "activeCompounds": [
+      "pinostrobin",
+      "pinocembrin",
+      "panduratin a"
+    ],
+    "safetyNotes": "Safety review required before publication."
+  },
+  {
+    "slug": "wormwood",
+    "name": "Wormwood",
+    "mechanisms": [
+      "gabaergic_modulation"
+    ],
+    "description": "Internal cross-linking supports Wormwood through compounds such as alpha-thujone, absinthin, beta-thujone.",
+    "activeCompounds": [
+      "alpha-thujone",
+      "absinthin",
+      "beta-thujone"
+    ],
+    "safetyNotes": "Safety review required before publication."
+  },
+  {
+    "slug": "horse-chestnut",
+    "name": "Horse Chestnut",
+    "mechanisms": [
+      "venous support",
+      "cardiovascular support",
+      "inflammation support",
+      "NF-κB inhibition",
+      "endothelial barrier modulation"
+    ],
+    "description": "Internal cross-linking supports Horse Chestnut through compounds such as aesculin, aescin, fraxin.",
+    "activeCompounds": [
+      "aescin",
+      "aesculin"
+    ],
+    "safetyNotes": "Review interactions and contraindications"
+  },
+  {
+    "slug": "bael",
+    "name": "Bael",
+    "mechanisms": [
+      "general or unknown targets"
+    ],
+    "description": "Internal cross-linking supports Bael through compounds such as skimmianine, aegeline, marmelosin.",
+    "activeCompounds": [
+      "skimmianine",
+      "aegeline",
+      "marmelosin"
+    ],
+    "safetyNotes": "Safety review required before publication."
+  },
+  {
+    "slug": "guayusa",
+    "name": "Guayusa",
+    "mechanisms": [
+      "ADORA1",
+      "ADORA2A (adenosine receptors)",
+      "adenosine_antagonism",
+      "dopaminergic_modulation"
+    ],
+    "description": "Internal cross-linking supports Guayusa through compounds such as caffeine, theobromine.",
+    "activeCompounds": [
+      "caffeine",
+      "theobromine"
+    ],
+    "safetyNotes": "Safety review required before publication."
+  },
+  {
+    "slug": "honeysuckle",
+    "name": "Honeysuckle",
+    "mechanisms": [
+      "MAPK pathway inhibition",
+      "NF-kB inhibition"
+    ],
+    "description": "Internal cross-linking supports Honeysuckle through compounds such as luteolin, chlorogenic acid.",
+    "activeCompounds": [
+      "luteolin",
+      "chlorogenic acid"
+    ],
+    "safetyNotes": "Safety review required before publication."
+  },
+  {
+    "slug": "cassia-alata",
+    "name": "Cassia Alata",
+    "mechanisms": [
+      "MAPK pathway",
+      "NF-kB inhibition"
+    ],
+    "description": "Internal cross-linking supports Cassia Alata through compounds such as aloe-emodin, chrysophanol.",
+    "activeCompounds": [
+      "aloe-emodin",
+      "chrysophanol"
+    ],
+    "safetyNotes": "Safety review required before publication."
+  },
+  {
+    "slug": "american-yellow-lotus",
+    "name": "American Yellow Lotus",
+    "mechanisms": [
+      "dopaminergic_modulation"
+    ],
+    "description": "Internal cross-linking supports American Yellow Lotus through compounds such as nuciferine, roemerine, n-methylasimilobine.",
+    "activeCompounds": [
+      "nuciferine",
+      "roemerine",
+      "n-methylasimilobine",
+      "armepavine"
+    ],
+    "safetyNotes": "Safety review required before publication."
+  },
+  {
+    "slug": "anise-hyssop",
+    "name": "Anise Hyssop",
+    "mechanisms": [
+      "endocannabinoid_modulation"
+    ],
+    "description": "Internal cross-linking supports Anise Hyssop through compounds such as limonene, anethole, estragole.",
+    "activeCompounds": [
+      "limonene",
+      "anethole",
+      "estragole"
+    ],
+    "safetyNotes": "Safety review required before publication."
+  },
+  {
+    "slug": "marshmallow",
+    "name": "Marshmallow",
+    "mechanisms": [
+      "demulcent",
+      "digestive support",
+      "throat support"
+    ],
+    "description": "Internal cross-linking supports Marshmallow through compounds such as pectin.",
+    "activeCompounds": [
+      "mucilage polysaccharides",
+      "flavonoids",
+      "pectin"
+    ],
+    "safetyNotes": "General use caution; separate from medications when timing matters"
+  },
+  {
+    "slug": "licorice",
+    "name": "Licorice",
+    "mechanisms": [
+      "general or unknown targets",
+      "HMGB1 inhibition",
+      "NF-κB inhibition"
+    ],
+    "description": "Internal cross-linking supports Licorice through compounds such as glycyrrhizin.",
+    "activeCompounds": [
+      "glycyrrhizin"
+    ],
+    "safetyNotes": "Safety review required before publication."
+  },
+  {
+    "slug": "elderberry",
+    "name": "Elderberry",
+    "mechanisms": [
+      "immune support",
+      "respiratory support",
+      "antioxidant"
+    ],
+    "description": "Internal cross-linking supports Elderberry through compounds such as sambunigrin.",
+    "activeCompounds": [
+      "cyanidin",
+      "rutin",
+      "quercetin"
+    ],
+    "safetyNotes": "General use caution; use properly prepared material only"
+  },
+  {
+    "slug": "punarnava",
+    "name": "Punarnava",
+    "mechanisms": [
+      "kidney support",
+      "diuretic support",
+      "anti-inflammatory"
+    ],
+    "description": "Internal cross-linking supports Punarnava through compounds such as punarnavine.",
+    "activeCompounds": [
+      "boeravinones",
+      "punarnavine",
+      "quercetin"
+    ],
+    "safetyNotes": "General use caution"
+  },
+  {
+    "slug": "coffee-cherry",
+    "name": "Coffee Cherry",
+    "mechanisms": [
+      "adenosine_antagonism",
+      "ADORA1",
+      "ADORA2A (adenosine receptors)",
+      "dopaminergic_modulation",
+      "Nrf2 activation",
+      "NF-κB inhibition"
+    ],
+    "description": "Internal cross-linking supports Coffee Cherry through compounds such as caffeine, trigonelline, cafestol.",
+    "activeCompounds": [
+      "caffeine",
+      "trigonelline",
+      "cafestol",
+      "kahweol"
+    ],
+    "safetyNotes": "Safety review required before publication."
+  },
+  {
+    "slug": "capsicum-frutescens",
+    "name": "Capsicum frutescens",
+    "activeCompounds": [
+      "capsaicin",
+      "capsorubin",
+      "dihydrocapsaicin",
+      "capsanthin"
+    ]
+  },
+  {
+    "slug": "boswellia-carterii",
+    "name": "Boswellia carterii",
+    "mechanisms": [
+      "anti-inflammatory",
+      "mobility support"
+    ],
+    "description": "It is best framed around boswellic acids with 5-lipoxygenase relevance.",
+    "activeCompounds": [
+      "boswellic acids",
+      "AKBA",
+      "acetyl-11-keto-beta-boswellic acid"
+    ],
+    "safetyNotes": "Generally well tolerated."
+  },
+  {
+    "slug": "selaginella-tamariscina",
+    "name": "Selaginella tamariscina",
+    "mechanisms": [
+      "5-lipoxygenase inhibition"
+    ],
+    "description": "Minimum source-backed intake for ginkgetin and 5-lipoxygenase inhibition cluster completion.",
+    "activeCompounds": [
+      "ginkgetin"
+    ]
+  },
+  {
+    "slug": "epimedium-brevicornum",
+    "name": "Epimedium brevicornum",
+    "mechanisms": [
+      "nitric oxide signaling",
+      "PDE5-related signaling"
+    ],
+    "description": "Minimum source-backed intake for Epimedium brevicornum. Active compounds include epimedin A, epimedin B, and epimedin C. Mechanism support retained at nitric oxide signaling level for cluster activation readiness. Icariin support added to complete the PDE5-related signaling cluster.",
+    "activeCompounds": [
+      "epimedin A",
+      "epimedin B",
+      "epimedin C",
+      "Icariin"
+    ]
+  },
+  {
+    "slug": "piper-longum",
+    "name": "Piper longum",
+    "mechanisms": [
+      "bioavailability modulation",
+      "ROS-mediated signaling modulation",
+      "STAT3 inhibition",
+      "NF-κB inhibition"
+    ],
+    "description": "Minimum source-backed intake for Piper longum. Active compound support includes piperine and the herb is used here only to complete the bioavailability modulation cluster. Chavicine support added to mirror the existing pepper isomer pattern in this cluster.",
+    "activeCompounds": [
+      "piperine",
+      "Chavicine",
+      "Piperlongumine"
+    ]
+  },
+  {
+    "slug": "brassica-oleracea",
+    "name": "Brassica oleracea",
+    "mechanisms": [
+      "Nrf2 activation"
+    ],
+    "description": "Minimum source-backed intake for Brassica oleracea. Active compound support includes sulforaphane. Mechanism support retained at Nrf2 activation level for future cluster completion.",
+    "activeCompounds": [
+      "sulforaphane"
+    ]
+  },
+  {
+    "slug": "brassica-juncea",
+    "name": "Brassica juncea",
+    "mechanisms": [
+      "Nrf2 activation"
+    ],
+    "description": "Minimum source-backed intake for Brassica juncea. Active compound support includes sulforaphane under current workbook standards. Mechanism support retained at Nrf2 activation level for second-anchor cluster completion.",
+    "activeCompounds": [
+      "sulforaphane"
+    ]
+  },
+  {
+    "slug": "black-seed",
+    "name": "Black Seed",
+    "mechanisms": [
+      "Nrf2 activation",
+      "NF-κB inhibition"
+    ],
+    "description": "Bulk-ingested support row carrying Thymoquinone with pathway-level mechanism coverage.",
+    "activeCompounds": [
+      "Thymoquinone"
+    ]
+  },
+  {
+    "slug": "olive-leaf",
+    "name": "Olive Leaf",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-κB inhibition",
+      "Nrf2 activation",
+      "PI3K/Akt modulation"
+    ],
+    "description": "Bulk-ingested support row carrying Oleuropein with pathway-level mechanism coverage.",
+    "activeCompounds": [
+      "Oleuropein",
+      "Hydroxytyrosol"
+    ]
+  },
+  {
+    "slug": "japanese-knotweed",
+    "name": "Japanese Knotweed",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "PI3K/Akt modulation",
+      "SIRT1 activation",
+      "AMPK activation"
+    ],
+    "description": "Bulk-ingested support row carrying Emodin with pathway-level mechanism coverage.",
+    "activeCompounds": [
+      "Emodin",
+      "Resveratrol"
+    ]
+  },
+  {
+    "slug": "thunder-god-vine",
+    "name": "Thunder God Vine",
+    "mechanisms": [
+      "HSP90 inhibition",
+      "NF-κB inhibition"
+    ],
+    "description": "Bulk-ingested support row carrying Celastrol with pathway-level mechanism coverage.",
+    "activeCompounds": [
+      "Celastrol"
+    ]
+  },
+  {
+    "slug": "clove",
+    "name": "Clove",
+    "mechanisms": [
+      "COX inhibition",
+      "TRP channel modulation"
+    ],
+    "description": "Bulk-ingested support row carrying Eugenol with pathway-level mechanism coverage.",
+    "activeCompounds": [
+      "Eugenol"
+    ]
+  },
+  {
+    "slug": "orange-peel",
+    "name": "Orange Peel",
+    "mechanisms": [
+      "AMPK activation",
+      "PI3K/Akt modulation",
+      "NF-κB inhibition"
+    ],
+    "description": "Bulk-ingested support row carrying Hesperidin with pathway-level mechanism coverage.",
+    "activeCompounds": [
+      "Hesperidin",
+      "Naringenin",
+      "Naringin"
+    ]
+  },
+  {
+    "slug": "scutellaria-baicalensis",
+    "name": "Scutellaria baicalensis",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "PI3K/Akt modulation",
+      "MAPK pathway modulation"
+    ],
+    "description": "Lean bulk ingestion row for Scutellaria baicalensis. Key active compounds include Baicalin; Baicalein; Wogonin.",
+    "activeCompounds": [
+      "Baicalin",
+      "Baicalein",
+      "Wogonin"
+    ],
+    "safetyNotes": "Audit later."
+  },
+  {
+    "slug": "nigella-sativa",
+    "name": "Nigella sativa",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "Nrf2 activation"
+    ],
+    "description": "Lean bulk ingestion row for Nigella sativa. Key active compounds include Thymoquinone.",
+    "activeCompounds": [
+      "Thymoquinone"
+    ],
+    "safetyNotes": "Audit later."
+  },
+  {
+    "slug": "olea-europaea",
+    "name": "Olea europaea",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "AMPK activation",
+      "Nrf2 activation",
+      "PI3K/Akt modulation",
+      "COX inhibition"
+    ],
+    "description": "Lean bulk ingestion row for Olea europaea. Key active compounds include Oleuropein; Hydroxytyrosol.",
+    "activeCompounds": [
+      "Oleuropein",
+      "Hydroxytyrosol",
+      "Oleocanthal",
+      "Oleacein"
+    ],
+    "safetyNotes": "Audit later."
+  },
+  {
+    "slug": "crocus-sativus",
+    "name": "Crocus sativus",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "MAPK pathway modulation",
+      "Nrf2 activation"
+    ],
+    "description": "Lean bulk ingestion row for Crocus sativus. Key active compounds include Crocin; Crocetin.",
+    "activeCompounds": [
+      "Crocin",
+      "Crocetin"
+    ],
+    "safetyNotes": "Audit later."
+  },
+  {
+    "slug": "glycyrrhiza-glabra",
+    "name": "Glycyrrhiza glabra",
+    "mechanisms": [
+      "HMGB1 inhibition",
+      "NF-κB inhibition"
+    ],
+    "description": "Lean bulk ingestion row for Glycyrrhiza glabra. Key active compounds include Glycyrrhizin.",
+    "activeCompounds": [
+      "Glycyrrhizin",
+      "Glycyrrhetinic acid"
+    ],
+    "safetyNotes": "Audit later."
+  },
+  {
+    "slug": "rheum-palmatum",
+    "name": "Rheum palmatum",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation",
+      "PI3K/Akt modulation"
+    ],
+    "description": "Lean bulk ingestion row for Rheum palmatum. Key active compounds include Emodin; Rhein.",
+    "activeCompounds": [
+      "Emodin",
+      "Rhein"
+    ],
+    "safetyNotes": "Audit later."
+  },
+  {
+    "slug": "schisandra-chinensis",
+    "name": "Schisandra chinensis",
+    "mechanisms": [
+      "Nrf2 activation",
+      "PI3K/Akt modulation"
+    ],
+    "description": "Lean bulk ingestion row for Schisandra chinensis. Key active compounds include Schisandrin.",
+    "activeCompounds": [
+      "Schisandrin"
+    ],
+    "safetyNotes": "Audit later."
+  },
+  {
+    "slug": "tripterygium-wilfordii",
+    "name": "Tripterygium wilfordii",
+    "mechanisms": [
+      "HSP90 inhibition",
+      "NF-κB inhibition"
+    ],
+    "description": "Lean bulk ingestion row for Tripterygium wilfordii. Key active compounds include Celastrol.",
+    "activeCompounds": [
+      "Celastrol"
+    ],
+    "safetyNotes": "Audit later."
+  },
+  {
+    "slug": "syzygium-aromaticum",
+    "name": "Syzygium aromaticum",
+    "mechanisms": [
+      "COX inhibition",
+      "TRP channel modulation"
+    ],
+    "description": "Lean bulk ingestion row for Syzygium aromaticum. Key active compounds include Eugenol.",
+    "activeCompounds": [
+      "Eugenol"
+    ],
+    "safetyNotes": "Audit later."
+  },
+  {
+    "slug": "lavandula-angustifolia",
+    "name": "Lavandula angustifolia",
+    "mechanisms": [
+      "GABA-A modulation",
+      "voltage-gated calcium channel modulation"
+    ],
+    "description": "Lean bulk ingestion row for Lavandula angustifolia. Key active compounds include Linalool.",
+    "activeCompounds": [
+      "Linalool"
+    ],
+    "safetyNotes": "Audit later."
+  },
+  {
+    "slug": "bupleurum-falcatum",
+    "name": "Bupleurum falcatum",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "description": "Lean bulk ingestion row for Bupleurum falcatum. Key active compounds include Saikosaponin A.",
+    "activeCompounds": [
+      "Saikosaponin A"
+    ],
+    "safetyNotes": "Audit later."
+  },
+  {
+    "slug": "citrus-sinensis",
+    "name": "Citrus sinensis",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "NF-κB inhibition"
+    ],
+    "description": "Lean bulk ingestion row for Citrus sinensis. Key active compounds include Hesperidin.",
+    "activeCompounds": [
+      "Hesperidin"
+    ],
+    "safetyNotes": "Audit later."
+  },
+  {
+    "slug": "berberis-vulgaris",
+    "name": "Berberis vulgaris",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "description": "Berberis vulgaris lean herb row for high-speed phytochemical ingestion.",
+    "activeCompounds": [
+      "Berberine",
+      "Columbamine"
+    ]
+  },
+  {
+    "slug": "phellodendron-amurense",
+    "name": "Phellodendron amurense",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-κB inhibition",
+      "PI3K/Akt modulation",
+      "MAPK pathway modulation"
+    ],
+    "description": "Phellodendron amurense lean herb row for high-speed phytochemical ingestion.",
+    "activeCompounds": [
+      "Berberine",
+      "Palmatine",
+      "Jatrorrhizine"
+    ]
+  },
+  {
+    "slug": "coptis-chinensis",
+    "name": "Coptis chinensis",
+    "mechanisms": [
+      "AMPK activation",
+      "MAPK pathway modulation",
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "description": "Coptis chinensis lean herb row for high-speed phytochemical ingestion.",
+    "activeCompounds": [
+      "Palmatine",
+      "Columbamine",
+      "Magnoflorine"
+    ]
+  },
+  {
+    "slug": "andrographis-paniculata",
+    "name": "Andrographis paniculata",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "JAK/STAT modulation",
+      "MAPK pathway modulation",
+      "PI3K/Akt modulation"
+    ],
+    "description": "Andrographis paniculata lean herb row for high-speed phytochemical ingestion.",
+    "activeCompounds": [
+      "Andrographolide",
+      "Neoandrographolide"
+    ]
+  },
+  {
+    "slug": "fenugreek",
+    "name": "Fenugreek",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "PPARγ activation",
+      "NO signaling modulation",
+      "Nrf2 activation",
+      "glucose metabolism modulation"
+    ],
+    "description": "Fenugreek lean herb row for high-speed phytochemical ingestion.",
+    "activeCompounds": [
+      "Diosgenin",
+      "Protodioscin",
+      "trigonelline"
+    ]
+  },
+  {
+    "slug": "wild-yam",
+    "name": "Wild Yam",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "PPARγ activation"
+    ],
+    "description": "Wild Yam lean herb row for high-speed phytochemical ingestion.",
+    "activeCompounds": [
+      "Diosgenin"
+    ]
+  },
+  {
+    "slug": "tribulus-terrestris",
+    "name": "Tribulus terrestris",
+    "mechanisms": [
+      "NO signaling modulation",
+      "PI3K/Akt modulation"
+    ],
+    "description": "Tribulus terrestris lean herb row for high-speed phytochemical ingestion.",
+    "activeCompounds": [
+      "Protodioscin"
+    ]
+  },
+  {
+    "slug": "bacopa-monnieri",
+    "name": "Bacopa monnieri",
+    "mechanisms": [
+      "cholinergic modulation",
+      "ERK pathway modulation",
+      "PI3K/Akt modulation"
+    ],
+    "description": "Bacopa monnieri lean herb row for high-speed phytochemical ingestion.",
+    "activeCompounds": [
+      "Bacoside A",
+      "Bacoside B"
+    ]
+  },
+  {
+    "slug": "bayberry",
+    "name": "Bayberry",
+    "mechanisms": [
+      "MAPK pathway modulation",
+      "NF-κB inhibition"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "activeCompounds": [
+      "Myricetin"
+    ]
+  },
+  {
+    "slug": "parsley",
+    "name": "Parsley",
+    "mechanisms": [
+      "GABA-A modulation",
+      "PI3K/Akt modulation"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "activeCompounds": [
+      "Apigenin"
+    ]
+  },
+  {
+    "slug": "grapefruit",
+    "name": "Grapefruit",
+    "mechanisms": [
+      "AMPK activation",
+      "PI3K/Akt modulation",
+      "NF-κB inhibition"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "activeCompounds": [
+      "Naringenin",
+      "Naringin"
+    ]
+  },
+  {
+    "slug": "buckwheat",
+    "name": "Buckwheat",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "activeCompounds": [
+      "Rutin"
+    ]
+  },
+  {
+    "slug": "black-tea",
+    "name": "Black Tea",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation",
+      "Nrf2 activation"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "activeCompounds": [
+      "Theaflavin",
+      "Thearubigin"
+    ]
+  },
+  {
+    "slug": "grape",
+    "name": "Grape",
+    "mechanisms": [
+      "SIRT1 activation",
+      "AMPK activation",
+      "NF-κB inhibition",
+      "PPAR activation"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "activeCompounds": [
+      "Resveratrol",
+      "Pterostilbene"
+    ]
+  },
+  {
+    "slug": "blueberry",
+    "name": "Blueberry",
+    "mechanisms": [
+      "AMPK activation",
+      "PPAR activation"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "activeCompounds": [
+      "Pterostilbene"
+    ]
+  },
+  {
+    "slug": "soybean",
+    "name": "Soybean",
+    "mechanisms": [
+      "estrogen receptor modulation",
+      "PI3K/Akt modulation",
+      "MAPK pathway modulation",
+      "NF-κB inhibition"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "activeCompounds": [
+      "Genistein",
+      "Daidzein",
+      "Biochanin A"
+    ]
+  },
+  {
+    "slug": "raspberry-leaf",
+    "name": "Raspberry Leaf",
+    "mechanisms": [
+      "Nrf2 activation",
+      "NF-κB inhibition"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "activeCompounds": [
+      "Ellagic acid"
+    ]
+  },
+  {
+    "slug": "angelica-sinensis",
+    "name": "Angelica sinensis",
+    "mechanisms": [
+      "Nrf2 activation",
+      "PI3K/Akt modulation",
+      "voltage-gated calcium channel modulation",
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "activeCompounds": [
+      "Ferulic acid",
+      "Ligustilide",
+      "Senkyunolide A",
+      "Butylidenephthalide"
+    ]
+  },
+  {
+    "slug": "rice-bran",
+    "name": "Rice Bran",
+    "mechanisms": [
+      "Nrf2 activation",
+      "PI3K/Akt modulation"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "activeCompounds": [
+      "Ferulic acid"
+    ]
+  },
+  {
+    "slug": "coffee",
+    "name": "Coffee",
+    "mechanisms": [
+      "AMPK activation",
+      "glucose metabolism modulation",
+      "NF-κB inhibition",
+      "MAPK pathway modulation",
+      "Nrf2 activation"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "activeCompounds": [
+      "Chlorogenic acid",
+      "Caffeic acid",
+      "trigonelline"
+    ]
+  },
+  {
+    "slug": "cnidium-monnieri",
+    "name": "Cnidium monnieri",
+    "mechanisms": [
+      "PDE4 inhibition",
+      "PI3K/Akt modulation",
+      "acetylcholinesterase inhibition",
+      "voltage-gated calcium channel modulation",
+      "MAPK pathway modulation"
+    ],
+    "description": "Cnidium monnieri lean monograph row enriched in bulk mode.",
+    "activeCompounds": [
+      "Osthole",
+      "Imperatorin",
+      "Isoimperatorin"
+    ]
+  },
+  {
+    "slug": "angelica-pubescens",
+    "name": "Angelica pubescens",
+    "mechanisms": [
+      "PDE4 inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "description": "Angelica pubescens lean monograph row enriched in bulk mode.",
+    "activeCompounds": [
+      "Osthole"
+    ]
+  },
+  {
+    "slug": "angelica-dahurica",
+    "name": "Angelica dahurica",
+    "mechanisms": [
+      "acetylcholinesterase inhibition",
+      "voltage-gated calcium channel modulation",
+      "MAPK pathway modulation",
+      "PDE inhibition"
+    ],
+    "description": "Angelica dahurica lean monograph row enriched in bulk mode.",
+    "activeCompounds": [
+      "Imperatorin",
+      "Isoimperatorin",
+      "Xanthotoxin"
+    ]
+  },
+  {
+    "slug": "psoralea-corylifolia",
+    "name": "Psoralea corylifolia",
+    "mechanisms": [
+      "estrogen receptor modulation",
+      "MAPK pathway modulation",
+      "NF-κB inhibition"
+    ],
+    "description": "Psoralea corylifolia lean monograph row enriched in bulk mode.",
+    "activeCompounds": [
+      "Psoralen",
+      "Angelicin",
+      "Bergapten"
+    ]
+  },
+  {
+    "slug": "ficus-carica",
+    "name": "Ficus carica",
+    "mechanisms": [
+      "estrogen receptor modulation",
+      "MAPK pathway modulation"
+    ],
+    "description": "Ficus carica lean monograph row enriched in bulk mode.",
+    "activeCompounds": [
+      "Psoralen"
+    ]
+  },
+  {
+    "slug": "angelica-archangelica",
+    "name": "Angelica archangelica",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation",
+      "Nrf2 activation"
+    ],
+    "description": "Angelica archangelica lean monograph row enriched in bulk mode.",
+    "activeCompounds": [
+      "Angelicin",
+      "Umbelliferone"
+    ]
+  },
+  {
+    "slug": "citrus-bergamia",
+    "name": "Citrus bergamia",
+    "mechanisms": [
+      "MAPK pathway modulation",
+      "NF-κB inhibition"
+    ],
+    "description": "Citrus bergamia lean monograph row enriched in bulk mode.",
+    "activeCompounds": [
+      "Bergapten"
+    ]
+  },
+  {
+    "slug": "morinda-citrifolia",
+    "name": "Morinda citrifolia",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "voltage-gated calcium channel modulation"
+    ],
+    "description": "Morinda citrifolia lean monograph row enriched in bulk mode.",
+    "activeCompounds": [
+      "Scopoletin"
+    ]
+  },
+  {
+    "slug": "artemisia-capillaris",
+    "name": "Artemisia capillaris",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "voltage-gated calcium channel modulation",
+      "5-lipoxygenase inhibition",
+      "Nrf2 activation"
+    ],
+    "description": "Artemisia capillaris lean monograph row enriched in bulk mode.",
+    "activeCompounds": [
+      "Scopoletin",
+      "Esculetin",
+      "Fraxetin"
+    ]
+  },
+  {
+    "slug": "cichorium-intybus",
+    "name": "Cichorium intybus",
+    "mechanisms": [
+      "5-lipoxygenase inhibition",
+      "NF-κB inhibition"
+    ],
+    "description": "Cichorium intybus lean monograph row enriched in bulk mode.",
+    "activeCompounds": [
+      "Esculetin"
+    ]
+  },
+  {
+    "slug": "fraxinus-rhynchophylla",
+    "name": "Fraxinus rhynchophylla",
+    "mechanisms": [
+      "Nrf2 activation",
+      "NF-κB inhibition"
+    ],
+    "description": "Fraxinus rhynchophylla lean monograph row enriched in bulk mode.",
+    "activeCompounds": [
+      "Fraxetin"
+    ]
+  },
+  {
+    "slug": "coriandrum-sativum",
+    "name": "Coriandrum sativum",
+    "mechanisms": [
+      "Nrf2 activation",
+      "MAPK pathway modulation"
+    ],
+    "description": "Coriandrum sativum lean monograph row enriched in bulk mode.",
+    "activeCompounds": [
+      "Umbelliferone"
+    ]
+  },
+  {
+    "slug": "daphne-odora",
+    "name": "Daphne odora",
+    "mechanisms": [
+      "JAK/STAT inhibition",
+      "NF-κB inhibition"
+    ],
+    "description": "Daphne odora lean monograph row enriched in bulk mode.",
+    "activeCompounds": [
+      "Daphnetin"
+    ]
+  },
+  {
+    "slug": "stellera-chamaejasme",
+    "name": "Stellera chamaejasme",
+    "mechanisms": [
+      "JAK/STAT inhibition",
+      "NF-κB inhibition"
+    ],
+    "description": "Stellera chamaejasme lean monograph row enriched in bulk mode.",
+    "activeCompounds": [
+      "Daphnetin"
+    ]
+  },
+  {
+    "slug": "sophora-alopecuroides",
+    "name": "Sophora alopecuroides",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "NF-κB inhibition",
+      "TGF-β signaling modulation"
+    ],
+    "description": "Sophora alopecuroides lean monograph row enriched in bulk mode.",
+    "activeCompounds": [
+      "Matrine",
+      "Oxymatrine"
+    ]
+  },
+  {
+    "slug": "stephania-tetrandra",
+    "name": "Stephania tetrandra",
+    "mechanisms": [
+      "voltage-gated calcium channel modulation",
+      "NF-κB inhibition"
+    ],
+    "description": "Stephania tetrandra lean monograph row enriched in bulk mode.",
+    "activeCompounds": [
+      "Tetrandrine"
+    ]
+  },
+  {
+    "slug": "cyclea-peltata",
+    "name": "Cyclea peltata",
+    "mechanisms": [
+      "voltage-gated calcium channel modulation",
+      "NF-κB inhibition"
+    ],
+    "description": "Cyclea peltata lean monograph row enriched in bulk mode.",
+    "activeCompounds": [
+      "Tetrandrine"
+    ]
+  },
+  {
+    "slug": "stephania-cepharantha",
+    "name": "Stephania cepharantha",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "description": "Stephania cepharantha lean monograph row enriched in bulk mode.",
+    "activeCompounds": [
+      "Cepharanthine"
+    ]
+  },
+  {
+    "slug": "stephania-japonica",
+    "name": "Stephania japonica",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "description": "Stephania japonica lean monograph row enriched in bulk mode.",
+    "activeCompounds": [
+      "Cepharanthine"
+    ]
+  },
+  {
+    "slug": "nelumbo-nucifera",
+    "name": "Nelumbo nucifera",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-κB inhibition"
+    ],
+    "description": "Nelumbo nucifera lean monograph row enriched in bulk mode.",
+    "activeCompounds": [
+      "Magnoflorine"
+    ]
+  },
+  {
+    "slug": "ligusticum-chuanxiong",
+    "name": "Ligusticum chuanxiong",
+    "mechanisms": [
+      "voltage-gated calcium channel modulation",
+      "NF-κB inhibition",
+      "MAPK pathway modulation",
+      "PI3K/Akt modulation"
+    ],
+    "description": "Ligusticum chuanxiong lean monograph row enriched in bulk mode.",
+    "activeCompounds": [
+      "Ligustilide",
+      "Senkyunolide A",
+      "Butylidenephthalide"
+    ]
+  },
+  {
+    "slug": "pastinaca-sativa",
+    "name": "Pastinaca sativa",
+    "mechanisms": [
+      "MAPK pathway modulation",
+      "PDE inhibition"
+    ],
+    "description": "Pastinaca sativa lean monograph row enriched in bulk mode.",
+    "activeCompounds": [
+      "Xanthotoxin"
+    ]
+  },
+  {
+    "slug": "boswellia-serrata",
+    "name": "Boswellia serrata",
+    "mechanisms": [
+      "5-lipoxygenase inhibition",
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "description": "Boswellia serrata contains Boswellic acid and is linked here to 5-lipoxygenase inhibition.",
+    "activeCompounds": [
+      "Boswellic acid",
+      "Acetyl-beta-boswellic acid",
+      "11-keto-beta-boswellic acid",
+      "Acetyl-11-keto-beta-boswellic acid"
+    ]
+  },
+  {
+    "slug": "valeriana-officinalis",
+    "name": "Valeriana officinalis",
+    "mechanisms": [
+      "GABA-A modulation",
+      "voltage-gated calcium channel modulation",
+      "MAPK pathway modulation"
+    ],
+    "description": "Valeriana officinalis contains Valerenic acid and is linked here to GABA-A modulation.",
+    "activeCompounds": [
+      "Valerenic acid",
+      "Valerenol",
+      "Valepotriates"
+    ]
+  },
+  {
+    "slug": "piper-methysticum",
+    "name": "Piper methysticum",
+    "mechanisms": [
+      "GABA-A modulation",
+      "voltage-gated sodium channel modulation",
+      "CB1 receptor modulation",
+      "MAO-B inhibition"
+    ],
+    "description": "Piper methysticum contains Kavalactones and is linked here to GABA-A modulation.",
+    "activeCompounds": [
+      "Kavalactones",
+      "Kavain",
+      "Yangonin",
+      "Methysticin"
+    ]
+  },
+  {
+    "slug": "hypericum-perforatum",
+    "name": "Hypericum perforatum",
+    "mechanisms": [
+      "TRPC6 channel modulation",
+      "monoamine reuptake inhibition",
+      "PKC modulation",
+      "apoptosis pathway modulation (caspase activation)"
+    ],
+    "description": "Hypericum perforatum contains Hyperforin and is linked here to TRPC6 channel modulation.",
+    "activeCompounds": [
+      "Hyperforin",
+      "Hypericin"
+    ]
+  },
+  {
+    "slug": "plantago-major",
+    "name": "Plantago major",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "description": "Plantago major contains Aucubin and is linked here to NF-κB inhibition.",
+    "activeCompounds": [
+      "Aucubin"
+    ]
+  },
+  {
+    "slug": "rehmannia-glutinosa",
+    "name": "Rehmannia glutinosa",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "AMPK activation"
+    ],
+    "description": "Rehmannia glutinosa contains Catalpol and is linked here to PI3K/Akt modulation.",
+    "activeCompounds": [
+      "Catalpol"
+    ]
+  },
+  {
+    "slug": "harpagophytum-procumbens",
+    "name": "Harpagophytum procumbens",
+    "mechanisms": [
+      "COX inhibition",
+      "NF-κB inhibition"
+    ],
+    "description": "Harpagophytum procumbens contains Harpagoside and is linked here to COX inhibition.",
+    "activeCompounds": [
+      "Harpagoside"
+    ]
+  },
+  {
+    "slug": "cornus-officinalis",
+    "name": "Cornus officinalis",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "Nrf2 activation"
+    ],
+    "description": "Cornus officinalis contains Loganin and is linked here to PI3K/Akt modulation.",
+    "activeCompounds": [
+      "Loganin",
+      "Morroniside"
+    ]
+  },
+  {
+    "slug": "cistanche-deserticola",
+    "name": "Cistanche deserticola",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "Nrf2 activation"
+    ],
+    "description": "Cistanche deserticola contains Echinacoside and is linked here to PI3K/Akt modulation.",
+    "activeCompounds": [
+      "Echinacoside"
+    ]
+  },
+  {
+    "slug": "verbena-officinalis",
+    "name": "Verbena officinalis",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "description": "Verbena officinalis contains Acteoside and is linked here to NF-κB inhibition.",
+    "activeCompounds": [
+      "Acteoside"
+    ]
+  },
+  {
+    "slug": "plantago-lanceolata",
+    "name": "Plantago lanceolata",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "description": "Plantago lanceolata contains Verbascoside and is linked here to NF-κB inhibition.",
+    "activeCompounds": [
+      "Verbascoside"
+    ]
+  },
+  {
+    "slug": "lithospermum-erythrorhizon",
+    "name": "Lithospermum erythrorhizon",
+    "mechanisms": [
+      "PKM2 inhibition",
+      "NF-κB inhibition",
+      "apoptosis pathway modulation (caspase activation)"
+    ],
+    "description": "Lithospermum erythrorhizon contains Shikonin and is linked here to PKM2 inhibition.",
+    "activeCompounds": [
+      "Shikonin",
+      "Acetylshikonin"
+    ]
+  },
+  {
+    "slug": "plumbago-zeylanica",
+    "name": "Plumbago zeylanica",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "STAT3 inhibition",
+      "ROS-mediated signaling modulation"
+    ],
+    "description": "Plumbago zeylanica contains Plumbagin and is linked here to NF-κB inhibition.",
+    "activeCompounds": [
+      "Plumbagin"
+    ]
+  },
+  {
+    "slug": "lawsonia-inermis",
+    "name": "Lawsonia inermis",
+    "mechanisms": [
+      "MAPK pathway modulation",
+      "NF-κB inhibition"
+    ],
+    "description": "Lawsonia inermis contains Lawsone and is linked here to MAPK pathway modulation.",
+    "activeCompounds": [
+      "Lawsone"
+    ]
+  },
+  {
+    "slug": "embelia-ribes",
+    "name": "Embelia ribes",
+    "mechanisms": [
+      "XIAP inhibition",
+      "NF-κB inhibition"
+    ],
+    "description": "Embelia ribes contains Embelin and is linked here to XIAP inhibition.",
+    "activeCompounds": [
+      "Embelin"
+    ]
+  },
+  {
+    "slug": "artemisia-absinthium",
+    "name": "Artemisia absinthium",
+    "mechanisms": [
+      "GABA-A receptor antagonism",
+      "TRP channel modulation"
+    ],
+    "description": "Artemisia absinthium contains Thujone and is linked here to GABA-A receptor antagonism.",
+    "activeCompounds": [
+      "Thujone"
+    ]
+  },
+  {
+    "slug": "astragalus-membranaceus",
+    "name": "Astragalus membranaceus",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "AMPK activation",
+      "TGF-β signaling modulation",
+      "estrogen receptor modulation",
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "description": "Astragalus membranaceus contains Astragaloside IV and is linked here to PI3K/Akt modulation.",
+    "activeCompounds": [
+      "Astragaloside IV",
+      "Calycosin",
+      "Formononetin",
+      "Astragalin"
+    ]
+  },
+  {
+    "slug": "pueraria-lobata",
+    "name": "Pueraria lobata",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "AMPK activation",
+      "estrogen receptor modulation",
+      "glucose absorption modulation"
+    ],
+    "description": "Pueraria lobata contains Puerarin and is linked here to PI3K/Akt modulation.",
+    "activeCompounds": [
+      "Puerarin",
+      "Daidzin",
+      "Ononin"
+    ]
+  },
+  {
+    "slug": "mangifera-indica",
+    "name": "Mangifera indica",
+    "mechanisms": [
+      "AMPK activation",
+      "Nrf2 activation",
+      "NF-κB inhibition"
+    ],
+    "description": "Mangifera indica contains Mangiferin and is linked here to AMPK activation.",
+    "activeCompounds": [
+      "Mangiferin"
+    ]
+  },
+  {
+    "slug": "garcinia-mangostana",
+    "name": "Garcinia mangostana",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "PI3K/Akt modulation",
+      "apoptosis pathway modulation (caspase activation)",
+      "STAT3 inhibition"
+    ],
+    "description": "Garcinia mangostana contains Mangostin and is linked here to NF-κB inhibition.",
+    "activeCompounds": [
+      "Mangostin",
+      "Alpha-mangostin"
+    ]
+  },
+  {
+    "slug": "garcinia-indica",
+    "name": "Garcinia indica",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "HAT inhibition",
+      "STAT3 inhibition"
+    ],
+    "description": "Garcinia indica contains Garcinol and is linked here to NF-κB inhibition.",
+    "activeCompounds": [
+      "Garcinol"
+    ]
+  },
+  {
+    "slug": "curcuma-zedoaria",
+    "name": "Curcuma zedoaria",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation",
+      "PI3K/Akt modulation",
+      "apoptosis pathway modulation (caspase activation)"
+    ],
+    "description": "Curcuma zedoaria contains Curcumol and is linked here to NF-κB inhibition.",
+    "activeCompounds": [
+      "Curcumol",
+      "Curdione"
+    ]
+  },
+  {
+    "slug": "curcuma-longa",
+    "name": "Curcuma longa",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "Nrf2 activation"
+    ],
+    "description": "Curcuma longa contains Demethoxycurcumin and is linked here to NF-κB inhibition.",
+    "activeCompounds": [
+      "Demethoxycurcumin",
+      "Bisdemethoxycurcumin"
+    ]
+  },
+  {
+    "slug": "paeonia-lactiflora",
+    "name": "Paeonia lactiflora",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "NF-κB inhibition",
+      "MAPK pathway modulation",
+      "monoamine reuptake inhibition"
+    ],
+    "description": "Paeonia lactiflora contains Paeoniflorin and is linked here to PI3K/Akt modulation.",
+    "activeCompounds": [
+      "Paeoniflorin",
+      "Albiflorin"
+    ]
+  },
+  {
+    "slug": "paeonia-suffruticosa",
+    "name": "Paeonia suffruticosa",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "Nrf2 activation"
+    ],
+    "description": "Paeonia suffruticosa contains Paeonol and is linked here to NF-κB inhibition.",
+    "activeCompounds": [
+      "Paeonol"
+    ]
+  },
+  {
+    "slug": "anemarrhena-asphodeloides",
+    "name": "Anemarrhena asphodeloides",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "apoptosis pathway modulation (caspase activation)",
+      "AMPK activation",
+      "Nrf2 activation"
+    ],
+    "description": "Anemarrhena asphodeloides contains Timosaponin AIII and is linked here to PI3K/Akt modulation.",
+    "activeCompounds": [
+      "Timosaponin AIII",
+      "Mangiferin aglycone"
+    ]
+  },
+  {
+    "slug": "lobelia-inflata",
+    "name": "Lobelia inflata",
+    "mechanisms": [
+      "nicotinic acetylcholine receptor modulation",
+      "dopamine transporter modulation"
+    ],
+    "description": "Lobelia inflata contains Lobeline and is linked here to nicotinic acetylcholine receptor modulation.",
+    "activeCompounds": [
+      "Lobeline"
+    ]
+  },
+  {
+    "slug": "huperzia-serrata",
+    "name": "Huperzia serrata",
+    "mechanisms": [
+      "acetylcholinesterase inhibition",
+      "NMDA receptor modulation"
+    ],
+    "description": "Huperzia serrata contains Huperzine A and is linked here to acetylcholinesterase inhibition.",
+    "activeCompounds": [
+      "Huperzine A",
+      "Huperzine B"
+    ]
+  },
+  {
+    "slug": "nicotiana-tabacum",
+    "name": "Nicotiana tabacum",
+    "mechanisms": [
+      "nicotinic acetylcholine receptor modulation",
+      "NF-κB inhibition",
+      "nicotinic acetylcholine receptor agonism",
+      "dopamine release modulation"
+    ],
+    "description": "Nicotiana tabacum contains Anatabine and is linked here to nicotinic acetylcholine receptor modulation.",
+    "activeCompounds": [
+      "Anatabine",
+      "Nicotine"
+    ]
+  },
+  {
+    "slug": "nicotiana-glauca",
+    "name": "Nicotiana glauca",
+    "mechanisms": [
+      "nicotinic acetylcholine receptor modulation"
+    ],
+    "description": "Nicotiana glauca contains Anabasine and is linked here to nicotinic acetylcholine receptor modulation.",
+    "activeCompounds": [
+      "Anabasine"
+    ]
+  },
+  {
+    "slug": "piper-nigrum",
+    "name": "Piper nigrum",
+    "mechanisms": [
+      "CB2 receptor agonism",
+      "NF-κB inhibition",
+      "apoptosis pathway modulation (caspase activation)"
+    ],
+    "description": "Piper nigrum contains Beta-caryophyllene and is linked here to CB2 receptor agonism.",
+    "activeCompounds": [
+      "Beta-caryophyllene",
+      "Caryophyllene oxide"
+    ]
+  },
+  {
+    "slug": "cymbopogon-citratus",
+    "name": "Cymbopogon citratus",
+    "mechanisms": [
+      "GABA-A modulation",
+      "PI3K/Akt modulation"
+    ],
+    "description": "Cymbopogon citratus contains Nerolidol and is linked here to GABA-A modulation.",
+    "activeCompounds": [
+      "Nerolidol"
+    ]
+  },
+  {
+    "slug": "matricaria-chamomilla",
+    "name": "Matricaria chamomilla",
+    "mechanisms": [
+      "PPAR activation",
+      "MAPK pathway modulation",
+      "COX inhibition",
+      "NF-κB inhibition",
+      "leukotriene pathway modulation"
+    ],
+    "description": "Matricaria chamomilla contains Farnesol and is linked here to PPAR activation.",
+    "activeCompounds": [
+      "Farnesol",
+      "Bisabolol",
+      "Chamazulene"
+    ]
+  },
+  {
+    "slug": "atractylodes-macrocephala",
+    "name": "Atractylodes macrocephala",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "description": "Atractylodes macrocephala contains Atractylenolide I and is linked here to PI3K/Akt modulation.",
+    "activeCompounds": [
+      "Atractylenolide I",
+      "Atractylenolide II",
+      "Atractylenolide III"
+    ]
+  },
+  {
+    "slug": "curcuma-wenyujin",
+    "name": "Curcuma wenyujin",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "apoptosis pathway modulation (caspase activation)"
+    ],
+    "description": "Curcuma wenyujin contains Beta-elemene and is linked here to PI3K/Akt modulation.",
+    "activeCompounds": [
+      "Beta-elemene"
+    ]
+  },
+  {
+    "slug": "myristica-fragrans",
+    "name": "Myristica fragrans",
+    "mechanisms": [
+      "monoamine oxidase inhibition",
+      "TRP channel modulation",
+      "acetylcholinesterase inhibition"
+    ],
+    "description": "Myristica fragrans contains Elemicin and is linked here to monoamine oxidase inhibition.",
+    "activeCompounds": [
+      "Elemicin",
+      "Myristicin"
+    ]
+  },
+  {
+    "slug": "ocotea-odorifera",
+    "name": "Ocotea odorifera",
+    "mechanisms": [
+      "TRP channel modulation",
+      "MAPK pathway modulation"
+    ],
+    "description": "Ocotea odorifera contains Safrole and is linked here to TRP channel modulation.",
+    "activeCompounds": [
+      "Safrole"
+    ]
+  },
+  {
+    "slug": "ocimum-basilicum",
+    "name": "Ocimum basilicum",
+    "mechanisms": [
+      "TRP channel modulation",
+      "GABA-A modulation"
+    ],
+    "description": "Ocimum basilicum contains Methyleugenol and is linked here to TRP channel modulation.",
+    "activeCompounds": [
+      "Methyleugenol"
+    ]
+  },
+  {
+    "slug": "ocimum-sanctum",
+    "name": "Ocimum sanctum",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "description": "Ocimum sanctum contains Ursolic acid and is linked here to AMPK activation.",
+    "activeCompounds": [
+      "Ursolic acid"
+    ]
+  },
+  {
+    "slug": "centella-asiatica",
+    "name": "Centella asiatica",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "TGF-β signaling modulation",
+      "NF-κB inhibition"
+    ],
+    "description": "Centella asiatica contains Asiatic acid and is linked here to PI3K/Akt modulation.",
+    "activeCompounds": [
+      "Asiatic acid",
+      "Madecassic acid",
+      "Asiaticoside",
+      "Madecassoside"
+    ]
+  },
+  {
+    "slug": "gymnema-sylvestre",
+    "name": "Gymnema sylvestre",
+    "mechanisms": [
+      "glucose absorption modulation",
+      "AMPK activation",
+      "sweet taste receptor modulation"
+    ],
+    "description": "Gymnema sylvestre contains Gymnemagenin and is linked here to glucose absorption modulation.",
+    "activeCompounds": [
+      "Gymnemagenin",
+      "Gurmarin"
+    ]
+  },
+  {
+    "slug": "lagerstroemia-speciosa",
+    "name": "Lagerstroemia speciosa",
+    "mechanisms": [
+      "AMPK activation",
+      "GLUT4 translocation modulation",
+      "PPAR activation",
+      "glucose uptake modulation"
+    ],
+    "description": "Lagerstroemia speciosa contains Corosolic acid and is linked here to AMPK activation.",
+    "activeCompounds": [
+      "Corosolic acid",
+      "Lagerstroemin"
+    ]
+  },
+  {
+    "slug": "morus-alba",
+    "name": "Morus alba",
+    "mechanisms": [
+      "glucose absorption modulation",
+      "alpha-glucosidase inhibition",
+      "PI3K/Akt modulation",
+      "NF-κB inhibition"
+    ],
+    "description": "Morus alba contains Mulberroside A and is linked here to glucose absorption modulation.",
+    "activeCompounds": [
+      "Mulberroside A",
+      "Oxyresveratrol",
+      "Morin"
+    ]
+  },
+  {
+    "slug": "elephantopus-scaber",
+    "name": "Elephantopus scaber",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "STAT3 inhibition",
+      "apoptosis pathway modulation (caspase activation)",
+      "MAPK pathway modulation"
+    ],
+    "description": "Elephantopus scaber contains Deoxyelephantopin and is linked here to NF-κB inhibition.",
+    "activeCompounds": [
+      "Deoxyelephantopin",
+      "Elephantopin"
+    ]
+  },
+  {
+    "slug": "commiphora-mukul",
+    "name": "Commiphora mukul",
+    "mechanisms": [
+      "FXR antagonism",
+      "NF-κB inhibition",
+      "PPAR activation"
+    ],
+    "description": "Commiphora mukul contains Guggulsterone and is linked here to FXR antagonism.",
+    "activeCompounds": [
+      "Guggulsterone",
+      "Commipheric acid"
+    ]
+  },
+  {
+    "slug": "serenoa-repens",
+    "name": "Serenoa repens",
+    "mechanisms": [
+      "PPAR activation",
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "description": "Serenoa repens contains Beta-sitosterol and is linked here to PPAR activation.",
+    "activeCompounds": [
+      "Beta-sitosterol",
+      "Stigmasterol"
+    ]
   }
 ]

--- a/reports/workbook-unmatched-compounds.json
+++ b/reports/workbook-unmatched-compounds.json
@@ -1,427 +1,11 @@
 [
   {
     "canonicalCompoundId": "",
-    "compoundName": "1,8-cineole"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "1-deoxynojirimycin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "11-keto-beta-boswellic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "23-epi-26-deoxyactein"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "4-hydroxyderricin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "5-hydroxytryptophan (5-HTP)"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "6-Gingerol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "6-Shogaol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "8-cineole"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "a-type proanthocyanidins"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "absinthin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "acetyl-11-keto-beta-boswellic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "acetyl-beta-boswellic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "acetyl-l-carnitine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Actein"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "acteoside"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "adenosine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "aegeline"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "aescin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "aesculin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "agaric acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "agnuside"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "ajmaline"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "ajoene"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "akba"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Akuammine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "alangine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "alantolactone"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "allantoin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "allicin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "allyl isothiocyanate"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "aloe-emodin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "aloin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "alpha-bisabolol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "alpha-gpc l-alpha-glycerylphosphorylcholine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "alpha-mangostin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "alpha-pinene"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "alpha-terpineol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "alpha-thujone"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "amarogentin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "amentoflavone"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Andrographolide"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "anethole"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "angelicin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "anisomelic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "annonacin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "anonaine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "anthocyanins delphinidin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "apomorphine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "arabinoxylans"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "arctiin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "arecaidine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "arecoline"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Arjunetin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Arjungenin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Arjunic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "arjunolic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "armepavine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "artemisinin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "asclepiadin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "ashwagandha withanolides"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "asiatic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "asiaticoside"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "asperuloside"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "aspidospermine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "astragaloside iv"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "atractylenolide i"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "atractylenolide ii"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "atractylenolide iii"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "atractylon"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "aucubin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "avenacosides"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "avenanthramides"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "azadirachtin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "bacopaside ii"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "bacoside a"
-  },
-  {
-    "canonicalCompoundId": "",
     "compoundName": "Baicalein"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "benzyl benzoate"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "berbamine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "berberine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "beta-amyrin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "beta-asarone low levels"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "beta-boswellic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "beta-caryophyllene"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "beta-glucans"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "beta-lapachone"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "beta-sitosterol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "beta-thujone"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "betulinic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Bilobalide"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "bilobetin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "bisabolol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Bisdemethoxycurcumin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "bonducin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "brunfelsamidine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "bryonin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "bulbocapnine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "buphanidrine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "cafestol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "calotropin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "cannabidiol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "capsaicin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "capsanthin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "capsorubin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "cardanol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "cardol"
+    "compoundName": "Thymoquinone"
   },
   {
     "canonicalCompoundId": "",
@@ -429,527 +13,103 @@
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "Carnosol"
+    "compoundName": "Oleuropein"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "carpaine"
+    "compoundName": "Hydroxytyrosol"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "carvone"
+    "compoundName": "Crocin"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "casimiroedine"
+    "compoundName": "Crocetin"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "casticin"
+    "compoundName": "Silibinin"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "catalpol"
+    "compoundName": "Glycyrrhizin"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "cathine"
+    "compoundName": "Emodin"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "cathinone"
+    "compoundName": "Rhein"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "celapagin"
+    "compoundName": "Schisandrin"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "celapanin"
+    "compoundName": "Celastrol"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "cepharanthine"
+    "compoundName": "Saikosaponin A"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "charantin"
+    "compoundName": "Curcumin"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "Chavicine"
+    "compoundName": "Hesperidin"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "chavicol"
+    "compoundName": "Berberine"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "chelerythrine"
+    "compoundName": "Palmatine"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "chelidonine"
+    "compoundName": "Jatrorrhizine"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "chicoric acid"
+    "compoundName": "Columbamine"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "choline"
+    "compoundName": "Andrographolide"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "chrysin"
+    "compoundName": "Neoandrographolide"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "chrysoeriol"
+    "compoundName": "Charantin"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "chrysophanol"
+    "compoundName": "Momordicoside K"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "chymopapain"
+    "compoundName": "Diosgenin"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "Cimicifugoside"
+    "compoundName": "Protodioscin"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "cimifugoside"
+    "compoundName": "Ginsenoside Rb1"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "cinnamaldehyde"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "cinnamoylcocaine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "cis-cinnamoylcocaine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "citicoline cdp-choline"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "citric acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "citronellal"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "cocaine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "columbamine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "conhydrine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "coniine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "convallatoxin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "convalloside cardiac glycosides"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "convolvine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "copalic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "coptisine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "cordycepin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "corosolic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "corydaline"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "crocetin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "crocin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "curcumin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "curcuminoids"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "curcuminoids curcumin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "cuscohygrine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "cyanidin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "cynarin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "cyperene"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "d-pinitol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "daidzein"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "damnacanthal"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Dehydrocorybulbine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "dehydrocorydalmine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Demethoxycurcumin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "dendrobine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "deoxymiroestrol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "desmethoxyyangonin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Desmethylicaritin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "diallyl disulfide"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "diallyl sulfide"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "diallyl trisulfide"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "dibenzyl trisulfide"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "digitoxin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "digoxin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "dihydrocapsaicin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "dihydrohelenalin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "dihydrokavain"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "dihydromethysticin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "dillapiole"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Dopamine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "ecdysterone"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "ECG"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "echinacoside"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "ecliptine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "EGCG"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "eleutherosides"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "emetine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "emodin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Epicatechin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Epimedin A"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Epimedin B"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Epimedin C"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "erinacines"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "eryngial"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "esculetin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "ethyl cinnamate"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "eucalyptol cineole"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "eurycomanone"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "evodiamine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "fangchinoline"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "faradiol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "faradiol esters"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "febrifugine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "fenchone"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "ferulenol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "flavokavain a"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "flavokavain b"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "flavokavain c"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "formononetin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "fraxin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "fucoidan"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Fukinolic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "galangin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "gamma-aminobutyric acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "gamma-linolenic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "gastrodin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "gelsedine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "gelsemicine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "gelsemine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "gelseminine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "gelseverine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "geniposide"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "geniposidic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "genistein"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "gentiopicroside"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "geraniin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "geraniol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "ginkgetin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "ginkgo biloba ginkgolides"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Ginkgolide A"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Ginkgolide B"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Ginkgolide C"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "ginkgolide j"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Ginsenoside RB1"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Ginsenoside Rd"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Ginsenoside Re"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Ginsenoside Rf"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Ginsenoside RG1"
+    "compoundName": "Ginsenoside Rg1"
   },
   {
     "canonicalCompoundId": "",
@@ -957,971 +117,15 @@
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "ginsenosides including rb1"
+    "compoundName": "Asiaticoside"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "ginsenosides rb1"
+    "compoundName": "Madecassoside"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "gitoxin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "glycyrrhizin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "gomisin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "gomisin a"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "grindelic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "gurmarin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "guvacine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "guvacoline"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "gypenosides dammarane-type saponins"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "harpagoside"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "helenalin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "hericenone c"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "hericenones"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "hesperidin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "hibiscus acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "hinokiflavone"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "humulone"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "hydrastine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "hydroxy-alpha-sanshool"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "hydroxy-beta-sanshool"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "hydroxycitric acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "hydroxytyrosol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "hydroxytyrosol acetate"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Hyperforin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Hypericin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Icariin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Icaritin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "imperatorin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "indirubin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "inotodiol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "inulin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "iodine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "iridin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "isocorypalmine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "isofebrifugine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Isoferulic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "isoflavones genistein"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "isomenthone"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "isomitraphylline"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "isosilybin a"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "isosilybin b"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "isosilychristin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "isovaltrate"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "jatamansone"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "jatrorrhizine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "juglone"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "jujuboside a"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "kahweol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "kava kavalactones"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "kotalanol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "kudinlactone"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "kurarinone"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "kutkoside"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "l-phenylalanine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "l-tyrosine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "lapachol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "ledol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "ligustilide"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "linoleic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "lithospermic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "lobelanidine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "lobeline"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "loganin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "lsa"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "lsd ergoline derivative"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "lupulone"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "lycopene"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "lycopodine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "lycorine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "macaenes"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "macamides"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "madecassic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "madecassoside"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "mahanimbine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "mangiferin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "matrine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "menthofuran"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "mescaline derivative"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "mesembranol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "miroestrol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "mitrajavine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "mitraphylline"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "mogroside v"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "mogrosides"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "moringin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "morroniside"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "myo-inositol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "myrcene"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "myrtenyl acetate"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "n-acetyl-l-tyrosine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "n-acetylcysteine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "n-dimethylhistamine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "n-dimethyltryptamine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "n-methylasimilobine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "n-monomethylhistamine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "neoquassin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "neral"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "neriine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "niacin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Nicotinic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "nigellone"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "nimbin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "nordihydrocapsaicin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "norephedrine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "notoginsenoside r1"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "oleandrin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "ophiopogonin d"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "osthole"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "oxyacanthine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "oxyberberine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "oxymatrine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "pachymic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "paeoniflorin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "palmatine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "palustrol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "panduratin a"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "papain"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "parthenolide"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "pectin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "pellucidin a"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "peruvoside"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "pfaffic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "phosphatidylserine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Phyllanthin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "picrocrocin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "pinene"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "pinostrobin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Piperine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "podophyllotoxin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "polygodial"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "polypeptide-p"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "pristimerin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "procyanidin b2"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "protoanemonin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "protopine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "pseudohypericin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "psilocin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "psilocybin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "psk"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "puerarin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Punarnavine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "punicalagins"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "pyridoxine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "quadrangularin a"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "quassin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "quebrachine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "rb2"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "reserpine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "rhodiola salidroside rosavin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "rhodiosin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "riboflavin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "ricin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "ricinoleic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "roemerine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Rosarin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Rosavin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Rosin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "rosiridin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "rutaecarpine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "s-adenosyl-l-methionine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "s-allyl-cysteine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "safranal"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "saikosaponin a"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "salacinol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "salicin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "salicylic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Salidroside"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Salvianolic acid B"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "salvinorin a"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "sambunigrin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "sanguinarine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "saponins hederacoside"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "sarsaponin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "schisandrin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "sciadopitysin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "scopadulcic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "scoparin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "sempervirine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "serpentine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "silica"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "silybin a"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "silybin b"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "silychristin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "silydianin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "silymarin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "silymarin silibinin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "sinigrin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "sitoindoside ix"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "sitoindoside x"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "skimmianine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "solamargine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "sulforaphane"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "swertiamarin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "synephrine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "tangshenoside i"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Tanshinone IIA"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "taraxasterol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "taspine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "taurine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "tenuifolin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "tephrosin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "terpinen-4-ol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "terpinyl acetate"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "tetrahydropalmatine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "tetramethylpyrazine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "tetrandrine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Theanine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "thevetin a"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "thevetin b"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "thymoquinone"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "timosaponin aiii"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "tocopherols"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "trans-cinnamoylcocaine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "trans-tiliroside"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "triandrin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "trigonelline"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "triketones leptospermone"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "tropacocaine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "tryptamine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "tryptanthrin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "turmerone"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "tussilagone"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "tylophorine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "Tyrosol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "umckalin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "unresolved herb level entry"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "uridine monophosphate"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "uscharin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "usnic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "valeranone"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "valerenal"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "valerenol"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "valerian valerenic acid"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "valtrate"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "vanillin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "vicine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "vincamine"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "viscotoxin"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "vitamin c"
-  },
-  {
-    "canonicalCompoundId": "",
-    "compoundName": "vitexin"
+    "compoundName": "Bacoside A"
   },
   {
     "canonicalCompoundId": "",
@@ -1933,54 +137,622 @@
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "withanolide d"
+    "compoundName": "Piperlongumine"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "withanolides withaferin a"
+    "compoundName": "Naringenin"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "withanone"
+    "compoundName": "Naringin"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "Withanoside IV"
+    "compoundName": "Epicatechin"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "Withanoside V"
+    "compoundName": "Epigallocatechin gallate (EGCG)"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "Wogonoside"
+    "compoundName": "Theaflavin"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "xanthoangelol"
+    "compoundName": "Thearubigin"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "xanthohumol"
+    "compoundName": "Pterostilbene"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "xanthotoxol"
+    "compoundName": "Genistein"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "xanthumin"
+    "compoundName": "Daidzein"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "zerumbone"
+    "compoundName": "Formononetin"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "zinc"
+    "compoundName": "Biochanin A"
   },
   {
     "canonicalCompoundId": "",
-    "compoundName": "zingerone"
+    "compoundName": "Osthole"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Imperatorin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Isoimperatorin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Psoralen"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Angelicin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Bergapten"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Esculetin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Fraxetin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Daphnetin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Matrine"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Oxymatrine"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Tetrandrine"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Cepharanthine"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Magnoflorine"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Ligustilide"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Senkyunolide A"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Butylidenephthalide"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Xanthotoxin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Acetyl-beta-boswellic acid"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "11-keto-beta-boswellic acid"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Acetyl-11-keto-beta-boswellic acid"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Valerenol"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Kavalactones"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Valepotriates"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Hyperforin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Hypericin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Aucubin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Catalpol"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Harpagoside"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Loganin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Morroniside"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Oleocanthal"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Oleacein"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Rosavin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Rosarin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Rosin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Salidroside"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Tyrosol"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Echinacoside"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Acteoside"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Forskolin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Bacoside B"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Glycyrrhetinic acid"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Shikonin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Acetylshikonin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Plumbagin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Lawsone"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Embelin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Artemisinin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Artesunate"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Artemisinin B"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Astragaloside IV"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Calycosin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Puerarin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Daidzin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Ononin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Mangiferin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Mangostin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Alpha-mangostin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Garcinol"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Curcumol"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Curdione"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Demethoxycurcumin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Bisdemethoxycurcumin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Paeoniflorin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Albiflorin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Paeonol"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Timosaponin AIII"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Mangiferin aglycone"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Lobeline"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Huperzine B"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Anatabine"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Beta-caryophyllene"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Caryophyllene oxide"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Nerolidol"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Bisabolol"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Atractylenolide I"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Atractylenolide II"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Atractylenolide III"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Beta-elemene"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Asiatic acid"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Madecassic acid"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Gymnemagenin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Gurmarin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Corosolic acid"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Lagerstroemin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Mulberroside A"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Oxyresveratrol"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Morin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Deoxyelephantopin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Elephantopin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Guggulsterone"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Commipheric acid"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Beta-sitosterol"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "Stigmasterol"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "ajoene"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "acemannan"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "aescin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "aspalathin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "bacopaside II"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "berbamine"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "betulinic acid"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "bilobetin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "cafestol"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "chicoric acid"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "citronellal"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "coptisine"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "deoxymiroestrol"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "desmethoxyyangonin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "dihydrokavain"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "dihydromethysticin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "erinacines"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "hericenones"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "indirubin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "kahweol"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "kotalanol"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "arjunolic acid"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "columbin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "cryptotanshinone"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "galangin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "ginkgolide B"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "honokiol"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "magnolol"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "piperine"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "safranal"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "theanine"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "cinnamaldehyde"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "trigonelline"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "withanoside IV"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "schisandrin B"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "eleutheroside B"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "eleutheroside E"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "punicalagin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "carnosol"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "glucomoringin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "anethole"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "silybin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "silychristin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "silydianin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "epigallocatechin"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "epicatechin gallate"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "epigallocatechin gallate"
+  },
+  {
+    "canonicalCompoundId": "",
+    "compoundName": "gallocatechin"
   }
 ]

--- a/reports/workbook-unmatched-herbs.json
+++ b/reports/workbook-unmatched-herbs.json
@@ -1,457 +1,782 @@
 [
   {
-    "slug": "",
-    "name": "Angelica Root",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Anise Hyssop",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Artichoke",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Astragalus",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Atractylodes",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Bael",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Berberis",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Bitter Melon",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Boswellia",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Bupleurum",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Burdock",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Butterbur",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Cacao",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Calendula",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Cat's Claw",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Catuba",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Cayenne",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Chaga",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Chinese Skullcap",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Chuanxiong",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Cinnamon",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Coffee Cherry",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Coleus Forskohlii",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Coptis",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Cordyceps",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Corydalis",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Dandelion",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Danshen",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Dendrobium",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Dong Quai",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Elderberry",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Elecampane",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Eleuthero",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Epimedium",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Eucalyptus",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Fennel",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Fingerroot",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Galangal",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
+    "slug": "garlic",
     "name": "Garlic",
     "scientificName": ""
   },
   {
-    "slug": "",
-    "name": "Gastrodia",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Goldenseal",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Green Tea",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Guarana",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Gudmar",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Gymnema",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Hawthorn",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Holy Basil Purple",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Holy Basil Seed",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Honeysuckle",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Horse Chestnut",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Jatamansi",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Juniper",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Kudzu",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Lemon Verbena",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Lemongrass",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Licorice",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Marshmallow",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Milk Oats",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
+    "slug": "milk-thistle",
     "name": "Milk Thistle",
     "scientificName": ""
   },
   {
-    "slug": "",
-    "name": "Moringa",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Mucuna",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Neem",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Nettle Root",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Noni",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Oatstraw",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Oregano",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Papaya Leaf",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Perilla",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Phellodendron",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Polygala",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Pomegranate",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Poria",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Psyllium",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Punarnava",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Red Clover",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Reishi",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Rose Hips",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Roselle Seed",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Rosemary",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Saffron",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Sage",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Salacia",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
+    "slug": "saw-palmetto",
     "name": "Saw Palmetto",
     "scientificName": ""
   },
   {
-    "slug": "",
-    "name": "Schisandra",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Schisandra Berry",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Shatavari",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
-    "name": "Soursop",
-    "scientificName": ""
-  },
-  {
-    "slug": "",
+    "slug": "st-johns-wort",
     "name": "St Johns Wort",
     "scientificName": ""
   },
   {
-    "slug": "",
-    "name": "Tamarind",
+    "slug": "kudzu",
+    "name": "Kudzu",
     "scientificName": ""
   },
   {
-    "slug": "",
+    "slug": "butterbur",
+    "name": "Butterbur",
+    "scientificName": ""
+  },
+  {
+    "slug": "dong-quai",
+    "name": "Dong Quai",
+    "scientificName": ""
+  },
+  {
+    "slug": "rosemary",
+    "name": "Rosemary",
+    "scientificName": ""
+  },
+  {
+    "slug": "sage",
+    "name": "Sage",
+    "scientificName": ""
+  },
+  {
+    "slug": "thyme",
     "name": "Thyme",
     "scientificName": ""
   },
   {
-    "slug": "",
-    "name": "Yerba Mate",
+    "slug": "oregano",
+    "name": "Oregano",
+    "scientificName": ""
+  },
+  {
+    "slug": "eucalyptus",
+    "name": "Eucalyptus",
+    "scientificName": ""
+  },
+  {
+    "slug": "artichoke",
+    "name": "Artichoke",
+    "scientificName": ""
+  },
+  {
+    "slug": "fennel",
+    "name": "Fennel",
+    "scientificName": ""
+  },
+  {
+    "slug": "cinnamon",
+    "name": "Cinnamon",
+    "scientificName": ""
+  },
+  {
+    "slug": "dandelion",
+    "name": "Dandelion",
+    "scientificName": ""
+  },
+  {
+    "slug": "burdock",
+    "name": "Burdock",
+    "scientificName": ""
+  },
+  {
+    "slug": "red-clover",
+    "name": "Red Clover",
+    "scientificName": ""
+  },
+  {
+    "slug": "oatstraw",
+    "name": "Oatstraw",
+    "scientificName": ""
+  },
+  {
+    "slug": "calendula",
+    "name": "Calendula",
+    "scientificName": ""
+  },
+  {
+    "slug": "gymnema",
+    "name": "Gymnema",
+    "scientificName": ""
+  },
+  {
+    "slug": "neem",
+    "name": "Neem",
+    "scientificName": ""
+  },
+  {
+    "slug": "lemon-verbena",
+    "name": "Lemon Verbena",
+    "scientificName": ""
+  },
+  {
+    "slug": "milk-oats",
+    "name": "Milk Oats",
+    "scientificName": ""
+  },
+  {
+    "slug": "pomegranate",
+    "name": "Pomegranate",
+    "scientificName": ""
+  },
+  {
+    "slug": "moringa",
+    "name": "Moringa",
+    "scientificName": ""
+  },
+  {
+    "slug": "noni",
+    "name": "Noni",
+    "scientificName": ""
+  },
+  {
+    "slug": "rose-hips",
+    "name": "Rose Hips",
+    "scientificName": ""
+  },
+  {
+    "slug": "juniper",
+    "name": "Juniper",
+    "scientificName": ""
+  },
+  {
+    "slug": "jatamansi",
+    "name": "Jatamansi",
+    "scientificName": ""
+  },
+  {
+    "slug": "soursop",
+    "name": "Soursop",
+    "scientificName": ""
+  },
+  {
+    "slug": "lemongrass",
+    "name": "Lemongrass",
+    "scientificName": ""
+  },
+  {
+    "slug": "perilla",
+    "name": "Perilla",
+    "scientificName": ""
+  },
+  {
+    "slug": "danshen",
+    "name": "Danshen",
+    "scientificName": ""
+  },
+  {
+    "slug": "polygala",
+    "name": "Polygala",
+    "scientificName": ""
+  },
+  {
+    "slug": "gastrodia",
+    "name": "Gastrodia",
+    "scientificName": ""
+  },
+  {
+    "slug": "bupleurum",
+    "name": "Bupleurum",
+    "scientificName": ""
+  },
+  {
+    "slug": "dendrobium",
+    "name": "Dendrobium",
+    "scientificName": ""
+  },
+  {
+    "slug": "atractylodes",
+    "name": "Atractylodes",
+    "scientificName": ""
+  },
+  {
+    "slug": "schisandra-berry",
+    "name": "Schisandra Berry",
+    "scientificName": ""
+  },
+  {
+    "slug": "catuba",
+    "name": "Catuba",
+    "scientificName": ""
+  },
+  {
+    "slug": "poria",
+    "name": "Poria",
+    "scientificName": ""
+  },
+  {
+    "slug": "elecampane",
+    "name": "Elecampane",
+    "scientificName": ""
+  },
+  {
+    "slug": "angelica-root",
+    "name": "Angelica Root",
+    "scientificName": ""
+  },
+  {
+    "slug": "galangal",
+    "name": "Galangal",
+    "scientificName": ""
+  },
+  {
+    "slug": "holy-basil-seed",
+    "name": "Holy Basil Seed",
+    "scientificName": ""
+  },
+  {
+    "slug": "psyllium",
+    "name": "Psyllium",
+    "scientificName": ""
+  },
+  {
+    "slug": "holy-basil-purple",
+    "name": "Holy Basil Purple",
+    "scientificName": ""
+  },
+  {
+    "slug": "gudmar",
+    "name": "Gudmar",
+    "scientificName": ""
+  },
+  {
+    "slug": "roselle-seed",
+    "name": "Roselle Seed",
+    "scientificName": ""
+  },
+  {
+    "slug": "tamarind",
+    "name": "Tamarind",
+    "scientificName": ""
+  },
+  {
+    "slug": "cordyceps",
+    "name": "Cordyceps",
+    "scientificName": ""
+  },
+  {
+    "slug": "eleuthero",
+    "name": "Eleuthero",
+    "scientificName": ""
+  },
+  {
+    "slug": "schisandra",
+    "name": "Schisandra",
+    "scientificName": ""
+  },
+  {
+    "slug": "reishi",
+    "name": "Reishi",
+    "scientificName": ""
+  },
+  {
+    "slug": "chaga",
+    "name": "Chaga",
+    "scientificName": ""
+  },
+  {
+    "slug": "boswellia",
+    "name": "Boswellia",
+    "scientificName": ""
+  },
+  {
+    "slug": "hawthorn",
+    "name": "Hawthorn",
+    "scientificName": ""
+  },
+  {
+    "slug": "astragalus",
+    "name": "Astragalus",
+    "scientificName": ""
+  },
+  {
+    "slug": "nettle-root",
+    "name": "Nettle Root",
+    "scientificName": ""
+  },
+  {
+    "slug": "mucuna",
+    "name": "Mucuna",
+    "scientificName": ""
+  },
+  {
+    "slug": "epimedium",
+    "name": "Epimedium",
+    "scientificName": ""
+  },
+  {
+    "slug": "shatavari",
+    "name": "Shatavari",
+    "scientificName": ""
+  },
+  {
+    "slug": "cacao",
+    "name": "Cacao",
+    "scientificName": ""
+  },
+  {
+    "slug": "cat-s-claw",
+    "name": "Cat's Claw",
+    "scientificName": ""
+  },
+  {
+    "slug": "berberis",
+    "name": "Berberis",
+    "scientificName": ""
+  },
+  {
+    "slug": "bitter-melon",
+    "name": "Bitter Melon",
+    "scientificName": ""
+  },
+  {
+    "slug": "coleus-forskohlii",
+    "name": "Coleus Forskohlii",
+    "scientificName": ""
+  },
+  {
+    "slug": "cayenne",
+    "name": "Cayenne",
+    "scientificName": ""
+  },
+  {
+    "slug": "corydalis",
+    "name": "Corydalis",
+    "scientificName": ""
+  },
+  {
+    "slug": "chinese-skullcap",
+    "name": "Chinese Skullcap",
+    "scientificName": ""
+  },
+  {
+    "slug": "phellodendron",
+    "name": "Phellodendron",
+    "scientificName": ""
+  },
+  {
+    "slug": "coptis",
+    "name": "Coptis",
+    "scientificName": ""
+  },
+  {
+    "slug": "saffron",
+    "name": "Saffron",
+    "scientificName": ""
+  },
+  {
+    "slug": "papaya-leaf",
+    "name": "Papaya Leaf",
+    "scientificName": ""
+  },
+  {
+    "slug": "green-tea",
+    "name": "Green Tea",
+    "scientificName": ""
+  },
+  {
+    "slug": "goldenseal",
+    "name": "Goldenseal",
+    "scientificName": ""
+  },
+  {
+    "slug": "salacia",
+    "name": "Salacia",
+    "scientificName": ""
+  },
+  {
+    "slug": "chuanxiong",
+    "name": "Chuanxiong",
+    "scientificName": ""
+  },
+  {
+    "slug": "fingerroot",
+    "name": "Fingerroot",
+    "scientificName": ""
+  },
+  {
+    "slug": "horse-chestnut",
+    "name": "Horse Chestnut",
+    "scientificName": ""
+  },
+  {
+    "slug": "bael",
+    "name": "Bael",
+    "scientificName": ""
+  },
+  {
+    "slug": "honeysuckle",
+    "name": "Honeysuckle",
+    "scientificName": ""
+  },
+  {
+    "slug": "anise-hyssop",
+    "name": "Anise Hyssop",
+    "scientificName": ""
+  },
+  {
+    "slug": "marshmallow",
+    "name": "Marshmallow",
+    "scientificName": ""
+  },
+  {
+    "slug": "licorice",
+    "name": "Licorice",
+    "scientificName": ""
+  },
+  {
+    "slug": "elderberry",
+    "name": "Elderberry",
+    "scientificName": ""
+  },
+  {
+    "slug": "punarnava",
+    "name": "Punarnava",
+    "scientificName": ""
+  },
+  {
+    "slug": "coffee-cherry",
+    "name": "Coffee Cherry",
+    "scientificName": ""
+  },
+  {
+    "slug": "capsicum-frutescens",
+    "name": "Capsicum frutescens",
+    "scientificName": ""
+  },
+  {
+    "slug": "boswellia-carterii",
+    "name": "Boswellia carterii",
+    "scientificName": ""
+  },
+  {
+    "slug": "epimedium-brevicornum",
+    "name": "Epimedium brevicornum",
+    "scientificName": ""
+  },
+  {
+    "slug": "piper-longum",
+    "name": "Piper longum",
+    "scientificName": ""
+  },
+  {
+    "slug": "brassica-oleracea",
+    "name": "Brassica oleracea",
+    "scientificName": ""
+  },
+  {
+    "slug": "brassica-juncea",
+    "name": "Brassica juncea",
+    "scientificName": ""
+  },
+  {
+    "slug": "black-seed",
+    "name": "Black Seed",
+    "scientificName": ""
+  },
+  {
+    "slug": "olive-leaf",
+    "name": "Olive Leaf",
+    "scientificName": ""
+  },
+  {
+    "slug": "japanese-knotweed",
+    "name": "Japanese Knotweed",
+    "scientificName": ""
+  },
+  {
+    "slug": "thunder-god-vine",
+    "name": "Thunder God Vine",
+    "scientificName": ""
+  },
+  {
+    "slug": "clove",
+    "name": "Clove",
+    "scientificName": ""
+  },
+  {
+    "slug": "orange-peel",
+    "name": "Orange Peel",
+    "scientificName": ""
+  },
+  {
+    "slug": "olea-europaea",
+    "name": "Olea europaea",
+    "scientificName": ""
+  },
+  {
+    "slug": "tripterygium-wilfordii",
+    "name": "Tripterygium wilfordii",
+    "scientificName": ""
+  },
+  {
+    "slug": "citrus-sinensis",
+    "name": "Citrus sinensis",
+    "scientificName": ""
+  },
+  {
+    "slug": "andrographis-paniculata",
+    "name": "Andrographis paniculata",
+    "scientificName": ""
+  },
+  {
+    "slug": "fenugreek",
+    "name": "Fenugreek",
+    "scientificName": ""
+  },
+  {
+    "slug": "wild-yam",
+    "name": "Wild Yam",
+    "scientificName": ""
+  },
+  {
+    "slug": "tribulus-terrestris",
+    "name": "Tribulus terrestris",
+    "scientificName": ""
+  },
+  {
+    "slug": "bayberry",
+    "name": "Bayberry",
+    "scientificName": ""
+  },
+  {
+    "slug": "parsley",
+    "name": "Parsley",
+    "scientificName": ""
+  },
+  {
+    "slug": "grapefruit",
+    "name": "Grapefruit",
+    "scientificName": ""
+  },
+  {
+    "slug": "buckwheat",
+    "name": "Buckwheat",
+    "scientificName": ""
+  },
+  {
+    "slug": "black-tea",
+    "name": "Black Tea",
+    "scientificName": ""
+  },
+  {
+    "slug": "grape",
+    "name": "Grape",
+    "scientificName": ""
+  },
+  {
+    "slug": "blueberry",
+    "name": "Blueberry",
+    "scientificName": ""
+  },
+  {
+    "slug": "soybean",
+    "name": "Soybean",
+    "scientificName": ""
+  },
+  {
+    "slug": "raspberry-leaf",
+    "name": "Raspberry Leaf",
+    "scientificName": ""
+  },
+  {
+    "slug": "rice-bran",
+    "name": "Rice Bran",
+    "scientificName": ""
+  },
+  {
+    "slug": "angelica-pubescens",
+    "name": "Angelica pubescens",
+    "scientificName": ""
+  },
+  {
+    "slug": "angelica-dahurica",
+    "name": "Angelica dahurica",
+    "scientificName": ""
+  },
+  {
+    "slug": "psoralea-corylifolia",
+    "name": "Psoralea corylifolia",
+    "scientificName": ""
+  },
+  {
+    "slug": "ficus-carica",
+    "name": "Ficus carica",
+    "scientificName": ""
+  },
+  {
+    "slug": "citrus-bergamia",
+    "name": "Citrus bergamia",
+    "scientificName": ""
+  },
+  {
+    "slug": "artemisia-capillaris",
+    "name": "Artemisia capillaris",
+    "scientificName": ""
+  },
+  {
+    "slug": "fraxinus-rhynchophylla",
+    "name": "Fraxinus rhynchophylla",
+    "scientificName": ""
+  },
+  {
+    "slug": "coriandrum-sativum",
+    "name": "Coriandrum sativum",
+    "scientificName": ""
+  },
+  {
+    "slug": "daphne-odora",
+    "name": "Daphne odora",
+    "scientificName": ""
+  },
+  {
+    "slug": "stellera-chamaejasme",
+    "name": "Stellera chamaejasme",
+    "scientificName": ""
+  },
+  {
+    "slug": "sophora-alopecuroides",
+    "name": "Sophora alopecuroides",
+    "scientificName": ""
+  },
+  {
+    "slug": "cyclea-peltata",
+    "name": "Cyclea peltata",
+    "scientificName": ""
+  },
+  {
+    "slug": "stephania-japonica",
+    "name": "Stephania japonica",
+    "scientificName": ""
+  },
+  {
+    "slug": "pastinaca-sativa",
+    "name": "Pastinaca sativa",
+    "scientificName": ""
+  },
+  {
+    "slug": "rehmannia-glutinosa",
+    "name": "Rehmannia glutinosa",
+    "scientificName": ""
+  },
+  {
+    "slug": "cistanche-deserticola",
+    "name": "Cistanche deserticola",
+    "scientificName": ""
+  },
+  {
+    "slug": "plantago-lanceolata",
+    "name": "Plantago lanceolata",
+    "scientificName": ""
+  },
+  {
+    "slug": "coleus-forskohlii",
+    "name": "Coleus forskohlii",
+    "scientificName": ""
+  },
+  {
+    "slug": "lithospermum-erythrorhizon",
+    "name": "Lithospermum erythrorhizon",
+    "scientificName": ""
+  },
+  {
+    "slug": "plumbago-zeylanica",
+    "name": "Plumbago zeylanica",
+    "scientificName": ""
+  },
+  {
+    "slug": "lawsonia-inermis",
+    "name": "Lawsonia inermis",
+    "scientificName": ""
+  },
+  {
+    "slug": "embelia-ribes",
+    "name": "Embelia ribes",
+    "scientificName": ""
+  },
+  {
+    "slug": "pueraria-lobata",
+    "name": "Pueraria lobata",
+    "scientificName": ""
+  },
+  {
+    "slug": "mangifera-indica",
+    "name": "Mangifera indica",
+    "scientificName": ""
+  },
+  {
+    "slug": "garcinia-mangostana",
+    "name": "Garcinia mangostana",
+    "scientificName": ""
+  },
+  {
+    "slug": "garcinia-indica",
+    "name": "Garcinia indica",
+    "scientificName": ""
+  },
+  {
+    "slug": "curcuma-zedoaria",
+    "name": "Curcuma zedoaria",
+    "scientificName": ""
+  },
+  {
+    "slug": "paeonia-lactiflora",
+    "name": "Paeonia lactiflora",
+    "scientificName": ""
+  },
+  {
+    "slug": "paeonia-suffruticosa",
+    "name": "Paeonia suffruticosa",
+    "scientificName": ""
+  },
+  {
+    "slug": "nicotiana-glauca",
+    "name": "Nicotiana glauca",
+    "scientificName": ""
+  },
+  {
+    "slug": "piper-nigrum",
+    "name": "Piper nigrum",
+    "scientificName": ""
+  },
+  {
+    "slug": "curcuma-wenyujin",
+    "name": "Curcuma wenyujin",
+    "scientificName": ""
+  },
+  {
+    "slug": "ocotea-odorifera",
+    "name": "Ocotea odorifera",
+    "scientificName": ""
+  },
+  {
+    "slug": "ocimum-basilicum",
+    "name": "Ocimum basilicum",
+    "scientificName": ""
+  },
+  {
+    "slug": "lagerstroemia-speciosa",
+    "name": "Lagerstroemia speciosa",
+    "scientificName": ""
+  },
+  {
+    "slug": "morus-alba",
+    "name": "Morus alba",
+    "scientificName": ""
+  },
+  {
+    "slug": "elephantopus-scaber",
+    "name": "Elephantopus scaber",
+    "scientificName": ""
+  },
+  {
+    "slug": "commiphora-mukul",
+    "name": "Commiphora mukul",
     "scientificName": ""
   }
 ]


### PR DESCRIPTION
### Motivation
- Refresh workbook-derived JSON and re-run the monograph import to bring `public/data/` and unmatched reports up to date after updating the source workbook.
- Ensure the canonical herb/compound identity mapping and aggregated `herbs.json` / `compounds.json` reflect the latest workbook rows.

### Description
- Re-ran the workbook export and monograph import which updated `public/data/workbook-herbs.json`, `public/data/workbook-compounds.json`, `public/data/workbook-herb-compound-map.json`, `public/data/herbs.json`, and `public/data/compounds.json` and wrote unmatched reports under `reports/`.
- The run produced merged/enriched changes to compound and herb entries (many record updates and additions) and normalized mapping entries in the herb<->compound map.
- Commit created with message `Run workbook export/import integration refresh` includes the updated `public/data/` JSON outputs and `reports/workbook-unmatched-{herbs,compounds}.json`.

### Testing
- Commands executed: `node scripts/export-workbook-to-json.mjs`, `node scripts/import-xlsx-monographs.mjs`, and a verification check via `node -e "..."` to confirm output file presence and row counts; all commands exited with status `0`.
- Exported rows: `workbook-herbs.json` 285, `workbook-compounds.json` 235, `workbook-herb-compound-map.json` 360; Import/read counts: herbs 290, compounds 235, herb-compound-map 654.
- Verification of output files: `public/data/workbook-herbs.json` (OK, 285), `public/data/workbook-compounds.json` (OK, 235), `public/data/workbook-herb-compound-map.json` (OK, 360), `public/data/herbs.json` (OK, 849), and `public/data/compounds.json` (OK, 407); unmatched counts: herbs 156, compounds 189.
- Hard failures: none; both scripts completed successfully and produced unmatched reports at `reports/workbook-unmatched-herbs.json` and `reports/workbook-unmatched-compounds.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e54126083c83238eb1909741fe3882)