### PR TITLE
Add workbook-only runtime scaffold for public/data-next

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "verify:deploy-readiness": "node scripts/ci/validate-deploy-readiness.mjs",
     "verify:workbook-import": "node scripts/verify-workbook-import-reconciliation.mjs",
     "data:project:monographs": "node scripts/generate-monograph-projection.mjs",
+    "data:build:next": "node scripts/data/build-runtime-from-workbook.mjs",
     "typecheck": "tsc --noEmit",
     "check": "npm run lint && npm run typecheck && npm run build"
   },

--- a/public/data-next/_meta/build-info.json
+++ b/public/data-next/_meta/build-info.json
@@ -1,0 +1,21 @@
+{
+  "generatedAt": "2026-04-24T16:22:42.535Z",
+  "source": {
+    "workbookPath": "/workspace/hippie-scientist-site/data-sources/herb_monograph_master.xlsx",
+    "sheets": {
+      "herbs": "Herb Master Clean",
+      "compounds": "Compound Master V3",
+      "herbCompoundMap": "Herb Compound Map V3",
+      "claimRows": "Claim Rows"
+    }
+  },
+  "counts": {
+    "herbs": 285,
+    "compounds": 235,
+    "herbsSummary": 285,
+    "compoundsSummary": 235,
+    "claimRows": 4349,
+    "skippedHerbs": 0,
+    "skippedCompounds": 0
+  }
+}

--- a/public/data-next/compounds-summary.json
+++ b/public/data-next/compounds-summary.json
@@ -1,0 +1,2352 @@
+[
+  {
+    "name": "11-keto-beta-boswellic acid",
+    "slug": "11-keto-beta-boswellic-acid",
+    "summary": "Keto-boswellic acid associated with 5-LOX-related signaling and inflammatory modulation.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "acemannan",
+    "slug": "acemannan",
+    "summary": "Acetylated mannose-rich polysaccharide from aloe gel commonly associated with immunomodulatory and wound-healing activity.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "acetyl-11-keto-beta-boswellic acid",
+    "slug": "acetyl-11-keto-beta-boswellic-acid",
+    "summary": "Acetyl-11-keto-beta-boswellic acid is a boswellic acid emphasized in Boswellia standardization discussions. Its relevance is mechanistically strong for inflammatory pathways, but isolated-compound human evidence is much thinner than extract-level evidence.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "acetyl-beta-boswellic acid",
+    "slug": "acetyl-beta-boswellic-acid",
+    "summary": "Acetylated boswellic acid linked to leukotriene-pathway suppression in Boswellia.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "acetylshikonin",
+    "slug": "acetylshikonin",
+    "summary": "Shikonin derivative linked to inflammatory and apoptotic signaling.",
+    "evidenceLevel": "preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "acteoside",
+    "slug": "acteoside",
+    "summary": "Phenylethanoid glycoside with inflammatory pathway modulation.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "aescin",
+    "slug": "aescin",
+    "summary": "Mixture of triterpene saponins from horse chestnut best known for venotonic and vascular permeability effects.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ajoene",
+    "slug": "ajoene",
+    "summary": "Organosulfur garlic derivative formed from allicin breakdown and linked to antiplatelet and inflammatory signaling effects.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "albiflorin",
+    "slug": "albiflorin",
+    "summary": "Paeonia glycoside linked to neurotransmitter and signaling pathway effects.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "alpha-asarone",
+    "slug": "alpha-asarone",
+    "summary": "Phenylpropanoid ether from Acorus species studied for CNS-active and cholinergic effects.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "alpha-mangostin",
+    "slug": "alpha-mangostin",
+    "summary": "Major mangosteen xanthone with inflammatory and apoptotic signaling activity.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "anabasine",
+    "slug": "anabasine",
+    "summary": "Pyridine alkaloid associated with nicotinic receptor activity.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 4,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "anatabine",
+    "slug": "anatabine",
+    "summary": "Minor tobacco alkaloid associated with nicotinic signaling and inflammatory pathway effects.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "andrographolide",
+    "slug": "andrographolide",
+    "summary": "Diterpene lactone from andrographis with strong pathway-level inflammatory signaling effects.",
+    "evidenceLevel": "human_indirect_from_andrographis; preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "anethole",
+    "slug": "anethole",
+    "summary": "Phenylpropene from fennel and anise associated with digestive and anti-inflammatory actions.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "angelicin",
+    "slug": "angelicin",
+    "summary": "Angelicin is a furocoumarin associated with photosensitizing pharmacology and occasional discussion in skin and bone research. The evidence base is primarily mechanistic, with efficacy claims constrained by limited human data and safety context.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "apigenin",
+    "slug": "apigenin",
+    "summary": "Apigenin is a flavone found in chamomile, parsley, and related plants, with frequent discussion in neuroinflammatory and calm-support research. The evidence base is still dominated by in vitro and animal work despite clear mechanistic interest.",
+    "evidenceLevel": "preclinical; human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 11,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "arjunolic acid",
+    "slug": "arjunolic-acid",
+    "summary": "Triterpenoid from Terminalia arjuna associated with cardioprotective effects.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "artemisinin",
+    "slug": "artemisinin",
+    "summary": "Sesquiterpene lactone endoperoxide linked to redox and survival pathway effects.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "artemisinin b",
+    "slug": "artemisinin-b",
+    "summary": "Artemisia metabolite associated with redox-related signaling.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "artesunate",
+    "slug": "artesunate",
+    "summary": "Semi-synthetic artemisinin derivative retained here in natural-derivative context.",
+    "evidenceLevel": "human_strong",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "asiatic acid",
+    "slug": "asiatic-acid",
+    "summary": "Triterpenoid aglycone associated with tissue repair and inflammatory pathway effects.",
+    "evidenceLevel": "human_indirect_from_centella_extracts",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 11,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "asiaticoside",
+    "slug": "asiaticoside",
+    "summary": "Centella triterpene glycoside linked to wound and matrix signaling pathways.",
+    "evidenceLevel": "human_indirect_from_centella; preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "aspalathin",
+    "slug": "aspalathin",
+    "summary": "C-glucosyl dihydrochalcone characteristic of rooibos with metabolic and redox-signaling activity.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "astragalin",
+    "slug": "astragalin",
+    "summary": "Flavonoid glycoside associated with inflammatory pathway control.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "astragaloside iv",
+    "slug": "astragaloside-iv",
+    "summary": "Astragalus saponin linked to metabolic signaling and tissue-protective pathways.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 13,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "atractylenolide i",
+    "slug": "atractylenolide-i",
+    "summary": "Sesquiterpene lactone associated with immune and survival signaling.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "atractylenolide ii",
+    "slug": "atractylenolide-ii",
+    "summary": "Atractylodes lactone linked to inflammatory signaling control.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "atractylenolide iii",
+    "slug": "atractylenolide-iii",
+    "summary": "Sesquiterpene lactone associated with immune and cytoprotective pathways.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "aucubin",
+    "slug": "aucubin",
+    "summary": "Aucubin is an iridoid glycoside associated with inflammatory pathway suppression.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "bacopaside ii",
+    "slug": "bacopaside-ii",
+    "summary": "Bacopa triterpenoid saponin associated with nootropic activity and kinase-linked neuroprotective signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "bacoside a",
+    "slug": "bacoside-a",
+    "summary": "Bacopa saponin fraction associated with cognitive signaling support.",
+    "evidenceLevel": "human_indirect_from_bacopa; preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "bacoside b",
+    "slug": "bacoside-b",
+    "summary": "Bacopa saponin fraction linked to cognition-related signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "baicalein",
+    "slug": "baicalein",
+    "summary": "Baicalein is the aglycone partner of baicalin and is widely studied in inflammation, redox biology, and cancer-mechanism literature. The evidence remains mainly preclinical, with limited isolated human intervention data.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "baicalin",
+    "slug": "baicalin",
+    "summary": "Baicalin is a flavone glycoside associated with Scutellaria species and related TCM research. Its strongest support is preclinical, especially for inflammatory and oxidative-stress pathways, while direct isolated-compound human evidence remains limited.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "berbamine",
+    "slug": "berbamine",
+    "summary": "Bis-benzylisoquinoline alkaloid from barberry-type plants with anti-inflammatory and signaling-modulatory activity.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "berberine",
+    "slug": "berberine",
+    "summary": "Berberine is a protoberberine alkaloid concentrated in barberry-type herbs and used most often in metabolic research. Human evidence is strongest for glucose and lipid endpoints, while mechanistic literature consistently points to energy-sensing and inflammatory pathway effects.",
+    "evidenceLevel": "human_limited; meta_analysis_for_metabolic_markers",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 27,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "bergapten",
+    "slug": "bergapten",
+    "summary": "Methoxypsoralen constituent of citrus and Psoralea commonly linked to MAPK and inflammatory pathway modulation.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "beta-caryophyllene",
+    "slug": "beta-caryophyllene",
+    "summary": "Sesquiterpene linked to cannabinoid-receptor and inflammatory signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "beta-elemene",
+    "slug": "beta-elemene",
+    "summary": "Sesquiterpene hydrocarbon associated with survival and apoptotic signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "beta-sitosterol",
+    "slug": "beta-sitosterol",
+    "summary": "Beta-sitosterol is a phytosterol widely distributed across medicinal plants and food plants. Human evidence is most relevant to cholesterol absorption and lower-urinary-tract endpoints, but many studies are mixture- or sterol-blend-based rather than isolated-compound-focused.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "betulinic acid",
+    "slug": "betulinic-acid",
+    "summary": "Pentacyclic triterpenoid found across several botanicals and fungi, often studied for inflammatory and apoptotic signaling effects.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "bilobetin",
+    "slug": "bilobetin",
+    "summary": "Biflavone from Ginkgo and related taxa associated with inflammatory pathway modulation.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "biochanin a",
+    "slug": "biochanin-a",
+    "summary": "Biochanin A is an isoflavone present in red clover and other legumes, with interest centered on estrogen-related, metabolic, and anti-inflammatory signaling. Human evidence for the isolated compound remains limited compared with broader isoflavone mixtures.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "bisabolol",
+    "slug": "bisabolol",
+    "summary": "Sesquiterpene alcohol associated with inflammatory pathway control.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "bisdemethoxycurcumin",
+    "slug": "bisdemethoxycurcumin",
+    "summary": "Curcuminoid linked to inflammatory pathway suppression and redox signaling.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "boswellic acid",
+    "slug": "boswellic-acid",
+    "summary": "Pentacyclic triterpenoid boswellic acid from frankincense resin with 5-LOX and inflammatory pathway activity.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "butylidenephthalide",
+    "slug": "butylidenephthalide",
+    "summary": "Phthalide constituent associated with PI3K/Akt and inflammatory pathway modulation.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cafestol",
+    "slug": "cafestol",
+    "summary": "Coffee diterpene best known from coffee lipids and studied for xenobiotic-response and inflammatory signaling effects.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "caffeic acid",
+    "slug": "caffeic-acid",
+    "summary": "Phenolic acid broadly present in herbs and coffee, commonly linked to NF-κB and MAPK signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "calycosin",
+    "slug": "calycosin",
+    "summary": "Calycosin is an isoflavone associated especially with Astragalus-derived phytochemistry. The literature emphasizes vascular, estrogen-related, and antioxidant signaling in preclinical models more than replicated human trials.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "carnosic acid",
+    "slug": "carnosic-acid",
+    "summary": "Carnosic acid is a diterpene phenol best known from rosemary and sage. It is mainly supported by antioxidant, neuroprotective, and anti-inflammatory preclinical literature rather than robust human trials.",
+    "evidenceLevel": "preclinical; human_indirect_from_rosemary",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "carnosol",
+    "slug": "carnosol",
+    "summary": "Phenolic diterpene from rosemary with antioxidant and anti-inflammatory pathway activity.",
+    "evidenceLevel": "animal / in vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 14,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "carvacrol",
+    "slug": "carvacrol",
+    "summary": "Carvacrol is a monoterpenoid phenol concentrated in oregano and thyme chemotypes. It is best supported by preclinical antimicrobial and anti-inflammatory data, with human evidence for isolated use still sparse.",
+    "evidenceLevel": "animal / in vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 15,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "caryophyllene oxide",
+    "slug": "caryophyllene-oxide",
+    "summary": "Oxidized caryophyllene derivative associated with inflammatory and apoptotic signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "catalpol",
+    "slug": "catalpol",
+    "summary": "Catalpol is an iridoid glycoside linked to metabolic and cytoprotective signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "catechin",
+    "slug": "catechin",
+    "summary": "Catechin is a flavanol found in tea, cacao, and many botanicals, but much of the human literature evaluates catechin-rich mixtures rather than isolated catechin alone. That makes the mechanism signal stronger than the isolated clinical signal.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "celastrol",
+    "slug": "celastrol",
+    "summary": "Quinone methide triterpenoid linked to HSP90 inhibition and NF-κB suppression.",
+    "evidenceLevel": "preclinical_high_caution",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cepharanthine",
+    "slug": "cepharanthine",
+    "summary": "Bisbenzylisoquinoline alkaloid associated with NF-κB suppression and PI3K/Akt pathway effects.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "chamazulene",
+    "slug": "chamazulene",
+    "summary": "Aromatic azulene derivative linked to inflammatory mediator modulation.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "charantin",
+    "slug": "charantin",
+    "summary": "Bitter melon sterol glycoside mixture associated with glucose uptake and metabolic regulation.",
+    "evidenceLevel": "human_indirect_from_bitter_melon; preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "chicoric acid",
+    "slug": "chicoric-acid",
+    "summary": "Caffeic acid derivative prominent in echinacea and chicory with anti-inflammatory signaling activity.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "chlorogenic acid",
+    "slug": "chlorogenic-acid",
+    "summary": "Caffeoylquinic acid widely reported from coffee and artichoke with AMPK and glucose-metabolism pathway effects.",
+    "evidenceLevel": "human_limited; food_based_evidence",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 17,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "cinnamaldehyde",
+    "slug": "cinnamaldehyde",
+    "summary": "Major aromatic aldehyde in cinnamon bark influencing metabolic and inflammatory signaling.",
+    "evidenceLevel": "animal / in vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 13,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "citronellal",
+    "slug": "citronellal",
+    "summary": "Monoterpene aldehyde common in citronella-type oils, recognized for aromatic and sensory-channel activity.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "columbamine",
+    "slug": "columbamine",
+    "summary": "Berberine-family alkaloid linked to metabolic regulation pathways.",
+    "evidenceLevel": "preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "columbin",
+    "slug": "columbin",
+    "summary": "Diterpenoid from Tinospora cordifolia linked to anti-inflammatory activity.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "commipheric acid",
+    "slug": "commipheric-acid",
+    "summary": "Guggul triterpenoid linked to lipid-signaling and inflammatory control.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "coptisine",
+    "slug": "coptisine",
+    "summary": "Protoberberine alkaloid from Coptis with metabolic and inflammatory pathway activity.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "corosolic acid",
+    "slug": "corosolic-acid",
+    "summary": "Triterpenoid associated with glucose disposal and metabolic signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "crocetin",
+    "slug": "crocetin",
+    "summary": "Saffron carotenoid aglycone linked to PI3K/Akt and Nrf2 pathway activity.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "crocin",
+    "slug": "crocin",
+    "summary": "Saffron carotenoid glycoside reported to influence PI3K/Akt and MAPK signaling.",
+    "evidenceLevel": "human_indirect_from_saffron; preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cryptotanshinone",
+    "slug": "cryptotanshinone",
+    "summary": "Abietane diterpene from Salvia miltiorrhiza with anticancer properties.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "curcumin",
+    "slug": "curcumin",
+    "summary": "Curcuminoid from turmeric commonly linked to NF-κB inhibition and Nrf2 activation.",
+    "evidenceLevel": "human_limited; multiple_meta_analyses_by_indication",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 20,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "curcumol",
+    "slug": "curcumol",
+    "summary": "Sesquiterpenoid from zedoary associated with inflammatory pathway modulation.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "curdione",
+    "slug": "curdione",
+    "summary": "Curcuma sesquiterpenoid linked to survival and apoptotic pathways.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "daidzein",
+    "slug": "daidzein",
+    "summary": "Isoflavone found in soy and clover, frequently linked to estrogen receptor and MAPK pathway activity.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "daidzin",
+    "slug": "daidzin",
+    "summary": "Isoflavone glycoside associated with hormone-related and glycemic effects.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "daphnetin",
+    "slug": "daphnetin",
+    "summary": "Coumarin derivative reported with JAK/STAT and NF-κB inhibitory activity.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "demethoxycurcumin",
+    "slug": "demethoxycurcumin",
+    "summary": "Curcuminoid analog associated with inflammatory and antioxidant-response pathways.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "deoxyelephantopin",
+    "slug": "deoxyelephantopin",
+    "summary": "Sesquiterpene lactone linked to inflammatory and apoptotic signaling.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "deoxymiroestrol",
+    "slug": "deoxymiroestrol",
+    "summary": "Phytoestrogen precursor compound associated with Pueraria mirifica and estrogenic signaling.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 4,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "desmethoxyyangonin",
+    "slug": "desmethoxyyangonin",
+    "summary": "Minor kavalactone from kava associated with monoamine and GABAergic signaling effects.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "dihydrokavain",
+    "slug": "dihydrokavain",
+    "summary": "Major kavalactone from kava linked to calming CNS activity through GABAergic mechanisms.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "dihydromethysticin",
+    "slug": "dihydromethysticin",
+    "summary": "Kavalactone from kava associated with GABAergic activity and monoamine-related signaling.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "diosgenin",
+    "slug": "diosgenin",
+    "summary": "Steroidal sapogenin broadly associated with endocrine and metabolic signaling.",
+    "evidenceLevel": "preclinical; human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "echinacoside",
+    "slug": "echinacoside",
+    "summary": "Echinacoside is a phenylethanoid glycoside found in Echinacea and Cistanche-related materials. It is mainly characterized by antioxidant, neuroprotective, and anti-inflammatory preclinical research rather than strong human intervention data.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 3,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "elemicin",
+    "slug": "elemicin",
+    "summary": "Phenylpropene associated with monoamine-related and sensory signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "elephantopin",
+    "slug": "elephantopin",
+    "summary": "Sesquiterpene lactone associated with inflammatory signaling control.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "eleutheroside b",
+    "slug": "eleutheroside-b",
+    "summary": "Phenylpropanoid glycoside from Eleuthero associated with adaptogenic effects.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "eleutheroside e",
+    "slug": "eleutheroside-e",
+    "summary": "Lignan glycoside from Eleuthero linked to endurance and stress adaptation.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ellagic acid",
+    "slug": "ellagic-acid",
+    "summary": "Polyphenolic acid associated with pomegranate and berry sources, linked to Nrf2 and NF-κB signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "embelin",
+    "slug": "embelin",
+    "summary": "Benzoquinone compound linked to apoptotic and inflammatory signaling.",
+    "evidenceLevel": "preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "emodin",
+    "slug": "emodin",
+    "summary": "Anthraquinone reported from rhubarb with NF-κB and MAPK pathway activity.",
+    "evidenceLevel": "preclinical; safety_known_by_class",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "epicatechin",
+    "slug": "epicatechin",
+    "summary": "Flavan-3-ol associated with cacao and tea, commonly linked to PI3K/Akt and endothelial nitric oxide signaling.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "epicatechin gallate",
+    "slug": "epicatechin-gallate",
+    "summary": "Gallated catechin from tea with anti-inflammatory signaling effects.",
+    "evidenceLevel": "animal / in vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 12,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "epigallocatechin",
+    "slug": "epigallocatechin",
+    "summary": "Tea catechin involved in redox regulation and cell signaling.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "epigallocatechin gallate",
+    "slug": "epigallocatechin-gallate",
+    "summary": "Major green tea catechin widely studied for metabolic and inflammatory pathway effects.",
+    "evidenceLevel": "human / animal / in vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 27,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "epigallocatechin gallate (egcg)",
+    "slug": "epigallocatechin-gallate-egcg",
+    "summary": "Major tea catechin with widely reported AMPK, NF-κB, and PI3K/Akt pathway activity.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "erinacines",
+    "slug": "erinacines",
+    "summary": "Cyathane diterpenoids from lion’s mane mycelium studied for nerve growth factor and neurotrophic signaling.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "esculetin",
+    "slug": "esculetin",
+    "summary": "Hydroxycoumarin reported from chicory and Artemisia with lipoxygenase and NF-κB pathway effects.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "eugenol",
+    "slug": "eugenol",
+    "summary": "Eugenol is a phenylpropanoid most associated with clove and other aromatic herbs. It is best supported by preclinical work showing analgesic, anti-inflammatory, antimicrobial, and membrane-active effects rather than broad human outcome evidence.",
+    "evidenceLevel": "human_limited_topical; preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "farnesol",
+    "slug": "farnesol",
+    "summary": "Sesquiterpene alcohol linked to lipid-signaling and pathway modulation.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ferulic acid",
+    "slug": "ferulic-acid",
+    "summary": "Phenolic acid common in grains and Angelica-related herbs, linked to Nrf2 and PI3K/Akt signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "formononetin",
+    "slug": "formononetin",
+    "summary": "Isoflavone commonly reported from clover and astragalus with estrogen receptor and PI3K/Akt pathway effects.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "forskolin",
+    "slug": "forskolin",
+    "summary": "Diterpene from Coleus known for direct adenylyl cyclase activation.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "fraxetin",
+    "slug": "fraxetin",
+    "summary": "Methoxylated coumarin linked to Nrf2 activation and inflammatory pathway suppression.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "galangin",
+    "slug": "galangin",
+    "summary": "Flavonol from Alpinia officinarum with antimicrobial and anti-inflammatory roles.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "gallic acid",
+    "slug": "gallic-acid",
+    "summary": "Gallic acid is a small phenolic acid present across many herbs, teas, and fruits. It is well represented in antioxidant and inflammatory pathway studies, but isolated human outcome evidence is limited.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "gallocatechin",
+    "slug": "gallocatechin",
+    "summary": "Catechin derivative present in tea with antioxidant signaling activity.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "garcinol",
+    "slug": "garcinol",
+    "summary": "Polyisoprenylated benzophenone linked to inflammatory and epigenetic signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "genistein",
+    "slug": "genistein",
+    "summary": "Isoflavone strongly associated with soy and clover, commonly linked to estrogen receptor and PI3K/Akt signaling.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ginkgolide b",
+    "slug": "ginkgolide-b",
+    "summary": "Terpene lactone from Ginkgo biloba affecting platelet activating factor.",
+    "evidenceLevel": "human_indirect_from_ginkgo_extracts",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 22,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "ginsenoside rb1",
+    "slug": "ginsenoside-rb1",
+    "summary": "Major ginsenoside with neuroprotective and metabolic signaling effects.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ginsenoside rg1",
+    "slug": "ginsenoside-rg1",
+    "summary": "Major ginsenoside associated with neurovascular and survival signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 18,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "ginsenoside rg3",
+    "slug": "ginsenoside-rg3",
+    "summary": "Heat-processed ginsenoside linked to inflammatory and angiogenic pathway control.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "glucomoringin",
+    "slug": "glucomoringin",
+    "summary": "Glucosinolate from moringa that yields bioactive isothiocyanates after hydrolysis.",
+    "evidenceLevel": "animal / in vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 11,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "glycyrrhetinic acid",
+    "slug": "glycyrrhetinic-acid",
+    "summary": "Triterpenoid metabolite of glycyrrhizin associated with inflammatory signaling modulation.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "glycyrrhizin",
+    "slug": "glycyrrhizin",
+    "summary": "Triterpene saponin from licorice with HMGB1 and NF-κB pathway activity.",
+    "evidenceLevel": "human_safety_known; mechanism_and_interaction_supported",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 20,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "guggulsterone",
+    "slug": "guggulsterone",
+    "summary": "Steroidal ketone associated with bile-acid receptor and inflammatory pathway effects.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "gurmarin",
+    "slug": "gurmarin",
+    "summary": "Peptide constituent associated with sweet-signal blocking and glycemic effects.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "gymnemagenin",
+    "slug": "gymnemagenin",
+    "summary": "Triterpenoid aglycone linked to glycemic regulation and intestinal glucose handling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "gymnemic acid",
+    "slug": "gymnemic-acid",
+    "summary": "Triterpenoid saponin complex from gymnema linked to intestinal glucose handling.",
+    "evidenceLevel": "human_indirect_from_gymnema; preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "harpagoside",
+    "slug": "harpagoside",
+    "summary": "Harpagoside is a devil’s claw iridoid associated with pain and inflammatory pathway modulation.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "hericenones",
+    "slug": "hericenones",
+    "summary": "Aromatic compounds from lion’s mane fruiting body linked to neurotrophic signaling.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "hesperidin",
+    "slug": "hesperidin",
+    "summary": "Citrus flavanone glycoside linked to PI3K/Akt and NF-κB pathway effects.",
+    "evidenceLevel": "human_limited; food_based",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "honokiol",
+    "slug": "honokiol",
+    "summary": "Biphenolic compound from Magnolia bark with anxiolytic and anti-inflammatory activity.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "huperzine a",
+    "slug": "huperzine-a",
+    "summary": "Lycopodium alkaloid widely associated with cholinergic and glutamatergic signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "huperzine b",
+    "slug": "huperzine-b",
+    "summary": "Minor huperzine alkaloid linked to cholinergic support pathways.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "hydroxytyrosol",
+    "slug": "hydroxytyrosol",
+    "summary": "Olive phenolic metabolite linked to Nrf2 activation and PI3K/Akt signaling.",
+    "evidenceLevel": "human_limited; food_based",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "hyperforin",
+    "slug": "hyperforin",
+    "summary": "Hyperforin is a St.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "hypericin",
+    "slug": "hypericin",
+    "summary": "Hypericin is a napthodianthrone marker from St.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "imperatorin",
+    "slug": "imperatorin",
+    "summary": "Furanocoumarin associated with cholinesterase inhibition and calcium-channel-related signaling effects.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "indirubin",
+    "slug": "indirubin",
+    "summary": "Bis-indole alkaloid pigment known from indigo-yielding plants and studied for kinase-targeted activity.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "isoimperatorin",
+    "slug": "isoimperatorin",
+    "summary": "Related furanocoumarin commonly reported from Angelica/Cnidium with cholinesterase and MAPK pathway activity.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "jatrorrhizine",
+    "slug": "jatrorrhizine",
+    "summary": "Protoberberine alkaloid associated with glucose and inflammatory signaling regulation.",
+    "evidenceLevel": "preclinical; human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "kaempferol",
+    "slug": "kaempferol",
+    "summary": "Flavonol commonly associated with PI3K/Akt and NF-κB pathway modulation in botanical systems.",
+    "evidenceLevel": "preclinical; human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 11,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "kahweol",
+    "slug": "kahweol",
+    "summary": "Coffee diterpene often paired with cafestol and associated with redox and inflammatory pathway modulation.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "kavain",
+    "slug": "kavain",
+    "summary": "Major kavalactone with calming and channel-modulating pharmacology.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "kavalactones",
+    "slug": "kavalactones",
+    "summary": "Collective kavalactone fraction associated with anxiolytic and ion-channel activity.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "kotalanol",
+    "slug": "kotalanol",
+    "summary": "Thiosugar sulfonium constituent from Salacia known for intestinal alpha-glucosidase inhibition.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 4,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "lagerstroemin",
+    "slug": "lagerstroemin",
+    "summary": "Ellagitannin linked to glucose transport and metabolic regulation.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "lawsone",
+    "slug": "lawsone",
+    "summary": "Naphthoquinone pigment linked to inflammatory signaling control.",
+    "evidenceLevel": "preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ligustilide",
+    "slug": "ligustilide",
+    "summary": "Phthalide constituent of Angelica/Ligusticum associated with calcium-channel-related and NF-κB effects.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "linalool",
+    "slug": "linalool",
+    "summary": "Monoterpene alcohol linked to GABA-A and calcium-channel related effects.",
+    "evidenceLevel": "preclinical; human_limited_aroma",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "lobeline",
+    "slug": "lobeline",
+    "summary": "Piperidine alkaloid from Lobelia linked to nicotinic receptor and catecholamine signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "loganin",
+    "slug": "loganin",
+    "summary": "Loganin is an iridoid glycoside tied to antioxidant-response and survival pathways.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "luteolin",
+    "slug": "luteolin",
+    "summary": "Flavone associated with thyme and artichoke, commonly linked to NF-κB and MAPK signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "madecassic acid",
+    "slug": "madecassic-acid",
+    "summary": "Centella triterpenoid associated with matrix-remodeling and survival signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "madecassoside",
+    "slug": "madecassoside",
+    "summary": "Centella triterpene glycoside associated with inflammatory and tissue-repair signaling.",
+    "evidenceLevel": "human_indirect_from_centella; preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "magnoflorine",
+    "slug": "magnoflorine",
+    "summary": "Aporphine alkaloid reported from Coptis and lotus with AMPK and inflammatory pathway activity.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "magnolol",
+    "slug": "magnolol",
+    "summary": "Bioactive lignan from Magnolia with neuroprotective and anti-inflammatory effects.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "mangiferin",
+    "slug": "mangiferin",
+    "summary": "Xanthone glucoside linked to metabolic and redox-responsive signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "mangiferin aglycone",
+    "slug": "mangiferin-aglycone",
+    "summary": "Xanthone-related metabolite linked to metabolic and redox-responsive pathways.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "mangostin",
+    "slug": "mangostin",
+    "summary": "Xanthone associated with inflammatory and survival pathway effects.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "matrine",
+    "slug": "matrine",
+    "summary": "Quinolizidine alkaloid from Sophora species commonly linked to PI3K/Akt and NF-κB pathway effects.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "mesembrenone",
+    "slug": "mesembrenone",
+    "summary": "Kanna alkaloid closely related to mesembrine and associated with serotonin-reuptake and PDE4 effects.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "mesembrine",
+    "slug": "mesembrine",
+    "summary": "Major Kanna alkaloid best known for serotonin-reuptake and PDE4-related activity.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "methyl eugenol",
+    "slug": "methyl-eugenol",
+    "summary": "Phenylpropanoid present in aromatic herbs with sensory and neuroactive effects.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "methyleugenol",
+    "slug": "methyleugenol",
+    "summary": "Phenylpropene associated with sensory and inhibitory neurotransmission pathways.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "methysticin",
+    "slug": "methysticin",
+    "summary": "Kavalactone reported with GABAergic and monoamine-related activity.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "momordicoside k",
+    "slug": "momordicoside-k",
+    "summary": "Bitter melon cucurbitane glycoside linked to metabolic signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "morin",
+    "slug": "morin",
+    "summary": "Flavonol associated with inflammatory and cell-survival pathway modulation.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "morroniside",
+    "slug": "morroniside",
+    "summary": "Morroniside is a Cornus iridoid with cytoprotective pathway activity.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "mulberroside a",
+    "slug": "mulberroside-a",
+    "summary": "Mulberry stilbene glycoside associated with postprandial glycemic control.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "myricetin",
+    "slug": "myricetin",
+    "summary": "Polyhydroxylated flavonol reported from tea and berry sources with MAPK and NF-κB pathway activity.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "myristicin",
+    "slug": "myristicin",
+    "summary": "Nutmeg phenylpropene linked to monoamine and cholinergic pathway effects.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "naringenin",
+    "slug": "naringenin",
+    "summary": "Citrus flavanone reported to influence AMPK and PI3K/Akt signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "naringin",
+    "slug": "naringin",
+    "summary": "Citrus glycoside that converts toward naringenin-related metabolic and inflammatory pathway activity.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "neoandrographolide",
+    "slug": "neoandrographolide",
+    "summary": "Andrographis diterpene glycoside associated with inflammatory and survival signaling modulation.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "nerolidol",
+    "slug": "nerolidol",
+    "summary": "Sesquiterpene alcohol associated with calming and cytoprotective signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "nicotine",
+    "slug": "nicotine",
+    "summary": "Canonical tobacco alkaloid with strong nicotinic and neurotransmitter pathway activity.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "oleacein",
+    "slug": "oleacein",
+    "summary": "Oleacein is an olive secoiridoid linked to antioxidant-response and inflammatory pathway control.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "oleanolic acid",
+    "slug": "oleanolic-acid",
+    "summary": "Pentacyclic triterpene associated with cytoprotective and inflammatory signaling control.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "oleocanthal",
+    "slug": "oleocanthal",
+    "summary": "Oleocanthal is an olive phenolic aldehyde associated with COX-related anti-inflammatory signaling.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "oleuropein",
+    "slug": "oleuropein",
+    "summary": "Olive secoiridoid associated with NF-κB and AMPK pathway modulation.",
+    "evidenceLevel": "human_limited; preclinical_strong",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ononin",
+    "slug": "ononin",
+    "summary": "Isoflavone glycoside tied to receptor-level estrogenic signaling.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "osthole",
+    "slug": "osthole",
+    "summary": "Prenylated coumarin reported from Cnidium and related Apiaceae with PDE4-linked and PI3K/Akt signaling activity.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "oxymatrine",
+    "slug": "oxymatrine",
+    "summary": "Matrine-related alkaloid associated with TGF-β-linked fibrosis pathways and NF-κB inhibition.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "oxyresveratrol",
+    "slug": "oxyresveratrol",
+    "summary": "Mulberry stilbene linked to carbohydrate-processing and signaling effects.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "paeoniflorin",
+    "slug": "paeoniflorin",
+    "summary": "Monoterpene glycoside associated with inflammatory and survival pathway effects.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "paeonol",
+    "slug": "paeonol",
+    "summary": "Phenolic ketone associated with inflammatory and antioxidant-response signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "palmatine",
+    "slug": "palmatine",
+    "summary": "Palmatine is a protoberberine alkaloid that often co-occurs with berberine-containing herbs. Its profile is driven mainly by preclinical metabolic, antimicrobial, and anti-inflammatory studies rather than direct clinical evidence.",
+    "evidenceLevel": "preclinical; human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "piperine",
+    "slug": "piperine",
+    "summary": "Piperine is the major pungent alkaloid of black pepper and a well-known bioavailability enhancer. Human evidence is strongest for pharmacokinetic interaction effects rather than broad stand-alone therapeutic outcomes.",
+    "evidenceLevel": "human_limited_for_pk; safety_interaction_relevant",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 19,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "piperlongumine",
+    "slug": "piperlongumine",
+    "summary": "Amide alkaloid from long pepper associated with redox-stress and inflammatory signaling.",
+    "evidenceLevel": "preclinical_high_caution",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "plumbagin",
+    "slug": "plumbagin",
+    "summary": "Naphthoquinone associated with inflammatory and redox-signaling effects.",
+    "evidenceLevel": "preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "protodioscin",
+    "slug": "protodioscin",
+    "summary": "Steroidal saponin associated with nitric-oxide and survival pathway signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "psoralen",
+    "slug": "psoralen",
+    "summary": "Furocoumarin associated with phytoestrogen-like and MAPK-linked signaling effects.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "pterostilbene",
+    "slug": "pterostilbene",
+    "summary": "Dimethylated stilbene associated with berry and grape sources and linked to AMPK and PPAR signaling.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "puerarin",
+    "slug": "puerarin",
+    "summary": "Puerarin is the major isoflavone linked to kudzu-derived materials and has been studied in vascular, metabolic, and estrogen-related contexts. Human evidence exists, especially in Asia, but it is narrower and less replicated than the strongest compound-level literatures.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "punicalagin",
+    "slug": "punicalagin",
+    "summary": "Major ellagitannin from pomegranate with strong polyphenolic bioactivity.",
+    "evidenceLevel": "human / animal / in vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 12,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "quercetin",
+    "slug": "quercetin",
+    "summary": "Quercetin is a broadly distributed flavonol found in many herbs, fruits, and vegetables. Human supplementation literature exists for blood-pressure, inflammatory, and exercise-recovery questions, but the overall signal is still mixed and endpoint-specific.",
+    "evidenceLevel": "human_limited; preclinical_strong",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 17,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "resveratrol",
+    "slug": "resveratrol",
+    "summary": "Resveratrol is a stilbene polyphenol best known from knotweed and grape-derived materials. It has substantial human literature across cardiometabolic and inflammatory biomarkers, although outcomes vary by dose, formulation, and population.",
+    "evidenceLevel": "human_limited; multiple_meta_analyses_by_marker",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 18,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "rhein",
+    "slug": "rhein",
+    "summary": "Anthraquinone constituent of rhubarb associated with NF-κB and PI3K/Akt signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "rosarin",
+    "slug": "rosarin",
+    "summary": "Rhodiola glycoside associated with stress-response and signaling pathway effects.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "rosavin",
+    "slug": "rosavin",
+    "summary": "Phenylpropanoid glycoside from Rhodiola linked to metabolic and cytoprotective signaling.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "rosin",
+    "slug": "rosin",
+    "summary": "Rhodiola phenylpropanoid linked to adaptive cellular signaling.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "rosmarinic acid",
+    "slug": "rosmarinic-acid",
+    "summary": "Rosmarinic acid is a caffeic-acid ester abundant in rosemary, lemon balm, perilla, and other Lamiaceae herbs. It is most convincing as an anti-inflammatory and mast-cell-modulating compound, but isolated-compound human evidence remains thin.",
+    "evidenceLevel": "preclinical; human_indirect_from_herbal_extracts",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 15,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "rutin",
+    "slug": "rutin",
+    "summary": "Flavonol glycoside commonly reported from buckwheat and St.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "safranal",
+    "slug": "safranal",
+    "summary": "Monoterpene aldehyde from saffron contributing to aroma and neuroactive effects.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "safrole",
+    "slug": "safrole",
+    "summary": "Phenylpropene associated with sensory and signaling pathway activity.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "saikosaponin a",
+    "slug": "saikosaponin-a",
+    "summary": "Triterpene saponin from Bupleurum with NF-κB and PI3K/Akt pathway activity.",
+    "evidenceLevel": "preclinical; human_indirect_from_bupleurum",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "salidroside",
+    "slug": "salidroside",
+    "summary": "Rhodiola marker glycoside associated with metabolic and cytoprotective pathway activity.",
+    "evidenceLevel": "human_indirect_from_rhodiola_extracts",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 14,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "schisandrin",
+    "slug": "schisandrin",
+    "summary": "Lignan from Schisandra associated with Nrf2 activation and PI3K/Akt signaling.",
+    "evidenceLevel": "preclinical; human_indirect_from_schisandra",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "schisandrin b",
+    "slug": "schisandrin-b",
+    "summary": "Lignan from Schisandra with hepatoprotective and redox-modulating actions.",
+    "evidenceLevel": "animal / in vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 11,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "scopoletin",
+    "slug": "scopoletin",
+    "summary": "Coumarin constituent associated with NF-κB suppression and calcium-channel-related activity.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "senkyunolide a",
+    "slug": "senkyunolide-a",
+    "summary": "Phthalide derivative commonly reported from chuanxiong and Angelica with MAPK and ion-channel-linked activity.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "shikonin",
+    "slug": "shikonin",
+    "summary": "Naphthoquinone pigment associated with metabolic and inflammatory pathway effects.",
+    "evidenceLevel": "preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "silibinin",
+    "slug": "silibinin",
+    "summary": "Major flavonolignan of milk thistle with STAT3 and PI3K/Akt pathway activity.",
+    "evidenceLevel": "human_limited; meta_analysis_by_liver/metabolic_markers",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "silybin",
+    "slug": "silybin",
+    "summary": "Major flavonolignan component of silymarin known for hepatoprotective signaling.",
+    "evidenceLevel": "human / animal / in vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 12,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "silychristin",
+    "slug": "silychristin",
+    "summary": "Flavonolignan from milk thistle contributing to antioxidant and transporter-related activity.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "silydianin",
+    "slug": "silydianin",
+    "summary": "Minor flavonolignan from milk thistle associated with liver-protective effects.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "stigmasterol",
+    "slug": "stigmasterol",
+    "summary": "Phytosterol linked to receptor-level lipid signaling and pathway modulation.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "tetrandrine",
+    "slug": "tetrandrine",
+    "summary": "Bisbenzylisoquinoline alkaloid known for calcium-channel-related and NF-κB pathway activity.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "theaflavin",
+    "slug": "theaflavin",
+    "summary": "Oxidative black tea polyphenol associated with NF-κB and MAPK pathway effects.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "theanine",
+    "slug": "theanine",
+    "summary": "Non-protein amino acid from tea associated with calming and attention-related effects.",
+    "evidenceLevel": "human / animal / in vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 11,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "thearubigin",
+    "slug": "thearubigin",
+    "summary": "Complex black tea polyphenol fraction broadly associated with inflammatory and redox pathway modulation.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "thujone",
+    "slug": "thujone",
+    "summary": "Thujone is a monoterpene ketone best known for neuroactive and toxicity-relevant pharmacology in sage- and wormwood-related discussions. Its importance is driven more by receptor-level safety relevance than by positive human efficacy evidence.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "thymol",
+    "slug": "thymol",
+    "summary": "Thymol is a monoterpene phenol prominent in thyme and related aromatic herbs. The best-supported effects are antimicrobial and neuroactive membrane-level actions, with little direct clinical evidence for isolated-compound outcomes.",
+    "evidenceLevel": "animal / in vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 15,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "thymoquinone",
+    "slug": "thymoquinone",
+    "summary": "Quinone constituent of Nigella sativa with reported NF-κB suppression and Nrf2 signaling support.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 16,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "timosaponin aiii",
+    "slug": "timosaponin-aiii",
+    "summary": "Steroidal saponin associated with survival and apoptotic signaling.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "trigonelline",
+    "slug": "trigonelline",
+    "summary": "Alkaloid found in coffee and fenugreek linked to metabolic and neuroprotective effects.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "tyrosol",
+    "slug": "tyrosol",
+    "summary": "Simple phenolic alcohol linked to antioxidant-response and survival signaling.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "umbelliferone",
+    "slug": "umbelliferone",
+    "summary": "Simple coumarin distributed across Apiaceae with antioxidant-response and MAPK pathway activity.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ursolic acid",
+    "slug": "ursolic-acid",
+    "summary": "Ursolic acid is a pentacyclic triterpene common in culinary and medicinal herbs. Its research profile is dominated by cell and animal studies covering inflammatory, metabolic, and muscle-related pathways rather than consistent clinical trials.",
+    "evidenceLevel": "preclinical; human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 14,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "valepotriates",
+    "slug": "valepotriates",
+    "summary": "Valerian iridoid ester fraction associated with sedative and stress-signaling effects.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "valerenic acid",
+    "slug": "valerenic-acid",
+    "summary": "Valerenic acid is a valerian sesquiterpenoid associated with GABAergic calming effects.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "valerenol",
+    "slug": "valerenol",
+    "summary": "Valerenol is a valerian constituent linked to positive modulation of GABA-A signaling.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 4,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "verbascoside",
+    "slug": "verbascoside",
+    "summary": "Also known as acteoside; linked to inflammatory signaling control.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "withaferin a",
+    "slug": "withaferin-a",
+    "summary": "Reactive withanolide from ashwagandha with strong inflammatory and stress-pathway effects.",
+    "evidenceLevel": "preclinical; human_indirect_from_ashwagandha_extracts",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 22,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "withanolide a",
+    "slug": "withanolide-a",
+    "summary": "Withanolide from ashwagandha associated with neuroactive pathway modulation.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "withanoside iv",
+    "slug": "withanoside-iv",
+    "summary": "Steroidal lactone glycoside from ashwagandha associated with neuroregenerative activity.",
+    "evidenceLevel": "animal / in vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 12,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "wogonin",
+    "slug": "wogonin",
+    "summary": "Wogonin is a flavone associated with Scutellaria research and immune-neuroinflammatory pathway studies. The compound is biologically interesting, but isolated human efficacy evidence remains thin.",
+    "evidenceLevel": "preclinical; human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "xanthotoxin",
+    "slug": "xanthotoxin",
+    "summary": "Linear furocoumarin reported from Angelica and parsnip with MAPK and phosphodiesterase-related activity.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "yangonin",
+    "slug": "yangonin",
+    "summary": "Yangonin is a kavalactone with cannabinoid-related and monoamine-associated signaling.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  }
+]

--- a/public/data-next/compounds.json
+++ b/public/data-next/compounds.json
@@ -1,0 +1,5726 @@
+[
+  {
+    "name": "11-keto-beta-boswellic acid",
+    "slug": "11-keto-beta-boswellic-acid",
+    "summary": "Keto-boswellic acid associated with 5-LOX-related signaling and inflammatory modulation.",
+    "description": "Keto-boswellic acid associated with 5-LOX-related signaling and inflammatory modulation.",
+    "compoundClass": "pentacyclic triterpene acid / boswellic acid",
+    "mechanisms": [
+      "5-lipoxygenase inhibition",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "5-LOX",
+      "NF-κB",
+      "leukotriene pathways",
+      "inflammatory cytokines"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Boswellia extracts can cause GI upset and may interact with anticoagulants/anti-inflammatory drugs; pregnancy safety is not established.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "acemannan",
+    "slug": "acemannan",
+    "summary": "Acetylated mannose-rich polysaccharide from aloe gel commonly associated with immunomodulatory and wound-healing activity.",
+    "description": "Acetylated mannose-rich polysaccharide from aloe gel commonly associated with immunomodulatory and wound-healing activity.",
+    "compoundClass": "acetylated polysaccharide",
+    "mechanisms": [
+      "TLR4 modulation",
+      "NF-κB modulation"
+    ],
+    "targets": [
+      "NF-κB"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "acetyl-11-keto-beta-boswellic acid",
+    "slug": "acetyl-11-keto-beta-boswellic-acid",
+    "summary": "Acetyl-11-keto-beta-boswellic acid is a boswellic acid emphasized in Boswellia standardization discussions. Its relevance is mechanistically strong for inflammatory pathways, but isolated-compound human evidence is much thinner than extract-level evidence.",
+    "description": "AKBA-type boswellic acid widely used as a core Boswellia marker compound.",
+    "compoundClass": "pentacyclic triterpene acid / boswellic acid",
+    "mechanisms": [
+      "5-lipoxygenase inhibition",
+      "leukotriene-pathway suppression",
+      "NF-kB-related inflammatory signaling reduction"
+    ],
+    "targets": [
+      "5-LOX",
+      "NF-κB",
+      "leukotriene pathways",
+      "inflammatory cytokines"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Boswellia extracts can cause GI upset and may interact with anticoagulants/anti-inflammatory drugs; pregnancy safety is not established.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "acetyl-beta-boswellic acid",
+    "slug": "acetyl-beta-boswellic-acid",
+    "summary": "Acetylated boswellic acid linked to leukotriene-pathway suppression in Boswellia.",
+    "description": "Acetylated boswellic acid linked to leukotriene-pathway suppression in Boswellia.",
+    "compoundClass": "pentacyclic triterpene acid / boswellic acid",
+    "mechanisms": [
+      "5-lipoxygenase inhibition",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "5-LOX",
+      "NF-κB",
+      "leukotriene pathways",
+      "inflammatory cytokines"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Boswellia extracts can cause GI upset and may interact with anticoagulants/anti-inflammatory drugs; pregnancy safety is not established.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "acetylshikonin",
+    "slug": "acetylshikonin",
+    "summary": "Shikonin derivative linked to inflammatory and apoptotic signaling.",
+    "description": "Shikonin derivative linked to inflammatory and apoptotic signaling.",
+    "compoundClass": "quinone / naphthoquinone-like phenolic",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "apoptosis pathway modulation (caspase activation)"
+    ],
+    "targets": [
+      "ROS/redox cycling",
+      "NF-κB",
+      "apoptosis signaling",
+      "Nrf2",
+      "antimicrobial pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Often preclinical; concentrated or isolated quinones may be irritant/cytotoxic. Avoid pregnancy and use caution with liver disease or anticoagulants.",
+    "evidenceLevel": "preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "acteoside",
+    "slug": "acteoside",
+    "summary": "Phenylethanoid glycoside with inflammatory pathway modulation.",
+    "description": "Phenylethanoid glycoside with inflammatory pathway modulation.",
+    "compoundClass": "phenylethanoid glycoside",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "antioxidant response",
+      "inflammatory cytokines",
+      "neuroprotective signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical/extract-derived; safety depends on source herb and product quality.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "aescin",
+    "slug": "aescin",
+    "summary": "Mixture of triterpene saponins from horse chestnut best known for venotonic and vascular permeability effects.",
+    "description": "Mixture of triterpene saponins from horse chestnut best known for venotonic and vascular permeability effects.",
+    "compoundClass": "saponin / glycoside",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "endothelial barrier modulation"
+    ],
+    "targets": [
+      "AMPK",
+      "PPAR",
+      "immune cytokines",
+      "membrane signaling",
+      "glucose/lipid metabolism"
+    ],
+    "foundIn": [],
+    "safetyNotes": "May cause GI irritation or hemolysis risk in isolated/high-dose contexts; herb-specific safety and pregnancy cautions apply.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ajoene",
+    "slug": "ajoene",
+    "summary": "Organosulfur garlic derivative formed from allicin breakdown and linked to antiplatelet and inflammatory signaling effects.",
+    "description": "Organosulfur garlic derivative formed from allicin breakdown and linked to antiplatelet and inflammatory signaling effects.",
+    "compoundClass": "organosulfur compound",
+    "mechanisms": [
+      "platelet aggregation inhibition",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "NF-κB",
+      "platelet aggregation"
+    ],
+    "foundIn": [],
+    "safetyNotes": "May affect platelet activity; use caution with anticoagulants/antiplatelets and before surgery.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "albiflorin",
+    "slug": "albiflorin",
+    "summary": "Paeonia glycoside linked to neurotransmitter and signaling pathway effects.",
+    "description": "Paeonia glycoside linked to neurotransmitter and signaling pathway effects.",
+    "compoundClass": "monoterpene glycoside / phenolic from Paeonia",
+    "mechanisms": [
+      "MAPK pathway modulation",
+      "monoamine reuptake inhibition"
+    ],
+    "targets": [
+      "NF-κB",
+      "immune cytokines",
+      "smooth muscle/analgesic signaling",
+      "antioxidant response"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preparation-derived. Caution with anticoagulants, pregnancy, and immune-modulating therapies.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "alpha-asarone",
+    "slug": "alpha-asarone",
+    "summary": "Phenylpropanoid ether from Acorus species studied for CNS-active and cholinergic effects.",
+    "description": "Phenylpropanoid ether from Acorus species studied for CNS-active and cholinergic effects.",
+    "compoundClass": "phenylpropanoid ether",
+    "mechanisms": [
+      "GABA-A modulation",
+      "acetylcholinesterase inhibition"
+    ],
+    "targets": [
+      "GABA-A receptors",
+      "acetylcholinesterase"
+    ],
+    "foundIn": [],
+    "safetyNotes": "High-caution aromatic compound with toxicology concerns; avoid concentrated internal use and pregnancy.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "alpha-mangostin",
+    "slug": "alpha-mangostin",
+    "summary": "Major mangosteen xanthone with inflammatory and apoptotic signaling activity.",
+    "description": "Major mangosteen xanthone with inflammatory and apoptotic signaling activity.",
+    "compoundClass": "xanthone / polyphenol",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "apoptosis pathway modulation (caspase activation)",
+      "STAT3 inhibition"
+    ],
+    "targets": [
+      "NF-κB",
+      "antioxidant response",
+      "apoptosis signaling",
+      "inflammatory cytokines"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical/extract-derived; concentrated Garcinia/mangosteen extracts may affect bleeding or liver risk depending product.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "anabasine",
+    "slug": "anabasine",
+    "summary": "Pyridine alkaloid associated with nicotinic receptor activity.",
+    "description": "Pyridine alkaloid associated with nicotinic receptor activity.",
+    "compoundClass": "alkaloid",
+    "mechanisms": [
+      "nicotinic acetylcholine receptor modulation"
+    ],
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 4,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "anatabine",
+    "slug": "anatabine",
+    "summary": "Minor tobacco alkaloid associated with nicotinic signaling and inflammatory pathway effects.",
+    "description": "Minor tobacco alkaloid associated with nicotinic signaling and inflammatory pathway effects.",
+    "compoundClass": "alkaloid",
+    "mechanisms": [
+      "nicotinic acetylcholine receptor modulation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "andrographolide",
+    "slug": "andrographolide",
+    "summary": "Diterpene lactone from andrographis with strong pathway-level inflammatory signaling effects.",
+    "description": "Diterpene lactone from andrographis with strong pathway-level inflammatory signaling effects.",
+    "compoundClass": "labdane diterpenoid lactone",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "JAK/STAT modulation",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "JAK/STAT",
+      "MAPK",
+      "inflammatory cytokines"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Human evidence is mostly from Andrographis extracts. Potential allergy, GI upset, and rare hypersensitivity; avoid pregnancy and caution with immunosuppressants/anticoagulants.",
+    "evidenceLevel": "human_indirect_from_andrographis; preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "anethole",
+    "slug": "anethole",
+    "summary": "Phenylpropene from fennel and anise associated with digestive and anti-inflammatory actions.",
+    "description": "Phenylpropene from fennel and anise associated with digestive and anti-inflammatory actions.",
+    "compoundClass": "terpene / essential-oil constituent",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "smooth muscle relaxation"
+    ],
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "angelicin",
+    "slug": "angelicin",
+    "summary": "Angelicin is a furocoumarin associated with photosensitizing pharmacology and occasional discussion in skin and bone research. The evidence base is primarily mechanistic, with efficacy claims constrained by limited human data and safety context.",
+    "description": "Angular furocoumarin reported from Psoralea/Angelica with NF-κB and MAPK pathway activity.",
+    "compoundClass": "coumarin / furanocoumarin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "apigenin",
+    "slug": "apigenin",
+    "summary": "Apigenin is a flavone found in chamomile, parsley, and related plants, with frequent discussion in neuroinflammatory and calm-support research. The evidence base is still dominated by in vitro and animal work despite clear mechanistic interest.",
+    "description": "Flavone found in chamomile and parsley, frequently linked to GABAergic and PI3K/Akt-related effects.",
+    "compoundClass": "flavone polyphenol",
+    "mechanisms": [
+      "GABA-A receptor modulation",
+      "PI3K/Akt modulation",
+      "NF-kB suppression",
+      "Nrf2-related antioxidant signaling"
+    ],
+    "targets": [
+      "GABAergic signaling",
+      "NF-κB",
+      "Nrf2",
+      "PI3K/Akt",
+      "inflammatory mediators"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Food exposure is low-risk; concentrated apigenin may be sedating and may interact with sedatives or CYP-metabolized drugs. Pregnancy/breastfeeding caution at supplement doses.",
+    "evidenceLevel": "preclinical; human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 11,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "arjunolic acid",
+    "slug": "arjunolic-acid",
+    "summary": "Triterpenoid from Terminalia arjuna associated with cardioprotective effects.",
+    "description": "Triterpenoid from Terminalia arjuna associated with cardioprotective effects.",
+    "compoundClass": "triterpene / triterpenoid acid",
+    "mechanisms": [
+      "PPAR activation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "NF-κB",
+      "AMPK",
+      "PPAR",
+      "inflammatory cytokines",
+      "apoptosis signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or extract-derived; concentrated doses may affect glucose, lipids, liver enzymes, or bleeding risk depending matrix.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "artemisinin",
+    "slug": "artemisinin",
+    "summary": "Sesquiterpene lactone endoperoxide linked to redox and survival pathway effects.",
+    "description": "Sesquiterpene lactone endoperoxide linked to redox and survival pathway effects.",
+    "compoundClass": "sesquiterpene lactone endoperoxide",
+    "mechanisms": [
+      "ROS-mediated signaling modulation",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "PI3K/Akt",
+      "redox signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "artemisinin b",
+    "slug": "artemisinin-b",
+    "summary": "Artemisia metabolite associated with redox-related signaling.",
+    "description": "Artemisia metabolite associated with redox-related signaling.",
+    "compoundClass": "sesquiterpene lactone",
+    "mechanisms": [
+      "ROS-mediated signaling modulation",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "MAPK",
+      "redox signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "artesunate",
+    "slug": "artesunate",
+    "summary": "Semi-synthetic artemisinin derivative retained here in natural-derivative context.",
+    "description": "Semi-synthetic artemisinin derivative retained here in natural-derivative context.",
+    "compoundClass": "semi-synthetic artemisinin derivative",
+    "mechanisms": [
+      "ROS-mediated signaling modulation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "NF-κB",
+      "redox signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "human_strong",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "asiatic acid",
+    "slug": "asiatic-acid",
+    "summary": "Triterpenoid aglycone associated with tissue repair and inflammatory pathway effects.",
+    "description": "Triterpenoid aglycone associated with tissue repair and inflammatory pathway effects.",
+    "compoundClass": "pentacyclic triterpenoid",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "TGF-β signaling modulation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "TGF-β/Smad",
+      "collagen synthesis",
+      "NF-κB",
+      "wound-healing and inflammatory signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Human evidence mostly from Centella extracts/topicals. Caution with liver disease, sedatives, pregnancy, and high-dose oral extracts.",
+    "evidenceLevel": "human_indirect_from_centella_extracts",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 11,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "asiaticoside",
+    "slug": "asiaticoside",
+    "summary": "Centella triterpene glycoside linked to wound and matrix signaling pathways.",
+    "description": "Centella triterpene glycoside linked to wound and matrix signaling pathways.",
+    "compoundClass": "triterpenoid saponin glycoside",
+    "mechanisms": [
+      "TGF-β signaling modulation",
+      "MAPK pathway modulation",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "collagen synthesis",
+      "TGF-β signaling",
+      "wound-healing pathways",
+      "NF-κB"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Human safety mostly from Centella extracts/topicals. Caution with liver disease, sedatives, pregnancy, and high-dose prolonged supplementation.",
+    "evidenceLevel": "human_indirect_from_centella; preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "aspalathin",
+    "slug": "aspalathin",
+    "summary": "C-glucosyl dihydrochalcone characteristic of rooibos with metabolic and redox-signaling activity.",
+    "description": "C-glucosyl dihydrochalcone characteristic of rooibos with metabolic and redox-signaling activity.",
+    "compoundClass": "C-glucosyl dihydrochalcone",
+    "mechanisms": [
+      "AMPK activation",
+      "Nrf2 activation"
+    ],
+    "targets": [
+      "Nrf2",
+      "AMPK"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "astragalin",
+    "slug": "astragalin",
+    "summary": "Flavonoid glycoside associated with inflammatory pathway control.",
+    "description": "Flavonoid glycoside associated with inflammatory pathway control.",
+    "compoundClass": "flavonol / flavonoid",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "AMPK",
+      "Nrf2",
+      "NF-κB",
+      "inflammatory cytokines",
+      "endothelial nitric oxide",
+      "antioxidant response"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly food/extract-derived human evidence. High-dose supplements may affect CYP/transporters or anticoagulant/antiplatelet risk.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "astragaloside iv",
+    "slug": "astragaloside-iv",
+    "summary": "Astragalus saponin linked to metabolic signaling and tissue-protective pathways.",
+    "description": "Astragalus saponin linked to metabolic signaling and tissue-protective pathways.",
+    "compoundClass": "cycloartane triterpenoid saponin",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "AMPK activation",
+      "TGF-β signaling modulation"
+    ],
+    "targets": [
+      "PI3K/Akt",
+      "AMPK",
+      "TGF-β/Smad",
+      "Nrf2",
+      "immune/inflammatory signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or Astragalus-formula derived. Caution with immunosuppressants, autoimmune disease, anticoagulants, pregnancy, and transplant contexts.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 13,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "atractylenolide i",
+    "slug": "atractylenolide-i",
+    "summary": "Sesquiterpene lactone associated with immune and survival signaling.",
+    "description": "Sesquiterpene lactone associated with immune and survival signaling.",
+    "compoundClass": "terpenoid",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "NF-κB",
+      "PI3K/Akt"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "atractylenolide ii",
+    "slug": "atractylenolide-ii",
+    "summary": "Atractylodes lactone linked to inflammatory signaling control.",
+    "description": "Atractylodes lactone linked to inflammatory signaling control.",
+    "compoundClass": "sesquiterpene lactone",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "NF-κB",
+      "MAPK"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "atractylenolide iii",
+    "slug": "atractylenolide-iii",
+    "summary": "Sesquiterpene lactone associated with immune and cytoprotective pathways.",
+    "description": "Sesquiterpene lactone associated with immune and cytoprotective pathways.",
+    "compoundClass": "terpenoid",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "NF-κB",
+      "PI3K/Akt"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "aucubin",
+    "slug": "aucubin",
+    "summary": "Aucubin is an iridoid glycoside associated with inflammatory pathway suppression.",
+    "description": "Aucubin is an iridoid glycoside associated with inflammatory pathway suppression.",
+    "compoundClass": "iridoid glycoside",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "NF-κB",
+      "antioxidant response",
+      "inflammatory cytokines",
+      "gut/liver metabolism"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly extract-derived/preclinical. GI effects and herb-specific contraindications matter more than isolated-compound evidence.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "bacopaside ii",
+    "slug": "bacopaside-ii",
+    "summary": "Bacopa triterpenoid saponin associated with nootropic activity and kinase-linked neuroprotective signaling.",
+    "description": "Bacopa triterpenoid saponin associated with nootropic activity and kinase-linked neuroprotective signaling.",
+    "compoundClass": "saponin / glycoside",
+    "mechanisms": [
+      "MARK4 inhibition",
+      "cholinergic modulation"
+    ],
+    "targets": [
+      "AMPK",
+      "PPAR",
+      "immune cytokines",
+      "membrane signaling",
+      "glucose/lipid metabolism"
+    ],
+    "foundIn": [],
+    "safetyNotes": "May cause GI irritation or hemolysis risk in isolated/high-dose contexts; herb-specific safety and pregnancy cautions apply.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "bacoside a",
+    "slug": "bacoside-a",
+    "summary": "Bacopa saponin fraction associated with cognitive signaling support.",
+    "description": "Bacopa saponin fraction associated with cognitive signaling support.",
+    "compoundClass": "triterpenoid saponin mixture",
+    "mechanisms": [
+      "cholinergic modulation",
+      "ERK pathway modulation"
+    ],
+    "targets": [
+      "cholinergic signaling",
+      "antioxidant enzymes",
+      "synaptic plasticity",
+      "neuroinflammatory pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Human safety is mostly Bacopa-extract derived. GI upset and sedation may occur; caution with sedatives, thyroid-active therapy, and pregnancy.",
+    "evidenceLevel": "human_indirect_from_bacopa; preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "bacoside b",
+    "slug": "bacoside-b",
+    "summary": "Bacopa saponin fraction linked to cognition-related signaling.",
+    "description": "Bacopa saponin fraction linked to cognition-related signaling.",
+    "compoundClass": "saponin / glycoside",
+    "mechanisms": [
+      "cholinergic modulation",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "AMPK",
+      "PPAR",
+      "immune cytokines",
+      "membrane signaling",
+      "glucose/lipid metabolism"
+    ],
+    "foundIn": [],
+    "safetyNotes": "May cause GI irritation or hemolysis risk in isolated/high-dose contexts; herb-specific safety and pregnancy cautions apply.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "baicalein",
+    "slug": "baicalein",
+    "summary": "Baicalein is the aglycone partner of baicalin and is widely studied in inflammation, redox biology, and cancer-mechanism literature. The evidence remains mainly preclinical, with limited isolated human intervention data.",
+    "description": "Flavone aglycone from Scutellaria associated with NF-κB and MAPK pathway modulation.",
+    "compoundClass": "flavone aglycone",
+    "mechanisms": [
+      "NF-kB suppression",
+      "PI3K/Akt modulation",
+      "lipoxygenase-related inflammatory signaling effects",
+      "Nrf2 support"
+    ],
+    "targets": [
+      "NF-κB",
+      "MAPK",
+      "PI3K/Akt",
+      "Nrf2",
+      "inflammatory cytokines"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical and extract-derived. Caution with anticoagulants/antiplatelets, liver disease, sedatives, and pregnancy at supplement doses.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "baicalin",
+    "slug": "baicalin",
+    "summary": "Baicalin is a flavone glycoside associated with Scutellaria species and related TCM research. Its strongest support is preclinical, especially for inflammatory and oxidative-stress pathways, while direct isolated-compound human evidence remains limited.",
+    "description": "Flavone glycoside commonly reported from Scutellaria with anti-inflammatory and PI3K/Akt pathway activity.",
+    "compoundClass": "flavone glycoside",
+    "mechanisms": [
+      "NF-kB suppression",
+      "Nrf2 activation",
+      "MAPK modulation",
+      "cytokine-signaling reduction"
+    ],
+    "targets": [
+      "NF-κB",
+      "MAPK",
+      "PI3K/Akt",
+      "Nrf2",
+      "inflammatory cytokines",
+      "GABAergic signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly supported through Scutellaria extracts and preclinical data. Use caution with liver disease, sedatives, anticoagulants/antiplatelets, immunosuppressants, and pregnancy.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "berbamine",
+    "slug": "berbamine",
+    "summary": "Bis-benzylisoquinoline alkaloid from barberry-type plants with anti-inflammatory and signaling-modulatory activity.",
+    "description": "Bis-benzylisoquinoline alkaloid from barberry-type plants with anti-inflammatory and signaling-modulatory activity.",
+    "compoundClass": "alkaloid",
+    "mechanisms": [
+      "JAK/STAT inhibition",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "NF-κB",
+      "JAK/STAT"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Isolated alkaloid exposure may affect CYP/P-gp handling, glucose, blood pressure, and GI tolerance; avoid pregnancy/breastfeeding unless clinician-directed.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "berberine",
+    "slug": "berberine",
+    "summary": "Berberine is a protoberberine alkaloid concentrated in barberry-type herbs and used most often in metabolic research. Human evidence is strongest for glucose and lipid endpoints, while mechanistic literature consistently points to energy-sensing and inflammatory pathway effects.",
+    "description": "Isoquinoline alkaloid best known from barberry-type herbs with metabolic and inflammatory signaling activity.",
+    "compoundClass": "isoquinoline alkaloid",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-kB suppression",
+      "PI3K/Akt modulation",
+      "gut-microbiome signaling effects",
+      "LDLR/PCSK9-related lipid regulation"
+    ],
+    "targets": [
+      "AMPK",
+      "PCSK9",
+      "LDLR",
+      "gut microbiota",
+      "NF-κB",
+      "CYP/P-gp interaction pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "GI upset is common. Avoid pregnancy/breastfeeding and neonatal exposure; caution with antidiabetic drugs, antihypertensives, anticoagulants, immunosuppressants, and CYP/P-gp substrates.",
+    "evidenceLevel": "human_limited; meta_analysis_for_metabolic_markers",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 27,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "bergapten",
+    "slug": "bergapten",
+    "summary": "Methoxypsoralen constituent of citrus and Psoralea commonly linked to MAPK and inflammatory pathway modulation.",
+    "description": "Methoxypsoralen constituent of citrus and Psoralea commonly linked to MAPK and inflammatory pathway modulation.",
+    "compoundClass": "coumarin / furanocoumarin",
+    "mechanisms": [
+      "MAPK pathway modulation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "beta-caryophyllene",
+    "slug": "beta-caryophyllene",
+    "summary": "Sesquiterpene linked to cannabinoid-receptor and inflammatory signaling.",
+    "description": "Sesquiterpene linked to cannabinoid-receptor and inflammatory signaling.",
+    "compoundClass": "terpene / essential-oil constituent",
+    "mechanisms": [
+      "CB2 receptor agonism",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "beta-elemene",
+    "slug": "beta-elemene",
+    "summary": "Sesquiterpene hydrocarbon associated with survival and apoptotic signaling.",
+    "description": "Sesquiterpene hydrocarbon associated with survival and apoptotic signaling.",
+    "compoundClass": "terpene / essential-oil constituent",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "apoptosis pathway modulation (caspase activation)"
+    ],
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "beta-sitosterol",
+    "slug": "beta-sitosterol",
+    "summary": "Beta-sitosterol is a phytosterol widely distributed across medicinal plants and food plants. Human evidence is most relevant to cholesterol absorption and lower-urinary-tract endpoints, but many studies are mixture- or sterol-blend-based rather than isolated-compound-focused.",
+    "description": "Plant sterol associated with lipid-signaling and inflammatory pathway control.",
+    "compoundClass": "phytosterol",
+    "mechanisms": [
+      "Competition with intestinal cholesterol absorption",
+      "NPC1L1-related sterol transport effects",
+      "PPAR/LXR signaling modulation",
+      "NF-kB suppression"
+    ],
+    "targets": [
+      "cholesterol absorption",
+      "inflammatory signaling",
+      "membrane sterol pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Generally food-associated, but supplements can affect lipid markers and may be unsuitable in sitosterolemia.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "betulinic acid",
+    "slug": "betulinic-acid",
+    "summary": "Pentacyclic triterpenoid found across several botanicals and fungi, often studied for inflammatory and apoptotic signaling effects.",
+    "description": "Pentacyclic triterpenoid found across several botanicals and fungi, often studied for inflammatory and apoptotic signaling effects.",
+    "compoundClass": "triterpene / triterpenoid acid",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "apoptosis pathway modulation"
+    ],
+    "targets": [
+      "NF-κB",
+      "AMPK",
+      "PPAR",
+      "inflammatory cytokines",
+      "apoptosis signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or extract-derived; concentrated doses may affect glucose, lipids, liver enzymes, or bleeding risk depending matrix.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "bilobetin",
+    "slug": "bilobetin",
+    "summary": "Biflavone from Ginkgo and related taxa associated with inflammatory pathway modulation.",
+    "description": "Biflavone from Ginkgo and related taxa associated with inflammatory pathway modulation.",
+    "compoundClass": "terpene lactone / biflavone",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK modulation"
+    ],
+    "targets": [
+      "platelet activating factor",
+      "antioxidant response",
+      "cerebral blood flow signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Ginkgo constituents are extract-specific. Bleeding interaction concerns apply with anticoagulants/antiplatelets.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "biochanin a",
+    "slug": "biochanin-a",
+    "summary": "Biochanin A is an isoflavone present in red clover and other legumes, with interest centered on estrogen-related, metabolic, and anti-inflammatory signaling. Human evidence for the isolated compound remains limited compared with broader isoflavone mixtures.",
+    "description": "Methylated isoflavone associated with clover and soy, linked to estrogen receptor and inflammatory pathway activity.",
+    "compoundClass": "isoflavone / phytoestrogen",
+    "mechanisms": [
+      "Estrogen-receptor modulation",
+      "CYP/aromatase-related signaling effects",
+      "PPAR modulation",
+      "NF-kB suppression"
+    ],
+    "targets": [
+      "estrogen receptor signaling",
+      "AMPK",
+      "PPAR",
+      "antioxidant response",
+      "bone/metabolic signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Phytoestrogenic activity warrants caution with hormone-sensitive conditions and hormone therapies; effects are preparation- and dose-specific.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "bisabolol",
+    "slug": "bisabolol",
+    "summary": "Sesquiterpene alcohol associated with inflammatory pathway control.",
+    "description": "Sesquiterpene alcohol associated with inflammatory pathway control.",
+    "compoundClass": "terpene / essential-oil constituent",
+    "mechanisms": [
+      "COX inhibition",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "bisdemethoxycurcumin",
+    "slug": "bisdemethoxycurcumin",
+    "summary": "Curcuminoid linked to inflammatory pathway suppression and redox signaling.",
+    "description": "Curcuminoid linked to inflammatory pathway suppression and redox signaling.",
+    "compoundClass": "curcuminoid / diarylheptanoid",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "Nrf2 activation"
+    ],
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "COX/LOX",
+      "inflammatory cytokines",
+      "AMPK"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Human evidence is mostly formulation-dependent. High-dose curcuminoids may cause GI upset and interact with anticoagulants/antiplatelets.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "boswellic acid",
+    "slug": "boswellic-acid",
+    "summary": "Pentacyclic triterpenoid boswellic acid from frankincense resin with 5-LOX and inflammatory pathway activity.",
+    "description": "Pentacyclic triterpenoid boswellic acid from frankincense resin with 5-LOX and inflammatory pathway activity.",
+    "compoundClass": "pentacyclic triterpene acid / boswellic acid",
+    "mechanisms": [
+      "5-lipoxygenase inhibition",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "5-LOX",
+      "NF-κB",
+      "leukotriene pathways",
+      "inflammatory cytokines"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Boswellia extracts can cause GI upset and may interact with anticoagulants/anti-inflammatory drugs; pregnancy safety is not established.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "butylidenephthalide",
+    "slug": "butylidenephthalide",
+    "summary": "Phthalide constituent associated with PI3K/Akt and inflammatory pathway modulation.",
+    "description": "Phthalide constituent associated with PI3K/Akt and inflammatory pathway modulation.",
+    "compoundClass": "phthalide",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "smooth muscle relaxation",
+      "nitric oxide/endothelial signaling",
+      "platelet aggregation pathways",
+      "inflammatory signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly extract-derived evidence. Potential additive bleeding, blood pressure, or sedative effects depending source herb.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cafestol",
+    "slug": "cafestol",
+    "summary": "Coffee diterpene best known from coffee lipids and studied for xenobiotic-response and inflammatory signaling effects.",
+    "description": "Coffee diterpene best known from coffee lipids and studied for xenobiotic-response and inflammatory signaling effects.",
+    "compoundClass": "diterpene / coffee alkaloid-related constituent",
+    "mechanisms": [
+      "Nrf2 activation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "lipid metabolism",
+      "bile acid signaling",
+      "adenosine/glucose metabolism depending compound"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Coffee matrix matters. Cafestol/kahweol can raise LDL with unfiltered coffee; caffeine-related effects may apply to coffee products.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "caffeic acid",
+    "slug": "caffeic-acid",
+    "summary": "Phenolic acid broadly present in herbs and coffee, commonly linked to NF-κB and MAPK signaling.",
+    "description": "Phenolic acid broadly present in herbs and coffee, commonly linked to NF-κB and MAPK signaling.",
+    "compoundClass": "phenolic acid / polyphenol",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "antioxidant response",
+      "glucose/lipid signaling",
+      "gut microbiome metabolism"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly food-associated; concentrated extracts may cause GI effects or interact with anticoagulants/antidiabetics depending matrix.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "calycosin",
+    "slug": "calycosin",
+    "summary": "Calycosin is an isoflavone associated especially with Astragalus-derived phytochemistry. The literature emphasizes vascular, estrogen-related, and antioxidant signaling in preclinical models more than replicated human trials.",
+    "description": "Isoflavonoid from Astragalus associated with estrogenic and survival signaling.",
+    "compoundClass": "isoflavone / phytoestrogen",
+    "mechanisms": [
+      "Estrogen-receptor beta modulation",
+      "PI3K/Akt signaling",
+      "Nrf2-related antioxidant response",
+      "endothelial signaling support"
+    ],
+    "targets": [
+      "estrogen receptor signaling",
+      "AMPK",
+      "PPAR",
+      "antioxidant response",
+      "bone/metabolic signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Phytoestrogenic activity warrants caution with hormone-sensitive conditions and hormone therapies; effects are preparation- and dose-specific.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "carnosic acid",
+    "slug": "carnosic-acid",
+    "summary": "Carnosic acid is a diterpene phenol best known from rosemary and sage. It is mainly supported by antioxidant, neuroprotective, and anti-inflammatory preclinical literature rather than robust human trials.",
+    "description": "Diterpene phenol associated with rosemary-family herbs and linked to Nrf2 and NF-κB pathways.",
+    "compoundClass": "phenolic diterpene",
+    "mechanisms": [
+      "Nrf2 activation",
+      "NF-kB suppression",
+      "redox-sensitive signaling modulation",
+      "mitochondrial protection pathways"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "oxidative-stress signaling",
+      "lipid peroxidation pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Primarily food/herb exposure through rosemary/sage; concentrated isolated-dose safety is less established. Caution with anticoagulants, pregnancy, and liver disease at high doses.",
+    "evidenceLevel": "preclinical; human_indirect_from_rosemary",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "carnosol",
+    "slug": "carnosol",
+    "summary": "Phenolic diterpene from rosemary with antioxidant and anti-inflammatory pathway activity.",
+    "description": "Phenolic diterpene from rosemary with antioxidant and anti-inflammatory pathway activity.",
+    "compoundClass": "terpene / essential-oil constituent",
+    "mechanisms": [
+      "Nrf2 activation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "Keap1-sensitive redox targets",
+      "STAT3-related signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "evidenceLevel": "animal / in vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 14,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "carvacrol",
+    "slug": "carvacrol",
+    "summary": "Carvacrol is a monoterpenoid phenol concentrated in oregano and thyme chemotypes. It is best supported by preclinical antimicrobial and anti-inflammatory data, with human evidence for isolated use still sparse.",
+    "description": "Monoterpenoid phenol from oregano and thyme with antimicrobial and sensory effects.",
+    "compoundClass": "terpene / essential-oil constituent",
+    "mechanisms": [
+      "Membrane disruption",
+      "TRPA1/TRPV3-related sensory modulation",
+      "NF-kB suppression",
+      "antimicrobial permeability effects"
+    ],
+    "targets": [
+      "TRPA1",
+      "membrane lipids"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "evidenceLevel": "animal / in vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 15,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "caryophyllene oxide",
+    "slug": "caryophyllene-oxide",
+    "summary": "Oxidized caryophyllene derivative associated with inflammatory and apoptotic signaling.",
+    "description": "Oxidized caryophyllene derivative associated with inflammatory and apoptotic signaling.",
+    "compoundClass": "terpene / essential-oil constituent",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "apoptosis pathway modulation (caspase activation)"
+    ],
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "catalpol",
+    "slug": "catalpol",
+    "summary": "Catalpol is an iridoid glycoside linked to metabolic and cytoprotective signaling.",
+    "description": "Catalpol is an iridoid glycoside linked to metabolic and cytoprotective signaling.",
+    "compoundClass": "iridoid glycoside",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "AMPK activation"
+    ],
+    "targets": [
+      "NF-κB",
+      "antioxidant response",
+      "inflammatory cytokines",
+      "gut/liver metabolism"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly extract-derived/preclinical. GI effects and herb-specific contraindications matter more than isolated-compound evidence.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "catechin",
+    "slug": "catechin",
+    "summary": "Catechin is a flavanol found in tea, cacao, and many botanicals, but much of the human literature evaluates catechin-rich mixtures rather than isolated catechin alone. That makes the mechanism signal stronger than the isolated clinical signal.",
+    "description": "Flavan-3-ol common in tea and cacao, often linked to AMPK and Nrf2 pathway effects.",
+    "compoundClass": "flavanol / tea polyphenol",
+    "mechanisms": [
+      "Nrf2 activation",
+      "NF-kB suppression",
+      "endothelial nitric-oxide signaling support",
+      "antioxidant redox modulation"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "AMPK",
+      "endothelial nitric oxide",
+      "antioxidant response",
+      "lipid/glucose signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Tea-food exposure is generally safer than concentrated extracts. High EGCG/catechin extracts have liver-injury concern and caffeine-containing products add stimulant risk.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "celastrol",
+    "slug": "celastrol",
+    "summary": "Quinone methide triterpenoid linked to HSP90 inhibition and NF-κB suppression.",
+    "description": "Quinone methide triterpenoid linked to HSP90 inhibition and NF-κB suppression.",
+    "compoundClass": "quinone methide triterpenoid",
+    "mechanisms": [
+      "HSP90 inhibition",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "HSP90",
+      "NF-κB",
+      "proteasome/stress-response pathways",
+      "leptin signaling",
+      "apoptosis signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "High-caution compound with narrow therapeutic window in preclinical literature. Do not infer supplement safety; avoid pregnancy, liver/kidney disease, and unsupervised use.",
+    "evidenceLevel": "preclinical_high_caution",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cepharanthine",
+    "slug": "cepharanthine",
+    "summary": "Bisbenzylisoquinoline alkaloid associated with NF-κB suppression and PI3K/Akt pathway effects.",
+    "description": "Bisbenzylisoquinoline alkaloid associated with NF-κB suppression and PI3K/Akt pathway effects.",
+    "compoundClass": "alkaloid",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "chamazulene",
+    "slug": "chamazulene",
+    "summary": "Aromatic azulene derivative linked to inflammatory mediator modulation.",
+    "description": "Aromatic azulene derivative linked to inflammatory mediator modulation.",
+    "compoundClass": "terpene / essential-oil constituent",
+    "mechanisms": [
+      "COX inhibition",
+      "leukotriene pathway modulation"
+    ],
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "charantin",
+    "slug": "charantin",
+    "summary": "Bitter melon sterol glycoside mixture associated with glucose uptake and metabolic regulation.",
+    "description": "Bitter melon sterol glycoside mixture associated with glucose uptake and metabolic regulation.",
+    "compoundClass": "steroidal saponin mixture",
+    "mechanisms": [
+      "AMPK activation",
+      "GLUT4 translocation modulation"
+    ],
+    "targets": [
+      "glucose metabolism",
+      "AMPK-related pathways",
+      "insulin signaling",
+      "GLUT4 modulation"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Human safety is bitter-melon/extract-derived. May potentiate hypoglycemia; avoid pregnancy and monitor with antidiabetic therapy.",
+    "evidenceLevel": "human_indirect_from_bitter_melon; preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "chicoric acid",
+    "slug": "chicoric-acid",
+    "summary": "Caffeic acid derivative prominent in echinacea and chicory with anti-inflammatory signaling activity.",
+    "description": "Caffeic acid derivative prominent in echinacea and chicory with anti-inflammatory signaling activity.",
+    "compoundClass": "phenolic acid / polyphenol",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK modulation"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "antioxidant response",
+      "glucose/lipid signaling",
+      "gut microbiome metabolism"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly food-associated; concentrated extracts may cause GI effects or interact with anticoagulants/antidiabetics depending matrix.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "chlorogenic acid",
+    "slug": "chlorogenic-acid",
+    "summary": "Caffeoylquinic acid widely reported from coffee and artichoke with AMPK and glucose-metabolism pathway effects.",
+    "description": "Caffeoylquinic acid widely reported from coffee and artichoke with AMPK and glucose-metabolism pathway effects.",
+    "compoundClass": "caffeoylquinic acid / phenolic acid",
+    "mechanisms": [
+      "AMPK activation",
+      "glucose metabolism modulation"
+    ],
+    "targets": [
+      "AMPK",
+      "glucose absorption pathways",
+      "antioxidant enzymes",
+      "inflammatory signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Generally food-associated; supplement doses may cause GI upset or caffeine-like effects if delivered via coffee/green coffee extracts. Caution with stimulant sensitivity and antidiabetic drugs.",
+    "evidenceLevel": "human_limited; food_based_evidence",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 17,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "cinnamaldehyde",
+    "slug": "cinnamaldehyde",
+    "summary": "Major aromatic aldehyde in cinnamon bark influencing metabolic and inflammatory signaling.",
+    "description": "Major aromatic aldehyde in cinnamon bark influencing metabolic and inflammatory signaling.",
+    "compoundClass": "terpene / essential-oil constituent",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "TRPA1",
+      "inflammatory enzymes"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "evidenceLevel": "animal / in vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 13,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "citronellal",
+    "slug": "citronellal",
+    "summary": "Monoterpene aldehyde common in citronella-type oils, recognized for aromatic and sensory-channel activity.",
+    "description": "Monoterpene aldehyde common in citronella-type oils, recognized for aromatic and sensory-channel activity.",
+    "compoundClass": "terpene / essential-oil constituent",
+    "mechanisms": [
+      "TRPA1 modulation",
+      "sensory ion-channel modulation"
+    ],
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "columbamine",
+    "slug": "columbamine",
+    "summary": "Berberine-family alkaloid linked to metabolic regulation pathways.",
+    "description": "Berberine-family alkaloid linked to metabolic regulation pathways.",
+    "compoundClass": "protoberberine isoquinoline alkaloid",
+    "mechanisms": [
+      "AMPK activation",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "NF-κB",
+      "apoptosis signaling",
+      "microbial targets",
+      "AMPK-related pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Human safety is not well established. Avoid pregnancy/breastfeeding; caution with CYP/P-gp substrates, antidiabetic drugs, and complex medication regimens.",
+    "evidenceLevel": "preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "columbin",
+    "slug": "columbin",
+    "summary": "Diterpenoid from Tinospora cordifolia linked to anti-inflammatory activity.",
+    "description": "Diterpenoid from Tinospora cordifolia linked to anti-inflammatory activity.",
+    "compoundClass": "terpenoid",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK modulation"
+    ],
+    "targets": [
+      "NF-κB",
+      "MAPK"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "commipheric acid",
+    "slug": "commipheric-acid",
+    "summary": "Guggul triterpenoid linked to lipid-signaling and inflammatory control.",
+    "description": "Guggul triterpenoid linked to lipid-signaling and inflammatory control.",
+    "compoundClass": "triterpene / triterpenoid acid",
+    "mechanisms": [
+      "PPAR activation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "NF-κB",
+      "AMPK",
+      "PPAR",
+      "inflammatory cytokines",
+      "apoptosis signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or extract-derived; concentrated doses may affect glucose, lipids, liver enzymes, or bleeding risk depending matrix.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "coptisine",
+    "slug": "coptisine",
+    "summary": "Protoberberine alkaloid from Coptis with metabolic and inflammatory pathway activity.",
+    "description": "Protoberberine alkaloid from Coptis with metabolic and inflammatory pathway activity.",
+    "compoundClass": "alkaloid",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-κB inhibition",
+      "MAPK modulation"
+    ],
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "corosolic acid",
+    "slug": "corosolic-acid",
+    "summary": "Triterpenoid associated with glucose disposal and metabolic signaling.",
+    "description": "Triterpenoid associated with glucose disposal and metabolic signaling.",
+    "compoundClass": "triterpene / triterpenoid acid",
+    "mechanisms": [
+      "AMPK activation",
+      "GLUT4 translocation modulation"
+    ],
+    "targets": [
+      "NF-κB",
+      "AMPK",
+      "PPAR",
+      "inflammatory cytokines",
+      "apoptosis signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or extract-derived; concentrated doses may affect glucose, lipids, liver enzymes, or bleeding risk depending matrix.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "crocetin",
+    "slug": "crocetin",
+    "summary": "Saffron carotenoid aglycone linked to PI3K/Akt and Nrf2 pathway activity.",
+    "description": "Saffron carotenoid aglycone linked to PI3K/Akt and Nrf2 pathway activity.",
+    "compoundClass": "apocarotenoid",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "Nrf2 activation"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "oxidative-stress signaling",
+      "lipid metabolism",
+      "retinal/neurovascular pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Human evidence is limited and often saffron-derived. Caution with pregnancy, serotonergic drugs, anticoagulants, and blood-pressure-lowering regimens.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "crocin",
+    "slug": "crocin",
+    "summary": "Saffron carotenoid glycoside reported to influence PI3K/Akt and MAPK signaling.",
+    "description": "Saffron carotenoid glycoside reported to influence PI3K/Akt and MAPK signaling.",
+    "compoundClass": "carotenoid glycoside",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "oxidative-stress signaling",
+      "serotonergic and dopaminergic pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Human safety is mostly inferred from saffron trials. Avoid pregnancy-dose escalation; caution with serotonergic drugs, anticoagulants, and hypotension-prone users.",
+    "evidenceLevel": "human_indirect_from_saffron; preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cryptotanshinone",
+    "slug": "cryptotanshinone",
+    "summary": "Abietane diterpene from Salvia miltiorrhiza with anticancer properties.",
+    "description": "Abietane diterpene from Salvia miltiorrhiza with anticancer properties.",
+    "compoundClass": "diterpenoid quinone",
+    "mechanisms": [
+      "STAT3 inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "NF-κB",
+      "MAPK",
+      "platelet aggregation",
+      "cardiovascular/inflammatory signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Danshen constituents may affect bleeding and cardiovascular medications; use clinician review with anticoagulants/antiplatelets.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "curcumin",
+    "slug": "curcumin",
+    "summary": "Curcuminoid from turmeric commonly linked to NF-κB inhibition and Nrf2 activation.",
+    "description": "Curcuminoid from turmeric commonly linked to NF-κB inhibition and Nrf2 activation.",
+    "compoundClass": "diarylheptanoid polyphenol",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "Nrf2 activation"
+    ],
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "COX-2",
+      "LOX",
+      "STAT3",
+      "AMPK",
+      "inflammatory cytokines"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Generally well tolerated in many trials, but high-dose extracts can cause GI upset and may interact with anticoagulants/antiplatelets or gallbladder disease contexts; piperine coformulas change exposure.",
+    "evidenceLevel": "human_limited; multiple_meta_analyses_by_indication",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 20,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "curcumol",
+    "slug": "curcumol",
+    "summary": "Sesquiterpenoid from zedoary associated with inflammatory pathway modulation.",
+    "description": "Sesquiterpenoid from zedoary associated with inflammatory pathway modulation.",
+    "compoundClass": "curcuminoid / diarylheptanoid",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "COX/LOX",
+      "inflammatory cytokines",
+      "AMPK"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Human evidence is mostly formulation-dependent. High-dose curcuminoids may cause GI upset and interact with anticoagulants/antiplatelets.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "curdione",
+    "slug": "curdione",
+    "summary": "Curcuma sesquiterpenoid linked to survival and apoptotic pathways.",
+    "description": "Curcuma sesquiterpenoid linked to survival and apoptotic pathways.",
+    "compoundClass": "curcuminoid / diarylheptanoid",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "apoptosis pathway modulation (caspase activation)"
+    ],
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "COX/LOX",
+      "inflammatory cytokines",
+      "AMPK"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Human evidence is mostly formulation-dependent. High-dose curcuminoids may cause GI upset and interact with anticoagulants/antiplatelets.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "daidzein",
+    "slug": "daidzein",
+    "summary": "Isoflavone found in soy and clover, frequently linked to estrogen receptor and MAPK pathway activity.",
+    "description": "Isoflavone found in soy and clover, frequently linked to estrogen receptor and MAPK pathway activity.",
+    "compoundClass": "isoflavone / phytoestrogen",
+    "mechanisms": [
+      "estrogen receptor modulation",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "estrogen receptor signaling",
+      "AMPK",
+      "PPAR",
+      "antioxidant response",
+      "bone/metabolic signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Phytoestrogenic activity warrants caution with hormone-sensitive conditions and hormone therapies; effects are preparation- and dose-specific.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "daidzin",
+    "slug": "daidzin",
+    "summary": "Isoflavone glycoside associated with hormone-related and glycemic effects.",
+    "description": "Isoflavone glycoside associated with hormone-related and glycemic effects.",
+    "compoundClass": "isoflavone / phytoestrogen",
+    "mechanisms": [
+      "estrogen receptor modulation",
+      "glucose absorption modulation"
+    ],
+    "targets": [
+      "estrogen receptor signaling",
+      "AMPK",
+      "PPAR",
+      "antioxidant response",
+      "bone/metabolic signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Phytoestrogenic activity warrants caution with hormone-sensitive conditions and hormone therapies; effects are preparation- and dose-specific.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "daphnetin",
+    "slug": "daphnetin",
+    "summary": "Coumarin derivative reported with JAK/STAT and NF-κB inhibitory activity.",
+    "description": "Coumarin derivative reported with JAK/STAT and NF-κB inhibitory activity.",
+    "compoundClass": "coumarin / furanocoumarin",
+    "mechanisms": [
+      "JAK/STAT inhibition",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "demethoxycurcumin",
+    "slug": "demethoxycurcumin",
+    "summary": "Curcuminoid analog associated with inflammatory and antioxidant-response pathways.",
+    "description": "Curcuminoid analog associated with inflammatory and antioxidant-response pathways.",
+    "compoundClass": "curcuminoid / diarylheptanoid",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "Nrf2 activation"
+    ],
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "COX/LOX",
+      "inflammatory cytokines",
+      "AMPK"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Human evidence is mostly formulation-dependent. High-dose curcuminoids may cause GI upset and interact with anticoagulants/antiplatelets.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "deoxyelephantopin",
+    "slug": "deoxyelephantopin",
+    "summary": "Sesquiterpene lactone linked to inflammatory and apoptotic signaling.",
+    "description": "Sesquiterpene lactone linked to inflammatory and apoptotic signaling.",
+    "compoundClass": "sesquiterpene lactone",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "STAT3 inhibition",
+      "apoptosis pathway modulation (caspase activation)"
+    ],
+    "targets": [
+      "NF-κB",
+      "STAT3",
+      "apoptosis/caspase signaling",
+      "caspase signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "deoxymiroestrol",
+    "slug": "deoxymiroestrol",
+    "summary": "Phytoestrogen precursor compound associated with Pueraria mirifica and estrogenic signaling.",
+    "description": "Phytoestrogen precursor compound associated with Pueraria mirifica and estrogenic signaling.",
+    "compoundClass": "isoflavone / phytoestrogen",
+    "mechanisms": [
+      "estrogen receptor modulation"
+    ],
+    "targets": [
+      "estrogen receptor signaling",
+      "AMPK",
+      "PPAR",
+      "antioxidant response",
+      "bone/metabolic signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Phytoestrogenic activity warrants caution with hormone-sensitive conditions and hormone therapies; effects are preparation- and dose-specific.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 4,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "desmethoxyyangonin",
+    "slug": "desmethoxyyangonin",
+    "summary": "Minor kavalactone from kava associated with monoamine and GABAergic signaling effects.",
+    "description": "Minor kavalactone from kava associated with monoamine and GABAergic signaling effects.",
+    "compoundClass": "kavalactone",
+    "mechanisms": [
+      "MAO-B inhibition",
+      "GABA-A modulation"
+    ],
+    "targets": [
+      "GABAergic signaling",
+      "voltage-gated ion channels",
+      "monoamine signaling",
+      "CYP enzymes"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Kava/kavalactones are linked with sedation and liver injury concerns; avoid alcohol, sedatives, liver disease, and pregnancy.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "dihydrokavain",
+    "slug": "dihydrokavain",
+    "summary": "Major kavalactone from kava linked to calming CNS activity through GABAergic mechanisms.",
+    "description": "Major kavalactone from kava linked to calming CNS activity through GABAergic mechanisms.",
+    "compoundClass": "kavalactone",
+    "mechanisms": [
+      "GABA-A modulation"
+    ],
+    "targets": [
+      "GABAergic signaling",
+      "voltage-gated ion channels",
+      "monoamine signaling",
+      "CYP enzymes"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Kava/kavalactones are linked with sedation and liver injury concerns; avoid alcohol, sedatives, liver disease, and pregnancy.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "dihydromethysticin",
+    "slug": "dihydromethysticin",
+    "summary": "Kavalactone from kava associated with GABAergic activity and monoamine-related signaling.",
+    "description": "Kavalactone from kava associated with GABAergic activity and monoamine-related signaling.",
+    "compoundClass": "kavalactone",
+    "mechanisms": [
+      "GABA-A modulation",
+      "MAO-B inhibition"
+    ],
+    "targets": [
+      "GABAergic signaling",
+      "voltage-gated ion channels",
+      "monoamine signaling",
+      "CYP enzymes"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Kava/kavalactones are linked with sedation and liver injury concerns; avoid alcohol, sedatives, liver disease, and pregnancy.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "diosgenin",
+    "slug": "diosgenin",
+    "summary": "Steroidal sapogenin broadly associated with endocrine and metabolic signaling.",
+    "description": "Steroidal sapogenin broadly associated with endocrine and metabolic signaling.",
+    "compoundClass": "steroidal sapogenin",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "PPARγ activation"
+    ],
+    "targets": [
+      "PPAR signaling",
+      "lipid metabolism",
+      "inflammatory cytokines",
+      "steroidal saponin pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or food/herb-associated. Caution with hormone-sensitive conditions, pregnancy, and anticoagulant/antidiabetic medication contexts.",
+    "evidenceLevel": "preclinical; human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "echinacoside",
+    "slug": "echinacoside",
+    "summary": "Echinacoside is a phenylethanoid glycoside found in Echinacea and Cistanche-related materials. It is mainly characterized by antioxidant, neuroprotective, and anti-inflammatory preclinical research rather than strong human intervention data.",
+    "description": "Phenylethanoid glycoside associated with neuroprotective and antioxidant-response pathways.",
+    "compoundClass": "phenylethanoid glycoside",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "Nrf2 activation"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "antioxidant response",
+      "inflammatory cytokines",
+      "neuroprotective signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical/extract-derived; safety depends on source herb and product quality.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 3,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "elemicin",
+    "slug": "elemicin",
+    "summary": "Phenylpropene associated with monoamine-related and sensory signaling.",
+    "description": "Phenylpropene associated with monoamine-related and sensory signaling.",
+    "compoundClass": "terpene / essential-oil constituent",
+    "mechanisms": [
+      "monoamine oxidase inhibition",
+      "TRP channel modulation"
+    ],
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "elephantopin",
+    "slug": "elephantopin",
+    "summary": "Sesquiterpene lactone associated with inflammatory signaling control.",
+    "description": "Sesquiterpene lactone associated with inflammatory signaling control.",
+    "compoundClass": "sesquiterpene lactone",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "NF-κB",
+      "MAPK"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "eleutheroside b",
+    "slug": "eleutheroside-b",
+    "summary": "Phenylpropanoid glycoside from Eleuthero associated with adaptogenic effects.",
+    "description": "Phenylpropanoid glycoside from Eleuthero associated with adaptogenic effects.",
+    "compoundClass": "lignan",
+    "mechanisms": [
+      "HPA-axis modulation",
+      "immune modulation"
+    ],
+    "targets": [
+      "CYP/P-gp modulation",
+      "Nrf2",
+      "AMPK",
+      "liver detoxification signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Schisandra-type lignans can affect drug-metabolizing enzymes/transporters; caution with complex medication regimens.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "eleutheroside e",
+    "slug": "eleutheroside-e",
+    "summary": "Lignan glycoside from Eleuthero linked to endurance and stress adaptation.",
+    "description": "Lignan glycoside from Eleuthero linked to endurance and stress adaptation.",
+    "compoundClass": "lignan",
+    "mechanisms": [
+      "AMPK activation",
+      "stress response modulation"
+    ],
+    "targets": [
+      "CYP/P-gp modulation",
+      "Nrf2",
+      "AMPK",
+      "liver detoxification signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Schisandra-type lignans can affect drug-metabolizing enzymes/transporters; caution with complex medication regimens.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ellagic acid",
+    "slug": "ellagic-acid",
+    "summary": "Polyphenolic acid associated with pomegranate and berry sources, linked to Nrf2 and NF-κB signaling.",
+    "description": "Polyphenolic acid associated with pomegranate and berry sources, linked to Nrf2 and NF-κB signaling.",
+    "compoundClass": "phenolic acid / polyphenol",
+    "mechanisms": [
+      "Nrf2 activation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "antioxidant response",
+      "glucose/lipid signaling",
+      "gut microbiome metabolism"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly food-associated; concentrated extracts may cause GI effects or interact with anticoagulants/antidiabetics depending matrix.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "embelin",
+    "slug": "embelin",
+    "summary": "Benzoquinone compound linked to apoptotic and inflammatory signaling.",
+    "description": "Benzoquinone compound linked to apoptotic and inflammatory signaling.",
+    "compoundClass": "quinone / naphthoquinone-like phenolic",
+    "mechanisms": [
+      "XIAP inhibition",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "ROS/redox cycling",
+      "NF-κB",
+      "apoptosis signaling",
+      "Nrf2",
+      "antimicrobial pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Often preclinical; concentrated or isolated quinones may be irritant/cytotoxic. Avoid pregnancy and use caution with liver disease or anticoagulants.",
+    "evidenceLevel": "preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "emodin",
+    "slug": "emodin",
+    "summary": "Anthraquinone reported from rhubarb with NF-κB and MAPK pathway activity.",
+    "description": "Anthraquinone reported from rhubarb with NF-κB and MAPK pathway activity.",
+    "compoundClass": "anthraquinone",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "NF-κB",
+      "MAPK",
+      "apoptosis signaling",
+      "intestinal motility pathways",
+      "CYP/P-gp interaction pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Anthraquinone laxative-like activity may cause diarrhea, electrolyte shifts, and interaction risks. Avoid chronic high-dose use, pregnancy, kidney disease, and stimulant-laxative stacking.",
+    "evidenceLevel": "preclinical; safety_known_by_class",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "epicatechin",
+    "slug": "epicatechin",
+    "summary": "Flavan-3-ol associated with cacao and tea, commonly linked to PI3K/Akt and endothelial nitric oxide signaling.",
+    "description": "Flavan-3-ol associated with cacao and tea, commonly linked to PI3K/Akt and endothelial nitric oxide signaling.",
+    "compoundClass": "flavanol / tea polyphenol",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "eNOS activation"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "AMPK",
+      "endothelial nitric oxide",
+      "antioxidant response",
+      "lipid/glucose signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Tea-food exposure is generally safer than concentrated extracts. High EGCG/catechin extracts have liver-injury concern and caffeine-containing products add stimulant risk.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "epicatechin gallate",
+    "slug": "epicatechin-gallate",
+    "summary": "Gallated catechin from tea with anti-inflammatory signaling effects.",
+    "description": "Gallated catechin from tea with anti-inflammatory signaling effects.",
+    "compoundClass": "flavanol / tea polyphenol",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK modulation"
+    ],
+    "targets": [
+      "Inflammatory kinases",
+      "redox-active enzymes"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Tea-food exposure is generally safer than concentrated extracts. High EGCG/catechin extracts have liver-injury concern and caffeine-containing products add stimulant risk.",
+    "evidenceLevel": "animal / in vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 12,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "epigallocatechin",
+    "slug": "epigallocatechin",
+    "summary": "Tea catechin involved in redox regulation and cell signaling.",
+    "description": "Tea catechin involved in redox regulation and cell signaling.",
+    "compoundClass": "flavanol / tea polyphenol",
+    "mechanisms": [
+      "Nrf2 activation",
+      "MAPK modulation"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "AMPK",
+      "endothelial nitric oxide",
+      "antioxidant response",
+      "lipid/glucose signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Tea-food exposure is generally safer than concentrated extracts. High EGCG/catechin extracts have liver-injury concern and caffeine-containing products add stimulant risk.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "epigallocatechin gallate",
+    "slug": "epigallocatechin-gallate",
+    "summary": "Major green tea catechin widely studied for metabolic and inflammatory pathway effects.",
+    "description": "Major green tea catechin widely studied for metabolic and inflammatory pathway effects.",
+    "compoundClass": "flavanol / tea polyphenol",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-κB inhibition",
+      "EGFR modulation"
+    ],
+    "targets": [
+      "AMPK",
+      "EGFR",
+      "IKK complex"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Tea-food exposure is generally safer than concentrated extracts. High EGCG/catechin extracts have liver-injury concern and caffeine-containing products add stimulant risk.",
+    "evidenceLevel": "human / animal / in vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 27,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "epigallocatechin gallate (egcg)",
+    "slug": "epigallocatechin-gallate-egcg",
+    "summary": "Major tea catechin with widely reported AMPK, NF-κB, and PI3K/Akt pathway activity.",
+    "description": "Major tea catechin with widely reported AMPK, NF-κB, and PI3K/Akt pathway activity.",
+    "compoundClass": "flavanol / tea polyphenol",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "AMPK",
+      "endothelial nitric oxide",
+      "antioxidant response",
+      "lipid/glucose signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Tea-food exposure is generally safer than concentrated extracts. High EGCG/catechin extracts have liver-injury concern and caffeine-containing products add stimulant risk.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "erinacines",
+    "slug": "erinacines",
+    "summary": "Cyathane diterpenoids from lion’s mane mycelium studied for nerve growth factor and neurotrophic signaling.",
+    "description": "Cyathane diterpenoids from lion’s mane mycelium studied for nerve growth factor and neurotrophic signaling.",
+    "compoundClass": "terpenoid",
+    "mechanisms": [
+      "NGF induction",
+      "ERK/CREB pathway modulation"
+    ],
+    "targets": [
+      "pathway targets not fully resolved"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "esculetin",
+    "slug": "esculetin",
+    "summary": "Hydroxycoumarin reported from chicory and Artemisia with lipoxygenase and NF-κB pathway effects.",
+    "description": "Hydroxycoumarin reported from chicory and Artemisia with lipoxygenase and NF-κB pathway effects.",
+    "compoundClass": "coumarin / furanocoumarin",
+    "mechanisms": [
+      "5-lipoxygenase inhibition",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "eugenol",
+    "slug": "eugenol",
+    "summary": "Eugenol is a phenylpropanoid most associated with clove and other aromatic herbs. It is best supported by preclinical work showing analgesic, anti-inflammatory, antimicrobial, and membrane-active effects rather than broad human outcome evidence.",
+    "description": "Phenylpropanoid from clove associated with COX inhibition and TRP channel activity.",
+    "compoundClass": "phenylpropanoid",
+    "mechanisms": [
+      "COX-2 inhibition",
+      "TRPV1/TRPA1 modulation",
+      "voltage-gated sodium-channel effects",
+      "membrane disruption",
+      "NF-kB suppression"
+    ],
+    "targets": [
+      "TRPV1",
+      "COX/LOX pathways",
+      "NF-κB",
+      "microbial membrane effects",
+      "local anesthetic signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Food/flavor exposure differs from essential-oil or concentrated use. High doses may irritate mucosa and affect bleeding or liver safety; caution with anticoagulants and dental/topical overuse.",
+    "evidenceLevel": "human_limited_topical; preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "farnesol",
+    "slug": "farnesol",
+    "summary": "Sesquiterpene alcohol linked to lipid-signaling and pathway modulation.",
+    "description": "Sesquiterpene alcohol linked to lipid-signaling and pathway modulation.",
+    "compoundClass": "terpene / essential-oil constituent",
+    "mechanisms": [
+      "PPAR activation",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ferulic acid",
+    "slug": "ferulic-acid",
+    "summary": "Phenolic acid common in grains and Angelica-related herbs, linked to Nrf2 and PI3K/Akt signaling.",
+    "description": "Phenolic acid common in grains and Angelica-related herbs, linked to Nrf2 and PI3K/Akt signaling.",
+    "compoundClass": "phenolic acid / polyphenol",
+    "mechanisms": [
+      "Nrf2 activation",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "antioxidant response",
+      "glucose/lipid signaling",
+      "gut microbiome metabolism"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly food-associated; concentrated extracts may cause GI effects or interact with anticoagulants/antidiabetics depending matrix.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "formononetin",
+    "slug": "formononetin",
+    "summary": "Isoflavone commonly reported from clover and astragalus with estrogen receptor and PI3K/Akt pathway effects.",
+    "description": "Isoflavone commonly reported from clover and astragalus with estrogen receptor and PI3K/Akt pathway effects.",
+    "compoundClass": "isoflavone / phytoestrogen",
+    "mechanisms": [
+      "estrogen receptor modulation",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "estrogen receptor signaling",
+      "AMPK",
+      "PPAR",
+      "antioxidant response",
+      "bone/metabolic signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Phytoestrogenic activity warrants caution with hormone-sensitive conditions and hormone therapies; effects are preparation- and dose-specific.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "forskolin",
+    "slug": "forskolin",
+    "summary": "Diterpene from Coleus known for direct adenylyl cyclase activation.",
+    "description": "Diterpene from Coleus known for direct adenylyl cyclase activation.",
+    "compoundClass": "labdane diterpene",
+    "mechanisms": [
+      "adenylyl cyclase activation",
+      "cAMP signaling"
+    ],
+    "targets": [
+      "adenylyl cyclase/cAMP",
+      "adenylyl cyclase"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "fraxetin",
+    "slug": "fraxetin",
+    "summary": "Methoxylated coumarin linked to Nrf2 activation and inflammatory pathway suppression.",
+    "description": "Methoxylated coumarin linked to Nrf2 activation and inflammatory pathway suppression.",
+    "compoundClass": "coumarin / furanocoumarin",
+    "mechanisms": [
+      "Nrf2 activation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "galangin",
+    "slug": "galangin",
+    "summary": "Flavonol from Alpinia officinarum with antimicrobial and anti-inflammatory roles.",
+    "description": "Flavonol from Alpinia officinarum with antimicrobial and anti-inflammatory roles.",
+    "compoundClass": "flavonol / flavonoid",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK modulation"
+    ],
+    "targets": [
+      "AMPK",
+      "Nrf2",
+      "NF-κB",
+      "inflammatory cytokines",
+      "endothelial nitric oxide",
+      "antioxidant response"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly food/extract-derived human evidence. High-dose supplements may affect CYP/transporters or anticoagulant/antiplatelet risk.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "gallic acid",
+    "slug": "gallic-acid",
+    "summary": "Gallic acid is a small phenolic acid present across many herbs, teas, and fruits. It is well represented in antioxidant and inflammatory pathway studies, but isolated human outcome evidence is limited.",
+    "description": "Simple phenolic acid widely reported from tea and fruit sources with MAPK and NF-κB pathway activity.",
+    "compoundClass": "phenolic acid / polyphenol",
+    "mechanisms": [
+      "NF-kB suppression",
+      "Nrf2-related antioxidant signaling",
+      "metal-chelation/redox effects",
+      "caspase-linked apoptosis signaling"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "antioxidant response",
+      "glucose/lipid signaling",
+      "gut microbiome metabolism"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly food-associated; concentrated extracts may cause GI effects or interact with anticoagulants/antidiabetics depending matrix.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "gallocatechin",
+    "slug": "gallocatechin",
+    "summary": "Catechin derivative present in tea with antioxidant signaling activity.",
+    "description": "Catechin derivative present in tea with antioxidant signaling activity.",
+    "compoundClass": "flavanol / tea polyphenol",
+    "mechanisms": [
+      "Nrf2 activation",
+      "MAPK modulation"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "AMPK",
+      "endothelial nitric oxide",
+      "antioxidant response",
+      "lipid/glucose signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Tea-food exposure is generally safer than concentrated extracts. High EGCG/catechin extracts have liver-injury concern and caffeine-containing products add stimulant risk.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "garcinol",
+    "slug": "garcinol",
+    "summary": "Polyisoprenylated benzophenone linked to inflammatory and epigenetic signaling.",
+    "description": "Polyisoprenylated benzophenone linked to inflammatory and epigenetic signaling.",
+    "compoundClass": "xanthone / polyphenol",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "HAT inhibition",
+      "STAT3 inhibition"
+    ],
+    "targets": [
+      "NF-κB",
+      "antioxidant response",
+      "apoptosis signaling",
+      "inflammatory cytokines"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical/extract-derived; concentrated Garcinia/mangosteen extracts may affect bleeding or liver risk depending product.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "genistein",
+    "slug": "genistein",
+    "summary": "Isoflavone strongly associated with soy and clover, commonly linked to estrogen receptor and PI3K/Akt signaling.",
+    "description": "Isoflavone strongly associated with soy and clover, commonly linked to estrogen receptor and PI3K/Akt signaling.",
+    "compoundClass": "isoflavone / phytoestrogen",
+    "mechanisms": [
+      "estrogen receptor modulation",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "estrogen receptor signaling",
+      "AMPK",
+      "PPAR",
+      "antioxidant response",
+      "bone/metabolic signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Phytoestrogenic activity warrants caution with hormone-sensitive conditions and hormone therapies; effects are preparation- and dose-specific.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ginkgolide b",
+    "slug": "ginkgolide-b",
+    "summary": "Terpene lactone from Ginkgo biloba affecting platelet activating factor.",
+    "description": "Terpene lactone from Ginkgo biloba affecting platelet activating factor.",
+    "compoundClass": "diterpene lactone / platelet-activating-factor antagonist",
+    "mechanisms": [
+      "PAF receptor antagonism",
+      "neuroprotection"
+    ],
+    "targets": [
+      "PAF receptor",
+      "platelet activation",
+      "inflammatory signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Human safety is mainly tied to Ginkgo preparations; caution with anticoagulants/antiplatelets, surgery, seizure risk, and bleeding disorders.",
+    "evidenceLevel": "human_indirect_from_ginkgo_extracts",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 22,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "ginsenoside rb1",
+    "slug": "ginsenoside-rb1",
+    "summary": "Major ginsenoside with neuroprotective and metabolic signaling effects.",
+    "description": "Major ginsenoside with neuroprotective and metabolic signaling effects.",
+    "compoundClass": "triterpenoid saponin / ginsenoside",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "cholinergic modulation",
+      "Nrf2 activation"
+    ],
+    "targets": [
+      "AMPK",
+      "PI3K/Akt",
+      "Nrf2",
+      "neurotrophic signaling",
+      "inflammatory cytokines"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Safety inferred from ginseng extracts. Caution with anticoagulants, antidiabetics, stimulants, immunosuppressants, and hormone-sensitive contexts.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ginsenoside rg1",
+    "slug": "ginsenoside-rg1",
+    "summary": "Major ginsenoside associated with neurovascular and survival signaling.",
+    "description": "Major ginsenoside associated with neurovascular and survival signaling.",
+    "compoundClass": "triterpenoid saponin / ginsenoside",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "NO signaling modulation",
+      "Nrf2 activation"
+    ],
+    "targets": [
+      "AMPK",
+      "PI3K/Akt",
+      "Nrf2",
+      "neurotrophic and inflammatory signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Safety is mostly inferred from Panax/ginseng extracts. Caution with anticoagulants, antidiabetics, stimulants, and hormone-sensitive contexts.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 18,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "ginsenoside rg3",
+    "slug": "ginsenoside-rg3",
+    "summary": "Heat-processed ginsenoside linked to inflammatory and angiogenic pathway control.",
+    "description": "Heat-processed ginsenoside linked to inflammatory and angiogenic pathway control.",
+    "compoundClass": "triterpenoid saponin / ginsenoside",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "PI3K/Akt modulation",
+      "VEGF signaling inhibition"
+    ],
+    "targets": [
+      "PI3K/Akt",
+      "apoptosis signaling",
+      "angiogenesis pathways",
+      "NF-κB",
+      "immune signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical and extract-derived. Caution with anticoagulants, antidiabetics, immune therapies, and oncology regimens without supervision.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "glucomoringin",
+    "slug": "glucomoringin",
+    "summary": "Glucosinolate from moringa that yields bioactive isothiocyanates after hydrolysis.",
+    "description": "Glucosinolate from moringa that yields bioactive isothiocyanates after hydrolysis.",
+    "compoundClass": "phytochemical constituent",
+    "mechanisms": [
+      "Nrf2 activation",
+      "isothiocyanate signaling"
+    ],
+    "targets": [
+      "Phase II detox enzymes",
+      "electrophile sensors"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "animal / in vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 11,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "glycyrrhetinic acid",
+    "slug": "glycyrrhetinic-acid",
+    "summary": "Triterpenoid metabolite of glycyrrhizin associated with inflammatory signaling modulation.",
+    "description": "Triterpenoid metabolite of glycyrrhizin associated with inflammatory signaling modulation.",
+    "compoundClass": "triterpenoid sapogenin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "HMGB1 inhibition"
+    ],
+    "targets": [
+      "NF-κB"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "glycyrrhizin",
+    "slug": "glycyrrhizin",
+    "summary": "Triterpene saponin from licorice with HMGB1 and NF-κB pathway activity.",
+    "description": "Triterpene saponin from licorice with HMGB1 and NF-κB pathway activity.",
+    "compoundClass": "triterpenoid saponin glycoside",
+    "mechanisms": [
+      "HMGB1 inhibition",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "11β-HSD2",
+      "mineralocorticoid-like sodium/potassium balance",
+      "HMGB1",
+      "inflammatory signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Can contribute to hypertension, hypokalemia, edema, and arrhythmia risk. Avoid with uncontrolled hypertension, kidney disease, pregnancy unless supervised, diuretics, digoxin, corticosteroids, and antihypertensives.",
+    "evidenceLevel": "human_safety_known; mechanism_and_interaction_supported",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 20,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "guggulsterone",
+    "slug": "guggulsterone",
+    "summary": "Steroidal ketone associated with bile-acid receptor and inflammatory pathway effects.",
+    "description": "Steroidal ketone associated with bile-acid receptor and inflammatory pathway effects.",
+    "compoundClass": "saponin / glycoside",
+    "mechanisms": [
+      "FXR antagonism",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "AMPK",
+      "PPAR",
+      "immune cytokines",
+      "membrane signaling",
+      "glucose/lipid metabolism"
+    ],
+    "foundIn": [],
+    "safetyNotes": "May cause GI irritation or hemolysis risk in isolated/high-dose contexts; herb-specific safety and pregnancy cautions apply.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "gurmarin",
+    "slug": "gurmarin",
+    "summary": "Peptide constituent associated with sweet-signal blocking and glycemic effects.",
+    "description": "Peptide constituent associated with sweet-signal blocking and glycemic effects.",
+    "compoundClass": "peptide",
+    "mechanisms": [
+      "sweet taste receptor modulation",
+      "glucose absorption modulation"
+    ],
+    "targets": [
+      "glucose transport/metabolism"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "gymnemagenin",
+    "slug": "gymnemagenin",
+    "summary": "Triterpenoid aglycone linked to glycemic regulation and intestinal glucose handling.",
+    "description": "Triterpenoid aglycone linked to glycemic regulation and intestinal glucose handling.",
+    "compoundClass": "triterpene / triterpenoid acid",
+    "mechanisms": [
+      "glucose absorption modulation",
+      "AMPK activation"
+    ],
+    "targets": [
+      "NF-κB",
+      "AMPK",
+      "PPAR",
+      "inflammatory cytokines",
+      "apoptosis signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or extract-derived; concentrated doses may affect glucose, lipids, liver enzymes, or bleeding risk depending matrix.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "gymnemic acid",
+    "slug": "gymnemic-acid",
+    "summary": "Triterpenoid saponin complex from gymnema linked to intestinal glucose handling.",
+    "description": "Triterpenoid saponin complex from gymnema linked to intestinal glucose handling.",
+    "compoundClass": "triterpenoid saponin mixture",
+    "mechanisms": [
+      "glucose absorption modulation",
+      "AMPK activation"
+    ],
+    "targets": [
+      "sweet taste receptors",
+      "intestinal glucose absorption",
+      "insulin signaling",
+      "AMPK-related pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "May lower blood glucose or reduce sweet taste perception. Monitor with antidiabetic therapies; avoid pregnancy/breastfeeding unless supervised.",
+    "evidenceLevel": "human_indirect_from_gymnema; preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "harpagoside",
+    "slug": "harpagoside",
+    "summary": "Harpagoside is a devil’s claw iridoid associated with pain and inflammatory pathway modulation.",
+    "description": "Harpagoside is a devil’s claw iridoid associated with pain and inflammatory pathway modulation.",
+    "compoundClass": "iridoid glycoside",
+    "mechanisms": [
+      "COX inhibition",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "NF-κB",
+      "antioxidant response",
+      "inflammatory cytokines",
+      "gut/liver metabolism"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly extract-derived/preclinical. GI effects and herb-specific contraindications matter more than isolated-compound evidence.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "hericenones",
+    "slug": "hericenones",
+    "summary": "Aromatic compounds from lion’s mane fruiting body linked to neurotrophic signaling.",
+    "description": "Aromatic compounds from lion’s mane fruiting body linked to neurotrophic signaling.",
+    "compoundClass": "phytochemical constituent",
+    "mechanisms": [
+      "NGF induction",
+      "ERK/CREB pathway modulation"
+    ],
+    "targets": [
+      "pathway targets not fully resolved"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "hesperidin",
+    "slug": "hesperidin",
+    "summary": "Citrus flavanone glycoside linked to PI3K/Akt and NF-κB pathway effects.",
+    "description": "Citrus flavanone glycoside linked to PI3K/Akt and NF-κB pathway effects.",
+    "compoundClass": "flavanone glycoside",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "endothelial nitric oxide",
+      "NF-κB",
+      "Nrf2",
+      "lipid metabolism",
+      "capillary/vascular signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Food-associated citrus flavonoid; concentrated use may interact with anticoagulant/antiplatelet or blood-pressure regimens. GI effects possible.",
+    "evidenceLevel": "human_limited; food_based",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "honokiol",
+    "slug": "honokiol",
+    "summary": "Biphenolic compound from Magnolia bark with anxiolytic and anti-inflammatory activity.",
+    "description": "Biphenolic compound from Magnolia bark with anxiolytic and anti-inflammatory activity.",
+    "compoundClass": "neolignan",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "GABA-A modulation"
+    ],
+    "targets": [
+      "GABA-A signaling",
+      "NF-κB",
+      "cannabinoid/endocannabinoid signaling",
+      "inflammatory cytokines"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Sedation and additive CNS depressant effects are possible; pregnancy safety is not established.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "huperzine a",
+    "slug": "huperzine-a",
+    "summary": "Lycopodium alkaloid widely associated with cholinergic and glutamatergic signaling.",
+    "description": "Lycopodium alkaloid widely associated with cholinergic and glutamatergic signaling.",
+    "compoundClass": "alkaloid",
+    "mechanisms": [
+      "acetylcholinesterase inhibition",
+      "NMDA receptor modulation"
+    ],
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "huperzine b",
+    "slug": "huperzine-b",
+    "summary": "Minor huperzine alkaloid linked to cholinergic support pathways.",
+    "description": "Minor huperzine alkaloid linked to cholinergic support pathways.",
+    "compoundClass": "alkaloid",
+    "mechanisms": [
+      "acetylcholinesterase inhibition",
+      "NMDA receptor modulation"
+    ],
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "hydroxytyrosol",
+    "slug": "hydroxytyrosol",
+    "summary": "Olive phenolic metabolite linked to Nrf2 activation and PI3K/Akt signaling.",
+    "description": "Olive phenolic metabolite linked to Nrf2 activation and PI3K/Akt signaling.",
+    "compoundClass": "phenylethanoid polyphenol",
+    "mechanisms": [
+      "Nrf2 activation",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "Nrf2",
+      "oxidative-stress pathways",
+      "LDL oxidation",
+      "endothelial signaling",
+      "NF-κB"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Food-associated from olive oil/olive leaf; high-dose supplement safety is less defined. Caution with blood-pressure and antiplatelet medication contexts.",
+    "evidenceLevel": "human_limited; food_based",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "hyperforin",
+    "slug": "hyperforin",
+    "summary": "Hyperforin is a St.",
+    "description": "Hyperforin is a St. John’s wort phloroglucinol known for TRPC6 and neurotransmitter effects.",
+    "compoundClass": "prenylated phloroglucinol",
+    "mechanisms": [
+      "TRPC6 channel modulation",
+      "monoamine reuptake inhibition"
+    ],
+    "targets": [
+      "pathway targets not fully resolved"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "hypericin",
+    "slug": "hypericin",
+    "summary": "Hypericin is a napthodianthrone marker from St.",
+    "description": "Hypericin is a napthodianthrone marker from St. John’s wort with photodynamic signaling effects.",
+    "compoundClass": "naphthodianthrone",
+    "mechanisms": [
+      "PKC modulation",
+      "apoptosis pathway modulation (caspase activation)"
+    ],
+    "targets": [
+      "apoptosis/caspase signaling",
+      "caspase signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "imperatorin",
+    "slug": "imperatorin",
+    "summary": "Furanocoumarin associated with cholinesterase inhibition and calcium-channel-related signaling effects.",
+    "description": "Furanocoumarin associated with cholinesterase inhibition and calcium-channel-related signaling effects.",
+    "compoundClass": "coumarin / furanocoumarin",
+    "mechanisms": [
+      "acetylcholinesterase inhibition",
+      "voltage-gated calcium channel modulation"
+    ],
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "indirubin",
+    "slug": "indirubin",
+    "summary": "Bis-indole alkaloid pigment known from indigo-yielding plants and studied for kinase-targeted activity.",
+    "description": "Bis-indole alkaloid pigment known from indigo-yielding plants and studied for kinase-targeted activity.",
+    "compoundClass": "alkaloid",
+    "mechanisms": [
+      "CDK inhibition",
+      "STAT3 inhibition"
+    ],
+    "targets": [
+      "STAT3"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Isolated alkaloid exposure may affect CYP/P-gp handling, glucose, blood pressure, and GI tolerance; avoid pregnancy/breastfeeding unless clinician-directed.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "isoimperatorin",
+    "slug": "isoimperatorin",
+    "summary": "Related furanocoumarin commonly reported from Angelica/Cnidium with cholinesterase and MAPK pathway activity.",
+    "description": "Related furanocoumarin commonly reported from Angelica/Cnidium with cholinesterase and MAPK pathway activity.",
+    "compoundClass": "coumarin / furanocoumarin",
+    "mechanisms": [
+      "acetylcholinesterase inhibition",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "jatrorrhizine",
+    "slug": "jatrorrhizine",
+    "summary": "Protoberberine alkaloid associated with glucose and inflammatory signaling regulation.",
+    "description": "Protoberberine alkaloid associated with glucose and inflammatory signaling regulation.",
+    "compoundClass": "protoberberine isoquinoline alkaloid",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "AMPK",
+      "NF-κB",
+      "lipid/glucose metabolism",
+      "microbial targets"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical. Use berberine-family cautions: avoid pregnancy/breastfeeding and monitor with antidiabetic, antihypertensive, anticoagulant, and CYP/P-gp substrate drugs.",
+    "evidenceLevel": "preclinical; human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "kaempferol",
+    "slug": "kaempferol",
+    "summary": "Flavonol commonly associated with PI3K/Akt and NF-κB pathway modulation in botanical systems.",
+    "description": "Flavonol commonly associated with PI3K/Akt and NF-κB pathway modulation in botanical systems.",
+    "compoundClass": "flavonol polyphenol",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "PI3K/Akt",
+      "MAPK",
+      "inflammatory cytokines"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Food exposure is low-risk; high-dose supplement safety is less established. Caution with anticoagulants, antidiabetics, and complex oncology regimens.",
+    "evidenceLevel": "preclinical; human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 11,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "kahweol",
+    "slug": "kahweol",
+    "summary": "Coffee diterpene often paired with cafestol and associated with redox and inflammatory pathway modulation.",
+    "description": "Coffee diterpene often paired with cafestol and associated with redox and inflammatory pathway modulation.",
+    "compoundClass": "diterpene / coffee alkaloid-related constituent",
+    "mechanisms": [
+      "Nrf2 activation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "lipid metabolism",
+      "bile acid signaling",
+      "adenosine/glucose metabolism depending compound"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Coffee matrix matters. Cafestol/kahweol can raise LDL with unfiltered coffee; caffeine-related effects may apply to coffee products.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "kavain",
+    "slug": "kavain",
+    "summary": "Major kavalactone with calming and channel-modulating pharmacology.",
+    "description": "Major kavalactone with calming and channel-modulating pharmacology.",
+    "compoundClass": "kavalactone",
+    "mechanisms": [
+      "GABA-A modulation",
+      "voltage-gated sodium channel modulation"
+    ],
+    "targets": [
+      "GABAergic signaling",
+      "voltage-gated ion channels",
+      "monoamine signaling",
+      "CYP enzymes"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Kava/kavalactones are linked with sedation and liver injury concerns; avoid alcohol, sedatives, liver disease, and pregnancy.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "kavalactones",
+    "slug": "kavalactones",
+    "summary": "Collective kavalactone fraction associated with anxiolytic and ion-channel activity.",
+    "description": "Collective kavalactone fraction associated with anxiolytic and ion-channel activity.",
+    "compoundClass": "kavalactone",
+    "mechanisms": [
+      "GABA-A modulation",
+      "voltage-gated sodium channel modulation"
+    ],
+    "targets": [
+      "GABAergic signaling",
+      "voltage-gated ion channels",
+      "monoamine signaling",
+      "CYP enzymes"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Kava/kavalactones are linked with sedation and liver injury concerns; avoid alcohol, sedatives, liver disease, and pregnancy.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "kotalanol",
+    "slug": "kotalanol",
+    "summary": "Thiosugar sulfonium constituent from Salacia known for intestinal alpha-glucosidase inhibition.",
+    "description": "Thiosugar sulfonium constituent from Salacia known for intestinal alpha-glucosidase inhibition.",
+    "compoundClass": "phytochemical constituent",
+    "mechanisms": [
+      "alpha-glucosidase inhibition"
+    ],
+    "targets": [
+      "alpha-glucosidase"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 4,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "lagerstroemin",
+    "slug": "lagerstroemin",
+    "summary": "Ellagitannin linked to glucose transport and metabolic regulation.",
+    "description": "Ellagitannin linked to glucose transport and metabolic regulation.",
+    "compoundClass": "ellagitannin",
+    "mechanisms": [
+      "PPAR activation",
+      "glucose uptake modulation"
+    ],
+    "targets": [
+      "PPARα/γ",
+      "glucose transport/metabolism"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "lawsone",
+    "slug": "lawsone",
+    "summary": "Naphthoquinone pigment linked to inflammatory signaling control.",
+    "description": "Naphthoquinone pigment linked to inflammatory signaling control.",
+    "compoundClass": "quinone / naphthoquinone-like phenolic",
+    "mechanisms": [
+      "MAPK pathway modulation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "ROS/redox cycling",
+      "NF-κB",
+      "apoptosis signaling",
+      "Nrf2",
+      "antimicrobial pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Often preclinical; concentrated or isolated quinones may be irritant/cytotoxic. Avoid pregnancy and use caution with liver disease or anticoagulants.",
+    "evidenceLevel": "preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ligustilide",
+    "slug": "ligustilide",
+    "summary": "Phthalide constituent of Angelica/Ligusticum associated with calcium-channel-related and NF-κB effects.",
+    "description": "Phthalide constituent of Angelica/Ligusticum associated with calcium-channel-related and NF-κB effects.",
+    "compoundClass": "phthalide",
+    "mechanisms": [
+      "voltage-gated calcium channel modulation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "smooth muscle relaxation",
+      "nitric oxide/endothelial signaling",
+      "platelet aggregation pathways",
+      "inflammatory signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly extract-derived evidence. Potential additive bleeding, blood pressure, or sedative effects depending source herb.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "linalool",
+    "slug": "linalool",
+    "summary": "Monoterpene alcohol linked to GABA-A and calcium-channel related effects.",
+    "description": "Monoterpene alcohol linked to GABA-A and calcium-channel related effects.",
+    "compoundClass": "monoterpene alcohol",
+    "mechanisms": [
+      "GABA-A modulation",
+      "voltage-gated calcium channel modulation"
+    ],
+    "targets": [
+      "GABAergic signaling",
+      "glutamate signaling",
+      "inflammatory cytokines",
+      "olfactory/CNS pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Primarily essential-oil/aroma exposure; topical allergy and CNS sedation are possible. Avoid ingestion of essential oils without supervision.",
+    "evidenceLevel": "preclinical; human_limited_aroma",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "lobeline",
+    "slug": "lobeline",
+    "summary": "Piperidine alkaloid from Lobelia linked to nicotinic receptor and catecholamine signaling.",
+    "description": "Piperidine alkaloid from Lobelia linked to nicotinic receptor and catecholamine signaling.",
+    "compoundClass": "alkaloid",
+    "mechanisms": [
+      "nicotinic acetylcholine receptor modulation",
+      "dopamine transporter modulation"
+    ],
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "loganin",
+    "slug": "loganin",
+    "summary": "Loganin is an iridoid glycoside tied to antioxidant-response and survival pathways.",
+    "description": "Loganin is an iridoid glycoside tied to antioxidant-response and survival pathways.",
+    "compoundClass": "iridoid glycoside",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "Nrf2 activation"
+    ],
+    "targets": [
+      "NF-κB",
+      "antioxidant response",
+      "inflammatory cytokines",
+      "gut/liver metabolism"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly extract-derived/preclinical. GI effects and herb-specific contraindications matter more than isolated-compound evidence.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "luteolin",
+    "slug": "luteolin",
+    "summary": "Flavone associated with thyme and artichoke, commonly linked to NF-κB and MAPK signaling.",
+    "description": "Flavone associated with thyme and artichoke, commonly linked to NF-κB and MAPK signaling.",
+    "compoundClass": "flavone / flavonoid",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "NF-κB",
+      "MAPK",
+      "PI3K/Akt",
+      "Nrf2",
+      "inflammatory cytokines",
+      "antioxidant response"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical and extract-derived. Use caution with sedatives, anticoagulants/antiplatelets, and liver disease depending source herb.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "madecassic acid",
+    "slug": "madecassic-acid",
+    "summary": "Centella triterpenoid associated with matrix-remodeling and survival signaling.",
+    "description": "Centella triterpenoid associated with matrix-remodeling and survival signaling.",
+    "compoundClass": "triterpene / triterpenoid acid",
+    "mechanisms": [
+      "TGF-β signaling modulation",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "NF-κB",
+      "AMPK",
+      "PPAR",
+      "inflammatory cytokines",
+      "apoptosis signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or extract-derived; concentrated doses may affect glucose, lipids, liver enzymes, or bleeding risk depending matrix.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "madecassoside",
+    "slug": "madecassoside",
+    "summary": "Centella triterpene glycoside associated with inflammatory and tissue-repair signaling.",
+    "description": "Centella triterpene glycoside associated with inflammatory and tissue-repair signaling.",
+    "compoundClass": "triterpenoid saponin glycoside",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "TGF-β signaling modulation",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "TGF-β",
+      "collagen remodeling",
+      "NF-κB",
+      "wound-healing and barrier pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly Centella/topical-derived evidence. Caution with liver disease, sedatives, pregnancy, and prolonged high-dose extracts.",
+    "evidenceLevel": "human_indirect_from_centella; preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "magnoflorine",
+    "slug": "magnoflorine",
+    "summary": "Aporphine alkaloid reported from Coptis and lotus with AMPK and inflammatory pathway activity.",
+    "description": "Aporphine alkaloid reported from Coptis and lotus with AMPK and inflammatory pathway activity.",
+    "compoundClass": "alkaloid",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "magnolol",
+    "slug": "magnolol",
+    "summary": "Bioactive lignan from Magnolia with neuroprotective and anti-inflammatory effects.",
+    "description": "Bioactive lignan from Magnolia with neuroprotective and anti-inflammatory effects.",
+    "compoundClass": "neolignan",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "GABA-A modulation"
+    ],
+    "targets": [
+      "GABA-A signaling",
+      "NF-κB",
+      "cannabinoid/endocannabinoid signaling",
+      "inflammatory cytokines"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Sedation and additive CNS depressant effects are possible; pregnancy safety is not established.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "mangiferin",
+    "slug": "mangiferin",
+    "summary": "Xanthone glucoside linked to metabolic and redox-responsive signaling.",
+    "description": "Xanthone glucoside linked to metabolic and redox-responsive signaling.",
+    "compoundClass": "xanthone / polyphenol",
+    "mechanisms": [
+      "AMPK activation",
+      "Nrf2 activation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "NF-κB",
+      "antioxidant response",
+      "apoptosis signaling",
+      "inflammatory cytokines"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical/extract-derived; concentrated Garcinia/mangosteen extracts may affect bleeding or liver risk depending product.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "mangiferin aglycone",
+    "slug": "mangiferin-aglycone",
+    "summary": "Xanthone-related metabolite linked to metabolic and redox-responsive pathways.",
+    "description": "Xanthone-related metabolite linked to metabolic and redox-responsive pathways.",
+    "compoundClass": "xanthone / polyphenol",
+    "mechanisms": [
+      "AMPK activation",
+      "Nrf2 activation"
+    ],
+    "targets": [
+      "NF-κB",
+      "antioxidant response",
+      "apoptosis signaling",
+      "inflammatory cytokines"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical/extract-derived; concentrated Garcinia/mangosteen extracts may affect bleeding or liver risk depending product.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "mangostin",
+    "slug": "mangostin",
+    "summary": "Xanthone associated with inflammatory and survival pathway effects.",
+    "description": "Xanthone associated with inflammatory and survival pathway effects.",
+    "compoundClass": "xanthone / polyphenol",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "PI3K/Akt modulation",
+      "apoptosis pathway modulation (caspase activation)"
+    ],
+    "targets": [
+      "NF-κB",
+      "antioxidant response",
+      "apoptosis signaling",
+      "inflammatory cytokines"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical/extract-derived; concentrated Garcinia/mangosteen extracts may affect bleeding or liver risk depending product.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "matrine",
+    "slug": "matrine",
+    "summary": "Quinolizidine alkaloid from Sophora species commonly linked to PI3K/Akt and NF-κB pathway effects.",
+    "description": "Quinolizidine alkaloid from Sophora species commonly linked to PI3K/Akt and NF-κB pathway effects.",
+    "compoundClass": "alkaloid",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "mesembrenone",
+    "slug": "mesembrenone",
+    "summary": "Kanna alkaloid closely related to mesembrine and associated with serotonin-reuptake and PDE4 effects.",
+    "description": "Kanna alkaloid closely related to mesembrine and associated with serotonin-reuptake and PDE4 effects.",
+    "compoundClass": "alkaloid",
+    "mechanisms": [
+      "serotonin reuptake inhibition",
+      "PDE4 inhibition"
+    ],
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "mesembrine",
+    "slug": "mesembrine",
+    "summary": "Major Kanna alkaloid best known for serotonin-reuptake and PDE4-related activity.",
+    "description": "Major Kanna alkaloid best known for serotonin-reuptake and PDE4-related activity.",
+    "compoundClass": "alkaloid",
+    "mechanisms": [
+      "serotonin reuptake inhibition",
+      "PDE4 inhibition"
+    ],
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "methyl eugenol",
+    "slug": "methyl-eugenol",
+    "summary": "Phenylpropanoid present in aromatic herbs with sensory and neuroactive effects.",
+    "description": "Phenylpropanoid present in aromatic herbs with sensory and neuroactive effects.",
+    "compoundClass": "terpene / essential-oil constituent",
+    "mechanisms": [
+      "TRPA1 modulation",
+      "voltage-gated channel modulation"
+    ],
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "methyleugenol",
+    "slug": "methyleugenol",
+    "summary": "Phenylpropene associated with sensory and inhibitory neurotransmission pathways.",
+    "description": "Phenylpropene associated with sensory and inhibitory neurotransmission pathways.",
+    "compoundClass": "terpene / essential-oil constituent",
+    "mechanisms": [
+      "TRP channel modulation",
+      "GABA-A modulation"
+    ],
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "methysticin",
+    "slug": "methysticin",
+    "summary": "Kavalactone reported with GABAergic and monoamine-related activity.",
+    "description": "Kavalactone reported with GABAergic and monoamine-related activity.",
+    "compoundClass": "kavalactone",
+    "mechanisms": [
+      "GABA-A modulation",
+      "MAO-B inhibition"
+    ],
+    "targets": [
+      "GABAergic signaling",
+      "voltage-gated ion channels",
+      "monoamine signaling",
+      "CYP enzymes"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Kava/kavalactones are linked with sedation and liver injury concerns; avoid alcohol, sedatives, liver disease, and pregnancy.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "momordicoside k",
+    "slug": "momordicoside-k",
+    "summary": "Bitter melon cucurbitane glycoside linked to metabolic signaling.",
+    "description": "Bitter melon cucurbitane glycoside linked to metabolic signaling.",
+    "compoundClass": "saponin / glycoside",
+    "mechanisms": [
+      "AMPK activation",
+      "PPARγ activation"
+    ],
+    "targets": [
+      "AMPK",
+      "PPAR",
+      "immune cytokines",
+      "membrane signaling",
+      "glucose/lipid metabolism"
+    ],
+    "foundIn": [],
+    "safetyNotes": "May cause GI irritation or hemolysis risk in isolated/high-dose contexts; herb-specific safety and pregnancy cautions apply.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "morin",
+    "slug": "morin",
+    "summary": "Flavonol associated with inflammatory and cell-survival pathway modulation.",
+    "description": "Flavonol associated with inflammatory and cell-survival pathway modulation.",
+    "compoundClass": "flavonol / flavonoid",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "AMPK",
+      "Nrf2",
+      "NF-κB",
+      "inflammatory cytokines",
+      "endothelial nitric oxide",
+      "antioxidant response"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly food/extract-derived human evidence. High-dose supplements may affect CYP/transporters or anticoagulant/antiplatelet risk.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "morroniside",
+    "slug": "morroniside",
+    "summary": "Morroniside is a Cornus iridoid with cytoprotective pathway activity.",
+    "description": "Morroniside is a Cornus iridoid with cytoprotective pathway activity.",
+    "compoundClass": "iridoid glycoside",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "Nrf2 activation"
+    ],
+    "targets": [
+      "NF-κB",
+      "antioxidant response",
+      "inflammatory cytokines",
+      "gut/liver metabolism"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly extract-derived/preclinical. GI effects and herb-specific contraindications matter more than isolated-compound evidence.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "mulberroside a",
+    "slug": "mulberroside-a",
+    "summary": "Mulberry stilbene glycoside associated with postprandial glycemic control.",
+    "description": "Mulberry stilbene glycoside associated with postprandial glycemic control.",
+    "compoundClass": "stilbene glycoside",
+    "mechanisms": [
+      "glucose absorption modulation",
+      "alpha-glucosidase inhibition"
+    ],
+    "targets": [
+      "alpha-glucosidase",
+      "glucose transport/metabolism"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "myricetin",
+    "slug": "myricetin",
+    "summary": "Polyhydroxylated flavonol reported from tea and berry sources with MAPK and NF-κB pathway activity.",
+    "description": "Polyhydroxylated flavonol reported from tea and berry sources with MAPK and NF-κB pathway activity.",
+    "compoundClass": "flavonol / flavonoid",
+    "mechanisms": [
+      "MAPK pathway modulation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "AMPK",
+      "Nrf2",
+      "NF-κB",
+      "inflammatory cytokines",
+      "endothelial nitric oxide",
+      "antioxidant response"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly food/extract-derived human evidence. High-dose supplements may affect CYP/transporters or anticoagulant/antiplatelet risk.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "myristicin",
+    "slug": "myristicin",
+    "summary": "Nutmeg phenylpropene linked to monoamine and cholinergic pathway effects.",
+    "description": "Nutmeg phenylpropene linked to monoamine and cholinergic pathway effects.",
+    "compoundClass": "terpene / essential-oil constituent",
+    "mechanisms": [
+      "monoamine oxidase inhibition",
+      "acetylcholinesterase inhibition"
+    ],
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "naringenin",
+    "slug": "naringenin",
+    "summary": "Citrus flavanone reported to influence AMPK and PI3K/Akt signaling.",
+    "description": "Citrus flavanone reported to influence AMPK and PI3K/Akt signaling.",
+    "compoundClass": "flavanone / citrus flavonoid",
+    "mechanisms": [
+      "AMPK activation",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "AMPK",
+      "PPAR signaling",
+      "NF-κB",
+      "endothelial nitric oxide",
+      "antioxidant response",
+      "drug transporters"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Citrus-derived compounds are generally food-associated, but grapefruit/citrus extracts can interact with CYP3A4/OATP/P-gp substrates.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "naringin",
+    "slug": "naringin",
+    "summary": "Citrus glycoside that converts toward naringenin-related metabolic and inflammatory pathway activity.",
+    "description": "Citrus glycoside that converts toward naringenin-related metabolic and inflammatory pathway activity.",
+    "compoundClass": "flavanone / citrus flavonoid",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "AMPK",
+      "PPAR signaling",
+      "NF-κB",
+      "endothelial nitric oxide",
+      "antioxidant response",
+      "drug transporters"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Citrus-derived compounds are generally food-associated, but grapefruit/citrus extracts can interact with CYP3A4/OATP/P-gp substrates.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "neoandrographolide",
+    "slug": "neoandrographolide",
+    "summary": "Andrographis diterpene glycoside associated with inflammatory and survival signaling modulation.",
+    "description": "Andrographis diterpene glycoside associated with inflammatory and survival signaling modulation.",
+    "compoundClass": "diterpenoid glycoside",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "MAPK",
+      "inflammatory cytokines",
+      "immune signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Human safety is mostly extract-derived. Avoid pregnancy; caution with immunosuppressants, anticoagulants, and users with severe allergy history.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "nerolidol",
+    "slug": "nerolidol",
+    "summary": "Sesquiterpene alcohol associated with calming and cytoprotective signaling.",
+    "description": "Sesquiterpene alcohol associated with calming and cytoprotective signaling.",
+    "compoundClass": "terpene / essential-oil constituent",
+    "mechanisms": [
+      "GABA-A modulation",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "nicotine",
+    "slug": "nicotine",
+    "summary": "Canonical tobacco alkaloid with strong nicotinic and neurotransmitter pathway activity.",
+    "description": "Canonical tobacco alkaloid with strong nicotinic and neurotransmitter pathway activity.",
+    "compoundClass": "alkaloid",
+    "mechanisms": [
+      "nicotinic acetylcholine receptor agonism",
+      "dopamine release modulation"
+    ],
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "oleacein",
+    "slug": "oleacein",
+    "summary": "Oleacein is an olive secoiridoid linked to antioxidant-response and inflammatory pathway control.",
+    "description": "Oleacein is an olive secoiridoid linked to antioxidant-response and inflammatory pathway control.",
+    "compoundClass": "olive phenolic secoiridoid/phenylethanol",
+    "mechanisms": [
+      "Nrf2 activation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "lipid oxidation",
+      "endothelial signaling",
+      "antioxidant response"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Food-associated in olive/olive oil matrices; concentrated extracts may affect blood pressure, glucose, or bleeding risk.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "oleanolic acid",
+    "slug": "oleanolic-acid",
+    "summary": "Pentacyclic triterpene associated with cytoprotective and inflammatory signaling control.",
+    "description": "Pentacyclic triterpene associated with cytoprotective and inflammatory signaling control.",
+    "compoundClass": "triterpene / triterpenoid acid",
+    "mechanisms": [
+      "Nrf2 activation",
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "NF-κB",
+      "AMPK",
+      "PPAR",
+      "inflammatory cytokines",
+      "apoptosis signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or extract-derived; concentrated doses may affect glucose, lipids, liver enzymes, or bleeding risk depending matrix.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "oleocanthal",
+    "slug": "oleocanthal",
+    "summary": "Oleocanthal is an olive phenolic aldehyde associated with COX-related anti-inflammatory signaling.",
+    "description": "Oleocanthal is an olive phenolic aldehyde associated with COX-related anti-inflammatory signaling.",
+    "compoundClass": "olive phenolic secoiridoid/phenylethanol",
+    "mechanisms": [
+      "COX inhibition",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "lipid oxidation",
+      "endothelial signaling",
+      "antioxidant response"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Food-associated in olive/olive oil matrices; concentrated extracts may affect blood pressure, glucose, or bleeding risk.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "oleuropein",
+    "slug": "oleuropein",
+    "summary": "Olive secoiridoid associated with NF-κB and AMPK pathway modulation.",
+    "description": "Olive secoiridoid associated with NF-κB and AMPK pathway modulation.",
+    "compoundClass": "secoiridoid phenolic glycoside",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "AMPK activation"
+    ],
+    "targets": [
+      "AMPK",
+      "Nrf2",
+      "NF-κB",
+      "endothelial nitric oxide",
+      "lipid/glucose metabolism"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Generally food-associated via olive/olive leaf, but concentrated extracts may lower blood pressure or glucose. Monitor with antihypertensive or antidiabetic therapy.",
+    "evidenceLevel": "human_limited; preclinical_strong",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ononin",
+    "slug": "ononin",
+    "summary": "Isoflavone glycoside tied to receptor-level estrogenic signaling.",
+    "description": "Isoflavone glycoside tied to receptor-level estrogenic signaling.",
+    "compoundClass": "isoflavone / phytoestrogen",
+    "mechanisms": [
+      "estrogen receptor modulation",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "estrogen receptor signaling",
+      "AMPK",
+      "PPAR",
+      "antioxidant response",
+      "bone/metabolic signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Phytoestrogenic activity warrants caution with hormone-sensitive conditions and hormone therapies; effects are preparation- and dose-specific.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "osthole",
+    "slug": "osthole",
+    "summary": "Prenylated coumarin reported from Cnidium and related Apiaceae with PDE4-linked and PI3K/Akt signaling activity.",
+    "description": "Prenylated coumarin reported from Cnidium and related Apiaceae with PDE4-linked and PI3K/Akt signaling activity.",
+    "compoundClass": "coumarin / furanocoumarin",
+    "mechanisms": [
+      "PDE4 inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "oxymatrine",
+    "slug": "oxymatrine",
+    "summary": "Matrine-related alkaloid associated with TGF-β-linked fibrosis pathways and NF-κB inhibition.",
+    "description": "Matrine-related alkaloid associated with TGF-β-linked fibrosis pathways and NF-κB inhibition.",
+    "compoundClass": "alkaloid",
+    "mechanisms": [
+      "TGF-β signaling modulation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "oxyresveratrol",
+    "slug": "oxyresveratrol",
+    "summary": "Mulberry stilbene linked to carbohydrate-processing and signaling effects.",
+    "description": "Mulberry stilbene linked to carbohydrate-processing and signaling effects.",
+    "compoundClass": "stilbene polyphenol",
+    "mechanisms": [
+      "alpha-glucosidase inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "SIRT1/AMPK",
+      "Nrf2",
+      "NF-κB",
+      "endothelial signaling",
+      "platelet aggregation pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "May affect bleeding risk and drug metabolism at supplement doses; GI upset and headache are possible.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "paeoniflorin",
+    "slug": "paeoniflorin",
+    "summary": "Monoterpene glycoside associated with inflammatory and survival pathway effects.",
+    "description": "Monoterpene glycoside associated with inflammatory and survival pathway effects.",
+    "compoundClass": "monoterpene glycoside / phenolic from Paeonia",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "NF-κB",
+      "immune cytokines",
+      "smooth muscle/analgesic signaling",
+      "antioxidant response"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preparation-derived. Caution with anticoagulants, pregnancy, and immune-modulating therapies.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "paeonol",
+    "slug": "paeonol",
+    "summary": "Phenolic ketone associated with inflammatory and antioxidant-response signaling.",
+    "description": "Phenolic ketone associated with inflammatory and antioxidant-response signaling.",
+    "compoundClass": "monoterpene glycoside / phenolic from Paeonia",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "Nrf2 activation"
+    ],
+    "targets": [
+      "NF-κB",
+      "immune cytokines",
+      "smooth muscle/analgesic signaling",
+      "antioxidant response"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preparation-derived. Caution with anticoagulants, pregnancy, and immune-modulating therapies.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "palmatine",
+    "slug": "palmatine",
+    "summary": "Palmatine is a protoberberine alkaloid that often co-occurs with berberine-containing herbs. Its profile is driven mainly by preclinical metabolic, antimicrobial, and anti-inflammatory studies rather than direct clinical evidence.",
+    "description": "Protoberberine alkaloid found in berberine-containing herbs with metabolic and inflammatory pathway effects.",
+    "compoundClass": "protoberberine isoquinoline alkaloid",
+    "mechanisms": [
+      "AMPK activation",
+      "MAPK pathway modulation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "AMPK",
+      "NF-κB",
+      "microbial targets",
+      "CYP/P-gp interaction pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Related to berberine-like alkaloids but less clinically characterized. Avoid pregnancy/breastfeeding and use caution with antidiabetic, anticoagulant, and CYP/P-gp substrate drugs.",
+    "evidenceLevel": "preclinical; human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "piperine",
+    "slug": "piperine",
+    "summary": "Piperine is the major pungent alkaloid of black pepper and a well-known bioavailability enhancer. Human evidence is strongest for pharmacokinetic interaction effects rather than broad stand-alone therapeutic outcomes.",
+    "description": "Alkaloid from black pepper enhancing bioavailability.",
+    "compoundClass": "piperidine alkaloid / bioenhancer",
+    "mechanisms": [
+      "TRPV1 activation",
+      "CYP3A4/CYP2C9 modulation",
+      "P-gp inhibition",
+      "intestinal permeability and absorption enhancement"
+    ],
+    "targets": [
+      "CYP3A4",
+      "CYP2C9",
+      "P-gp",
+      "intestinal permeability",
+      "TRPV1"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Pharmacokinetic interaction risk is the key issue. Use caution with narrow-therapeutic-index drugs, anticoagulants, antiepileptics, antidiabetics, and sedatives.",
+    "evidenceLevel": "human_limited_for_pk; safety_interaction_relevant",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 19,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "piperlongumine",
+    "slug": "piperlongumine",
+    "summary": "Amide alkaloid from long pepper associated with redox-stress and inflammatory signaling.",
+    "description": "Amide alkaloid from long pepper associated with redox-stress and inflammatory signaling.",
+    "compoundClass": "alkaloid / amide",
+    "mechanisms": [
+      "ROS-mediated signaling modulation",
+      "STAT3 inhibition",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "ROS stress-response pathways",
+      "NF-κB",
+      "apoptosis signaling",
+      "glutathione/oxidative-stress balance"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Primarily preclinical; isolated high-dose human safety is not established. Avoid pregnancy, liver disease, and complex oncology regimens without supervision.",
+    "evidenceLevel": "preclinical_high_caution",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "plumbagin",
+    "slug": "plumbagin",
+    "summary": "Naphthoquinone associated with inflammatory and redox-signaling effects.",
+    "description": "Naphthoquinone associated with inflammatory and redox-signaling effects.",
+    "compoundClass": "quinone / naphthoquinone-like phenolic",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "STAT3 inhibition",
+      "ROS-mediated signaling modulation"
+    ],
+    "targets": [
+      "ROS/redox cycling",
+      "NF-κB",
+      "apoptosis signaling",
+      "Nrf2",
+      "antimicrobial pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Often preclinical; concentrated or isolated quinones may be irritant/cytotoxic. Avoid pregnancy and use caution with liver disease or anticoagulants.",
+    "evidenceLevel": "preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "protodioscin",
+    "slug": "protodioscin",
+    "summary": "Steroidal saponin associated with nitric-oxide and survival pathway signaling.",
+    "description": "Steroidal saponin associated with nitric-oxide and survival pathway signaling.",
+    "compoundClass": "saponin / glycoside",
+    "mechanisms": [
+      "NO signaling modulation",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "AMPK",
+      "PPAR",
+      "immune cytokines",
+      "membrane signaling",
+      "glucose/lipid metabolism"
+    ],
+    "foundIn": [],
+    "safetyNotes": "May cause GI irritation or hemolysis risk in isolated/high-dose contexts; herb-specific safety and pregnancy cautions apply.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "psoralen",
+    "slug": "psoralen",
+    "summary": "Furocoumarin associated with phytoestrogen-like and MAPK-linked signaling effects.",
+    "description": "Furocoumarin associated with phytoestrogen-like and MAPK-linked signaling effects.",
+    "compoundClass": "coumarin / furanocoumarin",
+    "mechanisms": [
+      "estrogen receptor modulation",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "pterostilbene",
+    "slug": "pterostilbene",
+    "summary": "Dimethylated stilbene associated with berry and grape sources and linked to AMPK and PPAR signaling.",
+    "description": "Dimethylated stilbene associated with berry and grape sources and linked to AMPK and PPAR signaling.",
+    "compoundClass": "stilbene polyphenol",
+    "mechanisms": [
+      "AMPK activation",
+      "PPAR activation"
+    ],
+    "targets": [
+      "SIRT1/AMPK",
+      "Nrf2",
+      "NF-κB",
+      "endothelial signaling",
+      "platelet aggregation pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "May affect bleeding risk and drug metabolism at supplement doses; GI upset and headache are possible.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "puerarin",
+    "slug": "puerarin",
+    "summary": "Puerarin is the major isoflavone linked to kudzu-derived materials and has been studied in vascular, metabolic, and estrogen-related contexts. Human evidence exists, especially in Asia, but it is narrower and less replicated than the strongest compound-level literatures.",
+    "description": "Major kudzu isoflavone linked to metabolic and estrogen-related signaling.",
+    "compoundClass": "isoflavone / phytoestrogen",
+    "mechanisms": [
+      "AMPK activation",
+      "PI3K/Akt modulation",
+      "endothelial nitric-oxide signaling",
+      "estrogen-receptor modulation"
+    ],
+    "targets": [
+      "estrogen receptor signaling",
+      "AMPK",
+      "PPAR",
+      "antioxidant response",
+      "bone/metabolic signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Phytoestrogenic activity warrants caution with hormone-sensitive conditions and hormone therapies; effects are preparation- and dose-specific.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "punicalagin",
+    "slug": "punicalagin",
+    "summary": "Major ellagitannin from pomegranate with strong polyphenolic bioactivity.",
+    "description": "Major ellagitannin from pomegranate with strong polyphenolic bioactivity.",
+    "compoundClass": "phytochemical constituent",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "ellagitannin-mediated antioxidant signaling"
+    ],
+    "targets": [
+      "Inflammatory mediators",
+      "redox-sensitive enzymes"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "human / animal / in vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 12,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "quercetin",
+    "slug": "quercetin",
+    "summary": "Quercetin is a broadly distributed flavonol found in many herbs, fruits, and vegetables. Human supplementation literature exists for blood-pressure, inflammatory, and exercise-recovery questions, but the overall signal is still mixed and endpoint-specific.",
+    "description": "Flavonol widely distributed in herbs and fruits, commonly linked to NF-κB, PI3K/Akt, and Nrf2 pathway modulation.",
+    "compoundClass": "flavonol polyphenol",
+    "mechanisms": [
+      "NF-kB suppression",
+      "Nrf2 activation",
+      "PI3K/Akt modulation",
+      "mast-cell mediator stabilization",
+      "antioxidant redox signaling"
+    ],
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "PI3K/Akt",
+      "mast-cell mediators",
+      "CYP/P-gp interaction pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Food exposure is generally safe; high-dose supplements may affect drug transport/metabolism. Caution with anticoagulants, immunosuppressants, and kidney disease at high doses.",
+    "evidenceLevel": "human_limited; preclinical_strong",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 17,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "resveratrol",
+    "slug": "resveratrol",
+    "summary": "Resveratrol is a stilbene polyphenol best known from knotweed and grape-derived materials. It has substantial human literature across cardiometabolic and inflammatory biomarkers, although outcomes vary by dose, formulation, and population.",
+    "description": "Stilbene best known from knotweed and grape sources, strongly linked to SIRT1, AMPK, and NF-κB pathways.",
+    "compoundClass": "stilbene polyphenol",
+    "mechanisms": [
+      "SIRT1 activation",
+      "AMPK activation",
+      "NF-kB suppression",
+      "Nrf2 signaling support",
+      "endothelial nitric-oxide pathway modulation"
+    ],
+    "targets": [
+      "SIRT1",
+      "AMPK",
+      "Nrf2",
+      "NF-κB",
+      "endothelial nitric oxide signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Usually well tolerated short-term; caution with anticoagulants/antiplatelets, hormone-sensitive conditions, pregnancy, and high-dose extracts.",
+    "evidenceLevel": "human_limited; multiple_meta_analyses_by_marker",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 18,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "rhein",
+    "slug": "rhein",
+    "summary": "Anthraquinone constituent of rhubarb associated with NF-κB and PI3K/Akt signaling.",
+    "description": "Anthraquinone constituent of rhubarb associated with NF-κB and PI3K/Akt signaling.",
+    "compoundClass": "anthraquinone",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "NF-κB",
+      "MAPK",
+      "inflammatory cytokines",
+      "cartilage catabolism pathways",
+      "intestinal motility"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Anthraquinone-related GI effects and electrolyte concerns are relevant. Caution with laxatives, diuretics, kidney disease, pregnancy, and anticoagulants.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "rosarin",
+    "slug": "rosarin",
+    "summary": "Rhodiola glycoside associated with stress-response and signaling pathway effects.",
+    "description": "Rhodiola glycoside associated with stress-response and signaling pathway effects.",
+    "compoundClass": "phenylpropanoid glycoside / rosavin",
+    "mechanisms": [
+      "AMPK activation",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "HPA-axis stress response",
+      "monoamine signaling",
+      "AMPK",
+      "antioxidant response"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Evidence is mostly through Rhodiola extracts. May cause activation/insomnia or interact with stimulants/antidepressants.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "rosavin",
+    "slug": "rosavin",
+    "summary": "Phenylpropanoid glycoside from Rhodiola linked to metabolic and cytoprotective signaling.",
+    "description": "Phenylpropanoid glycoside from Rhodiola linked to metabolic and cytoprotective signaling.",
+    "compoundClass": "phenylpropanoid glycoside / rosavin",
+    "mechanisms": [
+      "AMPK activation",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "HPA-axis stress response",
+      "monoamine signaling",
+      "AMPK",
+      "antioxidant response"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Evidence is mostly through Rhodiola extracts. May cause activation/insomnia or interact with stimulants/antidepressants.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "rosin",
+    "slug": "rosin",
+    "summary": "Rhodiola phenylpropanoid linked to adaptive cellular signaling.",
+    "description": "Rhodiola phenylpropanoid linked to adaptive cellular signaling.",
+    "compoundClass": "phenylpropanoid glycoside / rosavin",
+    "mechanisms": [
+      "AMPK activation",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "HPA-axis stress response",
+      "monoamine signaling",
+      "AMPK",
+      "antioxidant response"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Evidence is mostly through Rhodiola extracts. May cause activation/insomnia or interact with stimulants/antidepressants.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "rosmarinic acid",
+    "slug": "rosmarinic-acid",
+    "summary": "Rosmarinic acid is a caffeic-acid ester abundant in rosemary, lemon balm, perilla, and other Lamiaceae herbs. It is most convincing as an anti-inflammatory and mast-cell-modulating compound, but isolated-compound human evidence remains thin.",
+    "description": "Polyphenol in rosemary and lemon balm with anti-inflammatory properties.",
+    "compoundClass": "caffeic acid ester / phenolic acid",
+    "mechanisms": [
+      "NF-kB suppression",
+      "complement modulation",
+      "COX/LOX-related inflammatory signaling effects",
+      "mast-cell mediator reduction"
+    ],
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "complement and inflammatory signaling",
+      "antiviral-entry pathways in vitro"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Food/herb exposure is generally low-risk; isolated high-dose safety is less established. Caution with pregnancy, anticoagulant use, and complex immune therapy contexts.",
+    "evidenceLevel": "preclinical; human_indirect_from_herbal_extracts",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 15,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "rutin",
+    "slug": "rutin",
+    "summary": "Flavonol glycoside commonly reported from buckwheat and St.",
+    "description": "Flavonol glycoside commonly reported from buckwheat and St. John's wort with inflammatory pathway activity.",
+    "compoundClass": "flavonol / flavonoid",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "AMPK",
+      "Nrf2",
+      "NF-κB",
+      "inflammatory cytokines",
+      "endothelial nitric oxide",
+      "antioxidant response"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly food/extract-derived human evidence. High-dose supplements may affect CYP/transporters or anticoagulant/antiplatelet risk.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "safranal",
+    "slug": "safranal",
+    "summary": "Monoterpene aldehyde from saffron contributing to aroma and neuroactive effects.",
+    "description": "Monoterpene aldehyde from saffron contributing to aroma and neuroactive effects.",
+    "compoundClass": "terpene / essential-oil constituent",
+    "mechanisms": [
+      "GABA-A modulation",
+      "NMDA modulation"
+    ],
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "safrole",
+    "slug": "safrole",
+    "summary": "Phenylpropene associated with sensory and signaling pathway activity.",
+    "description": "Phenylpropene associated with sensory and signaling pathway activity.",
+    "compoundClass": "terpene / essential-oil constituent",
+    "mechanisms": [
+      "TRP channel modulation",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "saikosaponin a",
+    "slug": "saikosaponin-a",
+    "summary": "Triterpene saponin from Bupleurum with NF-κB and PI3K/Akt pathway activity.",
+    "description": "Triterpene saponin from Bupleurum with NF-κB and PI3K/Akt pathway activity.",
+    "compoundClass": "triterpenoid saponin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "NF-κB",
+      "MAPK",
+      "HPA-axis signaling",
+      "inflammatory cytokines",
+      "apoptosis signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Human safety is formula/herb-derived. Bupleurum-containing products have liver-safety reports; caution with liver disease, immunomodulators, and pregnancy.",
+    "evidenceLevel": "preclinical; human_indirect_from_bupleurum",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "salidroside",
+    "slug": "salidroside",
+    "summary": "Rhodiola marker glycoside associated with metabolic and cytoprotective pathway activity.",
+    "description": "Rhodiola marker glycoside associated with metabolic and cytoprotective pathway activity.",
+    "compoundClass": "phenylethanoid glycoside",
+    "mechanisms": [
+      "AMPK activation",
+      "PI3K/Akt modulation",
+      "Nrf2 activation"
+    ],
+    "targets": [
+      "HPA-axis stress pathways",
+      "Nrf2",
+      "AMPK",
+      "mitochondrial and inflammatory signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Human evidence mainly derives from Rhodiola extracts. Avoid pregnancy/breastfeeding and caution with bipolar disorder, stimulants, antidepressants, and sedatives.",
+    "evidenceLevel": "human_indirect_from_rhodiola_extracts",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 14,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "schisandrin",
+    "slug": "schisandrin",
+    "summary": "Lignan from Schisandra associated with Nrf2 activation and PI3K/Akt signaling.",
+    "description": "Lignan from Schisandra associated with Nrf2 activation and PI3K/Akt signaling.",
+    "compoundClass": "dibenzocyclooctadiene lignan",
+    "mechanisms": [
+      "Nrf2 activation",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "Nrf2",
+      "CYP3A/P-gp pathways",
+      "mitochondrial oxidative-stress signaling",
+      "inflammatory cytokines"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Human safety is mostly extract-derived. Caution with CYP3A/P-gp substrate drugs, pregnancy, liver disease, and complex medication regimens.",
+    "evidenceLevel": "preclinical; human_indirect_from_schisandra",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "schisandrin b",
+    "slug": "schisandrin-b",
+    "summary": "Lignan from Schisandra with hepatoprotective and redox-modulating actions.",
+    "description": "Lignan from Schisandra with hepatoprotective and redox-modulating actions.",
+    "compoundClass": "lignan",
+    "mechanisms": [
+      "Nrf2 activation",
+      "mitochondrial protection"
+    ],
+    "targets": [
+      "Mitochondrial redox systems",
+      "antioxidant enzymes"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Schisandra-type lignans can affect drug-metabolizing enzymes/transporters; caution with complex medication regimens.",
+    "evidenceLevel": "animal / in vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 11,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "scopoletin",
+    "slug": "scopoletin",
+    "summary": "Coumarin constituent associated with NF-κB suppression and calcium-channel-related activity.",
+    "description": "Coumarin constituent associated with NF-κB suppression and calcium-channel-related activity.",
+    "compoundClass": "coumarin / furanocoumarin",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "voltage-gated calcium channel modulation"
+    ],
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "senkyunolide a",
+    "slug": "senkyunolide-a",
+    "summary": "Phthalide derivative commonly reported from chuanxiong and Angelica with MAPK and ion-channel-linked activity.",
+    "description": "Phthalide derivative commonly reported from chuanxiong and Angelica with MAPK and ion-channel-linked activity.",
+    "compoundClass": "phthalide",
+    "mechanisms": [
+      "MAPK pathway modulation",
+      "voltage-gated calcium channel modulation"
+    ],
+    "targets": [
+      "smooth muscle relaxation",
+      "nitric oxide/endothelial signaling",
+      "platelet aggregation pathways",
+      "inflammatory signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly extract-derived evidence. Potential additive bleeding, blood pressure, or sedative effects depending source herb.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "shikonin",
+    "slug": "shikonin",
+    "summary": "Naphthoquinone pigment associated with metabolic and inflammatory pathway effects.",
+    "description": "Naphthoquinone pigment associated with metabolic and inflammatory pathway effects.",
+    "compoundClass": "quinone / naphthoquinone-like phenolic",
+    "mechanisms": [
+      "PKM2 inhibition",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "ROS/redox cycling",
+      "NF-κB",
+      "apoptosis signaling",
+      "Nrf2",
+      "antimicrobial pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Often preclinical; concentrated or isolated quinones may be irritant/cytotoxic. Avoid pregnancy and use caution with liver disease or anticoagulants.",
+    "evidenceLevel": "preclinical",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "silibinin",
+    "slug": "silibinin",
+    "summary": "Major flavonolignan of milk thistle with STAT3 and PI3K/Akt pathway activity.",
+    "description": "Major flavonolignan of milk thistle with STAT3 and PI3K/Akt pathway activity.",
+    "compoundClass": "flavonolignan",
+    "mechanisms": [
+      "STAT3 inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "hepatic antioxidant pathways",
+      "inflammatory cytokines"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Generally well tolerated in milk-thistle trials; caution with Asteraceae allergy, antidiabetics, hormone-sensitive conditions, and CYP-metabolized drugs.",
+    "evidenceLevel": "human_limited; meta_analysis_by_liver/metabolic_markers",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "silybin",
+    "slug": "silybin",
+    "summary": "Major flavonolignan component of silymarin known for hepatoprotective signaling.",
+    "description": "Major flavonolignan component of silymarin known for hepatoprotective signaling.",
+    "compoundClass": "phytochemical constituent",
+    "mechanisms": [
+      "Nrf2 activation",
+      "TGF-β modulation"
+    ],
+    "targets": [
+      "TGF-β-related nodes",
+      "antioxidant enzymes"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "human / animal / in vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 12,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "silychristin",
+    "slug": "silychristin",
+    "summary": "Flavonolignan from milk thistle contributing to antioxidant and transporter-related activity.",
+    "description": "Flavonolignan from milk thistle contributing to antioxidant and transporter-related activity.",
+    "compoundClass": "phytochemical constituent",
+    "mechanisms": [
+      "Nrf2 activation",
+      "ABC transporter modulation"
+    ],
+    "targets": [
+      "Nrf2"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "silydianin",
+    "slug": "silydianin",
+    "summary": "Minor flavonolignan from milk thistle associated with liver-protective effects.",
+    "description": "Minor flavonolignan from milk thistle associated with liver-protective effects.",
+    "compoundClass": "phytochemical constituent",
+    "mechanisms": [
+      "Nrf2 activation",
+      "hepatocyte protection"
+    ],
+    "targets": [
+      "Nrf2"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "stigmasterol",
+    "slug": "stigmasterol",
+    "summary": "Phytosterol linked to receptor-level lipid signaling and pathway modulation.",
+    "description": "Phytosterol linked to receptor-level lipid signaling and pathway modulation.",
+    "compoundClass": "phytosterol",
+    "mechanisms": [
+      "PPAR activation",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "cholesterol absorption",
+      "inflammatory signaling",
+      "membrane sterol pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Generally food-associated, but supplements can affect lipid markers and may be unsuitable in sitosterolemia.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "tetrandrine",
+    "slug": "tetrandrine",
+    "summary": "Bisbenzylisoquinoline alkaloid known for calcium-channel-related and NF-κB pathway activity.",
+    "description": "Bisbenzylisoquinoline alkaloid known for calcium-channel-related and NF-κB pathway activity.",
+    "compoundClass": "alkaloid",
+    "mechanisms": [
+      "voltage-gated calcium channel modulation",
+      "NF-κB inhibition"
+    ],
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "theaflavin",
+    "slug": "theaflavin",
+    "summary": "Oxidative black tea polyphenol associated with NF-κB and MAPK pathway effects.",
+    "description": "Oxidative black tea polyphenol associated with NF-κB and MAPK pathway effects.",
+    "compoundClass": "flavanol / tea polyphenol",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "AMPK",
+      "endothelial nitric oxide",
+      "antioxidant response",
+      "lipid/glucose signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Tea-food exposure is generally safer than concentrated extracts. High EGCG/catechin extracts have liver-injury concern and caffeine-containing products add stimulant risk.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "theanine",
+    "slug": "theanine",
+    "summary": "Non-protein amino acid from tea associated with calming and attention-related effects.",
+    "description": "Non-protein amino acid from tea associated with calming and attention-related effects.",
+    "compoundClass": "amino acid / tea constituent",
+    "mechanisms": [
+      "glutamate receptor modulation",
+      "GABA upregulation"
+    ],
+    "targets": [
+      "Glutamate receptors",
+      "GABA-related signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Generally well tolerated in tea/supplement studies; additive effects with sedatives or stimulants are possible but usually mild.",
+    "evidenceLevel": "human / animal / in vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 11,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "thearubigin",
+    "slug": "thearubigin",
+    "summary": "Complex black tea polyphenol fraction broadly associated with inflammatory and redox pathway modulation.",
+    "description": "Complex black tea polyphenol fraction broadly associated with inflammatory and redox pathway modulation.",
+    "compoundClass": "flavanol / tea polyphenol",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "Nrf2 activation"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "AMPK",
+      "endothelial nitric oxide",
+      "antioxidant response",
+      "lipid/glucose signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Tea-food exposure is generally safer than concentrated extracts. High EGCG/catechin extracts have liver-injury concern and caffeine-containing products add stimulant risk.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "thujone",
+    "slug": "thujone",
+    "summary": "Thujone is a monoterpene ketone best known for neuroactive and toxicity-relevant pharmacology in sage- and wormwood-related discussions. Its importance is driven more by receptor-level safety relevance than by positive human efficacy evidence.",
+    "description": "Monoterpene ketone associated with GABAergic and sensory signaling.",
+    "compoundClass": "monoterpene ketone",
+    "mechanisms": [
+      "GABA-A receptor antagonism",
+      "neuronal excitability enhancement",
+      "seizure-threshold lowering at higher exposures"
+    ],
+    "targets": [
+      "GABA-A receptors"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Neuroactive monoterpene; high exposure may increase seizure/neurotoxicity risk. Avoid pregnancy, seizure disorders, and concentrated essential-oil ingestion.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "thymol",
+    "slug": "thymol",
+    "summary": "Thymol is a monoterpene phenol prominent in thyme and related aromatic herbs. The best-supported effects are antimicrobial and neuroactive membrane-level actions, with little direct clinical evidence for isolated-compound outcomes.",
+    "description": "Monoterpene phenol from thyme and oregano with antimicrobial and neuroactive properties.",
+    "compoundClass": "terpene / essential-oil constituent",
+    "mechanisms": [
+      "Membrane disruption",
+      "GABA-A receptor modulation",
+      "TRP-channel effects",
+      "antimicrobial permeability effects"
+    ],
+    "targets": [
+      "GABA-A-related sites",
+      "membrane targets"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety.",
+    "evidenceLevel": "animal / in vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 15,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "thymoquinone",
+    "slug": "thymoquinone",
+    "summary": "Quinone constituent of Nigella sativa with reported NF-κB suppression and Nrf2 signaling support.",
+    "description": "Quinone constituent of Nigella sativa with reported NF-κB suppression and Nrf2 signaling support.",
+    "compoundClass": "benzoquinone / monoterpene quinone",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "Nrf2 activation"
+    ],
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "apoptosis signaling",
+      "inflammatory cytokines"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Human evidence usually comes from Nigella sativa preparations rather than isolated thymoquinone. Avoid pregnancy-dose escalation; caution with anticoagulants, antidiabetics, antihypertensives, and liver disease.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 16,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "timosaponin aiii",
+    "slug": "timosaponin-aiii",
+    "summary": "Steroidal saponin associated with survival and apoptotic signaling.",
+    "description": "Steroidal saponin associated with survival and apoptotic signaling.",
+    "compoundClass": "saponin / glycoside",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "apoptosis pathway modulation (caspase activation)"
+    ],
+    "targets": [
+      "AMPK",
+      "PPAR",
+      "immune cytokines",
+      "membrane signaling",
+      "glucose/lipid metabolism"
+    ],
+    "foundIn": [],
+    "safetyNotes": "May cause GI irritation or hemolysis risk in isolated/high-dose contexts; herb-specific safety and pregnancy cautions apply.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "trigonelline",
+    "slug": "trigonelline",
+    "summary": "Alkaloid found in coffee and fenugreek linked to metabolic and neuroprotective effects.",
+    "description": "Alkaloid found in coffee and fenugreek linked to metabolic and neuroprotective effects.",
+    "compoundClass": "diterpene / coffee alkaloid-related constituent",
+    "mechanisms": [
+      "Nrf2 activation",
+      "glucose metabolism modulation"
+    ],
+    "targets": [
+      "lipid metabolism",
+      "bile acid signaling",
+      "adenosine/glucose metabolism depending compound"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Coffee matrix matters. Cafestol/kahweol can raise LDL with unfiltered coffee; caffeine-related effects may apply to coffee products.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "tyrosol",
+    "slug": "tyrosol",
+    "summary": "Simple phenolic alcohol linked to antioxidant-response and survival signaling.",
+    "description": "Simple phenolic alcohol linked to antioxidant-response and survival signaling.",
+    "compoundClass": "olive phenolic secoiridoid/phenylethanol",
+    "mechanisms": [
+      "Nrf2 activation",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "lipid oxidation",
+      "endothelial signaling",
+      "antioxidant response"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Food-associated in olive/olive oil matrices; concentrated extracts may affect blood pressure, glucose, or bleeding risk.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "umbelliferone",
+    "slug": "umbelliferone",
+    "summary": "Simple coumarin distributed across Apiaceae with antioxidant-response and MAPK pathway activity.",
+    "description": "Simple coumarin distributed across Apiaceae with antioxidant-response and MAPK pathway activity.",
+    "compoundClass": "coumarin / furanocoumarin",
+    "mechanisms": [
+      "Nrf2 activation",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ursolic acid",
+    "slug": "ursolic-acid",
+    "summary": "Ursolic acid is a pentacyclic triterpene common in culinary and medicinal herbs. Its research profile is dominated by cell and animal studies covering inflammatory, metabolic, and muscle-related pathways rather than consistent clinical trials.",
+    "description": "Pentacyclic triterpene common in culinary and medicinal herbs with broad pathway effects.",
+    "compoundClass": "pentacyclic triterpenoid",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "STAT3 inhibition",
+      "AMPK activation",
+      "PI3K/Akt modulation"
+    ],
+    "targets": [
+      "NF-κB",
+      "STAT3",
+      "AMPK",
+      "PPAR",
+      "apoptosis signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical and food/herb associated. High-dose isolated use lacks robust human safety data; caution with pregnancy, liver disease, and anticancer/immunomodulating therapies.",
+    "evidenceLevel": "preclinical; human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 14,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "valepotriates",
+    "slug": "valepotriates",
+    "summary": "Valerian iridoid ester fraction associated with sedative and stress-signaling effects.",
+    "description": "Valerian iridoid ester fraction associated with sedative and stress-signaling effects.",
+    "compoundClass": "sesquiterpenoid / valerian constituent",
+    "mechanisms": [
+      "GABA-A modulation",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "GABA-A signaling",
+      "adenosine signaling",
+      "CNS calming pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Evidence mostly comes from valerian extracts. Sedation and additive effects with CNS depressants are key concerns.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "valerenic acid",
+    "slug": "valerenic-acid",
+    "summary": "Valerenic acid is a valerian sesquiterpenoid associated with GABAergic calming effects.",
+    "description": "Valerenic acid is a valerian sesquiterpenoid associated with GABAergic calming effects.",
+    "compoundClass": "sesquiterpenoid / valerian constituent",
+    "mechanisms": [
+      "GABA-A modulation",
+      "voltage-gated calcium channel modulation"
+    ],
+    "targets": [
+      "GABA-A signaling",
+      "adenosine signaling",
+      "CNS calming pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Evidence mostly comes from valerian extracts. Sedation and additive effects with CNS depressants are key concerns.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "valerenol",
+    "slug": "valerenol",
+    "summary": "Valerenol is a valerian constituent linked to positive modulation of GABA-A signaling.",
+    "description": "Valerenol is a valerian constituent linked to positive modulation of GABA-A signaling.",
+    "compoundClass": "sesquiterpenoid / valerian constituent",
+    "mechanisms": [
+      "GABA-A modulation"
+    ],
+    "targets": [
+      "GABA-A signaling",
+      "adenosine signaling",
+      "CNS calming pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Evidence mostly comes from valerian extracts. Sedation and additive effects with CNS depressants are key concerns.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 4,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "verbascoside",
+    "slug": "verbascoside",
+    "summary": "Also known as acteoside; linked to inflammatory signaling control.",
+    "description": "Also known as acteoside; linked to inflammatory signaling control.",
+    "compoundClass": "phenylethanoid glycoside",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "antioxidant response",
+      "inflammatory cytokines",
+      "neuroprotective signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical/extract-derived; safety depends on source herb and product quality.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "withaferin a",
+    "slug": "withaferin-a",
+    "summary": "Reactive withanolide from ashwagandha with strong inflammatory and stress-pathway effects.",
+    "description": "Reactive withanolide from ashwagandha with strong inflammatory and stress-pathway effects.",
+    "compoundClass": "steroidal lactone / withanolide",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "HSP90 inhibition",
+      "apoptosis pathway modulation"
+    ],
+    "targets": [
+      "HSP90",
+      "NF-κB",
+      "Nrf2",
+      "PI3K/Akt",
+      "apoptosis signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical as isolated compound; whole ashwagandha safety does not equal isolated withaferin A safety. Avoid pregnancy and use caution with liver disease, immune disorders, and drug stacks.",
+    "evidenceLevel": "preclinical; human_indirect_from_ashwagandha_extracts",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 22,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "withanolide a",
+    "slug": "withanolide-a",
+    "summary": "Withanolide from ashwagandha associated with neuroactive pathway modulation.",
+    "description": "Withanolide from ashwagandha associated with neuroactive pathway modulation.",
+    "compoundClass": "withanolide / steroidal lactone",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "cholinergic modulation"
+    ],
+    "targets": [
+      "HPA-axis modulation",
+      "NF-κB",
+      "GABAergic signaling",
+      "apoptosis pathways"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Evidence usually comes from Withania extracts. Caution with pregnancy, liver disease, sedatives, thyroid medications, and autoimmune disease.",
+    "evidenceLevel": "human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "withanoside iv",
+    "slug": "withanoside-iv",
+    "summary": "Steroidal lactone glycoside from ashwagandha associated with neuroregenerative activity.",
+    "description": "Steroidal lactone glycoside from ashwagandha associated with neuroregenerative activity.",
+    "compoundClass": "withanolide / steroidal lactone",
+    "mechanisms": [
+      "BDNF upregulation",
+      "neurite outgrowth promotion"
+    ],
+    "targets": [
+      "Neurotrophic signaling nodes",
+      "cholinergic systems"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Evidence usually comes from Withania extracts. Caution with pregnancy, liver disease, sedatives, thyroid medications, and autoimmune disease.",
+    "evidenceLevel": "animal / in vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 12,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "wogonin",
+    "slug": "wogonin",
+    "summary": "Wogonin is a flavone associated with Scutellaria research and immune-neuroinflammatory pathway studies. The compound is biologically interesting, but isolated human efficacy evidence remains thin.",
+    "description": "Scutellaria flavone associated with NF-κB inhibition and PI3K/Akt pathway effects.",
+    "compoundClass": "flavone aglycone",
+    "mechanisms": [
+      "NF-kB suppression",
+      "Nrf2-related antioxidant signaling",
+      "GABA-A-related neuroactive modulation",
+      "apoptosis pathway effects"
+    ],
+    "targets": [
+      "NF-κB",
+      "MAPK",
+      "PI3K/Akt",
+      "apoptosis signaling",
+      "inflammatory cytokines"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Mostly preclinical and extract-derived. Isolated-dose human safety is not well established; caution with liver disease, anticoagulants/antiplatelets, sedatives, and pregnancy.",
+    "evidenceLevel": "preclinical; human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "xanthotoxin",
+    "slug": "xanthotoxin",
+    "summary": "Linear furocoumarin reported from Angelica and parsnip with MAPK and phosphodiesterase-related activity.",
+    "description": "Linear furocoumarin reported from Angelica and parsnip with MAPK and phosphodiesterase-related activity.",
+    "compoundClass": "coumarin / furanocoumarin",
+    "mechanisms": [
+      "MAPK pathway modulation",
+      "PDE inhibition"
+    ],
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils.",
+    "evidenceLevel": "preclinical_plus_human_indirect",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "yangonin",
+    "slug": "yangonin",
+    "summary": "Yangonin is a kavalactone with cannabinoid-related and monoamine-associated signaling.",
+    "description": "Yangonin is a kavalactone with cannabinoid-related and monoamine-associated signaling.",
+    "compoundClass": "kavalactone",
+    "mechanisms": [
+      "CB1 receptor modulation",
+      "MAO-B inhibition"
+    ],
+    "targets": [
+      "GABAergic signaling",
+      "voltage-gated ion channels",
+      "monoamine signaling",
+      "CYP enzymes"
+    ],
+    "foundIn": [],
+    "safetyNotes": "Kava/kavalactones are linked with sedation and liver injury concerns; avoid alcohol, sedatives, liver disease, and pregnancy.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  }
+]

--- a/public/data-next/herbs-summary.json
+++ b/public/data-next/herbs-summary.json
@@ -1,0 +1,2852 @@
+[
+  {
+    "name": "acerola",
+    "slug": "acerola",
+    "summary": "It is best framed as a vitamin-C-rich fruit botanical with food/supplement relevance.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "agarikon",
+    "slug": "agarikon",
+    "summary": "It should be framed modestly because traditional use is much stronger than modern evidence.",
+    "evidenceLevel": "traditional",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ajwain",
+    "slug": "ajwain",
+    "summary": "It is best framed as a culinary-medicinal seed with strong traditional GI positioning.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "aloe vera",
+    "slug": "aloe-vera",
+    "summary": "Internal cross-linking supports Aloe Vera through compounds such as aloin.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 17,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "american ginseng",
+    "slug": "american-ginseng",
+    "summary": "Internal cross-linking supports American Ginseng through compounds such as ginsenosides (including rb1, rg1), rb2.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 17,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "american yellow lotus",
+    "slug": "american-yellow-lotus",
+    "summary": "Internal cross-linking supports American Yellow Lotus through compounds such as nuciferine, roemerine, n-methylasimilobine.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "andrographis paniculata",
+    "slug": "andrographis-paniculata",
+    "summary": "Andrographis paniculata lean herb row for high-speed phytochemical ingestion.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "anemarrhena asphodeloides",
+    "slug": "anemarrhena-asphodeloides",
+    "summary": "Anemarrhena asphodeloides contains Timosaponin AIII and is linked here to PI3K/Akt modulation.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "angelica archangelica",
+    "slug": "angelica-archangelica",
+    "summary": "Angelica archangelica lean monograph row enriched in bulk mode.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "angelica dahurica",
+    "slug": "angelica-dahurica",
+    "summary": "Angelica dahurica lean monograph row enriched in bulk mode.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "angelica pubescens",
+    "slug": "angelica-pubescens",
+    "summary": "Angelica pubescens lean monograph row enriched in bulk mode.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "angelica root",
+    "slug": "angelica-root",
+    "summary": "It should be framed carefully because furanocoumarin context matters for some use cases.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "angelica sinensis",
+    "slug": "angelica-sinensis",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 11,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "anise hyssop",
+    "slug": "anise-hyssop",
+    "summary": "Internal cross-linking supports Anise Hyssop through compounds such as limonene, anethole, estragole.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "arjuna",
+    "slug": "arjuna",
+    "summary": "It is best framed around bark polyphenols and triterpenes with specific cardiotonic-support positioning.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "artemisia absinthium",
+    "slug": "artemisia-absinthium",
+    "summary": "Artemisia absinthium contains Thujone and is linked here to GABA-A receptor antagonism.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "artemisia annua",
+    "slug": "artemisia-annua",
+    "summary": "Artemisia annua contains Artemisinin and is linked here to ROS-mediated signaling modulation.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 17,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "artemisia capillaris",
+    "slug": "artemisia-capillaris",
+    "summary": "Artemisia capillaris lean monograph row enriched in bulk mode.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "artichoke",
+    "slug": "artichoke",
+    "summary": "It is best framed around bitter-compound and phenolic support for digestion and bile-related positioning rather than broad detox claims.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 12,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "ashitaba",
+    "slug": "ashitaba",
+    "summary": "It is best framed around chalcone-rich chemistry with modest translational evidence.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ashoka",
+    "slug": "ashoka",
+    "summary": "It should be framed conservatively because traditional gynecologic use is much stronger than modern evidence.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ashwagandha",
+    "slug": "ashwagandha",
+    "summary": "Ashwagandha centers on the root.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 33,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "astragalus",
+    "slug": "astragalus",
+    "summary": "It is best framed around astragalosides and polysaccharides.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "astragalus membranaceus",
+    "slug": "astragalus-membranaceus",
+    "summary": "Astragalus membranaceus contains Astragaloside IV and is linked here to PI3K/Akt modulation.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 15,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "atractylodes",
+    "slug": "atractylodes",
+    "summary": "It is best framed as a digestive-tonic rhizome with traditional-system relevance.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "atractylodes macrocephala",
+    "slug": "atractylodes-macrocephala",
+    "summary": "Atractylodes macrocephala contains Atractylenolide I and is linked here to PI3K/Akt modulation.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "bacopa",
+    "slug": "bacopa",
+    "summary": "It is best framed around bacosides with slower-onset cognitive relevance.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "bacopa monnieri",
+    "slug": "bacopa-monnieri",
+    "summary": "Bacopa monnieri lean herb row for high-speed phytochemical ingestion.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 15,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "bael",
+    "slug": "bael",
+    "summary": "Internal cross-linking supports Bael through compounds such as skimmianine, aegeline, marmelosin.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "banaba",
+    "slug": "banaba",
+    "summary": "It is best framed conservatively because evidence quality and standardization vary across products.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "bayberry",
+    "slug": "bayberry",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "berberis",
+    "slug": "berberis",
+    "summary": "It is best framed around berberine-bearing root bark with GI and medication-interaction caution.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "berberis vulgaris",
+    "slug": "berberis-vulgaris",
+    "summary": "Berberis vulgaris lean herb row for high-speed phytochemical ingestion.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 16,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "bitter melon",
+    "slug": "bitter-melon",
+    "summary": "It is best framed as a food-medicine with hypoglycemia-aware caution.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 12,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "black cohosh",
+    "slug": "black-cohosh",
+    "summary": "Black Cohosh centers on the root; rhizome.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 22,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "black pepper",
+    "slug": "black-pepper",
+    "summary": "It should be framed specifically around piperine and digestive relevance rather than as a stand-alone tonic.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "black seed",
+    "slug": "black-seed",
+    "summary": "Bulk-ingested support row carrying Thymoquinone with pathway-level mechanism coverage.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "black tea",
+    "slug": "black-tea",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "blue lotus",
+    "slug": "blue-lotus",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "blueberry",
+    "slug": "blueberry",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "boldo",
+    "slug": "boldo",
+    "summary": "It is best framed as an aromatic bitter leaf botanical with modest human evidence.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "boswellia",
+    "slug": "boswellia",
+    "summary": "It is best framed around boswellic acids with inflammatory-pathway relevance.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "boswellia carterii",
+    "slug": "boswellia-carterii",
+    "summary": "It is best framed around boswellic acids with 5-lipoxygenase relevance.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "boswellia serrata",
+    "slug": "boswellia-serrata",
+    "summary": "Boswellia serrata contains Boswellic acid and is linked here to 5-lipoxygenase inhibition.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "brassica juncea",
+    "slug": "brassica-juncea",
+    "summary": "Minimum source-backed intake for Brassica juncea.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "brassica oleracea",
+    "slug": "brassica-oleracea",
+    "summary": "Minimum source-backed intake for Brassica oleracea.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "buckwheat",
+    "slug": "buckwheat",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "bupleurum",
+    "slug": "bupleurum",
+    "summary": "It should be framed conservatively because traditional-system context matters more than casual wellness claims.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "bupleurum falcatum",
+    "slug": "bupleurum-falcatum",
+    "summary": "Lean bulk ingestion row for Bupleurum falcatum.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "burdock",
+    "slug": "burdock",
+    "summary": "It is best framed as a traditional root botanical with modest modern evidence rather than a definitive detox herb.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "butterbur",
+    "slug": "butterbur",
+    "summary": "Butterbur is a sesquiterpene-rich herb usually discussed around standardized root extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 13,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "cacao",
+    "slug": "cacao",
+    "summary": "It is best framed around flavanols and methylxanthines with stimulant awareness.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 14,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "calamus",
+    "slug": "calamus",
+    "summary": "Internal cross-linking supports Calamus through compounds such as eugenol, alpha-asarone, beta-asarone.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 11,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "calendula",
+    "slug": "calendula",
+    "summary": "It is best framed around topical and tissue-soothing use rather than overextended systemic claims.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "capsicum frutescens",
+    "slug": "capsicum-frutescens",
+    "summary": "Pepper species used for topical and metabolic effects.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 4,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "caraway",
+    "slug": "caraway",
+    "summary": "It is best framed as an aromatic seed with traditional GI relevance.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cardamom",
+    "slug": "cardamom",
+    "summary": "It is best framed as an aromatic culinary seed with modest translational evidence.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "carob",
+    "slug": "carob",
+    "summary": "It is best framed as a food-form legume pod with fiber and polyphenol relevance rather than strong pharmacologic action.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cassia alata",
+    "slug": "cassia-alata",
+    "summary": "Internal cross-linking supports Cassia Alata through compounds such as aloe-emodin, chrysophanol.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cat's claw",
+    "slug": "cat-s-claw",
+    "summary": "It is best framed around oxindole alkaloids with autoimmune and transplant-related caution.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "catuba",
+    "slug": "catuba",
+    "summary": "It should be framed conservatively because traditional aphrodisiac narratives exceed modern evidence depth.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cayenne",
+    "slug": "cayenne",
+    "summary": "Internal cross-linking supports Cayenne through compounds such as capsaicin, capsorubin, dihydrocapsaicin.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "celastrus paniculatus",
+    "slug": "celastrus-paniculatus",
+    "summary": "Internal cross-linking supports Celastrus Paniculatus through compounds such as beta-amyrin, celastrine, lupeol.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "centella asiatica",
+    "slug": "centella-asiatica",
+    "summary": "Centella asiatica contains Asiatic acid and is linked here to PI3K/Akt modulation.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 18,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "chaga",
+    "slug": "chaga",
+    "summary": "Oxidative stress.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "chamomile",
+    "slug": "chamomile",
+    "summary": "It is best handled as a gentle calming botanical with broad traditional use and modest clinical depth.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "chinese skullcap",
+    "slug": "chinese-skullcap",
+    "summary": "Internal cross-linking supports Chinese Skullcap through compounds such as baicalein, baicalin, wogonin.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "chuanxiong",
+    "slug": "chuanxiong",
+    "summary": "Internal cross-linking supports Chuanxiong through compounds such as ligustilide, ferulic acid, tetramethylpyrazine.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cichorium intybus",
+    "slug": "cichorium-intybus",
+    "summary": "Cichorium intybus lean monograph row enriched in bulk mode.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "cinnamon",
+    "slug": "cinnamon",
+    "summary": "It is best framed conservatively because product form and species matter, especially around coumarin exposure in non-verum types.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 15,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "cissus",
+    "slug": "cissus",
+    "summary": "It is best framed conservatively because evidence is mixed and product positioning often outruns the data.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cistanche",
+    "slug": "cistanche",
+    "summary": "It should be framed conservatively because traditional-system use is broader than modern clinical depth.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cistanche deserticola",
+    "slug": "cistanche-deserticola",
+    "summary": "Cistanche deserticola contains Echinacoside and is linked here to PI3K/Akt modulation.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "citrus bergamia",
+    "slug": "citrus-bergamia",
+    "summary": "Citrus bergamia lean monograph row enriched in bulk mode.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "citrus sinensis",
+    "slug": "citrus-sinensis",
+    "summary": "Lean bulk ingestion row for Citrus sinensis.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "clove",
+    "slug": "clove",
+    "summary": "Bulk-ingested support row carrying Eugenol with pathway-level mechanism coverage.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cnidium monnieri",
+    "slug": "cnidium-monnieri",
+    "summary": "Cnidium monnieri lean monograph row enriched in bulk mode.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "codonopsis",
+    "slug": "codonopsis",
+    "summary": "It is best framed as a gentler tonic-style root with modest modern evidence.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "coffee",
+    "slug": "coffee",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "coffee cherry",
+    "slug": "coffee-cherry",
+    "summary": "Internal cross-linking supports Coffee Cherry through compounds such as caffeine, trigonelline, cafestol.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 13,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "coleus forskohlii",
+    "slug": "coleus-forskohlii",
+    "summary": "Coleus forskohlii contains Forskolin and is linked here to adenylyl cyclase activation.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "commiphora mukul",
+    "slug": "commiphora-mukul",
+    "summary": "Commiphora mukul contains Guggulsterone and is linked here to FXR antagonism.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "coptis",
+    "slug": "coptis",
+    "summary": "Internal cross-linking supports Coptis through compounds such as berberine, palmatine, coptisine.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 11,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "coptis chinensis",
+    "slug": "coptis-chinensis",
+    "summary": "Coptis chinensis lean herb row for high-speed phytochemical ingestion.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cordyceps",
+    "slug": "cordyceps",
+    "summary": "Cordyceps militaris is most often discussed around cordycepin plus polysaccharides and related nucleosides.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 12,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "coriandrum sativum",
+    "slug": "coriandrum-sativum",
+    "summary": "Coriandrum sativum lean monograph row enriched in bulk mode.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "cornus officinalis",
+    "slug": "cornus-officinalis",
+    "summary": "Cornus officinalis contains Loganin and is linked here to PI3K/Akt modulation.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "corydalis",
+    "slug": "corydalis",
+    "summary": "Internal cross-linking supports Corydalis through compounds such as corydaline, isocorypalmine, dehydrocorybulbine.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cranberry",
+    "slug": "cranberry",
+    "summary": "It is best framed around proanthocyanidin-rich urinary-support positioning rather than broad antimicrobial claims.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "crocus sativus",
+    "slug": "crocus-sativus",
+    "summary": "Lean bulk ingestion row for Crocus sativus.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "curcuma longa",
+    "slug": "curcuma-longa",
+    "summary": "Curcuma longa contains Demethoxycurcumin and is linked here to NF-κB inhibition.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "curcuma wenyujin",
+    "slug": "curcuma-wenyujin",
+    "summary": "Curcuma wenyujin contains Beta-elemene and is linked here to PI3K/Akt modulation.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "curcuma zedoaria",
+    "slug": "curcuma-zedoaria",
+    "summary": "Curcuma zedoaria contains Curcumol and is linked here to NF-κB inhibition.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "curry leaf",
+    "slug": "curry-leaf",
+    "summary": "It is best framed as a culinary-medicinal leaf with food-form relevance.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cyclea peltata",
+    "slug": "cyclea-peltata",
+    "summary": "Cyclea peltata lean monograph row enriched in bulk mode.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cymbopogon citratus",
+    "slug": "cymbopogon-citratus",
+    "summary": "Cymbopogon citratus contains Nerolidol and is linked here to GABA-A modulation.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "damiana",
+    "slug": "damiana",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "dandelion",
+    "slug": "dandelion",
+    "summary": "It is best framed as a traditional food-like bitter herb rather than a strong cleansing intervention.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 3,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "danshen",
+    "slug": "danshen",
+    "summary": "It is best framed around tanshinones and salvianolic acids with specific vascular-support positioning.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "daphne odora",
+    "slug": "daphne-odora",
+    "summary": "Daphne odora lean monograph row enriched in bulk mode.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "dendrobium",
+    "slug": "dendrobium",
+    "summary": "It should be framed conservatively because luxury-tonic narratives often exceed evidence depth.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "dong quai",
+    "slug": "dong-quai",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "echinacea purpurea",
+    "slug": "echinacea-purpurea",
+    "summary": "Echinacea Purpurea centers on the unspecified.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 3,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "elderberry",
+    "slug": "elderberry",
+    "summary": "Internal cross-linking supports Elderberry through compounds such as sambunigrin.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "elecampane",
+    "slug": "elecampane",
+    "summary": "It is best framed as a bitter aromatic root with traditional bronchial relevance.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "elephantopus scaber",
+    "slug": "elephantopus-scaber",
+    "summary": "Elephantopus scaber contains Deoxyelephantopin and is linked here to NF-κB inhibition.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "eleuthero",
+    "slug": "eleuthero",
+    "summary": "Stress resilience.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 17,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "embelia ribes",
+    "slug": "embelia-ribes",
+    "summary": "Embelia ribes contains Embelin and is linked here to XIAP inhibition.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "epimedium",
+    "slug": "epimedium",
+    "summary": "Epimedium is represented here primarily through icariin and related prenylated flavonoids such as epimedin A, B, and C.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 14,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "epimedium brevicornum",
+    "slug": "epimedium-brevicornum",
+    "summary": "Minimum source-backed intake for Epimedium brevicornum.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 11,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "eucalyptus",
+    "slug": "eucalyptus",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "eucommia",
+    "slug": "eucommia",
+    "summary": "It is best framed conservatively because traditional tonic use is broader than modern evidence quality.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "fennel",
+    "slug": "fennel",
+    "summary": "It is best handled as an aromatic seed botanical with traditional GI-support use and modest mechanistic confidence.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 15,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "fenugreek",
+    "slug": "fenugreek",
+    "summary": "Fenugreek lean herb row for high-speed phytochemical ingestion.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "feverfew",
+    "slug": "feverfew",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ficus carica",
+    "slug": "ficus-carica",
+    "summary": "Ficus carica lean monograph row enriched in bulk mode.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "fingerroot",
+    "slug": "fingerroot",
+    "summary": "Internal cross-linking supports Fingerroot through compounds such as pinostrobin, pinocembrin, panduratin a.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "fraxinus rhynchophylla",
+    "slug": "fraxinus-rhynchophylla",
+    "summary": "Fraxinus rhynchophylla lean monograph row enriched in bulk mode.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "galangal",
+    "slug": "galangal",
+    "summary": "It is best framed as a culinary-medicinal rhizome with traditional GI relevance.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "garcinia indica",
+    "slug": "garcinia-indica",
+    "summary": "Garcinia indica contains Garcinol and is linked here to NF-κB inhibition.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "garcinia mangostana",
+    "slug": "garcinia-mangostana",
+    "summary": "Garcinia mangostana contains Mangostin and is linked here to NF-κB inhibition.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "garlic",
+    "slug": "garlic",
+    "summary": "Garlic centers on the unspecified.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 2,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "gastrodia",
+    "slug": "gastrodia",
+    "summary": "It should be framed conservatively because traditional neurologic use is broader than modern evidence.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ginger",
+    "slug": "ginger",
+    "summary": "Ginger centers on the unspecified.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 2,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ginkgo biloba",
+    "slug": "ginkgo-biloba",
+    "summary": "Ginkgo Biloba centers on the leaf.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 43,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "glycyrrhiza glabra",
+    "slug": "glycyrrhiza-glabra",
+    "summary": "Lean bulk ingestion row for Glycyrrhiza glabra.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 24,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "goldenseal",
+    "slug": "goldenseal",
+    "summary": "Internal cross-linking supports Goldenseal through compounds such as berberine, hydrastine.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 13,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "gotu kola",
+    "slug": "gotu-kola",
+    "summary": "NO support.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "grape",
+    "slug": "grape",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "grapefruit",
+    "slug": "grapefruit",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "green tea",
+    "slug": "green-tea",
+    "summary": "Internal cross-linking supports Green Tea through compounds such as caffeine, theanine, catechins (egcg).",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 39,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "guarana",
+    "slug": "guarana",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "guayusa",
+    "slug": "guayusa",
+    "summary": "Internal cross-linking supports Guayusa through compounds such as caffeine, theobromine.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "gudmar",
+    "slug": "gudmar",
+    "summary": "It should be framed consistently with gymnema while preserving alternate-name discoverability.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "gymnema",
+    "slug": "gymnema",
+    "summary": "Gymnema leaf is mainly anchored by gymnemic acids, a triterpene-glycoside cluster.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 12,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "gymnema sylvestre",
+    "slug": "gymnema-sylvestre",
+    "summary": "Gymnema sylvestre contains Gymnemagenin and is linked here to glucose absorption modulation.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "harpagophytum procumbens",
+    "slug": "harpagophytum-procumbens",
+    "summary": "Harpagophytum procumbens contains Harpagoside and is linked here to COX inhibition.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "hawthorn",
+    "slug": "hawthorn",
+    "summary": "It is best framed around procyanidins and flavonoids.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 2,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "holy basil",
+    "slug": "holy-basil",
+    "summary": "Holy Basil centers on the leaf; aerial parts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 28,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "holy basil purple",
+    "slug": "holy-basil-purple",
+    "summary": "It should be framed similarly to tulsi while noting cultivar/form distinctions are secondary to constituent variability.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "holy basil seed",
+    "slug": "holy-basil-seed",
+    "summary": "It should be framed distinctly from holy basil leaf because fiber and mucilage drive different use-cases.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "honeysuckle",
+    "slug": "honeysuckle",
+    "summary": "Internal cross-linking supports Honeysuckle through compounds such as luteolin, chlorogenic acid.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "hops",
+    "slug": "hops",
+    "summary": "It is best framed around bitter-resin and prenylflavonoid chemistry with modest selected human evidence.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "horse chestnut",
+    "slug": "horse-chestnut",
+    "summary": "Internal cross-linking supports Horse Chestnut through compounds such as aesculin, aescin, fraxin.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "houttuynia",
+    "slug": "houttuynia",
+    "summary": "It should be framed cautiously because strong folklore claims exceed the evidence.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "huperzia serrata",
+    "slug": "huperzia-serrata",
+    "summary": "Huperzia serrata contains Huperzine A and is linked here to acetylcholinesterase inhibition.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "hypericum perforatum",
+    "slug": "hypericum-perforatum",
+    "summary": "Hypericum perforatum contains Hyperforin and is linked here to TRPC6 channel modulation.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 25,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "isatis",
+    "slug": "isatis",
+    "summary": "It is best framed as a traditional-use herb with limited modern clinical depth.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "japanese knotweed",
+    "slug": "japanese-knotweed",
+    "summary": "Bulk-ingested support row carrying Emodin with pathway-level mechanism coverage.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "jatamansi",
+    "slug": "jatamansi",
+    "summary": "It should be framed as a traditional aromatic rhizome with modest clinical depth.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "jujube",
+    "slug": "jujube",
+    "summary": "It is best framed as a food-like fruit/seed botanical with gentle traditional positioning.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "juniper",
+    "slug": "juniper",
+    "summary": "It should be framed as an aromatic berry botanical with traditional GI and urinary relevance.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "kanna",
+    "slug": "kanna",
+    "summary": "Internal cross-linking supports Kanna through compounds such as mesembrenone, mesembranol, mesembrine.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "kava",
+    "slug": "kava",
+    "summary": "Kava centers on the root; rhizome.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 23,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "kuding tea",
+    "slug": "kuding-tea",
+    "summary": "It should be framed as a bitter tea botanical with food-form relevance and modest modern evidence.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "kudzu",
+    "slug": "kudzu",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "lagerstroemia speciosa",
+    "slug": "lagerstroemia-speciosa",
+    "summary": "Lagerstroemia speciosa contains Corosolic acid and is linked here to AMPK activation.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "lavandula angustifolia",
+    "slug": "lavandula-angustifolia",
+    "summary": "Lean bulk ingestion row for Lavandula angustifolia.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "lavender",
+    "slug": "lavender",
+    "summary": "It is best framed around volatile oils with sedation-aware positioning.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "lawsonia inermis",
+    "slug": "lawsonia-inermis",
+    "summary": "Lawsonia inermis contains Lawsone and is linked here to MAPK pathway modulation.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "lemon balm",
+    "slug": "lemon-balm",
+    "summary": "Lemon Balm centers on the leaf; aerial parts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 14,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "lemon verbena",
+    "slug": "lemon-verbena",
+    "summary": "It is best framed as a gentle aromatic botanical with modest evidence and pleasant tolerability.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "lemongrass",
+    "slug": "lemongrass",
+    "summary": "It is best framed as an aromatic culinary-medicinal grass with modest clinical depth.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "licorice",
+    "slug": "licorice",
+    "summary": "Internal cross-linking supports Licorice through compounds such as glycyrrhizin.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ligusticum chuanxiong",
+    "slug": "ligusticum-chuanxiong",
+    "summary": "Ligusticum chuanxiong lean monograph row enriched in bulk mode.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "lion's mane",
+    "slug": "lion-s-mane",
+    "summary": "NGF stimulation.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "lithospermum erythrorhizon",
+    "slug": "lithospermum-erythrorhizon",
+    "summary": "Lithospermum erythrorhizon contains Shikonin and is linked here to PKM2 inhibition.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "lobelia inflata",
+    "slug": "lobelia-inflata",
+    "summary": "Lobelia inflata contains Lobeline and is linked here to nicotinic acetylcholine receptor modulation.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "longan",
+    "slug": "longan",
+    "summary": "It should be framed as a food-like fruit botanical with modest modern evidence.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "luo han guo",
+    "slug": "luo-han-guo",
+    "summary": "It is best framed as a fruit botanical with sweet mogrosides and soothing traditional use.",
+    "evidenceLevel": "traditional",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "maca",
+    "slug": "maca",
+    "summary": "Maca centers on the root; hypocotyl.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 15,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "maitake d-fraction",
+    "slug": "maitake-d-fraction",
+    "summary": "It should be framed distinctly from whole maitake because extract-standardization claims can exceed the underlying evidence.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "mangifera indica",
+    "slug": "mangifera-indica",
+    "summary": "Mangifera indica contains Mangiferin and is linked here to AMPK activation.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "mangosteen",
+    "slug": "mangosteen",
+    "summary": "It should be framed conservatively because broad anti-inflammatory and disease claims outrun the evidence.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "maral root",
+    "slug": "maral-root",
+    "summary": "It is best framed carefully because ecdysteroid narratives often outpace evidence quality.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "marshmallow",
+    "slug": "marshmallow",
+    "summary": "Internal cross-linking supports Marshmallow through compounds such as pectin.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "matricaria chamomilla",
+    "slug": "matricaria-chamomilla",
+    "summary": "Matricaria chamomilla contains Farnesol and is linked here to PPAR activation.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "milk oats",
+    "slug": "milk-oats",
+    "summary": "They are best framed as a gentle traditional tonic rather than a strong acute intervention.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "milk thistle",
+    "slug": "milk-thistle",
+    "summary": "Milk Thistle centers on the seed; fruit.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 35,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "morinda citrifolia",
+    "slug": "morinda-citrifolia",
+    "summary": "Morinda citrifolia lean monograph row enriched in bulk mode.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "moringa",
+    "slug": "moringa",
+    "summary": "It is best framed as a nutrient-dense botanical with mixed translational evidence rather than as a universal superfood cure-all.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 17,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "morus alba",
+    "slug": "morus-alba",
+    "summary": "Morus alba contains Mulberroside A and is linked here to glucose absorption modulation.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "mucuna",
+    "slug": "mucuna",
+    "summary": "It is best framed around L-DOPA-rich seeds with clear neurologic and stimulation-related caution.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "mugwort",
+    "slug": "mugwort",
+    "summary": "It is best framed conservatively because strong folklore and ritual associations often outrun clinical evidence.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "muira puama",
+    "slug": "muira-puama",
+    "summary": "It is best framed as a traditional Amazonian botanical with modest modern evidence.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "mulberry leaf",
+    "slug": "mulberry-leaf",
+    "summary": "It is best framed around alpha-glucosidase-adjacent positioning rather than generalized wellness language.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "myristica fragrans",
+    "slug": "myristica-fragrans",
+    "summary": "Myristica fragrans contains Elemicin and is linked here to monoamine oxidase inhibition.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "myrtle",
+    "slug": "myrtle",
+    "summary": "It is best framed as an aromatic Mediterranean leaf botanical with modest modern evidence.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "neem",
+    "slug": "neem",
+    "summary": "It should be framed carefully because topical, oral, and seed-oil contexts differ substantially in safety relevance.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "nelumbo nucifera",
+    "slug": "nelumbo-nucifera",
+    "summary": "Nelumbo nucifera lean monograph row enriched in bulk mode.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "nettle root",
+    "slug": "nettle-root",
+    "summary": "It is best framed distinctly from nettle leaf.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "nicotiana glauca",
+    "slug": "nicotiana-glauca",
+    "summary": "Nicotiana glauca contains Anabasine and is linked here to nicotinic acetylcholine receptor modulation.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 4,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "nicotiana tabacum",
+    "slug": "nicotiana-tabacum",
+    "summary": "Nicotiana tabacum contains Anatabine and is linked here to nicotinic acetylcholine receptor modulation.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "nigella sativa",
+    "slug": "nigella-sativa",
+    "summary": "Lean bulk ingestion row for Nigella sativa.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 18,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "noni",
+    "slug": "noni",
+    "summary": "It should be framed conservatively because broad folk claims exceed the strength of modern evidence.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "notoginseng",
+    "slug": "notoginseng",
+    "summary": "It is best framed as a saponin-rich Panax relative with specific vascular-support positioning.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "oatstraw",
+    "slug": "oatstraw",
+    "summary": "It is best framed as a gentle nutritive herb with limited high-signal clinical depth.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ocimum basilicum",
+    "slug": "ocimum-basilicum",
+    "summary": "Ocimum basilicum contains Methyleugenol and is linked here to TRP channel modulation.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "ocimum sanctum",
+    "slug": "ocimum-sanctum",
+    "summary": "Ocimum sanctum contains Ursolic acid and is linked here to AMPK activation.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ocotea odorifera",
+    "slug": "ocotea-odorifera",
+    "summary": "Ocotea odorifera contains Safrole and is linked here to TRP channel modulation.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "olea europaea",
+    "slug": "olea-europaea",
+    "summary": "Lean bulk ingestion row for Olea europaea.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 18,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "olive leaf",
+    "slug": "olive-leaf",
+    "summary": "Bulk-ingested support row carrying Oleuropein with pathway-level mechanism coverage.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ophiopogon",
+    "slug": "ophiopogon",
+    "summary": "It is best framed as a moistening tonic-style root with traditional-system relevance.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "orange peel",
+    "slug": "orange-peel",
+    "summary": "Bulk-ingested support row carrying Hesperidin with pathway-level mechanism coverage.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "oregano",
+    "slug": "oregano",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 13,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "paeonia lactiflora",
+    "slug": "paeonia-lactiflora",
+    "summary": "Paeonia lactiflora contains Paeoniflorin and is linked here to PI3K/Akt modulation.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "paeonia suffruticosa",
+    "slug": "paeonia-suffruticosa",
+    "summary": "Paeonia suffruticosa contains Paeonol and is linked here to NF-κB inhibition.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "panax ginseng",
+    "slug": "panax-ginseng",
+    "summary": "Panax ginseng lean herb row for high-speed phytochemical ingestion.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 29,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "papaya leaf",
+    "slug": "papaya-leaf",
+    "summary": "Internal cross-linking supports Papaya Leaf through compounds such as carpaine, papain, benzyl isothiocyanate.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "parsley",
+    "slug": "parsley",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "passionflower",
+    "slug": "passionflower",
+    "summary": "EMA supports passionflower for relief of mild mental stress and to aid sleep on the basis of long-standing traditional use.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "pastinaca sativa",
+    "slug": "pastinaca-sativa",
+    "summary": "Pastinaca sativa lean monograph row enriched in bulk mode.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "pau d'arco",
+    "slug": "pau-d-arco",
+    "summary": "It should be framed conservatively because popular claims often exceed the evidence and preparation differences matter.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "peppermint",
+    "slug": "peppermint",
+    "summary": "Peppermint centers on the unspecified.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 14,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "perilla",
+    "slug": "perilla",
+    "summary": "It is best framed as a culinary-medicinal herb with modest but relevant translational evidence.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "phellodendron",
+    "slug": "phellodendron",
+    "summary": "Internal cross-linking supports Phellodendron through compounds such as berberine, jatrorrhizine, palmatine.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "phellodendron amurense",
+    "slug": "phellodendron-amurense",
+    "summary": "Phellodendron amurense lean herb row for high-speed phytochemical ingestion.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "piper longum",
+    "slug": "piper-longum",
+    "summary": "Minimum source-backed intake for Piper longum.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 11,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "piper methysticum",
+    "slug": "piper-methysticum",
+    "summary": "Piper methysticum contains Kavalactones and is linked here to GABA-A modulation.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "piper nigrum",
+    "slug": "piper-nigrum",
+    "summary": "Piper nigrum contains Beta-caryophyllene and is linked here to CB2 receptor agonism.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "plantago lanceolata",
+    "slug": "plantago-lanceolata",
+    "summary": "Plantago lanceolata contains Verbascoside and is linked here to NF-κB inhibition.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "plantago major",
+    "slug": "plantago-major",
+    "summary": "Plantago major contains Aucubin and is linked here to NF-κB inhibition.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "plumbago zeylanica",
+    "slug": "plumbago-zeylanica",
+    "summary": "Plumbago zeylanica contains Plumbagin and is linked here to NF-κB inhibition.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "polygala",
+    "slug": "polygala",
+    "summary": "It is best framed as a traditional nootropic-style root with limited modern clinical depth.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "pomegranate",
+    "slug": "pomegranate",
+    "summary": "It is best framed as a polyphenol-rich fruit botanical with food-form relevance and moderate evidence.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 18,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "poria",
+    "slug": "poria",
+    "summary": "It is best framed as a traditional medicinal fungus with modest modern clinical depth.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "psoralea corylifolia",
+    "slug": "psoralea-corylifolia",
+    "summary": "Psoralea corylifolia lean monograph row enriched in bulk mode.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "psyllium",
+    "slug": "psyllium",
+    "summary": "Psyllium is not a classic phytochemical-heavy herb; its value comes from gel-forming husk fiber.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 13,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "pueraria lobata",
+    "slug": "pueraria-lobata",
+    "summary": "Pueraria lobata contains Puerarin and is linked here to PI3K/Akt modulation.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "pueraria mirifica",
+    "slug": "pueraria-mirifica",
+    "summary": "It is best framed very cautiously due to potent estrogenic positioning.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "punarnava",
+    "slug": "punarnava",
+    "summary": "Internal cross-linking supports Punarnava through compounds such as punarnavine.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "raspberry leaf",
+    "slug": "raspberry-leaf",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "red clover",
+    "slug": "red-clover",
+    "summary": "It should be framed conservatively because endocrine-adjacent claims outrun the evidence in many product contexts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 13,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "rehmannia glutinosa",
+    "slug": "rehmannia-glutinosa",
+    "summary": "Rehmannia glutinosa contains Catalpol and is linked here to PI3K/Akt modulation.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "rehmannia prepared",
+    "slug": "rehmannia-prepared",
+    "summary": "It should be framed distinctly from raw rehmannia because processed-form use-cases differ materially.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "reishi",
+    "slug": "reishi",
+    "summary": "Immune modulation.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "rheum palmatum",
+    "slug": "rheum-palmatum",
+    "summary": "Lean bulk ingestion row for Rheum palmatum.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "rhodiola",
+    "slug": "rhodiola",
+    "summary": "Adaptogenic stress modulation.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "rhodiola rosea",
+    "slug": "rhodiola-rosea",
+    "summary": "Rhodiola rosea contains Rosavin and is linked here to AMPK activation.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 40,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "rice bran",
+    "slug": "rice-bran",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "rooibos",
+    "slug": "rooibos",
+    "summary": "It is best framed as a mild tea herb with low-intensity wellness positioning.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "rose hips",
+    "slug": "rose-hips",
+    "summary": "They are best framed as polyphenol- and vitamin-rich fruit material with modest but relevant human evidence.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "roselle seed",
+    "slug": "roselle-seed",
+    "summary": "It should be framed distinctly from hibiscus calyx because seed and calyx use-cases differ.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "rosemary",
+    "slug": "rosemary",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 27,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "saffron",
+    "slug": "saffron",
+    "summary": "Internal cross-linking supports Saffron through compounds such as picrocrocin, crocin, safranal.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 19,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "sage",
+    "slug": "sage",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 17,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "salacia",
+    "slug": "salacia",
+    "summary": "Internal cross-linking supports Salacia through compounds such as mangiferin, kotalanol, salacinol.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "saw palmetto",
+    "slug": "saw-palmetto",
+    "summary": "Saw Palmetto centers on the berry.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 13,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "schisandra",
+    "slug": "schisandra",
+    "summary": "Liver + stress.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 16,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "schisandra berry",
+    "slug": "schisandra-berry",
+    "summary": "It is best framed specifically around berry lignans and traditional stress-support positioning.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "schisandra chinensis",
+    "slug": "schisandra-chinensis",
+    "summary": "Lean bulk ingestion row for Schisandra chinensis.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "scutellaria baicalensis",
+    "slug": "scutellaria-baicalensis",
+    "summary": "Lean bulk ingestion row for Scutellaria baicalensis.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 22,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "selaginella tamariscina",
+    "slug": "selaginella-tamariscina",
+    "summary": "Minimum source-backed intake for ginkgetin and 5-lipoxygenase inhibition cluster completion.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 4,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "serenoa repens",
+    "slug": "serenoa-repens",
+    "summary": "Serenoa repens contains Beta-sitosterol and is linked here to PPAR activation.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "shankhpushpi",
+    "slug": "shankhpushpi",
+    "summary": "It is best framed as a traditional cognitive-support herb with limited modern clinical depth.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "shatavari",
+    "slug": "shatavari",
+    "summary": "It is best framed around steroidal saponins with hormonal-context caution.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "skullcap",
+    "slug": "skullcap",
+    "summary": "GABAergic.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 11,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "sophora alopecuroides",
+    "slug": "sophora-alopecuroides",
+    "summary": "Sophora alopecuroides lean monograph row enriched in bulk mode.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "sophora flavescens",
+    "slug": "sophora-flavescens",
+    "summary": "Sophora flavescens lean monograph row enriched in bulk mode.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 12,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "soursop",
+    "slug": "soursop",
+    "summary": "It must be framed carefully because anticancer folklore claims greatly exceed evidence and safety certainty.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "soybean",
+    "slug": "soybean",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "st johns wort",
+    "slug": "st-johns-wort",
+    "summary": "St.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 20,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "stellera chamaejasme",
+    "slug": "stellera-chamaejasme",
+    "summary": "Stellera chamaejasme lean monograph row enriched in bulk mode.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "stephania cepharantha",
+    "slug": "stephania-cepharantha",
+    "summary": "Stephania cepharantha lean monograph row enriched in bulk mode.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "stephania japonica",
+    "slug": "stephania-japonica",
+    "summary": "Stephania japonica lean monograph row enriched in bulk mode.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "stephania tetrandra",
+    "slug": "stephania-tetrandra",
+    "summary": "Stephania tetrandra lean monograph row enriched in bulk mode.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "suma",
+    "slug": "suma",
+    "summary": "It should be framed conservatively because traditional-use breadth exceeds evidence depth.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "syzygium aromaticum",
+    "slug": "syzygium-aromaticum",
+    "summary": "Lean bulk ingestion row for Syzygium aromaticum.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "tamarind",
+    "slug": "tamarind",
+    "summary": "It is best framed as a food-form fruit with digestive and polyphenol relevance.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "thunder god vine",
+    "slug": "thunder-god-vine",
+    "summary": "Bulk-ingested support row carrying Celastrol with pathway-level mechanism coverage.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "thyme",
+    "slug": "thyme",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 15,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "tongkat ali",
+    "slug": "tongkat-ali",
+    "summary": "It is best framed as a bitter root extract with endocrine and stimulation-related caution.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "tribulus terrestris",
+    "slug": "tribulus-terrestris",
+    "summary": "Tribulus terrestris lean herb row for high-speed phytochemical ingestion.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "tripterygium wilfordii",
+    "slug": "tripterygium-wilfordii",
+    "summary": "Lean bulk ingestion row for Tripterygium wilfordii.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "turkey tail",
+    "slug": "turkey-tail",
+    "summary": "Immune modulation.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "turmeric",
+    "slug": "turmeric",
+    "summary": "Turmeric centers on the unspecified.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 17,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "valerian",
+    "slug": "valerian",
+    "summary": "Valerian centers on the root; rhizome.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 14,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "valeriana officinalis",
+    "slug": "valeriana-officinalis",
+    "summary": "Valeriana officinalis contains Valerenic acid and is linked here to GABA-A modulation.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 14,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "verbena officinalis",
+    "slug": "verbena-officinalis",
+    "summary": "Verbena officinalis contains Acteoside and is linked here to NF-κB inhibition.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "white peony",
+    "slug": "white-peony",
+    "summary": "It is best framed as a paeoniflorin-rich root with traditional-system relevance.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "wild yam",
+    "slug": "wild-yam",
+    "summary": "Wild Yam lean herb row for high-speed phytochemical ingestion.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "wormwood",
+    "slug": "wormwood",
+    "summary": "Internal cross-linking supports Wormwood through compounds such as alpha-thujone, absinthin, beta-thujone.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "yarrow",
+    "slug": "yarrow",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "yerba mate",
+    "slug": "yerba-mate",
+    "summary": "Conservative evidence framing applied.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "yohimbe",
+    "slug": "yohimbe",
+    "summary": "Yohimbe is represented here as a bark-derived monograph anchored to yohimbine, an alpha-2 adrenergic antagonist with sympathomimetic effects.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 12,
+    "confidenceTier": "moderate"
+  }
+]

--- a/public/data-next/herbs.json
+++ b/public/data-next/herbs.json
@@ -1,0 +1,8222 @@
+[
+  {
+    "name": "acerola",
+    "slug": "acerola",
+    "summary": "It is best framed as a vitamin-C-rich fruit botanical with food/supplement relevance.",
+    "description": "It is best framed as a vitamin-C-rich fruit botanical with food/supplement relevance.",
+    "mechanisms": [
+      "antioxidant",
+      "nutritive support"
+    ],
+    "safetyNotes": "Immune-active potential; use caution with autoimmune disease, transplant medicines, immunosuppressants, and during active cancer treatment unless clinician-supervised.",
+    "contraindications": [
+      "Kidney stone risk",
+      "iron overload conditions",
+      "G6PD deficiency caution with very high vitamin C dosing"
+    ],
+    "interactions": [
+      "May affect iron absorption and some lab results at high vitamin C intakes."
+    ],
+    "dosage": "",
+    "preparation": "Fruit powder, juice, extracts, and vitamin C-standardized products.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "agarikon",
+    "slug": "agarikon",
+    "summary": "It should be framed modestly because traditional use is much stronger than modern evidence.",
+    "description": "It should be framed modestly because traditional use is much stronger than modern evidence.",
+    "mechanisms": [
+      "traditional immune support",
+      "respiratory support"
+    ],
+    "safetyNotes": "Immune-active potential; use caution with autoimmune disease, transplant medicines, immunosuppressants, and during active cancer treatment unless clinician-supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "traditional",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ajwain",
+    "slug": "ajwain",
+    "summary": "It is best framed as a culinary-medicinal seed with strong traditional GI positioning.",
+    "description": "It is best framed as a culinary-medicinal seed with strong traditional GI positioning.",
+    "mechanisms": [
+      "digestive support",
+      "aromatic support"
+    ],
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Seed/fiber preparations are commonly used as whole seed, powder, capsules, or food ingredients; fluid intake and preparation form matter.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "aloe vera",
+    "slug": "aloe-vera",
+    "summary": "Internal cross-linking supports Aloe Vera through compounds such as aloin.",
+    "description": "Internal cross-linking supports Aloe Vera through compounds such as aloin.",
+    "mechanisms": [
+      "acemannan immune modulation",
+      "anthraquinone laxative effects",
+      "AMPK/glucose-metabolism and wound-healing pathways"
+    ],
+    "safetyNotes": "Oral latex/whole-leaf aloe can cause diarrhea, electrolyte loss, and drug interactions; avoid pregnancy and kidney disease.",
+    "contraindications": [
+      "Pregnancy",
+      "inflammatory bowel disease",
+      "kidney disease",
+      "oral latex use in children"
+    ],
+    "interactions": [
+      "Oral latex may interact with diuretics",
+      "digoxin",
+      "corticosteroids",
+      "laxatives",
+      "and antidiabetics."
+    ],
+    "dosage": "",
+    "preparation": "Inner leaf gel for topical/digestive products; latex/whole-leaf laxative products carry higher risk.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 17,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "american ginseng",
+    "slug": "american-ginseng",
+    "summary": "Internal cross-linking supports American Ginseng through compounds such as ginsenosides (including rb1, rg1), rb2.",
+    "description": "Internal cross-linking supports American Ginseng through compounds such as ginsenosides (including rb1, rg1), rb2.",
+    "mechanisms": [
+      "ginsenoside effects on AMPK/glucose uptake",
+      "nitric-oxide/endothelial signaling",
+      "HPA-axis and cognition pathways"
+    ],
+    "safetyNotes": "May lower glucose; caution with diabetes drugs, anticoagulants/warfarin, stimulants, insomnia, and pregnancy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 17,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "american yellow lotus",
+    "slug": "american-yellow-lotus",
+    "summary": "Internal cross-linking supports American Yellow Lotus through compounds such as nuciferine, roemerine, n-methylasimilobine.",
+    "description": "Internal cross-linking supports American Yellow Lotus through compounds such as nuciferine, roemerine, n-methylasimilobine.",
+    "mechanisms": [
+      "aporphine alkaloid dopaminergic modulation",
+      "CNS sedative signaling",
+      "acetylcholinesterase and oxidative-stress pathway effects"
+    ],
+    "safetyNotes": "CNS-active alkaloid herb; avoid combining with sedatives, alcohol, dopamine-active drugs, or driving. Avoid pregnancy/breastfeeding and use caution with psychiatric conditions.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "andrographis paniculata",
+    "slug": "andrographis-paniculata",
+    "summary": "Andrographis paniculata lean herb row for high-speed phytochemical ingestion.",
+    "description": "Andrographis paniculata lean herb row for high-speed phytochemical ingestion.",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "JAK/STAT modulation",
+      "MAPK pathway modulation",
+      "PI3K/Akt modulation"
+    ],
+    "safetyNotes": "Immune-modulating activity is plausible; use caution with autoimmune disease, transplant medicines, or immunosuppressants.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "anemarrhena asphodeloides",
+    "slug": "anemarrhena-asphodeloides",
+    "summary": "Anemarrhena asphodeloides contains Timosaponin AIII and is linked here to PI3K/Akt modulation.",
+    "description": "Anemarrhena asphodeloides contains Timosaponin AIII and is linked here to PI3K/Akt modulation.",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "apoptosis pathway modulation (caspase activation)",
+      "AMPK activation",
+      "Nrf2 activation"
+    ],
+    "safetyNotes": "May lower blood glucose or alter metabolic markers; monitor with diabetes medications and avoid unsupervised use during pregnancy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "angelica archangelica",
+    "slug": "angelica-archangelica",
+    "summary": "Angelica archangelica lean monograph row enriched in bulk mode.",
+    "description": "Angelica archangelica lean monograph row enriched in bulk mode.",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation",
+      "Nrf2 activation"
+    ],
+    "safetyNotes": "May affect bleeding risk or circulation. Use caution with anticoagulants/antiplatelets and before surgery.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "bleeding disorder or upcoming surgery"
+    ],
+    "interactions": [
+      "Potential interaction concern with anticoagulants/antiplatelets",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "angelica dahurica",
+    "slug": "angelica-dahurica",
+    "summary": "Angelica dahurica lean monograph row enriched in bulk mode.",
+    "description": "Angelica dahurica lean monograph row enriched in bulk mode.",
+    "mechanisms": [
+      "acetylcholinesterase inhibition",
+      "voltage-gated calcium channel modulation",
+      "MAPK pathway modulation",
+      "PDE inhibition"
+    ],
+    "safetyNotes": "May affect bleeding risk or circulation. Use caution with anticoagulants/antiplatelets and before surgery.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "bleeding disorder or upcoming surgery"
+    ],
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "anticoagulants/antiplatelets",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "angelica pubescens",
+    "slug": "angelica-pubescens",
+    "summary": "Angelica pubescens lean monograph row enriched in bulk mode.",
+    "description": "Angelica pubescens lean monograph row enriched in bulk mode.",
+    "mechanisms": [
+      "PDE4 inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "safetyNotes": "May affect bleeding risk or circulation. Use caution with anticoagulants/antiplatelets and before surgery.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "bleeding disorder or upcoming surgery"
+    ],
+    "interactions": [
+      "Potential interaction concern with anticoagulants/antiplatelets",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "angelica root",
+    "slug": "angelica-root",
+    "summary": "It should be framed carefully because furanocoumarin context matters for some use cases.",
+    "description": "It should be framed carefully because furanocoumarin context matters for some use cases.",
+    "mechanisms": [
+      "digestive support",
+      "traditional cycle support"
+    ],
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "bleeding disorder or upcoming surgery"
+    ],
+    "interactions": [
+      "Potential interaction concern with anticoagulants/antiplatelets",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "angelica sinensis",
+    "slug": "angelica-sinensis",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied.",
+    "mechanisms": [
+      "ligustilide/ferulic-acid smooth-muscle and vascular effects",
+      "platelet-modulating activity",
+      "estrogen-receptor-related signaling",
+      "NF-κB modulation"
+    ],
+    "safetyNotes": "Bleeding, photosensitivity, and hormone-sensitive-condition cautions are central. Avoid in pregnancy unless medically directed.",
+    "contraindications": [
+      "Pregnancy",
+      "bleeding disorders",
+      "hormone-sensitive conditions",
+      "surgery",
+      "and anticoagulant/antiplatelet therapy without supervision."
+    ],
+    "interactions": [
+      "Potential additive bleeding risk with anticoagulants",
+      "antiplatelets",
+      "NSAIDs",
+      "and some herbal blood-thinning stacks."
+    ],
+    "dosage": "",
+    "preparation": "Evidence often comes from traditional formulas; single-herb confidence should remain conservative.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 11,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "anise hyssop",
+    "slug": "anise-hyssop",
+    "summary": "Internal cross-linking supports Anise Hyssop through compounds such as limonene, anethole, estragole.",
+    "description": "Internal cross-linking supports Anise Hyssop through compounds such as limonene, anethole, estragole.",
+    "mechanisms": [
+      "endocannabinoid_modulation"
+    ],
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "arjuna",
+    "slug": "arjuna",
+    "summary": "It is best framed around bark polyphenols and triterpenes with specific cardiotonic-support positioning.",
+    "description": "It is best framed around bark polyphenols and triterpenes with specific cardiotonic-support positioning.",
+    "mechanisms": [
+      "endothelial nitric oxide signaling",
+      "antioxidant myocardial protection",
+      "lipid-modulating tannins/flavonoids",
+      "mild positive inotropic and vascular effects"
+    ],
+    "safetyNotes": "Use cautiously with diagnosed heart disease unless supervised. Possible additive effects with antihypertensives, nitrates, beta-blockers, digoxin-like regimens, antiplatelets, or anticoagulants.",
+    "contraindications": [
+      "Unstable angina",
+      "heart failure without clinician oversight",
+      "pregnancy/breastfeeding caution",
+      "and planned surgery when combined with anticoagulant therapy."
+    ],
+    "interactions": [
+      "Potential additive blood-pressure",
+      "antianginal",
+      "antiplatelet",
+      "and cardiac-medication effects",
+      "monitor with cardiovascular drugs."
+    ],
+    "dosage": "",
+    "preparation": "Evidence is most relevant to bark preparations or standardized extracts used in clinical studies.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "artemisia absinthium",
+    "slug": "artemisia-absinthium",
+    "summary": "Artemisia absinthium contains Thujone and is linked here to GABA-A receptor antagonism.",
+    "description": "Artemisia absinthium contains Thujone and is linked here to GABA-A receptor antagonism.",
+    "mechanisms": [
+      "Thujone-mediated GABA-A antagonism",
+      "bitter sesquiterpene lactone digestive signaling",
+      "TRP channel interaction",
+      "inflammatory pathway modulation."
+    ],
+    "safetyNotes": "Thujone-containing wormwood can cause seizures/neurotoxicity at high doses; avoid in pregnancy, breastfeeding, seizure disorders, children, and with alcohol, sedatives, or other CNS-active drugs.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "seizure disorder or sedative/alcohol use"
+    ],
+    "interactions": [
+      "Potential interaction concern with sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Aromatic herb/spice forms and essential oils differ greatly; essential oils require conservative topical/diluted use and are not interchangeable with teas.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "artemisia annua",
+    "slug": "artemisia-annua",
+    "summary": "Artemisia annua contains Artemisinin and is linked here to ROS-mediated signaling modulation.",
+    "description": "Artemisia annua contains Artemisinin and is linked here to ROS-mediated signaling modulation.",
+    "mechanisms": [
+      "artemisinin endoperoxide activation under iron/heme conditions",
+      "parasite oxidative damage pathways",
+      "NF-κB and cytokine modulation reported preclinically"
+    ],
+    "safetyNotes": "Do not use crude Artemisia as a substitute for approved antimalarial therapy. Pregnancy, liver disease, and drug-interaction contexts require medical supervision.",
+    "contraindications": [
+      "Pregnancy/breastfeeding unless medically indicated",
+      "serious infection without medical care",
+      "liver disease",
+      "and unsupervised antimalarial use."
+    ],
+    "interactions": [
+      "Potential CYP/P-gp interactions and additive effects with antimalarials",
+      "hepatotoxic drugs",
+      "and seizure-threshold-lowering agents."
+    ],
+    "dosage": "",
+    "preparation": "Separate whole-herb Artemisia preparations from purified artemisinin derivatives; evidence and safety are not interchangeable.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 17,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "artemisia capillaris",
+    "slug": "artemisia-capillaris",
+    "summary": "Artemisia capillaris lean monograph row enriched in bulk mode.",
+    "description": "Artemisia capillaris lean monograph row enriched in bulk mode.",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "voltage-gated calcium channel modulation",
+      "5-lipoxygenase inhibition",
+      "Nrf2 activation"
+    ],
+    "safetyNotes": "May affect bleeding risk or circulation. Use caution with anticoagulants/antiplatelets and before surgery.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "active liver disease",
+      "bleeding disorder or upcoming surgery"
+    ],
+    "interactions": [
+      "Potential interaction concern with anticoagulants/antiplatelets",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "artichoke",
+    "slug": "artichoke",
+    "summary": "It is best framed around bitter-compound and phenolic support for digestion and bile-related positioning rather than broad detox claims.",
+    "description": "It is best framed around bitter-compound and phenolic support for digestion and bile-related positioning rather than broad detox claims.",
+    "mechanisms": [
+      "caffeoylquinic-acid signaling",
+      "bile-acid/cholesterol metabolism",
+      "HMG-CoA reductase and hepatic antioxidant modulation"
+    ],
+    "safetyNotes": "Avoid/caution with bile-duct obstruction, gallstones, and Asteraceae allergy; may cause GI effects.",
+    "contraindications": [
+      "Bile duct obstruction",
+      "gallstones without clinician guidance",
+      "Asteraceae allergy"
+    ],
+    "interactions": [
+      "May add to lipid-lowering or bile-flow effects",
+      "theoretical interaction with anticoagulants if high vitamin K diet changes."
+    ],
+    "dosage": "",
+    "preparation": "Leaf extracts standardized to caffeoylquinic acids/cynarin-like phenolics; food artichoke differs from leaf extract.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 12,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "ashitaba",
+    "slug": "ashitaba",
+    "summary": "It is best framed around chalcone-rich chemistry with modest translational evidence.",
+    "description": "It is best framed around chalcone-rich chemistry with modest translational evidence.",
+    "mechanisms": [
+      "metabolic support",
+      "antioxidant"
+    ],
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "anticoagulant use without review"
+    ],
+    "interactions": [
+      "Potential additive bleeding risk with anticoagulants/antiplatelets",
+      "limited clinical interaction data."
+    ],
+    "dosage": "",
+    "preparation": "Leaf/stem powder, tea, and extracts; chalcone content varies by product.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ashoka",
+    "slug": "ashoka",
+    "summary": "It should be framed conservatively because traditional gynecologic use is much stronger than modern evidence.",
+    "description": "It should be framed conservatively because traditional gynecologic use is much stronger than modern evidence.",
+    "mechanisms": [
+      "traditional cycle support"
+    ],
+    "safetyNotes": "Hormone- or cycle-related traditional use requires caution in pregnancy, breastfeeding, hormone-sensitive conditions, and with hormone therapies.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ashwagandha",
+    "slug": "ashwagandha",
+    "summary": "Ashwagandha centers on the root.",
+    "description": "Ashwagandha centers on the root. Key reported compounds include withaferin A; withanolide D; withanolide A; withanoside IV; sitoindosides; alkaloids. Typical preparation forms: Root powders and standardized extracts. Withanolides are thought to mediate adaptogenic and neuroprotective effects by modulating HPA-axis signaling, NF-κB, Nrf2 and GABAergic pathways. Interaction profile: May potentiate sedatives, antihypertensives, antidiabetics, thyroid hormones, and immunosuppressants. Use caution or avoid in: Pregnancy, breastfeeding, autoimmune disease, thyroid disorders, liver disease.",
+    "mechanisms": [
+      "HPA-axis cortisol modulation",
+      "GABA-A receptor signaling modulation",
+      "NF-κB inhibition",
+      "Nrf2 antioxidant-response activation",
+      "PI3K/Akt neuroprotective signaling"
+    ],
+    "safetyNotes": "Avoid in pregnancy/breastfeeding unless clinician-supervised. Caution with thyroid disease or thyroid-hormone therapy, autoimmune disease/immunosuppressants, sedatives/CNS depressants, antihypertensives, and antidiabetics. Rare idiosyncratic liver injury is reported; avoid with active liver disease and stop if jaundice, dark urine, pruritus, or right-upper-quadrant pain occur.",
+    "contraindications": [
+      "Pregnancy",
+      "breastfeeding without clinician supervision",
+      "active liver disease or prior ashwagandha-related liver injury",
+      "clinician review for autoimmune disease or thyroid disorders."
+    ],
+    "interactions": [
+      "May potentiate sedatives/CNS depressants",
+      "antihypertensives",
+      "antidiabetics",
+      "and thyroid hormone therapy",
+      "theoretical interaction with immunosuppressants",
+      "avoid stacking with hepatotoxic supplements/drugs."
+    ],
+    "dosage": "",
+    "preparation": "Root powder and extracts are most common; higher-extract products shift compound ratios.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 33,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "astragalus",
+    "slug": "astragalus",
+    "summary": "It is best framed around astragalosides and polysaccharides.",
+    "description": "It is best framed around astragalosides and polysaccharides.",
+    "mechanisms": [
+      "immune modulation",
+      "fatigue support",
+      "estrogen receptor modulation",
+      "PI3K/Akt modulation"
+    ],
+    "safetyNotes": "Immune-active potential; use caution with autoimmune disease, transplant medicines, immunosuppressants, and during active cancer treatment unless clinician-supervised.",
+    "contraindications": [
+      "Transplant/immunosuppression without clinician guidance",
+      "autoimmune flare risk",
+      "pregnancy without guidance"
+    ],
+    "interactions": [
+      "May counter immunosuppressants",
+      "may interact with lithium",
+      "diuretics",
+      "antidiabetics",
+      "and antivirals depending context."
+    ],
+    "dosage": "",
+    "preparation": "Root slices/decoction, powders, extracts; often used in formulas.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "astragalus membranaceus",
+    "slug": "astragalus-membranaceus",
+    "summary": "Astragalus membranaceus contains Astragaloside IV and is linked here to PI3K/Akt modulation.",
+    "description": "Astragalus membranaceus contains Astragaloside IV and is linked here to PI3K/Akt modulation.",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "AMPK activation",
+      "TGF-β signaling modulation",
+      "estrogen receptor modulation",
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "safetyNotes": "May lower blood glucose or alter metabolic markers; monitor with diabetes medications and avoid unsupervised use during pregnancy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "hormone-sensitive conditions without clinician review"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "antihypertensives/diuretics",
+      "hormonal therapies",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 15,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "atractylodes",
+    "slug": "atractylodes",
+    "summary": "It is best framed as a digestive-tonic rhizome with traditional-system relevance.",
+    "description": "It is best framed as a digestive-tonic rhizome with traditional-system relevance.",
+    "mechanisms": [
+      "digestive support",
+      "traditional restorative support"
+    ],
+    "safetyNotes": "Immune-active potential; use caution with autoimmune disease, transplant medicines, immunosuppressants, and during active cancer treatment unless clinician-supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "atractylodes macrocephala",
+    "slug": "atractylodes-macrocephala",
+    "summary": "Atractylodes macrocephala contains Atractylenolide I and is linked here to PI3K/Akt modulation.",
+    "description": "Atractylodes macrocephala contains Atractylenolide I and is linked here to PI3K/Akt modulation.",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "safetyNotes": "Immune-modulating activity is plausible; use caution with autoimmune disease, transplant medicines, or immunosuppressants.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "bacopa",
+    "slug": "bacopa",
+    "summary": "It is best framed around bacosides with slower-onset cognitive relevance.",
+    "description": "It is best framed around bacosides with slower-onset cognitive relevance.",
+    "mechanisms": [
+      "Bacosides support cholinergic signaling and synaptic plasticity",
+      "modulate oxidative stress",
+      "neuroinflammation",
+      "ERK/PI3K-Akt pathways",
+      "and BDNF-related signaling."
+    ],
+    "safetyNotes": "Common adverse effects include nausea, cramping, diarrhea, and fatigue/sedation. Use caution with sedatives, thyroid-active therapy, pregnancy, and GI sensitivity.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without guidance",
+      "bradycardia or cholinergic medication use without review"
+    ],
+    "interactions": [
+      "May interact with sedatives",
+      "thyroid medications",
+      "anticholinergics/cholinergics",
+      "and antiepileptics."
+    ],
+    "dosage": "",
+    "preparation": "Whole herb extracts standardized to bacosides; onset in trials is often weeks, not acute.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "bacopa monnieri",
+    "slug": "bacopa-monnieri",
+    "summary": "Bacopa monnieri lean herb row for high-speed phytochemical ingestion.",
+    "description": "Bacopa monnieri lean herb row for high-speed phytochemical ingestion.",
+    "mechanisms": [
+      "Bacosides support cholinergic signaling",
+      "antioxidant defenses",
+      "neuroinflammatory modulation",
+      "ERK/PI3K-Akt signaling",
+      "and BDNF-related synaptic plasticity."
+    ],
+    "safetyNotes": "May cause nausea, diarrhea, abdominal cramping, fatigue, or sedation. Use caution with sedatives, thyroid-active drugs, pregnancy, and sensitive GI conditions.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 15,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "bael",
+    "slug": "bael",
+    "summary": "Internal cross-linking supports Bael through compounds such as skimmianine, aegeline, marmelosin.",
+    "description": "Internal cross-linking supports Bael through compounds such as skimmianine, aegeline, marmelosin.",
+    "mechanisms": [
+      "tannin and coumarin-related gut barrier effects",
+      "intestinal motility and secretion modulation",
+      "alpha-glucosidase and antioxidant signaling"
+    ],
+    "safetyNotes": "Constipating or GI-active effects are possible depending on preparation. Monitor with antidiabetic drugs and avoid pregnancy/breastfeeding use without clinician supervision.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "banaba",
+    "slug": "banaba",
+    "summary": "It is best framed conservatively because evidence quality and standardization vary across products.",
+    "description": "It is best framed conservatively because evidence quality and standardization vary across products.",
+    "mechanisms": [
+      "corosolic-acid AMPK/GLUT4 modulation",
+      "α-glucosidase effects",
+      "postprandial glucose signaling"
+    ],
+    "safetyNotes": "May potentiate antidiabetic drugs; monitor hypoglycemia risk; pregnancy/breastfeeding safety unclear.",
+    "contraindications": [
+      "Hypoglycemia risk",
+      "pregnancy/breastfeeding without clinician guidance"
+    ],
+    "interactions": [
+      "May potentiate antidiabetic medications and other glucose-lowering supplements."
+    ],
+    "dosage": "",
+    "preparation": "Leaf extracts standardized to corosolic acid or ellagitannin content; tea use also occurs.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "bayberry",
+    "slug": "bayberry",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied.",
+    "mechanisms": [
+      "MAPK pathway modulation",
+      "NF-κB inhibition"
+    ],
+    "safetyNotes": "Immune-modulating activity is plausible; use caution with autoimmune disease, transplant medicines, or immunosuppressants.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Fruit/berry preparations are commonly used as foods, juices, powders, capsules, or extracts; sugar and extract concentration vary.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "berberis",
+    "slug": "berberis",
+    "summary": "It is best framed around berberine-bearing root bark with GI and medication-interaction caution.",
+    "description": "It is best framed around berberine-bearing root bark with GI and medication-interaction caution.",
+    "mechanisms": [
+      "berberine-mediated AMPK activation",
+      "LDL receptor/PCSK9 modulation",
+      "intestinal alpha-glucosidase inhibition",
+      "gut microbiome and bile-acid signaling effects",
+      "NF-κB/JAK-STAT inflammatory modulation",
+      "P-glycoprotein substrate/interaction relevance"
+    ],
+    "safetyNotes": "Avoid pregnancy, breastfeeding, and use in neonates/infants due to berberine-related bilirubin displacement/kernicterus concern. GI upset is common. Caution with antidiabetics, antihypertensives, anticoagulants/antiplatelets, cyclosporine/tacrolimus, macrolides, and CYP/P-gp substrates.",
+    "contraindications": [
+      "Pregnancy",
+      "breastfeeding",
+      "neonates/infants",
+      "clinician review for liver disease",
+      "complex medication regimens",
+      "or hypoglycemia-prone patients."
+    ],
+    "interactions": [
+      "Antidiabetics",
+      "antihypertensives",
+      "anticoagulants/antiplatelets",
+      "cyclosporine/tacrolimus",
+      "macrolides",
+      "CYP3A4/CYP2D6/P-gp substrates."
+    ],
+    "dosage": "",
+    "preparation": "Root/bark extracts containing berberine; avoid equating whole herb with purified berberine.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "berberis vulgaris",
+    "slug": "berberis-vulgaris",
+    "summary": "Berberis vulgaris lean herb row for high-speed phytochemical ingestion.",
+    "description": "Berberis vulgaris lean herb row for high-speed phytochemical ingestion.",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "safetyNotes": "May affect glucose, blood pressure, CYP/P-gp drug handling, and GI tolerance. Avoid pregnancy/breastfeeding unless clinician-directed.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "CYP/P-gp substrate medicines",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 16,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "bitter melon",
+    "slug": "bitter-melon",
+    "summary": "It is best framed as a food-medicine with hypoglycemia-aware caution.",
+    "description": "It is best framed as a food-medicine with hypoglycemia-aware caution.",
+    "mechanisms": [
+      "charantin and polypeptide-p hypoglycemic activity",
+      "AMPK activation",
+      "GLUT4 translocation",
+      "PPARγ modulation",
+      "pancreatic beta-cell and insulin-secretion effects"
+    ],
+    "safetyNotes": "Do not use as a replacement for diabetes medications. Hypoglycemia risk rises with insulin, sulfonylureas, and other antidiabetic therapy. Avoid pregnancy due to uterine/abortifacient concerns. Seeds have been associated with favism-like risk in G6PD deficiency. GI upset can occur.",
+    "contraindications": [
+      "Pregnancy",
+      "G6PD deficiency/severe seed exposure risk",
+      "recurrent hypoglycemia unless supervised."
+    ],
+    "interactions": [
+      "Insulin",
+      "sulfonylureas",
+      "GLP-1/SGLT2/metformin and other glucose-lowering therapy",
+      "monitor glucose."
+    ],
+    "dosage": "",
+    "preparation": "Fruit, juice, teas, powders, and extracts; seed preparations may be higher risk.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 12,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "black cohosh",
+    "slug": "black-cohosh",
+    "summary": "Black Cohosh centers on the root; rhizome.",
+    "description": "Black Cohosh centers on the root; rhizome. Key reported compounds include triterpene glycosides (actein, 23-epi-26-deoxyactein); cimifugoside; caffeic acid derivatives; fukinolic acid. Typical preparation forms: Root and rhizome used in standardized extracts, capsules, tablets, and tinctures. Proposed mechanism based on preclinical and limited clinical data: black cohosh may act through serotonergic pathways, selective estrogen receptor modulation, and anti-inflammatory signaling rather than as a classical estrogen. Interaction profile: Potential interactions with hepatotoxic drugs and with medications affecting estrogen or serotonergic pathways. Use caution or avoid in: Avoid in pregnancy and breastfeeding. Use caution in liver disease or hormone-sensitive conditions.",
+    "mechanisms": [
+      "central serotonergic signaling modulation",
+      "5-HT receptor-related thermoregulation effects",
+      "estrogen-receptor/SERM-like activity remains uncertain",
+      "NF-κB/inflammatory signaling modulation"
+    ],
+    "safetyNotes": "Avoid in pregnancy/breastfeeding. Caution or avoid with active liver disease, unexplained liver-enzyme elevation, or prior supplement-related liver injury. Rare severe hepatotoxicity reports exist. Use clinician review in hormone-sensitive cancers or with estrogenic/anti-estrogenic therapies; stop if jaundice, dark urine, right-upper-quadrant pain, or severe fatigue occurs.",
+    "contraindications": [
+      "Pregnancy",
+      "breastfeeding",
+      "active liver disease",
+      "unexplained liver-enzyme elevation",
+      "clinician review for hormone-sensitive cancer history."
+    ],
+    "interactions": [
+      "Potential concern with hepatotoxic drugs/supplements",
+      "clinician review with estrogenic/anti-estrogenic therapy",
+      "serotonergic medicines",
+      "and complex oncology/endocrine regimens."
+    ],
+    "dosage": "",
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 22,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "black pepper",
+    "slug": "black-pepper",
+    "summary": "It should be framed specifically around piperine and digestive relevance rather than as a stand-alone tonic.",
+    "description": "It should be framed specifically around piperine and digestive relevance rather than as a stand-alone tonic.",
+    "mechanisms": [
+      "piperine modulation of CYP3A4/CYP2C9/CYP2D6 and P-gp",
+      "UGT/glucuronidation effects",
+      "TRPV1 sensory signaling",
+      "NF-κB modulation"
+    ],
+    "safetyNotes": "Food use is low-risk; concentrated piperine extracts can alter drug exposure. Use caution with narrow-therapeutic-index drugs and multi-supplement stacks.",
+    "contraindications": [
+      "Use cautiously with prescription polypharmacy",
+      "pregnancy/breastfeeding supplements",
+      "ulcers/reflux sensitivity",
+      "and perioperative anticoagulant use."
+    ],
+    "interactions": [
+      "May increase exposure of CYP/P-gp substrates and enhance curcumin or other supplement bioavailability",
+      "caution with anticoagulants",
+      "antiepileptics",
+      "immunosuppressants",
+      "and cardiovascular drugs."
+    ],
+    "dosage": "",
+    "preparation": "Distinguish culinary black pepper from standardized high-piperine extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "black seed",
+    "slug": "black-seed",
+    "summary": "Bulk-ingested support row carrying Thymoquinone with pathway-level mechanism coverage.",
+    "description": "Bulk-ingested support row carrying Thymoquinone with pathway-level mechanism coverage.",
+    "mechanisms": [
+      "thymoquinone-mediated NF-κB inhibition",
+      "Nrf2/HO-1 antioxidant activation",
+      "AMPK-related glucose/lipid modulation",
+      "PPARγ/adiponectin signaling modulation"
+    ],
+    "safetyNotes": "May lower glucose and blood pressure; monitor with antidiabetic or antihypertensive therapy. GI upset and allergic dermatitis can occur. Avoid high-dose supplemental oil in pregnancy. Caution with anticoagulants/antiplatelets and perioperative use.",
+    "contraindications": [
+      "Pregnancy at supplemental/high doses",
+      "known allergy",
+      "hypoglycemia-prone patients without monitoring."
+    ],
+    "interactions": [
+      "Antidiabetics",
+      "antihypertensives",
+      "anticoagulants/antiplatelets",
+      "possible additive metabolic or sedative effects."
+    ],
+    "dosage": "",
+    "preparation": "Seed/fiber preparations are commonly used as whole seed, powder, capsules, or food ingredients; fluid intake and preparation form matter.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "black tea",
+    "slug": "black-tea",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied.",
+    "mechanisms": [
+      "theaflavin/catechin antioxidant signaling",
+      "endothelial nitric oxide effects",
+      "lipid and blood-pressure pathway modulation"
+    ],
+    "safetyNotes": "Caffeine-related insomnia/anxiety/reflux possible; caution with stimulants, iron absorption, and anticoagulant-sensitive users.",
+    "contraindications": [
+      "Severe caffeine sensitivity",
+      "pregnancy caffeine limits",
+      "iron deficiency timing caution"
+    ],
+    "interactions": [
+      "May interact with stimulants",
+      "sedatives",
+      "iron supplements",
+      "and some cardiovascular drugs."
+    ],
+    "dosage": "",
+    "preparation": "Oxidized Camellia sinensis leaf infusion; theaflavin/thearubigin content varies with processing.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "blue lotus",
+    "slug": "blue-lotus",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied.",
+    "mechanisms": [
+      "calming support",
+      "mood support",
+      "sleep support"
+    ],
+    "safetyNotes": "Limited human safety data. Treat as a CNS-active botanical; avoid driving or combining with alcohol/sedatives.",
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "sedative-sensitive users",
+      "seizure disorder",
+      "active psychiatric instability without clinician review."
+    ],
+    "interactions": [
+      "Possible additive sedation with alcohol",
+      "benzodiazepines",
+      "sleep aids",
+      "opioids",
+      "antihistamines",
+      "and other calming botanicals."
+    ],
+    "dosage": "",
+    "preparation": "Flower is used as tea, tincture, smoking blend, or extract; ingestion route and concentration strongly affect risk.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "blueberry",
+    "slug": "blueberry",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied.",
+    "mechanisms": [
+      "Anthocyanin-polyphenol activity",
+      "endothelial nitric oxide signaling",
+      "Nrf2 antioxidant response",
+      "NF-κB inflammatory modulation",
+      "AMPK and PPAR-related metabolic signaling."
+    ],
+    "safetyNotes": "Food-level use is usually low risk; concentrated extracts may affect glucose or platelet-related endpoints in sensitive users; caution with anticoagulant/antiplatelet therapy, diabetes medication, allergy, and kidney-restricted diets if high-potassium products are used.",
+    "contraindications": [
+      "Anticoagulant use without review for high-dose extracts",
+      "diabetes medication monitoring if large intake changes"
+    ],
+    "interactions": [
+      "Potential additive effects with antidiabetics or anticoagulants in concentrated extracts."
+    ],
+    "dosage": "",
+    "preparation": "Whole berries, juice, powder, freeze-dried extracts, anthocyanin-rich concentrates.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "boldo",
+    "slug": "boldo",
+    "summary": "It is best framed as an aromatic bitter leaf botanical with modest human evidence.",
+    "description": "It is best framed as an aromatic bitter leaf botanical with modest human evidence.",
+    "mechanisms": [
+      "digestive support",
+      "hepatobiliary support"
+    ],
+    "safetyNotes": "Avoid high-dose or prolonged internal use; alkaloid/essential-oil rich preparations may irritate the GI tract and are inappropriate in pregnancy, liver disease, or bile-duct obstruction.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "active liver disease"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Aromatic herb/spice forms and essential oils differ greatly; essential oils require conservative topical/diluted use and are not interchangeable with teas.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "boswellia",
+    "slug": "boswellia",
+    "summary": "It is best framed around boswellic acids with inflammatory-pathway relevance.",
+    "description": "It is best framed around boswellic acids with inflammatory-pathway relevance.",
+    "mechanisms": [
+      "Boswellic acids",
+      "especially AKBA",
+      "inhibit 5-lipoxygenase and leukotriene synthesis",
+      "modulate NF-κB",
+      "mPGES-1",
+      "and inflammatory cytokine signaling."
+    ],
+    "safetyNotes": "May cause reflux, nausea, diarrhea, or rash. Use caution with anticoagulants/antiplatelets, NSAIDs, pregnancy, and inflammatory-disease regimens where product quality matters.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "anticoagulant use without review"
+    ],
+    "interactions": [
+      "Potential additive effects with anti-inflammatory drugs",
+      "anticoagulants",
+      "and immunomodulators."
+    ],
+    "dosage": "",
+    "preparation": "Resin extracts standardized to boswellic acids/AKBA; gum resin and extract potency differ.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "boswellia carterii",
+    "slug": "boswellia-carterii",
+    "summary": "It is best framed around boswellic acids with 5-lipoxygenase relevance.",
+    "description": "It is best framed around boswellic acids with 5-lipoxygenase relevance.",
+    "mechanisms": [
+      "Boswellic acids inhibit 5-lipoxygenase-mediated leukotriene synthesis",
+      "modulate NF-κB",
+      "mPGES-1",
+      "and cytokine-driven inflammatory pathways."
+    ],
+    "safetyNotes": "May cause GI upset or reflux. Use caution with anticoagulants/antiplatelets, NSAIDs, pregnancy, and resin/extract quality variation.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "boswellia serrata",
+    "slug": "boswellia-serrata",
+    "summary": "Boswellia serrata contains Boswellic acid and is linked here to 5-lipoxygenase inhibition.",
+    "description": "Boswellia serrata contains Boswellic acid and is linked here to 5-lipoxygenase inhibition.",
+    "mechanisms": [
+      "AKBA/boswellic-acid 5-lipoxygenase inhibition",
+      "leukotriene reduction",
+      "NF-κB and MMP inflammatory-pathway modulation"
+    ],
+    "safetyNotes": "GI effects possible; caution with anticoagulants/antiplatelets and pregnancy; product standardization matters.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "anticoagulant use without review"
+    ],
+    "interactions": [
+      "Potential additive effects with anti-inflammatory drugs",
+      "anticoagulants",
+      "and immunomodulators."
+    ],
+    "dosage": "",
+    "preparation": "Resin extracts standardized to boswellic acids/AKBA; gum resin and extract potency differ.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "brassica juncea",
+    "slug": "brassica-juncea",
+    "summary": "Minimum source-backed intake for Brassica juncea.",
+    "description": "Minimum source-backed intake for Brassica juncea. Active compound support includes sulforaphane under current workbook standards. Mechanism support retained at Nrf2 activation level for second-anchor cluster completion.",
+    "mechanisms": [
+      "glucosinolate-myrosinase isothiocyanate formation",
+      "Nrf2 antioxidant-response activation",
+      "phase II detoxification enzyme induction"
+    ],
+    "safetyNotes": "Human safety data are limited for concentrated extracts. Use caution in pregnancy/breastfeeding, significant medical conditions, or prescription polypharmacy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "brassica oleracea",
+    "slug": "brassica-oleracea",
+    "summary": "Minimum source-backed intake for Brassica oleracea.",
+    "description": "Minimum source-backed intake for Brassica oleracea. Active compound support includes sulforaphane. Mechanism support retained at Nrf2 activation level for future cluster completion.",
+    "mechanisms": [
+      "glucosinolate-myrosinase conversion to isothiocyanates",
+      "Nrf2 antioxidant-response activation",
+      "phase II detoxification enzyme induction"
+    ],
+    "safetyNotes": "Human safety data are limited for concentrated extracts. Use caution in pregnancy/breastfeeding, significant medical conditions, or prescription polypharmacy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "buckwheat",
+    "slug": "buckwheat",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied.",
+    "mechanisms": [
+      "Rutin/quercetin polyphenol activity",
+      "endothelial nitric oxide signaling",
+      "α-glucosidase/α-amylase modulation",
+      "bile-acid and cholesterol metabolism effects",
+      "NF-κB and Nrf2 pathway modulation."
+    ],
+    "safetyNotes": "Food-level use is usually tolerated, but buckwheat allergy can be serious, including anaphylaxis; caution in known grain/pseudocereal allergy and when using concentrated extracts rather than food forms.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "antihypertensives/diuretics",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "bupleurum",
+    "slug": "bupleurum",
+    "summary": "It should be framed conservatively because traditional-system context matters more than casual wellness claims.",
+    "description": "It should be framed conservatively because traditional-system context matters more than casual wellness claims.",
+    "mechanisms": [
+      "traditional liver support",
+      "traditional stress support",
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "safetyNotes": "Hepatobiliary-active potential; use caution with liver disease, gallbladder disease, bile-duct obstruction, hepatotoxic drugs, and pregnancy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "active liver disease"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "bupleurum falcatum",
+    "slug": "bupleurum-falcatum",
+    "summary": "Lean bulk ingestion row for Bupleurum falcatum.",
+    "description": "Lean bulk ingestion row for Bupleurum falcatum. Key active compounds include Saikosaponin A.",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "safetyNotes": "Hepatobiliary-active potential; use caution with liver disease, gallbladder disease, bile-duct obstruction, hepatotoxic drugs, and pregnancy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "active liver disease"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "burdock",
+    "slug": "burdock",
+    "summary": "It is best framed as a traditional root botanical with modest modern evidence rather than a definitive detox herb.",
+    "description": "It is best framed as a traditional root botanical with modest modern evidence rather than a definitive detox herb.",
+    "mechanisms": [
+      "traditional skin support",
+      "anti-inflammatory"
+    ],
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "contraindications": [
+      "Asteraceae allergy",
+      "pregnancy/breastfeeding without clinician guidance",
+      "hypoglycemia risk"
+    ],
+    "interactions": [
+      "May add to antidiabetic or diuretic effects",
+      "use caution with lithium/diuretics if high intake."
+    ],
+    "dosage": "",
+    "preparation": "Root tea/decoction, tincture, food root, and seed preparations; root and seed are not interchangeable.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "butterbur",
+    "slug": "butterbur",
+    "summary": "Butterbur is a sesquiterpene-rich herb usually discussed around standardized root extracts.",
+    "description": "Butterbur is a sesquiterpene-rich herb usually discussed around standardized root extracts. Petasin and isopetasin are the anchor constituents most often linked to migraine and allergic-rhinitis relevance. The commercial problem is safety, because pyrrolizidine alkaloids (PAs) can damage the liver and lungs and may be carcinogenic. Keep claims narrow and safety-forward.",
+    "mechanisms": [
+      "petasin/isopetasin smooth-muscle effects",
+      "leukotriene and inflammatory-pathway modulation",
+      "trigeminal migraine-pathway effects"
+    ],
+    "safetyNotes": "Only PA-free extracts are acceptable; pyrrolizidine alkaloids can cause serious liver injury; avoid pregnancy/liver disease.",
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "liver disease",
+      "use of non-PA-free products",
+      "Asteraceae allergy"
+    ],
+    "interactions": [
+      "Caution with hepatotoxic drugs/supplements and enzyme-inducing medicines",
+      "clinician supervision advised."
+    ],
+    "dosage": "",
+    "preparation": "Use only certified PA-free root/rhizome or leaf extracts; raw/unprocessed plant is unsafe.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 13,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "cacao",
+    "slug": "cacao",
+    "summary": "It is best framed around flavanols and methylxanthines with stimulant awareness.",
+    "description": "It is best framed around flavanols and methylxanthines with stimulant awareness.",
+    "mechanisms": [
+      "flavanol nitric-oxide/endothelial signaling",
+      "ACE effects",
+      "antioxidant and platelet-function modulation"
+    ],
+    "safetyNotes": "Caffeine/theobromine effects possible; caution with migraine sensitivity, reflux, stimulants, and anticoagulant contexts.",
+    "contraindications": [
+      "Severe caffeine sensitivity",
+      "migraine/reflux triggers",
+      "oxalate stone risk with high intake"
+    ],
+    "interactions": [
+      "May add to stimulant effects",
+      "high-flavanol products may modestly affect blood pressure."
+    ],
+    "dosage": "",
+    "preparation": "Cocoa powder, dark chocolate, cacao nibs, and flavanol-standardized extracts; sugar/fat content varies.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 14,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "calamus",
+    "slug": "calamus",
+    "summary": "Internal cross-linking supports Calamus through compounds such as eugenol, alpha-asarone, beta-asarone.",
+    "description": "Internal cross-linking supports Calamus through compounds such as eugenol, alpha-asarone, beta-asarone.",
+    "mechanisms": [
+      "asarone-rich volatile oil activity",
+      "GABAergic and cholinergic CNS effects reported preclinically",
+      "smooth-muscle signaling"
+    ],
+    "safetyNotes": "High-caution herb because beta-asarone-containing preparations have toxicology and regulatory concerns. Avoid internal use unless verified beta-asarone-free and professionally supervised.",
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "children",
+      "seizure disorder",
+      "liver disease",
+      "and internal high-dose use."
+    ],
+    "interactions": [
+      "Potential additive CNS effects with sedatives",
+      "alcohol",
+      "antiepileptics",
+      "and other neuroactive agents."
+    ],
+    "dosage": "",
+    "preparation": "Distinguish beta-asarone-free Acorus calamus chemotypes from beta-asarone-containing materials; do not generalize safety across chemotypes.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 11,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "calendula",
+    "slug": "calendula",
+    "summary": "It is best framed around topical and tissue-soothing use rather than overextended systemic claims.",
+    "description": "It is best framed around topical and tissue-soothing use rather than overextended systemic claims.",
+    "mechanisms": [
+      "triterpenoid and flavonoid anti-inflammatory signaling",
+      "NF-κB modulation",
+      "wound-healing granulation/epithelialization support",
+      "antimicrobial barrier support"
+    ],
+    "safetyNotes": "Topical use can cause contact dermatitis or allergy, especially in Asteraceae-sensitive users. Oral/concentrated use needs pregnancy caution.",
+    "contraindications": [
+      "Asteraceae allergy",
+      "open/infected wounds without medical care",
+      "pregnancy for non-topical concentrated preparations."
+    ],
+    "interactions": [
+      "Topical interaction risk is low",
+      "avoid layering with irritating actives on compromised skin unless supervised."
+    ],
+    "dosage": "",
+    "preparation": "Evidence is strongest for topical creams/ointments used for radiation dermatitis, diaper dermatitis, wounds, or burns.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "capsicum frutescens",
+    "slug": "capsicum-frutescens",
+    "summary": "Pepper species used for topical and metabolic effects.",
+    "description": "Pepper species used for topical and metabolic effects.",
+    "mechanisms": [
+      "TRPV1 receptor activation followed by nociceptor desensitization",
+      "substance P depletion",
+      "CGRP/neuropeptide modulation",
+      "peripheral nociceptive signaling inhibition"
+    ],
+    "safetyNotes": "Topical use can cause burning, erythema, coughing, and eye irritation. Avoid mucous membranes, broken skin, occlusive dressings, and immediate hot showers. High-concentration patches require supervised application. Oral high-dose products may worsen reflux/GI irritation.",
+    "contraindications": [
+      "Broken or inflamed skin for topical use",
+      "known chili/capsaicin allergy",
+      "uncontrolled reflux for oral products."
+    ],
+    "interactions": [
+      "Additive skin irritation with other topical rubs",
+      "oral products may theoretically compound antihypertensive or anticoagulant regimens",
+      "but clinical evidence is limited."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 4,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "caraway",
+    "slug": "caraway",
+    "summary": "It is best framed as an aromatic seed with traditional GI relevance.",
+    "description": "It is best framed as an aromatic seed with traditional GI relevance.",
+    "mechanisms": [
+      "digestive support",
+      "aromatic support"
+    ],
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Aromatic herb/spice forms and essential oils differ greatly; essential oils require conservative topical/diluted use and are not interchangeable with teas.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cardamom",
+    "slug": "cardamom",
+    "summary": "It is best framed as an aromatic culinary seed with modest translational evidence.",
+    "description": "It is best framed as an aromatic culinary seed with modest translational evidence.",
+    "mechanisms": [
+      "digestive support",
+      "aromatic support"
+    ],
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Aromatic herb/spice forms and essential oils differ greatly; essential oils require conservative topical/diluted use and are not interchangeable with teas.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "carob",
+    "slug": "carob",
+    "summary": "It is best framed as a food-form legume pod with fiber and polyphenol relevance rather than strong pharmacologic action.",
+    "description": "It is best framed as a food-form legume pod with fiber and polyphenol relevance rather than strong pharmacologic action.",
+    "mechanisms": [
+      "digestive support",
+      "metabolic support"
+    ],
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "contraindications": [
+      "Severe constipation/obstruction risk",
+      "carob allergy"
+    ],
+    "interactions": [
+      "Fiber/tannin content may reduce absorption of some oral medications if taken together."
+    ],
+    "dosage": "",
+    "preparation": "Pod powder, gum, syrup, and fiber/tannin extracts; gum and pod powder differ.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cassia alata",
+    "slug": "cassia-alata",
+    "summary": "Internal cross-linking supports Cassia Alata through compounds such as aloe-emodin, chrysophanol.",
+    "description": "Internal cross-linking supports Cassia Alata through compounds such as aloe-emodin, chrysophanol.",
+    "mechanisms": [
+      "MAPK pathway",
+      "NF-kB inhibition"
+    ],
+    "safetyNotes": "Limited human safety data; use conservative preparation-specific framing and avoid pregnancy/breastfeeding or medication stacking without clinician review.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cat's claw",
+    "slug": "cat-s-claw",
+    "summary": "It is best framed around oxindole alkaloids with autoimmune and transplant-related caution.",
+    "description": "It is best framed around oxindole alkaloids with autoimmune and transplant-related caution.",
+    "mechanisms": [
+      "Pentacyclic oxindole alkaloid immunomodulation",
+      "TNF-α and NF-κB modulation",
+      "cytokine signaling effects."
+    ],
+    "safetyNotes": "Avoid in pregnancy, breastfeeding, transplant recipients, and immunosuppressed users; caution with autoimmune disease, anticoagulants/antiplatelets, antihypertensives, and perioperative use.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "catuba",
+    "slug": "catuba",
+    "summary": "It should be framed conservatively because traditional aphrodisiac narratives exceed modern evidence depth.",
+    "description": "It should be framed conservatively because traditional aphrodisiac narratives exceed modern evidence depth.",
+    "mechanisms": [
+      "traditional vitality support",
+      "mood support"
+    ],
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cayenne",
+    "slug": "cayenne",
+    "summary": "Internal cross-linking supports Cayenne through compounds such as capsaicin, capsorubin, dihydrocapsaicin.",
+    "description": "Internal cross-linking supports Cayenne through compounds such as capsaicin, capsorubin, dihydrocapsaicin.",
+    "mechanisms": [
+      "TRPV1 activation/desensitization",
+      "substance P depletion",
+      "neurogenic inflammation modulation",
+      "local vasodilation signaling"
+    ],
+    "safetyNotes": "Capsaicin can irritate skin, eyes, GI tract, and mucosa. Caution with ulcers/reflux, anticoagulants/antiplatelets, and before surgery; keep topical products away from eyes.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with anticoagulants/antiplatelets",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "celastrus paniculatus",
+    "slug": "celastrus-paniculatus",
+    "summary": "Internal cross-linking supports Celastrus Paniculatus through compounds such as beta-amyrin, celastrine, lupeol.",
+    "description": "Internal cross-linking supports Celastrus Paniculatus through compounds such as beta-amyrin, celastrine, lupeol.",
+    "mechanisms": [
+      "celastrine/beta-amyrin triterpenoid signaling",
+      "acetylcholinesterase and neuroinflammatory pathway modulation",
+      "NF-κB/oxidative-stress pathway effects"
+    ],
+    "safetyNotes": "Limited human safety data; use conservative preparation-specific framing and avoid pregnancy/breastfeeding or medication stacking without clinician review.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "centella asiatica",
+    "slug": "centella-asiatica",
+    "summary": "Centella asiatica contains Asiatic acid and is linked here to PI3K/Akt modulation.",
+    "description": "Centella asiatica contains Asiatic acid and is linked here to PI3K/Akt modulation.",
+    "mechanisms": [
+      "asiaticoside/madecassoside effects on collagen synthesis",
+      "microcirculation and endothelial signaling",
+      "antioxidant/NF-κB modulation"
+    ],
+    "safetyNotes": "Rare liver injury reported; avoid pregnancy and liver disease; caution with sedatives and hepatotoxic drugs.",
+    "contraindications": [
+      "Liver disease",
+      "pregnancy/breastfeeding without guidance",
+      "upcoming surgery"
+    ],
+    "interactions": [
+      "May potentiate sedatives and hepatotoxic drugs/supplements",
+      "caution with antidiabetics."
+    ],
+    "dosage": "",
+    "preparation": "Leaf tea/powder, tincture, extracts standardized to asiaticoside/madecassoside; topical use differs.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 18,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "chaga",
+    "slug": "chaga",
+    "summary": "Oxidative stress.",
+    "description": "Oxidative stress.",
+    "mechanisms": [
+      "Nrf2",
+      "NF-κB inhibition",
+      "apoptosis pathway modulation"
+    ],
+    "safetyNotes": "High oxalate exposure and immune effects are concerns; avoid with kidney disease, kidney stones, anticoagulants/antiplatelets, and immunosuppressants unless supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "chamomile",
+    "slug": "chamomile",
+    "summary": "It is best handled as a gentle calming botanical with broad traditional use and modest clinical depth.",
+    "description": "It is best handled as a gentle calming botanical with broad traditional use and modest clinical depth.",
+    "mechanisms": [
+      "apigenin GABA-A receptor interaction",
+      "flavonoid anti-inflammatory signaling",
+      "smooth-muscle and digestive-spasm modulation"
+    ],
+    "safetyNotes": "Allergy risk with Asteraceae sensitivity; sedation possible; caution with CNS depressants and anticoagulants.",
+    "contraindications": [
+      "Asteraceae/ragweed allergy",
+      "anticoagulant use without clinician review",
+      "pregnancy at medicinal doses without guidance"
+    ],
+    "interactions": [
+      "May potentiate sedatives/CNS depressants and anticoagulants/antiplatelets in susceptible users."
+    ],
+    "dosage": "",
+    "preparation": "Flower infusion, tincture, capsules, steam-distilled essential oil, and topical preparations.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "chinese skullcap",
+    "slug": "chinese-skullcap",
+    "summary": "Internal cross-linking supports Chinese Skullcap through compounds such as baicalein, baicalin, wogonin.",
+    "description": "Internal cross-linking supports Chinese Skullcap through compounds such as baicalein, baicalin, wogonin.",
+    "mechanisms": [
+      "baicalin/baicalein/wogonin NF-κB inhibition",
+      "MAPK and PI3K/Akt modulation",
+      "Nrf2 antioxidant signaling",
+      "cytokine modulation"
+    ],
+    "safetyNotes": "Use caution with liver disease and poor-quality products; rare liver injury reports exist for skullcap-containing supplements.",
+    "contraindications": [
+      "Liver disease",
+      "pregnancy/breastfeeding",
+      "immunosuppressive therapy without clinician oversight."
+    ],
+    "interactions": [
+      "Potential additive effects with sedatives",
+      "anticoagulants/antiplatelets",
+      "hepatotoxic drugs",
+      "and immune-modulating therapies."
+    ],
+    "dosage": "",
+    "preparation": "Require verified species identity and extract standardization; avoid products with unclear botanical identity.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "chuanxiong",
+    "slug": "chuanxiong",
+    "summary": "Internal cross-linking supports Chuanxiong through compounds such as ligustilide, ferulic acid, tetramethylpyrazine.",
+    "description": "Internal cross-linking supports Chuanxiong through compounds such as ligustilide, ferulic acid, tetramethylpyrazine.",
+    "mechanisms": [
+      "ligustilide/tetramethylpyrazine-related vasodilation",
+      "platelet aggregation modulation",
+      "nitric-oxide and calcium-channel signaling",
+      "inflammatory-pathway modulation"
+    ],
+    "safetyNotes": "Potential bleeding and blood-pressure effects. Use caution with cardiovascular disease or anticoagulant/antiplatelet therapy.",
+    "contraindications": [
+      "Pregnancy",
+      "bleeding disorders",
+      "planned surgery",
+      "and anticoagulant/antiplatelet use unless supervised."
+    ],
+    "interactions": [
+      "Potential additive effects with anticoagulants",
+      "antiplatelets",
+      "antihypertensives",
+      "nitrates",
+      "and migraine/circulation formulas."
+    ],
+    "dosage": "",
+    "preparation": "Most clinical evidence is formula-based; single-herb evidence remains limited.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cichorium intybus",
+    "slug": "cichorium-intybus",
+    "summary": "Cichorium intybus lean monograph row enriched in bulk mode.",
+    "description": "Cichorium intybus lean monograph row enriched in bulk mode.",
+    "mechanisms": [
+      "Inulin-type fructan prebiotic fermentation to short-chain fatty acids",
+      "bile-acid and lipid metabolism modulation",
+      "Bifidobacterium enrichment",
+      "NF-κB inflammatory modulation",
+      "5-lipoxygenase-related signaling."
+    ],
+    "safetyNotes": "Inulin/chicory can cause gas, bloating, diarrhea, or IBS/FODMAP intolerance; allergy risk exists in Asteraceae-sensitive users; caution with pregnancy/breastfeeding, gallbladder disease, and diabetes medications when using concentrated products.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "cinnamon",
+    "slug": "cinnamon",
+    "summary": "It is best framed conservatively because product form and species matter, especially around coumarin exposure in non-verum types.",
+    "description": "It is best framed conservatively because product form and species matter, especially around coumarin exposure in non-verum types.",
+    "mechanisms": [
+      "cinnamaldehyde/polyphenol insulin-signaling effects",
+      "AMPK/GLUT4 modulation",
+      "lipid-metabolism and inflammatory-pathway effects"
+    ],
+    "safetyNotes": "Cassia cinnamon can contain high coumarin; liver risk at high/chronic doses; monitor with diabetes drugs and anticoagulants.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Use caution with anticoagulants and glucose-lowering therapy."
+    ],
+    "dosage": "",
+    "preparation": "Bark powder or extract; species matters for coumarin exposure.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 15,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "cissus",
+    "slug": "cissus",
+    "summary": "It is best framed conservatively because evidence is mixed and product positioning often outruns the data.",
+    "description": "It is best framed conservatively because evidence is mixed and product positioning often outruns the data.",
+    "mechanisms": [
+      "connective tissue support",
+      "recovery support"
+    ],
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "diabetes medications without monitoring"
+    ],
+    "interactions": [
+      "May potentiate antidiabetic agents",
+      "caution with anticoagulants if blended products include additional actives."
+    ],
+    "dosage": "",
+    "preparation": "Stem extracts/powders; extracts vary in ketosteroid/flavonoid standardization.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cistanche",
+    "slug": "cistanche",
+    "summary": "It should be framed conservatively because traditional-system use is broader than modern clinical depth.",
+    "description": "It should be framed conservatively because traditional-system use is broader than modern clinical depth.",
+    "mechanisms": [
+      "traditional restorative support",
+      "fatigue support"
+    ],
+    "safetyNotes": "Limited human safety data; use conservative preparation-specific framing and avoid pregnancy/breastfeeding or medication stacking without clinician review.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without guidance",
+      "diarrhea-prone conditions"
+    ],
+    "interactions": [
+      "Limited clinical interaction data",
+      "caution with laxatives and glucose-lowering therapies."
+    ],
+    "dosage": "",
+    "preparation": "Stem decoction, powder, and extracts standardized to echinacoside/acteoside.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cistanche deserticola",
+    "slug": "cistanche-deserticola",
+    "summary": "Cistanche deserticola contains Echinacoside and is linked here to PI3K/Akt modulation.",
+    "description": "Cistanche deserticola contains Echinacoside and is linked here to PI3K/Akt modulation.",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "Nrf2 activation"
+    ],
+    "safetyNotes": "Human evidence is limited; GI effects possible due to laxative/moistening traditional use.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without guidance",
+      "diarrhea-prone conditions"
+    ],
+    "interactions": [
+      "Limited clinical interaction data",
+      "caution with laxatives and glucose-lowering therapies."
+    ],
+    "dosage": "",
+    "preparation": "Stem decoction, powder, and extracts standardized to echinacoside/acteoside.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "citrus bergamia",
+    "slug": "citrus-bergamia",
+    "summary": "Citrus bergamia lean monograph row enriched in bulk mode.",
+    "description": "Citrus bergamia lean monograph row enriched in bulk mode.",
+    "mechanisms": [
+      "Bergamot flavonoid/polyphenol signaling",
+      "HMG-CoA reductase–related cholesterol synthesis modulation",
+      "AMPK activation",
+      "LDL receptor expression support",
+      "endothelial nitric oxide and NF-κB modulation."
+    ],
+    "safetyNotes": "Clinically relevant caution: bergamot extracts may cause GI upset; photosensitizing furocoumarins can be present in some citrus preparations; use caution with statins/lipid-lowering therapy, CYP-interacting drugs, pregnancy/breastfeeding, and liver disease unless supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "antihypertensives/diuretics",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "citrus sinensis",
+    "slug": "citrus-sinensis",
+    "summary": "Lean bulk ingestion row for Citrus sinensis.",
+    "description": "Lean bulk ingestion row for Citrus sinensis. Key active compounds include Hesperidin.",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "NF-κB inhibition"
+    ],
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "clove",
+    "slug": "clove",
+    "summary": "Bulk-ingested support row carrying Eugenol with pathway-level mechanism coverage.",
+    "description": "Bulk-ingested support row carrying Eugenol with pathway-level mechanism coverage.",
+    "mechanisms": [
+      "Eugenol-mediated COX-2/LOX modulation",
+      "TRPV1/TRPA1 sensory receptor interaction",
+      "platelet aggregation effects."
+    ],
+    "safetyNotes": "Clove oil can irritate skin/mucosa and high doses may be toxic; caution with anticoagulants/antiplatelets, liver disease, surgery, children, pregnancy, and concentrated essential oil ingestion.",
+    "contraindications": [
+      "Bleeding disorder",
+      "liver disease",
+      "children for clove oil ingestion",
+      "pregnancy supplement dosing without guidance"
+    ],
+    "interactions": [
+      "May increase bleeding risk with anticoagulants/antiplatelets",
+      "caution with hepatotoxic drugs."
+    ],
+    "dosage": "",
+    "preparation": "Culinary buds, teas, diluted topical oil; essential oil requires careful dilution.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cnidium monnieri",
+    "slug": "cnidium-monnieri",
+    "summary": "Cnidium monnieri lean monograph row enriched in bulk mode.",
+    "description": "Cnidium monnieri lean monograph row enriched in bulk mode.",
+    "mechanisms": [
+      "PDE4 inhibition",
+      "PI3K/Akt modulation",
+      "acetylcholinesterase inhibition",
+      "voltage-gated calcium channel modulation",
+      "MAPK pathway modulation"
+    ],
+    "safetyNotes": "May affect bleeding risk or circulation. Use caution with anticoagulants/antiplatelets and before surgery.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "bleeding disorder or upcoming surgery"
+    ],
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "anticoagulants/antiplatelets",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "codonopsis",
+    "slug": "codonopsis",
+    "summary": "It is best framed as a gentler tonic-style root with modest modern evidence.",
+    "description": "It is best framed as a gentler tonic-style root with modest modern evidence.",
+    "mechanisms": [
+      "traditional restorative support",
+      "fatigue support"
+    ],
+    "safetyNotes": "Immune-active potential; use caution with autoimmune disease, transplant medicines, immunosuppressants, and during active cancer treatment unless clinician-supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "coffee",
+    "slug": "coffee",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied.",
+    "mechanisms": [
+      "chlorogenic-acid AMPK/glucose-metabolism effects",
+      "caffeine adenosine-receptor antagonism",
+      "endothelial and antioxidant signaling"
+    ],
+    "safetyNotes": "Caffeine can worsen insomnia, anxiety, reflux, palpitations, and hypertension in sensitive users; pregnancy dose limits apply.",
+    "contraindications": [
+      "Severe caffeine sensitivity",
+      "uncontrolled arrhythmia/anxiety",
+      "pregnancy caffeine limits"
+    ],
+    "interactions": [
+      "May interact with stimulants",
+      "sedatives",
+      "beta-agonists",
+      "lithium",
+      "and CYP1A2 substrates."
+    ],
+    "dosage": "",
+    "preparation": "Brewed coffee, espresso, decaf, green coffee extract; caffeine/chlorogenic acid content varies.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "coffee cherry",
+    "slug": "coffee-cherry",
+    "summary": "Internal cross-linking supports Coffee Cherry through compounds such as caffeine, trigonelline, cafestol.",
+    "description": "Internal cross-linking supports Coffee Cherry through compounds such as caffeine, trigonelline, cafestol.",
+    "mechanisms": [
+      "chlorogenic-acid antioxidant signaling",
+      "caffeine adenosine-receptor antagonism",
+      "polyphenol Nrf2/AMPK-related pathways"
+    ],
+    "safetyNotes": "Caffeine content varies; concentrated products may cause insomnia, anxiety, palpitations, reflux, or blood-pressure effects.",
+    "contraindications": [
+      "Uncontrolled hypertension",
+      "arrhythmias",
+      "severe anxiety/insomnia",
+      "pregnancy/breastfeeding caution",
+      "and stimulant sensitivity."
+    ],
+    "interactions": [
+      "Additive effects with caffeine",
+      "stimulants",
+      "decongestants",
+      "theophylline",
+      "and CYP1A2-modulating drugs."
+    ],
+    "dosage": "",
+    "preparation": "Disclose caffeine and polyphenol content; avoid stacking with coffee/energy products.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 13,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "coleus forskohlii",
+    "slug": "coleus-forskohlii",
+    "summary": "Coleus forskohlii contains Forskolin and is linked here to adenylyl cyclase activation.",
+    "description": "Coleus forskohlii contains Forskolin and is linked here to adenylyl cyclase activation.",
+    "mechanisms": [
+      "forskolin activation of adenylate cyclase",
+      "increased intracellular cAMP",
+      "protein kinase A signaling",
+      "smooth-muscle and lipolysis pathway effects"
+    ],
+    "safetyNotes": "May lower blood pressure or increase heart rate in sensitive users. Caution with anticoagulants, antihypertensives, nitrates, and perioperative use.",
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "hypotension",
+      "bleeding disorders",
+      "and cardiovascular disease without clinician oversight."
+    ],
+    "interactions": [
+      "Potential additive effects with antihypertensives",
+      "nitrates",
+      "antiplatelets/anticoagulants",
+      "and bronchodilator-style regimens."
+    ],
+    "dosage": "",
+    "preparation": "Evidence is strongest for standardized forskolin extracts, not all Coleus preparations.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "commiphora mukul",
+    "slug": "commiphora-mukul",
+    "summary": "Commiphora mukul contains Guggulsterone and is linked here to FXR antagonism.",
+    "description": "Commiphora mukul contains Guggulsterone and is linked here to FXR antagonism.",
+    "mechanisms": [
+      "guggulsterone FXR/lipid-metabolism effects",
+      "thyroid-axis signaling",
+      "NF-κB inflammatory modulation"
+    ],
+    "safetyNotes": "Can cause rash/GI effects; may affect thyroid function, CYP enzymes, anticoagulants, and hormone-sensitive contexts.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "anticoagulants/antiplatelets",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "coptis",
+    "slug": "coptis",
+    "summary": "Internal cross-linking supports Coptis through compounds such as berberine, palmatine, coptisine.",
+    "description": "Internal cross-linking supports Coptis through compounds such as berberine, palmatine, coptisine.",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-kB pathway inhibition",
+      "mitochondrial complex I inhibition",
+      "NF-κB inhibition",
+      "MAPK modulation"
+    ],
+    "safetyNotes": "Berberine-containing herb; avoid in pregnancy/breastfeeding and infants. Caution with antidiabetic drugs, anticoagulants, CYP/P-gp substrates, and bilirubin-risk contexts.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "CYP/P-gp substrate medicines",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 11,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "coptis chinensis",
+    "slug": "coptis-chinensis",
+    "summary": "Coptis chinensis lean herb row for high-speed phytochemical ingestion.",
+    "description": "Coptis chinensis lean herb row for high-speed phytochemical ingestion.",
+    "mechanisms": [
+      "AMPK activation",
+      "MAPK pathway modulation",
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "safetyNotes": "May affect glucose, blood pressure, CYP/P-gp drug handling, and GI tolerance. Avoid pregnancy/breastfeeding unless clinician-directed.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "CYP/P-gp substrate medicines",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cordyceps",
+    "slug": "cordyceps",
+    "summary": "Cordyceps militaris is most often discussed around cordycepin plus polysaccharides and related nucleosides.",
+    "description": "Cordyceps militaris is most often discussed around cordycepin plus polysaccharides and related nucleosides. Commercial interest is high, but the evidence base is still strongest at the preclinical and cultivation/constituent level rather than for broad human outcome claims.",
+    "mechanisms": [
+      "immune modulation",
+      "anti-inflammatory",
+      "NF-kappaB modulation",
+      "Nrf2/HO-1",
+      "cordycepin"
+    ],
+    "safetyNotes": "Commercial products vary by species identity, cultivation method, and cordycepin content. Keep benefit claims conservative unless tied to a specific studied product.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Mushroom preparations may be hot-water extracts, dual extracts, powders, or isolated polysaccharide fractions; extraction method matters.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 12,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "coriandrum sativum",
+    "slug": "coriandrum-sativum",
+    "summary": "Coriandrum sativum lean monograph row enriched in bulk mode.",
+    "description": "Coriandrum sativum lean monograph row enriched in bulk mode.",
+    "mechanisms": [
+      "Linalool-mediated GABA-A/glutamatergic modulation",
+      "α-glucosidase and insulin-signaling effects",
+      "Nrf2 and MAPK pathway modulation."
+    ],
+    "safetyNotes": "Culinary use is usually low risk; concentrated extracts may affect glucose or sedation; caution with Apiaceae allergy, diabetes medications, sedatives, pregnancy/breastfeeding, and perioperative use.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "seizure disorder or sedative/alcohol use"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "cornus officinalis",
+    "slug": "cornus-officinalis",
+    "summary": "Cornus officinalis contains Loganin and is linked here to PI3K/Akt modulation.",
+    "description": "Cornus officinalis contains Loganin and is linked here to PI3K/Akt modulation.",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "Nrf2 activation"
+    ],
+    "safetyNotes": "May lower blood glucose or alter metabolic markers; monitor with diabetes medications and avoid unsupervised use during pregnancy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "significant kidney disease or unstable electrolytes"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "corydalis",
+    "slug": "corydalis",
+    "summary": "Internal cross-linking supports Corydalis through compounds such as corydaline, isocorypalmine, dehydrocorybulbine.",
+    "description": "Internal cross-linking supports Corydalis through compounds such as corydaline, isocorypalmine, dehydrocorybulbine.",
+    "mechanisms": [
+      "tetrahydropalmatine-related dopamine D1/D2 modulation",
+      "GABAergic and opioid-pathway interaction",
+      "calcium-channel and nociceptive signaling modulation"
+    ],
+    "safetyNotes": "CNS depression, dizziness, sedation, and liver-safety concerns have been reported with Corydalis-containing products. Avoid combining with sedatives or alcohol.",
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "liver disease",
+      "seizure disorder",
+      "heavy alcohol use",
+      "and use of sedatives without medical oversight."
+    ],
+    "interactions": [
+      "Potential additive effects with benzodiazepines",
+      "opioids",
+      "sleep aids",
+      "alcohol",
+      "antipsychotics",
+      "and hepatotoxic drugs."
+    ],
+    "dosage": "",
+    "preparation": "Evidence and risks depend strongly on species, alkaloid profile, and dose; avoid unstandardized high-dose extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cranberry",
+    "slug": "cranberry",
+    "summary": "It is best framed around proanthocyanidin-rich urinary-support positioning rather than broad antimicrobial claims.",
+    "description": "It is best framed around proanthocyanidin-rich urinary-support positioning rather than broad antimicrobial claims.",
+    "mechanisms": [
+      "proanthocyanidin anti-adhesion effects against uropathogenic E. coli",
+      "urinary-tract anti-adherence signaling"
+    ],
+    "safetyNotes": "GI upset possible; caution with recurrent kidney stones and warfarin-sensitive patients; avoid treating active UTI without care.",
+    "contraindications": [
+      "History of kidney stones/oxalate stones",
+      "warfarin use requires clinician review"
+    ],
+    "interactions": [
+      "Warfarin interaction concern is reported",
+      "monitor INR if used with anticoagulation."
+    ],
+    "dosage": "",
+    "preparation": "Juice, capsules, tablets, and PAC-standardized extracts; sugar content varies in juices.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "crocus sativus",
+    "slug": "crocus-sativus",
+    "summary": "Lean bulk ingestion row for Crocus sativus.",
+    "description": "Lean bulk ingestion row for Crocus sativus. Key active compounds include Crocin; Crocetin.",
+    "mechanisms": [
+      "crocin/crocetin antioxidant signaling",
+      "serotonergic/dopaminergic modulation",
+      "HPA-axis and inflammatory-pathway effects"
+    ],
+    "safetyNotes": "High doses may cause GI/CNS effects and uterine stimulation; avoid pregnancy-level medicinal dosing; monitor with serotonergic drugs.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "curcuma longa",
+    "slug": "curcuma-longa",
+    "summary": "Curcuma longa contains Demethoxycurcumin and is linked here to NF-κB inhibition.",
+    "description": "Curcuma longa contains Demethoxycurcumin and is linked here to NF-κB inhibition.",
+    "mechanisms": [
+      "curcuminoid NF-κB inhibition",
+      "Nrf2 activation",
+      "COX/LOX and inflammatory cytokine modulation"
+    ],
+    "safetyNotes": "GI effects possible; caution with anticoagulants/antiplatelets, gallbladder disease, and liver-safety concerns at high doses.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "curcuma wenyujin",
+    "slug": "curcuma-wenyujin",
+    "summary": "Curcuma wenyujin contains Beta-elemene and is linked here to PI3K/Akt modulation.",
+    "description": "Curcuma wenyujin contains Beta-elemene and is linked here to PI3K/Akt modulation.",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "apoptosis pathway modulation (caspase activation)"
+    ],
+    "safetyNotes": "Human safety data are limited for concentrated extracts. Use caution in pregnancy/breastfeeding, significant medical conditions, or prescription polypharmacy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "curcuma zedoaria",
+    "slug": "curcuma-zedoaria",
+    "summary": "Curcuma zedoaria contains Curcumol and is linked here to NF-κB inhibition.",
+    "description": "Curcuma zedoaria contains Curcumol and is linked here to NF-κB inhibition.",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation",
+      "PI3K/Akt modulation",
+      "apoptosis pathway modulation (caspase activation)"
+    ],
+    "safetyNotes": "Immune-modulating activity is plausible; use caution with autoimmune disease, transplant medicines, or immunosuppressants.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "curry leaf",
+    "slug": "curry-leaf",
+    "summary": "It is best framed as a culinary-medicinal leaf with food-form relevance.",
+    "description": "It is best framed as a culinary-medicinal leaf with food-form relevance.",
+    "mechanisms": [
+      "antioxidant",
+      "metabolic support"
+    ],
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Leaf preparations are commonly used as teas, powders, tinctures, or standardized extracts; topical use may differ from oral use.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cyclea peltata",
+    "slug": "cyclea-peltata",
+    "summary": "Cyclea peltata lean monograph row enriched in bulk mode.",
+    "description": "Cyclea peltata lean monograph row enriched in bulk mode.",
+    "mechanisms": [
+      "voltage-gated calcium channel modulation",
+      "NF-κB inhibition"
+    ],
+    "safetyNotes": "Alkaloid-rich traditional herb; human safety data are limited. Avoid pregnancy/breastfeeding and unsupervised high-dose use.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "cymbopogon citratus",
+    "slug": "cymbopogon-citratus",
+    "summary": "Cymbopogon citratus contains Nerolidol and is linked here to GABA-A modulation.",
+    "description": "Cymbopogon citratus contains Nerolidol and is linked here to GABA-A modulation.",
+    "mechanisms": [
+      "Citral/myrcene activity",
+      "GABA-A-related signaling",
+      "vascular smooth-muscle and ACE-related effects",
+      "PI3K/Akt and NF-κB modulation."
+    ],
+    "safetyNotes": "Tea-level use is usually tolerated, but concentrated essential oil can irritate skin/mucosa and may cause CNS or GI effects; caution in pregnancy, breastfeeding, sedative use, hypotension, and antihypertensive therapy.",
+    "contraindications": [
+      "Pregnancy/breastfeeding supplement dosing without guidance",
+      "internal essential-oil use"
+    ],
+    "interactions": [
+      "Low documented interaction burden",
+      "caution with sedatives or antihypertensives at high doses."
+    ],
+    "dosage": "",
+    "preparation": "Leaf tea, culinary herb, tincture, and essential oil for topical/aromatic use.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "damiana",
+    "slug": "damiana",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied.",
+    "mechanisms": [
+      "mood support",
+      "calming support",
+      "libido support"
+    ],
+    "safetyNotes": "Human evidence is limited. Use conservative dosing; avoid stacking with sedatives, stimulants, or sexual-performance products without review.",
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "seizure disorder without clinician review",
+      "planned surgery or complex psychiatric medication regimens."
+    ],
+    "interactions": [
+      "Potential additive CNS effects with sedatives",
+      "alcohol",
+      "anxiolytics",
+      "and serotonergic or stimulant stacks",
+      "diabetes medication caution is theoretical."
+    ],
+    "dosage": "",
+    "preparation": "Leaf is used as tea, tincture, capsules, or aromatic blends; avoid high-dose extracts until safety is reviewed.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "dandelion",
+    "slug": "dandelion",
+    "summary": "It is best framed as a traditional food-like bitter herb rather than a strong cleansing intervention.",
+    "description": "It is best framed as a traditional food-like bitter herb rather than a strong cleansing intervention.",
+    "mechanisms": [
+      "potassium-rich leaf diuretic/natriuretic effects",
+      "bitter sesquiterpene lactone-mediated digestive secretion",
+      "inulin/fructan prebiotic effects",
+      "polyphenol-mediated Nrf2/NF-κB modulation"
+    ],
+    "safetyNotes": "Avoid with Asteraceae/ragweed allergy. Caution with diuretics, lithium, kidney disease, bile duct obstruction/gallbladder disease, GERD, and antihypertensive or glucose-lowering therapy. Monitor potassium and volume status if combined with diuretics. Human efficacy evidence remains narrow, so claims should stay conservative.",
+    "contraindications": [
+      "Asteraceae allergy",
+      "bile duct obstruction",
+      "serious kidney disease unless supervised",
+      "pregnancy/breastfeeding without clinician review."
+    ],
+    "interactions": [
+      "Diuretics",
+      "lithium",
+      "antihypertensives",
+      "glucose-lowering therapy",
+      "theoretical quinolone absorption concern and additive GI irritation possible."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 3,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "danshen",
+    "slug": "danshen",
+    "summary": "It is best framed around tanshinones and salvianolic acids with specific vascular-support positioning.",
+    "description": "It is best framed around tanshinones and salvianolic acids with specific vascular-support positioning.",
+    "mechanisms": [
+      "cardiovascular support",
+      "vascular support"
+    ],
+    "safetyNotes": "May increase bleeding risk and alter blood pressure; use caution with anticoagulants/antiplatelets, antihypertensives, digoxin/heart medicines, and before surgery.",
+    "contraindications": [
+      "Pregnancy",
+      "anticoagulant/antiplatelet therapy without clinician review",
+      "upcoming surgery"
+    ],
+    "interactions": [
+      "May interact with warfarin",
+      "aspirin",
+      "antiplatelets",
+      "antihypertensives",
+      "and cardiovascular drugs."
+    ],
+    "dosage": "",
+    "preparation": "Root decoction, granules, injections in clinical settings, and standardized extracts; route matters greatly.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "daphne odora",
+    "slug": "daphne-odora",
+    "summary": "Daphne odora lean monograph row enriched in bulk mode.",
+    "description": "Daphne odora lean monograph row enriched in bulk mode.",
+    "mechanisms": [
+      "JAK/STAT inhibition",
+      "NF-κB inhibition"
+    ],
+    "safetyNotes": "High-caution plant; toxic diterpenes/coumarin-related constituents may irritate skin and mucosa. Avoid internal supplement use outside expert supervision.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "dendrobium",
+    "slug": "dendrobium",
+    "summary": "It should be framed conservatively because luxury-tonic narratives often exceed evidence depth.",
+    "description": "It should be framed conservatively because luxury-tonic narratives often exceed evidence depth.",
+    "mechanisms": [
+      "traditional restorative support",
+      "mucosal support"
+    ],
+    "safetyNotes": "Food-like use is generally lower risk, but concentrated extracts may not match dietary safety. Use caution with pregnancy/breastfeeding, allergy, and chronic high-dose supplementation.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "dong quai",
+    "slug": "dong-quai",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied.",
+    "mechanisms": [
+      "ligustilide and ferulic-acid vascular signaling",
+      "smooth-muscle modulation",
+      "phytoestrogen-like activity",
+      "platelet and inflammatory-pathway modulation"
+    ],
+    "safetyNotes": "May increase bleeding risk and may not be appropriate in hormone-sensitive conditions. Pregnancy avoidance is important due to uterine/circulatory concerns.",
+    "contraindications": [
+      "Pregnancy",
+      "bleeding disorders",
+      "hormone-sensitive cancers/conditions",
+      "planned surgery",
+      "and anticoagulant therapy without supervision."
+    ],
+    "interactions": [
+      "Caution with anticoagulants",
+      "antiplatelets",
+      "NSAIDs",
+      "estrogenic therapies",
+      "and photosensitizing drugs."
+    ],
+    "dosage": "",
+    "preparation": "Often studied in formulas; do not generalize formula evidence to single-herb Angelica sinensis.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "echinacea purpurea",
+    "slug": "echinacea-purpurea",
+    "summary": "Echinacea Purpurea centers on the unspecified.",
+    "description": "Echinacea Purpurea centers on the unspecified. Key reported compounds include alkamides; chicoric acid; echinacoside; caffeic acid; cynarin. Typical preparation forms: Medicinal products use the roots and aerial parts in teas, juices, tinctures and standardized extracts. Roots, leaves and flowers of Echinacea purpurea contain mixtures of lipophilic alkamides and hydrophilic caffeic acid derivatives such as chicoric acid and echinacoside, along with polysaccharides and glycoproteins【880087072039746†L166-L200】【840476591578855†L240-L305】. These constituents stimulate immune function by enhancing phagocytosis, activating fibroblasts and respiratory burst activity, and modulating nitric‐oxide and cytokine production via cannabinoid type‐2 receptors【880087072039746†L215-L243】. They also inhibit cyclo‐oxygenase and lipoxygenase enzymes. Most mechanistic data are from cell and animal studies; human evidence is limited. Interaction profile: Echinacea may interact with immunosuppressant drugs by stimulating immune activity and could affect the pharmacokinetics of drugs metabolised by cytochrome P450 enzymes; caution is advised when taken with hepatic substrates or caffeine. Use caution or avoid in: Individuals with autoimmune disorders or allergies to ragweed and other Asteraceae plants should avoid echinacea. Use during pregnancy or breastfeeding is not recommended. People taking immunosuppressant drugs should avoid echinacea due to potential antagonism.",
+    "mechanisms": [
+      "macrophage and neutrophil activation",
+      "cytokine modulation (IL-1",
+      "IL-6",
+      "TNF-α)",
+      "CB2 receptor activity from alkamides",
+      "NF-κB/MAPK pathway modulation",
+      "COX/LOX enzyme inhibition"
+    ],
+    "safetyNotes": "Avoid in known Asteraceae/ragweed allergy; allergic rash and rare anaphylaxis are possible. Caution in autoimmune disease, transplant recipients, immunosuppressant therapy, and poorly characterized immune conditions. Avoid prolonged unsupervised use in pregnancy/breastfeeding.",
+    "contraindications": [
+      "Asteraceae allergy",
+      "transplant or significant immunosuppression without clinician review",
+      "autoimmune disease requiring immunosuppressive therapy unless supervised."
+    ],
+    "interactions": [
+      "May counter immunosuppressants",
+      "extract-specific CYP effects are possible",
+      "use caution with hepatically metabolized narrow-therapeutic-index drugs."
+    ],
+    "dosage": "",
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 3,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "elderberry",
+    "slug": "elderberry",
+    "summary": "Internal cross-linking supports Elderberry through compounds such as sambunigrin.",
+    "description": "Internal cross-linking supports Elderberry through compounds such as sambunigrin.",
+    "mechanisms": [
+      "anthocyanin/flavonoid antiviral and cytokine-modulating effects",
+      "influenza/respiratory symptom pathway support"
+    ],
+    "safetyNotes": "Use cooked/standardized berry preparations; raw/unripe parts can contain cyanogenic glycosides; caution in autoimmune/immunosuppressed contexts.",
+    "contraindications": [
+      "Autoimmune/transplant immunosuppression without clinician review",
+      "pregnancy/breastfeeding without guidance"
+    ],
+    "interactions": [
+      "May counter immunosuppressants",
+      "caution with diuretics or antidiabetics depending product."
+    ],
+    "dosage": "",
+    "preparation": "Cooked syrup, lozenges, extracts; avoid raw/unripe berries and non-berry plant parts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "elecampane",
+    "slug": "elecampane",
+    "summary": "It is best framed as a bitter aromatic root with traditional bronchial relevance.",
+    "description": "It is best framed as a bitter aromatic root with traditional bronchial relevance.",
+    "mechanisms": [
+      "traditional respiratory support",
+      "digestive support"
+    ],
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Aromatic herb/spice forms and essential oils differ greatly; essential oils require conservative topical/diluted use and are not interchangeable with teas.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "elephantopus scaber",
+    "slug": "elephantopus-scaber",
+    "summary": "Elephantopus scaber contains Deoxyelephantopin and is linked here to NF-κB inhibition.",
+    "description": "Elephantopus scaber contains Deoxyelephantopin and is linked here to NF-κB inhibition.",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "STAT3 inhibition",
+      "apoptosis pathway modulation (caspase activation)",
+      "MAPK pathway modulation"
+    ],
+    "safetyNotes": "Immune-modulating activity is plausible; use caution with autoimmune disease, transplant medicines, or immunosuppressants.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "eleuthero",
+    "slug": "eleuthero",
+    "summary": "Stress resilience.",
+    "description": "Stress resilience.",
+    "mechanisms": [
+      "HPA axis",
+      "HPA-axis modulation",
+      "immune modulation",
+      "AMPK activation",
+      "stress response modulation"
+    ],
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "contraindications": [
+      "Uncontrolled hypertension",
+      "pregnancy/breastfeeding without guidance",
+      "acute fever caution in some traditions"
+    ],
+    "interactions": [
+      "Use caution with stimulants or blood pressure-active agents."
+    ],
+    "dosage": "",
+    "preparation": "Root decoction or extract; standardized eleutheroside products are common.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 17,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "embelia ribes",
+    "slug": "embelia-ribes",
+    "summary": "Embelia ribes contains Embelin and is linked here to XIAP inhibition.",
+    "description": "Embelia ribes contains Embelin and is linked here to XIAP inhibition.",
+    "mechanisms": [
+      "XIAP inhibition",
+      "NF-κB inhibition"
+    ],
+    "safetyNotes": "Immune-modulating activity is plausible; use caution with autoimmune disease, transplant medicines, or immunosuppressants.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "epimedium",
+    "slug": "epimedium",
+    "summary": "Epimedium is represented here primarily through icariin and related prenylated flavonoids such as epimedin A, B, and C.",
+    "description": "Epimedium is represented here primarily through icariin and related prenylated flavonoids such as epimedin A, B, and C. The herb is commonly positioned for libido and circulation support, but a more disciplined framing keeps it in the traditional-use / limited-human-evidence tier. Mechanistic interest often centers on PDE-related signaling, endothelial nitric oxide activity, and broader bone-support and anti-inflammatory pathways observed in preclinical work.",
+    "mechanisms": [
+      "PDE-related signaling",
+      "nitric oxide signaling",
+      "sexual function",
+      "bone support",
+      "flavonoid activity"
+    ],
+    "safetyNotes": "Use caution in people with blood-pressure instability, hormone-sensitive conditions, or high sensitivity to activating supplements. Keep positioning moderate rather than performance-driven.",
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "hormone-sensitive conditions without review",
+      "arrhythmia/cardiovascular disease caution"
+    ],
+    "interactions": [
+      "May interact with antihypertensives",
+      "PDE5 inhibitors",
+      "anticoagulants",
+      "and hormone therapies."
+    ],
+    "dosage": "",
+    "preparation": "Leaf extracts standardized to icariin/flavonoids; often used in formulas.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 14,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "epimedium brevicornum",
+    "slug": "epimedium-brevicornum",
+    "summary": "Minimum source-backed intake for Epimedium brevicornum.",
+    "description": "Minimum source-backed intake for Epimedium brevicornum. Active compounds include epimedin A, epimedin B, and epimedin C. Mechanism support retained at nitric oxide signaling level for cluster activation readiness. Icariin support added to complete the PDE5-related signaling cluster.",
+    "mechanisms": [
+      "nitric oxide signaling",
+      "PDE5-related signaling"
+    ],
+    "safetyNotes": "Evidence and safety are extract-specific. Use caution with cardiovascular disease, hormone-sensitive conditions, and sexual-performance stacks.",
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "significant heart rhythm or blood-pressure instability",
+      "hormone-sensitive conditions without clinician review."
+    ],
+    "interactions": [
+      "Potential additive effects with PDE-5 inhibitors",
+      "antihypertensives",
+      "anticoagulants/antiplatelets",
+      "and stimulant sexual-performance products."
+    ],
+    "dosage": "",
+    "preparation": "Aerial parts/leaves are used as decoction, granules, capsules, or icariin-standardized extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 11,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "eucalyptus",
+    "slug": "eucalyptus",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied.",
+    "mechanisms": [
+      "respiratory support",
+      "antimicrobial",
+      "anti-inflammatory"
+    ],
+    "safetyNotes": "Eucalyptus oil is potentially toxic if ingested and can trigger bronchospasm in sensitive users; topical and inhaled use require dilution and caution.",
+    "contraindications": [
+      "Infants/young children for oil exposure near face",
+      "asthma/bronchospasm sensitivity",
+      "pregnancy/breastfeeding for internal oil use."
+    ],
+    "interactions": [
+      "Avoid combining internal oil with sedatives or hepatotoxic exposures",
+      "topical products may irritate skin or mucosa."
+    ],
+    "dosage": "",
+    "preparation": "Leaf is used as tea or steam; essential oil is used diluted topically or aromatically and should not be taken internally without medical supervision.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "eucommia",
+    "slug": "eucommia",
+    "summary": "It is best framed conservatively because traditional tonic use is broader than modern evidence quality.",
+    "description": "It is best framed conservatively because traditional tonic use is broader than modern evidence quality.",
+    "mechanisms": [
+      "connective tissue support",
+      "cardiometabolic support"
+    ],
+    "safetyNotes": "May affect circulation, blood pressure, or platelet function; use caution with anticoagulants/antiplatelets, antihypertensives, heart medications, and before surgery.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "hypotension or hypoglycemia risk"
+    ],
+    "interactions": [
+      "May potentiate antihypertensive or antidiabetic agents."
+    ],
+    "dosage": "",
+    "preparation": "Bark/leaf tea, decoction, powders, and extracts; bark and leaf chemistry differ.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "fennel",
+    "slug": "fennel",
+    "summary": "It is best handled as an aromatic seed botanical with traditional GI-support use and modest mechanistic confidence.",
+    "description": "It is best handled as an aromatic seed botanical with traditional GI-support use and modest mechanistic confidence.",
+    "mechanisms": [
+      "anethole-related smooth-muscle effects",
+      "phytoestrogenic signaling",
+      "COX/NO inflammatory modulation"
+    ],
+    "safetyNotes": "Avoid in pregnancy at medicinal doses; caution in estrogen-sensitive conditions and with seizure disorders; allergy possible.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "hormone-sensitive conditions without clinician review"
+    ],
+    "interactions": [
+      "Possible estrogenic interaction concerns with concentrated use."
+    ],
+    "dosage": "",
+    "preparation": "Tea or crushed seed is traditional; extracts concentrate volatile constituents.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 15,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "fenugreek",
+    "slug": "fenugreek",
+    "summary": "Fenugreek lean herb row for high-speed phytochemical ingestion.",
+    "description": "Fenugreek lean herb row for high-speed phytochemical ingestion.",
+    "mechanisms": [
+      "Galactomannan fiber slows carbohydrate absorption and bile-acid recycling",
+      "4-hydroxyisoleucine may affect insulin secretion/sensitivity",
+      "saponins influence lipid metabolism."
+    ],
+    "safetyNotes": "May cause gas, diarrhea, hypoglycemia, or maple-syrup body odor. Use caution with antidiabetic drugs, anticoagulants/antiplatelets, pregnancy, and legume/peanut allergy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "feverfew",
+    "slug": "feverfew",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied.",
+    "mechanisms": [
+      "parthenolide-mediated NF-κB inhibition",
+      "serotonin/platelet modulation",
+      "TRPA1 and prostaglandin-pathway effects"
+    ],
+    "safetyNotes": "Avoid in pregnancy; possible mouth ulcers/GI upset; allergy risk in Asteraceae-sensitive users; caution with anticoagulants/antiplatelets.",
+    "contraindications": [
+      "Pregnancy",
+      "Asteraceae/ragweed allergy",
+      "anticoagulant use without clinician review",
+      "upcoming surgery"
+    ],
+    "interactions": [
+      "May increase bleeding risk with anticoagulants/antiplatelets/NSAIDs",
+      "caution with migraine medications."
+    ],
+    "dosage": "",
+    "preparation": "Leaf capsules/extracts standardized to parthenolide; fresh leaf chewing increases mouth irritation risk.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ficus carica",
+    "slug": "ficus-carica",
+    "summary": "Ficus carica lean monograph row enriched in bulk mode.",
+    "description": "Ficus carica lean monograph row enriched in bulk mode.",
+    "mechanisms": [
+      "Polyphenol-mediated NF-κB/MAPK modulation",
+      "latex protease activity",
+      "antioxidant pathway support",
+      "estrogen-receptor activity remains uncertain."
+    ],
+    "safetyNotes": "Fig latex can trigger allergy or skin irritation; caution with latex/fruit allergy, diabetes medications, anticoagulants, pregnancy/breastfeeding, and concentrated latex or leaf extracts.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "hormone-sensitive conditions without clinician review"
+    ],
+    "interactions": [
+      "Potential interaction concern with hormonal therapies",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "fingerroot",
+    "slug": "fingerroot",
+    "summary": "Internal cross-linking supports Fingerroot through compounds such as pinostrobin, pinocembrin, panduratin a.",
+    "description": "Internal cross-linking supports Fingerroot through compounds such as pinostrobin, pinocembrin, panduratin a.",
+    "mechanisms": [
+      "panduratin A/pinostrobin NF-κB and MAPK modulation",
+      "COX/LOX inflammatory signaling",
+      "antimicrobial membrane and biofilm-pathway effects"
+    ],
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "fraxinus rhynchophylla",
+    "slug": "fraxinus-rhynchophylla",
+    "summary": "Fraxinus rhynchophylla lean monograph row enriched in bulk mode.",
+    "description": "Fraxinus rhynchophylla lean monograph row enriched in bulk mode.",
+    "mechanisms": [
+      "Nrf2 activation",
+      "NF-κB inhibition"
+    ],
+    "safetyNotes": "May affect bleeding risk or circulation. Use caution with anticoagulants/antiplatelets and before surgery.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "bleeding disorder or upcoming surgery"
+    ],
+    "interactions": [
+      "Potential interaction concern with anticoagulants/antiplatelets",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "galangal",
+    "slug": "galangal",
+    "summary": "It is best framed as a culinary-medicinal rhizome with traditional GI relevance.",
+    "description": "It is best framed as a culinary-medicinal rhizome with traditional GI relevance.",
+    "mechanisms": [
+      "digestive support",
+      "aromatic support"
+    ],
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "garcinia indica",
+    "slug": "garcinia-indica",
+    "summary": "Garcinia indica contains Garcinol and is linked here to NF-κB inhibition.",
+    "description": "Garcinia indica contains Garcinol and is linked here to NF-κB inhibition.",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "HAT inhibition",
+      "STAT3 inhibition"
+    ],
+    "safetyNotes": "May lower blood glucose or alter metabolic markers; monitor with diabetes medications and avoid unsupervised use during pregnancy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "garcinia mangostana",
+    "slug": "garcinia-mangostana",
+    "summary": "Garcinia mangostana contains Mangostin and is linked here to NF-κB inhibition.",
+    "description": "Garcinia mangostana contains Mangostin and is linked here to NF-κB inhibition.",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "PI3K/Akt modulation",
+      "apoptosis pathway modulation (caspase activation)",
+      "STAT3 inhibition"
+    ],
+    "safetyNotes": "Human evidence is limited; concentrated xanthone products may cause GI upset or interact with anticoagulants.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "bleeding disorder/anticoagulant use without review"
+    ],
+    "interactions": [
+      "Theoretical anticoagulant/antiplatelet interactions",
+      "product-specific evidence limited."
+    ],
+    "dosage": "",
+    "preparation": "Pericarp/rind extracts, juice blends, powders; fruit pulp differs from rind extract.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "garlic",
+    "slug": "garlic",
+    "summary": "Garlic centers on the unspecified.",
+    "description": "Garlic centers on the unspecified. Key reported compounds include diallyl sulfide; diallyl disulfide; diallyl trisulfide; ajoene; S‐allyl‐cysteine. Typical preparation forms: Fresh or dried bulbs are used as food and in remedies. Commercial supplements include aged garlic extracts, oils and powders standardized for organosulfur content. Garlic bulbs contain organosulfur compounds such as diallyl sulfide, diallyl disulfide, diallyl trisulfide, ajoene and S‐allyl‐cysteine. These constituents exert antioxidant, anti‐inflammatory and immunomodulatory effects in vitro and in animal models by scavenging free radicals and modulating inflammatory pathways. Human evidence is limited, so this should be regarded as a proposed mechanism based on preclinical data. Interaction profile: Garlic may potentiate the effects of anticoagulant and antiplatelet drugs (e.g., warfarin, aspirin) and should be discontinued before surgery. It may also enhance the effects of antihypertensive or antidiabetic medicines. Use caution or avoid in: People with bleeding disorders, those taking anticoagulant or antiplatelet drugs and individuals scheduled for surgery should avoid high‐dose garlic supplements. Because safety during pregnancy and breastfeeding has not been established, garlic supplements are not recommended in these populations.",
+    "mechanisms": [
+      "allicin/organosulfur signaling",
+      "ACE/endothelial nitric oxide modulation",
+      "HMG-CoA reductase and platelet aggregation modulation"
+    ],
+    "safetyNotes": "Bleeding risk with anticoagulants/antiplatelets or perioperative use; GI irritation/reflux possible; may modestly lower blood pressure and glucose.",
+    "contraindications": [
+      "Bleeding disorder",
+      "upcoming surgery",
+      "garlic allergy",
+      "clinician review during pregnancy/breastfeeding at supplement doses"
+    ],
+    "interactions": [
+      "May increase bleeding risk with anticoagulants/antiplatelets",
+      "may potentiate antihypertensives",
+      "possible interaction with some antiretrovirals."
+    ],
+    "dosage": "",
+    "preparation": "Fresh clove, aged garlic extract, powder, and oil preparations differ chemically; aged extract is common in trials.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 2,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "gastrodia",
+    "slug": "gastrodia",
+    "summary": "It should be framed conservatively because traditional neurologic use is broader than modern evidence.",
+    "description": "It should be framed conservatively because traditional neurologic use is broader than modern evidence.",
+    "mechanisms": [
+      "traditional nervous-system support",
+      "calming support"
+    ],
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without guidance",
+      "sedative use without review"
+    ],
+    "interactions": [
+      "May add to CNS depressant or antihypertensive effects",
+      "limited interaction data."
+    ],
+    "dosage": "",
+    "preparation": "Tuber decoction, powder, extract; often used in formulas.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ginger",
+    "slug": "ginger",
+    "summary": "Ginger centers on the unspecified.",
+    "description": "Ginger centers on the unspecified. Key reported compounds include [6]-gingerol; shogaols; zingerone; paradols. Typical preparation forms: The rhizome is used fresh, dried, pickled, preserved, candied or powdered. Supplements include encapsulated dried powders and extracts【418916103730052†L176-L189】. Ginger rhizomes contain phenolic constituents such as gingerols, shogaols, zingerone and paradols. These compounds modulate immune‐cell function and regulate signalling pathways including nuclear factor‐κB, MAPK and PI3K/Akt/mTOR, and they can activate AMP‐activated protein kinase (AMPK), NRF2, HO‐1 and PPARγ【69571933386645†L153-L169】【69571933386645†L240-L249】. Through these mechanisms ginger exhibits anti‐inflammatory, antioxidant and neuroprotective effects. Interaction profile: Ginger may increase the risk of bleeding when taken with anticoagulant or antiplatelet drugs and could lower blood glucose or blood pressure, potentiating antidiabetic or antihypertensive medications. Use caution or avoid in: Use cautiously in pregnancy, gallstone disease or bleeding disorders. Discontinue before surgery and avoid high‐dose supplements when taking anticoagulants.",
+    "mechanisms": [
+      "5-HT3 receptor antagonism",
+      "gastric motility modulation",
+      "COX-2 and LOX inhibition",
+      "NF-κB inhibition",
+      "thromboxane/platelet-aggregation modulation"
+    ],
+    "safetyNotes": "Heartburn and GI upset are common at higher doses. Pregnancy use should stay within studied doses and clinician guidance. Caution with anticoagulants/antiplatelets, bleeding disorders, perioperative use, gallstones/biliary disease, antidiabetic therapy, and antihypertensive therapy.",
+    "contraindications": [
+      "Bleeding disorder or perioperative use without clinician review",
+      "gallstone/biliary disease without clinician review",
+      "high-dose use in pregnancy without clinician guidance."
+    ],
+    "interactions": [
+      "Potential additive bleeding risk with warfarin",
+      "DOACs",
+      "antiplatelets",
+      "and NSAIDs",
+      "may compound glucose- or blood-pressure-lowering therapy."
+    ],
+    "dosage": "",
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 2,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ginkgo biloba",
+    "slug": "ginkgo-biloba",
+    "summary": "Ginkgo Biloba centers on the leaf.",
+    "description": "Ginkgo Biloba centers on the leaf. Key reported compounds include ginkgolides A, B, C, J; bilobalide; ginkgetin; bilobetin; sciadopitysin. Typical preparation forms: Standardized leaf extract (EGb 761). The standardized leaf extract (EGb 761) contains terpene lactones and flavone glycosides that modulate multiple neurotransmitter systems and platelet-activating factor pathways. Interaction profile: May potentiate NSAIDs, anticoagulants, antiplatelets, and interact with antidepressants and antidiabetic drugs. Use caution or avoid in: Pregnancy, breastfeeding, bleeding disorders, epilepsy, planned surgery.",
+    "mechanisms": [
+      "platelet-activating factor antagonism",
+      "antioxidant/free-radical scavenging",
+      "cerebral microcirculation and endothelial nitric-oxide modulation",
+      "mitochondrial protection",
+      "NF-κB/Nrf2 signaling modulation"
+    ],
+    "safetyNotes": "Bleeding risk is the primary public-facing concern; avoid with anticoagulants/antiplatelets or before surgery unless clinician-supervised. Seizure-threshold concerns exist from ginkgotoxin, especially with seeds or high-risk patients. Avoid fresh seeds. Caution with antiepileptics, pregnancy, and complex medication regimens.",
+    "contraindications": [
+      "Active bleeding disorder",
+      "perioperative period without clinician review",
+      "seizure disorder unless supervised",
+      "avoid fresh seeds entirely."
+    ],
+    "interactions": [
+      "Anticoagulants",
+      "antiplatelets",
+      "NSAIDs",
+      "antiepileptics",
+      "and other narrow-therapeutic-index drugs",
+      "possible extract-specific CYP effects."
+    ],
+    "dosage": "",
+    "preparation": "Leaf preparations are commonly used as teas, powders, tinctures, or standardized extracts; topical use may differ from oral use.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 43,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "glycyrrhiza glabra",
+    "slug": "glycyrrhiza-glabra",
+    "summary": "Lean bulk ingestion row for Glycyrrhiza glabra.",
+    "description": "Lean bulk ingestion row for Glycyrrhiza glabra. Key active compounds include Glycyrrhizin.",
+    "mechanisms": [
+      "glycyrrhizin/glycyrrhetinic-acid 11β-HSD2 inhibition",
+      "mineralocorticoid pathway activation",
+      "anti-inflammatory signaling"
+    ],
+    "safetyNotes": "Real risk of hypertension, hypokalemia, edema, arrhythmia; avoid with hypertension, kidney disease, pregnancy, diuretics, digoxin.",
+    "contraindications": [
+      "Hypertension",
+      "kidney disease",
+      "hypokalemia",
+      "heart disease",
+      "pregnancy",
+      "use with diuretics/corticosteroids/digoxin without review"
+    ],
+    "interactions": [
+      "High-risk with diuretics",
+      "corticosteroids",
+      "digoxin",
+      "antihypertensives",
+      "antiarrhythmics",
+      "and stimulant laxatives."
+    ],
+    "dosage": "",
+    "preparation": "Whole root, deglycyrrhizinated licorice (DGL), extracts, teas, and TCM formula components differ in glycyrrhizin exposure.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 24,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "goldenseal",
+    "slug": "goldenseal",
+    "summary": "Internal cross-linking supports Goldenseal through compounds such as berberine, hydrastine.",
+    "description": "Internal cross-linking supports Goldenseal through compounds such as berberine, hydrastine.",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-kB pathway inhibition",
+      "mitochondrial complex I inhibition",
+      "NF-κB inhibition",
+      "PI3K/Akt modulation",
+      "MAPK pathway modulation"
+    ],
+    "safetyNotes": "Berberine/hydrastine-containing herb; avoid in pregnancy/breastfeeding and infants. High interaction potential with CYP/P-gp substrates, diabetes medicines, anticoagulants, and narrow-therapeutic-index drugs.",
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "infants/newborns",
+      "complex medication regimens without clinician review"
+    ],
+    "interactions": [
+      "Potential CYP3A4/CYP2D6/P-gp interactions",
+      "caution with cyclosporine",
+      "tacrolimus",
+      "antidiabetics",
+      "anticoagulants",
+      "and many drugs."
+    ],
+    "dosage": "",
+    "preparation": "Root/rhizome powder, tincture, extracts; sustainability and adulteration issues are important.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 13,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "gotu kola",
+    "slug": "gotu-kola",
+    "summary": "NO support.",
+    "description": "NO support.",
+    "mechanisms": [
+      "asiaticoside/madecassoside collagen synthesis",
+      "microcirculation/endothelial effects",
+      "antioxidant/NF-κB modulation"
+    ],
+    "safetyNotes": "Rare liver injury reported; avoid pregnancy and liver disease; caution with sedatives and hepatotoxic drugs.",
+    "contraindications": [
+      "Liver disease",
+      "pregnancy/breastfeeding without guidance",
+      "upcoming surgery"
+    ],
+    "interactions": [
+      "May potentiate sedatives and hepatotoxic drugs/supplements",
+      "caution with antidiabetics."
+    ],
+    "dosage": "",
+    "preparation": "Leaf tea/powder, tincture, extracts standardized to asiaticoside/madecassoside; topical use differs.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "grape",
+    "slug": "grape",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied.",
+    "mechanisms": [
+      "proanthocyanidin endothelial nitric-oxide signaling",
+      "antioxidant/NF-κB modulation",
+      "platelet and lipid pathway effects"
+    ],
+    "safetyNotes": "May interact with anticoagulants/antiplatelets; GI effects possible; supplement dose varies widely.",
+    "contraindications": [
+      "Anticoagulant use without review",
+      "grape allergy",
+      "pregnancy supplement dosing without guidance"
+    ],
+    "interactions": [
+      "Potential additive bleeding risk with anticoagulants/antiplatelets",
+      "may modestly affect blood pressure."
+    ],
+    "dosage": "",
+    "preparation": "Fruit, juice, seed extract, skin extract, and wine-derived polyphenols differ substantially.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "grapefruit",
+    "slug": "grapefruit",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied.",
+    "mechanisms": [
+      "intestinal CYP3A4 mechanism-based inhibition by furanocoumarins",
+      "P-gp modulation",
+      "OATP transporter effects",
+      "naringin/naringenin flavonoid signaling"
+    ],
+    "safetyNotes": "Major food-drug interaction risk: can raise exposure of statins, calcium-channel blockers, immunosuppressants, antiarrhythmics, and other CYP3A4/OATP substrates.",
+    "contraindications": [
+      "Avoid or medically supervise with drugs labeled for grapefruit interaction",
+      "narrow-therapeutic-index drugs",
+      "and complex cardiovascular/transplant regimens."
+    ],
+    "interactions": [
+      "CYP3A4",
+      "P-gp",
+      "and OATP-mediated interactions",
+      "effects may persist beyond a single serving."
+    ],
+    "dosage": "",
+    "preparation": "Interaction risk varies by whole fruit, juice, cultivar, dose, and furanocoumarin content.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "green tea",
+    "slug": "green-tea",
+    "summary": "Internal cross-linking supports Green Tea through compounds such as caffeine, theanine, catechins (egcg).",
+    "description": "Internal cross-linking supports Green Tea through compounds such as caffeine, theanine, catechins (egcg).",
+    "mechanisms": [
+      "EGCG/catechins activate AMPK",
+      "modulate lipid absorption and oxidation",
+      "support endothelial nitric-oxide signaling",
+      "and provide caffeine-mediated adenosine antagonism."
+    ],
+    "safetyNotes": "Caffeine may worsen insomnia, anxiety, palpitations, or reflux. High-dose green-tea extracts can cause liver injury, especially fasting use; caution with anticoagulants and liver disease.",
+    "contraindications": [
+      "Severe caffeine sensitivity",
+      "liver disease with high-EGCG extracts",
+      "pregnancy caffeine limits"
+    ],
+    "interactions": [
+      "May interact with stimulants and iron absorption timing."
+    ],
+    "dosage": "",
+    "preparation": "Infusion or standardized extract; lower-temperature steeping preserves catechins and theanine balance.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 39,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "guarana",
+    "slug": "guarana",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied.",
+    "mechanisms": [
+      "caffeine-mediated adenosine A1/A2A antagonism",
+      "methylxanthine CNS stimulation",
+      "catecholamine/arousal signaling",
+      "polyphenol antioxidant signaling"
+    ],
+    "safetyNotes": "Caffeine exposure can cause insomnia, anxiety, tremor, tachycardia, blood-pressure elevation, and GI upset. Avoid stacking with energy drinks or other stimulants; use cautiously in pregnancy/breastfeeding and cardiovascular disease.",
+    "contraindications": [
+      "Uncontrolled hypertension",
+      "arrhythmia",
+      "severe anxiety/insomnia",
+      "stimulant sensitivity",
+      "and unsupervised pediatric use."
+    ],
+    "interactions": [
+      "Additive effects with caffeine",
+      "stimulants",
+      "theophylline",
+      "decongestants",
+      "and some ADHD medications",
+      "CYP1A2 inhibitors may increase caffeine exposure."
+    ],
+    "dosage": "",
+    "preparation": "Use standardized preparations that disclose caffeine content; avoid concentrated stimulant blends.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "guayusa",
+    "slug": "guayusa",
+    "summary": "Internal cross-linking supports Guayusa through compounds such as caffeine, theobromine.",
+    "description": "Internal cross-linking supports Guayusa through compounds such as caffeine, theobromine.",
+    "mechanisms": [
+      "caffeine-mediated adenosine A1/A2A antagonism",
+      "theobromine methylxanthine effects",
+      "chlorogenic-acid antioxidant signaling"
+    ],
+    "safetyNotes": "Caffeine-containing herb; may worsen insomnia, anxiety, palpitations, reflux, and blood pressure in sensitive users.",
+    "contraindications": [
+      "Uncontrolled hypertension",
+      "arrhythmia",
+      "severe anxiety/insomnia",
+      "pregnancy/breastfeeding caution",
+      "and stimulant sensitivity."
+    ],
+    "interactions": [
+      "Additive effects with caffeine",
+      "stimulants",
+      "theophylline",
+      "decongestants",
+      "and stimulant medications."
+    ],
+    "dosage": "",
+    "preparation": "Use moderate brewed preparations or products with disclosed caffeine content; avoid concentrated stimulant blends.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "gudmar",
+    "slug": "gudmar",
+    "summary": "It should be framed consistently with gymnema while preserving alternate-name discoverability.",
+    "description": "It should be framed consistently with gymnema while preserving alternate-name discoverability.",
+    "mechanisms": [
+      "gymnemic-acid sweet taste receptor inhibition",
+      "intestinal glucose absorption modulation",
+      "pancreatic beta-cell/insulin signaling support",
+      "AMPK/GLUT4-related metabolic signaling"
+    ],
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "gymnema",
+    "slug": "gymnema",
+    "summary": "Gymnema leaf is mainly anchored by gymnemic acids, a triterpene-glycoside cluster.",
+    "description": "Gymnema leaf is mainly anchored by gymnemic acids, a triterpene-glycoside cluster. The strongest mechanistic signal is sweet-taste suppression plus related effects on glucose handling, not generic wellness language. Keep human claims conservative and formulation-specific.",
+    "mechanisms": [
+      "glycemic support",
+      "sweet taste suppression",
+      "T1R2/T1R3 modulation",
+      "glucose absorption modulation",
+      "AMPK activation"
+    ],
+    "safetyNotes": "Generally well tolerated, but products positioned for glucose support should be handled cautiously in people already using glucose-lowering strategies.",
+    "contraindications": [
+      "Hypoglycemia risk",
+      "pregnancy/breastfeeding without clinician guidance",
+      "perioperative fasting"
+    ],
+    "interactions": [
+      "May potentiate insulin",
+      "sulfonylureas",
+      "metformin",
+      "and other glucose-lowering agents."
+    ],
+    "dosage": "",
+    "preparation": "Leaf powder/extracts standardized to gymnemic acids; chewing/tea can reduce sweet taste temporarily.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 12,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "gymnema sylvestre",
+    "slug": "gymnema-sylvestre",
+    "summary": "Gymnema sylvestre contains Gymnemagenin and is linked here to glucose absorption modulation.",
+    "description": "Gymnema sylvestre contains Gymnemagenin and is linked here to glucose absorption modulation.",
+    "mechanisms": [
+      "gymnemic acid sweet-taste receptor antagonism",
+      "SGLT1/intestinal glucose absorption inhibition",
+      "pancreatic beta-cell and insulin-secretion effects",
+      "AMPK activation",
+      "lipid-metabolism modulation"
+    ],
+    "safetyNotes": "Hypoglycemia risk increases with insulin, sulfonylureas, GLP-1 agonists, SGLT2 inhibitors, metformin, or other glucose-lowering medicines. Monitor glucose. GI upset can occur. Avoid pregnancy/breastfeeding. Stop before surgery because glucose variability may complicate perioperative management.",
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "hypoglycemia-prone patients without monitoring",
+      "perioperative use without clinician review."
+    ],
+    "interactions": [
+      "Antidiabetics including insulin",
+      "sulfonylureas",
+      "GLP-1 agonists",
+      "SGLT2 inhibitors",
+      "and metformin",
+      "may compound glucose-lowering effects."
+    ],
+    "dosage": "",
+    "preparation": "Leaf powder/extracts standardized to gymnemic acids; chewing/tea can reduce sweet taste temporarily.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "harpagophytum procumbens",
+    "slug": "harpagophytum-procumbens",
+    "summary": "Harpagophytum procumbens contains Harpagoside and is linked here to COX inhibition.",
+    "description": "Harpagophytum procumbens contains Harpagoside and is linked here to COX inhibition.",
+    "mechanisms": [
+      "harpagoside-mediated COX/LOX inflammatory modulation",
+      "NF-κB inhibition",
+      "pain-signaling modulation"
+    ],
+    "safetyNotes": "Avoid/caution with ulcers, gallstones, anticoagulants, pregnancy, and significant GI disease.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "hawthorn",
+    "slug": "hawthorn",
+    "summary": "It is best framed around procyanidins and flavonoids.",
+    "description": "It is best framed around procyanidins and flavonoids.",
+    "mechanisms": [
+      "positive inotropic effects",
+      "coronary vasodilation via endothelial nitric oxide",
+      "vascular-tone modulation",
+      "antioxidant flavonoid/procyanidin effects",
+      "phosphodiesterase inhibition"
+    ],
+    "safetyNotes": "Use only with clinician oversight in heart failure or cardiovascular disease. May potentiate antihypertensives, nitrates, digoxin/cardiac glycosides, beta-blockers, antiarrhythmics, and anticoagulant/antiplatelet regimens. Dizziness, hypotension, palpitations, and GI upset can occur. Do not substitute for heart-failure therapy.",
+    "contraindications": [
+      "Unstable cardiac disease without medical care",
+      "pregnancy/breastfeeding without clinician review",
+      "unexplained chest pain",
+      "syncope",
+      "or severe dyspnea requires urgent medical care."
+    ],
+    "interactions": [
+      "Digoxin/cardiac glycosides",
+      "antihypertensives",
+      "nitrates",
+      "beta-blockers",
+      "antiarrhythmics",
+      "anticoagulants",
+      "and antiplatelets."
+    ],
+    "dosage": "",
+    "preparation": "Leaf/flower/berry tea, tincture, and flavonoid/OPC standardized extracts.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 2,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "holy basil",
+    "slug": "holy-basil",
+    "summary": "Holy Basil centers on the leaf; aerial parts.",
+    "description": "Holy Basil centers on the leaf; aerial parts. Key reported compounds include eugenol; ursolic acid; rosmarinic acid. Typical preparation forms: Leaf extracts, teas. Adaptogenic; anti-inflammatory; modulates cortisol and stress pathways. Interaction profile: Anticoagulants, antidiabetic drugs. Use caution or avoid in: Pregnancy (limited data).",
+    "mechanisms": [
+      "eugenol/ursolic-acid signaling",
+      "cortisol/stress-axis modulation",
+      "AMPK/glucose and inflammatory-pathway effects"
+    ],
+    "safetyNotes": "May lower glucose and affect clotting; caution with diabetes drugs, anticoagulants, pregnancy, and perioperative use.",
+    "contraindications": [
+      "Pregnancy attempts/pregnancy without clinician guidance",
+      "hypoglycemia risk",
+      "bleeding disorder",
+      "upcoming surgery"
+    ],
+    "interactions": [
+      "May add to antidiabetic",
+      "antihypertensive",
+      "sedative",
+      "anticoagulant",
+      "or antiplatelet effects."
+    ],
+    "dosage": "",
+    "preparation": "Leaf tea, tincture, powder, and standardized extracts; seed preparations are a different data object.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 28,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "holy basil purple",
+    "slug": "holy-basil-purple",
+    "summary": "It should be framed similarly to tulsi while noting cultivar/form distinctions are secondary to constituent variability.",
+    "description": "It should be framed similarly to tulsi while noting cultivar/form distinctions are secondary to constituent variability.",
+    "mechanisms": [
+      "adaptogenic support",
+      "antioxidant"
+    ],
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "holy basil seed",
+    "slug": "holy-basil-seed",
+    "summary": "It should be framed distinctly from holy basil leaf because fiber and mucilage drive different use-cases.",
+    "description": "It should be framed distinctly from holy basil leaf because fiber and mucilage drive different use-cases.",
+    "mechanisms": [
+      "demulcent support",
+      "digestive support"
+    ],
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Leaf preparations are commonly used as teas, powders, tinctures, or standardized extracts; topical use may differ from oral use.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "honeysuckle",
+    "slug": "honeysuckle",
+    "summary": "Internal cross-linking supports Honeysuckle through compounds such as luteolin, chlorogenic acid.",
+    "description": "Internal cross-linking supports Honeysuckle through compounds such as luteolin, chlorogenic acid.",
+    "mechanisms": [
+      "MAPK pathway inhibition",
+      "NF-kB inhibition"
+    ],
+    "safetyNotes": "Immune-active potential; use caution with autoimmune disease, transplant medicines, immunosuppressants, and during active cancer treatment unless clinician-supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "hops",
+    "slug": "hops",
+    "summary": "It is best framed around bitter-resin and prenylflavonoid chemistry with modest selected human evidence.",
+    "description": "It is best framed around bitter-resin and prenylflavonoid chemistry with modest selected human evidence.",
+    "mechanisms": [
+      "calming support",
+      "sleep support"
+    ],
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without guidance",
+      "severe depression",
+      "hormone-sensitive conditions without review"
+    ],
+    "interactions": [
+      "May potentiate sedatives",
+      "alcohol",
+      "sleep medications",
+      "and other CNS depressants."
+    ],
+    "dosage": "",
+    "preparation": "Strobile tea/tincture/extract; often combined with valerian or passionflower.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "horse chestnut",
+    "slug": "horse-chestnut",
+    "summary": "Internal cross-linking supports Horse Chestnut through compounds such as aesculin, aescin, fraxin.",
+    "description": "Internal cross-linking supports Horse Chestnut through compounds such as aesculin, aescin, fraxin.",
+    "mechanisms": [
+      "aescin venotonic effects",
+      "capillary permeability reduction",
+      "NF-κB/inflammatory edema modulation"
+    ],
+    "safetyNotes": "Use only processed seed extract; raw seeds/bark/leaves are toxic; caution with anticoagulants, kidney disease, and pregnancy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "bleeding disorder or upcoming surgery"
+    ],
+    "interactions": [
+      "Potential interaction concern with anticoagulants/antiplatelets",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "houttuynia",
+    "slug": "houttuynia",
+    "summary": "It should be framed cautiously because strong folklore claims exceed the evidence.",
+    "description": "It should be framed cautiously because strong folklore claims exceed the evidence.",
+    "mechanisms": [
+      "traditional immune support",
+      "traditional respiratory support"
+    ],
+    "safetyNotes": "Immune-active potential; use caution with autoimmune disease, transplant medicines, immunosuppressants, and during active cancer treatment unless clinician-supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "huperzia serrata",
+    "slug": "huperzia-serrata",
+    "summary": "Huperzia serrata contains Huperzine A and is linked here to acetylcholinesterase inhibition.",
+    "description": "Huperzia serrata contains Huperzine A and is linked here to acetylcholinesterase inhibition.",
+    "mechanisms": [
+      "acetylcholinesterase inhibition",
+      "NMDA receptor modulation"
+    ],
+    "safetyNotes": "Human safety data are limited for concentrated extracts. Use caution in pregnancy/breastfeeding, significant medical conditions, or prescription polypharmacy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "hypericum perforatum",
+    "slug": "hypericum-perforatum",
+    "summary": "Hypericum perforatum contains Hyperforin and is linked here to TRPC6 channel modulation.",
+    "description": "Hypericum perforatum contains Hyperforin and is linked here to TRPC6 channel modulation.",
+    "mechanisms": [
+      "serotonin/norepinephrine/dopamine reuptake modulation",
+      "CYP3A4 and P-gp induction",
+      "hyperforin-mediated pregnane-X receptor activation"
+    ],
+    "safetyNotes": "Major interaction risk: antidepressants, oral contraceptives, anticoagulants, antiretrovirals, transplant drugs, and many CYP/P-gp substrates.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with sedatives/CNS depressants",
+      "CYP/P-gp substrate medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 25,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "isatis",
+    "slug": "isatis",
+    "summary": "It is best framed as a traditional-use herb with limited modern clinical depth.",
+    "description": "It is best framed as a traditional-use herb with limited modern clinical depth.",
+    "mechanisms": [
+      "traditional immune support",
+      "throat support",
+      "CDK inhibition",
+      "STAT3 inhibition"
+    ],
+    "safetyNotes": "Immune-active potential; use caution with autoimmune disease, transplant medicines, immunosuppressants, and during active cancer treatment unless clinician-supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "japanese knotweed",
+    "slug": "japanese-knotweed",
+    "summary": "Bulk-ingested support row carrying Emodin with pathway-level mechanism coverage.",
+    "description": "Bulk-ingested support row carrying Emodin with pathway-level mechanism coverage.",
+    "mechanisms": [
+      "resveratrol SIRT1/AMPK signaling",
+      "NF-κB modulation",
+      "Nrf2 antioxidant signaling",
+      "platelet-pathway effects"
+    ],
+    "safetyNotes": "Concentrated resveratrol-rich extracts may affect bleeding risk and drug metabolism. GI upset is possible at higher doses.",
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "bleeding disorders",
+      "anticoagulant/antiplatelet therapy without supervision",
+      "and surgery."
+    ],
+    "interactions": [
+      "Potential additive bleeding risk with anticoagulants/antiplatelets/NSAIDs",
+      "caution with CYP-metabolized drugs."
+    ],
+    "dosage": "",
+    "preparation": "Do not equate standardized resveratrol extracts with crude knotweed preparations.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "jatamansi",
+    "slug": "jatamansi",
+    "summary": "It should be framed as a traditional aromatic rhizome with modest clinical depth.",
+    "description": "It should be framed as a traditional aromatic rhizome with modest clinical depth.",
+    "mechanisms": [
+      "calming support",
+      "traditional nervous-system support"
+    ],
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Aromatic herb/spice forms and essential oils differ greatly; essential oils require conservative topical/diluted use and are not interchangeable with teas.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "jujube",
+    "slug": "jujube",
+    "summary": "It is best framed as a food-like fruit/seed botanical with gentle traditional positioning.",
+    "description": "It is best framed as a food-like fruit/seed botanical with gentle traditional positioning.",
+    "mechanisms": [
+      "calming support",
+      "nutritive support"
+    ],
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "contraindications": [
+      "Diabetes/glucose management if using sweet fruit products",
+      "pregnancy supplement dosing without guidance"
+    ],
+    "interactions": [
+      "May add to sedatives if seed extracts are used",
+      "monitor glucose with high fruit intake."
+    ],
+    "dosage": "",
+    "preparation": "Fruit, seed extracts, decoction, teas; seed and fruit differ pharmacologically.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "juniper",
+    "slug": "juniper",
+    "summary": "It should be framed as an aromatic berry botanical with traditional GI and urinary relevance.",
+    "description": "It should be framed as an aromatic berry botanical with traditional GI and urinary relevance.",
+    "mechanisms": [
+      "digestive support",
+      "urinary support",
+      "aromatic support"
+    ],
+    "safetyNotes": "Avoid during pregnancy and use cautiously with kidney disease. Concentrated preparations may irritate the urinary tract and may interact with diuretics or lithium.",
+    "contraindications": [
+      "Pregnancy",
+      "kidney disease",
+      "inflammatory kidney conditions",
+      "internal essential-oil use without supervision"
+    ],
+    "interactions": [
+      "May add to diuretics and affect lithium handling",
+      "caution with nephrotoxic drugs."
+    ],
+    "dosage": "",
+    "preparation": "Berry tea/tincture, culinary spice, and essential oil; internal essential oil is high risk.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "kanna",
+    "slug": "kanna",
+    "summary": "Internal cross-linking supports Kanna through compounds such as mesembrenone, mesembranol, mesembrine.",
+    "description": "Internal cross-linking supports Kanna through compounds such as mesembrenone, mesembranol, mesembrine.",
+    "mechanisms": [
+      "mesembrine alkaloid serotonin reuptake modulation",
+      "PDE4 inhibition",
+      "monoamine and stress-response pathway effects"
+    ],
+    "safetyNotes": "CNS-active and potentially serotonergic. Avoid casual stacking with antidepressants or empathogenic/stimulant products.",
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "bipolar/mania risk",
+      "serotonin-syndrome risk",
+      "active psychiatric medication use without clinician oversight."
+    ],
+    "interactions": [
+      "Avoid or clinician-review with SSRIs",
+      "SNRIs",
+      "MAOIs",
+      "TCAs",
+      "lithium",
+      "tramadol",
+      "linezolid",
+      "stimulants",
+      "and serotonergic supplements."
+    ],
+    "dosage": "",
+    "preparation": "Fermented aerial material, capsules, extracts, tinctures, and chewed preparations exist; standardized extracts can be much stronger than traditional use.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "kava",
+    "slug": "kava",
+    "summary": "Kava centers on the root; rhizome.",
+    "description": "Kava centers on the root; rhizome. Key reported compounds include kavain; dihydrokavain; methysticin; dihydromethysticin; yangonin; desmethoxyyangonin; flavokavain A/B/C. Typical preparation forms: Traditional aqueous root beverage; modern standardized root extracts. Kavalactones modulate GABA-A receptors and ion channels, producing anxiolytic and sedative effects without classical benzodiazepine-site binding. Interaction profile: Additive sedation with CNS depressants and alcohol; possible hepatic enzyme interactions. Use caution or avoid in: Liver disease, pregnancy, breastfeeding, concurrent CNS depressants or hepatotoxic drugs.",
+    "mechanisms": [
+      "GABA-A receptor positive modulation",
+      "voltage-gated sodium and calcium channel modulation",
+      "monoamine oxidase-B inhibition",
+      "glutamate/excitatory signaling modulation"
+    ],
+    "safetyNotes": "Not for active/history liver disease, heavy alcohol use, or concurrent hepatotoxic drugs/supplements. Rare serious liver injury has been reported. Additive sedation is possible with benzodiazepines, barbiturates, opioids, sleep aids, alcohol, and other CNS depressants. Avoid driving after use; avoid pregnancy/breastfeeding.",
+    "contraindications": [
+      "Active or previous liver disease",
+      "pregnancy/breastfeeding",
+      "current alcohol misuse",
+      "perioperative sedation risk unless medically supervised."
+    ],
+    "interactions": [
+      "CNS depressants",
+      "alcohol",
+      "benzodiazepines",
+      "opioids",
+      "sleep medicines",
+      "hepatotoxic drugs/supplements",
+      "and possible CYP-mediated interactions."
+    ],
+    "dosage": "",
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 23,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "kuding tea",
+    "slug": "kuding-tea",
+    "summary": "It should be framed as a bitter tea botanical with food-form relevance and modest modern evidence.",
+    "description": "It should be framed as a bitter tea botanical with food-form relevance and modest modern evidence.",
+    "mechanisms": [
+      "antioxidant",
+      "cardiometabolic support"
+    ],
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "kudzu",
+    "slug": "kudzu",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied.",
+    "mechanisms": [
+      "puerarin/daidzin/daidzein isoflavone activity",
+      "aldehyde dehydrogenase modulation",
+      "estrogen-receptor interaction",
+      "antioxidant and vascular signaling"
+    ],
+    "safetyNotes": "Isoflavone-rich preparations may interact with hormone-sensitive conditions and anticoagulant/antiplatelet therapy. Alcohol-use claims should not replace medical care.",
+    "contraindications": [
+      "Pregnancy/breastfeeding caution",
+      "hormone-sensitive cancers or conditions",
+      "and unsupervised alcohol-use disorder treatment."
+    ],
+    "interactions": [
+      "Potential additive effects with anticoagulants/antiplatelets and hormone-active therapies",
+      "caution with diabetes or blood-pressure medications."
+    ],
+    "dosage": "",
+    "preparation": "Evidence is strongest for standardized kudzu root extracts or isolated puerarin/daidzin; do not generalize to all crude preparations.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "lagerstroemia speciosa",
+    "slug": "lagerstroemia-speciosa",
+    "summary": "Lagerstroemia speciosa contains Corosolic acid and is linked here to AMPK activation.",
+    "description": "Lagerstroemia speciosa contains Corosolic acid and is linked here to AMPK activation.",
+    "mechanisms": [
+      "AMPK activation",
+      "GLUT4 translocation modulation",
+      "PPAR activation",
+      "glucose uptake modulation"
+    ],
+    "safetyNotes": "May lower blood glucose; GI upset possible. Use caution with kidney disease until product-specific data are clear.",
+    "contraindications": [
+      "Hypoglycemia risk",
+      "pregnancy/breastfeeding without clinician guidance"
+    ],
+    "interactions": [
+      "May potentiate antidiabetic medications and other glucose-lowering supplements."
+    ],
+    "dosage": "",
+    "preparation": "Leaf extracts standardized to corosolic acid or ellagitannin content; tea use also occurs.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "lavandula angustifolia",
+    "slug": "lavandula-angustifolia",
+    "summary": "Lean bulk ingestion row for Lavandula angustifolia.",
+    "description": "Lean bulk ingestion row for Lavandula angustifolia. Key active compounds include Linalool.",
+    "mechanisms": [
+      "Linalool/linalyl acetate modulate limbic signaling",
+      "voltage-gated calcium-channel activity",
+      "serotonergic tone",
+      "and GABA-A–related anxiolytic pathways."
+    ],
+    "safetyNotes": "May cause sedation, GI upset, lavender burps, or allergy. Avoid non-standard oral essential oil use; caution with CNS depressants, alcohol, driving, and pregnancy.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without guidance",
+      "internal essential-oil use",
+      "prepubertal endocrine concerns with topical overuse are debated"
+    ],
+    "interactions": [
+      "May potentiate sedatives",
+      "sleep medications",
+      "and CNS depressants."
+    ],
+    "dosage": "",
+    "preparation": "Flower tea, aromatherapy, topical diluted essential oil, and oral standardized oil capsules.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "lavender",
+    "slug": "lavender",
+    "summary": "It is best framed around volatile oils with sedation-aware positioning.",
+    "description": "It is best framed around volatile oils with sedation-aware positioning.",
+    "mechanisms": [
+      "Linalool and linalyl acetate influence limbic and serotonergic signaling",
+      "oral Silexan data suggest calcium-channel modulation and GABA-A–related anxiolytic effects."
+    ],
+    "safetyNotes": "May cause sedation, burping, nausea, or allergic reactions. Avoid undiluted oral essential oil. Use caution with CNS depressants, alcohol, driving, and pregnancy.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without guidance",
+      "internal essential-oil use",
+      "prepubertal endocrine concerns with topical overuse are debated"
+    ],
+    "interactions": [
+      "May potentiate sedatives",
+      "sleep medications",
+      "and CNS depressants."
+    ],
+    "dosage": "",
+    "preparation": "Flower tea, aromatherapy, topical diluted essential oil, and oral standardized oil capsules.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "lawsonia inermis",
+    "slug": "lawsonia-inermis",
+    "summary": "Lawsonia inermis contains Lawsone and is linked here to MAPK pathway modulation.",
+    "description": "Lawsonia inermis contains Lawsone and is linked here to MAPK pathway modulation.",
+    "mechanisms": [
+      "MAPK pathway modulation",
+      "NF-κB inhibition"
+    ],
+    "safetyNotes": "Immune-modulating activity is plausible; use caution with autoimmune disease, transplant medicines, or immunosuppressants.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "lemon balm",
+    "slug": "lemon-balm",
+    "summary": "Lemon Balm centers on the leaf; aerial parts.",
+    "description": "Lemon Balm centers on the leaf; aerial parts. Key reported compounds include rosmarinic acid; citral; citronellal; linalool; flavonoids. Typical preparation forms: Leaf extracts, teas, tinctures. GABAergic (GABA transaminase inhibition); mild cholinergic activity. Interaction profile: Sedatives, thyroid medications. Use caution or avoid in: Hypothyroidism (caution).",
+    "mechanisms": [
+      "GABA-transaminase inhibition",
+      "rosmarinic-acid anti-inflammatory signaling",
+      "cholinergic/acetylcholinesterase modulation"
+    ],
+    "safetyNotes": "Sedation possible; caution with CNS depressants, thyroid medication, pregnancy/breastfeeding, and perioperative use.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "thyroid disease/thyroid medication review",
+      "heavy sedation risk"
+    ],
+    "interactions": [
+      "May potentiate sedatives/CNS depressants",
+      "clinician review with thyroid medications."
+    ],
+    "dosage": "",
+    "preparation": "Leaf tea, tincture, glycerite, essential-oil-derived topical products, and standardized extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 14,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "lemon verbena",
+    "slug": "lemon-verbena",
+    "summary": "It is best framed as a gentle aromatic botanical with modest evidence and pleasant tolerability.",
+    "description": "It is best framed as a gentle aromatic botanical with modest evidence and pleasant tolerability.",
+    "mechanisms": [
+      "calming support",
+      "digestive support"
+    ],
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "kidney disease caution at high doses"
+    ],
+    "interactions": [
+      "Low documented interaction burden",
+      "caution with sedatives if used for sleep."
+    ],
+    "dosage": "",
+    "preparation": "Leaf infusion, tincture, aromatic extract, and essential-oil products.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "lemongrass",
+    "slug": "lemongrass",
+    "summary": "It is best framed as an aromatic culinary-medicinal grass with modest clinical depth.",
+    "description": "It is best framed as an aromatic culinary-medicinal grass with modest clinical depth.",
+    "mechanisms": [
+      "digestive support",
+      "calming support",
+      "aromatic support",
+      "TRPA1 modulation",
+      "sensory ion-channel modulation"
+    ],
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "contraindications": [
+      "Pregnancy/breastfeeding supplement dosing without guidance",
+      "internal essential-oil use"
+    ],
+    "interactions": [
+      "Low documented interaction burden",
+      "caution with sedatives or antihypertensives at high doses."
+    ],
+    "dosage": "",
+    "preparation": "Leaf tea, culinary herb, tincture, and essential oil for topical/aromatic use.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "licorice",
+    "slug": "licorice",
+    "summary": "Internal cross-linking supports Licorice through compounds such as glycyrrhizin.",
+    "description": "Internal cross-linking supports Licorice through compounds such as glycyrrhizin.",
+    "mechanisms": [
+      "glycyrrhizin/glycyrrhetinic acid 11β-HSD2 inhibition",
+      "mineralocorticoid-like sodium retention and potassium loss",
+      "HMGB1/NF-κB inflammatory modulation"
+    ],
+    "safetyNotes": "Clinically important risk: hypertension, hypokalemia, edema, arrhythmia, and pseudoaldosteronism, especially with chronic/high-dose glycyrrhizin exposure.",
+    "contraindications": [
+      "Hypertension",
+      "kidney disease",
+      "heart failure",
+      "hypokalemia",
+      "pregnancy",
+      "and use of digoxin or potassium-wasting diuretics unless medically supervised."
+    ],
+    "interactions": [
+      "High-risk with diuretics",
+      "digoxin",
+      "corticosteroids",
+      "antihypertensives",
+      "stimulant laxatives",
+      "and drugs affected by potassium status."
+    ],
+    "dosage": "",
+    "preparation": "Differentiate glycyrrhizin-containing licorice from deglycyrrhizinated licorice (DGL); safety profile differs.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ligusticum chuanxiong",
+    "slug": "ligusticum-chuanxiong",
+    "summary": "Ligusticum chuanxiong lean monograph row enriched in bulk mode.",
+    "description": "Ligusticum chuanxiong lean monograph row enriched in bulk mode.",
+    "mechanisms": [
+      "voltage-gated calcium channel modulation",
+      "NF-κB inhibition",
+      "MAPK pathway modulation",
+      "PI3K/Akt modulation"
+    ],
+    "safetyNotes": "May affect bleeding risk or circulation. Use caution with anticoagulants/antiplatelets and before surgery.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "bleeding disorder or upcoming surgery"
+    ],
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "anticoagulants/antiplatelets",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "lion's mane",
+    "slug": "lion-s-mane",
+    "summary": "NGF stimulation.",
+    "description": "NGF stimulation.",
+    "mechanisms": [
+      "hericenone/erinacine neurotrophic signaling",
+      "NGF-related pathways",
+      "anti-inflammatory and gut-brain-axis modulation"
+    ],
+    "safetyNotes": "GI or allergy reactions possible; caution with mushroom allergy, anticoagulants, pregnancy, and immunomodulating therapy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "lithospermum erythrorhizon",
+    "slug": "lithospermum-erythrorhizon",
+    "summary": "Lithospermum erythrorhizon contains Shikonin and is linked here to PKM2 inhibition.",
+    "description": "Lithospermum erythrorhizon contains Shikonin and is linked here to PKM2 inhibition.",
+    "mechanisms": [
+      "PKM2 inhibition",
+      "NF-κB inhibition",
+      "apoptosis pathway modulation (caspase activation)"
+    ],
+    "safetyNotes": "Immune-modulating activity is plausible; use caution with autoimmune disease, transplant medicines, or immunosuppressants.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "lobelia inflata",
+    "slug": "lobelia-inflata",
+    "summary": "Lobelia inflata contains Lobeline and is linked here to nicotinic acetylcholine receptor modulation.",
+    "description": "Lobelia inflata contains Lobeline and is linked here to nicotinic acetylcholine receptor modulation.",
+    "mechanisms": [
+      "nicotinic acetylcholine receptor modulation",
+      "dopamine transporter modulation"
+    ],
+    "safetyNotes": "Contains lobeline and related alkaloids; nausea, vomiting, dizziness, and cardiopulmonary toxicity are concerns at excess intake.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "seizure disorder or sedative/alcohol use"
+    ],
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "longan",
+    "slug": "longan",
+    "summary": "It should be framed as a food-like fruit botanical with modest modern evidence.",
+    "description": "It should be framed as a food-like fruit botanical with modest modern evidence.",
+    "mechanisms": [
+      "nutritive support",
+      "calming support"
+    ],
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Fruit/berry preparations are commonly used as foods, juices, powders, capsules, or extracts; sugar and extract concentration vary.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "luo han guo",
+    "slug": "luo-han-guo",
+    "summary": "It is best framed as a fruit botanical with sweet mogrosides and soothing traditional use.",
+    "description": "It is best framed as a fruit botanical with sweet mogrosides and soothing traditional use.",
+    "mechanisms": [
+      "throat support",
+      "sweetener-adjacent support"
+    ],
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "antihypertensives/diuretics",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Fruit/berry preparations are commonly used as foods, juices, powders, capsules, or extracts; sugar and extract concentration vary.",
+    "evidenceLevel": "traditional",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "maca",
+    "slug": "maca",
+    "summary": "Maca centers on the root; hypocotyl.",
+    "description": "Maca centers on the root; hypocotyl. Key reported compounds include macamides; macaenes; glucosinolates. Typical preparation forms: Dried root powder, extracts. May influence endocrine signaling and energy metabolism (unclear mechanism). Interaction profile: Limited data. Use caution or avoid in: Hormone-sensitive conditions (caution).",
+    "mechanisms": [
+      "macamide/macaene signaling",
+      "HPA-axis and NO-related sexual-function pathways",
+      "non-estrogenic neuroendocrine modulation"
+    ],
+    "safetyNotes": "Avoid assuming hormone-like replacement; caution in hormone-sensitive conditions and pregnancy due to limited long-term data.",
+    "contraindications": [
+      "Hormone-sensitive conditions without clinician review",
+      "pregnancy/breastfeeding without clinician guidance"
+    ],
+    "interactions": [
+      "Limited interaction data",
+      "review with hormone therapies or fertility treatments."
+    ],
+    "dosage": "",
+    "preparation": "Gelatinized or raw root powder and extracts; color phenotypes may differ.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 15,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "maitake d-fraction",
+    "slug": "maitake-d-fraction",
+    "summary": "It should be framed distinctly from whole maitake because extract-standardization claims can exceed the underlying evidence.",
+    "description": "It should be framed distinctly from whole maitake because extract-standardization claims can exceed the underlying evidence.",
+    "mechanisms": [
+      "beta-glucan/dectin-1 immune signaling",
+      "macrophage and NK-cell cytokine modulation",
+      "NF-κB-mediated immune-response modulation"
+    ],
+    "safetyNotes": "Immune-active mushroom extract; use caution with immunosuppressants, transplant medicines, autoimmune disease, and during active cancer treatment unless clinician-supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "mangifera indica",
+    "slug": "mangifera-indica",
+    "summary": "Mangifera indica contains Mangiferin and is linked here to AMPK activation.",
+    "description": "Mangifera indica contains Mangiferin and is linked here to AMPK activation.",
+    "mechanisms": [
+      "AMPK activation",
+      "Nrf2 activation",
+      "NF-κB inhibition"
+    ],
+    "safetyNotes": "May lower blood glucose or alter metabolic markers; monitor with diabetes medications and avoid unsupervised use during pregnancy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "mangosteen",
+    "slug": "mangosteen",
+    "summary": "It should be framed conservatively because broad anti-inflammatory and disease claims outrun the evidence.",
+    "description": "It should be framed conservatively because broad anti-inflammatory and disease claims outrun the evidence.",
+    "mechanisms": [
+      "antioxidant",
+      "traditional wellness support"
+    ],
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "bleeding disorder/anticoagulant use without review"
+    ],
+    "interactions": [
+      "Theoretical anticoagulant/antiplatelet interactions",
+      "product-specific evidence limited."
+    ],
+    "dosage": "",
+    "preparation": "Pericarp/rind extracts, juice blends, powders; fruit pulp differs from rind extract.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "maral root",
+    "slug": "maral-root",
+    "summary": "It is best framed carefully because ecdysteroid narratives often outpace evidence quality.",
+    "description": "It is best framed carefully because ecdysteroid narratives often outpace evidence quality.",
+    "mechanisms": [
+      "adaptogenic support",
+      "recovery support"
+    ],
+    "safetyNotes": "Limited human safety data; use conservative preparation-specific framing and avoid pregnancy/breastfeeding or medication stacking without clinician review.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "marshmallow",
+    "slug": "marshmallow",
+    "summary": "Internal cross-linking supports Marshmallow through compounds such as pectin.",
+    "description": "Internal cross-linking supports Marshmallow through compounds such as pectin.",
+    "mechanisms": [
+      "mucilage polysaccharide barrier effects",
+      "local soothing demulcent action",
+      "mild anti-inflammatory signaling in mucosal tissues"
+    ],
+    "safetyNotes": "May slow absorption of oral medications if taken together. Use caution with diabetes medications because mucilage/fiber may affect glucose handling.",
+    "contraindications": [
+      "Difficulty swallowing",
+      "severe GI obstruction risk",
+      "and use in infants without supervision."
+    ],
+    "interactions": [
+      "Separate from oral medications by at least 1–2 hours to reduce absorption interference",
+      "monitor with antidiabetic therapy."
+    ],
+    "dosage": "",
+    "preparation": "Cold infusion or mucilage-rich preparations are most aligned with traditional demulcent use.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "matricaria chamomilla",
+    "slug": "matricaria-chamomilla",
+    "summary": "Matricaria chamomilla contains Farnesol and is linked here to PPAR activation.",
+    "description": "Matricaria chamomilla contains Farnesol and is linked here to PPAR activation.",
+    "mechanisms": [
+      "apigenin GABA-A receptor interaction",
+      "flavonoid anti-inflammatory signaling",
+      "smooth-muscle and digestive-spasm modulation"
+    ],
+    "safetyNotes": "Allergy risk with Asteraceae sensitivity; sedation possible; caution with CNS depressants and anticoagulants.",
+    "contraindications": [
+      "Asteraceae/ragweed allergy",
+      "anticoagulant use without clinician review",
+      "pregnancy at medicinal doses without guidance"
+    ],
+    "interactions": [
+      "May potentiate sedatives/CNS depressants and anticoagulants/antiplatelets in susceptible users."
+    ],
+    "dosage": "",
+    "preparation": "Flower infusion, tincture, capsules, steam-distilled essential oil, and topical preparations.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "milk oats",
+    "slug": "milk-oats",
+    "summary": "They are best framed as a gentle traditional tonic rather than a strong acute intervention.",
+    "description": "They are best framed as a gentle traditional tonic rather than a strong acute intervention.",
+    "mechanisms": [
+      "nutritive support",
+      "calming support"
+    ],
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "contraindications": [
+      "Celiac/gluten sensitivity unless certified gluten-free",
+      "pregnancy/breastfeeding supplement use needs review"
+    ],
+    "interactions": [
+      "Low documented interaction burden",
+      "theoretical add-on sedation with CNS depressants."
+    ],
+    "dosage": "",
+    "preparation": "Fresh milky oat tincture is traditional; dried oatstraw infusion is a different preparation.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "milk thistle",
+    "slug": "milk-thistle",
+    "summary": "Milk Thistle centers on the seed; fruit.",
+    "description": "Milk Thistle centers on the seed; fruit. Key reported compounds include silybin A/B; isosilybin A/B; silychristin; silydianin; isosilychristin. Typical preparation forms: Seed/fruit extracts standardized to silymarin. Silymarin flavonolignans exhibit antioxidant, anti-inflammatory and antifibrotic activity relevant to hepatoprotection. Interaction profile: Possible CYP2C9/CYP3A4 interaction risk; may affect warfarin and some other drugs. Use caution or avoid in: Asteraceae allergy; caution in pregnancy/breastfeeding.",
+    "mechanisms": [
+      "silybin/silymarin antioxidant signaling",
+      "Nrf2 activation",
+      "NF-κB inhibition",
+      "hepatic glutathione and membrane-stabilizing effects"
+    ],
+    "safetyNotes": "GI upset/allergy possible; caution with diabetes medications and CYP-metabolized drugs; avoid relying on it as treatment for serious liver disease.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "active liver disease"
+    ],
+    "interactions": [
+      "May affect drug transport and metabolism in susceptible users."
+    ],
+    "dosage": "",
+    "preparation": "Seed extract is more practical than whole seed; standardized silymarin products are common.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 35,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "morinda citrifolia",
+    "slug": "morinda-citrifolia",
+    "summary": "Morinda citrifolia lean monograph row enriched in bulk mode.",
+    "description": "Morinda citrifolia lean monograph row enriched in bulk mode.",
+    "mechanisms": [
+      "NF-κB/COX inflammatory modulation",
+      "Nrf2-related antioxidant signaling",
+      "potassium-rich juice electrolyte effects",
+      "AKT/NF-κB signaling reported in preclinical contexts."
+    ],
+    "safetyNotes": "Noni has case reports of liver injury and can be high in potassium; avoid or use caution with liver disease, kidney disease, ACE inhibitors/ARBs, potassium-sparing diuretics, warfarin-sensitive regimens, pregnancy, and breastfeeding.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "active liver disease"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "moringa",
+    "slug": "moringa",
+    "summary": "It is best framed as a nutrient-dense botanical with mixed translational evidence rather than as a universal superfood cure-all.",
+    "description": "It is best framed as a nutrient-dense botanical with mixed translational evidence rather than as a universal superfood cure-all.",
+    "mechanisms": [
+      "isothiocyanate and glucosinolate Nrf2 activation",
+      "AMPK-related glucose/lipid signaling",
+      "NF-κB modulation",
+      "polyphenol antioxidant pathways"
+    ],
+    "safetyNotes": "Leaf preparations are commonly used as foods; concentrated extracts need caution. Avoid root/bark preparations in pregnancy; monitor if using antidiabetic or antihypertensive medication.",
+    "contraindications": [
+      "Pregnancy/breastfeeding caution for concentrated extracts",
+      "especially non-leaf parts",
+      "hypoglycemia-prone users should monitor."
+    ],
+    "interactions": [
+      "Potential additive effects with antidiabetic and antihypertensive therapies",
+      "theoretical interaction with thyroid-active therapy in high-dose extracts."
+    ],
+    "dosage": "",
+    "preparation": "Human relevance is strongest for leaf powder/extracts; root and bark preparations carry different safety concerns.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 17,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "morus alba",
+    "slug": "morus-alba",
+    "summary": "Morus alba contains Mulberroside A and is linked here to glucose absorption modulation.",
+    "description": "Morus alba contains Mulberroside A and is linked here to glucose absorption modulation.",
+    "mechanisms": [
+      "1-deoxynojirimycin α-glucosidase inhibition",
+      "postprandial glucose modulation",
+      "AMPK and lipid-metabolism effects"
+    ],
+    "safetyNotes": "May potentiate glucose-lowering drugs; GI effects possible; pregnancy safety uncertain.",
+    "contraindications": [
+      "Hypoglycemia risk",
+      "pregnancy/breastfeeding without clinician guidance"
+    ],
+    "interactions": [
+      "May potentiate antidiabetic drugs and other alpha-glucosidase inhibitors",
+      "monitor glucose."
+    ],
+    "dosage": "",
+    "preparation": "Leaf tea, powder, tablets, and extracts standardized to DNJ or flavonoids.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "mucuna",
+    "slug": "mucuna",
+    "summary": "It is best framed around L-DOPA-rich seeds with clear neurologic and stimulation-related caution.",
+    "description": "It is best framed around L-DOPA-rich seeds with clear neurologic and stimulation-related caution.",
+    "mechanisms": [
+      "natural L-DOPA dopaminergic replacement pathway",
+      "antioxidant and mitochondrial support mechanisms"
+    ],
+    "safetyNotes": "Can cause levodopa-like adverse effects; caution with Parkinson’s drugs, MAO inhibitors, psychosis, pregnancy, and cardiovascular disease.",
+    "contraindications": [
+      "Psychosis/bipolar risk",
+      "melanoma history caution",
+      "pregnancy/breastfeeding",
+      "use with levodopa drugs without clinician supervision"
+    ],
+    "interactions": [
+      "May interact with levodopa/carbidopa",
+      "MAOIs",
+      "antipsychotics",
+      "antihypertensives",
+      "and dopaminergic drugs."
+    ],
+    "dosage": "",
+    "preparation": "Seed powder/extract standardized to L-DOPA; product content varies widely.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "mugwort",
+    "slug": "mugwort",
+    "summary": "It is best framed conservatively because strong folklore and ritual associations often outrun clinical evidence.",
+    "description": "It is best framed conservatively because strong folklore and ritual associations often outrun clinical evidence.",
+    "mechanisms": [
+      "digestive support",
+      "traditional cycle support"
+    ],
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "contraindications": [
+      "Pregnancy",
+      "seizure disorder",
+      "Asteraceae allergy",
+      "internal essential-oil use"
+    ],
+    "interactions": [
+      "Caution with anticonvulsants",
+      "sedatives",
+      "and drugs affected by seizure threshold."
+    ],
+    "dosage": "",
+    "preparation": "Leaf tea/tincture, smoke/incense, and essential oil; internal essential oil is not appropriate for casual use.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "muira puama",
+    "slug": "muira-puama",
+    "summary": "It is best framed as a traditional Amazonian botanical with modest modern evidence.",
+    "description": "It is best framed as a traditional Amazonian botanical with modest modern evidence.",
+    "mechanisms": [
+      "traditional vitality support",
+      "stress support"
+    ],
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "mulberry leaf",
+    "slug": "mulberry-leaf",
+    "summary": "It is best framed around alpha-glucosidase-adjacent positioning rather than generalized wellness language.",
+    "description": "It is best framed around alpha-glucosidase-adjacent positioning rather than generalized wellness language.",
+    "mechanisms": [
+      "1-deoxynojirimycin α-glucosidase inhibition",
+      "postprandial glucose modulation",
+      "AMPK and lipid-metabolism effects"
+    ],
+    "safetyNotes": "May potentiate glucose-lowering drugs; GI effects possible; pregnancy safety uncertain.",
+    "contraindications": [
+      "Hypoglycemia risk",
+      "pregnancy/breastfeeding without clinician guidance"
+    ],
+    "interactions": [
+      "May potentiate antidiabetic drugs and other alpha-glucosidase inhibitors",
+      "monitor glucose."
+    ],
+    "dosage": "",
+    "preparation": "Leaf tea, powder, tablets, and extracts standardized to DNJ or flavonoids.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "myristica fragrans",
+    "slug": "myristica-fragrans",
+    "summary": "Myristica fragrans contains Elemicin and is linked here to monoamine oxidase inhibition.",
+    "description": "Myristica fragrans contains Elemicin and is linked here to monoamine oxidase inhibition.",
+    "mechanisms": [
+      "monoamine oxidase inhibition",
+      "TRP channel modulation",
+      "acetylcholinesterase inhibition"
+    ],
+    "safetyNotes": "High-dose nutmeg/myristicin exposure can cause neuropsychiatric and cardiovascular toxicity.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "myrtle",
+    "slug": "myrtle",
+    "summary": "It is best framed as an aromatic Mediterranean leaf botanical with modest modern evidence.",
+    "description": "It is best framed as an aromatic Mediterranean leaf botanical with modest modern evidence.",
+    "mechanisms": [
+      "aromatic support",
+      "antioxidant"
+    ],
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Aromatic herb/spice forms and essential oils differ greatly; essential oils require conservative topical/diluted use and are not interchangeable with teas.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "neem",
+    "slug": "neem",
+    "summary": "It should be framed carefully because topical, oral, and seed-oil contexts differ substantially in safety relevance.",
+    "description": "It should be framed carefully because topical, oral, and seed-oil contexts differ substantially in safety relevance.",
+    "mechanisms": [
+      "traditional skin support",
+      "antimicrobial support"
+    ],
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "contraindications": [
+      "Pregnancy/trying to conceive",
+      "children",
+      "liver disease",
+      "hypoglycemia risk",
+      "breastfeeding without guidance"
+    ],
+    "interactions": [
+      "May potentiate antidiabetics",
+      "immunosuppressants",
+      "and hepatotoxic drugs/supplements."
+    ],
+    "dosage": "",
+    "preparation": "Leaf, bark, seed oil, and topical preparations differ greatly; avoid internal neem oil.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "nelumbo nucifera",
+    "slug": "nelumbo-nucifera",
+    "summary": "Nelumbo nucifera lean monograph row enriched in bulk mode.",
+    "description": "Nelumbo nucifera lean monograph row enriched in bulk mode.",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-κB inhibition"
+    ],
+    "safetyNotes": "May lower blood glucose or alter metabolic markers; monitor with diabetes medications and avoid unsupervised use during pregnancy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "nettle root",
+    "slug": "nettle-root",
+    "summary": "It is best framed distinctly from nettle leaf.",
+    "description": "It is best framed distinctly from nettle leaf.",
+    "mechanisms": [
+      "phytosterol/lignan effects on SHBG/androgen signaling",
+      "prostate inflammatory-pathway modulation"
+    ],
+    "safetyNotes": "May affect diuretics, blood pressure, glucose, and anticoagulant therapy; avoid pregnancy at medicinal doses.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "nicotiana glauca",
+    "slug": "nicotiana-glauca",
+    "summary": "Nicotiana glauca contains Anabasine and is linked here to nicotinic acetylcholine receptor modulation.",
+    "description": "Nicotiana glauca contains Anabasine and is linked here to nicotinic acetylcholine receptor modulation.",
+    "mechanisms": [
+      "Anabasine-mediated nicotinic acetylcholine receptor agonism",
+      "autonomic and neuromuscular toxicity pathways",
+      "ganglionic signaling disruption."
+    ],
+    "safetyNotes": "Toxic plant; ingestion can cause serious poisoning, weakness, respiratory failure, and death. Not appropriate for consumer supplement use; avoid all unsupervised internal use.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "seizure disorder or sedative/alcohol use"
+    ],
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 4,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "nicotiana tabacum",
+    "slug": "nicotiana-tabacum",
+    "summary": "Nicotiana tabacum contains Anatabine and is linked here to nicotinic acetylcholine receptor modulation.",
+    "description": "Nicotiana tabacum contains Anatabine and is linked here to nicotinic acetylcholine receptor modulation.",
+    "mechanisms": [
+      "nicotinic acetylcholine receptor modulation",
+      "NF-κB inhibition",
+      "nicotinic acetylcholine receptor agonism",
+      "dopamine release modulation"
+    ],
+    "safetyNotes": "Nicotine-containing plant; toxic and addictive exposure risk. Not appropriate as a wellness supplement.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "seizure disorder or sedative/alcohol use"
+    ],
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "nigella sativa",
+    "slug": "nigella-sativa",
+    "summary": "Lean bulk ingestion row for Nigella sativa.",
+    "description": "Lean bulk ingestion row for Nigella sativa. Key active compounds include Thymoquinone.",
+    "mechanisms": [
+      "thymoquinone-mediated NF-κB inhibition",
+      "Nrf2/HO-1 activation",
+      "AMPK activation",
+      "PPARγ/adiponectin modulation",
+      "pancreatic beta-cell and insulin-sensitivity effects"
+    ],
+    "safetyNotes": "May reduce glucose, lipids, and blood pressure; monitor with antidiabetics, antihypertensives, anticoagulants, and antiplatelets. GI upset or allergic rash can occur. Avoid high-dose supplementation during pregnancy.",
+    "contraindications": [
+      "Pregnancy at supplemental/high doses",
+      "hypoglycemia-prone patients without monitoring",
+      "known allergy."
+    ],
+    "interactions": [
+      "Antidiabetics",
+      "antihypertensives",
+      "anticoagulants/antiplatelets",
+      "additive metabolic effects."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 18,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "noni",
+    "slug": "noni",
+    "summary": "It should be framed conservatively because broad folk claims exceed the strength of modern evidence.",
+    "description": "It should be framed conservatively because broad folk claims exceed the strength of modern evidence.",
+    "mechanisms": [
+      "traditional wellness support",
+      "antioxidant"
+    ],
+    "safetyNotes": "Immune-active potential; use caution with autoimmune disease, transplant medicines, immunosuppressants, and during active cancer treatment unless clinician-supervised.",
+    "contraindications": [
+      "Liver disease",
+      "kidney disease/hyperkalemia risk",
+      "pregnancy/breastfeeding without guidance"
+    ],
+    "interactions": [
+      "Caution with potassium-sparing diuretics",
+      "ACE inhibitors/ARBs",
+      "anticoagulants",
+      "and hepatotoxic drugs."
+    ],
+    "dosage": "",
+    "preparation": "Fruit juice, puree, powder, and leaf products; fruit and leaf safety differ.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "notoginseng",
+    "slug": "notoginseng",
+    "summary": "It is best framed as a saponin-rich Panax relative with specific vascular-support positioning.",
+    "description": "It is best framed as a saponin-rich Panax relative with specific vascular-support positioning.",
+    "mechanisms": [
+      "vascular support",
+      "recovery support"
+    ],
+    "safetyNotes": "May affect platelet aggregation and bleeding risk; use caution with anticoagulants/antiplatelets, before surgery, and during pregnancy unless supervised.",
+    "contraindications": [
+      "Pregnancy",
+      "anticoagulant/antiplatelet use without clinician review",
+      "upcoming surgery"
+    ],
+    "interactions": [
+      "May interact with anticoagulants",
+      "antiplatelets",
+      "antihypertensives",
+      "and antidiabetics."
+    ],
+    "dosage": "",
+    "preparation": "Root powder, decoction, extracts; saponin-standardized products exist.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "oatstraw",
+    "slug": "oatstraw",
+    "summary": "It is best framed as a gentle nutritive herb with limited high-signal clinical depth.",
+    "description": "It is best framed as a gentle nutritive herb with limited high-signal clinical depth.",
+    "mechanisms": [
+      "nutritive support",
+      "calming support"
+    ],
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "contraindications": [
+      "Celiac disease/gluten sensitivity unless certified gluten-free",
+      "pregnancy/breastfeeding supplement use needs review"
+    ],
+    "interactions": [
+      "Low documented interaction burden",
+      "caution if combined with strong sedatives due to intended calming use."
+    ],
+    "dosage": "",
+    "preparation": "Milky oat tops tincture, oatstraw infusion, and food oat preparations; milky oat and straw differ.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ocimum basilicum",
+    "slug": "ocimum-basilicum",
+    "summary": "Ocimum basilicum contains Methyleugenol and is linked here to TRP channel modulation.",
+    "description": "Ocimum basilicum contains Methyleugenol and is linked here to TRP channel modulation.",
+    "mechanisms": [
+      "Linalool/eugenol-mediated TRP channel and GABA-A-related signaling",
+      "NF-κB inflammatory modulation",
+      "Nrf2 antioxidant signaling",
+      "eugenol-related platelet effects."
+    ],
+    "safetyNotes": "Culinary basil is low risk, but essential oils/extracts differ; caution with anticoagulants/antiplatelets, pregnancy, children, liver disease, and high-methyleugenol concentrated products.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "bleeding disorder or upcoming surgery",
+      "seizure disorder or sedative/alcohol use"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "anticoagulants/antiplatelets",
+      "sedatives/CNS depressants",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "ocimum sanctum",
+    "slug": "ocimum-sanctum",
+    "summary": "Ocimum sanctum contains Ursolic acid and is linked here to AMPK activation.",
+    "description": "Ocimum sanctum contains Ursolic acid and is linked here to AMPK activation.",
+    "mechanisms": [
+      "eugenol/ursolic-acid signaling",
+      "cortisol/stress-axis modulation",
+      "AMPK/glucose and inflammatory-pathway effects"
+    ],
+    "safetyNotes": "May lower glucose and affect clotting; caution with diabetes drugs, anticoagulants, pregnancy, and perioperative use.",
+    "contraindications": [
+      "Pregnancy attempts/pregnancy without clinician guidance",
+      "hypoglycemia risk",
+      "bleeding disorder",
+      "upcoming surgery"
+    ],
+    "interactions": [
+      "May add to antidiabetic",
+      "antihypertensive",
+      "sedative",
+      "anticoagulant",
+      "or antiplatelet effects."
+    ],
+    "dosage": "",
+    "preparation": "Leaf tea, tincture, powder, and standardized extracts; seed preparations are a different data object.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ocotea odorifera",
+    "slug": "ocotea-odorifera",
+    "summary": "Ocotea odorifera contains Safrole and is linked here to TRP channel modulation.",
+    "description": "Ocotea odorifera contains Safrole and is linked here to TRP channel modulation.",
+    "mechanisms": [
+      "TRP channel modulation",
+      "MAPK pathway modulation"
+    ],
+    "safetyNotes": "Safrole-related safety concerns; avoid concentrated internal use and pregnancy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Aromatic herb/spice forms and essential oils differ greatly; essential oils require conservative topical/diluted use and are not interchangeable with teas.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "olea europaea",
+    "slug": "olea-europaea",
+    "summary": "Lean bulk ingestion row for Olea europaea.",
+    "description": "Lean bulk ingestion row for Olea europaea. Key active compounds include Oleuropein; Hydroxytyrosol.",
+    "mechanisms": [
+      "oleuropein/hydroxytyrosol antioxidant signaling",
+      "ACE/endothelial nitric oxide modulation",
+      "lipid and blood-pressure pathway effects"
+    ],
+    "safetyNotes": "May lower blood pressure/glucose; monitor with antihypertensive or antidiabetic therapy; GI effects possible.",
+    "contraindications": [
+      "Hypotension",
+      "hypoglycemia risk",
+      "pregnancy/breastfeeding without guidance"
+    ],
+    "interactions": [
+      "May potentiate antihypertensives and antidiabetics",
+      "caution with anticoagulants if product has vascular effects."
+    ],
+    "dosage": "",
+    "preparation": "Leaf tea, powder, and oleuropein-standardized extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 18,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "olive leaf",
+    "slug": "olive-leaf",
+    "summary": "Bulk-ingested support row carrying Oleuropein with pathway-level mechanism coverage.",
+    "description": "Bulk-ingested support row carrying Oleuropein with pathway-level mechanism coverage.",
+    "mechanisms": [
+      "oleuropein/hydroxytyrosol antioxidant signaling",
+      "ACE/endothelial nitric oxide modulation",
+      "lipid and blood-pressure pathway effects"
+    ],
+    "safetyNotes": "May lower blood pressure/glucose; monitor with antihypertensive or antidiabetic therapy; GI effects possible.",
+    "contraindications": [
+      "Hypotension",
+      "hypoglycemia risk",
+      "pregnancy/breastfeeding without guidance"
+    ],
+    "interactions": [
+      "May potentiate antihypertensives and antidiabetics",
+      "caution with anticoagulants if product has vascular effects."
+    ],
+    "dosage": "",
+    "preparation": "Leaf tea, powder, and oleuropein-standardized extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "ophiopogon",
+    "slug": "ophiopogon",
+    "summary": "It is best framed as a moistening tonic-style root with traditional-system relevance.",
+    "description": "It is best framed as a moistening tonic-style root with traditional-system relevance.",
+    "mechanisms": [
+      "demulcent support",
+      "traditional respiratory support"
+    ],
+    "safetyNotes": "Mucilage-rich preparations may slow absorption of oral medicines; separate from medications when practical. Use caution with diabetes medicines if metabolic effects are suspected.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "orange peel",
+    "slug": "orange-peel",
+    "summary": "Bulk-ingested support row carrying Hesperidin with pathway-level mechanism coverage.",
+    "description": "Bulk-ingested support row carrying Hesperidin with pathway-level mechanism coverage.",
+    "mechanisms": [
+      "AMPK activation",
+      "PI3K/Akt modulation",
+      "NF-κB inhibition"
+    ],
+    "safetyNotes": "Generally food-like; essential oil can irritate skin and photosensitivity is possible with some citrus oils.",
+    "contraindications": [
+      "Citrus allergy",
+      "internal essential-oil use without supervision"
+    ],
+    "interactions": [
+      "Lower interaction burden than grapefruit",
+      "but review with CYP-sensitive drugs if concentrated extracts are used."
+    ],
+    "dosage": "",
+    "preparation": "Dried peel tea/decoction, tincture, zest, and essential oil; bitter orange/sweet orange differ.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "oregano",
+    "slug": "oregano",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied.",
+    "mechanisms": [
+      "antimicrobial",
+      "digestive support",
+      "respiratory support",
+      "TRPA1 activation",
+      "membrane disruption",
+      "GABA-A modulation"
+    ],
+    "safetyNotes": "Culinary use is generally low-risk; oregano oil/high-thymol or carvacrol extracts can irritate GI mucosa and skin.",
+    "contraindications": [
+      "Pregnancy/breastfeeding for medicinal-dose essential oil",
+      "Lamiaceae allergy",
+      "active GI ulcer/irritation for concentrated extracts."
+    ],
+    "interactions": [
+      "Potential additive irritation with essential oils",
+      "theoretical bleeding or glucose interaction concerns at high supplemental doses."
+    ],
+    "dosage": "",
+    "preparation": "Leaf is used as food, tea, capsules, and tincture; oregano oil should be treated as a concentrated product, not a food-dose herb.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 13,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "paeonia lactiflora",
+    "slug": "paeonia-lactiflora",
+    "summary": "Paeonia lactiflora contains Paeoniflorin and is linked here to PI3K/Akt modulation.",
+    "description": "Paeonia lactiflora contains Paeoniflorin and is linked here to PI3K/Akt modulation.",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "NF-κB inhibition",
+      "MAPK pathway modulation",
+      "monoamine reuptake inhibition"
+    ],
+    "safetyNotes": "May affect coagulation or immune signaling; use caution around anticoagulation.",
+    "contraindications": [
+      "Pregnancy without clinician guidance",
+      "anticoagulant use without review"
+    ],
+    "interactions": [
+      "Potential additive bleeding risk with anticoagulants/antiplatelets",
+      "may interact with immunomodulators."
+    ],
+    "dosage": "",
+    "preparation": "Root decoction/extract; often paired with licorice or other TCM herbs.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "paeonia suffruticosa",
+    "slug": "paeonia-suffruticosa",
+    "summary": "Paeonia suffruticosa contains Paeonol and is linked here to NF-κB inhibition.",
+    "description": "Paeonia suffruticosa contains Paeonol and is linked here to NF-κB inhibition.",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "Nrf2 activation"
+    ],
+    "safetyNotes": "Immune-modulating activity is plausible; use caution with autoimmune disease, transplant medicines, or immunosuppressants.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "hormone-sensitive conditions without clinician review"
+    ],
+    "interactions": [
+      "Potential interaction concern with hormonal therapies",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "panax ginseng",
+    "slug": "panax-ginseng",
+    "summary": "Panax ginseng lean herb row for high-speed phytochemical ingestion.",
+    "description": "Panax ginseng lean herb row for high-speed phytochemical ingestion.",
+    "mechanisms": [
+      "Ginsenosides modulate AMPK and PI3K/Akt signaling",
+      "nitric-oxide/endothelial pathways",
+      "HPA-axis stress signaling",
+      "and glucose uptake/insulin-sensitivity pathways."
+    ],
+    "safetyNotes": "May cause insomnia, headache, blood pressure changes, or hypoglycemia. Use caution with antidiabetic drugs, anticoagulants/antiplatelets, stimulants, and hormone-sensitive conditions.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 29,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "papaya leaf",
+    "slug": "papaya-leaf",
+    "summary": "Internal cross-linking supports Papaya Leaf through compounds such as carpaine, papain, benzyl isothiocyanate.",
+    "description": "Internal cross-linking supports Papaya Leaf through compounds such as carpaine, papain, benzyl isothiocyanate.",
+    "mechanisms": [
+      "papain/chymopapain proteolytic enzymes",
+      "platelet-support signaling reported in dengue studies",
+      "flavonoid antioxidant signaling",
+      "inflammatory-pathway modulation"
+    ],
+    "safetyNotes": "Claims are dengue/thrombocytopenia-adjunct specific and should not replace medical care. Latex allergy and pregnancy caution are important; monitor bleeding/platelet contexts clinically.",
+    "contraindications": [
+      "Pregnancy",
+      "papaya/latex allergy",
+      "severe dengue without medical care",
+      "and use with anticoagulants/antiplatelets without supervision."
+    ],
+    "interactions": [
+      "Potential additive effects with anticoagulant/antiplatelet therapy",
+      "theoretical interaction with diabetes medications."
+    ],
+    "dosage": "",
+    "preparation": "Evidence is strongest for standardized Carica papaya leaf extract/juice in dengue-associated thrombocytopenia studies.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "parsley",
+    "slug": "parsley",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied.",
+    "mechanisms": [
+      "Apigenin/flavone-mediated GABA-A modulation",
+      "Nrf2 antioxidant signaling",
+      "PI3K/Akt signaling",
+      "apiol/myristicin activity in concentrated preparations."
+    ],
+    "safetyNotes": "Culinary use is usually low risk, but high-dose extracts/essential oil may be unsafe; avoid concentrated use in pregnancy, kidney disease, and with anticoagulants/warfarin-sensitive vitamin K management unless supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "significant kidney disease or unstable electrolytes",
+      "seizure disorder or sedative/alcohol use"
+    ],
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "passionflower",
+    "slug": "passionflower",
+    "summary": "EMA supports passionflower for relief of mild mental stress and to aid sleep on the basis of long-standing traditional use.",
+    "description": "EMA supports passionflower for relief of mild mental stress and to aid sleep on the basis of long-standing traditional use. That is useful, but it is weaker than strong modern clinical efficacy. Keep the positioning around traditional calming use and avoid overclaiming a clean single-target GABA story.",
+    "mechanisms": [
+      "GABAergic signaling modulation",
+      "harman alkaloid and flavonoid CNS effects",
+      "anxiolytic receptor-pathway activity"
+    ],
+    "safetyNotes": "Sedation possible; avoid combining with alcohol, benzodiazepines, opioids, or other CNS depressants; avoid pregnancy.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "heavy sedative use"
+    ],
+    "interactions": [
+      "May potentiate benzodiazepines",
+      "sleep aids",
+      "opioids",
+      "alcohol",
+      "and other CNS depressants."
+    ],
+    "dosage": "",
+    "preparation": "Aerial-part tea, tincture, capsules, and standardized extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "pastinaca sativa",
+    "slug": "pastinaca-sativa",
+    "summary": "Pastinaca sativa lean monograph row enriched in bulk mode.",
+    "description": "Pastinaca sativa lean monograph row enriched in bulk mode.",
+    "mechanisms": [
+      "MAPK pathway modulation",
+      "PDE inhibition"
+    ],
+    "safetyNotes": "May affect bleeding risk or circulation. Use caution with anticoagulants/antiplatelets and before surgery.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "bleeding disorder or upcoming surgery"
+    ],
+    "interactions": [
+      "Potential interaction concern with anticoagulants/antiplatelets",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "pau d'arco",
+    "slug": "pau-d-arco",
+    "summary": "It should be framed conservatively because popular claims often exceed the evidence and preparation differences matter.",
+    "description": "It should be framed conservatively because popular claims often exceed the evidence and preparation differences matter.",
+    "mechanisms": [
+      "traditional immune support",
+      "antimicrobial support"
+    ],
+    "safetyNotes": "Use conservatively; concentrated use may be irritating.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "peppermint",
+    "slug": "peppermint",
+    "summary": "Peppermint centers on the unspecified.",
+    "description": "Peppermint centers on the unspecified. Key reported compounds include l‐menthol; l‐menthone; isomenthone; menthyl acetate; 1,8‐cineole (eucalyptol); menthofuran; limonene. Typical preparation forms: Leaves and flowering tops are used fresh or dried to make teas and flavourings. Medicinal products include enteric‐coated capsules of peppermint oil and topical preparations. Peppermint oil contains more than 80 constituents; menthol is the main bioactive component. Menthol acts as a smooth‐muscle relaxant by blocking L‐type calcium channels and activating transient receptor potential channels (TRPM8 and TRPA1). These actions underlie the spasmolytic and analgesic properties of peppermint oil. Peppermint oil also has antimicrobial, antiviral and anti‐inflammatory effects【271856535371736†L224-L289】【271856535371736†L312-L333】. Interaction profile: Peppermint oil may inhibit cytochrome P450 enzymes (e.g., CYP2A6 and UGT2B7) and could theoretically interact with drugs metabolised by these pathways. Use caution or avoid in: Avoid in infants and young children, and in people with gastro‐oesophageal reflux disease or bile duct obstruction. Use cautiously in those taking hepatotoxic drugs due to potential pulegone/menthofuran toxicity.",
+    "mechanisms": [
+      "intestinal smooth-muscle calcium-channel blockade",
+      "TRPM8 receptor activation",
+      "visceral antinociception",
+      "carminative effects",
+      "antimicrobial effects in vitro"
+    ],
+    "safetyNotes": "Use enteric-coated peppermint oil for IBS claims. May worsen GERD/reflux and cause heartburn. Avoid peppermint oil in infants and young children. Caution with biliary obstruction, gallbladder disease, and hiatal hernia.",
+    "contraindications": [
+      "Poorly controlled GERD/hiatal hernia",
+      "biliary obstruction",
+      "infants/young children for peppermint oil",
+      "known peppermint allergy."
+    ],
+    "interactions": [
+      "Potential additive GI irritation",
+      "concentrated oil may have CYP3A4/P-gp considerations",
+      "but clinical impact is uncertain."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 14,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "perilla",
+    "slug": "perilla",
+    "summary": "It is best framed as a culinary-medicinal herb with modest but relevant translational evidence.",
+    "description": "It is best framed as a culinary-medicinal herb with modest but relevant translational evidence.",
+    "mechanisms": [
+      "seasonal support",
+      "antioxidant",
+      "aromatic support"
+    ],
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "contraindications": [
+      "Pregnancy/breastfeeding supplement use without guidance",
+      "anticoagulant use without review"
+    ],
+    "interactions": [
+      "May add to anticoagulant/antiplatelet effects",
+      "limited clinical data."
+    ],
+    "dosage": "",
+    "preparation": "Leaf tea/culinary use, seed oil, extracts standardized to rosmarinic acid or ALA.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "phellodendron",
+    "slug": "phellodendron",
+    "summary": "Internal cross-linking supports Phellodendron through compounds such as berberine, jatrorrhizine, palmatine.",
+    "description": "Internal cross-linking supports Phellodendron through compounds such as berberine, jatrorrhizine, palmatine.",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-kB pathway inhibition",
+      "mitochondrial complex I inhibition"
+    ],
+    "safetyNotes": "Berberine-containing bark; avoid in pregnancy/breastfeeding and infants. Caution with antidiabetic drugs, anticoagulants, CYP/P-gp substrates, and bilirubin-risk contexts.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "CYP/P-gp substrate medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "phellodendron amurense",
+    "slug": "phellodendron-amurense",
+    "summary": "Phellodendron amurense lean herb row for high-speed phytochemical ingestion.",
+    "description": "Phellodendron amurense lean herb row for high-speed phytochemical ingestion.",
+    "mechanisms": [
+      "AMPK activation",
+      "NF-κB inhibition",
+      "PI3K/Akt modulation",
+      "MAPK pathway modulation"
+    ],
+    "safetyNotes": "May affect glucose, blood pressure, CYP/P-gp drug handling, and GI tolerance. Avoid pregnancy/breastfeeding unless clinician-directed.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "CYP/P-gp substrate medicines",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "piper longum",
+    "slug": "piper-longum",
+    "summary": "Minimum source-backed intake for Piper longum.",
+    "description": "Minimum source-backed intake for Piper longum. Active compound support includes piperine and the herb is used here only to complete the bioavailability modulation cluster. Chavicine support added to mirror the existing pepper isomer pattern in this cluster.",
+    "mechanisms": [
+      "piperine/piperlongumine modulation of CYP/P-gp pathways",
+      "TRPV1 sensory signaling",
+      "NF-κB and oxidative-stress signaling"
+    ],
+    "safetyNotes": "Concentrated extracts may alter drug exposure and irritate GI mucosa. Distinguish traditional culinary/low-dose use from high-piperine formulations.",
+    "contraindications": [
+      "Pregnancy/breastfeeding caution",
+      "significant reflux/ulcer disease",
+      "and prescription polypharmacy without supervision."
+    ],
+    "interactions": [
+      "Potential interactions with CYP/P-gp substrates",
+      "anticoagulants",
+      "antiepileptics",
+      "immunosuppressants",
+      "and other high-bioavailability supplement blends."
+    ],
+    "dosage": "",
+    "preparation": "Evidence is strongest for piperine-containing extracts rather than all long-pepper preparations.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 11,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "piper methysticum",
+    "slug": "piper-methysticum",
+    "summary": "Piper methysticum contains Kavalactones and is linked here to GABA-A modulation.",
+    "description": "Piper methysticum contains Kavalactones and is linked here to GABA-A modulation.",
+    "mechanisms": [
+      "GABA-A receptor modulation",
+      "kavalactone effects on voltage-gated ion channels",
+      "MAO-B and glutamate-pathway modulation"
+    ],
+    "safetyNotes": "Liver injury risk; avoid liver disease, alcohol, hepatotoxic drugs, and CNS depressants; avoid pregnancy/breastfeeding.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "active liver disease",
+      "seizure disorder or sedative/alcohol use"
+    ],
+    "interactions": [
+      "Potential interaction concern with sedatives/CNS depressants",
+      "CYP/P-gp substrate medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "piper nigrum",
+    "slug": "piper-nigrum",
+    "summary": "Piper nigrum contains Beta-caryophyllene and is linked here to CB2 receptor agonism.",
+    "description": "Piper nigrum contains Beta-caryophyllene and is linked here to CB2 receptor agonism.",
+    "mechanisms": [
+      "piperine modulation of CYP3A4/CYP2C9/CYP2D6 and P-gp",
+      "UGT/glucuronidation effects",
+      "TRPV1 signaling",
+      "inflammatory-pathway modulation"
+    ],
+    "safetyNotes": "Food use is low-risk; high-piperine extracts may alter exposure to prescription drugs or other supplements.",
+    "contraindications": [
+      "Prescription polypharmacy",
+      "pregnancy/breastfeeding supplement use",
+      "significant reflux/ulcer disease",
+      "and perioperative anticoagulant use."
+    ],
+    "interactions": [
+      "Potentially increases exposure of CYP/P-gp substrates and bioavailability-enhanced botanicals such as curcumin."
+    ],
+    "dosage": "",
+    "preparation": "Culinary black pepper differs from standardized piperine extracts used in studies.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "plantago lanceolata",
+    "slug": "plantago-lanceolata",
+    "summary": "Plantago lanceolata contains Verbascoside and is linked here to NF-κB inhibition.",
+    "description": "Plantago lanceolata contains Verbascoside and is linked here to NF-κB inhibition.",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "safetyNotes": "Immune-modulating activity is plausible; use caution with autoimmune disease, transplant medicines, or immunosuppressants.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "plantago major",
+    "slug": "plantago-major",
+    "summary": "Plantago major contains Aucubin and is linked here to NF-κB inhibition.",
+    "description": "Plantago major contains Aucubin and is linked here to NF-κB inhibition.",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "safetyNotes": "Immune-modulating activity is plausible; use caution with autoimmune disease, transplant medicines, or immunosuppressants.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "plumbago zeylanica",
+    "slug": "plumbago-zeylanica",
+    "summary": "Plumbago zeylanica contains Plumbagin and is linked here to NF-κB inhibition.",
+    "description": "Plumbago zeylanica contains Plumbagin and is linked here to NF-κB inhibition.",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "STAT3 inhibition",
+      "ROS-mediated signaling modulation"
+    ],
+    "safetyNotes": "Irritant naphthoquinones may damage mucosa/skin at high exposure. Avoid pregnancy and internal high-dose use.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "polygala",
+    "slug": "polygala",
+    "summary": "It is best framed as a traditional nootropic-style root with limited modern clinical depth.",
+    "description": "It is best framed as a traditional nootropic-style root with limited modern clinical depth.",
+    "mechanisms": [
+      "traditional cognitive support",
+      "calming support"
+    ],
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without guidance",
+      "gastritis/ulcer sensitivity"
+    ],
+    "interactions": [
+      "Potential additive sedation or cognitive-drug interactions",
+      "limited clinical data."
+    ],
+    "dosage": "",
+    "preparation": "Processed root decoction/extract; raw high-dose use may be irritating.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "pomegranate",
+    "slug": "pomegranate",
+    "summary": "It is best framed as a polyphenol-rich fruit botanical with food-form relevance and moderate evidence.",
+    "description": "It is best framed as a polyphenol-rich fruit botanical with food-form relevance and moderate evidence.",
+    "mechanisms": [
+      "vascular support",
+      "antioxidant",
+      "Nrf2 activation",
+      "NF-κB inhibition",
+      "MAPK pathway modulation",
+      "ellagitannin-mediated antioxidant signaling"
+    ],
+    "safetyNotes": "May affect circulation, blood pressure, or platelet function; use caution with anticoagulants/antiplatelets, antihypertensives, heart medications, and before surgery.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Polyphenol-rich extracts may alter drug metabolism in some contexts."
+    ],
+    "dosage": "",
+    "preparation": "Juice and rind extracts differ substantially in tannin density.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 18,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "poria",
+    "slug": "poria",
+    "summary": "It is best framed as a traditional medicinal fungus with modest modern clinical depth.",
+    "description": "It is best framed as a traditional medicinal fungus with modest modern clinical depth.",
+    "mechanisms": [
+      "traditional fluid-balance support",
+      "calming support"
+    ],
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "significant kidney disease or unstable electrolytes"
+    ],
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "sedatives/CNS depressants",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "psoralea corylifolia",
+    "slug": "psoralea-corylifolia",
+    "summary": "Psoralea corylifolia lean monograph row enriched in bulk mode.",
+    "description": "Psoralea corylifolia lean monograph row enriched in bulk mode.",
+    "mechanisms": [
+      "psoralen/isopsoralen furanocoumarin photosensitization",
+      "estrogenic signaling",
+      "CYP interaction potential",
+      "oxidative-stress and inflammatory-pathway modulation"
+    ],
+    "safetyNotes": "High caution: photosensitivity, burns, hepatotoxicity reports, and interaction risks. Avoid unsupervised internal use or UV exposure after use.",
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "liver disease",
+      "photosensitivity disorders",
+      "melanoma/skin-cancer risk",
+      "and concurrent phototherapy unless supervised."
+    ],
+    "interactions": [
+      "Avoid with photosensitizing drugs",
+      "hepatotoxic drugs",
+      "anticoagulants",
+      "and hormone-active therapies unless supervised."
+    ],
+    "dosage": "",
+    "preparation": "Therapeutic use requires controlled dosing and light-exposure management; crude supplements are not interchangeable with monitored phototherapy.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "psyllium",
+    "slug": "psyllium",
+    "summary": "Psyllium is not a classic phytochemical-heavy herb; its value comes from gel-forming husk fiber.",
+    "description": "Psyllium is not a classic phytochemical-heavy herb; its value comes from gel-forming husk fiber. That makes it more of a functional-fiber tool than a general botanical tonic. Position it around bowel regularity, stool softening, and cautious cardiometabolic support.",
+    "mechanisms": [
+      "Gel-forming soluble fiber increases intestinal viscosity",
+      "binds bile acids and increases fecal bile-acid loss",
+      "slows gastric emptying and carbohydrate absorption",
+      "supports SCFA-mediated gut effects."
+    ],
+    "safetyNotes": "Must be taken with plenty of water; choking or bowel obstruction risk in dysphagia/strictures. Separate from oral medications by 2–4 hours. May cause bloating or gas.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Seed/fiber preparations are commonly used as whole seed, powder, capsules, or food ingredients; fluid intake and preparation form matter.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 13,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "pueraria lobata",
+    "slug": "pueraria-lobata",
+    "summary": "Pueraria lobata contains Puerarin and is linked here to PI3K/Akt modulation.",
+    "description": "Pueraria lobata contains Puerarin and is linked here to PI3K/Akt modulation.",
+    "mechanisms": [
+      "Puerarin-mediated PI3K/Akt/eNOS signaling",
+      "AMPK activation",
+      "estrogen receptor modulation",
+      "intestinal glucose transport/glucose absorption effects."
+    ],
+    "safetyNotes": "Caution with hormone-sensitive conditions, estrogenic therapies, anticoagulants/antiplatelets, antihypertensives, diabetes medications, pregnancy, and breastfeeding.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "hormone-sensitive conditions without clinician review"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "hormonal therapies",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "pueraria mirifica",
+    "slug": "pueraria-mirifica",
+    "summary": "It is best framed very cautiously due to potent estrogenic positioning.",
+    "description": "It is best framed very cautiously due to potent estrogenic positioning.",
+    "mechanisms": [
+      "Miroestrol/deoxymiroestrol phytoestrogen activity",
+      "estrogen receptor modulation",
+      "isoflavone-related endocrine signaling."
+    ],
+    "safetyNotes": "Avoid or use clinician supervision in pregnancy, breastfeeding, hormone-sensitive cancers/conditions, unexplained vaginal bleeding, or concurrent estrogen/SERM/endocrine therapy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "hormone-sensitive conditions without clinician review"
+    ],
+    "interactions": [
+      "Potential interaction concern with hormonal therapies",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "punarnava",
+    "slug": "punarnava",
+    "summary": "Internal cross-linking supports Punarnava through compounds such as punarnavine.",
+    "description": "Internal cross-linking supports Punarnava through compounds such as punarnavine.",
+    "mechanisms": [
+      "kidney support",
+      "diuretic support",
+      "anti-inflammatory"
+    ],
+    "safetyNotes": "May affect fluid balance or urinary tract irritation; use caution with kidney disease, diuretics, lithium, pregnancy, and dehydration risk.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "significant kidney disease or unstable electrolytes"
+    ],
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "raspberry leaf",
+    "slug": "raspberry-leaf",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied.",
+    "mechanisms": [
+      "Uterine smooth-muscle tone modulation",
+      "calcium-channel/oxytocin-related uterine signaling uncertainty",
+      "tannin/polyphenol NF-κB and Nrf2 modulation."
+    ],
+    "safetyNotes": "Use during pregnancy only with obstetric supervision; avoid in high-risk pregnancy, preterm labor risk, prior uterine surgery concerns, bleeding disorders, or concurrent uterotonic/labor-inducing agents unless directed by a clinician.",
+    "contraindications": [
+      "High-risk pregnancy",
+      "early pregnancy without clinician guidance",
+      "history of preterm labor"
+    ],
+    "interactions": [
+      "Limited interaction data",
+      "caution with uterotonic agents or sedatives if blended products."
+    ],
+    "dosage": "",
+    "preparation": "Leaf tea/infusion, tablets, tincture; fruit is a separate food entry.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "red clover",
+    "slug": "red-clover",
+    "summary": "It should be framed conservatively because endocrine-adjacent claims outrun the evidence in many product contexts.",
+    "description": "It should be framed conservatively because endocrine-adjacent claims outrun the evidence in many product contexts.",
+    "mechanisms": [
+      "isoflavone phytoestrogen signaling via estrogen receptors",
+      "lipid-metabolism modulation",
+      "antioxidant signaling"
+    ],
+    "safetyNotes": "Avoid/caution in estrogen-sensitive cancers or hormone therapy contexts; possible anticoagulant interaction concerns.",
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "hormone-sensitive cancer/condition without clinician review",
+      "anticoagulant use"
+    ],
+    "interactions": [
+      "May interact with hormone therapies and anticoagulants/antiplatelets."
+    ],
+    "dosage": "",
+    "preparation": "Flowering tops as tea, tincture, or isoflavone-standardized extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 13,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "rehmannia glutinosa",
+    "slug": "rehmannia-glutinosa",
+    "summary": "Rehmannia glutinosa contains Catalpol and is linked here to PI3K/Akt modulation.",
+    "description": "Rehmannia glutinosa contains Catalpol and is linked here to PI3K/Akt modulation.",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "AMPK activation"
+    ],
+    "safetyNotes": "May lower blood glucose or alter metabolic markers; monitor with diabetes medications and avoid unsupervised use during pregnancy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "active liver disease",
+      "significant kidney disease or unstable electrolytes"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "rehmannia prepared",
+    "slug": "rehmannia-prepared",
+    "summary": "It should be framed distinctly from raw rehmannia because processed-form use-cases differ materially.",
+    "description": "It should be framed distinctly from raw rehmannia because processed-form use-cases differ materially.",
+    "mechanisms": [
+      "traditional restorative support"
+    ],
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "active liver disease",
+      "significant kidney disease or unstable electrolytes"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "reishi",
+    "slug": "reishi",
+    "summary": "Immune modulation.",
+    "description": "Immune modulation.",
+    "mechanisms": [
+      "β-glucan immune modulation",
+      "triterpene effects on inflammatory signaling",
+      "antioxidant pathways"
+    ],
+    "safetyNotes": "GI upset, dizziness, rash possible; caution with anticoagulants/antiplatelets, immunosuppressants, and perioperative use.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with sedatives/CNS depressants",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "rheum palmatum",
+    "slug": "rheum-palmatum",
+    "summary": "Lean bulk ingestion row for Rheum palmatum.",
+    "description": "Lean bulk ingestion row for Rheum palmatum. Key active compounds include Emodin; Rhein.",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation",
+      "PI3K/Akt modulation"
+    ],
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "rhodiola",
+    "slug": "rhodiola",
+    "summary": "Adaptogenic stress modulation.",
+    "description": "Adaptogenic stress modulation.",
+    "mechanisms": [
+      "adaptogen",
+      "fatigue resistance",
+      "cognitive support"
+    ],
+    "safetyNotes": "Limited human safety data; use conservative preparation-specific framing and avoid pregnancy/breastfeeding or medication stacking without clinician review.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "rhodiola rosea",
+    "slug": "rhodiola-rosea",
+    "summary": "Rhodiola rosea contains Rosavin and is linked here to AMPK activation.",
+    "description": "Rhodiola rosea contains Rosavin and is linked here to AMPK activation.",
+    "mechanisms": [
+      "HPA-axis stress-response modulation",
+      "salidroside/rosavin-related AMPK activation",
+      "monoamine oxidase modulation",
+      "beta-endorphin/stress-mediator modulation",
+      "Nrf2 antioxidant signaling",
+      "mitochondrial stress-response signaling"
+    ],
+    "safetyNotes": "Can cause insomnia, agitation, dizziness, or dry mouth; avoid late-day dosing. Caution with bipolar disorder/mania history, stimulants, antidepressants/MAOIs, sedatives, pregnancy, and breastfeeding. Product adulteration and inconsistent salidroside/rosavin standardization are important quality risks.",
+    "contraindications": [
+      "Bipolar disorder or mania history without clinician supervision",
+      "pregnancy/breastfeeding",
+      "known allergy."
+    ],
+    "interactions": [
+      "Potential additive effects with stimulants",
+      "antidepressants/MAOIs",
+      "anxiolytics/sedatives",
+      "and therapies affecting blood pressure or glucose."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 40,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "rice bran",
+    "slug": "rice-bran",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied.",
+    "mechanisms": [
+      "γ-oryzanol and phytosterol effects on cholesterol absorption",
+      "bile-acid excretion and lipid metabolism modulation",
+      "AMPK/PPAR metabolic signaling",
+      "Nrf2 antioxidant response",
+      "dietary fiber/prebiotic effects."
+    ],
+    "safetyNotes": "Usually food-derived, but bran products can cause GI effects and may carry contaminant concerns if poorly sourced; use caution with diabetes medications, lipid-lowering therapy, grain allergy, and products lacking contaminant/heavy-metal quality controls.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "rooibos",
+    "slug": "rooibos",
+    "summary": "It is best framed as a mild tea herb with low-intensity wellness positioning.",
+    "description": "It is best framed as a mild tea herb with low-intensity wellness positioning.",
+    "mechanisms": [
+      "antioxidant support",
+      "soothing support",
+      "AMPK activation",
+      "Nrf2 activation"
+    ],
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 10,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "rose hips",
+    "slug": "rose-hips",
+    "summary": "They are best framed as polyphenol- and vitamin-rich fruit material with modest but relevant human evidence.",
+    "description": "They are best framed as polyphenol- and vitamin-rich fruit material with modest but relevant human evidence.",
+    "mechanisms": [
+      "galactolipid/GOPO anti-inflammatory signaling",
+      "COX/LOX and cartilage inflammatory mediator modulation"
+    ],
+    "safetyNotes": "GI effects possible; caution with anticoagulants/antiplatelets and kidney-stone risk in susceptible users.",
+    "contraindications": [
+      "Kidney stone risk",
+      "iron overload disorders with high vitamin C intake",
+      "pregnancy/breastfeeding supplement review"
+    ],
+    "interactions": [
+      "May affect iron absorption",
+      "caution with anticoagulants if high-dose vitamin C/polyphenol products."
+    ],
+    "dosage": "",
+    "preparation": "Fruit/hip tea, powder, extracts, syrups; seed oil is a separate topical product.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "roselle seed",
+    "slug": "roselle-seed",
+    "summary": "It should be framed distinctly from hibiscus calyx because seed and calyx use-cases differ.",
+    "description": "It should be framed distinctly from hibiscus calyx because seed and calyx use-cases differ.",
+    "mechanisms": [
+      "nutritive support",
+      "antioxidant"
+    ],
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Seed/fiber preparations are commonly used as whole seed, powder, capsules, or food ingredients; fluid intake and preparation form matter.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "rosemary",
+    "slug": "rosemary",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied. Lean bulk enrichment added: Carnosic acid.",
+    "mechanisms": [
+      "cognition",
+      "antioxidant",
+      "digestive support",
+      "Nrf2 activation",
+      "NF-κB inhibition",
+      "STAT3 inhibition",
+      "AMPK activation",
+      "PI3K/Akt modulation"
+    ],
+    "safetyNotes": "Generally well tolerated; review concentrated extract use.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Caution with concentrated extracts alongside anticoagulants."
+    ],
+    "dosage": "",
+    "preparation": "Leaf infusion for mild use; extracts provide higher diterpene exposure.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 27,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "saffron",
+    "slug": "saffron",
+    "summary": "Internal cross-linking supports Saffron through compounds such as picrocrocin, crocin, safranal.",
+    "description": "Internal cross-linking supports Saffron through compounds such as picrocrocin, crocin, safranal.",
+    "mechanisms": [
+      "crocin/crocetin antioxidant signaling",
+      "serotonergic and dopaminergic modulation",
+      "HPA-axis and inflammatory-pathway effects"
+    ],
+    "safetyNotes": "High doses may cause GI/CNS effects and uterine stimulation; avoid pregnancy-level medicinal dosing; monitor with serotonergic drugs.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Use caution with serotonergic medications and anticoagulants."
+    ],
+    "dosage": "",
+    "preparation": "Threads or standardized extract; aroma-rich preparations emphasize safranal exposure.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 19,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "sage",
+    "slug": "sage",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied. Lean bulk enrichment added: Carnosic acid.",
+    "mechanisms": [
+      "cognition",
+      "digestive support",
+      "antioxidant",
+      "Nrf2 activation",
+      "NF-κB inhibition",
+      "STAT3 inhibition",
+      "AMPK activation",
+      "PI3K/Akt modulation"
+    ],
+    "safetyNotes": "Generally well tolerated; review concentrated extract use.",
+    "contraindications": [
+      "Pregnancy",
+      "seizure disorder",
+      "high-dose essential oil use",
+      "breastfeeding where milk suppression is a concern"
+    ],
+    "interactions": [
+      "May interact with sedatives",
+      "anticonvulsants",
+      "antidiabetics",
+      "or cholinergic/anticholinergic drugs depending preparation."
+    ],
+    "dosage": "",
+    "preparation": "Leaf tea, tincture, culinary leaf, and essential oil; avoid internal essential-oil use unless professionally supervised.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 17,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "salacia",
+    "slug": "salacia",
+    "summary": "Internal cross-linking supports Salacia through compounds such as mangiferin, kotalanol, salacinol.",
+    "description": "Internal cross-linking supports Salacia through compounds such as mangiferin, kotalanol, salacinol.",
+    "mechanisms": [
+      "salacinol/kotalanol alpha-glucosidase inhibition",
+      "intestinal carbohydrate absorption modulation",
+      "AMPK/PPAR-related metabolic signaling"
+    ],
+    "safetyNotes": "May lower post-meal glucose; monitor with antidiabetic medications. GI effects are possible; avoid pregnancy/breastfeeding use without clinician supervision.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "saw palmetto",
+    "slug": "saw-palmetto",
+    "summary": "Saw Palmetto centers on the berry.",
+    "description": "Saw Palmetto centers on the berry. Key reported compounds include fatty acids; phytosterols (beta-sitosterol). Typical preparation forms: Berry extracts. 5-alpha-reductase inhibition; anti-androgenic effects. Interaction profile: Hormonal therapies, anticoagulants. Use caution or avoid in: Pregnancy.",
+    "mechanisms": [
+      "5-alpha-reductase inhibition",
+      "androgen receptor signaling modulation",
+      "anti-inflammatory COX/LOX pathway modulation",
+      "prostate epithelial anti-edema effects"
+    ],
+    "safetyNotes": "GI upset and headache can occur. Caution with anticoagulants/antiplatelets and before surgery. Avoid pregnancy/breastfeeding. New or worsening urinary symptoms require medical evaluation because LUTS can overlap with prostate cancer or infection.",
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "unexplained urinary symptoms without medical evaluation",
+      "perioperative use without clinician review."
+    ],
+    "interactions": [
+      "Anticoagulants",
+      "antiplatelets",
+      "hormone-active therapies",
+      "and perioperative medications",
+      "possible additive bleeding concern."
+    ],
+    "dosage": "",
+    "preparation": "Fruit/berry preparations are commonly used as foods, juices, powders, capsules, or extracts; sugar and extract concentration vary.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 13,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "schisandra",
+    "slug": "schisandra",
+    "summary": "Liver + stress.",
+    "description": "Liver + stress.",
+    "mechanisms": [
+      "Nrf2",
+      "Nrf2 activation",
+      "PI3K/Akt modulation",
+      "mitochondrial protection"
+    ],
+    "safetyNotes": "Can affect CYP/P-gp drug metabolism; review use with narrow-therapeutic-index drugs, sedatives, hepatotoxic drugs, and pregnancy/breastfeeding.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "active liver disease"
+    ],
+    "interactions": [
+      "Potential interactions with CYP-metabolized drugs."
+    ],
+    "dosage": "",
+    "preparation": "Berry decoction or extract; concentrated lignan extracts provide stronger exposure.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 16,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "schisandra berry",
+    "slug": "schisandra-berry",
+    "summary": "It is best framed specifically around berry lignans and traditional stress-support positioning.",
+    "description": "It is best framed specifically around berry lignans and traditional stress-support positioning.",
+    "mechanisms": [
+      "adaptogenic support",
+      "hepatoprotective support"
+    ],
+    "safetyNotes": "Can affect CYP/P-gp drug metabolism; review use with narrow-therapeutic-index drugs, sedatives, hepatotoxic drugs, and pregnancy/breastfeeding.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without guidance",
+      "active reflux/ulcer sensitivity",
+      "complex medication regimens without review"
+    ],
+    "interactions": [
+      "Potential CYP/P-gp interactions",
+      "caution with immunosuppressants",
+      "sedatives",
+      "anticoagulants",
+      "and hepatically metabolized drugs."
+    ],
+    "dosage": "",
+    "preparation": "Berry decoction, powder, tincture, and lignan-standardized extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "schisandra chinensis",
+    "slug": "schisandra-chinensis",
+    "summary": "Lean bulk ingestion row for Schisandra chinensis.",
+    "description": "Lean bulk ingestion row for Schisandra chinensis. Key active compounds include Schisandrin.",
+    "mechanisms": [
+      "Nrf2 activation",
+      "PI3K/Akt modulation"
+    ],
+    "safetyNotes": "Hepatobiliary-active potential; use caution with liver disease, gallbladder disease, bile-duct obstruction, hepatotoxic drugs, and pregnancy.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without guidance",
+      "active reflux/ulcer sensitivity",
+      "complex medication regimens without review"
+    ],
+    "interactions": [
+      "Potential CYP/P-gp interactions",
+      "caution with immunosuppressants",
+      "sedatives",
+      "anticoagulants",
+      "and hepatically metabolized drugs."
+    ],
+    "dosage": "",
+    "preparation": "Berry decoction, powder, tincture, and lignan-standardized extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "scutellaria baicalensis",
+    "slug": "scutellaria-baicalensis",
+    "summary": "Lean bulk ingestion row for Scutellaria baicalensis.",
+    "description": "Lean bulk ingestion row for Scutellaria baicalensis. Key active compounds include Baicalin; Baicalein; Wogonin.",
+    "mechanisms": [
+      "baicalin/baicalein/wogonin modulation of NF-κB",
+      "MAPK",
+      "PI3K/Akt",
+      "Nrf2",
+      "cytokines",
+      "and oxidative-stress pathways"
+    ],
+    "safetyNotes": "Generally studied as extracts/compounds, but liver injury reports and adulteration/quality issues exist for skullcap products. Use caution with liver disease.",
+    "contraindications": [
+      "Liver disease",
+      "pregnancy/breastfeeding",
+      "immunosuppressive therapy without supervision",
+      "and complex oncology regimens."
+    ],
+    "interactions": [
+      "Potential interactions with anticoagulants/antiplatelets",
+      "sedatives",
+      "immunosuppressants",
+      "and hepatotoxic drugs."
+    ],
+    "dosage": "",
+    "preparation": "Species identity matters; distinguish Scutellaria baicalensis from American skullcap and adulterated materials.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 22,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "selaginella tamariscina",
+    "slug": "selaginella-tamariscina",
+    "summary": "Minimum source-backed intake for ginkgetin and 5-lipoxygenase inhibition cluster completion.",
+    "description": "Minimum source-backed intake for ginkgetin and 5-lipoxygenase inhibition cluster completion.",
+    "mechanisms": [
+      "5-lipoxygenase inhibition"
+    ],
+    "safetyNotes": "Food-like use is generally lower risk, but concentrated extracts may not match dietary safety. Use caution with pregnancy/breastfeeding, allergy, and chronic high-dose supplementation.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 4,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "serenoa repens",
+    "slug": "serenoa-repens",
+    "summary": "Serenoa repens contains Beta-sitosterol and is linked here to PPAR activation.",
+    "description": "Serenoa repens contains Beta-sitosterol and is linked here to PPAR activation.",
+    "mechanisms": [
+      "5-alpha-reductase and androgen-signaling modulation",
+      "prostate inflammatory-pathway effects"
+    ],
+    "safetyNotes": "GI upset/headache possible; caution with hormone-sensitive conditions, anticoagulants, and perioperative use.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "shankhpushpi",
+    "slug": "shankhpushpi",
+    "summary": "It is best framed as a traditional cognitive-support herb with limited modern clinical depth.",
+    "description": "It is best framed as a traditional cognitive-support herb with limited modern clinical depth.",
+    "mechanisms": [
+      "traditional cognitive support",
+      "calming support"
+    ],
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "shatavari",
+    "slug": "shatavari",
+    "summary": "It is best framed around steroidal saponins with hormonal-context caution.",
+    "description": "It is best framed around steroidal saponins with hormonal-context caution.",
+    "mechanisms": [
+      "women's-health support",
+      "soothing support"
+    ],
+    "safetyNotes": "Hormone- or cycle-related traditional use requires caution in pregnancy, breastfeeding, hormone-sensitive conditions, and with hormone therapies.",
+    "contraindications": [
+      "Pregnancy/lactation use should be clinician-guided",
+      "hormone-sensitive conditions without review"
+    ],
+    "interactions": [
+      "May interact with hormone therapies",
+      "diuretics",
+      "lithium",
+      "or antidiabetics."
+    ],
+    "dosage": "",
+    "preparation": "Root powder, ghee preparations, decoction, and extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "skullcap",
+    "slug": "skullcap",
+    "summary": "GABAergic.",
+    "description": "GABAergic.",
+    "mechanisms": [
+      "GABAA",
+      "NF-κB inhibition",
+      "PI3K/Akt modulation",
+      "COX inhibition",
+      "MAPK pathway modulation"
+    ],
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without guidance",
+      "liver disease",
+      "sedative use without review"
+    ],
+    "interactions": [
+      "May add to sedatives/CNS depressants",
+      "caution with hepatotoxic drugs/supplements."
+    ],
+    "dosage": "",
+    "preparation": "Aerial parts of American skullcap as tea/tincture; roots of Chinese skullcap are a different herb.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 11,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "sophora alopecuroides",
+    "slug": "sophora-alopecuroides",
+    "summary": "Sophora alopecuroides lean monograph row enriched in bulk mode.",
+    "description": "Sophora alopecuroides lean monograph row enriched in bulk mode.",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "NF-κB inhibition",
+      "TGF-β signaling modulation"
+    ],
+    "safetyNotes": "Alkaloid-rich herb with toxicity concerns. Avoid pregnancy/breastfeeding and avoid unsupervised high-dose or long-term use.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "sophora flavescens",
+    "slug": "sophora-flavescens",
+    "summary": "Sophora flavescens lean monograph row enriched in bulk mode.",
+    "description": "Sophora flavescens lean monograph row enriched in bulk mode.",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "NF-κB inhibition",
+      "TGF-β signaling modulation"
+    ],
+    "safetyNotes": "Alkaloid-rich herb with meaningful safety-review needs; avoid casual internal use or unsupervised high-dose extracts.",
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "liver disease",
+      "arrhythmia/cardiac disease without clinician review",
+      "complex medication regimens."
+    ],
+    "interactions": [
+      "Potential interactions with hepatotoxic drugs",
+      "antiarrhythmics",
+      "immunomodulators",
+      "and sedative/CNS-active medicines are plausible and extract-specific."
+    ],
+    "dosage": "",
+    "preparation": "Root is used as decoction, granule, capsule, or alkaloid-standardized extract; standardized alkaloid products are not equivalent to crude root.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 12,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "soursop",
+    "slug": "soursop",
+    "summary": "It must be framed carefully because anticancer folklore claims greatly exceed evidence and safety certainty.",
+    "description": "It must be framed carefully because anticancer folklore claims greatly exceed evidence and safety certainty.",
+    "mechanisms": [
+      "traditional wellness support",
+      "antioxidant"
+    ],
+    "safetyNotes": "Avoid high-dose or chronic supplement use; annonaceous acetogenins have neurotoxicity concerns. Caution with Parkinsonism, neurologic disease, pregnancy, and sedating medications.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "soybean",
+    "slug": "soybean",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied.",
+    "mechanisms": [
+      "isoflavone estrogen-receptor modulation",
+      "lipid metabolism and bone-turnover signaling",
+      "antioxidant pathways"
+    ],
+    "safetyNotes": "Caution in hormone-sensitive conditions and with thyroid medication timing; allergy possible.",
+    "contraindications": [
+      "Soy allergy",
+      "hormone-sensitive conditions without clinician review",
+      "thyroid medication timing caution"
+    ],
+    "interactions": [
+      "May affect levothyroxine absorption timing",
+      "review with hormone therapies and anticoagulants if diet changes are large."
+    ],
+    "dosage": "",
+    "preparation": "Whole soy foods, protein isolate, isoflavone extracts; fermented/nonfermented forms differ.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 9,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "st johns wort",
+    "slug": "st-johns-wort",
+    "summary": "St.",
+    "description": "St. John's wort centers on the flowering tops. Key reported compounds include hyperforin; hypericin; pseudohypericin; quercetin; rutin; kaempferol. Typical preparation forms: Dried flowering tops or standardized extracts. Hyperforin and related compounds inhibit monoamine reuptake and affect TRPC6-linked neuroplasticity; additional monoamine oxidase and stress-pathway effects have been proposed. Interaction profile: Major interactions with antidepressants, oral contraceptives, cyclosporine, tacrolimus, HIV meds, anticancer drugs, warfarin, digoxin and others. Use caution or avoid in: Pregnancy, breastfeeding, bipolar disorder, concomitant prescription meds with CYP/P-gp liability.",
+    "mechanisms": [
+      "hyperforin-mediated pregnane X receptor activation",
+      "CYP3A4",
+      "CYP2C9",
+      "CYP2C19",
+      "and P-glycoprotein induction",
+      "serotonin/norepinephrine/dopamine reuptake modulation",
+      "variable MAO-related effects"
+    ],
+    "safetyNotes": "High interaction risk. Avoid with SSRIs, SNRIs, MAOIs, triptans, and other serotonergic drugs due to serotonin-toxicity risk. Can reduce effectiveness of oral contraceptives, warfarin/DOACs, antiretrovirals, immunosuppressants, oncology drugs, and anticonvulsants. Photosensitivity and mania risk occur; do not stop or replace antidepressants without clinician guidance.",
+    "contraindications": [
+      "Current antidepressant/serotonergic therapy unless clinician-supervised",
+      "bipolar disorder/mania history",
+      "transplant/immunosuppression",
+      "pregnancy/breastfeeding without clinician review."
+    ],
+    "interactions": [
+      "CYP3A4/CYP2C9/CYP2C19 and P-gp substrates",
+      "oral contraceptives",
+      "warfarin/DOACs",
+      "antiretrovirals",
+      "cyclosporine/tacrolimus",
+      "chemotherapy",
+      "anticonvulsants",
+      "SSRIs/SNRIs/MAOIs/triptans."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 20,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "stellera chamaejasme",
+    "slug": "stellera-chamaejasme",
+    "summary": "Stellera chamaejasme lean monograph row enriched in bulk mode.",
+    "description": "Stellera chamaejasme lean monograph row enriched in bulk mode.",
+    "mechanisms": [
+      "JAK/STAT inhibition",
+      "NF-κB inhibition"
+    ],
+    "safetyNotes": "High-caution plant; toxic diterpenoid constituents and irritant effects are possible. Avoid internal supplement use outside expert supervision.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "stephania cepharantha",
+    "slug": "stephania-cepharantha",
+    "summary": "Stephania cepharantha lean monograph row enriched in bulk mode.",
+    "description": "Stephania cepharantha lean monograph row enriched in bulk mode.",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "safetyNotes": "Alkaloid-rich herb; species substitution and nephrotoxicity/adulteration concerns require caution. Avoid pregnancy and unsupervised use.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "stephania japonica",
+    "slug": "stephania-japonica",
+    "summary": "Stephania japonica lean monograph row enriched in bulk mode.",
+    "description": "Stephania japonica lean monograph row enriched in bulk mode.",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "PI3K/Akt modulation"
+    ],
+    "safetyNotes": "Alkaloid-rich herb; species substitution and nephrotoxicity/adulteration concerns require caution. Avoid pregnancy and unsupervised use.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "stephania tetrandra",
+    "slug": "stephania-tetrandra",
+    "summary": "Stephania tetrandra lean monograph row enriched in bulk mode.",
+    "description": "Stephania tetrandra lean monograph row enriched in bulk mode.",
+    "mechanisms": [
+      "voltage-gated calcium channel modulation",
+      "NF-κB inhibition"
+    ],
+    "safetyNotes": "Alkaloid-rich herb; species substitution and nephrotoxicity/adulteration concerns require caution. Avoid pregnancy and unsupervised use.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "suma",
+    "slug": "suma",
+    "summary": "It should be framed conservatively because traditional-use breadth exceeds evidence depth.",
+    "description": "It should be framed conservatively because traditional-use breadth exceeds evidence depth.",
+    "mechanisms": [
+      "traditional restorative support",
+      "adaptogenic support"
+    ],
+    "safetyNotes": "Limited human safety data; use conservative preparation-specific framing and avoid pregnancy/breastfeeding or medication stacking without clinician review.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "syzygium aromaticum",
+    "slug": "syzygium-aromaticum",
+    "summary": "Lean bulk ingestion row for Syzygium aromaticum.",
+    "description": "Lean bulk ingestion row for Syzygium aromaticum. Key active compounds include Eugenol.",
+    "mechanisms": [
+      "Eugenol-mediated COX/LOX modulation",
+      "TRPV1/TRPA1 sensory receptor activity",
+      "platelet aggregation and oxidative-stress pathway effects."
+    ],
+    "safetyNotes": "Concentrated clove preparations may cause mucosal irritation, bleeding risk, or liver toxicity at high doses; avoid essential oil ingestion without supervision and use caution with anticoagulants, surgery, pregnancy, children, and liver disease.",
+    "contraindications": [
+      "Bleeding disorder",
+      "liver disease",
+      "children for clove oil ingestion",
+      "pregnancy supplement dosing without guidance"
+    ],
+    "interactions": [
+      "May increase bleeding risk with anticoagulants/antiplatelets",
+      "caution with hepatotoxic drugs."
+    ],
+    "dosage": "",
+    "preparation": "Culinary buds, teas, diluted topical oil; essential oil requires careful dilution.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "tamarind",
+    "slug": "tamarind",
+    "summary": "It is best framed as a food-form fruit with digestive and polyphenol relevance.",
+    "description": "It is best framed as a food-form fruit with digestive and polyphenol relevance.",
+    "mechanisms": [
+      "digestive support",
+      "antioxidant"
+    ],
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Fruit/berry preparations are commonly used as foods, juices, powders, capsules, or extracts; sugar and extract concentration vary.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "thunder god vine",
+    "slug": "thunder-god-vine",
+    "summary": "Bulk-ingested support row carrying Celastrol with pathway-level mechanism coverage.",
+    "description": "Bulk-ingested support row carrying Celastrol with pathway-level mechanism coverage.",
+    "mechanisms": [
+      "triptolide/celastrol-mediated NF-κB inhibition",
+      "HSP90 inhibition",
+      "calcineurin/T-cell signaling suppression",
+      "JAK/STAT modulation",
+      "pro-inflammatory cytokine inhibition"
+    ],
+    "safetyNotes": "High-toxicity herb; requires specialist supervision. Reproductive toxicity/infertility, severe GI effects, bone-marrow suppression, hepatotoxicity, nephrotoxicity, infection risk, and clinically important drug interactions are possible. Avoid pregnancy/breastfeeding and fertility attempts.",
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "fertility attempts",
+      "liver or kidney disease",
+      "cytopenias",
+      "immunosuppression unless specialist-managed."
+    ],
+    "interactions": [
+      "Immunosuppressants",
+      "DMARDs",
+      "corticosteroids",
+      "hepatotoxic/nephrotoxic drugs",
+      "anticoagulants",
+      "and antiplatelets",
+      "specialist-only context."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "thyme",
+    "slug": "thyme",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied.",
+    "mechanisms": [
+      "respiratory support",
+      "antimicrobial",
+      "digestive support",
+      "NF-κB inhibition",
+      "MAPK pathway modulation",
+      "TRPA1 activation",
+      "membrane disruption",
+      "GABA-A modulation"
+    ],
+    "safetyNotes": "Culinary use is generally low-risk; concentrated oil/extracts can irritate mucosa and require dose caution.",
+    "contraindications": [
+      "Pregnancy/breastfeeding for medicinal-dose essential oil",
+      "significant GI irritation",
+      "thyme/Lamiaceae allergy."
+    ],
+    "interactions": [
+      "Potential additive irritation with other essential oils",
+      "theoretical caution with anticoagulants for high-dose extracts."
+    ],
+    "dosage": "",
+    "preparation": "Leaf is used as tea, culinary herb, tincture, syrup, or steam aromatic; essential oil should not be taken internally without qualified guidance.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 15,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "tongkat ali",
+    "slug": "tongkat-ali",
+    "summary": "It is best framed as a bitter root extract with endocrine and stimulation-related caution.",
+    "description": "It is best framed as a bitter root extract with endocrine and stimulation-related caution.",
+    "mechanisms": [
+      "quassinoid/eurycomanone signaling",
+      "HPA-axis and testosterone-related endocrine modulation",
+      "stress-response pathways"
+    ],
+    "safetyNotes": "May cause insomnia/restlessness; avoid pregnancy and hormone-sensitive conditions; caution with stimulant or endocrine-active regimens.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "tribulus terrestris",
+    "slug": "tribulus-terrestris",
+    "summary": "Tribulus terrestris lean herb row for high-speed phytochemical ingestion.",
+    "description": "Tribulus terrestris lean herb row for high-speed phytochemical ingestion.",
+    "mechanisms": [
+      "NO signaling modulation",
+      "PI3K/Akt modulation"
+    ],
+    "safetyNotes": "Human safety data are limited for concentrated extracts. Use caution in pregnancy/breastfeeding, significant medical conditions, or prescription polypharmacy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "tripterygium wilfordii",
+    "slug": "tripterygium-wilfordii",
+    "summary": "Lean bulk ingestion row for Tripterygium wilfordii.",
+    "description": "Lean bulk ingestion row for Tripterygium wilfordii. Key active compounds include Celastrol.",
+    "mechanisms": [
+      "triptolide/celastrol-mediated NF-κB inhibition",
+      "HSP90 inhibition",
+      "calcineurin/T-cell signaling suppression",
+      "JAK/STAT modulation",
+      "pro-inflammatory cytokine inhibition"
+    ],
+    "safetyNotes": "High-toxicity herb; requires specialist supervision. Reproductive toxicity/infertility, severe GI effects, bone-marrow suppression, hepatotoxicity, nephrotoxicity, infection risk, and clinically important drug interactions are possible. Avoid pregnancy/breastfeeding and fertility attempts.",
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "fertility attempts",
+      "liver or kidney disease",
+      "cytopenias",
+      "immunosuppression unless specialist-managed."
+    ],
+    "interactions": [
+      "Immunosuppressants",
+      "DMARDs",
+      "corticosteroids",
+      "hepatotoxic/nephrotoxic drugs",
+      "anticoagulants",
+      "and antiplatelets",
+      "specialist-only context."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "turkey tail",
+    "slug": "turkey-tail",
+    "summary": "Immune modulation.",
+    "description": "Immune modulation.",
+    "mechanisms": [
+      "PSK/PSP beta-glucan immune signaling",
+      "dectin-1/TLR pathway modulation",
+      "macrophage/NK-cell cytokine signaling",
+      "NF-κB immune-response modulation"
+    ],
+    "safetyNotes": "Immune-active mushroom extract; use caution with immunosuppressants, transplant medicines, autoimmune disease, and during active cancer treatment unless clinician-supervised.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "turmeric",
+    "slug": "turmeric",
+    "summary": "Turmeric centers on the unspecified.",
+    "description": "Turmeric centers on the unspecified. Key reported compounds include curcumin; demethoxycurcumin; bisdemethoxycurcumin. Typical preparation forms: The rhizomes are boiled, dried and ground into powder used as a spice, dye and supplement. Extracts standardized for curcuminoid content are available as capsules or tablets. The golden rhizomes of turmeric contain non‐volatile curcuminoids-curcumin (curcumin I), demethoxycurcumin (curcumin II) and bisdemethoxycurcumin (curcumin III)-as well as volatile mono‐ and sesquiterpenoids【768158627760254†L420-L432】【768158627760254†L442-L468】. Curcumin and related curcuminoids exhibit antioxidant and anti‐inflammatory effects by modulating multiple molecular targets (e.g., NF‐κB, Nrf2, COX‐2). Most data are preclinical; human evidence is limited, so this mechanism should be considered proposed. Interaction profile: Curcumin may enhance the effects of anticoagulant, antiplatelet or antidiabetic drugs and could interact with drugs metabolized by cytochrome P450 enzymes; caution is advised. Use caution or avoid in: Avoid high‐dose turmeric supplements in people with gallbladder obstruction, bleeding disorders or those taking anticoagulant or antiplatelet medications. Use is not recommended during pregnancy or breastfeeding.",
+    "mechanisms": [
+      "curcumin-mediated NF-κB inhibition",
+      "COX-2 and LOX downregulation",
+      "Nrf2 antioxidant-response activation",
+      "JAK/STAT and MAPK modulation",
+      "inflammatory cytokine reduction (TNF-α",
+      "IL-6)"
+    ],
+    "safetyNotes": "GI upset is common at higher doses. High-bioavailability extracts can materially increase exposure. Caution with anticoagulants/antiplatelets/NSAIDs, gallbladder disease or bile duct obstruction, kidney stones, iron deficiency, antidiabetic therapy, and hepatotoxic drugs/supplements. Hepatotoxicity case reports exist for some turmeric/curcumin products.",
+    "contraindications": [
+      "Bile duct obstruction or active gallbladder disease without clinician review",
+      "active liver disease or prior turmeric/curcumin-related liver injury",
+      "perioperative use without clinician review."
+    ],
+    "interactions": [
+      "Anticoagulants",
+      "antiplatelets",
+      "NSAIDs",
+      "antidiabetics",
+      "iron supplements",
+      "hepatotoxic drugs/supplements",
+      "and oncology medications where CYP/P-gp concerns are clinically relevant."
+    ],
+    "dosage": "",
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "evidenceLevel": "meta_analysis",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 17,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "valerian",
+    "slug": "valerian",
+    "summary": "Valerian centers on the root; rhizome.",
+    "description": "Valerian centers on the root; rhizome. Key reported compounds include valerenic acid; valerenol; valerenal; valepotriates (valtrate, isovaltrate); sesquiterpenoids. Typical preparation forms: Dried roots/rhizomes as teas, tinctures, or extracts. Valerenic acid derivatives modulate GABA-A signaling and may inhibit GABA breakdown. Interaction profile: May potentiate sedatives and alcohol. Use caution or avoid in: Pregnancy, breastfeeding, liver disease, concurrent CNS depressants.",
+    "mechanisms": [
+      "valerenic-acid GABA-A receptor modulation",
+      "GABA degradation/transport effects",
+      "adenosine and serotonergic sleep-pathway modulation"
+    ],
+    "safetyNotes": "Sedation and next-day drowsiness possible; avoid combining with alcohol, benzodiazepines, opioids, or other CNS depressants.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "heavy sedative use",
+      "upcoming anesthesia"
+    ],
+    "interactions": [
+      "May potentiate alcohol",
+      "benzodiazepines",
+      "barbiturates",
+      "sleep aids",
+      "opioids",
+      "and other CNS depressants."
+    ],
+    "dosage": "",
+    "preparation": "Root/rhizome tea, tincture, capsules, and standardized extracts; odor reflects volatile constituents.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 14,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "valeriana officinalis",
+    "slug": "valeriana-officinalis",
+    "summary": "Valeriana officinalis contains Valerenic acid and is linked here to GABA-A modulation.",
+    "description": "Valeriana officinalis contains Valerenic acid and is linked here to GABA-A modulation.",
+    "mechanisms": [
+      "valerenic-acid GABA-A receptor modulation",
+      "GABA degradation/transport effects",
+      "adenosine and serotonergic sleep-pathway modulation"
+    ],
+    "safetyNotes": "Sedation and next-day drowsiness possible; avoid alcohol, benzodiazepines, opioids, and other CNS depressants.",
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "heavy sedative use",
+      "upcoming anesthesia"
+    ],
+    "interactions": [
+      "May potentiate alcohol",
+      "benzodiazepines",
+      "barbiturates",
+      "sleep aids",
+      "opioids",
+      "and other CNS depressants."
+    ],
+    "dosage": "",
+    "preparation": "Root/rhizome tea, tincture, capsules, and standardized extracts; odor reflects volatile constituents.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 14,
+    "confidenceTier": "moderate"
+  },
+  {
+    "name": "verbena officinalis",
+    "slug": "verbena-officinalis",
+    "summary": "Verbena officinalis contains Acteoside and is linked here to NF-κB inhibition.",
+    "description": "Verbena officinalis contains Acteoside and is linked here to NF-κB inhibition.",
+    "mechanisms": [
+      "NF-κB inhibition",
+      "MAPK pathway modulation"
+    ],
+    "safetyNotes": "May cause drowsiness or impaired alertness. Avoid combining high-dose extracts with alcohol, sedatives, or other CNS depressants.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with sedatives/CNS depressants",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "white peony",
+    "slug": "white-peony",
+    "summary": "It is best framed as a paeoniflorin-rich root with traditional-system relevance.",
+    "description": "It is best framed as a paeoniflorin-rich root with traditional-system relevance.",
+    "mechanisms": [
+      "traditional cycle support",
+      "calming support"
+    ],
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "contraindications": [
+      "Pregnancy without clinician guidance",
+      "anticoagulant use without review"
+    ],
+    "interactions": [
+      "Potential additive bleeding risk with anticoagulants/antiplatelets",
+      "may interact with immunomodulators."
+    ],
+    "dosage": "",
+    "preparation": "Root decoction/extract; often paired with licorice or other TCM herbs.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 6,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "wild yam",
+    "slug": "wild-yam",
+    "summary": "Wild Yam lean herb row for high-speed phytochemical ingestion.",
+    "description": "Wild Yam lean herb row for high-speed phytochemical ingestion.",
+    "mechanisms": [
+      "PI3K/Akt modulation",
+      "PPARγ activation"
+    ],
+    "safetyNotes": "May lower blood glucose or alter metabolic markers; monitor with diabetes medications and avoid unsupervised use during pregnancy.",
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "dosage": "",
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 5,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "wormwood",
+    "slug": "wormwood",
+    "summary": "Internal cross-linking supports Wormwood through compounds such as alpha-thujone, absinthin, beta-thujone.",
+    "description": "Internal cross-linking supports Wormwood through compounds such as alpha-thujone, absinthin, beta-thujone.",
+    "mechanisms": [
+      "thujone interaction with GABA-A signaling",
+      "bitter-receptor digestive signaling",
+      "sesquiterpene lactone inflammatory-pathway modulation"
+    ],
+    "safetyNotes": "Thujone-containing preparations can be neurotoxic at high exposure and may provoke seizures. Avoid concentrated essential oil or high-thujone products.",
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "seizure disorder",
+      "liver disease",
+      "children",
+      "and internal essential-oil use."
+    ],
+    "interactions": [
+      "Avoid with antiepileptics",
+      "sedatives",
+      "alcohol",
+      "and other neuroactive supplements or medicines."
+    ],
+    "dosage": "",
+    "preparation": "Use only regulated low-thujone preparations; essential oil is not equivalent to tea or standardized extracts.",
+    "evidenceLevel": "in_vitro",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "yarrow",
+    "slug": "yarrow",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied.",
+    "mechanisms": [
+      "digestive support",
+      "anti-inflammatory",
+      "women's health"
+    ],
+    "safetyNotes": "Asteraceae-family herb; allergy is a practical concern. Avoid high-dose or prolonged internal use without review.",
+    "contraindications": [
+      "Asteraceae/ragweed allergy",
+      "pregnancy",
+      "bleeding disorders or anticoagulant therapy without clinician review."
+    ],
+    "interactions": [
+      "Potential additive effects with anticoagulants/antiplatelets",
+      "possible allergy cross-reactivity with ragweed-family plants."
+    ],
+    "dosage": "",
+    "preparation": "Flowering tops are used as tea, tincture, compress, or topical preparation; essential oil use requires separate safety review.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 7,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "yerba mate",
+    "slug": "yerba-mate",
+    "summary": "Conservative evidence framing applied.",
+    "description": "Conservative evidence framing applied.",
+    "mechanisms": [
+      "caffeine/theobromine adenosine-receptor antagonism",
+      "chlorogenic-acid antioxidant signaling",
+      "AMPK-related metabolic signaling",
+      "saponin-mediated lipid metabolism"
+    ],
+    "safetyNotes": "Contains caffeine; excess intake may worsen insomnia, anxiety, palpitations, reflux, or blood pressure. Avoid very hot maté consumption patterns and stimulant stacking.",
+    "contraindications": [
+      "Uncontrolled hypertension",
+      "arrhythmia",
+      "severe anxiety/insomnia",
+      "pregnancy/breastfeeding caution",
+      "and stimulant sensitivity."
+    ],
+    "interactions": [
+      "Additive effects with stimulants",
+      "caffeine",
+      "theophylline",
+      "decongestants",
+      "and stimulant medications",
+      "CYP1A2-modulating drugs may alter caffeine exposure."
+    ],
+    "dosage": "",
+    "preparation": "Prefer moderate-temperature tea/extracts with disclosed caffeine content; avoid very hot repeated consumption and energy-drink style stacking.",
+    "evidenceLevel": "human_limited",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 8,
+    "confidenceTier": "low"
+  },
+  {
+    "name": "yohimbe",
+    "slug": "yohimbe",
+    "summary": "Yohimbe is represented here as a bark-derived monograph anchored to yohimbine, an alpha-2 adrenergic antagonist with sympathomimetic effects.",
+    "description": "Yohimbe is represented here as a bark-derived monograph anchored to yohimbine, an alpha-2 adrenergic antagonist with sympathomimetic effects. The herb is more appropriately framed around safety review than routine recommendation. Potential effects include increased alertness and sexual-function relevance, but tolerability can be poor and adverse effects may include anxiety, tachycardia, blood-pressure elevation, agitation, insomnia, and gastrointestinal distress. Use should be conservative and exclusion-heavy in people with cardiovascular, psychiatric, seizure, renal, or hepatic vulnerability.",
+    "mechanisms": [
+      "yohimbine alpha-2 adrenergic receptor antagonism",
+      "increased sympathetic outflow",
+      "norepinephrine signaling",
+      "serotonergic and dopaminergic modulation"
+    ],
+    "safetyNotes": "High-risk stimulant herb. Reported adverse events include anxiety, agitation, hypertension, tachycardia, GI distress, and rare serious cardiovascular/neurologic events.",
+    "contraindications": [
+      "Hypertension",
+      "arrhythmia",
+      "heart disease",
+      "anxiety/panic disorder",
+      "bipolar disorder/mania",
+      "kidney or liver disease",
+      "pregnancy/breastfeeding."
+    ],
+    "interactions": [
+      "Avoid with stimulants",
+      "decongestants",
+      "MAOIs",
+      "antidepressants",
+      "clonidine",
+      "antihypertensives",
+      "and drugs affecting blood pressure or heart rhythm."
+    ],
+    "dosage": "",
+    "preparation": "Do not equate crude bark products with pharmaceutical yohimbine; supplement yohimbine content can vary substantially.",
+    "evidenceLevel": "none",
+    "review_status": "partial",
+    "source_status": "partial",
+    "sourceCount": 12,
+    "confidenceTier": "moderate"
+  }
+]

--- a/scripts/data/build-runtime-from-workbook.mjs
+++ b/scripts/data/build-runtime-from-workbook.mjs
@@ -1,0 +1,278 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import XLSX from 'xlsx'
+import { resolveWorkbookPath } from '../workbook-source.mjs'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const repoRoot = path.resolve(__dirname, '../..')
+const outputDir = path.join(repoRoot, 'public', 'data-next')
+const metaDir = path.join(outputDir, '_meta')
+
+const REQUIRED_SHEETS = {
+  herbs: 'Herb Master Clean',
+  compounds: 'Compound Master V3',
+  herbCompoundMap: 'Herb Compound Map V3',
+}
+
+const OPTIONAL_SHEETS = {
+  claimRows: 'Claim Rows',
+}
+
+const PLACEHOLDER_TOKENS = new Set(['', 'unknown', 'nan', 'null', 'undefined', '[object object]'])
+
+function normalizeText(value) {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'number' && Number.isNaN(value)) return ''
+  const text = String(value).replace(/\s+/g, ' ').trim()
+  if (!text) return ''
+  if (isPlaceholderToken(text)) return ''
+  return text
+}
+
+function normalizeList(value) {
+  if (Array.isArray(value)) {
+    return [...new Set(value.map(item => normalizeText(item)).filter(Boolean))]
+  }
+  const text = normalizeText(value)
+  if (!text) return []
+  return [...new Set(text.split(/[;|,\n]/).map(item => normalizeText(item)).filter(Boolean))]
+}
+
+function normalizeSlug(value) {
+  const normalized = normalizeText(value)
+  if (!normalized) return ''
+  return normalized
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+function isPlaceholderToken(value) {
+  const text = String(value ?? '').trim().toLowerCase()
+  return PLACEHOLDER_TOKENS.has(text)
+}
+
+function toSimpleRow(row) {
+  const output = {}
+  for (const [key, value] of Object.entries(row || {})) {
+    const normalizedKey = String(key ?? '').trim()
+    if (!normalizedKey) continue
+    output[normalizedKey] = value
+  }
+  return output
+}
+
+function readSheetRows(workbook, sheetName, { optional = false } = {}) {
+  const sheet = workbook.Sheets[sheetName]
+  if (!sheet) {
+    if (optional) return []
+    throw new Error(`[data-next] Missing required sheet: ${sheetName}`)
+  }
+
+  const rows = XLSX.utils.sheet_to_json(sheet, {
+    defval: '',
+    raw: false,
+    blankrows: false,
+  })
+
+  return rows.map(row => toSimpleRow(row))
+}
+
+function firstNonEmpty(row, keys) {
+  for (const key of keys) {
+    const value = normalizeText(row[key])
+    if (value) return value
+  }
+  return ''
+}
+
+function parseSourceCount(row) {
+  const raw = firstNonEmpty(row, ['sourceCount', 'source_count', 'sourcesCount'])
+  if (!raw) return 0
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+function isValidIdentity(name, slug) {
+  const normalizedName = normalizeText(name)
+  const normalizedSlug = normalizeSlug(slug)
+  if (!normalizedName || !normalizedSlug) return false
+  if (isPlaceholderToken(normalizedName) || isPlaceholderToken(normalizedSlug)) return false
+  return true
+}
+
+function isValidCompoundIdentity(name, slug) {
+  if (!isValidIdentity(name, slug)) return false
+  const normalizedName = normalizeText(name)
+  const normalizedSlug = normalizeSlug(slug)
+  if (/^\d+$/.test(normalizedName) || /^\d+$/.test(normalizedSlug)) return false
+  if (normalizedName.length <= 1 || normalizedSlug.length <= 1) return false
+  return true
+}
+
+function createHerbRecord(row) {
+  const name = firstNonEmpty(row, ['name', 'herbName'])
+  const slug = normalizeSlug(firstNonEmpty(row, ['slug', 'herbSlug', 'name']))
+  return {
+    name,
+    slug,
+    summary: firstNonEmpty(row, ['summary', 'hero']),
+    description: firstNonEmpty(row, ['description']),
+    mechanisms: normalizeList(firstNonEmpty(row, ['mechanisms', 'mechanism', 'pathwayTargets'])),
+    safetyNotes: firstNonEmpty(row, ['safetyNotes', 'safety']),
+    contraindications: normalizeList(firstNonEmpty(row, ['contraindications'])),
+    interactions: normalizeList(firstNonEmpty(row, ['interactions'])),
+    dosage: firstNonEmpty(row, ['dosage', 'dose']),
+    preparation: firstNonEmpty(row, ['preparation']),
+    evidenceLevel: firstNonEmpty(row, ['evidenceLevel', 'evidenceTier', 'evidence_tier']),
+    review_status: firstNonEmpty(row, ['review_status', 'reviewStatus']),
+    source_status: firstNonEmpty(row, ['source_status', 'sourceStatus']),
+    sourceCount: parseSourceCount(row),
+    confidenceTier: firstNonEmpty(row, ['confidenceTier', 'confidenceLevel']),
+  }
+}
+
+function createCompoundRecord(row, foundIn) {
+  const name = firstNonEmpty(row, ['name', 'compoundName', 'canonicalCompoundName', 'compound'])
+  const slug = normalizeSlug(firstNonEmpty(row, ['slug', 'canonicalCompoundId', 'compoundName', 'name']))
+  return {
+    name,
+    slug,
+    summary: firstNonEmpty(row, ['summary']),
+    description: firstNonEmpty(row, ['description']),
+    compoundClass: firstNonEmpty(row, ['compoundClass', 'class']),
+    mechanisms: normalizeList(firstNonEmpty(row, ['mechanisms', 'mechanism', 'mechanismTags'])),
+    targets: normalizeList(firstNonEmpty(row, ['targets', 'pathwayTargets'])),
+    foundIn,
+    safetyNotes: firstNonEmpty(row, ['safetyNotes', 'safety']),
+    evidenceLevel: firstNonEmpty(row, ['evidenceLevel', 'evidenceTier', 'evidence_tier']),
+    review_status: firstNonEmpty(row, ['review_status', 'reviewStatus']),
+    source_status: firstNonEmpty(row, ['source_status', 'sourceStatus']),
+    sourceCount: parseSourceCount(row),
+    confidenceTier: firstNonEmpty(row, ['confidenceTier', 'confidenceLevel']),
+  }
+}
+
+function writeJson(filePath, payload) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8')
+}
+
+function run() {
+  const workbookPath = resolveWorkbookPath(repoRoot)
+  const workbook = XLSX.readFile(workbookPath)
+
+  const herbRows = readSheetRows(workbook, REQUIRED_SHEETS.herbs)
+  const compoundRows = readSheetRows(workbook, REQUIRED_SHEETS.compounds)
+  const mapRows = readSheetRows(workbook, REQUIRED_SHEETS.herbCompoundMap)
+  const claimRows = readSheetRows(workbook, OPTIONAL_SHEETS.claimRows, { optional: true })
+
+  const herbNameBySlug = new Map()
+  const herbs = []
+  let skippedHerbs = 0
+
+  for (const row of herbRows) {
+    const record = createHerbRecord(row)
+    if (!isValidIdentity(record.name, record.slug)) {
+      skippedHerbs += 1
+      continue
+    }
+    if (herbNameBySlug.has(record.slug)) continue
+    herbNameBySlug.set(record.slug, record.name)
+    herbs.push(record)
+  }
+
+  const foundInByCompoundSlug = new Map()
+  for (const row of mapRows) {
+    const herbSlug = normalizeSlug(firstNonEmpty(row, ['herbSlug', 'herb']))
+    const compoundSlug = normalizeSlug(
+      firstNonEmpty(row, ['slug', 'canonicalCompoundId', 'canonicalCompoundName', 'compoundName']),
+    )
+    if (!herbSlug || !compoundSlug) continue
+    const herbName = herbNameBySlug.get(herbSlug) || herbSlug
+    const existing = foundInByCompoundSlug.get(compoundSlug) || []
+    if (!existing.includes(herbName)) {
+      existing.push(herbName)
+      foundInByCompoundSlug.set(compoundSlug, existing)
+    }
+  }
+
+  const compounds = []
+  let skippedCompounds = 0
+
+  for (const row of compoundRows) {
+    const draft = createCompoundRecord(row, [])
+    if (!isValidCompoundIdentity(draft.name, draft.slug)) {
+      skippedCompounds += 1
+      continue
+    }
+    if (compounds.some(compound => compound.slug === draft.slug)) continue
+    draft.foundIn = (foundInByCompoundSlug.get(draft.slug) || []).sort((a, b) => a.localeCompare(b))
+    compounds.push(draft)
+  }
+
+  herbs.sort((a, b) => a.slug.localeCompare(b.slug))
+  compounds.sort((a, b) => a.slug.localeCompare(b.slug))
+
+  const herbsSummary = herbs.map(herb => ({
+    name: herb.name,
+    slug: herb.slug,
+    summary: herb.summary,
+    evidenceLevel: herb.evidenceLevel,
+    review_status: herb.review_status,
+    source_status: herb.source_status,
+    sourceCount: herb.sourceCount,
+    confidenceTier: herb.confidenceTier,
+  }))
+
+  const compoundsSummary = compounds.map(compound => ({
+    name: compound.name,
+    slug: compound.slug,
+    summary: compound.summary,
+    evidenceLevel: compound.evidenceLevel,
+    review_status: compound.review_status,
+    source_status: compound.source_status,
+    sourceCount: compound.sourceCount,
+    confidenceTier: compound.confidenceTier,
+  }))
+
+  writeJson(path.join(outputDir, 'herbs.json'), herbs)
+  writeJson(path.join(outputDir, 'compounds.json'), compounds)
+  writeJson(path.join(outputDir, 'herbs-summary.json'), herbsSummary)
+  writeJson(path.join(outputDir, 'compounds-summary.json'), compoundsSummary)
+
+  const buildInfo = {
+    generatedAt: new Date().toISOString(),
+    source: {
+      workbookPath,
+      sheets: {
+        herbs: REQUIRED_SHEETS.herbs,
+        compounds: REQUIRED_SHEETS.compounds,
+        herbCompoundMap: REQUIRED_SHEETS.herbCompoundMap,
+        claimRows: workbook.Sheets[OPTIONAL_SHEETS.claimRows] ? OPTIONAL_SHEETS.claimRows : null,
+      },
+    },
+    counts: {
+      herbs: herbs.length,
+      compounds: compounds.length,
+      herbsSummary: herbsSummary.length,
+      compoundsSummary: compoundsSummary.length,
+      claimRows: claimRows.length,
+      skippedHerbs,
+      skippedCompounds,
+    },
+  }
+
+  writeJson(path.join(metaDir, 'build-info.json'), buildInfo)
+
+  console.log(`[data-next] wrote herbs=${herbs.length} compounds=${compounds.length}`)
+  console.log(`[data-next] skipped herbs=${skippedHerbs} compounds=${skippedCompounds}`)
+  console.log(`[data-next] claim rows loaded=${claimRows.length}`)
+}
+
+run()


### PR DESCRIPTION
### Motivation
- Introduce a safe, parallel workbook-only data build path that does not touch the existing production pipeline or `public/data`.
- Provide a minimal first-step migration that produces shadow runtime artifacts for experiments and QA.
- Keep changes small, reversible, and self-contained under `public/data-next/`.

### Description
- Add a new runtime builder `scripts/data/build-runtime-from-workbook.mjs` which reuses `scripts/workbook-source.mjs` to resolve `data-sources/herb_monograph_master.xlsx` and reads `Herb Master Clean`, `Compound Master V3`, `Herb Compound Map V3`, and optional `Claim Rows`.
- Implement in-file normalization helpers (`normalizeText`, `normalizeList`, `normalizeSlug`, `isPlaceholderToken`) and record validation including compound-specific numeric and length guards, rejecting invalid name/slug tokens.
- Emit deterministic pretty JSON only to `public/data-next/` with the minimal requested payloads: `herbs.json`, `compounds.json`, `herbs-summary.json`, `compounds-summary.json`, and `_meta/build-info.json`.
- Add an npm script `data:build:next` in `package.json` to run the new builder and leave all legacy production scripts and `public/data/*.json` untouched.

### Testing
- Ran `npm run data:build:next` and the builder completed successfully producing the shadow outputs under `public/data-next/`.
- Generated counts: `herbs` = 285, `compounds` = 235, `herbs-summary` = 285, `compounds-summary` = 235, `claimRows` loaded = 4349, and total new files = 5 JSONs plus `_meta/build-info.json`.
- Skipped row counts: `skippedHerbs` = 0 and `skippedCompounds` = 0 as reported in `_meta/build-info.json`.
- Ran `npm run typecheck` (`tsc --noEmit`) and it passed with no TypeScript errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9867d9148323a37f1ab6f0fef4db)