### PR TITLE
Add herbs/compounds content-quality audit script

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "report:ops": "npm run data:report && npm run report:entity-route-payloads",
     "audit:data": "tsx scripts/validate-datasets.ts",
     "audit:blog-content": "node scripts/audit-blog-content.mjs",
+    "audit:content": "node scripts/audit-content-quality.mjs",
     "data:refresh": "npm run prebuild:data && npm run autofill:data && npm run data:validate",
     "data:refresh+build": "npm run data:refresh && npm run build",
     "data:merge": "node scripts/merge-herbs.mjs",

--- a/scripts/audit-content-quality.mjs
+++ b/scripts/audit-content-quality.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+
+const ROOT = process.cwd()
+const HERBS_FILE = path.join(ROOT, 'public/data/herbs.json')
+const COMPOUNDS_FILE = path.join(ROOT, 'public/data/compounds.json')
+const HERBS_DETAIL_DIR = path.join(ROOT, 'public/data/herbs-detail')
+const COMPOUNDS_DETAIL_DIR = path.join(ROOT, 'public/data/compounds-detail')
+
+const PLACEHOLDERS = ['nan', 'No direct effects data', 'Contextual inference']
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+}
+
+function readJsonFiles(dirPath) {
+  if (!fs.existsSync(dirPath)) return []
+
+  return fs
+    .readdirSync(dirPath)
+    .filter(name => name.endsWith('.json'))
+    .sort()
+    .map(name => {
+      const fullPath = path.join(dirPath, name)
+      return {
+        filePath: fullPath,
+        data: readJson(fullPath),
+      }
+    })
+}
+
+function findDuplicateSlugsInCollection(entities, label) {
+  const slugToLocations = new Map()
+
+  for (const entity of entities) {
+    if (typeof entity.slug !== 'string' || !entity.slug.trim()) continue
+    const slug = entity.slug.trim()
+    if (!slugToLocations.has(slug)) slugToLocations.set(slug, [])
+    slugToLocations.get(slug).push(entity.location)
+  }
+
+  return [...slugToLocations.entries()]
+    .filter(([, locations]) => locations.length > 1)
+    .map(([slug, locations]) => ({ slug, locations, label }))
+    .sort((a, b) => a.slug.localeCompare(b.slug))
+}
+
+function hasPlaceholder(value, placeholder) {
+  if (typeof value === 'string') {
+    if (placeholder === 'nan') return value.trim().toLowerCase() === 'nan'
+    return value.includes(placeholder)
+  }
+
+  if (Array.isArray(value)) return value.some(item => hasPlaceholder(item, placeholder))
+  if (value && typeof value === 'object') return Object.values(value).some(item => hasPlaceholder(item, placeholder))
+
+  return false
+}
+
+function countRecordsWithPlaceholder(records, placeholder) {
+  return records.reduce((count, record) => count + (hasPlaceholder(record.data, placeholder) ? 1 : 0), 0)
+}
+
+function isBlankText(value) {
+  return typeof value !== 'string' || value.trim() === ''
+}
+
+function normalizeSources(value) {
+  if (Array.isArray(value)) return value.filter(Boolean)
+  return []
+}
+
+function main() {
+  const herbs = readJson(HERBS_FILE)
+  const compounds = readJson(COMPOUNDS_FILE)
+  const herbsDetail = readJsonFiles(HERBS_DETAIL_DIR)
+  const compoundsDetail = readJsonFiles(COMPOUNDS_DETAIL_DIR)
+
+  const duplicateSlugGroups = [
+    ...findDuplicateSlugsInCollection(
+      herbs.map((item, index) => ({ slug: item.slug, location: `public/data/herbs.json#${index}` })),
+      'herbs.json'
+    ),
+    ...findDuplicateSlugsInCollection(
+      compounds.map((item, index) => ({ slug: item.slug, location: `public/data/compounds.json#${index}` })),
+      'compounds.json'
+    ),
+    ...findDuplicateSlugsInCollection(
+      herbsDetail.map(item => ({ slug: item.data?.slug, location: path.relative(ROOT, item.filePath) })),
+      'herbs-detail'
+    ),
+    ...findDuplicateSlugsInCollection(
+      compoundsDetail.map(item => ({ slug: item.data?.slug, location: path.relative(ROOT, item.filePath) })),
+      'compounds-detail'
+    ),
+  ]
+
+  const allRecords = [
+    { filePath: HERBS_FILE, data: herbs },
+    { filePath: COMPOUNDS_FILE, data: compounds },
+    ...herbsDetail,
+    ...compoundsDetail,
+  ]
+
+  const compoundsWithEmptySummary = compoundsDetail.filter(item => isBlankText(item.data?.summary))
+  const compoundsWithEmptyDescription = compoundsDetail.filter(item => isBlankText(item.data?.description))
+  const compoundsWithZeroSources = compoundsDetail.filter(item => normalizeSources(item.data?.sources).length === 0)
+
+  console.log('[audit-content-quality] Herbs + compounds data quality report')
+  console.log(`- records scanned: ${allRecords.length}`)
+  console.log(`- duplicate slug groups: ${duplicateSlugGroups.length}`)
+  console.log(`- "nan": ${countRecordsWithPlaceholder(allRecords, PLACEHOLDERS[0])}`)
+  console.log(`- "No direct effects data": ${countRecordsWithPlaceholder(allRecords, PLACEHOLDERS[1])}`)
+  console.log(`- "Contextual inference": ${countRecordsWithPlaceholder(allRecords, PLACEHOLDERS[2])}`)
+  console.log(`- compounds with empty summary: ${compoundsWithEmptySummary.length}`)
+  console.log(`- compounds with empty description: ${compoundsWithEmptyDescription.length}`)
+  console.log(`- compounds with zero sources: ${compoundsWithZeroSources.length}`)
+
+  if (duplicateSlugGroups.length > 0) {
+    console.log('\nDuplicate slug samples:')
+    duplicateSlugGroups.slice(0, 10).forEach(entry => {
+      console.log(`- [${entry.label}] ${entry.slug} (${entry.locations.length} matches)`)
+    })
+    if (duplicateSlugGroups.length > 10) {
+      console.log(`- ...and ${duplicateSlugGroups.length - 10} more`)
+    }
+    process.exitCode = 1
+  }
+}
+
+main()


### PR DESCRIPTION
### Motivation
- Provide a small, read-only verification tool to surface common data-quality issues in herb and compound source files. 
- Detect duplicate slugs early (fail the audit) while reporting other placeholder/empty-value issues for triage. 

### Description
- Add `scripts/audit-content-quality.mjs` which scans `public/data/herbs.json`, `public/data/compounds.json`, `public/data/herbs-detail/*.json`, and `public/data/compounds-detail/*.json` for duplicate slugs, placeholder values (`"nan"`, `"No direct effects data"`, `"Contextual inference"`), empty compound `summary`/`description`, and compounds with zero `sources`.
- The script prints a concise count-based report and sample duplicate groups with file locations, and sets a non-zero exit code only when duplicate slug groups are found.
- Add an npm script `"audit:content": "node scripts/audit-content-quality.mjs"` to `package.json` to run the check via `npm run audit:content`.
- The change is read-only and does not rewrite or regenerate any data files.

### Testing
- Ran `npm run audit:content` which printed counts for records scanned, duplicate slug groups, placeholder matches, empty summaries/descriptions, and zero-source compounds, and exited non-zero due to existing duplicate slugs (expected behavior).
- Files changed: `scripts/audit-content-quality.mjs` (new) and `package.json` (npm script added).
- The audit printed duplicate slug samples and counts as validation that detection logic is working; exit status was non-zero because duplicates are present in the current dataset.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e62e13015483238b2e0579e6ec2b48)