### PR TITLE
docs: make workbook-first pipeline the default production data path

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,54 +15,26 @@ Build production bundle:
 npm run build
 ```
 
-## Data pipeline (canonical)
+## Data pipeline (production default)
 
-The app now uses a single canonical runtime pipeline:
+Production data is generated from a single workbook source of truth:
 
-- Herb data source: `public/data/herbs.json`
-- Compound data source: `public/data/compounds.json`
-- Herb normalization + hooks: `src/lib/herb-data.ts`
-- Compound normalization + hooks: `src/lib/compound-data.ts`
-- Shared sanitization helpers: `src/lib/sanitize.ts`
-- Workbook-only migration contract: `docs/workbook-only-data-contract.md`
+- Source of truth workbook: `data-sources/herb_monograph_master.xlsx`
+- Generated runtime output: `public/data/*`
+- Do not manually edit generated JSON in `public/data`
+- Production data build command: `npm run data:build`
 
-When ingesting refreshed datasets:
+Build path summary:
 
-```bash
-npm run update-data
-```
+- `npm run build` runs `prebuild`
+- `prebuild` runs `npm run data:build` before compile/prerender steps
 
-## Workbook publish pipeline (minimal)
+Legacy rollback path (temporary only):
 
-Place workbook-derived JSON exports in:
+- `npm run data:build:legacy`
+- Use only for rollback while migration hardening continues
 
-`ops/publish-input/`
-
-Required input file names:
-
-- `API_PAYLOAD.json` → publishes `public/data/herbs.json`
-- `COMPOUND_API_PAYLOAD.json` → publishes `public/data/compounds.json`
-- `Goal Page Copy.json` → publishes `public/data/goal-pages.json`
-
-Run:
-
-```bash
-npm run publish-data
-```
-
-This **extends** the existing data sync script used by the build chain:
-
-- existing build path: `npm run build` → `prebuild` → `scripts/sync-updated-datasets.mjs`
-- publish path: `npm run publish-data` → `scripts/sync-updated-datasets.mjs --from-publish-input --skip-workbook-overlay`
-
-In other words, workbook-export ingestion is an additional input mode of the same sync pipeline, not a separate parallel system.
-
-The publish script fails hard on:
-
-- blank slug / route key
-- duplicate slug / route key
-- blank required names/titles
-- invalid goal route keys (must be lowercase kebab-case)
+See also: `docs/workbook-only-data-contract.md`.
 
 ## Learning routes
 


### PR DESCRIPTION
### Motivation

- Clarify the production default for data generation so builds use the workbook-first runtime pipeline rather than documenting the legacy sync/publish overlay as the default. 
- Reduce accidental manual edits by calling out `public/data` as generated output and documenting the workbook `data-sources/herb_monograph_master.xlsx` as the canonical source of truth. 
- Preserve the legacy path as a temporary rollback option while migration hardening continues and avoid removing legacy files or scripts at this time.

### Description

- Updated `README.md` to replace the previous default-path documentation with a `Data pipeline (production default)` section that documents `data-sources/herb_monograph_master.xlsx` as the source of truth and `public/data/*` as generated output. 
- Removed the README text that presented the legacy workbook publish overlay (`ops/publish-input` / `scripts/sync-updated-datasets.mjs` overlay) as the default and instead documented `npm run data:build` as the production data build command. 
- Documented the build path summary showing `npm run build` → `prebuild` → `npm run data:build` and kept `npm run data:build:legacy` documented as a temporary rollback command. 
- Made no deletions to legacy files or scripts and only changed `README.md` in this PR.

### Testing

- Ran `npm run data:build`, which completed successfully and wrote runtime artifacts to `public/data` (herbs and compounds output generated). 
- Ran `npm run data:validate`, which passed structural validation for `public/data`. 
- Ran `npm run typecheck` (`tsc --noEmit`), which completed without errors. 
- Ran `npm run build`, which failed during the existing `verify:affiliate-products` step with 3 flagged affiliate entries (`reishi-mushroom` `entity_page_mismatch`), reflecting an unrelated prebuild validation failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebca7f74ec8323b60395a6cbbeee73)