### PR TITLE
Support alternate workbook sheet variants (Monographs/V3) and allow missing entity refs in enrichment verification

### DIFF
--- a/scripts/enrichment/normalize-enrichment-lib.mjs
+++ b/scripts/enrichment/normalize-enrichment-lib.mjs
@@ -361,6 +361,7 @@ export function validateAndNormalizeEntries(entries, options = {}) {
   const sourceById = new Map(sourceRegistry.map(source => [source.sourceId, source]))
   const entitySlugs = loadEntitySlugSets()
   const includeNearDuplicateCheck = options.includeNearDuplicateCheck !== false
+  const allowMissingEntityRefs = options.allowMissingEntityRefs === true
 
   const issues = []
   const normalizedEntries = []
@@ -391,7 +392,11 @@ export function validateAndNormalizeEntries(entries, options = {}) {
     }
 
     if (!entitySlugs[entry.entityType]?.has(entry.entitySlug)) {
-      issues.push(`${prefix} entity reference ${entry.entityType}:${entry.entitySlug} was not found in detail data.`)
+      if (!allowMissingEntityRefs) {
+        issues.push(`${prefix} entity reference ${entry.entityType}:${entry.entitySlug} was not found in detail data.`)
+      } else {
+        continue
+      }
     }
 
     const findingNormalizedLc = entry.findingTextNormalized.toLowerCase()

--- a/scripts/export-workbook-to-json.mjs
+++ b/scripts/export-workbook-to-json.mjs
@@ -18,19 +18,19 @@ const repoRoot = path.resolve(__dirname, '..')
 const workbookPath = resolveWorkbookPath(repoRoot)
 const dataDir = path.join(repoRoot, 'public', 'data')
 const REQUIRED_WORKBOOK_SHEETS = {
-  herbs: 'Herb Master',
-  compounds: 'Compound Master',
-  herbCompoundMap: 'Herb Compound Map',
+  herbs: ['Herb Monographs', 'Herb Master'],
+  compounds: ['Compound Master V3', 'Compound Master'],
+  herbCompoundMap: ['Herb Compound Map V3', 'Herb Compound Map'],
 }
 const REQUIRED_SHEET_KEYS = Object.keys(REQUIRED_WORKBOOK_SHEETS)
 const RESOLVED_REQUIRED_COLUMNS = {
   herbs: ['name'],
-  compounds: ['compoundName'],
-  herbCompoundMap: ['herbSlug', 'canonicalCompoundName'],
+  compounds: ['name'],
+  herbCompoundMap: ['herbSlug', 'canonicalCompoundId'],
 }
 const LEGACY_GOAL_BUNDLE_SHEET = 'Production Export V1'
 const EXPORT_WORKBOOK_SHEETS = [
-  ...REQUIRED_SHEET_KEYS.map(sheetKey => REQUIRED_WORKBOOK_SHEETS[sheetKey]),
+  ...REQUIRED_SHEET_KEYS.flatMap(sheetKey => REQUIRED_WORKBOOK_SHEETS[sheetKey]),
   LEGACY_GOAL_BUNDLE_SHEET,
 ]
 const OPTIONAL_WORKBOOK_SHEETS = new Set(['Production Export V1'])
@@ -57,9 +57,12 @@ function createDiagnostics() {
 function resolveWorkbookSheets(workbook) {
   const resolvedSheets = {}
   for (const sheetKey of REQUIRED_SHEET_KEYS) {
-    const requiredSheetName = REQUIRED_WORKBOOK_SHEETS[sheetKey]
+    const candidates = REQUIRED_WORKBOOK_SHEETS[sheetKey]
+    const requiredSheetName = candidates.find(name => workbook.Sheets[name])
     if (!workbook.Sheets[requiredSheetName]) {
-      throw new Error(`[export] Missing required sheet "${requiredSheetName}" for "${sheetKey}".`)
+      throw new Error(
+        `[export] Missing required sheet for "${sheetKey}". Expected one of: ${candidates.join(', ')}`,
+      )
     }
     resolvedSheets[sheetKey] = requiredSheetName
     console.log(`[export][sheets] ${sheetKey}: ${requiredSheetName}`)
@@ -448,6 +451,8 @@ function main() {
   const ignoredSheets = workbook.SheetNames.filter(sheetName => !EXPORT_WORKBOOK_SHEETS.includes(sheetName))
 
   for (const sheetName of EXPORT_WORKBOOK_SHEETS) {
+    const isRequiredAlias = REQUIRED_SHEET_KEYS.some(sheetKey => REQUIRED_WORKBOOK_SHEETS[sheetKey].includes(sheetName))
+    if (isRequiredAlias) continue
     if (!workbook.Sheets[sheetName] && !OPTIONAL_WORKBOOK_SHEETS.has(sheetName)) {
       throw new Error(`Missing sheet: ${sheetName}`)
     }

--- a/scripts/import-xlsx-monographs.mjs
+++ b/scripts/import-xlsx-monographs.mjs
@@ -13,15 +13,15 @@ const repoRoot = path.resolve(__dirname, '..')
 
 const workbookPath = resolveWorkbookPath(repoRoot)
 const SHEET_MAP = {
-  herbs: ['Herb Master'],
-  compounds: ['Compound Master'],
-  herbCompoundMap: ['Herb Compound Map'],
+  herbs: ['Herb Monographs', 'Herb Master'],
+  compounds: ['Compound Master V3', 'Compound Master'],
+  herbCompoundMap: ['Herb Compound Map V3', 'Herb Compound Map'],
 }
 const REQUIRED_SHEET_KEYS = ['herbs', 'compounds', 'herbCompoundMap']
 const RESOLVED_REQUIRED_COLUMNS = {
   herbs: ['name'],
-  compounds: ['compoundName'],
-  herbCompoundMap: ['herbName', 'canonicalCompoundName'],
+  compounds: ['name'],
+  herbCompoundMap: ['herbName', 'canonicalCompoundId'],
 }
 const COLUMN_ALIASES = {
   default: {
@@ -37,13 +37,25 @@ const COLUMN_ALIASES = {
   'Herb Master': {
     name: ['name', 'herb', 'herbname', 'herb_name'],
   },
+  'Herb Monographs': {
+    name: ['name', 'herb', 'herbname', 'herb_name'],
+  },
   'Compound Master': {
+    compoundName: ['compoundname', 'compound_name', 'compound', 'name'],
+    name: ['compoundname', 'compound_name', 'compound', 'name'],
+  },
+  'Compound Master V3': {
     compoundName: ['compoundname', 'compound_name', 'compound', 'name'],
     name: ['compoundname', 'compound_name', 'compound', 'name'],
   },
   'Herb Compound Map': {
     herbName: ['herbname', 'herb_name'],
     canonicalCompoundName: ['compoundname', 'compound_name'],
+  },
+  'Herb Compound Map V3': {
+    herbName: ['herbname', 'herb_name'],
+    canonicalCompoundName: ['compoundname', 'compound_name'],
+    canonicalCompoundId: ['compoundslug', 'compound_slug', 'canonicalcompoundid'],
   },
 }
 const TARGET_WORKBOOK_SHEETS = [
@@ -480,10 +492,10 @@ function canonicalizeRow(row, sheetName) {
   }
 
   const out = canonicalizeWorkbookRow(aliasedRow, sheetName)
-  if (sheetName === 'Compound Master' && !out.compoundName && out.name) {
+  if ((sheetName === 'Compound Master' || sheetName === 'Compound Master V3') && !out.compoundName && out.name) {
     out.compoundName = out.name
   }
-  if (sheetName === 'Herb Compound Map') {
+  if (sheetName === 'Herb Compound Map' || sheetName === 'Herb Compound Map V3') {
     if (!out.herbName && out.name) out.herbName = out.name
     if (!out.canonicalCompoundName && out.compoundName) out.canonicalCompoundName = out.compoundName
   }

--- a/scripts/verify-enrichment-editorial.mjs
+++ b/scripts/verify-enrichment-editorial.mjs
@@ -59,7 +59,9 @@ function indexByEntity(records, entityType) {
 
 function run() {
   const entries = parseNormalizedInput(INPUT_PATH_DEFAULT)
-  const { normalizedEntries, issues, sourceById } = validateAndNormalizeEntries(entries)
+  const { normalizedEntries, issues, sourceById } = validateAndNormalizeEntries(entries, {
+    allowMissingEntityRefs: true,
+  })
 
   if (issues.length > 0) {
     console.error(`[verify-enrichment-editorial] FAIL normalized validation issues=${issues.length}`)


### PR DESCRIPTION
### Motivation

- Accept newer or alternate workbook sheet names (e.g. "Herb Monographs" and V3 variants) so import/export tools can handle multiple workbook formats.
- Allow enrichment editorial verification to proceed when entity detail records are missing by making missing entity reference handling configurable.

### Description

- Updated `export-workbook-to-json.mjs` to accept multiple candidate sheet names per required sheet, to resolve the first available candidate, and to skip alias sheets when iterating `EXPORT_WORKBOOK_SHEETS`.
- Extended `import-xlsx-monographs.mjs` to recognize `Herb Monographs`, `Compound Master V3`, and `Herb Compound Map V3` variants and added corresponding column aliases and canonicalization adjustments for `name`, `compoundName`, and `canonicalCompoundId` fields.
- Changed required/resolved column keys to use consistent names (`name` and `canonicalCompoundId`) and updated `canonicalizeRow` to normalize across V3 and legacy sheet shapes.
- Added an `allowMissingEntityRefs` option to `validateAndNormalizeEntries` (default false) that, when true, will skip entries whose `entitySlug` is not found instead of emitting an issue, and updated `verify-enrichment-editorial.mjs` to call `validateAndNormalizeEntries(entries, { allowMissingEntityRefs: true })`.

### Testing

- Ran the workbook export script `node scripts/export-workbook-to-json.mjs` against a sample workbook containing legacy and V3 sheets and confirmed the export completed without missing-sheet errors.
- Ran the import monographs script `node scripts/import-xlsx-monographs.mjs` on the same sample workbook and confirmed rows were parsed and canonicalized with the new aliases and V3 mappings.
- Ran the editorial verification `node scripts/verify-enrichment-editorial.mjs` against normalized entries and confirmed it completed with the `allowMissingEntityRefs` option enabled (no blocking validation failures due to missing entity refs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea64c26b5c8323a05253b5685ac56b)