### PR TITLE
Use workbook-driven compound narrative fields without synthetic fallback

### DIFF
--- a/scripts/generate-entity-payloads.mjs
+++ b/scripts/generate-entity-payloads.mjs
@@ -88,46 +88,12 @@ function formatEvidenceContext(governedSummary, hasEvidence, seed) {
 }
 
 function buildCompoundNarrative(record, governedSummary) {
-  const name = asText(record.name || record.commonName || record.slug || 'This compound')
-  const herbs = splitList(record.herbs || record.foundInHerbs || record.associatedHerbs)
-  const category = normalizeCategoryLabel(record)
-  const mechanism = cleanNarrative(record.mechanism || record.mechanismOfAction)
   const existingDescription = cleanNarrative(record.description)
   const existingSummary = cleanNarrative(record.summary)
-  const evidenceContext = formatEvidenceContext(governedSummary, hasEvidenceNotes(record), name)
-  const identityWithCategoryAndHerb = `${name} is ${withIndefiniteArticle(category)} compound ${formatHerbContext(herbs)}.`
-  const identityWithCategoryOnly = `${name} is ${withIndefiniteArticle(category)} compound.`
-  const identityWithHerbOnlyOptions = [
-    `${name} is a compound ${formatHerbContext(herbs)}.`,
-    `${name} appears in records as a compound ${formatHerbContext(herbs)}.`,
-  ]
-  const identityFallbackOptions = [
-    `${name} is listed as a compound in this profile.`,
-    `${name} is currently cataloged as a compound entry.`,
-  ]
+  const mechanism = cleanNarrative(record.mechanism || record.mechanismOfAction)
 
-  const identitySentence =
-    category && formatHerbContext(herbs)
-      ? identityWithCategoryAndHerb
-      : category
-        ? identityWithCategoryOnly
-        : formatHerbContext(herbs)
-          ? chooseVariant(name, identityWithHerbOnlyOptions)
-          : chooseVariant(name, identityFallbackOptions)
-
-  const mechanismSentence = mechanism
-    ? chooseVariant(name, [
-        `Mechanism notes currently mention ${mechanism.charAt(0).toLowerCase()}${mechanism.slice(1)}.`,
-        `Available mechanism notes describe ${mechanism.charAt(0).toLowerCase()}${mechanism.slice(1)}.`,
-      ])
-    : ''
-
-  const generatedDescription = clip(
-    [identitySentence, mechanismSentence, evidenceContext].filter(Boolean).join(' '),
-    320,
-  )
-  const description = existingDescription || generatedDescription
-  const summary = existingSummary || clip(existingDescription || generatedDescription, 180)
+  const description = existingDescription || mechanism || ''
+  const summary = existingSummary || clip(existingDescription || mechanism || '', 180)
 
   return { description, summary }
 }


### PR DESCRIPTION
### Motivation
- The workbook now supplies real `description` and `summary` for compounds, so generated synthetic identity prose should not appear on the site. 
- When workbook fields are present they must take priority and when absent the function must return empty strings rather than fabricate identity/evidence sentences.

### Description
- Replaced `buildCompoundNarrative()` in `scripts/generate-entity-payloads.mjs` with a workbook-first implementation that sets `description` = `record.description || record.mechanism || ''` and `summary` = `record.summary || clip(description/mechanism, 180) || ''`.
- Removed all synthetic identity/evidence sentence generation and `chooseVariant()`/`formatHerbContext()`/`formatEvidenceContext()` usage inside `buildCompoundNarrative()` while keeping those helper functions in the file for compatibility.
- Kept all other functions in the file unchanged and scoped the commit to the single function change, reverting generated `public/data` artifacts before commit to avoid unrelated payload changes.

### Testing
- Ran `node --check scripts/generate-entity-payloads.mjs` and it completed with no syntax errors.
- Executed an isolated verification via `node --input-type=module` to call `buildCompoundNarrative` directly and asserted that an empty record returns `{ description: '', summary: '' }` and that workbook-provided fields win, and those assertions passed.
- Ran `node scripts/generate-entity-payloads.mjs` to verify the generator runs (reported entity counts) and searched `public/data/compounds-detail` for the forbidden synthetic phrases with `rg`, which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead69ff10c8323b16c45f55d9c459a)