### PR TITLE
Improve content-quality audit: prefer summary sources and add CLI overrides

### DIFF
--- a/scripts/audit-content-quality.mjs
+++ b/scripts/audit-content-quality.mjs
@@ -3,8 +3,8 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 const ROOT = process.cwd()
-const HERBS_FILE = path.join(ROOT, 'public/data/herbs.json')
-const COMPOUNDS_FILE = path.join(ROOT, 'public/data/compounds.json')
+const HERBS_FILE_CANDIDATES = ['public/data/herbs-summary.json', 'public/data/herbs.json']
+const COMPOUNDS_FILE_CANDIDATES = ['public/data/compounds-summary.json', 'public/data/compounds.json']
 const HERBS_DETAIL_DIR = path.join(ROOT, 'public/data/herbs-detail')
 const COMPOUNDS_DETAIL_DIR = path.join(ROOT, 'public/data/compounds-detail')
 
@@ -12,6 +12,25 @@ const PLACEHOLDERS = ['nan', 'No direct effects data', 'Contextual inference']
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+}
+
+function resolveFirstExistingFile(candidates) {
+  for (const relativePath of candidates) {
+    const absolutePath = path.join(ROOT, relativePath)
+    if (fs.existsSync(absolutePath)) {
+      return absolutePath
+    }
+  }
+  throw new Error(`Missing expected source file. Checked: ${candidates.join(', ')}`)
+}
+
+function parseArgs(argv) {
+  const args = { herbs: null, compounds: null }
+  for (const raw of argv.slice(2)) {
+    if (raw.startsWith('--herbs=')) args.herbs = raw.split('=')[1] || null
+    if (raw.startsWith('--compounds=')) args.compounds = raw.split('=')[1] || null
+  }
+  return args
 }
 
 function readJsonFiles(dirPath) {
@@ -72,19 +91,24 @@ function normalizeSources(value) {
 }
 
 function main() {
-  const herbs = readJson(HERBS_FILE)
-  const compounds = readJson(COMPOUNDS_FILE)
+  const args = parseArgs(process.argv)
+  const herbsFilePath = args.herbs ? path.resolve(ROOT, args.herbs) : resolveFirstExistingFile(HERBS_FILE_CANDIDATES)
+  const compoundsFilePath = args.compounds
+    ? path.resolve(ROOT, args.compounds)
+    : resolveFirstExistingFile(COMPOUNDS_FILE_CANDIDATES)
+  const herbs = readJson(herbsFilePath)
+  const compounds = readJson(compoundsFilePath)
   const herbsDetail = readJsonFiles(HERBS_DETAIL_DIR)
   const compoundsDetail = readJsonFiles(COMPOUNDS_DETAIL_DIR)
 
   const duplicateSlugGroups = [
     ...findDuplicateSlugsInCollection(
-      herbs.map((item, index) => ({ slug: item.slug, location: `public/data/herbs.json#${index}` })),
-      'herbs.json'
+      herbs.map((item, index) => ({ slug: item.slug, location: `${path.relative(ROOT, herbsFilePath)}#${index}` })),
+      path.basename(herbsFilePath)
     ),
     ...findDuplicateSlugsInCollection(
-      compounds.map((item, index) => ({ slug: item.slug, location: `public/data/compounds.json#${index}` })),
-      'compounds.json'
+      compounds.map((item, index) => ({ slug: item.slug, location: `${path.relative(ROOT, compoundsFilePath)}#${index}` })),
+      path.basename(compoundsFilePath)
     ),
     ...findDuplicateSlugsInCollection(
       herbsDetail.map(item => ({ slug: item.data?.slug, location: path.relative(ROOT, item.filePath) })),
@@ -97,8 +121,8 @@ function main() {
   ]
 
   const allRecords = [
-    { filePath: HERBS_FILE, data: herbs },
-    { filePath: COMPOUNDS_FILE, data: compounds },
+    { filePath: herbsFilePath, data: herbs },
+    { filePath: compoundsFilePath, data: compounds },
     ...herbsDetail,
     ...compoundsDetail,
   ]


### PR DESCRIPTION
### Motivation
- Provide a small, focused data-quality verification that scans the canonical source data for herbs and compounds for known placeholders, empty text, and missing sources. 
- Ensure the audit uses the preferred published summary datasets when present while still supporting legacy inputs and targeted local testing without rewriting generated files. 

### Description
- Updated `scripts/audit-content-quality.mjs` to prefer `public/data/herbs-summary.json` and `public/data/compounds-summary.json` and fall back to legacy `public/data/herbs.json` / `public/data/compounds.json` when needed. 
- Added simple CLI overrides `--herbs=...` and `--compounds=...` so CI or operators can pin an explicit input file for audits. 
- The script still scans `public/data/*-detail` files, reports counts for duplicates, `nan`, `No direct effects data`, `Contextual inference`, empty compound summaries/descriptions, and compounds with zero sources, and only sets a non-zero exit code when duplicate slugs are found. 
- Only one file was changed: `scripts/audit-content-quality.mjs`, with no generated data files rewritten. 

### Testing
- Ran `npm run audit:content` which printed counts for all categories and exited successfully (no duplicate slugs present). 
- Simulated a duplicate case by creating a temporary herbs file and running `node scripts/audit-content-quality.mjs --herbs=tmp-herbs-dup.json`, which printed duplicate samples and produced a non-zero exit code as expected. 
- Verified the `npm` script entry `"audit:content": "node scripts/audit-content-quality.mjs"` is present and unchanged; no other automated tests were run and the modifications passed linting during commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e62f22877483239b15c70df31e68e7)