### PR TITLE
Clean corrupt compound effects during workbook import

### DIFF
--- a/scripts/import-xlsx-monographs.mjs
+++ b/scripts/import-xlsx-monographs.mjs
@@ -1079,6 +1079,16 @@ function writeJson(filePath, data) {
   fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, 'utf8')
 }
 
+function cleanCompoundEffects(effects) {
+  if (!Array.isArray(effects)) return []
+  const CORRUPT = [/\bno direct\b/i, /\bcontextual inference\b/i, /\bnan\b/, /\bprovisional_from\b/i, /\[object/i]
+  return effects.filter(item => {
+    const s = String(item || '').trim()
+    if (!s) return false
+    return !CORRUPT.some(p => p.test(s))
+  })
+}
+
 function main() {
   const options = parseArgs(process.argv.slice(2))
   const diagnostics = createDiagnostics()
@@ -1103,7 +1113,7 @@ function main() {
   parseSheet(workbook, 'Production Export V1', diagnostics, { optional: OPTIONAL_WORKBOOK_SHEETS.has('Production Export V1') })
 
   const herbs = JSON.parse(fs.readFileSync(herbsPath, 'utf8'))
-  const compounds = JSON.parse(fs.readFileSync(compoundsPath, 'utf8'))
+  let compounds = JSON.parse(fs.readFileSync(compoundsPath, 'utf8'))
 
   if (!Array.isArray(herbs) || !Array.isArray(compounds)) {
     throw new Error('[import-xlsx-monographs] Expected herbs.json and compounds.json to be arrays.')
@@ -1324,6 +1334,7 @@ function main() {
     }),
   }
   writeJson(identityMapSuggestionsPath, identityMapSuggestions)
+  compounds = compounds.map(c => ({ ...c, effects: cleanCompoundEffects(c.effects) }))
 
   if (!options.dryRun) {
     writeJson(herbsPath, herbs)


### PR DESCRIPTION
### Motivation
- Remove placeholder/corrupt effect entries left over from an older CSV ingestion pipeline so `compounds.json` and the generated compound pages no longer show artifacts like "No direct effects data", "nan.", or "[object...".

### Description
- Add a `cleanCompoundEffects(effects)` helper that filters out entries matching the requested patterns (`\bno direct\b`, `\bcontextual inference\b`, `\bnan\b`, `\bprovisional_from\b`, `\[object`) and empty values, change the `compounds` variable to `let`, and apply `compounds = compounds.map(c => ({ ...c, effects: cleanCompoundEffects(c.effects) }))` as a post-processing step after all `patchCompound()` work and immediately before writing `compounds.json`, without modifying any herb logic.

### Testing
- Ran `node scripts/import-xlsx-monographs.mjs --dry-run` (passed), `node --check scripts/import-xlsx-monographs.mjs` (passed), and `npm run verify:workbook-import` which failed with a pre-existing reconciliation parity error (`Compound Master rows=235, dry-run matched+unmatched=234`) not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead5e058c883238251569061468be7)