### PR TITLE
Add workbook-only production path verification script

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,6 +179,7 @@
     "import:xlsx:monographs": "node scripts/import-xlsx-monographs.mjs",
     "verify:deploy-readiness": "node scripts/ci/validate-deploy-readiness.mjs",
     "verify:workbook-import": "node scripts/verify-workbook-import-reconciliation.mjs",
+    "verify:workbook-only-path": "node scripts/data/verify-workbook-only-path.mjs",
     "data:project:monographs": "node scripts/generate-monograph-projection.mjs",
     "data:build:next": "node scripts/data/build-runtime-from-workbook.mjs",
     "data:build:workbook": "node scripts/data/build-runtime-from-workbook.mjs --out public/data",

--- a/scripts/data/verify-workbook-only-path.mjs
+++ b/scripts/data/verify-workbook-only-path.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const packageJsonPath = path.resolve(process.cwd(), 'package.json');
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+const scripts = packageJson.scripts ?? {};
+
+const defaultProductionCommands = ['prebuild', 'build', 'postbuild', 'verify:build'];
+const rollbackOnlyCommands = new Set(['data:build:legacy', 'publish-data']);
+
+const forbiddenReferences = [
+  { value: 'sync-updated-datasets.mjs', reason: 'Legacy sync pipeline is rollback-only.' },
+  { value: '--from-publish-input', reason: 'Publish-input mode is rollback-only.' },
+  { value: 'convert-herbs-csv.ts', reason: 'Legacy CSV conversion is not allowed in default production path.' },
+  { value: 'herbs_combined_updated.json', reason: 'Legacy combined dataset artifact is not allowed in default production path.' },
+  { value: 'compounds_combined_updated.json', reason: 'Legacy combined dataset artifact is not allowed in default production path.' },
+  { value: 'workbook-herbs.json', reason: 'Workbook export artifact is not allowed in default production path.' },
+  { value: 'workbook-compounds.json', reason: 'Workbook export artifact is not allowed in default production path.' },
+  { value: 'projections/monograph-runtime', reason: 'Projection runtime path is not allowed in default production path.' },
+];
+
+const npmRunPattern = /npm\s+run\s+([a-zA-Z0-9:_-]+)/g;
+
+function getDirectScriptCalls(command) {
+  const called = new Set();
+  let match;
+  while ((match = npmRunPattern.exec(command)) !== null) {
+    called.add(match[1]);
+  }
+  return [...called];
+}
+
+function collectCommandsToInspect() {
+  const collected = new Map();
+
+  for (const rootCommand of defaultProductionCommands) {
+    const rootScript = scripts[rootCommand];
+    if (!rootScript) continue;
+    collected.set(rootCommand, rootScript);
+
+    for (const calledScript of getDirectScriptCalls(rootScript)) {
+      if (scripts[calledScript]) {
+        collected.set(calledScript, scripts[calledScript]);
+      }
+    }
+  }
+
+  return collected;
+}
+
+function findOffenders(commandsToInspect) {
+  const offenders = [];
+
+  for (const [commandName, command] of commandsToInspect.entries()) {
+    if (rollbackOnlyCommands.has(commandName)) {
+      continue;
+    }
+
+    for (const { value, reason } of forbiddenReferences) {
+      if (command.includes(value)) {
+        offenders.push({
+          command: commandName,
+          reference: value,
+          reason,
+        });
+      }
+    }
+  }
+
+  return offenders;
+}
+
+const commandsToInspect = collectCommandsToInspect();
+const offenders = findOffenders(commandsToInspect);
+
+if (offenders.length > 0) {
+  console.error('command | offending reference | reason');
+  for (const offender of offenders) {
+    console.error(`${offender.command} | ${offender.reference} | ${offender.reason}`);
+  }
+  process.exit(1);
+}
+
+console.log('command | offending reference | reason');
+console.log('PASS | none | Default production path is workbook-only (rollback references are isolated).');


### PR DESCRIPTION
### Motivation
- Ensure default production build paths remain workbook-only and do not accidentally reference legacy rollback artifacts or commands.
- Provide a small, surgical verification step that can be run in CI or locally to catch regressions where legacy pipelines leak into the default production path.

### Description
- Added `scripts/data/verify-workbook-only-path.mjs`, a Node script that inspects `package.json` and the scripts for `prebuild`, `build`, `postbuild`, and `verify:build`, and also resolves direct `npm run` calls one level deep to check for forbidden legacy references.
- The verifier treats `data:build:legacy` and `publish-data` as allowed rollback-only commands and fails if default production commands reference any forbidden items such as `sync-updated-datasets.mjs`, `--from-publish-input`, `convert-herbs-csv.ts`, `herbs_combined_updated.json`, `compounds_combined_updated.json`, `workbook-herbs.json`, `workbook-compounds.json`, or `projections/monograph-runtime`.
- The script emits machine-readable output in the format `command | offending reference | reason` and exits non‑zero on failure.
- Added the npm shortcut script `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebfb2e60ec8323a15b00f613cf34bd)