### PR TITLE
Patch workbook compound import to populate description/summary/foundIn/targets

### DIFF
--- a/scripts/import-xlsx-monographs.mjs
+++ b/scripts/import-xlsx-monographs.mjs
@@ -979,6 +979,26 @@ function patchCompound(compound, row, reservedCanonicalIds, fieldPatchCounts) {
     patched = patchField(compound, 'mechanism', mechanismCandidate, fieldPatchCounts) || patched
   }
 
+  const descriptionCandidate = cleanText(row.description || row.summary)
+  if (shouldPatchScalar(compound.description, descriptionCandidate, { minCandidateLength: 20, minGain: 0 })) {
+    patched = patchField(compound, 'description', descriptionCandidate, fieldPatchCounts) || patched
+  }
+
+  const summaryCandidate = cleanText(row.summary || row.description)
+  if (shouldPatchScalar(compound.summary, summaryCandidate, { minCandidateLength: 20, minGain: 0 })) {
+    patched = patchField(compound, 'summary', summaryCandidate, fieldPatchCounts) || patched
+  }
+
+  const foundInCandidate = dedupeStrings(splitSemicolonDelimited(row.foundIn))
+  if (shouldPatchArray(compound.foundIn, foundInCandidate, { minItems: 1, minGain: 0 })) {
+    patched = patchField(compound, 'foundIn', foundInCandidate, fieldPatchCounts) || patched
+  }
+
+  const targetsCandidate = dedupeStrings(splitSemicolonDelimited(row.targets))
+  if (shouldPatchArray(compound.targets, targetsCandidate, { minItems: 1, minGain: 0 })) {
+    patched = patchField(compound, 'targets', targetsCandidate, fieldPatchCounts) || patched
+  }
+
   const effectsCandidate = dedupeStrings([
     ...splitSemicolonDelimited(row.mechanismTags),
     ...splitSemicolonDelimited(row.pathwayTargets),


### PR DESCRIPTION
### Motivation
- The compound import was not populating `description` and `summary` from the workbook, causing generated payloads to fall back to generic text; the workbook contains `description` and `summary` columns that should be applied to `compounds.json`.
- The workbook also contains `foundIn` and `targets` columns that improve compound metadata and should be patched into the compound records.

### Description
- Added scalar patching for `description` using `cleanText(row.description || row.summary)` with `shouldPatchScalar(..., { minCandidateLength: 20, minGain: 0 })` in `patchCompound()` immediately after the existing `mechanism` block.
- Added scalar patching for `summary` using `cleanText(row.summary || row.description)` with the same patch criteria and placement as above.
- Added array patching for `foundIn` by `dedupeStrings(splitSemicolonDelimited(row.foundIn))` and for `targets` by `dedupeStrings(splitSemicolonDelimited(row.targets))`, both using `shouldPatchArray(..., { minItems: 1, minGain: 0 })`.
- Changes are confined to `scripts/import-xlsx-monographs.mjs` and were inserted directly after the `mechanismCandidate` block without altering other logic or herb patching.

### Testing
- Ran `npm run build:compile` and the production compile completed successfully.
- Commit-time linting (`eslint --max-warnings=0`) executed as part of the pre-commit tasks and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead556eea08323b76bc658b271490e)