### PR TITLE
Guard sync boundary against placeholder canonical rows

### DIFF
--- a/public/data/compounds.json
+++ b/public/data/compounds.json
@@ -51,20 +51,6 @@
     "slug": "2-4-5-trimethoxybenzaldehyde"
   },
   {
-    "name": "5",
-    "herbs": [
-      "virola theiodora"
-    ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used by amazonian tribes as a snuff for spiritual rituals... No direct mechanismofaction data. Contextual inference: Used by amazonian tribes as a snuff for spiritual rituals... Used by Amazonian tribes as a snuff for spiritual rituals.. Used by Amazonian tribes as a snuff for spiritual rituals."
-    ],
-    "contraindications": [],
-    "category": null,
-    "sources": [],
-    "lastUpdated": "2026-03-21",
-    "slug": "5"
-  },
-  {
     "name": "5-MeO-DMT",
     "herbs": [
       "nan"
@@ -172,32 +158,6 @@
     ],
     "lastUpdated": "2026-03-21",
     "slug": "7-hydroxybaruol"
-  },
-  {
-    "name": "[object Object]",
-    "herbs": [
-      "kratom hybrids",
-      "nan",
-      "yarrow"
-    ],
-    "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
-      "Clarity",
-      "calm",
-      "subtle mood lift",
-      "No direct effects data. Contextual inference: Used in smudging rituals for purification and clarity... No direct mechanismofaction data. Contextual inference: Used in smudging rituals for purification and clarity... Used in smudging rituals for purification and clarity.. Used in smudging rituals for purification and clarity."
-    ],
-    "contraindications": [
-      "Avoid during pregnancy",
-      "neurotoxic in high doses"
-    ],
-    "category": null,
-    "sources": [],
-    "lastUpdated": "2026-03-21",
-    "slug": "object-object"
   },
   {
     "name": "acetylcholine",
@@ -7757,25 +7717,6 @@
     ]
   },
   {
-    "name": "N",
-    "herbs": [
-      "nan"
-    ],
-    "effects": [
-      "Closed-eye visuals",
-      "altered cognition",
-      "spiritual insight (when used with MAOI)",
-      "No direct effects data. Contextual inference: Ritual use.. No direct mechanismofaction data. Contextual inference: Ritual use.. Ritual use. Ritual use"
-    ],
-    "contraindications": [
-      "Use with SSRIs or MAOIs without supervision"
-    ],
-    "category": null,
-    "sources": [],
-    "lastUpdated": "2026-03-21",
-    "slug": "n"
-  },
-  {
     "name": "N-Dimethyltryptamine (DMT)",
     "herbs": [
       "nan"
@@ -8500,24 +8441,6 @@
     ],
     "lastUpdated": "2026-03-21",
     "slug": "other-saponins"
-  },
-  {
-    "name": "p",
-    "herbs": [
-      "dysphania ambrosioides"
-    ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. Used in ritual",
-      "dreaming or folk medicine. Used in ritual",
-      "dreaming or folk medicine"
-    ],
-    "contraindications": [],
-    "category": null,
-    "sources": [],
-    "lastUpdated": "2026-03-21",
-    "slug": "p"
   },
   {
     "name": "p-coumaric acid",

--- a/public/data/herbs.json
+++ b/public/data/herbs.json
@@ -23801,76 +23801,6 @@
     ]
   },
   {
-    "name": "nan",
-    "latin": "Acacia confusa Merr.",
-    "class": "Psychoactive, Ethnobotanical",
-    "intensity": "High (especially when used with MAOIs)",
-    "mechanism": "DMT acts as a 5-HT2A agonist; psychoactive effects enhanced by MAOIs",
-    "activeCompounds": [
-      "DMT",
-      "NMT",
-      "tannins",
-      "flavonoids",
-      "alkaloids"
-    ],
-    "effects": [
-      "Intense visual hallucinations",
-      "altered perception",
-      "emotional sensitivity",
-      "introspection"
-    ],
-    "contraindications": [
-      "Avoid in individuals with psychiatric disorders",
-      "may potentiate MAOIs"
-    ],
-    "safetyNotes": [
-      "High risk of psychological distress",
-      "unsafe in uncontrolled use",
-      "Nausea",
-      "vomiting",
-      "dissociation",
-      "confusion",
-      "anxiety",
-      "Not well-studied",
-      "primary risk is psychological or via MAOI combinations",
-      "Not established",
-      "DMT estimated oral LD50 > 50 mg/kg (in animals)"
-    ],
-    "sources": [
-      {
-        "title": "PubChem"
-      },
-      {
-        "title": "Erowid"
-      },
-      {
-        "title": "Shulgin reports"
-      },
-      {
-        "title": "scientific ethnobotanical reviews"
-      }
-    ],
-    "lastUpdated": "2026-03-21",
-    "description": "Acacia confusa is a tree native to Southeast Asia used traditionally for spiritual and healing purposes. It contains psychoactive tryptamines like DMT.",
-    "dosage": "Traditional root bark brew: 5–15g dried bark (not medically recommended)",
-    "duration": "4–8 hours",
-    "interactions": [
-      "Dangerous with MAOIs",
-      "SSRIs",
-      "or other serotonin agents"
-    ],
-    "legalStatus": "DMT is scheduled in most countries; plant legality varies",
-    "preparation": "Brewed as part of analog ayahuasca with MAOI-containing plants",
-    "region": "Southeast Asia, Taiwan, Philippines",
-    "therapeuticUses": [
-      "Traditional shamanic ceremonies",
-      "introspection",
-      "rarely as wood medicine"
-    ],
-    "traditionalUse": null,
-    "slug": "nan"
-  },
-  {
     "name": "nardostachys jatamansi",
     "latin": "Nardostachys jatamansi",
     "class": null,
@@ -40844,44 +40774,6 @@
       "limited data on adverse effects"
     ],
     "slug": "zornia-latifolia"
-  },
-  {
-    "name": "unknown",
-    "latin": null,
-    "class": null,
-    "intensity": "No direct intensity data. Contextual inference: Description not available.. No direct mechanismofaction data. Contextual inference: Description not available.. No direct effects data. Contextual inference: Description not available.. No direct mechanismofaction data. Contextual inference: Description not available.. No direct region data. Contextual inference: Description not available.. No direct mechanismofaction data. Contextual inference: Description not available.. No direct effects data. Contextual inference: Description not available.. No direct mechanismofaction data. Contextual inference: Description not available.",
-    "mechanism": "No direct mechanismofaction data. Contextual inference: Description not available.",
-    "activeCompounds": [],
-    "effects": [
-      "No direct effects data. Contextual inference: Description not available.. No direct mechanismofaction data. Contextual inference: Description not available."
-    ],
-    "contraindications": [
-      "avoid during pregnancy and breastfeeding unless advised by a clinician",
-      "Use caution with prescription medications and chronic conditions; monitor for intolerance.",
-      "discontinue if hypersensitivity or allergic symptoms occur"
-    ],
-    "safetyNotes": [],
-    "sources": [],
-    "lastUpdated": "2026-03-21",
-    "therapeuticUses": [
-      "traditional support for mild digestive comfort",
-      "traditional stress resilience support"
-    ],
-    "dosage": [
-      "No direct dosage data. Contextual inference: Description not available.. No direct mechanismofaction data. Contextual inference: Description not available.. No direct effects data. Contextual inference: Description not available.. No direct mechanismofaction data. Contextual inference: Description not available.. No direct region data. Contextual inference: Description not available.. No direct mechanismofaction data. Contextual inference: Description not available.. No direct effects data. Contextual inference: Description not available.. No direct mechanismofaction data. Contextual inference: Description not available."
-    ],
-    "duration": "No direct duration data. Contextual inference: Description not available.. No direct mechanismofaction data. Contextual inference: Description not available.. No direct effects data. Contextual inference: Description not available.. No direct mechanismofaction data. Contextual inference: Description not available.. No direct region data. Contextual inference: Description not available.. No direct mechanismofaction data. Contextual inference: Description not available.. No direct effects data. Contextual inference: Description not available.. No direct mechanismofaction data. Contextual inference: Description not available.",
-    "region": "No direct region data. Contextual inference: Description not available.. No direct mechanismofaction data. Contextual inference: Description not available.. No direct effects data. Contextual inference: Description not available.. No direct mechanismofaction data. Contextual inference: Description not available.",
-    "preparation": "No direct preparation data. Contextual inference: Description not available.. No direct mechanismofaction data. Contextual inference: Description not available.. No direct effects data. Contextual inference: Description not available.. No direct mechanismofaction data. Contextual inference: Description not available.. No direct region data. Contextual inference: Description not available.. No direct mechanismofaction data. Contextual inference: Description not available.. No direct effects data. Contextual inference: Description not available.. No direct mechanismofaction data. Contextual inference: Description not available.",
-    "legalStatus": null,
-    "interactions": [],
-    "description": "Description not available.",
-    "sideEffects": [
-      "mild gastrointestinal upset (nausea, cramping, or loose stool)",
-      "headache (more likely with higher intake)",
-      "allergic rash or itching in sensitive individuals"
-    ],
-    "slug": "unknown"
   },
   {
     "id": "black-cohosh",

--- a/scripts/sync-updated-datasets.mjs
+++ b/scripts/sync-updated-datasets.mjs
@@ -93,6 +93,48 @@ function normalizeSlug(value) {
   return asText(value).toLowerCase()
 }
 
+const INVALID_PLACEHOLDER_TOKENS = new Set([
+  '',
+  'unknown',
+  'nan',
+  'null',
+  'undefined',
+  '[object object]',
+])
+
+function isPlaceholderToken(value) {
+  return INVALID_PLACEHOLDER_TOKENS.has(asText(value).toLowerCase())
+}
+
+function isInvalidCanonicalEntityRecord(record, entityType) {
+  if (!record || typeof record !== 'object') return true
+
+  const name = asText(record.name ?? record.common ?? record.commonName ?? '')
+  const slug = normalizeSlug(record.slug)
+
+  if (isPlaceholderToken(name) || isPlaceholderToken(slug)) return true
+  if (name.length === 1 || slug.length === 1) return true
+  if (entityType === 'compounds' && (/^\d+$/.test(name) || /^\d+$/.test(slug))) return true
+
+  return false
+}
+
+function filterInvalidCanonicalRecords(records, entityType, sourceFile) {
+  const skipped = []
+  const filtered = records.filter((record, index) => {
+    if (!isInvalidCanonicalEntityRecord(record, entityType)) return true
+    const name = asText(record?.name ?? record?.common ?? record?.commonName ?? '')
+    const slug = normalizeSlug(record?.slug)
+    const details = { entityType, sourceFile, index, name, slug }
+    skipped.push(details)
+    console.warn(
+      `[data-sync] Skipping invalid canonical ${entityType} row (source=${sourceFile}, index=${index}, name="${name}", slug="${slug}")`
+    )
+    return false
+  })
+  return { filtered, skipped }
+}
+
 function assertUnique(values, label) {
   const seen = new Set()
   values.forEach(value => {
@@ -138,8 +180,18 @@ function ingestPublishInputIfAvailable({ required = false } = {}) {
 
   if (!hasAny && !required) return false
 
-  const herbs = readJsonArray(herbPath, 'herbs').map(normalizePublishHerbRecord)
-  const compounds = readJsonArray(compoundPath, 'compounds').map(normalizePublishCompoundRecord)
+  const normalizedHerbs = readJsonArray(herbPath, 'herbs').map(normalizePublishHerbRecord)
+  const normalizedCompounds = readJsonArray(compoundPath, 'compounds').map(normalizePublishCompoundRecord)
+  const { filtered: herbs } = filterInvalidCanonicalRecords(
+    normalizedHerbs,
+    'herbs',
+    path.relative(root, herbPath),
+  )
+  const { filtered: compounds } = filterInvalidCanonicalRecords(
+    normalizedCompounds,
+    'compounds',
+    path.relative(root, compoundPath),
+  )
   const goals = readJsonArray(goalsPath, 'goals').map(normalizePublishGoalRecord)
   assertUnique(
     herbs.map(record => record.slug),
@@ -189,7 +241,12 @@ function hydrateUpdatedDatasetSlugs(fileName, entity) {
   }
 
   const records = readJson(filePath)
-  const hydrated = withSlugs(records, entity)
+  const { filtered } = filterInvalidCanonicalRecords(
+    records,
+    entity,
+    path.relative(root, filePath),
+  )
+  const hydrated = withSlugs(filtered, entity)
   writeJson(filePath, hydrated)
   console.log(`[data-sync] Hydrated ${entity} slugs in ${filePath}`)
 }


### PR DESCRIPTION
### Motivation
- Prevent placeholder/junk rows from being promoted to canonical runtime data during the publish-input ingest and sync/hydration steps. 
- Keep the change minimal and surgical at the sync boundary so existing data pipelines and workbook sources are not altered.

### Description
- Added a small placeholder token set and helpers `isPlaceholderToken`, `isInvalidCanonicalEntityRecord`, and `filterInvalidCanonicalRecords` to `scripts/sync-updated-datasets.mjs` to detect invalid canonical records (empty, `unknown`, `nan`, `null`, `undefined`, `[object Object]`).
- Rejected one-character names/slugs for herbs and compounds, and additionally rejected numeric-only names/slugs for compounds only. 
- Applied the guard before slug hydration in `hydrateUpdatedDatasetSlugs` and before writing canonical arrays in `ingestPublishInputIfAvailable`, and emitted concise `console.warn` messages that include entity type, source file, index, name, and slug when skipping rows.
- Kept changes limited to `scripts/sync-updated-datasets.mjs` and regenerated canonical runtime datasets (`public/data/herbs.json` and `public/data/compounds.json`).

### Testing
- Files changed: `scripts/sync-updated-datasets.mjs`, `public/data/herbs.json`, and `public/data/compounds.json`.
- Rows skipped by the new guard during the sync run: herbs: 2 rows (`ops/publish-input/API_PAYLOAD.json` index 400 name="nan" slug="nan", index 702 name="unknown" slug="unknown`); compounds: 4 rows (`ops/publish-input/COMPOUND_API_PAYLOAD.json` index 2 name="5" slug="5", index 6 name="[object Object]" slug="object-object", index 244 name="N" slug="n", index 269 name="p" slug="p`).
- Generated files changed: `public/data/herbs.json` and `public/data/compounds.json` (regenerated via sync).
- Validation and type checks run: `node scripts/sync-updated-datasets.mjs --skip-workbook-overlay` (succeeded and emitted skip warnings), `npm run validate:data` (failed: `validate:data gate decision: FAIL (hard/structural validator failures detected)` with blocking structural issues), `npm run data:validate` (failed, same), and `npm run typecheck` (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb79c15f448323a5e4aad0c604110f)