### PR TITLE
Add inspection helper and import plan for citation workbook

### DIFF
--- a/docs/citation-import-plan.md
+++ b/docs/citation-import-plan.md
@@ -1,0 +1,168 @@
+# Citation Import Plan (Inspection-Only)
+
+## Detected file path
+
+- `data/import/citations.xlsx`
+
+## Workbook structure (headers + first 10 row shapes only)
+
+### Sheet: `Herb Master`
+
+- Headers:
+  - `name`, `slug`, `summary`, `description`, `primaryActions`, `mechanisms`, `activeCompounds`, `safetyNotes`, `contraindications`, `interactions`, `preparation`, `traditionalUses`, `evidenceLevel`, `relatedHerbs`, `region`
+- First 10 row shapes (summarized):
+  - All rows are 15-column rows.
+  - Row 1 has 10 populated fields.
+  - Rows 2-10 each have 7 populated fields.
+  - Most frequently populated fields in first 10 rows: `name`, `slug`, `summary`, `description`, `mechanisms`, `activeCompounds`, `safetyNotes`.
+
+### Sheet: `Compound Master`
+
+- Headers:
+  - `name`, `slug`, `summary`, `description`, `compoundClass`, `mechanisms`, `targets`, `pathways`, `foundIn`, `bioavailability`, `safetyNotes`, `evidenceLevel`, `relatedCompounds`
+- First 10 row shapes (summarized):
+  - All rows are 13-column rows.
+  - Rows 1-10 each have 6 populated fields.
+  - Most frequently populated fields in first 10 rows: `name`, `slug`, `summary`, `description`, `mechanisms`, `foundIn`.
+
+### Sheet: `Herb Compound Map`
+
+- Headers:
+  - `herb_name`, `compound_name`
+- First 10 row shapes (summarized):
+  - All rows are 2-column rows.
+  - Rows 1-10 each have 2 populated fields.
+
+## Column mapping assessment
+
+### Appears to map to herb/compound/entity
+
+- Herb entity identifiers/details:
+  - `Herb Master.name`, `Herb Master.slug`
+- Compound entity identifiers/details:
+  - `Compound Master.name`, `Compound Master.slug`
+- Herb-compound relationship:
+  - `Herb Compound Map.herb_name`, `Herb Compound Map.compound_name`
+
+### Appears to map to citation/source metadata
+
+- No explicit citation-source metadata columns were detected in inspected headers.
+- Missing expected source metadata fields (examples): publication title, DOI/PMID/PMCID, URL, journal, year, study design, source type.
+
+### Appears to map to claims/safety/mechanisms/interactions
+
+- Claim-like narrative fields:
+  - `summary`, `description`, `primaryActions`, `traditionalUses`, `evidenceLevel`
+- Safety/interactions:
+  - `safetyNotes`, `contraindications`, `interactions`
+- Mechanism-related:
+  - `mechanisms`, `targets`, `pathways`
+
+## Obvious data-quality concerns
+
+1. **File mismatch vs citation intent**: the workbook appears to be an entity master workbook, not a citation table.
+2. **No citation keys**: no unique citation IDs or resolvable source identifiers (DOI/PMID/URL) are present.
+3. **Narrative aggregation risk**: large free-text in `description` appears to aggregate multiple assertions and source-like statements, which cannot be safely split into citation-level facts without manual/source-grounded parsing.
+4. **Sparse optional fields in sample**: many columns are blank in first 10 rows, which increases import ambiguity.
+5. **Join reliability risk**: `Herb Compound Map` relies on names, not stable IDs, which can increase normalization/linking errors.
+
+## Smallest safe citation ingestion path (proposed)
+
+1. **Inspection gate only (this step)**
+   - Detect file + inspect sheets/headers/sample row shapes without writing to any production data files.
+2. **Require a citation-ready tabular schema before ingestion**
+   - Ask for/derive a dedicated citation table (CSV/XLSX tab) with explicit citation identifiers and source metadata.
+3. **Add a dry-run normalizer**
+   - Build a script that maps rows into normalized JSON objects and reports validation errors only (no writes to herb/compound datasets yet).
+4. **Introduce schema validation**
+   - Validate normalized records against explicit `Citation`, `Claim`, and `ClaimCitationLink` schemas.
+5. **Manual review checkpoint**
+   - Review unresolved links (entity not found, missing source IDs, ambiguous claims) before any apply step.
+
+This path keeps existing herb/compound data untouched and reduces risk of introducing unverifiable citations.
+
+## Proposed normalized schema
+
+### 1) Citation
+
+```json
+{
+  "id": "cit:pmid:12345678",
+  "sourceType": "journal_article",
+  "title": "string",
+  "authors": ["string"],
+  "journal": "string",
+  "year": 2024,
+  "datePublished": "2024-05-17",
+  "doi": "10.1000/xyz123",
+  "pmid": "12345678",
+  "pmcid": "PMC1234567",
+  "url": "https://...",
+  "abstract": "string",
+  "studyDesign": "rct|systematic_review|meta_analysis|cohort|case_control|in_vitro|animal|other",
+  "population": "string",
+  "sampleSize": 120,
+  "qualitySignals": {
+    "peerReviewed": true,
+    "riskOfBias": "low|moderate|high|unknown"
+  },
+  "ingestMeta": {
+    "sourceFile": "data/import/citations.xlsx",
+    "sourceSheet": "Citations",
+    "sourceRow": 42,
+    "ingestedAt": "2026-04-20T00:00:00Z"
+  }
+}
+```
+
+### 2) Claim
+
+```json
+{
+  "id": "clm:ashwagandha:stress-support:001",
+  "entityType": "herb|compound|formula|other",
+  "entityRef": {
+    "slug": "ashwagandha",
+    "name": "Ashwagandha"
+  },
+  "domain": "efficacy|safety|interaction|mechanism",
+  "claimType": "supports|associated_with|may_reduce|contraindicated_with|interacts_with|modulates",
+  "claimText": "Ashwagandha may support stress response.",
+  "mechanisms": ["HPA-axis modulation"],
+  "interactionTargets": ["sedatives"],
+  "safetyTags": ["pregnancy_caution"],
+  "evidenceGrade": "A|B|C|D|insufficient",
+  "status": "draft|reviewed|approved",
+  "ingestMeta": {
+    "sourceFile": "data/import/citations.xlsx",
+    "sourceSheet": "Herb Master",
+    "sourceRow": 2
+  }
+}
+```
+
+### 3) ClaimCitationLink
+
+```json
+{
+  "id": "lnk:clm:ashwagandha:stress-support:001:cit:pmid:12345678",
+  "claimId": "clm:ashwagandha:stress-support:001",
+  "citationId": "cit:pmid:12345678",
+  "relation": "supports|context|conflicts|safety_signal",
+  "quotedEvidence": "Optional short excerpt",
+  "evidenceLocation": {
+    "section": "Results",
+    "page": "5",
+    "table": "Table 2"
+  },
+  "confidence": 0.84,
+  "reviewStatus": "unreviewed|reviewed",
+  "reviewedBy": "string",
+  "reviewedAt": "2026-04-20T00:00:00Z"
+}
+```
+
+## Notes
+
+- No full import was performed.
+- No herb or compound source data was rewritten.

--- a/scripts/inspect-citation-import.mjs
+++ b/scripts/inspect-citation-import.mjs
@@ -1,0 +1,129 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import xlsx from 'xlsx';
+
+const CANDIDATE_PATHS = [
+  'data/import/citations.xlsx',
+  'data/import/citations.csv',
+  'public/data/import/citations.xlsx',
+  'public/data/import/citations.csv',
+];
+
+function detectFilePath() {
+  return CANDIDATE_PATHS.find((candidate) => fs.existsSync(candidate)) || null;
+}
+
+function normalizeHeader(value, index) {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed) return trimmed;
+  }
+  return `column_${index + 1}`;
+}
+
+function summarizeRows(rows, headers) {
+  return rows.slice(0, 10).map((row, rowIndex) => {
+    const values = headers.map((_, headerIndex) => row[headerIndex] ?? null);
+    const nonEmptyCount = values.filter(
+      (value) => value !== null && value !== '' && value !== undefined,
+    ).length;
+
+    const populatedColumns = [];
+    headers.forEach((header, headerIndex) => {
+      const value = values[headerIndex];
+      if (value !== null && value !== '' && value !== undefined) {
+        populatedColumns.push(header);
+      }
+    });
+
+    return {
+      rowNumber: rowIndex + 1,
+      columnCount: values.length,
+      nonEmptyCount,
+      populatedColumns,
+    };
+  });
+}
+
+function inspectSheet(rows) {
+  if (!rows.length) {
+    return {
+      headers: [],
+      rowCount: 0,
+      firstTenRows: [],
+    };
+  }
+
+  const headers = rows[0].map(normalizeHeader);
+  const dataRows = rows.slice(1);
+
+  return {
+    headers,
+    rowCount: dataRows.length,
+    firstTenRows: summarizeRows(dataRows, headers),
+  };
+}
+
+function readWorkbook(targetPath) {
+  const extension = path.extname(targetPath).toLowerCase();
+
+  if (extension === '.xlsx') {
+    const workbook = xlsx.readFile(targetPath, { cellDates: true });
+    const sheets = workbook.SheetNames.map((sheetName) => {
+      const sheet = workbook.Sheets[sheetName];
+      const rows = xlsx.utils.sheet_to_json(sheet, {
+        header: 1,
+        blankrows: false,
+        defval: null,
+        raw: false,
+      });
+      return {
+        sheetName,
+        ...inspectSheet(rows),
+      };
+    });
+
+    return {
+      type: 'xlsx',
+      sheets,
+    };
+  }
+
+  const workbook = xlsx.readFile(targetPath, {
+    type: 'string',
+    raw: false,
+    codepage: 65001,
+  });
+  const [sheetName] = workbook.SheetNames;
+  const sheet = workbook.Sheets[sheetName];
+  const rows = xlsx.utils.sheet_to_json(sheet, {
+    header: 1,
+    blankrows: false,
+    defval: null,
+    raw: false,
+  });
+
+  return {
+    type: 'csv',
+    sheets: [
+      {
+        sheetName,
+        ...inspectSheet(rows),
+      },
+    ],
+  };
+}
+
+const detectedPath = detectFilePath();
+
+if (!detectedPath) {
+  console.error('No citation import file found at configured candidate paths.');
+  process.exit(1);
+}
+
+const result = {
+  detectedPath,
+  ...readWorkbook(detectedPath),
+};
+
+console.log(JSON.stringify(result, null, 2));


### PR DESCRIPTION
### Motivation

- Provide a safe, minimal inspection step for an incoming citation workbook placed at one of the expected import paths so we can evaluate headers and sample rows without performing any import. 
- Surface whether the provided workbook is citation-ready (has DOI/PMID/URL/etc) and propose a minimal, low-risk ingestion path and normalized schemas for citations and claims. 

### Description

- Add `scripts/inspect-citation-import.mjs`, a small Node script that searches the four candidate paths, supports XLSX/CSV, normalizes headers, and prints sheet names, headers and only the first 10 data-row shapes (column counts, non-empty counts, populated columns) as JSON. 
- Add `docs/citation-import-plan.md`, an inspection-only report that records the detected path (`data/import/citations.xlsx`), sheet names and headers, first-10-row shape summaries, a column-mapping assessment (entity vs citation vs claim/safety/mechanism), obvious data-quality concerns, a smallest-safe ingestion proposal, and draft normalized schemas for `Citation`, `Claim`, and `ClaimCitationLink`. 
- This change is inspection-only and does not import or rewrite herb/compound datasets and avoids any automated apply/apply-patches flow. 

### Testing

- Ran the inspection helper with `node scripts/inspect-citation-import.mjs` which successfully detected `data/import/citations.xlsx` and produced the expected JSON inspection output. 
- Ran a full site build with `npm run build` which completed successfully (prebuild/build/postbuild steps passed) with only non-blocking warnings (Browserslist notice, chunk-size warnings, and an npm env warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e63615fc8483239583d74cec7eafc1)