### PR TITLE
Add publish-quality noindex gating for weak herb/compound pages

### DIFF
--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -43,6 +43,29 @@ function readJson(relativePath) {
   }
 }
 
+function hasPlaceholderText(value) {
+  const text = String(value || '').trim().toLowerCase()
+  if (!text) return false
+  return text === 'nan' || text.includes('no direct effects data') || text.includes('contextual inference')
+}
+
+function isPublishQualityIndexEntry(entry) {
+  if (!entry || typeof entry !== 'object') return false
+  const title = String(entry.title || entry.name || '').trim()
+  if (!title || hasPlaceholderText(title)) return false
+  if (hasPlaceholderText(entry.description)) return false
+
+  const sourceCount = Number(entry.sourceCountNormalized ?? entry.sourceCount ?? 0)
+  const reviewed = Boolean(
+    entry.reviewed ||
+      entry.reviewedAt ||
+      entry.lastReviewedAt ||
+      entry.publicationEligible === true,
+  )
+
+  return sourceCount >= 2 || reviewed
+}
+
 function normalizeDate(value) {
   if (!value) return null
   const date = new Date(value)
@@ -113,8 +136,20 @@ function buildSitemap() {
   const indexableCompounds = readJson('public/data/indexable-compounds.json')
 
   const blogEntries = getBlogEntries(readJson('public/blogdata/index.json'))
-  const herbRoutes = normalizeRoutes(indexableHerbs.map(getHerbSlug).filter(Boolean).map(slug => `/herbs/${slug}`))
-  const compoundRoutes = normalizeRoutes(indexableCompounds.map(getCompoundSlug).filter(Boolean).map(slug => `/compounds/${slug}`))
+  const herbRoutes = normalizeRoutes(
+    indexableHerbs
+      .filter(isPublishQualityIndexEntry)
+      .map(getHerbSlug)
+      .filter(Boolean)
+      .map(slug => `/herbs/${slug}`),
+  )
+  const compoundRoutes = normalizeRoutes(
+    indexableCompounds
+      .filter(isPublishQualityIndexEntry)
+      .map(getCompoundSlug)
+      .filter(Boolean)
+      .map(slug => `/compounds/${slug}`),
+  )
 
   const blockedRoutes = new Set(disallowedRoutes.map(route => normalizePathname(route)))
   const staticRoutes = normalizeRoutes(sitemapRoutes).filter(route => !blockedRoutes.has(route))

--- a/src/__tests__/publishQuality.test.ts
+++ b/src/__tests__/publishQuality.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { isPublishQualityDetailPage } from '@/lib/publishQuality'
+
+describe('isPublishQualityDetailPage', () => {
+  it('accepts pages with enough references and safety content', () => {
+    expect(
+      isPublishQualityDetailPage({
+        name: 'Valerian',
+        summary: 'Useful for sleep support.',
+        sources: [
+          { title: 'Study A', url: 'https://example.com/a' },
+          { title: 'Study B', url: 'https://example.com/b' },
+        ],
+        safety: ['May cause drowsiness'],
+      }),
+    ).toBe(true)
+  })
+
+  it('rejects placeholder copy', () => {
+    expect(
+      isPublishQualityDetailPage({
+        name: 'Valerian',
+        summary: 'Contextual inference only',
+        sources: ['https://example.com/a', 'https://example.com/b'],
+        safety: ['Use caution with sedatives'],
+      }),
+    ).toBe(false)
+  })
+
+  it('accepts reviewed pages with sparse sources', () => {
+    expect(
+      isPublishQualityDetailPage({
+        name: 'L-Theanine',
+        summary: 'A calming amino acid.',
+        sourceCount: 1,
+        reviewedMeta: { enrichedAndReviewed: true },
+        interactions: ['May enhance sedatives'],
+      }),
+    ).toBe(true)
+  })
+
+  it('rejects pages with missing safety details when safety fields are present', () => {
+    expect(
+      isPublishQualityDetailPage({
+        name: 'Kava',
+        summary: 'Traditional anxiolytic herb.',
+        sources: ['https://example.com/a', 'https://example.com/b'],
+        safety: 'nan',
+      }),
+    ).toBe(false)
+  })
+})

--- a/src/lib/publishQuality.ts
+++ b/src/lib/publishQuality.ts
@@ -1,0 +1,117 @@
+function toText(value: unknown): string {
+  return String(value ?? '').trim()
+}
+
+function hasPlaceholderText(value: unknown): boolean {
+  const text = toText(value).toLowerCase()
+  if (!text) return false
+  if (text === 'nan') return true
+  return text.includes('no direct effects data') || text.includes('contextual inference')
+}
+
+function toStringList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .flatMap(item => toStringList(item))
+      .map(item => item.trim())
+      .filter(Boolean)
+  }
+
+  if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>
+
+    if (typeof record.title === 'string' || typeof record.url === 'string') {
+      const parts = [toText(record.title), toText(record.url), toText(record.note)].filter(Boolean)
+      return parts.length > 0 ? [parts.join(' ')] : []
+    }
+
+    return Object.values(record)
+      .flatMap(item => toStringList(item))
+      .filter(Boolean)
+  }
+
+  if (typeof value === 'string') {
+    return value
+      .split(/[\n,;|]+/g)
+      .map(item => item.trim())
+      .filter(Boolean)
+  }
+
+  return []
+}
+
+function countReferences(value: unknown, fallback?: unknown): number {
+  const fromList = toStringList(value).filter(item => !hasPlaceholderText(item))
+  if (fromList.length > 0) return fromList.length
+
+  const fallbackNumber = Number(fallback)
+  if (Number.isFinite(fallbackNumber) && fallbackNumber > 0) {
+    return Math.round(fallbackNumber)
+  }
+
+  return 0
+}
+
+function hasReviewedFlag(value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false
+
+  const record = value as Record<string, unknown>
+  const reviewedSignals = [
+    record.reviewed,
+    record.reviewedAt,
+    record.lastReviewedAt,
+    record.enrichedAndReviewed,
+    record.publishable,
+  ]
+
+  return reviewedSignals.some(signal => {
+    if (typeof signal === 'boolean') return signal
+    if (typeof signal === 'string') return Boolean(signal.trim())
+    return false
+  })
+}
+
+export type PublishQualityInput = {
+  title?: unknown
+  name?: unknown
+  summary?: unknown
+  description?: unknown
+  sources?: unknown
+  sourceCount?: unknown
+  reviewed?: unknown
+  reviewedMeta?: unknown
+  safety?: unknown
+  contraindications?: unknown
+  interactions?: unknown
+}
+
+export function isPublishQualityDetailPage(input: PublishQualityInput): boolean {
+  const nameOrTitle = toText(input.title || input.name)
+  if (!nameOrTitle || hasPlaceholderText(nameOrTitle)) return false
+
+  const contentFields = [input.summary, input.description]
+  if (contentFields.some(hasPlaceholderText)) return false
+
+  const sourceCount = countReferences(input.sources, input.sourceCount)
+  const reviewed =
+    hasReviewedFlag(input.reviewed) ||
+    hasReviewedFlag(input.reviewedMeta)
+
+  if (sourceCount < 2 && !reviewed) return false
+
+  const safetyFields = [input.safety, input.contraindications, input.interactions]
+  const hasAnySafetyField = safetyFields.some(value => {
+    if (value == null) return false
+    if (Array.isArray(value)) return value.length > 0
+    if (typeof value === 'object') return Object.keys(value as Record<string, unknown>).length > 0
+    return toText(value).length > 0
+  })
+
+  if (!hasAnySafetyField) return true
+
+  const hasSafetyContent = safetyFields
+    .flatMap(value => toStringList(value))
+    .some(entry => !hasPlaceholderText(entry))
+
+  return hasSafetyContent
+}

--- a/src/pages/CompoundDetail.tsx
+++ b/src/pages/CompoundDetail.tsx
@@ -52,6 +52,7 @@ import { resolveGovernedCtaDecision } from '@/lib/governedCta'
 import { buildGovernedReviewFreshness } from '@/lib/governedReviewFreshness'
 import { shouldShowRawDebug } from '@/lib/semanticCompression'
 import { getProfileStatus, getSummaryQuality, shouldRenderSummary } from '@/lib/workbookRender'
+import { isPublishQualityDetailPage } from '@/lib/publishQuality'
 import {
   trackDetailBuilderClick,
   trackCtaSlotImpression,
@@ -507,6 +508,17 @@ export default function CompoundDetail() {
   )
   const pagePath = `/compounds/${compound.slug}`
   const breadcrumbId = `${SITE_URL}${pagePath}#breadcrumb`
+  const isPublishQuality = isPublishQualityDetailPage({
+    name,
+    summary: compoundDescription,
+    description: compoundMetaDescription,
+    sources: compound.sources,
+    sourceCount: compound.sourceCount,
+    reviewedMeta: compound.researchEnrichmentSummary,
+    safety: workbookSafety,
+    contraindications: compoundContraindications,
+    interactions: compoundInteractions,
+  })
 
   return (
     <main className='container mx-auto max-w-4xl px-4 py-8 text-white'>
@@ -514,6 +526,7 @@ export default function CompoundDetail() {
         title={compoundMetaTitle}
         description={compoundMetaDescription}
         path={pagePath}
+        noindex={!isPublishQuality}
         jsonLd={[
           compoundJsonLd({
             name,

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -12,6 +12,7 @@ import { HerbDetailSkeleton } from '@/components/skeletons/DetailSkeletons'
 import { SITE_URL, breadcrumbJsonLd, herbJsonLd } from '@/lib/seo'
 import { shouldShowRawDebug } from '@/lib/semanticCompression'
 import { getProfileStatus, getSummaryQuality, shouldRenderSummary } from '@/lib/workbookRender'
+import { isPublishQualityDetailPage } from '@/lib/publishQuality'
 
 type SourceRef = { title: string; url: string; note?: string }
 
@@ -252,6 +253,17 @@ export default function HerbDetail() {
     priorityWarning ? `Use caution: ${priorityWarning}.` : 'Avoid if safety context, medications, or medical status are unclear.',
   ].filter(Boolean)
   const pagePath = `/herbs/${herb.slug}`
+  const isPublishQuality = isPublishQualityDetailPage({
+    name: herbName,
+    summary: description,
+    description,
+    sources,
+    sourceCount: herb.sourceCount,
+    reviewedMeta: herb.researchEnrichmentSummary,
+    safety: safetyNotes,
+    contraindications,
+    interactions,
+  })
   const relatedHerbSlugs = splitTextList(herb.relatedHerbs)
   const herbIndex = new Map<string, string>()
   herbs.forEach(item => {
@@ -301,6 +313,7 @@ export default function HerbDetail() {
         title={`${herbName} Herb Guide | The Hippie Scientist`}
         description={`${herbName} effects, dosage context, safety notes, and sources.`}
         path={pagePath}
+        noindex={!isPublishQuality}
         image={`/og/herb/${herb.slug}.png`}
         jsonLd={[
           herbJsonLd({


### PR DESCRIPTION
### Motivation

- Prevent low-quality detail pages from being indexed while keeping them renderable for users by adding a small, testable publish-quality gate. 

### Description

- Added a reusable helper `isPublishQualityDetailPage` in `src/lib/publishQuality.ts` that enforces: has title/name, rejects obvious placeholder text (`nan`, `No direct effects data`, `Contextual inference`), requires ≥2 source/reference records or an explicit reviewed flag, and verifies safety/contraindication/interaction content when those fields are present. 
- Wire the helper into detail views so pages marked weak get `Meta` `noindex` via `noindex={!isPublishQuality}` in `src/pages/HerbDetail.tsx` and `src/pages/CompoundDetail.tsx`. 
- Filter sitemap emission with lightweight checks in `scripts/generate-sitemap.mjs` to exclude weak herb/compound entries from `sitemap.xml` where the indexable manifests are used. 
- Added focused unit tests for the helper at `src/__tests__/publishQuality.test.ts` and kept the helper isolated for easy testing.
- Files changed: `src/lib/publishQuality.ts`, `src/pages/HerbDetail.tsx`, `src/pages/CompoundDetail.tsx`, `scripts/generate-sitemap.mjs`, `src/__tests__/publishQuality.test.ts`.

### Testing

- Ran `node scripts/generate-sitemap.mjs dist` and the script completed successfully and wrote `dist/sitemap.xml` and `dist/robots.txt`. 
- Added unit tests and attempted to run `npx vitest run src/__tests__/publishQuality.test.ts`, but test execution failed in this environment due to missing project test dependency resolution (`vitest/config` not available); the test file is present and ready to run in CI or after installing dev deps. 
- Manual inspection verified that detail pages continue rendering unchanged and now pass `noindex` to the `Meta` component when the helper returns false.

Risks / follow-ups: ensure CI/dev environments install dev dependencies so `vitest` tests run; sitemap filtering uses fields in `public/data/indexable-*.json`, so final indexability alignment should be validated during a full data refresh if manifests change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e630b0f7d48323a18af6f6a5ba9475)