### PR TITLE
Ensure Cloudflare Pages catch-all is last in dist/_redirects

### DIFF
--- a/scripts/ensure-dist-redirects.mjs
+++ b/scripts/ensure-dist-redirects.mjs
@@ -42,23 +42,25 @@ async function appendEntityAliasRedirects() {
   }
 
   const existing = await readFile(target, 'utf8')
-  const existingLines = new Set(
-    existing
-      .split(/\r?\n/)
-      .map(line => line.trim())
-      .filter(Boolean)
-  )
+  const catchAllRule = '/* /index.html 200'
+  const existingRules = existing
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean)
+  const existingLines = new Set(existingRules)
 
   const rulesToAppend = aliasRules.filter(rule => !existingLines.has(rule))
-  if (rulesToAppend.length === 0) {
-    console.log('[ensure-dist-redirects] alias redirects already present')
-    return
-  }
+  const baseRules = existingRules.filter(
+    line => !/^\/\*\s+\/index\.html\s+200$/.test(line)
+  )
 
-  const separator = existing.endsWith('\n') ? '' : '\n'
-  const appended = `${existing}${separator}${rulesToAppend.join('\n')}\n`
-  await writeFile(target, appended, 'utf8')
-  console.log(`[ensure-dist-redirects] appended ${rulesToAppend.length} entity alias redirects`)
+  const updatedRules = [...baseRules, ...rulesToAppend, catchAllRule]
+  await writeFile(target, `${updatedRules.join('\n')}\n`, 'utf8')
+  if (rulesToAppend.length === 0) {
+    console.log('[ensure-dist-redirects] alias redirects already present; normalized catch-all ordering')
+  } else {
+    console.log(`[ensure-dist-redirects] appended ${rulesToAppend.length} entity alias redirects`)
+  }
 }
 
 await ensureBaseRedirects()

--- a/scripts/verify-redirects.mjs
+++ b/scripts/verify-redirects.mjs
@@ -1,14 +1,54 @@
-  import fs from "fs";
-  import path from "path";
-  const out = path.resolve("dist", "_redirects");
-  if (!fs.existsSync(out)) {
-    console.error("[verify-redirects] MISSING dist/_redirects — SPA deep links will 404.");
-    process.exit(1);
-  }
-  const txt = fs.readFileSync(out, "utf-8");
-  console.log("[verify-redirects] dist/_redirects present:\n---\n" + txt + "\n---");
-  if (!txt.includes("/index.html") || !txt.includes("200")) {
-    console.error("[verify-redirects] Rule looks wrong; expected: `/*  /index.html  200`");
-    process.exit(1);
-  }
-  console.log("[verify-redirects] OK");
+import fs from 'node:fs'
+import path from 'node:path'
+
+const out = path.resolve('dist', '_redirects')
+if (!fs.existsSync(out)) {
+  console.error('[verify-redirects] MISSING dist/_redirects — SPA deep links will 404.')
+  process.exit(1)
+}
+
+const txt = fs.readFileSync(out, 'utf-8')
+const lines = txt
+  .split(/\r?\n/)
+  .map(line => line.trim())
+  .filter(Boolean)
+
+console.log('[verify-redirects] dist/_redirects present:\n---\n' + txt + '\n---')
+
+const catchAllRule = '/* /index.html 200'
+const catchAllIndexes = lines
+  .map((line, idx) => (line === catchAllRule ? idx : -1))
+  .filter(idx => idx >= 0)
+
+if (catchAllIndexes.length !== 1) {
+  console.error(`[verify-redirects] Expected exactly one catch-all rule "${catchAllRule}"`)
+  process.exit(1)
+}
+
+const catchAllIndex = catchAllIndexes[0]
+if (catchAllIndex !== lines.length - 1) {
+  console.error('[verify-redirects] Catch-all rule must be the final line in dist/_redirects')
+  process.exit(1)
+}
+
+const atomIndex = lines.indexOf('/atom.xml /feed.xml 301')
+if (atomIndex < 0) {
+  console.error('[verify-redirects] Missing required atom.xml redirect')
+  process.exit(1)
+}
+if (atomIndex > catchAllIndex) {
+  console.error('[verify-redirects] /atom.xml redirect must appear before the catch-all rule')
+  process.exit(1)
+}
+
+const aliasAfterCatchAll = lines.find((line, idx) => {
+  const isAlias = /^\/(herbs|compounds)\//.test(line) && /\s301$/.test(line)
+  return isAlias && idx > catchAllIndex
+})
+
+if (aliasAfterCatchAll) {
+  console.error(`[verify-redirects] Alias redirect appears after catch-all: ${aliasAfterCatchAll}`)
+  process.exit(1)
+}
+
+console.log('[verify-redirects] OK')


### PR DESCRIPTION
### Motivation
- The SPA catch-all rule `/* /index.html 200` in `dist/_redirects` could appear before exact redirects (including herb/compound aliases), causing aliases to be shadowed by the catch-all and breaking alias redirects.
- The goal is to guarantee exact redirects (including `/atom.xml /feed.xml 301` and entity alias redirects) appear before a single final catch-all rule.

### Description
- Updated `scripts/ensure-dist-redirects.mjs` to read existing `dist/_redirects`, remove any existing catch-all occurrences, and rewrite rules so all exact redirects (base rules + entity alias redirects) are preserved before appending a single `/* /index.html 200` final rule.
- Adjusted logging so the script reports when alias redirects already existed and when ordering normalization was applied or new alias redirects were appended.
- Replaced and strengthened `scripts/verify-redirects.mjs` to assert that `dist/_redirects` exists, that the catch-all appears exactly once and is the last line, that `/atom.xml /feed.xml 301` appears before the catch-all, and that no herb/compound alias redirects appear after the catch-all.
- Kept change minimal and local to redirect generation and verification logic without altering other build or deploy steps.

### Testing
- Ran `mkdir -p dist && node scripts/ensure-dist-redirects.mjs && npm run verify:redirects` and the verification completed successfully with `dist/_redirects` showing `/atom.xml /feed.xml 301` and all herb/compound alias redirects before a single final `/* /index.html 200`.
- Verified pre-commit hooks/lint ran during commit and passed when committing the changes to the two modified files: `scripts/ensure-dist-redirects.mjs` and `scripts/verify-redirects.mjs`.
- Files changed: `scripts/ensure-dist-redirects.mjs`, `scripts/verify-redirects.mjs` and commit message was `Fix dist redirects ordering to keep catch-all last`.
- Automated `verify:redirects` returned OK (no failures) for the generated `dist/_redirects`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e59333a82c8323880befc4f0895265)