### PR TITLE
Cut over production data scripts to workbook runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "prebuild:validate": "node scripts/validate-herbs.mjs && npm run verify:affiliate-products",
     "clean:source-refs": "node scripts/clean-source-refs.mjs",
     "validate:data": "tsx scripts/validate-datasets.ts --fail-on-error",
-    "data:build": "npm run data:build:next",
-    "data:validate": "npm run data:validate:next",
+    "data:build": "node scripts/data/build-runtime-from-workbook.mjs --out public/data",
+    "data:validate": "node scripts/data/validate-data-next.mjs --data-dir public/data",
     "check:images": "node tools/check-images.mjs",
     "rebuild:data": "npm run data:refresh",
-    "prebuild": "node scripts/sync-updated-datasets.mjs && npm run clean:source-refs && node scripts/dedupe-entities.mjs && node scripts/generate-entity-payloads.mjs && node scripts/generate-site-counts.mjs && node scripts/generate-homepage-data.mjs && node scripts/generate-homepage-featured.mjs && node scripts/generate-rss.mjs && npm run verify:affiliate-products",
+    "prebuild": "npm run data:build && npm run clean:source-refs && node scripts/dedupe-entities.mjs && node scripts/generate-entity-payloads.mjs && node scripts/generate-site-counts.mjs && node scripts/generate-homepage-data.mjs && node scripts/generate-homepage-featured.mjs && node scripts/generate-rss.mjs && npm run verify:affiliate-products",
     "build:compile": "vite build",
     "build": "npm run build:compile",
     "postbuild": "node scripts/prerender-static.mjs && node scripts/generate-sitemap.mjs dist && node scripts/ensure-dist-redirects.mjs && npm run verify:enrichment-editorial && node scripts/validate-structured-data-smoke.mjs && node scripts/generate-version-json.mjs",
@@ -187,7 +187,8 @@
     "check": "npm run lint && npm run typecheck && npm run build",
     "data:validate:next": "node scripts/data/validate-data-next.mjs",
     "data:coverage:next": "node scripts/data/report-workbook-parser-coverage.mjs",
-    "data:report:quality": "npm run data:coverage:next"
+    "data:report:quality": "node scripts/data/report-workbook-parser-coverage.mjs --data-dir public/data",
+    "data:build:legacy": "node scripts/sync-updated-datasets.mjs && npm run clean:source-refs && node scripts/dedupe-entities.mjs && node scripts/generate-entity-payloads.mjs && node scripts/generate-site-counts.mjs && node scripts/generate-homepage-data.mjs && node scripts/generate-homepage-featured.mjs && node scripts/generate-rss.mjs && npm run verify:affiliate-products"
   },
   "engines": {
     "node": ">=20 <21"

--- a/scripts/data/report-workbook-parser-coverage.mjs
+++ b/scripts/data/report-workbook-parser-coverage.mjs
@@ -16,17 +16,37 @@ const SHEETS = {
   herbCompoundMap: 'Herb Compound Map V3',
 }
 
-const INPUTS = {
-  herbs: path.join(repoRoot, 'public', 'data-next', 'herbs.json'),
-  compounds: path.join(repoRoot, 'public', 'data-next', 'compounds.json'),
-}
-
 const OUTPUTS = {
   json: path.join(repoRoot, 'reports', 'data-next-workbook-parser-coverage.json'),
   md: path.join(repoRoot, 'reports', 'data-next-workbook-parser-coverage.md'),
 }
 
 const PLACEHOLDER_TOKENS = new Set(['', 'unknown', 'nan', 'null', 'undefined', '[object object]'])
+
+function parseArgs(argv) {
+  const args = argv.slice(2)
+  let dataDir = path.join('public', 'data-next')
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (arg === '--data-dir') {
+      dataDir = args[index + 1] || ''
+      index += 1
+      continue
+    }
+
+    if (arg.startsWith('--data-dir=')) {
+      dataDir = arg.slice('--data-dir='.length)
+    }
+  }
+
+  const normalized = String(dataDir || '').trim()
+  if (!normalized) {
+    throw new Error('[data-coverage-next] Missing value for --data-dir')
+  }
+
+  return path.resolve(repoRoot, normalized)
+}
 
 function normalizeText(value) {
   if (value === null || value === undefined) return ''
@@ -323,6 +343,11 @@ function writeReport(report) {
 }
 
 function run() {
+  const dataDir = parseArgs(process.argv)
+  const inputs = {
+    herbs: path.join(dataDir, 'herbs.json'),
+    compounds: path.join(dataDir, 'compounds.json'),
+  }
   const workbookPath = resolveWorkbookPath(repoRoot)
   const workbook = XLSX.readFile(workbookPath)
 
@@ -330,8 +355,8 @@ function run() {
   const compoundRows = readSheetRows(workbook, SHEETS.compounds)
   const herbCompoundMapRows = readSheetRows(workbook, SHEETS.herbCompoundMap)
 
-  const emittedHerbs = readJsonArray(INPUTS.herbs)
-  const emittedCompounds = readJsonArray(INPUTS.compounds)
+  const emittedHerbs = readJsonArray(inputs.herbs)
+  const emittedCompounds = readJsonArray(inputs.compounds)
 
   const herbs = analyzeEntity({
     entityName: 'herbs',

--- a/scripts/data/validate-data-next.mjs
+++ b/scripts/data/validate-data-next.mjs
@@ -21,12 +21,36 @@ function isPlaceholder(value) {
   return PLACEHOLDER_VALUES.has(normalized)
 }
 
-function readDataset(relativePath) {
-  const filePath = path.join(repoRoot, relativePath)
+function parseArgs(argv) {
+  const args = argv.slice(2)
+  let dataDir = path.join('public', 'data-next')
+
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (arg === '--data-dir') {
+      dataDir = args[index + 1] || ''
+      index += 1
+      continue
+    }
+
+    if (arg.startsWith('--data-dir=')) {
+      dataDir = arg.slice('--data-dir='.length)
+    }
+  }
+
+  const normalized = String(dataDir || '').trim()
+  if (!normalized) {
+    throw new Error('[data-next-validate] Missing value for --data-dir')
+  }
+
+  return path.resolve(repoRoot, normalized)
+}
+
+function readDataset(filePath) {
   const raw = fs.readFileSync(filePath, 'utf8')
   const parsed = JSON.parse(raw)
   if (!Array.isArray(parsed)) {
-    throw new Error(`[data-next-validate] Dataset must be an array: ${relativePath}`)
+    throw new Error(`[data-next-validate] Dataset must be an array: ${path.relative(repoRoot, filePath)}`)
   }
   return parsed
 }
@@ -105,8 +129,9 @@ function printErrors(errors) {
 }
 
 function run() {
-  const herbs = readDataset(path.join('public', 'data-next', 'herbs.json'))
-  const compounds = readDataset(path.join('public', 'data-next', 'compounds.json'))
+  const dataDir = parseArgs(process.argv)
+  const herbs = readDataset(path.join(dataDir, 'herbs.json'))
+  const compounds = readDataset(path.join(dataDir, 'compounds.json'))
 
   const errors = []
   validateDataset('herbs', herbs, 'herb', errors)
@@ -118,7 +143,7 @@ function run() {
     process.exit(1)
   }
 
-  console.log('[data-next-validate] PASS herbs+compounds structural validation')
+  console.log(`[data-next-validate] PASS herbs+compounds structural validation (${path.relative(repoRoot, dataDir)})`)
 }
 
 run()


### PR DESCRIPTION
### Motivation
- Switch the canonical production data pipeline to the workbook runtime that emits into `public/data` while preserving the previous sync/prebuild chain for rollback and compatibility.
- Provide blocking validation and non-blocking quality reporting that target the canonical `public/data` output with minimal, surgical changes.

### Description
- Updated `package.json` scripts: set `data:build` to `node scripts/data/build-runtime-from-workbook.mjs --out public/data`, set `data:validate` to `node scripts/data/validate-data-next.mjs --data-dir public/data`, set `data:report:quality` to `node scripts/data/report-workbook-parser-coverage.mjs --data-dir public/data`, updated `prebuild` to start with `npm run data:build`, and preserved the previous production prebuild/sync chain as `data:build:legacy`.
- Extended `scripts/data/validate-data-next.mjs` and `scripts/data/report-workbook-parser-coverage.mjs` to accept a `--data-dir` argument (defaulting to `public/data-next`) and to read inputs from the supplied directory, keeping original behavior intact.
- Did not remove legacy scripts or data, did not modify the workbook, and did not manually edit generated JSON artifacts.

### Testing
- Ran `npm run data:build` which succeeded and wrote `herbs=285` and `compounds=235` with detail files (herbs detail=285, compounds detail=235) and `claim rows loaded=4349` into `public/data`.
- Ran `npm run data:validate` which passed with `[data-next-validate] PASS herbs+compounds structural validation (public/data)`, and ran `npm run data:report:quality` which wrote reports and reported `herbs raw=290 emitted=285 skipped=5` and `compounds raw=235 emitted=235 skipped=0`.
- Ran `npm run typecheck` which passed, and ran `npm run build` which failed during `verify:affiliate-products` with 3 `entity_page_mismatch` failures for `reishi-mushroom`, which is unrelated to missing generated workbook outputs.
- Rollback command: `git revert fc30ce2`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebc9427604832380131d1ae92cc2a1)