### PR TITLE
Use a lightweight homepage featured dataset instead of full herbs import

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "data:validate": "npm run validate:data",
     "check:images": "node tools/check-images.mjs",
     "rebuild:data": "npm run data:refresh",
-    "prebuild": "node scripts/sync-updated-datasets.mjs && npm run clean:source-refs && node scripts/dedupe-entities.mjs && node scripts/quality-gate-data.mjs && node scripts/generate-publication-index.mjs && node scripts/generate-indexable-herbs.mjs && node scripts/generate-indexable-compounds.mjs && node scripts/generate-entity-payloads.mjs && node scripts/generate-site-counts.mjs && node scripts/generate-homepage-data.mjs && node scripts/generate-rss.mjs && npm run verify:affiliate-products",
+    "prebuild": "node scripts/sync-updated-datasets.mjs && npm run clean:source-refs && node scripts/dedupe-entities.mjs && node scripts/quality-gate-data.mjs && node scripts/generate-publication-index.mjs && node scripts/generate-indexable-herbs.mjs && node scripts/generate-indexable-compounds.mjs && node scripts/generate-entity-payloads.mjs && node scripts/generate-site-counts.mjs && node scripts/generate-homepage-data.mjs && node scripts/generate-homepage-featured.mjs && node scripts/generate-rss.mjs && npm run verify:affiliate-products",
     "build:compile": "vite build",
     "build": "npm run build:compile",
     "postbuild": "node scripts/prerender-static.mjs && node scripts/generate-sitemap.mjs dist && node scripts/assert-publication-counts.mjs && node scripts/ensure-dist-redirects.mjs && npm run verify:enrichment-editorial && node scripts/verify-prerender.mjs && node scripts/verify-publishing.mjs && node scripts/validate-structured-data-smoke.mjs && node scripts/generate-version-json.mjs",

--- a/public/data/homepage-featured.json
+++ b/public/data/homepage-featured.json
@@ -1,0 +1,158 @@
+{
+  "generatedAt": "2026-04-20T14:08:55.504Z",
+  "herbs": [
+    {
+      "name": "Curcuma longa",
+      "slug": "curcuma-longa",
+      "summary": "Anti-inflammatory, antioxidant, liver protective. Herbs often act via neurotransmitter modulation,…",
+      "tags": []
+    },
+    {
+      "name": "Camellia sinensis",
+      "slug": "camellia-sinensis",
+      "summary": "Internal cross-linking supports Green Tea through compounds such as caffeine, theanine, catechins (egcg).",
+      "tags": [
+        "adenosine_antagonism",
+        "adora1"
+      ]
+    },
+    {
+      "name": "Withania somnifera",
+      "slug": "withania-somnifera",
+      "summary": "Adaptogen, anti-anxiety, cognitive enhancer. Herbs often act via neurotransmitter modulation, antioxidant…",
+      "tags": []
+    },
+    {
+      "name": "Panax ginseng",
+      "slug": "panax-ginseng",
+      "summary": "Adaptogen, energy booster, cognitive enhancer. Herbs often act via neurotransmitter modulation, antioxidant…",
+      "tags": [
+        "ampk"
+      ]
+    },
+    {
+      "name": "Ginkgo biloba",
+      "slug": "ginkgo-biloba",
+      "summary": "Ginkgo Biloba is represented here as a monograph-style entry centered on the leaf. Key reported compounds…",
+      "tags": [
+        "antioxidant",
+        "cholinergic"
+      ]
+    },
+    {
+      "name": "Rosmarinus officinalis",
+      "slug": "rosmarinus-officinalis",
+      "summary": "Cognitive support, antimicrobial, digestive aid. Herbs often act via neurotransmitter modulation, antioxidant…",
+      "tags": [
+        "antioxidant",
+        "cognition"
+      ]
+    },
+    {
+      "name": "Glycyrrhiza glabra",
+      "slug": "glycyrrhiza-glabra",
+      "summary": "Anti-inflammatory, expectorant, adrenal support. Herbs often act via neurotransmitter modulation, antioxidant…",
+      "tags": [
+        "general or unknown targets"
+      ]
+    },
+    {
+      "name": "Nigella sativa",
+      "slug": "nigella-sativa",
+      "summary": "Anti-inflammatory, antioxidant, immune modulating. Herbs often act via neurotransmitter modulation,…",
+      "tags": []
+    },
+    {
+      "name": "Centella asiatica",
+      "slug": "centella-asiatica",
+      "summary": "Centella asiatica contains Asiatic acid and is linked here to PI3K/Akt modulation.",
+      "tags": []
+    },
+    {
+      "name": "Zingiber officinale",
+      "slug": "zingiber-officinale",
+      "summary": "Digestive stimulant, anti-nausea, anti-inflammatory. Herbs often act via neurotransmitter modulation,…",
+      "tags": []
+    },
+    {
+      "name": "Silybum marianum",
+      "slug": "silybum-marianum",
+      "summary": "Milk Thistle is represented here as a monograph-style entry centered on the seed; fruit. Key reported…",
+      "tags": [
+        "antioxidant",
+        "hepatoprotection"
+      ]
+    },
+    {
+      "name": "Rhodiola rosea",
+      "slug": "rhodiola-rosea",
+      "summary": "Rhodiola Rosea is represented here as a monograph-style entry centered on the root. Key reported compounds…",
+      "tags": [
+        "adaptogen",
+        "antioxidant"
+      ]
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Curcumin",
+      "slug": "curcumin",
+      "summary": "Open profile and review mechanism, confidence, and safety details."
+    },
+    {
+      "name": "Epigallocatechin gallate",
+      "slug": "epigallocatechin-gallate",
+      "summary": "Open profile and review mechanism, confidence, and safety details."
+    },
+    {
+      "name": "Withaferin A",
+      "slug": "withaferin-a",
+      "summary": "Open profile and review mechanism, confidence, and safety details."
+    },
+    {
+      "name": "Ginsenoside Rg1",
+      "slug": "ginsenoside-rg1",
+      "summary": "Open profile and review mechanism, confidence, and safety details."
+    },
+    {
+      "name": "Ginkgolide B",
+      "slug": "ginkgolide-b",
+      "summary": "Open profile and review mechanism, confidence, and safety details."
+    },
+    {
+      "name": "Carnosic acid",
+      "slug": "carnosic-acid",
+      "summary": "Open profile and review mechanism, confidence, and safety details."
+    },
+    {
+      "name": "Glycyrrhizin",
+      "slug": "glycyrrhizin",
+      "summary": "Open profile and review mechanism, confidence, and safety details."
+    },
+    {
+      "name": "Thymoquinone",
+      "slug": "thymoquinone",
+      "summary": "Open profile and review mechanism, confidence, and safety details."
+    },
+    {
+      "name": "Asiatic acid",
+      "slug": "asiatic-acid",
+      "summary": "Open profile and review mechanism, confidence, and safety details."
+    },
+    {
+      "name": "Berberine",
+      "slug": "berberine",
+      "summary": "Open profile and review mechanism, confidence, and safety details."
+    },
+    {
+      "name": "Quercetin",
+      "slug": "quercetin",
+      "summary": "Plant flavonoid supplement with limited clinical efficacy and bioavailability constraints."
+    },
+    {
+      "name": "Resveratrol",
+      "slug": "resveratrol",
+      "summary": "Grape-derived polyphenol with speculative anti-aging/cardiometabolic claims and low bioavailability."
+    }
+  ]
+}

--- a/scripts/generate-homepage-featured.mjs
+++ b/scripts/generate-homepage-featured.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const herbsPath = path.join(root, 'public/data/herbs.json')
+const compoundsSummaryPath = path.join(root, 'public/data/compounds-summary.json')
+const outPath = path.join(root, 'public/data/homepage-featured.json')
+
+const FEATURED_HERBS = [
+  'Curcuma longa',
+  'Camellia sinensis',
+  'Withania somnifera',
+  'Panax ginseng',
+  'Ginkgo biloba',
+  'Rosmarinus officinalis',
+  'Glycyrrhiza glabra',
+  'Nigella sativa',
+  'Centella asiatica',
+  'Zingiber officinale',
+  'Silybum marianum',
+  'Rhodiola rosea',
+]
+
+const FEATURED_COMPOUNDS = [
+  'Curcumin',
+  'Epigallocatechin gallate',
+  'Withaferin A',
+  'Ginsenoside Rg1',
+  'Ginkgolide B',
+  'Carnosic acid',
+  'Glycyrrhizin',
+  'Thymoquinone',
+  'Asiatic acid',
+  'Berberine',
+  'Quercetin',
+  'Resveratrol',
+]
+
+const FALLBACK_SUMMARY = 'Open profile and review mechanism, confidence, and safety details.'
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+}
+
+function cleanText(value) {
+  return String(value || '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function truncateCardLine(value, maxLength = 110) {
+  if (value.length <= maxLength) return value
+  return `${value.slice(0, maxLength).replace(/\s+\S*$/, '').trim()}…`
+}
+
+function pickSummary(record, fallback = FALLBACK_SUMMARY) {
+  const summary = cleanText(record?.summary || record?.summaryShort || record?.description || record?.effectsSummary)
+  if (!summary) return fallback
+  const cleaned = cleanText(
+    summary
+      .replace(/\bNone\.\s*/gi, '')
+      .replace(/;\s*nan\b/gi, '')
+      .replace(/nan\b/gi, '')
+      .replace(/\.\s*\./g, '.'),
+  )
+  const lowered = cleaned.toLowerCase()
+  if (
+    cleaned.length < 20 ||
+    lowered === 'nan' ||
+    lowered.includes('no direct ') ||
+    lowered.includes('contextual inference') ||
+    lowered.includes('reported in .')
+  ) {
+    return fallback
+  }
+  return truncateCardLine(cleaned)
+}
+
+function splitTags(value) {
+  const raw = Array.isArray(value) ? value : cleanText(value).split(/[;,|\n]+/g)
+  return raw
+    .map(cleanText)
+    .filter(Boolean)
+    .filter(tag => tag.length >= 3 && tag.length <= 28)
+    .slice(0, 2)
+}
+
+function normalizeSlug(name) {
+  return cleanText(name)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+function buildHerbsPayload(herbs) {
+  const lookup = new Map(
+    (Array.isArray(herbs) ? herbs : []).map(row => [cleanText(row?.name).toLowerCase(), row]),
+  )
+
+  return FEATURED_HERBS.map(name => {
+    const record = lookup.get(name.toLowerCase()) || {}
+    return {
+      name,
+      slug: cleanText(record.slug) || normalizeSlug(name),
+      summary: pickSummary(record, 'Science-first herbal reference profile.'),
+      tags: splitTags(record.mechanismTags || record.mechanisms || record.tags),
+    }
+  })
+}
+
+function buildCompoundsPayload(compounds) {
+  const lookup = new Map(
+    (Array.isArray(compounds) ? compounds : []).map(row => [cleanText(row?.name).toLowerCase(), row]),
+  )
+
+  return FEATURED_COMPOUNDS.map(name => {
+    const record = lookup.get(name.toLowerCase()) || {}
+    return {
+      name,
+      slug: cleanText(record.slug) || normalizeSlug(name),
+      summary: pickSummary(record, FALLBACK_SUMMARY),
+    }
+  })
+}
+
+const herbs = readJson(herbsPath)
+const compounds = readJson(compoundsSummaryPath)
+
+const payload = {
+  generatedAt: new Date().toISOString(),
+  herbs: buildHerbsPayload(herbs),
+  compounds: buildCompoundsPayload(compounds),
+}
+
+fs.writeFileSync(outPath, `${JSON.stringify(payload, null, 2)}\n`)
+console.log(`Wrote ${path.relative(root, outPath)}`)

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,40 +1,7 @@
 import { Link } from 'react-router-dom'
 import Meta from '../components/Meta'
 import { organizationJsonLd, websiteJsonLd } from '@/lib/seo'
-import herbsData from '../../public/data/herbs.json'
-import type { HerbRecord } from '@/types/herb'
-import { sanitizeSummaryText } from '@/lib/sanitize'
-import { sanitizeRenderChips } from '@/lib/renderGuard'
-
-const FEATURED_HERBS = [
-  'Curcuma longa',
-  'Camellia sinensis',
-  'Withania somnifera',
-  'Panax ginseng',
-  'Ginkgo biloba',
-  'Rosmarinus officinalis',
-  'Glycyrrhiza glabra',
-  'Nigella sativa',
-  'Centella asiatica',
-  'Zingiber officinale',
-  'Silybum marianum',
-  'Rhodiola rosea',
-] as const
-
-const FEATURED_COMPOUNDS = [
-  'Curcumin',
-  'Epigallocatechin gallate',
-  'Withaferin A',
-  'Ginsenoside Rg1',
-  'Ginkgolide B',
-  'Carnosic acid',
-  'Glycyrrhizin',
-  'Thymoquinone',
-  'Asiatic acid',
-  'Berberine',
-  'Quercetin',
-  'Resveratrol',
-] as const
+import featuredData from '../../public/data/homepage-featured.json'
 
 const TRUST_ITEMS = ['Evidence-linked entries', 'Safety framing on every profile', 'Methods and assumptions published']
 
@@ -42,31 +9,15 @@ function encodedQuery(name: string) {
   return encodeURIComponent(name)
 }
 
-const HERB_FALLBACK_SUMMARY = 'Science-first herbal reference profile.'
-
-const herbLookup = new Map(
-  (herbsData as HerbRecord[]).map(herb => [String(herb.name || '').trim().toLowerCase(), herb] as const),
-)
-
-function truncateCardLine(value: string, maxLength = 110) {
-  if (value.length <= maxLength) return value
-  return `${value.slice(0, maxLength).replace(/\s+\S*$/, '').trim()}…`
+type HomeFeaturedItem = {
+  name: string
+  slug: string
+  summary: string
+  tags?: string[]
 }
 
-function buildHerbSummary(herb: HerbRecord | undefined) {
-  const preferred = sanitizeSummaryText(herb?.summary, 1)
-  if (preferred) return truncateCardLine(preferred)
-
-  const fallbackDescription = sanitizeSummaryText(herb?.description, 1)
-  if (fallbackDescription) return truncateCardLine(fallbackDescription)
-
-  return HERB_FALLBACK_SUMMARY
-}
-
-function buildMechanismChips(herb: HerbRecord | undefined) {
-  const chips = sanitizeRenderChips([herb?.mechanismTags, herb?.mechanisms], 4)
-  return chips.filter(chip => chip.length >= 3 && chip.length <= 28).slice(0, 2)
-}
+const featuredHerbs = ((featuredData as { herbs?: HomeFeaturedItem[] }).herbs || []).slice(0, 12)
+const featuredCompounds = ((featuredData as { compounds?: HomeFeaturedItem[] }).compounds || []).slice(0, 12)
 
 export default function Home() {
   return (
@@ -130,24 +81,22 @@ export default function Home() {
           </Link>
         </div>
         <div className='grid gap-3 sm:grid-cols-2 lg:grid-cols-3'>
-          {FEATURED_HERBS.map(name => {
-            const herb = herbLookup.get(name.toLowerCase())
-            const summary = buildHerbSummary(herb)
-            const mechanismChips = buildMechanismChips(herb)
+          {featuredHerbs.map(herb => {
+            const mechanismChips = Array.isArray(herb.tags) ? herb.tags : []
 
             return (
               <Link
-                key={name}
-                to={`/herbs?query=${encodedQuery(name)}`}
+                key={herb.slug}
+                to={`/herbs?query=${encodedQuery(herb.name)}`}
                 className='premium-panel p-4 transition-colors hover:border-white/20'
               >
-                <h3 className='text-base font-semibold text-white'>{name}</h3>
-                <p className='mt-2 text-sm text-white/73'>{summary}</p>
+                <h3 className='text-base font-semibold text-white'>{herb.name}</h3>
+                <p className='mt-2 text-sm text-white/73'>{herb.summary}</p>
                 {mechanismChips.length > 0 ? (
                   <div className='mt-2 flex flex-wrap gap-1.5'>
                     {mechanismChips.map(chip => (
                       <span
-                        key={`${name}-${chip}`}
+                        key={`${herb.slug}-${chip}`}
                         className='rounded-full border border-white/15 bg-white/5 px-2 py-0.5 text-[11px] font-medium text-white/74'
                       >
                         {chip}
@@ -169,14 +118,14 @@ export default function Home() {
           </Link>
         </div>
         <div className='grid gap-3 sm:grid-cols-2 lg:grid-cols-3'>
-          {FEATURED_COMPOUNDS.map(name => (
+          {featuredCompounds.map(compound => (
             <Link
-              key={name}
-              to={`/compounds?query=${encodedQuery(name)}`}
+              key={compound.slug}
+              to={`/compounds?query=${encodedQuery(compound.name)}`}
               className='premium-panel p-4 transition-colors hover:border-white/20'
             >
-              <h3 className='text-base font-semibold text-white'>{name}</h3>
-              <p className='mt-2 text-sm text-white/73'>Open profile and review mechanism, confidence, and safety details.</p>
+              <h3 className='text-base font-semibold text-white'>{compound.name}</h3>
+              <p className='mt-2 text-sm text-white/73'>{compound.summary}</p>
             </Link>
           ))}
         </div>


### PR DESCRIPTION
### Motivation
- The homepage previously imported the entire herb dataset (`public/data/herbs.json`), inflating the client bundle and slowing builds. 
- Replace the heavy import with a compact, pre-generated payload containing only the fields needed to render homepage cards so the UI remains intact while the bundle is much smaller.

### Description
- `src/pages/Home.tsx` now imports `public/data/homepage-featured.json` and renders featured herbs/compounds from that compact payload instead of importing `public/data/herbs.json`. 
- Added `scripts/generate-homepage-featured.mjs` which generates `public/data/homepage-featured.json` from existing datasets and includes only minimal card fields (`name`, `slug`, `summary`, optional `tags`) with lightweight sanitization and fallbacks. 
- Wired the generator into the build chain by adding `node scripts/generate-homepage-featured.mjs` to the `prebuild` script in `package.json`. 
- Checked-in the generated artifact `public/data/homepage-featured.json` so the homepage can render without importing the full datasets at runtime.

### Testing
- Ran the generator with `node scripts/generate-homepage-featured.mjs` which wrote `public/data/homepage-featured.json` successfully. 
- Ran `npm run build` (before and after change) and verified the build completes without errors. 
- Compared Home chunk sizes from the build logs and observed the Home chunk shrink from `2,569.34 kB` (gzip `193.81 kB`) to `7.79 kB` (gzip `2.15 kB`), indicating a substantial bundle reduction. 
- Files changed/added in this PR: `src/pages/Home.tsx`, `scripts/generate-homepage-featured.mjs`, `package.json`, and `public/data/homepage-featured.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e632695ac48323b29361210b7dfc8c)