### PR TITLE
Fix regression: robust related-entity link resolution in HerbDetail

### DIFF
--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -28,6 +28,13 @@ function toTitleCase(value: string) {
     .replace(/\b\w/g, letter => letter.toUpperCase())
 }
 
+function normalizeEntityKey(value: unknown): string {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '')
+}
+
 function splitTextList(value: unknown): string[] {
   return normalizeTagList(value, { caseStyle: 'none', minLength: 1, maxItems: 50 })
 }
@@ -246,21 +253,43 @@ export default function HerbDetail() {
   ].filter(Boolean)
   const pagePath = `/herbs/${herb.slug}`
   const relatedHerbSlugs = splitTextList(herb.relatedHerbs)
+  const herbIndex = new Map<string, string>()
+  herbs.forEach(item => {
+    ;[item.slug, item.id, item.common, item.name, item.scientific, ...(item.aliases || [])].forEach(candidate => {
+      const key = normalizeEntityKey(candidate)
+      if (!key) return
+      herbIndex.set(key, item.slug)
+    })
+  })
+  const relatedHerbKeys = new Set(
+    relatedHerbSlugs
+      .map(entry => herbIndex.get(normalizeEntityKey(entry)) || normalizeEntityKey(entry))
+      .filter(Boolean),
+  )
   const relatedHerbs = herbs
-    .filter(item => item.slug && item.slug !== herb.slug && (relatedHerbSlugs.length === 0 || relatedHerbSlugs.includes(item.slug)))
+    .filter(item => item.slug && item.slug !== herb.slug)
+    .filter(item => relatedHerbKeys.size > 0 && relatedHerbKeys.has(normalizeEntityKey(item.slug)))
     .slice(0, 4)
     .map(item => ({
       label: toTitleCase(item.common || item.name || item.slug),
       to: `/herbs/${item.slug}`,
     }))
 
-  const compoundIndex = new Map(compounds.map(compound => [String(compound.name || '').toLowerCase(), compound]))
+  const compoundIndex = new Map<string, { label: string; slug: string }>()
+  compounds.forEach(compound => {
+    const label = toTitleCase(compound.name || compound.slug)
+    ;[compound.slug, compound.id, compound.name, ...(compound.aliases || [])].forEach(candidate => {
+      const key = normalizeEntityKey(candidate)
+      if (!key) return
+      compoundIndex.set(key, { label, slug: compound.slug })
+    })
+  })
   const relatedCompounds = [...activeCompounds, ...splitTextList(herb.relatedCompounds)]
-    .map(name => {
-      const match = compoundIndex.get(name.toLowerCase())
-      if (!match?.slug) return null
+    .map(entry => {
+      const match = compoundIndex.get(normalizeEntityKey(entry))
+      if (!match) return null
       return {
-        label: toTitleCase(match.name),
+        label: match.label,
         to: `/compounds/${match.slug}`,
       }
     })
@@ -343,7 +372,17 @@ export default function HerbDetail() {
           {activeCompounds.length > 0 ? (
             <ul className='list-disc space-y-1 pl-5'>
               {activeCompounds.map(compound => (
-                <li key={compound}>{compound}</li>
+                <li key={compound}>
+                  {(() => {
+                    const match = compoundIndex.get(normalizeEntityKey(compound))
+                    if (!match) return compound
+                    return (
+                      <Link to={`/compounds/${match.slug}`} className='text-cyan-200 hover:text-cyan-100'>
+                        {match.label}
+                      </Link>
+                    )
+                  })()}
+                </li>
               ))}
             </ul>
           ) : (


### PR DESCRIPTION
### Motivation
- A regression made herb/compound related links brittle by matching only exact names, causing broken or missing /herbs/:slug and /compounds/:slug navigation for related items.
- The intent is a minimal regression fix preserving existing route contracts and not adding new features, by normalizing lookups and avoiding broken hrefs.

### Description
- Restored robust link resolution in `HerbDetail` by adding a normalized key helper `normalizeEntityKey` and building lookup indexes for herbs and compounds to match slugs, ids, names, and aliases. (changed: `src/pages/HerbDetail.tsx`)
- Related herb matching now resolves canonical herb slugs (using the herb index) instead of relying on exact raw text matches. (changed: `src/pages/HerbDetail.tsx`)
- Compound lookup was reworked to populate a compound index keyed by normalized slug/id/name/aliases and related compounds are built from that index. (changed: `src/pages/HerbDetail.tsx`)
- Active compound list rendering now links only when a valid compound slug is found and otherwise renders plain text to avoid broken hrefs. (changed: `src/pages/HerbDetail.tsx`)

### Testing
- Regenerated entity payloads and site assets with `node scripts/generate-entity-payloads.mjs` and a full build run via `npm run build:compile`, both completed successfully. (passed)
- Performed data/link spot checks (scripted lookups) for representative rows: `ashwagandha`, `ginkgo biloba`, `curcuma longa`, `berberine`, and `quercetin`; results: herb detail pages exist for `ashwagandha` and `ginkgo biloba`, compound detail exists for `quercetin`, while `curcuma longa` and `berberine` are not present in the current canonical summary snapshot so they cannot resolve in this dataset state. (observed)
- Verified prerender/route manifest and structured-data smoke after the build; prerender and verification scripts completed with no failures. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e58d6313e48323a1d9dbb3adc273e1)