### PR TITLE
Refine featured herb cards with specific summaries and mechanism chips

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,10 @@
 import { Link } from 'react-router-dom'
 import Meta from '../components/Meta'
 import { organizationJsonLd, websiteJsonLd } from '@/lib/seo'
+import herbsData from '../../public/data/herbs.json'
+import type { HerbRecord } from '@/types/herb'
+import { sanitizeSummaryText } from '@/lib/sanitize'
+import { sanitizeRenderChips } from '@/lib/renderGuard'
 
 const FEATURED_HERBS = [
   'Curcuma longa',
@@ -36,6 +40,32 @@ const TRUST_ITEMS = ['Evidence-linked entries', 'Safety framing on every profile
 
 function encodedQuery(name: string) {
   return encodeURIComponent(name)
+}
+
+const HERB_FALLBACK_SUMMARY = 'Science-first herbal reference profile.'
+
+const herbLookup = new Map(
+  (herbsData as HerbRecord[]).map(herb => [String(herb.name || '').trim().toLowerCase(), herb] as const),
+)
+
+function truncateCardLine(value: string, maxLength = 110) {
+  if (value.length <= maxLength) return value
+  return `${value.slice(0, maxLength).replace(/\s+\S*$/, '').trim()}…`
+}
+
+function buildHerbSummary(herb: HerbRecord | undefined) {
+  const preferred = sanitizeSummaryText(herb?.summary, 1)
+  if (preferred) return truncateCardLine(preferred)
+
+  const fallbackDescription = sanitizeSummaryText(herb?.description, 1)
+  if (fallbackDescription) return truncateCardLine(fallbackDescription)
+
+  return HERB_FALLBACK_SUMMARY
+}
+
+function buildMechanismChips(herb: HerbRecord | undefined) {
+  const chips = sanitizeRenderChips([herb?.mechanismTags, herb?.mechanisms], 4)
+  return chips.filter(chip => chip.length >= 3 && chip.length <= 28).slice(0, 2)
 }
 
 export default function Home() {
@@ -100,12 +130,34 @@ export default function Home() {
           </Link>
         </div>
         <div className='grid gap-3 sm:grid-cols-2 lg:grid-cols-3'>
-          {FEATURED_HERBS.map(name => (
-            <Link key={name} to={`/herbs?query=${encodedQuery(name)}`} className='premium-panel p-4 transition-colors hover:border-white/20'>
-              <h3 className='text-base font-semibold text-white'>{name}</h3>
-              <p className='mt-2 text-sm text-white/73'>Open profile and review mechanism, confidence, and safety details.</p>
-            </Link>
-          ))}
+          {FEATURED_HERBS.map(name => {
+            const herb = herbLookup.get(name.toLowerCase())
+            const summary = buildHerbSummary(herb)
+            const mechanismChips = buildMechanismChips(herb)
+
+            return (
+              <Link
+                key={name}
+                to={`/herbs?query=${encodedQuery(name)}`}
+                className='premium-panel p-4 transition-colors hover:border-white/20'
+              >
+                <h3 className='text-base font-semibold text-white'>{name}</h3>
+                <p className='mt-2 text-sm text-white/73'>{summary}</p>
+                {mechanismChips.length > 0 ? (
+                  <div className='mt-2 flex flex-wrap gap-1.5'>
+                    {mechanismChips.map(chip => (
+                      <span
+                        key={`${name}-${chip}`}
+                        className='rounded-full border border-white/15 bg-white/5 px-2 py-0.5 text-[11px] font-medium text-white/74'
+                      >
+                        {chip}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+              </Link>
+            )
+          })}
         </div>
       </section>
 


### PR DESCRIPTION
### Motivation
- Replace the repeated generic placeholder on homepage featured herb cards with concise, herb-specific one-line summaries to improve perceived specificity and trustworthiness.
- Prefer existing canonical summary fields but fall back to cleaned description or a brief safe fallback to avoid filler copy.
- Add a compact mechanism row when clean mechanism tags are available so cards signal mechanistic context without overwhelming the layout.

### Description
- Updated homepage featured herb rendering in `src/pages/Home.tsx` to import `public/data/herbs.json` and look up matching herb records to power card content.
- Implemented `buildHerbSummary` that prefers `herb.summary` (sanitized to a single sentence), falls back to cleaned/truncated `herb.description`, then uses the fallback `"Science-first herbal reference profile."` when no usable text exists, with word-safe truncation for mobile readability.
- Implemented `buildMechanismChips` that uses `sanitizeRenderChips` to produce cleaned mechanism/tag chips and renders up to 2 compact chips (filtered for readable lengths) beneath the summary when present.
- Removed the line "Open profile and review mechanism, confidence, and safety details." from herb cards and preserved the existing card spacing and structure, adding only a small `mt-2` chip row for readability.

### Testing
- Changed files: `src/pages/Home.tsx`.
- Commands run: `npm run build:compile` (includes full prebuild data generation) and pre-commit lint (`eslint --max-warnings=0`) ran on the staged file.
- Verification results: `vite build` / `npm run build:compile` completed successfully and the pre-commit lint check passed.

Risks / follow-ups: static import of `public/data/herbs.json` increases the `Home` bundle footprint and contributed to a larger Home chunk in the build, so consider switching to a lightweight summary payload or lazy loading if bundle size is a concern.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e58bf421d88323b93bdfecc291e7ca)