### PR TITLE
Support workbook-only governed summaries in verify-enrichment-discovery

### DIFF
--- a/scripts/verify-enrichment-discovery.ts
+++ b/scripts/verify-enrichment-discovery.ts
@@ -90,7 +90,7 @@ function buildExpectedSummary(enrichment: Record<string, any>) {
   }
 }
 
-function verifySummaryPayload(
+function verifySummaryPayloadWithGovernedSource(
   entityType: 'herb' | 'compound',
   rows: Array<Record<string, any>>,
   publishableByEntity: Map<string, Record<string, any>>,
@@ -115,25 +115,51 @@ function verifySummaryPayload(
   }
 }
 
+function verifySummaryShapeOnly(
+  entityType: 'herb' | 'compound',
+  rows: Array<Record<string, any>>,
+) {
+  for (const row of rows) {
+    const slug = slugify(String(row.slug || row.id || ''))
+    const key = `${entityType}:${slug}`
+    const summary = row.researchEnrichmentSummary
+    if (summary === undefined) continue
+
+    assert.ok(summary && typeof summary === 'object', `Invalid governed summary payload for ${key}`)
+    const extraKeys = Object.keys(summary).filter(keyName => !SUMMARY_KEYS.includes(keyName))
+    assert.equal(extraKeys.length, 0, `Unexpected summary keys for ${key}: ${extraKeys.join(', ')}`)
+  }
+}
+
 function run() {
-  const governedRows = readJson<GovernedRow[]>('public/data/enrichment-governed.json')
   const herbSummary = readJson<Array<Record<string, any>>>('public/data/herbs-summary.json')
   const compoundSummary = readJson<Array<Record<string, any>>>('public/data/compounds-summary.json')
+  const allRows = [...herbSummary, ...compoundSummary]
+  const hasRuntimeGovernedSummaries = allRows.some(
+    row => row.researchEnrichmentSummary && typeof row.researchEnrichmentSummary === 'object',
+  )
 
   const publishableByEntity = new Map<string, Record<string, any>>()
   const ineligibleEntities: string[] = []
 
-  for (const row of governedRows) {
-    const key = `${row.entityType}:${slugify(row.entitySlug)}`
-    if (isPublishableEnrichment(row.researchEnrichment)) {
-      publishableByEntity.set(key, row.researchEnrichment)
-    } else {
-      ineligibleEntities.push(key)
-    }
-  }
+  if (hasRuntimeGovernedSummaries) {
+    const governedRows = readJson<GovernedRow[]>('public/data/enrichment-governed.json')
 
-  verifySummaryPayload('herb', herbSummary, publishableByEntity)
-  verifySummaryPayload('compound', compoundSummary, publishableByEntity)
+    for (const row of governedRows) {
+      const key = `${row.entityType}:${slugify(row.entitySlug)}`
+      if (isPublishableEnrichment(row.researchEnrichment)) {
+        publishableByEntity.set(key, row.researchEnrichment)
+      } else {
+        ineligibleEntities.push(key)
+      }
+    }
+
+    verifySummaryPayloadWithGovernedSource('herb', herbSummary, publishableByEntity)
+    verifySummaryPayloadWithGovernedSource('compound', compoundSummary, publishableByEntity)
+  } else {
+    verifySummaryShapeOnly('herb', herbSummary)
+    verifySummaryShapeOnly('compound', compoundSummary)
+  }
 
   const report = {
     generatedAt: new Date().toISOString(),
@@ -164,6 +190,12 @@ function run() {
       },
     ],
     publishableEntityCount: publishableByEntity.size,
+    runtimeSummaryEntityCount: allRows.filter(
+      row => row.researchEnrichmentSummary && typeof row.researchEnrichmentSummary === 'object',
+    ).length,
+    verificationSource: hasRuntimeGovernedSummaries
+      ? 'governed_rollup_parity'
+      : 'runtime_summary_shape_only',
     ineligibleEntities,
   }
 


### PR DESCRIPTION
### Motivation
- The verifier assumed `public/data/enrichment-governed.json` was always the authoritative source and required matching `researchEnrichmentSummary` entries on summary rows, which fails for workbook-only builds where those summary payloads are not produced (e.g., `kava`).
- The change must be minimal and avoid reintroducing legacy enrichment artifacts as the source of truth while still preserving strict parity checks when runtime governed summaries exist.
- Make verification resilient to workbook-generated runtime data without changing the data generation pipeline or workbook content.

### Description
- Updated `scripts/verify-enrichment-discovery.ts` to detect whether any runtime summary rows include a `researchEnrichmentSummary` and branch verification accordingly by evaluating `hasRuntimeGovernedSummaries`.
- Preserved the strict governed-rollup parity path in `verifySummaryPayloadWithGovernedSource` when runtime governed summaries are present and added `verifySummaryShapeOnly` to only validate summary shape (presence/type/allowed keys) when workbook-only output is in use.
- Added report metadata fields `runtimeSummaryEntityCount` and `verificationSource` to make the verification mode explicit in the generated report.
- Changed file: `scripts/verify-enrichment-discovery.ts`.

### Testing
- Ran `npm run data:build` and it completed successfully with workbook runtime artifacts written to `public/data`.
- Ran `npm run data:validate` and it reported a PASS for structural validation of `public/data`.
- Ran `npm run typecheck` (`tsc --noEmit`) with no errors and `npm run build` which completed successfully.
- Ran `npm run verify:build` (which runs `verify:enrichment-discovery`) and the verification passed (`PASS publishable=0 ineligible=0`) and wrote `ops/reports/enrichment-discovery-summary.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebd01dcd508323abf5b880297df396)