### PR TITLE
Regenerate runtime herb and compound JSON artifacts

### DIFF
--- a/public/data/compounds.json
+++ b/public/data/compounds.json
@@ -4,12 +4,7 @@
     "herbs": [
       "albizia julibrissin"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
-    ],
+    "effects": [],
     "contraindications": [
       "Limited safety data",
       "may potentiate sedative or antidepressant drugs",
@@ -18,7 +13,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "syringaresnol-4-o-d-apiofuranosyl-1-2-d-glucopyranoside"
+    "slug": "syringaresnol-4-o-d-apiofuranosyl-1-2-d-glucopyranoside",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "2,4,5-trimethoxybenzaldehyde",
@@ -48,18 +45,17 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "2-4-5-trimethoxybenzaldehyde"
+    "slug": "2-4-5-trimethoxybenzaldehyde",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "5-MeO-DMT",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Intense visuals",
       "spiritual experiences",
       "ego dissolution",
-      "No direct effects data. Contextual inference: Used by amazonian tribes as a snuff for spiritual rituals... No direct mechanismofaction data. Contextual inference: Used by amazonian tribes as a snuff for spiritual rituals... Used by Amazonian tribes as a snuff for spiritual rituals.. Used by Amazonian tribes as a snuff for spiritual rituals.",
       "Intense visions",
       "altered perception",
       "nausea",
@@ -68,11 +64,7 @@
       "Visuals",
       "euphoria",
       "altered states",
-      "stimulation",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "stimulation"
     ],
     "contraindications": [
       "Avoid with MAOIs or SSRIs",
@@ -99,13 +91,13 @@
     ],
     "description": "5-MeO-DMT is a short-acting psychedelic tryptamine found in some plants and toad secretions, with intense and rapidly onset alterations in perception and self-processing.",
     "mechanism": "Primary mechanism is serotonergic receptor agonism, especially strong 5-HT1A activity with additional 5-HT2A-mediated psychedelic effects.",
-    "safetyNotes": "Explicit risks include panic, severe confusion, accidents, emesis/aspiration risk, and dangerous behavior during acute intoxication. Interaction categories: serotonergic drugs (SSRIs/SNRIs/MAOIs/triptans; serotonin-toxicity risk), sympathomimetics/stimulants (cardiovascular stress), and other psychoactives/CNS depressants that impair judgment."
+    "safetyNotes": "Explicit risks include panic, severe confusion, accidents, emesis/aspiration risk, and dangerous behavior during acute intoxication. Interaction categories: serotonergic drugs (SSRIs/SNRIs/MAOIs/triptans; serotonin-toxicity risk), sympathomimetics/stimulants (cardiovascular stress), and other psychoactives/CNS depressants that impair judgment.",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "7-hydroxymitragynine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Stimulation",
       "mild euphoria",
@@ -134,7 +126,9 @@
     ],
     "description": "7-Hydroxymitragynine is a kratom alkaloid present at low natural levels but with high opioid-receptor potency relative to mitragynine.",
     "mechanism": "Acts primarily as a μ-opioid receptor partial agonist and drives opioid-like analgesic and respiratory-depressant effects.",
-    "safetyNotes": "Key risks include sedation, respiratory depression, dependence, and withdrawal with repeated exposure. Interaction categories: other CNS depressants (opioids, benzodiazepines, alcohol, gabapentinoids), sedating antihistamines, and additional opioid agonists with additive overdose risk."
+    "safetyNotes": "Key risks include sedation, respiratory depression, dependence, and withdrawal with repeated exposure. Interaction categories: other CNS depressants (opioids, benzodiazepines, alcohol, gabapentinoids), sedating antihistamines, and additional opioid agonists with additive overdose risk.",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "7α-hydroxybaruol",
@@ -157,20 +151,16 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "7-hydroxybaruol"
+    "slug": "7-hydroxybaruol",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "acetylcholine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Mild stimulation",
-      "increased circulation",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "increased circulation"
     ],
     "contraindications": [
       "Pregnancy (caution)",
@@ -182,7 +172,9 @@
     "slug": "acetylcholine",
     "description": "Acetylcholine is a core human neurotransmitter released at muscarinic and nicotinic synapses, including autonomic ganglia, parasympathetic targets, and the neuromuscular junction.",
     "mechanism": "Activates muscarinic and nicotinic acetylcholine receptors; signaling is rapidly terminated by acetylcholinesterase hydrolysis in the synaptic cleft.",
-    "safetyNotes": "Acetylcholine excess produces cholinergic toxicity patterns (bradycardia, bronchospasm, diarrhea, sweating, salivation, muscle weakness). Interaction categories: cholinergic agonists/acetylcholinesterase inhibitors (additive cholinergic effects) and anticholinergics (pharmacologic antagonism)."
+    "safetyNotes": "Acetylcholine excess produces cholinergic toxicity patterns (bradycardia, bronchospasm, diarrhea, sweating, salivation, muscle weakness). Interaction categories: cholinergic agonists/acetylcholinesterase inhibitors (additive cholinergic effects) and anticholinergics (pharmacologic antagonism).",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "aconine",
@@ -210,7 +202,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "aconine"
+    "slug": "aconine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "aconitine",
@@ -244,13 +238,13 @@
     "compoundClass": "aconitine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "acorin",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Stimulation",
       "mental clarity",
@@ -259,8 +253,6 @@
       "beta-asarone rich)",
       "Mild sedative",
       "hallucinogenic in high doses",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
@@ -280,7 +272,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "acorin"
+    "slug": "acorin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "aervine",
@@ -306,7 +300,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "aervine"
+    "slug": "aervine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "aervolanine",
@@ -332,7 +328,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "aervolanine"
+    "slug": "aervolanine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "aervoside",
@@ -358,7 +356,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "aervoside"
+    "slug": "aervoside",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "aescin (escin)",
@@ -386,7 +386,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "aescin-escin"
+    "slug": "aescin-escin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "agrimoniin",
@@ -420,7 +422,9 @@
     "mechanism": "Tannins, agrimoniin, flavonoids",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "alamarckine",
@@ -449,7 +453,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "alamarckine"
+    "slug": "alamarckine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "alamaridine",
@@ -478,7 +484,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "alamaridine"
+    "slug": "alamaridine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "alamarine",
@@ -507,7 +515,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "alamarine"
+    "slug": "alamarine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "alangamide",
@@ -536,7 +546,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "alangamide"
+    "slug": "alangamide",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "alangimaridine",
@@ -565,7 +577,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "alangimaridine"
+    "slug": "alangimaridine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "alangimarin",
@@ -594,7 +608,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "alangimarin"
+    "slug": "alangimarin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "alangimarine",
@@ -623,7 +639,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "alangimarine"
+    "slug": "alangimarine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "alangiside",
@@ -652,7 +670,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "alangiside"
+    "slug": "alangiside",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "albiziasaponins A–E",
@@ -677,16 +697,16 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "albiziasaponins-a-e"
+    "slug": "albiziasaponins-a-e",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "alchorneine",
     "herbs": [
-      "alchornea castaneifolia",
-      "nan"
+      "alchornea castaneifolia"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... No direct mechanismofaction data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... Used in traditional Amazonian medicine for arthritis and pain.. Used in traditional Amazonian medicine for arthritis and pain.",
       "Increased alertness",
       "minor euphoria",
       "divinatory visions",
@@ -710,23 +730,21 @@
     "compoundClass": "alchorneine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "alkaloids",
     "herbs": [
       "african dream root",
       "alchornea castaneifolia",
-      "Muira Puama",
-      "nan"
+      "Muira Puama"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
-      "No direct effects data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... No direct mechanismofaction data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... Used in traditional Amazonian medicine for arthritis and pain.. Used in traditional Amazonian medicine for arthritis and pain.",
       "Improved libido",
       "enhanced cognition",
       "mood elevation",
@@ -745,15 +763,10 @@
       "antioxidant",
       "anti-inflammatory",
       "lipid-lowering",
-      "No direct effects data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... No direct mechanismofaction data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... Used in Ayurveda and Buddhist practices for calm and devotion.. Used in Ayurveda and Buddhist practices for calm and devotion.",
       "Relaxation",
       "mild euphoria",
       "dream enhancement",
       "anxiolytic",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
       "Pain relief",
       "reduced inflammation",
       "worm expulsion",
@@ -768,7 +781,6 @@
       "Visual distortions",
       "sedation",
       "altered mental state",
-      "No direct effects data. Contextual inference: Used by mapuche shamans in ritual ceremonies... No direct mechanismofaction data. Contextual inference: Used by mapuche shamans in ritual ceremonies... Used by Mapuche shamans in ritual ceremonies.. Used by Mapuche shamans in ritual ceremonies.",
       "Increased alertness",
       "minor euphoria",
       "divinatory visions",
@@ -776,7 +788,6 @@
       "used as a hunting drug in Africa",
       "Euphoria",
       "empathy",
-      "stress relief",
       "stimulation",
       "Mood elevation",
       "sociability",
@@ -862,16 +873,16 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "alkaloids"
+    "slug": "alkaloids",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "alkaloids (nicotine, leucocyanidin)",
     "herbs": [
       "acacia nilotica"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine"
-    ],
+    "effects": [],
     "contraindications": [
       "High doses of bark decoction can irritate the digestive tract and cause constipation or nausea",
       "Avoid during pregnancy or lactation due to potential anti-fertility effects",
@@ -880,13 +891,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "alkaloids-nicotine-leucocyanidin"
+    "slug": "alkaloids-nicotine-leucocyanidin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "alkaloids (uncharacterized)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Muscle relaxation",
       "mild sedation",
@@ -903,13 +914,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "alkaloids-uncharacterized"
+    "slug": "alkaloids-uncharacterized",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "alkaloids (undetermined)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Color vision changes",
       "detachment",
@@ -919,8 +930,7 @@
       "altered consciousness",
       "Visual distortions",
       "sedation",
-      "altered mental state",
-      "No direct effects data. Contextual inference: Used by mapuche shamans in ritual ceremonies... No direct mechanismofaction data. Contextual inference: Used by mapuche shamans in ritual ceremonies... Used by Mapuche shamans in ritual ceremonies.. Used by Mapuche shamans in ritual ceremonies."
+      "altered mental state"
     ],
     "contraindications": [
       "Potentially toxic",
@@ -932,13 +942,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "alkaloids-undetermined"
+    "slug": "alkaloids-undetermined",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "alkylamides",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Local anesthesia",
       "salivation",
@@ -961,7 +971,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "alkylamides"
+    "slug": "alkylamides",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Alpha",
@@ -970,12 +982,6 @@
       "pogostemon cablin"
     ],
     "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine"
@@ -984,7 +990,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "alpha"
+    "slug": "alpha",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Alpha-asarone",
@@ -993,10 +1001,6 @@
       "calamus"
     ],
     "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
       "Stimulation",
       "mental clarity",
       "mild sedation (low dose)",
@@ -1004,8 +1008,6 @@
       "beta-asarone rich)",
       "Mild sedative",
       "hallucinogenic in high doses",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
@@ -1022,17 +1024,28 @@
       "pregnancy",
       "cancer risk (β-asarone in some strains)."
     ],
-    "category": "alpha-asarone",
+    "category": "phenylpropanoid ether",
     "sources": [],
     "lastUpdated": "2026-03-21",
     "slug": "alpha-asarone",
     "canonicalCompoundId": "alpha-asarone",
     "id": "alpha-asarone",
     "compoundName": "alpha-asarone",
-    "compoundClass": "alpha-asarone",
+    "compoundClass": "phenylpropanoid ether",
     "mechanismTags": [
       "adrenergic signaling"
-    ]
+    ],
+    "description": "Phenylpropanoid ether from Acorus species studied for CNS-active and cholinergic effects.",
+    "summary": "Phenylpropanoid ether from Acorus species studied for CNS-active and cholinergic effects.",
+    "foundIn": [
+      "calamus"
+    ],
+    "targets": [
+      "GABA-A receptors",
+      "acetylcholinesterase"
+    ],
+    "safetyNotes": "High-caution aromatic compound with toxicology concerns; avoid concentrated internal use and pregnancy.",
+    "linkedHerbs": []
   },
   {
     "name": "Alpha-bulnesene",
@@ -1040,8 +1053,6 @@
       "pogostemon cablin"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine"
@@ -1050,39 +1061,34 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "alpha-bulnesene"
+    "slug": "alpha-bulnesene",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Amorphigenin",
     "herbs": [
       "amorpha fruticosa"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "amorphigenin"
+    "slug": "amorphigenin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "anabasine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Stimulation",
       "mood elevation",
       "alertness"
     ],
     "contraindications": [
-      "Heart disease",
-      "pregnancy",
-      "epilepsy"
+      "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety."
     ],
     "category": "anabasine",
     "sources": [],
@@ -1094,30 +1100,42 @@
     "compoundClass": "anabasine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Pyridine alkaloid associated with nicotinic receptor activity.",
+    "summary": "Pyridine alkaloid associated with nicotinic receptor activity.",
+    "foundIn": [
+      "Nicotiana glauca"
+    ],
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety.",
+    "linkedHerbs": []
   },
   {
     "name": "Anthocyanins",
     "herbs": [
       "hibiscus sabdariffa"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "anthocyanins"
+    "slug": "anthocyanins",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "apigenin",
     "herbs": [
       "alchemilla vulgaris",
-      "chamomile"
+      "chamomile",
+      "yerba-mate"
     ],
     "effects": [
       "Uterine tonic",
@@ -1134,8 +1152,7 @@
       "relaxation",
       "increased libido",
       "Mild stimulation",
-      "mood enhancement",
-      "No direct effects data. Contextual inference: Used as an aphrodisiac and mood enhancer in mexican herbalism... No direct mechanismofaction data. Contextual inference: Used as an aphrodisiac and mood enhancer in mexican herbalism... Used as an aphrodisiac and mood enhancer in Mexican herbalism.. Used as an aphrodisiac and mood enhancer in Mexican herbalism."
+      "mood enhancement"
     ],
     "contraindications": [
       "Excessive internal use may cause constipation or dry mucous membranes",
@@ -1146,7 +1163,7 @@
       "Pregnancy",
       "hormone-sensitive conditions"
     ],
-    "category": "Flavonoid",
+    "category": "flavone polyphenol",
     "sources": [
       {
         "note": "Inferred from scientific name:"
@@ -1157,13 +1174,30 @@
     "canonicalCompoundId": "apigenin",
     "id": "apigenin",
     "compoundName": "Apigenin",
-    "compoundClass": "Flavonoid",
+    "compoundClass": "flavone polyphenol",
     "mechanismTags": [
       "anxiolytic signaling",
       "gaba-a modulation",
       "nf-kb inhibition",
       "unclassified"
-    ]
+    ],
+    "description": "Flavone found in chamomile and parsley, frequently linked to GABAergic and PI3K/Akt-related effects.",
+    "summary": "Flavone found in chamomile and parsley, frequently linked to GABAergic and PI3K/Akt-related effects.",
+    "foundIn": [
+      "yerba mate",
+      "chamomile",
+      "petroselinum crispum",
+      "parsley"
+    ],
+    "targets": [
+      "GABAergic signaling",
+      "NF-κB",
+      "Nrf2",
+      "PI3K/Akt",
+      "inflammatory mediators"
+    ],
+    "safetyNotes": "Food exposure is low-risk; concentrated apigenin may be sedating and may interact with sedatives or CYP-metabolized drugs. Pregnancy/breastfeeding caution at supplement doses.",
+    "linkedHerbs": []
   },
   {
     "name": "apigenin glycosides",
@@ -1190,16 +1224,16 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "apigenin-glycosides"
+    "slug": "apigenin-glycosides",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Aporphine",
     "herbs": [
-      "blue lotus",
-      "nan"
+      "blue lotus"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... No direct mechanismofaction data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... Used ceremonially in Ancient Egypt for euphoria and vision enhancement.. Used ceremonially in Ancient Egypt for euphoria and vision enhancement.",
       "Relaxation",
       "mild euphoria",
       "lucid dreaming",
@@ -1230,13 +1264,14 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "aporphine"
+    "slug": "aporphine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "arbutin",
     "herbs": [
-      "adenostoma fasciculatum",
-      "nan"
+      "adenostoma fasciculatum"
     ],
     "effects": [
       "Traditional uses include skin and respiratory conditions",
@@ -1249,8 +1284,7 @@
       "relaxation",
       "increased libido",
       "Mild stimulation",
-      "mood enhancement",
-      "No direct effects data. Contextual inference: Used as an aphrodisiac and mood enhancer in mexican herbalism... No direct mechanismofaction data. Contextual inference: Used as an aphrodisiac and mood enhancer in mexican herbalism... Used as an aphrodisiac and mood enhancer in Mexican herbalism.. Used as an aphrodisiac and mood enhancer in Mexican herbalism."
+      "mood enhancement"
     ],
     "contraindications": [
       "Limited safety data",
@@ -1274,7 +1308,9 @@
     "mechanism": "Arbutin, tannins, methyl salicylate",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "β-asarone",
@@ -1304,21 +1340,17 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "asarone"
+    "slug": "asarone",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Asarone (alpha & beta)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Mild stimulation",
       "focus",
-      "calm",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "calm"
     ],
     "contraindications": [
       "Similar risks to Acorus calamus",
@@ -1327,7 +1359,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "asarone-alpha-beta"
+    "slug": "asarone-alpha-beta",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Ascaridole",
@@ -1336,21 +1370,17 @@
       "peumus boldus"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
-      "dreaming or folk medicine",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "dreaming or folk medicine"
     ],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "ascaridole"
+    "slug": "ascaridole",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Astragalin",
@@ -1359,34 +1389,47 @@
       "astragalus-membranaceus"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used to treat asthma",
       "allergies",
-      "and liver issues in folk medicine... No direct mechanismofaction data. Contextual inference: Used to treat asthma",
       "and liver issues in folk medicine... Used to treat asthma",
       "and liver issues in folk medicine.. Used to treat asthma",
       "and liver issues in folk medicine."
     ],
-    "contraindications": [],
-    "category": null,
+    "contraindications": [
+      "Mostly food/extract-derived human evidence. High-dose supplements may affect CYP/transporters or anticoagulant/antiplatelet risk."
+    ],
+    "category": "flavonol / flavonoid",
     "sources": [],
     "lastUpdated": "2026-03-21",
     "slug": "astragalin",
     "canonicalCompoundId": "astragalin",
     "id": "astragalin",
-    "compoundName": "Astragalin"
+    "compoundName": "Astragalin",
+    "compoundClass": "flavonol / flavonoid",
+    "description": "Flavonoid glycoside associated with inflammatory pathway control.",
+    "summary": "Flavonoid glycoside associated with inflammatory pathway control.",
+    "foundIn": [
+      "Astragalus membranaceus"
+    ],
+    "targets": [
+      "AMPK",
+      "Nrf2",
+      "NF-κB",
+      "inflammatory cytokines",
+      "endothelial nitric oxide",
+      "antioxidant response"
+    ],
+    "safetyNotes": "Mostly food/extract-derived human evidence. High-dose supplements may affect CYP/transporters or anticoagulant/antiplatelet risk.",
+    "linkedHerbs": []
   },
   {
     "name": "Atropine",
     "herbs": [
-      "datura metel",
-      "nan"
+      "datura metel"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used in rituals but also associated with danger and toxicity... No direct mechanismofaction data. Contextual inference: Used in rituals but also associated with danger and toxicity... Used in rituals but also associated with danger and toxicity.. Used in rituals but also associated with danger and toxicity.",
       "Complete dissociation",
       "hallucinations",
       "amnesia",
-      "No direct effects data. Contextual inference: Ritual use.. No direct mechanismofaction data. Contextual inference: Ritual use.. Ritual use. Ritual use",
       "Intense hallucinations",
       "delirium",
       "Strong anticholinergic and hallucinogenic effects",
@@ -1429,13 +1472,13 @@
     "compoundClass": "atropine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Azulene",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Anti-inflammatory",
       "astringent",
@@ -1450,24 +1493,23 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "azulene"
+    "slug": "azulene",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Bacosides A and B",
     "herbs": [
       "bacopa monnieri"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "bacosides-a-and-b"
+    "slug": "bacosides-a-and-b",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Baicalin",
@@ -1480,32 +1522,45 @@
       "Mild sedation",
       "calm mood",
       "anxiety relief",
-      "No direct effects data. Contextual inference: Used by native american tribes for anxiety and insomnia... No direct mechanismofaction data. Contextual inference: Used by native american tribes for anxiety and insomnia... Used by Native American tribes for anxiety and insomnia.. Used by Native American tribes for anxiety and insomnia.",
       "Nervine",
       "anxiolytic",
       "anti-inflammatory",
       "used for insomnia and anxiety"
     ],
     "contraindications": [
-      "Avoid during pregnancy",
-      "caution with sedatives",
-      "pregnancy",
-      "sedative sensitivity."
+      "Mostly supported through Scutellaria extracts and preclinical data. Use caution with liver disease, sedatives, anticoagulants/antiplatelets, immunosuppressants, and pregnancy."
     ],
-    "category": "Flavonoid",
+    "category": "flavone glycoside",
     "sources": [],
     "lastUpdated": "2026-03-21",
     "slug": "baicalin",
     "canonicalCompoundId": "baicalin",
     "id": "baicalin",
     "compoundName": "Baicalin",
-    "compoundClass": "Flavonoid",
+    "compoundClass": "flavone glycoside",
     "mechanism": "Anti-inflammatory; neuroprotective",
     "mechanismTags": [
       "neuroprotective signaling",
       "nf-kb inhibition",
       "unclassified"
-    ]
+    ],
+    "description": "Flavone glycoside commonly reported from Scutellaria with anti-inflammatory and PI3K/Akt pathway activity.",
+    "summary": "Flavone glycoside commonly reported from Scutellaria with anti-inflammatory and PI3K/Akt pathway activity.",
+    "foundIn": [
+      "chinese skullcap",
+      "skullcap",
+      "scutellaria baicalensis"
+    ],
+    "targets": [
+      "NF-κB",
+      "MAPK",
+      "PI3K/Akt",
+      "Nrf2",
+      "inflammatory cytokines",
+      "GABAergic signaling"
+    ],
+    "safetyNotes": "Mostly supported through Scutellaria extracts and preclinical data. Use caution with liver disease, sedatives, anticoagulants/antiplatelets, immunosuppressants, and pregnancy.",
+    "linkedHerbs": []
   },
   {
     "name": "benzaconine",
@@ -1533,7 +1588,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "benzaconine"
+    "slug": "benzaconine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "benzoic acid",
@@ -1559,16 +1616,16 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "benzoic-acid"
+    "slug": "benzoic-acid",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Benzyl isothiocyanate",
     "herbs": [
       "tropaeolum majus"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used in andean herbalism to clear lungs and improve alertness... No direct mechanismofaction data. Contextual inference: Used in andean herbalism to clear lungs and improve alertness... Used in Andean herbalism to clear lungs and improve alertness.. Used in Andean herbalism to clear lungs and improve alertness."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": "benzyl isothiocyanate",
     "sources": [],
@@ -1580,7 +1637,9 @@
     "compoundClass": "benzyl isothiocyanate",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Beta",
@@ -1588,8 +1647,6 @@
       "acorus calamus var. angustatus"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine"
@@ -1598,17 +1655,16 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "beta"
+    "slug": "beta",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Beta-asarone",
     "herbs": [
-      "acorus calamus var. angustatus",
-      "nan"
+      "acorus calamus var. angustatus"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
@@ -1642,13 +1698,13 @@
     "compoundClass": "beta-asarone",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "beta-carbolines",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Intense visions",
       "altered perception",
@@ -1663,18 +1719,17 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "beta-carbolines"
+    "slug": "beta-carbolines",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "beta-carbolines (trace)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Closed-eye visuals",
       "altered cognition",
-      "spiritual insight (when used with MAOI)",
-      "No direct effects data. Contextual inference: Ritual use.. No direct mechanismofaction data. Contextual inference: Ritual use.. Ritual use. Ritual use"
+      "spiritual insight (when used with MAOI)"
     ],
     "contraindications": [
       "Use with SSRIs or MAOIs without supervision"
@@ -1682,7 +1737,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "beta-carbolines-trace"
+    "slug": "beta-carbolines-trace",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Boldine",
@@ -1690,12 +1747,7 @@
       "peumus boldus",
       "boldo"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": "boldine",
     "sources": [],
@@ -1707,7 +1759,9 @@
     "compoundClass": "boldine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "borneol",
@@ -1737,7 +1791,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "borneol"
+    "slug": "borneol",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Boswellic acids",
@@ -1749,15 +1805,30 @@
       "antibacterial"
     ],
     "contraindications": [
-      "Avoid use in bleeding disorders"
+      "Boswellia extracts can cause GI upset and may interact with anticoagulants/anti-inflammatory drugs",
+      "pregnancy safety is not established."
     ],
-    "category": null,
+    "category": "pentacyclic triterpene acid / boswellic acid",
     "sources": [],
     "lastUpdated": "2026-03-21",
     "slug": "boswellic-acids",
     "canonicalCompoundId": "boswellic-acid",
     "id": "boswellic-acid",
-    "compoundName": "Boswellic acid"
+    "compoundName": "Boswellic acid",
+    "compoundClass": "pentacyclic triterpene acid / boswellic acid",
+    "description": "Pentacyclic triterpenoid boswellic acid from frankincense resin with 5-LOX and inflammatory pathway activity.",
+    "summary": "Pentacyclic triterpenoid boswellic acid from frankincense resin with 5-LOX and inflammatory pathway activity.",
+    "foundIn": [
+      "Boswellia serrata"
+    ],
+    "targets": [
+      "5-LOX",
+      "NF-κB",
+      "leukotriene pathways",
+      "inflammatory cytokines"
+    ],
+    "safetyNotes": "Boswellia extracts can cause GI upset and may interact with anticoagulants/anti-inflammatory drugs; pregnancy safety is not established.",
+    "linkedHerbs": []
   },
   {
     "name": "budmunchiamines L1-L6",
@@ -1782,24 +1853,20 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "budmunchiamines-l1-l6"
+    "slug": "budmunchiamines-l1-l6",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Bufotenin",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Visuals",
       "nausea",
       "euphoria",
       "altered states",
       "stimulation",
-      "altered perception",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "altered perception"
     ],
     "contraindications": [
       "Asthma",
@@ -1819,36 +1886,30 @@
     "compoundClass": "bufotenin",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Bufotenine",
     "herbs": [
       "anadenanthera colubrina",
-      "nan",
       "anadenanthera peregrina",
       "virola theiodora"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
       "Intense visuals",
       "spiritual experiences",
       "ego dissolution",
-      "No direct effects data. Contextual inference: Used by amazonian tribes as a snuff for spiritual rituals... No direct mechanismofaction data. Contextual inference: Used by amazonian tribes as a snuff for spiritual rituals... Used by Amazonian tribes as a snuff for spiritual rituals.. Used by Amazonian tribes as a snuff for spiritual rituals.",
       "Visuals",
       "nausea",
       "euphoria",
       "altered states",
       "stimulation",
       "altered perception",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
       "Visual stimulation",
       "introspection"
     ],
@@ -1866,7 +1927,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "bufotenine"
+    "slug": "bufotenine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "bulnesene",
@@ -1874,8 +1937,6 @@
       "pogostemon cablin"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine"
@@ -1884,7 +1945,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "bulnesene"
+    "slug": "bulnesene",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "caffeic acid",
@@ -1907,7 +1970,7 @@
       "may interact with blood thinners due to tannin content【859641390196180†L297",
       "L313】."
     ],
-    "category": "caffeic acid",
+    "category": "phenolic acid / polyphenol",
     "sources": [
       {
         "note": "Inferred from scientific name:"
@@ -1918,11 +1981,27 @@
     "canonicalCompoundId": "caffeic-acid",
     "id": "caffeic-acid",
     "compoundName": "caffeic acid",
-    "compoundClass": "caffeic acid",
+    "compoundClass": "phenolic acid / polyphenol",
     "mechanism": "provisional_from_herb_monograph",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Phenolic acid broadly present in herbs and coffee, commonly linked to NF-κB and MAPK signaling.",
+    "summary": "Phenolic acid broadly present in herbs and coffee, commonly linked to NF-κB and MAPK signaling.",
+    "foundIn": [
+      "coffee",
+      "propolis",
+      "many herbs"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "antioxidant response",
+      "glucose/lipid signaling",
+      "gut microbiome metabolism"
+    ],
+    "safetyNotes": "Mostly food-associated; concentrated extracts may cause GI effects or interact with anticoagulants/antidiabetics depending matrix.",
+    "linkedHerbs": []
   },
   {
     "name": "Caffeine",
@@ -1930,7 +2009,9 @@
       "yerba mate",
       "camellia sinensis",
       "ilex-paraguariensis",
-      "guayusa"
+      "guayusa",
+      "guarana",
+      "yerba-mate"
     ],
     "effects": [
       "Mental alertness",
@@ -1972,13 +2053,13 @@
     "safetyNotes": [
       "Higher intake can worsen anxiety, palpitations, insomnia, or reflux; sensitivity varies widely by person and dose timing."
     ],
-    "evidenceLevel": "moderate"
+    "evidenceLevel": "moderate",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "caffeine-like alkaloids",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Mood lift",
       "mild stimulation",
@@ -1988,8 +2069,7 @@
       "relaxation",
       "increased libido",
       "Mild stimulation",
-      "mood enhancement",
-      "No direct effects data. Contextual inference: Used as an aphrodisiac and mood enhancer in mexican herbalism... No direct mechanismofaction data. Contextual inference: Used as an aphrodisiac and mood enhancer in mexican herbalism... Used as an aphrodisiac and mood enhancer in Mexican herbalism.. Used as an aphrodisiac and mood enhancer in Mexican herbalism."
+      "mood enhancement"
     ],
     "contraindications": [
       "Avoid in bipolar disorder and pregnancy",
@@ -1999,13 +2079,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "caffeine-like-alkaloids"
+    "slug": "caffeine-like-alkaloids",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "caffeine-like compounds",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Mood lift",
       "mild stimulation",
@@ -2015,8 +2095,7 @@
       "relaxation",
       "increased libido",
       "Mild stimulation",
-      "mood enhancement",
-      "No direct effects data. Contextual inference: Used as an aphrodisiac and mood enhancer in mexican herbalism... No direct mechanismofaction data. Contextual inference: Used as an aphrodisiac and mood enhancer in mexican herbalism... Used as an aphrodisiac and mood enhancer in Mexican herbalism.. Used as an aphrodisiac and mood enhancer in Mexican herbalism."
+      "mood enhancement"
     ],
     "contraindications": [
       "Avoid in bipolar disorder and pregnancy",
@@ -2026,13 +2105,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "caffeine-like-compounds"
+    "slug": "caffeine-like-compounds",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Caleicines",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Lucid dreaming",
       "relaxation",
@@ -2040,8 +2119,6 @@
       "Vivid dreams",
       "increased dream recall",
       "mild sedation",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
@@ -2058,13 +2135,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "caleicines"
+    "slug": "caleicines",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "calein A",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Lucid dreaming",
       "relaxation",
@@ -2072,8 +2149,6 @@
       "Vivid dreams",
       "increased dream recall",
       "mild sedation",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
@@ -2090,17 +2165,16 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "calein-a"
+    "slug": "calein-a",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "calein A and B",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Vivid and lucid dreams",
-      "dream recall",
-      "No direct effects data. Contextual inference: Used by chontal shamans to induce vivid dreams and visions... No direct mechanismofaction data. Contextual inference: Used by chontal shamans to induce vivid dreams and visions... Used by Chontal shamans to induce vivid dreams and visions.. Used by Chontal shamans to induce vivid dreams and visions."
+      "dream recall"
     ],
     "contraindications": [
       "Avoid in pregnancy and with CNS depressants"
@@ -2108,7 +2182,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "calein-a-and-b"
+    "slug": "calein-a-and-b",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "campesterol",
@@ -2131,7 +2207,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "campesterol"
+    "slug": "campesterol",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "camphene",
@@ -2161,15 +2239,16 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "camphene"
+    "slug": "camphene",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "camphor",
     "herbs": [
       "acorus tatarinowii",
       "artemisia abrotanum",
-      "artemisia ludoviciana",
-      "nan"
+      "artemisia ludoviciana"
     ],
     "effects": [
       "CNS stimulant",
@@ -2177,8 +2256,6 @@
       "and anti-epileptic in TCM",
       "and anti",
       "epileptic in TCM",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
@@ -2190,8 +2267,7 @@
       "memory enhancer",
       "Clarity",
       "calm",
-      "subtle mood lift",
-      "No direct effects data. Contextual inference: Used in smudging rituals for purification and clarity... No direct mechanismofaction data. Contextual inference: Used in smudging rituals for purification and clarity... Used in smudging rituals for purification and clarity.. Used in smudging rituals for purification and clarity."
+      "subtle mood lift"
     ],
     "contraindications": [
       "β",
@@ -2220,7 +2296,9 @@
     "compoundClass": "camphor",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "carvacrol",
@@ -2228,30 +2306,40 @@
       "ajwain"
     ],
     "effects": [
-      "Stress relief",
       "respiratory support",
       "antioxidant",
-      "mild energy boost",
-      "Adaptogen",
-      "anti-stress",
-      "immune support"
+      "mild energy boost"
     ],
     "contraindications": [
-      "Pregnancy (high doses)",
-      "blood clotting disorders"
+      "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses",
+      "use dilution and herb-specific safety."
     ],
-    "category": "carvacrol",
+    "category": "terpene / essential-oil constituent",
     "sources": [],
     "lastUpdated": "2026-03-21",
     "slug": "carvacrol",
     "canonicalCompoundId": "carvacrol",
     "id": "carvacrol",
     "compoundName": "carvacrol",
-    "compoundClass": "carvacrol",
+    "compoundClass": "terpene / essential-oil constituent",
     "mechanism": "phenolic monoterpenoid",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Monoterpenoid phenol from oregano and thyme with antimicrobial and sensory effects.",
+    "summary": "Monoterpenoid phenol from oregano and thyme with antimicrobial and sensory effects.",
+    "foundIn": [
+      "Sage",
+      "Ajwain",
+      "Oregano",
+      "Thyme"
+    ],
+    "targets": [
+      "TRPA1",
+      "membrane lipids"
+    ],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "linkedHerbs": []
   },
   {
     "name": "Casimiroin",
@@ -2259,9 +2347,7 @@
       "casimiroa edulis"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used to treat anxiety",
       "insomnia",
-      "and as a mild euphoric... No direct mechanismofaction data. Contextual inference: Used to treat anxiety",
       "and as a mild euphoric... Used to treat anxiety",
       "and as a mild euphoric.. Used to treat anxiety",
       "and as a mild euphoric."
@@ -2270,7 +2356,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "casimiroin"
+    "slug": "casimiroin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "catechin",
@@ -2298,7 +2386,7 @@
       "may interact with blood thinners due to tannin content【859641390196180†L297",
       "L313】."
     ],
-    "category": "Polyphenol",
+    "category": "flavanol / tea polyphenol",
     "sources": [
       {
         "note": "Inferred from scientific name:"
@@ -2309,10 +2397,28 @@
     "canonicalCompoundId": "catechin",
     "id": "catechin",
     "compoundName": "Catechin",
-    "compoundClass": "Polyphenol",
+    "compoundClass": "flavanol / tea polyphenol",
     "mechanismTags": [
       "oxidative stress reduction"
-    ]
+    ],
+    "description": "Flavan-3-ol common in tea and cacao, often linked to AMPK and Nrf2 pathway effects.",
+    "summary": "Flavan-3-ol common in tea and cacao, often linked to AMPK and Nrf2 pathway effects.",
+    "foundIn": [
+      "green tea",
+      "cacao",
+      "grape",
+      "berries"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "AMPK",
+      "endothelial nitric oxide",
+      "antioxidant response",
+      "lipid/glucose signaling"
+    ],
+    "safetyNotes": "Tea-food exposure is generally safer than concentrated extracts. High EGCG/catechin extracts have liver-injury concern and caffeine-containing products add stimulant risk.",
+    "linkedHerbs": []
   },
   {
     "name": "catechins",
@@ -2325,7 +2431,6 @@
       "Used in Ayurveda for asthma",
       "allergies",
       "and anxiety",
-      "No direct effects data. Contextual inference: Used in folk medicine to promote calm and wellness... No direct mechanismofaction data. Contextual inference: Used in folk medicine to promote calm and wellness... Used in folk medicine to promote calm and wellness.. Used in folk medicine to promote calm and wellness.",
       "Mental alertness",
       "energy",
       "appetite suppression",
@@ -2342,11 +2447,7 @@
       "hepatoprotective",
       "Alertness",
       "calm focus",
-      "mood lift",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "mood lift"
     ],
     "contraindications": [
       "No well‑documented contraindications",
@@ -2377,36 +2478,33 @@
     "compoundClass": "catechins (egcg)",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Catuabine",
     "herbs": [
       "catuaba"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine"
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "catuabine"
+    "slug": "catuabine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "CBD",
     "herbs": [
-      "nan",
       "cannabis sativa"
     ],
     "effects": [
       "Euphoria",
       "altered perception",
-      "sedation or stimulation",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "sedation or stimulation"
     ],
     "contraindications": [
       "Psychosis",
@@ -2423,21 +2521,17 @@
     "compoundClass": "cbd",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "CBN",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Euphoria",
       "altered perception",
-      "sedation or stimulation",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "sedation or stimulation"
     ],
     "contraindications": [
       "Psychosis",
@@ -2447,7 +2541,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "cbn"
+    "slug": "cbn",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Celastrine",
@@ -2455,9 +2551,7 @@
       "celastrus paniculatus"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used in ayurveda for cognition",
       "focus",
-      "and learning... No direct mechanismofaction data. Contextual inference: Used in ayurveda for cognition",
       "and learning... Used in Ayurveda for cognition",
       "and learning.. Used in Ayurveda for cognition",
       "and learning."
@@ -2473,7 +2567,9 @@
     "compoundClass": "celastrine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "cephaeline",
@@ -2509,7 +2605,9 @@
     "mechanism": "Emetine, cephaeline, alkaloids",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Chamazulene",
@@ -2524,21 +2622,34 @@
       "hemostatic"
     ],
     "contraindications": [
-      "Pregnancy",
-      "allergies to Asteraceae",
-      "bleeding disorders"
+      "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses",
+      "use dilution and herb-specific safety."
     ],
-    "category": "chamazulene",
+    "category": "terpene / essential-oil constituent",
     "sources": [],
     "lastUpdated": "2026-03-21",
     "slug": "chamazulene",
     "canonicalCompoundId": "chamazulene",
     "id": "chamazulene",
     "compoundName": "chamazulene",
-    "compoundClass": "chamazulene",
+    "compoundClass": "terpene / essential-oil constituent",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Aromatic azulene derivative linked to inflammatory mediator modulation.",
+    "summary": "Aromatic azulene derivative linked to inflammatory mediator modulation.",
+    "foundIn": [
+      "Chamomile",
+      "Matricaria chamomilla"
+    ],
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "linkedHerbs": []
   },
   {
     "name": "Chlorogenic acid",
@@ -2547,28 +2658,44 @@
       "coffee",
       "coffea-arabica"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... No direct mechanismofaction data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... Consumed as a social and energizing herbal tea throughout South America.. Consumed as a social and energizing herbal tea throughout South America."
+    "effects": [],
+    "contraindications": [
+      "Generally food-associated",
+      "supplement doses may cause GI upset or caffeine-like effects if delivered via coffee/green coffee extracts. Caution with stimulant sensitivity and antidiabetic drugs."
     ],
-    "contraindications": [],
-    "category": "chlorogenic acid",
+    "category": "caffeoylquinic acid / phenolic acid",
     "sources": [],
     "lastUpdated": "2026-03-21",
     "slug": "chlorogenic-acid",
     "canonicalCompoundId": "chlorogenic-acid",
     "id": "chlorogenic-acid",
     "compoundName": "chlorogenic acid",
-    "compoundClass": "chlorogenic acid",
+    "compoundClass": "caffeoylquinic acid / phenolic acid",
     "mechanism": "flavonoids; triterpenes",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Caffeoylquinic acid widely reported from coffee and artichoke with AMPK and glucose-metabolism pathway effects.",
+    "summary": "Caffeoylquinic acid widely reported from coffee and artichoke with AMPK and glucose-metabolism pathway effects.",
+    "foundIn": [
+      "coffee",
+      "yerba mate",
+      "artichoke",
+      "many plants"
+    ],
+    "targets": [
+      "AMPK",
+      "glucose absorption pathways",
+      "antioxidant enzymes",
+      "inflammatory signaling"
+    ],
+    "safetyNotes": "Generally food-associated; supplement doses may cause GI upset or caffeine-like effects if delivered via coffee/green coffee extracts. Caution with stimulant sensitivity and antidiabetic drugs.",
+    "linkedHerbs": []
   },
   {
     "name": "cineole",
     "herbs": [
       "acorus tatarinowii",
-      "nan",
       "salvia apiana"
     ],
     "effects": [
@@ -2597,8 +2724,7 @@
       "mild calm",
       "enhanced intuition",
       "menstrual regulator",
-      "mild sedative",
-      "No direct effects data. Contextual inference: Used in smudging rituals for purification and clarity... No direct mechanismofaction data. Contextual inference: Used in smudging rituals for purification and clarity... Used in smudging rituals for purification and clarity.. Used in smudging rituals for purification and clarity."
+      "mild sedative"
     ],
     "contraindications": [
       "β",
@@ -2632,21 +2758,17 @@
     "compoundClass": "cineole",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "cinnamic acid derivatives",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Mild stimulation",
       "hunger suppression",
-      "improved stamina",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "improved stamina"
     ],
     "contraindications": [
       "Heart issues",
@@ -2655,7 +2777,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "cinnamic-acid-derivatives"
+    "slug": "cinnamic-acid-derivatives",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "cis-methylisoeugenol",
@@ -2685,33 +2809,30 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "cis-methylisoeugenol"
+    "slug": "cis-methylisoeugenol",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Cissamine",
     "herbs": [
       "cissampelos pareira"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used in amazonian and ayurvedic traditions for pain and calming... No direct mechanismofaction data. Contextual inference: Used in amazonian and ayurvedic traditions for pain and calming... Used in Amazonian and Ayurvedic traditions for pain and calming.. Used in Amazonian and Ayurvedic traditions for pain and calming."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "cissamine"
+    "slug": "cissamine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Citral",
     "herbs": [
-      "aloysia citrodora",
-      "nan"
+      "aloysia citrodora"
     ],
     "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
       "Mild sedation",
       "relaxation",
       "antispasmodic",
@@ -2733,21 +2854,17 @@
     "mechanism": "monoterpenoid aldehyde",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Cocaine alkaloids (0.2–1%)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Mild stimulation",
       "hunger suppression",
-      "improved stamina",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "improved stamina"
     ],
     "contraindications": [
       "Heart issues",
@@ -2756,13 +2873,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "cocaine-alkaloids-0-2-1"
+    "slug": "cocaine-alkaloids-0-2-1",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "codeine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Pain relief",
       "euphoria",
@@ -2792,48 +2909,46 @@
     "compoundClass": "codeine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Combretin",
     "herbs": [
       "combretum quadrangulare"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used as a kratom alternative in southeast asian cultures... No direct mechanismofaction data. Contextual inference: Used as a kratom alternative in southeast asian cultures... Used as a kratom alternative in Southeast Asian cultures.. Used as a kratom alternative in Southeast Asian cultures."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "combretin"
+    "slug": "combretin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Combretol",
     "herbs": [
       "combretum quadrangulare"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used as a kratom alternative in southeast asian cultures... No direct mechanismofaction data. Contextual inference: Used as a kratom alternative in southeast asian cultures... Used as a kratom alternative in Southeast Asian cultures.. Used as a kratom alternative in Southeast Asian cultures."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "combretol"
+    "slug": "combretol",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "coronaridine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Altered perception",
       "stimulation",
       "euphoria",
       "potential visionary states",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine"
@@ -2853,13 +2968,13 @@
     "compoundClass": "coronaridine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "corynanthine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Stimulation",
       "increased blood flow",
@@ -2875,12 +2990,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "corynanthine"
+    "slug": "corynanthine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Coumarin",
     "herbs": [
-      "nan",
       "justicia pectoralis"
     ],
     "effects": [
@@ -2890,8 +3006,7 @@
       "Mild euphoria",
       "sedation",
       "muscle relaxation",
-      "spiritual openness",
-      "No direct effects data. Contextual inference: Used in amazonian herbal mixtures and healing brews... No direct mechanismofaction data. Contextual inference: Used in amazonian herbal mixtures and healing brews... Used in Amazonian herbal mixtures and healing brews.. Used in Amazonian herbal mixtures and healing brews."
+      "spiritual openness"
     ],
     "contraindications": [
       "Avoid large doses",
@@ -2902,13 +3017,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "coumarin"
+    "slug": "coumarin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "coumarins",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Local anesthesia",
       "salivation",
@@ -2931,12 +3046,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "coumarins"
+    "slug": "coumarins",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Cryogenine",
     "herbs": [
-      "nan",
       "heimia salicifolia"
     ],
     "effects": [
@@ -2948,16 +3064,11 @@
       "relaxation",
       "mild euphoria",
       "dream-like state",
-      "No direct effects data. Contextual inference: Used by aztecs and indigenous mexicans for spiritual insight... No direct mechanismofaction data. Contextual inference: Used by aztecs and indigenous mexicans for spiritual insight... Used by Aztecs and indigenous Mexicans for spiritual insight.. Used by Aztecs and indigenous Mexicans for spiritual insight.",
       "Mild auditory and memory effects",
       "traditional fermentation increases effects",
       "Auditory shifts",
       "relaxed dreamlike state",
       "Mild auditory and visual alterations",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
       "Mild auditory hallucinations",
       "warmth",
       "euphoria"
@@ -2979,13 +3090,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "cryogenine"
+    "slug": "cryogenine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Cryogenine (vertine)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Auditory distortion",
       "calmness",
@@ -2995,7 +3106,6 @@
       "relaxation",
       "mild euphoria",
       "dream-like state",
-      "No direct effects data. Contextual inference: Used by aztecs and indigenous mexicans for spiritual insight... No direct mechanismofaction data. Contextual inference: Used by aztecs and indigenous mexicans for spiritual insight... Used by Aztecs and indigenous Mexicans for spiritual insight.. Used by Aztecs and indigenous Mexicans for spiritual insight.",
       "Mild auditory and memory effects",
       "traditional fermentation increases effects",
       "Auditory hallucinations",
@@ -3023,7 +3133,9 @@
     "compoundClass": "cryogenine (vertine)",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Cymene",
@@ -3031,8 +3143,6 @@
       "dysphania ambrosioides"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine"
@@ -3041,23 +3151,20 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "cymene"
+    "slug": "cymene",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Cytisine",
     "herbs": [
-      "nan",
       "sophora secundiflora"
     ],
     "effects": [
       "Delirium",
       "nausea",
       "visionary trance",
-      "paralysis",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "paralysis"
     ],
     "contraindications": [
       "Highly toxic",
@@ -3066,22 +3173,18 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "cytisine"
+    "slug": "cytisine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Cytisine (nicotinic agonist)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Delirium",
       "nausea",
       "visionary trance",
-      "paralysis",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "paralysis"
     ],
     "contraindications": [
       "Highly toxic",
@@ -3090,12 +3193,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "cytisine-nicotinic-agonist"
+    "slug": "cytisine-nicotinic-agonist",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Damianin",
     "herbs": [
-      "nan",
       "turnera diffusa var. aphrodisiaca",
       "turnera diffusa"
     ],
@@ -3108,12 +3212,7 @@
       "relaxation",
       "increased libido",
       "Mild stimulation",
-      "mood enhancement",
-      "No direct effects data. Contextual inference: Used as an aphrodisiac and mood enhancer in mexican herbalism... No direct mechanismofaction data. Contextual inference: Used as an aphrodisiac and mood enhancer in mexican herbalism... Used as an aphrodisiac and mood enhancer in Mexican herbalism.. Used as an aphrodisiac and mood enhancer in Mexican herbalism.",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "mood enhancement"
     ],
     "contraindications": [
       "Avoid in bipolar disorder and pregnancy",
@@ -3123,7 +3222,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "damianin"
+    "slug": "damianin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "deoxyaconitine",
@@ -3151,7 +3252,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "deoxyaconitine"
+    "slug": "deoxyaconitine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "deoxytubulosine",
@@ -3180,12 +3283,13 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "deoxytubulosine"
+    "slug": "deoxytubulosine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Desfontainin",
     "herbs": [
-      "nan",
       "desfontainia spinosa"
     ],
     "effects": [
@@ -3197,8 +3301,7 @@
       "altered consciousness",
       "Visual distortions",
       "sedation",
-      "altered mental state",
-      "No direct effects data. Contextual inference: Used by mapuche shamans in ritual ceremonies... No direct mechanismofaction data. Contextual inference: Used by mapuche shamans in ritual ceremonies... Used by Mapuche shamans in ritual ceremonies.. Used by Mapuche shamans in ritual ceremonies."
+      "altered mental state"
     ],
     "contraindications": [
       "Potentially toxic",
@@ -3210,13 +3313,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "desfontainin"
+    "slug": "desfontainin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Desfontainine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Color vision changes",
       "detachment",
@@ -3226,8 +3329,7 @@
       "altered consciousness",
       "Visual distortions",
       "sedation",
-      "altered mental state",
-      "No direct effects data. Contextual inference: Used by mapuche shamans in ritual ceremonies... No direct mechanismofaction data. Contextual inference: Used by mapuche shamans in ritual ceremonies... Used by Mapuche shamans in ritual ceremonies.. Used by Mapuche shamans in ritual ceremonies."
+      "altered mental state"
     ],
     "contraindications": [
       "Potentially toxic",
@@ -3239,18 +3341,17 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "desfontainine"
+    "slug": "desfontainine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Desmodin",
     "herbs": [
-      "desmodium adscendens",
-      "nan"
+      "desmodium adscendens"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used to treat asthma",
       "allergies",
-      "and liver issues in folk medicine... No direct mechanismofaction data. Contextual inference: Used to treat asthma",
       "and liver issues in folk medicine... Used to treat asthma",
       "and liver issues in folk medicine.. Used to treat asthma",
       "and liver issues in folk medicine.",
@@ -3259,11 +3360,7 @@
       "mild clarity",
       "Calming",
       "expectorant",
-      "mild analgesic",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "mild analgesic"
     ],
     "contraindications": [
       "None known",
@@ -3273,17 +3370,16 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "desmodin"
+    "slug": "desmodin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "diterpenoids",
     "herbs": [
-      "african dream root",
-      "nan"
+      "african dream root"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
@@ -3311,12 +3407,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "diterpenoids"
+    "slug": "diterpenoids",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "DMT",
     "herbs": [
-      "nan",
       "acacia maidenii",
       "virola theiodora"
     ],
@@ -3327,16 +3424,11 @@
       "introspection",
       "Psychedelic visuals",
       "altered consciousness",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
       "Psychoactive (when extracted)",
       "vision alteration",
       "Intense visuals",
       "spiritual experiences",
       "ego dissolution",
-      "No direct effects data. Contextual inference: Used by amazonian tribes as a snuff for spiritual rituals... No direct mechanismofaction data. Contextual inference: Used by amazonian tribes as a snuff for spiritual rituals... Used by Amazonian tribes as a snuff for spiritual rituals.. Used by Amazonian tribes as a snuff for spiritual rituals.",
       "Intense visions",
       "nausea",
       "Source of DMT-rich resin",
@@ -3382,13 +3474,13 @@
     "compoundClass": "dmt",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "DMT (0.3–0.7%)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Psychedelic visions",
       "auditory changes",
@@ -3403,20 +3495,16 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "dmt-0-3-0-7"
+    "slug": "dmt-0-3-0-7",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "DMT (in root bark)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Psychedelic visuals",
-      "emotional shifts (with MAOI)",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "emotional shifts (with MAOI)"
     ],
     "contraindications": [
       "psychoactivity not fully studied"
@@ -3424,7 +3512,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "dmt-in-root-bark"
+    "slug": "dmt-in-root-bark",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "echinocystic acid (acacic acid)",
@@ -3449,7 +3539,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "echinocystic-acid-acacic-acid"
+    "slug": "echinocystic-acid-acacic-acid",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Elaeagnin",
@@ -3457,9 +3549,7 @@
       "elaeagnus angustifolia"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used traditionally to relieve pain",
       "stress",
-      "and inflammation... No direct mechanismofaction data. Contextual inference: Used traditionally to relieve pain",
       "and inflammation... Used traditionally to relieve pain",
       "and inflammation.. Used traditionally to relieve pain",
       "and inflammation."
@@ -3468,7 +3558,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "elaeagnin"
+    "slug": "elaeagnin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "elemicin",
@@ -3484,9 +3576,7 @@
       "sedation",
       "altered perception",
       "disorientation",
-      "No direct effects data. Contextual inference: Used in spice blends",
       "aphrodisiacs",
-      "and as a psychoactive in folk rituals... No direct mechanismofaction data. Contextual inference: Used in spice blends",
       "and as a psychoactive in folk rituals... Used in spice blends",
       "and as a psychoactive in folk rituals.. Used in spice blends",
       "and as a psychoactive in folk rituals."
@@ -3500,13 +3590,27 @@
       "dangerous interactions with MAOIs",
       "SSRIs"
     ],
-    "category": null,
+    "category": "terpene / essential-oil constituent",
     "sources": [],
     "lastUpdated": "2026-03-21",
     "slug": "elemicin",
     "canonicalCompoundId": "elemicin",
     "id": "elemicin",
-    "compoundName": "Elemicin"
+    "compoundName": "Elemicin",
+    "compoundClass": "terpene / essential-oil constituent",
+    "description": "Phenylpropene associated with monoamine-related and sensory signaling.",
+    "summary": "Phenylpropene associated with monoamine-related and sensory signaling.",
+    "foundIn": [
+      "Myristica fragrans"
+    ],
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "linkedHerbs": []
   },
   {
     "name": "ellagic acid",
@@ -3525,7 +3629,7 @@
       "due to tannins may cause constipation or reduce absorption of minerals",
       "avoid large doses during pregnancy."
     ],
-    "category": "ellagic acid",
+    "category": "phenolic acid / polyphenol",
     "sources": [
       {
         "note": "Inferred from scientific name:"
@@ -3536,10 +3640,26 @@
     "canonicalCompoundId": "ellagic-acid",
     "id": "ellagic-acid",
     "compoundName": "ellagic acid",
-    "compoundClass": "ellagic acid",
+    "compoundClass": "phenolic acid / polyphenol",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Polyphenolic acid associated with pomegranate and berry sources, linked to Nrf2 and NF-κB signaling.",
+    "summary": "Polyphenolic acid associated with pomegranate and berry sources, linked to Nrf2 and NF-κB signaling.",
+    "foundIn": [
+      "pomegranate",
+      "raspberry",
+      "oak/gall-rich botanicals"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "antioxidant response",
+      "glucose/lipid signaling",
+      "gut microbiome metabolism"
+    ],
+    "safetyNotes": "Mostly food-associated; concentrated extracts may cause GI effects or interact with anticoagulants/antidiabetics depending matrix.",
+    "linkedHerbs": []
   },
   {
     "name": "ellagitannins",
@@ -3568,21 +3688,23 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "ellagitannins"
+    "slug": "ellagitannins",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Elsholtzia ketone",
     "herbs": [
       "elsholtzia ciliata"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used in vietnamese herbal teas for alertness and wellness... No direct mechanismofaction data. Contextual inference: Used in vietnamese herbal teas for alertness and wellness... Used in Vietnamese herbal teas for alertness and wellness.. Used in Vietnamese herbal teas for alertness and wellness."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "elsholtzia-ketone"
+    "slug": "elsholtzia-ketone",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "emetin",
@@ -3611,13 +3733,14 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "emetin"
+    "slug": "emetin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "ephedrine",
     "herbs": [
-      "aconitum napellus",
-      "nan"
+      "aconitum napellus"
     ],
     "effects": [
       "Potent analgesic and anti-inflammatory",
@@ -3659,21 +3782,20 @@
     "compoundClass": "ephedrine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "ergine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Closed-eye visuals",
       "sedation",
       "dream-like mental state",
       "Visual distortion",
       "introspection",
-      "altered perception of time and self",
-      "No direct effects data. Contextual inference: Used in ayurvedic and polynesian traditions for mind-opening... No direct mechanismofaction data. Contextual inference: Used in ayurvedic and polynesian traditions for mind-opening... Used in Ayurvedic and Polynesian traditions for mind-opening.. Used in Ayurvedic and Polynesian traditions for mind-opening."
+      "altered perception of time and self"
     ],
     "contraindications": [
       "Avoid with antidepressants",
@@ -3692,41 +3814,37 @@
     "compoundClass": "ergine (lsa)",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Ergoline alkaloids (trace)",
     "herbs": [
       "convolvulus arvensis"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "ergoline-alkaloids-trace"
+    "slug": "ergoline-alkaloids-trace",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Ergotamine",
     "herbs": [
       "claviceps purpurea"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "ergotamine"
+    "slug": "ergotamine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "ervine",
@@ -3752,7 +3870,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "ervine"
+    "slug": "ervine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "ervolanine",
@@ -3778,7 +3898,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "ervolanine"
+    "slug": "ervolanine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "ervoside",
@@ -3804,13 +3926,13 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "ervoside"
+    "slug": "ervoside",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Erythravine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Relaxation",
       "improved sleep",
@@ -3820,8 +3942,6 @@
       "sedation",
       "muscle relaxation",
       "anxiety reduction",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
@@ -3842,13 +3962,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "erythravine"
+    "slug": "erythravine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "erythrinan alkaloids",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Relaxation",
       "improved sleep",
@@ -3858,8 +3978,6 @@
       "sedation",
       "muscle relaxation",
       "anxiety reduction",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
@@ -3880,13 +3998,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "erythrinan-alkaloids"
+    "slug": "erythrinan-alkaloids",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Erythrinian alkaloids",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Relaxation",
       "improved sleep",
@@ -3896,8 +4014,6 @@
       "sedation",
       "muscle relaxation",
       "anxiety reduction",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
@@ -3918,13 +4034,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "erythrinian-alkaloids"
+    "slug": "erythrinian-alkaloids",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "erythrinine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Relaxation",
       "improved sleep",
@@ -3934,8 +4050,6 @@
       "sedation",
       "muscle relaxation",
       "anxiety reduction",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
@@ -3956,20 +4070,17 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "erythrinine"
+    "slug": "erythrinine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "essential oils",
     "herbs": [
       "adhatoda vasica",
-      "helichrysum odoratissimum",
-      "nan"
+      "helichrysum odoratissimum"
     ],
     "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
       "Calming",
       "mild euphoria",
       "spiritual insight",
@@ -3977,7 +4088,6 @@
       "sedation",
       "muscle relaxation",
       "spiritual openness",
-      "No direct effects data. Contextual inference: Used in amazonian herbal mixtures and healing brews... No direct mechanismofaction data. Contextual inference: Used in amazonian herbal mixtures and healing brews... Used in Amazonian herbal mixtures and healing brews.. Used in Amazonian herbal mixtures and healing brews.",
       "Subtle clarity",
       "mild stimulation",
       "relaxation",
@@ -3985,9 +4095,7 @@
       "focus",
       "calm",
       "Mild sedation",
-      "No direct effects data. Contextual inference: Used traditionally to relieve pain",
       "stress",
-      "and inflammation... No direct mechanismofaction data. Contextual inference: Used traditionally to relieve pain",
       "and inflammation... Used traditionally to relieve pain",
       "and inflammation.. Used traditionally to relieve pain",
       "and inflammation."
@@ -4008,7 +4116,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "essential-oils"
+    "slug": "essential-oils",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "estragole",
@@ -4044,7 +4154,9 @@
     "compoundClass": "estragole",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Eucalyptol",
@@ -4054,8 +4166,7 @@
     "effects": [
       "Clarity",
       "calm",
-      "subtle mood lift",
-      "No direct effects data. Contextual inference: Used in smudging rituals for purification and clarity... No direct mechanismofaction data. Contextual inference: Used in smudging rituals for purification and clarity... Used in smudging rituals for purification and clarity.. Used in smudging rituals for purification and clarity."
+      "subtle mood lift"
     ],
     "contraindications": [
       "Avoid during pregnancy",
@@ -4071,7 +4182,9 @@
     "compoundClass": "eucalyptol",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "eugenol",
@@ -4096,32 +4209,22 @@
       "beta-asarone rich)",
       "Mild sedative",
       "hallucinogenic in high doses",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
       "digestive aid",
       "and purported hallucinogen",
       "contains β-asarone",
-      "Stress relief",
       "respiratory support",
       "antioxidant",
       "mild energy boost",
-      "Adaptogen",
-      "anti-stress",
-      "immune support",
       "disorientation",
-      "No direct effects data. Contextual inference: Used in spice blends",
       "aphrodisiacs",
-      "and as a psychoactive in folk rituals... No direct mechanismofaction data. Contextual inference: Used in spice blends",
       "and as a psychoactive in folk rituals... Used in spice blends",
       "and as a psychoactive in folk rituals.. Used in spice blends",
       "and as a psychoactive in folk rituals.",
       "Anxiolytic",
-      "relaxing",
-      "No direct effects data. Contextual inference: Used as a digestive tonic and flavoring spice with subtle psychoactivity... No direct mechanismofaction data. Contextual inference: Used as a digestive tonic and flavoring spice with subtle psychoactivity... Used as a digestive tonic and flavoring spice with subtle psychoactivity.. Used as a digestive tonic and flavoring spice with subtle psychoactivity.",
-      "No direct effects data. Contextual inference: Used in amazonian herbalism for sexual energy and digestion... No direct mechanismofaction data. Contextual inference: Used in amazonian herbalism for sexual energy and digestion... Used in Amazonian herbalism for sexual energy and digestion.. Used in Amazonian herbalism for sexual energy and digestion."
+      "relaxing"
     ],
     "contraindications": [
       "Avoid in pregnancy",
@@ -4154,7 +4257,25 @@
     "mechanismTags": [
       "reinforcement",
       "unclassified"
-    ]
+    ],
+    "description": "Phenylpropanoid from clove associated with COX inhibition and TRP channel activity.",
+    "summary": "Phenylpropanoid from clove associated with COX inhibition and TRP channel activity.",
+    "foundIn": [
+      "holy basil",
+      "holy basil purple",
+      "calamus",
+      "clove",
+      "syzygium aromaticum"
+    ],
+    "targets": [
+      "TRPV1",
+      "COX/LOX pathways",
+      "NF-κB",
+      "microbial membrane effects",
+      "local anesthetic signaling"
+    ],
+    "safetyNotes": "Food/flavor exposure differs from essential-oil or concentrated use. High doses may irritate mucosa and affect bleeding or liver safety; caution with anticoagulants and dental/topical overuse.",
+    "linkedHerbs": []
   },
   {
     "name": "Farnesol",
@@ -4164,50 +4285,51 @@
       "matricaria-chamomilla"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used as a calming tea for sleep",
       "anxiety",
-      "and tension... No direct mechanismofaction data. Contextual inference: Used as a calming tea for sleep",
       "and tension... Used as a calming tea for sleep",
       "and tension.. Used as a calming tea for sleep",
       "and tension.",
       "Mild sedative",
       "hallucinogenic in high doses",
       "Anxiolytic",
-      "relaxing",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "relaxing"
     ],
     "contraindications": [
-      "Pregnancy",
-      "high doses",
-      "None known"
+      "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses",
+      "use dilution and herb-specific safety."
     ],
-    "category": null,
+    "category": "terpene / essential-oil constituent",
     "sources": [],
     "lastUpdated": "2026-03-21",
     "slug": "farnesol",
     "canonicalCompoundId": "farnesol",
     "id": "farnesol",
-    "compoundName": "Farnesol"
+    "compoundName": "Farnesol",
+    "compoundClass": "terpene / essential-oil constituent",
+    "description": "Sesquiterpene alcohol linked to lipid-signaling and pathway modulation.",
+    "summary": "Sesquiterpene alcohol linked to lipid-signaling and pathway modulation.",
+    "foundIn": [
+      "Matricaria chamomilla"
+    ],
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "linkedHerbs": []
   },
   {
     "name": "fatty acids",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Mental clarity",
       "energy boost",
       "libido enhancement",
       "Aphrodisiac",
       "stimulant",
-      "nerve tonic",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "nerve tonic"
     ],
     "contraindications": [
       "High blood pressure",
@@ -4217,7 +4339,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "fatty-acids"
+    "slug": "fatty-acids",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "ferulic acid",
@@ -4230,10 +4354,10 @@
       "contains tannins"
     ],
     "contraindications": [
-      "Limited safety data",
-      "high doses may cause gastrointestinal upset or phototoxic reactions due to hydroquinone."
+      "Mostly food-associated",
+      "concentrated extracts may cause GI effects or interact with anticoagulants/antidiabetics depending matrix."
     ],
-    "category": "ferulic acid",
+    "category": "phenolic acid / polyphenol",
     "sources": [
       {
         "note": "Inferred from scientific name:"
@@ -4244,28 +4368,40 @@
     "canonicalCompoundId": "ferulic-acid",
     "id": "ferulic-acid",
     "compoundName": "ferulic acid",
-    "compoundClass": "ferulic acid",
+    "compoundClass": "phenolic acid / polyphenol",
     "mechanism": "Ferulic acid, ligustilide, polysaccharides",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Phenolic acid common in grains and Angelica-related herbs, linked to Nrf2 and PI3K/Akt signaling.",
+    "summary": "Phenolic acid common in grains and Angelica-related herbs, linked to Nrf2 and PI3K/Akt signaling.",
+    "foundIn": [
+      "rice bran",
+      "grains",
+      "angelica and many plants"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "antioxidant response",
+      "glucose/lipid signaling",
+      "gut microbiome metabolism"
+    ],
+    "safetyNotes": "Mostly food-associated; concentrated extracts may cause GI effects or interact with anticoagulants/antidiabetics depending matrix.",
+    "linkedHerbs": []
   },
   {
     "name": "flavones",
     "herbs": [
-      "alchornea castaneifolia",
-      "nan"
+      "alchornea castaneifolia"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... No direct mechanismofaction data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... Used in traditional Amazonian medicine for arthritis and pain.. Used in traditional Amazonian medicine for arthritis and pain.",
       "Lucid dreaming",
       "relaxation",
       "altered dream content",
       "Vivid dreams",
       "increased dream recall",
       "mild sedation",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
@@ -4286,7 +4422,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "flavones"
+    "slug": "flavones",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "flavonoids",
@@ -4296,16 +4434,11 @@
       "albizia julibrissin",
       "helichrysum odoratissimum",
       "Muira Puama",
-      "nan",
       "rhododendron anthopogon",
       "turnera diffusa var. aphrodisiaca",
       "elaeagnus angustifolia"
     ],
     "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
       "Astringent",
       "anti-inflammatory",
       "digestive tonic",
@@ -4349,7 +4482,6 @@
       "Calming",
       "antioxidant",
       "lipid-lowering",
-      "No direct effects data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... No direct mechanismofaction data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... Used in Ayurveda and Buddhist practices for calm and devotion.. Used in Ayurveda and Buddhist practices for calm and devotion.",
       "Psychoactive (when extracted)",
       "vision alteration",
       "dream enhancement",
@@ -4375,7 +4507,6 @@
       "increased libido",
       "Mild stimulation",
       "mood enhancement",
-      "No direct effects data. Contextual inference: Used as an aphrodisiac and mood enhancer in mexican herbalism... No direct mechanismofaction data. Contextual inference: Used as an aphrodisiac and mood enhancer in mexican herbalism... Used as an aphrodisiac and mood enhancer in Mexican herbalism.. Used as an aphrodisiac and mood enhancer in Mexican herbalism.",
       "Mental clarity",
       "mood boost",
       "Antimicrobial",
@@ -4383,7 +4514,6 @@
       "spiritual insight",
       "sedation",
       "spiritual openness",
-      "No direct effects data. Contextual inference: Used in amazonian herbal mixtures and healing brews... No direct mechanismofaction data. Contextual inference: Used in amazonian herbal mixtures and healing brews... Used in Amazonian herbal mixtures and healing brews.. Used in Amazonian herbal mixtures and healing brews.",
       "Vivid dreams",
       "mild calm",
       "enhanced intuition",
@@ -4404,9 +4534,7 @@
       "calming",
       "used in smoking blends",
       "Mild sedation",
-      "No direct effects data. Contextual inference: Used traditionally to relieve pain",
       "stress",
-      "and inflammation... No direct mechanismofaction data. Contextual inference: Used traditionally to relieve pain",
       "and inflammation... Used traditionally to relieve pain",
       "and inflammation.. Used traditionally to relieve pain",
       "and inflammation.",
@@ -4421,15 +4549,12 @@
       "Clarity",
       "calm",
       "subtle mood lift",
-      "No direct effects data. Contextual inference: Used in smudging rituals for purification and clarity... No direct mechanismofaction data. Contextual inference: Used in smudging rituals for purification and clarity... Used in smudging rituals for purification and clarity.. Used in smudging rituals for purification and clarity.",
       "Mild euphoric and sedative",
       "used in traditional African and Caribbean medicine",
       "improved sleep",
       "reduced stress",
       "reduced anxiety",
       "anxiety reduction",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
@@ -4437,8 +4562,7 @@
       "used for sleep and stress in South America",
       "slight mood enhancement",
       "antioxidant (inferred from related Calliandra species).",
-      "warming sensation",
-      "No direct effects data. Contextual inference: Burned in tibetan buddhist rituals and used in himalayan medicine... No direct mechanismofaction data. Contextual inference: Burned in tibetan buddhist rituals and used in himalayan medicine... Burned in Tibetan Buddhist rituals and used in Himalayan medicine.. Burned in Tibetan Buddhist rituals and used in Himalayan medicine."
+      "warming sensation"
     ],
     "contraindications": [
       "High doses may cause nausea or vomiting",
@@ -4526,19 +4650,17 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "flavonoids"
+    "slug": "flavonoids",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "flavonoids (exact psychoactive agent unknown)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Enhanced dreams",
       "altered awareness",
       "calm",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine"
@@ -4550,13 +4672,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "flavonoids-exact-psychoactive-agent-unknown"
+    "slug": "flavonoids-exact-psychoactive-agent-unknown",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Flavonoids (vitexin",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Calmness",
       "drowsiness",
@@ -4573,16 +4695,16 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "flavonoids-vitexin"
+    "slug": "flavonoids-vitexin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "flavonols",
     "herbs": [
       "alchornea castaneifolia"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... No direct mechanismofaction data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... Used in traditional Amazonian medicine for arthritis and pain.. Used in traditional Amazonian medicine for arthritis and pain."
-    ],
+    "effects": [],
     "contraindications": [
       "Little clinical research",
       "avoid during pregnancy or while breastfeeding",
@@ -4592,49 +4714,51 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "flavonols"
+    "slug": "flavonols",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Fragarine",
     "herbs": [
       "rubus idaeus"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used in midwifery and herbal traditions to support reproductive health... No direct mechanismofaction data. Contextual inference: Used in midwifery and herbal traditions to support reproductive health... Used in midwifery and herbal traditions to support reproductive health.. Used in midwifery and herbal traditions to support reproductive health."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "fragarine"
+    "slug": "fragarine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Furanocoumarins",
     "herbs": [
       "ficus religiosa"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used in ayurveda and spiritual practice for mindfulness and peace... No direct mechanismofaction data. Contextual inference: Used in ayurveda and spiritual practice for mindfulness and peace... Used in Ayurveda and spiritual practice for mindfulness and peace.. Used in Ayurveda and spiritual practice for mindfulness and peace."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "furanocoumarins"
+    "slug": "furanocoumarins",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Galbulimimine",
     "herbs": [
       "galbulimima belgraveana"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used with homalomena in psychoactive brews by papuan tribes... No direct mechanismofaction data. Contextual inference: Used with homalomena in psychoactive brews by papuan tribes... Used with Homalomena in psychoactive brews by Papuan tribes.. Used with Homalomena in psychoactive brews by Papuan tribes."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "galbulimimine"
+    "slug": "galbulimimine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "gallic acid",
@@ -4661,7 +4785,7 @@
       "L313】.",
       "Avoid during pregnancy due to uterine stimulation potential"
     ],
-    "category": "gallic acid",
+    "category": "phenolic acid / polyphenol",
     "sources": [
       {
         "note": "Inferred from scientific name:"
@@ -4672,10 +4796,27 @@
     "canonicalCompoundId": "gallic-acid",
     "id": "gallic-acid",
     "compoundName": "gallic acid",
-    "compoundClass": "gallic acid",
+    "compoundClass": "phenolic acid / polyphenol",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Simple phenolic acid widely reported from tea and fruit sources with MAPK and NF-κB pathway activity.",
+    "summary": "Simple phenolic acid widely reported from tea and fruit sources with MAPK and NF-κB pathway activity.",
+    "foundIn": [
+      "tea",
+      "sumac",
+      "gallnut",
+      "many tannin-rich plants"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "antioxidant response",
+      "glucose/lipid signaling",
+      "gut microbiome metabolism"
+    ],
+    "safetyNotes": "Mostly food-associated; concentrated extracts may cause GI effects or interact with anticoagulants/antidiabetics depending matrix.",
+    "linkedHerbs": []
   },
   {
     "name": "geraldone",
@@ -4700,7 +4841,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "geraldone"
+    "slug": "geraldone",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "geranial",
@@ -4729,26 +4872,24 @@
     "compoundClass": "geranial",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Germacranolides",
     "herbs": [
-      "nan",
       "calea zacatechichi"
     ],
     "effects": [
       "Vivid and lucid dreams",
       "dream recall",
-      "No direct effects data. Contextual inference: Used by chontal shamans to induce vivid dreams and visions... No direct mechanismofaction data. Contextual inference: Used by chontal shamans to induce vivid dreams and visions... Used by Chontal shamans to induce vivid dreams and visions.. Used by Chontal shamans to induce vivid dreams and visions.",
       "Lucid dreaming",
       "relaxation",
       "altered dream content",
       "Vivid dreams",
       "increased dream recall",
       "mild sedation",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
@@ -4766,7 +4907,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "germacranolides"
+    "slug": "germacranolides",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "glutinol",
@@ -4789,24 +4932,20 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "glutinol"
+    "slug": "glutinol",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "glycosides",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Relaxation",
       "mild euphoria",
       "lucid dreaming",
       "increased tactile sensation",
       "dream enhancement",
-      "anxiolytic",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "anxiolytic"
     ],
     "contraindications": [
       "Avoid use with CNS depressants",
@@ -4820,20 +4959,16 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "glycosides"
+    "slug": "glycosides",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "gramine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Visual stimulation",
-      "introspection",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "introspection"
     ],
     "contraindications": [
       "MAOIs",
@@ -4849,65 +4984,76 @@
     "compoundClass": "gramine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Graveoline",
     "herbs": [
       "ruta graveolens"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used historically in folk magic and herbalism... No direct mechanismofaction data. Contextual inference: Used historically in folk magic and herbalism... Used historically in folk magic and herbalism.. Used historically in folk magic and herbalism."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "graveoline"
+    "slug": "graveoline",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Gymnemic Acids",
     "herbs": [
       "gymnema sylvestre"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+    "effects": [],
+    "contraindications": [
+      "May lower blood glucose or reduce sweet taste perception. Monitor with antidiabetic therapies",
+      "avoid pregnancy/breastfeeding unless supervised."
     ],
-    "contraindications": [],
-    "category": "gymnemic acids",
+    "category": "triterpenoid saponin mixture",
     "sources": [],
     "lastUpdated": "2026-03-21",
     "slug": "gymnemic-acids",
     "canonicalCompoundId": "gymnemic-acids",
     "id": "gymnemic-acids",
     "compoundName": "gymnemic acids",
-    "compoundClass": "gymnemic acids",
+    "compoundClass": "triterpenoid saponin mixture",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Triterpenoid saponin complex from gymnema linked to intestinal glucose handling.",
+    "summary": "Triterpenoid saponin complex from gymnema linked to intestinal glucose handling.",
+    "foundIn": [
+      "gymnema"
+    ],
+    "targets": [
+      "sweet taste receptors",
+      "intestinal glucose absorption",
+      "insulin signaling",
+      "AMPK-related pathways"
+    ],
+    "safetyNotes": "May lower blood glucose or reduce sweet taste perception. Monitor with antidiabetic therapies; avoid pregnancy/breastfeeding unless supervised.",
+    "linkedHerbs": []
   },
   {
     "name": "Harmala alkaloids",
     "herbs": [
       "nicotiana rustica"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used in shamanic rituals for grounding and spirit communication... No direct mechanismofaction data. Contextual inference: Used in shamanic rituals for grounding and spirit communication... Used in shamanic rituals for grounding and spirit communication.. Used in shamanic rituals for grounding and spirit communication."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "harmala-alkaloids"
+    "slug": "harmala-alkaloids",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "harmala alkaloids (harmine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Intense stimulation",
       "nausea",
@@ -4924,7 +5070,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "harmala-alkaloids-harmine"
+    "slug": "harmala-alkaloids-harmine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "harmaline)",
@@ -4956,13 +5104,13 @@
       "mao-a inhibition",
       "monoamine preservation",
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Harmalol",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Altered perception",
       "dream intensification",
@@ -4997,21 +5145,20 @@
     "compoundClass": "harmalol",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "harman",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Intense stimulation",
       "purging",
       "altered consciousness",
       "clarity",
       "Potent tobacco",
-      "used in Amazonian rituals for purification and divination",
-      "No direct effects data. Contextual inference: Used in shamanic rituals for grounding and spirit communication... No direct mechanismofaction data. Contextual inference: Used in shamanic rituals for grounding and spirit communication... Used in shamanic rituals for grounding and spirit communication.. Used in shamanic rituals for grounding and spirit communication."
+      "used in Amazonian rituals for purification and divination"
     ],
     "contraindications": [
       "Cardiac issues",
@@ -5024,13 +5171,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "harman"
+    "slug": "harman",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "harman alkaloids",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Calmness",
       "drowsiness",
@@ -5047,7 +5194,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "harman-alkaloids"
+    "slug": "harman-alkaloids",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "harmine",
@@ -5070,11 +5219,7 @@
       "psychoactive",
       "Dreamlike visions",
       "introspection",
-      "emotional release",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "emotional release"
     ],
     "contraindications": [
       "Avoid with SSRIs",
@@ -5099,18 +5244,17 @@
       "mao-a inhibition",
       "monoamine preservation",
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Himandrine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Hallucinations",
       "dizziness",
-      "sedation",
-      "No direct effects data. Contextual inference: Used with homalomena in psychoactive brews by papuan tribes... No direct mechanismofaction data. Contextual inference: Used with homalomena in psychoactive brews by papuan tribes... Used with Homalomena in psychoactive brews by Papuan tribes.. Used with Homalomena in psychoactive brews by Papuan tribes."
+      "sedation"
     ],
     "contraindications": [
       "not recommended outside supervised research"
@@ -5118,32 +5262,31 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "himandrine"
+    "slug": "himandrine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Himbacine",
     "herbs": [
       "galbulimima belgraveana"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used with homalomena in psychoactive brews by papuan tribes... No direct mechanismofaction data. Contextual inference: Used with homalomena in psychoactive brews by papuan tribes... Used with Homalomena in psychoactive brews by Papuan tribes.. Used with Homalomena in psychoactive brews by Papuan tribes."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "himbacine"
+    "slug": "himbacine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "himbacine (alkaloids)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Hallucinations",
       "dizziness",
-      "sedation",
-      "No direct effects data. Contextual inference: Used with homalomena in psychoactive brews by papuan tribes... No direct mechanismofaction data. Contextual inference: Used with homalomena in psychoactive brews by papuan tribes... Used with Homalomena in psychoactive brews by Papuan tribes.. Used with Homalomena in psychoactive brews by Papuan tribes."
+      "sedation"
     ],
     "contraindications": [
       "not recommended outside supervised research"
@@ -5151,20 +5294,16 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "himbacine-alkaloids"
+    "slug": "himbacine-alkaloids",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Histamine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Mild stimulation",
-      "increased circulation",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "increased circulation"
     ],
     "contraindications": [
       "Pregnancy (caution)",
@@ -5180,7 +5319,9 @@
     "compoundClass": "histamine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Huperzine A",
@@ -5188,10 +5329,10 @@
       "huperzia serrata",
       "huperzia-serrata"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine"
+    "effects": [],
+    "contraindications": [
+      "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety."
     ],
-    "contraindications": [],
     "category": "huperzine A",
     "sources": [],
     "lastUpdated": "2026-03-21",
@@ -5203,7 +5344,21 @@
     "mechanism": "sesquiterpene alkaloid",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Lycopodium alkaloid widely associated with cholinergic and glutamatergic signaling.",
+    "summary": "Lycopodium alkaloid widely associated with cholinergic and glutamatergic signaling.",
+    "foundIn": [
+      "Huperzia serrata"
+    ],
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety.",
+    "linkedHerbs": []
   },
   {
     "name": "hydroquinone",
@@ -5226,18 +5381,17 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "hydroquinone"
+    "slug": "hydroquinone",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "hyoscyamine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Complete dissociation",
       "hallucinations",
       "amnesia",
-      "No direct effects data. Contextual inference: Ritual use.. No direct mechanismofaction data. Contextual inference: Ritual use.. Ritual use. Ritual use",
       "Intense hallucinations",
       "delirium",
       "Strong anticholinergic and hallucinogenic effects",
@@ -5280,7 +5434,9 @@
     "compoundClass": "hyoscyamine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "hypaconitine",
@@ -5314,13 +5470,13 @@
     "compoundClass": "hypaconitine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "hypaphorine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Relaxation",
       "improved sleep",
@@ -5330,8 +5486,6 @@
       "sedation",
       "muscle relaxation",
       "anxiety reduction",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
@@ -5352,18 +5506,17 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "hypaphorine"
+    "slug": "hypaphorine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Iboga alkaloids",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Inner visions",
       "deep introspection",
-      "energetic clarity",
-      "No direct effects data. Contextual inference: Used by indigenous healers to improve vision and intuition... No direct mechanismofaction data. Contextual inference: Used by indigenous healers to improve vision and intuition... Used by indigenous healers to improve vision and intuition.. Used by indigenous healers to improve vision and intuition."
+      "energetic clarity"
     ],
     "contraindications": [
       "Heart conditions",
@@ -5372,7 +5525,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "iboga-alkaloids"
+    "slug": "iboga-alkaloids",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Ibogaine",
@@ -5386,11 +5541,7 @@
       "ataxia",
       "dream states",
       "Powerful psychedelic and anti-addiction",
-      "long visionary experience",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "long visionary experience"
     ],
     "contraindications": [
       "Serious cardiac risk",
@@ -5413,20 +5564,18 @@
       "opioid receptor activity",
       "sigma receptor interaction",
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "ibogaine-related alkaloids",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Altered perception",
       "stimulation",
       "euphoria",
       "potential visionary states",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine"
@@ -5439,13 +5588,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "ibogaine-related-alkaloids"
+    "slug": "ibogaine-related-alkaloids",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "ibogamine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Tranquility",
       "mild distortion of time",
@@ -5460,12 +5609,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "ibogamine"
+    "slug": "ibogamine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "ibotenic acid",
     "herbs": [
-      "nan",
       "amanita muscaria"
     ],
     "effects": [
@@ -5473,8 +5623,6 @@
       "euphoria",
       "confusion",
       "dream-like states",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
@@ -5495,7 +5643,9 @@
     "compoundClass": "ibotenic acid",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "indaconitine",
@@ -5523,13 +5673,13 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "indaconitine"
+    "slug": "indaconitine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "indole alkaloids",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Stimulation",
       "increased blood flow",
@@ -5545,19 +5695,16 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "indole-alkaloids"
+    "slug": "indole-alkaloids",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Iridoids",
     "herbs": [
-      "mitchella repens",
-      "nan"
+      "mitchella repens"
     ],
     "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
       "Color vision changes",
       "detachment",
       "vivid hallucinations",
@@ -5567,7 +5714,6 @@
       "Visual distortions",
       "sedation",
       "altered mental state",
-      "No direct effects data. Contextual inference: Used by mapuche shamans in ritual ceremonies... No direct mechanismofaction data. Contextual inference: Used by mapuche shamans in ritual ceremonies... Used by Mapuche shamans in ritual ceremonies.. Used by Mapuche shamans in ritual ceremonies.",
       "Muscle relaxation",
       "mild sedation",
       "euphoria",
@@ -5588,7 +5734,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "iridoids"
+    "slug": "iridoids",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "isocephaeline",
@@ -5617,13 +5765,13 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "isocephaeline"
+    "slug": "isocephaeline",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "isoergine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Visual hallucinations",
       "euphoria",
@@ -5636,7 +5784,6 @@
       "Visual distortion",
       "introspection",
       "altered perception of time and self",
-      "No direct effects data. Contextual inference: Used in ayurvedic and polynesian traditions for mind-opening... No direct mechanismofaction data. Contextual inference: Used in ayurvedic and polynesian traditions for mind-opening... Used in Ayurvedic and Polynesian traditions for mind-opening.. Used in Ayurvedic and Polynesian traditions for mind-opening.",
       "emotional introspection",
       "nausea",
       "Entheogenic",
@@ -5664,7 +5811,9 @@
     "compoundClass": "isoergine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "isookanin",
@@ -5689,20 +5838,19 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "isookanin"
+    "slug": "isookanin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "isopetasin",
     "herbs": [
-      "nan",
       "petasites hybridus"
     ],
     "effects": [
       "Mild sedation",
       "muscle relaxation",
-      "No direct effects data. Contextual inference: Used historically to treat pain",
       "migraines",
-      "and spasms... No direct mechanismofaction data. Contextual inference: Used historically to treat pain",
       "and spasms... Used historically to treat pain",
       "and spasms.. Used historically to treat pain",
       "and spasms."
@@ -5713,7 +5861,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "isopetasin"
+    "slug": "isopetasin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "isoquercetin",
@@ -5740,7 +5890,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "isoquercetin"
+    "slug": "isoquercetin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "isorhamnetin",
@@ -5773,13 +5925,13 @@
     "compoundClass": "Flavonoid",
     "mechanismTags": [
       "oxidative stress reduction"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "isovaleric acid",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Sedation",
       "muscle relaxation",
@@ -5803,13 +5955,13 @@
     "compoundClass": "isovaleric acid",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "isovitexin)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Calmness",
       "drowsiness",
@@ -5826,7 +5978,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "isovitexin"
+    "slug": "isovitexin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "jesaconitine",
@@ -5854,19 +6008,16 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "jesaconitine"
+    "slug": "jesaconitine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "julibroside C1",
     "herbs": [
       "albizia julibrissin"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
-    ],
+    "effects": [],
     "contraindications": [
       "Limited safety data",
       "may potentiate sedative or antidepressant drugs",
@@ -5875,7 +6026,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "julibroside-c1"
+    "slug": "julibroside-c1",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "kaempferol",
@@ -5898,9 +6051,7 @@
       "Uterine tonic",
       "astringent",
       "regulates menstruation and bleeding.",
-      "No direct effects data. Contextual inference: Used as a calming tea for sleep",
       "anxiety",
-      "and tension... No direct mechanismofaction data. Contextual inference: Used as a calming tea for sleep",
       "and tension... Used as a calming tea for sleep",
       "and tension.. Used as a calming tea for sleep",
       "and tension."
@@ -5916,7 +6067,7 @@
       "may interact with blood thinners due to tannin content【859641390196180†L297",
       "L313】."
     ],
-    "category": "kaempferol",
+    "category": "flavonol polyphenol",
     "sources": [
       {
         "note": "Inferred from scientific name:"
@@ -5927,13 +6078,30 @@
     "canonicalCompoundId": "kaempferol",
     "id": "kaempferol",
     "compoundName": "Kaempferol",
-    "compoundClass": "kaempferol",
+    "compoundClass": "flavonol polyphenol",
     "mechanism": "Ethyl cinnamate, kaempferol, essential oils",
     "mechanismTags": [
       "nf-kb inhibition",
       "oxidative stress reduction",
       "unclassified"
-    ]
+    ],
+    "description": "Flavonol commonly associated with PI3K/Akt and NF-κB pathway modulation in botanical systems.",
+    "summary": "Flavonol commonly associated with PI3K/Akt and NF-κB pathway modulation in botanical systems.",
+    "foundIn": [
+      "tea",
+      "brassica",
+      "moringa",
+      "many leafy plants"
+    ],
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "PI3K/Akt",
+      "MAPK",
+      "inflammatory cytokines"
+    ],
+    "safetyNotes": "Food exposure is low-risk; high-dose supplement safety is less established. Caution with anticoagulants, antidiabetics, and complex oncology regimens.",
+    "linkedHerbs": []
   },
   {
     "name": "kaempferol glycosides",
@@ -5960,7 +6128,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "kaempferol-glycosides"
+    "slug": "kaempferol-glycosides",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Kavalactones (kavain",
@@ -5971,15 +6141,11 @@
     "effects": [
       "Euphoria",
       "calmness",
-      "muscle relaxation",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "muscle relaxation"
     ],
     "contraindications": [
-      "Liver conditions",
-      "concurrent alcohol use"
+      "Kava/kavalactones are linked with sedation and liver injury concerns",
+      "avoid alcohol, sedatives, liver disease, and pregnancy."
     ],
     "category": "kavain",
     "sources": [],
@@ -5988,24 +6154,32 @@
     "canonicalCompoundId": "kavain",
     "id": "kavain",
     "compoundName": "kavain",
-    "compoundClass": "kavain",
+    "compoundClass": "kavalactone",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Major kavalactone with calming and channel-modulating pharmacology.",
+    "summary": "Major kavalactone with calming and channel-modulating pharmacology.",
+    "foundIn": [
+      "Kava",
+      "Piper methysticum"
+    ],
+    "targets": [
+      "GABAergic signaling",
+      "voltage-gated ion channels",
+      "monoamine signaling",
+      "CYP enzymes"
+    ],
+    "safetyNotes": "Kava/kavalactones are linked with sedation and liver injury concerns; avoid alcohol, sedatives, liver disease, and pregnancy.",
+    "linkedHerbs": []
   },
   {
     "name": "L-theanine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Alertness",
       "calm focus",
-      "mood lift",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "mood lift"
     ],
     "contraindications": [
       "Insomnia",
@@ -6023,12 +6197,13 @@
     "mechanism": "amino acid derivative",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Lactucin",
     "herbs": [
-      "nan",
       "wild lettuce"
     ],
     "effects": [
@@ -6038,9 +6213,6 @@
       "Sedative",
       "analgesic",
       "antispasmodic",
-      "No direct effects data. Contextual inference: Used in 19th-century medicine for pain and insomnia... No direct mechanismofaction data. Contextual inference: Used in 19th-century medicine for pain and insomnia... Used in 19th-century medicine for pain and insomnia.. Used in 19th-century medicine for pain and insomnia.",
-      "No direct effects data. Contextual inference: Used in 19th",
-      "century medicine for pain and insomnia... No direct mechanismofaction data. Contextual inference: Used in 19th",
       "century medicine for pain and insomnia... Used in 19th",
       "century medicine for pain and insomnia.. Used in 19th",
       "century medicine for pain and insomnia."
@@ -6059,12 +6231,13 @@
     "mechanism": "Lactucin, lactucopicrin, sesquiterpene lactones",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "lactucopicrin",
     "herbs": [
-      "nan",
       "wild lettuce"
     ],
     "effects": [
@@ -6074,9 +6247,6 @@
       "Sedative",
       "analgesic",
       "antispasmodic",
-      "No direct effects data. Contextual inference: Used in 19th-century medicine for pain and insomnia... No direct mechanismofaction data. Contextual inference: Used in 19th-century medicine for pain and insomnia... Used in 19th-century medicine for pain and insomnia.. Used in 19th-century medicine for pain and insomnia.",
-      "No direct effects data. Contextual inference: Used in 19th",
-      "century medicine for pain and insomnia... No direct mechanismofaction data. Contextual inference: Used in 19th",
       "century medicine for pain and insomnia... Used in 19th",
       "century medicine for pain and insomnia.. Used in 19th",
       "century medicine for pain and insomnia."
@@ -6095,7 +6265,9 @@
     "mechanism": "Lactucin, lactucopicrin, sesquiterpene lactones",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "lebbeckalysin",
@@ -6120,7 +6292,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "lebbeckalysin"
+    "slug": "lebbeckalysin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "lebbeckoside C",
@@ -6145,7 +6319,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "lebbeckoside-c"
+    "slug": "lebbeckoside-c",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "lebbeckosides A and B",
@@ -6170,18 +6346,17 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "lebbeckosides-a-and-b"
+    "slug": "lebbeckosides-a-and-b",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Leonurine",
     "herbs": [
       "leonurus sibiricus",
-      "motherwort",
-      "nan"
+      "motherwort"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
@@ -6189,14 +6364,9 @@
       "uterine tonic",
       "and relaxant",
       "used in traditional Chinese medicine",
-      "No direct effects data. Contextual inference: Used in traditional herbalism for anxiety and female reproductive support... No direct mechanismofaction data. Contextual inference: Used in traditional herbalism for anxiety and female reproductive support... Used in traditional herbalism for anxiety and female reproductive support.. Used in traditional herbalism for anxiety and female reproductive support.",
       "Relaxation",
       "mild euphoria",
       "dream enhancement",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
       "Mild euphoric and calming",
       "used as cannabis substitute",
       "Mild euphoria",
@@ -6229,7 +6399,9 @@
     "compoundClass": "leonurine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "leucopelargonidin",
@@ -6254,19 +6426,17 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "leucopelargonidin"
+    "slug": "leucopelargonidin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "ligans",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Mild sedation",
       "relaxation",
-      "No direct effects data. Contextual inference: Used traditionally to relieve pain",
       "stress",
-      "and inflammation... No direct mechanismofaction data. Contextual inference: Used traditionally to relieve pain",
       "and inflammation... Used traditionally to relieve pain",
       "and inflammation.. Used traditionally to relieve pain",
       "and inflammation."
@@ -6277,19 +6447,16 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "ligans"
+    "slug": "ligans",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "lignan glycosides",
     "herbs": [
       "albizia julibrissin"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
-    ],
+    "effects": [],
     "contraindications": [
       "Limited safety data",
       "may potentiate sedative or antidepressant drugs",
@@ -6298,13 +6465,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "lignan-glycosides"
+    "slug": "lignan-glycosides",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "lignans",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Pain relief",
       "worm expulsion"
@@ -6315,7 +6482,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "lignans"
+    "slug": "lignans",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "limonene",
@@ -6368,13 +6537,13 @@
     "compoundClass": "limonene",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Limonoids",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Skin healing",
       "antiparasitic action",
@@ -6388,7 +6557,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "limonoids"
+    "slug": "limonoids",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "linalool",
@@ -6404,21 +6575,13 @@
       "and anti-epileptic in TCM",
       "and anti",
       "epileptic in TCM",
-      "Stress relief",
       "respiratory support",
       "antioxidant",
       "mild energy boost",
-      "Adaptogen",
-      "anti-stress",
-      "immune support",
       "Mild sedative",
       "hallucinogenic in high doses",
       "Anxiolytic",
-      "relaxing",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "relaxing"
     ],
     "contraindications": [
       "β",
@@ -6433,7 +6596,7 @@
       "high doses",
       "None known"
     ],
-    "category": "linalool",
+    "category": "monoterpene alcohol",
     "sources": [
       {
         "note": "Inferred from scientific name:"
@@ -6444,22 +6607,31 @@
     "canonicalCompoundId": "linalool",
     "id": "linalool",
     "compoundName": "linalool",
-    "compoundClass": "linalool",
+    "compoundClass": "monoterpene alcohol",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Monoterpene alcohol linked to GABA-A and calcium-channel related effects.",
+    "summary": "Monoterpene alcohol linked to GABA-A and calcium-channel related effects.",
+    "foundIn": [
+      "lavender",
+      "lavandula angustifolia"
+    ],
+    "targets": [
+      "GABAergic signaling",
+      "glutamate signaling",
+      "inflammatory cytokines",
+      "olfactory/CNS pathways"
+    ],
+    "safetyNotes": "Primarily essential-oil/aroma exposure; topical allergy and CNS sedation are possible. Avoid ingestion of essential oils without supervision.",
+    "linkedHerbs": []
   },
   {
     "name": "Linalyl acetate",
     "herbs": [
       "salvia sclarea"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": "linalyl acetate",
     "sources": [],
@@ -6471,13 +6643,14 @@
     "compoundClass": "linalyl acetate",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "long-chain fatty acids",
     "herbs": [
-      "Muira Puama",
-      "nan"
+      "Muira Puama"
     ],
     "effects": [
       "Improved libido",
@@ -6502,13 +6675,13 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "long-chain-fatty-acids"
+    "slug": "long-chain-fatty-acids",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "LSA (ergine)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Closed-eye visuals",
       "emotional introspection",
@@ -6524,7 +6697,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "lsa-ergine"
+    "slug": "lsa-ergine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "LSA (lysergic acid amide)",
@@ -6532,8 +6707,6 @@
       "argyreia nervosa"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used in ayurvedic and polynesian traditions for mind",
-      "opening... No direct mechanismofaction data. Contextual inference: Used in ayurvedic and polynesian traditions for mind",
       "opening... Used in Ayurvedic and Polynesian traditions for mind",
       "opening.. Used in Ayurvedic and Polynesian traditions for mind",
       "opening."
@@ -6542,13 +6715,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "lsa-lysergic-acid-amide"
+    "slug": "lsa-lysergic-acid-amide",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Lucidine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Lucid dreaming",
       "relaxation",
@@ -6561,7 +6734,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "lucidine"
+    "slug": "lucidine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "lupeol",
@@ -6578,8 +6753,7 @@
       "inflammatory",
       "Used in Ayurveda for asthma",
       "allergies",
-      "and anxiety",
-      "No direct effects data. Contextual inference: Used in traditional medicine and cuisine for digestive support... No direct mechanismofaction data. Contextual inference: Used in traditional medicine and cuisine for digestive support... Used in traditional medicine and cuisine for digestive support.. Used in traditional medicine and cuisine for digestive support."
+      "and anxiety"
     ],
     "contraindications": [
       "Limited safety data; some alkaloids may be toxic at high doses",
@@ -6602,7 +6776,9 @@
     "compoundClass": "lupeol",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "lupeol acetate",
@@ -6628,7 +6804,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "lupeol-acetate"
+    "slug": "lupeol-acetate",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "luteolin",
@@ -6656,7 +6834,7 @@
       "may interact with blood thinners due to tannin content【859641390196180†L297",
       "L313】."
     ],
-    "category": "Flavonoid",
+    "category": "flavone / flavonoid",
     "sources": [
       {
         "note": "Inferred from scientific name:"
@@ -6667,15 +6845,30 @@
     "canonicalCompoundId": "luteolin",
     "id": "luteolin",
     "compoundName": "Luteolin",
-    "compoundClass": "Flavonoid",
+    "compoundClass": "flavone / flavonoid",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Flavone associated with thyme and artichoke, commonly linked to NF-κB and MAPK signaling.",
+    "summary": "Flavone associated with thyme and artichoke, commonly linked to NF-κB and MAPK signaling.",
+    "foundIn": [
+      "thyme",
+      "artichoke"
+    ],
+    "targets": [
+      "NF-κB",
+      "MAPK",
+      "PI3K/Akt",
+      "Nrf2",
+      "inflammatory cytokines",
+      "antioxidant response"
+    ],
+    "safetyNotes": "Mostly preclinical and extract-derived. Use caution with sedatives, anticoagulants/antiplatelets, and liver disease depending source herb.",
+    "linkedHerbs": []
   },
   {
     "name": "lyfoline",
     "herbs": [
-      "nan",
       "heimia salicifolia"
     ],
     "effects": [
@@ -6687,16 +6880,11 @@
       "relaxation",
       "mild euphoria",
       "dream-like state",
-      "No direct effects data. Contextual inference: Used by aztecs and indigenous mexicans for spiritual insight... No direct mechanismofaction data. Contextual inference: Used by aztecs and indigenous mexicans for spiritual insight... Used by Aztecs and indigenous Mexicans for spiritual insight.. Used by Aztecs and indigenous Mexicans for spiritual insight.",
       "Mild auditory and memory effects",
       "traditional fermentation increases effects",
       "Auditory shifts",
       "relaxed dreamlike state",
       "Mild auditory and visual alterations",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
       "Mild auditory hallucinations",
       "warmth",
       "euphoria",
@@ -6722,13 +6910,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "lyfoline"
+    "slug": "lyfoline",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Lysergic acid amide (LSA)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Visual hallucinations",
       "euphoria",
@@ -6740,8 +6928,7 @@
       "dream-like mental state",
       "Visual distortion",
       "introspection",
-      "altered perception of time and self",
-      "No direct effects data. Contextual inference: Used in ayurvedic and polynesian traditions for mind-opening... No direct mechanismofaction data. Contextual inference: Used in ayurvedic and polynesian traditions for mind-opening... Used in Ayurvedic and Polynesian traditions for mind-opening.. Used in Ayurvedic and Polynesian traditions for mind-opening."
+      "altered perception of time and self"
     ],
     "contraindications": [
       "Avoid with psychiatric conditions",
@@ -6758,13 +6945,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "lysergic-acid-amide-lsa"
+    "slug": "lysergic-acid-amide-lsa",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "lythrine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Auditory distortion",
       "calmness",
@@ -6774,16 +6961,11 @@
       "relaxation",
       "mild euphoria",
       "dream-like state",
-      "No direct effects data. Contextual inference: Used by aztecs and indigenous mexicans for spiritual insight... No direct mechanismofaction data. Contextual inference: Used by aztecs and indigenous mexicans for spiritual insight... Used by Aztecs and indigenous Mexicans for spiritual insight.. Used by Aztecs and indigenous Mexicans for spiritual insight.",
       "Mild auditory and memory effects",
       "traditional fermentation increases effects",
       "Auditory shifts",
       "relaxed dreamlike state",
       "Mild auditory and visual alterations",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
       "Auditory hallucinations",
       "memory alterations",
       "vivid dreams"
@@ -6812,13 +6994,13 @@
     "compoundClass": "lythrine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "maltol",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Calmness",
       "drowsiness",
@@ -6843,16 +7025,16 @@
     "mechanism": "Flavonoids, harman alkaloids, maltol",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Marmelosin",
     "herbs": [
       "aegle marmelos"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine"
-    ],
+    "effects": [],
     "contraindications": [],
     "category": "marmelosin",
     "sources": [],
@@ -6864,19 +7046,16 @@
     "compoundClass": "marmelosin",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Marrubiin",
     "herbs": [
-      "marrubium vulgare",
-      "nan"
+      "marrubium vulgare"
     ],
     "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
       "Relaxation",
       "mild euphoria",
       "dream enhancement",
@@ -6891,7 +7070,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "marrubiin"
+    "slug": "marrubiin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "melanoxetin",
@@ -6916,13 +7097,13 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "melanoxetin"
+    "slug": "melanoxetin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Menthol",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Soothes GI tract",
       "reduces bloating",
@@ -6966,13 +7147,13 @@
     "mechanism": "monoterpenoid alcohol",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "menthone",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Soothes GI tract",
       "reduces bloating",
@@ -6998,13 +7179,13 @@
     "mechanism": "Menthol, menthone, flavonoids",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "menthyl acetate",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Soothes GI tract",
       "reduces bloating",
@@ -7030,21 +7211,23 @@
     "mechanism": "provisional_from_herb_monograph",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "MeO",
     "herbs": [
       "virola theiodora"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used by amazonian tribes as a snuff for spiritual rituals... No direct mechanismofaction data. Contextual inference: Used by amazonian tribes as a snuff for spiritual rituals... Used by Amazonian tribes as a snuff for spiritual rituals.. Used by Amazonian tribes as a snuff for spiritual rituals."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "meo"
+    "slug": "meo",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "mesaconitine",
@@ -7078,7 +7261,9 @@
     "compoundClass": "mesaconitine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Mescaline",
@@ -7086,10 +7271,6 @@
       "echinopsis pachanoi"
     ],
     "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
       "Psychedelic effects due to mescaline",
       "traditionally used in Andean ceremonies"
     ],
@@ -7107,17 +7288,16 @@
     "compoundClass": "mescaline",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "mesembrenol",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Euphoria",
       "empathy",
-      "stress relief",
       "stimulation",
       "Mood elevation",
       "sociability",
@@ -7147,7 +7327,9 @@
     "compoundClass": "mesembrenol",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "mesembrenone",
@@ -7157,7 +7339,6 @@
     "effects": [
       "Euphoria",
       "empathy",
-      "stress relief",
       "stimulation",
       "Mood elevation",
       "sociability",
@@ -7188,7 +7369,21 @@
     "mechanism": "mesembrine alkaloids",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Kanna alkaloid closely related to mesembrine and associated with serotonin-reuptake and PDE4 effects.",
+    "summary": "Kanna alkaloid closely related to mesembrine and associated with serotonin-reuptake and PDE4 effects.",
+    "foundIn": [
+      "kanna"
+    ],
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety.",
+    "linkedHerbs": []
   },
   {
     "name": "Mesembrine",
@@ -7196,13 +7391,8 @@
       "kanna"
     ],
     "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
       "Euphoria",
       "empathy",
-      "stress relief",
       "stimulation",
       "Mood elevation",
       "sociability",
@@ -7241,13 +7431,25 @@
     "compoundClass": "mesembrine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Major Kanna alkaloid best known for serotonin-reuptake and PDE4-related activity.",
+    "summary": "Major Kanna alkaloid best known for serotonin-reuptake and PDE4-related activity.",
+    "foundIn": [
+      "kanna"
+    ],
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety.",
+    "linkedHerbs": []
   },
   {
     "name": "Mesembrine analogues (suspected)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Mood elevation",
       "dream enhancement",
@@ -7266,7 +7468,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "mesembrine-analogues-suspected"
+    "slug": "mesembrine-analogues-suspected",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "methaervine",
@@ -7292,7 +7496,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "methaervine"
+    "slug": "methaervine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "methyl eugenol",
@@ -7315,7 +7521,7 @@
       "dose use",
       "contraindicated in pregnancy and children."
     ],
-    "category": null,
+    "category": "terpene / essential-oil constituent",
     "sources": [
       {
         "note": "Inferred from scientific name:"
@@ -7325,7 +7531,21 @@
     "slug": "methyl-eugenol",
     "canonicalCompoundId": "methyleugenol",
     "id": "methyleugenol",
-    "compoundName": "methyl eugenol"
+    "compoundName": "methyl eugenol",
+    "compoundClass": "terpene / essential-oil constituent",
+    "description": "Phenylpropanoid present in aromatic herbs with sensory and neuroactive effects.",
+    "summary": "Phenylpropanoid present in aromatic herbs with sensory and neuroactive effects.",
+    "foundIn": [
+      "Holy Basil"
+    ],
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "linkedHerbs": []
   },
   {
     "name": "methyl grevillate",
@@ -7351,7 +7571,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "methyl-grevillate"
+    "slug": "methyl-grevillate",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Methyl salicylate",
@@ -7360,13 +7582,7 @@
       "sweet violet"
     ],
     "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
-      "No direct effects data. Contextual inference: Used for sleep",
       "coughs",
-      "and gentle mood support... No direct mechanismofaction data. Contextual inference: Used for sleep",
       "and gentle mood support... Used for sleep",
       "and gentle mood support.. Used for sleep",
       "and gentle mood support."
@@ -7383,7 +7599,9 @@
     "mechanism": "Arbutin, tannins, methyl salicylate",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "methylervine",
@@ -7409,7 +7627,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "methylervine"
+    "slug": "methylervine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "methysticin",
@@ -7419,15 +7639,11 @@
     "effects": [
       "Euphoria",
       "calmness",
-      "muscle relaxation",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "muscle relaxation"
     ],
     "contraindications": [
-      "Liver conditions",
-      "concurrent alcohol use"
+      "Kava/kavalactones are linked with sedation and liver injury concerns",
+      "avoid alcohol, sedatives, liver disease, and pregnancy."
     ],
     "category": "methysticin",
     "sources": [],
@@ -7439,13 +7655,24 @@
     "compoundClass": "methysticin",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Kavalactone reported with GABAergic and monoamine-related activity.",
+    "summary": "Kavalactone reported with GABAergic and monoamine-related activity.",
+    "foundIn": [
+      "Piper methysticum"
+    ],
+    "targets": [
+      "GABAergic signaling",
+      "voltage-gated ion channels",
+      "monoamine signaling",
+      "CYP enzymes"
+    ],
+    "safetyNotes": "Kava/kavalactones are linked with sedation and liver injury concerns; avoid alcohol, sedatives, liver disease, and pregnancy.",
+    "linkedHerbs": []
   },
   {
     "name": "Mitragynine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Stimulation",
       "mild euphoria",
@@ -7471,13 +7698,13 @@
     "compoundClass": "mitragynine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "monoterpenes",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Stimulation",
       "mental clarity",
@@ -7486,8 +7713,6 @@
       "beta-asarone rich)",
       "Mild sedative",
       "hallucinogenic in high doses",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
@@ -7507,13 +7732,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "monoterpenes"
+    "slug": "monoterpenes",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Morphine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Pain relief",
       "euphoria",
@@ -7543,13 +7768,14 @@
     "compoundClass": "morphine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Muirapuamine",
     "herbs": [
-      "Muira Puama",
-      "nan"
+      "Muira Puama"
     ],
     "effects": [
       "Improved libido",
@@ -7574,13 +7800,13 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "muirapuamine"
+    "slug": "muirapuamine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "mulunguine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Relaxation",
       "improved sleep",
@@ -7590,8 +7816,6 @@
       "sedation",
       "muscle relaxation",
       "anxiety reduction",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
@@ -7612,12 +7836,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "mulunguine"
+    "slug": "mulunguine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Muscimol",
     "herbs": [
-      "nan",
       "amanita muscaria"
     ],
     "effects": [
@@ -7625,8 +7850,6 @@
       "euphoria",
       "confusion",
       "dream-like states",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
@@ -7647,32 +7870,50 @@
     "compoundClass": "muscimol",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "myricetin",
     "herbs": [
       "acacia nilotica"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine"
-    ],
+    "effects": [],
     "contraindications": [
       "High doses of bark decoction can irritate the digestive tract and cause constipation or nausea",
       "Avoid during pregnancy or lactation due to potential anti-fertility effects",
       "Not recommended for children under 12"
     ],
-    "category": "myricetin",
+    "category": "flavonol / flavonoid",
     "sources": [],
     "lastUpdated": "2026-03-21",
     "slug": "myricetin",
     "canonicalCompoundId": "myricetin",
     "id": "myricetin",
     "compoundName": "myricetin",
-    "compoundClass": "myricetin",
+    "compoundClass": "flavonol / flavonoid",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Polyhydroxylated flavonol reported from tea and berry sources with MAPK and NF-κB pathway activity.",
+    "summary": "Polyhydroxylated flavonol reported from tea and berry sources with MAPK and NF-κB pathway activity.",
+    "foundIn": [
+      "berries",
+      "tea",
+      "grape",
+      "many fruits"
+    ],
+    "targets": [
+      "AMPK",
+      "Nrf2",
+      "NF-κB",
+      "inflammatory cytokines",
+      "endothelial nitric oxide",
+      "antioxidant response"
+    ],
+    "safetyNotes": "Mostly food/extract-derived human evidence. High-dose supplements may affect CYP/transporters or anticoagulant/antiplatelet risk.",
+    "linkedHerbs": []
   },
   {
     "name": "Myristicin",
@@ -7688,9 +7929,7 @@
       "sedation",
       "altered perception",
       "disorientation",
-      "No direct effects data. Contextual inference: Used in spice blends",
       "aphrodisiacs",
-      "and as a psychoactive in folk rituals... No direct mechanismofaction data. Contextual inference: Used in spice blends",
       "and as a psychoactive in folk rituals... Used in spice blends",
       "and as a psychoactive in folk rituals.. Used in spice blends",
       "and as a psychoactive in folk rituals."
@@ -7704,28 +7943,38 @@
       "dangerous interactions with MAOIs",
       "SSRIs"
     ],
-    "category": "myristicin",
+    "category": "terpene / essential-oil constituent",
     "sources": [],
     "lastUpdated": "2026-03-21",
     "slug": "myristicin",
     "canonicalCompoundId": "myristicin",
     "id": "myristicin",
     "compoundName": "myristicin",
-    "compoundClass": "myristicin",
+    "compoundClass": "terpene / essential-oil constituent",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Nutmeg phenylpropene linked to monoamine and cholinergic pathway effects.",
+    "summary": "Nutmeg phenylpropene linked to monoamine and cholinergic pathway effects.",
+    "foundIn": [
+      "Myristica fragrans"
+    ],
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "linkedHerbs": []
   },
   {
     "name": "N-Dimethyltryptamine (DMT)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Closed-eye visuals",
       "altered cognition",
-      "spiritual insight (when used with MAOI)",
-      "No direct effects data. Contextual inference: Ritual use.. No direct mechanismofaction data. Contextual inference: Ritual use.. Ritual use. Ritual use"
+      "spiritual insight (when used with MAOI)"
     ],
     "contraindications": [
       "Use with SSRIs or MAOIs without supervision"
@@ -7733,7 +7982,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "n-dimethyltryptamine-dmt"
+    "slug": "n-dimethyltryptamine-dmt",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "N-methylcephaeline (alamarckine)",
@@ -7762,21 +8013,17 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "n-methylcephaeline-alamarckine"
+    "slug": "n-methylcephaeline-alamarckine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "N-methyltryptamine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Psychedelic visuals",
       "introspection",
-      "altered consciousness",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "altered consciousness"
     ],
     "contraindications": [
       "Mental health conditions",
@@ -7794,7 +8041,9 @@
     "compoundClass": "n-methyltryptamine (nmt)",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "napelline",
@@ -7822,20 +8071,20 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "napelline"
+    "slug": "napelline",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "neferine",
     "herbs": [
-      "nan",
       "nelumbo nucifera"
     ],
     "effects": [
       "Calming",
       "antioxidant",
       "anti-inflammatory",
-      "lipid-lowering",
-      "No direct effects data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... No direct mechanismofaction data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... Used in Ayurveda and Buddhist practices for calm and devotion.. Used in Ayurveda and Buddhist practices for calm and devotion."
+      "lipid-lowering"
     ],
     "contraindications": [
       "Pregnancy",
@@ -7845,7 +8094,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "neferine"
+    "slug": "neferine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "neoline",
@@ -7873,13 +8124,13 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "neoline"
+    "slug": "neoline",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "nepetaefolin",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Mild euphoria",
       "sedation",
@@ -7901,18 +8152,17 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "nepetaefolin"
+    "slug": "nepetaefolin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Nepetalactone",
     "herbs": [
-      "catnip",
-      "nan"
+      "catnip"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used in folk medicine for relaxation",
       "colds",
-      "and digestive issues... No direct mechanismofaction data. Contextual inference: Used in folk medicine for relaxation",
       "and digestive issues... Used in folk medicine for relaxation",
       "and digestive issues.. Used in folk medicine for relaxation",
       "and digestive issues.",
@@ -7929,13 +8179,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "nepetalactone"
+    "slug": "nepetalactone",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "nesodine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Auditory distortion",
       "calmness",
@@ -7945,7 +8195,6 @@
       "relaxation",
       "mild euphoria",
       "dream-like state",
-      "No direct effects data. Contextual inference: Used by aztecs and indigenous mexicans for spiritual insight... No direct mechanismofaction data. Contextual inference: Used by aztecs and indigenous mexicans for spiritual insight... Used by Aztecs and indigenous Mexicans for spiritual insight.. Used by Aztecs and indigenous Mexicans for spiritual insight.",
       "Mild auditory and memory effects",
       "traditional fermentation increases effects"
     ],
@@ -7968,7 +8217,9 @@
     "compoundClass": "nesodine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Nicotine",
@@ -7979,13 +8230,10 @@
     "effects": [
       "Stimulation",
       "mood elevation",
-      "alertness",
-      "No direct effects data. Contextual inference: Used in shamanic rituals for grounding and spirit communication... No direct mechanismofaction data. Contextual inference: Used in shamanic rituals for grounding and spirit communication... Used in shamanic rituals for grounding and spirit communication.. Used in shamanic rituals for grounding and spirit communication."
+      "alertness"
     ],
     "contraindications": [
-      "Heart disease",
-      "pregnancy",
-      "epilepsy"
+      "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety."
     ],
     "category": "nicotine",
     "sources": [],
@@ -7997,13 +8245,25 @@
     "compoundClass": "nicotine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Canonical tobacco alkaloid with strong nicotinic and neurotransmitter pathway activity.",
+    "summary": "Canonical tobacco alkaloid with strong nicotinic and neurotransmitter pathway activity.",
+    "foundIn": [
+      "Nicotiana tabacum"
+    ],
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety.",
+    "linkedHerbs": []
   },
   {
     "name": "Nicotine (9–15%)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Intense stimulation",
       "nausea",
@@ -8020,21 +8280,20 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "nicotine-9-15"
+    "slug": "nicotine-9-15",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Nicotine (up to 9%)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Intense stimulation",
       "purging",
       "altered consciousness",
       "clarity",
       "Potent tobacco",
-      "used in Amazonian rituals for purification and divination",
-      "No direct effects data. Contextual inference: Used in shamanic rituals for grounding and spirit communication... No direct mechanismofaction data. Contextual inference: Used in shamanic rituals for grounding and spirit communication... Used in shamanic rituals for grounding and spirit communication.. Used in shamanic rituals for grounding and spirit communication."
+      "used in Amazonian rituals for purification and divination"
     ],
     "contraindications": [
       "Cardiac issues",
@@ -8047,13 +8306,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "nicotine-up-to-9"
+    "slug": "nicotine-up-to-9",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "NMT",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Intense visual hallucinations",
       "altered perception",
@@ -8078,21 +8337,20 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "nmt"
+    "slug": "nmt",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "norharman",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Intense stimulation",
       "purging",
       "altered consciousness",
       "clarity",
       "Potent tobacco",
-      "used in Amazonian rituals for purification and divination",
-      "No direct effects data. Contextual inference: Used in shamanic rituals for grounding and spirit communication... No direct mechanismofaction data. Contextual inference: Used in shamanic rituals for grounding and spirit communication... Used in shamanic rituals for grounding and spirit communication.. Used in shamanic rituals for grounding and spirit communication."
+      "used in Amazonian rituals for purification and divination"
     ],
     "contraindications": [
       "Cardiac issues",
@@ -8105,24 +8363,20 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "norharman"
+    "slug": "norharman",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "noribogaine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Intense visions",
       "introspection",
       "ataxia",
       "dream states",
       "Powerful psychedelic and anti-addiction",
-      "long visionary experience",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "long visionary experience"
     ],
     "contraindications": [
       "Serious cardiac risk",
@@ -8133,13 +8387,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "noribogaine"
+    "slug": "noribogaine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "nornicotine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Stimulation",
       "mood elevation",
@@ -8149,8 +8403,7 @@
       "altered consciousness",
       "clarity",
       "Potent tobacco",
-      "used in Amazonian rituals for purification and divination",
-      "No direct effects data. Contextual inference: Used in shamanic rituals for grounding and spirit communication... No direct mechanismofaction data. Contextual inference: Used in shamanic rituals for grounding and spirit communication... Used in shamanic rituals for grounding and spirit communication.. Used in shamanic rituals for grounding and spirit communication."
+      "used in Amazonian rituals for purification and divination"
     ],
     "contraindications": [
       "Heart disease",
@@ -8172,13 +8425,13 @@
     "compoundClass": "nornicotine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "noscapine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Euphoria",
       "analgesia",
@@ -8196,7 +8449,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "noscapine"
+    "slug": "noscapine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Nuciferine",
@@ -8207,7 +8462,6 @@
       "blue-lotus"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... No direct mechanismofaction data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... Used ceremonially in Ancient Egypt for euphoria and vision enhancement.. Used ceremonially in Ancient Egypt for euphoria and vision enhancement.",
       "Relaxation",
       "mild euphoria",
       "lucid dreaming",
@@ -8216,7 +8470,6 @@
       "antioxidant",
       "anti-inflammatory",
       "lipid-lowering",
-      "No direct effects data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... No direct mechanismofaction data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... Used in Ayurveda and Buddhist practices for calm and devotion.. Used in Ayurveda and Buddhist practices for calm and devotion.",
       "Euphoria",
       "relaxation",
       "dream intensification",
@@ -8252,22 +8505,18 @@
     "compoundClass": "nuciferine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "nupharidine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Relaxation",
       "mild euphoria",
       "dream enhancement",
       "anxiolytic",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
       "Euphoria",
       "relaxation",
       "dream intensification",
@@ -8291,22 +8540,18 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "nupharidine"
+    "slug": "nupharidine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Nupharine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Relaxation",
       "mild euphoria",
       "dream enhancement",
       "anxiolytic",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
       "Euphoria",
       "relaxation",
       "dream intensification",
@@ -8330,7 +8575,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "nupharine"
+    "slug": "nupharine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "o-cymene",
@@ -8360,7 +8607,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "o-cymene"
+    "slug": "o-cymene",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "okanine",
@@ -8385,7 +8634,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "okanine"
+    "slug": "okanine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "oleanolic acid",
@@ -8402,7 +8653,7 @@
       "due to saponins and alkaloids",
       "excessive intake may cause gastrointestinal irritation or interact with medications."
     ],
-    "category": null,
+    "category": "triterpene / triterpenoid acid",
     "sources": [
       {
         "note": "Inferred from scientific name:"
@@ -8412,7 +8663,24 @@
     "slug": "oleanolic-acid",
     "canonicalCompoundId": "oleanolic-acid",
     "id": "oleanolic-acid",
-    "compoundName": "Oleanolic acid"
+    "compoundName": "Oleanolic acid",
+    "compoundClass": "triterpene / triterpenoid acid",
+    "description": "Pentacyclic triterpene associated with cytoprotective and inflammatory signaling control.",
+    "summary": "Pentacyclic triterpene associated with cytoprotective and inflammatory signaling control.",
+    "foundIn": [
+      "rosemary",
+      "sage",
+      "hawthorn"
+    ],
+    "targets": [
+      "NF-κB",
+      "AMPK",
+      "PPAR",
+      "inflammatory cytokines",
+      "apoptosis signaling"
+    ],
+    "safetyNotes": "Mostly preclinical or extract-derived; concentrated doses may affect glucose, lipids, liver enzymes, or bleeding risk depending matrix.",
+    "linkedHerbs": []
   },
   {
     "name": "other saponins",
@@ -8440,7 +8708,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "other-saponins"
+    "slug": "other-saponins",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "p-coumaric acid",
@@ -8472,7 +8742,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "p-coumaric-acid"
+    "slug": "p-coumaric-acid",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "p-Cymene",
@@ -8480,8 +8752,6 @@
       "dysphania ambrosioides"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine"
@@ -8490,7 +8760,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "p-cymene"
+    "slug": "p-cymene",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "p-hydroxybenzoic acid",
@@ -8513,7 +8785,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "p-hydroxybenzoic-acid"
+    "slug": "p-hydroxybenzoic-acid",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Paniculatin",
@@ -8521,9 +8795,7 @@
       "celastrus paniculatus"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used in ayurveda for cognition",
       "focus",
-      "and learning... No direct mechanismofaction data. Contextual inference: Used in ayurveda for cognition",
       "and learning... Used in Ayurveda for cognition",
       "and learning.. Used in Ayurveda for cognition",
       "and learning."
@@ -8539,13 +8811,13 @@
     "compoundClass": "paniculatin",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "papaverine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Pain relief",
       "euphoria",
@@ -8568,27 +8840,27 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "papaverine"
+    "slug": "papaverine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Pareirine",
     "herbs": [
       "cissampelos pareira"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used in amazonian and ayurvedic traditions for pain and calming... No direct mechanismofaction data. Contextual inference: Used in amazonian and ayurvedic traditions for pain and calming... Used in Amazonian and Ayurvedic traditions for pain and calming.. Used in Amazonian and Ayurvedic traditions for pain and calming."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "pareirine"
+    "slug": "pareirine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "parquine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Delirium",
       "confusion",
@@ -8601,7 +8873,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "parquine"
+    "slug": "parquine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Patchoulol",
@@ -8609,8 +8883,6 @@
       "pogostemon cablin"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine"
@@ -8619,30 +8891,30 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "patchoulol"
+    "slug": "patchoulol",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Pellitorine",
     "herbs": [
       "zanthoxylum clava-herculis"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used by native americans to numb toothaches and energize... No direct mechanismofaction data. Contextual inference: Used by native americans to numb toothaches and energize... Used by Native Americans to numb toothaches and energize.. Used by Native Americans to numb toothaches and energize."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "pellitorine"
+    "slug": "pellitorine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Perillaldehyde",
     "herbs": [
       "perilla frutescens"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine"
-    ],
+    "effects": [],
     "contraindications": [],
     "category": "perillaldehyde",
     "sources": [],
@@ -8655,7 +8927,9 @@
     "mechanism": "monoterpene aldehyde",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "persinol",
@@ -8681,7 +8955,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "persinol"
+    "slug": "persinol",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "persinosides A",
@@ -8707,7 +8983,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "persinosides-a"
+    "slug": "persinosides-a",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "persinosides B",
@@ -8733,7 +9011,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "persinosides-b"
+    "slug": "persinosides-b",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Petasin",
@@ -8744,9 +9024,7 @@
     "effects": [
       "Mild sedation",
       "muscle relaxation",
-      "No direct effects data. Contextual inference: Used historically to treat pain",
       "migraines",
-      "and spasms... No direct mechanismofaction data. Contextual inference: Used historically to treat pain",
       "and spasms... Used historically to treat pain",
       "and spasms.. Used historically to treat pain",
       "and spasms."
@@ -8764,13 +9042,14 @@
     "compoundClass": "petasin",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "phenolic acids",
     "herbs": [
-      "agrimonia eupatoria",
-      "nan"
+      "agrimonia eupatoria"
     ],
     "effects": [
       "Astringent",
@@ -8796,13 +9075,13 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "phenolic-acids"
+    "slug": "phenolic-acids",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Phenolics",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Wound healing",
       "anti-infective effects"
@@ -8813,16 +9092,16 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "phenolics"
+    "slug": "phenolics",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "phenols",
     "herbs": [
       "alchornea castaneifolia"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... No direct mechanismofaction data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... Used in traditional Amazonian medicine for arthritis and pain.. Used in traditional Amazonian medicine for arthritis and pain."
-    ],
+    "effects": [],
     "contraindications": [
       "Little clinical research",
       "avoid during pregnancy or while breastfeeding",
@@ -8832,13 +9111,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "phenols"
+    "slug": "phenols",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "phenylethylamine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Euphoria",
       "alertness",
@@ -8855,7 +9134,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "phenylethylamine"
+    "slug": "phenylethylamine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "phlorizin",
@@ -8878,7 +9159,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "phlorizin"
+    "slug": "phlorizin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "phytosterols",
@@ -8907,7 +9190,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "phytosterols"
+    "slug": "phytosterols",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "picraconitine",
@@ -8935,7 +9220,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "picraconitine"
+    "slug": "picraconitine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "pinitol",
@@ -8960,13 +9247,13 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "pinitol"
+    "slug": "pinitol",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "pinocembrin",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Mood lift",
       "mild stimulation",
@@ -8976,8 +9263,7 @@
       "relaxation",
       "increased libido",
       "Mild stimulation",
-      "mood enhancement",
-      "No direct effects data. Contextual inference: Used as an aphrodisiac and mood enhancer in mexican herbalism... No direct mechanismofaction data. Contextual inference: Used as an aphrodisiac and mood enhancer in mexican herbalism... Used as an aphrodisiac and mood enhancer in Mexican herbalism.. Used as an aphrodisiac and mood enhancer in Mexican herbalism."
+      "mood enhancement"
     ],
     "contraindications": [
       "Avoid in bipolar disorder and pregnancy",
@@ -8994,16 +9280,16 @@
     "compoundClass": "pinocembrin",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "polysaccharides (arabinose, rhamnose)",
     "herbs": [
       "acacia nilotica"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine"
-    ],
+    "effects": [],
     "contraindications": [
       "High doses of bark decoction can irritate the digestive tract and cause constipation or nausea",
       "Avoid during pregnancy or lactation due to potential anti-fertility effects",
@@ -9012,13 +9298,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "polysaccharides-arabinose-rhamnose"
+    "slug": "polysaccharides-arabinose-rhamnose",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Prenylated isoflavonoids",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Pain relief",
       "immune modulation"
@@ -9030,7 +9316,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "prenylated-isoflavonoids"
+    "slug": "prenylated-isoflavonoids",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "procyanidin oligomers",
@@ -9057,13 +9345,13 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "procyanidin-oligomers"
+    "slug": "procyanidin-oligomers",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "pseudoephedrine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Increased energy",
       "focus",
@@ -9091,7 +9379,9 @@
     "compoundClass": "pseudoephedrine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "psychotrin",
@@ -9120,24 +9410,20 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "psychotrin"
+    "slug": "psychotrin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "pterocarpans",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Relaxation",
       "improved mood",
       "mild clarity",
       "Calming",
       "expectorant",
-      "mild analgesic",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "mild analgesic"
     ],
     "contraindications": [
       "None known",
@@ -9147,13 +9433,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "pterocarpans"
+    "slug": "pterocarpans",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "pulegone",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Soothes GI tract",
       "reduces bloating",
@@ -9178,19 +9464,17 @@
     "compoundClass": "pulegone",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "pyrrolizidine alkaloids (toxic)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Mild sedation",
       "muscle relaxation",
-      "No direct effects data. Contextual inference: Used historically to treat pain",
       "migraines",
-      "and spasms... No direct mechanismofaction data. Contextual inference: Used historically to treat pain",
       "and spasms... Used historically to treat pain",
       "and spasms.. Used historically to treat pain",
       "and spasms."
@@ -9201,7 +9485,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "pyrrolizidine-alkaloids-toxic"
+    "slug": "pyrrolizidine-alkaloids-toxic",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Quercetin",
@@ -9216,10 +9502,10 @@
       "unclassified"
     ],
     "contraindications": [
-      "Long-term high-dose safety is not well established",
-      "Potential CYP/P-glycoprotein interactions are mostly theoretical"
+      "Food exposure is generally safe",
+      "high-dose supplements may affect drug transport/metabolism. Caution with anticoagulants, immunosuppressants, and kidney disease at high doses."
     ],
-    "category": "compound",
+    "category": "flavonol polyphenol",
     "sources": [
       {
         "title": "PubMed review literature on quercetin",
@@ -9232,7 +9518,7 @@
     "displayName": "Quercetin",
     "canonicalCompoundId": "quercetin",
     "compoundName": "Quercetin",
-    "compoundClass": "Flavonoid",
+    "compoundClass": "flavonol polyphenol",
     "mechanismTags": [
       "mast-cell modulation",
       "nf-kb inhibition",
@@ -9241,10 +9527,23 @@
     ],
     "description": "Quercetin is a dietary flavonol studied for antioxidant and inflammatory-pathway modulation, with early human data but limited high-certainty outcomes for major indications.",
     "mechanism": "Influences NF-kB-linked inflammatory signaling and may reduce mast-cell mediator release in preclinical and early translational work.",
-    "safetyNotes": [
-      "Long-term high-dose use has limited safety certainty; potential transporter/enzyme interactions should be reviewed case by case."
+    "safetyNotes": "Food exposure is generally safe; high-dose supplements may affect drug transport/metabolism. Caution with anticoagulants, immunosuppressants, and kidney disease at high doses.",
+    "evidenceLevel": "limited",
+    "summary": "Flavonol widely distributed in herbs and fruits, commonly linked to NF-κB, PI3K/Akt, and Nrf2 pathway modulation.",
+    "foundIn": [
+      "onion",
+      "buckwheat",
+      "capers",
+      "many flavonoid-rich herbs"
     ],
-    "evidenceLevel": "limited"
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "PI3K/Akt",
+      "mast-cell mediators",
+      "CYP/P-gp interaction pathways"
+    ],
+    "linkedHerbs": []
   },
   {
     "name": "quercetin derivatives",
@@ -9271,7 +9570,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "quercetin-derivatives"
+    "slug": "quercetin-derivatives",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "quercitrin",
@@ -9279,12 +9580,7 @@
       "albizia julibrissin",
       "houttuynia"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
-    ],
+    "effects": [],
     "contraindications": [
       "Limited safety data",
       "may potentiate sedative or antidepressant drugs",
@@ -9300,7 +9596,9 @@
     "compoundClass": "quercitrin",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "rosmarinic acid",
@@ -9324,7 +9622,7 @@
       "blood clotting disorders",
       "Avoid high doses of essential oil"
     ],
-    "category": "rosmarinic acid",
+    "category": "caffeic acid ester / phenolic acid",
     "sources": [
       {
         "title": "PubChem compound: Rosmarinic acid (CID 5281792)",
@@ -9349,7 +9647,7 @@
     "canonicalCompoundId": "rosmarinic-acid",
     "id": "rosmarinic-acid",
     "compoundName": "Rosmarinic acid",
-    "compoundClass": "rosmarinic acid",
+    "compoundClass": "caffeic acid ester / phenolic acid",
     "mechanism": "Antioxidant and anti-inflammatory signaling",
     "mechanismTags": [
       "nf-kb inhibition",
@@ -9357,55 +9655,81 @@
       "reinforcement",
       "unclassified"
     ],
-    "safetyNotes": [
-      "Typically well tolerated in food-level exposure; concentrated products may cause mild gastrointestinal upset in sensitive users."
+    "safetyNotes": "Food/herb exposure is generally low-risk; isolated high-dose safety is less established. Caution with pregnancy, anticoagulant use, and complex immune therapy contexts.",
+    "evidenceLevel": "limited",
+    "summary": "Polyphenol in rosemary and lemon balm with anti-inflammatory properties.",
+    "foundIn": [
+      "Lemon Balm",
+      "Rosmarinus officinalis",
+      "Holy Basil"
     ],
-    "evidenceLevel": "limited"
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "complement and inflammatory signaling",
+      "antiviral-entry pathways in vitro"
+    ],
+    "linkedHerbs": []
   },
   {
     "name": "Rutarin",
     "herbs": [
       "ruta graveolens"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used historically in folk magic and herbalism... No direct mechanismofaction data. Contextual inference: Used historically in folk magic and herbalism... Used historically in folk magic and herbalism.. Used historically in folk magic and herbalism."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "rutarin"
+    "slug": "rutarin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Rutin",
     "herbs": [
       "ruta graveolens"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used historically in folk magic and herbalism... No direct mechanismofaction data. Contextual inference: Used historically in folk magic and herbalism... Used historically in folk magic and herbalism.. Used historically in folk magic and herbalism."
+    "effects": [],
+    "contraindications": [
+      "Mostly food/extract-derived human evidence. High-dose supplements may affect CYP/transporters or anticoagulant/antiplatelet risk."
     ],
-    "contraindications": [],
-    "category": "rutin",
+    "category": "flavonol / flavonoid",
     "sources": [],
     "lastUpdated": "2026-03-21",
     "slug": "rutin",
     "canonicalCompoundId": "rutin",
     "id": "rutin",
     "compoundName": "rutin",
-    "compoundClass": "rutin",
+    "compoundClass": "flavonol / flavonoid",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Flavonol glycoside commonly reported from buckwheat and St. John's wort with inflammatory pathway activity.",
+    "summary": "Flavonol glycoside commonly reported from buckwheat and St. John's wort with inflammatory pathway activity.",
+    "foundIn": [
+      "buckwheat",
+      "citrus",
+      "elderflower",
+      "many plants"
+    ],
+    "targets": [
+      "AMPK",
+      "Nrf2",
+      "NF-κB",
+      "inflammatory cytokines",
+      "endothelial nitric oxide",
+      "antioxidant response"
+    ],
+    "safetyNotes": "Mostly food/extract-derived human evidence. High-dose supplements may affect CYP/transporters or anticoagulant/antiplatelet risk.",
+    "linkedHerbs": []
   },
   {
     "name": "Safrole",
     "herbs": [
-      "mexican pepperleaf",
-      "nan"
+      "mexican pepperleaf"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
@@ -9416,9 +9740,7 @@
       "sedation",
       "altered perception",
       "disorientation",
-      "No direct effects data. Contextual inference: Used in spice blends",
       "aphrodisiacs",
-      "and as a psychoactive in folk rituals... No direct mechanismofaction data. Contextual inference: Used in spice blends",
       "and as a psychoactive in folk rituals... Used in spice blends",
       "and as a psychoactive in folk rituals.. Used in spice blends",
       "and as a psychoactive in folk rituals."
@@ -9432,17 +9754,30 @@
       "dangerous interactions with MAOIs",
       "SSRIs"
     ],
-    "category": "safrole",
+    "category": "terpene / essential-oil constituent",
     "sources": [],
     "lastUpdated": "2026-03-21",
     "slug": "safrole",
     "canonicalCompoundId": "safrole",
     "id": "safrole",
     "compoundName": "safrole",
-    "compoundClass": "safrole",
+    "compoundClass": "terpene / essential-oil constituent",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Phenylpropene associated with sensory and signaling pathway activity.",
+    "summary": "Phenylpropene associated with sensory and signaling pathway activity.",
+    "foundIn": [
+      "Ocotea odorifera"
+    ],
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "linkedHerbs": []
   },
   {
     "name": "salicylic acid derivatives",
@@ -9471,7 +9806,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "salicylic-acid-derivatives"
+    "slug": "salicylic-acid-derivatives",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "salsoline",
@@ -9500,21 +9837,23 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "salsoline"
+    "slug": "salsoline",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Sanshools",
     "herbs": [
       "zanthoxylum clava-herculis"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used by native americans to numb toothaches and energize... No direct mechanismofaction data. Contextual inference: Used by native americans to numb toothaches and energize... Used by Native Americans to numb toothaches and energize.. Used by Native Americans to numb toothaches and energize."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "sanshools"
+    "slug": "sanshools",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "saponins",
@@ -9523,16 +9862,9 @@
       "albizia julibrissin",
       "alchornea castaneifolia",
       "mitchella repens",
-      "nan",
       "entada rheedii"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
-      "No direct effects data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... No direct mechanismofaction data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... Used in traditional Amazonian medicine for arthritis and pain.. Used in traditional Amazonian medicine for arthritis and pain.",
       "Mental alertness",
       "energy",
       "appetite suppression",
@@ -9554,8 +9886,6 @@
       "Vivid dreams",
       "dream recall",
       "mental clarity",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
@@ -9568,7 +9898,6 @@
       "Visual distortions",
       "sedation",
       "altered mental state",
-      "No direct effects data. Contextual inference: Used by mapuche shamans in ritual ceremonies... No direct mechanismofaction data. Contextual inference: Used by mapuche shamans in ritual ceremonies... Used by Mapuche shamans in ritual ceremonies.. Used by Mapuche shamans in ritual ceremonies.",
       "Enhanced dreams",
       "altered awareness",
       "calm",
@@ -9612,7 +9941,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "saponins"
+    "slug": "saponins",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "saponins (lebbekanin A-H)",
@@ -9637,37 +9968,33 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "saponins-lebbekanin-a-h"
+    "slug": "saponins-lebbekanin-a-h",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Sclareol",
     "herbs": [
       "salvia sclarea"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "sclareol"
+    "slug": "sclareol",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Scopolamine",
     "herbs": [
-      "datura metel",
-      "nan"
+      "datura metel"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used in rituals but also associated with danger and toxicity... No direct mechanismofaction data. Contextual inference: Used in rituals but also associated with danger and toxicity... Used in rituals but also associated with danger and toxicity.. Used in rituals but also associated with danger and toxicity.",
       "Complete dissociation",
       "hallucinations",
       "amnesia",
-      "No direct effects data. Contextual inference: Ritual use.. No direct mechanismofaction data. Contextual inference: Ritual use.. Ritual use. Ritual use",
       "Intense hallucinations",
       "delirium",
       "Strong anticholinergic and hallucinogenic effects",
@@ -9710,7 +10037,9 @@
     "compoundClass": "scopolamine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "scopoletin",
@@ -9721,10 +10050,6 @@
       "Relaxation",
       "mild euphoria",
       "dream enhancement",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
       "Mild euphoric and calming",
       "used as cannabis substitute"
     ],
@@ -9733,29 +10058,40 @@
       "pregnancy",
       "psychiatric conditions."
     ],
-    "category": "scopoletin",
+    "category": "coumarin / furanocoumarin",
     "sources": [],
     "lastUpdated": "2026-03-21",
     "slug": "scopoletin",
     "canonicalCompoundId": "scopoletin",
     "id": "scopoletin",
     "compoundName": "scopoletin",
-    "compoundClass": "scopoletin",
+    "compoundClass": "coumarin / furanocoumarin",
     "mechanism": "Scopoletin, damnacanthal, polysaccharides",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Coumarin constituent associated with NF-κB suppression and calcium-channel-related activity.",
+    "summary": "Coumarin constituent associated with NF-κB suppression and calcium-channel-related activity.",
+    "foundIn": [
+      "morinda citrifolia",
+      "artemisia capillaris"
+    ],
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils.",
+    "linkedHerbs": []
   },
   {
     "name": "scutellarein",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Mild sedation",
       "calm mood",
       "anxiety relief",
-      "No direct effects data. Contextual inference: Used by native american tribes for anxiety and insomnia... No direct mechanismofaction data. Contextual inference: Used by native american tribes for anxiety and insomnia... Used by Native American tribes for anxiety and insomnia.. Used by Native American tribes for anxiety and insomnia.",
       "Nervine",
       "anxiolytic",
       "anti-inflammatory",
@@ -9770,19 +10106,19 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "scutellarein"
+    "slug": "scutellarein",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Scutellarin",
     "herbs": [
-      "nan",
       "scutellaria lateriflora"
     ],
     "effects": [
       "Mild sedation",
       "calm mood",
       "anxiety relief",
-      "No direct effects data. Contextual inference: Used by native american tribes for anxiety and insomnia... No direct mechanismofaction data. Contextual inference: Used by native american tribes for anxiety and insomnia... Used by Native American tribes for anxiety and insomnia.. Used by Native American tribes for anxiety and insomnia.",
       "Nervine",
       "anxiolytic",
       "anti-inflammatory",
@@ -9804,20 +10140,16 @@
     "compoundClass": "scutellarin",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "serotonin",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Mild stimulation",
-      "increased circulation",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "increased circulation"
     ],
     "contraindications": [
       "Pregnancy (caution)",
@@ -9833,13 +10165,13 @@
     "compoundClass": "serotonin",
     "mechanismTags": [
       "serotonin signaling"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Sesquiterpene lactones",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Blood sugar regulation",
       "cytotoxic effects on cancer cells",
@@ -9857,13 +10189,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "sesquiterpene-lactones"
+    "slug": "sesquiterpene-lactones",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "sesquiterpenes",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Anti-inflammatory",
       "diuretic",
@@ -9880,8 +10212,6 @@
       "Vivid dreams",
       "increased dream recall",
       "mild sedation",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
@@ -9903,13 +10233,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "sesquiterpenes"
+    "slug": "sesquiterpenes",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Solanine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Delirium",
       "confusion",
@@ -9930,7 +10260,9 @@
     "mechanism": "Solanine, solamargine, flavonoids",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "songoramine",
@@ -9958,13 +10290,13 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "songoramine"
+    "slug": "songoramine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "speciogynine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Stimulation",
       "mild euphoria",
@@ -9983,13 +10315,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "speciogynine"
+    "slug": "speciogynine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Spilanthol",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Local anesthesia",
       "salivation",
@@ -10019,16 +10351,16 @@
     "compoundClass": "spilanthol",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Stachydrine",
     "herbs": [
       "motherwort"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used in traditional herbalism for anxiety and female reproductive support... No direct mechanismofaction data. Contextual inference: Used in traditional herbalism for anxiety and female reproductive support... Used in traditional herbalism for anxiety and female reproductive support.. Used in traditional herbalism for anxiety and female reproductive support."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": "stachydrine",
     "sources": [],
@@ -10040,16 +10372,16 @@
     "compoundClass": "stachydrine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "steroids",
     "herbs": [
       "alchornea castaneifolia"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... No direct mechanismofaction data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... Used in traditional Amazonian medicine for arthritis and pain.. Used in traditional Amazonian medicine for arthritis and pain."
-    ],
+    "effects": [],
     "contraindications": [
       "Little clinical research",
       "avoid during pregnancy or while breastfeeding",
@@ -10059,20 +10391,17 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "steroids"
+    "slug": "steroids",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "sterols",
     "herbs": [
       "albizia julibrissin",
-      "Muira Puama",
-      "nan"
+      "Muira Puama"
     ],
     "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
       "Improved libido",
       "enhanced cognition",
       "mood elevation",
@@ -10111,7 +10440,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "sterols"
+    "slug": "sterols",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "suberosol",
@@ -10134,13 +10465,13 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "suberosol"
+    "slug": "suberosol",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Sulfur compounds",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Calmness",
       "clarity",
@@ -10156,7 +10487,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "sulfur-compounds"
+    "slug": "sulfur-compounds",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "syringic acid",
@@ -10179,18 +10512,17 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "syringic-acid"
+    "slug": "syringic-acid",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "tabersonine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Inner visions",
       "deep introspection",
-      "energetic clarity",
-      "No direct effects data. Contextual inference: Used by indigenous healers to improve vision and intuition... No direct mechanismofaction data. Contextual inference: Used by indigenous healers to improve vision and intuition... Used by indigenous healers to improve vision and intuition.. Used by indigenous healers to improve vision and intuition."
+      "energetic clarity"
     ],
     "contraindications": [
       "Heart conditions",
@@ -10199,7 +10531,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "tabersonine"
+    "slug": "tabersonine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "tannic acid",
@@ -10225,15 +10559,16 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "tannic-acid"
+    "slug": "tannic-acid",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "tannins",
     "herbs": [
       "agrimonia eupatoria",
       "alchornea castaneifolia",
-      "ficus religiosa",
-      "nan"
+      "ficus religiosa"
     ],
     "effects": [
       "Astringent",
@@ -10241,8 +10576,6 @@
       "digestive tonic",
       "anti",
       "inflammatory",
-      "No direct effects data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... No direct mechanismofaction data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... Used in traditional Amazonian medicine for arthritis and pain.. Used in traditional Amazonian medicine for arthritis and pain.",
-      "No direct effects data. Contextual inference: Used in ayurveda and spiritual practice for mindfulness and peace... No direct mechanismofaction data. Contextual inference: Used in ayurveda and spiritual practice for mindfulness and peace... Used in Ayurveda and spiritual practice for mindfulness and peace.. Used in Ayurveda and spiritual practice for mindfulness and peace.",
       "Intense visual hallucinations",
       "altered perception",
       "emotional sensitivity",
@@ -10260,17 +10593,12 @@
       "antispasmodic",
       "Psychedelic visuals",
       "altered consciousness",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
       "astringent",
       "digestive aid",
       "hemostatic",
       "Calming",
       "antioxidant",
       "lipid-lowering",
-      "No direct effects data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... No direct mechanismofaction data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... Used in Ayurveda and Buddhist practices for calm and devotion.. Used in Ayurveda and Buddhist practices for calm and devotion.",
       "Mental alertness",
       "energy",
       "appetite suppression",
@@ -10296,9 +10624,7 @@
       "used as a hunting drug in Africa",
       "Mild sedation",
       "relaxation",
-      "No direct effects data. Contextual inference: Used traditionally to relieve pain",
       "stress",
-      "and inflammation... No direct mechanismofaction data. Contextual inference: Used traditionally to relieve pain",
       "and inflammation... Used traditionally to relieve pain",
       "and inflammation.. Used traditionally to relieve pain",
       "and inflammation.",
@@ -10363,16 +10689,16 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "tannins"
+    "slug": "tannins",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "tannins (gallic acid, ellagic acid, catechin)",
     "herbs": [
       "acacia nilotica"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine"
-    ],
+    "effects": [],
     "contraindications": [
       "High doses of bark decoction can irritate the digestive tract and cause constipation or nausea",
       "Avoid during pregnancy or lactation due to potential anti-fertility effects",
@@ -10381,16 +10707,16 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "tannins-gallic-acid-ellagic-acid-catechin"
+    "slug": "tannins-gallic-acid-ellagic-acid-catechin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Tartaric acid",
     "herbs": [
       "tamarindus indica"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used in traditional medicine and cuisine for digestive support... No direct mechanismofaction data. Contextual inference: Used in traditional medicine and cuisine for digestive support... Used in traditional medicine and cuisine for digestive support.. Used in traditional medicine and cuisine for digestive support."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": "tartaric acid",
     "sources": [],
@@ -10402,13 +10728,13 @@
     "compoundClass": "tartaric acid",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "terpenes",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Euphoria",
       "hallucinations",
@@ -10425,12 +10751,7 @@
       "increased libido",
       "Mild stimulation",
       "mood enhancement",
-      "No direct effects data. Contextual inference: Used as an aphrodisiac and mood enhancer in mexican herbalism... No direct mechanismofaction data. Contextual inference: Used as an aphrodisiac and mood enhancer in mexican herbalism... Used as an aphrodisiac and mood enhancer in Mexican herbalism.. Used as an aphrodisiac and mood enhancer in Mexican herbalism.",
-      "sedation or stimulation",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "sedation or stimulation"
     ],
     "contraindications": [
       "Avoid in pregnancy",
@@ -10447,13 +10768,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "terpenes"
+    "slug": "terpenes",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "terpenoids",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Skin healing",
       "antiparasitic action",
@@ -10467,13 +10788,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "terpenoids"
+    "slug": "terpenoids",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "tetrahydroharmine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Altered perception",
       "dream intensification",
@@ -10489,11 +10810,7 @@
       "psychoactive",
       "Dreamlike visions",
       "introspection",
-      "emotional release",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "emotional release"
     ],
     "contraindications": [
       "Avoid with SSRIs",
@@ -10516,13 +10833,13 @@
     "compoundClass": "tetrahydroharmine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "tetrahydroharmine (beta-carbolines)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Altered perception",
       "dream intensification",
@@ -10550,21 +10867,23 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "tetrahydroharmine-beta-carbolines"
+    "slug": "tetrahydroharmine-beta-carbolines",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Tetrahydropalmatine (THP)",
     "herbs": [
       "corydalis yanhusuo"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used in traditional chinese medicine for pain and sleep... No direct mechanismofaction data. Contextual inference: Used in traditional chinese medicine for pain and sleep... Used in Traditional Chinese Medicine for pain and sleep.. Used in Traditional Chinese Medicine for pain and sleep."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "tetrahydropalmatine-thp"
+    "slug": "tetrahydropalmatine-thp",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "thaliandiol",
@@ -10587,7 +10906,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "thaliandiol"
+    "slug": "thaliandiol",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "thalianol",
@@ -10610,22 +10931,19 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "thalianol"
+    "slug": "thalianol",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "THC",
     "herbs": [
-      "nan",
       "cannabis sativa"
     ],
     "effects": [
       "Euphoria",
       "altered perception",
-      "sedation or stimulation",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "sedation or stimulation"
     ],
     "contraindications": [
       "Psychosis",
@@ -10642,13 +10960,13 @@
     "compoundClass": "thc",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "thebaine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Pain relief",
       "euphoria",
@@ -10678,12 +10996,13 @@
     "compoundClass": "thebaine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "theobromine",
     "herbs": [
-      "nan",
       "yerba mate"
     ],
     "effects": [
@@ -10699,16 +11018,11 @@
       "Mental stimulation",
       "increased alertness",
       "mild diuretic",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
       "Euphoria",
       "alertness",
       "heart opening",
       "mild euphoriant",
-      "contains theobromine and caffeine",
-      "No direct effects data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... No direct mechanismofaction data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... Consumed as a social and energizing herbal tea throughout South America.. Consumed as a social and energizing herbal tea throughout South America."
+      "contains theobromine and caffeine"
     ],
     "contraindications": [
       "Anxiety",
@@ -10732,13 +11046,13 @@
     "compoundClass": "theobromine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "theophylline",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Mental alertness",
       "energy",
@@ -10768,7 +11082,9 @@
     "compoundClass": "theophylline",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Thujone",
@@ -10780,12 +11096,9 @@
       "artemisia-absinthium"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine",
-      "No direct effects data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... No direct mechanismofaction data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... Used in absinthe and traditional medicine for digestion and stimulation.. Used in absinthe and traditional medicine for digestion and stimulation.",
       "Anti-inflammatory",
       "astringent",
       "digestive aid",
@@ -10811,17 +11124,29 @@
       "or during pregnancy",
       "thujone sensitivity"
     ],
-    "category": "thujone",
+    "category": "monoterpene ketone",
     "sources": [],
     "lastUpdated": "2026-03-21",
     "slug": "thujone",
     "canonicalCompoundId": "thujone",
     "id": "thujone",
     "compoundName": "thujone",
-    "compoundClass": "thujone",
+    "compoundClass": "monoterpene ketone",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Monoterpene ketone associated with GABAergic and sensory signaling.",
+    "summary": "Monoterpene ketone associated with GABAergic and sensory signaling.",
+    "foundIn": [
+      "Mugwort",
+      "Sage",
+      "Artemisia absinthium"
+    ],
+    "targets": [
+      "GABA-A receptors"
+    ],
+    "safetyNotes": "Neuroactive monoterpene; high exposure may increase seizure/neurotoxicity risk. Avoid pregnancy, seizure disorders, and concentrated essential-oil ingestion.",
+    "linkedHerbs": []
   },
   {
     "name": "thymol",
@@ -10842,12 +11167,7 @@
       "stimulation",
       "increased libido",
       "Mild stimulation",
-      "mood enhancement",
-      "No direct effects data. Contextual inference: Used as an aphrodisiac and mood enhancer in mexican herbalism... No direct mechanismofaction data. Contextual inference: Used as an aphrodisiac and mood enhancer in mexican herbalism... Used as an aphrodisiac and mood enhancer in Mexican herbalism.. Used as an aphrodisiac and mood enhancer in Mexican herbalism.",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "mood enhancement"
     ],
     "contraindications": [
       "Pregnancy",
@@ -10855,18 +11175,32 @@
       "Avoid in bipolar disorder and pregnancy",
       "hormone-sensitive conditions"
     ],
-    "category": "thymol",
+    "category": "terpene / essential-oil constituent",
     "sources": [],
     "lastUpdated": "2026-03-21",
     "slug": "thymol",
     "canonicalCompoundId": "thymol",
     "id": "thymol",
     "compoundName": "thymol",
-    "compoundClass": "thymol",
+    "compoundClass": "terpene / essential-oil constituent",
     "mechanism": "Thymol, carvacrol, essential oils",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Monoterpene phenol from thyme and oregano with antimicrobial and neuroactive properties.",
+    "summary": "Monoterpene phenol from thyme and oregano with antimicrobial and neuroactive properties.",
+    "foundIn": [
+      "Rosemary",
+      "Ajwain",
+      "Thyme",
+      "Oregano"
+    ],
+    "targets": [
+      "GABA-A-related sites",
+      "membrane targets"
+    ],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "linkedHerbs": []
   },
   {
     "name": "tiliroside",
@@ -10879,8 +11213,7 @@
       "anti-inflammatory",
       "digestive tonic",
       "anti",
-      "inflammatory",
-      "No direct effects data. Contextual inference: Used in midwifery and herbal traditions to support reproductive health... No direct mechanismofaction data. Contextual inference: Used in midwifery and herbal traditions to support reproductive health... Used in midwifery and herbal traditions to support reproductive health.. Used in midwifery and herbal traditions to support reproductive health."
+      "inflammatory"
     ],
     "contraindications": [
       "Generally safe when used as tea",
@@ -10895,7 +11228,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "tiliroside"
+    "slug": "tiliroside",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "trans-methylisoeugenol",
@@ -10925,7 +11260,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "trans-methylisoeugenol"
+    "slug": "trans-methylisoeugenol",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "triterpene saponins",
@@ -10933,8 +11270,6 @@
       "african dream root"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine"
@@ -10948,13 +11283,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "triterpene-saponins"
+    "slug": "triterpene-saponins",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "triterpenes",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Anti-inflammatory",
       "hepatoprotective"
@@ -10965,7 +11300,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "triterpenes"
+    "slug": "triterpenes",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Triterpenoid saponins",
@@ -10973,8 +11310,6 @@
       "silene undulata"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used by xhosa shamans to induce vivid",
-      "meaningful dreams... No direct mechanismofaction data. Contextual inference: Used by xhosa shamans to induce vivid",
       "meaningful dreams... Used by Xhosa shamans to induce vivid",
       "meaningful dreams.. Used by Xhosa shamans to induce vivid",
       "meaningful dreams."
@@ -10983,14 +11318,15 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "triterpenoid-saponins"
+    "slug": "triterpenoid-saponins",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "triterpenoids",
     "herbs": [
       "agrimonia eupatoria",
-      "albizia julibrissin",
-      "nan"
+      "albizia julibrissin"
     ],
     "effects": [
       "Astringent",
@@ -10998,10 +11334,6 @@
       "digestive tonic",
       "anti",
       "inflammatory",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
       "Pain relief",
       "reduced inflammation"
     ],
@@ -11022,19 +11354,17 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "triterpenoids"
+    "slug": "triterpenoids",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "triterpenoids (undisclosed alkaloids)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Vivid dreams",
       "dream recall",
       "mental clarity",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine"
@@ -11045,13 +11375,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "triterpenoids-undisclosed-alkaloids"
+    "slug": "triterpenoids-undisclosed-alkaloids",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "trithiolanes",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Calmness",
       "clarity",
@@ -11067,13 +11397,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "trithiolanes"
+    "slug": "trithiolanes",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "tryptamines",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Psychedelic visions",
       "auditory changes",
@@ -11082,10 +11412,6 @@
       "Psychoactive (when extracted)",
       "vision alteration",
       "introspection",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
       "Psychedelic visuals",
       "emotional shifts (with MAOI)"
     ],
@@ -11100,21 +11426,23 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "tryptamines"
+    "slug": "tryptamines",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Tynanthin",
     "herbs": [
       "tynanthus panurensis"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used in amazonian herbalism for sexual energy and digestion... No direct mechanismofaction data. Contextual inference: Used in amazonian herbalism for sexual energy and digestion... Used in Amazonian herbalism for sexual energy and digestion.. Used in Amazonian herbalism for sexual energy and digestion."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "tynanthin"
+    "slug": "tynanthin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "umbelliferone",
@@ -11131,8 +11459,7 @@
       "Mild euphoria",
       "sedation",
       "muscle relaxation",
-      "spiritual openness",
-      "No direct effects data. Contextual inference: Used in amazonian herbal mixtures and healing brews... No direct mechanismofaction data. Contextual inference: Used in amazonian herbal mixtures and healing brews... Used in Amazonian herbal mixtures and healing brews.. Used in Amazonian herbal mixtures and healing brews."
+      "spiritual openness"
     ],
     "contraindications": [
       "Limited safety data",
@@ -11142,7 +11469,7 @@
       "Pregnancy",
       "anticoagulant therapy due to coumarin content"
     ],
-    "category": "umbelliferone",
+    "category": "coumarin / furanocoumarin",
     "sources": [
       {
         "note": "Inferred from scientific name:"
@@ -11153,30 +11480,42 @@
     "canonicalCompoundId": "umbelliferone",
     "id": "umbelliferone",
     "compoundName": "umbelliferone",
-    "compoundClass": "umbelliferone",
+    "compoundClass": "coumarin / furanocoumarin",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Simple coumarin distributed across Apiaceae with antioxidant-response and MAPK pathway activity.",
+    "summary": "Simple coumarin distributed across Apiaceae with antioxidant-response and MAPK pathway activity.",
+    "foundIn": [
+      "angelica archangelica",
+      "coriandrum sativum"
+    ],
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils.",
+    "linkedHerbs": []
   },
   {
     "name": "Umelliferone",
     "herbs": [
       "justicia pectoralis"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used in amazonian herbal mixtures and healing brews... No direct mechanismofaction data. Contextual inference: Used in amazonian herbal mixtures and healing brews... Used in Amazonian herbal mixtures and healing brews.. Used in Amazonian herbal mixtures and healing brews."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "umelliferone"
+    "slug": "umelliferone",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "unverified cannabinoids",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Calmness",
       "mild euphoria",
@@ -11189,7 +11528,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "unverified-cannabinoids"
+    "slug": "unverified-cannabinoids",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "ursolic acid",
@@ -11198,48 +11539,58 @@
       "ocimum-sanctum"
     ],
     "effects": [
-      "Stress relief",
       "respiratory support",
       "antioxidant",
-      "mild energy boost",
-      "Adaptogen",
-      "anti-stress",
-      "immune support"
+      "mild energy boost"
     ],
     "contraindications": [
-      "Pregnancy (high doses)",
-      "blood clotting disorders"
+      "Mostly preclinical and food/herb associated. High-dose isolated use lacks robust human safety data",
+      "caution with pregnancy, liver disease, and anticancer/immunomodulating therapies."
     ],
-    "category": "Triterpenoid",
+    "category": "pentacyclic triterpenoid",
     "sources": [],
     "lastUpdated": "2026-03-21",
     "slug": "ursolic-acid",
     "canonicalCompoundId": "ursolic-acid",
     "id": "ursolic-acid",
     "compoundName": "Ursolic acid",
-    "compoundClass": "Triterpenoid",
+    "compoundClass": "pentacyclic triterpenoid",
     "mechanism": "Anti-inflammatory and cytoprotective signaling",
     "mechanismTags": [
       "reinforcement",
       "unclassified"
-    ]
+    ],
+    "description": "Pentacyclic triterpene common in culinary and medicinal herbs with broad pathway effects.",
+    "summary": "Pentacyclic triterpene common in culinary and medicinal herbs with broad pathway effects.",
+    "foundIn": [
+      "holy basil",
+      "rosemary",
+      "sage",
+      "ocimum sanctum"
+    ],
+    "targets": [
+      "NF-κB",
+      "STAT3",
+      "AMPK",
+      "PPAR",
+      "apoptosis signaling"
+    ],
+    "safetyNotes": "Mostly preclinical and food/herb associated. High-dose isolated use lacks robust human safety data; caution with pregnancy, liver disease, and anticancer/immunomodulating therapies.",
+    "linkedHerbs": []
   },
   {
     "name": "Valeranon",
     "herbs": [
       "valeriana jatamansi"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "valeranon"
+    "slug": "valeranon",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Valerenic acid",
@@ -11256,11 +11607,9 @@
       "sleep aid"
     ],
     "contraindications": [
-      "Avoid with alcohol",
-      "benzodiazepines",
-      "or barbiturates"
+      "Evidence mostly comes from valerian extracts. Sedation and additive effects with CNS depressants are key concerns."
     ],
-    "category": "valerenic acid",
+    "category": "sesquiterpenoid / valerian constituent",
     "sources": [
       {
         "title": "PubChem compound: Valerenic acid (CID 6440940)",
@@ -11285,10 +11634,22 @@
     "canonicalCompoundId": "valerenic-acid",
     "id": "valerenic-acid",
     "compoundName": "valerenic acid",
-    "compoundClass": "valerenic acid",
+    "compoundClass": "sesquiterpenoid / valerian constituent",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "summary": "Valerenic acid is a valerian sesquiterpenoid associated with GABAergic calming effects.",
+    "foundIn": [
+      "Valerian",
+      "Valeriana officinalis"
+    ],
+    "targets": [
+      "GABA-A signaling",
+      "adenosine signaling",
+      "CNS calming pathways"
+    ],
+    "safetyNotes": "Evidence mostly comes from valerian extracts. Sedation and additive effects with CNS depressants are key concerns.",
+    "linkedHerbs": []
   },
   {
     "name": "vanillic acid",
@@ -11311,7 +11672,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "vanillic-acid"
+    "slug": "vanillic-acid",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "vasicine",
@@ -11320,12 +11683,7 @@
       "justicia adhatoda",
       "justicia-adhatoda"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
-    ],
+    "effects": [],
     "contraindications": [
       "High doses may cause nausea or vomiting",
       "Not recommended during pregnancy or lactation without medical guidance",
@@ -11343,20 +11701,17 @@
       "bronchodilatory signaling",
       "respiratory pathway",
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "vasicinone",
     "herbs": [
       "adhatoda vasica",
-      "justicia adhatoda",
-      "nan"
+      "justicia adhatoda"
     ],
     "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
       "Increased energy",
       "focus",
       "thermogenesis",
@@ -11386,7 +11741,9 @@
     "compoundClass": "vasicinone",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "venoterpine",
@@ -11415,62 +11772,71 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "venoterpine"
+    "slug": "venoterpine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Verbascoside",
     "herbs": [
       "aloysia citrodora"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+    "effects": [],
+    "contraindications": [
+      "Mostly preclinical/extract-derived",
+      "safety depends on source herb and product quality."
     ],
-    "contraindications": [],
-    "category": "verbascoside",
+    "category": "phenylethanoid glycoside",
     "sources": [],
     "lastUpdated": "2026-03-21",
     "slug": "verbascoside",
     "canonicalCompoundId": "verbascoside",
     "id": "verbascoside",
     "compoundName": "verbascoside",
-    "compoundClass": "verbascoside",
+    "compoundClass": "phenylethanoid glycoside",
     "mechanism": "iridoid glycosides; flavonoids",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Also known as acteoside; linked to inflammatory signaling control.",
+    "summary": "Also known as acteoside; linked to inflammatory signaling control.",
+    "foundIn": [
+      "Lemon Verbena",
+      "Plantago lanceolata"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "antioxidant response",
+      "inflammatory cytokines",
+      "neuroprotective signaling"
+    ],
+    "safetyNotes": "Mostly preclinical/extract-derived; safety depends on source herb and product quality.",
+    "linkedHerbs": []
   },
   {
     "name": "Verbenalin",
     "herbs": [
       "verbena officinalis"
     ],
-    "effects": [
-      "No direct effects data. Contextual inference: Used in european folk medicine for anxiety and dreaming... No direct mechanismofaction data. Contextual inference: Used in european folk medicine for anxiety and dreaming... Used in European folk medicine for anxiety and dreaming.. Used in European folk medicine for anxiety and dreaming."
-    ],
+    "effects": [],
     "contraindications": [],
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "verbenalin"
+    "slug": "verbenalin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Vertine (cryogenine)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Auditory shifts",
       "relaxed dreamlike state",
       "Mild auditory and visual alterations",
       "relaxation",
-      "dream enhancement",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "dream enhancement"
     ],
     "contraindications": [
       "CNS depressants",
@@ -11480,7 +11846,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "vertine-cryogenine"
+    "slug": "vertine-cryogenine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Violine",
@@ -11488,9 +11856,7 @@
       "sweet violet"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used for sleep",
       "coughs",
-      "and gentle mood support... No direct mechanismofaction data. Contextual inference: Used for sleep",
       "and gentle mood support... Used for sleep",
       "and gentle mood support.. Used for sleep",
       "and gentle mood support."
@@ -11499,13 +11865,13 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "violine"
+    "slug": "violine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Voacamine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Tranquility",
       "mild distortion of time",
@@ -11516,8 +11882,6 @@
       "stimulation",
       "euphoria",
       "potential visionary states",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine"
@@ -11532,25 +11896,23 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "voacamine"
+    "slug": "voacamine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "voacangine",
     "herbs": [
-      "nan",
       "tabernaemontana undulata"
     ],
     "effects": [
       "Inner visions",
       "deep introspection",
       "energetic clarity",
-      "No direct effects data. Contextual inference: Used by indigenous healers to improve vision and intuition... No direct mechanismofaction data. Contextual inference: Used by indigenous healers to improve vision and intuition... Used by indigenous healers to improve vision and intuition.. Used by indigenous healers to improve vision and intuition.",
       "Altered perception",
       "stimulation",
       "euphoria",
       "potential visionary states",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine"
@@ -11572,20 +11934,18 @@
     "compoundClass": "voacangine",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "voacristine",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Altered perception",
       "stimulation",
       "euphoria",
       "potential visionary states",
-      "No direct effects data. Contextual inference: Used in ritual",
-      "dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual",
       "dreaming or folk medicine.. Used in ritual",
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine"
@@ -11598,13 +11958,14 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "voacristine"
+    "slug": "voacristine",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "volatile oils",
     "herbs": [
       "agrimonia eupatoria",
-      "nan",
       "rhododendron anthopogon",
       "Silver Linden",
       "tilia tomentosa"
@@ -11617,11 +11978,6 @@
       "inflammatory",
       "Mild stimulation",
       "warming sensation",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan.",
-      "No direct effects data. Contextual inference: Burned in tibetan buddhist rituals and used in himalayan medicine... No direct mechanismofaction data. Contextual inference: Burned in tibetan buddhist rituals and used in himalayan medicine... Burned in Tibetan Buddhist rituals and used in Himalayan medicine.. Burned in Tibetan Buddhist rituals and used in Himalayan medicine.",
       "Anxiolytic",
       "relaxing"
     ],
@@ -11641,7 +11997,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "volatile-oils"
+    "slug": "volatile-oils",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "wogonin",
@@ -11653,38 +12011,49 @@
       "Mild sedation",
       "calm mood",
       "anxiety relief",
-      "No direct effects data. Contextual inference: Used by native american tribes for anxiety and insomnia... No direct mechanismofaction data. Contextual inference: Used by native american tribes for anxiety and insomnia... Used by Native American tribes for anxiety and insomnia.. Used by Native American tribes for anxiety and insomnia.",
       "Nervine",
       "anxiolytic",
       "anti-inflammatory",
       "used for insomnia and anxiety"
     ],
     "contraindications": [
-      "Avoid during pregnancy",
-      "caution with sedatives",
-      "pregnancy",
-      "sedative sensitivity."
+      "Mostly preclinical and extract-derived. Isolated-dose human safety is not well established",
+      "caution with liver disease, anticoagulants/antiplatelets, sedatives, and pregnancy."
     ],
-    "category": "wogonin",
+    "category": "flavone aglycone",
     "sources": [],
     "lastUpdated": "2026-03-21",
     "slug": "wogonin",
     "canonicalCompoundId": "wogonin",
     "id": "wogonin",
     "compoundName": "wogonin",
-    "compoundClass": "wogonin",
+    "compoundClass": "flavone aglycone",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Scutellaria flavone associated with NF-κB inhibition and PI3K/Akt pathway effects.",
+    "summary": "Scutellaria flavone associated with NF-κB inhibition and PI3K/Akt pathway effects.",
+    "foundIn": [
+      "chinese skullcap",
+      "skullcap",
+      "scutellaria baicalensis"
+    ],
+    "targets": [
+      "NF-κB",
+      "MAPK",
+      "PI3K/Akt",
+      "apoptosis signaling",
+      "inflammatory cytokines"
+    ],
+    "safetyNotes": "Mostly preclinical and extract-derived. Isolated-dose human safety is not well established; caution with liver disease, anticoagulants/antiplatelets, sedatives, and pregnancy.",
+    "linkedHerbs": []
   },
   {
     "name": "xanthones",
     "herbs": [
-      "alchornea castaneifolia",
-      "nan"
+      "alchornea castaneifolia"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... No direct mechanismofaction data. Contextual inference: Used in traditional amazonian medicine for arthritis and pain... Used in traditional Amazonian medicine for arthritis and pain.. Used in traditional Amazonian medicine for arthritis and pain.",
       "Pain relief",
       "worm expulsion"
     ],
@@ -11698,7 +12067,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "xanthones"
+    "slug": "xanthones",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "yangonin)",
@@ -11708,15 +12079,11 @@
     "effects": [
       "Euphoria",
       "calmness",
-      "muscle relaxation",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "muscle relaxation"
     ],
     "contraindications": [
-      "Liver conditions",
-      "concurrent alcohol use"
+      "Kava/kavalactones are linked with sedation and liver injury concerns",
+      "avoid alcohol, sedatives, liver disease, and pregnancy."
     ],
     "category": "yangonin",
     "sources": [],
@@ -11725,10 +12092,23 @@
     "canonicalCompoundId": "yangonin",
     "id": "yangonin",
     "compoundName": "yangonin",
-    "compoundClass": "yangonin",
+    "compoundClass": "kavalactone",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "description": "Yangonin is a kavalactone with cannabinoid-related and monoamine-associated signaling.",
+    "summary": "Yangonin is a kavalactone with cannabinoid-related and monoamine-associated signaling.",
+    "foundIn": [
+      "Piper methysticum"
+    ],
+    "targets": [
+      "GABAergic signaling",
+      "voltage-gated ion channels",
+      "monoamine signaling",
+      "CYP enzymes"
+    ],
+    "safetyNotes": "Kava/kavalactones are linked with sedation and liver injury concerns; avoid alcohol, sedatives, liver disease, and pregnancy.",
+    "linkedHerbs": []
   },
   {
     "name": "Yohimbine",
@@ -11761,7 +12141,9 @@
       "adrenergic signaling",
       "alpha-2 adrenergic antagonism",
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Zapotin",
@@ -11769,9 +12151,7 @@
       "casimiroa edulis"
     ],
     "effects": [
-      "No direct effects data. Contextual inference: Used to treat anxiety",
       "insomnia",
-      "and as a mild euphoric... No direct mechanismofaction data. Contextual inference: Used to treat anxiety",
       "and as a mild euphoric... Used to treat anxiety",
       "and as a mild euphoric.. Used to treat anxiety",
       "and as a mild euphoric."
@@ -11780,7 +12160,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "zapotin"
+    "slug": "zapotin",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "α-calacorene",
@@ -11810,7 +12192,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "calacorene"
+    "slug": "calacorene",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "β-pinene",
@@ -11840,7 +12224,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "pinene"
+    "slug": "pinene",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "γ-terpinene",
@@ -11870,7 +12256,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "terpinene"
+    "slug": "terpinene",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "α-terpineol",
@@ -11900,13 +12288,13 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "terpineol"
+    "slug": "terpineol",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "β-carbolines",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Intense stimulation",
       "nausea",
@@ -11915,11 +12303,7 @@
       "relaxation",
       "Psychedelic visuals",
       "introspection",
-      "altered consciousness",
-      "No direct effects data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan."
+      "altered consciousness"
     ],
     "contraindications": [
       "Cardiovascular disease",
@@ -11933,7 +12317,9 @@
     "category": null,
     "sources": [],
     "lastUpdated": "2026-03-21",
-    "slug": "carbolines"
+    "slug": "carbolines",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "β-caryophyllene",
@@ -11963,7 +12349,9 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "caryophyllene"
+    "slug": "caryophyllene",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "β-sitosteryl acetate",
@@ -11989,13 +12377,13 @@
       }
     ],
     "lastUpdated": "2026-03-21",
-    "slug": "sitosteryl-acetate"
+    "slug": "sitosteryl-acetate",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Magnesium",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Supports muscle and nerve function",
       "Supports energy metabolism"
@@ -12026,13 +12414,13 @@
     "safetyNotes": [
       "Excess supplemental magnesium can cause diarrhea; renal impairment increases risk of accumulation and should prompt medical supervision."
     ],
-    "evidenceLevel": "moderate"
+    "evidenceLevel": "moderate",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Pyridoxine (Vitamin B6)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Supports amino-acid metabolism",
       "Supports neurotransmitter synthesis",
@@ -12052,13 +12440,13 @@
     "lastUpdated": "2026-04-04",
     "slug": "pyridoxine-vitamin-b6",
     "id": "pyridoxine",
-    "displayName": "Pyridoxine (Vitamin B6)"
+    "displayName": "Pyridoxine (Vitamin B6)",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Riboflavin (Vitamin B2)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Supports energy metabolism via FMN/FAD cofactors",
       "Supports antioxidant enzyme function",
@@ -12088,13 +12476,13 @@
     "safetyNotes": [
       "Generally safe at nutritional doses; high supplemental doses can cause bright-yellow urine and occasional mild GI discomfort."
     ],
-    "evidenceLevel": "moderate"
+    "evidenceLevel": "moderate",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Selenium",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Supports antioxidant selenoprotein activity",
       "Supports thyroid hormone metabolism"
@@ -12120,13 +12508,13 @@
     "mechanism": "essential trace mineral",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Vitamin D (Calciferols)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Supports calcium and phosphorus homeostasis",
       "Supports bone mineralization",
@@ -12155,13 +12543,13 @@
     "compoundClass": "vitamin d",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "L-Tryptophan",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Supports serotonin and melatonin precursor pathways",
       "Supports essential amino-acid adequacy"
@@ -12187,13 +12575,13 @@
     "mechanism": "essential amino acid",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Melatonin",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Supports circadian sleep timing",
       "May reduce jet-lag symptoms"
@@ -12228,13 +12616,13 @@
     "safetyNotes": [
       "May cause next-day drowsiness in some users; review interactions with sedatives and anticoagulants before routine use."
     ],
-    "evidenceLevel": "moderate"
+    "evidenceLevel": "moderate",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Niacin (Vitamin B3)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Supports NAD/NADP-dependent energy metabolism",
       "Prevents niacin deficiency states (pellagra)",
@@ -12264,13 +12652,13 @@
     "safetyNotes": [
       "Pharmacologic doses can cause flushing and hepatotoxicity risk; use high-dose protocols only with clinician monitoring."
     ],
-    "evidenceLevel": "moderate"
+    "evidenceLevel": "moderate",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Omega-3 Fatty Acids (EPA/DHA)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "Supports triglyceride reduction at higher doses",
       "Supports membrane and neural lipid biology",
@@ -12306,13 +12694,13 @@
     "safetyNotes": [
       "May increase bleeding tendency at higher doses or with anticoagulants; product quality and oxidation control are important."
     ],
-    "evidenceLevel": "moderate"
+    "evidenceLevel": "moderate",
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Probiotics",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "May reduce antibiotic-associated diarrhea in some strains",
       "May modestly improve some IBS symptoms (strain dependent)"
@@ -12342,13 +12730,13 @@
     "mechanism": "live biotherapeutic / microbiome-active category",
     "mechanismTags": [
       "unclassified"
-    ]
+    ],
+    "foundIn": [],
+    "linkedHerbs": []
   },
   {
     "name": "Resveratrol",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "ampk activation",
       "oxidative stress reduction",
@@ -12356,10 +12744,10 @@
       "unclassified"
     ],
     "contraindications": [
-      "High doses may cause GI effects",
-      "Use caution with anticoagulants and CYP-sensitive medicines"
+      "Usually well tolerated short-term",
+      "caution with anticoagulants/antiplatelets, hormone-sensitive conditions, pregnancy, and high-dose extracts."
     ],
-    "category": "compound",
+    "category": "stilbene polyphenol",
     "sources": [
       {
         "title": "PubMed review literature on resveratrol",
@@ -12372,19 +12760,33 @@
     "displayName": "Resveratrol",
     "canonicalCompoundId": "resveratrol",
     "compoundName": "Resveratrol",
-    "compoundClass": "resveratrol",
+    "compoundClass": "stilbene polyphenol",
     "mechanismTags": [
       "ampk activation",
       "oxidative stress reduction",
       "sirt1-associated signaling",
       "unclassified"
-    ]
+    ],
+    "description": "Stilbene best known from knotweed and grape sources, strongly linked to SIRT1, AMPK, and NF-κB pathways.",
+    "summary": "Stilbene best known from knotweed and grape sources, strongly linked to SIRT1, AMPK, and NF-κB pathways.",
+    "foundIn": [
+      "grape skin",
+      "Japanese knotweed",
+      "berries"
+    ],
+    "targets": [
+      "SIRT1",
+      "AMPK",
+      "Nrf2",
+      "NF-κB",
+      "endothelial nitric oxide signaling"
+    ],
+    "safetyNotes": "Usually well tolerated short-term; caution with anticoagulants/antiplatelets, hormone-sensitive conditions, pregnancy, and high-dose extracts.",
+    "linkedHerbs": []
   },
   {
     "name": "S-Adenosyl-L-Methionine (SAMe)",
-    "herbs": [
-      "nan"
-    ],
+    "herbs": [],
     "effects": [
       "May support depressive symptom improvement in some studies",
       "May reduce osteoarthritis pain in selected trials",
@@ -12408,6 +12810,8 @@
     "lastUpdated": "2026-04-04",
     "slug": "s-adenosyl-l-methionine-same",
     "id": "s-adenosyl-l-methionine",
-    "displayName": "S-Adenosyl-L-Methionine (SAMe)"
+    "displayName": "S-Adenosyl-L-Methionine (SAMe)",
+    "foundIn": [],
+    "linkedHerbs": []
   }
 ]

--- a/public/data/herbs.json
+++ b/public/data/herbs.json
@@ -1436,7 +1436,10 @@
       "skin soother"
     ],
     "contraindications": [
-      "Use caution with diarrhea-prone or pregnancy-sensitive contexts when latex fractions are relevant"
+      "Pregnancy",
+      "inflammatory bowel disease",
+      "kidney disease",
+      "oral latex use in children"
     ],
     "safetyNotes": [
       "safe",
@@ -1469,7 +1472,7 @@
     "dosage": "0.5, 1 g, day gel or juice",
     "duration": "Varies with form",
     "interactions": [
-      "May amplify laxative-heavy or glucose-lowering contexts"
+      "Oral latex may interact with diuretics, digoxin, corticosteroids, laxatives, and antidiabetics."
     ],
     "legalStatus": "Approved for external use; oral use regulated",
     "preparation": "Fresh gel applied topically or taken internally (juice form); latex processed separately for laxative use",
@@ -1815,7 +1818,8 @@
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [
-      "Interaction review required before publication."
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -1885,7 +1889,8 @@
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [
-      "Interaction review required before publication."
+      "Potential interaction concern with sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -2251,7 +2256,10 @@
       "nan."
     ],
     "duration": "4–6 hours",
-    "interactions": [],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
     "legalStatus": "Legal globally",
     "preparation": "No direct preparation data. Contextual inference: Antipyretic, anti-inflammatory, and antidiabetic; used in tcm. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Antipyretic, anti-inflammatory, and antidiabetic; used in TCM. No direct region data. Contextual inference: Antipyretic, anti-inflammatory, and antidiabetic; used in tcm. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Antipyretic, anti-inflammatory, and antidiabetic; used in TCM. none. ; nan; nan. ; nan; nan",
     "region": "No direct region data. Contextual inference: Antipyretic, anti-inflammatory, and antidiabetic; used in tcm. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Antipyretic, anti-inflammatory, and antidiabetic; used in TCM. none. ; nan; nan",
@@ -2327,7 +2335,11 @@
       "digestive aid",
       "mild sedative"
     ],
-    "contraindications": [],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "bleeding disorder or upcoming surgery"
+    ],
     "safetyNotes": [
       "caution",
       "Photosensitivity",
@@ -2362,10 +2374,11 @@
     ],
     "duration": "2–4 hours",
     "interactions": [
-      "Use caution with photosensitivity-related contexts."
+      "Potential interaction concern with anticoagulants/antiplatelets, immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "legalStatus": "Legal; common in traditional European herbalism",
-    "preparation": "Roots and seeds decocted, used in tinctures, or added to liquors and tonics",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
     "region": "No direct region data. Contextual inference: Carminative, digestive aid, mild sedative. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Carminative, digestive aid, mild sedative. none. ; nan; nan",
     "therapeuticUses": [],
     "traditionalUse": "; nan; nan",
@@ -2401,7 +2414,7 @@
       "menstrual regulator"
     ],
     "contraindications": [
-      "Avoid pregnancy-sensitive contexts unless professionally guided."
+      "Pregnancy, bleeding disorders, hormone-sensitive conditions, surgery, and anticoagulant/antiplatelet therapy without supervision."
     ],
     "safetyNotes": [
       "safe",
@@ -2438,10 +2451,10 @@
     ],
     "duration": "6–8 hours",
     "interactions": [
-      "Use caution with anticoagulant-sensitive contexts."
+      "Potential additive bleeding risk with anticoagulants, antiplatelets, NSAIDs, and some herbal blood-thinning stacks."
     ],
     "legalStatus": "Legal; widely used in TCM",
-    "preparation": "Roots sliced, dried, decocted or tinctured; often used in TCM formulas",
+    "preparation": "Evidence often comes from traditional formulas; single-herb confidence should remain conservative.",
     "region": "No direct region data. Contextual inference: Blood tonic, hormone modulator, menstrual regulator. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Blood tonic, hormone modulator, menstrual regulator. none. ; nan; nan",
     "therapeuticUses": [],
     "traditionalUse": "; nan; nan",
@@ -3549,7 +3562,8 @@
     ],
     "duration": "No direct duration data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... No direct mechanismofaction data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... Used in absinthe and traditional medicine for digestion and stimulation.. No direct effects data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... No direct mechanismofaction data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... Used in absinthe and traditional medicine for digestion and stimulation.. Used in absinthe and traditional medicine for digestion and stimulation.. No direct region data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... No direct mechanismofaction data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... Used in absinthe and traditional medicine for digestion and stimulation.. No direct effects data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... No direct mechanismofaction data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... Used in absinthe and traditional medicine for digestion and stimulation.. Used in absinthe and traditional medicine for digestion and stimulation.. Used in absinthe and traditional medicine for digestion and stimulation.. Used in absinthe and traditional medicine for digestion and stimulation.",
     "interactions": [
-      "Interaction review required before publication."
+      "Potential interaction concern with sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... No direct mechanismofaction data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... Used in absinthe and traditional medicine for digestion and stimulation.. No direct effects data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... No direct mechanismofaction data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... Used in absinthe and traditional medicine for digestion and stimulation.. Used in absinthe and traditional medicine for digestion and stimulation.. No direct region data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... No direct mechanismofaction data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... Used in absinthe and traditional medicine for digestion and stimulation.. No direct effects data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... No direct mechanismofaction data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... Used in absinthe and traditional medicine for digestion and stimulation.. Used in absinthe and traditional medicine for digestion and stimulation.. Used in absinthe and traditional medicine for digestion and stimulation.. Used in absinthe and traditional medicine for digestion and stimulation.",
@@ -3589,7 +3603,7 @@
       "immune modulating"
     ],
     "contraindications": [
-      "Avoid pregnancy-sensitive contexts without stronger review"
+      "Pregnancy/breastfeeding unless medically indicated, serious infection without medical care, liver disease, and unsupervised antimalarial use."
     ],
     "safetyNotes": [
       "safe",
@@ -3625,10 +3639,10 @@
     ],
     "duration": "4–8 hours",
     "interactions": [
-      "May interact with liver-metabolized stacks and intensive antimicrobial protocols"
+      "Potential CYP/P-gp interactions and additive effects with antimalarials, hepatotoxic drugs, and seizure-threshold-lowering agents."
     ],
     "legalStatus": "Legal in many regions; artemisinin regulated",
-    "preparation": "Leaves and aerial parts used in decoctions or standardized extracts (e.g., artemisinin)",
+    "preparation": "Separate whole-herb Artemisia preparations from purified artemisinin derivatives; evidence and safety are not interchangeable.",
     "region": "No direct region data. Contextual inference: Antimalarial, antiviral, immune modulating. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Antimalarial, antiviral, immune modulating. none. ; nan; nan",
     "therapeuticUses": [],
     "traditionalUse": "; nan; nan",
@@ -4194,17 +4208,12 @@
       "nan."
     ],
     "contraindications": [
-      "avoid during pregnancy and breastfeeding",
-      "Use caution with prescription medications and chronic conditions; monitor for intolerance."
+      "Pregnancy",
+      "breastfeeding without clinician supervision",
+      "active liver disease or prior ashwagandha-related liver injury",
+      "clinician review for autoimmune disease or thyroid disorders."
     ],
-    "safetyNotes": [
-      "safe",
-      "No direct toxicity data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan. No direct effects data. Contextual inference:",
-      "nan."
-    ],
+    "safetyNotes": "Avoid in pregnancy/breastfeeding unless clinician-supervised. Caution with thyroid disease or thyroid-hormone therapy, autoimmune disease/immunosuppressants, sedatives/CNS depressants, antihypertensives, and antidiabetics. Rare idiosyncratic liver injury is reported; avoid with active liver disease and stop if jaundice, dark urine, pruritus, or right-upper-quadrant pain occur.",
     "sources": [
       {
         "title": "Recovered from prior batch output in this conversation"
@@ -4229,7 +4238,9 @@
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [
-      "May potentiate sedatives, antihypertensives, antidiabetics, thyroid hormones, and immunosuppressants."
+      "May potentiate sedatives/CNS depressants, antihypertensives, antidiabetics, and thyroid hormone therapy",
+      "theoretical interaction with immunosuppressants",
+      "avoid stacking with hepatotoxic supplements/drugs."
     ],
     "legalStatus": null,
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -4459,7 +4470,11 @@
       "adaptogen",
       "antiviral"
     ],
-    "contraindications": [],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "hormone-sensitive conditions without clinician review"
+    ],
     "safetyNotes": [
       "safe",
       "Safe for most people",
@@ -4496,10 +4511,11 @@
     ],
     "duration": "6–8 hours",
     "interactions": [
-      "Use caution in autoimmune contexts."
+      "Potential interaction concern with antidiabetic medicines, antihypertensives/diuretics, hormonal therapies, immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "legalStatus": "Legal and common in herbal commerce",
-    "preparation": "Roots sliced and decocted or simmered in soups; also extracted in capsules and tinctures",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
     "region": "No direct region data. Contextual inference: Immunostimulant, adaptogen, antiviral. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Immunostimulant, adaptogen, antiviral. none. ; nan; nan",
     "therapeuticUses": [],
     "traditionalUse": "; nan; nan",
@@ -4567,7 +4583,8 @@
     ],
     "duration": "4–6 hours",
     "interactions": [
-      "Avoid overextended metabolic claims."
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "legalStatus": "Legal globally",
     "preparation": "No direct preparation data. Contextual inference: Tonic for spleen and digestion in tcm. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Tonic for spleen and digestion in TCM. No direct region data. Contextual inference: Tonic for spleen and digestion in tcm. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Tonic for spleen and digestion in TCM. none. ; nan; nan. ; nan; nan",
@@ -4899,7 +4916,7 @@
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [
-      "Use caution with GI sensitivity."
+      "May interact with sedatives, thyroid medications, anticholinergics/cholinergics, and antiepileptics."
     ],
     "legalStatus": null,
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -4961,7 +4978,10 @@
       "nan. No direct region data. Contextual inference:"
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "interactions": [],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "region": "No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -5201,7 +5221,10 @@
       "bitter tonic",
       "liver support"
     ],
-    "contraindications": [],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
     "safetyNotes": [
       "safe",
       "GI irritation",
@@ -5237,10 +5260,11 @@
     ],
     "duration": "4–6 hours",
     "interactions": [
-      "May interact with cytochrome-metabolized drugs, glucose-lowering agents, and anticoagulants."
+      "Potential interaction concern with antidiabetic medicines, CYP/P-gp substrate medicines, immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "legalStatus": "Legal in herbal products",
-    "preparation": "Root bark decocted or tinctured; berries sometimes eaten or juiced",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
     "region": "No direct region data. Contextual inference: Antimicrobial, bitter tonic, liver support. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Antimicrobial, bitter tonic, liver support. none. ; nan; nan",
     "therapeuticUses": [],
     "traditionalUse": "; nan; nan",
@@ -5453,7 +5477,7 @@
     ],
     "duration": "No direct duration data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... No direct mechanismofaction data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... Used ceremonially in Ancient Egypt for euphoria and vision enhancement.. No direct effects data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... No direct mechanismofaction data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... Used ceremonially in Ancient Egypt for euphoria and vision enhancement.. Used ceremonially in Ancient Egypt for euphoria and vision enhancement.. No direct region data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... No direct mechanismofaction data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... Used ceremonially in Ancient Egypt for euphoria and vision enhancement.. No direct effects data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... No direct mechanismofaction data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... Used ceremonially in Ancient Egypt for euphoria and vision enhancement.. Used ceremonially in Ancient Egypt for euphoria and vision enhancement.. Used ceremonially in Ancient Egypt for euphoria and vision enhancement.. Used ceremonially in Ancient Egypt for euphoria and vision enhancement.",
     "interactions": [
-      "May compound sedative effects in calming/sleep stacks."
+      "Possible additive sedation with alcohol, benzodiazepines, sleep aids, opioids, antihistamines, and other calming botanicals."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... No direct mechanismofaction data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... Used ceremonially in Ancient Egypt for euphoria and vision enhancement.. No direct effects data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... No direct mechanismofaction data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... Used ceremonially in Ancient Egypt for euphoria and vision enhancement.. Used ceremonially in Ancient Egypt for euphoria and vision enhancement.. No direct region data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... No direct mechanismofaction data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... Used ceremonially in Ancient Egypt for euphoria and vision enhancement.. No direct effects data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... No direct mechanismofaction data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... Used ceremonially in Ancient Egypt for euphoria and vision enhancement.. Used ceremonially in Ancient Egypt for euphoria and vision enhancement.. Used ceremonially in Ancient Egypt for euphoria and vision enhancement.. Used ceremonially in Ancient Egypt for euphoria and vision enhancement.",
@@ -5824,7 +5848,8 @@
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [
-      "Avoid with bile obstruction or excessive casual use."
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
     "legalStatus": null,
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -6117,7 +6142,10 @@
       "Anti",
       "inflammatory"
     ],
-    "contraindications": [],
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "anticoagulant use without review"
+    ],
     "safetyNotes": [
       "safe",
       "Mild GI symptoms like nausea or diarrhea",
@@ -6151,7 +6179,7 @@
     ],
     "duration": "6–8 hours",
     "interactions": [
-      "Use caution with GI sensitivity."
+      "Potential additive effects with anti-inflammatory drugs, anticoagulants, and immunomodulators."
     ],
     "legalStatus": "Widely legal; used in supplements and Ayurvedic medicine",
     "preparation": "Resin (frankincense) collected and used in capsules, extracts, or chewed directly",
@@ -6397,7 +6425,11 @@
       "anti",
       "inflammatory"
     ],
-    "contraindications": [],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "active liver disease"
+    ],
     "safetyNotes": [
       "Occasional nausea",
       "dizziness",
@@ -6439,10 +6471,11 @@
     ],
     "duration": "4–6 hours",
     "interactions": [
-      "Avoid overgeneralized mood claims."
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "legalStatus": "Legal in TCM and supplements",
-    "preparation": "Roots decocted or extracted in Traditional Chinese Medicine",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
     "region": "No direct region data. Contextual inference: Liver tonic, anti-inflammatory, immunomodulatory. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Liver tonic, anti-inflammatory, immunomodulatory. none. ; nan; nan",
     "therapeuticUses": [],
     "traditionalUse": "; nan; nan",
@@ -6739,7 +6772,9 @@
       "nan. No direct region data. Contextual inference:"
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "interactions": [],
+    "interactions": [
+      "Potential additive CNS effects with sedatives, alcohol, antiepileptics, and other neuroactive agents."
+    ],
     "legalStatus": null,
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "region": "No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -8019,7 +8054,8 @@
     ],
     "duration": "6–8 hours",
     "interactions": [
-      "Interaction review required before publication."
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
     "legalStatus": "Legal globally",
     "preparation": "No direct preparation data. Contextual inference: Antifungal and laxative properties; used for skin infections. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Antifungal and laxative properties; used for skin infections. No direct region data. Contextual inference: Antifungal and laxative properties; used for skin infections. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Antifungal and laxative properties; used for skin infections. none. ; nan; nan. ; nan; nan",
@@ -8510,7 +8546,8 @@
     ],
     "duration": "No direct duration data. Contextual inference: Used in ayurveda for cognition, focus, and learning... No direct mechanismofaction data. Contextual inference: Used in ayurveda for cognition, focus, and learning... Used in Ayurveda for cognition, focus, and learning.. No direct effects data. Contextual inference: Used in ayurveda for cognition, focus, and learning... No direct mechanismofaction data. Contextual inference: Used in ayurveda for cognition, focus, and learning... Used in Ayurveda for cognition, focus, and learning.. Used in Ayurveda for cognition, focus, and learning.. No direct region data. Contextual inference: Used in ayurveda for cognition, focus, and learning... No direct mechanismofaction data. Contextual inference: Used in ayurveda for cognition, focus, and learning... Used in Ayurveda for cognition, focus, and learning.. No direct effects data. Contextual inference: Used in ayurveda for cognition, focus, and learning... No direct mechanismofaction data. Contextual inference: Used in ayurveda for cognition, focus, and learning... Used in Ayurveda for cognition, focus, and learning.. Used in Ayurveda for cognition, focus, and learning.. Used in Ayurveda for cognition, focus, and learning.. Used in Ayurveda for cognition, focus, and learning.",
     "interactions": [
-      "Interaction review required before publication."
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: Used in ayurveda for cognition, focus, and learning... No direct mechanismofaction data. Contextual inference: Used in ayurveda for cognition, focus, and learning... Used in Ayurveda for cognition, focus, and learning.. No direct effects data. Contextual inference: Used in ayurveda for cognition, focus, and learning... No direct mechanismofaction data. Contextual inference: Used in ayurveda for cognition, focus, and learning... Used in Ayurveda for cognition, focus, and learning.. Used in Ayurveda for cognition, focus, and learning.. No direct region data. Contextual inference: Used in ayurveda for cognition, focus, and learning... No direct mechanismofaction data. Contextual inference: Used in ayurveda for cognition, focus, and learning... Used in Ayurveda for cognition, focus, and learning.. No direct effects data. Contextual inference: Used in ayurveda for cognition, focus, and learning... No direct mechanismofaction data. Contextual inference: Used in ayurveda for cognition, focus, and learning... Used in Ayurveda for cognition, focus, and learning.. Used in Ayurveda for cognition, focus, and learning.. Used in Ayurveda for cognition, focus, and learning.. Used in Ayurveda for cognition, focus, and learning.",
@@ -8656,8 +8693,9 @@
       "triterpenes improve circulation"
     ],
     "contraindications": [
-      "liver conditions",
-      "pregnancy."
+      "Liver disease",
+      "pregnancy/breastfeeding without guidance",
+      "upcoming surgery"
     ],
     "safetyNotes": [
       "safe",
@@ -8685,8 +8723,8 @@
     ],
     "duration": "No direct duration data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. No direct region data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. Folk medicine. Folk medicine",
     "interactions": [
-      "sedatives",
-      "hepatotoxic drugs."
+      "May potentiate sedatives and hepatotoxic drugs/supplements",
+      "caution with antidiabetics."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. No direct region data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. Folk medicine. Folk medicine",
@@ -9020,7 +9058,7 @@
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [
-      "Use caution with ragweed-family allergy contexts."
+      "May potentiate sedatives/CNS depressants and anticoagulants/antiplatelets in susceptible users."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -9269,14 +9307,7 @@
       "discontinue if hypersensitivity or allergic symptoms occur",
       "avoid during pregnancy and breastfeeding unless advised by a clinician"
     ],
-    "safetyNotes": [
-      "safe",
-      "No direct toxicity data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan. No direct effects data. Contextual inference:",
-      "nan."
-    ],
+    "safetyNotes": "Inulin/chicory can cause gas, bloating, diarrhea, or IBS/FODMAP intolerance; allergy risk exists in Asteraceae-sensitive users; caution with pregnancy/breastfeeding, gallbladder disease, and diabetes medications when using concentrated products.",
     "sources": [],
     "lastUpdated": "2026-03-21",
     "description": "Cichorium intybus lean monograph row enriched in bulk mode.",
@@ -9289,7 +9320,10 @@
       "nan. No direct region data. Contextual inference:"
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "interactions": [],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines, immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "region": "No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -9913,7 +9947,11 @@
       "antipruritic",
       "antifungal"
     ],
-    "contraindications": [],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "bleeding disorder or upcoming surgery"
+    ],
     "safetyNotes": [
       "caution",
       "Possible skin irritation",
@@ -9943,9 +9981,12 @@
       "day seed extract"
     ],
     "duration": "4–6 hours",
-    "interactions": [],
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics, anticoagulants/antiplatelets",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
     "legalStatus": "Legal in traditional medicine; not widely regulated",
-    "preparation": "Seeds (She Chuang Zi) decocted or powdered; used in Traditional Chinese Medicine, topically or internally",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
     "region": "No direct region data. Contextual inference: Aphrodisiac, antipruritic, antifungal. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Aphrodisiac, antipruritic, antifungal. none. ; nan; nan",
     "therapeuticUses": [],
     "traditionalUse": "; nan; nan",
@@ -10298,7 +10339,7 @@
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [
-      "Interaction review required before publication."
+      "May interact with stimulants, sedatives, beta-agonists, lithium, and CYP1A2 substrates."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -11022,7 +11063,8 @@
     ],
     "duration": "6–8 hours",
     "interactions": [
-      "Interaction review required before publication."
+      "Potential interaction concern with antidiabetic medicines, CYP/P-gp substrate medicines, immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "legalStatus": "Legal globally",
     "preparation": "No direct preparation data. Contextual inference: Rich in berberine; antimicrobial, anti-diabetic, and digestive tonic. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Rich in berberine; antimicrobial, anti-diabetic, and digestive tonic. No direct region data. Contextual inference: Rich in berberine; antimicrobial, anti-diabetic, and digestive tonic. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Rich in berberine; antimicrobial, anti-diabetic, and digestive tonic. none. ; nan; nan. ; nan; nan",
@@ -11246,7 +11288,11 @@
       "kidney and liver tonic",
       "antioxidant"
     ],
-    "contraindications": [],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "significant kidney disease or unstable electrolytes"
+    ],
     "safetyNotes": [
       "Generally safe",
       "may cause mild GI upset or dizziness in sensitive individuals",
@@ -11282,7 +11328,10 @@
       "nan."
     ],
     "duration": "4–6 hours",
-    "interactions": [],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
     "legalStatus": "Legal; used in TCM",
     "preparation": "Fruit decocted or dried and consumed in Traditional Chinese Medicine (Shan Zhu Yu); often paired with tonic herbs",
     "region": "No direct region data. Contextual inference: Astringent, kidney and liver tonic, antioxidant. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Astringent, kidney and liver tonic, antioxidant. none. ; nan; nan",
@@ -11645,7 +11694,8 @@
     ],
     "duration": "No direct duration data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. No direct region data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine",
     "interactions": [
-      "Interaction review required before publication."
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. No direct region data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine",
@@ -11738,7 +11788,10 @@
       "Anti",
       "inflammatory"
     ],
-    "contraindications": [],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
     "safetyNotes": [
       "safe",
       "High doses may cause GI upset",
@@ -11770,9 +11823,12 @@
       "day standardized extract"
     ],
     "duration": "6–8 hours",
-    "interactions": [],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
     "legalStatus": "Legal globally",
-    "preparation": "Rhizome dried and powdered (turmeric); also decocted or extracted in oil or alcohol-based preparations",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
     "region": "No direct region data. Contextual inference: Anti-inflammatory, antioxidant, liver protective. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Anti-inflammatory, antioxidant, liver protective. none. ; nan; nan",
     "therapeuticUses": [],
     "traditionalUse": "; nan; nan",
@@ -11802,7 +11858,10 @@
       "antimicrobial",
       "digestive aid"
     ],
-    "contraindications": [],
+    "contraindications": [
+      "Pregnancy/breastfeeding supplement dosing without guidance",
+      "internal essential-oil use"
+    ],
     "safetyNotes": [
       "safe",
       "Generally well tolerated",
@@ -11843,7 +11902,8 @@
     ],
     "duration": "2–4 hours",
     "interactions": [
-      "Use caution with concentrated oil assumptions."
+      "Low documented interaction burden",
+      "caution with sedatives or antihypertensives at high doses."
     ],
     "legalStatus": "Legal worldwide",
     "preparation": "Leaves used fresh or dried in teas and infusions; also distilled for lemongrass oil",
@@ -12235,7 +12295,9 @@
       "nan."
     ],
     "contraindications": [
-      "Use caution in pregnancy-sensitive contexts."
+      "Pregnancy/breastfeeding",
+      "seizure disorder without clinician review",
+      "planned surgery or complex psychiatric medication regimens."
     ],
     "safetyNotes": [
       "safe",
@@ -12262,7 +12324,8 @@
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [
-      "Use caution in complex mood stacks."
+      "Potential additive CNS effects with sedatives, alcohol, anxiolytics, and serotonergic or stimulant stacks",
+      "diabetes medication caution is theoretical."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -15944,8 +16007,9 @@
       "No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine"
     ],
     "contraindications": [
-      "Avoid during pregnancy and breastfeeding unless supervised by a qualified clinician.",
-      "Do not use with known allergy to this plant or related species."
+      "Bleeding disorder or perioperative use without clinician review",
+      "gallstone/biliary disease without clinician review",
+      "high-dose use in pregnancy without clinician guidance."
     ],
     "safetyNotes": "Ginger is widely consumed as a food and supplement and is generally regarded as safe. Research suggests it may help with mild nausea and menstrual cramps. Reported side effects at high doses include abdominal discomfort, heartburn, diarrhoea and irritation of the mouth or throat. Clinical studies using up to 1 000 mg/day of dried powdered extract report adverse event rates similar to placebo. The safety of high‑dose ginger during pregnancy has not been conclusively established.",
     "sources": [
@@ -16011,16 +16075,12 @@
       "nan."
     ],
     "contraindications": [
-      "Pregnancy, breastfeeding, bleeding disorders, epilepsy, planned surgery."
+      "Active bleeding disorder",
+      "perioperative period without clinician review",
+      "seizure disorder unless supervised",
+      "avoid fresh seeds entirely."
     ],
-    "safetyNotes": [
-      "safe",
-      "No direct toxicity data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan. No direct effects data. Contextual inference:",
-      "nan."
-    ],
+    "safetyNotes": "Bleeding risk is the primary public-facing concern; avoid with anticoagulants/antiplatelets or before surgery unless clinician-supervised. Seizure-threshold concerns exist from ginkgotoxin, especially with seeds or high-risk patients. Avoid fresh seeds. Caution with antiepileptics, pregnancy, and complex medication regimens.",
     "sources": [
       {
         "title": "Recovered from prior batch output in this conversation"
@@ -16045,7 +16105,8 @@
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [
-      "May potentiate NSAIDs, anticoagulants, antiplatelets, and interact with antidepressants and antidiabetic drugs."
+      "Anticoagulants, antiplatelets, NSAIDs, antiepileptics, and other narrow-therapeutic-index drugs",
+      "possible extract-specific CYP effects."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -16185,7 +16246,14 @@
       "Anti",
       "inflammatory"
     ],
-    "contraindications": [],
+    "contraindications": [
+      "Hypertension",
+      "kidney disease",
+      "hypokalemia",
+      "heart disease",
+      "pregnancy",
+      "use with diuretics/corticosteroids/digoxin without review"
+    ],
     "safetyNotes": [
       "safe",
       "Hypertension",
@@ -16220,10 +16288,10 @@
     ],
     "duration": "4–6 hours",
     "interactions": [
-      "Interaction review required before publication."
+      "High-risk with diuretics, corticosteroids, digoxin, antihypertensives, antiarrhythmics, and stimulant laxatives."
     ],
     "legalStatus": "Legal with warnings for chronic use",
-    "preparation": "Roots dried and decocted or powdered; commonly used in teas, extracts, and tablets",
+    "preparation": "Whole root, deglycyrrhizinated licorice (DGL), extracts, teas, and TCM formula components differ in glycyrrhizin exposure.",
     "region": "No direct region data. Contextual inference: Anti-inflammatory, expectorant, adrenal support. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Anti-inflammatory, expectorant, adrenal support. none. ; nan; nan",
     "therapeuticUses": [],
     "traditionalUse": "; nan; nan",
@@ -16531,16 +16599,9 @@
       "nan."
     ],
     "contraindications": [
-      "Use caution in uncontrolled blood pressure-sensitive contexts."
+      "Uncontrolled hypertension, arrhythmia, severe anxiety/insomnia, stimulant sensitivity, and unsupervised pediatric use."
     ],
-    "safetyNotes": [
-      "safe",
-      "No direct toxicity data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan. No direct effects data. Contextual inference:",
-      "nan."
-    ],
+    "safetyNotes": "Caffeine exposure can cause insomnia, anxiety, tremor, tachycardia, blood-pressure elevation, and GI upset. Avoid stacking with energy drinks or other stimulants; use cautiously in pregnancy/breastfeeding and cardiovascular disease.",
     "sources": [
       {
         "title": "Internal workbook + enrichment queue"
@@ -16558,7 +16619,8 @@
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [
-      "May stack strongly with caffeine-heavy or stimulant-heavy formulas."
+      "Additive effects with caffeine, stimulants, theophylline, decongestants, and some ADHD medications",
+      "CYP1A2 inhibitors may increase caffeine exposure."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -16647,7 +16709,9 @@
       "dreaming or folk medicine. Used in ritual",
       "dreaming or folk medicine"
     ],
-    "contraindications": "Pregnancy, heart conditions, anxiety",
+    "contraindications": [
+      "Uncontrolled hypertension, arrhythmia, severe anxiety/insomnia, pregnancy/breastfeeding caution, and stimulant sensitivity."
+    ],
     "safetyNotes": [
       "safe",
       "No direct toxicity data. Contextual inference: Used in ritual",
@@ -16670,7 +16734,9 @@
       "dreaming or folk medicine"
     ],
     "duration": "No direct duration data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. No direct region data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine",
-    "interactions": [],
+    "interactions": [
+      "Additive effects with caffeine, stimulants, theophylline, decongestants, and stimulant medications."
+    ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. No direct region data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine",
     "region": "No direct region data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine",
@@ -16700,14 +16766,7 @@
       "Avoid during pregnancy and breastfeeding unless supervised by a qualified clinician.",
       "Do not use with known allergy to this plant or related species."
     ],
-    "safetyNotes": [
-      "safe",
-      "No direct toxicity data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan. No direct effects data. Contextual inference:",
-      "nan."
-    ],
+    "safetyNotes": "Hypoglycemia risk increases with insulin, sulfonylureas, GLP-1 agonists, SGLT2 inhibitors, metformin, or other glucose-lowering medicines. Monitor glucose. GI upset can occur. Avoid pregnancy/breastfeeding. Stop before surgery because glucose variability may complicate perioperative management.",
     "sources": [
       {
         "title": "Internal workbook + enrichment queue"
@@ -16725,7 +16784,8 @@
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [
-      "Use caution with glucose-lowering strategies."
+      "Antidiabetics including insulin, sulfonylureas, GLP-1 agonists, SGLT2 inhibitors, and metformin",
+      "may compound glucose-lowering effects."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -16872,7 +16932,10 @@
       "Anti",
       "inflammatory"
     ],
-    "contraindications": [],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
     "safetyNotes": [
       "GI discomfort",
       "diarrhea",
@@ -16910,9 +16973,12 @@
       "nan."
     ],
     "duration": "6–8 hours",
-    "interactions": [],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
     "legalStatus": "Legal; used in herbal medicine",
-    "preparation": "Dried root tubers decocted or powdered; available in capsules or teas (devil’s claw)",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
     "region": "No direct region data. Contextual inference: Anti-inflammatory, analgesic, osteoarthritis relief. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Anti-inflammatory, analgesic, osteoarthritis relief. none. ; nan; nan",
     "therapeuticUses": [],
     "traditionalUse": "; nan; nan",
@@ -17633,7 +17699,7 @@
     ],
     "duration": "No direct duration data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. No direct region data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine",
     "interactions": [
-      "Anticoagulants, antidiabetic drugs"
+      "May add to antidiabetic, antihypertensive, sedative, anticoagulant, or antiplatelet effects."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. No direct region data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine",
@@ -17776,8 +17842,7 @@
     ],
     "duration": "4–8 hours",
     "interactions": [
-      "sedatives",
-      "cns depressants."
+      "May potentiate sedatives, alcohol, sleep medications, and other CNS depressants."
     ],
     "legalStatus": "Legal globally",
     "preparation": "No direct preparation data. Contextual inference: Sedative, hypnotic, digestive bitter; used in beer and herbal medicine. Gaba-a receptor modulation and sedative flavonoids.. ; nan; nan.. GABA-A receptor modulation and sedative flavonoids.. Sedative, hypnotic, digestive bitter; used in beer and herbal medicine. No direct region data. Contextual inference: Sedative, hypnotic, digestive bitter; used in beer and herbal medicine. Gaba-a receptor modulation and sedative flavonoids.. ; nan; nan.. GABA-A receptor modulation and sedative flavonoids.. Sedative, hypnotic, digestive bitter; used in beer and herbal medicine. ; nan; nan. ; nan; nan",
@@ -17916,7 +17981,10 @@
       "No direct dosage data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. No direct region data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. Folk medicine. Folk medicine"
     ],
     "duration": "No direct duration data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. No direct region data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. Folk medicine. Folk medicine",
-    "interactions": [],
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. No direct region data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. Folk medicine. Folk medicine",
     "region": "No direct region data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. Folk medicine",
@@ -18135,7 +18203,8 @@
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [
-      "Major interactions with antidepressants, oral contraceptives, cyclosporine, tacrolimus, HIV meds, anticancer drugs, warfarin, digoxin and others."
+      "Potential interaction concern with sedatives/CNS depressants, CYP/P-gp substrate medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -19009,7 +19078,8 @@
     ],
     "duration": "No direct duration data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. No direct region data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. Folk medicine. Folk medicine",
     "interactions": [
-      "Use caution with sedative stacking."
+      "May add to sedatives if seed extracts are used",
+      "monitor glucose with high fruit intake."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. No direct region data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. Folk medicine. Folk medicine",
@@ -19397,7 +19467,9 @@
       "nan. No direct region data. Contextual inference:"
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "interactions": [],
+    "interactions": [
+      "Avoid or clinician-review with SSRIs, SNRIs, MAOIs, TCAs, lithium, tramadol, linezolid, stimulants, and serotonergic supplements."
+    ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "region": "No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -19439,16 +19511,12 @@
       "nan."
     ],
     "contraindications": [
-      "Liver disease, pregnancy, breastfeeding, concurrent CNS depressants or hepatotoxic drugs."
+      "Active or previous liver disease",
+      "pregnancy/breastfeeding",
+      "current alcohol misuse",
+      "perioperative sedation risk unless medically supervised."
     ],
-    "safetyNotes": [
-      "caution",
-      "No direct toxicity data. Contextual inference:",
-      "nan.. No direct mechanismofaction data. Contextual inference:",
-      "nan..",
-      "nan. No direct effects data. Contextual inference:",
-      "nan."
-    ],
+    "safetyNotes": "Not for active/history liver disease, heavy alcohol use, or concurrent hepatotoxic drugs/supplements. Rare serious liver injury has been reported. Additive sedation is possible with benzodiazepines, barbiturates, opioids, sleep aids, alcohol, and other CNS depressants. Avoid driving after use; avoid pregnancy/breastfeeding.",
     "sources": [
       {
         "title": "Recovered from prior batch output in this conversation"
@@ -19473,8 +19541,7 @@
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [
-      "Additive sedation with CNS depressants and alcohol",
-      "possible hepatic enzyme interactions."
+      "CNS depressants, alcohol, benzodiazepines, opioids, sleep medicines, hepatotoxic drugs/supplements, and possible CYP-mediated interactions."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -19961,8 +20028,9 @@
       "used in aromatherapy and teas"
     ],
     "contraindications": [
-      "pregnancy (high doses)",
-      "hormone-sensitive conditions."
+      "Pregnancy/breastfeeding without guidance",
+      "internal essential-oil use",
+      "prepubertal endocrine concerns with topical overuse are debated"
     ],
     "safetyNotes": [
       "safe",
@@ -20145,7 +20213,8 @@
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [
-      "Sedatives, thyroid medications"
+      "May potentiate sedatives/CNS depressants",
+      "clinician review with thyroid medications."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -20599,7 +20668,8 @@
     ],
     "duration": "4–6 hours",
     "interactions": [
-      "May interact with anticoagulant-sensitive stacks"
+      "Potential interaction concern with antihypertensives/diuretics, anticoagulants/antiplatelets, immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "legalStatus": "Legal globally",
     "preparation": "No direct preparation data. Contextual inference: Invigorates blood, relieves pain; key herb in tcm. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Invigorates blood, relieves pain; key herb in TCM. No direct region data. Contextual inference: Invigorates blood, relieves pain; key herb in tcm. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Invigorates blood, relieves pain; key herb in TCM. none. ; nan; nan. ; nan; nan",
@@ -20852,7 +20922,8 @@
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [
-      "Mild GI possible"
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -20970,7 +21041,10 @@
       "nan. No direct region data. Contextual inference:"
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "interactions": [],
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "region": "No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -21480,7 +21554,8 @@
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [
-      "Limited data"
+      "Limited interaction data",
+      "review with hormone therapies or fertility treatments."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -22099,7 +22174,11 @@
       "anti",
       "inflammatory"
     ],
-    "contraindications": [],
+    "contraindications": [
+      "Asteraceae/ragweed allergy",
+      "anticoagulant use without clinician review",
+      "pregnancy at medicinal doses without guidance"
+    ],
     "safetyNotes": [
       "safe",
       "Allergic reactions",
@@ -22130,7 +22209,9 @@
       "500 mg extract"
     ],
     "duration": "2–6 hours",
-    "interactions": [],
+    "interactions": [
+      "May potentiate sedatives/CNS depressants and anticoagulants/antiplatelets in susceptible users."
+    ],
     "legalStatus": "Legal and widely used in herbal teas",
     "preparation": "Flowers dried and infused for tea or tincture; widely used for calming and digestive support",
     "region": "No direct region data. Contextual inference: Calming, anti-inflammatory, digestive support. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Calming, anti-inflammatory, digestive support. none. ; nan; nan",
@@ -23166,7 +23247,11 @@
       "anti",
       "inflammatory"
     ],
-    "contraindications": [],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "active liver disease"
+    ],
     "safetyNotes": [
       "safe",
       "May cause liver toxicity in high doses",
@@ -23207,10 +23292,11 @@
     ],
     "duration": "Chronic",
     "interactions": [
-      "Use caution with overgeneralized disease claims."
+      "Potential interaction concern with antidiabetic medicines, immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "legalStatus": "Legal in most countries",
-    "preparation": "Fruit juice fermented or taken fresh; commonly called noni; used in Polynesian medicine",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
     "region": "No direct region data. Contextual inference: Immune support, anti-inflammatory, antioxidant. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Immune support, anti-inflammatory, antioxidant. none. ; nan; nan",
     "therapeuticUses": [],
     "traditionalUse": "; nan; nan",
@@ -23565,7 +23651,7 @@
     ],
     "duration": "No direct duration data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. No direct region data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine",
     "interactions": [
-      "Avoid during pregnancy."
+      "Caution with anticonvulsants, sedatives, and drugs affected by seizure threshold."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. No direct region data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine",
@@ -23658,7 +23744,7 @@
       "antidepressants."
     ],
     "legalStatus": "Legal and widely sold in supplements globally",
-    "preparation": "Decoction from root bark; also used in tinctures or powdered extract",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
     "region": "Amazon rainforest (Brazil, Guyana, parts of Peru)",
     "therapeuticUses": [
       "Libido enhancement",
@@ -23962,7 +24048,11 @@
       "nan..",
       "nan."
     ],
-    "contraindications": "Cardiovascular disease, pregnancy",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "seizure disorder or sedative/alcohol use"
+    ],
     "safetyNotes": [
       "Toxic – nicotine dependency",
       "No direct toxicity data. Contextual inference:",
@@ -23983,7 +24073,10 @@
       "nan. No direct region data. Contextual inference:"
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "interactions": [],
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics, immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
     "legalStatus": "restricted",
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "region": "No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -24010,7 +24103,11 @@
       "Anti",
       "inflammatory"
     ],
-    "contraindications": [],
+    "contraindications": [
+      "Pregnancy at supplemental/high doses",
+      "hypoglycemia-prone patients without monitoring",
+      "known allergy."
+    ],
     "safetyNotes": [
       "safe",
       "GI upset",
@@ -24041,9 +24138,12 @@
       "day seed extract"
     ],
     "duration": "6–12 hours",
-    "interactions": [],
+    "interactions": [
+      "Antidiabetics, antihypertensives, anticoagulants/antiplatelets",
+      "additive metabolic effects."
+    ],
     "legalStatus": "Legal globally",
-    "preparation": "Seeds used whole, ground, or as extracted oil (black seed oil); immune and anti-inflammatory support",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
     "region": "No direct region data. Contextual inference: Anti-inflammatory, antioxidant, immune modulating. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Anti-inflammatory, antioxidant, immune modulating. none. ; nan; nan",
     "therapeuticUses": [],
     "traditionalUse": "; nan; nan",
@@ -24508,7 +24608,10 @@
       "energy booster",
       "cognitive enhancer"
     ],
-    "contraindications": [],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
     "safetyNotes": [
       "safe",
       "Insomnia",
@@ -24544,10 +24647,11 @@
     ],
     "duration": "4–8 hours",
     "interactions": [
-      "Stimulatory in high doses"
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "legalStatus": "Legal globally; traditional and supplement use",
-    "preparation": "Roots dried and decocted, tinctured, or powdered; tonic and adaptogen for energy and vitality",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
     "region": "No direct region data. Contextual inference: Adaptogen, energy booster, cognitive enhancer. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Adaptogen, energy booster, cognitive enhancer. none. ; nan; nan",
     "therapeuticUses": [],
     "traditionalUse": "; nan; nan",
@@ -24699,7 +24803,10 @@
       "nan..",
       "nan."
     ],
-    "contraindications": "Pregnancy, CNS depressants",
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "heavy sedative use"
+    ],
     "safetyNotes": [
       "safe",
       "No direct toxicity data. Contextual inference:",
@@ -24725,7 +24832,7 @@
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [
-      "Sedation possible"
+      "May potentiate benzodiazepines, sleep aids, opioids, alcohol, and other CNS depressants."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -25473,7 +25580,8 @@
     ],
     "duration": "4–6 hours",
     "interactions": [
-      "Interaction review required before publication."
+      "Potential interaction concern with antidiabetic medicines, CYP/P-gp substrate medicines, immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "legalStatus": "Legal globally",
     "preparation": "No direct preparation data. Contextual inference: Anti-inflammatory and antimicrobial; contains berberine. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Anti-inflammatory and antimicrobial; contains berberine. No direct region data. Contextual inference: Anti-inflammatory and antimicrobial; contains berberine. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Anti-inflammatory and antimicrobial; contains berberine. none. ; nan; nan. ; nan; nan",
@@ -26013,7 +26121,10 @@
       "Anti",
       "inflammatory"
     ],
-    "contraindications": [],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
     "safetyNotes": [
       "safe",
       "Generally safe",
@@ -26043,9 +26154,12 @@
       "day leaf extract"
     ],
     "duration": "4–6 hours",
-    "interactions": [],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
     "legalStatus": "Legal globally",
-    "preparation": "Leaves fresh or dried for teas, poultices, or tinctures; seeds also used for mucilage (demulcent)",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
     "region": "No direct region data. Contextual inference: Anti-inflammatory, wound healing, demulcent. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Anti-inflammatory, wound healing, demulcent. none. ; nan; nan",
     "therapeuticUses": [],
     "traditionalUse": "; nan; nan",
@@ -27004,7 +27118,11 @@
       "Phytoestrogenic",
       "menopausal support"
     ],
-    "contraindications": [],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "hormone-sensitive conditions without clinician review"
+    ],
     "safetyNotes": [
       "caution",
       "Estrogenic effects",
@@ -27037,10 +27155,11 @@
     ],
     "duration": "Weeks to months",
     "interactions": [
-      "May interact with hormonal therapies, contraceptives, and endocrine-active drugs."
+      "Potential interaction concern with hormonal therapies",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "legalStatus": "Legal with restrictions in some countries",
-    "preparation": "Root powdered or tinctured; used in traditional Thai medicine and supplements for phytoestrogenic effects",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
     "region": "No direct region data. Contextual inference: Phytoestrogenic, menopausal support. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Phytoestrogenic, menopausal support. none. ; nan; nan",
     "therapeuticUses": [],
     "traditionalUse": "; nan; nan",
@@ -27444,7 +27563,10 @@
       "digestive aid",
       "antimicrobial"
     ],
-    "contraindications": [],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
     "safetyNotes": [
       "safe",
       "Laxative",
@@ -27475,9 +27597,12 @@
       "day processed root"
     ],
     "duration": "Up to 12 hours",
-    "interactions": [],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
     "legalStatus": "Legal; regulated as a laxative",
-    "preparation": "Root dried and decocted in small doses; purgative and liver-stimulating; common in TCM (Chinese rhubarb)",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
     "region": "No direct region data. Contextual inference: Laxative, digestive aid, antimicrobial. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Laxative, digestive aid, antimicrobial. none. ; nan; nan",
     "therapeuticUses": [],
     "traditionalUse": "; nan; nan",
@@ -27630,8 +27755,8 @@
       "nan."
     ],
     "contraindications": [
-      "bipolar disorder",
-      "pregnancy."
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ],
     "safetyNotes": [
       "safe",
@@ -27670,9 +27795,8 @@
     ],
     "duration": "4–6 hours",
     "interactions": [
-      "ssris",
-      "maois",
-      "stimulants."
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
     "legalStatus": "Legal globally",
     "preparation": "No direct preparation data. Contextual inference: Adaptogen, mental performance enhancer, antidepressant. Inhibits monoamine oxidase; modulates cortisol and neurotransmitters.. ; nan; nan.. Inhibits monoamine oxidase; modulates cortisol and neurotransmitters.. Adaptogen, mental performance enhancer, antidepressant. No direct region data. Contextual inference: Adaptogen, mental performance enhancer, antidepressant. Inhibits monoamine oxidase; modulates cortisol and neurotransmitters.. ; nan; nan.. Inhibits monoamine oxidase; modulates cortisol and neurotransmitters.. Adaptogen, mental performance enhancer, antidepressant. ; nan; nan. ; nan; nan",
@@ -29202,7 +29326,11 @@
       "liver tonic",
       "antioxidant"
     ],
-    "contraindications": [],
+    "contraindications": [
+      "Pregnancy/breastfeeding without guidance",
+      "active reflux/ulcer sensitivity",
+      "complex medication regimens without review"
+    ],
     "safetyNotes": [
       "safe",
       "GI upset",
@@ -29241,7 +29369,8 @@
     ],
     "duration": "Chronic",
     "interactions": [
-      "Use caution with CYP-sensitive medication contexts."
+      "Potential CYP/P-gp interactions",
+      "caution with immunosuppressants, sedatives, anticoagulants, and hepatically metabolized drugs."
     ],
     "legalStatus": "Legal globally",
     "preparation": "Berries dried and decocted, infused, or tinctured; adaptogenic tonic in TCM for vitality and liver support",
@@ -29450,7 +29579,9 @@
       "Anti",
       "inflammatory"
     ],
-    "contraindications": [],
+    "contraindications": [
+      "Liver disease, pregnancy/breastfeeding, immunosuppressive therapy without supervision, and complex oncology regimens."
+    ],
     "safetyNotes": [
       "safe",
       "Generally safe",
@@ -29484,7 +29615,7 @@
     ],
     "duration": "6–10 hours",
     "interactions": [
-      "Interaction review required before publication."
+      "Potential interactions with anticoagulants/antiplatelets, sedatives, immunosuppressants, and hepatotoxic drugs."
     ],
     "legalStatus": "Legal globally",
     "preparation": "Root dried and decocted or tinctured; used in TCM for heat-clearing and inflammation (Huang Qin)",
@@ -29556,7 +29687,10 @@
       "nan."
     ],
     "duration": "6–8 hours",
-    "interactions": [],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
     "legalStatus": "Legal globally",
     "preparation": "No direct preparation data. Contextual inference: Antioxidant and anti-aging effects; traditional chinese medicine. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Antioxidant and anti-aging effects; traditional Chinese medicine. No direct region data. Contextual inference: Antioxidant and anti-aging effects; traditional chinese medicine. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Antioxidant and anti-aging effects; traditional Chinese medicine. none. ; nan; nan. ; nan; nan",
     "region": "No direct region data. Contextual inference: Antioxidant and anti-aging effects; traditional chinese medicine. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Antioxidant and anti-aging effects; traditional Chinese medicine. none. ; nan; nan",
@@ -29693,7 +29827,8 @@
       "used for BPH support"
     ],
     "contraindications": [
-      "Pregnancy"
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ],
     "safetyNotes": [
       "Usually well tolerated; possible gastrointestinal upset, headache, or dizziness.",
@@ -29734,10 +29869,11 @@
     ],
     "duration": "Chronic",
     "interactions": [
-      "Hormonal therapies, anticoagulants"
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "legalStatus": "Legal globally",
-    "preparation": "Fruit dried and extracted into lipophilic extracts or tinctures; used for benign prostatic hyperplasia (BPH)",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
     "region": "Southeastern United States; berry extracts are used globally in commercial preparations.",
     "therapeuticUses": [],
     "traditionalUse": "Historically used for urinary and reproductive health support in traditional and modern herbal practice.",
@@ -29845,7 +29981,8 @@
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [
-      "Avoid overstated nootropic claims."
+      "Potential interaction concern with sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -30487,7 +30624,12 @@
       "Antimicrobial and anti",
       "inflammatory"
     ],
-    "contraindications": [],
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "liver disease",
+      "arrhythmia/cardiac disease without clinician review",
+      "complex medication regimens."
+    ],
     "safetyNotes": [
       "GI irritation",
       "hepatotoxicity with prolonged use",
@@ -30526,10 +30668,10 @@
     ],
     "duration": "4–6 hours",
     "interactions": [
-      "Avoid overextended antimicrobial claims."
+      "Potential interactions with hepatotoxic drugs, antiarrhythmics, immunomodulators, and sedative/CNS-active medicines are plausible and extract-specific."
     ],
     "legalStatus": "Unregulated",
-    "preparation": "Root dried and decocted in TCM (Ku Shen); anti-parasitic and anti-inflammatory uses",
+    "preparation": "Root is used as decoction, granule, capsule, or alkaloid-standardized extract; standardized alkaloid products are not equivalent to crude root.",
     "region": "No direct region data. Contextual inference: Antimicrobial and anti-inflammatory; source of matrine alkaloids. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Antimicrobial and anti-inflammatory; source of matrine alkaloids. none. ; nan; nan",
     "therapeuticUses": [],
     "traditionalUse": "; nan; nan",
@@ -30653,7 +30795,10 @@
       "nan."
     ],
     "duration": "4–6 hours",
-    "interactions": [],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
     "legalStatus": "Unregulated",
     "preparation": "No direct preparation data. Contextual inference: Traditionally used in chinese medicine for inflammation and pain relief. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Traditionally used in Chinese medicine for inflammation and pain relief. No direct region data. Contextual inference: Traditionally used in chinese medicine for inflammation and pain relief. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Traditionally used in Chinese medicine for inflammation and pain relief. none. ; nan; nan. ; nan; nan",
     "region": "No direct region data. Contextual inference: Traditionally used in chinese medicine for inflammation and pain relief. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Traditionally used in Chinese medicine for inflammation and pain relief. none. ; nan; nan",
@@ -30687,7 +30832,10 @@
       "Anti",
       "inflammatory"
     ],
-    "contraindications": [],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
     "safetyNotes": [
       "Nephrotoxic at high doses",
       "dizziness",
@@ -30725,9 +30873,12 @@
       "nan."
     ],
     "duration": "4–6 hours",
-    "interactions": [],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
     "legalStatus": "Legal in Chinese and Western herbal practices",
-    "preparation": "Root decocted in TCM (Han Fang Ji); used for edema, inflammation, and hypertension",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
     "region": "No direct region data. Contextual inference: Anti-inflammatory, antihypertensive, used in tcm. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Anti-inflammatory, antihypertensive, used in TCM. none. ; nan; nan",
     "therapeuticUses": [],
     "traditionalUse": "; nan; nan",
@@ -31077,7 +31228,12 @@
       "analgesic (especially dental)",
       "antioxidant"
     ],
-    "contraindications": [],
+    "contraindications": [
+      "Bleeding disorder",
+      "liver disease",
+      "children for clove oil ingestion",
+      "pregnancy supplement dosing without guidance"
+    ],
     "safetyNotes": [
       "Allergic reactions",
       "clove oil may cause mucosal irritation",
@@ -31113,7 +31269,10 @@
       "nan."
     ],
     "duration": "2–4 hours",
-    "interactions": [],
+    "interactions": [
+      "May increase bleeding risk with anticoagulants/antiplatelets",
+      "caution with hepatotoxic drugs."
+    ],
     "legalStatus": "Legal and widely used",
     "preparation": "Dried flower buds (clove) used as spice, infusion, tincture, or essential oil; analgesic and antiseptic",
     "region": "No direct region data. Contextual inference: Antiseptic, analgesic (especially dental), antioxidant. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Antiseptic, analgesic (especially dental), antioxidant. none. ; nan; nan",
@@ -32480,7 +32639,8 @@
     ],
     "duration": "6–8 hours",
     "interactions": [
-      "Use caution with stimulants, glucose-lowering agents, and hormone-sensitive contexts."
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
     "legalStatus": "Legal globally",
     "preparation": "No direct preparation data. Contextual inference: Aphrodisiac, testosterone booster, and energy tonic. Boosts free testosterone; reduces cortisol.. ; nan; nan.. Boosts free testosterone; reduces cortisol.. Aphrodisiac, testosterone booster, and energy tonic. No direct region data. Contextual inference: Aphrodisiac, testosterone booster, and energy tonic. Boosts free testosterone; reduces cortisol.. ; nan; nan.. Boosts free testosterone; reduces cortisol.. Aphrodisiac, testosterone booster, and energy tonic. ; nan; nan. ; nan; nan",
@@ -33680,7 +33840,7 @@
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [
-      "May potentiate sedatives and alcohol."
+      "May potentiate alcohol, benzodiazepines, barbiturates, sleep aids, opioids, and other CNS depressants."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -33919,7 +34079,10 @@
       "No direct dosage data. Contextual inference: Used in european folk medicine for anxiety and dreaming... No direct mechanismofaction data. Contextual inference: Used in european folk medicine for anxiety and dreaming... Used in European folk medicine for anxiety and dreaming.. No direct effects data. Contextual inference: Used in european folk medicine for anxiety and dreaming... No direct mechanismofaction data. Contextual inference: Used in european folk medicine for anxiety and dreaming... Used in European folk medicine for anxiety and dreaming.. Used in European folk medicine for anxiety and dreaming.. No direct region data. Contextual inference: Used in european folk medicine for anxiety and dreaming... No direct mechanismofaction data. Contextual inference: Used in european folk medicine for anxiety and dreaming... Used in European folk medicine for anxiety and dreaming.. No direct effects data. Contextual inference: Used in european folk medicine for anxiety and dreaming... No direct mechanismofaction data. Contextual inference: Used in european folk medicine for anxiety and dreaming... Used in European folk medicine for anxiety and dreaming.. Used in European folk medicine for anxiety and dreaming.. Used in European folk medicine for anxiety and dreaming.. Used in European folk medicine for anxiety and dreaming."
     ],
     "duration": "No direct duration data. Contextual inference: Used in european folk medicine for anxiety and dreaming... No direct mechanismofaction data. Contextual inference: Used in european folk medicine for anxiety and dreaming... Used in European folk medicine for anxiety and dreaming.. No direct effects data. Contextual inference: Used in european folk medicine for anxiety and dreaming... No direct mechanismofaction data. Contextual inference: Used in european folk medicine for anxiety and dreaming... Used in European folk medicine for anxiety and dreaming.. Used in European folk medicine for anxiety and dreaming.. No direct region data. Contextual inference: Used in european folk medicine for anxiety and dreaming... No direct mechanismofaction data. Contextual inference: Used in european folk medicine for anxiety and dreaming... Used in European folk medicine for anxiety and dreaming.. No direct effects data. Contextual inference: Used in european folk medicine for anxiety and dreaming... No direct mechanismofaction data. Contextual inference: Used in european folk medicine for anxiety and dreaming... Used in European folk medicine for anxiety and dreaming.. Used in European folk medicine for anxiety and dreaming.. Used in European folk medicine for anxiety and dreaming.. Used in European folk medicine for anxiety and dreaming.",
-    "interactions": [],
+    "interactions": [
+      "Potential interaction concern with sedatives/CNS depressants, immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: Used in european folk medicine for anxiety and dreaming... No direct mechanismofaction data. Contextual inference: Used in european folk medicine for anxiety and dreaming... Used in European folk medicine for anxiety and dreaming.. No direct effects data. Contextual inference: Used in european folk medicine for anxiety and dreaming... No direct mechanismofaction data. Contextual inference: Used in european folk medicine for anxiety and dreaming... Used in European folk medicine for anxiety and dreaming.. Used in European folk medicine for anxiety and dreaming.. No direct region data. Contextual inference: Used in european folk medicine for anxiety and dreaming... No direct mechanismofaction data. Contextual inference: Used in european folk medicine for anxiety and dreaming... Used in European folk medicine for anxiety and dreaming.. No direct effects data. Contextual inference: Used in european folk medicine for anxiety and dreaming... No direct mechanismofaction data. Contextual inference: Used in european folk medicine for anxiety and dreaming... Used in European folk medicine for anxiety and dreaming.. Used in European folk medicine for anxiety and dreaming.. Used in European folk medicine for anxiety and dreaming.. Used in European folk medicine for anxiety and dreaming.",
     "region": "No direct region data. Contextual inference: Used in european folk medicine for anxiety and dreaming... No direct mechanismofaction data. Contextual inference: Used in european folk medicine for anxiety and dreaming... Used in European folk medicine for anxiety and dreaming.. No direct effects data. Contextual inference: Used in european folk medicine for anxiety and dreaming... No direct mechanismofaction data. Contextual inference: Used in european folk medicine for anxiety and dreaming... Used in European folk medicine for anxiety and dreaming.. Used in European folk medicine for anxiety and dreaming.. Used in European folk medicine for anxiety and dreaming.",
@@ -34990,7 +35153,9 @@
       "dreaming or folk medicine"
     ],
     "duration": "No direct duration data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. No direct region data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine",
-    "interactions": [],
+    "interactions": [
+      "Avoid with antiepileptics, sedatives, alcohol, and other neuroactive supplements or medicines."
+    ],
     "legalStatus": "restricted",
     "preparation": "No direct preparation data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. No direct region data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine",
     "region": "No direct region data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine",
@@ -35118,7 +35283,8 @@
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [
-      "Use caution in anticoagulant-sensitive or complex women's health stacks."
+      "Potential additive effects with anticoagulants/antiplatelets",
+      "possible allergy cross-reactivity with ragweed-family plants."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -35206,7 +35372,8 @@
     "activeCompounds": [
       "Caffeine",
       "Theobromine",
-      "Chlorogenic acid"
+      "Chlorogenic acid",
+      "apigenin"
     ],
     "effects": [
       "No direct effects data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... No direct mechanismofaction data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... Consumed as a social and energizing herbal tea throughout South America.. Consumed as a social and energizing herbal tea throughout South America."
@@ -35232,7 +35399,8 @@
     ],
     "duration": "No direct duration data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... No direct mechanismofaction data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... Consumed as a social and energizing herbal tea throughout South America.. No direct effects data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... No direct mechanismofaction data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... Consumed as a social and energizing herbal tea throughout South America.. Consumed as a social and energizing herbal tea throughout South America.. No direct region data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... No direct mechanismofaction data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... Consumed as a social and energizing herbal tea throughout South America.. No direct effects data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... No direct mechanismofaction data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... Consumed as a social and energizing herbal tea throughout South America.. Consumed as a social and energizing herbal tea throughout South America.. Consumed as a social and energizing herbal tea throughout South America.. Consumed as a social and energizing herbal tea throughout South America.",
     "interactions": [
-      "May stack strongly with caffeine-heavy formulas."
+      "Additive effects with stimulants, caffeine, theophylline, decongestants, and stimulant medications",
+      "CYP1A2-modulating drugs may alter caffeine exposure."
     ],
     "legalStatus": "legal",
     "preparation": "No direct preparation data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... No direct mechanismofaction data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... Consumed as a social and energizing herbal tea throughout South America.. No direct effects data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... No direct mechanismofaction data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... Consumed as a social and energizing herbal tea throughout South America.. Consumed as a social and energizing herbal tea throughout South America.. No direct region data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... No direct mechanismofaction data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... Consumed as a social and energizing herbal tea throughout South America.. No direct effects data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... No direct mechanismofaction data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... Consumed as a social and energizing herbal tea throughout South America.. Consumed as a social and energizing herbal tea throughout South America.. Consumed as a social and energizing herbal tea throughout South America.. Consumed as a social and energizing herbal tea throughout South America.",
@@ -35296,7 +35464,7 @@
     ],
     "duration": "No direct duration data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "interactions": [
-      "High BP risk"
+      "Avoid with stimulants, decongestants, MAOIs, antidepressants, clonidine, antihypertensives, and drugs affecting blood pressure or heart rhythm."
     ],
     "legalStatus": "restricted",
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
@@ -37380,10 +37548,11 @@
       "triterpenes improve circulation"
     ],
     "contraindications": [
-      "liver conditions",
-      "pregnancy."
+      "Liver disease",
+      "pregnancy/breastfeeding without guidance",
+      "upcoming surgery"
     ],
-    "safetyNotes": [],
+    "safetyNotes": "Rare liver injury reported; avoid pregnancy and liver disease; caution with sedatives and hepatotoxic drugs.",
     "sources": [
       {
         "note": "Inferred from scientific name:"
@@ -37415,8 +37584,8 @@
     "preparation": "No direct preparation data. Contextual inference: Cognitive enhancer, anxiolytic, wound healing; triterpenes improve circulation. Boosts collagen synthesis, modulates gaba and blood flow.. ; nan; nan.. Boosts collagen synthesis, modulates GABA and blood flow.. Cognitive enhancer, anxiolytic, wound healing; triterpenes improve circulation. No direct region data. Contextual inference: Cognitive enhancer, anxiolytic, wound healing; triterpenes improve circulation. Boosts collagen synthesis, modulates gaba and blood flow.. ; nan; nan.. Boosts collagen synthesis, modulates GABA and blood flow.. Cognitive enhancer, anxiolytic, wound healing; triterpenes improve circulation. ; nan; nan. ; nan; nan",
     "legalStatus": "Legal globally",
     "interactions": [
-      "sedatives",
-      "hepatotoxic drugs."
+      "May potentiate sedatives and hepatotoxic drugs/supplements",
+      "caution with antidiabetics."
     ],
     "description": "Cognitive enhancer, anxiolytic, wound healing; triterpenes improve circulation. Boosts collagen synthesis, modulates gaba and blood flow.. ; nan; nan.",
     "sideEffects": [
@@ -37930,11 +38099,11 @@
       "used in aromatherapy and teas"
     ],
     "contraindications": [
-      "pregnancy (high doses)",
-      "hormone",
-      "sensitive conditions."
+      "Pregnancy/breastfeeding without guidance",
+      "internal essential-oil use",
+      "prepubertal endocrine concerns with topical overuse are debated"
     ],
-    "safetyNotes": "Can be sedating in some users.",
+    "safetyNotes": "May cause sedation, burping, nausea, or allergic reactions. Avoid undiluted oral essential oil. Use caution with CNS depressants, alcohol, driving, and pregnancy.",
     "sources": [
       {
         "note": "Inferred from scientific name:"
@@ -38346,7 +38515,7 @@
       "Use caution with prescription medications and chronic conditions; monitor for intolerance.",
       "discontinue if hypersensitivity or allergic symptoms occur"
     ],
-    "safetyNotes": [],
+    "safetyNotes": "High-dose nutmeg/myristicin exposure can cause neuropsychiatric and cardiovascular toxicity.",
     "sources": [],
     "lastUpdated": "2026-03-21",
     "therapeuticUses": [
@@ -38367,7 +38536,10 @@
     "region": "No direct region data. Contextual inference: Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals... No direct mechanismofaction data. Contextual inference: Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals... Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals.. No direct effects data. Contextual inference: Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals... No direct mechanismofaction data. Contextual inference: Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals... Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals.. Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals.. Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals.",
     "preparation": "No direct preparation data. Contextual inference: Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals... No direct mechanismofaction data. Contextual inference: Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals... Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals.. No direct effects data. Contextual inference: Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals... No direct mechanismofaction data. Contextual inference: Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals... Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals.. Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals.. No direct region data. Contextual inference: Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals... No direct mechanismofaction data. Contextual inference: Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals... Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals.. No direct effects data. Contextual inference: Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals... No direct mechanismofaction data. Contextual inference: Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals... Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals.. Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals.. Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals.. Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals.",
     "legalStatus": "legal",
-    "interactions": [],
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics, sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
     "description": "Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals..",
     "sideEffects": [
       "mild gastrointestinal upset (nausea, cramping, or loose stool)",
@@ -38397,7 +38569,7 @@
       "Use caution with sedatives, alcohol, or other CNS depressants.",
       "discontinue if hypersensitivity or allergic symptoms occur"
     ],
-    "safetyNotes": [],
+    "safetyNotes": "May lower blood glucose or alter metabolic markers; monitor with diabetes medications and avoid unsupervised use during pregnancy.",
     "sources": [],
     "lastUpdated": "2026-03-21",
     "therapeuticUses": [
@@ -38411,7 +38583,10 @@
     "region": "No direct region data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... No direct mechanismofaction data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... Used in Ayurveda and Buddhist practices for calm and devotion.. No direct effects data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... No direct mechanismofaction data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... Used in Ayurveda and Buddhist practices for calm and devotion.. Used in Ayurveda and Buddhist practices for calm and devotion.. Used in Ayurveda and Buddhist practices for calm and devotion.",
     "preparation": "No direct preparation data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... No direct mechanismofaction data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... Used in Ayurveda and Buddhist practices for calm and devotion.. No direct effects data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... No direct mechanismofaction data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... Used in Ayurveda and Buddhist practices for calm and devotion.. Used in Ayurveda and Buddhist practices for calm and devotion.. No direct region data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... No direct mechanismofaction data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... Used in Ayurveda and Buddhist practices for calm and devotion.. No direct effects data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... No direct mechanismofaction data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... Used in Ayurveda and Buddhist practices for calm and devotion.. Used in Ayurveda and Buddhist practices for calm and devotion.. Used in Ayurveda and Buddhist practices for calm and devotion.. Used in Ayurveda and Buddhist practices for calm and devotion.",
     "legalStatus": "legal",
-    "interactions": [],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines, immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
     "description": "Used in ayurveda and buddhist practices for calm and devotion..",
     "sideEffects": [
       "mild gastrointestinal upset (nausea, cramping, or loose stool)",
@@ -38610,8 +38785,13 @@
       "stress",
       "immune support"
     ],
-    "contraindications": [],
-    "safetyNotes": [],
+    "contraindications": [
+      "Pregnancy attempts/pregnancy without clinician guidance",
+      "hypoglycemia risk",
+      "bleeding disorder",
+      "upcoming surgery"
+    ],
+    "safetyNotes": "May lower glucose and affect clotting; caution with diabetes drugs, anticoagulants, pregnancy, and perioperative use.",
     "sources": [
       {
         "note": "Inferred from scientific name:"
@@ -38628,7 +38808,9 @@
     "region": "No direct region data. Contextual inference: Adaptogen, anti-stress, immune support. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Adaptogen, anti-stress, immune support. none. ; nan; nan",
     "preparation": "Leaves used fresh or dried in teas, decoctions, tinctures; sacred basil with adaptogenic effects",
     "legalStatus": "Legal worldwide",
-    "interactions": [],
+    "interactions": [
+      "May add to antidiabetic, antihypertensive, sedative, anticoagulant, or antiplatelet effects."
+    ],
     "description": "Adaptogen, anti-stress, immune support. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.",
     "sideEffects": [
       "Mild GI issues",
@@ -39046,7 +39228,7 @@
       "Use caution with prescription medications and chronic conditions; monitor for intolerance.",
       "discontinue if hypersensitivity or allergic symptoms occur"
     ],
-    "safetyNotes": [],
+    "safetyNotes": "Liver injury risk; avoid liver disease, alcohol, hepatotoxic drugs, and CNS depressants; avoid pregnancy/breastfeeding.",
     "sources": [],
     "lastUpdated": "2026-03-21",
     "therapeuticUses": [
@@ -39065,7 +39247,10 @@
     "region": "No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan",
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "legalStatus": "restricted",
-    "interactions": [],
+    "interactions": [
+      "Potential interaction concern with sedatives/CNS depressants, CYP/P-gp substrate medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
     "description": "Piper methysticum contains Kavalactones and is linked here to GABA-A modulation.",
     "sideEffects": [
       "mild gastrointestinal upset (nausea, cramping, or loose stool)",
@@ -39239,7 +39424,7 @@
       "Use caution with prescription medications and chronic conditions; monitor for intolerance.",
       "discontinue if hypersensitivity or allergic symptoms occur"
     ],
-    "safetyNotes": "Generally well tolerated; possible dizziness, dry mouth, insomnia",
+    "safetyNotes": "Can cause insomnia, agitation, dizziness, or dry mouth; avoid late-day dosing. Caution with bipolar disorder/mania history, stimulants, antidepressants/MAOIs, sedatives, pregnancy, and breastfeeding. Product adulteration and inconsistent salidroside/rosavin standardization are important quality risks.",
     "sources": [
       {
         "title": "NCCIH"
@@ -39277,7 +39462,7 @@
     "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
     "legalStatus": "legal",
     "interactions": [
-      "SSRIs, MAOIs, stimulants"
+      "Potential additive effects with stimulants, antidepressants/MAOIs, anxiolytics/sedatives, and therapies affecting blood pressure or glucose."
     ],
     "description": "Rhodiola Rosea is represented here as a monograph-style entry centered on the root. Key reported compounds include rosavin; rosarin; rosin; salidroside; tyrosol. Typical preparation forms: Standardized root extracts. Adaptogen; modulates HPA axis; influences serotonin, dopamine, norepinephrine; antioxidant. Interaction profile: SSRIs, MAOIs, stimulants. Use caution or avoid in: Bipolar disorder; avoid high doses before sleep.",
     "sideEffects": [
@@ -39853,10 +40038,11 @@
       "used for insomnia and anxiety"
     ],
     "contraindications": [
-      "pregnancy",
-      "sedative sensitivity."
+      "Pregnancy/breastfeeding without guidance",
+      "liver disease",
+      "sedative use without review"
     ],
-    "safetyNotes": [],
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
     "sources": [
       {
         "note": "Inferred from scientific name:"
@@ -39889,8 +40075,8 @@
     "preparation": "No direct preparation data. Contextual inference: Nervine, anxiolytic, anti-inflammatory; used for insomnia and anxiety. Flavonoids modulate gaba receptors; offers calming and anxiolytic effects.. ; nan; nan.. Flavonoids modulate GABA receptors; offers calming and anxiolytic effects.. Nervine, anxiolytic, anti-inflammatory; used for insomnia and anxiety. No direct region data. Contextual inference: Nervine, anxiolytic, anti-inflammatory; used for insomnia and anxiety. Flavonoids modulate gaba receptors; offers calming and anxiolytic effects.. ; nan; nan.. Flavonoids modulate GABA receptors; offers calming and anxiolytic effects.. Nervine, anxiolytic, anti-inflammatory; used for insomnia and anxiety. ; nan; nan. ; nan; nan",
     "legalStatus": "Legal globally",
     "interactions": [
-      "cns depressants",
-      "alcohol."
+      "May add to sedatives/CNS depressants",
+      "caution with hepatotoxic drugs/supplements."
     ],
     "description": "Nervine, anxiolytic, anti-inflammatory; used for insomnia and anxiety. Flavonoids modulate gaba receptors; offers calming and anxiolytic effects.. ; nan; nan.",
     "sideEffects": [
@@ -40499,8 +40685,12 @@
       "anxiolytic",
       "sleep aid"
     ],
-    "contraindications": [],
-    "safetyNotes": [],
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "heavy sedative use",
+      "upcoming anesthesia"
+    ],
+    "safetyNotes": "Sedation and next-day drowsiness possible; avoid alcohol, benzodiazepines, opioids, and other CNS depressants.",
     "sources": [
       {
         "note": "Inferred from scientific name:"
@@ -40517,7 +40707,9 @@
     "region": "No direct region data. Contextual inference: Sedative, anxiolytic, sleep aid. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Sedative, anxiolytic, sleep aid. none. ; nan; nan",
     "preparation": "Root dried and used in teas, tinctures, or capsules; sedative and anxiolytic properties",
     "legalStatus": "Legal worldwide",
-    "interactions": [],
+    "interactions": [
+      "May potentiate alcohol, benzodiazepines, barbiturates, sleep aids, opioids, and other CNS depressants."
+    ],
     "description": "Sedative, anxiolytic, sleep aid. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.",
     "sideEffects": [
       "Drowsiness",
@@ -40785,8 +40977,8 @@
     "benefits": [],
     "latin": "Actaea racemosa",
     "mechanism": "Proposed mechanism based on preclinical and limited clinical data: black cohosh may act through serotonergic pathways, selective estrogen receptor modulation, and anti-inflammatory signaling rather than as a classical estrogen.",
-    "safetyNotes": "Generally well tolerated in short-term studies, but rare cases of liver injury have been reported. Product contamination or misidentification is a known issue.",
-    "preparation": "Root and rhizome used in standardized extracts, capsules, tablets, and tinctures.",
+    "safetyNotes": "Avoid in pregnancy/breastfeeding. Caution or avoid with active liver disease, unexplained liver-enzyme elevation, or prior supplement-related liver injury. Rare severe hepatotoxicity reports exist. Use clinician review in hormone-sensitive cancers or with estrogenic/anti-estrogenic therapies; stop if jaundice, dark urine, right-upper-quadrant pain, or severe fatigue occurs.",
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
     "region": "Native to North America, especially the eastern United States.",
     "aliases": [
       "black cohosh",
@@ -40802,10 +40994,15 @@
       "23-epi-26-deoxyactein"
     ],
     "interactions": [
-      "Potential interactions with hepatotoxic drugs and with medications affecting estrogen or serotonergic pathways."
+      "Potential concern with hepatotoxic drugs/supplements",
+      "clinician review with estrogenic/anti-estrogenic therapy, serotonergic medicines, and complex oncology/endocrine regimens."
     ],
     "contraindications": [
-      "Avoid in pregnancy and breastfeeding. Use caution in liver disease or hormone-sensitive conditions."
+      "Pregnancy",
+      "breastfeeding",
+      "active liver disease",
+      "unexplained liver-enzyme elevation",
+      "clinician review for hormone-sensitive cancer history."
     ],
     "mechanismTags": [
       "anti-inflammatory",
@@ -40849,7 +41046,7 @@
     "benefits": [],
     "latin": "Tanacetum parthenium",
     "mechanism": "Mechanistic activity supported by mixed evidence.",
-    "safetyNotes": "Review interactions and contraindications",
+    "safetyNotes": "Avoid in pregnancy; possible mouth ulcers/GI upset; allergy risk in Asteraceae-sensitive users; caution with anticoagulants/antiplatelets.",
     "region": "global",
     "aliases": [
       "Feverfew"
@@ -40859,10 +41056,14 @@
       "flavonoids"
     ],
     "interactions": [
-      "May interact with anticoagulant-sensitive contexts"
+      "May increase bleeding risk with anticoagulants/antiplatelets/NSAIDs",
+      "caution with migraine medications."
     ],
     "contraindications": [
-      "Use caution in pregnancy-sensitive and surgery-sensitive contexts"
+      "Pregnancy",
+      "Asteraceae/ragweed allergy",
+      "anticoagulant use without clinician review",
+      "upcoming surgery"
     ],
     "mechanismTags": [
       "headache support",
@@ -40874,7 +41075,8 @@
         "title": "Internal workbook + enrichment queue"
       }
     ],
-    "confidenceTier": "low"
+    "confidenceTier": "low",
+    "preparation": "Leaf capsules/extracts standardized to parthenolide; fresh leaf chewing increases mouth irritation risk."
   },
   {
     "id": "pau-darco",
@@ -40887,7 +41089,7 @@
     "latin": "Handroanthus impetiginosus",
     "mechanism": "Naphthoquinones are associated with antimicrobial and redox-related positioning in preclinical contexts.",
     "safetyNotes": "Use conservatively; concentrated use may be irritating.",
-    "region": "South America",
+    "region": "South America traditional medicine",
     "aliases": [
       "pau d'arco"
     ],
@@ -40896,7 +41098,8 @@
       "naphthoquinones"
     ],
     "interactions": [
-      "Avoid exaggerated disease-treatment claims."
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "mechanismTags": [
       "antimicrobial support",
@@ -40906,6 +41109,11 @@
       {
         "title": "Internal workbook + enrichment queue"
       }
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ]
   },
   {
@@ -40918,7 +41126,7 @@
     "benefits": [],
     "latin": "Lagerstroemia speciosa",
     "mechanism": "Triterpene constituents are associated with glycemic-support positioning.",
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "May potentiate antidiabetic drugs; monitor hypoglycemia risk; pregnancy/breastfeeding safety unclear.",
     "region": "Southeast Asia",
     "aliases": [
       "banaba"
@@ -40927,7 +41135,7 @@
       "corosolic acid"
     ],
     "interactions": [
-      "Use caution with glucose-lowering strategies."
+      "May potentiate antidiabetic medications and other glucose-lowering supplements."
     ],
     "mechanismTags": [
       "glycemic support",
@@ -40937,6 +41145,11 @@
       {
         "title": "Internal workbook + enrichment queue"
       }
+    ],
+    "preparation": "Leaf extracts standardized to corosolic acid or ellagitannin content; tea use also occurs.",
+    "contraindications": [
+      "Hypoglycemia risk",
+      "pregnancy/breastfeeding without clinician guidance"
     ]
   },
   {
@@ -40949,7 +41162,7 @@
     "benefits": [],
     "latin": "Morus alba",
     "mechanism": "Iminosugars are associated with carbohydrate-handling support.",
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "May potentiate glucose-lowering drugs; GI effects possible; pregnancy safety uncertain.",
     "region": "China and cultivated broadly",
     "aliases": [
       "mulberry leaf"
@@ -40959,7 +41172,8 @@
       "flavonoids"
     ],
     "interactions": [
-      "Use caution with glucose-lowering strategies."
+      "May potentiate antidiabetic drugs and other alpha-glucosidase inhibitors",
+      "monitor glucose."
     ],
     "mechanismTags": [
       "glycemic support"
@@ -40968,6 +41182,11 @@
       {
         "title": "Internal workbook + enrichment queue"
       }
+    ],
+    "preparation": "Leaf tea, powder, tablets, and extracts standardized to DNJ or flavonoids.",
+    "contraindications": [
+      "Hypoglycemia risk",
+      "pregnancy/breastfeeding without clinician guidance"
     ]
   },
   {
@@ -40980,7 +41199,7 @@
     "benefits": [],
     "latin": "Cissus quadrangularis",
     "mechanism": "Constituents are associated with connective-tissue and recovery-adjacent positioning.",
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
     "region": "Africa and South Asia",
     "aliases": [
       "cissus"
@@ -40991,7 +41210,8 @@
       "quadrangularin A"
     ],
     "interactions": [
-      "Use caution with aggressive performance claims."
+      "May potentiate antidiabetic agents",
+      "caution with anticoagulants if blended products include additional actives."
     ],
     "mechanismTags": [
       "connective tissue support",
@@ -41001,6 +41221,11 @@
       {
         "title": "Internal workbook + enrichment queue"
       }
+    ],
+    "preparation": "Stem extracts/powders; extracts vary in ketosteroid/flavonoid standardization.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "diabetes medications without monitoring"
     ]
   },
   {
@@ -41013,7 +41238,7 @@
     "benefits": [],
     "latin": "Angelica keiskei",
     "mechanism": "Chalcones are associated with antioxidant and metabolic-support positioning.",
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
     "region": "Japan",
     "aliases": [
       "ashitaba"
@@ -41023,7 +41248,8 @@
       "4-hydroxyderricin"
     ],
     "interactions": [
-      "Use caution with concentrated extract marketing claims."
+      "Potential additive bleeding risk with anticoagulants/antiplatelets",
+      "limited clinical interaction data."
     ],
     "mechanismTags": [
       "antioxidant",
@@ -41033,6 +41259,11 @@
       {
         "title": "Internal workbook + enrichment queue"
       }
+    ],
+    "preparation": "Leaf/stem powder, tea, and extracts; chalcone content varies by product.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "anticoagulant use without review"
     ]
   },
   {
@@ -41045,7 +41276,7 @@
     "benefits": [],
     "latin": "Terminalia arjuna",
     "mechanism": "Triterpenes and polyphenols support cardiovascular and antioxidant positioning.",
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "Use cautiously with diagnosed heart disease unless supervised. Possible additive effects with antihypertensives, nitrates, beta-blockers, digoxin-like regimens, antiplatelets, or anticoagulants.",
     "region": "India and South Asia",
     "aliases": [
       "arjuna"
@@ -41055,7 +41286,8 @@
       "triterpenes"
     ],
     "interactions": [
-      "Use caution with blood-pressure-lowering strategies."
+      "Potential additive blood-pressure, antianginal, antiplatelet, and cardiac-medication effects",
+      "monitor with cardiovascular drugs."
     ],
     "mechanismTags": [
       "cardiovascular support",
@@ -41072,6 +41304,10 @@
       {
         "title": "Curated expansion"
       }
+    ],
+    "preparation": "Evidence is most relevant to bark preparations or standardized extracts used in clinical studies.",
+    "contraindications": [
+      "Unstable angina, heart failure without clinician oversight, pregnancy/breastfeeding caution, and planned surgery when combined with anticoagulant therapy."
     ]
   },
   {
@@ -41084,7 +41320,7 @@
     "benefits": [],
     "latin": "Vaccinium macrocarpon",
     "mechanism": "Polyphenols support urinary and antioxidant positioning.",
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "GI upset possible; caution with recurrent kidney stones and warfarin-sensitive patients; avoid treating active UTI without care.",
     "region": "North America",
     "aliases": [
       "cranberry"
@@ -41093,7 +41329,8 @@
       "A-type proanthocyanidins"
     ],
     "interactions": [
-      "Use caution with anticoagulant-sensitive contexts."
+      "Warfarin interaction concern is reported",
+      "monitor INR if used with anticoagulation."
     ],
     "mechanismTags": [
       "antioxidant",
@@ -41110,6 +41347,11 @@
       {
         "title": "Curated expansion"
       }
+    ],
+    "preparation": "Juice, capsules, tablets, and PAC-standardized extracts; sugar content varies in juices.",
+    "contraindications": [
+      "History of kidney stones/oxalate stones",
+      "warfarin use requires clinician review"
     ]
   },
   {
@@ -41122,7 +41364,7 @@
     "benefits": [],
     "latin": "Myrtus communis",
     "mechanism": "Volatile constituents and polyphenols support aromatic and antioxidant positioning.",
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
     "region": "Mediterranean",
     "aliases": [
       "myrtle"
@@ -41132,7 +41374,8 @@
       "myricetin"
     ],
     "interactions": [
-      "Use caution with concentrated oil assumptions."
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
     "mechanismTags": [
       "antioxidant",
@@ -41149,6 +41392,11 @@
       {
         "title": "Curated expansion"
       }
+    ],
+    "preparation": "Aromatic herb/spice forms and essential oils differ greatly; essential oils require conservative topical/diluted use and are not interchangeable with teas.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ]
   },
   {
@@ -41161,7 +41409,7 @@
     "benefits": [],
     "latin": "Malpighia emarginata",
     "mechanism": "Fruit polyphenols and vitamin content support antioxidant and nutritive positioning.",
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "Immune-active potential; use caution with autoimmune disease, transplant medicines, immunosuppressants, and during active cancer treatment unless clinician-supervised.",
     "region": "Caribbean; tropical Americas",
     "aliases": [
       "acerola cherry"
@@ -41171,7 +41419,7 @@
       "carotenoids"
     ],
     "interactions": [
-      "Use caution with overextended immune claims."
+      "May affect iron absorption and some lab results at high vitamin C intakes."
     ],
     "mechanismTags": [
       "antioxidant",
@@ -41188,6 +41436,12 @@
       {
         "title": "Curated expansion"
       }
+    ],
+    "preparation": "Fruit powder, juice, extracts, and vitamin C-standardized products.",
+    "contraindications": [
+      "Kidney stone risk",
+      "iron overload conditions",
+      "G6PD deficiency caution with very high vitamin C dosing"
     ]
   },
   {
@@ -41200,7 +41454,7 @@
     "benefits": [],
     "latin": "Garcinia mangostana",
     "mechanism": "Xanthones support antioxidant and traditional-support positioning.",
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
     "region": "Southeast Asia",
     "aliases": [
       "mangosteen"
@@ -41210,7 +41464,8 @@
       "xanthones"
     ],
     "interactions": [
-      "Use caution with exaggerated anti-inflammatory claims."
+      "Theoretical anticoagulant/antiplatelet interactions",
+      "product-specific evidence limited."
     ],
     "mechanismTags": [
       "antioxidant",
@@ -41227,6 +41482,11 @@
       {
         "title": "Curated expansion"
       }
+    ],
+    "preparation": "Pericarp/rind extracts, juice blends, powders; fruit pulp differs from rind extract.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "bleeding disorder/anticoagulant use without review"
     ]
   },
   {
@@ -41239,8 +41499,8 @@
     "benefits": [],
     "latin": "Pfaffia paniculata",
     "mechanism": "Saponins support traditional restorative and adaptogenic positioning.",
-    "safetyNotes": "Generally well tolerated.",
-    "region": "South America",
+    "safetyNotes": "Limited human safety data; use conservative preparation-specific framing and avoid pregnancy/breastfeeding or medication stacking without clinician review.",
+    "region": "South America traditional medicine",
     "aliases": [
       "suma",
       "Brazilian ginseng"
@@ -41250,7 +41510,8 @@
       "saponins"
     ],
     "interactions": [
-      "Avoid overextended vitality claims."
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
     "mechanismTags": [
       "adaptogenic support",
@@ -41267,6 +41528,11 @@
       {
         "title": "Curated expansion"
       }
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ]
   },
   {
@@ -41279,8 +41545,8 @@
     "benefits": [],
     "latin": "Rhaponticum carthamoides",
     "mechanism": "Ecdysteroids support adaptogenic and performance-adjacent positioning.",
-    "safetyNotes": "Generally well tolerated.",
-    "region": "Central Asia",
+    "safetyNotes": "Limited human safety data; use conservative preparation-specific framing and avoid pregnancy/breastfeeding or medication stacking without clinician review.",
+    "region": "Central Asia/Siberia",
     "aliases": [
       "maral root"
     ],
@@ -41288,7 +41554,8 @@
       "ecdysterone"
     ],
     "interactions": [
-      "Use caution with aggressive performance claims."
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
     "mechanismTags": [
       "adaptogenic support",
@@ -41305,6 +41572,11 @@
       {
         "title": "Curated expansion"
       }
+    ],
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ]
   },
   {
@@ -41317,7 +41589,7 @@
     "benefits": [],
     "latin": "Saraca asoca",
     "mechanism": "Polyphenols support traditional cycle-related positioning.",
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "Hormone- or cycle-related traditional use requires caution in pregnancy, breastfeeding, hormone-sensitive conditions, and with hormone therapies.",
     "region": "India and South Asia",
     "aliases": [
       "ashoka"
@@ -41327,7 +41599,8 @@
       "flavonoids"
     ],
     "interactions": [
-      "Avoid overextended reproductive-health claims."
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
     "mechanismTags": [
       "traditional cycle support"
@@ -41343,6 +41616,11 @@
       {
         "title": "Curated expansion"
       }
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ]
   },
   {
@@ -41355,7 +41633,7 @@
     "benefits": [],
     "latin": "Ceratonia siliqua",
     "mechanism": "Inositol derivatives and polyphenols support metabolic and digestive positioning.",
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
     "region": "Mediterranean",
     "aliases": [
       "carob"
@@ -41365,7 +41643,7 @@
       "polyphenols"
     ],
     "interactions": [
-      "Use caution with overextended glycemic claims."
+      "Fiber/tannin content may reduce absorption of some oral medications if taken together."
     ],
     "mechanismTags": [
       "digestive support",
@@ -41382,6 +41660,11 @@
       {
         "title": "Curated expansion"
       }
+    ],
+    "preparation": "Pod powder, gum, syrup, and fiber/tannin extracts; gum and pod powder differ.",
+    "contraindications": [
+      "Severe constipation/obstruction risk",
+      "carob allergy"
     ]
   },
   {
@@ -41394,7 +41677,7 @@
     "benefits": [],
     "latin": "Eucommia ulmoides",
     "mechanism": "Iridoids and lignans support connective-tissue and metabolic positioning.",
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "May affect circulation, blood pressure, or platelet function; use caution with anticoagulants/antiplatelets, antihypertensives, heart medications, and before surgery.",
     "region": "China and East Asia",
     "aliases": [
       "eucommia"
@@ -41414,6 +41697,11 @@
       {
         "title": "Internal workbook + enrichment queue"
       }
+    ],
+    "preparation": "Bark/leaf tea, decoction, powders, and extracts; bark and leaf chemistry differ.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "hypotension or hypoglycemia risk"
     ]
   },
   {
@@ -41426,7 +41714,7 @@
     "benefits": [],
     "latin": "Cistanche deserticola",
     "mechanism": "Phenylethanoid glycosides support restorative and antioxidant positioning.",
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "Limited human safety data; use conservative preparation-specific framing and avoid pregnancy/breastfeeding or medication stacking without clinician review.",
     "region": "China and Central Asia",
     "aliases": [
       "cistanche"
@@ -41436,7 +41724,8 @@
       "acteoside"
     ],
     "interactions": [
-      "Use caution with exaggerated vitality claims."
+      "Limited clinical interaction data",
+      "caution with laxatives and glucose-lowering therapies."
     ],
     "mechanismTags": [
       "fatigue support",
@@ -41446,6 +41735,11 @@
       {
         "title": "Internal workbook + enrichment queue"
       }
+    ],
+    "preparation": "Stem decoction, powder, and extracts standardized to echinacoside/acteoside.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without guidance",
+      "diarrhea-prone conditions"
     ]
   },
   {
@@ -41458,7 +41752,7 @@
     "benefits": [],
     "latin": "Dimocarpus longan",
     "mechanism": "Polyphenols support antioxidant and nutritive positioning.",
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
     "region": "Southeast Asia",
     "aliases": [
       "longan"
@@ -41468,7 +41762,8 @@
       "gallic acid"
     ],
     "interactions": [
-      "Avoid overextended nootropic claims."
+      "Potential interaction concern with sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "mechanismTags": [
       "calming support",
@@ -41478,6 +41773,11 @@
       {
         "title": "Internal workbook + enrichment queue"
       }
+    ],
+    "preparation": "Fruit/berry preparations are commonly used as foods, juices, powders, capsules, or extracts; sugar and extract concentration vary.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ]
   },
   {
@@ -41490,7 +41790,7 @@
     "benefits": [],
     "latin": "Paeonia lactiflora",
     "mechanism": "Monoterpene glycosides support traditional cycle and calming positioning.",
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
     "region": "China and East Asia",
     "aliases": [
       "white peony"
@@ -41499,7 +41799,8 @@
       "paeoniflorin"
     ],
     "interactions": [
-      "Use caution with anticoagulant-sensitive contexts."
+      "Potential additive bleeding risk with anticoagulants/antiplatelets",
+      "may interact with immunomodulators."
     ],
     "mechanismTags": [
       "calming support",
@@ -41509,6 +41810,11 @@
       {
         "title": "Internal workbook + enrichment queue"
       }
+    ],
+    "preparation": "Root decoction/extract; often paired with licorice or other TCM herbs.",
+    "contraindications": [
+      "Pregnancy without clinician guidance",
+      "anticoagulant use without review"
     ]
   },
   {
@@ -41521,8 +41827,8 @@
     "benefits": [],
     "latin": "Codonopsis pilosula",
     "mechanism": "Polysaccharides and glycosides support restorative and fatigue-support positioning.",
-    "safetyNotes": "Generally well tolerated.",
-    "region": "China and East Asia",
+    "safetyNotes": "Immune-active potential; use caution with autoimmune disease, transplant medicines, immunosuppressants, and during active cancer treatment unless clinician-supervised.",
+    "region": "East Asia / Traditional Chinese Medicine",
     "aliases": [
       "codonopsis",
       "dang shen"
@@ -41533,7 +41839,8 @@
       "tangshenoside I"
     ],
     "interactions": [
-      "Avoid exaggerated adaptogen claims."
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "mechanismTags": [
       "fatigue support",
@@ -41543,6 +41850,11 @@
       {
         "title": "Internal workbook + enrichment queue"
       }
+    ],
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ]
   },
   {
@@ -41555,8 +41867,8 @@
     "benefits": [],
     "latin": "Ophiopogon japonicus",
     "mechanism": "Saponins support demulcent and traditional respiratory positioning.",
-    "safetyNotes": "Generally well tolerated.",
-    "region": "China and East Asia",
+    "safetyNotes": "Mucilage-rich preparations may slow absorption of oral medicines; separate from medications when practical. Use caution with diabetes medicines if metabolic effects are suspected.",
+    "region": "East Asia / Traditional Chinese Medicine",
     "aliases": [
       "ophiopogon",
       "mai men dong"
@@ -41566,7 +41878,8 @@
       "ophiopogonin D"
     ],
     "interactions": [
-      "Avoid overextended pulmonary claims."
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
     "mechanismTags": [
       "demulcent support",
@@ -41576,6 +41889,11 @@
       {
         "title": "Internal workbook + enrichment queue"
       }
+    ],
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ]
   },
   {
@@ -41588,8 +41906,8 @@
     "benefits": [],
     "latin": "Houttuynia cordata",
     "mechanism": "Flavonoids and volatiles support traditional immune and respiratory positioning.",
-    "safetyNotes": "Generally well tolerated.",
-    "region": "East and Southeast Asia",
+    "safetyNotes": "Immune-active potential; use caution with autoimmune disease, transplant medicines, immunosuppressants, and during active cancer treatment unless clinician-supervised.",
+    "region": "East Asia / Traditional Chinese Medicine",
     "aliases": [
       "houttuynia"
     ],
@@ -41598,7 +41916,8 @@
       "volatile oils"
     ],
     "interactions": [
-      "Avoid exaggerated antiviral claims."
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "mechanismTags": [
       "traditional immune support",
@@ -41608,6 +41927,11 @@
       {
         "title": "Internal workbook + enrichment queue"
       }
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ]
   },
   {
@@ -41620,7 +41944,7 @@
     "benefits": [],
     "latin": "Isatis tinctoria",
     "mechanism": "Indole derivatives support traditional immune-related positioning.",
-    "region": "China and Eurasia",
+    "region": "East Asia / Traditional Chinese Medicine",
     "aliases": [
       "isatis",
       "ban lan gen"
@@ -41630,7 +41954,8 @@
       "tryptanthrin"
     ],
     "interactions": [
-      "Avoid exaggerated infection-treatment claims."
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "mechanismTags": [
       "throat support",
@@ -41640,6 +41965,12 @@
       {
         "title": "Internal workbook + enrichment queue"
       }
+    ],
+    "safetyNotes": "Immune-active potential; use caution with autoimmune disease, transplant medicines, immunosuppressants, and during active cancer treatment unless clinician-supervised.",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ]
   },
   {
@@ -41652,8 +41983,8 @@
     "benefits": [],
     "latin": "Panax notoginseng",
     "mechanism": "Saponins support vascular and recovery-related positioning.",
-    "safetyNotes": "Generally well tolerated.",
-    "region": "China",
+    "safetyNotes": "May affect platelet aggregation and bleeding risk; use caution with anticoagulants/antiplatelets, before surgery, and during pregnancy unless supervised.",
+    "region": "China; TCM",
     "aliases": [
       "notoginseng",
       "san qi"
@@ -41663,7 +41994,7 @@
       "ginsenosides"
     ],
     "interactions": [
-      "Use caution with anticoagulant-sensitive contexts."
+      "May interact with anticoagulants, antiplatelets, antihypertensives, and antidiabetics."
     ],
     "mechanismTags": [
       "recovery support",
@@ -41673,6 +42004,12 @@
       {
         "title": "Internal workbook + enrichment queue"
       }
+    ],
+    "preparation": "Root powder, decoction, extracts; saponin-standardized products exist.",
+    "contraindications": [
+      "Pregnancy",
+      "anticoagulant/antiplatelet use without clinician review",
+      "upcoming surgery"
     ]
   },
   {
@@ -41685,8 +42022,8 @@
     "benefits": [],
     "latin": "Siraitia grosvenorii",
     "mechanism": "Triterpene glycosides support sweetener and throat-soothing positioning.",
-    "safetyNotes": "Generally well tolerated.",
-    "region": "China",
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "region": "China / East Asia",
     "aliases": [
       "monk fruit",
       "luo han guo"
@@ -41696,7 +42033,8 @@
       "mogroside V"
     ],
     "interactions": [
-      "Avoid overextended glycemic claims."
+      "Potential interaction concern with antidiabetic medicines, antihypertensives/diuretics",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "mechanismTags": [
       "sweetener-adjacent support",
@@ -41706,6 +42044,11 @@
       {
         "title": "Internal workbook + enrichment queue"
       }
+    ],
+    "preparation": "Fruit/berry preparations are commonly used as foods, juices, powders, capsules, or extracts; sugar and extract concentration vary.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ]
   },
   {
@@ -41718,8 +42061,8 @@
     "benefits": [],
     "latin": "Ilex kudingcha",
     "mechanism": "Bitters and polyphenols support antioxidant and metabolic positioning.",
-    "safetyNotes": "Generally well tolerated.",
-    "region": "China",
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "region": "China / East Asia",
     "aliases": [
       "kuding tea"
     ],
@@ -41729,7 +42072,8 @@
       "kudinlactone"
     ],
     "interactions": [
-      "Use caution with strong bitterness and GI sensitivity."
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "mechanismTags": [
       "antioxidant",
@@ -41739,6 +42083,11 @@
       {
         "title": "Internal workbook + enrichment queue"
       }
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ]
   },
   {
@@ -41751,7 +42100,7 @@
     "benefits": [],
     "latin": "Grifola frondosa",
     "mechanism": "Beta-glucan-rich extracts support immune-modulating positioning.",
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "Immune-active mushroom extract; use caution with immunosuppressants, transplant medicines, autoimmune disease, and during active cancer treatment unless clinician-supervised.",
     "region": "Japan; cultivated globally",
     "aliases": [
       "maitake D-fraction"
@@ -41760,7 +42109,8 @@
       "beta-glucans"
     ],
     "interactions": [
-      "Avoid exaggerated oncology-treatment claims."
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "mechanismTags": [
       "immune modulation"
@@ -41769,6 +42119,11 @@
       {
         "title": "Internal workbook + enrichment queue"
       }
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ]
   },
   {
@@ -41781,8 +42136,8 @@
     "benefits": [],
     "latin": "Rehmannia glutinosa praeparata",
     "mechanism": "Traditional preparation context supports restorative positioning.",
-    "safetyNotes": "Generally well tolerated.",
-    "region": "China and East Asia",
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "region": "East Asia / Traditional Chinese Medicine",
     "aliases": [
       "prepared rehmannia",
       "shu di huang"
@@ -41792,7 +42147,8 @@
       "rehmanniosides"
     ],
     "interactions": [
-      "Avoid conflating raw and prepared-form actions."
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "mechanismTags": [
       "traditional restorative support"
@@ -41801,6 +42157,13 @@
       {
         "title": "Internal workbook + enrichment queue"
       }
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "active liver disease",
+      "significant kidney disease or unstable electrolytes"
     ]
   },
   {
@@ -41822,7 +42185,8 @@
       "polysaccharides"
     ],
     "interactions": [
-      "Avoid exaggerated antimicrobial claims."
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "mechanismTags": [
       "respiratory support",
@@ -41832,6 +42196,12 @@
       {
         "title": "Internal workbook + enrichment queue"
       }
+    ],
+    "safetyNotes": "Immune-active potential; use caution with autoimmune disease, transplant medicines, immunosuppressants, and during active cancer treatment unless clinician-supervised.",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ]
   },
   {
@@ -41844,7 +42214,7 @@
     "benefits": [],
     "latin": "Piper nigrum",
     "mechanism": "Alkaloids support digestive and absorption-related positioning.",
-    "safetyNotes": "Generally well tolerated; use caution with concentrated extracts.",
+    "safetyNotes": "Food use is low-risk; concentrated piperine extracts can alter drug exposure. Use caution with narrow-therapeutic-index drugs and multi-supplement stacks.",
     "region": "India; cultivated globally",
     "aliases": [
       "black pepper"
@@ -41853,10 +42223,11 @@
       "piperine"
     ],
     "interactions": [
-      "Use caution with drug-metabolism-sensitive contexts and tightly dosed stacks."
+      "May increase exposure of CYP/P-gp substrates and enhance curcumin or other supplement bioavailability",
+      "caution with anticoagulants, antiepileptics, immunosuppressants, and cardiovascular drugs."
     ],
     "contraindications": [
-      "Use caution in reflux-sensitive contexts."
+      "Use cautiously with prescription polypharmacy, pregnancy/breastfeeding supplements, ulcers/reflux sensitivity, and perioperative anticoagulant use."
     ],
     "mechanismTags": [
       "bioavailability support",
@@ -41867,7 +42238,8 @@
       {
         "title": "Internal workbook + enrichment queue"
       }
-    ]
+    ],
+    "preparation": "Distinguish culinary black pepper from standardized high-piperine extracts."
   },
   {
     "id": "cardamom",
@@ -41879,7 +42251,7 @@
     "benefits": [],
     "latin": "Elettaria cardamomum",
     "mechanism": "Volatiles support digestive and aromatic positioning.",
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
     "region": "India and Guatemala; cultivated broadly",
     "aliases": [
       "cardamom"
@@ -41889,7 +42261,8 @@
       "terpinyl acetate"
     ],
     "interactions": [
-      "Use caution with concentrated essential-oil assumptions."
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
     "mechanismTags": [
       "aromatic support",
@@ -41899,6 +42272,11 @@
       {
         "title": "Internal workbook + enrichment queue"
       }
+    ],
+    "preparation": "Aromatic herb/spice forms and essential oils differ greatly; essential oils require conservative topical/diluted use and are not interchangeable with teas.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ]
   },
   {
@@ -41911,7 +42289,7 @@
     "benefits": [],
     "latin": "Carum carvi",
     "mechanism": "Volatile constituents support digestive and aromatic positioning.",
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
     "region": "Europe and Western Asia",
     "aliases": [
       "caraway"
@@ -41921,7 +42299,8 @@
       "limonene"
     ],
     "interactions": [
-      "Use caution with concentrated oil assumptions."
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
     "mechanismTags": [
       "aromatic support",
@@ -41931,6 +42310,11 @@
       {
         "title": "Internal workbook + enrichment queue"
       }
+    ],
+    "preparation": "Aromatic herb/spice forms and essential oils differ greatly; essential oils require conservative topical/diluted use and are not interchangeable with teas.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ]
   },
   {
@@ -41943,7 +42327,7 @@
     "benefits": [],
     "latin": "Trachyspermum ammi",
     "mechanism": "Aromatic phenols support digestive and antimicrobial-adjacent positioning.",
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
     "region": "India and South Asia",
     "aliases": [
       "ajwain"
@@ -41953,7 +42337,8 @@
       "carvacrol"
     ],
     "interactions": [
-      "Avoid overextended antimicrobial claims."
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
     "mechanismTags": [
       "aromatic support",
@@ -41963,6 +42348,11 @@
       {
         "title": "Internal workbook + enrichment queue"
       }
+    ],
+    "preparation": "Seed/fiber preparations are commonly used as whole seed, powder, capsules, or food ingredients; fluid intake and preparation form matter.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ]
   },
   {
@@ -41975,7 +42365,7 @@
     "benefits": [],
     "latin": "Murraya koenigii",
     "mechanism": "Alkaloids and polyphenols support antioxidant and metabolic positioning.",
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
     "region": "India and South Asia",
     "aliases": [
       "curry leaf"
@@ -41985,7 +42375,8 @@
       "carbazole alkaloids"
     ],
     "interactions": [
-      "Avoid overextended glycemic claims."
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "mechanismTags": [
       "antioxidant",
@@ -41995,6 +42386,11 @@
       {
         "title": "Internal workbook + enrichment queue"
       }
+    ],
+    "preparation": "Leaf preparations are commonly used as teas, powders, tinctures, or standardized extracts; topical use may differ from oral use.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ]
   },
   {
@@ -42006,7 +42402,7 @@
     "compounds": [],
     "benefits": [],
     "latin": "Trametes versicolor",
-    "region": "Global",
+    "region": "Global woodland mushroom",
     "aliases": [
       "turkey tail"
     ],
@@ -42014,7 +42410,8 @@
       "PSK"
     ],
     "interactions": [
-      "Generally safe"
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "mechanismTags": [
       "nfkb"
@@ -42024,7 +42421,13 @@
         "title": "Internal workbook + enrichment queue"
       }
     ],
-    "confidenceTier": "low"
+    "confidenceTier": "low",
+    "safetyNotes": "Immune-active mushroom extract; use caution with immunosuppressants, transplant medicines, autoimmune disease, and during active cancer treatment unless clinician-supervised.",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ]
   },
   {
     "id": "rooibos",
@@ -42036,7 +42439,7 @@
     "benefits": [],
     "latin": "Aspalathus linearis",
     "mechanism": "Polyphenol-linked antioxidant relevance supports mild positioning.",
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
     "region": "South Africa",
     "aliases": [
       "rooibos",
@@ -42048,8 +42451,8 @@
       "flavonoids"
     ],
     "interactions": [
-      "No major interaction pattern is firmly established",
-      "use routine caution in polypharmacy."
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
     "mechanismTags": [
       "antioxidant support",
@@ -42059,6 +42462,11 @@
       {
         "title": "Internal workbook cross-link"
       }
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ]
   }
 ]


### PR DESCRIPTION
### Motivation
- Refresh published runtime datasets from the cleaned combined workbook/publish inputs so the site runtime payloads reflect the latest canonical and workbook data.
- Keep the change narrowly scoped to derived runtime outputs under `public/data` without altering source code or the workbook.
- Preserve existing route contracts and slug hygiene while applying the workbook overlay during sync.

### Description
- Regenerated `public/data/herbs.json` and `public/data/compounds.json` by running the sync pipeline with workbook/publish-input ingestion using `node scripts/sync-updated-datasets.mjs`. 
- Hydrated slugs and added/normalized fields (`foundIn`, `linkedHerbs`, descriptions, targets, safetyNotes, summaries, etc.) across many compound and herb entries as produced by the sync/enrichment pipeline. 
- Kept scope limited to derived artifacts only; no source code, workbooks, or formatting tooling were changed. 
- Committed the two updated runtime JSON artifacts only.

### Testing
- Ran `node scripts/sync-updated-datasets.mjs` to regenerate the outputs and observed workbook export/overlay and hydration logs (herbs=738 compounds=397 written). 
- Ran `npm run validate:data` and `npm run data:validate` which reported `STRUCTURAL_HARD issues: 5` and `Blocking structural issue count: 2` and thus the data validation gate failed. 
- Ran `npm run typecheck` (`tsc --noEmit`) which completed successfully. 
- Performed a targeted scan for placeholder/bad values and found a remaining `"[object Object]"` occurrence in `public/data/herbs.json` (activeCompounds for entry `kratom hybrids`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb88b083f48323aa00ebdfc937a50e)