### PR TITLE
Add read-only workbook and generated output inspection tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,7 +189,10 @@
     "data:validate:next": "node scripts/data/validate-data-next.mjs",
     "data:coverage:next": "node scripts/data/report-workbook-parser-coverage.mjs",
     "data:report:quality": "node scripts/data/report-workbook-parser-coverage.mjs --data-dir public/data",
-    "data:build:legacy": "node scripts/sync-updated-datasets.mjs && npm run clean:source-refs && node scripts/dedupe-entities.mjs && node scripts/generate-entity-payloads.mjs && node scripts/generate-site-counts.mjs && node scripts/generate-homepage-data.mjs && node scripts/generate-homepage-featured.mjs && node scripts/generate-rss.mjs && npm run verify:affiliate-products"
+    "data:build:legacy": "node scripts/sync-updated-datasets.mjs && npm run clean:source-refs && node scripts/dedupe-entities.mjs && node scripts/generate-entity-payloads.mjs && node scripts/generate-site-counts.mjs && node scripts/generate-homepage-data.mjs && node scripts/generate-homepage-featured.mjs && node scripts/generate-rss.mjs && npm run verify:affiliate-products",
+    "data:check:workbook-source": "node scripts/check-workbook-source.mjs",
+    "data:inspect": "node scripts/inspect-workbook.mjs",
+    "data:check:generated": "node scripts/check-generated-output.mjs"
   },
   "engines": {
     "node": ">=20 <21"

--- a/scripts/check-generated-output.mjs
+++ b/scripts/check-generated-output.mjs
@@ -1,0 +1,91 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { getRepoRoot } from './workbook-source.mjs'
+
+const TARGETS = ['public/data', 'public/data-next', 'public/data/projections']
+
+function walkFiles(dirPath) {
+  const files = []
+  const stack = [dirPath]
+
+  while (stack.length > 0) {
+    const current = stack.pop()
+    const entries = fs.readdirSync(current, { withFileTypes: true })
+
+    for (const entry of entries) {
+      const absolute = path.join(current, entry.name)
+      if (entry.isDirectory()) {
+        stack.push(absolute)
+      } else if (entry.isFile()) {
+        files.push(absolute)
+      }
+    }
+  }
+
+  return files
+}
+
+function summarizeDirectory(rootDir, relativeDir) {
+  const absoluteDir = path.resolve(rootDir, relativeDir)
+  const exists = fs.existsSync(absoluteDir) && fs.statSync(absoluteDir).isDirectory()
+
+  console.log(`\n[check-generated-output] ${relativeDir}`)
+  console.log(`- status: ${exists ? 'exists' : 'missing'}`)
+
+  if (!exists) {
+    return
+  }
+
+  const files = walkFiles(absoluteDir)
+  const jsonFiles = files.filter((filePath) => filePath.toLowerCase().endsWith('.json'))
+  const nonJsonFiles = files.length - jsonFiles.length
+
+  const largest = files
+    .map((filePath) => ({
+      filePath,
+      size: fs.statSync(filePath).size,
+      relativeFilePath: path.relative(rootDir, filePath),
+    }))
+    .sort((a, b) => b.size - a.size)
+    .slice(0, 5)
+
+  const subfolders = fs
+    .readdirSync(absoluteDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort((a, b) => a.localeCompare(b))
+
+  console.log(`- total file count: ${files.length}`)
+  console.log(`- JSON file count: ${jsonFiles.length}`)
+  console.log(`- non-JSON file count: ${nonJsonFiles}`)
+  console.log('- 5 largest files by byte size:')
+
+  if (!largest.length) {
+    console.log('  - (none)')
+  } else {
+    for (const item of largest) {
+      console.log(`  - ${item.relativeFilePath}: ${item.size} bytes`)
+    }
+  }
+
+  console.log('- subfolders present:')
+  if (!subfolders.length) {
+    console.log('  - (none)')
+  } else {
+    for (const folder of subfolders) {
+      console.log(`  - ${folder}`)
+    }
+  }
+}
+
+try {
+  const rootDir = getRepoRoot()
+  for (const target of TARGETS) {
+    summarizeDirectory(rootDir, target)
+  }
+  process.exit(0)
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error)
+  console.error(`Error: ${message}`)
+  process.exit(1)
+}

--- a/scripts/check-workbook-source.mjs
+++ b/scripts/check-workbook-source.mjs
@@ -1,0 +1,13 @@
+import { assertWorkbookExists, getRepoRoot, resolveWorkbookPath } from './workbook-source.mjs'
+
+try {
+  const rootDir = getRepoRoot()
+  const workbookPath = resolveWorkbookPath(rootDir)
+  assertWorkbookExists(workbookPath)
+  console.log(`WORKBOOK_SOURCE_OK — workbook found at ${workbookPath}`)
+  process.exit(0)
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error)
+  console.error(`Error: ${message}`)
+  process.exit(1)
+}

--- a/scripts/inspect-workbook.mjs
+++ b/scripts/inspect-workbook.mjs
@@ -1,0 +1,97 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { createRequire } from 'node:module'
+import { assertWorkbookExists, getRepoRoot, resolveWorkbookPath } from './workbook-source.mjs'
+
+const require = createRequire(import.meta.url)
+
+function detectExcelLibrary(rootDir) {
+  const packageJsonPath = path.resolve(rootDir, 'package.json')
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
+  const combinedDeps = {
+    ...(packageJson.dependencies ?? {}),
+    ...(packageJson.devDependencies ?? {}),
+  }
+
+  const ordered = ['xlsx', 'exceljs', 'read-excel-file']
+  return ordered.find((name) => Object.prototype.hasOwnProperty.call(combinedDeps, name))
+}
+
+async function getWorkbookSummary(workbookPath, libraryName) {
+  if (libraryName === 'xlsx') {
+    const XLSX = require('xlsx')
+    const workbook = XLSX.readFile(workbookPath)
+    return workbook.SheetNames.map((sheetName) => {
+      const rows = XLSX.utils.sheet_to_json(workbook.Sheets[sheetName], {
+        header: 1,
+        blankrows: false,
+        defval: '',
+      })
+      const headers = Array.isArray(rows[0]) ? rows[0] : []
+      const rowCount = Math.max(rows.length - 1, 0)
+      return { sheetName, headers, rowCount }
+    })
+  }
+
+  if (libraryName === 'exceljs') {
+    const ExcelJS = require('exceljs')
+    const workbook = new ExcelJS.Workbook()
+    await workbook.xlsx.readFile(workbookPath)
+    return workbook.worksheets.map((worksheet) => {
+      const headerRow = worksheet.getRow(1)
+      const headers = (headerRow.values || [])
+        .slice(1)
+        .map((value) => (value == null ? '' : String(value)))
+      const rowCount = Math.max(worksheet.actualRowCount - 1, 0)
+      return { sheetName: worksheet.name, headers, rowCount }
+    })
+  }
+
+  if (libraryName === 'read-excel-file') {
+    const { default: readXlsxFile, readSheetNames } = await import('read-excel-file/node')
+    const sheetNames = await readSheetNames(workbookPath)
+
+    const summaries = []
+    for (const sheetName of sheetNames) {
+      const rows = await readXlsxFile(workbookPath, { sheet: sheetName })
+      const headers = Array.isArray(rows[0]) ? rows[0].map((value) => (value == null ? '' : String(value))) : []
+      const rowCount = Math.max(rows.length - 1, 0)
+      summaries.push({ sheetName, headers, rowCount })
+    }
+    return summaries
+  }
+
+  throw new Error(`Unsupported library: ${libraryName}`)
+}
+
+async function main() {
+  const rootDir = getRepoRoot()
+  const workbookPath = resolveWorkbookPath(rootDir)
+  assertWorkbookExists(workbookPath)
+
+  const libraryName = detectExcelLibrary(rootDir)
+  if (!libraryName) {
+    console.error('Error: No xlsx library found. Install xlsx, exceljs, or read-excel-file.')
+    process.exit(1)
+  }
+
+  console.log(`[inspect-workbook] Using library: ${libraryName}`)
+  const summary = await getWorkbookSummary(workbookPath, libraryName)
+
+  console.log('Sheet names:')
+  for (const sheet of summary) {
+    const headerText = sheet.headers.length ? sheet.headers.join(' | ') : '(none)'
+    console.log(`- ${sheet.sheetName}`)
+    console.log(`  Headers: ${headerText}`)
+    console.log(`  Row count (excluding header): ${sheet.rowCount}`)
+  }
+}
+
+try {
+  await main()
+  process.exit(0)
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error)
+  console.error(`Error: ${message}`)
+  process.exit(1)
+}

--- a/scripts/workbook-source.mjs
+++ b/scripts/workbook-source.mjs
@@ -1,16 +1,46 @@
+import fs from 'node:fs'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const DEFAULT_WORKBOOK_RELATIVE_PATH = 'data-sources/herb_monograph_master.xlsx'
+export const DEFAULT_WORKBOOK_RELATIVE_PATH = 'data-sources/herb_monograph_master.xlsx'
 
-export function resolveWorkbookPath(rootDir, { envPath = process.env.HERB_XLSX_PATH } = {}) {
-  let resolvedPath
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 
-  if (typeof envPath === 'string' && envPath.trim()) {
-    resolvedPath = path.resolve(rootDir, envPath.trim())
-  } else {
-    resolvedPath = path.resolve(rootDir, DEFAULT_WORKBOOK_RELATIVE_PATH)
+export function getRepoRoot() {
+  return path.resolve(__dirname, '..')
+}
+
+export function resolveWorkbookPath(rootDir, options = {}) {
+  const candidatePath =
+    options.envPath ?? process.env.HERB_XLSX_PATH ?? DEFAULT_WORKBOOK_RELATIVE_PATH
+
+  const normalizedCandidate = String(candidatePath).trim()
+  const absolutePath = path.isAbsolute(normalizedCandidate)
+    ? path.normalize(normalizedCandidate)
+    : path.resolve(rootDir, normalizedCandidate)
+
+  console.log(`[workbook-source] Resolved: ${absolutePath}`)
+  return absolutePath
+}
+
+export function assertWorkbookExists(absolutePath) {
+  if (!path.isAbsolute(absolutePath)) {
+    throw new Error(`Invalid workbook path (must be absolute): ${absolutePath}`)
   }
 
-  console.log(`[workbook-source] Resolved workbook path: ${resolvedPath}`)
-  return resolvedPath
+  if (!absolutePath.toLowerCase().endsWith('.xlsx')) {
+    throw new Error(`Invalid workbook extension (expected .xlsx): ${absolutePath}`)
+  }
+
+  if (!fs.existsSync(absolutePath)) {
+    throw new Error(`Workbook file does not exist: ${absolutePath}`)
+  }
+
+  const stats = fs.statSync(absolutePath)
+  if (!stats.isFile()) {
+    throw new Error(`Workbook path is not a file: ${absolutePath}`)
+  }
+
+  return true
 }


### PR DESCRIPTION
### Motivation
- Provide safe, read-only tooling to validate and inspect the workbook source and generated output folders before running data pipelines.
- Make workbook path resolution and existence checks explicit with clear errors to avoid accidental writes or silent failures.

### Description
- Exported `DEFAULT_WORKBOOK_RELATIVE_PATH`, added `getRepoRoot()`, and implemented `resolveWorkbookPath(rootDir, options = {})` and `assertWorkbookExists(absolutePath)` in `scripts/workbook-source.mjs` with the required precedence (`options.envPath`, `process.env.HERB_XLSX_PATH`, then default), absolute-path resolution, logging, and validation.
- Added `scripts/check-workbook-source.mjs` to resolve the workbook path and assert existence without reading the workbook, printing a success marker on OK and exiting non-zero on failure.
- Added `scripts/inspect-workbook.mjs` to detect installed Excel libraries in the order `xlsx`, `exceljs`, `read-excel-file`, then read sheet names, first-row headers, and row counts (excluding header) using the detected library, exiting with a clear error if no library is installed; the script is read-only and does not write files.
- Added `scripts/check-generated-output.mjs` to summarize `public/data`, `public/data-next`, and `public/data/projections` (if present) with existence, total file counts, JSON vs non-JSON counts, five largest files by bytes, and subfolder listing, and added npm scripts `data:check:workbook-source`, `data:inspect`, and `data:check:generated` to `package.json`.

### Testing
- Ran `npm run data:check:workbook-source` and it passed, printing the resolved path and `WORKBOOK_SOURCE_OK`.
- Ran `npm run data:inspect` and it passed, detecting `xlsx` and printing sheet names, headers, and row counts.
- Ran `npm run data:check:generated` and it passed, summarizing `public/data` and `public/data-next` and reporting `public/data/projections` as missing.
- Verified `git diff --name-only` shows `package.json` and `scripts/workbook-source.mjs` as modified and `git diff --check` returned no whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee2282dd98832392b289c17bd38a3a)