### PR TITLE
chore: thin enrichment pipeline validation to runtime safety

### DIFF
--- a/scripts/enrichment/normalize-enrichment-lib.mjs
+++ b/scripts/enrichment/normalize-enrichment-lib.mjs
@@ -356,10 +356,11 @@ export function evaluateEntryReadiness(entry, source, validationIssues = []) {
 }
 
 export function validateAndNormalizeEntries(entries, options = {}) {
-  const validate = compileValidator()
-  const sourceRegistry = readJson(SOURCE_REGISTRY_PATH)
+  const runtimeSafetyOnly = options.runtimeSafetyOnly === true
+  const validate = runtimeSafetyOnly ? null : compileValidator()
+  const sourceRegistry = fs.existsSync(SOURCE_REGISTRY_PATH) ? readJson(SOURCE_REGISTRY_PATH) : []
   const sourceById = new Map(sourceRegistry.map(source => [source.sourceId, source]))
-  const entitySlugs = loadEntitySlugSets()
+  const entitySlugs = runtimeSafetyOnly ? null : loadEntitySlugSets()
   const includeNearDuplicateCheck = options.includeNearDuplicateCheck !== false
   const allowMissingEntityRefs = options.allowMissingEntityRefs === true
 
@@ -373,6 +374,35 @@ export function validateAndNormalizeEntries(entries, options = {}) {
     const entry = normalizeEntry(rawEntry)
     const idPart = entry.enrichmentId ?? `row-${index + 1}`
     const prefix = `[entry:${index}:${idPart}]`
+
+    if (runtimeSafetyOnly) {
+      if (!entry || typeof entry !== 'object') {
+        issues.push(`${prefix} entry must be an object.`)
+        continue
+      }
+      if (!['herb', 'compound'].includes(entry.entityType)) {
+        issues.push(`${prefix} entityType must be herb|compound.`)
+        continue
+      }
+      if (!isNonEmptyText(entry.entitySlug)) {
+        issues.push(`${prefix} entitySlug is required.`)
+        continue
+      }
+      if (!isNonEmptyText(entry.sourceId)) {
+        issues.push(`${prefix} sourceId is required.`)
+        continue
+      }
+      if (!isNonEmptyText(entry.topicType) || !TOPIC_TO_ROLLUP_FIELD[entry.topicType]) {
+        issues.push(`${prefix} topicType is required and must be supported by rollup.`)
+        continue
+      }
+      if (!isNonEmptyText(entry.findingTextNormalized)) {
+        issues.push(`${prefix} findingTextNormalized is required.`)
+        continue
+      }
+      normalizedEntries.push(entry)
+      continue
+    }
 
     if (!validate(entry)) {
       issues.push(`${prefix} schema invalid: ${JSON.stringify(validate.errors ?? [])}`)

--- a/scripts/verify-enrichment-editorial.mjs
+++ b/scripts/verify-enrichment-editorial.mjs
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import fs from 'node:fs'
 import path from 'node:path'
 import {
   EDITORIAL_READINESS_REPORT_PATH,
@@ -11,60 +10,17 @@ import {
 } from './enrichment/normalize-enrichment-lib.mjs'
 
 const ROOT = process.cwd()
-const HERBS_PATH = path.join(ROOT, 'public', 'data', 'herbs.json')
-const COMPOUNDS_PATH = path.join(ROOT, 'public', 'data', 'compounds.json')
-
-function readJsonArray(filePath) {
-  if (!fs.existsSync(filePath)) return []
-  const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'))
-  return Array.isArray(parsed) ? parsed : []
-}
-
-function normalizeSlug(value) {
-  return String(value || '')
-    .trim()
-    .toLowerCase()
-}
-
-function hasRenderableEnrichmentSections(payload) {
-  const enrichment = payload?.researchEnrichment
-  if (!enrichment || typeof enrichment !== 'object') return false
-
-  const claimFields = [
-    'supportedUses',
-    'unsupportedOrUnclearUses',
-    'mechanisms',
-    'constituents',
-    'interactions',
-    'contraindications',
-    'adverseEffects',
-    'dosageContextNotes',
-    'populationSpecificNotes',
-    'conflictNotes',
-    'researchGaps',
-  ]
-
-  return claimFields.some(field => Array.isArray(enrichment[field]) && enrichment[field].length > 0)
-}
-
-function indexByEntity(records, entityType) {
-  const map = new Map()
-  for (const row of records) {
-    const slug = normalizeSlug(row?.slug)
-    if (!slug) continue
-    map.set(`${entityType}:${slug}`, row)
-  }
-  return map
-}
 
 function run() {
   const entries = parseNormalizedInput(INPUT_PATH_DEFAULT)
   const { normalizedEntries, issues, sourceById } = validateAndNormalizeEntries(entries, {
+    runtimeSafetyOnly: true,
+    includeNearDuplicateCheck: false,
     allowMissingEntityRefs: true,
   })
 
   if (issues.length > 0) {
-    console.error(`[verify-enrichment-editorial] FAIL normalized validation issues=${issues.length}`)
+    console.error(`[verify-enrichment-editorial] FAIL runtime safety issues=${issues.length}`)
     for (const issue of issues.slice(0, 50)) console.error(`- ${issue}`)
     if (issues.length > 50) console.error(`- ...and ${issues.length - 50} more`)
     process.exit(1)
@@ -73,44 +29,8 @@ function run() {
   const readiness = buildEditorialReadinessReport(normalizedEntries, sourceById)
   writeJson(EDITORIAL_READINESS_REPORT_PATH, readiness)
 
-  const blockedOrPartialEntities = [
-    ...readiness.entitiesPartiallyEnrichedButBlocked,
-    ...readiness.entitiesBlocked,
-  ]
-
-  const herbMap = indexByEntity(readJsonArray(HERBS_PATH), 'herb')
-  const compoundMap = indexByEntity(readJsonArray(COMPOUNDS_PATH), 'compound')
-  const entityMap = new Map([...herbMap.entries(), ...compoundMap.entries()])
-
-  const renderViolations = []
-  for (const entity of blockedOrPartialEntities) {
-    const key = `${entity.entityType}:${entity.entitySlug}`
-    const payload = entityMap.get(key)
-    if (!payload) continue
-    if (hasRenderableEnrichmentSections(payload)) {
-      renderViolations.push({
-        entityType: entity.entityType,
-        entitySlug: entity.entitySlug,
-        readinessState: entity.readinessState,
-        blockedReasons: entity.blockedReasons,
-      })
-    }
-  }
-
-  if (renderViolations.length > 0) {
-    console.error(
-      `[verify-enrichment-editorial] FAIL blocked-or-partial entities still expose renderable enrichment sections=${renderViolations.length}`,
-    )
-    for (const violation of renderViolations.slice(0, 50)) {
-      console.error(
-        `- ${violation.entityType}:${violation.entitySlug} readiness=${violation.readinessState} reasons=${violation.blockedReasons.join(',')}`,
-      )
-    }
-    process.exit(1)
-  }
-
   console.log(
-    `[verify-enrichment-editorial] PASS entries=${normalizedEntries.length} ready=${readiness.summary.entitiesReadyForEnrichedPublish} partial=${readiness.summary.entitiesPartiallyBlocked} blocked=${readiness.summary.entitiesBlocked}`,
+    `[verify-enrichment-editorial] PASS runtime-safe entries=${normalizedEntries.length}`,
   )
   console.log(`[verify-enrichment-editorial] report=${path.relative(ROOT, EDITORIAL_READINESS_REPORT_PATH)}`)
 }


### PR DESCRIPTION
### Motivation
- The enrichment normalization and postbuild editorial verifier included overlapping editorial/coverage checks that duplicate workbook validation and block builds; the goal is to make the publish pipeline thin and keep the workbook as authoritative.
- Keep only minimal runtime-safety checks so payload generation and site routes do not crash while removing editorial/completeness gates from the build.

### Description
- Added a `runtimeSafetyOnly` mode to `validateAndNormalizeEntries` in `scripts/enrichment/normalize-enrichment-lib.mjs` and implemented a lightweight runtime-safety validation branch that only enforces basic shape and runtime identifiers (`entityType`, `entitySlug`, `sourceId`, supported `topicType`, `findingTextNormalized`).
- Kept the original strict/editorial validation code path intact and used only when `runtimeSafetyOnly` is not set.
- Updated `scripts/verify-enrichment-editorial.mjs` to call `validateAndNormalizeEntries` with `runtimeSafetyOnly: true`, `includeNearDuplicateCheck: false`, and `allowMissingEntityRefs: true`, and removed the build-time enforcement of blocked/partial renderability and other editorial gates.
- Files changed: `scripts/enrichment/normalize-enrichment-lib.mjs` and `scripts/verify-enrichment-editorial.mjs`.

### Testing
- Ran `npm run verify:enrichment-editorial`, which completed successfully and reported `PASS runtime-safe entries=18`.
- Ran `npm run build` (including `postbuild` hooks) and `npm run build:compile`, both of which completed successfully with the altered verifier in place.

Validations removed (for the pipeline/runtime-safety path)
- Schema-hard/strict validation enforced in the build path (now only run when not in `runtimeSafetyOnly`).
- Source registry sufficiency and evidence-class consistency checks.
- Entity/target reference completeness enforcement and legacy entity-reference failures.
- Editorial/vague-text and evidence completeness checks (token-length, vague-pattern checks, weak-evidence uncertainty-note gating).
- Topic relation and safety policy checks (relation/type/target enforcement and safety-specific fields validation) in the runtime path.
- Duplicate/near-duplicate and contradictory-severity conflict checks.
- Renderability/blocking enforcement that failed the build when partial/blocked entities still expose enriched sections.

Validations retained (runtime-safety)
- JSON parsing / input format validation via `parseNormalizedInput` to ensure valid JSON/JSONL input.
- Minimal runtime guards that prevent payload-generator crashes, specifically: entry must be an object, `entityType` must be `herb|compound`, non-empty `entitySlug`, non-empty `sourceId`, `topicType` must map to a rollup field, and non-empty `findingTextNormalized`.
- The full editorial/reporting path remains available for non-runtime callers by omitting `runtimeSafetyOnly` (so editorial checks are preserved for workbook/ops workflows).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea743557608323bff38ff1ff5ce54e)