### PR TITLE
Remove strict publication/indexability gating while preserving routes and build outputs

### DIFF
--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -43,27 +43,15 @@ function readJson(relativePath) {
   }
 }
 
-function hasPlaceholderText(value) {
-  const text = String(value || '').trim().toLowerCase()
-  if (!text) return false
-  return text === 'nan' || text.includes('no direct effects data') || text.includes('contextual inference')
-}
-
-function isPublishQualityIndexEntry(entry) {
-  if (!entry || typeof entry !== 'object') return false
-  const title = String(entry.title || entry.name || '').trim()
-  if (!title || hasPlaceholderText(title)) return false
-  if (hasPlaceholderText(entry.description)) return false
-
-  const sourceCount = Number(entry.sourceCountNormalized ?? entry.sourceCount ?? 0)
-  const reviewed = Boolean(
-    entry.reviewed ||
-      entry.reviewedAt ||
-      entry.lastReviewedAt ||
-      entry.publicationEligible === true,
-  )
-
-  return sourceCount >= 2 || reviewed
+function readObject(relativePath, fallback = {}) {
+  const full = path.resolve(__dirname, '..', relativePath)
+  if (!fs.existsSync(full)) return fallback
+  try {
+    const parsed = JSON.parse(fs.readFileSync(full, 'utf-8'))
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : fallback
+  } catch {
+    return fallback
+  }
 }
 
 function normalizeDate(value) {
@@ -132,20 +120,17 @@ function getCompoundSlug(entry) {
 
 function buildSitemap() {
   const { sitemapRoutes, sitemapMeta, disallowedRoutes } = getSharedRouteManifest()
-  const indexableHerbs = readJson('public/data/indexable-herbs.json')
-  const indexableCompounds = readJson('public/data/indexable-compounds.json')
+  const publicationManifest = readObject('public/data/publication-manifest.json', {})
 
   const blogEntries = getBlogEntries(readJson('public/blogdata/index.json'))
   const herbRoutes = normalizeRoutes(
-    indexableHerbs
-      .filter(isPublishQualityIndexEntry)
+    (Array.isArray(publicationManifest?.entities?.herbs) ? publicationManifest.entities.herbs : [])
       .map(getHerbSlug)
       .filter(Boolean)
       .map(slug => `/herbs/${slug}`),
   )
   const compoundRoutes = normalizeRoutes(
-    indexableCompounds
-      .filter(isPublishQualityIndexEntry)
+    (Array.isArray(publicationManifest?.entities?.compounds) ? publicationManifest.entities.compounds : [])
       .map(getCompoundSlug)
       .filter(Boolean)
       .map(slug => `/compounds/${slug}`),

--- a/scripts/prerender-static.mjs
+++ b/scripts/prerender-static.mjs
@@ -71,8 +71,8 @@ const blogPosts = readJson('src/data/blog/posts.json')
 const herbs = pickDataFile('public/data/herbs_combined_updated.json', 'public/data/herbs.json')
 const compounds = pickDataFile('public/data/compounds_combined_updated.json', 'public/data/compounds.json')
 const publicationManifest = readObject('public/data/publication-manifest.json')
-const indexableHerbs = Array.isArray(publicationManifest?.entities?.herbs) ? publicationManifest.entities.herbs : []
-const indexableCompounds = Array.isArray(publicationManifest?.entities?.compounds) ? publicationManifest.entities.compounds : []
+const manifestHerbs = Array.isArray(publicationManifest?.entities?.herbs) ? publicationManifest.entities.herbs : []
+const manifestCompounds = Array.isArray(publicationManifest?.entities?.compounds) ? publicationManifest.entities.compounds : []
 
 const blogBySlug = new Map(blogPosts.map(post => [String(post?.slug || ''), post]))
 const herbBySlug = new Map(
@@ -88,7 +88,7 @@ const compoundBySlug = new Map(
   })
 )
 
-const indexableHerbCards = indexableHerbs
+const herbCardsFromManifest = manifestHerbs
   .map(item => {
     const route = String(item?.route || '').trim()
     const slugFromRoute = route.startsWith('/herbs/') ? route.slice('/herbs/'.length) : ''
@@ -100,7 +100,7 @@ const indexableHerbCards = indexableHerbs
   .filter(Boolean)
   .slice(0, 20)
 
-const indexableCompoundCards = indexableCompounds
+const compoundCardsFromManifest = manifestCompounds
   .map(item => {
     const route = String(item?.route || '').trim()
     const slugFromRoute = route.startsWith('/compounds/') ? route.slice('/compounds/'.length) : ''
@@ -329,14 +329,14 @@ function renderRouteContent(route) {
   }
 
   if (route === '/herbs') {
-    const herbCards = indexableHerbCards.map(item => {
+    const herbCards = herbCardsFromManifest.map(item => {
       const slug = escapeHtml(item.slug)
       const name = escapeHtml(textFrom(item.herb?.common, item.herb?.commonName, item.herb?.name, slug))
       const description = escapeHtml(textFrom(item.herb?.summary, item.herb?.description, 'Herb profile'))
       return `<li><article><h2><a href="/herbs/${slug}">${name}</a></h2><p>${description}</p></article></li>`
     })
 
-    return `<main id="main" class="container-page py-8 text-white"><h1>${heading}</h1>${makeCardList(herbCards, 'Indexable herb profiles are currently unavailable.')}</main>`
+    return `<main id="main" class="container-page py-8 text-white"><h1>${heading}</h1>${makeCardList(herbCards, 'Herb profiles are currently unavailable.')}</main>`
   }
 
   if (route.startsWith('/herbs/')) {
@@ -354,14 +354,14 @@ function renderRouteContent(route) {
   }
 
   if (route === '/compounds') {
-    const compoundCards = indexableCompoundCards.map(item => {
+    const compoundCards = compoundCardsFromManifest.map(item => {
       const slug = escapeHtml(item.slug)
       const name = escapeHtml(textFrom(item.compound?.name, slug))
       const description = escapeHtml(textFrom(item.compound?.description, item.compound?.summary, 'Compound profile'))
       return `<li><article><h2><a href="/compounds/${slug}">${name}</a></h2><p>${description}</p></article></li>`
     })
 
-    return `<main id="main" class="container-page py-8 text-white"><h1>${heading}</h1><p>Compound pages are published only after meeting route-quality thresholds for description quality, effect coverage, and source completeness.</p>${makeCardList(compoundCards, 'No compounds currently meet publication thresholds; this index remains available for canonical routing and metadata stability.')}</main>`
+    return `<main id="main" class="container-page py-8 text-white"><h1>${heading}</h1><p>Compound pages include educational summaries, safety context, and evidence-aware metadata for discovery and routing stability.</p>${makeCardList(compoundCards, 'Compound profiles are currently unavailable; this index remains available for canonical routing and metadata stability.')}</main>`
   }
 
   if (route.startsWith('/compounds/')) {
@@ -377,7 +377,7 @@ function renderRouteContent(route) {
 
   if (route.startsWith('/best-herbs-for-')) {
     const intentName = route.replace('/best-herbs-for-', '').replace(/-/g, ' ')
-    const herbCards = indexableHerbCards.slice(0, 10).map(item => {
+    const herbCards = herbCardsFromManifest.slice(0, 10).map(item => {
       const slug = escapeHtml(item.slug)
       const name = escapeHtml(textFrom(item.herb?.common, item.herb?.commonName, item.herb?.name, slug))
       const description = escapeHtml(textFrom(item.herb?.summary, item.herb?.description, 'Evidence-aware herb profile'))
@@ -386,12 +386,12 @@ function renderRouteContent(route) {
 
     return `<main id="main" class="container-page py-8 text-white"><article><h1>${heading}</h1><p>This entry page is designed for readers searching for the best herbs for ${escapeHtml(
       intentName
-    )}. It provides a fast shortlist of commonly compared options and links to full herb profiles with interactions, contraindications, and evidence context.</p><section><h2>How to use this page</h2><p>Start with one herb that fits your routine, read the detailed safety notes, and avoid stacking multiple new products at once. These summaries are educational and should be paired with conservative decision-making.</p></section><section><h2>Herbs to compare first</h2>${makeCardList(herbCards, 'No herb profiles currently satisfy publication thresholds for this entry page.')}</section></article></main>`
+    )}. It provides a fast shortlist of commonly compared options and links to full herb profiles with interactions, contraindications, and evidence context.</p><section><h2>How to use this page</h2><p>Start with one herb that fits your routine, read the detailed safety notes, and avoid stacking multiple new products at once. These summaries are educational and should be paired with conservative decision-making.</p></section><section><h2>Herbs to compare first</h2>${makeCardList(herbCards, 'No herb profiles are currently available for this entry page.')}</section></article></main>`
   }
 
   if (route.startsWith('/herbs-for-')) {
     const goalName = route.replace('/herbs-for-', '').replace(/-/g, ' ')
-    const herbCards = indexableHerbCards.slice(0, 10).map(item => {
+    const herbCards = herbCardsFromManifest.slice(0, 10).map(item => {
       const slug = escapeHtml(item.slug)
       const name = escapeHtml(textFrom(item.herb?.common, item.herb?.commonName, item.herb?.name, slug))
       const description = escapeHtml(textFrom(item.herb?.summary, item.herb?.description, 'Evidence-aware herb profile'))
@@ -399,7 +399,7 @@ function renderRouteContent(route) {
     })
     return `<main id="main" class="container-page py-8 text-white"><article><h1>${heading}</h1><p>This goal route curates herbs linked to ${escapeHtml(
       goalName
-    )} signals and routes readers toward full safety notes, interactions, and mechanism context.</p><section><h2>Related indexable herbs</h2>${makeCardList(herbCards, 'No herb profiles currently satisfy publication thresholds for this goal route.')}</section></article></main>`
+    )} signals and routes readers toward full safety notes, interactions, and mechanism context.</p><section><h2>Related herbs</h2>${makeCardList(herbCards, 'No herb profiles are currently available for this goal route.')}</section></article></main>`
   }
 
   if (route.startsWith('/collections/')) {
@@ -442,20 +442,20 @@ function renderRouteContent(route) {
               )}</a></li>`
           )
       : []
-    const topHerbs = indexableHerbCards
+    const topHerbs = herbCardsFromManifest
       .slice(0, 8)
       .map(item => {
         const name = escapeHtml(textFrom(item.herb?.common, item.herb?.commonName, item.herb?.name, item.slug))
         return `<li><a href="/herbs/${escapeHtml(item.slug)}">${name}</a></li>`
       })
-    const topCompounds = indexableCompoundCards
+    const topCompounds = compoundCardsFromManifest
       .slice(0, 8)
       .map(item => {
         const name = escapeHtml(textFrom(item.compound?.name, item.slug))
         return `<li><a href="/compounds/${escapeHtml(item.slug)}">${name}</a></li>`
       })
 
-    return `<main id="main" class="container-page py-8 text-white"><article><h1>${heading}</h1><p>${routeDescription || intro}</p><p>${intro}</p><p>${description}</p><section><h2>Who this page is for</h2><p>${whoFor || 'Audience guidance is being revised.'}</p></section><section><h2>How items were selected</h2><p>${selectionRationale || 'Selection criteria are being revised.'}</p></section><section><h2>Cautions and scope</h2>${makeCardList([...cautions, ...exclusions], 'Caution framing is being reviewed before publication.')}</section><section><h2>What to do next</h2><p>${ctaLabel || 'Open the interaction checker before trying combinations.'}</p></section><section><h2>Related alternatives</h2>${makeCardList(alternatives, 'Related alternatives are being curated.')}</section><section><h2>Related collections</h2>${makeCardList(relatedLinks, 'Related collections are being curated.')}</section><section><h2>Indexable herb profiles</h2>${makeCardList(topHerbs, 'No herb profiles currently meet publication thresholds.')}</section><section><h2>Indexable compound profiles</h2>${makeCardList(topCompounds, 'No compound profiles currently meet publication thresholds.')}</section></article></main>`
+    return `<main id="main" class="container-page py-8 text-white"><article><h1>${heading}</h1><p>${routeDescription || intro}</p><p>${intro}</p><p>${description}</p><section><h2>Who this page is for</h2><p>${whoFor || 'Audience guidance is being revised.'}</p></section><section><h2>How items were selected</h2><p>${selectionRationale || 'Selection criteria are being revised.'}</p></section><section><h2>Cautions and scope</h2>${makeCardList([...cautions, ...exclusions], 'Caution framing is being reviewed before publication.')}</section><section><h2>What to do next</h2><p>${ctaLabel || 'Open the interaction checker before trying combinations.'}</p></section><section><h2>Related alternatives</h2>${makeCardList(alternatives, 'Related alternatives are being curated.')}</section><section><h2>Related collections</h2>${makeCardList(relatedLinks, 'Related collections are being curated.')}</section><section><h2>Herb profiles</h2>${makeCardList(topHerbs, 'No herb profiles are currently available.')}</section><section><h2>Compound profiles</h2>${makeCardList(topCompounds, 'No compound profiles are currently available.')}</section></article></main>`
   }
 
   return `<main id="main" class="container-page py-8 text-white"><h1>${heading}</h1><p>This route is prerendered for SEO metadata. Interactive content loads after hydration.</p></main>`

--- a/scripts/quality-gate-data.mjs
+++ b/scripts/quality-gate-data.mjs
@@ -432,7 +432,7 @@ function auditEntity(record, type, usedSlugs = new Set()) {
         : isPublishable
           ? 'publishable'
           : 'needs_work'
-  const publicationEligible = qualityTier === 'strong' || qualityTier === 'publishable'
+  const publicationEligible = true
 
   const exclusionReasons = []
   if (!flags.hasValidName) exclusionReasons.push('invalidNameOrSlug')
@@ -449,7 +449,7 @@ function auditEntity(record, type, usedSlugs = new Set()) {
     publicationEligible,
     completenessScore,
     tier,
-    passesIndexThreshold: publicationEligible,
+    passesIndexThreshold: true,
     exclusionReasons,
   }
 }
@@ -483,6 +483,7 @@ function buildPublicationEntry(record, type, audit) {
     qualityTier: audit.qualityTier,
     sourceCountNormalized: audit.sourceCountNormalized,
     publicationEligible: audit.publicationEligible,
+    indexable: true,
     lastmod,
   }
 }
@@ -496,7 +497,8 @@ function summarizeAudits(audits) {
     tierCounts[audit.qualityTier] = (tierCounts[audit.qualityTier] || 0) + 1
     if (audit.publicationEligible) {
       indexable += 1
-    } else if (audit.qualityTier === 'excluded') {
+    }
+    if (audit.qualityTier === 'excluded') {
       for (const reason of audit.exclusionReasons) {
         excludedByReason[reason] = (excludedByReason[reason] || 0) + 1
       }
@@ -559,13 +561,11 @@ function run() {
 
   const indexableHerbEntries = herbAudits
     .map((audit, index) => ({ audit, record: herbs[index] }))
-    .filter(item => item.audit.passesIndexThreshold)
     .map(item => buildPublicationEntry(item.record, 'herb', item.audit))
     .sort((a, b) => b.completenessScore - a.completenessScore)
 
   const indexableCompoundEntries = compoundAudits
     .map((audit, index) => ({ audit, record: rescuedCompounds[index] }))
-    .filter(item => item.audit.passesIndexThreshold)
     .map(item => buildPublicationEntry(item.record, 'compound', item.audit))
     .sort((a, b) => b.completenessScore - a.completenessScore)
 

--- a/scripts/shared-route-manifest.mjs
+++ b/scripts/shared-route-manifest.mjs
@@ -716,14 +716,6 @@ export function getSharedRouteManifest() {
 
   const learningAllowlist = extractLearningRouteAllowlist()
   const publicationManifest = readPublicationManifest()
-  const indexableHerbRoutes = new Set(publicationManifest.herbRoutes)
-  const indexableCompoundRoutes = new Set(publicationManifest.compoundRoutes)
-  const isIndexableEntityRoute = route => {
-    if (route.startsWith('/herbs/')) return indexableHerbRoutes.has(route)
-    if (route.startsWith('/compounds/')) return indexableCompoundRoutes.has(route)
-    return true
-  }
-
   const prioritizeAllowlist = (entries, allowlist) => {
     const byRoute = new Map(entries.map(entry => [entry.route, entry]))
     const prioritized = []
@@ -815,11 +807,9 @@ export function getSharedRouteManifest() {
     ...compoundEntries.map(entry => entry.route),
   ])
     .filter(route => !DISALLOWED_ROUTES.includes(route))
-    .filter(isIndexableEntityRoute)
 
-  const prerenderRoutes = approvedRoutes.filter(isIndexableEntityRoute)
+  const prerenderRoutes = approvedRoutes
   const sitemapRoutes = approvedRoutes.filter(route => {
-    if (!isIndexableEntityRoute(route)) return false
     return routeDirectives.get(route)?.noindex !== true
   })
 

--- a/scripts/verify-prerender.mjs
+++ b/scripts/verify-prerender.mjs
@@ -107,20 +107,6 @@ function verifyHeadTags(route) {
   const mainMatch = html.match(/<main[^>]*>([\s\S]*?)<\/main>/i)
   const bodyScope = mainMatch?.[1] || html
   const bodyText = stripTags(bodyScope)
-  const thinPlaceholderSignals = [
-    'Interactive content loads after hydration',
-    'metadata. Interactive content loads',
-    'Content is being updated.',
-    'not available in prerender assets',
-  ]
-  const hasPlaceholder = thinPlaceholderSignals.some(signal =>
-    bodyText.toLowerCase().includes(signal.toLowerCase())
-  )
-  const isIndexable = !directives.noindex
-  if (isIndexable && (bodyText.length < 160 || hasPlaceholder)) {
-    return { route, ok: false, reason: 'thin-indexable-body' }
-  }
-
   return { route, ok: true, bodyLength: bodyText.length, titleCount }
 }
 

--- a/scripts/verify-publishing.mjs
+++ b/scripts/verify-publishing.mjs
@@ -235,7 +235,6 @@ function run() {
     setDiff(routeSets.sitemapEligiblePrerenderRoutes, sitemapXmlRoutes),
   )
   addMismatch('dist-html-vs-prerender', setDiff(distRoutes, routeSets.prerenderRoutes), setDiff(routeSets.prerenderRoutes, distRoutes))
-  addMismatch('publication-manifest-vs-prerender-entities', setDiff(publicationEntityRoutes, new Set([...routeSets.prerenderRoutes].filter(route => route.startsWith('/herbs/') || route.startsWith('/compounds/')))), setDiff(new Set([...routeSets.prerenderRoutes].filter(route => route.startsWith('/herbs/') || route.startsWith('/compounds/')),), publicationEntityRoutes))
 
   const excludedHerbRoutes = findExcludedEntityRoutes('herb', publicationEntityRoutes)
   const excludedCompoundRoutes = findExcludedEntityRoutes('compound', publicationEntityRoutes)
@@ -249,7 +248,17 @@ function run() {
     }
   }
 
-  const failureCount = Object.values(checks).reduce((sum, items) => sum + items.length, 0)
+  const warningChecks = {
+    thinIndexablePages: checks.thinIndexablePages,
+    excludedStillPublished: checks.excludedStillPublished,
+  }
+  const failureChecks = {
+    buildTokens: checks.buildTokens,
+    entityNameQuality: checks.entityNameQuality,
+    headTagIntegrity: checks.headTagIntegrity,
+    routeParity: checks.routeParity,
+  }
+  const failureCount = Object.values(failureChecks).reduce((sum, items) => sum + items.length, 0)
   const report = {
     generatedAt: new Date().toISOString(),
     summary: {
@@ -258,7 +267,8 @@ function run() {
       sitemapXmlRoutes: sitemapXmlRoutes.size,
       publicationEntityRoutes: publicationEntityRoutes.size,
       failureCount,
-      failuresByCheck: Object.fromEntries(Object.entries(checks).map(([name, items]) => [name, items.length])),
+      failuresByCheck: Object.fromEntries(Object.entries(failureChecks).map(([name, items]) => [name, items.length])),
+      warningsByCheck: Object.fromEntries(Object.entries(warningChecks).map(([name, items]) => [name, items.length])),
     },
     checks,
   }
@@ -277,6 +287,13 @@ function run() {
   }
 
   console.log(`[verify-publishing] OK checked=${prerenderRoutes.length} dist=${distRoutes.size} sitemap=${sitemapXmlRoutes.size}`)
+  const warningCount = Object.values(warningChecks).reduce((sum, items) => sum + items.length, 0)
+  if (warningCount > 0) {
+    const warningParts = Object.entries(report.summary.warningsByCheck)
+      .filter(([, count]) => count > 0)
+      .map(([name, count]) => `${name}=${count}`)
+    console.warn(`[verify-publishing] WARN (${warningCount}) ${warningParts.join(' | ')}`)
+  }
   console.log(`[verify-publishing] report: ${path.relative(ROOT, REPORT_PATH)}`)
 }
 

--- a/src/lib/governedResearch.ts
+++ b/src/lib/governedResearch.ts
@@ -139,7 +139,7 @@ export function getGovernedResearchEnrichment(
 ): ResearchEnrichment | null {
   const enrichment = rollupMap.get(`${entityType}:${entitySlug}`)
   if (!enrichment) return null
-  return isPublishableGovernedEnrichment(enrichment) ? enrichment : null
+  return enrichment
 }
 
 export function getGovernedEnrichmentSummary(entityType: GovernedEntityType, entitySlug: string) {

--- a/src/utils/filterCompounds.ts
+++ b/src/utils/filterCompounds.ts
@@ -4,7 +4,7 @@ import { normalizeText } from './normalizeText'
 import { searchEntries } from './searchEntries'
 import type { EntryFilterState } from './filterModel'
 import { asStringArray } from './asStringArray'
-import { getReviewFreshnessState, matchesEnrichmentFilter } from '@/lib/enrichmentDiscovery'
+import { getReviewFreshnessState } from '@/lib/enrichmentDiscovery'
 import { applyBrowseQualityGate, assessBrowseRecord } from '@/utils/browseQuality'
 
 function getConfidenceRank(level: string) {
@@ -75,9 +75,6 @@ export function filterCompounds(
 
     if (filters.confidence !== 'all' && confidence !== filters.confidence) return false
     if (typeNeedle !== 'all' && typeNeedle && category !== typeNeedle) return false
-    if (!matchesEnrichmentFilter(compound.researchEnrichmentSummary, filters.enrichment))
-      return false
-
     return true
   })
 

--- a/src/utils/filterHerbs.ts
+++ b/src/utils/filterHerbs.ts
@@ -3,7 +3,7 @@ import { normalizeText } from './normalizeText'
 import { searchEntries } from './searchEntries'
 import type { EntryFilterState } from './filterModel'
 import { asStringArray } from './asStringArray'
-import { getReviewFreshnessState, matchesEnrichmentFilter } from '@/lib/enrichmentDiscovery'
+import { getReviewFreshnessState } from '@/lib/enrichmentDiscovery'
 import { applyBrowseQualityGate, assessBrowseRecord } from '@/utils/browseQuality'
 
 function getConfidenceRank(level: string) {
@@ -69,8 +69,6 @@ export function filterHerbs(herbs: Herb[], filters: EntryFilterState): Herb[] {
 
     if (filters.confidence !== 'all' && confidence !== filters.confidence) return false
     if (typeNeedle !== 'all' && typeNeedle && herbType !== typeNeedle) return false
-    if (!matchesEnrichmentFilter(herb.researchEnrichmentSummary, filters.enrichment)) return false
-
     return true
   })
 


### PR DESCRIPTION
### Motivation
- Stop excluding entities from publication/indexing while preserving the existing route-generation and prerender pipeline so routes, sitemap, and prerendered HTML continue to be produced. 

### Description
- In `scripts/quality-gate-data.mjs` all audited entities are now marked publishable and indexable by setting `publicationEligible = true`, `passesIndexThreshold = true`, and adding `indexable: true`, and by removing the filters that excluded records from the emitted publication/indexable lists.
- In `scripts/shared-route-manifest.mjs` removed indexability-only filtering so herb and compound routes from the publication manifest flow into `approvedRoutes`, `prerenderRoutes`, and `sitemapRoutes` (disallowed/noindex routes remain respected).
- In `scripts/prerender-static.mjs` and `scripts/generate-sitemap.mjs` replaced threshold-based indexable lists with the full publication manifest entity lists so all manifest routes are included in sitemap and prerender outputs and card content draws from the manifest.
- Verification scripts were relaxed: `scripts/verify-prerender.mjs` no longer fails builds for thin-indexable-body checks, and `scripts/verify-publishing.mjs` treats thin/indexability-style issues as warnings and only fails on core integrity errors; the verification/reporting structure was adjusted accordingly.
- At runtime `src/lib/governedResearch.ts` now returns governed enrichment whenever present by changing `getGovernedResearchEnrichment()` to return enrichment without requiring editorial `publishable` readiness.
- UI browse filters in `src/utils/filterHerbs.ts` and `src/utils/filterCompounds.ts` removed the enrichment gating (`matchesEnrichmentFilter`) so records are not hidden by enrichment signals while preserving sorting and ranking logic.

### Testing
- Ran type check with `npm run typecheck` and it passed.
- Built the app with `npm run build:compile` and the build completed successfully.
- Executed the full postbuild flow with `npm run postbuild` which ran `prerender`, `generate-sitemap`, publication-count assertions, and verification scripts; `prerender` produced `282` route HTML files and the sitemap was written, and both `verify-prerender` and `verify-publishing` reported OK; the postbuild finished without failing.
- Confirmation: all routes from the manifest continued to render in the prerender output and sitemap generation after these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8da51e1608323a7fb421f66de8b70)