### PR TITLE
Add postbuild guard for publication route count regressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "prebuild": "node scripts/sync-updated-datasets.mjs && npm run clean:source-refs && node scripts/dedupe-entities.mjs && node scripts/quality-gate-data.mjs && node scripts/generate-publication-index.mjs && node scripts/generate-indexable-herbs.mjs && node scripts/generate-indexable-compounds.mjs && node scripts/generate-entity-payloads.mjs && node scripts/generate-site-counts.mjs && node scripts/generate-homepage-data.mjs && node scripts/generate-rss.mjs && npm run verify:affiliate-products",
     "build:compile": "vite build",
     "build": "npm run build:compile",
-    "postbuild": "node scripts/prerender-static.mjs && node scripts/generate-sitemap.mjs dist && node scripts/ensure-dist-redirects.mjs && npm run verify:enrichment-editorial && node scripts/verify-prerender.mjs && node scripts/verify-publishing.mjs && node scripts/validate-structured-data-smoke.mjs && node scripts/generate-version-json.mjs",
+    "postbuild": "node scripts/prerender-static.mjs && node scripts/generate-sitemap.mjs dist && node scripts/assert-publication-counts.mjs && node scripts/ensure-dist-redirects.mjs && npm run verify:enrichment-editorial && node scripts/verify-prerender.mjs && node scripts/verify-publishing.mjs && node scripts/validate-structured-data-smoke.mjs && node scripts/generate-version-json.mjs",
     "verify:build": "npm run verify:enrichment-editorial && npm run verify:enrichment-discovery && npm run verify:prerender && npm run verify:publishing && npm run verify:structured-data && npm run verify:redirects",
     "sitemap": "node scripts/generate-sitemap.mjs dist",
     "build:blog": "node scripts/build-blog.mjs",

--- a/scripts/assert-publication-counts.mjs
+++ b/scripts/assert-publication-counts.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+
+const ROOT = process.cwd()
+const DIST = path.join(ROOT, 'dist')
+
+const DEFAULTS = {
+  herbs: 4,
+  compounds: 150,
+  blogPosts: 10,
+  sitemapUrls: 200,
+}
+
+function intFromEnv(name, fallback) {
+  const raw = process.env[name]
+  if (raw == null || raw.trim() === '') return fallback
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    console.error(`[publication-counts] Invalid ${name}=${raw}. Expected a non-negative integer.`)
+    process.exit(1)
+  }
+  return parsed
+}
+
+function collectRoutesFromDist() {
+  if (!fs.existsSync(DIST)) {
+    console.error('[publication-counts] dist/ is missing. Run build + postbuild first.')
+    process.exit(1)
+  }
+
+  const routes = []
+  const stack = [DIST]
+  while (stack.length > 0) {
+    const next = stack.pop()
+    const entries = fs.readdirSync(next, { withFileTypes: true })
+    for (const entry of entries) {
+      const fullPath = path.join(next, entry.name)
+      if (entry.isDirectory()) {
+        stack.push(fullPath)
+      } else if (entry.isFile() && entry.name.toLowerCase() === 'index.html') {
+        const relPath = path.relative(DIST, fullPath).replace(/\\/g, '/')
+        const route = relPath === 'index.html' ? '/' : `/${relPath.replace(/\/index\.html$/, '')}`
+        routes.push(route)
+      }
+    }
+  }
+
+  return routes
+}
+
+function countSitemapUrls() {
+  const sitemapPath = path.join(DIST, 'sitemap.xml')
+  if (!fs.existsSync(sitemapPath)) {
+    console.error('[publication-counts] dist/sitemap.xml is missing. Run sitemap generation first.')
+    process.exit(1)
+  }
+  const xml = fs.readFileSync(sitemapPath, 'utf8')
+  return (xml.match(/<loc>/g) || []).length
+}
+
+function main() {
+  const minimums = {
+    herbs: intFromEnv('MIN_HERB_ROUTES', DEFAULTS.herbs),
+    compounds: intFromEnv('MIN_COMPOUND_ROUTES', DEFAULTS.compounds),
+    blogPosts: intFromEnv('MIN_BLOG_POST_ROUTES', DEFAULTS.blogPosts),
+    sitemapUrls: intFromEnv('MIN_SITEMAP_URLS', DEFAULTS.sitemapUrls),
+  }
+
+  const routes = collectRoutesFromDist()
+  const counts = {
+    herbs: routes.filter(route => /^\/herbs\/[^/]+$/.test(route)).length,
+    compounds: routes.filter(route => /^\/compounds\/[^/]+$/.test(route)).length,
+    blogPosts: routes.filter(route => /^\/blog\/[^/]+$/.test(route)).length,
+    sitemapUrls: countSitemapUrls(),
+  }
+
+  console.log('[publication-counts] Observed vs minimum thresholds:')
+  console.log(` - herb routes: ${counts.herbs} (min ${minimums.herbs})`)
+  console.log(` - compound routes: ${counts.compounds} (min ${minimums.compounds})`)
+  console.log(` - blog post routes: ${counts.blogPosts} (min ${minimums.blogPosts})`)
+  console.log(` - sitemap URLs: ${counts.sitemapUrls} (min ${minimums.sitemapUrls})`)
+
+  const failures = Object.entries(minimums).flatMap(([key, min]) => {
+    const actual = counts[key]
+    return actual < min ? [`${key}: ${actual} < ${min}`] : []
+  })
+
+  if (failures.length > 0) {
+    console.error('[publication-counts] FAIL threshold regression detected:')
+    failures.forEach(failure => console.error(` - ${failure}`))
+    process.exit(1)
+  }
+
+  console.log('[publication-counts] PASS publication route counts are above configured minimums.')
+}
+
+main()


### PR DESCRIPTION
### Motivation
- Prevent accidental large drops in published routes by asserting built output meets conservative minimums before a deploy step.

### Description
- Added `scripts/assert-publication-counts.mjs`, a small node script that scans `dist/` for prerendered `index.html` files and counts detail routes and sitemap `<loc>` entries.
- The script enforces conservative defaults and environment-variable overrides for thresholds: `MIN_HERB_ROUTES` (default `4`), `MIN_COMPOUND_ROUTES` (default `150`), `MIN_BLOG_POST_ROUTES` (default `10`), and `MIN_SITEMAP_URLS` (default `200`).
- The script prints observed counts alongside configured minimums and exits nonzero if any threshold fails.
- Wired the check into the `postbuild` script in `package.json` to run immediately after sitemap generation.
- Files changed: `scripts/assert-publication-counts.mjs`, `package.json`.

### Testing
- Ran `npm run build`, which completed successfully and exercised the new postbuild check (observed counts met thresholds). (PASS)
- Executed the script directly with `node scripts/assert-publication-counts.mjs`, which printed counts and returned success. (PASS)
- No automated unit tests were added; the change is a small CLI guard integrated into the existing build flow. (N/A)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e62348dc648323b05c07d0baa69ab8)