### PR TITLE
docs: clarify workbook-only production data pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@ npm run build
 Production data is generated from a single workbook source of truth:
 
 - Source of truth workbook: `data-sources/herb_monograph_master.xlsx`
-- Generated runtime output: `public/data/*`
+- `public/data` is generated output
 - Do not manually edit generated JSON in `public/data`
-- Production data build command: `npm run data:build`
+- Production data is built with: `npm run data:build`
 
 Build path summary:
 
 - `npm run build` runs `prebuild`
 - `prebuild` runs `npm run data:build` before compile/prerender steps
 
-Legacy rollback path (temporary only):
+Legacy rollback path (temporary rollback only):
 
 - `npm run data:build:legacy`
 - Use only for rollback while migration hardening continues


### PR DESCRIPTION
### Motivation
- Clarify that production data is built from the single workbook source and to avoid accidental use of legacy/overlay pipelines during normal builds.

### Description
- Update `README.md` data pipeline section to explicitly state the source workbook (`data-sources/herb_monograph_master.xlsx`), that `public/data` is generated output and must not be manually edited, that production data is built with `npm run data:build`, and that `npm run data:build:legacy` is a temporary rollback-only path; only `README.md` was modified.

### Testing
- Ran `npm run data:build` which completed and wrote `public/data` (herbs=285 compounds=235) successfully.
- Ran `npm run data:validate` which passed structural validation for `public/data`.
- Ran `npm run typecheck` (`tsc --noEmit`) which completed with no errors.
- Ran `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebcd49aa4083239425fd1847186f62)