### PR TITLE
Fix duplicated herb detail prose between summary and full description

### DIFF
--- a/src/pages/HerbDetail.tsx
+++ b/src/pages/HerbDetail.tsx
@@ -185,10 +185,13 @@ export default function HerbDetail() {
   const summaryQuality = getSummaryQuality(rawRecord)
   const isMinimalProfile = profileStatus === 'minimal'
   const showSummaryRegion = shouldRenderSummary(profileStatus, summaryQuality)
-  const description = String(herb.summary || herb.description || '').trim() || String(curatedData.summary || '').trim()
+  const rawSummary = String(herb.summary || '').trim() || String(curatedData.summary || '').trim()
+  const rawDescription = String(herb.description || '').trim()
+  const description = rawSummary || rawDescription
   const descriptionIsPlaceholder = isPlaceholder(description, herbName)
   const summary = sanitizeSummaryText(description, 2)
-  const fullDescription = sanitizeReadableText(description)
+  const fullDescription =
+    rawDescription && rawDescription !== rawSummary ? sanitizeReadableText(rawDescription) : ''
   const uniqueCopy = buildUniqueDetailCopy({
     hero: summary,
     overview: sanitizeSummaryText(


### PR DESCRIPTION
### Motivation
- The herb detail page was rendering the same prose in the header summary and in the "Full Description" and "Context" sections because `summary` and `fullDescription` were derived from the same fallback `description` value.
- The goal is to prevent repeated paragraphs by only showing the full description when the detail-level `herb.description` is materially different from the short `herb.summary`.

### Description
- Updated `src/pages/HerbDetail.tsx` to derive `rawSummary` from `herb.summary` (with curated fallback) and `rawDescription` strictly from `herb.description`.
- Set `description = rawSummary || rawDescription` and compute `summary` with `sanitizeSummaryText(description, 2)` so the header shows the short summary.
- Compute `fullDescription` only when `rawDescription` exists and differs from `rawSummary` using `sanitizeReadableText(rawDescription)` to avoid duplication.
- Preserved existing rendering guards and left the `context` uniqueness check unchanged.

### Testing
- Ran `npm run build` which completed successfully without errors.
- Ran `npm run build:compile` successfully after the change to verify the compiled output.
- The pre-commit hook executed `eslint --max-warnings=0` during commit and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead78bdc148323b4ec4b9810e60ad9)