### PR TITLE
Add display-name quality checks for herb and compound records

### DIFF
--- a/scripts/validate-datasets.ts
+++ b/scripts/validate-datasets.ts
@@ -144,6 +144,10 @@ const COMPOUND_ARRAY_FIELDS = new Set([
   'sources',
 ])
 
+const INVALID_DISPLAY_NAME_VALUES = new Set(['[object object]', 'nan', 'null', 'undefined'])
+const NUMERIC_ONLY_DISPLAY_NAME_PATTERN = /^\d+(?:[\s.,/-]\d+)*$/
+const ALLOWED_SINGLE_CHARACTER_DISPLAY_NAMES = new Set<string>()
+
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
@@ -422,6 +426,86 @@ function validateStringField(
   return []
 }
 
+function validateDisplayNameQuality(
+  value: unknown,
+  dataset: DatasetType,
+  recordId: string,
+  field: string,
+): AuditIssue[] {
+  const entityType = dataset === 'compound' ? 'compound' : 'herb'
+  const location = recordId || '(unknown-record)'
+
+  if (typeof value !== 'string') {
+    return [
+      issue(
+        'structural-hard',
+        'invalid-display-name',
+        dataset,
+        recordId,
+        `Invalid ${entityType} ${field} at '${location}': rejected value '${String(value)}' (reason: non-string).`,
+        { field, details: { value, reason: 'non-string' } },
+      ),
+    ]
+  }
+
+  const raw = value
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return [
+      issue(
+        'structural-hard',
+        'invalid-display-name',
+        dataset,
+        recordId,
+        `Invalid ${entityType} ${field} at '${location}': rejected value '${raw}' (reason: empty/whitespace-only).`,
+        { field, details: { value: raw, reason: 'empty/whitespace-only' } },
+      ),
+    ]
+  }
+
+  const normalized = trimmed.toLowerCase()
+  if (INVALID_DISPLAY_NAME_VALUES.has(normalized)) {
+    return [
+      issue(
+        'structural-hard',
+        'invalid-display-name',
+        dataset,
+        recordId,
+        `Invalid ${entityType} ${field} at '${location}': rejected value '${trimmed}' (reason: known junk token).`,
+        { field, details: { value: trimmed, reason: 'known-junk-token' } },
+      ),
+    ]
+  }
+
+  if (NUMERIC_ONLY_DISPLAY_NAME_PATTERN.test(trimmed)) {
+    return [
+      issue(
+        'structural-hard',
+        'invalid-display-name',
+        dataset,
+        recordId,
+        `Invalid ${entityType} ${field} at '${location}': rejected value '${trimmed}' (reason: numeric-only).`,
+        { field, details: { value: trimmed, reason: 'numeric-only' } },
+      ),
+    ]
+  }
+
+  if (trimmed.length === 1 && !ALLOWED_SINGLE_CHARACTER_DISPLAY_NAMES.has(normalized)) {
+    return [
+      issue(
+        'structural-hard',
+        'invalid-display-name',
+        dataset,
+        recordId,
+        `Invalid ${entityType} ${field} at '${location}': rejected value '${trimmed}' (reason: one-character degenerate name).`,
+        { field, details: { value: trimmed, reason: 'one-character-degenerate-name' } },
+      ),
+    ]
+  }
+
+  return []
+}
+
 function validateStringArrayField(
   value: unknown,
   dataset: DatasetType,
@@ -635,6 +719,8 @@ function validateHerbRecordShape(
     }
   }
 
+  findings.push(...validateDisplayNameQuality(record.name, dataset, recordId, 'name'))
+
   return findings
 }
 
@@ -654,6 +740,8 @@ function validateCompoundRecordShape(record: GenericRecord, recordId: string): A
       findings.push(...validateStringArrayField(record[field], 'compound', recordId, field, requiredSet.has(field)))
     }
   }
+
+  findings.push(...validateDisplayNameQuality(record.name, 'compound', recordId, 'name'))
 
   return findings
 }


### PR DESCRIPTION
### Motivation

- Prevent low-quality or junk `name` values from entering datasets by rejecting non-strings, empty/whitespace-only values, known junk tokens, numeric-only names, and degenerate one-character names.

### Description

- Add new constants `INVALID_DISPLAY_NAME_VALUES`, `NUMERIC_ONLY_DISPLAY_NAME_PATTERN`, and `ALLOWED_SINGLE_CHARACTER_DISPLAY_NAMES` to enumerate disallowed tokens and patterns.
- Implement `validateDisplayNameQuality` to produce `structural-hard` `invalid-display-name` issues for invalid `name` values and to include dataset/record context and a reason in `details`.
- Integrate `validateDisplayNameQuality` into `validateHerbRecordShape` and `validateCompoundRecordShape` so `name` is checked for both `herb` and `compound` records.

### Testing

- Ran TypeScript typecheck with `tsc` (via project build) and the repository test suite with `yarn test`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb6a5a44bc8323ba58e6ccbb661ad7)