### PR TITLE
Add compatibility route for /goals/:slug

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,6 +36,7 @@ const StarterPackSuccess = lazy(() => import('./pages/StarterPackSuccess'))
 const Downloads = lazy(() => import('./pages/Downloads'))
 const LearningPaths = lazy(() => import('./pages/LearningPaths'))
 const HerbGoalPage = lazy(() => import('./pages/HerbGoalPage'))
+const GoalProfilePage = lazy(() => import('./pages/GoalProfilePage'))
 const BestHerbsEntryPage = lazy(() => import('./pages/BestHerbsEntryPage'))
 const Methodology = lazy(() => import('./pages/Methodology'))
 const InteractionsPage = lazy(() => import('./pages/InteractionsPage'))
@@ -96,6 +97,7 @@ export default function App() {
                   />
                   <Route path='/learning' element={<LearningPaths />} />
                   <Route path='/herbs-for-:goal' element={<HerbGoalPage />} />
+                  <Route path='/goals/:slug' element={<GoalProfilePage />} />
                   <Route path='/best-herbs-for-:intent' element={<BestHerbsEntryPage />} />
                   <Route path='/favorites' element={<Favorites />} />
                   <Route path='/newsletter' element={<Newsletter />} />

--- a/src/pages/GoalProfilePage.tsx
+++ b/src/pages/GoalProfilePage.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import Meta from '@/components/Meta'
+
+type GoalPageRecord = {
+  slug?: string
+  title?: string
+  summary?: string
+}
+
+function toTitleCase(value: string) {
+  return value
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+
+export default function GoalProfilePage() {
+  const { slug = '' } = useParams<{ slug: string }>()
+  const goalSlug = String(slug || '').trim().toLowerCase()
+  const [goalRecord, setGoalRecord] = useState<GoalPageRecord | null>(null)
+
+  useEffect(() => {
+    let active = true
+
+    if (!goalSlug) {
+      setGoalRecord(null)
+      return () => {
+        active = false
+      }
+    }
+
+    const loadGoalRecord = async () => {
+      try {
+        const response = await fetch('/data/goal-pages.json')
+        if (!response.ok) return
+
+        const payload: unknown = await response.json()
+        if (!Array.isArray(payload)) return
+
+        const match = payload.find(item => {
+          if (!item || typeof item !== 'object') return false
+          const candidate = (item as { slug?: unknown }).slug
+          return typeof candidate === 'string' && candidate.trim().toLowerCase() === goalSlug
+        })
+
+        if (!active) return
+
+        if (match && typeof match === 'object') {
+          setGoalRecord(match as GoalPageRecord)
+        } else {
+          setGoalRecord(null)
+        }
+      } catch {
+        if (active) setGoalRecord(null)
+      }
+    }
+
+    loadGoalRecord()
+
+    return () => {
+      active = false
+    }
+  }, [goalSlug])
+
+  const fallbackTitle = useMemo(() => toTitleCase(goalSlug), [goalSlug])
+  const heading = goalRecord?.title?.trim() || fallbackTitle || 'Goal'
+  const summary = goalRecord?.summary?.trim() || 'Goal profile pending review.'
+
+  return (
+    <main className='container-page py-8'>
+      <Meta
+        title={`${heading} Goal | The Hippie Scientist`}
+        description='Goal profile pending review.'
+        path={goalSlug ? `/goals/${goalSlug}` : '/goals'}
+      />
+
+      <section className='ds-card-lg'>
+        <h1 className='text-3xl font-semibold text-white'>{heading}</h1>
+        <p className='mt-3 text-sm text-white/80'>{summary}</p>
+
+        <div className='mt-5 flex flex-wrap gap-2'>
+          {goalSlug ? (
+            <Link
+              to={`/herbs-for-${encodeURIComponent(goalSlug)}`}
+              className='rounded-full border border-white/15 bg-white/5 px-3 py-1.5 text-xs text-white/85 transition hover:border-cyan-300/50 hover:text-cyan-100'
+            >
+              Browse herbs for this goal
+            </Link>
+          ) : null}
+          <Link
+            to='/learning'
+            className='rounded-full border border-white/15 bg-white/5 px-3 py-1.5 text-xs text-white/85 transition hover:border-cyan-300/50 hover:text-cyan-100'
+          >
+            Explore learning paths
+          </Link>
+        </div>
+      </section>
+    </main>
+  )
+}


### PR DESCRIPTION
### Motivation
- Ensure the app honors the route contract by adding a minimal compatibility route at `/goals/:slug` so legacy links and integrations continue to work. 
- Keep the change surgical: preserve existing `/herbs-for-:goal` behavior, avoid changing the data pipeline, and tolerate absent goal data. 

### Description
- Wired a lazy-loaded `GoalProfilePage` and added a new route `'/goals/:slug'` in `src/App.tsx` to provide the compatibility endpoint. 
- Implemented `src/pages/GoalProfilePage.tsx` as a thin, resilient page that title-cases the slug for the `h1`, shows fallback text (`Goal profile pending review.`), attempts to load `/data/goal-pages.json` for a matching record, and gracefully falls back when data is missing. 
- The page includes lightweight navigation links to the existing collection page (`/herbs-for-:goal`) and learning paths (`/learning`) and does not remove or change legacy files or data generation scripts. 
- Changed files: `src/App.tsx`, `src/pages/GoalProfilePage.tsx`. 

### Testing
- Ran `npm run typecheck`, which completed successfully. 
- Ran `npm run build`, which completed successfully (full build and prerender passed). 
- No automated tests failed as part of these checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebc0d36f7883239a0d379d606b77d2)