### PR TITLE
Remove legacy data fallbacks from default route discovery

### DIFF
--- a/scripts/generate-sitemap.mjs
+++ b/scripts/generate-sitemap.mjs
@@ -113,23 +113,26 @@ function pickEntityData(primaryPath, fallbackPath) {
   return readJson(fallbackPath)
 }
 
+function readDetailSlugs(detailDir) {
+  const fullDir = path.resolve(__dirname, '..', 'public', 'data', detailDir)
+  if (!fs.existsSync(fullDir)) return []
+  return fs
+    .readdirSync(fullDir, { withFileTypes: true })
+    .filter(entry => entry.isFile() && entry.name.endsWith('.json'))
+    .map(entry => entry.name.replace(/\.json$/i, '').trim())
+    .filter(Boolean)
+}
+
 function buildSitemap() {
   const { sitemapRoutes, sitemapMeta, disallowedRoutes } = getSharedRouteManifest()
-  const herbs = pickEntityData('public/data/herbs_combined_updated.json', 'public/data/herbs.json')
-  const compounds = pickEntityData('public/data/compounds_combined_updated.json', 'public/data/compounds.json')
+  const herbs = pickEntityData('public/data/herbs.json', 'public/data/herbs-summary.json')
+  const compounds = pickEntityData('public/data/compounds.json', 'public/data/compounds-summary.json')
   const blogEntries = getBlogEntries(readJson('public/blogdata/index.json'))
-  const herbRoutes = normalizeRoutes(
-    herbs
-      .map(getHerbSlug)
-      .filter(Boolean)
-      .map(slug => `/herbs/${slug}`),
-  )
-  const compoundRoutes = normalizeRoutes(
-    compounds
-      .map(getCompoundSlug)
-      .filter(Boolean)
-      .map(slug => `/compounds/${slug}`),
-  )
+  const herbSlugs = herbs.length > 0 ? herbs.map(getHerbSlug).filter(Boolean) : readDetailSlugs('herbs-detail')
+  const compoundSlugs =
+    compounds.length > 0 ? compounds.map(getCompoundSlug).filter(Boolean) : readDetailSlugs('compounds-detail')
+  const herbRoutes = normalizeRoutes(herbSlugs.map(slug => `/herbs/${slug}`))
+  const compoundRoutes = normalizeRoutes(compoundSlugs.map(slug => `/compounds/${slug}`))
 
   const blockedRoutes = new Set(disallowedRoutes.map(route => normalizePathname(route)))
   const staticRoutes = normalizeRoutes(sitemapRoutes).filter(route => !blockedRoutes.has(route))

--- a/scripts/prerender-static.mjs
+++ b/scripts/prerender-static.mjs
@@ -64,6 +64,28 @@ function pickFirstDataFile(paths) {
   return []
 }
 
+function readDetailDataFiles(dir) {
+  const fullDir = path.join(ROOT, 'public', 'data', dir)
+  if (!fs.existsSync(fullDir)) return []
+  const files = fs
+    .readdirSync(fullDir, { withFileTypes: true })
+    .filter(entry => entry.isFile() && entry.name.endsWith('.json'))
+    .map(entry => path.join(fullDir, entry.name))
+
+  const records = []
+  for (const filePath of files) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        records.push(parsed)
+      }
+    } catch {
+      // ignore unreadable detail records
+    }
+  }
+  return records
+}
+
 function readDetailJson(dir, slug) {
   const file = path.join(ROOT, 'public', 'data', dir, `${slug}.json`)
   if (!fs.existsSync(file)) return null
@@ -76,31 +98,31 @@ function readDetailJson(dir, slug) {
 
 const blogPosts = readJson('src/data/blog/posts.json')
 const herbs = pickFirstDataFile([
-  'public/data/workbook-herbs.json',
-  'public/data/herbs_combined_updated.json',
   'public/data/herbs.json',
+  'public/data/herbs-summary.json',
 ])
+const herbRecords = herbs.length > 0 ? herbs : readDetailDataFiles('herbs-detail')
 const compounds = pickFirstDataFile([
-  'public/data/workbook-compounds.json',
-  'public/data/compounds_combined_updated.json',
   'public/data/compounds.json',
+  'public/data/compounds-summary.json',
 ])
+const compoundRecords = compounds.length > 0 ? compounds : readDetailDataFiles('compounds-detail')
 
 const blogBySlug = new Map(blogPosts.map(post => [String(post?.slug || ''), post]))
 const herbBySlug = new Map(
-  herbs.map(record => {
+  herbRecords.map(record => {
     const slug = String(record?.slug || '').trim()
     return [slug, record]
   })
 )
 const compoundBySlug = new Map(
-  compounds.map(record => {
+  compoundRecords.map(record => {
     const slug = String(record?.slug || '').trim()
     return [slug, record]
   })
 )
 
-const herbCardsFromManifest = herbs
+const herbCardsFromManifest = herbRecords
   .map(item => {
     const slug = String(item?.slug || '').trim()
     if (!slug) return null
@@ -109,7 +131,7 @@ const herbCardsFromManifest = herbs
   .filter(Boolean)
   .slice(0, 20)
 
-const compoundCardsFromManifest = compounds
+const compoundCardsFromManifest = compoundRecords
   .map(item => {
     const slug = String(item?.slug || '').trim()
     if (!slug) return null

--- a/scripts/shared-route-manifest.mjs
+++ b/scripts/shared-route-manifest.mjs
@@ -251,6 +251,27 @@ function pickFirstDataFile(paths) {
   return []
 }
 
+function readDetailDataFiles(dir) {
+  const fullDir = path.join(ROOT, 'public', 'data', dir)
+  if (!fs.existsSync(fullDir)) return []
+  const files = fs
+    .readdirSync(fullDir, { withFileTypes: true })
+    .filter(entry => entry.isFile() && entry.name.endsWith('.json'))
+    .map(entry => path.join(fullDir, entry.name))
+  const records = []
+  for (const filePath of files) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        records.push(parsed)
+      }
+    } catch {
+      // ignore malformed detail files
+    }
+  }
+  return records
+}
+
 const readText = relativePath => {
   const fullPath = path.join(ROOT, relativePath)
   return fs.existsSync(fullPath) ? fs.readFileSync(fullPath, 'utf8') : ''
@@ -704,16 +725,14 @@ export function getSharedRouteManifest() {
   })
 
   const learningAllowlist = extractLearningRouteAllowlist()
-  const herbRecords = pickFirstDataFile([
-    'public/data/herbs_combined_updated.json',
-    'public/data/workbook-herbs.json',
-    'public/data/herbs.json',
-  ])
-  const compoundRecords = pickFirstDataFile([
-    'public/data/workbook-compounds.json',
-    'public/data/compounds_combined_updated.json',
+  const herbSeedRecords = pickFirstDataFile(['public/data/herbs.json', 'public/data/herbs-summary.json'])
+  const herbRecords = herbSeedRecords.length > 0 ? herbSeedRecords : readDetailDataFiles('herbs-detail')
+  const compoundSeedRecords = pickFirstDataFile([
     'public/data/compounds.json',
+    'public/data/compounds-summary.json',
   ])
+  const compoundRecords =
+    compoundSeedRecords.length > 0 ? compoundSeedRecords : readDetailDataFiles('compounds-detail')
   const prioritizeAllowlist = (entries, allowlist) => {
     const byRoute = new Map(entries.map(entry => [entry.route, entry]))
     const prioritized = []


### PR DESCRIPTION
### Motivation
- Make the default production build/prerender/sitemap route discovery source the canonical workbook-generated runtime outputs under `public/data` instead of legacy workbook/combined fallbacks.
- Keep legacy import/publish fallbacks available only under explicit legacy commands and avoid deleting generated artifacts or changing legacy scripts yet.

### Description
- Updated `scripts/prerender-static.mjs`, `scripts/generate-sitemap.mjs`, and `scripts/shared-route-manifest.mjs` to prefer `public/data/herbs.json` / `public/data/compounds.json` and `public/data/*-summary.json`, falling back to `public/data/*-detail/` files when necessary, instead of referencing `workbook-herbs.json`, `workbook-compounds.json`, `herbs_combined_updated.json`, or `compounds_combined_updated.json` in the default discovery path.
- Added lightweight helpers `readDetailDataFiles` / `readDetailSlugs` to load per-entity detail files from `public/data/herbs-detail` and `public/data/compounds-detail` as a final fallback for route discovery.
- Kept legacy support and outputs untouched (no deletion of legacy files, no change to `data:build:legacy`), and avoided manual edits to generated `public/data` artifacts per scope.
- Replaced fallback lists only in default discovery code paths and left other legacy scripts (e.g., workbook reconciliation, sync/publish helpers, `src/lib/herbs.ts`) unchanged so legacy flows remain available.

### Testing
- Ran `npm run data:build` which completed successfully and wrote runtime artifacts to `public/data` (herbs/compounds + detail files).
- Ran `npm run data:validate` which passed `herbs+compounds structural validation (public/data)`.
- Ran `npm run typecheck` which completed with no TypeScript errors.
- Ran `npm run build` (including `prebuild`/`postbuild`) and `npm run verify:build`, and the build + postbuild verification completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebf9eaef8083239201f230eb895206)