### PR TITLE
Add postbuild dist/version.json generator for deploy verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prebuild": "node scripts/sync-updated-datasets.mjs && npm run clean:source-refs && node scripts/dedupe-entities.mjs && node scripts/quality-gate-data.mjs && node scripts/generate-publication-index.mjs && node scripts/generate-indexable-herbs.mjs && node scripts/generate-indexable-compounds.mjs && node scripts/generate-entity-payloads.mjs && node scripts/generate-site-counts.mjs && node scripts/generate-homepage-data.mjs && node scripts/generate-rss.mjs && npm run verify:affiliate-products",
     "build:compile": "vite build",
     "build": "npm run build:compile",
-    "postbuild": "node scripts/prerender-static.mjs && node scripts/generate-sitemap.mjs dist && node scripts/ensure-dist-redirects.mjs && npm run verify:enrichment-editorial && node scripts/verify-prerender.mjs && node scripts/verify-publishing.mjs && node scripts/validate-structured-data-smoke.mjs",
+    "postbuild": "node scripts/prerender-static.mjs && node scripts/generate-sitemap.mjs dist && node scripts/ensure-dist-redirects.mjs && npm run verify:enrichment-editorial && node scripts/verify-prerender.mjs && node scripts/verify-publishing.mjs && node scripts/validate-structured-data-smoke.mjs && node scripts/generate-version-json.mjs",
     "verify:build": "npm run verify:enrichment-editorial && npm run verify:enrichment-discovery && npm run verify:prerender && npm run verify:publishing && npm run verify:structured-data && npm run verify:redirects",
     "sitemap": "node scripts/generate-sitemap.mjs dist",
     "build:blog": "node scripts/build-blog.mjs",

--- a/scripts/generate-version-json.mjs
+++ b/scripts/generate-version-json.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+import { execSync } from 'node:child_process'
+
+const ROOT = process.cwd()
+const DIST = path.join(ROOT, 'dist')
+const VERSION_PATH = path.join(DIST, 'version.json')
+const SITEMAP_PATH = path.join(DIST, 'sitemap.xml')
+
+function findPrerenderedRoutes() {
+  const routes = []
+
+  function walk(dir) {
+    const entries = fs.readdirSync(dir, { withFileTypes: true })
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        walk(fullPath)
+        continue
+      }
+      if (!entry.isFile() || entry.name !== 'index.html') continue
+
+      const relative = path.relative(DIST, fullPath).replace(/\\/g, '/')
+      const routePath = `/${relative.replace(/\/index\.html$/u, '').replace(/^index$/u, '')}`
+      routes.push(routePath === '/' ? routePath : routePath.replace(/\/+$/u, ''))
+    }
+  }
+
+  walk(DIST)
+  return routes.sort((a, b) => a.localeCompare(b))
+}
+
+function countSitemapUrls() {
+  if (!fs.existsSync(SITEMAP_PATH)) return 0
+  const xml = fs.readFileSync(SITEMAP_PATH, 'utf8')
+  return (xml.match(/<loc>/g) || []).length
+}
+
+function resolveCommitSha() {
+  const envSha = process.env.GITHUB_SHA || process.env.CF_PAGES_COMMIT_SHA || process.env.COMMIT_SHA
+  if (typeof envSha === 'string' && envSha.trim().length > 0) return envSha.trim()
+
+  try {
+    return execSync('git rev-parse HEAD', { cwd: ROOT, stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim() || null
+  } catch {
+    return null
+  }
+}
+
+function main() {
+  if (!fs.existsSync(DIST)) {
+    console.error('[version] dist/ is missing. Run build + postbuild first.')
+    process.exit(1)
+  }
+
+  const routes = findPrerenderedRoutes()
+  const payload = {
+    commitSha: resolveCommitSha(),
+    buildTimestampIso: new Date().toISOString(),
+    herbRouteCount: routes.filter(route => route.startsWith('/herbs/')).length,
+    compoundRouteCount: routes.filter(route => route.startsWith('/compounds/')).length,
+    blogRouteCount: routes.filter(route => route === '/blog' || route.startsWith('/blog/')).length,
+    sitemapUrlCount: countSitemapUrls(),
+    totalPrerenderedHtmlRouteCount: routes.length,
+  }
+
+  fs.mkdirSync(DIST, { recursive: true })
+  fs.writeFileSync(VERSION_PATH, `${JSON.stringify(payload, null, 2)}\n`, 'utf8')
+  console.log(`[version] wrote ${path.relative(ROOT, VERSION_PATH)}`)
+}
+
+main()


### PR DESCRIPTION
### Motivation
- Provide a small, build-time artifact `dist/version.json` that teams and CI can use to verify the deploy corresponds to a specific build and has the expected prerendered surface counts.

### Description
- Add `scripts/generate-version-json.mjs` which walks `dist/**/index.html` and reads `dist/sitemap.xml` to compute `herbRouteCount`, `compoundRouteCount`, `blogRouteCount`, `sitemapUrlCount`, and `totalPrerenderedHtmlRouteCount`, and resolves a `commitSha` (from env fallbacks or `git rev-parse HEAD`) and `buildTimestampIso`, then writes pretty JSON to `dist/version.json`.
- Wire the generator into the existing `postbuild` pipeline by appending `node scripts/generate-version-json.mjs` in `package.json` so `npm run build` produces `dist/version.json`.
- Changed files: `scripts/generate-version-json.mjs` (new) and `package.json` (postbuild script updated).

### Testing
- Commands executed: `npm run build` (full prebuild + build + postbuild), `npm run build:compile && node scripts/prerender-static.mjs && node scripts/generate-sitemap.mjs dist && node scripts/generate-version-json.mjs`, and `node -e "JSON.parse(require('fs').readFileSync('dist/version.json','utf8'))"` to validate JSON parsing.
- Results: all commands completed successfully and `dist/version.json` was written and parsed as valid, human-readable JSON containing the required fields.
- Risks / follow-ups: `npm run build` triggers heavy prebuild data refresh steps that can modify many tracked files (these unrelated changes were discarded before committing); route counts are derived from `dist` path prefixes and `sitemap.xml` so they will reflect actual artifacts but may diverge if prerender routing conventions change; no production runtime dependency was added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e59440f258832399d8003f8f355cf2)