### PR TITLE
Normalize `sources` structure for 30 enriched herb rows

### DIFF
--- a/src/data/herbs_enriched.json
+++ b/src/data/herbs_enriched.json
@@ -62,7 +62,11 @@
     "affiliatelink": null,
     "slug": "acacia-maidenii",
     "compounds": "DMT",
-    "sources": "https://erowid.org/plants/acacia_maidenii/;PubMed ID: 21798319;Trouts Notes – Acacia Alkaloid Profiles",
+    "sources": [
+      "https://erowid.org/plants/acacia_maidenii/",
+      "PubMed ID: 21798319",
+      "Trouts Notes – Acacia Alkaloid Profiles"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -100,7 +104,11 @@
     "affiliatelink": null,
     "slug": "achillea-millefolium",
     "compounds": "Thujone",
-    "sources": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6331677/;British Herbal Compendium;Plants of the Gods – Rätsch",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6331677/",
+      "British Herbal Compendium",
+      "Plants of the Gods – Rätsch"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -176,7 +184,11 @@
     "affiliatelink": null,
     "slug": "acmella-oleracea",
     "compounds": null,
-    "sources": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3817685/;Plants of the Gods – Rätsch;Journal of Ethnopharmacology",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3817685/",
+      "Plants of the Gods – Rätsch",
+      "Journal of Ethnopharmacology"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -252,7 +264,11 @@
     "affiliatelink": null,
     "slug": "acorus-calamus",
     "compounds": null,
-    "sources": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6383205/;PubChem CID: 73568;Botanical Safety Handbook, 2nd ed.",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6383205/",
+      "PubChem CID: 73568",
+      "Botanical Safety Handbook, 2nd ed."
+    ],
     "needsreview": false,
     "image": "https://upload.wikimedia.org/wikipedia/commons/c/c5/Calamus_aromaticus_-_K%C3%B6hler%E2%80%93s_Medizinal-Pflanzen-020.jpg",
     "safetyrating": null,
@@ -328,7 +344,11 @@
     "affiliatelink": null,
     "slug": "acorus-gramineus",
     "compounds": null,
-    "sources": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3545267/;Botanical Safety Handbook;Journal of Ethnopharmacology, 2012",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3545267/",
+      "Botanical Safety Handbook",
+      "Journal of Ethnopharmacology, 2012"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": 1,
@@ -366,7 +386,12 @@
     "affiliatelink": null,
     "slug": "adhatoda-vasica",
     "compounds": null,
-    "sources": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3249957/;Phytomedicine. 2000;7(1):37-44.;Ayurvedic Pharmacopoeia of India",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3249957/",
+      "Phytomedicine. 2000",
+      "7(1):37-44.",
+      "Ayurvedic Pharmacopoeia of India"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -404,7 +429,11 @@
     "affiliatelink": null,
     "slug": "aegle-marmelos",
     "compounds": "Marmelosin",
-    "sources": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4027290/;Indian Journal of Traditional Knowledge, 2009;Ayurvedic Pharmacopoeia of India",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4027290/",
+      "Indian Journal of Traditional Knowledge, 2009",
+      "Ayurvedic Pharmacopoeia of India"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -442,7 +471,11 @@
     "affiliatelink": null,
     "slug": "african-dream-root",
     "compounds": null,
-    "sources": "https://erowid.org/plants/silene_capensis/;Dreaming Plant Guide – Ratsch;Journal of Ethnopharmacology, 2008",
+    "sources": [
+      "https://erowid.org/plants/silene_capensis/",
+      "Dreaming Plant Guide – Ratsch",
+      "Journal of Ethnopharmacology, 2008"
+    ],
     "needsreview": false,
     "image": "https://upload.wikimedia.org/wikipedia/commons/f/fa/Silene_capensis_plant.jpg",
     "safetyrating": null,
@@ -480,7 +513,11 @@
     "affiliatelink": null,
     "slug": "albizia-julibrissin",
     "compounds": null,
-    "sources": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6834330/;Chinese Herbal Medicine: Materia Medica, 3rd ed.;Journal of Ethnopharmacology, 2009",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6834330/",
+      "Chinese Herbal Medicine: Materia Medica, 3rd ed.",
+      "Journal of Ethnopharmacology, 2009"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -518,7 +555,11 @@
     "affiliatelink": null,
     "slug": "alchornea-castaneifolia",
     "compounds": null,
-    "sources": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4127826/;Rainforest Healing Herb Profiles;Journal of Ethnopharmacology, 2007",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4127826/",
+      "Rainforest Healing Herb Profiles",
+      "Journal of Ethnopharmacology, 2007"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -594,7 +635,11 @@
     "affiliatelink": null,
     "slug": "alpinia-galanga",
     "compounds": null,
-    "sources": "https://pubmed.ncbi.nlm.nih.gov/20428007/;Phytomedicine. 2005;Ayurvedic Materia Medica",
+    "sources": [
+      "https://pubmed.ncbi.nlm.nih.gov/20428007/",
+      "Phytomedicine. 2005",
+      "Ayurvedic Materia Medica"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -632,7 +677,11 @@
     "affiliatelink": null,
     "slug": "althaea-officinalis",
     "compounds": null,
-    "sources": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5452227/;British Herbal Compendium;Herbal Medicine – Mills & Bone",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5452227/",
+      "British Herbal Compendium",
+      "Herbal Medicine – Mills & Bone"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -670,7 +719,12 @@
     "affiliatelink": null,
     "slug": "amanita-muscaria",
     "compounds": "Muscimol;Ibotenic Acid",
-    "sources": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC10454585/;Erowid Amanita Vault;Journal of Ethnopharmacology, 2008;Toxicological Profile: Muscimol & Ibotenic Acid (NIH)",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC10454585/",
+      "Erowid Amanita Vault",
+      "Journal of Ethnopharmacology, 2008",
+      "Toxicological Profile: Muscimol & Ibotenic Acid (NIH)"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -822,7 +876,12 @@
     "affiliatelink": null,
     "slug": "anadenanthera-colubrina",
     "compounds": "Bufotenine",
-    "sources": "https://erowid.org/plants/anadenanthera/;PubMed ID: 12065154;Journal of Ethnopharmacology, 1994;TiHKAL by Alexander Shulgin",
+    "sources": [
+      "https://erowid.org/plants/anadenanthera/",
+      "PubMed ID: 12065154",
+      "Journal of Ethnopharmacology, 1994",
+      "TiHKAL by Alexander Shulgin"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -860,7 +919,12 @@
     "affiliatelink": null,
     "slug": "anadenanthera-colubrina",
     "compounds": "Bufotenine",
-    "sources": "https://erowid.org/plants/anadenanthera/;PubMed ID: 12065154;Journal of Ethnopharmacology, 1994;TiHKAL by Alexander Shulgin",
+    "sources": [
+      "https://erowid.org/plants/anadenanthera/",
+      "PubMed ID: 12065154",
+      "Journal of Ethnopharmacology, 1994",
+      "TiHKAL by Alexander Shulgin"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -974,7 +1038,11 @@
     "affiliatelink": null,
     "slug": "anadenanthera-peregrina",
     "compounds": "Bufotenine",
-    "sources": "https://erowid.org/plants/anadenanthera_peregrina/;Ratsch: The Encyclopedia of Psychoactive Plants;Journal of Psychoactive Drugs, 1986",
+    "sources": [
+      "https://erowid.org/plants/anadenanthera_peregrina/",
+      "Ratsch: The Encyclopedia of Psychoactive Plants",
+      "Journal of Psychoactive Drugs, 1986"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -1012,7 +1080,11 @@
     "affiliatelink": null,
     "slug": "anadenanthera-peregrina",
     "compounds": "Bufotenine",
-    "sources": "https://erowid.org/plants/anadenanthera_peregrina/;Ratsch: The Encyclopedia of Psychoactive Plants;Journal of Psychoactive Drugs, 1986",
+    "sources": [
+      "https://erowid.org/plants/anadenanthera_peregrina/",
+      "Ratsch: The Encyclopedia of Psychoactive Plants",
+      "Journal of Psychoactive Drugs, 1986"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -1126,7 +1198,11 @@
     "affiliatelink": null,
     "slug": "arctostaphylos-uva-ursi",
     "compounds": null,
-    "sources": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6204622/;Herbal Medicine – Mills & Bone;ESCOP Monographs",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6204622/",
+      "Herbal Medicine – Mills & Bone",
+      "ESCOP Monographs"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -1202,7 +1278,11 @@
     "affiliatelink": null,
     "slug": "argyreia-nervosa",
     "compounds": null,
-    "sources": "https://erowid.org/plants/hbw/;TiHKAL by Alexander Shulgin;Journal of Ethnopharmacology, 1996",
+    "sources": [
+      "https://erowid.org/plants/hbw/",
+      "TiHKAL by Alexander Shulgin",
+      "Journal of Ethnopharmacology, 1996"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -1240,7 +1320,11 @@
     "affiliatelink": null,
     "slug": "argyreia-speciosa",
     "compounds": null,
-    "sources": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3880486/;Ayurvedic Pharmacopoeia of India;Journal of Ethnopharmacology, 2001",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3880486/",
+      "Ayurvedic Pharmacopoeia of India",
+      "Journal of Ethnopharmacology, 2001"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -1316,7 +1400,11 @@
     "affiliatelink": null,
     "slug": "artemisia-absinthium",
     "compounds": null,
-    "sources": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3265070/;Herbal Medicine: Biomolecular and Clinical Aspects, 2nd ed.;Journal of Ethnopharmacology, 2003",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3265070/",
+      "Herbal Medicine: Biomolecular and Clinical Aspects, 2nd ed.",
+      "Journal of Ethnopharmacology, 2003"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -1354,7 +1442,11 @@
     "affiliatelink": null,
     "slug": "artemisia-absinthium",
     "compounds": null,
-    "sources": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3265070/;Herbal Medicine: Biomolecular and Clinical Aspects, 2nd ed.;Journal of Ethnopharmacology, 2003",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3265070/",
+      "Herbal Medicine: Biomolecular and Clinical Aspects, 2nd ed.",
+      "Journal of Ethnopharmacology, 2003"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -1430,7 +1522,11 @@
     "affiliatelink": null,
     "slug": "artemisia-vulgaris",
     "compounds": null,
-    "sources": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5313054/;Plants of the Gods – Rätsch;British Herbal Pharmacopoeia",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5313054/",
+      "Plants of the Gods – Rätsch",
+      "British Herbal Pharmacopoeia"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -1544,7 +1640,11 @@
     "affiliatelink": null,
     "slug": "arundo-donax",
     "compounds": null,
-    "sources": "https://erowid.org/plants/arundo_donax/;Trout’s Notes on Some Other Ayahuasca Analog Plants;PubChem CID: 442018 (gramine)",
+    "sources": [
+      "https://erowid.org/plants/arundo_donax/",
+      "Trout’s Notes on Some Other Ayahuasca Analog Plants",
+      "PubChem CID: 442018 (gramine)"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -1582,7 +1682,11 @@
     "affiliatelink": null,
     "slug": "asarum-canadense",
     "compounds": null,
-    "sources": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4428597/;Herbal Medicine: Expanded Commission E Monographs;PubChem CID: 8467 (safrole)",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4428597/",
+      "Herbal Medicine: Expanded Commission E Monographs",
+      "PubChem CID: 8467 (safrole)"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -1620,7 +1724,12 @@
     "affiliatelink": null,
     "slug": "asclepias-syriaca",
     "compounds": null,
-    "sources": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4271739/;North American Ethnobotany Database;HerbalGram. 2004; (63): 34–45.",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4271739/",
+      "North American Ethnobotany Database",
+      "HerbalGram. 2004",
+      "(63): 34–45."
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -1696,7 +1805,11 @@
     "affiliatelink": null,
     "slug": "withania-somnifera",
     "compounds": null,
-    "sources": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6979308/;Herbal Medicine – Mills & Bone;Indian Journal of Psychological Medicine, 2012",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6979308/",
+      "Herbal Medicine – Mills & Bone",
+      "Indian Journal of Psychological Medicine, 2012"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -1772,7 +1885,11 @@
     "affiliatelink": null,
     "slug": "avena-sativa",
     "compounds": null,
-    "sources": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5989095/;Medical Herbalism – David Hoffmann;The Earthwise Herbal – Matthew Wood",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5989095/",
+      "Medical Herbalism – David Hoffmann",
+      "The Earthwise Herbal – Matthew Wood"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -1962,7 +2079,11 @@
     "affiliatelink": null,
     "slug": "banisteriopsis-caapi",
     "compounds": "Harmine",
-    "sources": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6082376/;Journal of Ethnopharmacology, 2010;MAPS Ayahuasca Research Summary",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC6082376/",
+      "Journal of Ethnopharmacology, 2010",
+      "MAPS Ayahuasca Research Summary"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,
@@ -2190,7 +2311,11 @@
     "affiliatelink": null,
     "slug": "nymphaea-caerulea",
     "compounds": null,
-    "sources": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3504522/;Plants of the Gods – Rätsch;Journal of Psychoactive Herbs – 2009",
+    "sources": [
+      "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3504522/",
+      "Plants of the Gods – Rätsch",
+      "Journal of Psychoactive Herbs – 2009"
+    ],
     "needsreview": false,
     "image": null,
     "safetyrating": null,


### PR DESCRIPTION
### Motivation
- Fix inconsistent `sources` shapes in the enriched herb dataset so entries conform to the schema which expects `sources` to be an array (or null), and remove inline semicolon-delimited strings that break downstream validation and tooling.

### Description
- Converted `sources` from semicolon-delimited strings to arrays of trimmed strings for 30 rows in `src/data/herbs_enriched.json` and dropped any empty tokens produced by splitting. 
- Changes were strictly limited to `sources` shape normalization and did not modify any other fields, files, or attempt content enrichment. 
- Scope was kept within the required limit (30 rows changed) and committed to the repository in a single update to `src/data/herbs_enriched.json`.

### Testing
- Ran dataset validation with `npm run validate:data` which completed and reported no blocking structural failures. 
- Verified before/after counts using small `node` scripts: before `array=0`, `string=173`, `null=597`; after `array=30`, `string=143`, `null=597`. 
- Confirmed the converted rows contain no invalid/null source items (trimmed and filtered), and the repository commit was created for the single modified file `src/data/herbs_enriched.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6ef0a9acc83238fc552e4b9a9012b)