### PR TITLE
Prefer detail entity payloads in static prerender for herb/compound routes

### DIFF
--- a/scripts/prerender-static.mjs
+++ b/scripts/prerender-static.mjs
@@ -64,6 +64,16 @@ function pickFirstDataFile(paths) {
   return []
 }
 
+function readDetailJson(dir, slug) {
+  const file = path.join(ROOT, 'public', 'data', dir, `${slug}.json`)
+  if (!fs.existsSync(file)) return null
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'))
+  } catch {
+    return null
+  }
+}
+
 const blogPosts = readJson('src/data/blog/posts.json')
 const herbs = pickFirstDataFile([
   'public/data/herbs_combined_updated.json',
@@ -352,7 +362,7 @@ function renderRouteContent(route) {
 
   if (route.startsWith('/herbs/')) {
     const slug = route.split('/').pop() || ''
-    const herb = herbBySlug.get(slug)
+    const herb = readDetailJson('herbs-detail', slug) || herbBySlug.get(slug)
     const displayName = safeStr(herb?.common) || safeStr(herb?.commonName) || safeStr(herb?.name) || slug
     const name = escapeHtml(displayName)
     const description = escapeHtml(
@@ -378,7 +388,7 @@ function renderRouteContent(route) {
 
   if (route.startsWith('/compounds/')) {
     const slug = route.split('/').pop() || ''
-    const compound = compoundBySlug.get(slug)
+    const compound = readDetailJson('compounds-detail', slug) || compoundBySlug.get(slug)
     const name = escapeHtml(textFrom(compound?.name, slug))
     const description = escapeHtml(inferCompoundDescription(compound, textFrom(compound?.name, slug)))
     const effects = textList(compound?.effects, 8)
@@ -481,7 +491,7 @@ function renderPrerenderNoscript(route) {
 
   if (route.startsWith('/herbs/')) {
     const slug = route.split('/').pop() || ''
-    const herb = herbBySlug.get(slug)
+    const herb = readDetailJson('herbs-detail', slug) || herbBySlug.get(slug)
     const displayName = safeStr(herb?.common) || safeStr(herb?.commonName) || safeStr(herb?.name) || slug
     const description = trimToChars(
       safeStr(herb?.description) || safeStr(herb?.summary) || `${displayName} herb profile.`,
@@ -530,7 +540,7 @@ function renderPrerenderNoscript(route) {
 
   if (route.startsWith('/compounds/')) {
     const slug = route.split('/').pop() || ''
-    const compound = compoundBySlug.get(slug)
+    const compound = readDetailJson('compounds-detail', slug) || compoundBySlug.get(slug)
     const name = textFrom(compound?.name, slug)
     const description = trimToChars(
       textFrom(compound?.description, compound?.summary, `${name || slug} compound profile.`),


### PR DESCRIPTION
### Motivation
- Prerendered herb and compound detail pages should use the workbook-enriched per-entity payloads (`public/data/*-detail/<slug>.json`) so descriptions, mechanisms, and `safetyNotes` reflect the latest workbook enrichment instead of stale combined-summary arrays.

### Description
- Added a `readDetailJson(dir, slug)` helper in `scripts/prerender-static.mjs` to safely load `public/data/<dir>/<slug>.json` and return `null` on missing/invalid files.
- Updated `/herbs/:slug` and `/compounds/:slug` route handlers to prefer the detail JSON (`herbs-detail` / `compounds-detail`) before falling back to the existing summary maps (`herbBySlug` / `compoundBySlug`).
- Applied the same detail-first lookup in the prerender `<noscript>` generation so static SEO content aligns with the main prerender output.
- Left existing fallback arrays, blog logic, and other route handlers unchanged.

### Testing
- Ran `npm run build:compile` successfully to produce production assets.
- Ran `npm run prerender:static` successfully and confirmed prerender completed for all planned routes.
- Executed Node verification scripts which confirmed that `/dist/herbs/ashwagandha/index.html` and `/dist/compounds/berberine/index.html` include text from their respective `public/data/*-detail/*.json` files and that a slug without a detail file (e.g. `ephedra`) still falls back to the summary data; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead85942988323b9805996c8dc62cd)