### PR TITLE
Normalize `dosage` field from arrays to strings for 30 herb records

### DIFF
--- a/public/data/herbs.json
+++ b/public/data/herbs.json
@@ -25,9 +25,7 @@
     "sources": [],
     "lastUpdated": "2026-03-21",
     "description": "Acacia nilotica is an astringent medicinal tree used in traditional systems for oral, skin, and gastrointestinal applications; its bark and pods are rich in tannins and other polyphenols.",
-    "dosage": [
-      "No direct dosage data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. No direct region data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. Folk medicine. Folk medicine"
-    ],
+    "dosage": "No direct dosage data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. No direct region data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. Folk medicine. Folk medicine",
     "duration": "No direct duration data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. No direct region data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. Folk medicine. Folk medicine",
     "interactions": [],
     "legalStatus": "legal",
@@ -81,17 +79,7 @@
     ],
     "lastUpdated": "2026-03-21",
     "description": "Highly toxic; traditionally used as analgesic after detoxification. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.",
-    "dosage": [
-      "No direct dosage data. Contextual inference: Highly toxic",
-      "traditionally used as analgesic after detoxification. Herbs often act via neurotransmitter modulation",
-      "antioxidant effects",
-      "or enzyme inhibition.. None.",
-      "nan.. Herbs often act via neurotransmitter modulation",
-      "or enzyme inhibition.. Highly toxic",
-      "traditionally used as analgesic after detoxification. No direct region data. Contextual inference: Highly toxic",
-      "traditionally used as analgesic after detoxification. none.",
-      "nan."
-    ],
+    "dosage": "No direct dosage data. Contextual inference: Highly toxic, traditionally used as analgesic after detoxification. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None., nan.. Herbs often act via neurotransmitter modulation, or enzyme inhibition.. Highly toxic, traditionally used as analgesic after detoxification. No direct region data. Contextual inference: Highly toxic, traditionally used as analgesic after detoxification. none., nan.",
     "duration": "6–12 hours",
     "interactions": [],
     "legalStatus": "Controlled in many regions",
@@ -147,10 +135,7 @@
     ],
     "lastUpdated": "2026-03-21",
     "description": "Aconitum napellus (monkshood) contains highly toxic diterpenoid alkaloids and is unsafe for unsupervised internal use; severe poisoning can occur with small dosing errors.",
-    "dosage": [
-      "Toxic",
-      "used in homeopathy only"
-    ],
+    "dosage": "Toxic, used in homeopathy only",
     "duration": "4–8 hours",
     "interactions": [],
     "legalStatus": "Restricted or banned in many countries",
@@ -185,14 +170,7 @@
     "sources": [],
     "lastUpdated": "2026-03-21",
     "description": "Acorus americanus (American sweet flag) is a North American aromatic wetland herb used traditionally for digestive and calming purposes; modern human clinical evidence is limited.",
-    "dosage": [
-      "No direct dosage data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan. No direct effects data. Contextual inference:",
-      "nan.",
-      "nan. No direct region data. Contextual inference:"
-    ],
+    "dosage": "No direct dosage data. Contextual inference:, nan.. No direct mechanismofaction data. Contextual inference:, nan.., nan. No direct effects data. Contextual inference:, nan., nan. No direct region data. Contextual inference:",
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [],
     "legalStatus": null,
@@ -244,15 +222,7 @@
     "sources": [],
     "lastUpdated": "2026-03-21",
     "description": "Used in ritual, dreaming or folk medicine.",
-    "dosage": [
-      "No direct dosage data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. Used in ritual",
-      "dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine. Used in ritual",
-      "dreaming or folk medicine. No direct region data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine"
-    ],
+    "dosage": "No direct dosage data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. No direct region data. Contextual inference: Used in ritual, dreaming or folk medicine",
     "duration": "No direct duration data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. No direct region data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine",
     "interactions": [],
     "legalStatus": null,
@@ -328,19 +298,7 @@
     ],
     "lastUpdated": "2026-03-21",
     "description": "Cns stimulant, memory aid, and anti-epileptic in tcm. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.",
-    "dosage": [
-      "No direct dosage data. Contextual inference: Cns stimulant",
-      "memory aid",
-      "and anti",
-      "epileptic in tcm. Herbs often act via neurotransmitter modulation",
-      "antioxidant effects",
-      "or enzyme inhibition.. None.",
-      "nan.. Herbs often act via neurotransmitter modulation",
-      "or enzyme inhibition.. CNS stimulant",
-      "epileptic in TCM. No direct region data. Contextual inference: Cns stimulant",
-      "epileptic in TCM. none.",
-      "nan."
-    ],
+    "dosage": "No direct dosage data. Contextual inference: Cns stimulant, memory aid, and anti, epileptic in tcm. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None., nan.. Herbs often act via neurotransmitter modulation, or enzyme inhibition.. CNS stimulant, epileptic in TCM. No direct region data. Contextual inference: Cns stimulant, epileptic in TCM. none., nan.",
     "duration": "4–6 hours",
     "interactions": [],
     "legalStatus": "Restricted in some countries",
@@ -387,17 +345,7 @@
     ],
     "lastUpdated": "2026-03-21",
     "description": "Highly toxic; cardiac glycoside effects. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.",
-    "dosage": [
-      "No direct dosage data. Contextual inference: Highly toxic",
-      "cardiac glycoside effects. Herbs often act via neurotransmitter modulation",
-      "antioxidant effects",
-      "or enzyme inhibition.. None.",
-      "nan.. Herbs often act via neurotransmitter modulation",
-      "or enzyme inhibition.. Highly toxic",
-      "cardiac glycoside effects. No direct region data. Contextual inference: Highly toxic",
-      "cardiac glycoside effects. none.",
-      "nan."
-    ],
+    "dosage": "No direct dosage data. Contextual inference: Highly toxic, cardiac glycoside effects. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None., nan.. Herbs often act via neurotransmitter modulation, or enzyme inhibition.. Highly toxic, cardiac glycoside effects. No direct region data. Contextual inference: Highly toxic, cardiac glycoside effects. none., nan.",
     "duration": "Varies; potentially fatal if ingested",
     "interactions": [],
     "legalStatus": "Ornamental use legal; internal use prohibited or restricted",
@@ -463,17 +411,7 @@
     ],
     "lastUpdated": "2026-03-21",
     "description": "Traditional uses include skin and respiratory conditions; contains tannins. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.",
-    "dosage": [
-      "No direct dosage data. Contextual inference: Traditional uses include skin and respiratory conditions",
-      "contains tannins. Herbs often act via neurotransmitter modulation",
-      "antioxidant effects",
-      "or enzyme inhibition.. None.",
-      "nan.. Herbs often act via neurotransmitter modulation",
-      "or enzyme inhibition.. Traditional uses include skin and respiratory conditions",
-      "contains tannins. No direct region data. Contextual inference: Traditional uses include skin and respiratory conditions",
-      "contains tannins. none.",
-      "nan."
-    ],
+    "dosage": "No direct dosage data. Contextual inference: Traditional uses include skin and respiratory conditions, contains tannins. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None., nan.. Herbs often act via neurotransmitter modulation, or enzyme inhibition.. Traditional uses include skin and respiratory conditions, contains tannins. No direct region data. Contextual inference: Traditional uses include skin and respiratory conditions, contains tannins. none., nan.",
     "duration": "4–6 hours",
     "interactions": [],
     "legalStatus": "Unregulated",
@@ -517,14 +455,7 @@
     "sources": [],
     "lastUpdated": "2026-03-21",
     "description": "; nan; nan.",
-    "dosage": [
-      "No direct dosage data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan. No direct effects data. Contextual inference:",
-      "nan.",
-      "nan. No direct region data. Contextual inference:"
-    ],
+    "dosage": "No direct dosage data. Contextual inference:, nan.. No direct mechanismofaction data. Contextual inference:, nan.., nan. No direct effects data. Contextual inference:, nan., nan. No direct region data. Contextual inference:",
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [],
     "legalStatus": "legal",
@@ -567,9 +498,7 @@
     ],
     "lastUpdated": "2026-03-21",
     "description": "Internal cross-linking supports Bael through compounds such as skimmianine, aegeline, marmelosin.",
-    "dosage": [
-      "No direct dosage data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. No direct region data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. Folk medicine. Folk medicine"
-    ],
+    "dosage": "No direct dosage data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. No direct region data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. Folk medicine. Folk medicine",
     "duration": "No direct duration data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. No direct region data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. Folk medicine. Folk medicine",
     "interactions": [
       "Interaction review required before publication."
@@ -656,19 +585,7 @@
     ],
     "lastUpdated": "2026-03-21",
     "description": "Diuretic, anti-inflammatory, antimicrobial. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.",
-    "dosage": [
-      "No direct dosage data. Contextual inference: Diuretic",
-      "anti",
-      "inflammatory",
-      "antimicrobial. Herbs often act via neurotransmitter modulation",
-      "antioxidant effects",
-      "or enzyme inhibition.. None.",
-      "nan.. Herbs often act via neurotransmitter modulation",
-      "or enzyme inhibition.. Diuretic",
-      "antimicrobial. No direct region data. Contextual inference: Diuretic",
-      "antimicrobial. none.",
-      "nan."
-    ],
+    "dosage": "No direct dosage data. Contextual inference: Diuretic, anti, inflammatory, antimicrobial. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None., nan.. Herbs often act via neurotransmitter modulation, or enzyme inhibition.. Diuretic, antimicrobial. No direct region data. Contextual inference: Diuretic, antimicrobial. none., nan.",
     "duration": "3–5 hours",
     "interactions": [],
     "legalStatus": "Traditional medicine use; not formally regulated",
@@ -740,19 +657,7 @@
     ],
     "lastUpdated": "2026-03-21",
     "description": "Venotonic, anti-inflammatory, edema relief. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.",
-    "dosage": [
-      "No direct dosage data. Contextual inference: Venotonic",
-      "anti",
-      "inflammatory",
-      "edema relief. Herbs often act via neurotransmitter modulation",
-      "antioxidant effects",
-      "or enzyme inhibition.. None.",
-      "nan.. Herbs often act via neurotransmitter modulation",
-      "or enzyme inhibition.. Venotonic",
-      "edema relief. No direct region data. Contextual inference: Venotonic",
-      "edema relief. none.",
-      "nan."
-    ],
+    "dosage": "No direct dosage data. Contextual inference: Venotonic, anti, inflammatory, edema relief. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None., nan.. Herbs often act via neurotransmitter modulation, or enzyme inhibition.. Venotonic, edema relief. No direct region data. Contextual inference: Venotonic, edema relief. none., nan.",
     "duration": "6–8 hours",
     "interactions": [
       "May interact with blood-thinning contexts"
@@ -819,15 +724,7 @@
     "sources": [],
     "lastUpdated": "2026-03-21",
     "description": "Used in ritual, dreaming or folk medicine.",
-    "dosage": [
-      "No direct dosage data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. Used in ritual",
-      "dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine. Used in ritual",
-      "dreaming or folk medicine. No direct region data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine"
-    ],
+    "dosage": "No direct dosage data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. No direct region data. Contextual inference: Used in ritual, dreaming or folk medicine",
     "duration": "No direct duration data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. No direct region data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine",
     "interactions": [],
     "legalStatus": "legal",
@@ -883,18 +780,7 @@
     ],
     "lastUpdated": "2026-03-21",
     "description": "Carminative, antibacterial, mild sedative. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.",
-    "dosage": [
-      "No direct dosage data. Contextual inference: Carminative",
-      "antibacterial",
-      "mild sedative. Herbs often act via neurotransmitter modulation",
-      "antioxidant effects",
-      "or enzyme inhibition.. None.",
-      "nan.. Herbs often act via neurotransmitter modulation",
-      "or enzyme inhibition.. Carminative",
-      "mild sedative. No direct region data. Contextual inference: Carminative",
-      "mild sedative. none.",
-      "nan."
-    ],
+    "dosage": "No direct dosage data. Contextual inference: Carminative, antibacterial, mild sedative. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None., nan.. Herbs often act via neurotransmitter modulation, or enzyme inhibition.. Carminative, mild sedative. No direct region data. Contextual inference: Carminative, mild sedative. none., nan.",
     "duration": "2–4 hours",
     "interactions": [
       "Interaction review required before publication."
@@ -971,11 +857,7 @@
     ],
     "lastUpdated": "2026-03-21",
     "description": "Astringent, anti-inflammatory, digestive tonic. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.",
-    "dosage": [
-      "2",
-      "4 g",
-      "day herb infusion or 500 mg extract"
-    ],
+    "dosage": "2, 4 g, day herb infusion or 500 mg extract",
     "duration": "3–5 hours",
     "interactions": [],
     "legalStatus": "Legal and widely available in herbal products",
@@ -1044,20 +926,7 @@
     ],
     "lastUpdated": "2026-03-21",
     "description": "Used in ayurveda for anti-epileptic, anti-inflammatory, and analgesic properties. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.",
-    "dosage": [
-      "No direct dosage data. Contextual inference: Used in ayurveda for anti",
-      "epileptic",
-      "anti",
-      "inflammatory",
-      "and analgesic properties. Herbs often act via neurotransmitter modulation",
-      "antioxidant effects",
-      "or enzyme inhibition.. None.",
-      "nan.. Herbs often act via neurotransmitter modulation",
-      "or enzyme inhibition.. Used in Ayurveda for anti",
-      "and analgesic properties. No direct region data. Contextual inference: Used in ayurveda for anti",
-      "and analgesic properties. none.",
-      "nan."
-    ],
+    "dosage": "No direct dosage data. Contextual inference: Used in ayurveda for anti, epileptic, anti, inflammatory, and analgesic properties. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None., nan.. Herbs often act via neurotransmitter modulation, or enzyme inhibition.. Used in Ayurveda for anti, and analgesic properties. No direct region data. Contextual inference: Used in ayurveda for anti, and analgesic properties. none., nan.",
     "duration": "6–8 hours",
     "interactions": [],
     "legalStatus": "Legal globally",
@@ -1101,14 +970,7 @@
     "sources": [],
     "lastUpdated": "2026-03-21",
     "description": "; nan; nan.",
-    "dosage": [
-      "No direct dosage data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan. No direct effects data. Contextual inference:",
-      "nan.",
-      "nan. No direct region data. Contextual inference:"
-    ],
+    "dosage": "No direct dosage data. Contextual inference:, nan.. No direct mechanismofaction data. Contextual inference:, nan.., nan. No direct effects data. Contextual inference:, nan., nan. No direct region data. Contextual inference:",
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [],
     "legalStatus": "legal",
@@ -1173,11 +1035,7 @@
     ],
     "lastUpdated": "2026-03-21",
     "description": "Used in ayurveda for asthma, allergies, and anxiety. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.",
-    "dosage": [
-      "500",
-      "1000 mg",
-      "day bark or flower extract"
-    ],
+    "dosage": "500, 1000 mg, day bark or flower extract",
     "duration": "4–6 hours",
     "interactions": [],
     "legalStatus": "Legal globally",
@@ -1240,11 +1098,7 @@
     ],
     "lastUpdated": "2026-03-21",
     "description": "Uterine tonic, astringent, anti-inflammatory; regulates menstruation and bleeding.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.",
-    "dosage": [
-      "1",
-      "3 g",
-      "day aerial parts or 300 mg extract"
-    ],
+    "dosage": "1, 3 g, day aerial parts or 300 mg extract",
     "duration": "Cyclic (e.g., 2 weeks/month)",
     "interactions": [],
     "legalStatus": "Legal in EU and US as traditional remedy; used for gynecological purposes.",
@@ -1289,9 +1143,7 @@
     "sources": [],
     "lastUpdated": "2026-03-21",
     "description": "Used in traditional amazonian medicine for arthritis and pain..",
-    "dosage": [
-      "No direct dosage data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... No direct mechanismofaction data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... Used in traditional Amazonian medicine for arthritis and pain.. No direct effects data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... No direct mechanismofaction data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... Used in traditional Amazonian medicine for arthritis and pain.. Used in traditional Amazonian medicine for arthritis and pain.. No direct region data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... No direct mechanismofaction data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... Used in traditional Amazonian medicine for arthritis and pain.. No direct effects data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... No direct mechanismofaction data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... Used in traditional Amazonian medicine for arthritis and pain.. Used in traditional Amazonian medicine for arthritis and pain.. Used in traditional Amazonian medicine for arthritis and pain.. Used in traditional Amazonian medicine for arthritis and pain."
-    ],
+    "dosage": "No direct dosage data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... No direct mechanismofaction data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... Used in traditional Amazonian medicine for arthritis and pain.. No direct effects data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... No direct mechanismofaction data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... Used in traditional Amazonian medicine for arthritis and pain.. Used in traditional Amazonian medicine for arthritis and pain.. No direct region data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... No direct mechanismofaction data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... Used in traditional Amazonian medicine for arthritis and pain.. No direct effects data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... No direct mechanismofaction data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... Used in traditional Amazonian medicine for arthritis and pain.. Used in traditional Amazonian medicine for arthritis and pain.. Used in traditional Amazonian medicine for arthritis and pain.. Used in traditional Amazonian medicine for arthritis and pain.",
     "duration": "No direct duration data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... No direct mechanismofaction data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... Used in traditional Amazonian medicine for arthritis and pain.. No direct effects data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... No direct mechanismofaction data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... Used in traditional Amazonian medicine for arthritis and pain.. Used in traditional Amazonian medicine for arthritis and pain.. No direct region data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... No direct mechanismofaction data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... Used in traditional Amazonian medicine for arthritis and pain.. No direct effects data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... No direct mechanismofaction data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... Used in traditional Amazonian medicine for arthritis and pain.. Used in traditional Amazonian medicine for arthritis and pain.. Used in traditional Amazonian medicine for arthritis and pain.. Used in traditional Amazonian medicine for arthritis and pain.",
     "interactions": [],
     "legalStatus": "legal",
@@ -1333,9 +1185,7 @@
     ],
     "lastUpdated": "2026-03-21",
     "description": "Parasitic herb in the Orobanchaceae family; possibly used in traditional African medicine.",
-    "dosage": [
-      "Not established."
-    ],
+    "dosage": "Not established.",
     "duration": "Acute topical application.",
     "interactions": [],
     "legalStatus": "Unregulated",
@@ -1384,17 +1234,7 @@
     ],
     "lastUpdated": "2026-03-21",
     "description": "Uterine tonic, bitter digestive. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.",
-    "dosage": [
-      "No direct dosage data. Contextual inference: Uterine tonic",
-      "bitter digestive. Herbs often act via neurotransmitter modulation",
-      "antioxidant effects",
-      "or enzyme inhibition.. None.",
-      "nan.. Herbs often act via neurotransmitter modulation",
-      "or enzyme inhibition.. Uterine tonic",
-      "bitter digestive. No direct region data. Contextual inference: Uterine tonic",
-      "bitter digestive. none.",
-      "nan."
-    ],
+    "dosage": "No direct dosage data. Contextual inference: Uterine tonic, bitter digestive. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None., nan.. Herbs often act via neurotransmitter modulation, or enzyme inhibition.. Uterine tonic, bitter digestive. No direct region data. Contextual inference: Uterine tonic, bitter digestive. none., nan.",
     "duration": "4–6 hours",
     "interactions": [],
     "legalStatus": "Used in traditional medicine; limited regulatory recognition",
@@ -1450,12 +1290,7 @@
     ],
     "lastUpdated": "2026-03-21",
     "description": "Garlic is represented here as a monograph-style entry centered on the unspecified. Key reported compounds include diallyl sulfide; diallyl disulfide; diallyl trisulfide; ajoene; S‑allyl‑cysteine. Typical preparation forms: Fresh or dried bulbs are used as food and in remedies. Commercial supplements include aged garlic extracts, oils and powders standardized for organosulfur content. Garlic bulbs contain organosulfur compounds such as diallyl sulfide, diallyl disulfide, diallyl trisulfide, ajoene and S‑allyl‑cysteine. These constituents exert antioxidant, anti‑inflammatory and immunomodulatory effects in vitro and in animal models by scavenging free radicals and modulating inflammatory pathways. Human evidence is limited, so this should be regarded as a proposed mechanism based on preclinical data. Interaction profile: Garlic may potentiate the effects of anticoagulant and antiplatelet drugs (e.g., warfarin, aspirin) and should be discontinued before surgery. It may also enhance the effects of antihypertensive or antidiabetic medicines. Use caution or avoid in: People with bleeding disorders, those taking anticoagulant or antiplatelet drugs and individuals scheduled for surgery should avoid high‑dose garlic supplements. Because safety during pregnancy and breastfeeding has not been established, garlic supplements are not recommended in these populations.",
-    "dosage": [
-      "300",
-      "900 mg",
-      "day extract or 1",
-      "2 cloves"
-    ],
+    "dosage": "300, 900 mg, day extract or 1, 2 cloves",
     "duration": "Daily use safe, long-term",
     "interactions": [
       "Garlic may potentiate the effects of anticoagulant and antiplatelet drugs (e.g., warfarin, aspirin) and should be discontinued before surgery. It may also enhance the effects of antihypertensive or antidiabetic medicines."
@@ -1520,19 +1355,7 @@
     ],
     "lastUpdated": "2026-03-21",
     "description": "Anti-inflammatory, astringent, febrifuge. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.",
-    "dosage": [
-      "No direct dosage data. Contextual inference: Anti",
-      "inflammatory",
-      "astringent",
-      "febrifuge. Herbs often act via neurotransmitter modulation",
-      "antioxidant effects",
-      "or enzyme inhibition.. None.",
-      "nan.. Herbs often act via neurotransmitter modulation",
-      "or enzyme inhibition.. Anti",
-      "febrifuge. No direct region data. Contextual inference: Anti",
-      "febrifuge. none.",
-      "nan."
-    ],
+    "dosage": "No direct dosage data. Contextual inference: Anti, inflammatory, astringent, febrifuge. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None., nan.. Herbs often act via neurotransmitter modulation, or enzyme inhibition.. Anti, febrifuge. No direct region data. Contextual inference: Anti, febrifuge. none., nan.",
     "duration": "2–4 hours",
     "interactions": [],
     "legalStatus": "Not restricted; used in North American herbalism",
@@ -1595,11 +1418,7 @@
     ],
     "lastUpdated": "2026-03-21",
     "description": "Laxative, wound healing, skin soother. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.",
-    "dosage": [
-      "0.5",
-      "1 g",
-      "day gel or juice"
-    ],
+    "dosage": "0.5, 1 g, day gel or juice",
     "duration": "Varies with form",
     "interactions": [
       "May amplify laxative-heavy or glucose-lowering contexts"
@@ -1660,14 +1479,7 @@
     ],
     "lastUpdated": "2026-03-21",
     "description": "It is best framed as a gentle aromatic botanical with modest evidence and pleasant tolerability.",
-    "dosage": [
-      "No direct dosage data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan. No direct effects data. Contextual inference:",
-      "nan.",
-      "nan. No direct region data. Contextual inference:"
-    ],
+    "dosage": "No direct dosage data. Contextual inference:, nan.. No direct mechanismofaction data. Contextual inference:, nan.., nan. No direct effects data. Contextual inference:, nan., nan. No direct region data. Contextual inference:",
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [
       "Use caution with concentrated essential-oil contexts."
@@ -1725,14 +1537,7 @@
     ],
     "lastUpdated": "2026-03-21",
     "description": "It is best framed as a culinary-medicinal rhizome with traditional GI relevance.",
-    "dosage": [
-      "No direct dosage data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan. No direct effects data. Contextual inference:",
-      "nan.",
-      "nan. No direct region data. Contextual inference:"
-    ],
+    "dosage": "No direct dosage data. Contextual inference:, nan.. No direct mechanismofaction data. Contextual inference:, nan.., nan. No direct effects data. Contextual inference:, nan., nan. No direct region data. Contextual inference:",
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [
       "Avoid overextended antimicrobial claims."
@@ -1797,19 +1602,7 @@
     ],
     "lastUpdated": "2026-03-21",
     "description": "Demulcent, anti-inflammatory, soothing for mucous membranes. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.",
-    "dosage": [
-      "No direct dosage data. Contextual inference: Demulcent",
-      "anti",
-      "inflammatory",
-      "soothing for mucous membranes. Herbs often act via neurotransmitter modulation",
-      "antioxidant effects",
-      "or enzyme inhibition.. None.",
-      "nan.. Herbs often act via neurotransmitter modulation",
-      "or enzyme inhibition.. Demulcent",
-      "soothing for mucous membranes. No direct region data. Contextual inference: Demulcent",
-      "soothing for mucous membranes. none.",
-      "nan."
-    ],
+    "dosage": "No direct dosage data. Contextual inference: Demulcent, anti, inflammatory, soothing for mucous membranes. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None., nan.. Herbs often act via neurotransmitter modulation, or enzyme inhibition.. Demulcent, soothing for mucous membranes. No direct region data. Contextual inference: Demulcent, soothing for mucous membranes. none., nan.",
     "duration": "2–4 hours",
     "interactions": [
       "May slow absorption of co-administered agents when taken together"
@@ -1864,15 +1657,7 @@
     ],
     "lastUpdated": "2026-03-21",
     "description": "Traditional hawaiian use as tonic and for childbirth. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.",
-    "dosage": [
-      "No direct dosage data. Contextual inference: Traditional hawaiian use as tonic and for childbirth. Herbs often act via neurotransmitter modulation",
-      "antioxidant effects",
-      "or enzyme inhibition.. None.",
-      "nan.. Herbs often act via neurotransmitter modulation",
-      "or enzyme inhibition.. Traditional Hawaiian use as tonic and for childbirth. No direct region data. Contextual inference: Traditional hawaiian use as tonic and for childbirth. Herbs often act via neurotransmitter modulation",
-      "or enzyme inhibition.. Traditional Hawaiian use as tonic and for childbirth. none.",
-      "nan."
-    ],
+    "dosage": "No direct dosage data. Contextual inference: Traditional hawaiian use as tonic and for childbirth. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None., nan.. Herbs often act via neurotransmitter modulation, or enzyme inhibition.. Traditional Hawaiian use as tonic and for childbirth. No direct region data. Contextual inference: Traditional hawaiian use as tonic and for childbirth. Herbs often act via neurotransmitter modulation, or enzyme inhibition.. Traditional Hawaiian use as tonic and for childbirth. none., nan.",
     "duration": "4–6 hours",
     "interactions": [],
     "legalStatus": "Unregulated; used in Hawaiian folk medicine",
@@ -1911,14 +1696,7 @@
     "sources": [],
     "lastUpdated": "2026-03-21",
     "description": "; nan; nan.",
-    "dosage": [
-      "No direct dosage data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan. No direct effects data. Contextual inference:",
-      "nan.",
-      "nan. No direct region data. Contextual inference:"
-    ],
+    "dosage": "No direct dosage data. Contextual inference:, nan.. No direct mechanismofaction data. Contextual inference:, nan.., nan. No direct effects data. Contextual inference:, nan., nan. No direct region data. Contextual inference:",
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [],
     "legalStatus": "restricted",


### PR DESCRIPTION
### Motivation
- Address one non-blocking structural issue class: `dosage` values stored as arrays where the schema expects a single string, minimizing downstream rendering/type errors.
- Keep changes minimal and reviewable by editing only a small set of rows (within the 25–50 limit) and only the affected field.

### Description
- Converted `dosage` entries that were arrays into normalized single strings using `, ` joining for **30 herb rows** in `public/data/herbs.json` and did not change other fields or files.
- Scope was strictly limited to string/array mismatches for the `dosage` field and avoided touching other issue types or restructuring files.
- Summary of impact: `dosage` array rows reduced from **702 → 672** and `invalid-field-type` issues decreased from **1521 → 1491**, with the specific `Field 'dosage' must be a string.` mismatch dropping from **701 → 671**.
- Files changed: `public/data/herbs.json`.

### Testing
- Ran `npm run validate:data` after the edits and it passed with no blocking structural failures (STRUCTURAL_HARD unchanged at 12).
- Verified the `dosage` array row counts before/after with a node comparison script which reported `before=702 after=672`.
- Queried the generated audit report to confirm the reduction in `invalid-field-type` and `dosage`-specific mismatches, and observed the expected decreases (reports updated accordingly).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6eb3d241083238ab2cd83d2d8a23c)