### PR TITLE
Harden data-next parity reporting with slug alias mapping and root-cause buckets

### DIFF
--- a/scripts/data/report-migration-parity.mjs
+++ b/scripts/data/report-migration-parity.mjs
@@ -3,6 +3,9 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+import XLSX from 'xlsx'
+import { resolveWorkbookPath } from '../workbook-source.mjs'
+import { SLUG_ALIASES } from './slug-aliases.mjs'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -25,6 +28,19 @@ const REQUIRED_FIELDS = {
   compounds: ['name', 'slug', 'summary'],
 }
 
+const WORKBOOK_SHEETS = {
+  herbs: 'Herb Master Clean',
+  compounds: 'Compound Master V3',
+}
+
+const ROOT_CAUSES = {
+  MISSING_WORKBOOK_ROW: 'missing_workbook_row',
+  PARSER_SKIP: 'parser_skip',
+  ALIAS_MISSING: 'alias_missing',
+  NORMALIZATION_DRIFT: 'normalization_drift',
+  UNKNOWN: 'unknown',
+}
+
 function readJsonArray(filePath) {
   if (!fs.existsSync(filePath)) {
     throw new Error(`Missing required file: ${path.relative(repoRoot, filePath)}`)
@@ -45,9 +61,67 @@ function readJsonArray(filePath) {
   return parsed
 }
 
-function normalizeSlug(value) {
+function normalizeText(value) {
   if (value === null || value === undefined) return ''
-  return String(value).trim().toLowerCase()
+  return String(value).trim().replace(/\s+/g, ' ').toLowerCase()
+}
+
+function normalizeSlug(value) {
+  return normalizeText(value)
+}
+
+function getComparableSlug(value) {
+  return normalizeSlug(value).replace(/[^a-z0-9]/g, '')
+}
+
+function firstNonEmpty(row, keys) {
+  for (const key of keys) {
+    const value = String(row?.[key] ?? '').trim()
+    if (value) return value
+  }
+  return ''
+}
+
+function toSimpleRow(row) {
+  const output = {}
+  for (const [key, value] of Object.entries(row || {})) {
+    const normalizedKey = String(key ?? '').trim()
+    if (!normalizedKey) continue
+    output[normalizedKey] = value
+  }
+  return output
+}
+
+function readWorkbookRows(entityName) {
+  const workbookPath = resolveWorkbookPath(repoRoot)
+  const workbook = XLSX.readFile(workbookPath)
+  const sheetName = WORKBOOK_SHEETS[entityName]
+  const sheet = workbook.Sheets[sheetName]
+  if (!sheet) {
+    throw new Error(`[parity] missing workbook sheet: ${sheetName}`)
+  }
+
+  return XLSX.utils
+    .sheet_to_json(sheet, {
+      defval: '',
+      raw: false,
+      blankrows: false,
+    })
+    .map(toSimpleRow)
+}
+
+function getWorkbookIdentity(entityName, row) {
+  if (entityName === 'herbs') {
+    return {
+      name: firstNonEmpty(row, ['name', 'herbName']),
+      slug: normalizeSlug(firstNonEmpty(row, ['slug', 'herbSlug', 'name'])),
+    }
+  }
+
+  return {
+    name: firstNonEmpty(row, ['name', 'compoundName', 'canonicalCompoundName', 'compound']),
+    slug: normalizeSlug(firstNonEmpty(row, ['slug', 'canonicalCompoundId', 'compoundName', 'name'])),
+  }
 }
 
 function findDuplicateSlugs(records) {
@@ -66,12 +140,6 @@ function findDuplicateSlugs(records) {
 
 function buildSlugSet(records) {
   return new Set(records.map(record => normalizeSlug(record?.slug)).filter(Boolean))
-}
-
-function diffSlugSets(currentSet, nextSet) {
-  const missingInNext = Array.from(currentSet).filter(slug => !nextSet.has(slug)).sort()
-  const extraInNext = Array.from(nextSet).filter(slug => !currentSet.has(slug)).sort()
-  return { missingInNext, extraInNext }
 }
 
 function assessRequiredFields(records, requiredFields) {
@@ -107,10 +175,174 @@ function assessRequiredFields(records, requiredFields) {
   return { totals, missingByField }
 }
 
-function buildEntityParity(entityName, currentRecords, nextRecords) {
+function countByRootCause(items) {
+  const counts = {
+    [ROOT_CAUSES.MISSING_WORKBOOK_ROW]: 0,
+    [ROOT_CAUSES.PARSER_SKIP]: 0,
+    [ROOT_CAUSES.ALIAS_MISSING]: 0,
+    [ROOT_CAUSES.NORMALIZATION_DRIFT]: 0,
+    [ROOT_CAUSES.UNKNOWN]: 0,
+  }
+
+  for (const item of items) {
+    const bucket = item?.rootCause || ROOT_CAUSES.UNKNOWN
+    if (!Object.prototype.hasOwnProperty.call(counts, bucket)) {
+      counts[ROOT_CAUSES.UNKNOWN] += 1
+      continue
+    }
+    counts[bucket] += 1
+  }
+
+  return counts
+}
+
+function classifyByNameSlugDifference(currentSlug, nextSlug) {
+  if (!currentSlug || !nextSlug) return ROOT_CAUSES.UNKNOWN
+  return getComparableSlug(currentSlug) === getComparableSlug(nextSlug)
+    ? ROOT_CAUSES.NORMALIZATION_DRIFT
+    : ROOT_CAUSES.ALIAS_MISSING
+}
+
+function createIndexes(records) {
+  const bySlug = new Map()
+  const byName = new Map()
+
+  for (const record of records) {
+    const slug = normalizeSlug(record?.slug)
+    const name = normalizeText(record?.name)
+    if (slug && !bySlug.has(slug)) {
+      bySlug.set(slug, record)
+    }
+    if (name && !byName.has(name)) {
+      byName.set(name, record)
+    }
+  }
+
+  return { bySlug, byName }
+}
+
+function createWorkbookIndexes(entityName, rows) {
+  const bySlug = new Set()
+  const byName = new Set()
+
+  for (const row of rows) {
+    const identity = getWorkbookIdentity(entityName, row)
+    if (identity.slug) bySlug.add(identity.slug)
+    if (normalizeText(identity.name)) byName.add(normalizeText(identity.name))
+  }
+
+  return { bySlug, byName }
+}
+
+function analyzeSlugParity(entityName, currentRecords, nextRecords, workbookRows) {
+  const aliases = SLUG_ALIASES[entityName] || {}
+  const currentIndexes = createIndexes(currentRecords)
+  const nextIndexes = createIndexes(nextRecords)
+  const workbookIndexes = createWorkbookIndexes(entityName, workbookRows)
+
   const currentSet = buildSlugSet(currentRecords)
   const nextSet = buildSlugSet(nextRecords)
-  const { missingInNext, extraInNext } = diffSlugSets(currentSet, nextSet)
+
+  const directMatches = Array.from(currentSet).filter(slug => nextSet.has(slug)).sort()
+
+  const aliasMatches = []
+  const matchedCurrentSlugs = new Set(directMatches)
+  const matchedNextSlugs = new Set(directMatches)
+
+  for (const [fromSlugRaw, toSlugRaw] of Object.entries(aliases)) {
+    const fromSlug = normalizeSlug(fromSlugRaw)
+    const toSlug = normalizeSlug(toSlugRaw)
+    if (!fromSlug || !toSlug) continue
+    if (!currentSet.has(fromSlug)) continue
+    if (!nextSet.has(toSlug)) continue
+
+    const currentRecord = currentIndexes.bySlug.get(fromSlug)
+    const nextRecord = nextIndexes.bySlug.get(toSlug)
+
+    aliasMatches.push({
+      fromSlug,
+      toSlug,
+      currentName: currentRecord?.name || '',
+      nextName: nextRecord?.name || '',
+    })
+
+    matchedCurrentSlugs.add(fromSlug)
+    matchedNextSlugs.add(toSlug)
+  }
+
+  const unresolvedMissing = Array.from(currentSet)
+    .filter(slug => !matchedCurrentSlugs.has(slug))
+    .map(slug => {
+      const currentRecord = currentIndexes.bySlug.get(slug)
+      const normalizedName = normalizeText(currentRecord?.name)
+      const nextByName = normalizedName ? nextIndexes.byName.get(normalizedName) : null
+
+      let rootCause = ROOT_CAUSES.UNKNOWN
+      let evidence = ''
+
+      if (nextByName && normalizeSlug(nextByName.slug) !== slug) {
+        rootCause = classifyByNameSlugDifference(slug, normalizeSlug(nextByName.slug))
+        evidence = `name_match:${normalizeSlug(nextByName.slug)}`
+      } else {
+        const inWorkbook = workbookIndexes.bySlug.has(slug) || (normalizedName && workbookIndexes.byName.has(normalizedName))
+        if (inWorkbook) {
+          rootCause = ROOT_CAUSES.PARSER_SKIP
+          evidence = 'present_in_workbook_not_emitted'
+        } else {
+          rootCause = ROOT_CAUSES.MISSING_WORKBOOK_ROW
+          evidence = 'absent_from_workbook_rows'
+        }
+      }
+
+      return {
+        slug,
+        name: currentRecord?.name || '',
+        rootCause,
+        evidence,
+      }
+    })
+    .sort((a, b) => a.slug.localeCompare(b.slug))
+
+  const unresolvedExtras = Array.from(nextSet)
+    .filter(slug => !matchedNextSlugs.has(slug))
+    .map(slug => {
+      const nextRecord = nextIndexes.bySlug.get(slug)
+      const normalizedName = normalizeText(nextRecord?.name)
+      const currentByName = normalizedName ? currentIndexes.byName.get(normalizedName) : null
+
+      let rootCause = ROOT_CAUSES.UNKNOWN
+      let evidence = ''
+
+      if (currentByName && normalizeSlug(currentByName.slug) !== slug) {
+        rootCause = classifyByNameSlugDifference(normalizeSlug(currentByName.slug), slug)
+        evidence = `name_match:${normalizeSlug(currentByName.slug)}`
+      }
+
+      return {
+        slug,
+        name: nextRecord?.name || '',
+        rootCause,
+        evidence,
+      }
+    })
+    .sort((a, b) => a.slug.localeCompare(b.slug))
+
+  return {
+    currentSet,
+    nextSet,
+    directMatches,
+    aliasMatches,
+    unresolvedMissing,
+    unresolvedExtras,
+    rootCauseBuckets: {
+      unresolvedMissing: countByRootCause(unresolvedMissing),
+      unresolvedExtras: countByRootCause(unresolvedExtras),
+    },
+  }
+}
+
+function buildEntityParity(entityName, currentRecords, nextRecords, workbookRows) {
+  const slugParity = analyzeSlugParity(entityName, currentRecords, nextRecords, workbookRows)
 
   return {
     entity: entityName,
@@ -120,12 +352,17 @@ function buildEntityParity(entityName, currentRecords, nextRecords) {
       delta: nextRecords.length - currentRecords.length,
     },
     slugSets: {
-      currentUnique: currentSet.size,
-      nextUnique: nextSet.size,
-      missingInNextCount: missingInNext.length,
-      extraInNextCount: extraInNext.length,
-      missingInNext,
-      extraInNext,
+      currentUnique: slugParity.currentSet.size,
+      nextUnique: slugParity.nextSet.size,
+      directMatchesCount: slugParity.directMatches.length,
+      aliasMatchesCount: slugParity.aliasMatches.length,
+      missingInNextCount: slugParity.unresolvedMissing.length,
+      extraInNextCount: slugParity.unresolvedExtras.length,
+      directMatches: slugParity.directMatches,
+      aliasMatches: slugParity.aliasMatches,
+      unresolvedMissing: slugParity.unresolvedMissing,
+      unresolvedExtras: slugParity.unresolvedExtras,
+      rootCauseBuckets: slugParity.rootCauseBuckets,
     },
     requiredFields: {
       current: assessRequiredFields(currentRecords, REQUIRED_FIELDS[entityName]),
@@ -138,11 +375,30 @@ function buildEntityParity(entityName, currentRecords, nextRecords) {
   }
 }
 
+function formatTopList(items, label, count = 25) {
+  const sliced = items.slice(0, count)
+  if (sliced.length === 0) {
+    return [`### ${label}`, '', '- none', '']
+  }
+
+  const lines = [`### ${label}`, '']
+  for (const item of sliced) {
+    lines.push(`- ${item.slug}${item.name ? ` (${item.name})` : ''} [${item.rootCause}]`)
+  }
+  lines.push('')
+  return lines
+}
+
 function writeOutputs(report) {
   fs.mkdirSync(path.dirname(OUTPUTS.json), { recursive: true })
   fs.writeFileSync(OUTPUTS.json, `${JSON.stringify(report, null, 2)}\n`, 'utf8')
 
-  const md = [
+  const rootCauseLines = entity =>
+    Object.entries(report[entity].slugSets.rootCauseBuckets.unresolvedMissing)
+      .map(([bucket, value]) => `${bucket}=${value}`)
+      .join(', ')
+
+  const mdLines = [
     '# Data-next parity report',
     '',
     `Generated: ${report.generatedAt}`,
@@ -156,10 +412,19 @@ function writeOutputs(report) {
     '',
     '## Slug parity',
     '',
-    `- Herbs missing in data-next: ${report.herbs.slugSets.missingInNextCount}`,
-    `- Herbs extra in data-next: ${report.herbs.slugSets.extraInNextCount}`,
-    `- Compounds missing in data-next: ${report.compounds.slugSets.missingInNextCount}`,
-    `- Compounds extra in data-next: ${report.compounds.slugSets.extraInNextCount}`,
+    `- Herbs direct matches: ${report.herbs.slugSets.directMatchesCount}`,
+    `- Herbs alias matches: ${report.herbs.slugSets.aliasMatchesCount}`,
+    `- Herbs unresolved missing in data-next: ${report.herbs.slugSets.missingInNextCount}`,
+    `- Herbs unresolved extra in data-next: ${report.herbs.slugSets.extraInNextCount}`,
+    `- Compounds direct matches: ${report.compounds.slugSets.directMatchesCount}`,
+    `- Compounds alias matches: ${report.compounds.slugSets.aliasMatchesCount}`,
+    `- Compounds unresolved missing in data-next: ${report.compounds.slugSets.missingInNextCount}`,
+    `- Compounds unresolved extra in data-next: ${report.compounds.slugSets.extraInNextCount}`,
+    '',
+    '## Root-cause bucket counts (unresolved missing)',
+    '',
+    `- Herbs: ${rootCauseLines('herbs')}`,
+    `- Compounds: ${rootCauseLines('compounds')}`,
     '',
     '## Required field gaps (data-next)',
     '',
@@ -175,9 +440,13 @@ function writeOutputs(report) {
     `- Herbs current/data-next: ${report.herbs.duplicateSlugs.current.length}/${report.herbs.duplicateSlugs.next.length}`,
     `- Compounds current/data-next: ${report.compounds.duplicateSlugs.current.length}/${report.compounds.duplicateSlugs.next.length}`,
     '',
-  ].join('\n')
+    ...formatTopList(report.herbs.slugSets.unresolvedMissing, 'Top 25 unresolved missing herbs'),
+    ...formatTopList(report.compounds.slugSets.unresolvedMissing, 'Top 25 unresolved missing compounds'),
+    ...formatTopList(report.herbs.slugSets.unresolvedExtras, 'Top 25 extra herbs'),
+    ...formatTopList(report.compounds.slugSets.unresolvedExtras, 'Top 25 extra compounds'),
+  ]
 
-  fs.writeFileSync(OUTPUTS.md, `${md}\n`, 'utf8')
+  fs.writeFileSync(OUTPUTS.md, `${mdLines.join('\n')}\n`, 'utf8')
 }
 
 function printSummary(report) {
@@ -185,7 +454,7 @@ function printSummary(report) {
   console.log(`- herbs current=${report.herbs.counts.current} next=${report.herbs.counts.next} delta=${report.herbs.counts.delta}`)
   console.log(`- compounds current=${report.compounds.counts.current} next=${report.compounds.counts.next} delta=${report.compounds.counts.delta}`)
   console.log(
-    `- slug gaps herbs missing=${report.herbs.slugSets.missingInNextCount} extra=${report.herbs.slugSets.extraInNextCount}; compounds missing=${report.compounds.slugSets.missingInNextCount} extra=${report.compounds.slugSets.extraInNextCount}`,
+    `- slug gaps herbs missing=${report.herbs.slugSets.missingInNextCount} extra=${report.herbs.slugSets.extraInNextCount} alias=${report.herbs.slugSets.aliasMatchesCount}; compounds missing=${report.compounds.slugSets.missingInNextCount} extra=${report.compounds.slugSets.extraInNextCount} alias=${report.compounds.slugSets.aliasMatchesCount}`,
   )
   console.log(
     `- duplicate slug groups herbs current/next=${report.herbs.duplicateSlugs.current.length}/${report.herbs.duplicateSlugs.next.length}; compounds current/next=${report.compounds.duplicateSlugs.current.length}/${report.compounds.duplicateSlugs.next.length}`,
@@ -200,10 +469,13 @@ function run() {
   const nextHerbs = readJsonArray(INPUTS.nextHerbs)
   const nextCompounds = readJsonArray(INPUTS.nextCompounds)
 
+  const workbookHerbs = readWorkbookRows('herbs')
+  const workbookCompounds = readWorkbookRows('compounds')
+
   const report = {
     generatedAt: new Date().toISOString(),
-    herbs: buildEntityParity('herbs', currentHerbs, nextHerbs),
-    compounds: buildEntityParity('compounds', currentCompounds, nextCompounds),
+    herbs: buildEntityParity('herbs', currentHerbs, nextHerbs, workbookHerbs),
+    compounds: buildEntityParity('compounds', currentCompounds, nextCompounds, workbookCompounds),
   }
 
   writeOutputs(report)

--- a/scripts/data/slug-aliases.mjs
+++ b/scripts/data/slug-aliases.mjs
@@ -1,0 +1,6 @@
+export const SLUG_ALIASES = {
+  herbs: {},
+  compounds: {
+    'aescin-escin': 'aescin',
+  },
+}


### PR DESCRIPTION
### Motivation

- Improve parity diagnostics so migration gaps are actionable by surfacing alias matches and conservative root-cause buckets.  
- Avoid noisy or speculative aliasing by seeding only proven, obvious mappings.  
- Provide top-25 unresolved lists and clear counts to prioritize workbook/parser fixes.

### Description

- Changed files: `scripts/data/slug-aliases.mjs` and `scripts/data/report-migration-parity.mjs`, and regenerated parity artifacts `reports/data-next-parity-report.json` and `reports/data-next-parity-report.md` (report outputs only; no changes to `public/data/*.json`).
- Alias map contents: `SLUG_ALIASES = { herbs: {}, compounds: { 'aescin-escin': 'aescin' } }` which seeds the single proven compound alias and supports per-entity aliasing.
- Report logic: the parity script now loads workbook rows and `SLUG_ALIASES`, applies alias-aware matching to produce `directMatches`, `aliasMatches`, `unresolvedMissing`, and `unresolvedExtras`, and emits `rootCauseBuckets` in the JSON report and enhanced markdown (top-25 lists included).
- Root-cause buckets and heuristics: implemented `missing_workbook_row`, `parser_skip`, `alias_missing`, `normalization_drift`, and `unknown`, with conservative rules that prefer name-based evidence and comparable-slug checks to distinguish normalization drift vs alias issues.

### Testing

- `npm run data:build:next` — ran successfully and emitted `data-next` counts (`herbs=285 compounds=235`).
- `npm run data:parity:report` — ran successfully and wrote parity artifacts (`reports/data-next-parity-report.json` / `.md`).
- `npm run data:validate:next` — ran successfully and passed structural validation (`[data-next-validate] PASS herbs+compounds structural validation`).
- `npm run typecheck` — ran successfully (`tsc --noEmit` completed with no errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eba5a1bbcc8323908fae4ffa938a43)