### PR TITLE
Fix stale reishi curated affiliate mappings after workbook slug cutover

### DIFF
--- a/src/data/curatedProducts.ts
+++ b/src/data/curatedProducts.ts
@@ -117,7 +117,7 @@ export const curatedProductRecommendations: CuratedProductRecommendation[] = [
   },
   {
     entityType: 'herb',
-    entitySlug: 'reishi-mushroom',
+    entitySlug: 'reishi',
     productId: 'reishi-fruiting-body-capsules',
     productTitle: 'Organic Reishi Mushroom Fruiting Body Capsules',
     brand: 'Real Mushrooms',
@@ -142,7 +142,7 @@ export const curatedProductRecommendations: CuratedProductRecommendation[] = [
   },
   {
     entityType: 'herb',
-    entitySlug: 'reishi-mushroom',
+    entitySlug: 'reishi',
     productId: 'reishi-liquid-dual-extract',
     productTitle: 'Reishi Mushroom Liquid Dual Extract',
     brand: 'Hawaii Pharm',
@@ -167,7 +167,7 @@ export const curatedProductRecommendations: CuratedProductRecommendation[] = [
   },
   {
     entityType: 'herb',
-    entitySlug: 'reishi-mushroom',
+    entitySlug: 'reishi',
     productId: 'reishi-tea-bags',
     productTitle: 'Organic Reishi Mushroom Tea Bags',
     brand: 'FGO',


### PR DESCRIPTION
### Motivation
- The workbook cutover standardized the canonical herb slug to `reishi`, while curated affiliate mappings still referenced the legacy `reishi-mushroom`, causing `verify:affiliate-products` to fail for three curated products. 

### Description
- Edited only `src/data/curatedProducts.ts` to update `entitySlug` on the three affected entries without changing any other product data or verifier logic. 
- Changed `entitySlug` values (before → after): `reishi-fruiting-body-capsules`: `reishi-mushroom` → `reishi`; `reishi-liquid-dual-extract`: `reishi-mushroom` → `reishi`; `reishi-tea-bags`: `reishi-mushroom` → `reishi`.

### Testing
- Ran `npm run data:build`, `npm run data:validate`, `npm run typecheck`, and `npm run build` and all steps completed successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebcc91d8748323910e3726dc5f70f2)