### PR TITLE
Suppress low-quality/generated prose and gate profile sections

### DIFF
--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -53,6 +53,18 @@ const FILLER_CHIP_PATTERNS = [
   /^related herbs?\b/i,
   /^contextual inference\b/i,
 ]
+const LOW_QUALITY_PROSE_PATTERNS: RegExp[] = [
+  /\bis a compound reported in\b/i,
+  /\bappears in records as a compound reported in\b/i,
+  /available references are still early and incomplete/i,
+  /source coverage is limited and still developing/i,
+  /usage context is still being expanded/i,
+  /\bprovisional_from\b/i,
+  /\bappears in records\b/i,
+  /\bcurrently mentions\b/i,
+  /\brelated herbs listed below\b/i,
+  /\btracked for mechanism context and potential outcomes\b/i,
+]
 
 /** True if a string is entirely junk — should not be rendered at all. */
 export function isJunk(value: unknown): boolean {
@@ -265,4 +277,11 @@ export function sanitizeSummaryText(value: unknown, maxSentences = 2): string {
   const sentences = cleaned.match(/[^.!?]+[.!?]?/g) || [cleaned]
   const kept = dedupePresentationList(sentences, maxSentences)
   return kept.join(' ').trim()
+}
+
+export function isLowQualityProse(value: unknown): boolean {
+  const cleaned = sanitizeReadableText(value)
+  if (!cleaned) return true
+  if (isJunk(cleaned)) return true
+  return LOW_QUALITY_PROSE_PATTERNS.some(pattern => pattern.test(cleaned))
 }

--- a/src/lib/workbookRender.ts
+++ b/src/lib/workbookRender.ts
@@ -1,4 +1,4 @@
-import { cleanEffectChips, isJunk, sanitizeSummaryText, splitClean } from '@/lib/sanitize'
+import { cleanEffectChips, isJunk, isLowQualityProse, sanitizeSummaryText, splitClean } from '@/lib/sanitize'
 
 export type ProfileStatus = 'complete' | 'partial' | 'minimal'
 export type SummaryQuality = 'strong' | 'weak' | 'none'
@@ -36,7 +36,7 @@ export function resolveHeroSummary(
   maxSentences = 1,
 ): string {
   const summary = sanitizeSummaryText(input?.summary || input?.description || '', maxSentences)
-  return isJunk(summary) ? '' : summary
+  return isJunk(summary) || isLowQualityProse(summary) ? '' : summary
 }
 
 export function resolveCoreInsight(
@@ -44,5 +44,5 @@ export function resolveCoreInsight(
   maxSentences = 1,
 ): string {
   const insight = sanitizeSummaryText(input?.whyItMatters || '', maxSentences)
-  return isJunk(insight) ? '' : insight
+  return isJunk(insight) || isLowQualityProse(insight) ? '' : insight
 }

--- a/src/pages/CompoundDetail.tsx
+++ b/src/pages/CompoundDetail.tsx
@@ -6,6 +6,7 @@ import { useCompoundDataState, useCompoundDetailState } from '@/lib/compound-dat
 import { useHerbDataState } from '@/lib/herb-data'
 import {
   cleanEffectChips,
+  isLowQualityProse,
   sanitizeReadableText,
   sanitizeSummaryText,
   splitClean,
@@ -244,6 +245,7 @@ export default function CompoundDetail() {
   const coreInsight = uniqueCopy.overview
   const compoundDescription = uniqueCopy.hero
   const compoundMechanism = uniqueCopy.mechanism
+  const contextSummary = uniqueCopy.context
   const workbookSafety = sanitizeRenderChips(
     splitClean(safetyRecord.notes || safetyRecord.summary || safetyRecord.caution || rawRecord.safety),
     8,
@@ -290,11 +292,16 @@ export default function CompoundDetail() {
     compoundDescription || coreInsight || compoundMechanism,
     1,
   )
+  const hasRenderableTopSummary = Boolean(topSummary) && !isLowQualityProse(topSummary)
+  const hasRenderableWhyItMatters = Boolean(whyItMatters) && !isLowQualityProse(whyItMatters)
+  const hasRenderableMechanism = Boolean(compoundMechanism) && !isLowQualityProse(compoundMechanism)
+  const hasRenderableContext = Boolean(contextSummary) && !isLowQualityProse(contextSummary)
   const consumeSectionBody = createSectionBodyTracker()
   const whyItMattersBody = !isMinimalProfile
-    ? consumeSectionBody(whyItMatters || 'Tracked for mechanism context and potential outcomes.')
+    ? consumeSectionBody(hasRenderableWhyItMatters ? whyItMatters : '')
     : ''
-  const mechanismBody = !isMinimalProfile ? consumeSectionBody(compoundMechanism) : ''
+  const mechanismBody = !isMinimalProfile ? consumeSectionBody(hasRenderableMechanism ? compoundMechanism : '') : ''
+  const contextBody = !isMinimalProfile ? consumeSectionBody(hasRenderableContext ? contextSummary : '') : ''
   const pharmacokineticsBody = !isMinimalProfile ? consumeSectionBody(pharmacokinetics) : ''
   const dosageBody = consumeSectionBody(compound.dosage)
   const durationBody = consumeSectionBody(compound.duration)
@@ -562,7 +569,7 @@ export default function CompoundDetail() {
           <div className='flex flex-wrap items-start justify-between gap-3'>
             <h1 className='text-3xl font-semibold leading-tight'>{name}</h1>
           </div>
-          {shouldRenderSummary(profileStatus, summaryQuality) && topSummary && (
+          {shouldRenderSummary(profileStatus, summaryQuality) && hasRenderableTopSummary && (
             <p className='mt-3 max-w-3xl text-sm leading-relaxed text-white/80'>
               {topSummary}
             </p>
@@ -586,10 +593,10 @@ export default function CompoundDetail() {
                 ) : null}
               </div>
             </section>
-            {!isMinimalProfile && <section className='detail-panel rounded-lg p-3'>
+            {!isMinimalProfile && whereAppears.length > 0 && <section className='detail-panel rounded-lg p-3'>
               <h2 className='text-[11px] font-semibold uppercase tracking-[0.14em] text-white/56'>Where it appears</h2>
               <p className='mt-1 text-xs text-white/80'>
-                {whereAppears.join(', ') || 'Related herbs listed below.'}
+                {whereAppears.join(', ')}
               </p>
             </section>}
           </div>
@@ -629,6 +636,7 @@ export default function CompoundDetail() {
 
         {/* Mechanisms */}
         {mechanismBody && <Section title='Mechanisms'>{mechanismBody}</Section>}
+        {contextBody && <Section title='Context'>{contextBody}</Section>}
 
         {/* Targets */}
         {!isMinimalProfile && targetList.length > 0 && (

--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -5,7 +5,13 @@ import { Link, useLocation, useParams } from 'react-router-dom'
 import Meta from '@/components/Meta'
 import { useCompoundDataState } from '@/lib/compound-data'
 import { useHerbDataState, useHerbDetailState } from '@/lib/herb-data'
-import { dedupePresentationList, normalizePresentationLabel, sanitizeReadableText, sanitizeSummaryText } from '@/lib/sanitize'
+import {
+  dedupePresentationList,
+  isLowQualityProse,
+  normalizePresentationLabel,
+  sanitizeReadableText,
+  sanitizeSummaryText,
+} from '@/lib/sanitize'
 import { buildUniqueDetailCopy, sanitizeRenderChips, sanitizeRenderList } from '@/lib/renderGuard'
 import { normalizeTagList } from '@/lib/tagNormalization'
 import { HerbDetailSkeleton } from '@/components/skeletons/DetailSkeletons'
@@ -199,6 +205,11 @@ export default function HerbDetail() {
       String(curatedData.mechanism || '').trim(),
   })
   const coreInsight = uniqueCopy.overview
+  const hasRenderableSummary = Boolean(summary) && !isLowQualityProse(summary)
+  const hasRenderableCoreInsight = Boolean(coreInsight) && !isLowQualityProse(coreInsight)
+  const hasRenderableFullDescription = Boolean(fullDescription) && !isLowQualityProse(fullDescription)
+  const hasRenderableMechanism = Boolean(uniqueCopy.mechanism) && !isLowQualityProse(uniqueCopy.mechanism)
+  const hasRenderableContext = Boolean(uniqueCopy.context) && !isLowQualityProse(uniqueCopy.context)
 
   const primaryActions = sanitizeRenderChips(
     dedupePresentationList(
@@ -210,7 +221,6 @@ export default function HerbDetail() {
   const keyEffects = primaryActions.slice(0, 4)
   const activeCompounds = sanitizeRenderList(splitTextList(herb.activeCompounds), 10)
   const traditionalUses = sanitizeRenderList(splitTextList(herb.traditionalUses), 8)
-  const mechanism = uniqueCopy.mechanism
   const contextSummary = uniqueCopy.context
   const dosage = String(herb.dosage || '').trim()
   const duration = String(herb.duration || '').trim()
@@ -332,14 +342,14 @@ export default function HerbDetail() {
       <article className='space-y-5'>
         <div className='sr-only' aria-hidden='true'>
           <h1>{herbName}</h1>
-          <p>{summary}</p>
+          {hasRenderableSummary && <p>{summary}</p>}
           <ul>{safetyNotes.map(note => <li key={`static-safety-${note}`}>{note}</li>)}</ul>
         </div>
 
         <header className='premium-panel fade-in-surface p-5 sm:p-7'>
           <p className='section-label'>Herb profile</p><h1 className='mt-2 text-4xl font-semibold sm:text-5xl'>{herbName}</h1>
           {scientificName && <p className='mt-1 text-sm italic text-white/55'>{scientificName}</p>}
-          {showSummaryRegion && !descriptionIsPlaceholder && (
+          {showSummaryRegion && !descriptionIsPlaceholder && hasRenderableSummary && (
             <p className='mt-3 max-w-3xl text-sm leading-relaxed text-white/80'>{summary}</p>
           )}
 
@@ -363,9 +373,9 @@ export default function HerbDetail() {
           </div>
         </section>
 
-        {!isMinimalProfile && mechanism && (
+        {!isMinimalProfile && hasRenderableMechanism && (
           <DisclosureSection title='Mechanisms' defaultOpen>
-            <p>{mechanism}</p>
+            <p>{uniqueCopy.mechanism}</p>
           </DisclosureSection>
         )}
 
@@ -440,20 +450,20 @@ export default function HerbDetail() {
           </DisclosureSection>
         )}
 
-        {!isMinimalProfile && summaryQuality === 'strong' && coreInsight && coreInsight !== summary && (
+        {!isMinimalProfile && summaryQuality === 'strong' && hasRenderableCoreInsight && coreInsight !== summary && (
           <section className='browse-shell fade-in-surface p-5 sm:p-6'>
             <h2 className='text-sm font-semibold uppercase tracking-[0.16em] text-white/85'>Core insight</h2>
             <p className='mt-2 text-sm leading-relaxed text-white/85'>{coreInsight}</p>
           </section>
         )}
 
-        {!isMinimalProfile && !descriptionIsPlaceholder && fullDescription && fullDescription !== summary && (
+        {!isMinimalProfile && !descriptionIsPlaceholder && hasRenderableFullDescription && fullDescription !== summary && (
           <DisclosureSection title='Full Description'>
             <p>{fullDescription}</p>
           </DisclosureSection>
         )}
 
-        {!isMinimalProfile && contextSummary && contextSummary !== summary && (
+        {!isMinimalProfile && hasRenderableContext && contextSummary !== summary && (
           <DisclosureSection title='Context'>
             <p>{contextSummary}</p>
           </DisclosureSection>


### PR DESCRIPTION
### Motivation

- Prevent visible rendering of low-quality or placeholder prose (e.g. automated "appears in records" or provisional phrases) so user-facing summaries and sections are more reliable.
- Reduce noisy fallback copy like "Related herbs listed below" and avoid surfacing context/mechanism text that is low quality.

### Description

- Added `LOW_QUALITY_PROSE_PATTERNS` and a new `isLowQualityProse` function in `src/lib/sanitize.ts` to detect low-quality autogenerated/provisional phrases.
- Integrated `isLowQualityProse` into `workbookRender` so `resolveHeroSummary` and `resolveCoreInsight` return empty for low-quality prose.
- Updated `CompoundDetail.tsx` to gate top summary, why-it-matters, mechanism, and context sections using the new low-quality check, added a `Context` section, and removed the fallback "Related herbs listed below" for the "Where it appears" panel so it only renders when entries exist.
- Updated `HerbDetail.tsx` to gate summary, core insight, full description, mechanism, and context rendering with the new low-quality prose checks and adjusted imports accordingly.

### Testing

- Ran the project build (`npm run build`) and TypeScript typecheck (`tsc --noEmit`) and they completed successfully.
- Executed the test suite (`npm test`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea5bbf700c832395a67b618af9fa44)