### PR TITLE
Add blocking structural validator for public/data-next datasets

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,8 @@
     "data:build:next": "node scripts/data/build-runtime-from-workbook.mjs",
     "data:parity:report": "node scripts/data/report-migration-parity.mjs",
     "typecheck": "tsc --noEmit",
-    "check": "npm run lint && npm run typecheck && npm run build"
+    "check": "npm run lint && npm run typecheck && npm run build",
+    "data:validate:next": "node scripts/data/validate-data-next.mjs"
   },
   "engines": {
     "node": ">=20 <21"

--- a/public/data-next/_meta/build-info.json
+++ b/public/data-next/_meta/build-info.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-24T16:22:42.535Z",
+  "generatedAt": "2026-04-24T16:33:54.060Z",
   "source": {
     "workbookPath": "/workspace/hippie-scientist-site/data-sources/herb_monograph_master.xlsx",
     "sheets": {

--- a/scripts/data/validate-data-next.mjs
+++ b/scripts/data/validate-data-next.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const repoRoot = path.resolve(__dirname, '../..')
+
+const PLACEHOLDER_VALUES = new Set(['unknown', 'nan', 'null', 'undefined', '[object object]'])
+
+function normalize(value) {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'number' && Number.isNaN(value)) return 'nan'
+  return String(value).trim()
+}
+
+function isPlaceholder(value) {
+  const normalized = normalize(value).toLowerCase()
+  return PLACEHOLDER_VALUES.has(normalized)
+}
+
+function readDataset(relativePath) {
+  const filePath = path.join(repoRoot, relativePath)
+  const raw = fs.readFileSync(filePath, 'utf8')
+  const parsed = JSON.parse(raw)
+  if (!Array.isArray(parsed)) {
+    throw new Error(`[data-next-validate] Dataset must be an array: ${relativePath}`)
+  }
+  return parsed
+}
+
+function pushError(errors, dataset, index, slug, field, value, reason) {
+  errors.push({ dataset, index, slug: normalize(slug), field, value: normalize(value), reason })
+}
+
+function validateDataset(datasetName, records, kind, errors) {
+  const slugIndexByValue = new Map()
+
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index] || {}
+    const name = normalize(record.name)
+    const slug = normalize(record.slug)
+
+    if (!name) {
+      pushError(errors, datasetName, index, slug, 'name', name, 'missing name')
+    }
+
+    if (!slug) {
+      pushError(errors, datasetName, index, slug, 'slug', slug, 'missing slug')
+    }
+
+    if (name && isPlaceholder(name)) {
+      pushError(errors, datasetName, index, slug, 'name', name, 'placeholder value')
+    }
+
+    if (slug && isPlaceholder(slug)) {
+      pushError(errors, datasetName, index, slug, 'slug', slug, 'placeholder value')
+    }
+
+    if (kind === 'compound') {
+      if (/^\d+$/.test(name)) {
+        pushError(errors, datasetName, index, slug, 'name', name, 'compound name cannot be numeric-only')
+      }
+      if (/^\d+$/.test(slug)) {
+        pushError(errors, datasetName, index, slug, 'slug', slug, 'compound slug cannot be numeric-only')
+      }
+      if (name.length === 1) {
+        pushError(errors, datasetName, index, slug, 'name', name, 'compound name cannot be one character')
+      }
+      if (slug.length === 1) {
+        pushError(errors, datasetName, index, slug, 'slug', slug, 'compound slug cannot be one character')
+      }
+    }
+
+    if (kind === 'herb') {
+      if (name.length === 1) {
+        pushError(errors, datasetName, index, slug, 'name', name, 'herb name cannot be one character')
+      }
+      if (slug.length === 1) {
+        pushError(errors, datasetName, index, slug, 'slug', slug, 'herb slug cannot be one character')
+      }
+    }
+
+    if (slug) {
+      const existingIndexes = slugIndexByValue.get(slug) || []
+      existingIndexes.push(index)
+      slugIndexByValue.set(slug, existingIndexes)
+    }
+  }
+
+  for (const [slug, indexes] of slugIndexByValue.entries()) {
+    if (indexes.length <= 1) continue
+    for (const index of indexes) {
+      pushError(errors, datasetName, index, slug, 'slug', slug, `duplicate slug appears ${indexes.length} times`)
+    }
+  }
+}
+
+function printErrors(errors) {
+  for (const err of errors) {
+    console.error(`${err.dataset} | ${err.index} | ${err.slug} | ${err.field} | ${err.value} | ${err.reason}`)
+  }
+}
+
+function run() {
+  const herbs = readDataset(path.join('public', 'data-next', 'herbs.json'))
+  const compounds = readDataset(path.join('public', 'data-next', 'compounds.json'))
+
+  const errors = []
+  validateDataset('herbs', herbs, 'herb', errors)
+  validateDataset('compounds', compounds, 'compound', errors)
+
+  if (errors.length > 0) {
+    printErrors(errors)
+    console.error(`[data-next-validate] blocking structural issues: ${errors.length}`)
+    process.exit(1)
+  }
+
+  console.log('[data-next-validate] PASS herbs+compounds structural validation')
+}
+
+run()


### PR DESCRIPTION
### Motivation
- Ensure structural integrity of the runtime data artifacts in `public/data-next` by adding a blocking validator that prevents shipping malformed records for entity routes.

### Description
- Add `scripts/data/validate-data-next.mjs` which validates `public/data-next/herbs.json` and `public/data-next/compounds.json` for missing/placeholder `name` and `slug`, duplicate slugs, compound-specific numeric-only and one-character constraints, and herb one-character constraints, printing errors as `dataset | index | slug | field | value | reason` and exiting with code `1` only on blocking issues.
- Add `data:validate:next` npm script (`node scripts/data/validate-data-next.mjs`) and do not change existing `validate:data` behavior, public `data/*.json`, or the workbook pipeline.
- Regenerate `public/data-next/_meta/build-info.json` by running the existing build step (`data:build:next`) so the validator runs against current runtime outputs.

### Testing
- Ran `npm run data:build:next` which completed and produced `[data-next] wrote herbs=285 compounds=235` and updated `public/data-next/_meta/build-info.json` (succeeded).
- Ran `npm run data:validate:next` which printed `[data-next-validate] PASS herbs+compounds structural validation` (succeeded).
- Ran `npm run typecheck` (`tsc --noEmit`) which completed with no TypeScript errors (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9b3f4bfc8323b7d605b65bc55b71)