### PR TITLE
Add junk-token guard for herb list normalization

### DIFF
--- a/scripts/export-workbook-to-json.mjs
+++ b/scripts/export-workbook-to-json.mjs
@@ -82,8 +82,16 @@ function toCleanString(value) {
   return String(cleaned).trim()
 }
 
+const JUNK_LIST_TOKENS = new Set(['', 'nan', 'null', 'undefined', '[object object]'])
+
+function isJunkListToken(value) {
+  return JUNK_LIST_TOKENS.has(toCleanString(value).toLowerCase())
+}
+
 function splitList(value, pattern = /[;|]/) {
-  return normalizeWorkbookMultiValue(value, pattern).map(item => toCleanString(item)).filter(Boolean)
+  return normalizeWorkbookMultiValue(value, pattern)
+    .map(item => toCleanString(item))
+    .filter(item => !isJunkListToken(item))
 }
 
 function cleanScalar(value) {


### PR DESCRIPTION
### Motivation
- Prevent placeholder tokens like `"[object Object]"` and other junk (empty, `nan`, `null`, `undefined`) from persisting in herb string-array fields such as `activeCompounds` by tightening the list normalization used during export.

### Description
- Introduced `JUNK_LIST_TOKENS` and `isJunkListToken` in `scripts/export-workbook-to-json.mjs` and updated `splitList` to filter out `""`, `"nan"`, `"null"`, `"undefined"`, and `"[object Object]"` (case-insensitive), which affects fields that flow through `splitSemicolonOrCommaList`/`splitList` including `activeCompounds`, `topCompounds`, `markerCompounds`, `commonNames`, `interactions`, `contraindications`, `pathwayTargets`, `relatedHerbs`, and citation `sources`.

### Testing
- Ran `npm run typecheck` (`tsc --noEmit`) which passed, and the commit's pre-commit hook (including `eslint`) ran successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb8d5cf5148323b84a47530dc672e4)