### PR TITLE
Lock workbook ingestion to V3-only sheets and add fail-fast validation

### DIFF
--- a/ops/reports/enrichment-editorial-readiness.json
+++ b/ops/reports/enrichment-editorial-readiness.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-25T13:58:34.251Z",
+  "generatedAt": "2026-04-26T18:18:43.137Z",
   "summary": {
     "totalEntries": 18,
     "totalEntities": 5,

--- a/public/data/_meta/build-info.json
+++ b/public/data/_meta/build-info.json
@@ -1,12 +1,13 @@
 {
-  "generatedAt": "2026-04-25T13:57:52.037Z",
+  "generatedAt": "2026-04-26T18:18:21.410Z",
   "source": {
-    "workbookPath": "/workspaces/hippie-scientist-site/data-sources/herb_monograph_master.xlsx",
+    "workbookPath": "/workspace/hippie-scientist-site/data-sources/herb_monograph_master.xlsx",
     "sheets": {
-      "herbs": "Herb Master Clean",
+      "herbs": "Herb Master V3",
       "compounds": "Compound Master V3",
       "herbCompoundMap": "Herb Compound Map V3",
-      "claimRows": "Claim Rows"
+      "claimRows": "Claim Rows",
+      "researchQueue": "Research Queue"
     }
   },
   "output": "public/data",
@@ -18,6 +19,7 @@
     "herbDetails": 285,
     "compoundDetails": 235,
     "claimRows": 4349,
+    "researchQueueRows": 290,
     "skippedHerbs": 0,
     "skippedCompounds": 0
   }

--- a/public/data/dedupe-report.json
+++ b/public/data/dedupe-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-25T13:57:52.414Z",
+  "generatedAt": "2026-04-26T18:18:22.058Z",
   "summary": {
     "herbs": {
       "before": 285,

--- a/public/data/herbs-detail/artemisia-annua.json
+++ b/public/data/herbs-detail/artemisia-annua.json
@@ -1,8 +1,8 @@
 {
   "name": "artemisia annua",
   "slug": "artemisia-annua",
-  "summary": "Artemisia annua contains Artemisinin and is linked here to ROS-mediated signaling modulation.",
-  "description": "Artemisia annua contains Artemisinin and is linked here to ROS-mediated signaling modulation.",
+  "summary": "Internal cross-linking supports Artemisia Annua through compounds such as artemisinin.",
+  "description": "Internal cross-linking supports Artemisia Annua through compounds such as artemisinin.",
   "primaryActions": [],
   "mechanisms": [
     "artemisinin endoperoxide activation under iron/heme conditions",
@@ -24,7 +24,7 @@
   ],
   "preparation": "Separate whole-herb Artemisia preparations from purified artemisinin derivatives; evidence and safety are not interchangeable.",
   "traditionalUses": [],
-  "evidenceLevel": "in_vitro",
+  "evidenceLevel": "none",
   "relatedHerbs": [],
   "region": ""
 }

--- a/public/data/herbs-detail/coleus-forskohlii.json
+++ b/public/data/herbs-detail/coleus-forskohlii.json
@@ -1,8 +1,8 @@
 {
   "name": "coleus forskohlii",
   "slug": "coleus-forskohlii",
-  "summary": "Coleus forskohlii contains Forskolin and is linked here to adenylyl cyclase activation.",
-  "description": "Coleus forskohlii contains Forskolin and is linked here to adenylyl cyclase activation.",
+  "summary": "It is best framed around forskolin with blood-pressure and stimulant-stack caution.",
+  "description": "It is best framed around forskolin with blood-pressure and stimulant-stack caution.",
   "primaryActions": [],
   "mechanisms": [
     "forskolin activation of adenylate cyclase",

--- a/public/data/herbs-detail/panax-ginseng.json
+++ b/public/data/herbs-detail/panax-ginseng.json
@@ -1,8 +1,8 @@
 {
   "name": "panax ginseng",
   "slug": "panax-ginseng",
-  "summary": "Panax ginseng lean herb row for high-speed phytochemical ingestion.",
-  "description": "Panax ginseng lean herb row for high-speed phytochemical ingestion.",
+  "summary": "Energy + stress.",
+  "description": "Energy + stress.",
   "primaryActions": [],
   "mechanisms": [
     "Ginsenosides modulate AMPK and PI3K/Akt signaling",

--- a/public/data/herbs-detail/rhodiola-rosea.json
+++ b/public/data/herbs-detail/rhodiola-rosea.json
@@ -1,8 +1,8 @@
 {
   "name": "rhodiola rosea",
   "slug": "rhodiola-rosea",
-  "summary": "Rhodiola rosea contains Rosavin and is linked here to AMPK activation.",
-  "description": "Rhodiola rosea contains Rosavin and is linked here to AMPK activation.",
+  "summary": "Rhodiola Rosea centers on the root.",
+  "description": "Rhodiola Rosea centers on the root. Key reported compounds include rosavin; rosarin; rosin; salidroside; tyrosol. Typical preparation forms: Standardized root extracts. Adaptogen; modulates HPA axis; influences serotonin, dopamine, norepinephrine; antioxidant. Interaction profile: SSRIs, MAOIs, stimulants. Use caution or avoid in: Bipolar disorder; avoid high doses before sleep.",
   "primaryActions": [],
   "mechanisms": [
     "HPA-axis stress-response modulation",
@@ -25,7 +25,7 @@
     "anxiolytics/sedatives",
     "and therapies affecting blood pressure or glucose."
   ],
-  "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+  "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
   "traditionalUses": [],
   "evidenceLevel": "meta_analysis",
   "relatedHerbs": [],

--- a/public/data/herbs-detail/sophora-flavescens.json
+++ b/public/data/herbs-detail/sophora-flavescens.json
@@ -1,31 +1,26 @@
 {
   "name": "sophora flavescens",
   "slug": "sophora-flavescens",
-  "summary": "Sophora flavescens lean monograph row enriched in bulk mode.",
-  "description": "Sophora flavescens lean monograph row enriched in bulk mode.",
+  "summary": "It should be framed conservatively because alkaloid-rich roots can have stronger tolerability issues.",
+  "description": "It should be framed conservatively because alkaloid-rich roots can have stronger tolerability issues.",
   "primaryActions": [],
   "mechanisms": [
-    "PI3K/Akt modulation",
-    "NF-κB inhibition",
-    "TGF-β signaling modulation"
+    "traditional skin support",
+    "GI support"
   ],
   "activeCompounds": [],
-  "safetyNotes": "Alkaloid-rich herb with meaningful safety-review needs; avoid casual internal use or unsupervised high-dose extracts.",
+  "safetyNotes": "Alkaloid-rich herb; use caution with liver disease, immunosuppressants, pregnancy/breastfeeding, and medications with narrow therapeutic windows.",
   "contraindications": [
-    "Pregnancy/breastfeeding",
-    "liver disease",
-    "arrhythmia/cardiac disease without clinician review",
-    "complex medication regimens."
+    "pregnancy/breastfeeding without clinician supervision",
+    "known allergy to the plant/family"
   ],
   "interactions": [
-    "Potential interactions with hepatotoxic drugs",
-    "antiarrhythmics",
-    "immunomodulators",
-    "and sedative/CNS-active medicines are plausible and extract-specific."
+    "Potential additive effects with medications affecting the same body system",
+    "review high-dose extracts with a clinician."
   ],
-  "preparation": "Root is used as decoction, granule, capsule, or alkaloid-standardized extract; standardized alkaloid products are not equivalent to crude root.",
+  "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
   "traditionalUses": [],
-  "evidenceLevel": "in_vitro",
+  "evidenceLevel": "none",
   "relatedHerbs": [],
   "region": ""
 }

--- a/public/data/herbs-summary.json
+++ b/public/data/herbs-summary.json
@@ -522,8 +522,8 @@
     "name": "artemisia annua",
     "common": "artemisia annua",
     "scientific": "",
-    "summary": "Artemisia annua contains Artemisinin and is linked here to ROS-mediated signaling modulation.",
-    "description": "Artemisia annua contains Artemisinin and is linked here to ROS-mediated signaling modulation.",
+    "summary": "Internal cross-linking supports Artemisia Annua through compounds such as artemisinin.",
+    "description": "Internal cross-linking supports Artemisia Annua through compounds such as artemisinin.",
     "primaryActions": [],
     "mechanisms": [
       "artemisinin endoperoxide activation under iron/heme conditions",
@@ -546,7 +546,7 @@
     ],
     "preparation": "Separate whole-herb Artemisia preparations from purified artemisinin derivatives; evidence and safety are not interchangeable.",
     "traditionalUses": [],
-    "evidenceLevel": "in_vitro",
+    "evidenceLevel": "none",
     "relatedHerbs": [],
     "region": ""
   },
@@ -2627,8 +2627,8 @@
     "name": "coleus forskohlii",
     "common": "coleus forskohlii",
     "scientific": "",
-    "summary": "Coleus forskohlii contains Forskolin and is linked here to adenylyl cyclase activation.",
-    "description": "Coleus forskohlii contains Forskolin and is linked here to adenylyl cyclase activation.",
+    "summary": "It is best framed around forskolin with blood-pressure and stimulant-stack caution.",
+    "description": "It is best framed around forskolin with blood-pressure and stimulant-stack caution.",
     "primaryActions": [],
     "mechanisms": [
       "forskolin activation of adenylate cyclase",
@@ -6784,8 +6784,8 @@
     "name": "panax ginseng",
     "common": "panax ginseng",
     "scientific": "",
-    "summary": "Panax ginseng lean herb row for high-speed phytochemical ingestion.",
-    "description": "Panax ginseng lean herb row for high-speed phytochemical ingestion.",
+    "summary": "Energy + stress.",
+    "description": "Energy + stress.",
     "primaryActions": [],
     "mechanisms": [
       "Ginsenosides modulate AMPK and PI3K/Akt signaling",
@@ -7789,8 +7789,8 @@
     "name": "rhodiola rosea",
     "common": "rhodiola rosea",
     "scientific": "",
-    "summary": "Rhodiola rosea contains Rosavin and is linked here to AMPK activation.",
-    "description": "Rhodiola rosea contains Rosavin and is linked here to AMPK activation.",
+    "summary": "Rhodiola Rosea centers on the root.",
+    "description": "Rhodiola Rosea centers on the root. Key reported compounds include rosavin; rosarin; rosin; salidroside; tyrosol. Typical preparation forms: Standardized root extracts. Adaptogen; modulates HPA axis; influences serotonin, dopamine, norepinephrine; antioxidant. Interaction profile: SSRIs, MAOIs, stimulants. Use caution or avoid in: Bipolar disorder; avoid high doses before sleep.",
     "primaryActions": [],
     "mechanisms": [
       "HPA-axis stress-response modulation",
@@ -7814,7 +7814,7 @@
       "anxiolytics/sedatives",
       "and therapies affecting blood pressure or glucose."
     ],
-    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
     "traditionalUses": [],
     "evidenceLevel": "meta_analysis",
     "relatedHerbs": [],
@@ -8448,32 +8448,27 @@
     "name": "sophora flavescens",
     "common": "sophora flavescens",
     "scientific": "",
-    "summary": "Sophora flavescens lean monograph row enriched in bulk mode.",
-    "description": "Sophora flavescens lean monograph row enriched in bulk mode.",
+    "summary": "It should be framed conservatively because alkaloid-rich roots can have stronger tolerability issues.",
+    "description": "It should be framed conservatively because alkaloid-rich roots can have stronger tolerability issues.",
     "primaryActions": [],
     "mechanisms": [
-      "PI3K/Akt modulation",
-      "NF-κB inhibition",
-      "TGF-β signaling modulation"
+      "traditional skin support",
+      "GI support"
     ],
     "confidence": "low",
     "activeCompounds": [],
-    "safetyNotes": "Alkaloid-rich herb with meaningful safety-review needs; avoid casual internal use or unsupervised high-dose extracts.",
+    "safetyNotes": "Alkaloid-rich herb; use caution with liver disease, immunosuppressants, pregnancy/breastfeeding, and medications with narrow therapeutic windows.",
     "contraindications": [
-      "Pregnancy/breastfeeding",
-      "liver disease",
-      "arrhythmia/cardiac disease without clinician review",
-      "complex medication regimens."
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ],
     "interactions": [
-      "Potential interactions with hepatotoxic drugs",
-      "antiarrhythmics",
-      "immunomodulators",
-      "and sedative/CNS-active medicines are plausible and extract-specific."
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "preparation": "Root is used as decoction, granule, capsule, or alkaloid-standardized extract; standardized alkaloid products are not equivalent to crude root.",
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
     "traditionalUses": [],
-    "evidenceLevel": "in_vitro",
+    "evidenceLevel": "none",
     "relatedHerbs": [],
     "region": ""
   },

--- a/public/data/herbs.json
+++ b/public/data/herbs.json
@@ -503,8 +503,8 @@
   {
     "name": "artemisia annua",
     "slug": "artemisia-annua",
-    "summary": "Artemisia annua contains Artemisinin and is linked here to ROS-mediated signaling modulation.",
-    "description": "Artemisia annua contains Artemisinin and is linked here to ROS-mediated signaling modulation.",
+    "summary": "Internal cross-linking supports Artemisia Annua through compounds such as artemisinin.",
+    "description": "Internal cross-linking supports Artemisia Annua through compounds such as artemisinin.",
     "mechanisms": [
       "artemisinin endoperoxide activation under iron/heme conditions",
       "parasite oxidative damage pathways",
@@ -524,7 +524,7 @@
     ],
     "dosage": "",
     "preparation": "Separate whole-herb Artemisia preparations from purified artemisinin derivatives; evidence and safety are not interchangeable.",
-    "evidenceLevel": "in_vitro",
+    "evidenceLevel": "none",
     "review_status": "partial",
     "source_status": "partial",
     "sourceCount": 17,
@@ -2544,8 +2544,8 @@
   {
     "name": "coleus forskohlii",
     "slug": "coleus-forskohlii",
-    "summary": "Coleus forskohlii contains Forskolin and is linked here to adenylyl cyclase activation.",
-    "description": "Coleus forskohlii contains Forskolin and is linked here to adenylyl cyclase activation.",
+    "summary": "It is best framed around forskolin with blood-pressure and stimulant-stack caution.",
+    "description": "It is best framed around forskolin with blood-pressure and stimulant-stack caution.",
     "mechanisms": [
       "forskolin activation of adenylate cyclase",
       "increased intracellular cAMP",
@@ -6574,8 +6574,8 @@
   {
     "name": "panax ginseng",
     "slug": "panax-ginseng",
-    "summary": "Panax ginseng lean herb row for high-speed phytochemical ingestion.",
-    "description": "Panax ginseng lean herb row for high-speed phytochemical ingestion.",
+    "summary": "Energy + stress.",
+    "description": "Energy + stress.",
     "mechanisms": [
       "Ginsenosides modulate AMPK and PI3K/Akt signaling",
       "nitric-oxide/endothelial pathways",
@@ -7548,8 +7548,8 @@
   {
     "name": "rhodiola rosea",
     "slug": "rhodiola-rosea",
-    "summary": "Rhodiola rosea contains Rosavin and is linked here to AMPK activation.",
-    "description": "Rhodiola rosea contains Rosavin and is linked here to AMPK activation.",
+    "summary": "Rhodiola Rosea centers on the root.",
+    "description": "Rhodiola Rosea centers on the root. Key reported compounds include rosavin; rosarin; rosin; salidroside; tyrosol. Typical preparation forms: Standardized root extracts. Adaptogen; modulates HPA axis; influences serotonin, dopamine, norepinephrine; antioxidant. Interaction profile: SSRIs, MAOIs, stimulants. Use caution or avoid in: Bipolar disorder; avoid high doses before sleep.",
     "mechanisms": [
       "HPA-axis stress-response modulation",
       "salidroside/rosavin-related AMPK activation",
@@ -7571,7 +7571,7 @@
       "and therapies affecting blood pressure or glucose."
     ],
     "dosage": "",
-    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
     "evidenceLevel": "meta_analysis",
     "review_status": "partial",
     "source_status": "partial",
@@ -8187,29 +8187,24 @@
   {
     "name": "sophora flavescens",
     "slug": "sophora-flavescens",
-    "summary": "Sophora flavescens lean monograph row enriched in bulk mode.",
-    "description": "Sophora flavescens lean monograph row enriched in bulk mode.",
+    "summary": "It should be framed conservatively because alkaloid-rich roots can have stronger tolerability issues.",
+    "description": "It should be framed conservatively because alkaloid-rich roots can have stronger tolerability issues.",
     "mechanisms": [
-      "PI3K/Akt modulation",
-      "NF-κB inhibition",
-      "TGF-β signaling modulation"
+      "traditional skin support",
+      "GI support"
     ],
-    "safetyNotes": "Alkaloid-rich herb with meaningful safety-review needs; avoid casual internal use or unsupervised high-dose extracts.",
+    "safetyNotes": "Alkaloid-rich herb; use caution with liver disease, immunosuppressants, pregnancy/breastfeeding, and medications with narrow therapeutic windows.",
     "contraindications": [
-      "Pregnancy/breastfeeding",
-      "liver disease",
-      "arrhythmia/cardiac disease without clinician review",
-      "complex medication regimens."
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ],
     "interactions": [
-      "Potential interactions with hepatotoxic drugs",
-      "antiarrhythmics",
-      "immunomodulators",
-      "and sedative/CNS-active medicines are plausible and extract-specific."
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
     "dosage": "",
-    "preparation": "Root is used as decoction, granule, capsule, or alkaloid-standardized extract; standardized alkaloid products are not equivalent to crude root.",
-    "evidenceLevel": "in_vitro",
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "evidenceLevel": "none",
     "review_status": "partial",
     "source_status": "partial",
     "sourceCount": 12,

--- a/public/data/homepage-featured.json
+++ b/public/data/homepage-featured.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-25T13:57:53.169Z",
+  "generatedAt": "2026-04-26T18:18:23.065Z",
   "herbs": [
     {
       "name": "Curcuma longa",
@@ -25,7 +25,7 @@
     {
       "name": "Panax ginseng",
       "slug": "panax-ginseng",
-      "summary": "Panax ginseng lean herb row for high-speed phytochemical ingestion.",
+      "summary": "Science-first herbal reference profile.",
       "tags": [
         "HPA-axis stress signaling"
       ]
@@ -84,7 +84,7 @@
     {
       "name": "Rhodiola rosea",
       "slug": "rhodiola-rosea",
-      "summary": "Rhodiola rosea contains Rosavin and is linked here to AMPK activation.",
+      "summary": "Rhodiola Rosea centers on the root.",
       "tags": [
         "monoamine oxidase modulation",
         "Nrf2 antioxidant signaling"

--- a/public/data/workbook-compounds.json
+++ b/public/data/workbook-compounds.json
@@ -3,1359 +3,2340 @@
     "id": "baicalin",
     "slug": "baicalin",
     "canonicalCompoundId": "baicalin",
-    "name": "Baicalin",
-    "compoundName": "Baicalin",
-    "canonicalCompoundName": "Baicalin",
+    "name": "baicalin",
+    "compoundName": "baicalin",
+    "canonicalCompoundName": "baicalin",
     "mechanisms": [
-      "NF-κB inhibition",
-      "PI3K/Akt modulation"
+      "NF-kB suppression",
+      "Nrf2 activation",
+      "MAPK modulation",
+      "cytokine-signaling reduction"
+    ],
+    "compoundClass": "flavone glycoside",
+    "class": "flavone glycoside",
+    "targets": [
+      "NF-κB",
+      "MAPK",
+      "PI3K/Akt",
+      "Nrf2",
+      "inflammatory cytokines",
+      "GABAergic signaling"
     ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "chinese skullcap",
+      "skullcap",
+      "scutellaria baicalensis"
+    ],
+    "safetyNotes": "Mostly supported through Scutellaria extracts and preclinical data. Use caution with liver disease, sedatives, anticoagulants/antiplatelets, immunosuppressants, and pregnancy."
   },
   {
     "id": "baicalein",
     "slug": "baicalein",
     "canonicalCompoundId": "baicalein",
-    "name": "Baicalein",
-    "compoundName": "Baicalein",
-    "canonicalCompoundName": "Baicalein",
+    "name": "baicalein",
+    "compoundName": "baicalein",
+    "canonicalCompoundName": "baicalein",
     "mechanisms": [
-      "NF-κB inhibition",
-      "MAPK pathway modulation"
+      "NF-kB suppression",
+      "PI3K/Akt modulation",
+      "lipoxygenase-related inflammatory signaling effects",
+      "Nrf2 support"
+    ],
+    "compoundClass": "flavone aglycone",
+    "class": "flavone aglycone",
+    "targets": [
+      "NF-κB",
+      "MAPK",
+      "PI3K/Akt",
+      "Nrf2",
+      "inflammatory cytokines"
     ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "chinese skullcap",
+      "skullcap",
+      "scutellaria baicalensis"
+    ],
+    "safetyNotes": "Mostly preclinical and extract-derived. Caution with anticoagulants/antiplatelets, liver disease, sedatives, and pregnancy at supplement doses."
   },
   {
     "id": "wogonin",
     "slug": "wogonin",
     "canonicalCompoundId": "wogonin",
-    "name": "Wogonin",
-    "compoundName": "Wogonin",
-    "canonicalCompoundName": "Wogonin",
+    "name": "wogonin",
+    "compoundName": "wogonin",
+    "canonicalCompoundName": "wogonin",
     "mechanisms": [
-      "NF-κB inhibition",
-      "PI3K/Akt modulation"
+      "NF-kB suppression",
+      "Nrf2-related antioxidant signaling",
+      "GABA-A-related neuroactive modulation",
+      "apoptosis pathway effects"
+    ],
+    "compoundClass": "flavone aglycone",
+    "class": "flavone aglycone",
+    "targets": [
+      "NF-κB",
+      "MAPK",
+      "PI3K/Akt",
+      "apoptosis signaling",
+      "inflammatory cytokines"
     ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "chinese skullcap",
+      "skullcap",
+      "scutellaria baicalensis"
+    ],
+    "safetyNotes": "Mostly preclinical and extract-derived. Isolated-dose human safety is not well established; caution with liver disease, anticoagulants/antiplatelets, sedatives, and pregnancy."
   },
   {
     "id": "thymoquinone",
     "slug": "thymoquinone",
     "canonicalCompoundId": "thymoquinone",
-    "name": "Thymoquinone",
-    "compoundName": "Thymoquinone",
-    "canonicalCompoundName": "Thymoquinone",
+    "name": "thymoquinone",
+    "compoundName": "thymoquinone",
+    "canonicalCompoundName": "thymoquinone",
     "mechanisms": [
       "NF-κB inhibition",
       "Nrf2 activation"
     ],
+    "compoundClass": "benzoquinone / monoterpene quinone",
+    "class": "benzoquinone / monoterpene quinone",
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "apoptosis signaling",
+      "inflammatory cytokines"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "black seed",
+      "nigella sativa"
+    ],
+    "safetyNotes": "Human evidence usually comes from Nigella sativa preparations rather than isolated thymoquinone. Avoid pregnancy-dose escalation; caution with anticoagulants, antidiabetics, antihypertensives, and liver disease."
   },
   {
     "id": "carnosic-acid",
     "slug": "carnosic-acid",
     "canonicalCompoundId": "carnosic-acid",
-    "name": "Carnosic acid",
-    "compoundName": "Carnosic acid",
-    "canonicalCompoundName": "Carnosic acid",
+    "name": "carnosic acid",
+    "compoundName": "carnosic acid",
+    "canonicalCompoundName": "carnosic acid",
     "mechanisms": [
       "Nrf2 activation",
-      "NF-κB inhibition"
+      "NF-kB suppression",
+      "redox-sensitive signaling modulation",
+      "mitochondrial protection pathways"
+    ],
+    "compoundClass": "phenolic diterpene",
+    "class": "phenolic diterpene",
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "oxidative-stress signaling",
+      "lipid peroxidation pathways"
     ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "rosemary",
+      "sage"
+    ],
+    "safetyNotes": "Primarily food/herb exposure through rosemary/sage; concentrated isolated-dose safety is less established. Caution with anticoagulants, pregnancy, and liver disease at high doses."
   },
   {
     "id": "oleuropein",
     "slug": "oleuropein",
     "canonicalCompoundId": "oleuropein",
-    "name": "Oleuropein",
-    "compoundName": "Oleuropein",
-    "canonicalCompoundName": "Oleuropein",
+    "name": "oleuropein",
+    "compoundName": "oleuropein",
+    "canonicalCompoundName": "oleuropein",
     "mechanisms": [
       "NF-κB inhibition",
       "AMPK activation"
     ],
+    "compoundClass": "secoiridoid phenolic glycoside",
+    "class": "secoiridoid phenolic glycoside",
+    "targets": [
+      "AMPK",
+      "Nrf2",
+      "NF-κB",
+      "endothelial nitric oxide",
+      "lipid/glucose metabolism"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "olive leaf",
+      "olea europaea"
+    ],
+    "safetyNotes": "Generally food-associated via olive/olive leaf, but concentrated extracts may lower blood pressure or glucose. Monitor with antihypertensive or antidiabetic therapy."
   },
   {
     "id": "hydroxytyrosol",
     "slug": "hydroxytyrosol",
     "canonicalCompoundId": "hydroxytyrosol",
-    "name": "Hydroxytyrosol",
-    "compoundName": "Hydroxytyrosol",
-    "canonicalCompoundName": "Hydroxytyrosol",
+    "name": "hydroxytyrosol",
+    "compoundName": "hydroxytyrosol",
+    "canonicalCompoundName": "hydroxytyrosol",
     "mechanisms": [
       "Nrf2 activation",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "phenylethanoid polyphenol",
+    "class": "phenylethanoid polyphenol",
+    "targets": [
+      "Nrf2",
+      "oxidative-stress pathways",
+      "LDL oxidation",
+      "endothelial signaling",
+      "NF-κB"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "olive leaf",
+      "olea europaea"
+    ],
+    "safetyNotes": "Food-associated from olive oil/olive leaf; high-dose supplement safety is less defined. Caution with blood-pressure and antiplatelet medication contexts."
   },
   {
     "id": "crocin",
     "slug": "crocin",
     "canonicalCompoundId": "crocin",
-    "name": "Crocin",
-    "compoundName": "Crocin",
-    "canonicalCompoundName": "Crocin",
+    "name": "crocin",
+    "compoundName": "crocin",
+    "canonicalCompoundName": "crocin",
     "mechanisms": [
       "PI3K/Akt modulation",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "carotenoid glycoside",
+    "class": "carotenoid glycoside",
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "oxidative-stress signaling",
+      "serotonergic and dopaminergic pathways"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "saffron",
+      "crocus sativus"
+    ],
+    "safetyNotes": "Human safety is mostly inferred from saffron trials. Avoid pregnancy-dose escalation; caution with serotonergic drugs, anticoagulants, and hypotension-prone users."
   },
   {
     "id": "crocetin",
     "slug": "crocetin",
     "canonicalCompoundId": "crocetin",
-    "name": "Crocetin",
-    "compoundName": "Crocetin",
-    "canonicalCompoundName": "Crocetin",
+    "name": "crocetin",
+    "compoundName": "crocetin",
+    "canonicalCompoundName": "crocetin",
     "mechanisms": [
       "PI3K/Akt modulation",
       "Nrf2 activation"
     ],
+    "compoundClass": "apocarotenoid",
+    "class": "apocarotenoid",
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "oxidative-stress signaling",
+      "lipid metabolism",
+      "retinal/neurovascular pathways"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "saffron",
+      "crocus sativus"
+    ],
+    "safetyNotes": "Human evidence is limited and often saffron-derived. Caution with pregnancy, serotonergic drugs, anticoagulants, and blood-pressure-lowering regimens."
   },
   {
     "id": "silibinin",
     "slug": "silibinin",
     "canonicalCompoundId": "silibinin",
-    "name": "Silibinin",
-    "compoundName": "Silibinin",
-    "canonicalCompoundName": "Silibinin",
+    "name": "silibinin",
+    "compoundName": "silibinin",
+    "canonicalCompoundName": "silibinin",
     "mechanisms": [
       "STAT3 inhibition",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "flavonolignan",
+    "class": "flavonolignan",
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "hepatic antioxidant pathways",
+      "inflammatory cytokines"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "milk thistle"
+    ],
+    "safetyNotes": "Generally well tolerated in milk-thistle trials; caution with Asteraceae allergy, antidiabetics, hormone-sensitive conditions, and CYP-metabolized drugs."
   },
   {
     "id": "glycyrrhizin",
     "slug": "glycyrrhizin",
     "canonicalCompoundId": "glycyrrhizin",
-    "name": "Glycyrrhizin",
-    "compoundName": "Glycyrrhizin",
-    "canonicalCompoundName": "Glycyrrhizin",
+    "name": "glycyrrhizin",
+    "compoundName": "glycyrrhizin",
+    "canonicalCompoundName": "glycyrrhizin",
     "mechanisms": [
       "HMGB1 inhibition",
       "NF-κB inhibition"
     ],
+    "compoundClass": "triterpenoid saponin glycoside",
+    "class": "triterpenoid saponin glycoside",
+    "targets": [
+      "11β-HSD2",
+      "mineralocorticoid-like sodium/potassium balance",
+      "HMGB1",
+      "inflammatory signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "licorice",
+      "glycyrrhiza glabra"
+    ],
+    "safetyNotes": "Can contribute to hypertension, hypokalemia, edema, and arrhythmia risk. Avoid with uncontrolled hypertension, kidney disease, pregnancy unless supervised, diuretics, digoxin, corticosteroids, and antihypertensives."
   },
   {
     "id": "emodin",
     "slug": "emodin",
     "canonicalCompoundId": "emodin",
-    "name": "Emodin",
-    "compoundName": "Emodin",
-    "canonicalCompoundName": "Emodin",
+    "name": "emodin",
+    "compoundName": "emodin",
+    "canonicalCompoundName": "emodin",
     "mechanisms": [
       "NF-κB inhibition",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "anthraquinone",
+    "class": "anthraquinone",
+    "targets": [
+      "NF-κB",
+      "MAPK",
+      "apoptosis signaling",
+      "intestinal motility pathways",
+      "CYP/P-gp interaction pathways"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "japanese knotweed",
+      "aloe vera",
+      "rheum palmatum"
+    ],
+    "safetyNotes": "Anthraquinone laxative-like activity may cause diarrhea, electrolyte shifts, and interaction risks. Avoid chronic high-dose use, pregnancy, kidney disease, and stimulant-laxative stacking."
   },
   {
     "id": "rhein",
     "slug": "rhein",
     "canonicalCompoundId": "rhein",
-    "name": "Rhein",
-    "compoundName": "Rhein",
-    "canonicalCompoundName": "Rhein",
+    "name": "rhein",
+    "compoundName": "rhein",
+    "canonicalCompoundName": "rhein",
     "mechanisms": [
       "NF-κB inhibition",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "anthraquinone",
+    "class": "anthraquinone",
+    "targets": [
+      "NF-κB",
+      "MAPK",
+      "inflammatory cytokines",
+      "cartilage catabolism pathways",
+      "intestinal motility"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "aloe vera",
+      "rheum palmatum"
+    ],
+    "safetyNotes": "Anthraquinone-related GI effects and electrolyte concerns are relevant. Caution with laxatives, diuretics, kidney disease, pregnancy, and anticoagulants."
   },
   {
     "id": "schisandrin",
     "slug": "schisandrin",
     "canonicalCompoundId": "schisandrin",
-    "name": "Schisandrin",
-    "compoundName": "Schisandrin",
-    "canonicalCompoundName": "Schisandrin",
+    "name": "schisandrin",
+    "compoundName": "schisandrin",
+    "canonicalCompoundName": "schisandrin",
     "mechanisms": [
       "Nrf2 activation",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "dibenzocyclooctadiene lignan",
+    "class": "dibenzocyclooctadiene lignan",
+    "targets": [
+      "Nrf2",
+      "CYP3A/P-gp pathways",
+      "mitochondrial oxidative-stress signaling",
+      "inflammatory cytokines"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "schisandra",
+      "schisandra chinensis"
+    ],
+    "safetyNotes": "Human safety is mostly extract-derived. Caution with CYP3A/P-gp substrate drugs, pregnancy, liver disease, and complex medication regimens."
   },
   {
     "id": "celastrol",
     "slug": "celastrol",
     "canonicalCompoundId": "celastrol",
-    "name": "Celastrol",
-    "compoundName": "Celastrol",
-    "canonicalCompoundName": "Celastrol",
+    "name": "celastrol",
+    "compoundName": "celastrol",
+    "canonicalCompoundName": "celastrol",
     "mechanisms": [
       "HSP90 inhibition",
       "NF-κB inhibition"
     ],
+    "compoundClass": "quinone methide triterpenoid",
+    "class": "quinone methide triterpenoid",
+    "targets": [
+      "HSP90",
+      "NF-κB",
+      "proteasome/stress-response pathways",
+      "leptin signaling",
+      "apoptosis signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "thunder god vine",
+      "tripterygium wilfordii"
+    ],
+    "safetyNotes": "High-caution compound with narrow therapeutic window in preclinical literature. Do not infer supplement safety; avoid pregnancy, liver/kidney disease, and unsupervised use."
   },
   {
     "id": "eugenol",
     "slug": "eugenol",
     "canonicalCompoundId": "eugenol",
-    "name": "Eugenol",
-    "compoundName": "Eugenol",
-    "canonicalCompoundName": "Eugenol",
+    "name": "eugenol",
+    "compoundName": "eugenol",
+    "canonicalCompoundName": "eugenol",
     "mechanisms": [
-      "COX inhibition",
-      "TRP channel modulation"
+      "COX-2 inhibition",
+      "TRPV1/TRPA1 modulation",
+      "voltage-gated sodium-channel effects",
+      "membrane disruption",
+      "NF-kB suppression"
+    ],
+    "compoundClass": "phenylpropanoid",
+    "class": "phenylpropanoid",
+    "targets": [
+      "TRPV1",
+      "COX/LOX pathways",
+      "NF-κB",
+      "microbial membrane effects",
+      "local anesthetic signaling"
     ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "holy basil",
+      "holy basil purple",
+      "calamus",
+      "clove",
+      "syzygium aromaticum"
+    ],
+    "safetyNotes": "Food/flavor exposure differs from essential-oil or concentrated use. High doses may irritate mucosa and affect bleeding or liver safety; caution with anticoagulants and dental/topical overuse."
   },
   {
     "id": "linalool",
     "slug": "linalool",
     "canonicalCompoundId": "linalool",
-    "name": "Linalool",
-    "compoundName": "Linalool",
-    "canonicalCompoundName": "Linalool",
+    "name": "linalool",
+    "compoundName": "linalool",
+    "canonicalCompoundName": "linalool",
     "mechanisms": [
       "GABA-A modulation",
       "voltage-gated calcium channel modulation"
     ],
+    "compoundClass": "monoterpene alcohol",
+    "class": "monoterpene alcohol",
+    "targets": [
+      "GABAergic signaling",
+      "glutamate signaling",
+      "inflammatory cytokines",
+      "olfactory/CNS pathways"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "lavender",
+      "lavandula angustifolia"
+    ],
+    "safetyNotes": "Primarily essential-oil/aroma exposure; topical allergy and CNS sedation are possible. Avoid ingestion of essential oils without supervision."
   },
   {
     "id": "saikosaponin-a",
     "slug": "saikosaponin-a",
     "canonicalCompoundId": "saikosaponin-a",
-    "name": "Saikosaponin A",
-    "compoundName": "Saikosaponin A",
-    "canonicalCompoundName": "Saikosaponin A",
+    "name": "saikosaponin a",
+    "compoundName": "saikosaponin a",
+    "canonicalCompoundName": "saikosaponin a",
     "mechanisms": [
       "NF-κB inhibition",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "triterpenoid saponin",
+    "class": "triterpenoid saponin",
+    "targets": [
+      "NF-κB",
+      "MAPK",
+      "HPA-axis signaling",
+      "inflammatory cytokines",
+      "apoptosis signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "bupleurum",
+      "bupleurum falcatum"
+    ],
+    "safetyNotes": "Human safety is formula/herb-derived. Bupleurum-containing products have liver-safety reports; caution with liver disease, immunomodulators, and pregnancy."
   },
   {
     "id": "curcumin",
     "slug": "curcumin",
     "canonicalCompoundId": "curcumin",
-    "name": "Curcumin",
-    "compoundName": "Curcumin",
-    "canonicalCompoundName": "Curcumin",
+    "name": "curcumin",
+    "compoundName": "curcumin",
+    "canonicalCompoundName": "curcumin",
     "mechanisms": [
       "NF-κB inhibition",
       "Nrf2 activation"
     ],
+    "compoundClass": "diarylheptanoid polyphenol",
+    "class": "diarylheptanoid polyphenol",
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "COX-2",
+      "LOX",
+      "STAT3",
+      "AMPK",
+      "inflammatory cytokines"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "dong quai",
+      "turmeric"
+    ],
+    "safetyNotes": "Generally well tolerated in many trials, but high-dose extracts can cause GI upset and may interact with anticoagulants/antiplatelets or gallbladder disease contexts; piperine coformulas change exposure."
   },
   {
     "id": "hesperidin",
     "slug": "hesperidin",
     "canonicalCompoundId": "hesperidin",
-    "name": "Hesperidin",
-    "compoundName": "Hesperidin",
-    "canonicalCompoundName": "Hesperidin",
+    "name": "hesperidin",
+    "compoundName": "hesperidin",
+    "canonicalCompoundName": "hesperidin",
     "mechanisms": [
       "PI3K/Akt modulation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "flavanone glycoside",
+    "class": "flavanone glycoside",
+    "targets": [
+      "endothelial nitric oxide",
+      "NF-κB",
+      "Nrf2",
+      "lipid metabolism",
+      "capillary/vascular signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "orange peel",
+      "citrus peel"
+    ],
+    "safetyNotes": "Food-associated citrus flavonoid; concentrated use may interact with anticoagulant/antiplatelet or blood-pressure regimens. GI effects possible."
   },
   {
     "id": "berberine",
     "slug": "berberine",
     "canonicalCompoundId": "berberine",
-    "name": "Berberine",
-    "compoundName": "Berberine",
-    "canonicalCompoundName": "Berberine",
+    "name": "berberine",
+    "compoundName": "berberine",
+    "canonicalCompoundName": "berberine",
     "mechanisms": [
       "AMPK activation",
-      "NF-κB inhibition",
-      "PI3K/Akt modulation"
+      "NF-kB suppression",
+      "PI3K/Akt modulation",
+      "gut-microbiome signaling effects",
+      "LDLR/PCSK9-related lipid regulation"
+    ],
+    "compoundClass": "isoquinoline alkaloid",
+    "class": "isoquinoline alkaloid",
+    "targets": [
+      "AMPK",
+      "PCSK9",
+      "LDLR",
+      "gut microbiota",
+      "NF-κB",
+      "CYP/P-gp interaction pathways"
     ],
     "foundIn": [
-      "PubMed",
-      "review literature"
-    ]
+      "berberis",
+      "coptis",
+      "goldenseal",
+      "phellodendron",
+      "berberis vulgaris",
+      "phellodendron amurense"
+    ],
+    "safetyNotes": "GI upset is common. Avoid pregnancy/breastfeeding and neonatal exposure; caution with antidiabetic drugs, antihypertensives, anticoagulants, immunosuppressants, and CYP/P-gp substrates."
   },
   {
     "id": "palmatine",
     "slug": "palmatine",
     "canonicalCompoundId": "palmatine",
-    "name": "Palmatine",
-    "compoundName": "Palmatine",
-    "canonicalCompoundName": "Palmatine",
+    "name": "palmatine",
+    "compoundName": "palmatine",
+    "canonicalCompoundName": "palmatine",
     "mechanisms": [
       "AMPK activation",
       "MAPK pathway modulation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "protoberberine isoquinoline alkaloid",
+    "class": "protoberberine isoquinoline alkaloid",
+    "targets": [
+      "AMPK",
+      "NF-κB",
+      "microbial targets",
+      "CYP/P-gp interaction pathways"
+    ],
     "foundIn": [
-      "PubMed",
-      "review literature"
-    ]
+      "coptis",
+      "phellodendron",
+      "goldenseal",
+      "phellodendron amurense",
+      "coptis chinensis"
+    ],
+    "safetyNotes": "Related to berberine-like alkaloids but less clinically characterized. Avoid pregnancy/breastfeeding and use caution with antidiabetic, anticoagulant, and CYP/P-gp substrate drugs."
   },
   {
     "id": "jatrorrhizine",
     "slug": "jatrorrhizine",
     "canonicalCompoundId": "jatrorrhizine",
-    "name": "Jatrorrhizine",
-    "compoundName": "Jatrorrhizine",
-    "canonicalCompoundName": "Jatrorrhizine",
+    "name": "jatrorrhizine",
+    "compoundName": "jatrorrhizine",
+    "canonicalCompoundName": "jatrorrhizine",
     "mechanisms": [
       "AMPK activation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "protoberberine isoquinoline alkaloid",
+    "class": "protoberberine isoquinoline alkaloid",
+    "targets": [
+      "AMPK",
+      "NF-κB",
+      "lipid/glucose metabolism",
+      "microbial targets"
+    ],
     "foundIn": [
-      "PubMed",
-      "review literature"
-    ]
+      "goldenseal",
+      "phellodendron amurense"
+    ],
+    "safetyNotes": "Mostly preclinical. Use berberine-family cautions: avoid pregnancy/breastfeeding and monitor with antidiabetic, antihypertensive, anticoagulant, and CYP/P-gp substrate drugs."
   },
   {
     "id": "columbamine",
     "slug": "columbamine",
     "canonicalCompoundId": "columbamine",
-    "name": "Columbamine",
-    "compoundName": "Columbamine",
-    "canonicalCompoundName": "Columbamine",
+    "name": "columbamine",
+    "compoundName": "columbamine",
+    "canonicalCompoundName": "columbamine",
     "mechanisms": [
       "AMPK activation",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "protoberberine isoquinoline alkaloid",
+    "class": "protoberberine isoquinoline alkaloid",
+    "targets": [
+      "NF-κB",
+      "apoptosis signaling",
+      "microbial targets",
+      "AMPK-related pathways"
+    ],
     "foundIn": [
-      "PubMed",
-      "review literature"
-    ]
+      "berberis vulgaris",
+      "coptis chinensis"
+    ],
+    "safetyNotes": "Human safety is not well established. Avoid pregnancy/breastfeeding; caution with CYP/P-gp substrates, antidiabetic drugs, and complex medication regimens."
   },
   {
     "id": "andrographolide",
     "slug": "andrographolide",
     "canonicalCompoundId": "andrographolide",
-    "name": "Andrographolide",
-    "compoundName": "Andrographolide",
-    "canonicalCompoundName": "Andrographolide",
+    "name": "andrographolide",
+    "compoundName": "andrographolide",
+    "canonicalCompoundName": "andrographolide",
     "mechanisms": [
       "NF-κB inhibition",
       "JAK/STAT modulation",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "labdane diterpenoid lactone",
+    "class": "labdane diterpenoid lactone",
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "JAK/STAT",
+      "MAPK",
+      "inflammatory cytokines"
+    ],
     "foundIn": [
-      "PubMed",
-      "review literature"
-    ]
+      "andrographis paniculata"
+    ],
+    "safetyNotes": "Human evidence is mostly from Andrographis extracts. Potential allergy, GI upset, and rare hypersensitivity; avoid pregnancy and caution with immunosuppressants/anticoagulants."
   },
   {
     "id": "neoandrographolide",
     "slug": "neoandrographolide",
     "canonicalCompoundId": "neoandrographolide",
-    "name": "Neoandrographolide",
-    "compoundName": "Neoandrographolide",
-    "canonicalCompoundName": "Neoandrographolide",
+    "name": "neoandrographolide",
+    "compoundName": "neoandrographolide",
+    "canonicalCompoundName": "neoandrographolide",
     "mechanisms": [
       "NF-κB inhibition",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "diterpenoid glycoside",
+    "class": "diterpenoid glycoside",
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "MAPK",
+      "inflammatory cytokines",
+      "immune signaling"
+    ],
     "foundIn": [
-      "PubMed",
-      "review literature"
-    ]
+      "andrographis paniculata"
+    ],
+    "safetyNotes": "Human safety is mostly extract-derived. Avoid pregnancy; caution with immunosuppressants, anticoagulants, and users with severe allergy history."
   },
   {
     "id": "gymnemic-acid",
     "slug": "gymnemic-acid",
     "canonicalCompoundId": "gymnemic-acid",
-    "name": "Gymnemic acid",
-    "compoundName": "Gymnemic acid",
-    "canonicalCompoundName": "Gymnemic acid",
+    "name": "gymnemic acid",
+    "compoundName": "gymnemic acid",
+    "canonicalCompoundName": "gymnemic acid",
     "mechanisms": [
       "glucose absorption modulation",
       "AMPK activation"
     ],
+    "compoundClass": "triterpenoid saponin mixture",
+    "class": "triterpenoid saponin mixture",
+    "targets": [
+      "sweet taste receptors",
+      "intestinal glucose absorption",
+      "insulin signaling",
+      "AMPK-related pathways"
+    ],
     "foundIn": [
-      "PubMed",
-      "review literature"
-    ]
+      "gymnema"
+    ],
+    "safetyNotes": "May lower blood glucose or reduce sweet taste perception. Monitor with antidiabetic therapies; avoid pregnancy/breastfeeding unless supervised."
   },
   {
     "id": "charantin",
     "slug": "charantin",
     "canonicalCompoundId": "charantin",
-    "name": "Charantin",
-    "compoundName": "Charantin",
-    "canonicalCompoundName": "Charantin",
+    "name": "charantin",
+    "compoundName": "charantin",
+    "canonicalCompoundName": "charantin",
     "mechanisms": [
       "AMPK activation",
       "GLUT4 translocation modulation"
     ],
+    "compoundClass": "steroidal saponin mixture",
+    "class": "steroidal saponin mixture",
+    "targets": [
+      "glucose metabolism",
+      "AMPK-related pathways",
+      "insulin signaling",
+      "GLUT4 modulation"
+    ],
     "foundIn": [
-      "PubMed",
-      "review literature"
-    ]
+      "bitter melon"
+    ],
+    "safetyNotes": "Human safety is bitter-melon/extract-derived. May potentiate hypoglycemia; avoid pregnancy and monitor with antidiabetic therapy."
   },
   {
     "id": "momordicoside-k",
     "slug": "momordicoside-k",
     "canonicalCompoundId": "momordicoside-k",
-    "name": "Momordicoside K",
-    "compoundName": "Momordicoside K",
-    "canonicalCompoundName": "Momordicoside K",
+    "name": "momordicoside k",
+    "compoundName": "momordicoside k",
+    "canonicalCompoundName": "momordicoside k",
     "mechanisms": [
       "AMPK activation",
       "PPARγ activation"
     ],
+    "compoundClass": "saponin / glycoside",
+    "class": "saponin / glycoside",
+    "targets": [
+      "AMPK",
+      "PPAR",
+      "immune cytokines",
+      "membrane signaling",
+      "glucose/lipid metabolism"
+    ],
     "foundIn": [
-      "PubMed",
-      "review literature"
-    ]
+      "bitter melon"
+    ],
+    "safetyNotes": "May cause GI irritation or hemolysis risk in isolated/high-dose contexts; herb-specific safety and pregnancy cautions apply."
   },
   {
     "id": "diosgenin",
     "slug": "diosgenin",
     "canonicalCompoundId": "diosgenin",
-    "name": "Diosgenin",
-    "compoundName": "Diosgenin",
-    "canonicalCompoundName": "Diosgenin",
+    "name": "diosgenin",
+    "compoundName": "diosgenin",
+    "canonicalCompoundName": "diosgenin",
     "mechanisms": [
       "PI3K/Akt modulation",
       "PPARγ activation"
     ],
+    "compoundClass": "steroidal sapogenin",
+    "class": "steroidal sapogenin",
+    "targets": [
+      "PPAR signaling",
+      "lipid metabolism",
+      "inflammatory cytokines",
+      "steroidal saponin pathways"
+    ],
     "foundIn": [
-      "PubMed",
-      "review literature"
-    ]
+      "fenugreek",
+      "wild yam",
+      "dioscorea villosa"
+    ],
+    "safetyNotes": "Mostly preclinical or food/herb-associated. Caution with hormone-sensitive conditions, pregnancy, and anticoagulant/antidiabetic medication contexts."
   },
   {
     "id": "protodioscin",
     "slug": "protodioscin",
     "canonicalCompoundId": "protodioscin",
-    "name": "Protodioscin",
-    "compoundName": "Protodioscin",
-    "canonicalCompoundName": "Protodioscin",
+    "name": "protodioscin",
+    "compoundName": "protodioscin",
+    "canonicalCompoundName": "protodioscin",
     "mechanisms": [
       "NO signaling modulation",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "saponin / glycoside",
+    "class": "saponin / glycoside",
+    "targets": [
+      "AMPK",
+      "PPAR",
+      "immune cytokines",
+      "membrane signaling",
+      "glucose/lipid metabolism"
+    ],
     "foundIn": [
-      "PubMed",
-      "review literature"
-    ]
+      "tribulus terrestris",
+      "fenugreek"
+    ],
+    "safetyNotes": "May cause GI irritation or hemolysis risk in isolated/high-dose contexts; herb-specific safety and pregnancy cautions apply."
   },
   {
     "id": "ginsenoside-rb1",
     "slug": "ginsenoside-rb1",
     "canonicalCompoundId": "ginsenoside-rb1",
-    "name": "Ginsenoside Rb1",
-    "compoundName": "Ginsenoside Rb1",
-    "canonicalCompoundName": "Ginsenoside Rb1",
+    "name": "ginsenoside rb1",
+    "compoundName": "ginsenoside rb1",
+    "canonicalCompoundName": "ginsenoside rb1",
     "mechanisms": [
       "PI3K/Akt modulation",
       "cholinergic modulation",
       "Nrf2 activation"
     ],
+    "compoundClass": "triterpenoid saponin / ginsenoside",
+    "class": "triterpenoid saponin / ginsenoside",
+    "targets": [
+      "AMPK",
+      "PI3K/Akt",
+      "Nrf2",
+      "neurotrophic signaling",
+      "inflammatory cytokines"
+    ],
     "foundIn": [
-      "PubMed",
-      "review literature"
-    ]
+      "panax ginseng",
+      "american ginseng"
+    ],
+    "safetyNotes": "Safety inferred from ginseng extracts. Caution with anticoagulants, antidiabetics, stimulants, immunosuppressants, and hormone-sensitive contexts."
   },
   {
     "id": "ginsenoside-rg1",
     "slug": "ginsenoside-rg1",
     "canonicalCompoundId": "ginsenoside-rg1",
-    "name": "Ginsenoside Rg1",
-    "compoundName": "Ginsenoside Rg1",
-    "canonicalCompoundName": "Ginsenoside Rg1",
+    "name": "ginsenoside rg1",
+    "compoundName": "ginsenoside rg1",
+    "canonicalCompoundName": "ginsenoside rg1",
     "mechanisms": [
       "PI3K/Akt modulation",
       "NO signaling modulation",
       "Nrf2 activation"
     ],
+    "compoundClass": "triterpenoid saponin / ginsenoside",
+    "class": "triterpenoid saponin / ginsenoside",
+    "targets": [
+      "AMPK",
+      "PI3K/Akt",
+      "Nrf2",
+      "neurotrophic and inflammatory signaling"
+    ],
     "foundIn": [
-      "PubMed",
-      "review literature"
-    ]
+      "panax ginseng",
+      "american ginseng"
+    ],
+    "safetyNotes": "Safety is mostly inferred from Panax/ginseng extracts. Caution with anticoagulants, antidiabetics, stimulants, and hormone-sensitive contexts."
   },
   {
     "id": "ginsenoside-rg3",
     "slug": "ginsenoside-rg3",
     "canonicalCompoundId": "ginsenoside-rg3",
-    "name": "Ginsenoside Rg3",
-    "compoundName": "Ginsenoside Rg3",
-    "canonicalCompoundName": "Ginsenoside Rg3",
+    "name": "ginsenoside rg3",
+    "compoundName": "ginsenoside rg3",
+    "canonicalCompoundName": "ginsenoside rg3",
     "mechanisms": [
       "NF-κB inhibition",
       "PI3K/Akt modulation",
       "VEGF signaling inhibition"
     ],
+    "compoundClass": "triterpenoid saponin / ginsenoside",
+    "class": "triterpenoid saponin / ginsenoside",
+    "targets": [
+      "PI3K/Akt",
+      "apoptosis signaling",
+      "angiogenesis pathways",
+      "NF-κB",
+      "immune signaling"
+    ],
     "foundIn": [
-      "PubMed",
-      "review literature"
-    ]
+      "panax ginseng",
+      "american ginseng"
+    ],
+    "safetyNotes": "Mostly preclinical and extract-derived. Caution with anticoagulants, antidiabetics, immune therapies, and oncology regimens without supervision."
   },
   {
     "id": "ursolic-acid",
     "slug": "ursolic-acid",
     "canonicalCompoundId": "ursolic-acid",
-    "name": "Ursolic acid",
-    "compoundName": "Ursolic acid",
-    "canonicalCompoundName": "Ursolic acid",
+    "name": "ursolic acid",
+    "compoundName": "ursolic acid",
+    "canonicalCompoundName": "ursolic acid",
     "mechanisms": [
       "NF-κB inhibition",
       "STAT3 inhibition",
       "AMPK activation",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "pentacyclic triterpenoid",
+    "class": "pentacyclic triterpenoid",
+    "targets": [
+      "NF-κB",
+      "STAT3",
+      "AMPK",
+      "PPAR",
+      "apoptosis signaling"
+    ],
     "foundIn": [
-      "PubMed",
-      "review literature"
-    ]
+      "holy basil",
+      "rosemary",
+      "sage",
+      "ocimum sanctum"
+    ],
+    "safetyNotes": "Mostly preclinical and food/herb associated. High-dose isolated use lacks robust human safety data; caution with pregnancy, liver disease, and anticancer/immunomodulating therapies."
   },
   {
     "id": "oleanolic-acid",
     "slug": "oleanolic-acid",
     "canonicalCompoundId": "oleanolic-acid",
-    "name": "Oleanolic acid",
-    "compoundName": "Oleanolic acid",
-    "canonicalCompoundName": "Oleanolic acid",
+    "name": "oleanolic acid",
+    "compoundName": "oleanolic acid",
+    "canonicalCompoundName": "oleanolic acid",
     "mechanisms": [
       "Nrf2 activation",
       "NF-κB inhibition",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "triterpene / triterpenoid acid",
+    "class": "triterpene / triterpenoid acid",
+    "targets": [
+      "NF-κB",
+      "AMPK",
+      "PPAR",
+      "inflammatory cytokines",
+      "apoptosis signaling"
+    ],
     "foundIn": [
-      "PubMed",
-      "review literature"
-    ]
+      "rosemary",
+      "sage",
+      "hawthorn"
+    ],
+    "safetyNotes": "Mostly preclinical or extract-derived; concentrated doses may affect glucose, lipids, liver enzymes, or bleeding risk depending matrix."
   },
   {
     "id": "asiaticoside",
     "slug": "asiaticoside",
     "canonicalCompoundId": "asiaticoside",
-    "name": "Asiaticoside",
-    "compoundName": "Asiaticoside",
-    "canonicalCompoundName": "Asiaticoside",
+    "name": "asiaticoside",
+    "compoundName": "asiaticoside",
+    "canonicalCompoundName": "asiaticoside",
     "mechanisms": [
       "TGF-β signaling modulation",
       "MAPK pathway modulation",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "triterpenoid saponin glycoside",
+    "class": "triterpenoid saponin glycoside",
+    "targets": [
+      "collagen synthesis",
+      "TGF-β signaling",
+      "wound-healing pathways",
+      "NF-κB"
+    ],
     "foundIn": [
-      "PubMed",
-      "review literature"
-    ]
+      "gotu kola",
+      "centella asiatica"
+    ],
+    "safetyNotes": "Human safety mostly from Centella extracts/topicals. Caution with liver disease, sedatives, pregnancy, and high-dose prolonged supplementation."
   },
   {
     "id": "madecassoside",
     "slug": "madecassoside",
     "canonicalCompoundId": "madecassoside",
-    "name": "Madecassoside",
-    "compoundName": "Madecassoside",
-    "canonicalCompoundName": "Madecassoside",
+    "name": "madecassoside",
+    "compoundName": "madecassoside",
+    "canonicalCompoundName": "madecassoside",
     "mechanisms": [
       "NF-κB inhibition",
       "TGF-β signaling modulation",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "triterpenoid saponin glycoside",
+    "class": "triterpenoid saponin glycoside",
+    "targets": [
+      "TGF-β",
+      "collagen remodeling",
+      "NF-κB",
+      "wound-healing and barrier pathways"
+    ],
     "foundIn": [
-      "PubMed",
-      "review literature"
-    ]
+      "gotu kola",
+      "centella asiatica"
+    ],
+    "safetyNotes": "Mostly Centella/topical-derived evidence. Caution with liver disease, sedatives, pregnancy, and prolonged high-dose extracts."
   },
   {
     "id": "bacoside-a",
     "slug": "bacoside-a",
     "canonicalCompoundId": "bacoside-a",
-    "name": "Bacoside A",
-    "compoundName": "Bacoside A",
-    "canonicalCompoundName": "Bacoside A",
+    "name": "bacoside a",
+    "compoundName": "bacoside a",
+    "canonicalCompoundName": "bacoside a",
     "mechanisms": [
       "cholinergic modulation",
       "ERK pathway modulation"
     ],
+    "compoundClass": "triterpenoid saponin mixture",
+    "class": "triterpenoid saponin mixture",
+    "targets": [
+      "cholinergic signaling",
+      "antioxidant enzymes",
+      "synaptic plasticity",
+      "neuroinflammatory pathways"
+    ],
     "foundIn": [
-      "PubMed",
-      "review literature"
-    ]
+      "bacopa",
+      "bacopa monnieri"
+    ],
+    "safetyNotes": "Human safety is mostly Bacopa-extract derived. GI upset and sedation may occur; caution with sedatives, thyroid-active therapy, and pregnancy."
   },
   {
     "id": "withaferin-a",
     "slug": "withaferin-a",
     "canonicalCompoundId": "withaferin-a",
-    "name": "Withaferin A",
-    "compoundName": "Withaferin A",
-    "canonicalCompoundName": "Withaferin A",
+    "name": "withaferin a",
+    "compoundName": "withaferin a",
+    "canonicalCompoundName": "withaferin a",
     "mechanisms": [
       "NF-κB inhibition",
       "HSP90 inhibition",
       "apoptosis pathway modulation"
     ],
+    "compoundClass": "steroidal lactone / withanolide",
+    "class": "steroidal lactone / withanolide",
+    "targets": [
+      "HSP90",
+      "NF-κB",
+      "Nrf2",
+      "PI3K/Akt",
+      "apoptosis signaling"
+    ],
     "foundIn": [
-      "PubMed",
-      "review literature"
-    ]
+      "ashwagandha"
+    ],
+    "safetyNotes": "Mostly preclinical as isolated compound; whole ashwagandha safety does not equal isolated withaferin A safety. Avoid pregnancy and use caution with liver disease, immune disorders, and drug stacks."
   },
   {
     "id": "withanolide-a",
     "slug": "withanolide-a",
     "canonicalCompoundId": "withanolide-a",
-    "name": "Withanolide A",
-    "compoundName": "Withanolide A",
-    "canonicalCompoundName": "Withanolide A",
+    "name": "withanolide a",
+    "compoundName": "withanolide a",
+    "canonicalCompoundName": "withanolide a",
     "mechanisms": [
       "PI3K/Akt modulation",
       "cholinergic modulation"
     ],
+    "compoundClass": "withanolide / steroidal lactone",
+    "class": "withanolide / steroidal lactone",
+    "targets": [
+      "HPA-axis modulation",
+      "NF-κB",
+      "GABAergic signaling",
+      "apoptosis pathways"
+    ],
     "foundIn": [
-      "PubMed",
-      "review literature"
-    ]
+      "ashwagandha"
+    ],
+    "safetyNotes": "Evidence usually comes from Withania extracts. Caution with pregnancy, liver disease, sedatives, thyroid medications, and autoimmune disease."
   },
   {
     "id": "piperlongumine",
     "slug": "piperlongumine",
     "canonicalCompoundId": "piperlongumine",
-    "name": "Piperlongumine",
-    "compoundName": "Piperlongumine",
-    "canonicalCompoundName": "Piperlongumine",
+    "name": "piperlongumine",
+    "compoundName": "piperlongumine",
+    "canonicalCompoundName": "piperlongumine",
     "mechanisms": [
       "ROS-mediated signaling modulation",
       "STAT3 inhibition",
       "NF-κB inhibition"
     ],
+    "compoundClass": "alkaloid / amide",
+    "class": "alkaloid / amide",
+    "targets": [
+      "ROS stress-response pathways",
+      "NF-κB",
+      "apoptosis signaling",
+      "glutathione/oxidative-stress balance"
+    ],
     "foundIn": [
-      "PubMed",
-      "review literature"
-    ]
+      "piper longum"
+    ],
+    "safetyNotes": "Primarily preclinical; isolated high-dose human safety is not established. Avoid pregnancy, liver disease, and complex oncology regimens without supervision."
   },
   {
     "id": "quercetin",
     "slug": "quercetin",
     "canonicalCompoundId": "quercetin",
-    "name": "Quercetin",
-    "compoundName": "Quercetin",
-    "canonicalCompoundName": "Quercetin",
+    "name": "quercetin",
+    "compoundName": "quercetin",
+    "canonicalCompoundName": "quercetin",
     "mechanisms": [
-      "NF-κB inhibition",
+      "NF-kB suppression",
+      "Nrf2 activation",
       "PI3K/Akt modulation",
-      "Nrf2 activation"
+      "mast-cell mediator stabilization",
+      "antioxidant redox signaling"
+    ],
+    "compoundClass": "flavonol polyphenol",
+    "class": "flavonol polyphenol",
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "PI3K/Akt",
+      "mast-cell mediators",
+      "CYP/P-gp interaction pathways"
     ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "onion",
+      "buckwheat",
+      "capers",
+      "many flavonoid-rich herbs"
+    ],
+    "safetyNotes": "Food exposure is generally safe; high-dose supplements may affect drug transport/metabolism. Caution with anticoagulants, immunosuppressants, and kidney disease at high doses."
   },
   {
     "id": "kaempferol",
     "slug": "kaempferol",
     "canonicalCompoundId": "kaempferol",
-    "name": "Kaempferol",
-    "compoundName": "Kaempferol",
-    "canonicalCompoundName": "Kaempferol",
+    "name": "kaempferol",
+    "compoundName": "kaempferol",
+    "canonicalCompoundName": "kaempferol",
     "mechanisms": [
       "PI3K/Akt modulation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "flavonol polyphenol",
+    "class": "flavonol polyphenol",
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "PI3K/Akt",
+      "MAPK",
+      "inflammatory cytokines"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "tea",
+      "brassica",
+      "moringa",
+      "many leafy plants"
+    ],
+    "safetyNotes": "Food exposure is low-risk; high-dose supplement safety is less established. Caution with anticoagulants, antidiabetics, and complex oncology regimens."
   },
   {
     "id": "myricetin",
     "slug": "myricetin",
     "canonicalCompoundId": "myricetin",
-    "name": "Myricetin",
-    "compoundName": "Myricetin",
-    "canonicalCompoundName": "Myricetin",
+    "name": "myricetin",
+    "compoundName": "myricetin",
+    "canonicalCompoundName": "myricetin",
     "mechanisms": [
       "MAPK pathway modulation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "flavonol / flavonoid",
+    "class": "flavonol / flavonoid",
+    "targets": [
+      "AMPK",
+      "Nrf2",
+      "NF-κB",
+      "inflammatory cytokines",
+      "endothelial nitric oxide",
+      "antioxidant response"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "berries",
+      "tea",
+      "grape",
+      "many fruits"
+    ],
+    "safetyNotes": "Mostly food/extract-derived human evidence. High-dose supplements may affect CYP/transporters or anticoagulant/antiplatelet risk."
   },
   {
     "id": "apigenin",
     "slug": "apigenin",
     "canonicalCompoundId": "apigenin",
-    "name": "Apigenin",
-    "compoundName": "Apigenin",
-    "canonicalCompoundName": "Apigenin",
+    "name": "apigenin",
+    "compoundName": "apigenin",
+    "canonicalCompoundName": "apigenin",
     "mechanisms": [
-      "GABA-A modulation",
-      "PI3K/Akt modulation"
+      "GABA-A receptor modulation",
+      "PI3K/Akt modulation",
+      "NF-kB suppression",
+      "Nrf2-related antioxidant signaling"
+    ],
+    "compoundClass": "flavone polyphenol",
+    "class": "flavone polyphenol",
+    "targets": [
+      "GABAergic signaling",
+      "NF-κB",
+      "Nrf2",
+      "PI3K/Akt",
+      "inflammatory mediators"
     ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "yerba mate",
+      "chamomile",
+      "petroselinum crispum",
+      "parsley"
+    ],
+    "safetyNotes": "Food exposure is low-risk; concentrated apigenin may be sedating and may interact with sedatives or CYP-metabolized drugs. Pregnancy/breastfeeding caution at supplement doses."
   },
   {
     "id": "luteolin",
     "slug": "luteolin",
     "canonicalCompoundId": "luteolin",
-    "name": "Luteolin",
-    "compoundName": "Luteolin",
-    "canonicalCompoundName": "Luteolin",
+    "name": "luteolin",
+    "compoundName": "luteolin",
+    "canonicalCompoundName": "luteolin",
     "mechanisms": [
       "NF-κB inhibition",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "flavone / flavonoid",
+    "class": "flavone / flavonoid",
+    "targets": [
+      "NF-κB",
+      "MAPK",
+      "PI3K/Akt",
+      "Nrf2",
+      "inflammatory cytokines",
+      "antioxidant response"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "thyme",
+      "artichoke"
+    ],
+    "safetyNotes": "Mostly preclinical and extract-derived. Use caution with sedatives, anticoagulants/antiplatelets, and liver disease depending source herb."
   },
   {
     "id": "naringenin",
     "slug": "naringenin",
     "canonicalCompoundId": "naringenin",
-    "name": "Naringenin",
-    "compoundName": "Naringenin",
-    "canonicalCompoundName": "Naringenin",
+    "name": "naringenin",
+    "compoundName": "naringenin",
+    "canonicalCompoundName": "naringenin",
     "mechanisms": [
       "AMPK activation",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "flavanone / citrus flavonoid",
+    "class": "flavanone / citrus flavonoid",
+    "targets": [
+      "AMPK",
+      "PPAR signaling",
+      "NF-κB",
+      "endothelial nitric oxide",
+      "antioxidant response",
+      "drug transporters"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "citrus peel/fruit",
+      "grapefruit"
+    ],
+    "safetyNotes": "Citrus-derived compounds are generally food-associated, but grapefruit/citrus extracts can interact with CYP3A4/OATP/P-gp substrates."
   },
   {
     "id": "naringin",
     "slug": "naringin",
     "canonicalCompoundId": "naringin",
-    "name": "Naringin",
-    "compoundName": "Naringin",
-    "canonicalCompoundName": "Naringin",
+    "name": "naringin",
+    "compoundName": "naringin",
+    "canonicalCompoundName": "naringin",
     "mechanisms": [
       "AMPK activation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "flavanone / citrus flavonoid",
+    "class": "flavanone / citrus flavonoid",
+    "targets": [
+      "AMPK",
+      "PPAR signaling",
+      "NF-κB",
+      "endothelial nitric oxide",
+      "antioxidant response",
+      "drug transporters"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "grapefruit",
+      "citrus peel"
+    ],
+    "safetyNotes": "Citrus-derived compounds are generally food-associated, but grapefruit/citrus extracts can interact with CYP3A4/OATP/P-gp substrates."
   },
   {
     "id": "rutin",
     "slug": "rutin",
     "canonicalCompoundId": "rutin",
-    "name": "Rutin",
-    "compoundName": "Rutin",
-    "canonicalCompoundName": "Rutin",
+    "name": "rutin",
+    "compoundName": "rutin",
+    "canonicalCompoundName": "rutin",
     "mechanisms": [
       "NF-κB inhibition",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "flavonol / flavonoid",
+    "class": "flavonol / flavonoid",
+    "targets": [
+      "AMPK",
+      "Nrf2",
+      "NF-κB",
+      "inflammatory cytokines",
+      "endothelial nitric oxide",
+      "antioxidant response"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "buckwheat",
+      "citrus",
+      "elderflower",
+      "many plants"
+    ],
+    "safetyNotes": "Mostly food/extract-derived human evidence. High-dose supplements may affect CYP/transporters or anticoagulant/antiplatelet risk."
   },
   {
     "id": "catechin",
     "slug": "catechin",
     "canonicalCompoundId": "catechin",
-    "name": "Catechin",
-    "compoundName": "Catechin",
-    "canonicalCompoundName": "Catechin",
+    "name": "catechin",
+    "compoundName": "catechin",
+    "canonicalCompoundName": "catechin",
     "mechanisms": [
-      "AMPK activation",
-      "Nrf2 activation"
+      "Nrf2 activation",
+      "NF-kB suppression",
+      "endothelial nitric-oxide signaling support",
+      "antioxidant redox modulation"
+    ],
+    "compoundClass": "flavanol / tea polyphenol",
+    "class": "flavanol / tea polyphenol",
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "AMPK",
+      "endothelial nitric oxide",
+      "antioxidant response",
+      "lipid/glucose signaling"
     ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "green tea",
+      "cacao",
+      "grape",
+      "berries"
+    ],
+    "safetyNotes": "Tea-food exposure is generally safer than concentrated extracts. High EGCG/catechin extracts have liver-injury concern and caffeine-containing products add stimulant risk."
   },
   {
     "id": "epicatechin",
     "slug": "epicatechin",
     "canonicalCompoundId": "epicatechin",
-    "name": "Epicatechin",
-    "compoundName": "Epicatechin",
-    "canonicalCompoundName": "Epicatechin",
+    "name": "epicatechin",
+    "compoundName": "epicatechin",
+    "canonicalCompoundName": "epicatechin",
     "mechanisms": [
       "PI3K/Akt modulation",
       "eNOS activation"
     ],
+    "compoundClass": "flavanol / tea polyphenol",
+    "class": "flavanol / tea polyphenol",
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "AMPK",
+      "endothelial nitric oxide",
+      "antioxidant response",
+      "lipid/glucose signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "cacao",
+      "green tea",
+      "grape",
+      "apple"
+    ],
+    "safetyNotes": "Tea-food exposure is generally safer than concentrated extracts. High EGCG/catechin extracts have liver-injury concern and caffeine-containing products add stimulant risk."
   },
   {
     "id": "epigallocatechin-gallate-egcg",
     "slug": "epigallocatechin-gallate-egcg",
     "canonicalCompoundId": "epigallocatechin-gallate-egcg",
-    "name": "Epigallocatechin gallate (EGCG)",
-    "compoundName": "Epigallocatechin gallate (EGCG)",
-    "canonicalCompoundName": "Epigallocatechin gallate (EGCG)",
+    "name": "epigallocatechin gallate (egcg)",
+    "compoundName": "epigallocatechin gallate (egcg)",
+    "canonicalCompoundName": "epigallocatechin gallate (egcg)",
     "mechanisms": [
       "AMPK activation",
       "NF-κB inhibition",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "flavanol / tea polyphenol",
+    "class": "flavanol / tea polyphenol",
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "AMPK",
+      "endothelial nitric oxide",
+      "antioxidant response",
+      "lipid/glucose signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "green tea",
+      "Camellia sinensis"
+    ],
+    "safetyNotes": "Tea-food exposure is generally safer than concentrated extracts. High EGCG/catechin extracts have liver-injury concern and caffeine-containing products add stimulant risk."
   },
   {
     "id": "theaflavin",
     "slug": "theaflavin",
     "canonicalCompoundId": "theaflavin",
-    "name": "Theaflavin",
-    "compoundName": "Theaflavin",
-    "canonicalCompoundName": "Theaflavin",
+    "name": "theaflavin",
+    "compoundName": "theaflavin",
+    "canonicalCompoundName": "theaflavin",
     "mechanisms": [
       "NF-κB inhibition",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "flavanol / tea polyphenol",
+    "class": "flavanol / tea polyphenol",
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "AMPK",
+      "endothelial nitric oxide",
+      "antioxidant response",
+      "lipid/glucose signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "black tea"
+    ],
+    "safetyNotes": "Tea-food exposure is generally safer than concentrated extracts. High EGCG/catechin extracts have liver-injury concern and caffeine-containing products add stimulant risk."
   },
   {
     "id": "thearubigin",
     "slug": "thearubigin",
     "canonicalCompoundId": "thearubigin",
-    "name": "Thearubigin",
-    "compoundName": "Thearubigin",
-    "canonicalCompoundName": "Thearubigin",
+    "name": "thearubigin",
+    "compoundName": "thearubigin",
+    "canonicalCompoundName": "thearubigin",
     "mechanisms": [
       "NF-κB inhibition",
       "Nrf2 activation"
     ],
+    "compoundClass": "flavanol / tea polyphenol",
+    "class": "flavanol / tea polyphenol",
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "AMPK",
+      "endothelial nitric oxide",
+      "antioxidant response",
+      "lipid/glucose signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "black tea"
+    ],
+    "safetyNotes": "Tea-food exposure is generally safer than concentrated extracts. High EGCG/catechin extracts have liver-injury concern and caffeine-containing products add stimulant risk."
   },
   {
     "id": "resveratrol",
     "slug": "resveratrol",
     "canonicalCompoundId": "resveratrol",
-    "name": "Resveratrol",
-    "compoundName": "Resveratrol",
-    "canonicalCompoundName": "Resveratrol",
+    "name": "resveratrol",
+    "compoundName": "resveratrol",
+    "canonicalCompoundName": "resveratrol",
     "mechanisms": [
       "SIRT1 activation",
       "AMPK activation",
-      "NF-κB inhibition"
+      "NF-kB suppression",
+      "Nrf2 signaling support",
+      "endothelial nitric-oxide pathway modulation"
+    ],
+    "compoundClass": "stilbene polyphenol",
+    "class": "stilbene polyphenol",
+    "targets": [
+      "SIRT1",
+      "AMPK",
+      "Nrf2",
+      "NF-κB",
+      "endothelial nitric oxide signaling"
     ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "grape skin",
+      "Japanese knotweed",
+      "berries"
+    ],
+    "safetyNotes": "Usually well tolerated short-term; caution with anticoagulants/antiplatelets, hormone-sensitive conditions, pregnancy, and high-dose extracts."
   },
   {
     "id": "pterostilbene",
     "slug": "pterostilbene",
     "canonicalCompoundId": "pterostilbene",
-    "name": "Pterostilbene",
-    "compoundName": "Pterostilbene",
-    "canonicalCompoundName": "Pterostilbene",
+    "name": "pterostilbene",
+    "compoundName": "pterostilbene",
+    "canonicalCompoundName": "pterostilbene",
     "mechanisms": [
       "AMPK activation",
       "PPAR activation"
     ],
+    "compoundClass": "stilbene polyphenol",
+    "class": "stilbene polyphenol",
+    "targets": [
+      "SIRT1/AMPK",
+      "Nrf2",
+      "NF-κB",
+      "endothelial signaling",
+      "platelet aggregation pathways"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "blueberry",
+      "grape",
+      "Pterocarpus species"
+    ],
+    "safetyNotes": "May affect bleeding risk and drug metabolism at supplement doses; GI upset and headache are possible."
   },
   {
     "id": "genistein",
     "slug": "genistein",
     "canonicalCompoundId": "genistein",
-    "name": "Genistein",
-    "compoundName": "Genistein",
-    "canonicalCompoundName": "Genistein",
+    "name": "genistein",
+    "compoundName": "genistein",
+    "canonicalCompoundName": "genistein",
     "mechanisms": [
       "estrogen receptor modulation",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "isoflavone / phytoestrogen",
+    "class": "isoflavone / phytoestrogen",
+    "targets": [
+      "estrogen receptor signaling",
+      "AMPK",
+      "PPAR",
+      "antioxidant response",
+      "bone/metabolic signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "soybean",
+      "red clover",
+      "kudzu-related legumes"
+    ],
+    "safetyNotes": "Phytoestrogenic activity warrants caution with hormone-sensitive conditions and hormone therapies; effects are preparation- and dose-specific."
   },
   {
     "id": "daidzein",
     "slug": "daidzein",
     "canonicalCompoundId": "daidzein",
-    "name": "Daidzein",
-    "compoundName": "Daidzein",
-    "canonicalCompoundName": "Daidzein",
+    "name": "daidzein",
+    "compoundName": "daidzein",
+    "canonicalCompoundName": "daidzein",
     "mechanisms": [
       "estrogen receptor modulation",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "isoflavone / phytoestrogen",
+    "class": "isoflavone / phytoestrogen",
+    "targets": [
+      "estrogen receptor signaling",
+      "AMPK",
+      "PPAR",
+      "antioxidant response",
+      "bone/metabolic signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "soybean",
+      "kudzu",
+      "red clover"
+    ],
+    "safetyNotes": "Phytoestrogenic activity warrants caution with hormone-sensitive conditions and hormone therapies; effects are preparation- and dose-specific."
   },
   {
     "id": "formononetin",
     "slug": "formononetin",
     "canonicalCompoundId": "formononetin",
-    "name": "Formononetin",
-    "compoundName": "Formononetin",
-    "canonicalCompoundName": "Formononetin",
+    "name": "formononetin",
+    "compoundName": "formononetin",
+    "canonicalCompoundName": "formononetin",
     "mechanisms": [
       "estrogen receptor modulation",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "isoflavone / phytoestrogen",
+    "class": "isoflavone / phytoestrogen",
+    "targets": [
+      "estrogen receptor signaling",
+      "AMPK",
+      "PPAR",
+      "antioxidant response",
+      "bone/metabolic signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "red clover",
+      "astragalus",
+      "legumes"
+    ],
+    "safetyNotes": "Phytoestrogenic activity warrants caution with hormone-sensitive conditions and hormone therapies; effects are preparation- and dose-specific."
   },
   {
     "id": "biochanin-a",
     "slug": "biochanin-a",
     "canonicalCompoundId": "biochanin-a",
-    "name": "Biochanin A",
-    "compoundName": "Biochanin A",
-    "canonicalCompoundName": "Biochanin A",
+    "name": "biochanin a",
+    "compoundName": "biochanin a",
+    "canonicalCompoundName": "biochanin a",
     "mechanisms": [
-      "estrogen receptor modulation",
-      "NF-κB inhibition"
+      "Estrogen-receptor modulation",
+      "CYP/aromatase-related signaling effects",
+      "PPAR modulation",
+      "NF-kB suppression"
+    ],
+    "compoundClass": "isoflavone / phytoestrogen",
+    "class": "isoflavone / phytoestrogen",
+    "targets": [
+      "estrogen receptor signaling",
+      "AMPK",
+      "PPAR",
+      "antioxidant response",
+      "bone/metabolic signaling"
     ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "red clover",
+      "legumes"
+    ],
+    "safetyNotes": "Phytoestrogenic activity warrants caution with hormone-sensitive conditions and hormone therapies; effects are preparation- and dose-specific."
   },
   {
     "id": "ellagic-acid",
     "slug": "ellagic-acid",
     "canonicalCompoundId": "ellagic-acid",
-    "name": "Ellagic acid",
-    "compoundName": "Ellagic acid",
-    "canonicalCompoundName": "Ellagic acid",
+    "name": "ellagic acid",
+    "compoundName": "ellagic acid",
+    "canonicalCompoundName": "ellagic acid",
     "mechanisms": [
       "Nrf2 activation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "phenolic acid / polyphenol",
+    "class": "phenolic acid / polyphenol",
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "antioxidant response",
+      "glucose/lipid signaling",
+      "gut microbiome metabolism"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "pomegranate",
+      "raspberry",
+      "oak/gall-rich botanicals"
+    ],
+    "safetyNotes": "Mostly food-associated; concentrated extracts may cause GI effects or interact with anticoagulants/antidiabetics depending matrix."
   },
   {
     "id": "gallic-acid",
     "slug": "gallic-acid",
     "canonicalCompoundId": "gallic-acid",
-    "name": "Gallic acid",
-    "compoundName": "Gallic acid",
-    "canonicalCompoundName": "Gallic acid",
+    "name": "gallic acid",
+    "compoundName": "gallic acid",
+    "canonicalCompoundName": "gallic acid",
     "mechanisms": [
-      "MAPK pathway modulation",
-      "NF-κB inhibition"
+      "NF-kB suppression",
+      "Nrf2-related antioxidant signaling",
+      "metal-chelation/redox effects",
+      "caspase-linked apoptosis signaling"
+    ],
+    "compoundClass": "phenolic acid / polyphenol",
+    "class": "phenolic acid / polyphenol",
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "antioxidant response",
+      "glucose/lipid signaling",
+      "gut microbiome metabolism"
     ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "tea",
+      "sumac",
+      "gallnut",
+      "many tannin-rich plants"
+    ],
+    "safetyNotes": "Mostly food-associated; concentrated extracts may cause GI effects or interact with anticoagulants/antidiabetics depending matrix."
   },
   {
     "id": "ferulic-acid",
     "slug": "ferulic-acid",
     "canonicalCompoundId": "ferulic-acid",
-    "name": "Ferulic acid",
-    "compoundName": "Ferulic acid",
-    "canonicalCompoundName": "Ferulic acid",
+    "name": "ferulic acid",
+    "compoundName": "ferulic acid",
+    "canonicalCompoundName": "ferulic acid",
     "mechanisms": [
       "Nrf2 activation",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "phenolic acid / polyphenol",
+    "class": "phenolic acid / polyphenol",
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "antioxidant response",
+      "glucose/lipid signaling",
+      "gut microbiome metabolism"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "rice bran",
+      "grains",
+      "angelica and many plants"
+    ],
+    "safetyNotes": "Mostly food-associated; concentrated extracts may cause GI effects or interact with anticoagulants/antidiabetics depending matrix."
   },
   {
     "id": "chlorogenic-acid",
     "slug": "chlorogenic-acid",
     "canonicalCompoundId": "chlorogenic-acid",
-    "name": "Chlorogenic acid",
-    "compoundName": "Chlorogenic acid",
-    "canonicalCompoundName": "Chlorogenic acid",
+    "name": "chlorogenic acid",
+    "compoundName": "chlorogenic acid",
+    "canonicalCompoundName": "chlorogenic acid",
     "mechanisms": [
       "AMPK activation",
       "glucose metabolism modulation"
     ],
+    "compoundClass": "caffeoylquinic acid / phenolic acid",
+    "class": "caffeoylquinic acid / phenolic acid",
+    "targets": [
+      "AMPK",
+      "glucose absorption pathways",
+      "antioxidant enzymes",
+      "inflammatory signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "coffee",
+      "yerba mate",
+      "artichoke",
+      "many plants"
+    ],
+    "safetyNotes": "Generally food-associated; supplement doses may cause GI upset or caffeine-like effects if delivered via coffee/green coffee extracts. Caution with stimulant sensitivity and antidiabetic drugs."
   },
   {
     "id": "caffeic-acid",
     "slug": "caffeic-acid",
     "canonicalCompoundId": "caffeic-acid",
-    "name": "Caffeic acid",
-    "compoundName": "Caffeic acid",
-    "canonicalCompoundName": "Caffeic acid",
+    "name": "caffeic acid",
+    "compoundName": "caffeic acid",
+    "canonicalCompoundName": "caffeic acid",
     "mechanisms": [
       "NF-κB inhibition",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "phenolic acid / polyphenol",
+    "class": "phenolic acid / polyphenol",
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "antioxidant response",
+      "glucose/lipid signaling",
+      "gut microbiome metabolism"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "coffee",
+      "propolis",
+      "many herbs"
+    ],
+    "safetyNotes": "Mostly food-associated; concentrated extracts may cause GI effects or interact with anticoagulants/antidiabetics depending matrix."
   },
   {
     "id": "osthole",
     "slug": "osthole",
     "canonicalCompoundId": "osthole",
-    "name": "Osthole",
-    "compoundName": "Osthole",
-    "canonicalCompoundName": "Osthole",
+    "name": "osthole",
+    "compoundName": "osthole",
+    "canonicalCompoundName": "osthole",
     "mechanisms": [
       "PDE4 inhibition",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "coumarin / furanocoumarin",
+    "class": "coumarin / furanocoumarin",
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "Cnidium monnieri",
+      "Angelica species"
+    ],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils."
   },
   {
     "id": "imperatorin",
     "slug": "imperatorin",
     "canonicalCompoundId": "imperatorin",
-    "name": "Imperatorin",
-    "compoundName": "Imperatorin",
-    "canonicalCompoundName": "Imperatorin",
+    "name": "imperatorin",
+    "compoundName": "imperatorin",
+    "canonicalCompoundName": "imperatorin",
     "mechanisms": [
       "acetylcholinesterase inhibition",
       "voltage-gated calcium channel modulation"
     ],
+    "compoundClass": "coumarin / furanocoumarin",
+    "class": "coumarin / furanocoumarin",
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "Angelica dahurica",
+      "Apiaceae roots"
+    ],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils."
   },
   {
     "id": "isoimperatorin",
     "slug": "isoimperatorin",
     "canonicalCompoundId": "isoimperatorin",
-    "name": "Isoimperatorin",
-    "compoundName": "Isoimperatorin",
-    "canonicalCompoundName": "Isoimperatorin",
+    "name": "isoimperatorin",
+    "compoundName": "isoimperatorin",
+    "canonicalCompoundName": "isoimperatorin",
     "mechanisms": [
       "acetylcholinesterase inhibition",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "coumarin / furanocoumarin",
+    "class": "coumarin / furanocoumarin",
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "Angelica dahurica",
+      "Apiaceae roots"
+    ],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils."
   },
   {
     "id": "psoralen",
     "slug": "psoralen",
     "canonicalCompoundId": "psoralen",
-    "name": "Psoralen",
-    "compoundName": "Psoralen",
-    "canonicalCompoundName": "Psoralen",
+    "name": "psoralen",
+    "compoundName": "psoralen",
+    "canonicalCompoundName": "psoralen",
     "mechanisms": [
       "estrogen receptor modulation",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "coumarin / furanocoumarin",
+    "class": "coumarin / furanocoumarin",
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "Psoralea corylifolia",
+      "fig",
+      "celery-family plants"
+    ],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils."
   },
   {
     "id": "angelicin",
     "slug": "angelicin",
     "canonicalCompoundId": "angelicin",
-    "name": "Angelicin",
-    "compoundName": "Angelicin",
-    "canonicalCompoundName": "Angelicin",
+    "name": "angelicin",
+    "compoundName": "angelicin",
+    "canonicalCompoundName": "angelicin",
     "mechanisms": [
       "NF-κB inhibition",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "coumarin / furanocoumarin",
+    "class": "coumarin / furanocoumarin",
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "Psoralea corylifolia",
+      "fig",
+      "Apiaceae plants"
+    ],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils."
   },
   {
     "id": "bergapten",
     "slug": "bergapten",
     "canonicalCompoundId": "bergapten",
-    "name": "Bergapten",
-    "compoundName": "Bergapten",
-    "canonicalCompoundName": "Bergapten",
+    "name": "bergapten",
+    "compoundName": "bergapten",
+    "canonicalCompoundName": "bergapten",
     "mechanisms": [
       "MAPK pathway modulation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "coumarin / furanocoumarin",
+    "class": "coumarin / furanocoumarin",
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "citrus peel/oils",
+      "Apiaceae plants"
+    ],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils."
   },
   {
     "id": "scopoletin",
     "slug": "scopoletin",
     "canonicalCompoundId": "scopoletin",
-    "name": "Scopoletin",
-    "compoundName": "Scopoletin",
-    "canonicalCompoundName": "Scopoletin",
+    "name": "scopoletin",
+    "compoundName": "scopoletin",
+    "canonicalCompoundName": "scopoletin",
     "mechanisms": [
       "NF-κB inhibition",
       "voltage-gated calcium channel modulation"
     ],
+    "compoundClass": "coumarin / furanocoumarin",
+    "class": "coumarin / furanocoumarin",
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "morinda citrifolia",
+      "artemisia capillaris"
+    ],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils."
   },
   {
     "id": "esculetin",
     "slug": "esculetin",
     "canonicalCompoundId": "esculetin",
-    "name": "Esculetin",
-    "compoundName": "Esculetin",
-    "canonicalCompoundName": "Esculetin",
+    "name": "esculetin",
+    "compoundName": "esculetin",
+    "canonicalCompoundName": "esculetin",
     "mechanisms": [
       "5-lipoxygenase inhibition",
       "NF-κB inhibition"
     ],
+    "compoundClass": "coumarin / furanocoumarin",
+    "class": "coumarin / furanocoumarin",
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "cichorium intybus",
+      "artemisia capillaris"
+    ],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils."
   },
   {
     "id": "fraxetin",
     "slug": "fraxetin",
     "canonicalCompoundId": "fraxetin",
-    "name": "Fraxetin",
-    "compoundName": "Fraxetin",
-    "canonicalCompoundName": "Fraxetin",
+    "name": "fraxetin",
+    "compoundName": "fraxetin",
+    "canonicalCompoundName": "fraxetin",
     "mechanisms": [
       "Nrf2 activation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "coumarin / furanocoumarin",
+    "class": "coumarin / furanocoumarin",
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "fraxinus rhynchophylla",
+      "artemisia capillaris"
+    ],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils."
   },
   {
     "id": "umbelliferone",
     "slug": "umbelliferone",
     "canonicalCompoundId": "umbelliferone",
-    "name": "Umbelliferone",
-    "compoundName": "Umbelliferone",
-    "canonicalCompoundName": "Umbelliferone",
+    "name": "umbelliferone",
+    "compoundName": "umbelliferone",
+    "canonicalCompoundName": "umbelliferone",
     "mechanisms": [
       "Nrf2 activation",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "coumarin / furanocoumarin",
+    "class": "coumarin / furanocoumarin",
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "angelica archangelica",
+      "coriandrum sativum"
+    ],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils."
   },
   {
     "id": "daphnetin",
     "slug": "daphnetin",
     "canonicalCompoundId": "daphnetin",
-    "name": "Daphnetin",
-    "compoundName": "Daphnetin",
-    "canonicalCompoundName": "Daphnetin",
+    "name": "daphnetin",
+    "compoundName": "daphnetin",
+    "canonicalCompoundName": "daphnetin",
     "mechanisms": [
       "JAK/STAT inhibition",
       "NF-κB inhibition"
     ],
+    "compoundClass": "coumarin / furanocoumarin",
+    "class": "coumarin / furanocoumarin",
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "daphne odora",
+      "stellera chamaejasme"
+    ],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils."
   },
   {
     "id": "matrine",
     "slug": "matrine",
     "canonicalCompoundId": "matrine",
-    "name": "Matrine",
-    "compoundName": "Matrine",
-    "canonicalCompoundName": "Matrine",
+    "name": "matrine",
+    "compoundName": "matrine",
+    "canonicalCompoundName": "matrine",
     "mechanisms": [
       "PI3K/Akt modulation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "alkaloid",
+    "class": "alkaloid",
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "Sophora flavescens",
+      "Sophora alopecuroides"
+    ],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety."
   },
   {
     "id": "oxymatrine",
     "slug": "oxymatrine",
     "canonicalCompoundId": "oxymatrine",
-    "name": "Oxymatrine",
-    "compoundName": "Oxymatrine",
-    "canonicalCompoundName": "Oxymatrine",
+    "name": "oxymatrine",
+    "compoundName": "oxymatrine",
+    "canonicalCompoundName": "oxymatrine",
     "mechanisms": [
       "TGF-β signaling modulation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "alkaloid",
+    "class": "alkaloid",
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "Sophora flavescens",
+      "Sophora alopecuroides"
+    ],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety."
   },
   {
     "id": "tetrandrine",
     "slug": "tetrandrine",
     "canonicalCompoundId": "tetrandrine",
-    "name": "Tetrandrine",
-    "compoundName": "Tetrandrine",
-    "canonicalCompoundName": "Tetrandrine",
+    "name": "tetrandrine",
+    "compoundName": "tetrandrine",
+    "canonicalCompoundName": "tetrandrine",
     "mechanisms": [
       "voltage-gated calcium channel modulation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "alkaloid",
+    "class": "alkaloid",
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "Stephania tetrandra"
+    ],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety."
   },
   {
     "id": "cepharanthine",
     "slug": "cepharanthine",
     "canonicalCompoundId": "cepharanthine",
-    "name": "Cepharanthine",
-    "compoundName": "Cepharanthine",
-    "canonicalCompoundName": "Cepharanthine",
+    "name": "cepharanthine",
+    "compoundName": "cepharanthine",
+    "canonicalCompoundName": "cepharanthine",
     "mechanisms": [
       "NF-κB inhibition",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "alkaloid",
+    "class": "alkaloid",
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "Stephania cepharantha"
+    ],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety."
   },
   {
     "id": "magnoflorine",
     "slug": "magnoflorine",
     "canonicalCompoundId": "magnoflorine",
-    "name": "Magnoflorine",
-    "compoundName": "Magnoflorine",
-    "canonicalCompoundName": "Magnoflorine",
+    "name": "magnoflorine",
+    "compoundName": "magnoflorine",
+    "canonicalCompoundName": "magnoflorine",
     "mechanisms": [
       "AMPK activation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "alkaloid",
+    "class": "alkaloid",
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "Magnolia",
+      "Coptis",
+      "many medicinal plants"
+    ],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety."
   },
   {
     "id": "ligustilide",
     "slug": "ligustilide",
     "canonicalCompoundId": "ligustilide",
-    "name": "Ligustilide",
-    "compoundName": "Ligustilide",
-    "canonicalCompoundName": "Ligustilide",
+    "name": "ligustilide",
+    "compoundName": "ligustilide",
+    "canonicalCompoundName": "ligustilide",
     "mechanisms": [
       "voltage-gated calcium channel modulation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "phthalide",
+    "class": "phthalide",
+    "targets": [
+      "smooth muscle relaxation",
+      "nitric oxide/endothelial signaling",
+      "platelet aggregation pathways",
+      "inflammatory signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "Ligusticum chuanxiong",
+      "Angelica sinensis"
+    ],
+    "safetyNotes": "Mostly extract-derived evidence. Potential additive bleeding, blood pressure, or sedative effects depending source herb."
   },
   {
     "id": "senkyunolide-a",
     "slug": "senkyunolide-a",
     "canonicalCompoundId": "senkyunolide-a",
-    "name": "Senkyunolide A",
-    "compoundName": "Senkyunolide A",
-    "canonicalCompoundName": "Senkyunolide A",
+    "name": "senkyunolide a",
+    "compoundName": "senkyunolide a",
+    "canonicalCompoundName": "senkyunolide a",
     "mechanisms": [
       "MAPK pathway modulation",
       "voltage-gated calcium channel modulation"
     ],
+    "compoundClass": "phthalide",
+    "class": "phthalide",
+    "targets": [
+      "smooth muscle relaxation",
+      "nitric oxide/endothelial signaling",
+      "platelet aggregation pathways",
+      "inflammatory signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "Ligusticum chuanxiong",
+      "Angelica sinensis"
+    ],
+    "safetyNotes": "Mostly extract-derived evidence. Potential additive bleeding, blood pressure, or sedative effects depending source herb."
   },
   {
     "id": "butylidenephthalide",
     "slug": "butylidenephthalide",
     "canonicalCompoundId": "butylidenephthalide",
-    "name": "Butylidenephthalide",
-    "compoundName": "Butylidenephthalide",
-    "canonicalCompoundName": "Butylidenephthalide",
+    "name": "butylidenephthalide",
+    "compoundName": "butylidenephthalide",
+    "canonicalCompoundName": "butylidenephthalide",
     "mechanisms": [
       "PI3K/Akt modulation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "phthalide",
+    "class": "phthalide",
+    "targets": [
+      "smooth muscle relaxation",
+      "nitric oxide/endothelial signaling",
+      "platelet aggregation pathways",
+      "inflammatory signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "Angelica sinensis",
+      "Ligusticum species"
+    ],
+    "safetyNotes": "Mostly extract-derived evidence. Potential additive bleeding, blood pressure, or sedative effects depending source herb."
   },
   {
     "id": "xanthotoxin",
     "slug": "xanthotoxin",
     "canonicalCompoundId": "xanthotoxin",
-    "name": "Xanthotoxin",
-    "compoundName": "Xanthotoxin",
-    "canonicalCompoundName": "Xanthotoxin",
+    "name": "xanthotoxin",
+    "compoundName": "xanthotoxin",
+    "canonicalCompoundName": "xanthotoxin",
     "mechanisms": [
       "MAPK pathway modulation",
       "PDE inhibition"
     ],
+    "compoundClass": "coumarin / furanocoumarin",
+    "class": "coumarin / furanocoumarin",
+    "targets": [
+      "CYP enzymes",
+      "P-gp/OATP transporters",
+      "photoreactive DNA crosslinking",
+      "inflammatory signaling"
+    ],
     "foundIn": [
-      "bulk-ingestion-fast-pass"
-    ]
+      "Pastinaca",
+      "Ammi",
+      "Apiaceae plants"
+    ],
+    "safetyNotes": "Photosensitivity and CYP/transport interactions are key concerns, especially for furanocoumarin-rich plants and essential oils."
   },
   {
     "id": "boswellic-acid",
     "slug": "boswellic-acid",
     "canonicalCompoundId": "boswellic-acid",
-    "name": "Boswellic acid",
-    "compoundName": "Boswellic acid",
-    "canonicalCompoundName": "Boswellic acid",
+    "name": "boswellic acid",
+    "compoundName": "boswellic acid",
+    "canonicalCompoundName": "boswellic acid",
     "mechanisms": [
       "5-lipoxygenase inhibition",
       "NF-κB inhibition"
     ],
+    "compoundClass": "pentacyclic triterpene acid / boswellic acid",
+    "class": "pentacyclic triterpene acid / boswellic acid",
+    "targets": [
+      "5-LOX",
+      "NF-κB",
+      "leukotriene pathways",
+      "inflammatory cytokines"
+    ],
     "foundIn": [
       "Boswellia serrata"
-    ]
+    ],
+    "safetyNotes": "Boswellia extracts can cause GI upset and may interact with anticoagulants/anti-inflammatory drugs; pregnancy safety is not established."
   },
   {
     "id": "acetyl-beta-boswellic-acid",
     "slug": "acetyl-beta-boswellic-acid",
     "canonicalCompoundId": "acetyl-beta-boswellic-acid",
-    "name": "Acetyl-beta-boswellic acid",
-    "compoundName": "Acetyl-beta-boswellic acid",
-    "canonicalCompoundName": "Acetyl-beta-boswellic acid",
+    "name": "acetyl-beta-boswellic acid",
+    "compoundName": "acetyl-beta-boswellic acid",
+    "canonicalCompoundName": "acetyl-beta-boswellic acid",
     "mechanisms": [
       "5-lipoxygenase inhibition",
       "NF-κB inhibition"
     ],
+    "compoundClass": "pentacyclic triterpene acid / boswellic acid",
+    "class": "pentacyclic triterpene acid / boswellic acid",
+    "targets": [
+      "5-LOX",
+      "NF-κB",
+      "leukotriene pathways",
+      "inflammatory cytokines"
+    ],
     "foundIn": [
       "Boswellia serrata"
-    ]
+    ],
+    "safetyNotes": "Boswellia extracts can cause GI upset and may interact with anticoagulants/anti-inflammatory drugs; pregnancy safety is not established."
   },
   {
     "id": "11-keto-beta-boswellic-acid",
@@ -1368,1418 +2349,2252 @@
       "5-lipoxygenase inhibition",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "pentacyclic triterpene acid / boswellic acid",
+    "class": "pentacyclic triterpene acid / boswellic acid",
+    "targets": [
+      "5-LOX",
+      "NF-κB",
+      "leukotriene pathways",
+      "inflammatory cytokines"
+    ],
     "foundIn": [
       "Boswellia serrata"
-    ]
+    ],
+    "safetyNotes": "Boswellia extracts can cause GI upset and may interact with anticoagulants/anti-inflammatory drugs; pregnancy safety is not established."
   },
   {
     "id": "acetyl-11-keto-beta-boswellic-acid",
     "slug": "acetyl-11-keto-beta-boswellic-acid",
     "canonicalCompoundId": "acetyl-11-keto-beta-boswellic-acid",
-    "name": "Acetyl-11-keto-beta-boswellic acid",
-    "compoundName": "Acetyl-11-keto-beta-boswellic acid",
-    "canonicalCompoundName": "Acetyl-11-keto-beta-boswellic acid",
+    "name": "acetyl-11-keto-beta-boswellic acid",
+    "compoundName": "acetyl-11-keto-beta-boswellic acid",
+    "canonicalCompoundName": "acetyl-11-keto-beta-boswellic acid",
     "mechanisms": [
       "5-lipoxygenase inhibition",
-      "NF-κB inhibition"
+      "leukotriene-pathway suppression",
+      "NF-kB-related inflammatory signaling reduction"
+    ],
+    "compoundClass": "pentacyclic triterpene acid / boswellic acid",
+    "class": "pentacyclic triterpene acid / boswellic acid",
+    "targets": [
+      "5-LOX",
+      "NF-κB",
+      "leukotriene pathways",
+      "inflammatory cytokines"
     ],
     "foundIn": [
       "Boswellia",
       "Boswellia carterii",
       "Boswellia serrata"
-    ]
+    ],
+    "safetyNotes": "Boswellia extracts can cause GI upset and may interact with anticoagulants/anti-inflammatory drugs; pregnancy safety is not established."
   },
   {
     "id": "valerenic-acid",
     "slug": "valerenic-acid",
     "canonicalCompoundId": "valerenic-acid",
-    "name": "Valerenic acid",
-    "compoundName": "Valerenic acid",
-    "canonicalCompoundName": "Valerenic acid",
+    "name": "valerenic acid",
+    "compoundName": "valerenic acid",
+    "canonicalCompoundName": "valerenic acid",
     "mechanisms": [
       "GABA-A modulation",
       "voltage-gated calcium channel modulation"
     ],
+    "compoundClass": "sesquiterpenoid / valerian constituent",
+    "class": "sesquiterpenoid / valerian constituent",
+    "targets": [
+      "GABA-A signaling",
+      "adenosine signaling",
+      "CNS calming pathways"
+    ],
     "foundIn": [
       "Valerian",
       "Valeriana officinalis"
-    ]
+    ],
+    "safetyNotes": "Evidence mostly comes from valerian extracts. Sedation and additive effects with CNS depressants are key concerns."
   },
   {
     "id": "valerenol",
     "slug": "valerenol",
     "canonicalCompoundId": "valerenol",
-    "name": "Valerenol",
-    "compoundName": "Valerenol",
-    "canonicalCompoundName": "Valerenol",
+    "name": "valerenol",
+    "compoundName": "valerenol",
+    "canonicalCompoundName": "valerenol",
     "mechanisms": [
       "GABA-A modulation"
     ],
+    "compoundClass": "sesquiterpenoid / valerian constituent",
+    "class": "sesquiterpenoid / valerian constituent",
+    "targets": [
+      "GABA-A signaling",
+      "adenosine signaling",
+      "CNS calming pathways"
+    ],
     "foundIn": [
       "Valeriana officinalis"
-    ]
+    ],
+    "safetyNotes": "Evidence mostly comes from valerian extracts. Sedation and additive effects with CNS depressants are key concerns."
   },
   {
     "id": "kavalactones",
     "slug": "kavalactones",
     "canonicalCompoundId": "kavalactones",
-    "name": "Kavalactones",
-    "compoundName": "Kavalactones",
-    "canonicalCompoundName": "Kavalactones",
+    "name": "kavalactones",
+    "compoundName": "kavalactones",
+    "canonicalCompoundName": "kavalactones",
     "mechanisms": [
       "GABA-A modulation",
       "voltage-gated sodium channel modulation"
     ],
+    "compoundClass": "kavalactone",
+    "class": "kavalactone",
+    "targets": [
+      "GABAergic signaling",
+      "voltage-gated ion channels",
+      "monoamine signaling",
+      "CYP enzymes"
+    ],
     "foundIn": [
       "Piper methysticum"
-    ]
+    ],
+    "safetyNotes": "Kava/kavalactones are linked with sedation and liver injury concerns; avoid alcohol, sedatives, liver disease, and pregnancy."
   },
   {
     "id": "kavain",
     "slug": "kavain",
     "canonicalCompoundId": "kavain",
-    "name": "Kavain",
-    "compoundName": "Kavain",
-    "canonicalCompoundName": "Kavain",
+    "name": "kavain",
+    "compoundName": "kavain",
+    "canonicalCompoundName": "kavain",
     "mechanisms": [
       "GABA-A modulation",
       "voltage-gated sodium channel modulation"
     ],
+    "compoundClass": "kavalactone",
+    "class": "kavalactone",
+    "targets": [
+      "GABAergic signaling",
+      "voltage-gated ion channels",
+      "monoamine signaling",
+      "CYP enzymes"
+    ],
     "foundIn": [
       "Kava",
       "Piper methysticum"
-    ]
+    ],
+    "safetyNotes": "Kava/kavalactones are linked with sedation and liver injury concerns; avoid alcohol, sedatives, liver disease, and pregnancy."
   },
   {
     "id": "yangonin",
     "slug": "yangonin",
     "canonicalCompoundId": "yangonin",
-    "name": "Yangonin",
-    "compoundName": "Yangonin",
-    "canonicalCompoundName": "Yangonin",
+    "name": "yangonin",
+    "compoundName": "yangonin",
+    "canonicalCompoundName": "yangonin",
     "mechanisms": [
       "CB1 receptor modulation",
       "MAO-B inhibition"
     ],
+    "compoundClass": "kavalactone",
+    "class": "kavalactone",
+    "targets": [
+      "GABAergic signaling",
+      "voltage-gated ion channels",
+      "monoamine signaling",
+      "CYP enzymes"
+    ],
     "foundIn": [
       "Piper methysticum"
-    ]
+    ],
+    "safetyNotes": "Kava/kavalactones are linked with sedation and liver injury concerns; avoid alcohol, sedatives, liver disease, and pregnancy."
   },
   {
     "id": "methysticin",
     "slug": "methysticin",
     "canonicalCompoundId": "methysticin",
-    "name": "Methysticin",
-    "compoundName": "Methysticin",
-    "canonicalCompoundName": "Methysticin",
+    "name": "methysticin",
+    "compoundName": "methysticin",
+    "canonicalCompoundName": "methysticin",
     "mechanisms": [
       "GABA-A modulation",
       "MAO-B inhibition"
     ],
+    "compoundClass": "kavalactone",
+    "class": "kavalactone",
+    "targets": [
+      "GABAergic signaling",
+      "voltage-gated ion channels",
+      "monoamine signaling",
+      "CYP enzymes"
+    ],
     "foundIn": [
       "Piper methysticum"
-    ]
+    ],
+    "safetyNotes": "Kava/kavalactones are linked with sedation and liver injury concerns; avoid alcohol, sedatives, liver disease, and pregnancy."
   },
   {
     "id": "valepotriates",
     "slug": "valepotriates",
     "canonicalCompoundId": "valepotriates",
-    "name": "Valepotriates",
-    "compoundName": "Valepotriates",
-    "canonicalCompoundName": "Valepotriates",
+    "name": "valepotriates",
+    "compoundName": "valepotriates",
+    "canonicalCompoundName": "valepotriates",
     "mechanisms": [
       "GABA-A modulation",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "sesquiterpenoid / valerian constituent",
+    "class": "sesquiterpenoid / valerian constituent",
+    "targets": [
+      "GABA-A signaling",
+      "adenosine signaling",
+      "CNS calming pathways"
+    ],
     "foundIn": [
       "Valeriana officinalis"
-    ]
+    ],
+    "safetyNotes": "Evidence mostly comes from valerian extracts. Sedation and additive effects with CNS depressants are key concerns."
   },
   {
     "id": "hyperforin",
     "slug": "hyperforin",
     "canonicalCompoundId": "hyperforin",
-    "name": "Hyperforin",
-    "compoundName": "Hyperforin",
-    "canonicalCompoundName": "Hyperforin",
+    "name": "hyperforin",
+    "compoundName": "hyperforin",
+    "canonicalCompoundName": "hyperforin",
     "mechanisms": [
       "TRPC6 channel modulation",
       "monoamine reuptake inhibition"
     ],
+    "compoundClass": "prenylated phloroglucinol",
+    "class": "prenylated phloroglucinol",
+    "targets": [
+      "pathway targets not fully resolved"
+    ],
     "foundIn": [
       "St Johns Wort",
       "Hypericum perforatum"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "hypericin",
     "slug": "hypericin",
     "canonicalCompoundId": "hypericin",
-    "name": "Hypericin",
-    "compoundName": "Hypericin",
-    "canonicalCompoundName": "Hypericin",
+    "name": "hypericin",
+    "compoundName": "hypericin",
+    "canonicalCompoundName": "hypericin",
     "mechanisms": [
       "PKC modulation",
       "apoptosis pathway modulation (caspase activation)"
     ],
+    "compoundClass": "naphthodianthrone",
+    "class": "naphthodianthrone",
+    "targets": [
+      "apoptosis/caspase signaling",
+      "caspase signaling"
+    ],
     "foundIn": [
       "Hypericum perforatum",
       "St Johns Wort"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "aucubin",
     "slug": "aucubin",
     "canonicalCompoundId": "aucubin",
-    "name": "Aucubin",
-    "compoundName": "Aucubin",
-    "canonicalCompoundName": "Aucubin",
+    "name": "aucubin",
+    "compoundName": "aucubin",
+    "canonicalCompoundName": "aucubin",
     "mechanisms": [
       "NF-κB inhibition",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "iridoid glycoside",
+    "class": "iridoid glycoside",
+    "targets": [
+      "NF-κB",
+      "antioxidant response",
+      "inflammatory cytokines",
+      "gut/liver metabolism"
+    ],
     "foundIn": [
       "Plantago major"
-    ]
+    ],
+    "safetyNotes": "Mostly extract-derived/preclinical. GI effects and herb-specific contraindications matter more than isolated-compound evidence."
   },
   {
     "id": "catalpol",
     "slug": "catalpol",
     "canonicalCompoundId": "catalpol",
-    "name": "Catalpol",
-    "compoundName": "Catalpol",
-    "canonicalCompoundName": "Catalpol",
+    "name": "catalpol",
+    "compoundName": "catalpol",
+    "canonicalCompoundName": "catalpol",
     "mechanisms": [
       "PI3K/Akt modulation",
       "AMPK activation"
     ],
+    "compoundClass": "iridoid glycoside",
+    "class": "iridoid glycoside",
+    "targets": [
+      "NF-κB",
+      "antioxidant response",
+      "inflammatory cytokines",
+      "gut/liver metabolism"
+    ],
     "foundIn": [
       "Rehmannia Prepared",
       "Rehmannia glutinosa"
-    ]
+    ],
+    "safetyNotes": "Mostly extract-derived/preclinical. GI effects and herb-specific contraindications matter more than isolated-compound evidence."
   },
   {
     "id": "harpagoside",
     "slug": "harpagoside",
     "canonicalCompoundId": "harpagoside",
-    "name": "Harpagoside",
-    "compoundName": "Harpagoside",
-    "canonicalCompoundName": "Harpagoside",
+    "name": "harpagoside",
+    "compoundName": "harpagoside",
+    "canonicalCompoundName": "harpagoside",
     "mechanisms": [
       "COX inhibition",
       "NF-κB inhibition"
     ],
+    "compoundClass": "iridoid glycoside",
+    "class": "iridoid glycoside",
+    "targets": [
+      "NF-κB",
+      "antioxidant response",
+      "inflammatory cytokines",
+      "gut/liver metabolism"
+    ],
     "foundIn": [
       "Harpagophytum procumbens"
-    ]
+    ],
+    "safetyNotes": "Mostly extract-derived/preclinical. GI effects and herb-specific contraindications matter more than isolated-compound evidence."
   },
   {
     "id": "loganin",
     "slug": "loganin",
     "canonicalCompoundId": "loganin",
-    "name": "Loganin",
-    "compoundName": "Loganin",
-    "canonicalCompoundName": "Loganin",
+    "name": "loganin",
+    "compoundName": "loganin",
+    "canonicalCompoundName": "loganin",
     "mechanisms": [
       "PI3K/Akt modulation",
       "Nrf2 activation"
     ],
+    "compoundClass": "iridoid glycoside",
+    "class": "iridoid glycoside",
+    "targets": [
+      "NF-κB",
+      "antioxidant response",
+      "inflammatory cytokines",
+      "gut/liver metabolism"
+    ],
     "foundIn": [
       "Cornus officinalis"
-    ]
+    ],
+    "safetyNotes": "Mostly extract-derived/preclinical. GI effects and herb-specific contraindications matter more than isolated-compound evidence."
   },
   {
     "id": "morroniside",
     "slug": "morroniside",
     "canonicalCompoundId": "morroniside",
-    "name": "Morroniside",
-    "compoundName": "Morroniside",
-    "canonicalCompoundName": "Morroniside",
+    "name": "morroniside",
+    "compoundName": "morroniside",
+    "canonicalCompoundName": "morroniside",
     "mechanisms": [
       "PI3K/Akt modulation",
       "Nrf2 activation"
     ],
+    "compoundClass": "iridoid glycoside",
+    "class": "iridoid glycoside",
+    "targets": [
+      "NF-κB",
+      "antioxidant response",
+      "inflammatory cytokines",
+      "gut/liver metabolism"
+    ],
     "foundIn": [
       "Cornus officinalis"
-    ]
+    ],
+    "safetyNotes": "Mostly extract-derived/preclinical. GI effects and herb-specific contraindications matter more than isolated-compound evidence."
   },
   {
     "id": "oleocanthal",
     "slug": "oleocanthal",
     "canonicalCompoundId": "oleocanthal",
-    "name": "Oleocanthal",
-    "compoundName": "Oleocanthal",
-    "canonicalCompoundName": "Oleocanthal",
+    "name": "oleocanthal",
+    "compoundName": "oleocanthal",
+    "canonicalCompoundName": "oleocanthal",
     "mechanisms": [
       "COX inhibition",
       "NF-κB inhibition"
     ],
+    "compoundClass": "olive phenolic secoiridoid/phenylethanol",
+    "class": "olive phenolic secoiridoid/phenylethanol",
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "lipid oxidation",
+      "endothelial signaling",
+      "antioxidant response"
+    ],
     "foundIn": [
       "Olea europaea"
-    ]
+    ],
+    "safetyNotes": "Food-associated in olive/olive oil matrices; concentrated extracts may affect blood pressure, glucose, or bleeding risk."
   },
   {
     "id": "oleacein",
     "slug": "oleacein",
     "canonicalCompoundId": "oleacein",
-    "name": "Oleacein",
-    "compoundName": "Oleacein",
-    "canonicalCompoundName": "Oleacein",
+    "name": "oleacein",
+    "compoundName": "oleacein",
+    "canonicalCompoundName": "oleacein",
     "mechanisms": [
       "Nrf2 activation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "olive phenolic secoiridoid/phenylethanol",
+    "class": "olive phenolic secoiridoid/phenylethanol",
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "lipid oxidation",
+      "endothelial signaling",
+      "antioxidant response"
+    ],
     "foundIn": [
       "Olea europaea"
-    ]
+    ],
+    "safetyNotes": "Food-associated in olive/olive oil matrices; concentrated extracts may affect blood pressure, glucose, or bleeding risk."
   },
   {
     "id": "rosavin",
     "slug": "rosavin",
     "canonicalCompoundId": "rosavin",
-    "name": "Rosavin",
-    "compoundName": "Rosavin",
-    "canonicalCompoundName": "Rosavin",
+    "name": "rosavin",
+    "compoundName": "rosavin",
+    "canonicalCompoundName": "rosavin",
     "mechanisms": [
       "AMPK activation",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "phenylpropanoid glycoside / rosavin",
+    "class": "phenylpropanoid glycoside / rosavin",
+    "targets": [
+      "HPA-axis stress response",
+      "monoamine signaling",
+      "AMPK",
+      "antioxidant response"
+    ],
     "foundIn": [
       "Rhodiola Rosea",
       "Rhodiola"
-    ]
+    ],
+    "safetyNotes": "Evidence is mostly through Rhodiola extracts. May cause activation/insomnia or interact with stimulants/antidepressants."
   },
   {
     "id": "rosarin",
     "slug": "rosarin",
     "canonicalCompoundId": "rosarin",
-    "name": "Rosarin",
-    "compoundName": "Rosarin",
-    "canonicalCompoundName": "Rosarin",
+    "name": "rosarin",
+    "compoundName": "rosarin",
+    "canonicalCompoundName": "rosarin",
     "mechanisms": [
       "AMPK activation",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "phenylpropanoid glycoside / rosavin",
+    "class": "phenylpropanoid glycoside / rosavin",
+    "targets": [
+      "HPA-axis stress response",
+      "monoamine signaling",
+      "AMPK",
+      "antioxidant response"
+    ],
     "foundIn": [
       "Rhodiola",
       "Rhodiola Rosea"
-    ]
+    ],
+    "safetyNotes": "Evidence is mostly through Rhodiola extracts. May cause activation/insomnia or interact with stimulants/antidepressants."
   },
   {
     "id": "rosin",
     "slug": "rosin",
     "canonicalCompoundId": "rosin",
-    "name": "Rosin",
-    "compoundName": "Rosin",
-    "canonicalCompoundName": "Rosin",
+    "name": "rosin",
+    "compoundName": "rosin",
+    "canonicalCompoundName": "rosin",
     "mechanisms": [
       "AMPK activation",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "phenylpropanoid glycoside / rosavin",
+    "class": "phenylpropanoid glycoside / rosavin",
+    "targets": [
+      "HPA-axis stress response",
+      "monoamine signaling",
+      "AMPK",
+      "antioxidant response"
+    ],
     "foundIn": [
       "Rhodiola",
       "Rhodiola Rosea"
-    ]
+    ],
+    "safetyNotes": "Evidence is mostly through Rhodiola extracts. May cause activation/insomnia or interact with stimulants/antidepressants."
   },
   {
     "id": "salidroside",
     "slug": "salidroside",
     "canonicalCompoundId": "salidroside",
-    "name": "Salidroside",
-    "compoundName": "Salidroside",
-    "canonicalCompoundName": "Salidroside",
+    "name": "salidroside",
+    "compoundName": "salidroside",
+    "canonicalCompoundName": "salidroside",
     "mechanisms": [
       "AMPK activation",
       "PI3K/Akt modulation",
       "Nrf2 activation"
     ],
+    "compoundClass": "phenylethanoid glycoside",
+    "class": "phenylethanoid glycoside",
+    "targets": [
+      "HPA-axis stress pathways",
+      "Nrf2",
+      "AMPK",
+      "mitochondrial and inflammatory signaling"
+    ],
     "foundIn": [
       "Rhodiola",
       "Rhodiola Rosea"
-    ]
+    ],
+    "safetyNotes": "Human evidence mainly derives from Rhodiola extracts. Avoid pregnancy/breastfeeding and caution with bipolar disorder, stimulants, antidepressants, and sedatives."
   },
   {
     "id": "tyrosol",
     "slug": "tyrosol",
     "canonicalCompoundId": "tyrosol",
-    "name": "Tyrosol",
-    "compoundName": "Tyrosol",
-    "canonicalCompoundName": "Tyrosol",
+    "name": "tyrosol",
+    "compoundName": "tyrosol",
+    "canonicalCompoundName": "tyrosol",
     "mechanisms": [
       "Nrf2 activation",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "olive phenolic secoiridoid/phenylethanol",
+    "class": "olive phenolic secoiridoid/phenylethanol",
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "lipid oxidation",
+      "endothelial signaling",
+      "antioxidant response"
+    ],
     "foundIn": [
       "Rhodiola",
       "Rhodiola Rosea"
-    ]
+    ],
+    "safetyNotes": "Food-associated in olive/olive oil matrices; concentrated extracts may affect blood pressure, glucose, or bleeding risk."
   },
   {
     "id": "echinacoside",
     "slug": "echinacoside",
     "canonicalCompoundId": "echinacoside",
-    "name": "Echinacoside",
-    "compoundName": "Echinacoside",
-    "canonicalCompoundName": "Echinacoside",
+    "name": "echinacoside",
+    "compoundName": "echinacoside",
+    "canonicalCompoundName": "echinacoside",
     "mechanisms": [
       "PI3K/Akt modulation",
       "Nrf2 activation"
+    ],
+    "compoundClass": "phenylethanoid glycoside",
+    "class": "phenylethanoid glycoside",
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "antioxidant response",
+      "inflammatory cytokines",
+      "neuroprotective signaling"
     ],
     "foundIn": [
       "Cistanche",
       "Echinacea Purpurea",
       "Cistanche deserticola"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical/extract-derived; safety depends on source herb and product quality."
   },
   {
     "id": "acteoside",
     "slug": "acteoside",
     "canonicalCompoundId": "acteoside",
-    "name": "Acteoside",
-    "compoundName": "Acteoside",
-    "canonicalCompoundName": "Acteoside",
+    "name": "acteoside",
+    "compoundName": "acteoside",
+    "canonicalCompoundName": "acteoside",
     "mechanisms": [
       "NF-κB inhibition",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "phenylethanoid glycoside",
+    "class": "phenylethanoid glycoside",
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "antioxidant response",
+      "inflammatory cytokines",
+      "neuroprotective signaling"
+    ],
     "foundIn": [
       "Verbena officinalis"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical/extract-derived; safety depends on source herb and product quality."
   },
   {
     "id": "verbascoside",
     "slug": "verbascoside",
     "canonicalCompoundId": "verbascoside",
-    "name": "Verbascoside",
-    "compoundName": "Verbascoside",
-    "canonicalCompoundName": "Verbascoside",
+    "name": "verbascoside",
+    "compoundName": "verbascoside",
+    "canonicalCompoundName": "verbascoside",
     "mechanisms": [
       "NF-κB inhibition",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "phenylethanoid glycoside",
+    "class": "phenylethanoid glycoside",
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "antioxidant response",
+      "inflammatory cytokines",
+      "neuroprotective signaling"
+    ],
     "foundIn": [
       "Lemon Verbena",
       "Plantago lanceolata"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical/extract-derived; safety depends on source herb and product quality."
   },
   {
     "id": "forskolin",
     "slug": "forskolin",
     "canonicalCompoundId": "forskolin",
-    "name": "Forskolin",
-    "compoundName": "Forskolin",
-    "canonicalCompoundName": "Forskolin",
+    "name": "forskolin",
+    "compoundName": "forskolin",
+    "canonicalCompoundName": "forskolin",
     "mechanisms": [
       "adenylyl cyclase activation",
       "cAMP signaling"
     ],
+    "compoundClass": "labdane diterpene",
+    "class": "labdane diterpene",
+    "targets": [
+      "adenylyl cyclase/cAMP",
+      "adenylyl cyclase"
+    ],
     "foundIn": [
       "Coleus forskohlii"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "bacoside-b",
     "slug": "bacoside-b",
     "canonicalCompoundId": "bacoside-b",
-    "name": "Bacoside B",
-    "compoundName": "Bacoside B",
-    "canonicalCompoundName": "Bacoside B",
+    "name": "bacoside b",
+    "compoundName": "bacoside b",
+    "canonicalCompoundName": "bacoside b",
     "mechanisms": [
       "cholinergic modulation",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "saponin / glycoside",
+    "class": "saponin / glycoside",
+    "targets": [
+      "AMPK",
+      "PPAR",
+      "immune cytokines",
+      "membrane signaling",
+      "glucose/lipid metabolism"
+    ],
     "foundIn": [
       "Bacopa monnieri"
-    ]
+    ],
+    "safetyNotes": "May cause GI irritation or hemolysis risk in isolated/high-dose contexts; herb-specific safety and pregnancy cautions apply."
   },
   {
     "id": "glycyrrhetinic-acid",
     "slug": "glycyrrhetinic-acid",
     "canonicalCompoundId": "glycyrrhetinic-acid",
-    "name": "Glycyrrhetinic acid",
-    "compoundName": "Glycyrrhetinic acid",
-    "canonicalCompoundName": "Glycyrrhetinic acid",
+    "name": "glycyrrhetinic acid",
+    "compoundName": "glycyrrhetinic acid",
+    "canonicalCompoundName": "glycyrrhetinic acid",
     "mechanisms": [
       "NF-κB inhibition",
       "HMGB1 inhibition"
     ],
+    "compoundClass": "triterpenoid sapogenin",
+    "class": "triterpenoid sapogenin",
+    "targets": [
+      "NF-κB"
+    ],
     "foundIn": [
       "Glycyrrhiza glabra"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "shikonin",
     "slug": "shikonin",
     "canonicalCompoundId": "shikonin",
-    "name": "Shikonin",
-    "compoundName": "Shikonin",
-    "canonicalCompoundName": "Shikonin",
+    "name": "shikonin",
+    "compoundName": "shikonin",
+    "canonicalCompoundName": "shikonin",
     "mechanisms": [
       "PKM2 inhibition",
       "NF-κB inhibition"
     ],
+    "compoundClass": "quinone / naphthoquinone-like phenolic",
+    "class": "quinone / naphthoquinone-like phenolic",
+    "targets": [
+      "ROS/redox cycling",
+      "NF-κB",
+      "apoptosis signaling",
+      "Nrf2",
+      "antimicrobial pathways"
+    ],
     "foundIn": [
       "Lithospermum erythrorhizon"
-    ]
+    ],
+    "safetyNotes": "Often preclinical; concentrated or isolated quinones may be irritant/cytotoxic. Avoid pregnancy and use caution with liver disease or anticoagulants."
   },
   {
     "id": "acetylshikonin",
     "slug": "acetylshikonin",
     "canonicalCompoundId": "acetylshikonin",
-    "name": "Acetylshikonin",
-    "compoundName": "Acetylshikonin",
-    "canonicalCompoundName": "Acetylshikonin",
+    "name": "acetylshikonin",
+    "compoundName": "acetylshikonin",
+    "canonicalCompoundName": "acetylshikonin",
     "mechanisms": [
       "NF-κB inhibition",
       "apoptosis pathway modulation (caspase activation)"
     ],
+    "compoundClass": "quinone / naphthoquinone-like phenolic",
+    "class": "quinone / naphthoquinone-like phenolic",
+    "targets": [
+      "ROS/redox cycling",
+      "NF-κB",
+      "apoptosis signaling",
+      "Nrf2",
+      "antimicrobial pathways"
+    ],
     "foundIn": [
       "Lithospermum erythrorhizon"
-    ]
+    ],
+    "safetyNotes": "Often preclinical; concentrated or isolated quinones may be irritant/cytotoxic. Avoid pregnancy and use caution with liver disease or anticoagulants."
   },
   {
     "id": "plumbagin",
     "slug": "plumbagin",
     "canonicalCompoundId": "plumbagin",
-    "name": "Plumbagin",
-    "compoundName": "Plumbagin",
-    "canonicalCompoundName": "Plumbagin",
+    "name": "plumbagin",
+    "compoundName": "plumbagin",
+    "canonicalCompoundName": "plumbagin",
     "mechanisms": [
       "NF-κB inhibition",
       "STAT3 inhibition",
       "ROS-mediated signaling modulation"
     ],
+    "compoundClass": "quinone / naphthoquinone-like phenolic",
+    "class": "quinone / naphthoquinone-like phenolic",
+    "targets": [
+      "ROS/redox cycling",
+      "NF-κB",
+      "apoptosis signaling",
+      "Nrf2",
+      "antimicrobial pathways"
+    ],
     "foundIn": [
       "Plumbago zeylanica"
-    ]
+    ],
+    "safetyNotes": "Often preclinical; concentrated or isolated quinones may be irritant/cytotoxic. Avoid pregnancy and use caution with liver disease or anticoagulants."
   },
   {
     "id": "lawsone",
     "slug": "lawsone",
     "canonicalCompoundId": "lawsone",
-    "name": "Lawsone",
-    "compoundName": "Lawsone",
-    "canonicalCompoundName": "Lawsone",
+    "name": "lawsone",
+    "compoundName": "lawsone",
+    "canonicalCompoundName": "lawsone",
     "mechanisms": [
       "MAPK pathway modulation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "quinone / naphthoquinone-like phenolic",
+    "class": "quinone / naphthoquinone-like phenolic",
+    "targets": [
+      "ROS/redox cycling",
+      "NF-κB",
+      "apoptosis signaling",
+      "Nrf2",
+      "antimicrobial pathways"
+    ],
     "foundIn": [
       "Lawsonia inermis"
-    ]
+    ],
+    "safetyNotes": "Often preclinical; concentrated or isolated quinones may be irritant/cytotoxic. Avoid pregnancy and use caution with liver disease or anticoagulants."
   },
   {
     "id": "embelin",
     "slug": "embelin",
     "canonicalCompoundId": "embelin",
-    "name": "Embelin",
-    "compoundName": "Embelin",
-    "canonicalCompoundName": "Embelin",
+    "name": "embelin",
+    "compoundName": "embelin",
+    "canonicalCompoundName": "embelin",
     "mechanisms": [
       "XIAP inhibition",
       "NF-κB inhibition"
     ],
+    "compoundClass": "quinone / naphthoquinone-like phenolic",
+    "class": "quinone / naphthoquinone-like phenolic",
+    "targets": [
+      "ROS/redox cycling",
+      "NF-κB",
+      "apoptosis signaling",
+      "Nrf2",
+      "antimicrobial pathways"
+    ],
     "foundIn": [
       "Embelia ribes"
-    ]
+    ],
+    "safetyNotes": "Often preclinical; concentrated or isolated quinones may be irritant/cytotoxic. Avoid pregnancy and use caution with liver disease or anticoagulants."
   },
   {
     "id": "thujone",
     "slug": "thujone",
     "canonicalCompoundId": "thujone",
-    "name": "Thujone",
-    "compoundName": "Thujone",
-    "canonicalCompoundName": "Thujone",
+    "name": "thujone",
+    "compoundName": "thujone",
+    "canonicalCompoundName": "thujone",
     "mechanisms": [
       "GABA-A receptor antagonism",
-      "TRP channel modulation"
+      "neuronal excitability enhancement",
+      "seizure-threshold lowering at higher exposures"
+    ],
+    "compoundClass": "monoterpene ketone",
+    "class": "monoterpene ketone",
+    "targets": [
+      "GABA-A receptors"
     ],
     "foundIn": [
       "Mugwort",
       "Sage",
       "Artemisia absinthium"
-    ]
+    ],
+    "safetyNotes": "Neuroactive monoterpene; high exposure may increase seizure/neurotoxicity risk. Avoid pregnancy, seizure disorders, and concentrated essential-oil ingestion."
   },
   {
     "id": "artemisinin",
     "slug": "artemisinin",
     "canonicalCompoundId": "artemisinin",
-    "name": "Artemisinin",
-    "compoundName": "Artemisinin",
-    "canonicalCompoundName": "Artemisinin",
+    "name": "artemisinin",
+    "compoundName": "artemisinin",
+    "canonicalCompoundName": "artemisinin",
     "mechanisms": [
       "ROS-mediated signaling modulation",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "sesquiterpene lactone endoperoxide",
+    "class": "sesquiterpene lactone endoperoxide",
+    "targets": [
+      "PI3K/Akt",
+      "redox signaling"
+    ],
     "foundIn": [
       "Artemisia annua"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "artesunate",
     "slug": "artesunate",
     "canonicalCompoundId": "artesunate",
-    "name": "Artesunate",
-    "compoundName": "Artesunate",
-    "canonicalCompoundName": "Artesunate",
+    "name": "artesunate",
+    "compoundName": "artesunate",
+    "canonicalCompoundName": "artesunate",
     "mechanisms": [
       "ROS-mediated signaling modulation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "semi-synthetic artemisinin derivative",
+    "class": "semi-synthetic artemisinin derivative",
+    "targets": [
+      "NF-κB",
+      "redox signaling"
+    ],
     "foundIn": [
       "Artemisia annua"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "artemisinin-b",
     "slug": "artemisinin-b",
     "canonicalCompoundId": "artemisinin-b",
-    "name": "Artemisinin B",
-    "compoundName": "Artemisinin B",
-    "canonicalCompoundName": "Artemisinin B",
+    "name": "artemisinin b",
+    "compoundName": "artemisinin b",
+    "canonicalCompoundName": "artemisinin b",
     "mechanisms": [
       "ROS-mediated signaling modulation",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "sesquiterpene lactone",
+    "class": "sesquiterpene lactone",
+    "targets": [
+      "MAPK",
+      "redox signaling"
+    ],
     "foundIn": [
       "Artemisia annua"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "astragaloside-iv",
     "slug": "astragaloside-iv",
     "canonicalCompoundId": "astragaloside-iv",
-    "name": "Astragaloside IV",
-    "compoundName": "Astragaloside IV",
-    "canonicalCompoundName": "Astragaloside IV",
+    "name": "astragaloside iv",
+    "compoundName": "astragaloside iv",
+    "canonicalCompoundName": "astragaloside iv",
     "mechanisms": [
       "PI3K/Akt modulation",
       "AMPK activation",
       "TGF-β signaling modulation"
     ],
+    "compoundClass": "cycloartane triterpenoid saponin",
+    "class": "cycloartane triterpenoid saponin",
+    "targets": [
+      "PI3K/Akt",
+      "AMPK",
+      "TGF-β/Smad",
+      "Nrf2",
+      "immune/inflammatory signaling"
+    ],
     "foundIn": [
       "Astragalus",
       "Astragalus membranaceus"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical or Astragalus-formula derived. Caution with immunosuppressants, autoimmune disease, anticoagulants, pregnancy, and transplant contexts."
   },
   {
     "id": "calycosin",
     "slug": "calycosin",
     "canonicalCompoundId": "calycosin",
-    "name": "Calycosin",
-    "compoundName": "Calycosin",
-    "canonicalCompoundName": "Calycosin",
+    "name": "calycosin",
+    "compoundName": "calycosin",
+    "canonicalCompoundName": "calycosin",
     "mechanisms": [
-      "estrogen receptor modulation",
-      "PI3K/Akt modulation"
+      "Estrogen-receptor beta modulation",
+      "PI3K/Akt signaling",
+      "Nrf2-related antioxidant response",
+      "endothelial signaling support"
+    ],
+    "compoundClass": "isoflavone / phytoestrogen",
+    "class": "isoflavone / phytoestrogen",
+    "targets": [
+      "estrogen receptor signaling",
+      "AMPK",
+      "PPAR",
+      "antioxidant response",
+      "bone/metabolic signaling"
     ],
     "foundIn": [
       "Astragalus",
       "Red Clover",
       "Astragalus membranaceus"
-    ]
+    ],
+    "safetyNotes": "Phytoestrogenic activity warrants caution with hormone-sensitive conditions and hormone therapies; effects are preparation- and dose-specific."
   },
   {
     "id": "astragalin",
     "slug": "astragalin",
     "canonicalCompoundId": "astragalin",
-    "name": "Astragalin",
-    "compoundName": "Astragalin",
-    "canonicalCompoundName": "Astragalin",
+    "name": "astragalin",
+    "compoundName": "astragalin",
+    "canonicalCompoundName": "astragalin",
     "mechanisms": [
       "NF-κB inhibition",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "flavonol / flavonoid",
+    "class": "flavonol / flavonoid",
+    "targets": [
+      "AMPK",
+      "Nrf2",
+      "NF-κB",
+      "inflammatory cytokines",
+      "endothelial nitric oxide",
+      "antioxidant response"
+    ],
     "foundIn": [
       "Astragalus membranaceus"
-    ]
+    ],
+    "safetyNotes": "Mostly food/extract-derived human evidence. High-dose supplements may affect CYP/transporters or anticoagulant/antiplatelet risk."
   },
   {
     "id": "puerarin",
     "slug": "puerarin",
     "canonicalCompoundId": "puerarin",
-    "name": "Puerarin",
-    "compoundName": "Puerarin",
-    "canonicalCompoundName": "Puerarin",
+    "name": "puerarin",
+    "compoundName": "puerarin",
+    "canonicalCompoundName": "puerarin",
     "mechanisms": [
-      "PI3K/Akt modulation",
       "AMPK activation",
-      "estrogen receptor modulation"
+      "PI3K/Akt modulation",
+      "endothelial nitric-oxide signaling",
+      "estrogen-receptor modulation"
+    ],
+    "compoundClass": "isoflavone / phytoestrogen",
+    "class": "isoflavone / phytoestrogen",
+    "targets": [
+      "estrogen receptor signaling",
+      "AMPK",
+      "PPAR",
+      "antioxidant response",
+      "bone/metabolic signaling"
     ],
     "foundIn": [
       "Blue Lotus",
       "Kudzu",
       "Pueraria lobata"
-    ]
+    ],
+    "safetyNotes": "Phytoestrogenic activity warrants caution with hormone-sensitive conditions and hormone therapies; effects are preparation- and dose-specific."
   },
   {
     "id": "daidzin",
     "slug": "daidzin",
     "canonicalCompoundId": "daidzin",
-    "name": "Daidzin",
-    "compoundName": "Daidzin",
-    "canonicalCompoundName": "Daidzin",
+    "name": "daidzin",
+    "compoundName": "daidzin",
+    "canonicalCompoundName": "daidzin",
     "mechanisms": [
       "estrogen receptor modulation",
       "glucose absorption modulation"
+    ],
+    "compoundClass": "isoflavone / phytoestrogen",
+    "class": "isoflavone / phytoestrogen",
+    "targets": [
+      "estrogen receptor signaling",
+      "AMPK",
+      "PPAR",
+      "antioxidant response",
+      "bone/metabolic signaling"
     ],
     "foundIn": [
       "Kudzu",
       "Pueraria Mirifica",
       "Pueraria lobata"
-    ]
+    ],
+    "safetyNotes": "Phytoestrogenic activity warrants caution with hormone-sensitive conditions and hormone therapies; effects are preparation- and dose-specific."
   },
   {
     "id": "ononin",
     "slug": "ononin",
     "canonicalCompoundId": "ononin",
-    "name": "Ononin",
-    "compoundName": "Ononin",
-    "canonicalCompoundName": "Ononin",
+    "name": "ononin",
+    "compoundName": "ononin",
+    "canonicalCompoundName": "ononin",
     "mechanisms": [
       "estrogen receptor modulation",
       "PI3K/Akt modulation"
+    ],
+    "compoundClass": "isoflavone / phytoestrogen",
+    "class": "isoflavone / phytoestrogen",
+    "targets": [
+      "estrogen receptor signaling",
+      "AMPK",
+      "PPAR",
+      "antioxidant response",
+      "bone/metabolic signaling"
     ],
     "foundIn": [
       "Red Clover",
       "Kudzu",
       "Pueraria lobata"
-    ]
+    ],
+    "safetyNotes": "Phytoestrogenic activity warrants caution with hormone-sensitive conditions and hormone therapies; effects are preparation- and dose-specific."
   },
   {
     "id": "mangiferin",
     "slug": "mangiferin",
     "canonicalCompoundId": "mangiferin",
-    "name": "Mangiferin",
-    "compoundName": "Mangiferin",
-    "canonicalCompoundName": "Mangiferin",
+    "name": "mangiferin",
+    "compoundName": "mangiferin",
+    "canonicalCompoundName": "mangiferin",
     "mechanisms": [
       "AMPK activation",
       "Nrf2 activation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "xanthone / polyphenol",
+    "class": "xanthone / polyphenol",
+    "targets": [
+      "NF-κB",
+      "antioxidant response",
+      "apoptosis signaling",
+      "inflammatory cytokines"
+    ],
     "foundIn": [
       "Mangifera indica"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical/extract-derived; concentrated Garcinia/mangosteen extracts may affect bleeding or liver risk depending product."
   },
   {
     "id": "mangostin",
     "slug": "mangostin",
     "canonicalCompoundId": "mangostin",
-    "name": "Mangostin",
-    "compoundName": "Mangostin",
-    "canonicalCompoundName": "Mangostin",
+    "name": "mangostin",
+    "compoundName": "mangostin",
+    "canonicalCompoundName": "mangostin",
     "mechanisms": [
       "NF-κB inhibition",
       "PI3K/Akt modulation",
       "apoptosis pathway modulation (caspase activation)"
     ],
+    "compoundClass": "xanthone / polyphenol",
+    "class": "xanthone / polyphenol",
+    "targets": [
+      "NF-κB",
+      "antioxidant response",
+      "apoptosis signaling",
+      "inflammatory cytokines"
+    ],
     "foundIn": [
       "Garcinia mangostana"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical/extract-derived; concentrated Garcinia/mangosteen extracts may affect bleeding or liver risk depending product."
   },
   {
     "id": "alpha-mangostin",
     "slug": "alpha-mangostin",
     "canonicalCompoundId": "alpha-mangostin",
-    "name": "Alpha-mangostin",
-    "compoundName": "Alpha-mangostin",
-    "canonicalCompoundName": "Alpha-mangostin",
+    "name": "alpha-mangostin",
+    "compoundName": "alpha-mangostin",
+    "canonicalCompoundName": "alpha-mangostin",
     "mechanisms": [
       "NF-κB inhibition",
       "apoptosis pathway modulation (caspase activation)",
       "STAT3 inhibition"
     ],
+    "compoundClass": "xanthone / polyphenol",
+    "class": "xanthone / polyphenol",
+    "targets": [
+      "NF-κB",
+      "antioxidant response",
+      "apoptosis signaling",
+      "inflammatory cytokines"
+    ],
     "foundIn": [
       "Mangosteen",
       "Garcinia mangostana"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical/extract-derived; concentrated Garcinia/mangosteen extracts may affect bleeding or liver risk depending product."
   },
   {
     "id": "garcinol",
     "slug": "garcinol",
     "canonicalCompoundId": "garcinol",
-    "name": "Garcinol",
-    "compoundName": "Garcinol",
-    "canonicalCompoundName": "Garcinol",
+    "name": "garcinol",
+    "compoundName": "garcinol",
+    "canonicalCompoundName": "garcinol",
     "mechanisms": [
       "NF-κB inhibition",
       "HAT inhibition",
       "STAT3 inhibition"
     ],
+    "compoundClass": "xanthone / polyphenol",
+    "class": "xanthone / polyphenol",
+    "targets": [
+      "NF-κB",
+      "antioxidant response",
+      "apoptosis signaling",
+      "inflammatory cytokines"
+    ],
     "foundIn": [
       "Garcinia indica"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical/extract-derived; concentrated Garcinia/mangosteen extracts may affect bleeding or liver risk depending product."
   },
   {
     "id": "curcumol",
     "slug": "curcumol",
     "canonicalCompoundId": "curcumol",
-    "name": "Curcumol",
-    "compoundName": "Curcumol",
-    "canonicalCompoundName": "Curcumol",
+    "name": "curcumol",
+    "compoundName": "curcumol",
+    "canonicalCompoundName": "curcumol",
     "mechanisms": [
       "NF-κB inhibition",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "curcuminoid / diarylheptanoid",
+    "class": "curcuminoid / diarylheptanoid",
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "COX/LOX",
+      "inflammatory cytokines",
+      "AMPK"
+    ],
     "foundIn": [
       "Curcuma zedoaria"
-    ]
+    ],
+    "safetyNotes": "Human evidence is mostly formulation-dependent. High-dose curcuminoids may cause GI upset and interact with anticoagulants/antiplatelets."
   },
   {
     "id": "curdione",
     "slug": "curdione",
     "canonicalCompoundId": "curdione",
-    "name": "Curdione",
-    "compoundName": "Curdione",
-    "canonicalCompoundName": "Curdione",
+    "name": "curdione",
+    "compoundName": "curdione",
+    "canonicalCompoundName": "curdione",
     "mechanisms": [
       "PI3K/Akt modulation",
       "apoptosis pathway modulation (caspase activation)"
     ],
+    "compoundClass": "curcuminoid / diarylheptanoid",
+    "class": "curcuminoid / diarylheptanoid",
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "COX/LOX",
+      "inflammatory cytokines",
+      "AMPK"
+    ],
     "foundIn": [
       "Curcuma zedoaria"
-    ]
+    ],
+    "safetyNotes": "Human evidence is mostly formulation-dependent. High-dose curcuminoids may cause GI upset and interact with anticoagulants/antiplatelets."
   },
   {
     "id": "demethoxycurcumin",
     "slug": "demethoxycurcumin",
     "canonicalCompoundId": "demethoxycurcumin",
-    "name": "Demethoxycurcumin",
-    "compoundName": "Demethoxycurcumin",
-    "canonicalCompoundName": "Demethoxycurcumin",
+    "name": "demethoxycurcumin",
+    "compoundName": "demethoxycurcumin",
+    "canonicalCompoundName": "demethoxycurcumin",
     "mechanisms": [
       "NF-κB inhibition",
       "Nrf2 activation"
     ],
+    "compoundClass": "curcuminoid / diarylheptanoid",
+    "class": "curcuminoid / diarylheptanoid",
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "COX/LOX",
+      "inflammatory cytokines",
+      "AMPK"
+    ],
     "foundIn": [
       "Turmeric",
       "Curcuma longa"
-    ]
+    ],
+    "safetyNotes": "Human evidence is mostly formulation-dependent. High-dose curcuminoids may cause GI upset and interact with anticoagulants/antiplatelets."
   },
   {
     "id": "bisdemethoxycurcumin",
     "slug": "bisdemethoxycurcumin",
     "canonicalCompoundId": "bisdemethoxycurcumin",
-    "name": "Bisdemethoxycurcumin",
-    "compoundName": "Bisdemethoxycurcumin",
-    "canonicalCompoundName": "Bisdemethoxycurcumin",
+    "name": "bisdemethoxycurcumin",
+    "compoundName": "bisdemethoxycurcumin",
+    "canonicalCompoundName": "bisdemethoxycurcumin",
     "mechanisms": [
       "NF-κB inhibition",
       "Nrf2 activation"
     ],
+    "compoundClass": "curcuminoid / diarylheptanoid",
+    "class": "curcuminoid / diarylheptanoid",
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "COX/LOX",
+      "inflammatory cytokines",
+      "AMPK"
+    ],
     "foundIn": [
       "Turmeric",
       "Curcuma longa"
-    ]
+    ],
+    "safetyNotes": "Human evidence is mostly formulation-dependent. High-dose curcuminoids may cause GI upset and interact with anticoagulants/antiplatelets."
   },
   {
     "id": "paeoniflorin",
     "slug": "paeoniflorin",
     "canonicalCompoundId": "paeoniflorin",
-    "name": "Paeoniflorin",
-    "compoundName": "Paeoniflorin",
-    "canonicalCompoundName": "Paeoniflorin",
+    "name": "paeoniflorin",
+    "compoundName": "paeoniflorin",
+    "canonicalCompoundName": "paeoniflorin",
     "mechanisms": [
       "PI3K/Akt modulation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "monoterpene glycoside / phenolic from Paeonia",
+    "class": "monoterpene glycoside / phenolic from Paeonia",
+    "targets": [
+      "NF-κB",
+      "immune cytokines",
+      "smooth muscle/analgesic signaling",
+      "antioxidant response"
+    ],
     "foundIn": [
       "White Peony",
       "Paeonia lactiflora"
-    ]
+    ],
+    "safetyNotes": "Mostly preparation-derived. Caution with anticoagulants, pregnancy, and immune-modulating therapies."
   },
   {
     "id": "albiflorin",
     "slug": "albiflorin",
     "canonicalCompoundId": "albiflorin",
-    "name": "Albiflorin",
-    "compoundName": "Albiflorin",
-    "canonicalCompoundName": "Albiflorin",
+    "name": "albiflorin",
+    "compoundName": "albiflorin",
+    "canonicalCompoundName": "albiflorin",
     "mechanisms": [
       "MAPK pathway modulation",
       "monoamine reuptake inhibition"
     ],
+    "compoundClass": "monoterpene glycoside / phenolic from Paeonia",
+    "class": "monoterpene glycoside / phenolic from Paeonia",
+    "targets": [
+      "NF-κB",
+      "immune cytokines",
+      "smooth muscle/analgesic signaling",
+      "antioxidant response"
+    ],
     "foundIn": [
       "Paeonia lactiflora"
-    ]
+    ],
+    "safetyNotes": "Mostly preparation-derived. Caution with anticoagulants, pregnancy, and immune-modulating therapies."
   },
   {
     "id": "paeonol",
     "slug": "paeonol",
     "canonicalCompoundId": "paeonol",
-    "name": "Paeonol",
-    "compoundName": "Paeonol",
-    "canonicalCompoundName": "Paeonol",
+    "name": "paeonol",
+    "compoundName": "paeonol",
+    "canonicalCompoundName": "paeonol",
     "mechanisms": [
       "NF-κB inhibition",
       "Nrf2 activation"
     ],
+    "compoundClass": "monoterpene glycoside / phenolic from Paeonia",
+    "class": "monoterpene glycoside / phenolic from Paeonia",
+    "targets": [
+      "NF-κB",
+      "immune cytokines",
+      "smooth muscle/analgesic signaling",
+      "antioxidant response"
+    ],
     "foundIn": [
       "Paeonia suffruticosa"
-    ]
+    ],
+    "safetyNotes": "Mostly preparation-derived. Caution with anticoagulants, pregnancy, and immune-modulating therapies."
   },
   {
     "id": "timosaponin-aiii",
     "slug": "timosaponin-aiii",
     "canonicalCompoundId": "timosaponin-aiii",
-    "name": "Timosaponin AIII",
-    "compoundName": "Timosaponin AIII",
-    "canonicalCompoundName": "Timosaponin AIII",
+    "name": "timosaponin aiii",
+    "compoundName": "timosaponin aiii",
+    "canonicalCompoundName": "timosaponin aiii",
     "mechanisms": [
       "PI3K/Akt modulation",
       "apoptosis pathway modulation (caspase activation)"
     ],
+    "compoundClass": "saponin / glycoside",
+    "class": "saponin / glycoside",
+    "targets": [
+      "AMPK",
+      "PPAR",
+      "immune cytokines",
+      "membrane signaling",
+      "glucose/lipid metabolism"
+    ],
     "foundIn": [
       "Anemarrhena asphodeloides"
-    ]
+    ],
+    "safetyNotes": "May cause GI irritation or hemolysis risk in isolated/high-dose contexts; herb-specific safety and pregnancy cautions apply."
   },
   {
     "id": "mangiferin-aglycone",
     "slug": "mangiferin-aglycone",
     "canonicalCompoundId": "mangiferin-aglycone",
-    "name": "Mangiferin aglycone",
-    "compoundName": "Mangiferin aglycone",
-    "canonicalCompoundName": "Mangiferin aglycone",
+    "name": "mangiferin aglycone",
+    "compoundName": "mangiferin aglycone",
+    "canonicalCompoundName": "mangiferin aglycone",
     "mechanisms": [
       "AMPK activation",
       "Nrf2 activation"
     ],
+    "compoundClass": "xanthone / polyphenol",
+    "class": "xanthone / polyphenol",
+    "targets": [
+      "NF-κB",
+      "antioxidant response",
+      "apoptosis signaling",
+      "inflammatory cytokines"
+    ],
     "foundIn": [
       "Anemarrhena asphodeloides"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical/extract-derived; concentrated Garcinia/mangosteen extracts may affect bleeding or liver risk depending product."
   },
   {
     "id": "lobeline",
     "slug": "lobeline",
     "canonicalCompoundId": "lobeline",
-    "name": "Lobeline",
-    "compoundName": "Lobeline",
-    "canonicalCompoundName": "Lobeline",
+    "name": "lobeline",
+    "compoundName": "lobeline",
+    "canonicalCompoundName": "lobeline",
     "mechanisms": [
       "nicotinic acetylcholine receptor modulation",
       "dopamine transporter modulation"
     ],
+    "compoundClass": "alkaloid",
+    "class": "alkaloid",
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
     "foundIn": [
       "Lobelia inflata"
-    ]
+    ],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety."
   },
   {
     "id": "huperzine-a",
     "slug": "huperzine-a",
     "canonicalCompoundId": "huperzine-a",
-    "name": "Huperzine A",
-    "compoundName": "Huperzine A",
-    "canonicalCompoundName": "Huperzine A",
+    "name": "huperzine a",
+    "compoundName": "huperzine a",
+    "canonicalCompoundName": "huperzine a",
     "mechanisms": [
       "acetylcholinesterase inhibition",
       "NMDA receptor modulation"
     ],
+    "compoundClass": "alkaloid",
+    "class": "alkaloid",
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
     "foundIn": [
       "Huperzia serrata"
-    ]
+    ],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety."
   },
   {
     "id": "huperzine-b",
     "slug": "huperzine-b",
     "canonicalCompoundId": "huperzine-b",
-    "name": "Huperzine B",
-    "compoundName": "Huperzine B",
-    "canonicalCompoundName": "Huperzine B",
+    "name": "huperzine b",
+    "compoundName": "huperzine b",
+    "canonicalCompoundName": "huperzine b",
     "mechanisms": [
       "acetylcholinesterase inhibition",
       "NMDA receptor modulation"
     ],
+    "compoundClass": "alkaloid",
+    "class": "alkaloid",
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
     "foundIn": [
       "Huperzia serrata"
-    ]
+    ],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety."
   },
   {
     "id": "anatabine",
     "slug": "anatabine",
     "canonicalCompoundId": "anatabine",
-    "name": "Anatabine",
-    "compoundName": "Anatabine",
-    "canonicalCompoundName": "Anatabine",
+    "name": "anatabine",
+    "compoundName": "anatabine",
+    "canonicalCompoundName": "anatabine",
     "mechanisms": [
       "nicotinic acetylcholine receptor modulation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "alkaloid",
+    "class": "alkaloid",
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
     "foundIn": [
       "Nicotiana tabacum"
-    ]
+    ],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety."
   },
   {
     "id": "anabasine",
     "slug": "anabasine",
     "canonicalCompoundId": "anabasine",
-    "name": "Anabasine",
-    "compoundName": "Anabasine",
-    "canonicalCompoundName": "Anabasine",
+    "name": "anabasine",
+    "compoundName": "anabasine",
+    "canonicalCompoundName": "anabasine",
     "mechanisms": [
       "nicotinic acetylcholine receptor modulation"
     ],
+    "compoundClass": "alkaloid",
+    "class": "alkaloid",
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
     "foundIn": [
       "Nicotiana glauca"
-    ]
+    ],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety."
   },
   {
     "id": "nicotine",
     "slug": "nicotine",
     "canonicalCompoundId": "nicotine",
-    "name": "Nicotine",
-    "compoundName": "Nicotine",
-    "canonicalCompoundName": "Nicotine",
+    "name": "nicotine",
+    "compoundName": "nicotine",
+    "canonicalCompoundName": "nicotine",
     "mechanisms": [
       "nicotinic acetylcholine receptor agonism",
       "dopamine release modulation"
     ],
+    "compoundClass": "alkaloid",
+    "class": "alkaloid",
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
     "foundIn": [
       "Nicotiana tabacum"
-    ]
+    ],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety."
   },
   {
     "id": "beta-caryophyllene",
     "slug": "beta-caryophyllene",
     "canonicalCompoundId": "beta-caryophyllene",
-    "name": "Beta-caryophyllene",
-    "compoundName": "Beta-caryophyllene",
-    "canonicalCompoundName": "Beta-caryophyllene",
+    "name": "beta-caryophyllene",
+    "compoundName": "beta-caryophyllene",
+    "canonicalCompoundName": "beta-caryophyllene",
     "mechanisms": [
       "CB2 receptor agonism",
       "NF-κB inhibition"
     ],
+    "compoundClass": "terpene / essential-oil constituent",
+    "class": "terpene / essential-oil constituent",
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
     "foundIn": [
       "Piper nigrum"
-    ]
+    ],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety."
   },
   {
     "id": "caryophyllene-oxide",
     "slug": "caryophyllene-oxide",
     "canonicalCompoundId": "caryophyllene-oxide",
-    "name": "Caryophyllene oxide",
-    "compoundName": "Caryophyllene oxide",
-    "canonicalCompoundName": "Caryophyllene oxide",
+    "name": "caryophyllene oxide",
+    "compoundName": "caryophyllene oxide",
+    "canonicalCompoundName": "caryophyllene oxide",
     "mechanisms": [
       "NF-κB inhibition",
       "apoptosis pathway modulation (caspase activation)"
     ],
+    "compoundClass": "terpene / essential-oil constituent",
+    "class": "terpene / essential-oil constituent",
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
     "foundIn": [
       "Piper nigrum"
-    ]
+    ],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety."
   },
   {
     "id": "nerolidol",
     "slug": "nerolidol",
     "canonicalCompoundId": "nerolidol",
-    "name": "Nerolidol",
-    "compoundName": "Nerolidol",
-    "canonicalCompoundName": "Nerolidol",
+    "name": "nerolidol",
+    "compoundName": "nerolidol",
+    "canonicalCompoundName": "nerolidol",
     "mechanisms": [
       "GABA-A modulation",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "terpene / essential-oil constituent",
+    "class": "terpene / essential-oil constituent",
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
     "foundIn": [
       "Cymbopogon citratus"
-    ]
+    ],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety."
   },
   {
     "id": "farnesol",
     "slug": "farnesol",
     "canonicalCompoundId": "farnesol",
-    "name": "Farnesol",
-    "compoundName": "Farnesol",
-    "canonicalCompoundName": "Farnesol",
+    "name": "farnesol",
+    "compoundName": "farnesol",
+    "canonicalCompoundName": "farnesol",
     "mechanisms": [
       "PPAR activation",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "terpene / essential-oil constituent",
+    "class": "terpene / essential-oil constituent",
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
     "foundIn": [
       "Matricaria chamomilla"
-    ]
+    ],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety."
   },
   {
     "id": "bisabolol",
     "slug": "bisabolol",
     "canonicalCompoundId": "bisabolol",
-    "name": "Bisabolol",
-    "compoundName": "Bisabolol",
-    "canonicalCompoundName": "Bisabolol",
+    "name": "bisabolol",
+    "compoundName": "bisabolol",
+    "canonicalCompoundName": "bisabolol",
     "mechanisms": [
       "COX inhibition",
       "NF-κB inhibition"
     ],
+    "compoundClass": "terpene / essential-oil constituent",
+    "class": "terpene / essential-oil constituent",
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
     "foundIn": [
       "Matricaria chamomilla"
-    ]
+    ],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety."
   },
   {
     "id": "chamazulene",
     "slug": "chamazulene",
     "canonicalCompoundId": "chamazulene",
-    "name": "Chamazulene",
-    "compoundName": "Chamazulene",
-    "canonicalCompoundName": "Chamazulene",
+    "name": "chamazulene",
+    "compoundName": "chamazulene",
+    "canonicalCompoundName": "chamazulene",
     "mechanisms": [
       "COX inhibition",
       "leukotriene pathway modulation"
     ],
+    "compoundClass": "terpene / essential-oil constituent",
+    "class": "terpene / essential-oil constituent",
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
     "foundIn": [
       "Chamomile",
       "Matricaria chamomilla"
-    ]
+    ],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety."
   },
   {
     "id": "atractylenolide-i",
     "slug": "atractylenolide-i",
     "canonicalCompoundId": "atractylenolide-i",
-    "name": "Atractylenolide I",
-    "compoundName": "Atractylenolide I",
-    "canonicalCompoundName": "Atractylenolide I",
+    "name": "atractylenolide i",
+    "compoundName": "atractylenolide i",
+    "canonicalCompoundName": "atractylenolide i",
     "mechanisms": [
       "PI3K/Akt modulation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "terpenoid",
+    "class": "terpenoid",
+    "targets": [
+      "NF-κB",
+      "PI3K/Akt"
+    ],
     "foundIn": [
       "Atractylodes",
       "Atractylodes macrocephala"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "atractylenolide-ii",
     "slug": "atractylenolide-ii",
     "canonicalCompoundId": "atractylenolide-ii",
-    "name": "Atractylenolide II",
-    "compoundName": "Atractylenolide II",
-    "canonicalCompoundName": "Atractylenolide II",
+    "name": "atractylenolide ii",
+    "compoundName": "atractylenolide ii",
+    "canonicalCompoundName": "atractylenolide ii",
     "mechanisms": [
       "NF-κB inhibition",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "sesquiterpene lactone",
+    "class": "sesquiterpene lactone",
+    "targets": [
+      "NF-κB",
+      "MAPK"
+    ],
     "foundIn": [
       "Atractylodes macrocephala"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "atractylenolide-iii",
     "slug": "atractylenolide-iii",
     "canonicalCompoundId": "atractylenolide-iii",
-    "name": "Atractylenolide III",
-    "compoundName": "Atractylenolide III",
-    "canonicalCompoundName": "Atractylenolide III",
+    "name": "atractylenolide iii",
+    "compoundName": "atractylenolide iii",
+    "canonicalCompoundName": "atractylenolide iii",
     "mechanisms": [
       "PI3K/Akt modulation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "terpenoid",
+    "class": "terpenoid",
+    "targets": [
+      "NF-κB",
+      "PI3K/Akt"
+    ],
     "foundIn": [
       "Atractylodes macrocephala"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "beta-elemene",
     "slug": "beta-elemene",
     "canonicalCompoundId": "beta-elemene",
-    "name": "Beta-elemene",
-    "compoundName": "Beta-elemene",
-    "canonicalCompoundName": "Beta-elemene",
+    "name": "beta-elemene",
+    "compoundName": "beta-elemene",
+    "canonicalCompoundName": "beta-elemene",
     "mechanisms": [
       "PI3K/Akt modulation",
       "apoptosis pathway modulation (caspase activation)"
     ],
+    "compoundClass": "terpene / essential-oil constituent",
+    "class": "terpene / essential-oil constituent",
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
     "foundIn": [
       "Curcuma wenyujin"
-    ]
+    ],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety."
   },
   {
     "id": "elemicin",
     "slug": "elemicin",
     "canonicalCompoundId": "elemicin",
-    "name": "Elemicin",
-    "compoundName": "Elemicin",
-    "canonicalCompoundName": "Elemicin",
+    "name": "elemicin",
+    "compoundName": "elemicin",
+    "canonicalCompoundName": "elemicin",
     "mechanisms": [
       "monoamine oxidase inhibition",
       "TRP channel modulation"
     ],
+    "compoundClass": "terpene / essential-oil constituent",
+    "class": "terpene / essential-oil constituent",
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
     "foundIn": [
       "Myristica fragrans"
-    ]
+    ],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety."
   },
   {
     "id": "myristicin",
     "slug": "myristicin",
     "canonicalCompoundId": "myristicin",
-    "name": "Myristicin",
-    "compoundName": "Myristicin",
-    "canonicalCompoundName": "Myristicin",
+    "name": "myristicin",
+    "compoundName": "myristicin",
+    "canonicalCompoundName": "myristicin",
     "mechanisms": [
       "monoamine oxidase inhibition",
       "acetylcholinesterase inhibition"
     ],
+    "compoundClass": "terpene / essential-oil constituent",
+    "class": "terpene / essential-oil constituent",
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
     "foundIn": [
       "Myristica fragrans"
-    ]
+    ],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety."
   },
   {
     "id": "safrole",
     "slug": "safrole",
     "canonicalCompoundId": "safrole",
-    "name": "Safrole",
-    "compoundName": "Safrole",
-    "canonicalCompoundName": "Safrole",
+    "name": "safrole",
+    "compoundName": "safrole",
+    "canonicalCompoundName": "safrole",
     "mechanisms": [
       "TRP channel modulation",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "terpene / essential-oil constituent",
+    "class": "terpene / essential-oil constituent",
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
     "foundIn": [
       "Ocotea odorifera"
-    ]
+    ],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety."
   },
   {
     "id": "methyleugenol",
     "slug": "methyleugenol",
     "canonicalCompoundId": "methyleugenol",
-    "name": "Methyleugenol",
-    "compoundName": "Methyleugenol",
-    "canonicalCompoundName": "Methyleugenol",
+    "name": "methyleugenol",
+    "compoundName": "methyleugenol",
+    "canonicalCompoundName": "methyleugenol",
     "mechanisms": [
       "TRP channel modulation",
       "GABA-A modulation"
     ],
+    "compoundClass": "terpene / essential-oil constituent",
+    "class": "terpene / essential-oil constituent",
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
     "foundIn": [
       "Ocimum basilicum"
-    ]
+    ],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety."
   },
   {
     "id": "asiatic-acid",
     "slug": "asiatic-acid",
     "canonicalCompoundId": "asiatic-acid",
-    "name": "Asiatic acid",
-    "compoundName": "Asiatic acid",
-    "canonicalCompoundName": "Asiatic acid",
+    "name": "asiatic acid",
+    "compoundName": "asiatic acid",
+    "canonicalCompoundName": "asiatic acid",
     "mechanisms": [
       "PI3K/Akt modulation",
       "TGF-β signaling modulation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "pentacyclic triterpenoid",
+    "class": "pentacyclic triterpenoid",
+    "targets": [
+      "TGF-β/Smad",
+      "collagen synthesis",
+      "NF-κB",
+      "wound-healing and inflammatory signaling"
+    ],
     "foundIn": [
       "Centella asiatica"
-    ]
+    ],
+    "safetyNotes": "Human evidence mostly from Centella extracts/topicals. Caution with liver disease, sedatives, pregnancy, and high-dose oral extracts."
   },
   {
     "id": "madecassic-acid",
     "slug": "madecassic-acid",
     "canonicalCompoundId": "madecassic-acid",
-    "name": "Madecassic acid",
-    "compoundName": "Madecassic acid",
-    "canonicalCompoundName": "Madecassic acid",
+    "name": "madecassic acid",
+    "compoundName": "madecassic acid",
+    "canonicalCompoundName": "madecassic acid",
     "mechanisms": [
       "TGF-β signaling modulation",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "triterpene / triterpenoid acid",
+    "class": "triterpene / triterpenoid acid",
+    "targets": [
+      "NF-κB",
+      "AMPK",
+      "PPAR",
+      "inflammatory cytokines",
+      "apoptosis signaling"
+    ],
     "foundIn": [
       "Centella asiatica"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical or extract-derived; concentrated doses may affect glucose, lipids, liver enzymes, or bleeding risk depending matrix."
   },
   {
     "id": "gymnemagenin",
     "slug": "gymnemagenin",
     "canonicalCompoundId": "gymnemagenin",
-    "name": "Gymnemagenin",
-    "compoundName": "Gymnemagenin",
-    "canonicalCompoundName": "Gymnemagenin",
+    "name": "gymnemagenin",
+    "compoundName": "gymnemagenin",
+    "canonicalCompoundName": "gymnemagenin",
     "mechanisms": [
       "glucose absorption modulation",
       "AMPK activation"
     ],
+    "compoundClass": "triterpene / triterpenoid acid",
+    "class": "triterpene / triterpenoid acid",
+    "targets": [
+      "NF-κB",
+      "AMPK",
+      "PPAR",
+      "inflammatory cytokines",
+      "apoptosis signaling"
+    ],
     "foundIn": [
       "Gymnema sylvestre"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical or extract-derived; concentrated doses may affect glucose, lipids, liver enzymes, or bleeding risk depending matrix."
   },
   {
     "id": "gurmarin",
     "slug": "gurmarin",
     "canonicalCompoundId": "gurmarin",
-    "name": "Gurmarin",
-    "compoundName": "Gurmarin",
-    "canonicalCompoundName": "Gurmarin",
+    "name": "gurmarin",
+    "compoundName": "gurmarin",
+    "canonicalCompoundName": "gurmarin",
     "mechanisms": [
       "sweet taste receptor modulation",
       "glucose absorption modulation"
     ],
+    "compoundClass": "peptide",
+    "class": "peptide",
+    "targets": [
+      "glucose transport/metabolism"
+    ],
     "foundIn": [
       "Gymnema sylvestre"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "corosolic-acid",
     "slug": "corosolic-acid",
     "canonicalCompoundId": "corosolic-acid",
-    "name": "Corosolic acid",
-    "compoundName": "Corosolic acid",
-    "canonicalCompoundName": "Corosolic acid",
+    "name": "corosolic acid",
+    "compoundName": "corosolic acid",
+    "canonicalCompoundName": "corosolic acid",
     "mechanisms": [
       "AMPK activation",
       "GLUT4 translocation modulation"
     ],
+    "compoundClass": "triterpene / triterpenoid acid",
+    "class": "triterpene / triterpenoid acid",
+    "targets": [
+      "NF-κB",
+      "AMPK",
+      "PPAR",
+      "inflammatory cytokines",
+      "apoptosis signaling"
+    ],
     "foundIn": [
       "Banaba",
       "Lagerstroemia speciosa"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical or extract-derived; concentrated doses may affect glucose, lipids, liver enzymes, or bleeding risk depending matrix."
   },
   {
     "id": "lagerstroemin",
     "slug": "lagerstroemin",
     "canonicalCompoundId": "lagerstroemin",
-    "name": "Lagerstroemin",
-    "compoundName": "Lagerstroemin",
-    "canonicalCompoundName": "Lagerstroemin",
+    "name": "lagerstroemin",
+    "compoundName": "lagerstroemin",
+    "canonicalCompoundName": "lagerstroemin",
     "mechanisms": [
       "PPAR activation",
       "glucose uptake modulation"
     ],
+    "compoundClass": "ellagitannin",
+    "class": "ellagitannin",
+    "targets": [
+      "PPARα/γ",
+      "glucose transport/metabolism"
+    ],
     "foundIn": [
       "Lagerstroemia speciosa"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "mulberroside-a",
     "slug": "mulberroside-a",
     "canonicalCompoundId": "mulberroside-a",
-    "name": "Mulberroside A",
-    "compoundName": "Mulberroside A",
-    "canonicalCompoundName": "Mulberroside A",
+    "name": "mulberroside a",
+    "compoundName": "mulberroside a",
+    "canonicalCompoundName": "mulberroside a",
     "mechanisms": [
       "glucose absorption modulation",
       "alpha-glucosidase inhibition"
     ],
+    "compoundClass": "stilbene glycoside",
+    "class": "stilbene glycoside",
+    "targets": [
+      "alpha-glucosidase",
+      "glucose transport/metabolism"
+    ],
     "foundIn": [
       "Morus alba"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "oxyresveratrol",
     "slug": "oxyresveratrol",
     "canonicalCompoundId": "oxyresveratrol",
-    "name": "Oxyresveratrol",
-    "compoundName": "Oxyresveratrol",
-    "canonicalCompoundName": "Oxyresveratrol",
+    "name": "oxyresveratrol",
+    "compoundName": "oxyresveratrol",
+    "canonicalCompoundName": "oxyresveratrol",
     "mechanisms": [
       "alpha-glucosidase inhibition",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "stilbene polyphenol",
+    "class": "stilbene polyphenol",
+    "targets": [
+      "SIRT1/AMPK",
+      "Nrf2",
+      "NF-κB",
+      "endothelial signaling",
+      "platelet aggregation pathways"
+    ],
     "foundIn": [
       "Morus alba"
-    ]
+    ],
+    "safetyNotes": "May affect bleeding risk and drug metabolism at supplement doses; GI upset and headache are possible."
   },
   {
     "id": "morin",
     "slug": "morin",
     "canonicalCompoundId": "morin",
-    "name": "Morin",
-    "compoundName": "Morin",
-    "canonicalCompoundName": "Morin",
+    "name": "morin",
+    "compoundName": "morin",
+    "canonicalCompoundName": "morin",
     "mechanisms": [
       "NF-κB inhibition",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "flavonol / flavonoid",
+    "class": "flavonol / flavonoid",
+    "targets": [
+      "AMPK",
+      "Nrf2",
+      "NF-κB",
+      "inflammatory cytokines",
+      "endothelial nitric oxide",
+      "antioxidant response"
+    ],
     "foundIn": [
       "Morus alba"
-    ]
+    ],
+    "safetyNotes": "Mostly food/extract-derived human evidence. High-dose supplements may affect CYP/transporters or anticoagulant/antiplatelet risk."
   },
   {
     "id": "deoxyelephantopin",
     "slug": "deoxyelephantopin",
     "canonicalCompoundId": "deoxyelephantopin",
-    "name": "Deoxyelephantopin",
-    "compoundName": "Deoxyelephantopin",
-    "canonicalCompoundName": "Deoxyelephantopin",
+    "name": "deoxyelephantopin",
+    "compoundName": "deoxyelephantopin",
+    "canonicalCompoundName": "deoxyelephantopin",
     "mechanisms": [
       "NF-κB inhibition",
       "STAT3 inhibition",
       "apoptosis pathway modulation (caspase activation)"
     ],
+    "compoundClass": "sesquiterpene lactone",
+    "class": "sesquiterpene lactone",
+    "targets": [
+      "NF-κB",
+      "STAT3",
+      "apoptosis/caspase signaling",
+      "caspase signaling"
+    ],
     "foundIn": [
       "Elephantopus scaber"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "elephantopin",
     "slug": "elephantopin",
     "canonicalCompoundId": "elephantopin",
-    "name": "Elephantopin",
-    "compoundName": "Elephantopin",
-    "canonicalCompoundName": "Elephantopin",
+    "name": "elephantopin",
+    "compoundName": "elephantopin",
+    "canonicalCompoundName": "elephantopin",
     "mechanisms": [
       "NF-κB inhibition",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "sesquiterpene lactone",
+    "class": "sesquiterpene lactone",
+    "targets": [
+      "NF-κB",
+      "MAPK"
+    ],
     "foundIn": [
       "Elephantopus scaber"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "guggulsterone",
     "slug": "guggulsterone",
     "canonicalCompoundId": "guggulsterone",
-    "name": "Guggulsterone",
-    "compoundName": "Guggulsterone",
-    "canonicalCompoundName": "Guggulsterone",
+    "name": "guggulsterone",
+    "compoundName": "guggulsterone",
+    "canonicalCompoundName": "guggulsterone",
     "mechanisms": [
       "FXR antagonism",
       "NF-κB inhibition"
     ],
+    "compoundClass": "saponin / glycoside",
+    "class": "saponin / glycoside",
+    "targets": [
+      "AMPK",
+      "PPAR",
+      "immune cytokines",
+      "membrane signaling",
+      "glucose/lipid metabolism"
+    ],
     "foundIn": [
       "Commiphora mukul"
-    ]
+    ],
+    "safetyNotes": "May cause GI irritation or hemolysis risk in isolated/high-dose contexts; herb-specific safety and pregnancy cautions apply."
   },
   {
     "id": "commipheric-acid",
     "slug": "commipheric-acid",
     "canonicalCompoundId": "commipheric-acid",
-    "name": "Commipheric acid",
-    "compoundName": "Commipheric acid",
-    "canonicalCompoundName": "Commipheric acid",
+    "name": "commipheric acid",
+    "compoundName": "commipheric acid",
+    "canonicalCompoundName": "commipheric acid",
     "mechanisms": [
       "PPAR activation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "triterpene / triterpenoid acid",
+    "class": "triterpene / triterpenoid acid",
+    "targets": [
+      "NF-κB",
+      "AMPK",
+      "PPAR",
+      "inflammatory cytokines",
+      "apoptosis signaling"
+    ],
     "foundIn": [
       "Commiphora mukul"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical or extract-derived; concentrated doses may affect glucose, lipids, liver enzymes, or bleeding risk depending matrix."
   },
   {
     "id": "beta-sitosterol",
     "slug": "beta-sitosterol",
     "canonicalCompoundId": "beta-sitosterol",
-    "name": "Beta-sitosterol",
-    "compoundName": "Beta-sitosterol",
-    "canonicalCompoundName": "Beta-sitosterol",
+    "name": "beta-sitosterol",
+    "compoundName": "beta-sitosterol",
+    "canonicalCompoundName": "beta-sitosterol",
     "mechanisms": [
-      "PPAR activation",
-      "NF-κB inhibition"
+      "Competition with intestinal cholesterol absorption",
+      "NPC1L1-related sterol transport effects",
+      "PPAR/LXR signaling modulation",
+      "NF-kB suppression"
+    ],
+    "compoundClass": "phytosterol",
+    "class": "phytosterol",
+    "targets": [
+      "cholesterol absorption",
+      "inflammatory signaling",
+      "membrane sterol pathways"
     ],
     "foundIn": [
       "Muira Puama",
       "Nettle Root",
       "Saw Palmetto",
       "Serenoa repens"
-    ]
+    ],
+    "safetyNotes": "Generally food-associated, but supplements can affect lipid markers and may be unsuitable in sitosterolemia."
   },
   {
     "id": "stigmasterol",
     "slug": "stigmasterol",
     "canonicalCompoundId": "stigmasterol",
-    "name": "Stigmasterol",
-    "compoundName": "Stigmasterol",
-    "canonicalCompoundName": "Stigmasterol",
+    "name": "stigmasterol",
+    "compoundName": "stigmasterol",
+    "canonicalCompoundName": "stigmasterol",
     "mechanisms": [
       "PPAR activation",
       "MAPK pathway modulation"
     ],
+    "compoundClass": "phytosterol",
+    "class": "phytosterol",
+    "targets": [
+      "cholesterol absorption",
+      "inflammatory signaling",
+      "membrane sterol pathways"
+    ],
     "foundIn": [
       "Serenoa repens"
-    ]
+    ],
+    "safetyNotes": "Generally food-associated, but supplements can affect lipid markers and may be unsuitable in sitosterolemia."
   },
   {
     "id": "ajoene",
@@ -2792,9 +4607,16 @@
       "platelet aggregation inhibition",
       "NF-κB inhibition"
     ],
+    "compoundClass": "organosulfur compound",
+    "class": "organosulfur compound",
+    "targets": [
+      "NF-κB",
+      "platelet aggregation"
+    ],
     "foundIn": [
-      "lean-bulk-pass-010"
-    ]
+      "garlic"
+    ],
+    "safetyNotes": "May affect platelet activity; use caution with anticoagulants/antiplatelets and before surgery."
   },
   {
     "id": "acemannan",
@@ -2807,9 +4629,15 @@
       "TLR4 modulation",
       "NF-κB modulation"
     ],
+    "compoundClass": "acetylated polysaccharide",
+    "class": "acetylated polysaccharide",
+    "targets": [
+      "NF-κB"
+    ],
     "foundIn": [
-      "lean-bulk-pass-010"
-    ]
+      "aloe vera"
+    ],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "aescin",
@@ -2822,9 +4650,19 @@
       "NF-κB inhibition",
       "endothelial barrier modulation"
     ],
+    "compoundClass": "saponin / glycoside",
+    "class": "saponin / glycoside",
+    "targets": [
+      "AMPK",
+      "PPAR",
+      "immune cytokines",
+      "membrane signaling",
+      "glucose/lipid metabolism"
+    ],
     "foundIn": [
-      "lean-bulk-pass-010"
-    ]
+      "horse chestnut"
+    ],
+    "safetyNotes": "May cause GI irritation or hemolysis risk in isolated/high-dose contexts; herb-specific safety and pregnancy cautions apply."
   },
   {
     "id": "alpha-asarone",
@@ -2837,9 +4675,16 @@
       "GABA-A modulation",
       "acetylcholinesterase inhibition"
     ],
+    "compoundClass": "phenylpropanoid ether",
+    "class": "phenylpropanoid ether",
+    "targets": [
+      "GABA-A receptors",
+      "acetylcholinesterase"
+    ],
     "foundIn": [
-      "lean-bulk-pass-010"
-    ]
+      "calamus"
+    ],
+    "safetyNotes": "High-caution aromatic compound with toxicology concerns; avoid concentrated internal use and pregnancy."
   },
   {
     "id": "aspalathin",
@@ -2852,24 +4697,41 @@
       "AMPK activation",
       "Nrf2 activation"
     ],
+    "compoundClass": "C-glucosyl dihydrochalcone",
+    "class": "C-glucosyl dihydrochalcone",
+    "targets": [
+      "Nrf2",
+      "AMPK"
+    ],
     "foundIn": [
-      "lean-bulk-pass-010"
-    ]
+      "rooibos"
+    ],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "bacopaside-ii",
     "slug": "bacopaside-ii",
     "canonicalCompoundId": "bacopaside-ii",
-    "name": "bacopaside II",
-    "compoundName": "bacopaside II",
-    "canonicalCompoundName": "bacopaside II",
+    "name": "bacopaside ii",
+    "compoundName": "bacopaside ii",
+    "canonicalCompoundName": "bacopaside ii",
     "mechanisms": [
       "MARK4 inhibition",
       "cholinergic modulation"
     ],
+    "compoundClass": "saponin / glycoside",
+    "class": "saponin / glycoside",
+    "targets": [
+      "AMPK",
+      "PPAR",
+      "immune cytokines",
+      "membrane signaling",
+      "glucose/lipid metabolism"
+    ],
     "foundIn": [
-      "lean-bulk-pass-010"
-    ]
+      "bacopa"
+    ],
+    "safetyNotes": "May cause GI irritation or hemolysis risk in isolated/high-dose contexts; herb-specific safety and pregnancy cautions apply."
   },
   {
     "id": "berbamine",
@@ -2882,9 +4744,16 @@
       "JAK/STAT inhibition",
       "NF-κB inhibition"
     ],
+    "compoundClass": "alkaloid",
+    "class": "alkaloid",
+    "targets": [
+      "NF-κB",
+      "JAK/STAT"
+    ],
     "foundIn": [
-      "lean-bulk-pass-010"
-    ]
+      "berberis"
+    ],
+    "safetyNotes": "Isolated alkaloid exposure may affect CYP/P-gp handling, glucose, blood pressure, and GI tolerance; avoid pregnancy/breastfeeding unless clinician-directed."
   },
   {
     "id": "betulinic-acid",
@@ -2897,9 +4766,19 @@
       "NF-κB inhibition",
       "apoptosis pathway modulation"
     ],
+    "compoundClass": "triterpene / triterpenoid acid",
+    "class": "triterpene / triterpenoid acid",
+    "targets": [
+      "NF-κB",
+      "AMPK",
+      "PPAR",
+      "inflammatory cytokines",
+      "apoptosis signaling"
+    ],
     "foundIn": [
-      "lean-bulk-pass-010"
-    ]
+      "chaga"
+    ],
+    "safetyNotes": "Mostly preclinical or extract-derived; concentrated doses may affect glucose, lipids, liver enzymes, or bleeding risk depending matrix."
   },
   {
     "id": "bilobetin",
@@ -2912,9 +4791,17 @@
       "NF-κB inhibition",
       "MAPK modulation"
     ],
+    "compoundClass": "terpene lactone / biflavone",
+    "class": "terpene lactone / biflavone",
+    "targets": [
+      "platelet activating factor",
+      "antioxidant response",
+      "cerebral blood flow signaling"
+    ],
     "foundIn": [
-      "lean-bulk-pass-010"
-    ]
+      "ginkgo biloba"
+    ],
+    "safetyNotes": "Ginkgo constituents are extract-specific. Bleeding interaction concerns apply with anticoagulants/antiplatelets."
   },
   {
     "id": "cafestol",
@@ -2927,9 +4814,17 @@
       "Nrf2 activation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "diterpene / coffee alkaloid-related constituent",
+    "class": "diterpene / coffee alkaloid-related constituent",
+    "targets": [
+      "lipid metabolism",
+      "bile acid signaling",
+      "adenosine/glucose metabolism depending compound"
+    ],
     "foundIn": [
-      "lean-bulk-pass-010"
-    ]
+      "coffee cherry"
+    ],
+    "safetyNotes": "Coffee matrix matters. Cafestol/kahweol can raise LDL with unfiltered coffee; caffeine-related effects may apply to coffee products."
   },
   {
     "id": "chicoric-acid",
@@ -2942,9 +4837,19 @@
       "NF-κB inhibition",
       "MAPK modulation"
     ],
+    "compoundClass": "phenolic acid / polyphenol",
+    "class": "phenolic acid / polyphenol",
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "antioxidant response",
+      "glucose/lipid signaling",
+      "gut microbiome metabolism"
+    ],
     "foundIn": [
-      "lean-bulk-pass-010"
-    ]
+      "echinacea purpurea"
+    ],
+    "safetyNotes": "Mostly food-associated; concentrated extracts may cause GI effects or interact with anticoagulants/antidiabetics depending matrix."
   },
   {
     "id": "citronellal",
@@ -2957,9 +4862,18 @@
       "TRPA1 modulation",
       "sensory ion-channel modulation"
     ],
+    "compoundClass": "terpene / essential-oil constituent",
+    "class": "terpene / essential-oil constituent",
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
     "foundIn": [
-      "lean-bulk-pass-010"
-    ]
+      "lemongrass"
+    ],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety."
   },
   {
     "id": "coptisine",
@@ -2973,9 +4887,19 @@
       "NF-κB inhibition",
       "MAPK modulation"
     ],
+    "compoundClass": "alkaloid",
+    "class": "alkaloid",
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
     "foundIn": [
-      "lean-bulk-pass-010"
-    ]
+      "coptis"
+    ],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety."
   },
   {
     "id": "deoxymiroestrol",
@@ -2987,9 +4911,19 @@
     "mechanisms": [
       "estrogen receptor modulation"
     ],
+    "compoundClass": "isoflavone / phytoestrogen",
+    "class": "isoflavone / phytoestrogen",
+    "targets": [
+      "estrogen receptor signaling",
+      "AMPK",
+      "PPAR",
+      "antioxidant response",
+      "bone/metabolic signaling"
+    ],
     "foundIn": [
-      "lean-bulk-pass-010"
-    ]
+      "pueraria mirifica"
+    ],
+    "safetyNotes": "Phytoestrogenic activity warrants caution with hormone-sensitive conditions and hormone therapies; effects are preparation- and dose-specific."
   },
   {
     "id": "desmethoxyyangonin",
@@ -3002,9 +4936,18 @@
       "MAO-B inhibition",
       "GABA-A modulation"
     ],
+    "compoundClass": "kavalactone",
+    "class": "kavalactone",
+    "targets": [
+      "GABAergic signaling",
+      "voltage-gated ion channels",
+      "monoamine signaling",
+      "CYP enzymes"
+    ],
     "foundIn": [
-      "lean-bulk-pass-010"
-    ]
+      "kava"
+    ],
+    "safetyNotes": "Kava/kavalactones are linked with sedation and liver injury concerns; avoid alcohol, sedatives, liver disease, and pregnancy."
   },
   {
     "id": "dihydrokavain",
@@ -3016,9 +4959,18 @@
     "mechanisms": [
       "GABA-A modulation"
     ],
+    "compoundClass": "kavalactone",
+    "class": "kavalactone",
+    "targets": [
+      "GABAergic signaling",
+      "voltage-gated ion channels",
+      "monoamine signaling",
+      "CYP enzymes"
+    ],
     "foundIn": [
-      "lean-bulk-pass-010"
-    ]
+      "kava"
+    ],
+    "safetyNotes": "Kava/kavalactones are linked with sedation and liver injury concerns; avoid alcohol, sedatives, liver disease, and pregnancy."
   },
   {
     "id": "dihydromethysticin",
@@ -3031,9 +4983,18 @@
       "GABA-A modulation",
       "MAO-B inhibition"
     ],
+    "compoundClass": "kavalactone",
+    "class": "kavalactone",
+    "targets": [
+      "GABAergic signaling",
+      "voltage-gated ion channels",
+      "monoamine signaling",
+      "CYP enzymes"
+    ],
     "foundIn": [
-      "lean-bulk-pass-010"
-    ]
+      "kava"
+    ],
+    "safetyNotes": "Kava/kavalactones are linked with sedation and liver injury concerns; avoid alcohol, sedatives, liver disease, and pregnancy."
   },
   {
     "id": "erinacines",
@@ -3046,9 +5007,15 @@
       "NGF induction",
       "ERK/CREB pathway modulation"
     ],
+    "compoundClass": "terpenoid",
+    "class": "terpenoid",
+    "targets": [
+      "pathway targets not fully resolved"
+    ],
     "foundIn": [
-      "lean-bulk-pass-010"
-    ]
+      "lion's mane"
+    ],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "hericenones",
@@ -3061,9 +5028,15 @@
       "NGF induction",
       "ERK/CREB pathway modulation"
     ],
+    "compoundClass": "phytochemical constituent",
+    "class": "phytochemical constituent",
+    "targets": [
+      "pathway targets not fully resolved"
+    ],
     "foundIn": [
-      "lean-bulk-pass-010"
-    ]
+      "lion's mane"
+    ],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "indirubin",
@@ -3076,9 +5049,15 @@
       "CDK inhibition",
       "STAT3 inhibition"
     ],
+    "compoundClass": "alkaloid",
+    "class": "alkaloid",
+    "targets": [
+      "STAT3"
+    ],
     "foundIn": [
-      "lean-bulk-pass-010"
-    ]
+      "isatis"
+    ],
+    "safetyNotes": "Isolated alkaloid exposure may affect CYP/P-gp handling, glucose, blood pressure, and GI tolerance; avoid pregnancy/breastfeeding unless clinician-directed."
   },
   {
     "id": "kahweol",
@@ -3091,9 +5070,17 @@
       "Nrf2 activation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "diterpene / coffee alkaloid-related constituent",
+    "class": "diterpene / coffee alkaloid-related constituent",
+    "targets": [
+      "lipid metabolism",
+      "bile acid signaling",
+      "adenosine/glucose metabolism depending compound"
+    ],
     "foundIn": [
-      "lean-bulk-pass-010"
-    ]
+      "coffee cherry"
+    ],
+    "safetyNotes": "Coffee matrix matters. Cafestol/kahweol can raise LDL with unfiltered coffee; caffeine-related effects may apply to coffee products."
   },
   {
     "id": "kotalanol",
@@ -3105,9 +5092,15 @@
     "mechanisms": [
       "alpha-glucosidase inhibition"
     ],
+    "compoundClass": "phytochemical constituent",
+    "class": "phytochemical constituent",
+    "targets": [
+      "alpha-glucosidase"
+    ],
     "foundIn": [
-      "lean-bulk-pass-010"
-    ]
+      "salacia"
+    ],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "mesembrine",
@@ -3120,9 +5113,19 @@
       "serotonin reuptake inhibition",
       "PDE4 inhibition"
     ],
+    "compoundClass": "alkaloid",
+    "class": "alkaloid",
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
     "foundIn": [
-      "lean-bulk-pass-010"
-    ]
+      "kanna"
+    ],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety."
   },
   {
     "id": "mesembrenone",
@@ -3135,9 +5138,19 @@
       "serotonin reuptake inhibition",
       "PDE4 inhibition"
     ],
+    "compoundClass": "alkaloid",
+    "class": "alkaloid",
+    "targets": [
+      "CNS/autonomic receptors",
+      "ion channels",
+      "CYP/P-gp",
+      "inflammatory signaling",
+      "apoptosis pathways"
+    ],
     "foundIn": [
-      "lean-bulk-pass-010"
-    ]
+      "kanna"
+    ],
+    "safetyNotes": "Alkaloid safety varies widely and can be narrow-margin. Use herb-specific safety controls and avoid assuming food-like safety."
   },
   {
     "id": "arjunolic-acid",
@@ -3150,10 +5163,20 @@
       "PPAR activation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "triterpene / triterpenoid acid",
+    "class": "triterpene / triterpenoid acid",
+    "targets": [
+      "NF-κB",
+      "AMPK",
+      "PPAR",
+      "inflammatory cytokines",
+      "apoptosis signaling"
+    ],
     "foundIn": [
       "Arjuna",
       "Terminalia arjuna"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical or extract-derived; concentrated doses may affect glucose, lipids, liver enzymes, or bleeding risk depending matrix."
   },
   {
     "id": "columbin",
@@ -3166,9 +5189,16 @@
       "NF-κB inhibition",
       "MAPK modulation"
     ],
+    "compoundClass": "terpenoid",
+    "class": "terpenoid",
+    "targets": [
+      "NF-κB",
+      "MAPK"
+    ],
     "foundIn": [
       "Tinospora cordifolia"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "cryptotanshinone",
@@ -3181,9 +5211,18 @@
       "STAT3 inhibition",
       "PI3K/Akt modulation"
     ],
+    "compoundClass": "diterpenoid quinone",
+    "class": "diterpenoid quinone",
+    "targets": [
+      "NF-κB",
+      "MAPK",
+      "platelet aggregation",
+      "cardiovascular/inflammatory signaling"
+    ],
     "foundIn": [
       "Salvia miltiorrhiza"
-    ]
+    ],
+    "safetyNotes": "Danshen constituents may affect bleeding and cardiovascular medications; use clinician review with anticoagulants/antiplatelets."
   },
   {
     "id": "galangin",
@@ -3196,25 +5235,44 @@
       "NF-κB inhibition",
       "MAPK modulation"
     ],
+    "compoundClass": "flavonol / flavonoid",
+    "class": "flavonol / flavonoid",
+    "targets": [
+      "AMPK",
+      "Nrf2",
+      "NF-κB",
+      "inflammatory cytokines",
+      "endothelial nitric oxide",
+      "antioxidant response"
+    ],
     "foundIn": [
       "Galangal",
       "Alpinia officinarum"
-    ]
+    ],
+    "safetyNotes": "Mostly food/extract-derived human evidence. High-dose supplements may affect CYP/transporters or anticoagulant/antiplatelet risk."
   },
   {
     "id": "ginkgolide-b",
     "slug": "ginkgolide-b",
     "canonicalCompoundId": "ginkgolide-b",
-    "name": "ginkgolide B",
-    "compoundName": "ginkgolide B",
-    "canonicalCompoundName": "ginkgolide B",
+    "name": "ginkgolide b",
+    "compoundName": "ginkgolide b",
+    "canonicalCompoundName": "ginkgolide b",
     "mechanisms": [
       "PAF receptor antagonism",
       "neuroprotection"
     ],
+    "compoundClass": "diterpene lactone / platelet-activating-factor antagonist",
+    "class": "diterpene lactone / platelet-activating-factor antagonist",
+    "targets": [
+      "PAF receptor",
+      "platelet activation",
+      "inflammatory signaling"
+    ],
     "foundIn": [
       "Ginkgo Biloba"
-    ]
+    ],
+    "safetyNotes": "Human safety is mainly tied to Ginkgo preparations; caution with anticoagulants/antiplatelets, surgery, seizure risk, and bleeding disorders."
   },
   {
     "id": "honokiol",
@@ -3227,9 +5285,18 @@
       "NF-κB inhibition",
       "GABA-A modulation"
     ],
+    "compoundClass": "neolignan",
+    "class": "neolignan",
+    "targets": [
+      "GABA-A signaling",
+      "NF-κB",
+      "cannabinoid/endocannabinoid signaling",
+      "inflammatory cytokines"
+    ],
     "foundIn": [
       "Magnolia officinalis"
-    ]
+    ],
+    "safetyNotes": "Sedation and additive CNS depressant effects are possible; pregnancy safety is not established."
   },
   {
     "id": "magnolol",
@@ -3242,9 +5309,18 @@
       "NF-κB inhibition",
       "GABA-A modulation"
     ],
+    "compoundClass": "neolignan",
+    "class": "neolignan",
+    "targets": [
+      "GABA-A signaling",
+      "NF-κB",
+      "cannabinoid/endocannabinoid signaling",
+      "inflammatory cytokines"
+    ],
     "foundIn": [
       "Magnolia officinalis"
-    ]
+    ],
+    "safetyNotes": "Sedation and additive CNS depressant effects are possible; pregnancy safety is not established."
   },
   {
     "id": "piperine",
@@ -3255,13 +5331,25 @@
     "canonicalCompoundName": "piperine",
     "mechanisms": [
       "TRPV1 activation",
-      "CYP3A4 inhibition"
+      "CYP3A4/CYP2C9 modulation",
+      "P-gp inhibition",
+      "intestinal permeability and absorption enhancement"
+    ],
+    "compoundClass": "piperidine alkaloid / bioenhancer",
+    "class": "piperidine alkaloid / bioenhancer",
+    "targets": [
+      "CYP3A4",
+      "CYP2C9",
+      "P-gp",
+      "intestinal permeability",
+      "TRPV1"
     ],
     "foundIn": [
       "Black Pepper",
       "Piper longum",
       "Piper nigrum"
-    ]
+    ],
+    "safetyNotes": "Pharmacokinetic interaction risk is the key issue. Use caution with narrow-therapeutic-index drugs, anticoagulants, antiepileptics, antidiabetics, and sedatives."
   },
   {
     "id": "rosmarinic-acid",
@@ -3271,14 +5359,25 @@
     "compoundName": "rosmarinic acid",
     "canonicalCompoundName": "rosmarinic acid",
     "mechanisms": [
-      "NF-κB inhibition",
-      "complement inhibition"
+      "NF-kB suppression",
+      "complement modulation",
+      "COX/LOX-related inflammatory signaling effects",
+      "mast-cell mediator reduction"
+    ],
+    "compoundClass": "caffeic acid ester / phenolic acid",
+    "class": "caffeic acid ester / phenolic acid",
+    "targets": [
+      "NF-κB",
+      "Nrf2",
+      "complement and inflammatory signaling",
+      "antiviral-entry pathways in vitro"
     ],
     "foundIn": [
       "Lemon Balm",
       "Rosmarinus officinalis",
       "Holy Basil"
-    ]
+    ],
+    "safetyNotes": "Food/herb exposure is generally low-risk; isolated high-dose safety is less established. Caution with pregnancy, anticoagulant use, and complex immune therapy contexts."
   },
   {
     "id": "safranal",
@@ -3291,9 +5390,18 @@
       "GABA-A modulation",
       "NMDA modulation"
     ],
+    "compoundClass": "terpene / essential-oil constituent",
+    "class": "terpene / essential-oil constituent",
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
     "foundIn": [
       "Saffron"
-    ]
+    ],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety."
   },
   {
     "id": "theanine",
@@ -3306,18 +5414,16 @@
       "glutamate receptor modulation",
       "GABA upregulation"
     ],
+    "compoundClass": "amino acid / tea constituent",
+    "class": "amino acid / tea constituent",
     "targets": [
       "Glutamate receptors",
       "GABA-related signaling"
     ],
-    "pathways": [
-      "glutamatergic signaling",
-      "GABAergic signaling"
-    ],
     "foundIn": [
       "Green Tea"
     ],
-    "bioavailability": "Readily absorbed orally and crosses the blood-brain barrier."
+    "safetyNotes": "Generally well tolerated in tea/supplement studies; additive effects with sedatives or stimulants are possible but usually mild."
   },
   {
     "id": "cinnamaldehyde",
@@ -3330,19 +5436,16 @@
       "AMPK activation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "terpene / essential-oil constituent",
+    "class": "terpene / essential-oil constituent",
     "targets": [
       "TRPA1",
       "inflammatory enzymes"
     ],
-    "pathways": [
-      "AMPK",
-      "NF-κB",
-      "TRPA1-linked signaling"
-    ],
     "foundIn": [
       "Cinnamon"
     ],
-    "bioavailability": "Volatile and reactive; whole-bark preparations differ from isolated compound exposure."
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety."
   },
   {
     "id": "trigonelline",
@@ -3355,88 +5458,110 @@
       "Nrf2 activation",
       "glucose metabolism modulation"
     ],
+    "compoundClass": "diterpene / coffee alkaloid-related constituent",
+    "class": "diterpene / coffee alkaloid-related constituent",
+    "targets": [
+      "lipid metabolism",
+      "bile acid signaling",
+      "adenosine/glucose metabolism depending compound"
+    ],
     "foundIn": [
       "Coffee",
       "Fenugreek"
-    ]
+    ],
+    "safetyNotes": "Coffee matrix matters. Cafestol/kahweol can raise LDL with unfiltered coffee; caffeine-related effects may apply to coffee products."
   },
   {
     "id": "withanoside-iv",
     "slug": "withanoside-iv",
     "canonicalCompoundId": "withanoside-iv",
-    "name": "withanoside IV",
-    "compoundName": "withanoside IV",
-    "canonicalCompoundName": "withanoside IV",
+    "name": "withanoside iv",
+    "compoundName": "withanoside iv",
+    "canonicalCompoundName": "withanoside iv",
     "mechanisms": [
       "BDNF upregulation",
       "neurite outgrowth promotion"
     ],
+    "compoundClass": "withanolide / steroidal lactone",
+    "class": "withanolide / steroidal lactone",
     "targets": [
       "Neurotrophic signaling nodes",
       "cholinergic systems"
     ],
-    "pathways": [
-      "BDNF-linked signaling",
-      "neurite outgrowth pathways"
-    ],
     "foundIn": [
       "Ashwagandha"
     ],
-    "bioavailability": "Usually consumed within root extracts rather than as an isolated compound."
+    "safetyNotes": "Evidence usually comes from Withania extracts. Caution with pregnancy, liver disease, sedatives, thyroid medications, and autoimmune disease."
   },
   {
     "id": "schisandrin-b",
     "slug": "schisandrin-b",
     "canonicalCompoundId": "schisandrin-b",
-    "name": "schisandrin B",
-    "compoundName": "schisandrin B",
-    "canonicalCompoundName": "schisandrin B",
+    "name": "schisandrin b",
+    "compoundName": "schisandrin b",
+    "canonicalCompoundName": "schisandrin b",
     "mechanisms": [
       "Nrf2 activation",
       "mitochondrial protection"
     ],
+    "compoundClass": "lignan",
+    "class": "lignan",
     "targets": [
       "Mitochondrial redox systems",
       "antioxidant enzymes"
     ],
-    "pathways": [
-      "Nrf2",
-      "mitochondrial stress response"
-    ],
     "foundIn": [
       "Schisandra"
     ],
-    "bioavailability": "Lipophilic lignan with better delivery in whole extracts than isolated dry powder."
+    "safetyNotes": "Schisandra-type lignans can affect drug-metabolizing enzymes/transporters; caution with complex medication regimens."
   },
   {
     "id": "eleutheroside-b",
     "slug": "eleutheroside-b",
     "canonicalCompoundId": "eleutheroside-b",
-    "name": "eleutheroside B",
-    "compoundName": "eleutheroside B",
-    "canonicalCompoundName": "eleutheroside B",
+    "name": "eleutheroside b",
+    "compoundName": "eleutheroside b",
+    "canonicalCompoundName": "eleutheroside b",
     "mechanisms": [
       "HPA-axis modulation",
       "immune modulation"
     ],
+    "compoundClass": "lignan",
+    "class": "lignan",
+    "targets": [
+      "CYP/P-gp modulation",
+      "Nrf2",
+      "AMPK",
+      "liver detoxification signaling"
+    ],
     "foundIn": [
       "Eleuthero"
-    ]
+    ],
+    "safetyNotes": "Schisandra-type lignans can affect drug-metabolizing enzymes/transporters; caution with complex medication regimens."
   },
   {
     "id": "eleutheroside-e",
     "slug": "eleutheroside-e",
     "canonicalCompoundId": "eleutheroside-e",
-    "name": "eleutheroside E",
-    "compoundName": "eleutheroside E",
-    "canonicalCompoundName": "eleutheroside E",
+    "name": "eleutheroside e",
+    "compoundName": "eleutheroside e",
+    "canonicalCompoundName": "eleutheroside e",
     "mechanisms": [
       "AMPK activation",
       "stress response modulation"
     ],
+    "compoundClass": "lignan",
+    "class": "lignan",
+    "targets": [
+      "CYP/P-gp modulation",
+      "Nrf2",
+      "AMPK",
+      "liver detoxification signaling"
+    ],
     "foundIn": [
       "Eleuthero"
-    ]
+    ],
+    "safetyNotes": "Schisandra-type lignans can affect drug-metabolizing enzymes/transporters; caution with complex medication regimens."
   },
   {
     "id": "punicalagin",
@@ -3449,18 +5574,16 @@
       "NF-κB inhibition",
       "ellagitannin-mediated antioxidant signaling"
     ],
+    "compoundClass": "phytochemical constituent",
+    "class": "phytochemical constituent",
     "targets": [
       "Inflammatory mediators",
       "redox-sensitive enzymes"
     ],
-    "pathways": [
-      "NF-κB",
-      "oxidative stress response"
-    ],
     "foundIn": [
       "Pomegranate"
     ],
-    "bioavailability": "Parent compound is transformed extensively; downstream urolithin formation varies by microbiome."
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "carnosol",
@@ -3473,20 +5596,17 @@
       "Nrf2 activation",
       "NF-κB inhibition"
     ],
+    "compoundClass": "terpene / essential-oil constituent",
+    "class": "terpene / essential-oil constituent",
     "targets": [
       "Keap1-sensitive redox targets",
       "STAT3-related signaling"
-    ],
-    "pathways": [
-      "Nrf2",
-      "NF-κB",
-      "STAT3"
     ],
     "foundIn": [
       "Rosmarinus officinalis",
       "Rosemary"
     ],
-    "bioavailability": "Lipophilic compound; best delivered in extracts or fat-containing preparations."
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety."
   },
   {
     "id": "glucomoringin",
@@ -3499,18 +5619,16 @@
       "Nrf2 activation",
       "isothiocyanate signaling"
     ],
+    "compoundClass": "phytochemical constituent",
+    "class": "phytochemical constituent",
     "targets": [
       "Phase II detox enzymes",
       "electrophile sensors"
     ],
-    "pathways": [
-      "Nrf2",
-      "phase II detox response"
-    ],
     "foundIn": [
       "Moringa"
     ],
-    "bioavailability": "Bioactivity depends on conversion to isothiocyanates after processing or digestion."
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "methyl-eugenol",
@@ -3523,9 +5641,18 @@
       "TRPA1 modulation",
       "voltage-gated channel modulation"
     ],
+    "compoundClass": "terpene / essential-oil constituent",
+    "class": "terpene / essential-oil constituent",
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
     "foundIn": [
       "Holy Basil"
-    ]
+    ],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety."
   },
   {
     "id": "anethole",
@@ -3538,10 +5665,19 @@
       "NF-κB inhibition",
       "smooth muscle relaxation"
     ],
+    "compoundClass": "terpene / essential-oil constituent",
+    "class": "terpene / essential-oil constituent",
+    "targets": [
+      "TRP channels",
+      "antimicrobial membranes",
+      "COX/LOX",
+      "GABAergic or adrenergic signaling depending compound"
+    ],
     "foundIn": [
       "Fennel",
       "Anise Hyssop"
-    ]
+    ],
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety."
   },
   {
     "id": "carvacrol",
@@ -3551,16 +5687,16 @@
     "compoundName": "carvacrol",
     "canonicalCompoundName": "carvacrol",
     "mechanisms": [
-      "TRPA1 activation",
-      "membrane disruption"
+      "Membrane disruption",
+      "TRPA1/TRPV3-related sensory modulation",
+      "NF-kB suppression",
+      "antimicrobial permeability effects"
     ],
+    "compoundClass": "terpene / essential-oil constituent",
+    "class": "terpene / essential-oil constituent",
     "targets": [
       "TRPA1",
       "membrane lipids"
-    ],
-    "pathways": [
-      "TRPA1-related signaling",
-      "membrane stress response"
     ],
     "foundIn": [
       "Sage",
@@ -3568,7 +5704,7 @@
       "Oregano",
       "Thyme"
     ],
-    "bioavailability": "Lipophilic volatile; delivery varies substantially by extract type."
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety."
   },
   {
     "id": "thymol",
@@ -3578,16 +5714,16 @@
     "compoundName": "thymol",
     "canonicalCompoundName": "thymol",
     "mechanisms": [
-      "GABA-A modulation",
-      "membrane disruption"
+      "Membrane disruption",
+      "GABA-A receptor modulation",
+      "TRP-channel effects",
+      "antimicrobial permeability effects"
     ],
+    "compoundClass": "terpene / essential-oil constituent",
+    "class": "terpene / essential-oil constituent",
     "targets": [
       "GABA-A-related sites",
       "membrane targets"
-    ],
-    "pathways": [
-      "GABAergic signaling",
-      "TRPA1-related sensory signaling"
     ],
     "foundIn": [
       "Rosemary",
@@ -3595,7 +5731,7 @@
       "Thyme",
       "Oregano"
     ],
-    "bioavailability": "Volatile constituent; concentrated essential oil exposure is stronger than culinary intake."
+    "safetyNotes": "Essential-oil constituents can irritate skin/mucosa and may be toxic internally at high doses; use dilution and herb-specific safety."
   },
   {
     "id": "silybin",
@@ -3608,18 +5744,16 @@
       "Nrf2 activation",
       "TGF-β modulation"
     ],
+    "compoundClass": "phytochemical constituent",
+    "class": "phytochemical constituent",
     "targets": [
       "TGF-β-related nodes",
       "antioxidant enzymes"
     ],
-    "pathways": [
-      "Nrf2",
-      "TGF-β"
-    ],
     "foundIn": [
       "Milk Thistle"
     ],
-    "bioavailability": "Poor water solubility; phospholipid complexes can improve absorption."
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "silychristin",
@@ -3632,9 +5766,15 @@
       "Nrf2 activation",
       "ABC transporter modulation"
     ],
+    "compoundClass": "phytochemical constituent",
+    "class": "phytochemical constituent",
+    "targets": [
+      "Nrf2"
+    ],
     "foundIn": [
       "Milk Thistle"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "silydianin",
@@ -3647,9 +5787,15 @@
       "Nrf2 activation",
       "hepatocyte protection"
     ],
+    "compoundClass": "phytochemical constituent",
+    "class": "phytochemical constituent",
+    "targets": [
+      "Nrf2"
+    ],
     "foundIn": [
       "Milk Thistle"
-    ]
+    ],
+    "safetyNotes": "Mostly preclinical or source-extract evidence. Isolated-compound safety is not equivalent to food/herb exposure; use caution with pregnancy, liver/kidney disease, and polypharmacy."
   },
   {
     "id": "epigallocatechin",
@@ -3662,9 +5808,20 @@
       "Nrf2 activation",
       "MAPK modulation"
     ],
+    "compoundClass": "flavanol / tea polyphenol",
+    "class": "flavanol / tea polyphenol",
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "AMPK",
+      "endothelial nitric oxide",
+      "antioxidant response",
+      "lipid/glucose signaling"
+    ],
     "foundIn": [
       "Green Tea"
-    ]
+    ],
+    "safetyNotes": "Tea-food exposure is generally safer than concentrated extracts. High EGCG/catechin extracts have liver-injury concern and caffeine-containing products add stimulant risk."
   },
   {
     "id": "epicatechin-gallate",
@@ -3677,18 +5834,16 @@
       "NF-κB inhibition",
       "MAPK modulation"
     ],
+    "compoundClass": "flavanol / tea polyphenol",
+    "class": "flavanol / tea polyphenol",
     "targets": [
       "Inflammatory kinases",
       "redox-active enzymes"
     ],
-    "pathways": [
-      "NF-κB",
-      "MAPK"
-    ],
     "foundIn": [
       "Green Tea"
     ],
-    "bioavailability": "Part of the tea catechin pool; stability and absorption depend on preparation."
+    "safetyNotes": "Tea-food exposure is generally safer than concentrated extracts. High EGCG/catechin extracts have liver-injury concern and caffeine-containing products add stimulant risk."
   },
   {
     "id": "epigallocatechin-gallate",
@@ -3702,20 +5857,17 @@
       "NF-κB inhibition",
       "EGFR modulation"
     ],
+    "compoundClass": "flavanol / tea polyphenol",
+    "class": "flavanol / tea polyphenol",
     "targets": [
       "AMPK",
       "EGFR",
       "IKK complex"
     ],
-    "pathways": [
-      "AMPK",
-      "NF-κB",
-      "MAPK"
-    ],
     "foundIn": [
       "Green Tea"
     ],
-    "bioavailability": "Oral absorption is limited; exposure improves with repeated intake and formulation support."
+    "safetyNotes": "Tea-food exposure is generally safer than concentrated extracts. High EGCG/catechin extracts have liver-injury concern and caffeine-containing products add stimulant risk."
   },
   {
     "id": "gallocatechin",
@@ -3728,8 +5880,19 @@
       "Nrf2 activation",
       "MAPK modulation"
     ],
+    "compoundClass": "flavanol / tea polyphenol",
+    "class": "flavanol / tea polyphenol",
+    "targets": [
+      "Nrf2",
+      "NF-κB",
+      "AMPK",
+      "endothelial nitric oxide",
+      "antioxidant response",
+      "lipid/glucose signaling"
+    ],
     "foundIn": [
       "Green Tea"
-    ]
+    ],
+    "safetyNotes": "Tea-food exposure is generally safer than concentrated extracts. High EGCG/catechin extracts have liver-injury concern and caffeine-containing products add stimulant risk."
   }
 ]

--- a/public/data/workbook-herb-compound-map.json
+++ b/public/data/workbook-herb-compound-map.json
@@ -1,1442 +1,3326 @@
 [
   {
-    "herbSlug": "withaferin-a",
-    "herbName": "Withaferin A"
+    "herbSlug": "ashwagandha",
+    "herbName": "Ashwagandha",
+    "canonicalCompoundId": "withaferin-a",
+    "canonicalCompoundName": "Withaferin A"
   },
   {
-    "herbSlug": "triterpene-glycosides-actein-23-epi-26-deoxyactein",
-    "herbName": "triterpene glycosides (actein, 23-epi-26-deoxyactein)"
+    "herbSlug": "black-cohosh",
+    "herbName": "Black Cohosh",
+    "canonicalCompoundId": "triterpene-glycosides-actein-23-epi-26-deoxyactein",
+    "canonicalCompoundName": "triterpene glycosides (actein, 23-epi-26-deoxyactein)"
   },
   {
-    "herbSlug": "alkamides",
-    "herbName": "alkamides"
+    "herbSlug": "echinacea-purpurea",
+    "herbName": "Echinacea Purpurea",
+    "canonicalCompoundId": "alkamides",
+    "canonicalCompoundName": "alkamides"
   },
   {
-    "herbSlug": "diallyl-sulfide",
-    "herbName": "diallyl sulfide"
+    "herbSlug": "garlic",
+    "herbName": "Garlic",
+    "canonicalCompoundId": "diallyl-sulfide",
+    "canonicalCompoundName": "diallyl sulfide"
   },
   {
-    "herbSlug": "6-gingerol",
-    "herbName": "6-Gingerol"
+    "herbSlug": "ginger",
+    "herbName": "Ginger",
+    "canonicalCompoundId": "6-gingerol",
+    "canonicalCompoundName": "6-Gingerol"
   },
   {
-    "herbSlug": "ginkgolides-a-b-c-j",
-    "herbName": "ginkgolides A, B, C, J"
+    "herbSlug": "ginkgo-biloba",
+    "herbName": "Ginkgo Biloba",
+    "canonicalCompoundId": "ginkgolides-a-b-c-j",
+    "canonicalCompoundName": "ginkgolides A, B, C, J"
   },
   {
-    "herbSlug": "eugenol",
-    "herbName": "Eugenol"
+    "herbSlug": "holy-basil",
+    "herbName": "Holy Basil",
+    "canonicalCompoundId": "eugenol",
+    "canonicalCompoundName": "Eugenol"
   },
   {
-    "herbSlug": "kavain",
-    "herbName": "kavain"
+    "herbSlug": "kava",
+    "herbName": "Kava",
+    "canonicalCompoundId": "kavain",
+    "canonicalCompoundName": "kavain"
   },
   {
-    "herbSlug": "rosmarinic-acid",
-    "herbName": "Rosmarinic acid"
+    "herbSlug": "lemon-balm",
+    "herbName": "Lemon Balm",
+    "canonicalCompoundId": "rosmarinic-acid",
+    "canonicalCompoundName": "Rosmarinic acid"
   },
   {
-    "herbSlug": "macamides",
-    "herbName": "macamides"
+    "herbSlug": "maca",
+    "herbName": "Maca",
+    "canonicalCompoundId": "macamides",
+    "canonicalCompoundName": "macamides"
   },
   {
-    "herbSlug": "silybin-a-b",
-    "herbName": "silybin A/B"
+    "herbSlug": "milk-thistle",
+    "herbName": "Milk Thistle",
+    "canonicalCompoundId": "silybin-a-b",
+    "canonicalCompoundName": "silybin A/B"
   },
   {
-    "herbSlug": "l-menthol",
-    "herbName": "l‐menthol"
+    "herbSlug": "peppermint",
+    "herbName": "Peppermint",
+    "canonicalCompoundId": "l-menthol",
+    "canonicalCompoundName": "l‐menthol"
   },
   {
-    "herbSlug": "rosavin",
-    "herbName": "Rosavin"
+    "herbSlug": "rhodiola-rosea",
+    "herbName": "Rhodiola Rosea",
+    "canonicalCompoundId": "rosavin",
+    "canonicalCompoundName": "Rosavin"
   },
   {
-    "herbSlug": "fatty-acids",
-    "herbName": "fatty acids"
+    "herbSlug": "saw-palmetto",
+    "herbName": "Saw Palmetto",
+    "canonicalCompoundId": "fatty-acids",
+    "canonicalCompoundName": "fatty acids"
   },
   {
-    "herbSlug": "hyperforin",
-    "herbName": "Hyperforin"
+    "herbSlug": "st-johns-wort",
+    "herbName": "St Johns Wort",
+    "canonicalCompoundId": "hyperforin",
+    "canonicalCompoundName": "Hyperforin"
   },
   {
-    "herbSlug": "demethoxycurcumin",
-    "herbName": "Demethoxycurcumin"
+    "herbSlug": "turmeric",
+    "herbName": "Turmeric",
+    "canonicalCompoundId": "demethoxycurcumin",
+    "canonicalCompoundName": "Demethoxycurcumin"
   },
   {
-    "herbSlug": "valerenic-acid",
-    "herbName": "valerenic acid"
+    "herbSlug": "valerian",
+    "herbName": "Valerian",
+    "canonicalCompoundId": "valerenic-acid",
+    "canonicalCompoundName": "valerenic acid"
   },
   {
-    "herbSlug": "caffeine",
-    "herbName": "Caffeine"
+    "herbSlug": "guarana",
+    "herbName": "Guarana",
+    "canonicalCompoundId": "caffeine",
+    "canonicalCompoundName": "Caffeine"
   },
   {
-    "herbSlug": "apigenin",
-    "herbName": "Apigenin"
+    "herbSlug": "yerba-mate",
+    "herbName": "Yerba Mate",
+    "canonicalCompoundId": "apigenin",
+    "canonicalCompoundName": "Apigenin"
   },
   {
-    "herbSlug": "nuciferine",
-    "herbName": "nuciferine"
+    "herbSlug": "damiana",
+    "herbName": "Damiana",
+    "canonicalCompoundId": "nuciferine",
+    "canonicalCompoundName": "nuciferine"
   },
   {
-    "herbSlug": "puerarin",
-    "herbName": "puerarin"
+    "herbSlug": "blue-lotus",
+    "herbName": "Blue Lotus",
+    "canonicalCompoundId": "puerarin",
+    "canonicalCompoundName": "puerarin"
   },
   {
-    "herbSlug": "parthenolide",
-    "herbName": "parthenolide"
+    "herbSlug": "kudzu",
+    "herbName": "Kudzu",
+    "canonicalCompoundId": "parthenolide",
+    "canonicalCompoundName": "parthenolide"
   },
   {
-    "herbSlug": "petasin",
-    "herbName": "petasin"
+    "herbSlug": "yarrow",
+    "herbName": "Yarrow",
+    "canonicalCompoundId": "petasin",
+    "canonicalCompoundName": "petasin"
   },
   {
-    "herbSlug": "actein",
-    "herbName": "Actein"
+    "herbSlug": "feverfew",
+    "herbName": "Feverfew",
+    "canonicalCompoundId": "actein",
+    "canonicalCompoundName": "Actein"
   },
   {
-    "herbSlug": "curcumin",
-    "herbName": "curcumin"
+    "herbSlug": "butterbur",
+    "herbName": "Butterbur",
+    "canonicalCompoundId": "petasin",
+    "canonicalCompoundName": "petasin"
   },
   {
-    "herbSlug": "thymol",
-    "herbName": "thymol"
+    "herbSlug": "dong-quai",
+    "herbName": "Dong Quai",
+    "canonicalCompoundId": "curcumin",
+    "canonicalCompoundName": "curcumin"
   },
   {
-    "herbSlug": "carvacrol",
-    "herbName": "carvacrol"
+    "herbSlug": "rosemary",
+    "herbName": "Rosemary",
+    "canonicalCompoundId": "thymol",
+    "canonicalCompoundName": "thymol"
   },
   {
-    "herbSlug": "eucalyptol",
-    "herbName": "eucalyptol"
+    "herbSlug": "sage",
+    "herbName": "Sage",
+    "canonicalCompoundId": "carvacrol",
+    "canonicalCompoundName": "carvacrol"
   },
   {
-    "herbSlug": "cynarin",
-    "herbName": "cynarin"
+    "herbSlug": "thyme",
+    "herbName": "Thyme",
+    "canonicalCompoundId": "eucalyptol",
+    "canonicalCompoundName": "eucalyptol"
   },
   {
-    "herbSlug": "anethole",
-    "herbName": "anethole"
+    "herbSlug": "artichoke",
+    "herbName": "Artichoke",
+    "canonicalCompoundId": "cynarin",
+    "canonicalCompoundName": "cynarin"
   },
   {
-    "herbSlug": "cinnamaldehyde",
-    "herbName": "cinnamaldehyde"
+    "herbSlug": "fennel",
+    "herbName": "Fennel",
+    "canonicalCompoundId": "anethole",
+    "canonicalCompoundName": "anethole"
   },
   {
-    "herbSlug": "taraxasterol",
-    "herbName": "taraxasterol"
+    "herbSlug": "cinnamon",
+    "herbName": "Cinnamon",
+    "canonicalCompoundId": "cinnamaldehyde",
+    "canonicalCompoundName": "cinnamaldehyde"
   },
   {
-    "herbSlug": "arctiin",
-    "herbName": "arctiin"
+    "herbSlug": "dandelion",
+    "herbName": "Dandelion",
+    "canonicalCompoundId": "taraxasterol",
+    "canonicalCompoundName": "taraxasterol"
   },
   {
-    "herbSlug": "genistein",
-    "herbName": "genistein"
+    "herbSlug": "burdock",
+    "herbName": "Burdock",
+    "canonicalCompoundId": "arctiin",
+    "canonicalCompoundName": "arctiin"
   },
   {
-    "herbSlug": "avenanthramides",
-    "herbName": "avenanthramides"
+    "herbSlug": "chamomile",
+    "herbName": "Chamomile",
+    "canonicalCompoundId": "apigenin",
+    "canonicalCompoundName": "Apigenin"
   },
   {
-    "herbSlug": "faradiol",
-    "herbName": "faradiol"
+    "herbSlug": "red-clover",
+    "herbName": "Red Clover",
+    "canonicalCompoundId": "genistein",
+    "canonicalCompoundName": "genistein"
   },
   {
-    "herbSlug": "lapachol",
-    "herbName": "lapachol"
+    "herbSlug": "oatstraw",
+    "herbName": "Oatstraw",
+    "canonicalCompoundId": "avenanthramides",
+    "canonicalCompoundName": "avenanthramides"
   },
   {
-    "herbSlug": "gymnemic-acids",
-    "herbName": "gymnemic acids"
+    "herbSlug": "calendula",
+    "herbName": "Calendula",
+    "canonicalCompoundId": "faradiol",
+    "canonicalCompoundName": "faradiol"
   },
   {
-    "herbSlug": "corosolic-acid",
-    "herbName": "corosolic acid"
+    "herbSlug": "pau-d-arco",
+    "herbName": "Pau d'Arco",
+    "canonicalCompoundId": "lapachol",
+    "canonicalCompoundName": "lapachol"
   },
   {
-    "herbSlug": "1-deoxynojirimycin",
-    "herbName": "1-deoxynojirimycin"
+    "herbSlug": "gymnema",
+    "herbName": "Gymnema",
+    "canonicalCompoundId": "gymnemic-acids",
+    "canonicalCompoundName": "gymnemic acids"
   },
   {
-    "herbSlug": "nimbin",
-    "herbName": "nimbin"
+    "herbSlug": "banaba",
+    "herbName": "Banaba",
+    "canonicalCompoundId": "corosolic-acid",
+    "canonicalCompoundName": "corosolic acid"
   },
   {
-    "herbSlug": "thujone",
-    "herbName": "thujone"
+    "herbSlug": "mulberry-leaf",
+    "herbName": "Mulberry Leaf",
+    "canonicalCompoundId": "1-deoxynojirimycin",
+    "canonicalCompoundName": "1-deoxynojirimycin"
   },
   {
-    "herbSlug": "verbascoside",
-    "herbName": "verbascoside"
+    "herbSlug": "neem",
+    "herbName": "Neem",
+    "canonicalCompoundId": "nimbin",
+    "canonicalCompoundName": "nimbin"
   },
   {
-    "herbSlug": "avenacosides",
-    "herbName": "avenacosides"
+    "herbSlug": "mugwort",
+    "herbName": "Mugwort",
+    "canonicalCompoundId": "thujone",
+    "canonicalCompoundName": "thujone"
   },
   {
-    "herbSlug": "quadrangularin-a",
-    "herbName": "quadrangularin a"
+    "herbSlug": "lemon-verbena",
+    "herbName": "Lemon Verbena",
+    "canonicalCompoundId": "verbascoside",
+    "canonicalCompoundName": "verbascoside"
   },
   {
-    "herbSlug": "4-hydroxyderricin",
-    "herbName": "4-hydroxyderricin"
+    "herbSlug": "milk-oats",
+    "herbName": "Milk Oats",
+    "canonicalCompoundId": "avenacosides",
+    "canonicalCompoundName": "avenacosides"
   },
   {
-    "herbSlug": "punicalagins",
-    "herbName": "punicalagins"
+    "herbSlug": "cissus",
+    "herbName": "Cissus",
+    "canonicalCompoundId": "quadrangularin-a",
+    "canonicalCompoundName": "quadrangularin a"
   },
   {
-    "herbSlug": "moringin",
-    "herbName": "moringin"
+    "herbSlug": "ashitaba",
+    "herbName": "Ashitaba",
+    "canonicalCompoundId": "4-hydroxyderricin",
+    "canonicalCompoundName": "4-hydroxyderricin"
   },
   {
-    "herbSlug": "arjunolic-acid",
-    "herbName": "arjunolic acid"
+    "herbSlug": "pomegranate",
+    "herbName": "Pomegranate",
+    "canonicalCompoundId": "punicalagins",
+    "canonicalCompoundName": "punicalagins"
   },
   {
-    "herbSlug": "damnacanthal",
-    "herbName": "damnacanthal"
+    "herbSlug": "moringa",
+    "herbName": "Moringa",
+    "canonicalCompoundId": "moringin",
+    "canonicalCompoundName": "moringin"
   },
   {
-    "herbSlug": "a-type-proanthocyanidins",
-    "herbName": "a-type proanthocyanidins"
+    "herbSlug": "arjuna",
+    "herbName": "Arjuna",
+    "canonicalCompoundId": "arjunolic-acid",
+    "canonicalCompoundName": "arjunolic acid"
   },
   {
-    "herbSlug": "trans-tiliroside",
-    "herbName": "trans-tiliroside"
+    "herbSlug": "noni",
+    "herbName": "Noni",
+    "canonicalCompoundId": "damnacanthal",
+    "canonicalCompoundName": "damnacanthal"
   },
   {
-    "herbSlug": "alpha-pinene",
-    "herbName": "alpha-pinene"
+    "herbSlug": "cranberry",
+    "herbName": "Cranberry",
+    "canonicalCompoundId": "a-type-proanthocyanidins",
+    "canonicalCompoundName": "a-type proanthocyanidins"
   },
   {
-    "herbSlug": "myrtenyl-acetate",
-    "herbName": "myrtenyl acetate"
+    "herbSlug": "rose-hips",
+    "herbName": "Rose Hips",
+    "canonicalCompoundId": "trans-tiliroside",
+    "canonicalCompoundName": "trans-tiliroside"
   },
   {
-    "herbSlug": "ascorbic-acid",
-    "herbName": "ascorbic acid"
+    "herbSlug": "juniper",
+    "herbName": "Juniper",
+    "canonicalCompoundId": "alpha-pinene",
+    "canonicalCompoundName": "alpha-pinene"
   },
   {
-    "herbSlug": "alpha-mangostin",
-    "herbName": "alpha-mangostin"
+    "herbSlug": "myrtle",
+    "herbName": "Myrtle",
+    "canonicalCompoundId": "myrtenyl-acetate",
+    "canonicalCompoundName": "myrtenyl acetate"
   },
   {
-    "herbSlug": "boldine",
-    "herbName": "boldine"
+    "herbSlug": "acerola",
+    "herbName": "Acerola",
+    "canonicalCompoundId": "ascorbic-acid",
+    "canonicalCompoundName": "ascorbic acid"
   },
   {
-    "herbSlug": "pfaffic-acid",
-    "herbName": "pfaffic acid"
+    "herbSlug": "mangosteen",
+    "herbName": "Mangosteen",
+    "canonicalCompoundId": "alpha-mangostin",
+    "canonicalCompoundName": "alpha-mangostin"
   },
   {
-    "herbSlug": "ecdysterone",
-    "herbName": "ecdysterone"
+    "herbSlug": "boldo",
+    "herbName": "Boldo",
+    "canonicalCompoundId": "boldine",
+    "canonicalCompoundName": "boldine"
   },
   {
-    "herbSlug": "jatamansone",
-    "herbName": "jatamansone"
+    "herbSlug": "suma",
+    "herbName": "Suma",
+    "canonicalCompoundId": "pfaffic-acid",
+    "canonicalCompoundName": "pfaffic acid"
   },
   {
-    "herbSlug": "annonacin",
-    "herbName": "annonacin"
+    "herbSlug": "maral-root",
+    "herbName": "Maral Root",
+    "canonicalCompoundId": "ecdysterone",
+    "canonicalCompoundName": "ecdysterone"
   },
   {
-    "herbSlug": "catechins",
-    "herbName": "catechins"
+    "herbSlug": "jatamansi",
+    "herbName": "Jatamansi",
+    "canonicalCompoundId": "jatamansone",
+    "canonicalCompoundName": "jatamansone"
   },
   {
-    "herbSlug": "convolvine",
-    "herbName": "convolvine"
+    "herbSlug": "soursop",
+    "herbName": "Soursop",
+    "canonicalCompoundId": "annonacin",
+    "canonicalCompoundName": "annonacin"
   },
   {
-    "herbSlug": "humulone",
-    "herbName": "humulone"
+    "herbSlug": "ashoka",
+    "herbName": "Ashoka",
+    "canonicalCompoundId": "catechins",
+    "canonicalCompoundName": "catechins"
   },
   {
-    "herbSlug": "citral",
-    "herbName": "citral"
+    "herbSlug": "shankhpushpi",
+    "herbName": "Shankhpushpi",
+    "canonicalCompoundId": "convolvine",
+    "canonicalCompoundName": "convolvine"
   },
   {
-    "herbSlug": "perillaldehyde",
-    "herbName": "perillaldehyde"
+    "herbSlug": "hops",
+    "herbName": "Hops",
+    "canonicalCompoundId": "humulone",
+    "canonicalCompoundName": "humulone"
   },
   {
-    "herbSlug": "d-pinitol",
-    "herbName": "d-pinitol"
+    "herbSlug": "lemongrass",
+    "herbName": "Lemongrass",
+    "canonicalCompoundId": "citral",
+    "canonicalCompoundName": "citral"
   },
   {
-    "herbSlug": "tanshinone-iia",
-    "herbName": "Tanshinone IIA"
+    "herbSlug": "perilla",
+    "herbName": "Perilla",
+    "canonicalCompoundId": "perillaldehyde",
+    "canonicalCompoundName": "perillaldehyde"
   },
   {
-    "herbSlug": "geniposidic-acid",
-    "herbName": "geniposidic acid"
+    "herbSlug": "carob",
+    "herbName": "Carob",
+    "canonicalCompoundId": "d-pinitol",
+    "canonicalCompoundName": "d-pinitol"
   },
   {
-    "herbSlug": "echinacoside",
-    "herbName": "echinacoside"
+    "herbSlug": "danshen",
+    "herbName": "Danshen",
+    "canonicalCompoundId": "tanshinone-iia",
+    "canonicalCompoundName": "Tanshinone IIA"
   },
   {
-    "herbSlug": "jujuboside-a",
-    "herbName": "jujuboside a"
+    "herbSlug": "eucommia",
+    "herbName": "Eucommia",
+    "canonicalCompoundId": "geniposidic-acid",
+    "canonicalCompoundName": "geniposidic acid"
   },
   {
-    "herbSlug": "gallic-acid",
-    "herbName": "gallic acid"
+    "herbSlug": "cistanche",
+    "herbName": "Cistanche",
+    "canonicalCompoundId": "echinacoside",
+    "canonicalCompoundName": "echinacoside"
   },
   {
-    "herbSlug": "tenuifolin",
-    "herbName": "tenuifolin"
+    "herbSlug": "jujube",
+    "herbName": "Jujube",
+    "canonicalCompoundId": "jujuboside-a",
+    "canonicalCompoundName": "jujuboside a"
   },
   {
-    "herbSlug": "gastrodin",
-    "herbName": "gastrodin"
+    "herbSlug": "longan",
+    "herbName": "Longan",
+    "canonicalCompoundId": "gallic-acid",
+    "canonicalCompoundName": "gallic acid"
   },
   {
-    "herbSlug": "paeoniflorin",
-    "herbName": "paeoniflorin"
+    "herbSlug": "polygala",
+    "herbName": "Polygala",
+    "canonicalCompoundId": "tenuifolin",
+    "canonicalCompoundName": "tenuifolin"
   },
   {
-    "herbSlug": "saikosaponin-a",
-    "herbName": "saikosaponin a"
+    "herbSlug": "gastrodia",
+    "herbName": "Gastrodia",
+    "canonicalCompoundId": "gastrodin",
+    "canonicalCompoundName": "gastrodin"
   },
   {
-    "herbSlug": "tangshenoside-i",
-    "herbName": "tangshenoside i"
+    "herbSlug": "white-peony",
+    "herbName": "White Peony",
+    "canonicalCompoundId": "paeoniflorin",
+    "canonicalCompoundName": "paeoniflorin"
   },
   {
-    "herbSlug": "dendrobine",
-    "herbName": "dendrobine"
+    "herbSlug": "bupleurum",
+    "herbName": "Bupleurum",
+    "canonicalCompoundId": "saikosaponin-a",
+    "canonicalCompoundName": "saikosaponin a"
   },
   {
-    "herbSlug": "ophiopogonin-d",
-    "herbName": "ophiopogonin d"
+    "herbSlug": "codonopsis",
+    "herbName": "Codonopsis",
+    "canonicalCompoundId": "tangshenoside-i",
+    "canonicalCompoundName": "tangshenoside i"
   },
   {
-    "herbSlug": "quercitrin",
-    "herbName": "quercitrin"
+    "herbSlug": "dendrobium",
+    "herbName": "Dendrobium",
+    "canonicalCompoundId": "dendrobine",
+    "canonicalCompoundName": "dendrobine"
   },
   {
-    "herbSlug": "tryptanthrin",
-    "herbName": "tryptanthrin"
+    "herbSlug": "ophiopogon",
+    "herbName": "Ophiopogon",
+    "canonicalCompoundId": "ophiopogonin-d",
+    "canonicalCompoundName": "ophiopogonin d"
   },
   {
-    "herbSlug": "matrine",
-    "herbName": "matrine"
+    "herbSlug": "houttuynia",
+    "herbName": "Houttuynia",
+    "canonicalCompoundId": "quercitrin",
+    "canonicalCompoundName": "quercitrin"
   },
   {
-    "herbSlug": "notoginsenoside-r1",
-    "herbName": "notoginsenoside r1"
+    "herbSlug": "isatis",
+    "herbName": "Isatis",
+    "canonicalCompoundId": "tryptanthrin",
+    "canonicalCompoundName": "tryptanthrin"
   },
   {
-    "herbSlug": "mogroside-v",
-    "herbName": "mogroside v"
+    "herbSlug": "sophora-flavescens",
+    "herbName": "Sophora Flavescens",
+    "canonicalCompoundId": "matrine",
+    "canonicalCompoundName": "matrine"
   },
   {
-    "herbSlug": "kudinlactone",
-    "herbName": "kudinlactone"
+    "herbSlug": "notoginseng",
+    "herbName": "Notoginseng",
+    "canonicalCompoundId": "notoginsenoside-r1",
+    "canonicalCompoundName": "notoginsenoside r1"
   },
   {
-    "herbSlug": "atractylenolide-i",
-    "herbName": "atractylenolide i"
+    "herbSlug": "luo-han-guo",
+    "herbName": "Luo Han Guo",
+    "canonicalCompoundId": "mogroside-v",
+    "canonicalCompoundName": "mogroside v"
   },
   {
-    "herbSlug": "gomisin-a",
-    "herbName": "gomisin a"
+    "herbSlug": "kuding-tea",
+    "herbName": "Kuding Tea",
+    "canonicalCompoundId": "kudinlactone",
+    "canonicalCompoundName": "kudinlactone"
   },
   {
-    "herbSlug": "catuabine",
-    "herbName": "catuabine"
+    "herbSlug": "atractylodes",
+    "herbName": "Atractylodes",
+    "canonicalCompoundId": "atractylenolide-i",
+    "canonicalCompoundName": "atractylenolide i"
   },
   {
-    "herbSlug": "beta-sitosterol",
-    "herbName": "beta-sitosterol"
+    "herbSlug": "schisandra-berry",
+    "herbName": "Schisandra Berry",
+    "canonicalCompoundId": "gomisin-a",
+    "canonicalCompoundName": "gomisin a"
   },
   {
-    "herbSlug": "beta-glucans",
-    "herbName": "beta-glucans"
+    "herbSlug": "catuaba",
+    "herbName": "Catuaba",
+    "canonicalCompoundId": "catuabine",
+    "canonicalCompoundName": "catuabine"
   },
   {
-    "herbSlug": "pachymic-acid",
-    "herbName": "pachymic acid"
+    "herbSlug": "muira-puama",
+    "herbName": "Muira Puama",
+    "canonicalCompoundId": "beta-sitosterol",
+    "canonicalCompoundName": "beta-sitosterol"
   },
   {
-    "herbSlug": "catalpol",
-    "herbName": "catalpol"
+    "herbSlug": "maitake-d-fraction",
+    "herbName": "Maitake D-Fraction",
+    "canonicalCompoundId": "beta-glucans",
+    "canonicalCompoundName": "beta-glucans"
   },
   {
-    "herbSlug": "agaric-acid",
-    "herbName": "agaric acid"
+    "herbSlug": "poria",
+    "herbName": "Poria",
+    "canonicalCompoundId": "pachymic-acid",
+    "canonicalCompoundName": "pachymic acid"
   },
   {
-    "herbSlug": "alantolactone",
-    "herbName": "alantolactone"
+    "herbSlug": "rehmannia-prepared",
+    "herbName": "Rehmannia Prepared",
+    "canonicalCompoundId": "catalpol",
+    "canonicalCompoundName": "catalpol"
   },
   {
-    "herbSlug": "angelicin",
-    "herbName": "angelicin"
+    "herbSlug": "agarikon",
+    "herbName": "Agarikon",
+    "canonicalCompoundId": "agaric-acid",
+    "canonicalCompoundName": "agaric acid"
   },
   {
-    "herbSlug": "galangin",
-    "herbName": "galangin"
+    "herbSlug": "elecampane",
+    "herbName": "Elecampane",
+    "canonicalCompoundId": "alantolactone",
+    "canonicalCompoundName": "alantolactone"
   },
   {
-    "herbSlug": "piperine",
-    "herbName": "Piperine"
+    "herbSlug": "angelica-root",
+    "herbName": "Angelica Root",
+    "canonicalCompoundId": "angelicin",
+    "canonicalCompoundName": "angelicin"
   },
   {
-    "herbSlug": "terpinyl-acetate",
-    "herbName": "terpinyl acetate"
+    "herbSlug": "galangal",
+    "herbName": "Galangal",
+    "canonicalCompoundId": "galangin",
+    "canonicalCompoundName": "galangin"
   },
   {
-    "herbSlug": "mucilage",
-    "herbName": "mucilage"
+    "herbSlug": "black-pepper",
+    "herbName": "Black Pepper",
+    "canonicalCompoundId": "piperine",
+    "canonicalCompoundName": "Piperine"
   },
   {
-    "herbSlug": "carvone",
-    "herbName": "carvone"
+    "herbSlug": "cardamom",
+    "herbName": "Cardamom",
+    "canonicalCompoundId": "terpinyl-acetate",
+    "canonicalCompoundName": "terpinyl acetate"
   },
   {
-    "herbSlug": "mahanimbine",
-    "herbName": "mahanimbine"
+    "herbSlug": "holy-basil-seed",
+    "herbName": "Holy Basil Seed",
+    "canonicalCompoundId": "mucilage",
+    "canonicalCompoundName": "mucilage"
   },
   {
-    "herbSlug": "tocopherols",
-    "herbName": "tocopherols"
+    "herbSlug": "psyllium",
+    "herbName": "Psyllium",
+    "canonicalCompoundId": "mucilage",
+    "canonicalCompoundName": "mucilage"
   },
   {
-    "herbSlug": "tartaric-acid",
-    "herbName": "tartaric acid"
+    "herbSlug": "caraway",
+    "herbName": "Caraway",
+    "canonicalCompoundId": "carvone",
+    "canonicalCompoundName": "carvone"
   },
   {
-    "herbSlug": "akba",
-    "herbName": "akba"
+    "herbSlug": "ajwain",
+    "herbName": "Ajwain",
+    "canonicalCompoundId": "thymol",
+    "canonicalCompoundName": "thymol"
   },
   {
-    "herbSlug": "procyanidin-b2",
-    "herbName": "procyanidin b2"
+    "herbSlug": "holy-basil-purple",
+    "herbName": "Holy Basil Purple",
+    "canonicalCompoundId": "eugenol",
+    "canonicalCompoundName": "Eugenol"
   },
   {
-    "herbSlug": "astragaloside-iv",
-    "herbName": "astragaloside iv"
+    "herbSlug": "curry-leaf",
+    "herbName": "Curry Leaf",
+    "canonicalCompoundId": "mahanimbine",
+    "canonicalCompoundName": "mahanimbine"
   },
   {
-    "herbSlug": "salidroside",
-    "herbName": "Salidroside"
+    "herbSlug": "gudmar",
+    "herbName": "Gudmar",
+    "canonicalCompoundId": "gymnemic-acids",
+    "canonicalCompoundName": "gymnemic acids"
   },
   {
-    "herbSlug": "bacoside-a",
-    "herbName": "bacoside a"
+    "herbSlug": "roselle-seed",
+    "herbName": "Roselle Seed",
+    "canonicalCompoundId": "tocopherols",
+    "canonicalCompoundName": "tocopherols"
   },
   {
-    "herbSlug": "chrysin",
-    "herbName": "chrysin"
+    "herbSlug": "tamarind",
+    "herbName": "Tamarind",
+    "canonicalCompoundId": "tartaric-acid",
+    "canonicalCompoundName": "tartaric acid"
   },
   {
-    "herbSlug": "cordycepin",
-    "herbName": "cordycepin"
+    "herbSlug": "boswellia",
+    "herbName": "Boswellia",
+    "canonicalCompoundId": "akba",
+    "canonicalCompoundName": "akba"
   },
   {
-    "herbSlug": "hericenone-c",
-    "herbName": "hericenone c"
+    "herbSlug": "hawthorn",
+    "herbName": "Hawthorn",
+    "canonicalCompoundId": "procyanidin-b2",
+    "canonicalCompoundName": "procyanidin b2"
   },
   {
-    "herbSlug": "psk",
-    "herbName": "psk"
+    "herbSlug": "astragalus",
+    "herbName": "Astragalus",
+    "canonicalCompoundId": "astragaloside-iv",
+    "canonicalCompoundName": "astragaloside iv"
   },
   {
-    "herbSlug": "icariin",
-    "herbName": "Icariin"
+    "herbSlug": "nettle-root",
+    "herbName": "Nettle Root",
+    "canonicalCompoundId": "beta-sitosterol",
+    "canonicalCompoundName": "beta-sitosterol"
   },
   {
-    "herbSlug": "yohimbine",
-    "herbName": "Yohimbine"
+    "herbSlug": "rhodiola",
+    "herbName": "Rhodiola",
+    "canonicalCompoundId": "salidroside",
+    "canonicalCompoundName": "Salidroside"
   },
   {
-    "herbSlug": "eleutherosides",
-    "herbName": "eleutherosides"
+    "herbSlug": "bacopa",
+    "herbName": "Bacopa",
+    "canonicalCompoundId": "bacoside-a",
+    "canonicalCompoundName": "bacoside a"
   },
   {
-    "herbSlug": "bisdemethoxycurcumin",
-    "herbName": "Bisdemethoxycurcumin"
+    "herbSlug": "passionflower",
+    "herbName": "Passionflower",
+    "canonicalCompoundId": "chrysin",
+    "canonicalCompoundName": "chrysin"
   },
   {
-    "herbSlug": "theanine",
-    "herbName": "Theanine"
+    "herbSlug": "cordyceps",
+    "herbName": "Cordyceps",
+    "canonicalCompoundId": "cordycepin",
+    "canonicalCompoundName": "cordycepin"
   },
   {
-    "herbSlug": "hypericin",
-    "herbName": "Hypericin"
+    "herbSlug": "lion-s-mane",
+    "herbName": "Lion's Mane",
+    "canonicalCompoundId": "hericenone-c",
+    "canonicalCompoundName": "hericenone c"
   },
   {
-    "herbSlug": "ginkgolide-b",
-    "herbName": "Ginkgolide B"
+    "herbSlug": "reishi",
+    "herbName": "Reishi",
+    "canonicalCompoundId": "beta-glucans",
+    "canonicalCompoundName": "beta-glucans"
   },
   {
-    "herbSlug": "bilobalide",
-    "herbName": "Bilobalide"
+    "herbSlug": "turkey-tail",
+    "herbName": "Turkey Tail",
+    "canonicalCompoundId": "psk",
+    "canonicalCompoundName": "psk"
   },
   {
-    "herbSlug": "ginsenoside-rg1",
-    "herbName": "Ginsenoside RG1"
+    "herbSlug": "epimedium",
+    "herbName": "Epimedium",
+    "canonicalCompoundId": "icariin",
+    "canonicalCompoundName": "Icariin"
   },
   {
-    "herbSlug": "ginsenoside-rb1",
-    "herbName": "Ginsenoside RB1"
+    "herbSlug": "yohimbe",
+    "herbName": "Yohimbe",
+    "canonicalCompoundId": "yohimbine",
+    "canonicalCompoundName": "Yohimbine"
   },
   {
-    "herbSlug": "withanolide-a",
-    "herbName": "Withanolide A"
+    "herbSlug": "eleuthero",
+    "herbName": "Eleuthero",
+    "canonicalCompoundId": "eleutherosides",
+    "canonicalCompoundName": "eleutherosides"
   },
   {
-    "herbSlug": "harmine",
-    "herbName": "Harmine"
+    "herbSlug": "turmeric",
+    "herbName": "Turmeric",
+    "canonicalCompoundId": "curcumin",
+    "canonicalCompoundName": "curcumin"
   },
   {
-    "herbSlug": "harmaline",
-    "herbName": "Harmaline"
+    "herbSlug": "turmeric",
+    "herbName": "Turmeric",
+    "canonicalCompoundId": "bisdemethoxycurcumin",
+    "canonicalCompoundName": "Bisdemethoxycurcumin"
   },
   {
-    "herbSlug": "salvianolic-acid-b",
-    "herbName": "Salvianolic acid B"
+    "herbSlug": "green-tea",
+    "herbName": "Green Tea",
+    "canonicalCompoundId": "caffeine",
+    "canonicalCompoundName": "Caffeine"
   },
   {
-    "herbSlug": "vasicine",
-    "herbName": "Vasicine"
+    "herbSlug": "green-tea",
+    "herbName": "Green Tea",
+    "canonicalCompoundId": "theanine",
+    "canonicalCompoundName": "Theanine"
   },
   {
-    "herbSlug": "ibogaine",
-    "herbName": "Ibogaine"
+    "herbSlug": "hypericum-perforatum",
+    "herbName": "Hypericum perforatum",
+    "canonicalCompoundId": "hypericin",
+    "canonicalCompoundName": "Hypericin"
   },
   {
-    "herbSlug": "akuammine",
-    "herbName": "Akuammine"
+    "herbSlug": "hypericum-perforatum",
+    "herbName": "Hypericum perforatum",
+    "canonicalCompoundId": "hyperforin",
+    "canonicalCompoundName": "Hyperforin"
   },
   {
-    "herbSlug": "dehydrocorybulbine",
-    "herbName": "Dehydrocorybulbine"
+    "herbSlug": "ginkgo-biloba",
+    "herbName": "Ginkgo Biloba",
+    "canonicalCompoundId": "ginkgolide-b",
+    "canonicalCompoundName": "Ginkgolide B"
   },
   {
-    "herbSlug": "andrographolide",
-    "herbName": "Andrographolide"
+    "herbSlug": "ginkgo-biloba",
+    "herbName": "Ginkgo Biloba",
+    "canonicalCompoundId": "bilobalide",
+    "canonicalCompoundName": "Bilobalide"
   },
   {
-    "herbSlug": "phyllanthin",
-    "herbName": "Phyllanthin"
+    "herbSlug": "panax-ginseng",
+    "herbName": "Panax Ginseng",
+    "canonicalCompoundId": "ginsenoside-rg1",
+    "canonicalCompoundName": "Ginsenoside RG1"
   },
   {
-    "herbSlug": "l-dopa",
-    "herbName": "L-DOPA"
+    "herbSlug": "panax-ginseng",
+    "herbName": "Panax Ginseng",
+    "canonicalCompoundId": "ginsenoside-rb1",
+    "canonicalCompoundName": "Ginsenoside RB1"
   },
   {
-    "herbSlug": "dopamine",
-    "herbName": "Dopamine"
+    "herbSlug": "ashwagandha",
+    "herbName": "Ashwagandha",
+    "canonicalCompoundId": "withanolide-a",
+    "canonicalCompoundName": "Withanolide A"
   },
   {
-    "herbSlug": "resveratrol",
-    "herbName": "Resveratrol"
+    "herbSlug": "peganum-harmala",
+    "herbName": "Peganum harmala",
+    "canonicalCompoundId": "harmine",
+    "canonicalCompoundName": "Harmine"
   },
   {
-    "herbSlug": "quercetin",
-    "herbName": "Quercetin"
+    "herbSlug": "peganum-harmala",
+    "herbName": "Peganum harmala",
+    "canonicalCompoundId": "harmaline",
+    "canonicalCompoundName": "Harmaline"
   },
   {
-    "herbSlug": "baicalin",
-    "herbName": "Baicalin"
+    "herbSlug": "salvia-miltiorrhiza",
+    "herbName": "Salvia miltiorrhiza",
+    "canonicalCompoundId": "tanshinone-iia",
+    "canonicalCompoundName": "Tanshinone IIA"
   },
   {
-    "herbSlug": "baicalein",
-    "herbName": "Baicalein"
+    "herbSlug": "salvia-miltiorrhiza",
+    "herbName": "Salvia miltiorrhiza",
+    "canonicalCompoundId": "salvianolic-acid-b",
+    "canonicalCompoundName": "Salvianolic acid B"
   },
   {
-    "herbSlug": "carnosic-acid",
-    "herbName": "Carnosic acid"
+    "herbSlug": "justicia-adhatoda",
+    "herbName": "Justicia adhatoda",
+    "canonicalCompoundId": "vasicine",
+    "canonicalCompoundName": "Vasicine"
   },
   {
-    "herbSlug": "carnosol",
-    "herbName": "Carnosol"
+    "herbSlug": "tabernanthe-iboga",
+    "herbName": "Tabernanthe iboga",
+    "canonicalCompoundId": "ibogaine",
+    "canonicalCompoundName": "Ibogaine"
   },
   {
-    "herbSlug": "6-shogaol",
-    "herbName": "6-Shogaol"
+    "herbSlug": "picralima-nitida",
+    "herbName": "Picralima nitida",
+    "canonicalCompoundId": "akuammine",
+    "canonicalCompoundName": "Akuammine"
   },
   {
-    "herbSlug": "ginsenoside-rg3",
-    "herbName": "Ginsenoside Rg3"
+    "herbSlug": "corydalis-yanhusuo",
+    "herbName": "Corydalis yanhusuo",
+    "canonicalCompoundId": "dehydrocorybulbine",
+    "canonicalCompoundName": "Dehydrocorybulbine"
   },
   {
-    "herbSlug": "kaempferol",
-    "herbName": "Kaempferol"
+    "herbSlug": "andrographis-paniculata",
+    "herbName": "Andrographis paniculata",
+    "canonicalCompoundId": "andrographolide",
+    "canonicalCompoundName": "Andrographolide"
   },
   {
-    "herbSlug": "isorhamnetin",
-    "herbName": "Isorhamnetin"
+    "herbSlug": "phyllanthus-amarus",
+    "herbName": "Phyllanthus amarus",
+    "canonicalCompoundId": "phyllanthin",
+    "canonicalCompoundName": "Phyllanthin"
   },
   {
-    "herbSlug": "ginsenoside-re",
-    "herbName": "Ginsenoside Re"
+    "herbSlug": "mucuna-pruriens",
+    "herbName": "Mucuna pruriens",
+    "canonicalCompoundId": "l-dopa",
+    "canonicalCompoundName": "L-DOPA"
   },
   {
-    "herbSlug": "ginsenoside-rd",
-    "herbName": "Ginsenoside Rd"
+    "herbSlug": "mucuna-pruriens",
+    "herbName": "Mucuna pruriens",
+    "canonicalCompoundId": "dopamine",
+    "canonicalCompoundName": "Dopamine"
   },
   {
-    "herbSlug": "ginsenoside-rf",
-    "herbName": "Ginsenoside Rf"
+    "herbSlug": "pausinystalia-yohimbe",
+    "herbName": "Pausinystalia yohimbe",
+    "canonicalCompoundId": "yohimbine",
+    "canonicalCompoundName": "Yohimbine"
   },
   {
-    "herbSlug": "wogonin",
-    "herbName": "wogonin"
+    "herbSlug": "polygonum-cuspidatum",
+    "herbName": "Polygonum cuspidatum",
+    "canonicalCompoundId": "resveratrol",
+    "canonicalCompoundName": "Resveratrol"
   },
   {
-    "herbSlug": "wogonoside",
-    "herbName": "Wogonoside"
+    "herbSlug": "green-tea",
+    "herbName": "Green Tea",
+    "canonicalCompoundId": "quercetin",
+    "canonicalCompoundName": "Quercetin"
   },
   {
-    "herbSlug": "alpha-bisabolol",
-    "herbName": "alpha-bisabolol"
+    "herbSlug": "ginkgo-biloba",
+    "herbName": "Ginkgo Biloba",
+    "canonicalCompoundId": "quercetin",
+    "canonicalCompoundName": "Quercetin"
   },
   {
-    "herbSlug": "chamazulene",
-    "herbName": "chamazulene"
+    "herbSlug": "hypericum-perforatum",
+    "herbName": "Hypericum perforatum",
+    "canonicalCompoundId": "quercetin",
+    "canonicalCompoundName": "Quercetin"
   },
   {
-    "herbSlug": "epimedin-a",
-    "herbName": "Epimedin A"
+    "herbSlug": "petroselinum-crispum",
+    "herbName": "Petroselinum crispum",
+    "canonicalCompoundId": "apigenin",
+    "canonicalCompoundName": "Apigenin"
   },
   {
-    "herbSlug": "epimedin-b",
-    "herbName": "Epimedin B"
+    "herbSlug": "vitis-vinifera",
+    "herbName": "Vitis vinifera",
+    "canonicalCompoundId": "resveratrol",
+    "canonicalCompoundName": "Resveratrol"
   },
   {
-    "herbSlug": "epimedin-c",
-    "herbName": "Epimedin C"
+    "herbSlug": "ilex-paraguariensis",
+    "herbName": "Ilex paraguariensis",
+    "canonicalCompoundId": "caffeine",
+    "canonicalCompoundName": "Caffeine"
   },
   {
-    "herbSlug": "egcg",
-    "herbName": "EGCG"
+    "herbSlug": "rosmarinus-officinalis",
+    "herbName": "Rosmarinus officinalis",
+    "canonicalCompoundId": "rosmarinic-acid",
+    "canonicalCompoundName": "Rosmarinic acid"
   },
   {
-    "herbSlug": "ecg",
-    "herbName": "ECG"
+    "herbSlug": "chinese-skullcap",
+    "herbName": "Chinese Skullcap",
+    "canonicalCompoundId": "baicalin",
+    "canonicalCompoundName": "Baicalin"
   },
   {
-    "herbSlug": "catechin",
-    "herbName": "Catechin"
+    "herbSlug": "zingiber-officinale",
+    "herbName": "Zingiber officinale",
+    "canonicalCompoundId": "6-gingerol",
+    "canonicalCompoundName": "6-Gingerol"
   },
   {
-    "herbSlug": "chavicine",
-    "herbName": "Chavicine"
+    "herbSlug": "chinese-skullcap",
+    "herbName": "Chinese Skullcap",
+    "canonicalCompoundId": "baicalein",
+    "canonicalCompoundName": "Baicalein"
   },
   {
-    "herbSlug": "apomorphine",
-    "herbName": "apomorphine"
+    "herbSlug": "rosmarinus-officinalis",
+    "herbName": "Rosmarinus officinalis",
+    "canonicalCompoundId": "carnosic-acid",
+    "canonicalCompoundName": "Carnosic acid"
   },
   {
-    "herbSlug": "cimicifugoside",
-    "herbName": "Cimicifugoside"
+    "herbSlug": "rosmarinus-officinalis",
+    "herbName": "Rosmarinus officinalis",
+    "canonicalCompoundId": "carnosol",
+    "canonicalCompoundName": "Carnosol"
   },
   {
-    "herbSlug": "isoferulic-acid",
-    "herbName": "Isoferulic acid"
+    "herbSlug": "zingiber-officinale",
+    "herbName": "Zingiber officinale",
+    "canonicalCompoundId": "6-shogaol",
+    "canonicalCompoundName": "6-Shogaol"
   },
   {
-    "herbSlug": "arjunic-acid",
-    "herbName": "Arjunic acid"
+    "herbSlug": "panax-ginseng",
+    "herbName": "Panax Ginseng",
+    "canonicalCompoundId": "ginsenoside-rg3",
+    "canonicalCompoundName": "Ginsenoside Rg3"
   },
   {
-    "herbSlug": "ursolic-acid",
-    "herbName": "Ursolic acid"
+    "herbSlug": "ginkgo-biloba",
+    "herbName": "Ginkgo Biloba",
+    "canonicalCompoundId": "kaempferol",
+    "canonicalCompoundName": "Kaempferol"
   },
   {
-    "herbSlug": "rosarin",
-    "herbName": "Rosarin"
+    "herbSlug": "ginkgo-biloba",
+    "herbName": "Ginkgo Biloba",
+    "canonicalCompoundId": "isorhamnetin",
+    "canonicalCompoundName": "Isorhamnetin"
   },
   {
-    "herbSlug": "rosin",
-    "herbName": "Rosin"
+    "herbSlug": "panax-ginseng",
+    "herbName": "Panax Ginseng",
+    "canonicalCompoundId": "ginsenoside-re",
+    "canonicalCompoundName": "Ginsenoside Re"
   },
   {
-    "herbSlug": "tyrosol",
-    "herbName": "Tyrosol"
+    "herbSlug": "panax-ginseng",
+    "herbName": "Panax Ginseng",
+    "canonicalCompoundId": "ginsenoside-rd",
+    "canonicalCompoundName": "Ginsenoside Rd"
   },
   {
-    "herbSlug": "arjungenin",
-    "herbName": "Arjungenin"
+    "herbSlug": "panax-ginseng",
+    "herbName": "Panax Ginseng",
+    "canonicalCompoundId": "ginsenoside-rf",
+    "canonicalCompoundName": "Ginsenoside Rf"
   },
   {
-    "herbSlug": "arjunetin",
-    "herbName": "Arjunetin"
+    "herbSlug": "chinese-skullcap",
+    "herbName": "Chinese Skullcap",
+    "canonicalCompoundId": "wogonin",
+    "canonicalCompoundName": "wogonin"
   },
   {
-    "herbSlug": "23-epi-26-deoxyactein",
-    "herbName": "23-epi-26-deoxyactein"
+    "herbSlug": "chinese-skullcap",
+    "herbName": "Chinese Skullcap",
+    "canonicalCompoundId": "wogonoside",
+    "canonicalCompoundName": "Wogonoside"
   },
   {
-    "herbSlug": "fukinolic-acid",
-    "herbName": "Fukinolic acid"
+    "herbSlug": "chamomile",
+    "herbName": "Chamomile",
+    "canonicalCompoundId": "alpha-bisabolol",
+    "canonicalCompoundName": "alpha-bisabolol"
   },
   {
-    "herbSlug": "withanoside-iv",
-    "herbName": "Withanoside IV"
+    "herbSlug": "chamomile",
+    "herbName": "Chamomile",
+    "canonicalCompoundId": "chamazulene",
+    "canonicalCompoundName": "chamazulene"
   },
   {
-    "herbSlug": "withanoside-v",
-    "herbName": "Withanoside V"
+    "herbSlug": "epimedium",
+    "herbName": "Epimedium",
+    "canonicalCompoundId": "epimedin-a",
+    "canonicalCompoundName": "Epimedin A"
   },
   {
-    "herbSlug": "icaritin",
-    "herbName": "Icaritin"
+    "herbSlug": "epimedium",
+    "herbName": "Epimedium",
+    "canonicalCompoundId": "epimedin-b",
+    "canonicalCompoundName": "Epimedin B"
   },
   {
-    "herbSlug": "desmethylicaritin",
-    "herbName": "Desmethylicaritin"
+    "herbSlug": "epimedium",
+    "herbName": "Epimedium",
+    "canonicalCompoundId": "epimedin-c",
+    "canonicalCompoundName": "Epimedin C"
   },
   {
-    "herbSlug": "isopetasin",
-    "herbName": "isopetasin"
+    "herbSlug": "green-tea",
+    "herbName": "Green Tea",
+    "canonicalCompoundId": "egcg",
+    "canonicalCompoundName": "EGCG"
   },
   {
-    "herbSlug": "berberine",
-    "herbName": "berberine"
+    "herbSlug": "green-tea",
+    "herbName": "Green Tea",
+    "canonicalCompoundId": "ecg",
+    "canonicalCompoundName": "ECG"
   },
   {
-    "herbSlug": "palmatine",
-    "herbName": "palmatine"
+    "herbSlug": "green-tea",
+    "herbName": "Green Tea",
+    "canonicalCompoundId": "catechin",
+    "canonicalCompoundName": "Catechin"
   },
   {
-    "herbSlug": "1-8-cineole",
-    "herbName": "1,8-cineole"
+    "herbSlug": "black-pepper",
+    "herbName": "Black Pepper",
+    "canonicalCompoundId": "chavicine",
+    "canonicalCompoundName": "Chavicine"
   },
   {
-    "herbSlug": "limonene",
-    "herbName": "limonene"
+    "herbSlug": "blue-lotus",
+    "herbName": "Blue Lotus",
+    "canonicalCompoundId": "nuciferine",
+    "canonicalCompoundName": "nuciferine"
   },
   {
-    "herbSlug": "acetyl-11-keto-beta-boswellic-acid",
-    "herbName": "acetyl-11-keto-beta-boswellic acid"
+    "herbSlug": "blue-lotus",
+    "herbName": "Blue Lotus",
+    "canonicalCompoundId": "apomorphine",
+    "canonicalCompoundName": "apomorphine"
   },
   {
-    "herbSlug": "ginkgetin",
-    "herbName": "ginkgetin"
+    "herbSlug": "black-cohosh",
+    "herbName": "Black Cohosh",
+    "canonicalCompoundId": "cimicifugoside",
+    "canonicalCompoundName": "Cimicifugoside"
   },
   {
-    "herbSlug": "capsanthin",
-    "herbName": "capsanthin"
+    "herbSlug": "black-cohosh",
+    "herbName": "Black Cohosh",
+    "canonicalCompoundId": "isoferulic-acid",
+    "canonicalCompoundName": "Isoferulic acid"
   },
   {
-    "herbSlug": "capsorubin",
-    "herbName": "capsorubin"
+    "herbSlug": "arjuna",
+    "herbName": "Arjuna",
+    "canonicalCompoundId": "arjunic-acid",
+    "canonicalCompoundName": "Arjunic acid"
   },
   {
-    "herbSlug": "dihydrocapsaicin",
-    "herbName": "dihydrocapsaicin"
+    "herbSlug": "ajwain",
+    "herbName": "Ajwain",
+    "canonicalCompoundId": "carvacrol",
+    "canonicalCompoundName": "carvacrol"
   },
   {
-    "herbSlug": "biochanin-a",
-    "herbName": "biochanin A"
+    "herbSlug": "holy-basil",
+    "herbName": "Holy Basil",
+    "canonicalCompoundId": "ursolic-acid",
+    "canonicalCompoundName": "Ursolic acid"
   },
   {
-    "herbSlug": "calycosin",
-    "herbName": "calycosin"
+    "herbSlug": "holy-basil",
+    "herbName": "Holy Basil",
+    "canonicalCompoundId": "rosmarinic-acid",
+    "canonicalCompoundName": "Rosmarinic acid"
   },
   {
-    "herbSlug": "coumestrol",
-    "herbName": "coumestrol"
+    "herbSlug": "rhodiola",
+    "herbName": "Rhodiola",
+    "canonicalCompoundId": "rosavin",
+    "canonicalCompoundName": "Rosavin"
   },
   {
-    "herbSlug": "daidzin",
-    "herbName": "daidzin"
+    "herbSlug": "rhodiola",
+    "herbName": "Rhodiola",
+    "canonicalCompoundId": "rosarin",
+    "canonicalCompoundName": "Rosarin"
   },
   {
-    "herbSlug": "ononin",
-    "herbName": "ononin"
+    "herbSlug": "rhodiola",
+    "herbName": "Rhodiola",
+    "canonicalCompoundId": "rosin",
+    "canonicalCompoundName": "Rosin"
   },
   {
-    "herbSlug": "capsaicin",
-    "herbName": "capsaicin"
+    "herbSlug": "rhodiola",
+    "herbName": "Rhodiola",
+    "canonicalCompoundId": "tyrosol",
+    "canonicalCompoundName": "Tyrosol"
   },
   {
-    "herbSlug": "sulforaphane",
-    "herbName": "sulforaphane"
+    "herbSlug": "arjuna",
+    "herbName": "Arjuna",
+    "canonicalCompoundId": "arjungenin",
+    "canonicalCompoundName": "Arjungenin"
   },
   {
-    "herbSlug": "thymoquinone",
-    "herbName": "Thymoquinone"
+    "herbSlug": "arjuna",
+    "herbName": "Arjuna",
+    "canonicalCompoundId": "arjunetin",
+    "canonicalCompoundName": "Arjunetin"
   },
   {
-    "herbSlug": "oleuropein",
-    "herbName": "Oleuropein"
+    "herbSlug": "black-cohosh",
+    "herbName": "Black Cohosh",
+    "canonicalCompoundId": "actein",
+    "canonicalCompoundName": "Actein"
   },
   {
-    "herbSlug": "hydroxytyrosol",
-    "herbName": "Hydroxytyrosol"
+    "herbSlug": "black-cohosh",
+    "herbName": "Black Cohosh",
+    "canonicalCompoundId": "23-epi-26-deoxyactein",
+    "canonicalCompoundName": "23-epi-26-deoxyactein"
   },
   {
-    "herbSlug": "crocin",
-    "herbName": "Crocin"
+    "herbSlug": "ashwagandha",
+    "herbName": "Ashwagandha",
+    "canonicalCompoundId": "withanoside-iv",
+    "canonicalCompoundName": "Withanoside IV"
   },
   {
-    "herbSlug": "crocetin",
-    "herbName": "Crocetin"
+    "herbSlug": "ashwagandha",
+    "herbName": "Ashwagandha",
+    "canonicalCompoundId": "withanoside-v",
+    "canonicalCompoundName": "Withanoside V"
   },
   {
-    "herbSlug": "silibinin",
-    "herbName": "Silibinin"
+    "herbSlug": "epimedium",
+    "herbName": "Epimedium",
+    "canonicalCompoundId": "icaritin",
+    "canonicalCompoundName": "Icaritin"
   },
   {
-    "herbSlug": "glycyrrhizin",
-    "herbName": "Glycyrrhizin"
+    "herbSlug": "epimedium",
+    "herbName": "Epimedium",
+    "canonicalCompoundId": "desmethylicaritin",
+    "canonicalCompoundName": "Desmethylicaritin"
   },
   {
-    "herbSlug": "emodin",
-    "herbName": "Emodin"
+    "herbSlug": "butterbur",
+    "herbName": "Butterbur",
+    "canonicalCompoundId": "isopetasin",
+    "canonicalCompoundName": "isopetasin"
   },
   {
-    "herbSlug": "rhein",
-    "herbName": "Rhein"
+    "herbSlug": "anise-hyssop",
+    "herbName": "Anise Hyssop",
+    "canonicalCompoundId": "anethole",
+    "canonicalCompoundName": "anethole"
   },
   {
-    "herbSlug": "schisandrin",
-    "herbName": "Schisandrin"
+    "herbSlug": "sage",
+    "herbName": "Sage",
+    "canonicalCompoundId": "thujone",
+    "canonicalCompoundName": "thujone"
   },
   {
-    "herbSlug": "celastrol",
-    "herbName": "Celastrol"
+    "herbSlug": "echinacea-purpurea",
+    "herbName": "Echinacea Purpurea",
+    "canonicalCompoundId": "cynarin",
+    "canonicalCompoundName": "cynarin"
   },
   {
-    "herbSlug": "linalool",
-    "herbName": "Linalool"
+    "herbSlug": "eucalyptus",
+    "herbName": "Eucalyptus",
+    "canonicalCompoundId": "eucalyptol",
+    "canonicalCompoundName": "eucalyptol"
   },
   {
-    "herbSlug": "hesperidin",
-    "herbName": "Hesperidin"
+    "herbSlug": "milk-oats",
+    "herbName": "Milk Oats",
+    "canonicalCompoundId": "avenanthramides",
+    "canonicalCompoundName": "avenanthramides"
   },
   {
-    "herbSlug": "jatrorrhizine",
-    "herbName": "Jatrorrhizine"
+    "herbSlug": "kudzu",
+    "herbName": "Kudzu",
+    "canonicalCompoundId": "puerarin",
+    "canonicalCompoundName": "puerarin"
   },
   {
-    "herbSlug": "columbamine",
-    "herbName": "Columbamine"
+    "herbSlug": "feverfew",
+    "herbName": "Feverfew",
+    "canonicalCompoundId": "parthenolide",
+    "canonicalCompoundName": "parthenolide"
   },
   {
-    "herbSlug": "neoandrographolide",
-    "herbName": "Neoandrographolide"
+    "herbSlug": "eucalyptus",
+    "herbName": "Eucalyptus",
+    "canonicalCompoundId": "alpha-pinene",
+    "canonicalCompoundName": "alpha-pinene"
   },
   {
-    "herbSlug": "gymnemic-acid",
-    "herbName": "Gymnemic acid"
+    "herbSlug": "echinacea-purpurea",
+    "herbName": "Echinacea Purpurea",
+    "canonicalCompoundId": "echinacoside",
+    "canonicalCompoundName": "echinacoside"
   },
   {
-    "herbSlug": "charantin",
-    "herbName": "Charantin"
+    "herbSlug": "green-tea",
+    "herbName": "Green Tea",
+    "canonicalCompoundId": "catechins",
+    "canonicalCompoundName": "catechins"
   },
   {
-    "herbSlug": "momordicoside-k",
-    "herbName": "Momordicoside K"
+    "herbSlug": "cacao",
+    "herbName": "Cacao",
+    "canonicalCompoundId": "catechins",
+    "canonicalCompoundName": "catechins"
   },
   {
-    "herbSlug": "diosgenin",
-    "herbName": "Diosgenin"
+    "herbSlug": "st-johns-wort",
+    "herbName": "St Johns Wort",
+    "canonicalCompoundId": "hypericin",
+    "canonicalCompoundName": "Hypericin"
   },
   {
-    "herbSlug": "protodioscin",
-    "herbName": "Protodioscin"
+    "herbSlug": "danshen",
+    "herbName": "Danshen",
+    "canonicalCompoundId": "salvianolic-acid-b",
+    "canonicalCompoundName": "Salvianolic acid B"
   },
   {
-    "herbSlug": "oleanolic-acid",
-    "herbName": "Oleanolic acid"
+    "herbSlug": "corydalis",
+    "herbName": "Corydalis",
+    "canonicalCompoundId": "dehydrocorybulbine",
+    "canonicalCompoundName": "Dehydrocorybulbine"
   },
   {
-    "herbSlug": "asiaticoside",
-    "herbName": "Asiaticoside"
+    "herbSlug": "mucuna",
+    "herbName": "Mucuna",
+    "canonicalCompoundId": "l-dopa",
+    "canonicalCompoundName": "L-DOPA"
   },
   {
-    "herbSlug": "madecassoside",
-    "herbName": "Madecassoside"
+    "herbSlug": "skullcap",
+    "herbName": "Skullcap",
+    "canonicalCompoundId": "baicalin",
+    "canonicalCompoundName": "Baicalin"
   },
   {
-    "herbSlug": "piperlongumine",
-    "herbName": "Piperlongumine"
+    "herbSlug": "st-johns-wort",
+    "herbName": "St Johns Wort",
+    "canonicalCompoundId": "kaempferol",
+    "canonicalCompoundName": "Kaempferol"
   },
   {
-    "herbSlug": "myricetin",
-    "herbName": "Myricetin"
+    "herbSlug": "catuba",
+    "herbName": "Catuba",
+    "canonicalCompoundId": "catuabine",
+    "canonicalCompoundName": "catuabine"
   },
   {
-    "herbSlug": "luteolin",
-    "herbName": "Luteolin"
+    "herbSlug": "rhodiola-rosea",
+    "herbName": "Rhodiola Rosea",
+    "canonicalCompoundId": "salidroside",
+    "canonicalCompoundName": "Salidroside"
   },
   {
-    "herbSlug": "naringenin",
-    "herbName": "Naringenin"
+    "herbSlug": "rhodiola-rosea",
+    "herbName": "Rhodiola Rosea",
+    "canonicalCompoundId": "rosarin",
+    "canonicalCompoundName": "Rosarin"
   },
   {
-    "herbSlug": "naringin",
-    "herbName": "Naringin"
+    "herbSlug": "rhodiola-rosea",
+    "herbName": "Rhodiola Rosea",
+    "canonicalCompoundId": "rosin",
+    "canonicalCompoundName": "Rosin"
   },
   {
-    "herbSlug": "rutin",
-    "herbName": "Rutin"
+    "herbSlug": "rhodiola-rosea",
+    "herbName": "Rhodiola Rosea",
+    "canonicalCompoundId": "tyrosol",
+    "canonicalCompoundName": "Tyrosol"
   },
   {
-    "herbSlug": "epicatechin",
-    "herbName": "Epicatechin"
+    "herbSlug": "berberis",
+    "herbName": "Berberis",
+    "canonicalCompoundId": "berberine",
+    "canonicalCompoundName": "berberine"
   },
   {
-    "herbSlug": "epigallocatechin-gallate-egcg",
-    "herbName": "Epigallocatechin gallate (EGCG)"
+    "herbSlug": "coptis",
+    "herbName": "Coptis",
+    "canonicalCompoundId": "berberine",
+    "canonicalCompoundName": "berberine"
   },
   {
-    "herbSlug": "theaflavin",
-    "herbName": "Theaflavin"
+    "herbSlug": "goldenseal",
+    "herbName": "Goldenseal",
+    "canonicalCompoundId": "berberine",
+    "canonicalCompoundName": "berberine"
   },
   {
-    "herbSlug": "thearubigin",
-    "herbName": "Thearubigin"
+    "herbSlug": "phellodendron",
+    "herbName": "Phellodendron",
+    "canonicalCompoundId": "berberine",
+    "canonicalCompoundName": "berberine"
   },
   {
-    "herbSlug": "pterostilbene",
-    "herbName": "Pterostilbene"
+    "herbSlug": "coptis",
+    "herbName": "Coptis",
+    "canonicalCompoundId": "palmatine",
+    "canonicalCompoundName": "palmatine"
   },
   {
-    "herbSlug": "daidzein",
-    "herbName": "Daidzein"
+    "herbSlug": "phellodendron",
+    "herbName": "Phellodendron",
+    "canonicalCompoundId": "palmatine",
+    "canonicalCompoundName": "palmatine"
   },
   {
-    "herbSlug": "formononetin",
-    "herbName": "Formononetin"
+    "herbSlug": "saw-palmetto",
+    "herbName": "Saw Palmetto",
+    "canonicalCompoundId": "beta-sitosterol",
+    "canonicalCompoundName": "beta-sitosterol"
   },
   {
-    "herbSlug": "ellagic-acid",
-    "herbName": "Ellagic acid"
+    "herbSlug": "coffee-cherry",
+    "herbName": "Coffee Cherry",
+    "canonicalCompoundId": "caffeine",
+    "canonicalCompoundName": "Caffeine"
   },
   {
-    "herbSlug": "ferulic-acid",
-    "herbName": "Ferulic acid"
+    "herbSlug": "guayusa",
+    "herbName": "Guayusa",
+    "canonicalCompoundId": "caffeine",
+    "canonicalCompoundName": "Caffeine"
   },
   {
-    "herbSlug": "chlorogenic-acid",
-    "herbName": "Chlorogenic acid"
+    "herbSlug": "yerba-mate",
+    "herbName": "Yerba Mate",
+    "canonicalCompoundId": "caffeine",
+    "canonicalCompoundName": "Caffeine"
   },
   {
-    "herbSlug": "caffeic-acid",
-    "herbName": "Caffeic acid"
+    "herbSlug": "oregano",
+    "herbName": "Oregano",
+    "canonicalCompoundId": "carvacrol",
+    "canonicalCompoundName": "carvacrol"
   },
   {
-    "herbSlug": "osthole",
-    "herbName": "Osthole"
+    "herbSlug": "calamus",
+    "herbName": "Calamus",
+    "canonicalCompoundId": "eugenol",
+    "canonicalCompoundName": "Eugenol"
   },
   {
-    "herbSlug": "imperatorin",
-    "herbName": "Imperatorin"
+    "herbSlug": "cardamom",
+    "herbName": "Cardamom",
+    "canonicalCompoundId": "1-8-cineole",
+    "canonicalCompoundName": "1,8-cineole"
   },
   {
-    "herbSlug": "isoimperatorin",
-    "herbName": "Isoimperatorin"
+    "herbSlug": "eucalyptus",
+    "herbName": "Eucalyptus",
+    "canonicalCompoundId": "1-8-cineole",
+    "canonicalCompoundName": "1,8-cineole"
   },
   {
-    "herbSlug": "psoralen",
-    "herbName": "Psoralen"
+    "herbSlug": "peppermint",
+    "herbName": "Peppermint",
+    "canonicalCompoundId": "eucalyptol",
+    "canonicalCompoundName": "eucalyptol"
   },
   {
-    "herbSlug": "bergapten",
-    "herbName": "Bergapten"
+    "herbSlug": "peppermint",
+    "herbName": "Peppermint",
+    "canonicalCompoundId": "limonene",
+    "canonicalCompoundName": "limonene"
   },
   {
-    "herbSlug": "scopoletin",
-    "herbName": "Scopoletin"
+    "herbSlug": "boswellia",
+    "herbName": "Boswellia",
+    "canonicalCompoundId": "acetyl-11-keto-beta-boswellic-acid",
+    "canonicalCompoundName": "acetyl-11-keto-beta-boswellic acid"
   },
   {
-    "herbSlug": "esculetin",
-    "herbName": "Esculetin"
+    "herbSlug": "ginkgo-biloba",
+    "herbName": "Ginkgo Biloba",
+    "canonicalCompoundId": "ginkgetin",
+    "canonicalCompoundName": "ginkgetin"
   },
   {
-    "herbSlug": "fraxetin",
-    "herbName": "Fraxetin"
+    "herbSlug": "cayenne",
+    "herbName": "Cayenne",
+    "canonicalCompoundId": "capsanthin",
+    "canonicalCompoundName": "capsanthin"
   },
   {
-    "herbSlug": "umbelliferone",
-    "herbName": "Umbelliferone"
+    "herbSlug": "cayenne",
+    "herbName": "Cayenne",
+    "canonicalCompoundId": "capsorubin",
+    "canonicalCompoundName": "capsorubin"
   },
   {
-    "herbSlug": "daphnetin",
-    "herbName": "Daphnetin"
+    "herbSlug": "cayenne",
+    "herbName": "Cayenne",
+    "canonicalCompoundId": "dihydrocapsaicin",
+    "canonicalCompoundName": "dihydrocapsaicin"
   },
   {
-    "herbSlug": "oxymatrine",
-    "herbName": "Oxymatrine"
+    "herbSlug": "red-clover",
+    "herbName": "Red Clover",
+    "canonicalCompoundId": "biochanin-a",
+    "canonicalCompoundName": "biochanin A"
   },
   {
-    "herbSlug": "tetrandrine",
-    "herbName": "Tetrandrine"
+    "herbSlug": "kudzu",
+    "herbName": "Kudzu",
+    "canonicalCompoundId": "biochanin-a",
+    "canonicalCompoundName": "biochanin A"
   },
   {
-    "herbSlug": "cepharanthine",
-    "herbName": "Cepharanthine"
+    "herbSlug": "astragalus",
+    "herbName": "Astragalus",
+    "canonicalCompoundId": "calycosin",
+    "canonicalCompoundName": "calycosin"
   },
   {
-    "herbSlug": "magnoflorine",
-    "herbName": "Magnoflorine"
+    "herbSlug": "red-clover",
+    "herbName": "Red Clover",
+    "canonicalCompoundId": "calycosin",
+    "canonicalCompoundName": "calycosin"
   },
   {
-    "herbSlug": "ligustilide",
-    "herbName": "Ligustilide"
+    "herbSlug": "red-clover",
+    "herbName": "Red Clover",
+    "canonicalCompoundId": "coumestrol",
+    "canonicalCompoundName": "coumestrol"
   },
   {
-    "herbSlug": "senkyunolide-a",
-    "herbName": "Senkyunolide A"
+    "herbSlug": "pueraria-mirifica",
+    "herbName": "Pueraria Mirifica",
+    "canonicalCompoundId": "coumestrol",
+    "canonicalCompoundName": "coumestrol"
   },
   {
-    "herbSlug": "butylidenephthalide",
-    "herbName": "Butylidenephthalide"
+    "herbSlug": "kudzu",
+    "herbName": "Kudzu",
+    "canonicalCompoundId": "daidzin",
+    "canonicalCompoundName": "daidzin"
   },
   {
-    "herbSlug": "xanthotoxin",
-    "herbName": "Xanthotoxin"
+    "herbSlug": "pueraria-mirifica",
+    "herbName": "Pueraria Mirifica",
+    "canonicalCompoundId": "daidzin",
+    "canonicalCompoundName": "daidzin"
   },
   {
-    "herbSlug": "boswellic-acid",
-    "herbName": "Boswellic acid"
+    "herbSlug": "red-clover",
+    "herbName": "Red Clover",
+    "canonicalCompoundId": "ononin",
+    "canonicalCompoundName": "ononin"
   },
   {
-    "herbSlug": "acetyl-beta-boswellic-acid",
-    "herbName": "Acetyl-beta-boswellic acid"
+    "herbSlug": "kudzu",
+    "herbName": "Kudzu",
+    "canonicalCompoundId": "ononin",
+    "canonicalCompoundName": "ononin"
   },
   {
-    "herbSlug": "11-keto-beta-boswellic-acid",
-    "herbName": "11-keto-beta-boswellic acid"
+    "herbSlug": "capsicum-frutescens",
+    "herbName": "Capsicum frutescens",
+    "canonicalCompoundId": "dihydrocapsaicin",
+    "canonicalCompoundName": "dihydrocapsaicin"
   },
   {
-    "herbSlug": "valerenol",
-    "herbName": "Valerenol"
+    "herbSlug": "capsicum-frutescens",
+    "herbName": "Capsicum frutescens",
+    "canonicalCompoundId": "capsanthin",
+    "canonicalCompoundName": "capsanthin"
   },
   {
-    "herbSlug": "kavalactones",
-    "herbName": "Kavalactones"
+    "herbSlug": "capsicum-frutescens",
+    "herbName": "Capsicum frutescens",
+    "canonicalCompoundId": "capsorubin",
+    "canonicalCompoundName": "capsorubin"
   },
   {
-    "herbSlug": "yangonin",
-    "herbName": "Yangonin"
+    "herbSlug": "capsicum-frutescens",
+    "herbName": "Capsicum frutescens",
+    "canonicalCompoundId": "capsaicin",
+    "canonicalCompoundName": "capsaicin"
   },
   {
-    "herbSlug": "methysticin",
-    "herbName": "Methysticin"
+    "herbSlug": "american-ginseng",
+    "herbName": "American Ginseng",
+    "canonicalCompoundId": "ginsenoside-rb1",
+    "canonicalCompoundName": "Ginsenoside RB1"
   },
   {
-    "herbSlug": "valepotriates",
-    "herbName": "Valepotriates"
+    "herbSlug": "boswellia-carterii",
+    "herbName": "Boswellia carterii",
+    "canonicalCompoundId": "acetyl-11-keto-beta-boswellic-acid",
+    "canonicalCompoundName": "acetyl-11-keto-beta-boswellic acid"
   },
   {
-    "herbSlug": "aucubin",
-    "herbName": "Aucubin"
+    "herbSlug": "selaginella-tamariscina",
+    "herbName": "Selaginella tamariscina",
+    "canonicalCompoundId": "ginkgetin",
+    "canonicalCompoundName": "ginkgetin"
   },
   {
-    "herbSlug": "harpagoside",
-    "herbName": "Harpagoside"
+    "herbSlug": "epimedium-brevicornum",
+    "herbName": "Epimedium brevicornum",
+    "canonicalCompoundId": "epimedin-a",
+    "canonicalCompoundName": "Epimedin A"
   },
   {
-    "herbSlug": "loganin",
-    "herbName": "Loganin"
+    "herbSlug": "epimedium-brevicornum",
+    "herbName": "Epimedium brevicornum",
+    "canonicalCompoundId": "epimedin-b",
+    "canonicalCompoundName": "Epimedin B"
   },
   {
-    "herbSlug": "morroniside",
-    "herbName": "Morroniside"
+    "herbSlug": "epimedium-brevicornum",
+    "herbName": "Epimedium brevicornum",
+    "canonicalCompoundId": "epimedin-c",
+    "canonicalCompoundName": "Epimedin C"
   },
   {
-    "herbSlug": "oleocanthal",
-    "herbName": "Oleocanthal"
+    "herbSlug": "piper-longum",
+    "herbName": "Piper longum",
+    "canonicalCompoundId": "piperine",
+    "canonicalCompoundName": "Piperine"
   },
   {
-    "herbSlug": "oleacein",
-    "herbName": "Oleacein"
+    "herbSlug": "brassica-oleracea",
+    "herbName": "Brassica oleracea",
+    "canonicalCompoundId": "sulforaphane",
+    "canonicalCompoundName": "sulforaphane"
   },
   {
-    "herbSlug": "acteoside",
-    "herbName": "Acteoside"
+    "herbSlug": "brassica-juncea",
+    "herbName": "Brassica juncea",
+    "canonicalCompoundId": "sulforaphane",
+    "canonicalCompoundName": "sulforaphane"
   },
   {
-    "herbSlug": "forskolin",
-    "herbName": "Forskolin"
+    "herbSlug": "piper-longum",
+    "herbName": "Piper longum",
+    "canonicalCompoundId": "chavicine",
+    "canonicalCompoundName": "Chavicine"
   },
   {
-    "herbSlug": "bacoside-b",
-    "herbName": "Bacoside B"
+    "herbSlug": "epimedium-brevicornum",
+    "herbName": "Epimedium brevicornum",
+    "canonicalCompoundId": "icariin",
+    "canonicalCompoundName": "Icariin"
   },
   {
-    "herbSlug": "glycyrrhetinic-acid",
-    "herbName": "Glycyrrhetinic acid"
+    "herbSlug": "skullcap",
+    "herbName": "Skullcap",
+    "canonicalCompoundId": "baicalein",
+    "canonicalCompoundName": "Baicalein"
   },
   {
-    "herbSlug": "shikonin",
-    "herbName": "Shikonin"
+    "herbSlug": "skullcap",
+    "herbName": "Skullcap",
+    "canonicalCompoundId": "wogonin",
+    "canonicalCompoundName": "Wogonin"
   },
   {
-    "herbSlug": "acetylshikonin",
-    "herbName": "Acetylshikonin"
+    "herbSlug": "black-seed",
+    "herbName": "Black Seed",
+    "canonicalCompoundId": "thymoquinone",
+    "canonicalCompoundName": "Thymoquinone"
   },
   {
-    "herbSlug": "plumbagin",
-    "herbName": "Plumbagin"
+    "herbSlug": "rosemary",
+    "herbName": "Rosemary",
+    "canonicalCompoundId": "carnosic-acid",
+    "canonicalCompoundName": "Carnosic acid"
   },
   {
-    "herbSlug": "lawsone",
-    "herbName": "Lawsone"
+    "herbSlug": "sage",
+    "herbName": "Sage",
+    "canonicalCompoundId": "carnosic-acid",
+    "canonicalCompoundName": "Carnosic acid"
   },
   {
-    "herbSlug": "embelin",
-    "herbName": "Embelin"
+    "herbSlug": "olive-leaf",
+    "herbName": "Olive Leaf",
+    "canonicalCompoundId": "oleuropein",
+    "canonicalCompoundName": "Oleuropein"
   },
   {
-    "herbSlug": "artemisinin",
-    "herbName": "Artemisinin"
+    "herbSlug": "olive-leaf",
+    "herbName": "Olive Leaf",
+    "canonicalCompoundId": "hydroxytyrosol",
+    "canonicalCompoundName": "Hydroxytyrosol"
   },
   {
-    "herbSlug": "artesunate",
-    "herbName": "Artesunate"
+    "herbSlug": "saffron",
+    "herbName": "Saffron",
+    "canonicalCompoundId": "crocin",
+    "canonicalCompoundName": "Crocin"
   },
   {
-    "herbSlug": "artemisinin-b",
-    "herbName": "Artemisinin B"
+    "herbSlug": "saffron",
+    "herbName": "Saffron",
+    "canonicalCompoundId": "crocetin",
+    "canonicalCompoundName": "Crocetin"
   },
   {
-    "herbSlug": "astragalin",
-    "herbName": "Astragalin"
+    "herbSlug": "milk-thistle",
+    "herbName": "Milk Thistle",
+    "canonicalCompoundId": "silibinin",
+    "canonicalCompoundName": "Silibinin"
   },
   {
-    "herbSlug": "mangiferin",
-    "herbName": "Mangiferin"
+    "herbSlug": "licorice",
+    "herbName": "Licorice",
+    "canonicalCompoundId": "glycyrrhizin",
+    "canonicalCompoundName": "Glycyrrhizin"
   },
   {
-    "herbSlug": "mangostin",
-    "herbName": "Mangostin"
+    "herbSlug": "japanese-knotweed",
+    "herbName": "Japanese Knotweed",
+    "canonicalCompoundId": "emodin",
+    "canonicalCompoundName": "Emodin"
   },
   {
-    "herbSlug": "garcinol",
-    "herbName": "Garcinol"
+    "herbSlug": "aloe-vera",
+    "herbName": "Aloe Vera",
+    "canonicalCompoundId": "emodin",
+    "canonicalCompoundName": "Emodin"
   },
   {
-    "herbSlug": "curcumol",
-    "herbName": "Curcumol"
+    "herbSlug": "aloe-vera",
+    "herbName": "Aloe Vera",
+    "canonicalCompoundId": "rhein",
+    "canonicalCompoundName": "Rhein"
   },
   {
-    "herbSlug": "curdione",
-    "herbName": "Curdione"
+    "herbSlug": "schisandra",
+    "herbName": "Schisandra",
+    "canonicalCompoundId": "schisandrin",
+    "canonicalCompoundName": "Schisandrin"
   },
   {
-    "herbSlug": "albiflorin",
-    "herbName": "Albiflorin"
+    "herbSlug": "thunder-god-vine",
+    "herbName": "Thunder God Vine",
+    "canonicalCompoundId": "celastrol",
+    "canonicalCompoundName": "Celastrol"
   },
   {
-    "herbSlug": "paeonol",
-    "herbName": "Paeonol"
+    "herbSlug": "clove",
+    "herbName": "Clove",
+    "canonicalCompoundId": "eugenol",
+    "canonicalCompoundName": "Eugenol"
   },
   {
-    "herbSlug": "timosaponin-aiii",
-    "herbName": "Timosaponin AIII"
+    "herbSlug": "lavender",
+    "herbName": "Lavender",
+    "canonicalCompoundId": "linalool",
+    "canonicalCompoundName": "Linalool"
   },
   {
-    "herbSlug": "mangiferin-aglycone",
-    "herbName": "Mangiferin aglycone"
+    "herbSlug": "orange-peel",
+    "herbName": "Orange Peel",
+    "canonicalCompoundId": "hesperidin",
+    "canonicalCompoundName": "Hesperidin"
   },
   {
-    "herbSlug": "lobeline",
-    "herbName": "Lobeline"
+    "herbSlug": "scutellaria-baicalensis",
+    "herbName": "Scutellaria baicalensis",
+    "canonicalCompoundId": "baicalin",
+    "canonicalCompoundName": "Baicalin"
   },
   {
-    "herbSlug": "huperzine-a",
-    "herbName": "Huperzine A"
+    "herbSlug": "scutellaria-baicalensis",
+    "herbName": "Scutellaria baicalensis",
+    "canonicalCompoundId": "baicalein",
+    "canonicalCompoundName": "Baicalein"
   },
   {
-    "herbSlug": "huperzine-b",
-    "herbName": "Huperzine B"
+    "herbSlug": "scutellaria-baicalensis",
+    "herbName": "Scutellaria baicalensis",
+    "canonicalCompoundId": "wogonin",
+    "canonicalCompoundName": "Wogonin"
   },
   {
-    "herbSlug": "anatabine",
-    "herbName": "Anatabine"
+    "herbSlug": "nigella-sativa",
+    "herbName": "Nigella sativa",
+    "canonicalCompoundId": "thymoquinone",
+    "canonicalCompoundName": "Thymoquinone"
   },
   {
-    "herbSlug": "anabasine",
-    "herbName": "Anabasine"
+    "herbSlug": "olea-europaea",
+    "herbName": "Olea europaea",
+    "canonicalCompoundId": "oleuropein",
+    "canonicalCompoundName": "Oleuropein"
   },
   {
-    "herbSlug": "nicotine",
-    "herbName": "Nicotine"
+    "herbSlug": "olea-europaea",
+    "herbName": "Olea europaea",
+    "canonicalCompoundId": "hydroxytyrosol",
+    "canonicalCompoundName": "Hydroxytyrosol"
   },
   {
-    "herbSlug": "beta-caryophyllene",
-    "herbName": "Beta-caryophyllene"
+    "herbSlug": "crocus-sativus",
+    "herbName": "Crocus sativus",
+    "canonicalCompoundId": "crocin",
+    "canonicalCompoundName": "Crocin"
   },
   {
-    "herbSlug": "caryophyllene-oxide",
-    "herbName": "Caryophyllene oxide"
+    "herbSlug": "crocus-sativus",
+    "herbName": "Crocus sativus",
+    "canonicalCompoundId": "crocetin",
+    "canonicalCompoundName": "Crocetin"
   },
   {
-    "herbSlug": "nerolidol",
-    "herbName": "Nerolidol"
+    "herbSlug": "glycyrrhiza-glabra",
+    "herbName": "Glycyrrhiza glabra",
+    "canonicalCompoundId": "glycyrrhizin",
+    "canonicalCompoundName": "Glycyrrhizin"
   },
   {
-    "herbSlug": "farnesol",
-    "herbName": "Farnesol"
+    "herbSlug": "rheum-palmatum",
+    "herbName": "Rheum palmatum",
+    "canonicalCompoundId": "emodin",
+    "canonicalCompoundName": "Emodin"
   },
   {
-    "herbSlug": "bisabolol",
-    "herbName": "Bisabolol"
+    "herbSlug": "rheum-palmatum",
+    "herbName": "Rheum palmatum",
+    "canonicalCompoundId": "rhein",
+    "canonicalCompoundName": "Rhein"
   },
   {
-    "herbSlug": "atractylenolide-ii",
-    "herbName": "Atractylenolide II"
+    "herbSlug": "schisandra-chinensis",
+    "herbName": "Schisandra chinensis",
+    "canonicalCompoundId": "schisandrin",
+    "canonicalCompoundName": "Schisandrin"
   },
   {
-    "herbSlug": "atractylenolide-iii",
-    "herbName": "Atractylenolide III"
+    "herbSlug": "tripterygium-wilfordii",
+    "herbName": "Tripterygium wilfordii",
+    "canonicalCompoundId": "celastrol",
+    "canonicalCompoundName": "Celastrol"
   },
   {
-    "herbSlug": "beta-elemene",
-    "herbName": "Beta-elemene"
+    "herbSlug": "syzygium-aromaticum",
+    "herbName": "Syzygium aromaticum",
+    "canonicalCompoundId": "eugenol",
+    "canonicalCompoundName": "Eugenol"
   },
   {
-    "herbSlug": "elemicin",
-    "herbName": "Elemicin"
+    "herbSlug": "lavandula-angustifolia",
+    "herbName": "Lavandula angustifolia",
+    "canonicalCompoundId": "linalool",
+    "canonicalCompoundName": "Linalool"
   },
   {
-    "herbSlug": "myristicin",
-    "herbName": "Myristicin"
+    "herbSlug": "bupleurum-falcatum",
+    "herbName": "Bupleurum falcatum",
+    "canonicalCompoundId": "saikosaponin-a",
+    "canonicalCompoundName": "Saikosaponin A"
   },
   {
-    "herbSlug": "safrole",
-    "herbName": "Safrole"
+    "herbSlug": "citrus-sinensis",
+    "herbName": "Citrus sinensis",
+    "canonicalCompoundId": "hesperidin",
+    "canonicalCompoundName": "Hesperidin"
   },
   {
-    "herbSlug": "methyleugenol",
-    "herbName": "Methyleugenol"
+    "herbSlug": "berberis-vulgaris",
+    "herbName": "Berberis vulgaris",
+    "canonicalCompoundId": "berberine",
+    "canonicalCompoundName": "Berberine"
   },
   {
-    "herbSlug": "asiatic-acid",
-    "herbName": "Asiatic acid"
+    "herbSlug": "phellodendron-amurense",
+    "herbName": "Phellodendron amurense",
+    "canonicalCompoundId": "berberine",
+    "canonicalCompoundName": "Berberine"
   },
   {
-    "herbSlug": "madecassic-acid",
-    "herbName": "Madecassic acid"
+    "herbSlug": "goldenseal",
+    "herbName": "Goldenseal",
+    "canonicalCompoundId": "palmatine",
+    "canonicalCompoundName": "Palmatine"
   },
   {
-    "herbSlug": "gymnemagenin",
-    "herbName": "Gymnemagenin"
+    "herbSlug": "phellodendron-amurense",
+    "herbName": "Phellodendron amurense",
+    "canonicalCompoundId": "palmatine",
+    "canonicalCompoundName": "Palmatine"
   },
   {
-    "herbSlug": "gurmarin",
-    "herbName": "Gurmarin"
+    "herbSlug": "coptis-chinensis",
+    "herbName": "Coptis chinensis",
+    "canonicalCompoundId": "palmatine",
+    "canonicalCompoundName": "Palmatine"
   },
   {
-    "herbSlug": "lagerstroemin",
-    "herbName": "Lagerstroemin"
+    "herbSlug": "goldenseal",
+    "herbName": "Goldenseal",
+    "canonicalCompoundId": "jatrorrhizine",
+    "canonicalCompoundName": "Jatrorrhizine"
   },
   {
-    "herbSlug": "mulberroside-a",
-    "herbName": "Mulberroside A"
+    "herbSlug": "phellodendron-amurense",
+    "herbName": "Phellodendron amurense",
+    "canonicalCompoundId": "jatrorrhizine",
+    "canonicalCompoundName": "Jatrorrhizine"
   },
   {
-    "herbSlug": "oxyresveratrol",
-    "herbName": "Oxyresveratrol"
+    "herbSlug": "berberis-vulgaris",
+    "herbName": "Berberis vulgaris",
+    "canonicalCompoundId": "columbamine",
+    "canonicalCompoundName": "Columbamine"
   },
   {
-    "herbSlug": "morin",
-    "herbName": "Morin"
+    "herbSlug": "coptis-chinensis",
+    "herbName": "Coptis chinensis",
+    "canonicalCompoundId": "columbamine",
+    "canonicalCompoundName": "Columbamine"
   },
   {
-    "herbSlug": "deoxyelephantopin",
-    "herbName": "Deoxyelephantopin"
+    "herbSlug": "andrographis-paniculata",
+    "herbName": "Andrographis paniculata",
+    "canonicalCompoundId": "neoandrographolide",
+    "canonicalCompoundName": "Neoandrographolide"
   },
   {
-    "herbSlug": "elephantopin",
-    "herbName": "Elephantopin"
+    "herbSlug": "gymnema",
+    "herbName": "Gymnema",
+    "canonicalCompoundId": "gymnemic-acid",
+    "canonicalCompoundName": "Gymnemic acid"
   },
   {
-    "herbSlug": "guggulsterone",
-    "herbName": "Guggulsterone"
+    "herbSlug": "bitter-melon",
+    "herbName": "Bitter Melon",
+    "canonicalCompoundId": "charantin",
+    "canonicalCompoundName": "Charantin"
   },
   {
-    "herbSlug": "commipheric-acid",
-    "herbName": "Commipheric acid"
+    "herbSlug": "bitter-melon",
+    "herbName": "Bitter Melon",
+    "canonicalCompoundId": "momordicoside-k",
+    "canonicalCompoundName": "Momordicoside K"
   },
   {
-    "herbSlug": "stigmasterol",
-    "herbName": "Stigmasterol"
+    "herbSlug": "fenugreek",
+    "herbName": "Fenugreek",
+    "canonicalCompoundId": "diosgenin",
+    "canonicalCompoundName": "Diosgenin"
   },
   {
-    "herbSlug": "ajoene",
-    "herbName": "ajoene"
+    "herbSlug": "wild-yam",
+    "herbName": "Wild Yam",
+    "canonicalCompoundId": "diosgenin",
+    "canonicalCompoundName": "Diosgenin"
   },
   {
-    "herbSlug": "acemannan",
-    "herbName": "acemannan"
+    "herbSlug": "tribulus-terrestris",
+    "herbName": "Tribulus terrestris",
+    "canonicalCompoundId": "protodioscin",
+    "canonicalCompoundName": "Protodioscin"
   },
   {
-    "herbSlug": "aescin",
-    "herbName": "aescin"
+    "herbSlug": "fenugreek",
+    "herbName": "Fenugreek",
+    "canonicalCompoundId": "protodioscin",
+    "canonicalCompoundName": "Protodioscin"
   },
   {
-    "herbSlug": "alpha-asarone",
-    "herbName": "alpha-asarone"
+    "herbSlug": "american-ginseng",
+    "herbName": "American Ginseng",
+    "canonicalCompoundId": "ginsenoside-rg1",
+    "canonicalCompoundName": "Ginsenoside Rg1"
   },
   {
-    "herbSlug": "aspalathin",
-    "herbName": "aspalathin"
+    "herbSlug": "american-ginseng",
+    "herbName": "American Ginseng",
+    "canonicalCompoundId": "ginsenoside-rg3",
+    "canonicalCompoundName": "Ginsenoside Rg3"
   },
   {
-    "herbSlug": "bacopaside-ii",
-    "herbName": "bacopaside II"
+    "herbSlug": "rosemary",
+    "herbName": "Rosemary",
+    "canonicalCompoundId": "ursolic-acid",
+    "canonicalCompoundName": "Ursolic acid"
   },
   {
-    "herbSlug": "berbamine",
-    "herbName": "berbamine"
+    "herbSlug": "sage",
+    "herbName": "Sage",
+    "canonicalCompoundId": "ursolic-acid",
+    "canonicalCompoundName": "Ursolic acid"
   },
   {
-    "herbSlug": "betulinic-acid",
-    "herbName": "betulinic acid"
+    "herbSlug": "rosemary",
+    "herbName": "Rosemary",
+    "canonicalCompoundId": "oleanolic-acid",
+    "canonicalCompoundName": "Oleanolic acid"
   },
   {
-    "herbSlug": "bilobetin",
-    "herbName": "bilobetin"
+    "herbSlug": "sage",
+    "herbName": "Sage",
+    "canonicalCompoundId": "oleanolic-acid",
+    "canonicalCompoundName": "Oleanolic acid"
   },
   {
-    "herbSlug": "cafestol",
-    "herbName": "cafestol"
+    "herbSlug": "hawthorn",
+    "herbName": "Hawthorn",
+    "canonicalCompoundId": "oleanolic-acid",
+    "canonicalCompoundName": "Oleanolic acid"
   },
   {
-    "herbSlug": "chicoric-acid",
-    "herbName": "chicoric acid"
+    "herbSlug": "gotu-kola",
+    "herbName": "Gotu Kola",
+    "canonicalCompoundId": "asiaticoside",
+    "canonicalCompoundName": "Asiaticoside"
   },
   {
-    "herbSlug": "citronellal",
-    "herbName": "citronellal"
+    "herbSlug": "gotu-kola",
+    "herbName": "Gotu Kola",
+    "canonicalCompoundId": "madecassoside",
+    "canonicalCompoundName": "Madecassoside"
   },
   {
-    "herbSlug": "coptisine",
-    "herbName": "coptisine"
+    "herbSlug": "bacopa-monnieri",
+    "herbName": "Bacopa monnieri",
+    "canonicalCompoundId": "bacoside-a",
+    "canonicalCompoundName": "Bacoside A"
   },
   {
-    "herbSlug": "deoxymiroestrol",
-    "herbName": "deoxymiroestrol"
+    "herbSlug": "piper-longum",
+    "herbName": "Piper longum",
+    "canonicalCompoundId": "piperlongumine",
+    "canonicalCompoundName": "Piperlongumine"
   },
   {
-    "herbSlug": "desmethoxyyangonin",
-    "herbName": "desmethoxyyangonin"
+    "herbSlug": "st-johns-wort",
+    "herbName": "St Johns Wort",
+    "canonicalCompoundId": "quercetin",
+    "canonicalCompoundName": "Quercetin"
   },
   {
-    "herbSlug": "dihydrokavain",
-    "herbName": "dihydrokavain"
+    "herbSlug": "green-tea",
+    "herbName": "Green Tea",
+    "canonicalCompoundId": "myricetin",
+    "canonicalCompoundName": "Myricetin"
   },
   {
-    "herbSlug": "dihydromethysticin",
-    "herbName": "dihydromethysticin"
+    "herbSlug": "bayberry",
+    "herbName": "Bayberry",
+    "canonicalCompoundId": "myricetin",
+    "canonicalCompoundName": "Myricetin"
   },
   {
-    "herbSlug": "erinacines",
-    "herbName": "erinacines"
+    "herbSlug": "parsley",
+    "herbName": "Parsley",
+    "canonicalCompoundId": "apigenin",
+    "canonicalCompoundName": "Apigenin"
   },
   {
-    "herbSlug": "hericenones",
-    "herbName": "hericenones"
+    "herbSlug": "thyme",
+    "herbName": "Thyme",
+    "canonicalCompoundId": "luteolin",
+    "canonicalCompoundName": "Luteolin"
   },
   {
-    "herbSlug": "indirubin",
-    "herbName": "indirubin"
+    "herbSlug": "artichoke",
+    "herbName": "Artichoke",
+    "canonicalCompoundId": "luteolin",
+    "canonicalCompoundName": "Luteolin"
   },
   {
-    "herbSlug": "kahweol",
-    "herbName": "kahweol"
+    "herbSlug": "grapefruit",
+    "herbName": "Grapefruit",
+    "canonicalCompoundId": "naringenin",
+    "canonicalCompoundName": "Naringenin"
   },
   {
-    "herbSlug": "kotalanol",
-    "herbName": "kotalanol"
+    "herbSlug": "orange-peel",
+    "herbName": "Orange Peel",
+    "canonicalCompoundId": "naringenin",
+    "canonicalCompoundName": "Naringenin"
   },
   {
-    "herbSlug": "mesembrine",
-    "herbName": "mesembrine"
+    "herbSlug": "grapefruit",
+    "herbName": "Grapefruit",
+    "canonicalCompoundId": "naringin",
+    "canonicalCompoundName": "Naringin"
   },
   {
-    "herbSlug": "mesembrenone",
-    "herbName": "mesembrenone"
+    "herbSlug": "orange-peel",
+    "herbName": "Orange Peel",
+    "canonicalCompoundId": "naringin",
+    "canonicalCompoundName": "Naringin"
   },
   {
-    "herbSlug": "columbin",
-    "herbName": "columbin"
+    "herbSlug": "st-johns-wort",
+    "herbName": "St Johns Wort",
+    "canonicalCompoundId": "rutin",
+    "canonicalCompoundName": "Rutin"
   },
   {
-    "herbSlug": "cryptotanshinone",
-    "herbName": "cryptotanshinone"
+    "herbSlug": "buckwheat",
+    "herbName": "Buckwheat",
+    "canonicalCompoundId": "rutin",
+    "canonicalCompoundName": "Rutin"
   },
   {
-    "herbSlug": "honokiol",
-    "herbName": "honokiol"
+    "herbSlug": "cacao",
+    "herbName": "Cacao",
+    "canonicalCompoundId": "catechin",
+    "canonicalCompoundName": "Catechin"
   },
   {
-    "herbSlug": "magnolol",
-    "herbName": "magnolol"
+    "herbSlug": "green-tea",
+    "herbName": "Green Tea",
+    "canonicalCompoundId": "epicatechin",
+    "canonicalCompoundName": "Epicatechin"
   },
   {
-    "herbSlug": "safranal",
-    "herbName": "safranal"
+    "herbSlug": "cacao",
+    "herbName": "Cacao",
+    "canonicalCompoundId": "epicatechin",
+    "canonicalCompoundName": "Epicatechin"
   },
   {
-    "herbSlug": "trigonelline",
-    "herbName": "trigonelline"
+    "herbSlug": "green-tea",
+    "herbName": "Green Tea",
+    "canonicalCompoundId": "epigallocatechin-gallate-egcg",
+    "canonicalCompoundName": "Epigallocatechin gallate (EGCG)"
   },
   {
-    "herbSlug": "schisandrin-b",
-    "herbName": "schisandrin B"
+    "herbSlug": "black-tea",
+    "herbName": "Black Tea",
+    "canonicalCompoundId": "theaflavin",
+    "canonicalCompoundName": "Theaflavin"
   },
   {
-    "herbSlug": "eleutheroside-b",
-    "herbName": "eleutheroside B"
+    "herbSlug": "black-tea",
+    "herbName": "Black Tea",
+    "canonicalCompoundId": "thearubigin",
+    "canonicalCompoundName": "Thearubigin"
   },
   {
-    "herbSlug": "eleutheroside-e",
-    "herbName": "eleutheroside E"
+    "herbSlug": "japanese-knotweed",
+    "herbName": "Japanese Knotweed",
+    "canonicalCompoundId": "resveratrol",
+    "canonicalCompoundName": "Resveratrol"
   },
   {
-    "herbSlug": "punicalagin",
-    "herbName": "punicalagin"
+    "herbSlug": "grape",
+    "herbName": "Grape",
+    "canonicalCompoundId": "resveratrol",
+    "canonicalCompoundName": "Resveratrol"
   },
   {
-    "herbSlug": "glucomoringin",
-    "herbName": "glucomoringin"
+    "herbSlug": "blueberry",
+    "herbName": "Blueberry",
+    "canonicalCompoundId": "pterostilbene",
+    "canonicalCompoundName": "Pterostilbene"
   },
   {
-    "herbSlug": "methyl-eugenol",
-    "herbName": "methyl eugenol"
+    "herbSlug": "grape",
+    "herbName": "Grape",
+    "canonicalCompoundId": "pterostilbene",
+    "canonicalCompoundName": "Pterostilbene"
   },
   {
-    "herbSlug": "silybin",
-    "herbName": "silybin"
+    "herbSlug": "soybean",
+    "herbName": "Soybean",
+    "canonicalCompoundId": "genistein",
+    "canonicalCompoundName": "Genistein"
   },
   {
-    "herbSlug": "silychristin",
-    "herbName": "silychristin"
+    "herbSlug": "soybean",
+    "herbName": "Soybean",
+    "canonicalCompoundId": "daidzein",
+    "canonicalCompoundName": "Daidzein"
   },
   {
-    "herbSlug": "silydianin",
-    "herbName": "silydianin"
+    "herbSlug": "red-clover",
+    "herbName": "Red Clover",
+    "canonicalCompoundId": "daidzein",
+    "canonicalCompoundName": "Daidzein"
   },
   {
-    "herbSlug": "epigallocatechin",
-    "herbName": "epigallocatechin"
+    "herbSlug": "red-clover",
+    "herbName": "Red Clover",
+    "canonicalCompoundId": "formononetin",
+    "canonicalCompoundName": "Formononetin"
   },
   {
-    "herbSlug": "epicatechin-gallate",
-    "herbName": "epicatechin gallate"
+    "herbSlug": "astragalus",
+    "herbName": "Astragalus",
+    "canonicalCompoundId": "formononetin",
+    "canonicalCompoundName": "Formononetin"
   },
   {
-    "herbSlug": "epigallocatechin-gallate",
-    "herbName": "epigallocatechin gallate"
+    "herbSlug": "soybean",
+    "herbName": "Soybean",
+    "canonicalCompoundId": "biochanin-a",
+    "canonicalCompoundName": "Biochanin A"
   },
   {
-    "herbSlug": "gallocatechin",
-    "herbName": "gallocatechin"
+    "herbSlug": "pomegranate",
+    "herbName": "Pomegranate",
+    "canonicalCompoundId": "ellagic-acid",
+    "canonicalCompoundName": "Ellagic acid"
+  },
+  {
+    "herbSlug": "raspberry-leaf",
+    "herbName": "Raspberry Leaf",
+    "canonicalCompoundId": "ellagic-acid",
+    "canonicalCompoundName": "Ellagic acid"
+  },
+  {
+    "herbSlug": "green-tea",
+    "herbName": "Green Tea",
+    "canonicalCompoundId": "gallic-acid",
+    "canonicalCompoundName": "Gallic acid"
+  },
+  {
+    "herbSlug": "pomegranate",
+    "herbName": "Pomegranate",
+    "canonicalCompoundId": "gallic-acid",
+    "canonicalCompoundName": "Gallic acid"
+  },
+  {
+    "herbSlug": "angelica-sinensis",
+    "herbName": "Angelica sinensis",
+    "canonicalCompoundId": "ferulic-acid",
+    "canonicalCompoundName": "Ferulic acid"
+  },
+  {
+    "herbSlug": "rice-bran",
+    "herbName": "Rice Bran",
+    "canonicalCompoundId": "ferulic-acid",
+    "canonicalCompoundName": "Ferulic acid"
+  },
+  {
+    "herbSlug": "coffee",
+    "herbName": "Coffee",
+    "canonicalCompoundId": "chlorogenic-acid",
+    "canonicalCompoundName": "Chlorogenic acid"
+  },
+  {
+    "herbSlug": "artichoke",
+    "herbName": "Artichoke",
+    "canonicalCompoundId": "chlorogenic-acid",
+    "canonicalCompoundName": "Chlorogenic acid"
+  },
+  {
+    "herbSlug": "echinacea-purpurea",
+    "herbName": "Echinacea Purpurea",
+    "canonicalCompoundId": "caffeic-acid",
+    "canonicalCompoundName": "Caffeic acid"
+  },
+  {
+    "herbSlug": "coffee",
+    "herbName": "Coffee",
+    "canonicalCompoundId": "caffeic-acid",
+    "canonicalCompoundName": "Caffeic acid"
+  },
+  {
+    "herbSlug": "cnidium-monnieri",
+    "herbName": "Cnidium monnieri",
+    "canonicalCompoundId": "osthole",
+    "canonicalCompoundName": "Osthole"
+  },
+  {
+    "herbSlug": "angelica-pubescens",
+    "herbName": "Angelica pubescens",
+    "canonicalCompoundId": "osthole",
+    "canonicalCompoundName": "Osthole"
+  },
+  {
+    "herbSlug": "angelica-dahurica",
+    "herbName": "Angelica dahurica",
+    "canonicalCompoundId": "imperatorin",
+    "canonicalCompoundName": "Imperatorin"
+  },
+  {
+    "herbSlug": "cnidium-monnieri",
+    "herbName": "Cnidium monnieri",
+    "canonicalCompoundId": "imperatorin",
+    "canonicalCompoundName": "Imperatorin"
+  },
+  {
+    "herbSlug": "angelica-dahurica",
+    "herbName": "Angelica dahurica",
+    "canonicalCompoundId": "isoimperatorin",
+    "canonicalCompoundName": "Isoimperatorin"
+  },
+  {
+    "herbSlug": "cnidium-monnieri",
+    "herbName": "Cnidium monnieri",
+    "canonicalCompoundId": "isoimperatorin",
+    "canonicalCompoundName": "Isoimperatorin"
+  },
+  {
+    "herbSlug": "psoralea-corylifolia",
+    "herbName": "Psoralea corylifolia",
+    "canonicalCompoundId": "psoralen",
+    "canonicalCompoundName": "Psoralen"
+  },
+  {
+    "herbSlug": "ficus-carica",
+    "herbName": "Ficus carica",
+    "canonicalCompoundId": "psoralen",
+    "canonicalCompoundName": "Psoralen"
+  },
+  {
+    "herbSlug": "psoralea-corylifolia",
+    "herbName": "Psoralea corylifolia",
+    "canonicalCompoundId": "angelicin",
+    "canonicalCompoundName": "Angelicin"
+  },
+  {
+    "herbSlug": "angelica-archangelica",
+    "herbName": "Angelica archangelica",
+    "canonicalCompoundId": "angelicin",
+    "canonicalCompoundName": "Angelicin"
+  },
+  {
+    "herbSlug": "citrus-bergamia",
+    "herbName": "Citrus bergamia",
+    "canonicalCompoundId": "bergapten",
+    "canonicalCompoundName": "Bergapten"
+  },
+  {
+    "herbSlug": "psoralea-corylifolia",
+    "herbName": "Psoralea corylifolia",
+    "canonicalCompoundId": "bergapten",
+    "canonicalCompoundName": "Bergapten"
+  },
+  {
+    "herbSlug": "morinda-citrifolia",
+    "herbName": "Morinda citrifolia",
+    "canonicalCompoundId": "scopoletin",
+    "canonicalCompoundName": "Scopoletin"
+  },
+  {
+    "herbSlug": "artemisia-capillaris",
+    "herbName": "Artemisia capillaris",
+    "canonicalCompoundId": "scopoletin",
+    "canonicalCompoundName": "Scopoletin"
+  },
+  {
+    "herbSlug": "cichorium-intybus",
+    "herbName": "Cichorium intybus",
+    "canonicalCompoundId": "esculetin",
+    "canonicalCompoundName": "Esculetin"
+  },
+  {
+    "herbSlug": "artemisia-capillaris",
+    "herbName": "Artemisia capillaris",
+    "canonicalCompoundId": "esculetin",
+    "canonicalCompoundName": "Esculetin"
+  },
+  {
+    "herbSlug": "fraxinus-rhynchophylla",
+    "herbName": "Fraxinus rhynchophylla",
+    "canonicalCompoundId": "fraxetin",
+    "canonicalCompoundName": "Fraxetin"
+  },
+  {
+    "herbSlug": "artemisia-capillaris",
+    "herbName": "Artemisia capillaris",
+    "canonicalCompoundId": "fraxetin",
+    "canonicalCompoundName": "Fraxetin"
+  },
+  {
+    "herbSlug": "angelica-archangelica",
+    "herbName": "Angelica archangelica",
+    "canonicalCompoundId": "umbelliferone",
+    "canonicalCompoundName": "Umbelliferone"
+  },
+  {
+    "herbSlug": "coriandrum-sativum",
+    "herbName": "Coriandrum sativum",
+    "canonicalCompoundId": "umbelliferone",
+    "canonicalCompoundName": "Umbelliferone"
+  },
+  {
+    "herbSlug": "daphne-odora",
+    "herbName": "Daphne odora",
+    "canonicalCompoundId": "daphnetin",
+    "canonicalCompoundName": "Daphnetin"
+  },
+  {
+    "herbSlug": "stellera-chamaejasme",
+    "herbName": "Stellera chamaejasme",
+    "canonicalCompoundId": "daphnetin",
+    "canonicalCompoundName": "Daphnetin"
+  },
+  {
+    "herbSlug": "sophora-alopecuroides",
+    "herbName": "Sophora alopecuroides",
+    "canonicalCompoundId": "matrine",
+    "canonicalCompoundName": "Matrine"
+  },
+  {
+    "herbSlug": "sophora-flavescens",
+    "herbName": "Sophora flavescens",
+    "canonicalCompoundId": "oxymatrine",
+    "canonicalCompoundName": "Oxymatrine"
+  },
+  {
+    "herbSlug": "sophora-alopecuroides",
+    "herbName": "Sophora alopecuroides",
+    "canonicalCompoundId": "oxymatrine",
+    "canonicalCompoundName": "Oxymatrine"
+  },
+  {
+    "herbSlug": "stephania-tetrandra",
+    "herbName": "Stephania tetrandra",
+    "canonicalCompoundId": "tetrandrine",
+    "canonicalCompoundName": "Tetrandrine"
+  },
+  {
+    "herbSlug": "cyclea-peltata",
+    "herbName": "Cyclea peltata",
+    "canonicalCompoundId": "tetrandrine",
+    "canonicalCompoundName": "Tetrandrine"
+  },
+  {
+    "herbSlug": "stephania-cepharantha",
+    "herbName": "Stephania cepharantha",
+    "canonicalCompoundId": "cepharanthine",
+    "canonicalCompoundName": "Cepharanthine"
+  },
+  {
+    "herbSlug": "stephania-japonica",
+    "herbName": "Stephania japonica",
+    "canonicalCompoundId": "cepharanthine",
+    "canonicalCompoundName": "Cepharanthine"
+  },
+  {
+    "herbSlug": "coptis-chinensis",
+    "herbName": "Coptis chinensis",
+    "canonicalCompoundId": "magnoflorine",
+    "canonicalCompoundName": "Magnoflorine"
+  },
+  {
+    "herbSlug": "nelumbo-nucifera",
+    "herbName": "Nelumbo nucifera",
+    "canonicalCompoundId": "magnoflorine",
+    "canonicalCompoundName": "Magnoflorine"
+  },
+  {
+    "herbSlug": "angelica-sinensis",
+    "herbName": "Angelica sinensis",
+    "canonicalCompoundId": "ligustilide",
+    "canonicalCompoundName": "Ligustilide"
+  },
+  {
+    "herbSlug": "ligusticum-chuanxiong",
+    "herbName": "Ligusticum chuanxiong",
+    "canonicalCompoundId": "ligustilide",
+    "canonicalCompoundName": "Ligustilide"
+  },
+  {
+    "herbSlug": "ligusticum-chuanxiong",
+    "herbName": "Ligusticum chuanxiong",
+    "canonicalCompoundId": "senkyunolide-a",
+    "canonicalCompoundName": "Senkyunolide A"
+  },
+  {
+    "herbSlug": "angelica-sinensis",
+    "herbName": "Angelica sinensis",
+    "canonicalCompoundId": "senkyunolide-a",
+    "canonicalCompoundName": "Senkyunolide A"
+  },
+  {
+    "herbSlug": "angelica-sinensis",
+    "herbName": "Angelica sinensis",
+    "canonicalCompoundId": "butylidenephthalide",
+    "canonicalCompoundName": "Butylidenephthalide"
+  },
+  {
+    "herbSlug": "ligusticum-chuanxiong",
+    "herbName": "Ligusticum chuanxiong",
+    "canonicalCompoundId": "butylidenephthalide",
+    "canonicalCompoundName": "Butylidenephthalide"
+  },
+  {
+    "herbSlug": "angelica-dahurica",
+    "herbName": "Angelica dahurica",
+    "canonicalCompoundId": "xanthotoxin",
+    "canonicalCompoundName": "Xanthotoxin"
+  },
+  {
+    "herbSlug": "pastinaca-sativa",
+    "herbName": "Pastinaca sativa",
+    "canonicalCompoundId": "xanthotoxin",
+    "canonicalCompoundName": "Xanthotoxin"
+  },
+  {
+    "herbSlug": "boswellia-serrata",
+    "herbName": "Boswellia serrata",
+    "canonicalCompoundId": "boswellic-acid",
+    "canonicalCompoundName": "Boswellic acid"
+  },
+  {
+    "herbSlug": "boswellia-serrata",
+    "herbName": "Boswellia serrata",
+    "canonicalCompoundId": "acetyl-beta-boswellic-acid",
+    "canonicalCompoundName": "Acetyl-beta-boswellic acid"
+  },
+  {
+    "herbSlug": "boswellia-serrata",
+    "herbName": "Boswellia serrata",
+    "canonicalCompoundId": "11-keto-beta-boswellic-acid",
+    "canonicalCompoundName": "11-keto-beta-boswellic acid"
+  },
+  {
+    "herbSlug": "boswellia-serrata",
+    "herbName": "Boswellia serrata",
+    "canonicalCompoundId": "acetyl-11-keto-beta-boswellic-acid",
+    "canonicalCompoundName": "Acetyl-11-keto-beta-boswellic acid"
+  },
+  {
+    "herbSlug": "valeriana-officinalis",
+    "herbName": "Valeriana officinalis",
+    "canonicalCompoundId": "valerenic-acid",
+    "canonicalCompoundName": "Valerenic acid"
+  },
+  {
+    "herbSlug": "valeriana-officinalis",
+    "herbName": "Valeriana officinalis",
+    "canonicalCompoundId": "valerenol",
+    "canonicalCompoundName": "Valerenol"
+  },
+  {
+    "herbSlug": "piper-methysticum",
+    "herbName": "Piper methysticum",
+    "canonicalCompoundId": "kavalactones",
+    "canonicalCompoundName": "Kavalactones"
+  },
+  {
+    "herbSlug": "piper-methysticum",
+    "herbName": "Piper methysticum",
+    "canonicalCompoundId": "kavain",
+    "canonicalCompoundName": "Kavain"
+  },
+  {
+    "herbSlug": "piper-methysticum",
+    "herbName": "Piper methysticum",
+    "canonicalCompoundId": "yangonin",
+    "canonicalCompoundName": "Yangonin"
+  },
+  {
+    "herbSlug": "piper-methysticum",
+    "herbName": "Piper methysticum",
+    "canonicalCompoundId": "methysticin",
+    "canonicalCompoundName": "Methysticin"
+  },
+  {
+    "herbSlug": "valeriana-officinalis",
+    "herbName": "Valeriana officinalis",
+    "canonicalCompoundId": "valepotriates",
+    "canonicalCompoundName": "Valepotriates"
+  },
+  {
+    "herbSlug": "plantago-major",
+    "herbName": "Plantago major",
+    "canonicalCompoundId": "aucubin",
+    "canonicalCompoundName": "Aucubin"
+  },
+  {
+    "herbSlug": "rehmannia-glutinosa",
+    "herbName": "Rehmannia glutinosa",
+    "canonicalCompoundId": "catalpol",
+    "canonicalCompoundName": "Catalpol"
+  },
+  {
+    "herbSlug": "harpagophytum-procumbens",
+    "herbName": "Harpagophytum procumbens",
+    "canonicalCompoundId": "harpagoside",
+    "canonicalCompoundName": "Harpagoside"
+  },
+  {
+    "herbSlug": "cornus-officinalis",
+    "herbName": "Cornus officinalis",
+    "canonicalCompoundId": "loganin",
+    "canonicalCompoundName": "Loganin"
+  },
+  {
+    "herbSlug": "cornus-officinalis",
+    "herbName": "Cornus officinalis",
+    "canonicalCompoundId": "morroniside",
+    "canonicalCompoundName": "Morroniside"
+  },
+  {
+    "herbSlug": "olea-europaea",
+    "herbName": "Olea europaea",
+    "canonicalCompoundId": "oleocanthal",
+    "canonicalCompoundName": "Oleocanthal"
+  },
+  {
+    "herbSlug": "olea-europaea",
+    "herbName": "Olea europaea",
+    "canonicalCompoundId": "oleacein",
+    "canonicalCompoundName": "Oleacein"
+  },
+  {
+    "herbSlug": "cistanche-deserticola",
+    "herbName": "Cistanche deserticola",
+    "canonicalCompoundId": "echinacoside",
+    "canonicalCompoundName": "Echinacoside"
+  },
+  {
+    "herbSlug": "verbena-officinalis",
+    "herbName": "Verbena officinalis",
+    "canonicalCompoundId": "acteoside",
+    "canonicalCompoundName": "Acteoside"
+  },
+  {
+    "herbSlug": "plantago-lanceolata",
+    "herbName": "Plantago lanceolata",
+    "canonicalCompoundId": "verbascoside",
+    "canonicalCompoundName": "Verbascoside"
+  },
+  {
+    "herbSlug": "coleus-forskohlii",
+    "herbName": "Coleus forskohlii",
+    "canonicalCompoundId": "forskolin",
+    "canonicalCompoundName": "Forskolin"
+  },
+  {
+    "herbSlug": "bacopa-monnieri",
+    "herbName": "Bacopa monnieri",
+    "canonicalCompoundId": "bacoside-b",
+    "canonicalCompoundName": "Bacoside B"
+  },
+  {
+    "herbSlug": "glycyrrhiza-glabra",
+    "herbName": "Glycyrrhiza glabra",
+    "canonicalCompoundId": "glycyrrhetinic-acid",
+    "canonicalCompoundName": "Glycyrrhetinic acid"
+  },
+  {
+    "herbSlug": "lithospermum-erythrorhizon",
+    "herbName": "Lithospermum erythrorhizon",
+    "canonicalCompoundId": "shikonin",
+    "canonicalCompoundName": "Shikonin"
+  },
+  {
+    "herbSlug": "lithospermum-erythrorhizon",
+    "herbName": "Lithospermum erythrorhizon",
+    "canonicalCompoundId": "acetylshikonin",
+    "canonicalCompoundName": "Acetylshikonin"
+  },
+  {
+    "herbSlug": "plumbago-zeylanica",
+    "herbName": "Plumbago zeylanica",
+    "canonicalCompoundId": "plumbagin",
+    "canonicalCompoundName": "Plumbagin"
+  },
+  {
+    "herbSlug": "lawsonia-inermis",
+    "herbName": "Lawsonia inermis",
+    "canonicalCompoundId": "lawsone",
+    "canonicalCompoundName": "Lawsone"
+  },
+  {
+    "herbSlug": "embelia-ribes",
+    "herbName": "Embelia ribes",
+    "canonicalCompoundId": "embelin",
+    "canonicalCompoundName": "Embelin"
+  },
+  {
+    "herbSlug": "artemisia-absinthium",
+    "herbName": "Artemisia absinthium",
+    "canonicalCompoundId": "thujone",
+    "canonicalCompoundName": "Thujone"
+  },
+  {
+    "herbSlug": "artemisia-annua",
+    "herbName": "Artemisia annua",
+    "canonicalCompoundId": "artemisinin",
+    "canonicalCompoundName": "Artemisinin"
+  },
+  {
+    "herbSlug": "artemisia-annua",
+    "herbName": "Artemisia annua",
+    "canonicalCompoundId": "artesunate",
+    "canonicalCompoundName": "Artesunate"
+  },
+  {
+    "herbSlug": "artemisia-annua",
+    "herbName": "Artemisia annua",
+    "canonicalCompoundId": "artemisinin-b",
+    "canonicalCompoundName": "Artemisinin B"
+  },
+  {
+    "herbSlug": "astragalus-membranaceus",
+    "herbName": "Astragalus membranaceus",
+    "canonicalCompoundId": "astragaloside-iv",
+    "canonicalCompoundName": "Astragaloside IV"
+  },
+  {
+    "herbSlug": "astragalus-membranaceus",
+    "herbName": "Astragalus membranaceus",
+    "canonicalCompoundId": "calycosin",
+    "canonicalCompoundName": "Calycosin"
+  },
+  {
+    "herbSlug": "astragalus-membranaceus",
+    "herbName": "Astragalus membranaceus",
+    "canonicalCompoundId": "formononetin",
+    "canonicalCompoundName": "Formononetin"
+  },
+  {
+    "herbSlug": "astragalus-membranaceus",
+    "herbName": "Astragalus membranaceus",
+    "canonicalCompoundId": "astragalin",
+    "canonicalCompoundName": "Astragalin"
+  },
+  {
+    "herbSlug": "pueraria-lobata",
+    "herbName": "Pueraria lobata",
+    "canonicalCompoundId": "puerarin",
+    "canonicalCompoundName": "Puerarin"
+  },
+  {
+    "herbSlug": "pueraria-lobata",
+    "herbName": "Pueraria lobata",
+    "canonicalCompoundId": "daidzin",
+    "canonicalCompoundName": "Daidzin"
+  },
+  {
+    "herbSlug": "pueraria-lobata",
+    "herbName": "Pueraria lobata",
+    "canonicalCompoundId": "ononin",
+    "canonicalCompoundName": "Ononin"
+  },
+  {
+    "herbSlug": "mangifera-indica",
+    "herbName": "Mangifera indica",
+    "canonicalCompoundId": "mangiferin",
+    "canonicalCompoundName": "Mangiferin"
+  },
+  {
+    "herbSlug": "garcinia-mangostana",
+    "herbName": "Garcinia mangostana",
+    "canonicalCompoundId": "mangostin",
+    "canonicalCompoundName": "Mangostin"
+  },
+  {
+    "herbSlug": "garcinia-mangostana",
+    "herbName": "Garcinia mangostana",
+    "canonicalCompoundId": "alpha-mangostin",
+    "canonicalCompoundName": "Alpha-mangostin"
+  },
+  {
+    "herbSlug": "garcinia-indica",
+    "herbName": "Garcinia indica",
+    "canonicalCompoundId": "garcinol",
+    "canonicalCompoundName": "Garcinol"
+  },
+  {
+    "herbSlug": "curcuma-zedoaria",
+    "herbName": "Curcuma zedoaria",
+    "canonicalCompoundId": "curcumol",
+    "canonicalCompoundName": "Curcumol"
+  },
+  {
+    "herbSlug": "curcuma-zedoaria",
+    "herbName": "Curcuma zedoaria",
+    "canonicalCompoundId": "curdione",
+    "canonicalCompoundName": "Curdione"
+  },
+  {
+    "herbSlug": "curcuma-longa",
+    "herbName": "Curcuma longa",
+    "canonicalCompoundId": "demethoxycurcumin",
+    "canonicalCompoundName": "Demethoxycurcumin"
+  },
+  {
+    "herbSlug": "curcuma-longa",
+    "herbName": "Curcuma longa",
+    "canonicalCompoundId": "bisdemethoxycurcumin",
+    "canonicalCompoundName": "Bisdemethoxycurcumin"
+  },
+  {
+    "herbSlug": "paeonia-lactiflora",
+    "herbName": "Paeonia lactiflora",
+    "canonicalCompoundId": "paeoniflorin",
+    "canonicalCompoundName": "Paeoniflorin"
+  },
+  {
+    "herbSlug": "paeonia-lactiflora",
+    "herbName": "Paeonia lactiflora",
+    "canonicalCompoundId": "albiflorin",
+    "canonicalCompoundName": "Albiflorin"
+  },
+  {
+    "herbSlug": "paeonia-suffruticosa",
+    "herbName": "Paeonia suffruticosa",
+    "canonicalCompoundId": "paeonol",
+    "canonicalCompoundName": "Paeonol"
+  },
+  {
+    "herbSlug": "anemarrhena-asphodeloides",
+    "herbName": "Anemarrhena asphodeloides",
+    "canonicalCompoundId": "timosaponin-aiii",
+    "canonicalCompoundName": "Timosaponin AIII"
+  },
+  {
+    "herbSlug": "anemarrhena-asphodeloides",
+    "herbName": "Anemarrhena asphodeloides",
+    "canonicalCompoundId": "mangiferin-aglycone",
+    "canonicalCompoundName": "Mangiferin aglycone"
+  },
+  {
+    "herbSlug": "lobelia-inflata",
+    "herbName": "Lobelia inflata",
+    "canonicalCompoundId": "lobeline",
+    "canonicalCompoundName": "Lobeline"
+  },
+  {
+    "herbSlug": "huperzia-serrata",
+    "herbName": "Huperzia serrata",
+    "canonicalCompoundId": "huperzine-a",
+    "canonicalCompoundName": "Huperzine A"
+  },
+  {
+    "herbSlug": "huperzia-serrata",
+    "herbName": "Huperzia serrata",
+    "canonicalCompoundId": "huperzine-b",
+    "canonicalCompoundName": "Huperzine B"
+  },
+  {
+    "herbSlug": "nicotiana-tabacum",
+    "herbName": "Nicotiana tabacum",
+    "canonicalCompoundId": "anatabine",
+    "canonicalCompoundName": "Anatabine"
+  },
+  {
+    "herbSlug": "nicotiana-glauca",
+    "herbName": "Nicotiana glauca",
+    "canonicalCompoundId": "anabasine",
+    "canonicalCompoundName": "Anabasine"
+  },
+  {
+    "herbSlug": "nicotiana-tabacum",
+    "herbName": "Nicotiana tabacum",
+    "canonicalCompoundId": "nicotine",
+    "canonicalCompoundName": "Nicotine"
+  },
+  {
+    "herbSlug": "piper-nigrum",
+    "herbName": "Piper nigrum",
+    "canonicalCompoundId": "beta-caryophyllene",
+    "canonicalCompoundName": "Beta-caryophyllene"
+  },
+  {
+    "herbSlug": "piper-nigrum",
+    "herbName": "Piper nigrum",
+    "canonicalCompoundId": "caryophyllene-oxide",
+    "canonicalCompoundName": "Caryophyllene oxide"
+  },
+  {
+    "herbSlug": "cymbopogon-citratus",
+    "herbName": "Cymbopogon citratus",
+    "canonicalCompoundId": "nerolidol",
+    "canonicalCompoundName": "Nerolidol"
+  },
+  {
+    "herbSlug": "matricaria-chamomilla",
+    "herbName": "Matricaria chamomilla",
+    "canonicalCompoundId": "farnesol",
+    "canonicalCompoundName": "Farnesol"
+  },
+  {
+    "herbSlug": "matricaria-chamomilla",
+    "herbName": "Matricaria chamomilla",
+    "canonicalCompoundId": "bisabolol",
+    "canonicalCompoundName": "Bisabolol"
+  },
+  {
+    "herbSlug": "matricaria-chamomilla",
+    "herbName": "Matricaria chamomilla",
+    "canonicalCompoundId": "chamazulene",
+    "canonicalCompoundName": "Chamazulene"
+  },
+  {
+    "herbSlug": "atractylodes-macrocephala",
+    "herbName": "Atractylodes macrocephala",
+    "canonicalCompoundId": "atractylenolide-i",
+    "canonicalCompoundName": "Atractylenolide I"
+  },
+  {
+    "herbSlug": "atractylodes-macrocephala",
+    "herbName": "Atractylodes macrocephala",
+    "canonicalCompoundId": "atractylenolide-ii",
+    "canonicalCompoundName": "Atractylenolide II"
+  },
+  {
+    "herbSlug": "atractylodes-macrocephala",
+    "herbName": "Atractylodes macrocephala",
+    "canonicalCompoundId": "atractylenolide-iii",
+    "canonicalCompoundName": "Atractylenolide III"
+  },
+  {
+    "herbSlug": "curcuma-wenyujin",
+    "herbName": "Curcuma wenyujin",
+    "canonicalCompoundId": "beta-elemene",
+    "canonicalCompoundName": "Beta-elemene"
+  },
+  {
+    "herbSlug": "myristica-fragrans",
+    "herbName": "Myristica fragrans",
+    "canonicalCompoundId": "elemicin",
+    "canonicalCompoundName": "Elemicin"
+  },
+  {
+    "herbSlug": "myristica-fragrans",
+    "herbName": "Myristica fragrans",
+    "canonicalCompoundId": "myristicin",
+    "canonicalCompoundName": "Myristicin"
+  },
+  {
+    "herbSlug": "ocotea-odorifera",
+    "herbName": "Ocotea odorifera",
+    "canonicalCompoundId": "safrole",
+    "canonicalCompoundName": "Safrole"
+  },
+  {
+    "herbSlug": "ocimum-basilicum",
+    "herbName": "Ocimum basilicum",
+    "canonicalCompoundId": "methyleugenol",
+    "canonicalCompoundName": "Methyleugenol"
+  },
+  {
+    "herbSlug": "ocimum-sanctum",
+    "herbName": "Ocimum sanctum",
+    "canonicalCompoundId": "ursolic-acid",
+    "canonicalCompoundName": "Ursolic acid"
+  },
+  {
+    "herbSlug": "centella-asiatica",
+    "herbName": "Centella asiatica",
+    "canonicalCompoundId": "asiatic-acid",
+    "canonicalCompoundName": "Asiatic acid"
+  },
+  {
+    "herbSlug": "centella-asiatica",
+    "herbName": "Centella asiatica",
+    "canonicalCompoundId": "madecassic-acid",
+    "canonicalCompoundName": "Madecassic acid"
+  },
+  {
+    "herbSlug": "centella-asiatica",
+    "herbName": "Centella asiatica",
+    "canonicalCompoundId": "asiaticoside",
+    "canonicalCompoundName": "Asiaticoside"
+  },
+  {
+    "herbSlug": "centella-asiatica",
+    "herbName": "Centella asiatica",
+    "canonicalCompoundId": "madecassoside",
+    "canonicalCompoundName": "Madecassoside"
+  },
+  {
+    "herbSlug": "gymnema-sylvestre",
+    "herbName": "Gymnema sylvestre",
+    "canonicalCompoundId": "gymnemagenin",
+    "canonicalCompoundName": "Gymnemagenin"
+  },
+  {
+    "herbSlug": "gymnema-sylvestre",
+    "herbName": "Gymnema sylvestre",
+    "canonicalCompoundId": "gurmarin",
+    "canonicalCompoundName": "Gurmarin"
+  },
+  {
+    "herbSlug": "lagerstroemia-speciosa",
+    "herbName": "Lagerstroemia speciosa",
+    "canonicalCompoundId": "corosolic-acid",
+    "canonicalCompoundName": "Corosolic acid"
+  },
+  {
+    "herbSlug": "lagerstroemia-speciosa",
+    "herbName": "Lagerstroemia speciosa",
+    "canonicalCompoundId": "lagerstroemin",
+    "canonicalCompoundName": "Lagerstroemin"
+  },
+  {
+    "herbSlug": "morus-alba",
+    "herbName": "Morus alba",
+    "canonicalCompoundId": "mulberroside-a",
+    "canonicalCompoundName": "Mulberroside A"
+  },
+  {
+    "herbSlug": "morus-alba",
+    "herbName": "Morus alba",
+    "canonicalCompoundId": "oxyresveratrol",
+    "canonicalCompoundName": "Oxyresveratrol"
+  },
+  {
+    "herbSlug": "morus-alba",
+    "herbName": "Morus alba",
+    "canonicalCompoundId": "morin",
+    "canonicalCompoundName": "Morin"
+  },
+  {
+    "herbSlug": "elephantopus-scaber",
+    "herbName": "Elephantopus scaber",
+    "canonicalCompoundId": "deoxyelephantopin",
+    "canonicalCompoundName": "Deoxyelephantopin"
+  },
+  {
+    "herbSlug": "elephantopus-scaber",
+    "herbName": "Elephantopus scaber",
+    "canonicalCompoundId": "elephantopin",
+    "canonicalCompoundName": "Elephantopin"
+  },
+  {
+    "herbSlug": "commiphora-mukul",
+    "herbName": "Commiphora mukul",
+    "canonicalCompoundId": "guggulsterone",
+    "canonicalCompoundName": "Guggulsterone"
+  },
+  {
+    "herbSlug": "commiphora-mukul",
+    "herbName": "Commiphora mukul",
+    "canonicalCompoundId": "commipheric-acid",
+    "canonicalCompoundName": "Commipheric acid"
+  },
+  {
+    "herbSlug": "serenoa-repens",
+    "herbName": "Serenoa repens",
+    "canonicalCompoundId": "beta-sitosterol",
+    "canonicalCompoundName": "Beta-sitosterol"
+  },
+  {
+    "herbSlug": "serenoa-repens",
+    "herbName": "Serenoa repens",
+    "canonicalCompoundId": "stigmasterol",
+    "canonicalCompoundName": "Stigmasterol"
+  },
+  {
+    "herbSlug": "garlic",
+    "herbName": "Garlic",
+    "canonicalCompoundId": "ajoene",
+    "canonicalCompoundName": "ajoene"
+  },
+  {
+    "herbSlug": "aloe-vera",
+    "herbName": "Aloe Vera",
+    "canonicalCompoundId": "acemannan",
+    "canonicalCompoundName": "acemannan"
+  },
+  {
+    "herbSlug": "horse-chestnut",
+    "herbName": "Horse Chestnut",
+    "canonicalCompoundId": "aescin",
+    "canonicalCompoundName": "aescin"
+  },
+  {
+    "herbSlug": "calamus",
+    "herbName": "Calamus",
+    "canonicalCompoundId": "alpha-asarone",
+    "canonicalCompoundName": "alpha-asarone"
+  },
+  {
+    "herbSlug": "rooibos",
+    "herbName": "Rooibos",
+    "canonicalCompoundId": "aspalathin",
+    "canonicalCompoundName": "aspalathin"
+  },
+  {
+    "herbSlug": "bacopa",
+    "herbName": "Bacopa",
+    "canonicalCompoundId": "bacopaside-ii",
+    "canonicalCompoundName": "bacopaside II"
+  },
+  {
+    "herbSlug": "berberis",
+    "herbName": "Berberis",
+    "canonicalCompoundId": "berbamine",
+    "canonicalCompoundName": "berbamine"
+  },
+  {
+    "herbSlug": "chaga",
+    "herbName": "Chaga",
+    "canonicalCompoundId": "betulinic-acid",
+    "canonicalCompoundName": "betulinic acid"
+  },
+  {
+    "herbSlug": "ginkgo-biloba",
+    "herbName": "Ginkgo Biloba",
+    "canonicalCompoundId": "bilobetin",
+    "canonicalCompoundName": "bilobetin"
+  },
+  {
+    "herbSlug": "coffee-cherry",
+    "herbName": "Coffee Cherry",
+    "canonicalCompoundId": "cafestol",
+    "canonicalCompoundName": "cafestol"
+  },
+  {
+    "herbSlug": "echinacea-purpurea",
+    "herbName": "Echinacea Purpurea",
+    "canonicalCompoundId": "chicoric-acid",
+    "canonicalCompoundName": "chicoric acid"
+  },
+  {
+    "herbSlug": "lemongrass",
+    "herbName": "Lemongrass",
+    "canonicalCompoundId": "citronellal",
+    "canonicalCompoundName": "citronellal"
+  },
+  {
+    "herbSlug": "coptis",
+    "herbName": "Coptis",
+    "canonicalCompoundId": "coptisine",
+    "canonicalCompoundName": "coptisine"
+  },
+  {
+    "herbSlug": "pueraria-mirifica",
+    "herbName": "Pueraria Mirifica",
+    "canonicalCompoundId": "deoxymiroestrol",
+    "canonicalCompoundName": "deoxymiroestrol"
+  },
+  {
+    "herbSlug": "kava",
+    "herbName": "Kava",
+    "canonicalCompoundId": "desmethoxyyangonin",
+    "canonicalCompoundName": "desmethoxyyangonin"
+  },
+  {
+    "herbSlug": "kava",
+    "herbName": "Kava",
+    "canonicalCompoundId": "dihydrokavain",
+    "canonicalCompoundName": "dihydrokavain"
+  },
+  {
+    "herbSlug": "kava",
+    "herbName": "Kava",
+    "canonicalCompoundId": "dihydromethysticin",
+    "canonicalCompoundName": "dihydromethysticin"
+  },
+  {
+    "herbSlug": "lion-s-mane",
+    "herbName": "Lion's Mane",
+    "canonicalCompoundId": "erinacines",
+    "canonicalCompoundName": "erinacines"
+  },
+  {
+    "herbSlug": "lion-s-mane",
+    "herbName": "Lion's Mane",
+    "canonicalCompoundId": "hericenones",
+    "canonicalCompoundName": "hericenones"
+  },
+  {
+    "herbSlug": "isatis",
+    "herbName": "Isatis",
+    "canonicalCompoundId": "indirubin",
+    "canonicalCompoundName": "indirubin"
+  },
+  {
+    "herbSlug": "coffee-cherry",
+    "herbName": "Coffee Cherry",
+    "canonicalCompoundId": "kahweol",
+    "canonicalCompoundName": "kahweol"
+  },
+  {
+    "herbSlug": "salacia",
+    "herbName": "Salacia",
+    "canonicalCompoundId": "kotalanol",
+    "canonicalCompoundName": "kotalanol"
+  },
+  {
+    "herbSlug": "kanna",
+    "herbName": "Kanna",
+    "canonicalCompoundId": "mesembrine",
+    "canonicalCompoundName": "mesembrine"
+  },
+  {
+    "herbSlug": "kanna",
+    "herbName": "Kanna",
+    "canonicalCompoundId": "mesembrenone",
+    "canonicalCompoundName": "mesembrenone"
+  },
+  {
+    "herbSlug": "terminalia-arjuna",
+    "herbName": "Terminalia arjuna",
+    "canonicalCompoundId": "arjunolic-acid",
+    "canonicalCompoundName": "arjunolic acid"
+  },
+  {
+    "herbSlug": "camellia-sinensis",
+    "herbName": "Camellia sinensis",
+    "canonicalCompoundId": "catechin",
+    "canonicalCompoundName": "catechin"
+  },
+  {
+    "herbSlug": "coffea-arabica",
+    "herbName": "Coffea arabica",
+    "canonicalCompoundId": "chlorogenic-acid",
+    "canonicalCompoundName": "chlorogenic acid"
+  },
+  {
+    "herbSlug": "tinospora-cordifolia",
+    "herbName": "Tinospora cordifolia",
+    "canonicalCompoundId": "columbin",
+    "canonicalCompoundName": "columbin"
+  },
+  {
+    "herbSlug": "salvia-miltiorrhiza",
+    "herbName": "Salvia miltiorrhiza",
+    "canonicalCompoundId": "cryptotanshinone",
+    "canonicalCompoundName": "cryptotanshinone"
+  },
+  {
+    "herbSlug": "dioscorea-villosa",
+    "herbName": "Dioscorea villosa",
+    "canonicalCompoundId": "diosgenin",
+    "canonicalCompoundName": "diosgenin"
+  },
+  {
+    "herbSlug": "alpinia-officinarum",
+    "herbName": "Alpinia officinarum",
+    "canonicalCompoundId": "galangin",
+    "canonicalCompoundName": "galangin"
+  },
+  {
+    "herbSlug": "magnolia-officinalis",
+    "herbName": "Magnolia officinalis",
+    "canonicalCompoundId": "honokiol",
+    "canonicalCompoundName": "honokiol"
+  },
+  {
+    "herbSlug": "magnolia-officinalis",
+    "herbName": "Magnolia officinalis",
+    "canonicalCompoundId": "magnolol",
+    "canonicalCompoundName": "magnolol"
+  },
+  {
+    "herbSlug": "citrus-sinensis",
+    "herbName": "Citrus sinensis",
+    "canonicalCompoundId": "naringenin",
+    "canonicalCompoundName": "naringenin"
+  },
+  {
+    "herbSlug": "piper-nigrum",
+    "herbName": "Piper nigrum",
+    "canonicalCompoundId": "piperine",
+    "canonicalCompoundName": "piperine"
+  },
+  {
+    "herbSlug": "saffron",
+    "herbName": "Saffron",
+    "canonicalCompoundId": "safranal",
+    "canonicalCompoundName": "safranal"
+  },
+  {
+    "herbSlug": "coffee",
+    "herbName": "Coffee",
+    "canonicalCompoundId": "trigonelline",
+    "canonicalCompoundName": "trigonelline"
+  },
+  {
+    "herbSlug": "fenugreek",
+    "herbName": "Fenugreek",
+    "canonicalCompoundId": "trigonelline",
+    "canonicalCompoundName": "trigonelline"
+  },
+  {
+    "herbSlug": "schisandra",
+    "herbName": "Schisandra",
+    "canonicalCompoundId": "schisandrin-b",
+    "canonicalCompoundName": "schisandrin B"
+  },
+  {
+    "herbSlug": "eleuthero",
+    "herbName": "Eleuthero",
+    "canonicalCompoundId": "eleutheroside-b",
+    "canonicalCompoundName": "eleutheroside B"
+  },
+  {
+    "herbSlug": "eleuthero",
+    "herbName": "Eleuthero",
+    "canonicalCompoundId": "eleutheroside-e",
+    "canonicalCompoundName": "eleutheroside E"
+  },
+  {
+    "herbSlug": "pomegranate",
+    "herbName": "Pomegranate",
+    "canonicalCompoundId": "punicalagin",
+    "canonicalCompoundName": "punicalagin"
+  },
+  {
+    "herbSlug": "rosemary",
+    "herbName": "Rosemary",
+    "canonicalCompoundId": "carnosol",
+    "canonicalCompoundName": "carnosol"
+  },
+  {
+    "herbSlug": "moringa",
+    "herbName": "Moringa",
+    "canonicalCompoundId": "glucomoringin",
+    "canonicalCompoundName": "glucomoringin"
+  },
+  {
+    "herbSlug": "holy-basil",
+    "herbName": "Holy Basil",
+    "canonicalCompoundId": "methyl-eugenol",
+    "canonicalCompoundName": "methyl eugenol"
+  },
+  {
+    "herbSlug": "thyme",
+    "herbName": "Thyme",
+    "canonicalCompoundId": "carvacrol",
+    "canonicalCompoundName": "carvacrol"
+  },
+  {
+    "herbSlug": "thyme",
+    "herbName": "Thyme",
+    "canonicalCompoundId": "thymol",
+    "canonicalCompoundName": "thymol"
+  },
+  {
+    "herbSlug": "oregano",
+    "herbName": "Oregano",
+    "canonicalCompoundId": "thymol",
+    "canonicalCompoundName": "thymol"
+  },
+  {
+    "herbSlug": "milk-thistle",
+    "herbName": "Milk Thistle",
+    "canonicalCompoundId": "silybin",
+    "canonicalCompoundName": "silybin"
+  },
+  {
+    "herbSlug": "milk-thistle",
+    "herbName": "Milk Thistle",
+    "canonicalCompoundId": "silychristin",
+    "canonicalCompoundName": "silychristin"
+  },
+  {
+    "herbSlug": "milk-thistle",
+    "herbName": "Milk Thistle",
+    "canonicalCompoundId": "silydianin",
+    "canonicalCompoundName": "silydianin"
+  },
+  {
+    "herbSlug": "green-tea",
+    "herbName": "Green Tea",
+    "canonicalCompoundId": "epigallocatechin",
+    "canonicalCompoundName": "epigallocatechin"
+  },
+  {
+    "herbSlug": "green-tea",
+    "herbName": "Green Tea",
+    "canonicalCompoundId": "epicatechin-gallate",
+    "canonicalCompoundName": "epicatechin gallate"
+  },
+  {
+    "herbSlug": "green-tea",
+    "herbName": "Green Tea",
+    "canonicalCompoundId": "epigallocatechin-gallate",
+    "canonicalCompoundName": "epigallocatechin gallate"
+  },
+  {
+    "herbSlug": "green-tea",
+    "herbName": "Green Tea",
+    "canonicalCompoundId": "gallocatechin",
+    "canonicalCompoundName": "gallocatechin"
   }
 ]

--- a/public/data/workbook-herbs.json
+++ b/public/data/workbook-herbs.json
@@ -1,715 +1,1012 @@
 [
   {
     "slug": "ashwagandha",
-    "name": "Ashwagandha",
+    "name": "ashwagandha",
+    "region": "South Asia",
     "primaryActions": [
-      "Stress response support",
-      "neurotrophic support",
-      "inflammatory modulation"
+      "stress response support",
+      "sleep support",
+      "anxiety/stress symptom support"
     ],
     "mechanisms": [
-      "HPA-axis stress signaling modulation",
-      "GABAergic signaling modulation",
-      "NF-κB pathway modulation"
+      "HPA-axis cortisol modulation",
+      "GABA-A receptor signaling modulation",
+      "NF-κB inhibition",
+      "Nrf2 antioxidant-response activation",
+      "PI3K/Akt neuroprotective signaling"
     ],
-    "description": "Ashwagandha (Withania somnifera) is an adaptogenic root used most often as powder or standardized extract for stress and sleep support. Human studies are mixed but suggest modest improvements in perceived stress and sleep quality in some adults. Benefits and tolerability depend on extract standardization, dose, and concurrent medications.",
-    "activeCompounds": [
-      "withanolides",
-      "Withaferin A",
-      "Withanolide A",
-      "withanoside IV"
-    ],
-    "safetyNotes": "Usually tolerated in short-term use, but adverse effects can include drowsiness, GI upset, and headache. Rare clinically apparent liver injury has been reported after supplement use. It can add to sedative effects and may alter thyroid or glucose-related therapy, so medication review is advised.",
+    "description": "Ashwagandha centers on the root. Key reported compounds include withaferin A; withanolide D; withanolide A; withanoside IV; sitoindosides; alkaloids. Typical preparation forms: Root powders and standardized extracts. Withanolides are thought to mediate adaptogenic and neuroprotective effects by modulating HPA-axis signaling, NF-κB, Nrf2 and GABAergic pathways. Interaction profile: May potentiate sedatives, antihypertensives, antidiabetics, thyroid hormones, and immunosuppressants. Use caution or avoid in: Pregnancy, breastfeeding, autoimmune disease, thyroid disorders, liver disease.",
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "Avoid in pregnancy/breastfeeding unless clinician-supervised. Caution with thyroid disease or thyroid-hormone therapy, autoimmune disease/immunosuppressants, sedatives/CNS depressants, antihypertensives, and antidiabetics. Rare idiosyncratic liver injury is reported; avoid with active liver disease and stop if jaundice, dark urine, pruritus, or right-upper-quadrant pain occur.",
     "interactions": [
-      "Use caution with sedatives",
-      "thyroid-active therapy",
-      "or immunomodulators."
+      "May potentiate sedatives/CNS depressants",
+      "antihypertensives",
+      "antidiabetics",
+      "and thyroid hormone therapy",
+      "theoretical interaction with immunosuppressants",
+      "avoid stacking with hepatotoxic supplements/drugs."
+    ],
+    "contraindications": [
+      "Pregnancy",
+      "breastfeeding without clinician supervision",
+      "active liver disease or prior ashwagandha-related liver injury",
+      "clinician review for autoimmune disease or thyroid disorders."
     ],
     "preparation": "Root powder and extracts are most common; higher-extract products shift compound ratios.",
-    "affiliateProducts": [
-      {
-        "name": "Ashwagandha Capsules",
-        "type": "capsule",
-        "affiliateUrl": "https://www.amazon.com/s?k=ashwagandha+capsules&tag=razzleberry02-20"
-      },
-      {
-        "name": "Ashwagandha Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=ashwagandha+extract&tag=razzleberry02-20"
-      }
+    "traditionalUses": [
+      "stress response",
+      "sleep",
+      "anxiety/stress symptom"
     ]
   },
   {
     "slug": "black-cohosh",
-    "name": "Black Cohosh",
+    "name": "black cohosh",
+    "region": "North America",
+    "primaryActions": [
+      "menopause symptom support",
+      "vasomotor symptom support",
+      "women’s health education"
+    ],
     "mechanisms": [
-      "serotonergic",
-      "anti-inflammatory",
-      "hormonal"
+      "central serotonergic signaling modulation",
+      "5-HT receptor-related thermoregulation effects",
+      "estrogen-receptor/SERM-like activity remains uncertain",
+      "NF-κB/inflammatory signaling modulation"
     ],
     "description": "Black Cohosh centers on the root; rhizome. Key reported compounds include triterpene glycosides (actein, 23-epi-26-deoxyactein); cimifugoside; caffeic acid derivatives; fukinolic acid. Typical preparation forms: Root and rhizome used in standardized extracts, capsules, tablets, and tinctures. Proposed mechanism based on preclinical and limited clinical data: black cohosh may act through serotonergic pathways, selective estrogen receptor modulation, and anti-inflammatory signaling rather than as a classical estrogen. Interaction profile: Potential interactions with hepatotoxic drugs and with medications affecting estrogen or serotonergic pathways. Use caution or avoid in: Avoid in pregnancy and breastfeeding. Use caution in liver disease or hormone-sensitive conditions.",
-    "activeCompounds": [
-      "triterpene glycosides (actein",
-      "23-epi-26-deoxyactein)",
-      "cimifugoside",
-      "caffeic acid derivatives",
-      "fukinolic acid"
-    ],
-    "safetyNotes": "Generally well tolerated in short-term studies, but rare cases of liver injury have been reported. Product contamination or misidentification is a known issue.",
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "Avoid in pregnancy/breastfeeding. Caution or avoid with active liver disease, unexplained liver-enzyme elevation, or prior supplement-related liver injury. Rare severe hepatotoxicity reports exist. Use clinician review in hormone-sensitive cancers or with estrogenic/anti-estrogenic therapies; stop if jaundice, dark urine, right-upper-quadrant pain, or severe fatigue occurs.",
     "interactions": [
-      "serotonergic medications"
+      "Potential concern with hepatotoxic drugs/supplements",
+      "clinician review with estrogenic/anti-estrogenic therapy",
+      "serotonergic medicines",
+      "and complex oncology/endocrine regimens."
     ],
-    "preparation": "Root and rhizome used in standardized extracts, capsules, tablets, and tinctures",
-    "primaryActions": [
-      "anti-inflammatory",
-      "hepatoprotective"
+    "contraindications": [
+      "Pregnancy",
+      "breastfeeding",
+      "active liver disease",
+      "unexplained liver-enzyme elevation",
+      "clinician review for hormone-sensitive cancer history."
+    ],
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "traditionalUses": [
+      "menopause symptom",
+      "vasomotor symptom",
+      "women’s health"
     ]
   },
   {
     "slug": "echinacea-purpurea",
-    "name": "Echinacea Purpurea",
+    "name": "echinacea purpurea",
+    "region": "North America",
+    "primaryActions": [
+      "upper respiratory immune support",
+      "cold-duration prevention/management",
+      "immune safety education"
+    ],
     "mechanisms": [
-      "immunomodulatory",
-      "NF-κB inhibition",
-      "MAPK pathway modulation",
-      "MAPK modulation"
+      "macrophage and neutrophil activation",
+      "cytokine modulation (IL-1",
+      "IL-6",
+      "TNF-α)",
+      "CB2 receptor activity from alkamides",
+      "NF-κB/MAPK pathway modulation",
+      "COX/LOX enzyme inhibition"
     ],
     "description": "Echinacea Purpurea centers on the unspecified. Key reported compounds include alkamides; chicoric acid; echinacoside; caffeic acid; cynarin. Typical preparation forms: Medicinal products use the roots and aerial parts in teas, juices, tinctures and standardized extracts. Roots, leaves and flowers of Echinacea purpurea contain mixtures of lipophilic alkamides and hydrophilic caffeic acid derivatives such as chicoric acid and echinacoside, along with polysaccharides and glycoproteins【880087072039746†L166-L200】【840476591578855†L240-L305】. These constituents stimulate immune function by enhancing phagocytosis, activating fibroblasts and respiratory burst activity, and modulating nitric‐oxide and cytokine production via cannabinoid type‐2 receptors【880087072039746†L215-L243】. They also inhibit cyclo‐oxygenase and lipoxygenase enzymes. Most mechanistic data are from cell and animal studies; human evidence is limited. Interaction profile: Echinacea may interact with immunosuppressant drugs by stimulating immune activity and could affect the pharmacokinetics of drugs metabolised by cytochrome P450 enzymes; caution is advised when taken with hepatic substrates or caffeine. Use caution or avoid in: Individuals with autoimmune disorders or allergies to ragweed and other Asteraceae plants should avoid echinacea. Use during pregnancy or breastfeeding is not recommended. People taking immunosuppressant drugs should avoid echinacea due to potential antagonism.",
-    "activeCompounds": [
-      "alkamides",
-      "chicoric acid",
-      "echinacoside",
-      "caffeic acid",
-      "cynarin"
-    ],
-    "safetyNotes": "Short‐term use of echinacea extracts appears safe for most adults. Reported side effects include digestive upset and rash; allergic reactions can occur, especially in individuals sensitive to plants in the Asteraceae family. Some children have developed rashes after echinacea use. Safety during pregnancy or breastfeeding is not established. There is conflicting evidence about whether echinacea alters the metabolism of drugs processed by the liver; theoretical interactions with immunosuppressants or caffeine have been proposed【246299874455786†L194-L213】.",
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "Avoid in known Asteraceae/ragweed allergy; allergic rash and rare anaphylaxis are possible. Caution in autoimmune disease, transplant recipients, immunosuppressant therapy, and poorly characterized immune conditions. Avoid prolonged unsupervised use in pregnancy/breastfeeding.",
     "interactions": [
-      "immunosuppressants",
-      "CYP-metabolized medications"
+      "May counter immunosuppressants",
+      "extract-specific CYP effects are possible",
+      "use caution with hepatically metabolized narrow-therapeutic-index drugs."
     ],
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "immunomodulatory",
-      "hepatoprotective"
+    "contraindications": [
+      "Asteraceae allergy",
+      "transplant or significant immunosuppression without clinician review",
+      "autoimmune disease requiring immunosuppressive therapy unless supervised."
     ],
-    "affiliateProducts": [
-      {
-        "name": "Echinacea Tea",
-        "type": "tea",
-        "affiliateUrl": "https://www.amazon.com/s?k=echinacea+purpurea+tea&tag=razzleberry02-20"
-      },
-      {
-        "name": "Echinacea Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=echinacea+purpurea+extract&tag=razzleberry02-20"
-      }
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "traditionalUses": [
+      "upper respiratory immune",
+      "cold-duration prevention/management",
+      "immune safety"
     ]
   },
   {
     "slug": "garlic",
-    "name": "Garlic",
+    "name": "garlic",
+    "region": "Mediterranean; Europe; Asia",
+    "primaryActions": [
+      "cardiometabolic support",
+      "blood pressure/lipid education",
+      "antimicrobial traditional use"
+    ],
     "mechanisms": [
-      "anti-inflammatory",
-      "antioxidant",
-      "immunomodulatory",
-      "platelet aggregation inhibition",
-      "NF-κB inhibition"
+      "allicin/organosulfur signaling",
+      "ACE/endothelial nitric oxide modulation",
+      "HMG-CoA reductase and platelet aggregation modulation"
     ],
     "description": "Garlic centers on the unspecified. Key reported compounds include diallyl sulfide; diallyl disulfide; diallyl trisulfide; ajoene; S‐allyl‐cysteine. Typical preparation forms: Fresh or dried bulbs are used as food and in remedies. Commercial supplements include aged garlic extracts, oils and powders standardized for organosulfur content. Garlic bulbs contain organosulfur compounds such as diallyl sulfide, diallyl disulfide, diallyl trisulfide, ajoene and S‐allyl‐cysteine. These constituents exert antioxidant, anti‐inflammatory and immunomodulatory effects in vitro and in animal models by scavenging free radicals and modulating inflammatory pathways. Human evidence is limited, so this should be regarded as a proposed mechanism based on preclinical data. Interaction profile: Garlic may potentiate the effects of anticoagulant and antiplatelet drugs (e.g., warfarin, aspirin) and should be discontinued before surgery. It may also enhance the effects of antihypertensive or antidiabetic medicines. Use caution or avoid in: People with bleeding disorders, those taking anticoagulant or antiplatelet drugs and individuals scheduled for surgery should avoid high‐dose garlic supplements. Because safety during pregnancy and breastfeeding has not been established, garlic supplements are not recommended in these populations.",
-    "activeCompounds": [
-      "diallyl sulfide",
-      "diallyl disulfide",
-      "diallyl trisulfide",
-      "ajoene",
-      "S‐allyl‐cysteine"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Bleeding risk with anticoagulants/antiplatelets or perioperative use; GI irritation/reflux possible; may modestly lower blood pressure and glucose.",
+    "interactions": [
+      "May increase bleeding risk with anticoagulants/antiplatelets",
+      "may potentiate antihypertensives",
+      "possible interaction with some antiretrovirals."
     ],
-    "safetyNotes": "Oral garlic preparations are generally safe when used for up to seven years; side effects include breath and body odour, abdominal pain, flatulence and nausea. Because garlic can inhibit platelet aggregation it may increase the risk of bleeding, especially when combined with anticoagulants or antiplatelet drugs. Raw garlic applied to the skin can cause severe irritation or burns. The safety of garlic supplements during pregnancy or breastfeeding is uncertain【945608786527328†L190-L207】.",
-    "affiliateProducts": [
-      {
-        "name": "Garlic Capsules",
-        "type": "capsule",
-        "affiliateUrl": "https://www.amazon.com/s?k=garlic+capsules&tag=razzleberry02-20"
-      },
-      {
-        "name": "Garlic Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=garlic+extract&tag=razzleberry02-20"
-      }
+    "contraindications": [
+      "Bleeding disorder",
+      "upcoming surgery",
+      "garlic allergy",
+      "clinician review during pregnancy/breastfeeding at supplement doses"
+    ],
+    "preparation": "Fresh clove, aged garlic extract, powder, and oil preparations differ chemically; aged extract is common in trials.",
+    "traditionalUses": [
+      "Cardiovascular",
+      "respiratory",
+      "digestive",
+      "and antimicrobial traditional use"
     ]
   },
   {
     "slug": "ginger",
-    "name": "Ginger",
-    "mechanisms": [
-      "anti-inflammatory",
+    "name": "ginger",
+    "region": "South/Southeast Asia",
+    "primaryActions": [
+      "nausea support",
       "digestive support",
-      "nausea modulation"
+      "osteoarthritis symptom support",
+      "pregnancy-nausea education"
+    ],
+    "mechanisms": [
+      "5-HT3 receptor antagonism",
+      "gastric motility modulation",
+      "COX-2 and LOX inhibition",
+      "NF-κB inhibition",
+      "thromboxane/platelet-aggregation modulation"
     ],
     "description": "Ginger centers on the unspecified. Key reported compounds include [6]-gingerol; shogaols; zingerone; paradols. Typical preparation forms: The rhizome is used fresh, dried, pickled, preserved, candied or powdered. Supplements include encapsulated dried powders and extracts【418916103730052†L176-L189】. Ginger rhizomes contain phenolic constituents such as gingerols, shogaols, zingerone and paradols. These compounds modulate immune‐cell function and regulate signalling pathways including nuclear factor‐κB, MAPK and PI3K/Akt/mTOR, and they can activate AMP‐activated protein kinase (AMPK), NRF2, HO‐1 and PPARγ【69571933386645†L153-L169】【69571933386645†L240-L249】. Through these mechanisms ginger exhibits anti‐inflammatory, antioxidant and neuroprotective effects. Interaction profile: Ginger may increase the risk of bleeding when taken with anticoagulant or antiplatelet drugs and could lower blood glucose or blood pressure, potentiating antidiabetic or antihypertensive medications. Use caution or avoid in: Use cautiously in pregnancy, gallstone disease or bleeding disorders. Discontinue before surgery and avoid high‐dose supplements when taking anticoagulants.",
-    "activeCompounds": [
-      "gingerol",
-      "shogaol"
-    ],
-    "safetyNotes": "Ginger is widely consumed as a food and supplement and is generally regarded as safe. Research suggests it may help with mild nausea and menstrual cramps. Reported side effects at high doses include abdominal discomfort, heartburn, diarrhoea and irritation of the mouth or throat【799387966105800†L29-L56】. Clinical studies using up to 1 000 mg/day of dried powdered extract report adverse event rates similar to placebo【739669106228210†L96-L133】. The safety of high‐dose ginger during pregnancy has not been conclusively established.",
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "Heartburn and GI upset are common at higher doses. Pregnancy use should stay within studied doses and clinician guidance. Caution with anticoagulants/antiplatelets, bleeding disorders, perioperative use, gallstones/biliary disease, antidiabetic therapy, and antihypertensive therapy.",
     "interactions": [
-      "anticoagulants/antiplatelets",
-      "antihypertensives",
-      "antidiabetic medications"
+      "Potential additive bleeding risk with warfarin",
+      "DOACs",
+      "antiplatelets",
+      "and NSAIDs",
+      "may compound glucose- or blood-pressure-lowering therapy."
     ],
-    "preparation": "No direct preparation data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. No direct region data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. Folk medicine. Folk medicine",
-    "primaryActions": [
-      "immunomodulatory",
-      "antioxidant",
-      "glycemic support"
+    "contraindications": [
+      "Bleeding disorder or perioperative use without clinician review",
+      "gallstone/biliary disease without clinician review",
+      "high-dose use in pregnancy without clinician guidance."
     ],
-    "affiliateProducts": [
-      {
-        "name": "Ginger Powder",
-        "type": "powder",
-        "affiliateUrl": "https://www.amazon.com/s?k=ginger+powder&tag=razzleberry02-20"
-      },
-      {
-        "name": "Ginger Capsules",
-        "type": "capsule",
-        "affiliateUrl": "https://www.amazon.com/s?k=ginger+capsules&tag=razzleberry02-20"
-      }
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "traditionalUses": [
+      "nausea",
+      "digestive",
+      "osteoarthritis symptom",
+      "pregnancy-nausea"
     ]
   },
   {
     "slug": "ginkgo-biloba",
-    "name": "Ginkgo Biloba",
+    "name": "ginkgo biloba",
+    "region": "East Asia",
+    "primaryActions": [
+      "cognitive support education",
+      "circulation support",
+      "dementia-adjacent evidence education"
+    ],
     "mechanisms": [
-      "dopaminergic",
-      "serotonergic",
-      "cholinergic",
-      "antioxidant",
-      "NF-κB inhibition",
-      "PI3K/Akt modulation",
-      "Nrf2 activation",
-      "MAPK modulation"
+      "platelet-activating factor antagonism",
+      "antioxidant/free-radical scavenging",
+      "cerebral microcirculation and endothelial nitric-oxide modulation",
+      "mitochondrial protection",
+      "NF-κB/Nrf2 signaling modulation"
     ],
     "description": "Ginkgo Biloba centers on the leaf. Key reported compounds include ginkgolides A, B, C, J; bilobalide; ginkgetin; bilobetin; sciadopitysin. Typical preparation forms: Standardized leaf extract (EGb 761). The standardized leaf extract (EGb 761) contains terpene lactones and flavone glycosides that modulate multiple neurotransmitter systems and platelet-activating factor pathways. Interaction profile: May potentiate NSAIDs, anticoagulants, antiplatelets, and interact with antidepressants and antidiabetic drugs. Use caution or avoid in: Pregnancy, breastfeeding, bleeding disorders, epilepsy, planned surgery.",
-    "activeCompounds": [
-      "ginkgolides A",
-      "B",
-      "C",
-      "J",
-      "bilobalide",
-      "ginkgetin",
-      "bilobetin",
-      "sciadopitysin",
-      "Quercetin",
-      "Kaempferol"
-    ],
-    "safetyNotes": "Appears safe at recommended doses, but fresh seeds are toxic. May increase bleeding risk and lower seizure threshold.",
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "Bleeding risk is the primary public-facing concern; avoid with anticoagulants/antiplatelets or before surgery unless clinician-supervised. Seizure-threshold concerns exist from ginkgotoxin, especially with seeds or high-risk patients. Avoid fresh seeds. Caution with antiepileptics, pregnancy, and complex medication regimens.",
     "interactions": [
-      "anticoagulants/antiplatelets",
-      "serotonergic medications",
-      "antidiabetic medications"
+      "Anticoagulants",
+      "antiplatelets",
+      "NSAIDs",
+      "antiepileptics",
+      "and other narrow-therapeutic-index drugs",
+      "possible extract-specific CYP effects."
     ],
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "nootropic"
+    "contraindications": [
+      "Active bleeding disorder",
+      "perioperative period without clinician review",
+      "seizure disorder unless supervised",
+      "avoid fresh seeds entirely."
     ],
-    "affiliateProducts": [
-      {
-        "name": "Ginkgo Biloba Capsules",
-        "type": "capsule",
-        "affiliateUrl": "https://www.amazon.com/s?k=ginkgo+biloba+capsules&tag=razzleberry02-20"
-      },
-      {
-        "name": "Ginkgo Biloba Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=ginkgo+biloba+extract&tag=razzleberry02-20"
-      }
+    "preparation": "Leaf preparations are commonly used as teas, powders, tinctures, or standardized extracts; topical use may differ from oral use.",
+    "traditionalUses": [
+      "cognitive",
+      "circulation",
+      "dementia-adjacent evidence"
     ]
   },
   {
     "slug": "holy-basil",
-    "name": "Holy Basil",
+    "name": "holy basil",
+    "region": "South Asia; Ayurveda",
+    "primaryActions": [
+      "stress response support",
+      "metabolic support",
+      "respiratory traditional use"
+    ],
     "mechanisms": [
-      "adaptogen",
-      "anti-inflammatory",
-      "antioxidant",
-      "COX inhibition",
-      "TRP channel modulation",
-      "NF-κB inhibition",
-      "STAT3 inhibition",
-      "AMPK activation",
-      "TRPA1 modulation",
-      "voltage-gated channel modulation"
+      "eugenol/ursolic-acid signaling",
+      "cortisol/stress-axis modulation",
+      "AMPK/glucose and inflammatory-pathway effects"
     ],
     "description": "Holy Basil centers on the leaf; aerial parts. Key reported compounds include eugenol; ursolic acid; rosmarinic acid. Typical preparation forms: Leaf extracts, teas. Adaptogenic; anti-inflammatory; modulates cortisol and stress pathways. Interaction profile: Anticoagulants, antidiabetic drugs. Use caution or avoid in: Pregnancy (limited data).",
-    "activeCompounds": [
-      "eugenol",
-      "ursolic acid",
-      "rosmarinic acid",
-      "methyl eugenol"
-    ],
-    "safetyNotes": "Generally safe; possible mild GI upset",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May lower glucose and affect clotting; caution with diabetes drugs, anticoagulants, pregnancy, and perioperative use.",
     "interactions": [
-      "anticoagulants/antiplatelets",
-      "antidiabetic medications"
+      "May add to antidiabetic",
+      "antihypertensive",
+      "sedative",
+      "anticoagulant",
+      "or antiplatelet effects."
     ],
-    "preparation": "No direct preparation data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. No direct region data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine",
-    "primaryActions": [
-      "anti-inflammatory",
-      "adaptogenic"
+    "contraindications": [
+      "Pregnancy attempts/pregnancy without clinician guidance",
+      "hypoglycemia risk",
+      "bleeding disorder",
+      "upcoming surgery"
+    ],
+    "preparation": "Leaf tea, tincture, powder, and standardized extracts; seed preparations are a different data object.",
+    "traditionalUses": [
+      "Ayurvedic rasayana/adaptogen",
+      "respiratory and digestive support"
     ]
   },
   {
     "slug": "kava",
-    "name": "Kava",
+    "name": "kava",
+    "region": "Pacific Islands",
+    "primaryActions": [
+      "anxiety symptom support",
+      "relaxation support",
+      "safety-first supplement education"
+    ],
     "mechanisms": [
-      "gabaergic",
-      "MAO-B inhibition",
-      "GABA-A modulation"
+      "GABA-A receptor positive modulation",
+      "voltage-gated sodium and calcium channel modulation",
+      "monoamine oxidase-B inhibition",
+      "glutamate/excitatory signaling modulation"
     ],
     "description": "Kava centers on the root; rhizome. Key reported compounds include kavain; dihydrokavain; methysticin; dihydromethysticin; yangonin; desmethoxyyangonin; flavokavain A/B/C. Typical preparation forms: Traditional aqueous root beverage; modern standardized root extracts. Kavalactones modulate GABA-A receptors and ion channels, producing anxiolytic and sedative effects without classical benzodiazepine-site binding. Interaction profile: Additive sedation with CNS depressants and alcohol; possible hepatic enzyme interactions. Use caution or avoid in: Liver disease, pregnancy, breastfeeding, concurrent CNS depressants or hepatotoxic drugs.",
-    "activeCompounds": [
-      "kavain",
-      "dihydrokavain",
-      "methysticin",
-      "dihydromethysticin",
-      "yangonin",
-      "desmethoxyyangonin",
-      "flavokavain A/B/C"
-    ],
-    "safetyNotes": "Rare but serious liver injury has been reported, especially with nontraditional extracts or concurrent alcohol/hepatotoxic drug use.",
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "Not for active/history liver disease, heavy alcohol use, or concurrent hepatotoxic drugs/supplements. Rare serious liver injury has been reported. Additive sedation is possible with benzodiazepines, barbiturates, opioids, sleep aids, alcohol, and other CNS depressants. Avoid driving after use; avoid pregnancy/breastfeeding.",
     "interactions": [
-      "CNS depressants"
+      "CNS depressants",
+      "alcohol",
+      "benzodiazepines",
+      "opioids",
+      "sleep medicines",
+      "hepatotoxic drugs/supplements",
+      "and possible CYP-mediated interactions."
     ],
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "anxiolytic",
-      "sedative",
-      "hepatoprotective"
+    "contraindications": [
+      "Active or previous liver disease",
+      "pregnancy/breastfeeding",
+      "current alcohol misuse",
+      "perioperative sedation risk unless medically supervised."
+    ],
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "traditionalUses": [
+      "anxiety symptom",
+      "relaxation",
+      "safety-first supplement"
     ]
   },
   {
     "slug": "lemon-balm",
-    "name": "Lemon Balm",
+    "name": "lemon balm",
+    "region": "Europe; Mediterranean",
+    "primaryActions": [
+      "calm/sleep support",
+      "mild anxiety support",
+      "digestive comfort"
+    ],
     "mechanisms": [
-      "anxiolytic",
-      "antiviral",
-      "calming"
+      "GABA-transaminase inhibition",
+      "rosmarinic-acid anti-inflammatory signaling",
+      "cholinergic/acetylcholinesterase modulation"
     ],
     "description": "Lemon Balm centers on the leaf; aerial parts. Key reported compounds include rosmarinic acid; citral; citronellal; linalool; flavonoids. Typical preparation forms: Leaf extracts, teas, tinctures. GABAergic (GABA transaminase inhibition); mild cholinergic activity. Interaction profile: Sedatives, thyroid medications. Use caution or avoid in: Hypothyroidism (caution).",
-    "activeCompounds": [
-      "rosmarinic acid"
-    ],
-    "safetyNotes": "Generally safe; mild sedation possible",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Sedation possible; caution with CNS depressants, thyroid medication, pregnancy/breastfeeding, and perioperative use.",
     "interactions": [
-      "CNS depressants",
-      "thyroid medications"
+      "May potentiate sedatives/CNS depressants",
+      "clinician review with thyroid medications."
     ],
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "cholinergic modulation",
-      "anxiolytic",
-      "sedative"
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "thyroid disease/thyroid medication review",
+      "heavy sedation risk"
+    ],
+    "preparation": "Leaf tea, tincture, glycerite, essential-oil-derived topical products, and standardized extracts.",
+    "traditionalUses": [
+      "Nervous tension",
+      "sleep",
+      "digestion",
+      "and aromatic calming use"
     ]
   },
   {
     "slug": "maca",
-    "name": "Maca",
+    "name": "maca",
+    "region": "Peruvian Andes",
+    "primaryActions": [
+      "sexual function support",
+      "energy/vitality support",
+      "menopause symptom education"
+    ],
     "mechanisms": [
-      "adaptogen",
-      "hormonal"
+      "macamide/macaene signaling",
+      "HPA-axis and NO-related sexual-function pathways",
+      "non-estrogenic neuroendocrine modulation"
     ],
     "description": "Maca centers on the root; hypocotyl. Key reported compounds include macamides; macaenes; glucosinolates. Typical preparation forms: Dried root powder, extracts. May influence endocrine signaling and energy metabolism (unclear mechanism). Interaction profile: Limited data. Use caution or avoid in: Hormone-sensitive conditions (caution).",
-    "activeCompounds": [
-      "macamides",
-      "macaenes",
-      "glucosinolates"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Avoid assuming hormone-like replacement; caution in hormone-sensitive conditions and pregnancy due to limited long-term data.",
+    "interactions": [
+      "Limited interaction data",
+      "review with hormone therapies or fertility treatments."
     ],
-    "safetyNotes": "Generally safe; mild GI upset possible",
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan"
+    "contraindications": [
+      "Hormone-sensitive conditions without clinician review",
+      "pregnancy/breastfeeding without clinician guidance"
+    ],
+    "preparation": "Gelatinized or raw root powder and extracts; color phenotypes may differ.",
+    "traditionalUses": [
+      "Andean food-tonic for stamina",
+      "fertility",
+      "and vitality"
+    ]
   },
   {
     "slug": "milk-thistle",
-    "name": "Milk Thistle",
+    "name": "milk thistle",
+    "region": "Mediterranean/Europe",
     "primaryActions": [
       "Hepatocyte protection",
       "antioxidant response support",
       "antifibrotic signaling"
     ],
     "mechanisms": [
-      "Nrf2 antioxidant response activation",
-      "NF-κB inflammatory signaling modulation",
-      "hepatocyte membrane stabilization"
+      "silybin/silymarin antioxidant signaling",
+      "Nrf2 activation",
+      "NF-κB inhibition",
+      "hepatic glutathione and membrane-stabilizing effects"
     ],
-    "description": "Milk thistle seed extract supplies silymarin compounds, often used for liver support. Study results show mixed clinical effect, though lab work suggests antioxidant and anti-inflammatory activity. Most use relies on fixed-dose extract products.",
-    "activeCompounds": [
-      "silymarin",
-      "Silibinin",
-      "silybin",
-      "silychristin",
-      "silydianin"
-    ],
-    "safetyNotes": "Generally well tolerated, with mild nausea, bloating, or loose stools as the most common adverse effects. Allergic reactions can occur, especially in people with Asteraceae (ragweed/daisy family) sensitivity. Potential CYP-mediated interaction risk warrants caution with narrow-therapeutic-index drugs such as warfarin.",
+    "description": "Milk Thistle centers on the seed; fruit. Key reported compounds include silybin A/B; isosilybin A/B; silychristin; silydianin; isosilychristin. Typical preparation forms: Seed/fruit extracts standardized to silymarin. Silymarin flavonolignans exhibit antioxidant, anti-inflammatory and antifibrotic activity relevant to hepatoprotection. Interaction profile: Possible CYP2C9/CYP3A4 interaction risk; may affect warfarin and some other drugs. Use caution or avoid in: Asteraceae allergy; caution in pregnancy/breastfeeding.",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "GI upset/allergy possible; caution with diabetes medications and CYP-metabolized drugs; avoid relying on it as treatment for serious liver disease.",
     "interactions": [
       "May affect drug transport and metabolism in susceptible users."
     ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "active liver disease"
+    ],
     "preparation": "Seed extract is more practical than whole seed; standardized silymarin products are common.",
-    "affiliateProducts": [
-      {
-        "name": "Milk Thistle Capsules",
-        "type": "capsule",
-        "affiliateUrl": "https://www.amazon.com/s?k=milk+thistle+capsules&tag=razzleberry02-20"
-      },
-      {
-        "name": "Milk Thistle Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=milk+thistle+extract&tag=razzleberry02-20"
-      }
+    "traditionalUses": [
+      "Hepatocyte protection",
+      "antioxidant response",
+      "antifibrotic signaling"
     ]
   },
   {
     "slug": "peppermint",
-    "name": "Peppermint",
+    "name": "peppermint",
+    "region": "Europe/Middle East",
+    "primaryActions": [
+      "IBS symptom support",
+      "gut spasm support",
+      "digestive comfort"
+    ],
     "mechanisms": [
-      "digestive support",
-      "smooth muscle relaxation"
+      "intestinal smooth-muscle calcium-channel blockade",
+      "TRPM8 receptor activation",
+      "visceral antinociception",
+      "carminative effects",
+      "antimicrobial effects in vitro"
     ],
     "description": "Peppermint centers on the unspecified. Key reported compounds include l‐menthol; l‐menthone; isomenthone; menthyl acetate; 1,8‐cineole (eucalyptol); menthofuran; limonene. Typical preparation forms: Leaves and flowering tops are used fresh or dried to make teas and flavourings. Medicinal products include enteric‐coated capsules of peppermint oil and topical preparations. Peppermint oil contains more than 80 constituents; menthol is the main bioactive component. Menthol acts as a smooth‐muscle relaxant by blocking L‐type calcium channels and activating transient receptor potential channels (TRPM8 and TRPA1). These actions underlie the spasmolytic and analgesic properties of peppermint oil. Peppermint oil also has antimicrobial, antiviral and anti‐inflammatory effects【271856535371736†L224-L289】【271856535371736†L312-L333】. Interaction profile: Peppermint oil may inhibit cytochrome P450 enzymes (e.g., CYP2A6 and UGT2B7) and could theoretically interact with drugs metabolised by these pathways. Use caution or avoid in: Avoid in infants and young children, and in people with gastro‐oesophageal reflux disease or bile duct obstruction. Use cautiously in those taking hepatotoxic drugs due to potential pulegone/menthofuran toxicity.",
-    "activeCompounds": [
-      "menthol"
-    ],
-    "safetyNotes": "Menthol is generally regarded as safe. Enteric‐coated peppermint oil is well tolerated; the most common adverse effects reported in clinical trials are heartburn, nausea, abdominal pain and dry mouth【220193048567304†L45-L53】. High doses of minor constituents such as pulegone or menthofuran can cause hepatotoxicity in animals, but typical medicinal doses contain negligible amounts and no cases of human hepatotoxicity have been reported【271856535371736†L1296-L1354】. Peppermint oil should not be applied near the faces of infants or young children because menthol inhalation can cause serious adverse reactions【220193048567304†L45-L53】.",
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "Use enteric-coated peppermint oil for IBS claims. May worsen GERD/reflux and cause heartburn. Avoid peppermint oil in infants and young children. Caution with biliary obstruction, gallbladder disease, and hiatal hernia.",
     "interactions": [
-      "CYP-metabolized medications"
+      "Potential additive GI irritation",
+      "concentrated oil may have CYP3A4/P-gp considerations",
+      "but clinical impact is uncertain."
     ],
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "hepatoprotective",
-      "antimicrobial",
-      "analgesic"
+    "contraindications": [
+      "Poorly controlled GERD/hiatal hernia",
+      "biliary obstruction",
+      "infants/young children for peppermint oil",
+      "known peppermint allergy."
     ],
-    "affiliateProducts": [
-      {
-        "name": "Peppermint Tea",
-        "type": "tea",
-        "affiliateUrl": "https://www.amazon.com/s?k=mentha+piperita+tea&tag=razzleberry02-20"
-      },
-      {
-        "name": "Peppermint Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=mentha+piperita+extract&tag=razzleberry02-20"
-      }
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "IBS symptom",
+      "gut spasm",
+      "digestive comfort"
     ]
   },
   {
     "slug": "rhodiola-rosea",
-    "name": "Rhodiola Rosea",
+    "name": "rhodiola rosea",
+    "region": "Eurasian high-altitude/arctic regions",
+    "primaryActions": [
+      "fatigue/stress support",
+      "adaptogen education",
+      "performance and mood-adjacent support"
+    ],
     "mechanisms": [
-      "adaptogen",
-      "serotonergic",
-      "dopaminergic",
-      "antioxidant"
+      "HPA-axis stress-response modulation",
+      "salidroside/rosavin-related AMPK activation",
+      "monoamine oxidase modulation",
+      "beta-endorphin/stress-mediator modulation",
+      "Nrf2 antioxidant signaling",
+      "mitochondrial stress-response signaling"
     ],
     "description": "Rhodiola Rosea centers on the root. Key reported compounds include rosavin; rosarin; rosin; salidroside; tyrosol. Typical preparation forms: Standardized root extracts. Adaptogen; modulates HPA axis; influences serotonin, dopamine, norepinephrine; antioxidant. Interaction profile: SSRIs, MAOIs, stimulants. Use caution or avoid in: Bipolar disorder; avoid high doses before sleep.",
-    "activeCompounds": [
-      "rosavin",
-      "rosarin",
-      "rosin",
-      "salidroside",
-      "tyrosol"
-    ],
-    "safetyNotes": "Generally well tolerated; possible dizziness; dry mouth; insomnia",
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "Can cause insomnia, agitation, dizziness, or dry mouth; avoid late-day dosing. Caution with bipolar disorder/mania history, stimulants, antidepressants/MAOIs, sedatives, pregnancy, and breastfeeding. Product adulteration and inconsistent salidroside/rosavin standardization are important quality risks.",
     "interactions": [
-      "serotonergic medications"
+      "Potential additive effects with stimulants",
+      "antidepressants/MAOIs",
+      "anxiolytics/sedatives",
+      "and therapies affecting blood pressure or glucose."
     ],
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "adaptogenic",
-      "sedative",
-      "antioxidant"
+    "contraindications": [
+      "Bipolar disorder or mania history without clinician supervision",
+      "pregnancy/breastfeeding",
+      "known allergy."
     ],
-    "affiliateProducts": [
-      {
-        "name": "Rhodiola Rosea Capsules",
-        "type": "capsule",
-        "affiliateUrl": "https://www.amazon.com/s?k=rhodiola+rosea+capsules&tag=razzleberry02-20"
-      },
-      {
-        "name": "Rhodiola Rosea Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=rhodiola+rosea+extract&tag=razzleberry02-20"
-      }
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "traditionalUses": [
+      "fatigue/stress",
+      "adaptogen",
+      "performance and mood-adjacent"
     ]
   },
   {
     "slug": "saw-palmetto",
-    "name": "Saw Palmetto",
+    "name": "saw palmetto",
+    "region": "Southeastern North America",
+    "primaryActions": [
+      "prostate/LUTS education",
+      "men’s health support",
+      "urinary symptom support"
+    ],
     "mechanisms": [
-      "hormonal",
-      "anti-androgenic"
+      "5-alpha-reductase inhibition",
+      "androgen receptor signaling modulation",
+      "anti-inflammatory COX/LOX pathway modulation",
+      "prostate epithelial anti-edema effects"
     ],
     "description": "Saw Palmetto centers on the berry. Key reported compounds include fatty acids; phytosterols (beta-sitosterol). Typical preparation forms: Berry extracts. 5-alpha-reductase inhibition; anti-androgenic effects. Interaction profile: Hormonal therapies, anticoagulants. Use caution or avoid in: Pregnancy.",
-    "activeCompounds": [
-      "fatty acids",
-      "phytosterols (beta-sitosterol)"
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "GI upset and headache can occur. Caution with anticoagulants/antiplatelets and before surgery. Avoid pregnancy/breastfeeding. New or worsening urinary symptoms require medical evaluation because LUTS can overlap with prostate cancer or infection.",
+    "interactions": [
+      "Anticoagulants",
+      "antiplatelets",
+      "hormone-active therapies",
+      "and perioperative medications",
+      "possible additive bleeding concern."
     ],
-    "safetyNotes": "Generally safe; mild GI upset; headache"
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "unexplained urinary symptoms without medical evaluation",
+      "perioperative use without clinician review."
+    ],
+    "preparation": "Fruit/berry preparations are commonly used as foods, juices, powders, capsules, or extracts; sugar and extract concentration vary.",
+    "traditionalUses": [
+      "prostate/LUTS",
+      "men’s health",
+      "urinary symptom"
+    ]
   },
   {
     "slug": "st-johns-wort",
-    "name": "St Johns Wort",
+    "name": "st johns wort",
+    "region": "Europe/West Asia",
+    "primaryActions": [
+      "mood support education",
+      "depression evidence education",
+      "interaction safety"
+    ],
     "mechanisms": [
-      "serotonergic",
-      "dopaminergic",
-      "NF-κB inhibition",
-      "PI3K/Akt modulation",
-      "Nrf2 activation"
+      "hyperforin-mediated pregnane X receptor activation",
+      "CYP3A4",
+      "CYP2C9",
+      "CYP2C19",
+      "and P-glycoprotein induction",
+      "serotonin/norepinephrine/dopamine reuptake modulation",
+      "variable MAO-related effects"
     ],
     "description": "St. John's wort centers on the flowering tops. Key reported compounds include hyperforin; hypericin; pseudohypericin; quercetin; rutin; kaempferol. Typical preparation forms: Dried flowering tops or standardized extracts. Hyperforin and related compounds inhibit monoamine reuptake and affect TRPC6-linked neuroplasticity; additional monoamine oxidase and stress-pathway effects have been proposed. Interaction profile: Major interactions with antidepressants, oral contraceptives, cyclosporine, tacrolimus, HIV meds, anticancer drugs, warfarin, digoxin and others. Use caution or avoid in: Pregnancy, breastfeeding, bipolar disorder, concomitant prescription meds with CYP/P-gp liability.",
-    "activeCompounds": [
-      "hyperforin",
-      "hypericin",
-      "pseudohypericin",
-      "quercetin",
-      "rutin",
-      "kaempferol"
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "High interaction risk. Avoid with SSRIs, SNRIs, MAOIs, triptans, and other serotonergic drugs due to serotonin-toxicity risk. Can reduce effectiveness of oral contraceptives, warfarin/DOACs, antiretrovirals, immunosuppressants, oncology drugs, and anticonvulsants. Photosensitivity and mania risk occur; do not stop or replace antidepressants without clinician guidance.",
+    "interactions": [
+      "CYP3A4/CYP2C9/CYP2C19 and P-gp substrates",
+      "oral contraceptives",
+      "warfarin/DOACs",
+      "antiretrovirals",
+      "cyclosporine/tacrolimus",
+      "chemotherapy",
+      "anticonvulsants",
+      "SSRIs/SNRIs/MAOIs/triptans."
     ],
-    "safetyNotes": "Can cause photosensitivity, GI upset, dizziness, insomnia, restlessness. Strong inducer of CYP3A4 and P-gp."
+    "contraindications": [
+      "Current antidepressant/serotonergic therapy unless clinician-supervised",
+      "bipolar disorder/mania history",
+      "transplant/immunosuppression",
+      "pregnancy/breastfeeding without clinician review."
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "mood",
+      "depression evidence",
+      "interaction safety"
+    ]
   },
   {
     "slug": "turmeric",
-    "name": "Turmeric",
+    "name": "turmeric",
+    "region": "South Asia",
+    "primaryActions": [
+      "joint/inflammation support",
+      "pain-adjacent support",
+      "metabolic-inflammatory education"
+    ],
     "mechanisms": [
-      "anti-inflammatory",
-      "antioxidant",
-      "nf-kb modulation",
-      "NF-κB inhibition",
-      "Nrf2 activation"
+      "curcumin-mediated NF-κB inhibition",
+      "COX-2 and LOX downregulation",
+      "Nrf2 antioxidant-response activation",
+      "JAK/STAT and MAPK modulation",
+      "inflammatory cytokine reduction (TNF-α",
+      "IL-6)"
     ],
     "description": "Turmeric centers on the unspecified. Key reported compounds include curcumin; demethoxycurcumin; bisdemethoxycurcumin. Typical preparation forms: The rhizomes are boiled, dried and ground into powder used as a spice, dye and supplement. Extracts standardized for curcuminoid content are available as capsules or tablets. The golden rhizomes of turmeric contain non‐volatile curcuminoids-curcumin (curcumin I), demethoxycurcumin (curcumin II) and bisdemethoxycurcumin (curcumin III)-as well as volatile mono‐ and sesquiterpenoids【768158627760254†L420-L432】【768158627760254†L442-L468】. Curcumin and related curcuminoids exhibit antioxidant and anti‐inflammatory effects by modulating multiple molecular targets (e.g., NF‐κB, Nrf2, COX‐2). Most data are preclinical; human evidence is limited, so this mechanism should be considered proposed. Interaction profile: Curcumin may enhance the effects of anticoagulant, antiplatelet or antidiabetic drugs and could interact with drugs metabolized by cytochrome P450 enzymes; caution is advised. Use caution or avoid in: Avoid high‐dose turmeric supplements in people with gallbladder obstruction, bleeding disorders or those taking anticoagulant or antiplatelet medications. Use is not recommended during pregnancy or breastfeeding.",
-    "activeCompounds": [
-      "curcumin",
-      "demethoxycurcumin"
-    ],
-    "safetyNotes": "Conventional oral preparations of turmeric or curcumin appear safe for up to 2-3 months. Reported adverse effects include nausea, vomiting, acid reflux, stomach upset, diarrhoea or constipation. Highly bioavailable curcumin products have been linked to liver damage in rare cases. The safety of turmeric supplements during pregnancy or breastfeeding is uncertain【628537290338832†L207-L223】.",
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "GI upset is common at higher doses. High-bioavailability extracts can materially increase exposure. Caution with anticoagulants/antiplatelets/NSAIDs, gallbladder disease or bile duct obstruction, kidney stones, iron deficiency, antidiabetic therapy, and hepatotoxic drugs/supplements. Hepatotoxicity case reports exist for some turmeric/curcumin products.",
     "interactions": [
-      "anticoagulants/antiplatelets",
-      "antidiabetic medications",
-      "CYP-metabolized medications"
+      "Anticoagulants",
+      "antiplatelets",
+      "NSAIDs",
+      "antidiabetics",
+      "iron supplements",
+      "hepatotoxic drugs/supplements",
+      "and oncology medications where CYP/P-gp concerns are clinically relevant."
     ],
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "anti-inflammatory",
-      "antioxidant",
-      "analgesic"
+    "contraindications": [
+      "Bile duct obstruction or active gallbladder disease without clinician review",
+      "active liver disease or prior turmeric/curcumin-related liver injury",
+      "perioperative use without clinician review."
+    ],
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "traditionalUses": [
+      "joint/inflammation",
+      "pain-adjacent",
+      "metabolic-inflammatory"
     ]
   },
   {
     "slug": "valerian",
-    "name": "Valerian",
+    "name": "valerian",
+    "region": "Europe; Western herbalism",
+    "primaryActions": [
+      "sleep latency support",
+      "relaxation support",
+      "mild anxiety symptom education"
+    ],
     "mechanisms": [
-      "sedative",
-      "sleep support",
-      "gaba modulation"
+      "valerenic-acid GABA-A receptor modulation",
+      "GABA degradation/transport effects",
+      "adenosine and serotonergic sleep-pathway modulation"
     ],
     "description": "Valerian centers on the root; rhizome. Key reported compounds include valerenic acid; valerenol; valerenal; valepotriates (valtrate, isovaltrate); sesquiterpenoids. Typical preparation forms: Dried roots/rhizomes as teas, tinctures, or extracts. Valerenic acid derivatives modulate GABA-A signaling and may inhibit GABA breakdown. Interaction profile: May potentiate sedatives and alcohol. Use caution or avoid in: Pregnancy, breastfeeding, liver disease, concurrent CNS depressants.",
-    "activeCompounds": [
-      "valerenic acid"
-    ],
-    "safetyNotes": "Short-term use appears safe; side effects include headache, GI upset, mental dullness, excitability, vivid dreams. Rare liver injury reported.",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Sedation and next-day drowsiness possible; avoid combining with alcohol, benzodiazepines, opioids, or other CNS depressants.",
     "interactions": [
-      "CNS depressants"
+      "May potentiate alcohol",
+      "benzodiazepines",
+      "barbiturates",
+      "sleep aids",
+      "opioids",
+      "and other CNS depressants."
     ],
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "anxiolytic",
-      "sedative",
-      "hepatoprotective"
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "heavy sedative use",
+      "upcoming anesthesia"
+    ],
+    "preparation": "Root/rhizome tea, tincture, capsules, and standardized extracts; odor reflects volatile constituents.",
+    "traditionalUses": [
+      "European sleep and nervous-system herb"
     ]
   },
   {
     "slug": "guarana",
-    "name": "Guarana",
-    "mechanisms": [
+    "name": "guarana",
+    "region": "Amazon Basin",
+    "primaryActions": [
       "energy support",
-      "cognition",
-      "metabolic support"
+      "alertness/fatigue support",
+      "cognition support"
     ],
-    "description": "Guarana is typically used as a supplemental botanical with context-dependent effects. It is commonly discussed around caffeine, while human evidence remains mixed across indications.",
-    "activeCompounds": [
-      "caffeine"
+    "mechanisms": [
+      "caffeine-mediated adenosine A1/A2A antagonism",
+      "methylxanthine CNS stimulation",
+      "catecholamine/arousal signaling",
+      "polyphenol antioxidant signaling"
     ],
-    "safetyNotes": "Use caution with stimulant sensitivity, anxiety, or insomnia-prone contexts.",
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan"
+    "description": "Conservative evidence framing applied.",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Caffeine exposure can cause insomnia, anxiety, tremor, tachycardia, blood-pressure elevation, and GI upset. Avoid stacking with energy drinks or other stimulants; use cautiously in pregnancy/breastfeeding and cardiovascular disease.",
+    "interactions": [
+      "Additive effects with caffeine",
+      "stimulants",
+      "theophylline",
+      "decongestants",
+      "and some ADHD medications",
+      "CYP1A2 inhibitors may increase caffeine exposure."
+    ],
+    "contraindications": [
+      "Uncontrolled hypertension",
+      "arrhythmia",
+      "severe anxiety/insomnia",
+      "stimulant sensitivity",
+      "and unsupervised pediatric use."
+    ],
+    "preparation": "Use standardized preparations that disclose caffeine content; avoid concentrated stimulant blends.",
+    "traditionalUses": [
+      "energy",
+      "alertness/fatigue",
+      "cognition"
+    ]
   },
   {
     "slug": "yerba-mate",
-    "name": "Yerba Mate",
-    "mechanisms": [
+    "name": "yerba mate",
+    "region": "South America",
+    "primaryActions": [
       "energy support",
-      "cognition",
-      "metabolic support"
+      "metabolic support",
+      "lipid/cardiometabolic support"
     ],
-    "description": "Yerba Mate is typically used as a supplemental botanical with context-dependent effects. It is commonly discussed around caffeine and polyphenols, while human evidence remains mixed across indications.",
-    "activeCompounds": [
+    "mechanisms": [
+      "caffeine/theobromine adenosine-receptor antagonism",
+      "chlorogenic-acid antioxidant signaling",
+      "AMPK-related metabolic signaling",
+      "saponin-mediated lipid metabolism"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Contains caffeine; excess intake may worsen insomnia, anxiety, palpitations, reflux, or blood pressure. Avoid very hot maté consumption patterns and stimulant stacking.",
+    "interactions": [
+      "Additive effects with stimulants",
       "caffeine",
-      "polyphenols"
+      "theophylline",
+      "decongestants",
+      "and stimulant medications",
+      "CYP1A2-modulating drugs may alter caffeine exposure."
     ],
-    "safetyNotes": "Use caution with stimulant sensitivity or insomnia-prone contexts.",
-    "preparation": "No direct preparation data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... No direct mechanismofaction data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... Consumed as a social and energizing herbal tea throughout South America.. No direct effects data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... No direct mechanismofaction data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... Consumed as a social and energizing herbal tea throughout South America.. Consumed as a social and energizing herbal tea throughout South America.. No direct region data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... No direct mechanismofaction data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... Consumed as a social and energizing herbal tea throughout South America.. No direct effects data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... No direct mechanismofaction data. Contextual inference: Consumed as a social and energizing herbal tea throughout south america... Consumed as a social and energizing herbal tea throughout South America.. Consumed as a social and energizing herbal tea throughout South America.. Consumed as a social and energizing herbal tea throughout South America.. Consumed as a social and energizing herbal tea throughout South America"
+    "contraindications": [
+      "Uncontrolled hypertension",
+      "arrhythmia",
+      "severe anxiety/insomnia",
+      "pregnancy/breastfeeding caution",
+      "and stimulant sensitivity."
+    ],
+    "preparation": "Prefer moderate-temperature tea/extracts with disclosed caffeine content; avoid very hot repeated consumption and energy-drink style stacking.",
+    "traditionalUses": [
+      "energy",
+      "metabolic",
+      "lipid/cardiometabolic"
+    ]
   },
   {
     "slug": "damiana",
-    "name": "Damiana",
+    "name": "damiana",
+    "region": "Mexico/Central America",
+    "primaryActions": [
+      "traditional mood/libido support",
+      "mild relaxation support",
+      "digestive bitter/aromatic use"
+    ],
     "mechanisms": [
       "mood support",
       "calming support",
       "libido support"
     ],
-    "description": "Damiana is typically used as a supplemental botanical with context-dependent effects. It is commonly discussed around flavonoids, while human evidence remains mixed across indications.",
-    "activeCompounds": [
-      "flavonoids"
+    "description": "Conservative evidence framing applied.",
+    "safetyNotes": "Human evidence is limited. Use conservative dosing; avoid stacking with sedatives, stimulants, or sexual-performance products without review.",
+    "interactions": [
+      "Potential additive CNS effects with sedatives",
+      "alcohol",
+      "anxiolytics",
+      "and serotonergic or stimulant stacks",
+      "diabetes medication caution is theoretical."
     ],
-    "safetyNotes": "General use caution; review stimulating vs calming stack context.",
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan"
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "seizure disorder without clinician review",
+      "planned surgery or complex psychiatric medication regimens."
+    ],
+    "preparation": "Leaf is used as tea, tincture, capsules, or aromatic blends; avoid high-dose extracts until safety is reviewed.",
+    "traditionalUses": [
+      "traditional mood/libido",
+      "mild relaxation",
+      "digestive bitter/aromatic use"
+    ]
   },
   {
     "slug": "blue-lotus",
-    "name": "Blue Lotus",
+    "name": "blue lotus",
+    "region": "Nile region/North Africa",
+    "primaryActions": [
+      "traditional relaxation support",
+      "sleep/ritual-use education",
+      "mild mood support"
+    ],
     "mechanisms": [
       "calming support",
       "mood support",
       "sleep support"
     ],
-    "description": "Blue Lotus is typically used as a supplemental botanical with context-dependent effects. It is commonly discussed around aporphine alkaloids, while human evidence remains mixed across indications.",
-    "activeCompounds": [
-      "aporphine alkaloids"
-    ],
-    "safetyNotes": "Use caution with sedative-sensitive contexts and stacked calming formulas.",
+    "description": "Conservative evidence framing applied.",
+    "safetyNotes": "Limited human safety data. Treat as a CNS-active botanical; avoid driving or combining with alcohol/sedatives.",
     "interactions": [
-      "CNS depressants"
+      "Possible additive sedation with alcohol",
+      "benzodiazepines",
+      "sleep aids",
+      "opioids",
+      "antihistamines",
+      "and other calming botanicals."
     ],
-    "preparation": "No direct preparation data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... No direct mechanismofaction data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... Used ceremonially in Ancient Egypt for euphoria and vision enhancement.. No direct effects data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... No direct mechanismofaction data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... Used ceremonially in Ancient Egypt for euphoria and vision enhancement.. Used ceremonially in Ancient Egypt for euphoria and vision enhancement.. No direct region data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... No direct mechanismofaction data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... Used ceremonially in Ancient Egypt for euphoria and vision enhancement.. No direct effects data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... No direct mechanismofaction data. Contextual inference: Used ceremonially in ancient egypt for euphoria and vision enhancement... Used ceremonially in Ancient Egypt for euphoria and vision enhancement.. Used ceremonially in Ancient Egypt for euphoria and vision enhancement.. Used ceremonially in Ancient Egypt for euphoria and vision enhancement.. Used ceremonially in Ancient Egypt for euphoria and vision enhancement"
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "sedative-sensitive users",
+      "seizure disorder",
+      "active psychiatric instability without clinician review."
+    ],
+    "preparation": "Flower is used as tea, tincture, smoking blend, or extract; ingestion route and concentration strongly affect risk.",
+    "traditionalUses": [
+      "traditional relaxation",
+      "sleep/ritual-use",
+      "mild mood"
+    ]
   },
   {
     "slug": "kudzu",
-    "name": "Kudzu",
+    "name": "kudzu",
+    "region": "East Asia",
+    "primaryActions": [
+      "alcohol-use support",
+      "menopause/isoflavone support",
+      "metabolic support"
+    ],
     "mechanisms": [
-      "multi-domain"
+      "puerarin/daidzin/daidzein isoflavone activity",
+      "aldehyde dehydrogenase modulation",
+      "estrogen-receptor interaction",
+      "antioxidant and vascular signaling"
     ],
     "description": "Conservative evidence framing applied.",
-    "activeCompounds": [
-      "isoflavones"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Isoflavone-rich preparations may interact with hormone-sensitive conditions and anticoagulant/antiplatelet therapy. Alcohol-use claims should not replace medical care.",
+    "interactions": [
+      "Potential additive effects with anticoagulants/antiplatelets and hormone-active therapies",
+      "caution with diabetes or blood-pressure medications."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "Pregnancy/breastfeeding caution",
+      "hormone-sensitive cancers or conditions",
+      "and unsupervised alcohol-use disorder treatment."
+    ],
+    "preparation": "Evidence is strongest for standardized kudzu root extracts or isolated puerarin/daidzin; do not generalize to all crude preparations.",
+    "traditionalUses": [
+      "alcohol-use",
+      "menopause/isoflavone",
+      "metabolic"
+    ]
   },
   {
     "slug": "yarrow",
-    "name": "Yarrow",
+    "name": "yarrow",
+    "region": "Europe/West Asia/North America",
+    "primaryActions": [
+      "traditional digestive bitter",
+      "topical/skin-soothing support",
+      "menstrual-comfort education"
+    ],
     "mechanisms": [
       "digestive support",
       "anti-inflammatory",
       "women's health"
     ],
-    "description": "Yarrow is typically used as a supplemental botanical with context-dependent effects. It is commonly discussed around flavonoids, while human evidence remains mixed across indications.",
-    "activeCompounds": [
-      "flavonoids"
-    ],
-    "safetyNotes": "Review interactions and contraindications.",
+    "description": "Conservative evidence framing applied.",
+    "safetyNotes": "Asteraceae-family herb; allergy is a practical concern. Avoid high-dose or prolonged internal use without review.",
     "interactions": [
-      "anticoagulants/antiplatelets"
+      "Potential additive effects with anticoagulants/antiplatelets",
+      "possible allergy cross-reactivity with ragweed-family plants."
     ],
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan"
+    "contraindications": [
+      "Asteraceae/ragweed allergy",
+      "pregnancy",
+      "bleeding disorders or anticoagulant therapy without clinician review."
+    ],
+    "preparation": "Flowering tops are used as tea, tincture, compress, or topical preparation; essential oil use requires separate safety review.",
+    "traditionalUses": [
+      "traditional digestive bitter",
+      "topical/skin-soothing",
+      "menstrual-comfort"
+    ]
   },
   {
     "slug": "feverfew",
-    "name": "Feverfew",
+    "name": "feverfew",
+    "region": "Europe",
+    "primaryActions": [
+      "migraine prevention education",
+      "inflammatory signaling modulation",
+      "headache traditional use"
+    ],
     "mechanisms": [
-      "inflammation support",
-      "headache support",
-      "vascular modulation"
+      "parthenolide-mediated NF-κB inhibition",
+      "serotonin/platelet modulation",
+      "TRPA1 and prostaglandin-pathway effects"
     ],
-    "description": "Feverfew is typically used as a supplemental botanical with context-dependent effects. It is commonly discussed around parthenolide and flavonoids, while human evidence remains mixed across indications.",
-    "activeCompounds": [
-      "parthenolide",
-      "flavonoids"
-    ],
-    "safetyNotes": "Review interactions and contraindications",
+    "description": "Conservative evidence framing applied.",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Avoid in pregnancy; possible mouth ulcers/GI upset; allergy risk in Asteraceae-sensitive users; caution with anticoagulants/antiplatelets.",
     "interactions": [
-      "anticoagulants/antiplatelets"
+      "May increase bleeding risk with anticoagulants/antiplatelets/NSAIDs",
+      "caution with migraine medications."
+    ],
+    "contraindications": [
+      "Pregnancy",
+      "Asteraceae/ragweed allergy",
+      "anticoagulant use without clinician review",
+      "upcoming surgery"
+    ],
+    "preparation": "Leaf capsules/extracts standardized to parthenolide; fresh leaf chewing increases mouth irritation risk.",
+    "traditionalUses": [
+      "Headache",
+      "fever",
+      "and inflammatory complaints"
     ]
   },
   {
     "slug": "butterbur",
-    "name": "Butterbur",
+    "name": "butterbur",
+    "region": "Europe; Asia",
+    "primaryActions": [
+      "migraine prevention education",
+      "allergic rhinitis support",
+      "smooth-muscle spasm modulation"
+    ],
     "mechanisms": [
-      "migraine support",
-      "anti-inflammatory",
-      "TRPA1/TRPV1 modulation",
-      "CGRP modulation"
+      "petasin/isopetasin smooth-muscle effects",
+      "leukotriene and inflammatory-pathway modulation",
+      "trigeminal migraine-pathway effects"
     ],
     "description": "Butterbur is a sesquiterpene-rich herb usually discussed around standardized root extracts. Petasin and isopetasin are the anchor constituents most often linked to migraine and allergic-rhinitis relevance. The commercial problem is safety, because pyrrolizidine alkaloids (PAs) can damage the liver and lungs and may be carcinogenic. Keep claims narrow and safety-forward.",
-    "activeCompounds": [
-      "petasin",
-      "isopetasin",
-      "sesquiterpene esters"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Only PA-free extracts are acceptable; pyrrolizidine alkaloids can cause serious liver injury; avoid pregnancy/liver disease.",
+    "interactions": [
+      "Caution with hepatotoxic drugs/supplements and enzyme-inducing medicines",
+      "clinician supervision advised."
     ],
-    "safetyNotes": "PA-containing butterbur products are unsafe. Only PA-free products should be considered, and even then rare liver injury has been reported. Use caution with ragweed-family allergy."
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "liver disease",
+      "use of non-PA-free products",
+      "Asteraceae allergy"
+    ],
+    "preparation": "Use only certified PA-free root/rhizome or leaf extracts; raw/unprocessed plant is unsafe.",
+    "traditionalUses": [
+      "Migraine",
+      "spasms",
+      "and respiratory/allergy complaints"
+    ]
   },
   {
     "slug": "dong-quai",
-    "name": "Dong Quai",
-    "mechanisms": [
+    "name": "dong quai",
+    "region": "East Asia",
+    "primaryActions": [
+      "women's health traditional use",
       "circulation support",
-      "women's health",
-      "smooth muscle support"
+      "menstrual comfort research"
+    ],
+    "mechanisms": [
+      "ligustilide and ferulic-acid vascular signaling",
+      "smooth-muscle modulation",
+      "phytoestrogen-like activity",
+      "platelet and inflammatory-pathway modulation"
     ],
     "description": "Conservative evidence framing applied.",
-    "activeCompounds": [
-      "ferulic acid"
+    "safetyNotes": "May increase bleeding risk and may not be appropriate in hormone-sensitive conditions. Pregnancy avoidance is important due to uterine/circulatory concerns.",
+    "interactions": [
+      "Caution with anticoagulants",
+      "antiplatelets",
+      "NSAIDs",
+      "estrogenic therapies",
+      "and photosensitizing drugs."
     ],
-    "safetyNotes": "Review interactions and contraindications."
+    "contraindications": [
+      "Pregnancy",
+      "bleeding disorders",
+      "hormone-sensitive cancers/conditions",
+      "planned surgery",
+      "and anticoagulant therapy without supervision."
+    ],
+    "preparation": "Often studied in formulas; do not generalize formula evidence to single-herb Angelica sinensis.",
+    "traditionalUses": [
+      "women's health traditional use",
+      "circulation",
+      "menstrual comfort"
+    ]
   },
   {
     "slug": "rosemary",
-    "name": "Rosemary",
+    "name": "rosemary",
+    "region": "Mediterranean",
     "primaryActions": [
       "Nrf2 support",
       "inflammatory pathway control",
       "cognitive and digestive support"
     ],
     "mechanisms": [
-      "Nrf2 antioxidant pathway activation",
-      "NF-κB inflammatory signaling modulation",
-      "acetylcholinesterase inhibition"
+      "cognition",
+      "antioxidant",
+      "digestive support",
+      "Nrf2 activation",
+      "NF-κB inhibition",
+      "STAT3 inhibition",
+      "AMPK activation",
+      "PI3K/Akt modulation"
     ],
-    "description": "Rosemary leaf is used as food herb plus extract forms rich in carnosic acid and rosmarinic acid. Evidence supports antioxidant and anti-inflammatory bioactivity, while clinical effect in people is modest. Use is best framed as food use or well-characterized extract use.",
-    "activeCompounds": [
-      "rosmarinic acid",
-      "Carnosic acid",
-      "Ursolic acid",
-      "Oleanolic acid",
-      "carnosol"
-    ],
-    "safetyNotes": "Food-level use is usually well tolerated, but concentrated products can cause GI irritation, and essential oil should not be ingested undiluted. High-exposure preparations may increase adverse-effect risk in people with seizure disorders. Review use with antihypertensive or antiplatelet regimens when using concentrated extracts.",
+    "description": "Conservative evidence framing applied. Lean bulk enrichment added: Carnosic acid.",
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Generally well tolerated; review concentrated extract use.",
     "interactions": [
       "Caution with concentrated extracts alongside anticoagulants."
     ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
     "preparation": "Leaf infusion for mild use; extracts provide higher diterpene exposure.",
-    "affiliateProducts": [
-      {
-        "name": "Rosemary Tea",
-        "type": "tea",
-        "affiliateUrl": "https://www.amazon.com/s?k=rosemary+tea&tag=razzleberry02-20"
-      },
-      {
-        "name": "Rosemary Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=rosemary+extract&tag=razzleberry02-20"
-      }
+    "traditionalUses": [
+      "Nrf2",
+      "inflammatory pathway control",
+      "cognitive and digestive"
     ]
   },
   {
     "slug": "sage",
-    "name": "Sage",
+    "name": "sage",
+    "region": "Mediterranean; Europe",
+    "primaryActions": [
+      "cognitive/menopause symptom support",
+      "digestive comfort",
+      "antimicrobial traditional use"
+    ],
     "mechanisms": [
       "cognition",
       "digestive support",
@@ -721,17 +1018,38 @@
       "PI3K/Akt modulation"
     ],
     "description": "Conservative evidence framing applied. Lean bulk enrichment added: Carnosic acid.",
-    "activeCompounds": [
-      "thujone",
-      "Carnosic acid",
-      "Ursolic acid",
-      "Oleanolic acid"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Generally well tolerated; review concentrated extract use.",
+    "interactions": [
+      "May interact with sedatives",
+      "anticonvulsants",
+      "antidiabetics",
+      "or cholinergic/anticholinergic drugs depending preparation."
     ],
-    "safetyNotes": "Generally well tolerated; review concentrated extract use."
+    "contraindications": [
+      "Pregnancy",
+      "seizure disorder",
+      "high-dose essential oil use",
+      "breastfeeding where milk suppression is a concern"
+    ],
+    "preparation": "Leaf tea, tincture, culinary leaf, and essential oil; avoid internal essential-oil use unless professionally supervised.",
+    "traditionalUses": [
+      "Culinary",
+      "digestive",
+      "oral/throat",
+      "cognitive",
+      "and menopausal support"
+    ]
   },
   {
     "slug": "thyme",
-    "name": "Thyme",
+    "name": "thyme",
+    "region": "Mediterranean",
+    "primaryActions": [
+      "respiratory comfort support",
+      "antimicrobial-aromatic education",
+      "digestive carminative support"
+    ],
     "mechanisms": [
       "respiratory support",
       "antimicrobial",
@@ -743,16 +1061,33 @@
       "GABA-A modulation"
     ],
     "description": "Conservative evidence framing applied.",
-    "activeCompounds": [
-      "thymol",
-      "Luteolin",
-      "carvacrol"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Culinary use is generally low-risk; concentrated oil/extracts can irritate mucosa and require dose caution.",
+    "interactions": [
+      "Potential additive irritation with other essential oils",
+      "theoretical caution with anticoagulants for high-dose extracts."
     ],
-    "safetyNotes": "Generally well tolerated; review concentrated oil use carefully."
+    "contraindications": [
+      "Pregnancy/breastfeeding for medicinal-dose essential oil",
+      "significant GI irritation",
+      "thyme/Lamiaceae allergy."
+    ],
+    "preparation": "Leaf is used as tea, culinary herb, tincture, syrup, or steam aromatic; essential oil should not be taken internally without qualified guidance.",
+    "traditionalUses": [
+      "respiratory comfort",
+      "antimicrobial-aromatic",
+      "digestive carminative"
+    ]
   },
   {
     "slug": "oregano",
-    "name": "Oregano",
+    "name": "oregano",
+    "region": "Mediterranean",
+    "primaryActions": [
+      "digestive/aromatic support",
+      "antimicrobial-aromatic education",
+      "respiratory-seasonal support"
+    ],
     "mechanisms": [
       "antimicrobial",
       "digestive support",
@@ -762,249 +1097,388 @@
       "GABA-A modulation"
     ],
     "description": "Conservative evidence framing applied.",
-    "activeCompounds": [
-      "carvacrol",
-      "thymol",
-      "rosmarinic acid"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Culinary use is generally low-risk; oregano oil/high-thymol or carvacrol extracts can irritate GI mucosa and skin.",
+    "interactions": [
+      "Potential additive irritation with essential oils",
+      "theoretical bleeding or glucose interaction concerns at high supplemental doses."
     ],
-    "safetyNotes": "General use caution; concentrated extracts can be irritating"
+    "contraindications": [
+      "Pregnancy/breastfeeding for medicinal-dose essential oil",
+      "Lamiaceae allergy",
+      "active GI ulcer/irritation for concentrated extracts."
+    ],
+    "preparation": "Leaf is used as food, tea, capsules, and tincture; oregano oil should be treated as a concentrated product, not a food-dose herb.",
+    "traditionalUses": [
+      "digestive/aromatic",
+      "antimicrobial-aromatic",
+      "respiratory-seasonal"
+    ]
   },
   {
     "slug": "eucalyptus",
-    "name": "Eucalyptus",
+    "name": "eucalyptus",
+    "region": "Australia",
+    "primaryActions": [
+      "respiratory aromatic support",
+      "topical vapor-rub education",
+      "seasonal airway comfort"
+    ],
     "mechanisms": [
       "respiratory support",
       "antimicrobial",
       "anti-inflammatory"
     ],
     "description": "Conservative evidence framing applied.",
-    "activeCompounds": [
-      "eucalyptol",
-      "alpha-pinene",
-      "tannins"
+    "safetyNotes": "Eucalyptus oil is potentially toxic if ingested and can trigger bronchospasm in sensitive users; topical and inhaled use require dilution and caution.",
+    "interactions": [
+      "Avoid combining internal oil with sedatives or hepatotoxic exposures",
+      "topical products may irritate skin or mucosa."
     ],
-    "safetyNotes": "Review interactions and contraindications"
+    "contraindications": [
+      "Infants/young children for oil exposure near face",
+      "asthma/bronchospasm sensitivity",
+      "pregnancy/breastfeeding for internal oil use."
+    ],
+    "preparation": "Leaf is used as tea or steam; essential oil is used diluted topically or aromatically and should not be taken internally without medical supervision.",
+    "traditionalUses": [
+      "respiratory aromatic",
+      "topical vapor-rub",
+      "seasonal airway comfort"
+    ]
   },
   {
     "slug": "artichoke",
-    "name": "Artichoke",
+    "name": "artichoke",
+    "region": "Mediterranean",
+    "primaryActions": [
+      "digestive/bile-flow support",
+      "lipid/metabolic support",
+      "liver enzyme education"
+    ],
     "mechanisms": [
-      "digestive support",
-      "hepatobiliary support",
-      "NF-κB inhibition",
-      "MAPK pathway modulation",
-      "AMPK activation",
-      "glucose metabolism modulation"
+      "caffeoylquinic-acid signaling",
+      "bile-acid/cholesterol metabolism",
+      "HMG-CoA reductase and hepatic antioxidant modulation"
     ],
     "description": "It is best framed around bitter-compound and phenolic support for digestion and bile-related positioning rather than broad detox claims.",
-    "activeCompounds": [
-      "cynarin",
-      "chlorogenic acid",
-      "Luteolin"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Avoid/caution with bile-duct obstruction, gallstones, and Asteraceae allergy; may cause GI effects.",
+    "interactions": [
+      "May add to lipid-lowering or bile-flow effects",
+      "theoretical interaction with anticoagulants if high vitamin K diet changes."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "Bile duct obstruction",
+      "gallstones without clinician guidance",
+      "Asteraceae allergy"
+    ],
+    "preparation": "Leaf extracts standardized to caffeoylquinic acids/cynarin-like phenolics; food artichoke differs from leaf extract.",
+    "traditionalUses": [
+      "Digestive bitters",
+      "liver/gallbladder support"
+    ]
   },
   {
     "slug": "fennel",
-    "name": "Fennel",
+    "name": "fennel",
+    "region": "Mediterranean/West Asia",
     "primaryActions": [
       "Digestive support",
       "smooth muscle relaxation",
       "aromatic carminative action"
     ],
     "mechanisms": [
-      "digestive support",
-      "antispasmodic support",
-      "NF-κB inhibition",
-      "smooth muscle relaxation"
+      "anethole-related smooth-muscle effects",
+      "phytoestrogenic signaling",
+      "COX/NO inflammatory modulation"
     ],
     "description": "It is best handled as an aromatic seed botanical with traditional GI-support use and modest mechanistic confidence.",
-    "activeCompounds": [
-      "anethole",
-      "volatile oils"
-    ],
-    "safetyNotes": "Generally well tolerated.",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Avoid in pregnancy at medicinal doses; caution in estrogen-sensitive conditions and with seizure disorders; allergy possible.",
     "interactions": [
       "Possible estrogenic interaction concerns with concentrated use."
     ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "hormone-sensitive conditions without clinician review"
+    ],
     "preparation": "Tea or crushed seed is traditional; extracts concentrate volatile constituents.",
-    "affiliateProducts": [
-      {
-        "name": "Fennel Tea",
-        "type": "tea",
-        "affiliateUrl": "https://www.amazon.com/s?k=fennel+tea&tag=razzleberry02-20"
-      },
-      {
-        "name": "Fennel Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=foeniculum+vulgare+extract&tag=razzleberry02-20"
-      }
+    "traditionalUses": [
+      "Digestive",
+      "smooth muscle relaxation",
+      "aromatic carminative action"
     ]
   },
   {
     "slug": "cinnamon",
-    "name": "Cinnamon",
+    "name": "cinnamon",
+    "region": "South/Southeast Asia",
     "primaryActions": [
       "Metabolic support",
       "inflammatory control",
       "sensory channel activity"
     ],
     "mechanisms": [
-      "AMPK pathway activation",
-      "intestinal alpha-glucosidase inhibition",
-      "insulin receptor signaling sensitization"
+      "cinnamaldehyde/polyphenol insulin-signaling effects",
+      "AMPK/GLUT4 modulation",
+      "lipid-metabolism and inflammatory-pathway effects"
     ],
-    "description": "This spice varies by species; C. verum tends to have less coumarin than cassia types. Trials suggest small glucose-related benefit in some groups, with effect tied to dose and product quality. It should be used as support, not as sole glycemic therapy.",
-    "activeCompounds": [
-      "cinnamaldehyde",
-      "polyphenols"
-    ],
-    "safetyNotes": "Culinary intake is usually safe, but chronic high intake of cassia cinnamon can increase coumarin exposure and liver risk. Concentrated supplements may add to glucose-lowering medication effects and raise hypoglycemia risk. Monitor liver symptoms and glycemic response when using high-dose products.",
+    "description": "It is best framed conservatively because product form and species matter, especially around coumarin exposure in non-verum types.",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Cassia cinnamon can contain high coumarin; liver risk at high/chronic doses; monitor with diabetes drugs and anticoagulants.",
     "interactions": [
       "Use caution with anticoagulants and glucose-lowering therapy."
     ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
     "preparation": "Bark powder or extract; species matters for coumarin exposure.",
-    "affiliateProducts": [
-      {
-        "name": "Ceylon Cinnamon Powder",
-        "type": "powder",
-        "affiliateUrl": "https://www.amazon.com/s?k=ceylon+cinnamon+powder&tag=razzleberry02-20"
-      },
-      {
-        "name": "Ceylon Cinnamon Capsules",
-        "type": "capsule",
-        "affiliateUrl": "https://www.amazon.com/s?k=ceylon+cinnamon+capsules&tag=razzleberry02-20"
-      }
+    "traditionalUses": [
+      "Metabolic",
+      "inflammatory control",
+      "sensory channel activity"
     ]
   },
   {
     "slug": "dandelion",
-    "name": "Dandelion",
+    "name": "dandelion",
+    "region": "Europe/Asia/North America",
+    "primaryActions": [
+      "digestive/fluid-balance education",
+      "diuretic tradition",
+      "safety education"
+    ],
     "mechanisms": [
-      "digestive support",
-      "mild diuretic support"
+      "potassium-rich leaf diuretic/natriuretic effects",
+      "bitter sesquiterpene lactone-mediated digestive secretion",
+      "inulin/fructan prebiotic effects",
+      "polyphenol-mediated Nrf2/NF-κB modulation"
     ],
     "description": "It is best framed as a traditional food-like bitter herb rather than a strong cleansing intervention.",
-    "activeCompounds": [
-      "taraxasterol",
-      "sesquiterpene lactones"
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "Avoid with Asteraceae/ragweed allergy. Caution with diuretics, lithium, kidney disease, bile duct obstruction/gallbladder disease, GERD, and antihypertensive or glucose-lowering therapy. Monitor potassium and volume status if combined with diuretics. Human efficacy evidence remains narrow, so claims should stay conservative.",
+    "interactions": [
+      "Diuretics",
+      "lithium",
+      "antihypertensives",
+      "glucose-lowering therapy",
+      "theoretical quinolone absorption concern and additive GI irritation possible."
     ],
-    "safetyNotes": "Generally well tolerated.",
-    "affiliateProducts": [
-      {
-        "name": "Dandelion Tea",
-        "type": "tea",
-        "affiliateUrl": "https://www.amazon.com/s?k=taraxacum+officinale+tea&tag=razzleberry02-20"
-      },
-      {
-        "name": "Dandelion Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=taraxacum+officinale+extract&tag=razzleberry02-20"
-      }
+    "contraindications": [
+      "Asteraceae allergy",
+      "bile duct obstruction",
+      "serious kidney disease unless supervised",
+      "pregnancy/breastfeeding without clinician review."
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "digestive/fluid-balance",
+      "diuretic tradition",
+      "safety"
     ]
   },
   {
     "slug": "burdock",
-    "name": "Burdock",
+    "name": "burdock",
+    "region": "Europe; Asia; North America",
+    "primaryActions": [
+      "skin/detox traditional use",
+      "digestive bitter support",
+      "prebiotic fiber source"
+    ],
     "mechanisms": [
       "traditional skin support",
       "anti-inflammatory"
     ],
     "description": "It is best framed as a traditional root botanical with modest modern evidence rather than a definitive detox herb.",
-    "activeCompounds": [
-      "arctiin",
-      "lignans"
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "interactions": [
+      "May add to antidiabetic or diuretic effects",
+      "use caution with lithium/diuretics if high intake."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "Asteraceae allergy",
+      "pregnancy/breastfeeding without clinician guidance",
+      "hypoglycemia risk"
+    ],
+    "preparation": "Root tea/decoction, tincture, food root, and seed preparations; root and seed are not interchangeable.",
+    "traditionalUses": [
+      "Skin eruptions",
+      "lymphatic/detox formulas",
+      "digestive bitters"
+    ]
   },
   {
     "slug": "chamomile",
-    "name": "Chamomile",
+    "name": "chamomile",
+    "region": "Europe; Western herbalism",
+    "primaryActions": [
+      "digestive comfort",
+      "sleep/calm support",
+      "topical skin-soothing support"
+    ],
     "mechanisms": [
-      "anxiolytic",
-      "sleep support",
-      "anti-inflammatory",
-      "GABA-A modulation",
-      "PI3K/Akt modulation"
+      "apigenin GABA-A receptor interaction",
+      "flavonoid anti-inflammatory signaling",
+      "smooth-muscle and digestive-spasm modulation"
     ],
     "description": "It is best handled as a gentle calming botanical with broad traditional use and modest clinical depth.",
-    "activeCompounds": [
-      "apigenin"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Allergy risk with Asteraceae sensitivity; sedation possible; caution with CNS depressants and anticoagulants.",
+    "interactions": [
+      "May potentiate sedatives/CNS depressants and anticoagulants/antiplatelets in susceptible users."
     ],
-    "safetyNotes": "Generally well tolerated.",
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "anxiolytic"
+    "contraindications": [
+      "Asteraceae/ragweed allergy",
+      "anticoagulant use without clinician review",
+      "pregnancy at medicinal doses without guidance"
+    ],
+    "preparation": "Flower infusion, tincture, capsules, steam-distilled essential oil, and topical preparations.",
+    "traditionalUses": [
+      "Digestive spasm",
+      "sleep",
+      "calming",
+      "skin and mucosal irritation"
     ]
   },
   {
     "slug": "red-clover",
-    "name": "Red Clover",
+    "name": "red clover",
+    "region": "Europe; North America",
+    "primaryActions": [
+      "menopause symptom education",
+      "isoflavone phytoestrogen support",
+      "skin/lymph traditional use"
+    ],
     "mechanisms": [
-      "phytoestrogen-adjacent support",
-      "estrogen receptor modulation",
-      "PI3K/Akt modulation",
-      "MAPK pathway modulation",
-      "NF-κB inhibition"
+      "isoflavone phytoestrogen signaling via estrogen receptors",
+      "lipid-metabolism modulation",
+      "antioxidant signaling"
     ],
     "description": "It should be framed conservatively because endocrine-adjacent claims outrun the evidence in many product contexts.",
-    "activeCompounds": [
-      "isoflavones",
-      "genistein",
-      "Daidzein",
-      "Formononetin",
-      "Biochanin A"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Avoid/caution in estrogen-sensitive cancers or hormone therapy contexts; possible anticoagulant interaction concerns.",
+    "interactions": [
+      "May interact with hormone therapies and anticoagulants/antiplatelets."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "hormone-sensitive cancer/condition without clinician review",
+      "anticoagulant use"
+    ],
+    "preparation": "Flowering tops as tea, tincture, or isoflavone-standardized extracts.",
+    "traditionalUses": [
+      "Menopause",
+      "skin",
+      "lymphatic and respiratory formulas"
+    ]
   },
   {
     "slug": "oatstraw",
-    "name": "Oatstraw",
+    "name": "oatstraw",
+    "region": "Europe; North America",
+    "primaryActions": [
+      "nervine nutritive support",
+      "mineral-rich tonic",
+      "stress resilience traditional use"
+    ],
     "mechanisms": [
       "nutritive support",
       "calming support"
     ],
     "description": "It is best framed as a gentle nutritive herb with limited high-signal clinical depth.",
-    "activeCompounds": [
-      "avenanthramides",
-      "minerals"
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "interactions": [
+      "Low documented interaction burden",
+      "caution if combined with strong sedatives due to intended calming use."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "Celiac disease/gluten sensitivity unless certified gluten-free",
+      "pregnancy/breastfeeding supplement use needs review"
+    ],
+    "preparation": "Milky oat tops tincture, oatstraw infusion, and food oat preparations; milky oat and straw differ.",
+    "traditionalUses": [
+      "Nervine tonic",
+      "mineral support",
+      "convalescence"
+    ]
   },
   {
     "slug": "calendula",
-    "name": "Calendula",
+    "name": "calendula",
+    "region": "Mediterranean/Europe",
+    "primaryActions": [
+      "topical skin support",
+      "wound/dermatitis support",
+      "soothing anti-inflammatory support"
+    ],
     "mechanisms": [
-      "topical soothing support",
-      "anti-inflammatory"
+      "triterpenoid and flavonoid anti-inflammatory signaling",
+      "NF-κB modulation",
+      "wound-healing granulation/epithelialization support",
+      "antimicrobial barrier support"
     ],
     "description": "It is best framed around topical and tissue-soothing use rather than overextended systemic claims.",
-    "activeCompounds": [
-      "faradiol esters",
-      "flavonoids"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Topical use can cause contact dermatitis or allergy, especially in Asteraceae-sensitive users. Oral/concentrated use needs pregnancy caution.",
+    "interactions": [
+      "Topical interaction risk is low",
+      "avoid layering with irritating actives on compromised skin unless supervised."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "Asteraceae allergy",
+      "open/infected wounds without medical care",
+      "pregnancy for non-topical concentrated preparations."
+    ],
+    "preparation": "Evidence is strongest for topical creams/ointments used for radiation dermatitis, diaper dermatitis, wounds, or burns.",
+    "traditionalUses": [
+      "topical skin",
+      "wound/dermatitis",
+      "soothing anti-inflammatory"
+    ]
   },
   {
     "slug": "pau-d-arco",
-    "name": "Pau d'Arco",
+    "name": "pau d'arco",
+    "region": "South America traditional medicine",
+    "primaryActions": [
+      "antimicrobial traditional use",
+      "inflammatory pathway research",
+      "skin/gut support education"
+    ],
     "mechanisms": [
       "traditional immune support",
       "antimicrobial support"
     ],
     "description": "It should be framed conservatively because popular claims often exceed the evidence and preparation differences matter.",
-    "activeCompounds": [
-      "lapachol",
-      "naphthoquinones"
-    ],
     "safetyNotes": "Use conservatively; concentrated use may be irritating.",
-    "primaryActions": [
-      "antimicrobial"
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "antimicrobial traditional use",
+      "inflammatory pathway",
+      "skin/gut"
     ]
   },
   {
     "slug": "gymnema",
-    "name": "Gymnema",
+    "name": "gymnema",
+    "region": "India; Ayurveda",
+    "primaryActions": [
+      "glucose metabolism support",
+      "sweet-taste modulation",
+      "metabolic syndrome education"
+    ],
     "mechanisms": [
       "glycemic support",
       "sweet taste suppression",
@@ -1013,468 +1487,836 @@
       "AMPK activation"
     ],
     "description": "Gymnema leaf is mainly anchored by gymnemic acids, a triterpene-glycoside cluster. The strongest mechanistic signal is sweet-taste suppression plus related effects on glucose handling, not generic wellness language. Keep human claims conservative and formulation-specific.",
-    "activeCompounds": [
-      "gymnemic acids",
-      "Gymnemic acid"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Generally well tolerated, but products positioned for glucose support should be handled cautiously in people already using glucose-lowering strategies.",
+    "interactions": [
+      "May potentiate insulin",
+      "sulfonylureas",
+      "metformin",
+      "and other glucose-lowering agents."
     ],
-    "safetyNotes": "Generally well tolerated, but products positioned for glucose support should be handled cautiously in people already using glucose-lowering strategies."
+    "contraindications": [
+      "Hypoglycemia risk",
+      "pregnancy/breastfeeding without clinician guidance",
+      "perioperative fasting"
+    ],
+    "preparation": "Leaf powder/extracts standardized to gymnemic acids; chewing/tea can reduce sweet taste temporarily.",
+    "traditionalUses": [
+      "Ayurvedic glucose and metabolic support"
+    ]
   },
   {
     "slug": "banaba",
-    "name": "Banaba",
+    "name": "banaba",
+    "region": "Southeast Asia",
+    "primaryActions": [
+      "glucose metabolism support",
+      "metabolic syndrome education",
+      "antioxidant polyphenol support"
+    ],
     "mechanisms": [
-      "glycemic support",
-      "metabolic support"
+      "corosolic-acid AMPK/GLUT4 modulation",
+      "α-glucosidase effects",
+      "postprandial glucose signaling"
     ],
     "description": "It is best framed conservatively because evidence quality and standardization vary across products.",
-    "activeCompounds": [
-      "corosolic acid"
-    ],
-    "safetyNotes": "Generally well tolerated.",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May potentiate antidiabetic drugs; monitor hypoglycemia risk; pregnancy/breastfeeding safety unclear.",
     "interactions": [
-      "antidiabetic medications"
+      "May potentiate antidiabetic medications and other glucose-lowering supplements."
     ],
-    "primaryActions": [
-      "glycemic support"
+    "contraindications": [
+      "Hypoglycemia risk",
+      "pregnancy/breastfeeding without clinician guidance"
+    ],
+    "preparation": "Leaf extracts standardized to corosolic acid or ellagitannin content; tea use also occurs.",
+    "traditionalUses": [
+      "Traditional glucose and urinary support"
     ]
   },
   {
     "slug": "mulberry-leaf",
-    "name": "Mulberry Leaf",
+    "name": "mulberry leaf",
+    "region": "China; Japan; Korea",
+    "primaryActions": [
+      "postprandial glucose support",
+      "carbohydrate absorption modulation",
+      "metabolic education"
+    ],
     "mechanisms": [
-      "glycemic support"
+      "1-deoxynojirimycin α-glucosidase inhibition",
+      "postprandial glucose modulation",
+      "AMPK and lipid-metabolism effects"
     ],
     "description": "It is best framed around alpha-glucosidase-adjacent positioning rather than generalized wellness language.",
-    "activeCompounds": [
-      "1-deoxynojirimycin",
-      "flavonoids"
-    ],
-    "safetyNotes": "Generally well tolerated.",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May potentiate glucose-lowering drugs; GI effects possible; pregnancy safety uncertain.",
     "interactions": [
-      "antidiabetic medications"
+      "May potentiate antidiabetic drugs and other alpha-glucosidase inhibitors",
+      "monitor glucose."
+    ],
+    "contraindications": [
+      "Hypoglycemia risk",
+      "pregnancy/breastfeeding without clinician guidance"
+    ],
+    "preparation": "Leaf tea, powder, tablets, and extracts standardized to DNJ or flavonoids.",
+    "traditionalUses": [
+      "East Asian metabolic and tea use"
     ]
   },
   {
     "slug": "neem",
-    "name": "Neem",
+    "name": "neem",
+    "region": "South Asia",
+    "primaryActions": [
+      "skin/oral traditional use",
+      "antimicrobial traditional use",
+      "metabolic and immune signaling research"
+    ],
     "mechanisms": [
       "traditional skin support",
       "antimicrobial support"
     ],
     "description": "It should be framed carefully because topical, oral, and seed-oil contexts differ substantially in safety relevance.",
-    "activeCompounds": [
-      "nimbin",
-      "azadirachtin"
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "interactions": [
+      "May potentiate antidiabetics",
+      "immunosuppressants",
+      "and hepatotoxic drugs/supplements."
     ],
-    "safetyNotes": "Use caution with concentrated internal use."
+    "contraindications": [
+      "Pregnancy/trying to conceive",
+      "children",
+      "liver disease",
+      "hypoglycemia risk",
+      "breastfeeding without guidance"
+    ],
+    "preparation": "Leaf, bark, seed oil, and topical preparations differ greatly; avoid internal neem oil.",
+    "traditionalUses": [
+      "Ayurvedic skin",
+      "oral",
+      "insect",
+      "and metabolic uses"
+    ]
   },
   {
     "slug": "mugwort",
-    "name": "Mugwort",
+    "name": "mugwort",
+    "region": "Europe; Asia",
+    "primaryActions": [
+      "digestive bitter/aromatic support",
+      "menstrual traditional use",
+      "ritual/aromatic use"
+    ],
     "mechanisms": [
       "digestive support",
       "traditional cycle support"
     ],
     "description": "It is best framed conservatively because strong folklore and ritual associations often outrun clinical evidence.",
-    "activeCompounds": [
-      "volatile oils",
-      "flavonoids"
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "interactions": [
+      "Caution with anticonvulsants",
+      "sedatives",
+      "and drugs affected by seizure threshold."
     ],
-    "safetyNotes": "Use caution with concentrated preparations.",
-    "preparation": "No direct preparation data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. No direct region data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine"
+    "contraindications": [
+      "Pregnancy",
+      "seizure disorder",
+      "Asteraceae allergy",
+      "internal essential-oil use"
+    ],
+    "preparation": "Leaf tea/tincture, smoke/incense, and essential oil; internal essential oil is not appropriate for casual use.",
+    "traditionalUses": [
+      "Digestive bitter",
+      "menses",
+      "dreams/ritual",
+      "aromatic use"
+    ]
   },
   {
     "slug": "lemon-verbena",
-    "name": "Lemon Verbena",
+    "name": "lemon verbena",
+    "region": "South America; Mediterranean cultivation",
+    "primaryActions": [
+      "digestive comfort",
+      "relaxation/sleep support",
+      "antioxidant aromatic herb support"
+    ],
     "mechanisms": [
       "calming support",
       "digestive support"
     ],
     "description": "It is best framed as a gentle aromatic botanical with modest evidence and pleasant tolerability.",
-    "activeCompounds": [
-      "verbascoside",
-      "volatile oils"
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "interactions": [
+      "Low documented interaction burden",
+      "caution with sedatives if used for sleep."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "kidney disease caution at high doses"
+    ],
+    "preparation": "Leaf infusion, tincture, aromatic extract, and essential-oil products.",
+    "traditionalUses": [
+      "Digestive",
+      "calming",
+      "aromatic tea"
+    ]
   },
   {
     "slug": "milk-oats",
-    "name": "Milk Oats",
+    "name": "milk oats",
+    "region": "Europe; North America",
+    "primaryActions": [
+      "nervine restorative support",
+      "stress depletion traditional use",
+      "sleep/calm support"
+    ],
     "mechanisms": [
       "nutritive support",
       "calming support"
     ],
     "description": "They are best framed as a gentle traditional tonic rather than a strong acute intervention.",
-    "activeCompounds": [
-      "avenacosides",
-      "avenanthramides"
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "interactions": [
+      "Low documented interaction burden",
+      "theoretical add-on sedation with CNS depressants."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "Celiac/gluten sensitivity unless certified gluten-free",
+      "pregnancy/breastfeeding supplement use needs review"
+    ],
+    "preparation": "Fresh milky oat tincture is traditional; dried oatstraw infusion is a different preparation.",
+    "traditionalUses": [
+      "Nervous exhaustion",
+      "convalescence",
+      "stress support"
+    ]
   },
   {
     "slug": "cissus",
-    "name": "Cissus",
+    "name": "cissus",
+    "region": "India; Africa",
+    "primaryActions": [
+      "joint/tendon support",
+      "exercise recovery education",
+      "metabolic support research"
+    ],
     "mechanisms": [
       "connective tissue support",
       "recovery support"
     ],
     "description": "It is best framed conservatively because evidence is mixed and product positioning often outruns the data.",
-    "activeCompounds": [
-      "ketosteroids",
-      "flavonoids"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "interactions": [
+      "May potentiate antidiabetic agents",
+      "caution with anticoagulants if blended products include additional actives."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "diabetes medications without monitoring"
+    ],
+    "preparation": "Stem extracts/powders; extracts vary in ketosteroid/flavonoid standardization.",
+    "traditionalUses": [
+      "Ayurvedic bone/joint and injury support"
+    ]
   },
   {
     "slug": "ashitaba",
-    "name": "Ashitaba",
+    "name": "ashitaba",
+    "region": "Japan",
+    "primaryActions": [
+      "metabolic/antioxidant support research",
+      "digestive traditional use",
+      "chalcone-rich botanical education"
+    ],
     "mechanisms": [
       "metabolic support",
       "antioxidant"
     ],
     "description": "It is best framed around chalcone-rich chemistry with modest translational evidence.",
-    "activeCompounds": [
-      "xanthoangelol",
-      "4-hydroxyderricin"
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "interactions": [
+      "Potential additive bleeding risk with anticoagulants/antiplatelets",
+      "limited clinical interaction data."
     ],
-    "safetyNotes": "Generally well tolerated.",
-    "primaryActions": [
-      "antioxidant"
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "anticoagulant use without review"
+    ],
+    "preparation": "Leaf/stem powder, tea, and extracts; chalcone content varies by product.",
+    "traditionalUses": [
+      "Japanese vegetable/tonic and digestive use"
     ]
   },
   {
     "slug": "pomegranate",
-    "name": "Pomegranate",
+    "name": "pomegranate",
+    "region": "West Asia/Mediterranean",
     "primaryActions": [
       "Inflammatory control",
       "tannin-rich antioxidant activity",
       "vascular support"
     ],
     "mechanisms": [
-      "Nrf2 antioxidant response activation",
-      "NF-κB inflammatory signaling modulation",
-      "endothelial nitric oxide bioavailability support"
+      "vascular support",
+      "antioxidant",
+      "Nrf2 activation",
+      "NF-κB inhibition",
+      "MAPK pathway modulation",
+      "ellagitannin-mediated antioxidant signaling"
     ],
-    "description": "This fruit is polyphenol-rich with ellagitannin-derived metabolites of cardio-metabolic interest. Clinical data suggest modest shifts in vascular and inflammatory markers, with results tied to dose and product type. Food use offers the most reliable baseline option.",
-    "activeCompounds": [
-      "punicalagins",
-      "ellagic acid",
-      "Gallic acid",
-      "punicalagin"
-    ],
-    "safetyNotes": "Usually well tolerated, though GI upset can occur with concentrated juice or extract intake. It may modestly lower blood pressure, which can add to antihypertensive effects in susceptible users. Check medication compatibility before using concentrated extracts alongside cardiometabolic therapies.",
+    "description": "It is best framed as a polyphenol-rich fruit botanical with food-form relevance and moderate evidence.",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May affect circulation, blood pressure, or platelet function; use caution with anticoagulants/antiplatelets, antihypertensives, heart medications, and before surgery.",
     "interactions": [
       "Polyphenol-rich extracts may alter drug metabolism in some contexts."
     ],
-    "preparation": "Juice and rind extracts differ substantially in tannin density."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Juice and rind extracts differ substantially in tannin density.",
+    "traditionalUses": [
+      "Inflammatory control",
+      "tannin-rich antioxidant activity",
+      "vascular"
+    ]
   },
   {
     "slug": "moringa",
-    "name": "Moringa",
+    "name": "moringa",
+    "region": "South Asia/Africa",
     "primaryActions": [
-      "Phase II detox support",
-      "redox signaling",
-      "nutrient-dense tonic use"
+      "metabolic support",
+      "antioxidant support",
+      "nutrition support"
     ],
     "mechanisms": [
-      "nutritive support",
-      "antioxidant",
-      "metabolic support",
-      "Nrf2 activation",
-      "isothiocyanate signaling"
+      "isothiocyanate and glucosinolate Nrf2 activation",
+      "AMPK-related glucose/lipid signaling",
+      "NF-κB modulation",
+      "polyphenol antioxidant pathways"
     ],
     "description": "It is best framed as a nutrient-dense botanical with mixed translational evidence rather than as a universal superfood cure-all.",
-    "activeCompounds": [
-      "moringin",
-      "isothiocyanates",
-      "glucomoringin"
-    ],
-    "safetyNotes": "Generally well tolerated.",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Leaf preparations are commonly used as foods; concentrated extracts need caution. Avoid root/bark preparations in pregnancy; monitor if using antidiabetic or antihypertensive medication.",
     "interactions": [
-      "Use caution with glucose-lowering therapy when using concentrated extracts."
+      "Potential additive effects with antidiabetic and antihypertensive therapies",
+      "theoretical interaction with thyroid-active therapy in high-dose extracts."
     ],
-    "preparation": "Leaf powder is common; myrosinase-active processing changes glucosinolate conversion.",
-    "affiliateProducts": [
-      {
-        "name": "Moringa Powder",
-        "type": "powder",
-        "affiliateUrl": "https://www.amazon.com/s?k=moringa+powder&tag=razzleberry02-20"
-      },
-      {
-        "name": "Moringa Capsules",
-        "type": "capsule",
-        "affiliateUrl": "https://www.amazon.com/s?k=moringa+capsules&tag=razzleberry02-20"
-      }
+    "contraindications": [
+      "Pregnancy/breastfeeding caution for concentrated extracts",
+      "especially non-leaf parts",
+      "hypoglycemia-prone users should monitor."
+    ],
+    "preparation": "Human relevance is strongest for leaf powder/extracts; root and bark preparations carry different safety concerns.",
+    "traditionalUses": [
+      "metabolic",
+      "antioxidant",
+      "nutrition"
     ]
   },
   {
     "slug": "arjuna",
-    "name": "Arjuna",
-    "mechanisms": [
+    "name": "arjuna",
+    "region": "South Asia",
+    "primaryActions": [
       "cardiovascular support",
-      "vascular support"
+      "angina-support research",
+      "endurance/circulation support"
+    ],
+    "mechanisms": [
+      "endothelial nitric oxide signaling",
+      "antioxidant myocardial protection",
+      "lipid-modulating tannins/flavonoids",
+      "mild positive inotropic and vascular effects"
     ],
     "description": "It is best framed around bark polyphenols and triterpenes with specific cardiotonic-support positioning.",
-    "activeCompounds": [
-      "arjunolic acid",
-      "triterpenes"
-    ],
-    "safetyNotes": "Generally well tolerated.",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Use cautiously with diagnosed heart disease unless supervised. Possible additive effects with antihypertensives, nitrates, beta-blockers, digoxin-like regimens, antiplatelets, or anticoagulants.",
     "interactions": [
-      "antihypertensives"
+      "Potential additive blood-pressure",
+      "antianginal",
+      "antiplatelet",
+      "and cardiac-medication effects",
+      "monitor with cardiovascular drugs."
     ],
-    "primaryActions": [
-      "antioxidant",
-      "cardiovascular support"
+    "contraindications": [
+      "Unstable angina",
+      "heart failure without clinician oversight",
+      "pregnancy/breastfeeding caution",
+      "and planned surgery when combined with anticoagulant therapy."
+    ],
+    "preparation": "Evidence is most relevant to bark preparations or standardized extracts used in clinical studies.",
+    "traditionalUses": [
+      "cardiovascular",
+      "angina-support",
+      "endurance/circulation"
     ]
   },
   {
     "slug": "noni",
-    "name": "Noni",
+    "name": "noni",
+    "region": "Polynesia; Pacific Islands",
+    "primaryActions": [
+      "immune/tonic traditional use",
+      "pain/inflammation education",
+      "antioxidant fruit support"
+    ],
     "mechanisms": [
       "traditional wellness support",
       "antioxidant"
     ],
     "description": "It should be framed conservatively because broad folk claims exceed the strength of modern evidence.",
-    "activeCompounds": [
-      "damnacanthal",
-      "iridoids"
+    "safetyNotes": "Immune-active potential; use caution with autoimmune disease, transplant medicines, immunosuppressants, and during active cancer treatment unless clinician-supervised.",
+    "interactions": [
+      "Caution with potassium-sparing diuretics",
+      "ACE inhibitors/ARBs",
+      "anticoagulants",
+      "and hepatotoxic drugs."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "Liver disease",
+      "kidney disease/hyperkalemia risk",
+      "pregnancy/breastfeeding without guidance"
+    ],
+    "preparation": "Fruit juice, puree, powder, and leaf products; fruit and leaf safety differ.",
+    "traditionalUses": [
+      "Polynesian tonic",
+      "pain",
+      "infection",
+      "and digestive use"
+    ]
   },
   {
     "slug": "cranberry",
-    "name": "Cranberry",
+    "name": "cranberry",
+    "region": "North America",
+    "primaryActions": [
+      "urinary tract support",
+      "anti-adhesion proanthocyanidin support",
+      "antioxidant fruit support"
+    ],
     "mechanisms": [
-      "urinary support",
-      "antioxidant"
+      "proanthocyanidin anti-adhesion effects against uropathogenic E. coli",
+      "urinary-tract anti-adherence signaling"
     ],
     "description": "It is best framed around proanthocyanidin-rich urinary-support positioning rather than broad antimicrobial claims.",
-    "activeCompounds": [
-      "A-type proanthocyanidins"
-    ],
-    "safetyNotes": "Generally well tolerated.",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "GI upset possible; caution with recurrent kidney stones and warfarin-sensitive patients; avoid treating active UTI without care.",
     "interactions": [
-      "anticoagulants/antiplatelets"
+      "Warfarin interaction concern is reported",
+      "monitor INR if used with anticoagulation."
     ],
-    "primaryActions": [
-      "antioxidant",
-      "antimicrobial"
+    "contraindications": [
+      "History of kidney stones/oxalate stones",
+      "warfarin use requires clinician review"
+    ],
+    "preparation": "Juice, capsules, tablets, and PAC-standardized extracts; sugar content varies in juices.",
+    "traditionalUses": [
+      "Urinary support and food use"
     ]
   },
   {
     "slug": "rose-hips",
-    "name": "Rose Hips",
+    "name": "rose hips",
+    "region": "Europe; Western Asia",
+    "primaryActions": [
+      "vitamin C/polyphenol support",
+      "joint comfort education",
+      "antioxidant fruit support"
+    ],
     "mechanisms": [
-      "antioxidant",
-      "nutritive support"
+      "galactolipid/GOPO anti-inflammatory signaling",
+      "COX/LOX and cartilage inflammatory mediator modulation"
     ],
     "description": "They are best framed as polyphenol- and vitamin-rich fruit material with modest but relevant human evidence.",
-    "activeCompounds": [
-      "trans-tiliroside",
-      "vitamin C"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "GI effects possible; caution with anticoagulants/antiplatelets and kidney-stone risk in susceptible users.",
+    "interactions": [
+      "May affect iron absorption",
+      "caution with anticoagulants if high-dose vitamin C/polyphenol products."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "Kidney stone risk",
+      "iron overload disorders with high vitamin C intake",
+      "pregnancy/breastfeeding supplement review"
+    ],
+    "preparation": "Fruit/hip tea, powder, extracts, syrups; seed oil is a separate topical product.",
+    "traditionalUses": [
+      "Vitamin-rich tonic",
+      "colds",
+      "joints",
+      "and food use"
+    ]
   },
   {
     "slug": "juniper",
-    "name": "Juniper",
+    "name": "juniper",
+    "region": "Europe; Northern Hemisphere",
+    "primaryActions": [
+      "urinary aromatic traditional use",
+      "digestive bitter support",
+      "antimicrobial essential-oil research"
+    ],
     "mechanisms": [
       "digestive support",
       "urinary support",
       "aromatic support"
     ],
     "description": "It should be framed as an aromatic berry botanical with traditional GI and urinary relevance.",
-    "activeCompounds": [
-      "alpha-pinene",
-      "terpenes"
+    "safetyNotes": "Avoid during pregnancy and use cautiously with kidney disease. Concentrated preparations may irritate the urinary tract and may interact with diuretics or lithium.",
+    "interactions": [
+      "May add to diuretics and affect lithium handling",
+      "caution with nephrotoxic drugs."
     ],
-    "safetyNotes": "Use cautiously in concentrated forms."
+    "contraindications": [
+      "Pregnancy",
+      "kidney disease",
+      "inflammatory kidney conditions",
+      "internal essential-oil use without supervision"
+    ],
+    "preparation": "Berry tea/tincture, culinary spice, and essential oil; internal essential oil is high risk.",
+    "traditionalUses": [
+      "Urinary",
+      "digestive",
+      "and aromatic cleansing use"
+    ]
   },
   {
     "slug": "myrtle",
-    "name": "Myrtle",
+    "name": "myrtle",
+    "region": "Mediterranean",
+    "primaryActions": [
+      "antioxidant/cellular stress support"
+    ],
     "mechanisms": [
       "aromatic support",
       "antioxidant"
     ],
     "description": "It is best framed as an aromatic Mediterranean leaf botanical with modest modern evidence.",
-    "activeCompounds": [
-      "myrtenyl acetate",
-      "myricetin"
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "safetyNotes": "Generally well tolerated.",
-    "primaryActions": [
-      "antioxidant"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Aromatic herb/spice forms and essential oils differ greatly; essential oils require conservative topical/diluted use and are not interchangeable with teas.",
+    "traditionalUses": [
+      "antioxidant/cellular stress"
     ]
   },
   {
     "slug": "acerola",
-    "name": "Acerola",
+    "name": "acerola",
+    "region": "Caribbean; South America",
+    "primaryActions": [
+      "vitamin C support",
+      "antioxidant fruit support",
+      "immune nutrition education"
+    ],
     "mechanisms": [
       "antioxidant",
       "nutritive support"
     ],
     "description": "It is best framed as a vitamin-C-rich fruit botanical with food/supplement relevance.",
-    "activeCompounds": [
-      "ascorbic acid",
-      "carotenoids"
+    "safetyNotes": "Immune-active potential; use caution with autoimmune disease, transplant medicines, immunosuppressants, and during active cancer treatment unless clinician-supervised.",
+    "interactions": [
+      "May affect iron absorption and some lab results at high vitamin C intakes."
     ],
-    "safetyNotes": "Generally well tolerated.",
-    "primaryActions": [
-      "antioxidant"
+    "contraindications": [
+      "Kidney stone risk",
+      "iron overload conditions",
+      "G6PD deficiency caution with very high vitamin C dosing"
+    ],
+    "preparation": "Fruit powder, juice, extracts, and vitamin C-standardized products.",
+    "traditionalUses": [
+      "Food fruit and vitamin-rich tonic"
     ]
   },
   {
     "slug": "mangosteen",
-    "name": "Mangosteen",
+    "name": "mangosteen",
+    "region": "Southeast Asia",
+    "primaryActions": [
+      "antioxidant xanthone support",
+      "inflammation research",
+      "skin/digestive traditional use"
+    ],
     "mechanisms": [
       "antioxidant",
       "traditional wellness support"
     ],
     "description": "It should be framed conservatively because broad anti-inflammatory and disease claims outrun the evidence.",
-    "activeCompounds": [
-      "alpha-mangostin",
-      "xanthones"
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "interactions": [
+      "Theoretical anticoagulant/antiplatelet interactions",
+      "product-specific evidence limited."
     ],
-    "safetyNotes": "Generally well tolerated.",
-    "primaryActions": [
-      "anti-inflammatory",
-      "antioxidant"
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "bleeding disorder/anticoagulant use without review"
+    ],
+    "preparation": "Pericarp/rind extracts, juice blends, powders; fruit pulp differs from rind extract.",
+    "traditionalUses": [
+      "Southeast Asian rind use for diarrhea",
+      "skin",
+      "and infections"
     ]
   },
   {
     "slug": "boldo",
-    "name": "Boldo",
+    "name": "boldo",
+    "region": "South America",
+    "primaryActions": [
+      "digestive support",
+      "bile-flow tradition",
+      "liver-safety education"
+    ],
     "mechanisms": [
       "digestive support",
       "hepatobiliary support"
     ],
     "description": "It is best framed as an aromatic bitter leaf botanical with modest human evidence.",
-    "activeCompounds": [
-      "boldine"
+    "safetyNotes": "Avoid high-dose or prolonged internal use; alkaloid/essential-oil rich preparations may irritate the GI tract and are inappropriate in pregnancy, liver disease, or bile-duct obstruction.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "safetyNotes": "Use cautiously in concentrated forms.",
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "digestive support"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "active liver disease"
+    ],
+    "preparation": "Aromatic herb/spice forms and essential oils differ greatly; essential oils require conservative topical/diluted use and are not interchangeable with teas.",
+    "traditionalUses": [
+      "digestive",
+      "bile-flow tradition",
+      "liver-safety"
     ]
   },
   {
     "slug": "suma",
-    "name": "Suma",
+    "name": "suma",
+    "region": "South America traditional medicine",
+    "primaryActions": [
+      "adaptogen tradition",
+      "fatigue support education",
+      "inflammatory pathway research"
+    ],
     "mechanisms": [
       "traditional restorative support",
       "adaptogenic support"
     ],
     "description": "It should be framed conservatively because traditional-use breadth exceeds evidence depth.",
-    "activeCompounds": [
-      "pfaffic acid",
-      "saponins"
+    "safetyNotes": "Limited human safety data; use conservative preparation-specific framing and avoid pregnancy/breastfeeding or medication stacking without clinician review.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "safetyNotes": "Generally well tolerated.",
-    "primaryActions": [
-      "adaptogenic"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "adaptogen tradition",
+      "fatigue",
+      "inflammatory pathway"
     ]
   },
   {
     "slug": "maral-root",
-    "name": "Maral Root",
+    "name": "maral root",
+    "region": "Central Asia/Siberia",
+    "primaryActions": [
+      "adaptogen tradition",
+      "performance/fatigue support education"
+    ],
     "mechanisms": [
       "adaptogenic support",
       "recovery support"
     ],
     "description": "It is best framed carefully because ecdysteroid narratives often outpace evidence quality.",
-    "activeCompounds": [
-      "ecdysterone"
+    "safetyNotes": "Limited human safety data; use conservative preparation-specific framing and avoid pregnancy/breastfeeding or medication stacking without clinician review.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "safetyNotes": "Generally well tolerated.",
-    "primaryActions": [
-      "adaptogenic"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "traditionalUses": [
+      "adaptogen tradition",
+      "performance/fatigue"
     ]
   },
   {
     "slug": "jatamansi",
-    "name": "Jatamansi",
+    "name": "jatamansi",
+    "region": "Himalayan/South Asia traditional medicine",
+    "primaryActions": [
+      "calming/sleep tradition",
+      "neuroprotective pathway research"
+    ],
     "mechanisms": [
       "calming support",
       "traditional nervous-system support"
     ],
     "description": "It should be framed as a traditional aromatic rhizome with modest clinical depth.",
-    "activeCompounds": [
-      "jatamansone"
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "interactions": [
+      "Potential interaction concern with sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Aromatic herb/spice forms and essential oils differ greatly; essential oils require conservative topical/diluted use and are not interchangeable with teas.",
+    "traditionalUses": [
+      "calming/sleep tradition",
+      "neuroprotective pathway"
+    ]
   },
   {
     "slug": "soursop",
-    "name": "Soursop",
+    "name": "soursop",
+    "region": "Tropical Americas",
+    "primaryActions": [
+      "traditional antimicrobial use",
+      "antioxidant pathway research",
+      "safety education"
+    ],
     "mechanisms": [
       "traditional wellness support",
       "antioxidant"
     ],
     "description": "It must be framed carefully because anticancer folklore claims greatly exceed evidence and safety certainty.",
-    "activeCompounds": [
-      "annonacin"
+    "safetyNotes": "Avoid high-dose or chronic supplement use; annonaceous acetogenins have neurotoxicity concerns. Caution with Parkinsonism, neurologic disease, pregnancy, and sedating medications.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "safetyNotes": "Use cautiously."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "traditional antimicrobial use",
+      "antioxidant pathway",
+      "safety"
+    ]
   },
   {
     "slug": "ashoka",
-    "name": "Ashoka",
+    "name": "ashoka",
+    "region": "South Asia / Ayurveda",
+    "primaryActions": [
+      "women’s health tradition",
+      "uterine support tradition",
+      "inflammatory pathway research"
+    ],
     "mechanisms": [
       "traditional cycle support"
     ],
     "description": "It should be framed conservatively because traditional gynecologic use is much stronger than modern evidence.",
-    "activeCompounds": [
-      "catechins",
-      "flavonoids"
+    "safetyNotes": "Hormone- or cycle-related traditional use requires caution in pregnancy, breastfeeding, hormone-sensitive conditions, and with hormone therapies.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "women’s health tradition",
+      "uterine tradition",
+      "inflammatory pathway"
+    ]
   },
   {
     "slug": "shankhpushpi",
-    "name": "Shankhpushpi",
+    "name": "shankhpushpi",
+    "region": "South Asia / Ayurveda",
+    "primaryActions": [
+      "cognitive/calm support tradition",
+      "neuroprotective pathway research"
+    ],
     "mechanisms": [
       "traditional cognitive support",
       "calming support"
     ],
     "description": "It is best framed as a traditional cognitive-support herb with limited modern clinical depth.",
-    "activeCompounds": [
-      "convolvine"
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "interactions": [
+      "Potential interaction concern with sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Generally well tolerated.",
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "nootropic"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "cognitive/calm tradition",
+      "neuroprotective pathway"
     ]
   },
   {
     "slug": "hops",
-    "name": "Hops",
+    "name": "hops",
+    "region": "Europe",
+    "primaryActions": [
+      "sleep/calm support",
+      "menopause symptom education",
+      "bitter digestive support"
+    ],
     "mechanisms": [
       "calming support",
       "sleep support"
     ],
     "description": "It is best framed around bitter-resin and prenylflavonoid chemistry with modest selected human evidence.",
-    "activeCompounds": [
-      "humulone",
-      "xanthohumol"
-    ],
-    "safetyNotes": "Generally well tolerated.",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
     "interactions": [
-      "CNS depressants"
+      "May potentiate sedatives",
+      "alcohol",
+      "sleep medications",
+      "and other CNS depressants."
     ],
-    "preparation": "No direct preparation data. Contextual inference: Sedative, hypnotic, digestive bitter; used in beer and herbal medicine. Gaba-a receptor modulation and sedative flavonoids.. ; nan; nan.. GABA-A receptor modulation and sedative flavonoids.. Sedative, hypnotic, digestive bitter; used in beer and herbal medicine. No direct region data. Contextual inference: Sedative, hypnotic, digestive bitter; used in beer and herbal medicine. Gaba-a receptor modulation and sedative flavonoids.. ; nan; nan.. GABA-A receptor modulation and sedative flavonoids.. Sedative, hypnotic, digestive bitter; used in beer and herbal medicine. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "anxiolytic",
-      "sedative",
-      "digestive support"
+    "contraindications": [
+      "Pregnancy/breastfeeding without guidance",
+      "severe depression",
+      "hormone-sensitive conditions without review"
+    ],
+    "preparation": "Strobile tea/tincture/extract; often combined with valerian or passionflower.",
+    "traditionalUses": [
+      "Sleep",
+      "bitters",
+      "brewing",
+      "and menopausal support"
     ]
   },
   {
     "slug": "lemongrass",
-    "name": "Lemongrass",
+    "name": "lemongrass",
+    "region": "Tropical Asia; Africa",
+    "primaryActions": [
+      "digestive comfort",
+      "antimicrobial aromatic support",
+      "metabolic/vascular research"
+    ],
     "mechanisms": [
       "digestive support",
       "calming support",
@@ -1483,173 +2325,332 @@
       "sensory ion-channel modulation"
     ],
     "description": "It is best framed as an aromatic culinary-medicinal grass with modest clinical depth.",
-    "activeCompounds": [
-      "citral",
-      "citronellal"
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "interactions": [
+      "Low documented interaction burden",
+      "caution with sedatives or antihypertensives at high doses."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "Pregnancy/breastfeeding supplement dosing without guidance",
+      "internal essential-oil use"
+    ],
+    "preparation": "Leaf tea, culinary herb, tincture, and essential oil for topical/aromatic use.",
+    "traditionalUses": [
+      "Digestive",
+      "fever",
+      "aromatic",
+      "and culinary use"
+    ]
   },
   {
     "slug": "perilla",
-    "name": "Perilla",
+    "name": "perilla",
+    "region": "China; Japan; Korea",
+    "primaryActions": [
+      "allergy/respiratory support research",
+      "omega-rich seed support",
+      "digestive aromatic use"
+    ],
     "mechanisms": [
       "seasonal support",
       "antioxidant",
       "aromatic support"
     ],
     "description": "It is best framed as a culinary-medicinal herb with modest but relevant translational evidence.",
-    "activeCompounds": [
-      "perillaldehyde",
-      "rosmarinic acid"
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "interactions": [
+      "May add to anticoagulant/antiplatelet effects",
+      "limited clinical data."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "Pregnancy/breastfeeding supplement use without guidance",
+      "anticoagulant use without review"
+    ],
+    "preparation": "Leaf tea/culinary use, seed oil, extracts standardized to rosmarinic acid or ALA.",
+    "traditionalUses": [
+      "East Asian culinary",
+      "respiratory",
+      "and digestive use"
+    ]
   },
   {
     "slug": "carob",
-    "name": "Carob",
+    "name": "carob",
+    "region": "Mediterranean",
+    "primaryActions": [
+      "digestive fiber support",
+      "tannin-rich diarrhea traditional use",
+      "caffeine-free cacao alternative"
+    ],
     "mechanisms": [
       "digestive support",
       "metabolic support"
     ],
     "description": "It is best framed as a food-form legume pod with fiber and polyphenol relevance rather than strong pharmacologic action.",
-    "activeCompounds": [
-      "D-pinitol",
-      "polyphenols"
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "interactions": [
+      "Fiber/tannin content may reduce absorption of some oral medications if taken together."
     ],
-    "safetyNotes": "Generally well tolerated.",
-    "primaryActions": [
-      "digestive support"
+    "contraindications": [
+      "Severe constipation/obstruction risk",
+      "carob allergy"
+    ],
+    "preparation": "Pod powder, gum, syrup, and fiber/tannin extracts; gum and pod powder differ.",
+    "traditionalUses": [
+      "Food",
+      "digestive support",
+      "infant diarrhea folk use"
     ]
   },
   {
     "slug": "danshen",
-    "name": "Danshen",
+    "name": "danshen",
+    "region": "China; TCM",
+    "primaryActions": [
+      "cardiovascular circulation support research",
+      "microcirculation education",
+      "TCM blood-moving use"
+    ],
     "mechanisms": [
       "cardiovascular support",
       "vascular support"
     ],
     "description": "It is best framed around tanshinones and salvianolic acids with specific vascular-support positioning.",
-    "activeCompounds": [
-      "tanshinone IIA",
-      "salvianolic acid B"
+    "safetyNotes": "May increase bleeding risk and alter blood pressure; use caution with anticoagulants/antiplatelets, antihypertensives, digoxin/heart medicines, and before surgery.",
+    "interactions": [
+      "May interact with warfarin",
+      "aspirin",
+      "antiplatelets",
+      "antihypertensives",
+      "and cardiovascular drugs."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "Pregnancy",
+      "anticoagulant/antiplatelet therapy without clinician review",
+      "upcoming surgery"
+    ],
+    "preparation": "Root decoction, granules, injections in clinical settings, and standardized extracts; route matters greatly.",
+    "traditionalUses": [
+      "TCM blood stasis/circulation and chest discomfort formulas"
+    ]
   },
   {
     "slug": "eucommia",
-    "name": "Eucommia",
+    "name": "eucommia",
+    "region": "China; TCM",
+    "primaryActions": [
+      "blood pressure/metabolic research",
+      "musculoskeletal traditional support",
+      "kidney-yang TCM use"
+    ],
     "mechanisms": [
       "connective tissue support",
       "cardiometabolic support"
     ],
     "description": "It is best framed conservatively because traditional tonic use is broader than modern evidence quality.",
-    "activeCompounds": [
-      "geniposidic acid",
-      "lignans"
+    "safetyNotes": "May affect circulation, blood pressure, or platelet function; use caution with anticoagulants/antiplatelets, antihypertensives, heart medications, and before surgery.",
+    "interactions": [
+      "May potentiate antihypertensive or antidiabetic agents."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "hypotension or hypoglycemia risk"
+    ],
+    "preparation": "Bark/leaf tea, decoction, powders, and extracts; bark and leaf chemistry differ.",
+    "traditionalUses": [
+      "TCM kidney/liver tonic",
+      "tendons/bones",
+      "blood pressure folk use"
+    ]
   },
   {
     "slug": "cistanche",
-    "name": "Cistanche",
+    "name": "cistanche",
+    "region": "China; Central Asia",
+    "primaryActions": [
+      "fatigue/vitality traditional support",
+      "cognition/neuroprotection research",
+      "bowel-moistening TCM use"
+    ],
     "mechanisms": [
       "traditional restorative support",
       "fatigue support"
     ],
     "description": "It should be framed conservatively because traditional-system use is broader than modern clinical depth.",
-    "activeCompounds": [
-      "echinacoside",
-      "acteoside"
+    "safetyNotes": "Limited human safety data; use conservative preparation-specific framing and avoid pregnancy/breastfeeding or medication stacking without clinician review.",
+    "interactions": [
+      "Limited clinical interaction data",
+      "caution with laxatives and glucose-lowering therapies."
     ],
-    "safetyNotes": "Generally well tolerated.",
-    "primaryActions": [
-      "antioxidant"
+    "contraindications": [
+      "Pregnancy/breastfeeding without guidance",
+      "diarrhea-prone conditions"
+    ],
+    "preparation": "Stem decoction, powder, and extracts standardized to echinacoside/acteoside.",
+    "traditionalUses": [
+      "TCM kidney-yang tonic",
+      "fatigue",
+      "bowel dryness"
     ]
   },
   {
     "slug": "jujube",
-    "name": "Jujube",
+    "name": "jujube",
+    "region": "China; East Asia",
+    "primaryActions": [
+      "sleep/calm traditional use",
+      "digestive/nutritive support",
+      "antioxidant fruit support"
+    ],
     "mechanisms": [
       "calming support",
       "nutritive support"
     ],
     "description": "It is best framed as a food-like fruit/seed botanical with gentle traditional positioning.",
-    "activeCompounds": [
-      "jujubosides",
-      "flavonoids"
-    ],
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
     "interactions": [
-      "CNS depressants"
+      "May add to sedatives if seed extracts are used",
+      "monitor glucose with high fruit intake."
     ],
-    "preparation": "No direct preparation data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. No direct region data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. Folk medicine. Folk medicine"
+    "contraindications": [
+      "Diabetes/glucose management if using sweet fruit products",
+      "pregnancy supplement dosing without guidance"
+    ],
+    "preparation": "Fruit, seed extracts, decoction, teas; seed and fruit differ pharmacologically.",
+    "traditionalUses": [
+      "TCM calm-spirit",
+      "spleen/digestion",
+      "food tonic"
+    ]
   },
   {
     "slug": "longan",
-    "name": "Longan",
+    "name": "longan",
+    "region": "Southeast/East Asia",
+    "primaryActions": [
+      "sleep/calm tradition",
+      "antioxidant support"
+    ],
     "mechanisms": [
       "nutritive support",
       "calming support"
     ],
     "description": "It should be framed as a food-like fruit botanical with modest modern evidence.",
-    "activeCompounds": [
-      "polyphenols",
-      "gallic acid"
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "interactions": [
+      "Potential interaction concern with sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Generally well tolerated.",
-    "primaryActions": [
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Fruit/berry preparations are commonly used as foods, juices, powders, capsules, or extracts; sugar and extract concentration vary.",
+    "traditionalUses": [
+      "sleep/calm tradition",
       "antioxidant"
     ]
   },
   {
     "slug": "polygala",
-    "name": "Polygala",
+    "name": "polygala",
+    "region": "China; TCM",
+    "primaryActions": [
+      "cognition/mood traditional support",
+      "expectorant use",
+      "TCM shen-calming education"
+    ],
     "mechanisms": [
       "traditional cognitive support",
       "calming support"
     ],
     "description": "It is best framed as a traditional nootropic-style root with limited modern clinical depth.",
-    "activeCompounds": [
-      "tenuifolin",
-      "polygalasaponins"
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "interactions": [
+      "Potential additive sedation or cognitive-drug interactions",
+      "limited clinical data."
     ],
-    "safetyNotes": "Use cautiously."
+    "contraindications": [
+      "Pregnancy/breastfeeding without guidance",
+      "gastritis/ulcer sensitivity"
+    ],
+    "preparation": "Processed root decoction/extract; raw high-dose use may be irritating.",
+    "traditionalUses": [
+      "TCM memory",
+      "mood",
+      "sleep",
+      "phlegm/expectorant use"
+    ]
   },
   {
     "slug": "gastrodia",
-    "name": "Gastrodia",
+    "name": "gastrodia",
+    "region": "China; TCM",
+    "primaryActions": [
+      "headache/dizziness traditional use",
+      "neuroprotective research",
+      "TCM wind-calming support"
+    ],
     "mechanisms": [
       "traditional nervous-system support",
       "calming support"
     ],
     "description": "It should be framed conservatively because traditional neurologic use is broader than modern evidence.",
-    "activeCompounds": [
-      "gastrodin"
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "interactions": [
+      "May add to CNS depressant or antihypertensive effects",
+      "limited interaction data."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "Pregnancy/breastfeeding without guidance",
+      "sedative use without review"
+    ],
+    "preparation": "Tuber decoction, powder, extract; often used in formulas.",
+    "traditionalUses": [
+      "TCM headache",
+      "dizziness",
+      "tremor/wind conditions"
+    ]
   },
   {
     "slug": "white-peony",
-    "name": "White Peony",
+    "name": "white peony",
+    "region": "China; TCM",
+    "primaryActions": [
+      "menstrual/cramp traditional support",
+      "liver-blood TCM support",
+      "immune/inflammation research"
+    ],
     "mechanisms": [
       "traditional cycle support",
       "calming support"
     ],
     "description": "It is best framed as a paeoniflorin-rich root with traditional-system relevance.",
-    "activeCompounds": [
-      "paeoniflorin"
-    ],
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
     "interactions": [
-      "anticoagulants/antiplatelets"
+      "Potential additive bleeding risk with anticoagulants/antiplatelets",
+      "may interact with immunomodulators."
     ],
-    "primaryActions": [
-      "anxiolytic"
+    "contraindications": [
+      "Pregnancy without clinician guidance",
+      "anticoagulant use without review"
+    ],
+    "preparation": "Root decoction/extract; often paired with licorice or other TCM herbs.",
+    "traditionalUses": [
+      "TCM blood/liver support",
+      "cramps",
+      "pain",
+      "formulas"
     ]
   },
   {
     "slug": "bupleurum",
-    "name": "Bupleurum",
+    "name": "bupleurum",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "liver/inflammatory pathway research",
+      "TCM formula context"
+    ],
     "mechanisms": [
       "traditional liver support",
       "traditional stress support",
@@ -1657,73 +2658,143 @@
       "PI3K/Akt modulation"
     ],
     "description": "It should be framed conservatively because traditional-system context matters more than casual wellness claims.",
-    "activeCompounds": [
-      "saikosaponins",
-      "Saikosaponin A"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Hepatobiliary-active potential; use caution with liver disease, gallbladder disease, bile-duct obstruction, hepatotoxic drugs, and pregnancy.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Use cautiously."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "active liver disease"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "liver/inflammatory pathway",
+      "TCM formula context"
+    ]
   },
   {
     "slug": "codonopsis",
-    "name": "Codonopsis",
+    "name": "codonopsis",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "adaptogen/tonic tradition",
+      "immune support education"
+    ],
     "mechanisms": [
       "traditional restorative support",
       "fatigue support"
     ],
     "description": "It is best framed as a gentler tonic-style root with modest modern evidence.",
-    "activeCompounds": [
-      "tangshenosides",
-      "polysaccharides"
+    "safetyNotes": "Immune-active potential; use caution with autoimmune disease, transplant medicines, immunosuppressants, and during active cancer treatment unless clinician-supervised.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "traditionalUses": [
+      "adaptogen/tonic tradition",
+      "immune"
+    ]
   },
   {
     "slug": "dendrobium",
-    "name": "Dendrobium",
+    "name": "dendrobium",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "dryness/throat tradition",
+      "antioxidant pathway research"
+    ],
     "mechanisms": [
       "traditional restorative support",
       "mucosal support"
     ],
     "description": "It should be framed conservatively because luxury-tonic narratives often exceed evidence depth.",
-    "activeCompounds": [
-      "polysaccharides",
-      "alkaloids"
+    "safetyNotes": "Food-like use is generally lower risk, but concentrated extracts may not match dietary safety. Use caution with pregnancy/breastfeeding, allergy, and chronic high-dose supplementation.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "dryness/throat tradition",
+      "antioxidant pathway"
+    ]
   },
   {
     "slug": "ophiopogon",
-    "name": "Ophiopogon",
+    "name": "ophiopogon",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "respiratory/throat tradition",
+      "mucosal support education"
+    ],
     "mechanisms": [
       "demulcent support",
       "traditional respiratory support"
     ],
     "description": "It is best framed as a moistening tonic-style root with traditional-system relevance.",
-    "activeCompounds": [
-      "ophiopogonins"
+    "safetyNotes": "Mucilage-rich preparations may slow absorption of oral medicines; separate from medications when practical. Use caution with diabetes medicines if metabolic effects are suspected.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "traditionalUses": [
+      "respiratory/throat tradition",
+      "mucosal"
+    ]
   },
   {
     "slug": "houttuynia",
-    "name": "Houttuynia",
+    "name": "houttuynia",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "respiratory/immune traditional use",
+      "antimicrobial pathway research"
+    ],
     "mechanisms": [
       "traditional immune support",
       "traditional respiratory support"
     ],
     "description": "It should be framed cautiously because strong folklore claims exceed the evidence.",
-    "activeCompounds": [
-      "quercitrin",
-      "volatile oils"
+    "safetyNotes": "Immune-active potential; use caution with autoimmune disease, transplant medicines, immunosuppressants, and during active cancer treatment unless clinician-supervised.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Generally well tolerated.",
-    "primaryActions": [
-      "immunomodulatory"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "respiratory/immune traditional use",
+      "antimicrobial pathway"
     ]
   },
   {
     "slug": "isatis",
-    "name": "Isatis",
+    "name": "isatis",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "immune/respiratory traditional use",
+      "antiviral pathway research"
+    ],
     "mechanisms": [
       "traditional immune support",
       "throat support",
@@ -1731,446 +2802,830 @@
       "STAT3 inhibition"
     ],
     "description": "It is best framed as a traditional-use herb with limited modern clinical depth.",
-    "activeCompounds": [
-      "indirubin",
-      "tryptanthrin"
+    "safetyNotes": "Immune-active potential; use caution with autoimmune disease, transplant medicines, immunosuppressants, and during active cancer treatment unless clinician-supervised.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Use cautiously.",
-    "primaryActions": [
-      "immunomodulatory"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "immune/respiratory traditional use",
+      "antiviral pathway"
     ]
   },
   {
     "slug": "sophora-flavescens",
-    "name": "Sophora Flavescens",
+    "name": "sophora flavescens",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "inflammatory pathway research",
+      "antimicrobial traditional use"
+    ],
     "mechanisms": [
       "traditional skin support",
       "GI support"
     ],
     "description": "It should be framed conservatively because alkaloid-rich roots can have stronger tolerability issues.",
-    "activeCompounds": [
-      "matrine",
-      "oxymatrine"
+    "safetyNotes": "Alkaloid-rich herb; use caution with liver disease, immunosuppressants, pregnancy/breastfeeding, and medications with narrow therapeutic windows.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "safetyNotes": "Use cautiously.",
-    "preparation": "Root dried and decocted in TCM (Ku Shen); anti-parasitic and anti-inflammatory uses",
-    "primaryActions": [
-      "anti-inflammatory",
-      "antioxidant",
-      "nootropic"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "traditionalUses": [
+      "inflammatory pathway",
+      "antimicrobial traditional use"
     ]
   },
   {
     "slug": "notoginseng",
-    "name": "Notoginseng",
+    "name": "notoginseng",
+    "region": "China; TCM",
+    "primaryActions": [
+      "circulation/hemostasis education",
+      "cardiovascular research",
+      "TCM blood-moving use"
+    ],
     "mechanisms": [
       "vascular support",
       "recovery support"
     ],
     "description": "It is best framed as a saponin-rich Panax relative with specific vascular-support positioning.",
-    "activeCompounds": [
-      "notoginsenoside R1",
-      "ginsenosides"
-    ],
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "May affect platelet aggregation and bleeding risk; use caution with anticoagulants/antiplatelets, before surgery, and during pregnancy unless supervised.",
     "interactions": [
-      "anticoagulants/antiplatelets"
+      "May interact with anticoagulants",
+      "antiplatelets",
+      "antihypertensives",
+      "and antidiabetics."
     ],
-    "primaryActions": [
-      "cardiovascular support"
+    "contraindications": [
+      "Pregnancy",
+      "anticoagulant/antiplatelet use without clinician review",
+      "upcoming surgery"
+    ],
+    "preparation": "Root powder, decoction, extracts; saponin-standardized products exist.",
+    "traditionalUses": [
+      "TCM trauma",
+      "bleeding",
+      "circulation",
+      "cardiovascular formulas"
     ]
   },
   {
     "slug": "luo-han-guo",
-    "name": "Luo Han Guo",
+    "name": "luo han guo",
+    "region": "China / East Asia",
+    "primaryActions": [
+      "throat/respiratory support",
+      "sweetener/metabolic education"
+    ],
     "mechanisms": [
       "throat support",
       "sweetener-adjacent support"
     ],
     "description": "It is best framed as a fruit botanical with sweet mogrosides and soothing traditional use.",
-    "activeCompounds": [
-      "mogrosides"
+    "evidenceLevel": "traditional",
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "antihypertensives/diuretics",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Fruit/berry preparations are commonly used as foods, juices, powders, capsules, or extracts; sugar and extract concentration vary.",
+    "traditionalUses": [
+      "throat/respiratory",
+      "sweetener/metabolic"
+    ]
   },
   {
     "slug": "kuding-tea",
-    "name": "Kuding Tea",
+    "name": "kuding tea",
+    "region": "China / East Asia",
+    "primaryActions": [
+      "cardiometabolic traditional use",
+      "antioxidant support"
+    ],
     "mechanisms": [
       "antioxidant",
       "cardiometabolic support"
     ],
     "description": "It should be framed as a bitter tea botanical with food-form relevance and modest modern evidence.",
-    "activeCompounds": [
-      "triterpenoid saponins",
-      "polyphenols"
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Generally well tolerated.",
-    "primaryActions": [
-      "antioxidant",
-      "digestive support"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "cardiometabolic traditional use",
+      "antioxidant"
     ]
   },
   {
     "slug": "atractylodes",
-    "name": "Atractylodes",
+    "name": "atractylodes",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "digestive/tonic tradition",
+      "immune-gut support education"
+    ],
     "mechanisms": [
       "digestive support",
       "traditional restorative support"
     ],
     "description": "It is best framed as a digestive-tonic rhizome with traditional-system relevance.",
-    "activeCompounds": [
-      "atractylenolide I"
+    "safetyNotes": "Immune-active potential; use caution with autoimmune disease, transplant medicines, immunosuppressants, and during active cancer treatment unless clinician-supervised.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "traditionalUses": [
+      "digestive/tonic tradition",
+      "immune-gut"
+    ]
   },
   {
     "slug": "schisandra-berry",
-    "name": "Schisandra Berry",
+    "name": "schisandra berry",
+    "region": "China; Russia",
+    "primaryActions": [
+      "stress/liver support research",
+      "adaptogen education",
+      "respiratory traditional use"
+    ],
     "mechanisms": [
       "adaptogenic support",
       "hepatoprotective support"
     ],
     "description": "It is best framed specifically around berry lignans and traditional stress-support positioning.",
-    "activeCompounds": [
-      "schisandrin",
-      "gomisin A"
+    "safetyNotes": "Can affect CYP/P-gp drug metabolism; review use with narrow-therapeutic-index drugs, sedatives, hepatotoxic drugs, and pregnancy/breastfeeding.",
+    "interactions": [
+      "Potential CYP/P-gp interactions",
+      "caution with immunosuppressants",
+      "sedatives",
+      "anticoagulants",
+      "and hepatically metabolized drugs."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "Pregnancy/breastfeeding without guidance",
+      "active reflux/ulcer sensitivity",
+      "complex medication regimens without review"
+    ],
+    "preparation": "Berry decoction, powder, tincture, and lignan-standardized extracts.",
+    "traditionalUses": [
+      "TCM five-flavor tonic",
+      "liver",
+      "lung",
+      "kidney",
+      "endurance support"
+    ]
   },
   {
     "slug": "catuba",
-    "name": "Catuba",
+    "name": "catuba",
+    "region": "Brazil / South America",
+    "primaryActions": [
+      "libido/energy traditional use",
+      "CNS pathway research"
+    ],
     "mechanisms": [
       "traditional vitality support",
       "mood support"
     ],
     "description": "It should be framed conservatively because traditional aphrodisiac narratives exceed modern evidence depth.",
-    "activeCompounds": [
-      "alkaloids",
-      "flavonoids"
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "interactions": [
+      "Potential interaction concern with sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "libido/energy traditional use",
+      "CNS pathway"
+    ]
   },
   {
     "slug": "muira-puama",
-    "name": "Muira Puama",
+    "name": "muira puama",
+    "region": "Brazil / South America",
+    "primaryActions": [
+      "libido/energy traditional use",
+      "CNS pathway research"
+    ],
     "mechanisms": [
       "traditional vitality support",
       "stress support"
     ],
     "description": "It is best framed as a traditional Amazonian botanical with modest modern evidence.",
-    "activeCompounds": [
-      "sterols",
-      "terpenes"
-    ],
-    "safetyNotes": "Generally well tolerated.",
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
     "interactions": [
-      "serotonergic medications"
+      "Potential interaction concern with sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "Decoction from root bark; also used in tinctures or powdered extract",
-    "primaryActions": [
-      "adaptogenic",
-      "nootropic"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "libido/energy traditional use",
+      "CNS pathway"
     ]
   },
   {
     "slug": "maitake-d-fraction",
-    "name": "Maitake D-Fraction",
+    "name": "maitake d-fraction",
+    "region": "East Asia",
+    "primaryActions": [
+      "immune support education",
+      "beta-glucan pathway research"
+    ],
     "mechanisms": [
-      "immune modulation"
+      "beta-glucan/dectin-1 immune signaling",
+      "macrophage and NK-cell cytokine modulation",
+      "NF-κB-mediated immune-response modulation"
     ],
     "description": "It should be framed distinctly from whole maitake because extract-standardization claims can exceed the underlying evidence.",
-    "activeCompounds": [
-      "beta-glucans"
+    "safetyNotes": "Immune-active mushroom extract; use caution with immunosuppressants, transplant medicines, autoimmune disease, and during active cancer treatment unless clinician-supervised.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Generally well tolerated.",
-    "primaryActions": [
-      "immunomodulatory"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "immune",
+      "beta-glucan pathway"
     ]
   },
   {
     "slug": "poria",
-    "name": "Poria",
+    "name": "poria",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "diuretic/digestive tradition",
+      "immune modulation research"
+    ],
     "mechanisms": [
       "traditional fluid-balance support",
       "calming support"
     ],
     "description": "It is best framed as a traditional medicinal fungus with modest modern clinical depth.",
-    "activeCompounds": [
-      "pachymic acid",
-      "polysaccharides"
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "sedatives/CNS depressants",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "significant kidney disease or unstable electrolytes"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "diuretic/digestive tradition",
+      "immune modulation"
+    ]
   },
   {
     "slug": "rehmannia-prepared",
-    "name": "Rehmannia Prepared",
+    "name": "rehmannia prepared",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "kidney/liver tonic tradition",
+      "metabolic and inflammatory pathway research"
+    ],
     "mechanisms": [
       "traditional restorative support"
     ],
     "description": "It should be framed distinctly from raw rehmannia because processed-form use-cases differ materially.",
-    "activeCompounds": [
-      "catalpol",
-      "rehmanniosides"
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "active liver disease",
+      "significant kidney disease or unstable electrolytes"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "kidney/liver tonic tradition",
+      "metabolic and inflammatory pathway"
+    ]
   },
   {
     "slug": "agarikon",
-    "name": "Agarikon",
+    "name": "agarikon",
+    "region": "North America/Eurasian forests",
+    "primaryActions": [
+      "immune support education",
+      "mushroom beta-glucan pathway research"
+    ],
     "mechanisms": [
       "traditional immune support",
       "respiratory support"
     ],
     "description": "It should be framed modestly because traditional use is much stronger than modern evidence.",
-    "activeCompounds": [
-      "agaric acid",
-      "polysaccharides"
+    "evidenceLevel": "traditional",
+    "safetyNotes": "Immune-active potential; use caution with autoimmune disease, transplant medicines, immunosuppressants, and during active cancer treatment unless clinician-supervised.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Use cautiously.",
-    "primaryActions": [
-      "immunomodulatory"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "immune",
+      "mushroom beta-glucan pathway"
     ]
   },
   {
     "slug": "elecampane",
-    "name": "Elecampane",
+    "name": "elecampane",
+    "region": "Europe/West Asia",
+    "primaryActions": [
+      "respiratory/digestive traditional use",
+      "antimicrobial pathway research"
+    ],
     "mechanisms": [
       "traditional respiratory support",
       "digestive support"
     ],
     "description": "It is best framed as a bitter aromatic root with traditional bronchial relevance.",
-    "activeCompounds": [
-      "alantolactone",
-      "inulin"
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "safetyNotes": "Use cautiously in concentrated forms."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Aromatic herb/spice forms and essential oils differ greatly; essential oils require conservative topical/diluted use and are not interchangeable with teas.",
+    "traditionalUses": [
+      "respiratory/digestive traditional use",
+      "antimicrobial pathway"
+    ]
   },
   {
     "slug": "angelica-root",
-    "name": "Angelica Root",
+    "name": "angelica root",
+    "region": "Europe / Asia traditional herbalism",
+    "primaryActions": [
+      "women’s health and digestive tradition",
+      "coumarin-pathway safety education"
+    ],
     "mechanisms": [
       "digestive support",
       "traditional cycle support"
     ],
     "description": "It should be framed carefully because furanocoumarin context matters for some use cases.",
-    "activeCompounds": [
-      "angelicin",
-      "essential oils"
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "interactions": [
+      "Potential interaction concern with anticoagulants/antiplatelets",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Use cautiously."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "bleeding disorder or upcoming surgery"
+    ],
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "traditionalUses": [
+      "women’s health and digestive tradition",
+      "coumarin-pathway safety"
+    ]
   },
   {
     "slug": "galangal",
-    "name": "Galangal",
+    "name": "galangal",
+    "region": "Southeast Asia",
+    "primaryActions": [
+      "digestive support",
+      "anti-nausea tradition",
+      "inflammatory pathway research"
+    ],
     "mechanisms": [
       "digestive support",
       "aromatic support"
     ],
     "description": "It is best framed as a culinary-medicinal rhizome with traditional GI relevance.",
-    "activeCompounds": [
-      "galangin",
-      "volatile oils"
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "traditionalUses": [
+      "digestive",
+      "anti-nausea tradition",
+      "inflammatory pathway"
+    ]
   },
   {
     "slug": "black-pepper",
-    "name": "Black Pepper",
-    "mechanisms": [
-      "digestive support",
+    "name": "black pepper",
+    "region": "South Asia / Southeast Asia",
+    "primaryActions": [
       "bioavailability support",
-      "metabolic support"
+      "digestive spice",
+      "metabolic/anti-inflammatory research"
+    ],
+    "mechanisms": [
+      "piperine modulation of CYP3A4/CYP2C9/CYP2D6 and P-gp",
+      "UGT/glucuronidation effects",
+      "TRPV1 sensory signaling",
+      "NF-κB modulation"
     ],
     "description": "It should be framed specifically around piperine and digestive relevance rather than as a stand-alone tonic.",
-    "activeCompounds": [
-      "piperine"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Food use is low-risk; concentrated piperine extracts can alter drug exposure. Use caution with narrow-therapeutic-index drugs and multi-supplement stacks.",
+    "interactions": [
+      "May increase exposure of CYP/P-gp substrates and enhance curcumin or other supplement bioavailability",
+      "caution with anticoagulants",
+      "antiepileptics",
+      "immunosuppressants",
+      "and cardiovascular drugs."
     ],
-    "safetyNotes": "Generally well tolerated; use caution with concentrated extracts.",
-    "primaryActions": [
-      "digestive support"
+    "contraindications": [
+      "Use cautiously with prescription polypharmacy",
+      "pregnancy/breastfeeding supplements",
+      "ulcers/reflux sensitivity",
+      "and perioperative anticoagulant use."
+    ],
+    "preparation": "Distinguish culinary black pepper from standardized high-piperine extracts.",
+    "traditionalUses": [
+      "bioavailability",
+      "digestive spice",
+      "metabolic/anti-inflammatory"
     ]
   },
   {
     "slug": "cardamom",
-    "name": "Cardamom",
+    "name": "cardamom",
+    "region": "South Asia / Southeast Asia",
+    "primaryActions": [
+      "digestive support",
+      "breath/respiratory tradition",
+      "antioxidant support"
+    ],
     "mechanisms": [
       "digestive support",
       "aromatic support"
     ],
     "description": "It is best framed as an aromatic culinary seed with modest translational evidence.",
-    "activeCompounds": [
-      "1",
-      "8-cineole",
-      "terpinyl acetate"
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "safetyNotes": "Generally well tolerated.",
-    "primaryActions": [
-      "digestive support"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Aromatic herb/spice forms and essential oils differ greatly; essential oils require conservative topical/diluted use and are not interchangeable with teas.",
+    "traditionalUses": [
+      "digestive",
+      "breath/respiratory tradition",
+      "antioxidant"
     ]
   },
   {
     "slug": "holy-basil-seed",
-    "name": "Holy Basil Seed",
+    "name": "holy basil seed",
+    "region": "South Asia",
+    "primaryActions": [
+      "metabolic and digestive support education",
+      "mucilage/fiber support"
+    ],
     "mechanisms": [
       "demulcent support",
       "digestive support"
     ],
     "description": "It should be framed distinctly from holy basil leaf because fiber and mucilage drive different use-cases.",
-    "activeCompounds": [
-      "mucilage",
-      "fiber"
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Leaf preparations are commonly used as teas, powders, tinctures, or standardized extracts; topical use may differ from oral use.",
+    "traditionalUses": [
+      "metabolic and digestive",
+      "mucilage/fiber"
+    ]
   },
   {
     "slug": "psyllium",
-    "name": "Psyllium",
+    "name": "psyllium",
+    "region": "South Asia / Mediterranean",
+    "primaryActions": [
+      "fiber/laxation support",
+      "cholesterol and glycemic support education"
+    ],
     "mechanisms": [
-      "bulk laxative",
-      "GI support",
-      "stool-softening",
-      "cholesterol support"
+      "Gel-forming soluble fiber increases intestinal viscosity",
+      "binds bile acids and increases fecal bile-acid loss",
+      "slows gastric emptying and carbohydrate absorption",
+      "supports SCFA-mediated gut effects."
     ],
     "description": "Psyllium is not a classic phytochemical-heavy herb; its value comes from gel-forming husk fiber. That makes it more of a functional-fiber tool than a general botanical tonic. Position it around bowel regularity, stool softening, and cautious cardiometabolic support.",
-    "activeCompounds": [
-      "mucilage",
-      "arabinoxylans"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Must be taken with plenty of water; choking or bowel obstruction risk in dysphagia/strictures. Separate from oral medications by 2–4 hours. May cause bloating or gas.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Must be taken with plenty of liquid. Without enough fluid there is a risk of choking or bowel obstruction; allergy is also possible."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Seed/fiber preparations are commonly used as whole seed, powder, capsules, or food ingredients; fluid intake and preparation form matter.",
+    "traditionalUses": [
+      "fiber/laxation",
+      "cholesterol and glycemic"
+    ]
   },
   {
     "slug": "caraway",
-    "name": "Caraway",
+    "name": "caraway",
+    "region": "Europe / Western Asia",
+    "primaryActions": [
+      "digestive comfort support",
+      "carminative tradition"
+    ],
     "mechanisms": [
       "digestive support",
       "aromatic support"
     ],
     "description": "It is best framed as an aromatic seed with traditional GI relevance.",
-    "activeCompounds": [
-      "carvone",
-      "limonene"
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "safetyNotes": "Generally well tolerated.",
-    "primaryActions": [
-      "digestive support"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Aromatic herb/spice forms and essential oils differ greatly; essential oils require conservative topical/diluted use and are not interchangeable with teas.",
+    "traditionalUses": [
+      "digestive comfort",
+      "carminative tradition"
     ]
   },
   {
     "slug": "ajwain",
-    "name": "Ajwain",
+    "name": "ajwain",
+    "region": "South Asia",
+    "primaryActions": [
+      "digestive comfort support",
+      "antimicrobial traditional use"
+    ],
     "mechanisms": [
       "digestive support",
       "aromatic support"
     ],
     "description": "It is best framed as a culinary-medicinal seed with strong traditional GI positioning.",
-    "activeCompounds": [
-      "thymol"
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "safetyNotes": "Generally well tolerated.",
-    "primaryActions": [
-      "digestive support",
-      "antimicrobial"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Seed/fiber preparations are commonly used as whole seed, powder, capsules, or food ingredients; fluid intake and preparation form matter.",
+    "traditionalUses": [
+      "digestive comfort",
+      "antimicrobial traditional use"
     ]
   },
   {
     "slug": "holy-basil-purple",
-    "name": "Holy Basil Purple",
+    "name": "holy basil purple",
+    "region": "South Asia",
+    "primaryActions": [
+      "stress/adaptogen support",
+      "metabolic and inflammatory pathway research"
+    ],
     "mechanisms": [
       "adaptogenic support",
       "antioxidant"
     ],
     "description": "It should be framed similarly to tulsi while noting cultivar/form distinctions are secondary to constituent variability.",
-    "activeCompounds": [
-      "eugenol",
-      "rosmarinic acid"
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "stress/adaptogen",
+      "metabolic and inflammatory pathway"
+    ]
   },
   {
     "slug": "curry-leaf",
-    "name": "Curry Leaf",
+    "name": "curry leaf",
+    "region": "South Asia",
+    "primaryActions": [
+      "metabolic support education",
+      "antioxidant pathway research"
+    ],
     "mechanisms": [
       "antioxidant",
       "metabolic support"
     ],
     "description": "It is best framed as a culinary-medicinal leaf with food-form relevance.",
-    "activeCompounds": [
-      "mahanimbine",
-      "carbazole alkaloids"
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Generally well tolerated.",
-    "primaryActions": [
-      "antioxidant"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Leaf preparations are commonly used as teas, powders, tinctures, or standardized extracts; topical use may differ from oral use.",
+    "traditionalUses": [
+      "metabolic",
+      "antioxidant pathway"
     ]
   },
   {
     "slug": "gudmar",
-    "name": "Gudmar",
+    "name": "gudmar",
+    "region": "South Asia / Ayurveda",
+    "primaryActions": [
+      "glucose and sugar-craving support education",
+      "taste receptor pathway research"
+    ],
     "mechanisms": [
-      "glycemic support"
+      "gymnemic-acid sweet taste receptor inhibition",
+      "intestinal glucose absorption modulation",
+      "pancreatic beta-cell/insulin signaling support",
+      "AMPK/GLUT4-related metabolic signaling"
     ],
     "description": "It should be framed consistently with gymnema while preserving alternate-name discoverability.",
-    "activeCompounds": [
-      "gymnemic acids"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "glucose and sugar-craving",
+      "taste receptor pathway"
+    ]
   },
   {
     "slug": "roselle-seed",
-    "name": "Roselle Seed",
+    "name": "roselle seed",
+    "region": "Africa / Asia tropics",
+    "primaryActions": [
+      "cardiometabolic support education",
+      "antioxidant pathway research"
+    ],
     "mechanisms": [
       "nutritive support",
       "antioxidant"
     ],
     "description": "It should be framed distinctly from hibiscus calyx because seed and calyx use-cases differ.",
-    "activeCompounds": [
-      "tocopherols",
-      "fatty acids"
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Seed/fiber preparations are commonly used as whole seed, powder, capsules, or food ingredients; fluid intake and preparation form matter.",
+    "traditionalUses": [
+      "cardiometabolic",
+      "antioxidant pathway"
+    ]
   },
   {
     "slug": "tamarind",
-    "name": "Tamarind",
+    "name": "tamarind",
+    "region": "Africa / South Asia tropics",
+    "primaryActions": [
+      "digestive support",
+      "antioxidant/metabolic support education"
+    ],
     "mechanisms": [
       "digestive support",
       "antioxidant"
     ],
     "description": "It is best framed as a food-form fruit with digestive and polyphenol relevance.",
-    "activeCompounds": [
-      "tartaric acid",
-      "polyphenols"
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Fruit/berry preparations are commonly used as foods, juices, powders, capsules, or extracts; sugar and extract concentration vary.",
+    "traditionalUses": [
+      "digestive",
+      "antioxidant/metabolic"
+    ]
   },
   {
     "slug": "rhodiola",
-    "name": "Rhodiola",
+    "name": "rhodiola",
+    "region": "Eurasian arctic/alpine traditional use",
+    "primaryActions": [
+      "stress/adaptogen support",
+      "fatigue support education"
+    ],
     "mechanisms": [
       "adaptogen",
       "fatigue resistance",
       "cognitive support"
     ],
-    "description": "Rhodiola is typically used for adaptogenic and nootropic support, with effects depending on dose and extract profile. It is commonly discussed around rosavins and salidroside, while human evidence remains mixed across indications.",
-    "activeCompounds": [
-      "rosavins",
-      "salidroside"
-    ],
-    "safetyNotes": "Safe",
+    "description": "Adaptogenic stress modulation.",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Limited human safety data; use conservative preparation-specific framing and avoid pregnancy/breastfeeding or medication stacking without clinician review.",
     "interactions": [
-      "serotonergic medications"
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "preparation": "No direct preparation data. Contextual inference: Adaptogen, mental performance enhancer, antidepressant. Inhibits monoamine oxidase; modulates cortisol and neurotransmitters.. ; nan; nan.. Inhibits monoamine oxidase; modulates cortisol and neurotransmitters.. Adaptogen, mental performance enhancer, antidepressant. No direct region data. Contextual inference: Adaptogen, mental performance enhancer, antidepressant. Inhibits monoamine oxidase; modulates cortisol and neurotransmitters.. ; nan; nan.. Inhibits monoamine oxidase; modulates cortisol and neurotransmitters.. Adaptogen, mental performance enhancer, antidepressant. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "adaptogenic",
-      "nootropic"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "stress/adaptogen",
+      "fatigue"
     ]
   },
   {
     "slug": "cordyceps",
-    "name": "Cordyceps",
+    "name": "cordyceps",
+    "region": "Tibetan / East Asian traditional medicine",
+    "primaryActions": [
+      "energy/fatigue support education",
+      "immune and mitochondrial pathway research"
+    ],
     "mechanisms": [
       "immune modulation",
       "anti-inflammatory",
@@ -2179,103 +3634,169 @@
       "cordycepin"
     ],
     "description": "Cordyceps militaris is most often discussed around cordycepin plus polysaccharides and related nucleosides. Commercial interest is high, but the evidence base is still strongest at the preclinical and cultivation/constituent level rather than for broad human outcome claims.",
-    "activeCompounds": [
-      "cordycepin",
-      "polysaccharides",
-      "adenosine"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Commercial products vary by species identity, cultivation method, and cordycepin content. Keep benefit claims conservative unless tied to a specific studied product.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Commercial products vary by species identity, cultivation method, and cordycepin content. Keep benefit claims conservative unless tied to a specific studied product."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Mushroom preparations may be hot-water extracts, dual extracts, powders, or isolated polysaccharide fractions; extraction method matters.",
+    "traditionalUses": [
+      "energy/fatigue",
+      "immune and mitochondrial pathway"
+    ]
   },
   {
     "slug": "lion-s-mane",
-    "name": "Lion's Mane",
+    "name": "lion's mane",
+    "region": "East Asia / North America / Europe",
+    "primaryActions": [
+      "cognitive support education",
+      "neurotrophic pathway research"
+    ],
     "mechanisms": [
-      "NGF",
-      "NGF induction",
-      "ERK/CREB pathway modulation"
+      "hericenone/erinacine neurotrophic signaling",
+      "NGF-related pathways",
+      "anti-inflammatory and gut-brain-axis modulation"
     ],
-    "description": "Lion's Mane is typically used as a supplemental botanical with context-dependent effects. It is commonly discussed around hericenones and erinacines, while human evidence remains mixed across indications.",
-    "activeCompounds": [
-      "hericenones",
-      "erinacines"
+    "description": "NGF stimulation.",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "GI or allergy reactions possible; caution with mushroom allergy, anticoagulants, pregnancy, and immunomodulating therapy.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "safetyNotes": "Safe",
-    "preparation": "No direct preparation data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. No direct region data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. Folk medicine. Folk medicine"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "cognitive",
+      "neurotrophic pathway"
+    ]
   },
   {
     "slug": "panax-ginseng",
-    "name": "Panax Ginseng",
-    "mechanisms": [
-      "AMPK"
-    ],
-    "description": "Panax Ginseng is typically used for adaptogenic and antioxidant support, with effects depending on dose and extract profile. It is commonly discussed around ginsenosides, while human evidence remains mixed across indications.",
-    "activeCompounds": [
-      "ginsenosides"
-    ],
-    "safetyNotes": "Safe",
-    "preparation": "Roots dried and decocted, tinctured, or powdered; tonic and adaptogen for energy and vitality",
+    "name": "panax ginseng",
+    "region": "East Asia",
     "primaryActions": [
-      "adaptogenic",
-      "antioxidant",
-      "nootropic"
+      "energy/fatigue support",
+      "stress/adaptogen support",
+      "metabolic support education"
     ],
-    "affiliateProducts": [
-      {
-        "name": "Panax Ginseng Capsules",
-        "type": "capsule",
-        "affiliateUrl": "https://www.amazon.com/s?k=panax+ginseng+capsules&tag=razzleberry02-20"
-      },
-      {
-        "name": "Panax Ginseng Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=panax+ginseng+extract&tag=razzleberry02-20"
-      }
+    "mechanisms": [
+      "Ginsenosides modulate AMPK and PI3K/Akt signaling",
+      "nitric-oxide/endothelial pathways",
+      "HPA-axis stress signaling",
+      "and glucose uptake/insulin-sensitivity pathways."
+    ],
+    "description": "Energy + stress.",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May cause insomnia, headache, blood pressure changes, or hypoglycemia. Use caution with antidiabetic drugs, anticoagulants/antiplatelets, stimulants, and hormone-sensitive conditions.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "energy/fatigue",
+      "stress/adaptogen",
+      "metabolic"
     ]
   },
   {
     "slug": "passionflower",
-    "name": "Passionflower",
-    "mechanisms": [
-      "calming support",
+    "name": "passionflower",
+    "region": "Americas; Western herbalism",
+    "primaryActions": [
+      "mild anxiety support",
       "sleep support",
-      "traditional-use sedative",
-      "possible GABAergic modulation"
+      "nervous restlessness education"
+    ],
+    "mechanisms": [
+      "GABAergic signaling modulation",
+      "harman alkaloid and flavonoid CNS effects",
+      "anxiolytic receptor-pathway activity"
     ],
     "description": "EMA supports passionflower for relief of mild mental stress and to aid sleep on the basis of long-standing traditional use. That is useful, but it is weaker than strong modern clinical efficacy. Keep the positioning around traditional calming use and avoid overclaiming a clean single-target GABA story.",
-    "activeCompounds": [
-      "chrysin"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Sedation possible; avoid combining with alcohol, benzodiazepines, opioids, or other CNS depressants; avoid pregnancy.",
+    "interactions": [
+      "May potentiate benzodiazepines",
+      "sleep aids",
+      "opioids",
+      "alcohol",
+      "and other CNS depressants."
     ],
-    "safetyNotes": "EMA reported no side effects at the time of assessment, but prudence still supports sedative-stacking caution.",
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "anxiolytic",
-      "sedative"
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "heavy sedative use"
+    ],
+    "preparation": "Aerial-part tea, tincture, capsules, and standardized extracts.",
+    "traditionalUses": [
+      "Nervous tension",
+      "sleep",
+      "restlessness"
     ]
   },
   {
     "slug": "yohimbe",
-    "name": "Yohimbe",
+    "name": "yohimbe",
+    "region": "West Africa",
+    "primaryActions": [
+      "sexual-function research",
+      "stimulant/sympathomimetic activity",
+      "safety education"
+    ],
     "mechanisms": [
-      "adrenergic signaling",
-      "alpha-2 adrenergic antagonism",
-      "stimulant activity",
-      "sexual function"
+      "yohimbine alpha-2 adrenergic receptor antagonism",
+      "increased sympathetic outflow",
+      "norepinephrine signaling",
+      "serotonergic and dopaminergic modulation"
     ],
     "description": "Yohimbe is represented here as a bark-derived monograph anchored to yohimbine, an alpha-2 adrenergic antagonist with sympathomimetic effects. The herb is more appropriately framed around safety review than routine recommendation. Potential effects include increased alertness and sexual-function relevance, but tolerability can be poor and adverse effects may include anxiety, tachycardia, blood-pressure elevation, agitation, insomnia, and gastrointestinal distress. Use should be conservative and exclusion-heavy in people with cardiovascular, psychiatric, seizure, renal, or hepatic vulnerability.",
-    "activeCompounds": [
-      "yohimbine",
-      "rauwolscine"
+    "safetyNotes": "High-risk stimulant herb. Reported adverse events include anxiety, agitation, hypertension, tachycardia, GI distress, and rare serious cardiovascular/neurologic events.",
+    "interactions": [
+      "Avoid with stimulants",
+      "decongestants",
+      "MAOIs",
+      "antidepressants",
+      "clonidine",
+      "antihypertensives",
+      "and drugs affecting blood pressure or heart rhythm."
     ],
-    "safetyNotes": "High-caution herb. Prioritize cardiovascular and psychiatric risk review. Avoid escalation framing, avoid use in people prone to panic, hypertension, arrhythmia, or seizure, and avoid positioning as a routine tonic.",
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "cardiovascular support",
-      "hepatoprotective"
+    "contraindications": [
+      "Hypertension",
+      "arrhythmia",
+      "heart disease",
+      "anxiety/panic disorder",
+      "bipolar disorder/mania",
+      "kidney or liver disease",
+      "pregnancy/breastfeeding."
+    ],
+    "preparation": "Do not equate crude bark products with pharmaceutical yohimbine; supplement yohimbine content can vary substantially.",
+    "traditionalUses": [
+      "West African aphrodisiac/stimulant bark use"
     ]
   },
   {
     "slug": "skullcap",
-    "name": "Skullcap",
+    "name": "skullcap",
+    "region": "North America",
+    "primaryActions": [
+      "nervous tension support",
+      "sleep/calm education",
+      "flavone anti-inflammatory research"
+    ],
     "mechanisms": [
       "GABAA",
       "NF-κB inhibition",
@@ -2283,87 +3804,95 @@
       "COX inhibition",
       "MAPK pathway modulation"
     ],
-    "description": "Skullcap is typically used for anti-inflammatory and anxiolytic support, with effects depending on dose and extract profile. It is commonly discussed around baicalin and Baicalein, while human evidence remains mixed across indications.",
-    "activeCompounds": [
-      "baicalin",
-      "Baicalein",
-      "Wogonin"
-    ],
-    "safetyNotes": "Safe",
+    "description": "GABAergic.",
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "CNS-active potential; avoid stacking with sedatives, alcohol, sleep aids, antidepressants, or other psychoactive supplements without clinician review. Avoid pregnancy/breastfeeding use unless supervised.",
     "interactions": [
-      "CNS depressants"
+      "May add to sedatives/CNS depressants",
+      "caution with hepatotoxic drugs/supplements."
     ],
-    "preparation": "No direct preparation data. Contextual inference: Nervine, anxiolytic, anti-inflammatory; used for insomnia and anxiety. Flavonoids modulate gaba receptors; offers calming and anxiolytic effects.. ; nan; nan.. Flavonoids modulate GABA receptors; offers calming and anxiolytic effects.. Nervine, anxiolytic, anti-inflammatory; used for insomnia and anxiety. No direct region data. Contextual inference: Nervine, anxiolytic, anti-inflammatory; used for insomnia and anxiety. Flavonoids modulate gaba receptors; offers calming and anxiolytic effects.. ; nan; nan.. Flavonoids modulate GABA receptors; offers calming and anxiolytic effects.. Nervine, anxiolytic, anti-inflammatory; used for insomnia and anxiety. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "anti-inflammatory",
-      "anxiolytic"
+    "contraindications": [
+      "Pregnancy/breastfeeding without guidance",
+      "liver disease",
+      "sedative use without review"
+    ],
+    "preparation": "Aerial parts of American skullcap as tea/tincture; roots of Chinese skullcap are a different herb.",
+    "traditionalUses": [
+      "Nervine relaxant",
+      "sleep",
+      "tension"
     ]
   },
   {
     "slug": "eleuthero",
-    "name": "Eleuthero",
+    "name": "eleuthero",
+    "region": "Russia; Northeast Asia",
     "primaryActions": [
       "Stress adaptation",
       "endurance support",
       "immune modulation"
     ],
     "mechanisms": [
-      "HPA-axis stress signaling modulation",
-      "sympathoadrenal stress-response modulation",
-      "innate immune signaling modulation"
+      "HPA axis",
+      "HPA-axis modulation",
+      "immune modulation",
+      "AMPK activation",
+      "stress response modulation"
     ],
-    "description": "Eleuthero (Eleutherococcus senticosus) is an adaptogenic root used for fatigue and stress resilience. Clinical evidence is limited to modest, variable benefits and is sensitive to extract composition and dosing. It is best positioned as conservative supportive care rather than a primary treatment.",
-    "activeCompounds": [
-      "eleutherosides",
-      "eleutheroside B",
-      "eleutheroside E"
-    ],
-    "safetyNotes": "Reported adverse effects include insomnia, irritability, headache, and occasional palpitations, especially with stimulating combinations. Blood-pressure and heart-rate effects are possible in sensitive users, so caution is warranted in uncontrolled hypertension or arrhythmia. Review concurrent stimulant, anticoagulant, and cardiometabolic medications before use.",
+    "description": "Stress resilience.",
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
     "interactions": [
       "Use caution with stimulants or blood pressure-active agents."
     ],
+    "contraindications": [
+      "Uncontrolled hypertension",
+      "pregnancy/breastfeeding without guidance",
+      "acute fever caution in some traditions"
+    ],
     "preparation": "Root decoction or extract; standardized eleutheroside products are common.",
-    "affiliateProducts": [
-      {
-        "name": "Eleuthero Capsules",
-        "type": "capsule",
-        "affiliateUrl": "https://www.amazon.com/s?k=eleutherococcus+senticosus+capsules&tag=razzleberry02-20"
-      },
-      {
-        "name": "Eleuthero Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=eleutherococcus+senticosus+extract&tag=razzleberry02-20"
-      }
+    "traditionalUses": [
+      "Siberian/Russian adaptogen and endurance tonic"
     ]
   },
   {
     "slug": "gotu-kola",
-    "name": "Gotu Kola",
-    "mechanisms": [
-      "NO",
-      "TGF-β signaling modulation",
-      "MAPK pathway modulation",
-      "NF-κB inhibition"
-    ],
-    "description": "Gotu Kola is typically used for anxiolytic and cardiovascular support support, with effects depending on dose and extract profile. It is commonly discussed around asiaticoside and Madecassoside, while human evidence remains mixed across indications.",
-    "activeCompounds": [
-      "asiaticoside",
-      "Madecassoside"
-    ],
-    "safetyNotes": "Safe",
-    "interactions": [
-      "CNS depressants"
-    ],
-    "preparation": "No direct preparation data. Contextual inference: Cognitive enhancer, anxiolytic, wound healing; triterpenes improve circulation. Boosts collagen synthesis, modulates gaba and blood flow.. ; nan; nan.. Boosts collagen synthesis, modulates GABA and blood flow.. Cognitive enhancer, anxiolytic, wound healing; triterpenes improve circulation. No direct region data. Contextual inference: Cognitive enhancer, anxiolytic, wound healing; triterpenes improve circulation. Boosts collagen synthesis, modulates gaba and blood flow.. ; nan; nan.. Boosts collagen synthesis, modulates GABA and blood flow.. Cognitive enhancer, anxiolytic, wound healing; triterpenes improve circulation. ; nan; nan. ; nan; nan",
+    "name": "gotu kola",
+    "region": "South Asia; Southeast Asia",
     "primaryActions": [
-      "anxiolytic",
-      "cardiovascular support",
-      "nootropic"
+      "cognition/circulation support",
+      "wound/skin support",
+      "connective tissue education"
+    ],
+    "mechanisms": [
+      "asiaticoside/madecassoside collagen synthesis",
+      "microcirculation/endothelial effects",
+      "antioxidant/NF-κB modulation"
+    ],
+    "description": "NO support.",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Rare liver injury reported; avoid pregnancy and liver disease; caution with sedatives and hepatotoxic drugs.",
+    "interactions": [
+      "May potentiate sedatives and hepatotoxic drugs/supplements",
+      "caution with antidiabetics."
+    ],
+    "contraindications": [
+      "Liver disease",
+      "pregnancy/breastfeeding without guidance",
+      "upcoming surgery"
+    ],
+    "preparation": "Leaf tea/powder, tincture, extracts standardized to asiaticoside/madecassoside; topical use differs.",
+    "traditionalUses": [
+      "Ayurveda/TCM wound",
+      "cognition",
+      "circulation",
+      "longevity"
     ]
   },
   {
     "slug": "schisandra",
-    "name": "Schisandra",
+    "name": "schisandra",
+    "region": "East Asia/Russia Far East",
     "primaryActions": [
       "Stress adaptation",
       "hepatic support",
@@ -2376,91 +3905,199 @@
       "mitochondrial protection"
     ],
     "description": "Liver + stress.",
-    "activeCompounds": [
-      "gomisins",
-      "Schisandrin",
-      "schisandrin B"
-    ],
-    "safetyNotes": "Safe",
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Can affect CYP/P-gp drug metabolism; review use with narrow-therapeutic-index drugs, sedatives, hepatotoxic drugs, and pregnancy/breastfeeding.",
     "interactions": [
       "Potential interactions with CYP-metabolized drugs."
     ],
-    "preparation": "Berry decoction or extract; concentrated lignan extracts provide stronger exposure."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "active liver disease"
+    ],
+    "preparation": "Berry decoction or extract; concentrated lignan extracts provide stronger exposure.",
+    "traditionalUses": [
+      "Stress adaptation",
+      "hepatic",
+      "mitochondrial resilience"
+    ]
   },
   {
     "slug": "reishi",
-    "name": "Reishi",
+    "name": "reishi",
+    "region": "East Asia traditional medicine",
+    "primaryActions": [
+      "immune support education",
+      "stress/sleep support tradition"
+    ],
     "mechanisms": [
-      "NFkB"
+      "β-glucan immune modulation",
+      "triterpene effects on inflammatory signaling",
+      "antioxidant pathways"
     ],
     "description": "Immune modulation.",
-    "activeCompounds": [
-      "triterpenes"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "GI upset, dizziness, rash possible; caution with anticoagulants/antiplatelets, immunosuppressants, and perioperative use.",
+    "interactions": [
+      "Potential interaction concern with sedatives/CNS depressants",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Safe"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "immune",
+      "stress/sleep tradition"
+    ]
   },
   {
     "slug": "chaga",
-    "name": "Chaga",
+    "name": "chaga",
+    "region": "Northern Eurasia traditional use",
+    "primaryActions": [
+      "antioxidant support education",
+      "immune pathway research"
+    ],
     "mechanisms": [
       "Nrf2",
       "NF-κB inhibition",
       "apoptosis pathway modulation"
     ],
     "description": "Oxidative stress.",
-    "activeCompounds": [
-      "betulinic acid"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "High oxalate exposure and immune effects are concerns; avoid with kidney disease, kidney stones, anticoagulants/antiplatelets, and immunosuppressants unless supervised.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Safe"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "antioxidant",
+      "immune pathway"
+    ]
   },
   {
     "slug": "turkey-tail",
-    "name": "Turkey Tail",
+    "name": "turkey tail",
+    "region": "Global woodland mushroom",
+    "primaryActions": [
+      "immune support education",
+      "beta-glucan pathway research"
+    ],
     "mechanisms": [
-      "NFkB"
+      "PSK/PSP beta-glucan immune signaling",
+      "dectin-1/TLR pathway modulation",
+      "macrophage/NK-cell cytokine signaling",
+      "NF-κB immune-response modulation"
     ],
-    "description": "Turkey Tail is typically used as a supplemental botanical with context-dependent effects. It is commonly discussed around PSK, while human evidence remains mixed across indications.",
-    "activeCompounds": [
-      "PSK"
+    "description": "Immune modulation.",
+    "safetyNotes": "Immune-active mushroom extract; use caution with immunosuppressants, transplant medicines, autoimmune disease, and during active cancer treatment unless clinician-supervised.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Safe"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "immune",
+      "beta-glucan pathway"
+    ]
   },
   {
     "slug": "boswellia",
-    "name": "Boswellia",
+    "name": "boswellia",
+    "region": "India; Arabian Peninsula",
+    "primaryActions": [
+      "joint comfort support",
+      "inflammatory pathway modulation",
+      "gut inflammation education"
+    ],
     "mechanisms": [
-      "anti-inflammatory",
-      "mobility support"
+      "Boswellic acids",
+      "especially AKBA",
+      "inhibit 5-lipoxygenase and leukotriene synthesis",
+      "modulate NF-κB",
+      "mPGES-1",
+      "and inflammatory cytokine signaling."
     ],
     "description": "It is best framed around boswellic acids with inflammatory-pathway relevance.",
-    "activeCompounds": [
-      "boswellic acids",
-      "AKBA",
-      "acetyl-11-keto-beta-boswellic acid"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May cause reflux, nausea, diarrhea, or rash. Use caution with anticoagulants/antiplatelets, NSAIDs, pregnancy, and inflammatory-disease regimens where product quality matters.",
+    "interactions": [
+      "Potential additive effects with anti-inflammatory drugs",
+      "anticoagulants",
+      "and immunomodulators."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "anticoagulant use without review"
+    ],
+    "preparation": "Resin extracts standardized to boswellic acids/AKBA; gum resin and extract potency differ.",
+    "traditionalUses": [
+      "Ayurvedic joint",
+      "respiratory",
+      "and inflammatory support"
+    ]
   },
   {
     "slug": "hawthorn",
-    "name": "Hawthorn",
+    "name": "hawthorn",
+    "region": "Europe",
+    "primaryActions": [
+      "cardiovascular support education",
+      "heart-failure adjunct evidence education",
+      "circulation support"
+    ],
     "mechanisms": [
-      "cardiovascular support",
-      "vascular support",
-      "Nrf2 activation",
-      "NF-κB inhibition",
-      "PI3K/Akt modulation"
+      "positive inotropic effects",
+      "coronary vasodilation via endothelial nitric oxide",
+      "vascular-tone modulation",
+      "antioxidant flavonoid/procyanidin effects",
+      "phosphodiesterase inhibition"
     ],
     "description": "It is best framed around procyanidins and flavonoids.",
-    "activeCompounds": [
-      "procyanidin B2",
-      "flavonoids",
-      "Oleanolic acid"
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "Use only with clinician oversight in heart failure or cardiovascular disease. May potentiate antihypertensives, nitrates, digoxin/cardiac glycosides, beta-blockers, antiarrhythmics, and anticoagulant/antiplatelet regimens. Dizziness, hypotension, palpitations, and GI upset can occur. Do not substitute for heart-failure therapy.",
+    "interactions": [
+      "Digoxin/cardiac glycosides",
+      "antihypertensives",
+      "nitrates",
+      "beta-blockers",
+      "antiarrhythmics",
+      "anticoagulants",
+      "and antiplatelets."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "Unstable cardiac disease without medical care",
+      "pregnancy/breastfeeding without clinician review",
+      "unexplained chest pain",
+      "syncope",
+      "or severe dyspnea requires urgent medical care."
+    ],
+    "preparation": "Leaf/flower/berry tea, tincture, and flavonoid/OPC standardized extracts.",
+    "traditionalUses": [
+      "European cardiovascular tonic"
+    ]
   },
   {
     "slug": "astragalus",
-    "name": "Astragalus",
+    "name": "astragalus",
+    "region": "China; TCM",
+    "primaryActions": [
+      "immune support education",
+      "fatigue/adaptogen support",
+      "TCM qi tonic"
+    ],
     "mechanisms": [
       "immune modulation",
       "fatigue support",
@@ -2468,76 +4105,135 @@
       "PI3K/Akt modulation"
     ],
     "description": "It is best framed around astragalosides and polysaccharides.",
-    "activeCompounds": [
-      "astragaloside IV",
-      "polysaccharides",
-      "Formononetin"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Immune-active potential; use caution with autoimmune disease, transplant medicines, immunosuppressants, and during active cancer treatment unless clinician-supervised.",
+    "interactions": [
+      "May counter immunosuppressants",
+      "may interact with lithium",
+      "diuretics",
+      "antidiabetics",
+      "and antivirals depending context."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "Transplant/immunosuppression without clinician guidance",
+      "autoimmune flare risk",
+      "pregnancy without guidance"
+    ],
+    "preparation": "Root slices/decoction, powders, extracts; often used in formulas.",
+    "traditionalUses": [
+      "TCM qi tonic",
+      "fatigue",
+      "immune and respiratory support"
+    ]
   },
   {
     "slug": "nettle-root",
-    "name": "Nettle Root",
+    "name": "nettle root",
+    "region": "Europe / North America",
+    "primaryActions": [
+      "men’s urinary/prostate support education",
+      "inflammatory pathway research"
+    ],
     "mechanisms": [
-      "urinary support",
-      "men's-health support"
+      "phytosterol/lignan effects on SHBG/androgen signaling",
+      "prostate inflammatory-pathway modulation"
     ],
     "description": "It is best framed distinctly from nettle leaf.",
-    "activeCompounds": [
-      "beta-sitosterol",
-      "lignans"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May affect diuretics, blood pressure, glucose, and anticoagulant therapy; avoid pregnancy at medicinal doses.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "safetyNotes": "Generally well tolerated.",
-    "affiliateProducts": [
-      {
-        "name": "Nettle Root Capsules",
-        "type": "capsule",
-        "affiliateUrl": "https://www.amazon.com/s?k=urtica+dioica+capsules&tag=razzleberry02-20"
-      },
-      {
-        "name": "Nettle Root Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=urtica+dioica+extract&tag=razzleberry02-20"
-      }
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "traditionalUses": [
+      "men’s urinary/prostate",
+      "inflammatory pathway"
     ]
   },
   {
     "slug": "bacopa",
-    "name": "Bacopa",
+    "name": "bacopa",
+    "region": "India; Ayurveda",
+    "primaryActions": [
+      "memory/cognition support",
+      "stress resilience education",
+      "neuroprotective research"
+    ],
     "mechanisms": [
-      "cognitive support",
-      "calming support",
-      "MARK4 inhibition",
-      "cholinergic modulation"
+      "Bacosides support cholinergic signaling and synaptic plasticity",
+      "modulate oxidative stress",
+      "neuroinflammation",
+      "ERK/PI3K-Akt pathways",
+      "and BDNF-related signaling."
     ],
     "description": "It is best framed around bacosides with slower-onset cognitive relevance.",
-    "activeCompounds": [
-      "bacoside A",
-      "bacopaside II"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Common adverse effects include nausea, cramping, diarrhea, and fatigue/sedation. Use caution with sedatives, thyroid-active therapy, pregnancy, and GI sensitivity.",
+    "interactions": [
+      "May interact with sedatives",
+      "thyroid medications",
+      "anticholinergics/cholinergics",
+      "and antiepileptics."
     ],
-    "safetyNotes": "Generally well tolerated.",
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "nootropic"
+    "contraindications": [
+      "Pregnancy/breastfeeding without guidance",
+      "bradycardia or cholinergic medication use without review"
+    ],
+    "preparation": "Whole herb extracts standardized to bacosides; onset in trials is often weeks, not acute.",
+    "traditionalUses": [
+      "Ayurvedic medhya rasayana for learning/memory"
     ]
   },
   {
     "slug": "mucuna",
-    "name": "Mucuna",
+    "name": "mucuna",
+    "region": "India; Africa",
+    "primaryActions": [
+      "dopamine/L-DOPA support education",
+      "Parkinsonian symptom traditional research",
+      "mood/libido traditional use"
+    ],
     "mechanisms": [
-      "dopamine support",
-      "vitality support"
+      "natural L-DOPA dopaminergic replacement pathway",
+      "antioxidant and mitochondrial support mechanisms"
     ],
     "description": "It is best framed around L-DOPA-rich seeds with clear neurologic and stimulation-related caution.",
-    "activeCompounds": [
-      "L-DOPA",
-      "alkaloids"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Can cause levodopa-like adverse effects; caution with Parkinson’s drugs, MAO inhibitors, psychosis, pregnancy, and cardiovascular disease.",
+    "interactions": [
+      "May interact with levodopa/carbidopa",
+      "MAOIs",
+      "antipsychotics",
+      "antihypertensives",
+      "and dopaminergic drugs."
     ],
-    "safetyNotes": "Use caution in psychiatric, cardiovascular, and dopaminergic contexts."
+    "contraindications": [
+      "Psychosis/bipolar risk",
+      "melanoma history caution",
+      "pregnancy/breastfeeding",
+      "use with levodopa drugs without clinician supervision"
+    ],
+    "preparation": "Seed powder/extract standardized to L-DOPA; product content varies widely.",
+    "traditionalUses": [
+      "Ayurvedic nervous system",
+      "fertility",
+      "and vitality use"
+    ]
   },
   {
     "slug": "epimedium",
-    "name": "Epimedium",
+    "name": "epimedium",
+    "region": "China; TCM",
+    "primaryActions": [
+      "sexual function traditional use",
+      "bone/menopause research",
+      "PDE5/NO pathway education"
+    ],
     "mechanisms": [
       "PDE-related signaling",
       "nitric oxide signaling",
@@ -2546,90 +4242,161 @@
       "flavonoid activity"
     ],
     "description": "Epimedium is represented here primarily through icariin and related prenylated flavonoids such as epimedin A, B, and C. The herb is commonly positioned for libido and circulation support, but a more disciplined framing keeps it in the traditional-use / limited-human-evidence tier. Mechanistic interest often centers on PDE-related signaling, endothelial nitric oxide activity, and broader bone-support and anti-inflammatory pathways observed in preclinical work.",
-    "activeCompounds": [
-      "icariin",
-      "epimedin A",
-      "epimedin B",
-      "epimedin C"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Use caution in people with blood-pressure instability, hormone-sensitive conditions, or high sensitivity to activating supplements. Keep positioning moderate rather than performance-driven.",
+    "interactions": [
+      "May interact with antihypertensives",
+      "PDE5 inhibitors",
+      "anticoagulants",
+      "and hormone therapies."
     ],
-    "safetyNotes": "Use caution in people with blood-pressure instability, hormone-sensitive conditions, or high sensitivity to activating supplements. Keep positioning moderate rather than performance-driven."
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "hormone-sensitive conditions without review",
+      "arrhythmia/cardiovascular disease caution"
+    ],
+    "preparation": "Leaf extracts standardized to icariin/flavonoids; often used in formulas.",
+    "traditionalUses": [
+      "TCM kidney-yang tonic",
+      "libido",
+      "bones"
+    ]
   },
   {
     "slug": "tongkat-ali",
-    "name": "Tongkat Ali",
+    "name": "tongkat ali",
+    "region": "Southeast Asia",
+    "primaryActions": [
+      "men’s vitality support",
+      "stress/testosterone-axis education"
+    ],
     "mechanisms": [
-      "vitality support",
-      "stress support"
+      "quassinoid/eurycomanone signaling",
+      "HPA-axis and testosterone-related endocrine modulation",
+      "stress-response pathways"
     ],
     "description": "It is best framed as a bitter root extract with endocrine and stimulation-related caution.",
-    "activeCompounds": [
-      "eurycomanone",
-      "quassinoids"
-    ],
-    "safetyNotes": "May be activating and is not ideal for anxiety-prone or sleep-fragile users.",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May cause insomnia/restlessness; avoid pregnancy and hormone-sensitive conditions; caution with stimulant or endocrine-active regimens.",
     "interactions": [
-      "antidiabetic medications"
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "preparation": "No direct preparation data. Contextual inference: Aphrodisiac, testosterone booster, and energy tonic. Boosts free testosterone; reduces cortisol.. ; nan; nan.. Boosts free testosterone; reduces cortisol.. Aphrodisiac, testosterone booster, and energy tonic. No direct region data. Contextual inference: Aphrodisiac, testosterone booster, and energy tonic. Boosts free testosterone; reduces cortisol.. ; nan; nan.. Boosts free testosterone; reduces cortisol.. Aphrodisiac, testosterone booster, and energy tonic. ; nan; nan. ; nan; nan"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "traditionalUses": [
+      "men’s vitality",
+      "stress/testosterone-axis"
+    ]
   },
   {
     "slug": "shatavari",
-    "name": "Shatavari",
+    "name": "shatavari",
+    "region": "India; Ayurveda",
+    "primaryActions": [
+      "women’s health traditional support",
+      "lactation traditional use",
+      "adaptogen/nourishing tonic"
+    ],
     "mechanisms": [
       "women's-health support",
       "soothing support"
     ],
     "description": "It is best framed around steroidal saponins with hormonal-context caution.",
-    "activeCompounds": [
-      "shatavarins",
-      "saponins"
+    "safetyNotes": "Hormone- or cycle-related traditional use requires caution in pregnancy, breastfeeding, hormone-sensitive conditions, and with hormone therapies.",
+    "interactions": [
+      "May interact with hormone therapies",
+      "diuretics",
+      "lithium",
+      "or antidiabetics."
     ],
-    "safetyNotes": "Use caution in hormone-sensitive conditions."
+    "contraindications": [
+      "Pregnancy/lactation use should be clinician-guided",
+      "hormone-sensitive conditions without review"
+    ],
+    "preparation": "Root powder, ghee preparations, decoction, and extracts.",
+    "traditionalUses": [
+      "Ayurvedic reproductive",
+      "lactation",
+      "digestive",
+      "and rasayana tonic"
+    ]
   },
   {
     "slug": "pueraria-mirifica",
-    "name": "Pueraria Mirifica",
+    "name": "pueraria mirifica",
+    "region": "Thailand / Southeast Asia",
+    "primaryActions": [
+      "women’s health support",
+      "phytoestrogen education"
+    ],
     "mechanisms": [
-      "phytoestrogen support",
-      "women's-health support",
-      "estrogen receptor modulation"
+      "Miroestrol/deoxymiroestrol phytoestrogen activity",
+      "estrogen receptor modulation",
+      "isoflavone-related endocrine signaling."
     ],
     "description": "It is best framed very cautiously due to potent estrogenic positioning.",
-    "activeCompounds": [
-      "miroestrol",
-      "deoxymiroestrol"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Avoid or use clinician supervision in pregnancy, breastfeeding, hormone-sensitive cancers/conditions, unexplained vaginal bleeding, or concurrent estrogen/SERM/endocrine therapy.",
+    "interactions": [
+      "Potential interaction concern with hormonal therapies",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Use caution or avoid in hormone-sensitive conditions, pregnancy, and breastfeeding.",
-    "preparation": "Root powdered or tinctured; used in traditional Thai medicine and supplements for phytoestrogenic effects",
-    "primaryActions": [
-      "antioxidant",
-      "nootropic"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "hormone-sensitive conditions without clinician review"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "women’s health",
+      "phytoestrogen"
     ]
   },
   {
     "slug": "cacao",
-    "name": "Cacao",
+    "name": "cacao",
+    "region": "Mesoamerica",
+    "primaryActions": [
+      "flavanol vascular support",
+      "mood/energy food support",
+      "antioxidant polyphenol education"
+    ],
     "mechanisms": [
-      "mood support",
-      "circulation support",
-      "AMPK activation",
-      "Nrf2 activation",
-      "PI3K/Akt modulation",
-      "eNOS activation"
+      "flavanol nitric-oxide/endothelial signaling",
+      "ACE effects",
+      "antioxidant and platelet-function modulation"
     ],
     "description": "It is best framed around flavanols and methylxanthines with stimulant awareness.",
-    "activeCompounds": [
-      "theobromine",
-      "flavanols",
-      "catechins",
-      "Catechin",
-      "Epicatechin"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Caffeine/theobromine effects possible; caution with migraine sensitivity, reflux, stimulants, and anticoagulant contexts.",
+    "interactions": [
+      "May add to stimulant effects",
+      "high-flavanol products may modestly affect blood pressure."
     ],
-    "safetyNotes": "Use caution in stimulant-sensitive users and with migraine triggers."
+    "contraindications": [
+      "Severe caffeine sensitivity",
+      "migraine/reflux triggers",
+      "oxalate stone risk with high intake"
+    ],
+    "preparation": "Cocoa powder, dark chocolate, cacao nibs, and flavanol-standardized extracts; sugar/fat content varies.",
+    "traditionalUses": [
+      "Mesoamerican food",
+      "ritual",
+      "and stimulant use"
+    ]
   },
   {
     "slug": "rooibos",
-    "name": "Rooibos",
+    "name": "rooibos",
+    "region": "Southern Africa",
+    "primaryActions": [
+      "antioxidant support",
+      "caffeine-free beverage wellness"
+    ],
     "mechanisms": [
       "antioxidant support",
       "soothing support",
@@ -2637,288 +4404,510 @@
       "Nrf2 activation"
     ],
     "description": "It is best framed as a mild tea herb with low-intensity wellness positioning.",
-    "activeCompounds": [
-      "aspalathin",
-      "nothofagin",
-      "flavonoids"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Generally well tolerated.",
-    "primaryActions": [
-      "antioxidant"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "antioxidant",
+      "caffeine-free beverage wellness"
     ]
   },
   {
     "slug": "cat-s-claw",
-    "name": "Cat's Claw",
+    "name": "cat's claw",
+    "region": "Amazon Basin/South America",
+    "primaryActions": [
+      "inflammatory and immune support education"
+    ],
     "mechanisms": [
-      "immune support",
-      "inflammatory support"
+      "Pentacyclic oxindole alkaloid immunomodulation",
+      "TNF-α and NF-κB modulation",
+      "cytokine signaling effects."
     ],
     "description": "It is best framed around oxindole alkaloids with autoimmune and transplant-related caution.",
-    "activeCompounds": [
-      "oxindole alkaloids",
-      "quinovic acid glycosides"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Avoid in pregnancy, breastfeeding, transplant recipients, and immunosuppressed users; caution with autoimmune disease, anticoagulants/antiplatelets, antihypertensives, and perioperative use.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Use caution or avoid in autoimmune disease, transplant settings, pregnancy, and breastfeeding."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "inflammatory and immune"
+    ]
   },
   {
     "slug": "lavender",
-    "name": "Lavender",
+    "name": "lavender",
+    "region": "Mediterranean; Europe",
+    "primaryActions": [
+      "calm/anxiety support",
+      "sleep support",
+      "topical aromatic use"
+    ],
     "mechanisms": [
-      "calming support",
-      "tension support",
-      "GABA-A modulation",
-      "voltage-gated calcium channel modulation"
+      "Linalool and linalyl acetate influence limbic and serotonergic signaling",
+      "oral Silexan data suggest calcium-channel modulation and GABA-A–related anxiolytic effects."
     ],
     "description": "It is best framed around volatile oils with sedation-aware positioning.",
-    "activeCompounds": [
-      "linalool",
-      "linalyl acetate"
-    ],
-    "safetyNotes": "Can be sedating in some users.",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May cause sedation, burping, nausea, or allergic reactions. Avoid undiluted oral essential oil. Use caution with CNS depressants, alcohol, driving, and pregnancy.",
     "interactions": [
-      "CNS depressants",
-      "serotonergic medications"
+      "May potentiate sedatives",
+      "sleep medications",
+      "and CNS depressants."
     ],
-    "preparation": "No direct preparation data. Contextual inference: Anxiolytic, sedative, anti-inflammatory; used in aromatherapy and teas. Linalool modulates gaba and serotonin pathways; anxiolytic and sedative.. ; nan; nan.. Linalool modulates GABA and serotonin pathways; anxiolytic and sedative.. Anxiolytic, sedative, anti-inflammatory; used in aromatherapy and teas. No direct region data. Contextual inference: Anxiolytic, sedative, anti-inflammatory; used in aromatherapy and teas. Linalool modulates gaba and serotonin pathways; anxiolytic and sedative.. ; nan; nan.. Linalool modulates GABA and serotonin pathways; anxiolytic and sedative.. Anxiolytic, sedative, anti-inflammatory; used in aromatherapy and teas. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "anti-inflammatory",
-      "anxiolytic",
-      "sedative"
+    "contraindications": [
+      "Pregnancy/breastfeeding without guidance",
+      "internal essential-oil use",
+      "prepubertal endocrine concerns with topical overuse are debated"
+    ],
+    "preparation": "Flower tea, aromatherapy, topical diluted essential oil, and oral standardized oil capsules.",
+    "traditionalUses": [
+      "Aromatic calming",
+      "sleep",
+      "digestion",
+      "topical skin use"
     ]
   },
   {
     "slug": "berberis",
-    "name": "Berberis",
+    "name": "berberis",
+    "region": "Europe; Asia",
+    "primaryActions": [
+      "glucose/lipid metabolic support",
+      "insulin-sensitivity education",
+      "antimicrobial-adjacent education"
+    ],
     "mechanisms": [
-      "metabolic support",
-      "antimicrobial support",
-      "JAK/STAT inhibition",
-      "NF-κB inhibition"
+      "berberine-mediated AMPK activation",
+      "LDL receptor/PCSK9 modulation",
+      "intestinal alpha-glucosidase inhibition",
+      "gut microbiome and bile-acid signaling effects",
+      "NF-κB/JAK-STAT inflammatory modulation",
+      "P-glycoprotein substrate/interaction relevance"
     ],
     "description": "It is best framed around berberine-bearing root bark with GI and medication-interaction caution.",
-    "activeCompounds": [
-      "berberine",
-      "berbamine"
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "Avoid pregnancy, breastfeeding, and use in neonates/infants due to berberine-related bilirubin displacement/kernicterus concern. GI upset is common. Caution with antidiabetics, antihypertensives, anticoagulants/antiplatelets, cyclosporine/tacrolimus, macrolides, and CYP/P-gp substrates.",
+    "interactions": [
+      "Antidiabetics",
+      "antihypertensives",
+      "anticoagulants/antiplatelets",
+      "cyclosporine/tacrolimus",
+      "macrolides",
+      "CYP3A4/CYP2D6/P-gp substrates."
     ],
-    "safetyNotes": "Use caution in pregnancy, breastfeeding, and in those prone to GI upset."
+    "contraindications": [
+      "Pregnancy",
+      "breastfeeding",
+      "neonates/infants",
+      "clinician review for liver disease",
+      "complex medication regimens",
+      "or hypoglycemia-prone patients."
+    ],
+    "preparation": "Root/bark extracts containing berberine; avoid equating whole herb with purified berberine.",
+    "traditionalUses": [
+      "Digestive bitter",
+      "infections",
+      "bile support"
+    ]
   },
   {
     "slug": "bitter-melon",
-    "name": "Bitter Melon",
-    "mechanisms": [
-      "glucose support",
+    "name": "bitter melon",
+    "region": "Asia; Caribbean; Africa",
+    "primaryActions": [
+      "blood sugar support education",
       "metabolic support",
+      "diabetes-adjacent content"
+    ],
+    "mechanisms": [
+      "charantin and polypeptide-p hypoglycemic activity",
       "AMPK activation",
-      "GLUT4 translocation modulation",
-      "PPARγ activation"
+      "GLUT4 translocation",
+      "PPARγ modulation",
+      "pancreatic beta-cell and insulin-secretion effects"
     ],
     "description": "It is best framed as a food-medicine with hypoglycemia-aware caution.",
-    "activeCompounds": [
-      "charantin",
-      "polypeptide-p",
-      "cucurbitanes",
-      "Momordicoside K"
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "Do not use as a replacement for diabetes medications. Hypoglycemia risk rises with insulin, sulfonylureas, and other antidiabetic therapy. Avoid pregnancy due to uterine/abortifacient concerns. Seeds have been associated with favism-like risk in G6PD deficiency. GI upset can occur.",
+    "interactions": [
+      "Insulin",
+      "sulfonylureas",
+      "GLP-1/SGLT2/metformin and other glucose-lowering therapy",
+      "monitor glucose."
     ],
-    "safetyNotes": "Use caution in people prone to low blood sugar and during pregnancy."
+    "contraindications": [
+      "Pregnancy",
+      "G6PD deficiency/severe seed exposure risk",
+      "recurrent hypoglycemia unless supervised."
+    ],
+    "preparation": "Fruit, juice, teas, powders, and extracts; seed preparations may be higher risk.",
+    "traditionalUses": [
+      "Asian",
+      "Caribbean",
+      "and Ayurvedic metabolic/food use"
+    ]
   },
   {
     "slug": "coleus-forskohlii",
-    "name": "Coleus Forskohlii",
+    "name": "coleus forskohlii",
+    "region": "South Asia / Ayurveda",
+    "primaryActions": [
+      "body composition research",
+      "cAMP signaling support",
+      "respiratory/traditional support"
+    ],
     "mechanisms": [
-      "metabolic support",
-      "vascular support"
+      "forskolin activation of adenylate cyclase",
+      "increased intracellular cAMP",
+      "protein kinase A signaling",
+      "smooth-muscle and lipolysis pathway effects"
     ],
     "description": "It is best framed around forskolin with blood-pressure and stimulant-stack caution.",
-    "activeCompounds": [
-      "forskolin"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May lower blood pressure or increase heart rate in sensitive users. Caution with anticoagulants, antihypertensives, nitrates, and perioperative use.",
+    "interactions": [
+      "Potential additive effects with antihypertensives",
+      "nitrates",
+      "antiplatelets/anticoagulants",
+      "and bronchodilator-style regimens."
     ],
-    "safetyNotes": "Use caution with low blood pressure, bleeding risk, and GI sensitivity."
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "hypotension",
+      "bleeding disorders",
+      "and cardiovascular disease without clinician oversight."
+    ],
+    "preparation": "Evidence is strongest for standardized forskolin extracts, not all Coleus preparations.",
+    "traditionalUses": [
+      "body composition",
+      "cAMP signaling",
+      "respiratory/traditional"
+    ]
   },
   {
     "slug": "aloe-vera",
-    "name": "Aloe Vera",
+    "name": "aloe vera",
+    "region": "Africa; Mediterranean; global cultivation",
+    "primaryActions": [
+      "topical skin-soothing support",
+      "constipation laxative education",
+      "digestive mucosa research"
+    ],
     "mechanisms": [
-      "demulcent",
-      "digestive support",
-      "anti-inflammatory",
-      "NF-κB inhibition",
-      "PI3K/Akt modulation",
-      "MAPK pathway modulation",
-      "TLR4 modulation",
-      "NF-κB modulation"
+      "acemannan immune modulation",
+      "anthraquinone laxative effects",
+      "AMPK/glucose-metabolism and wound-healing pathways"
     ],
     "description": "Internal cross-linking supports Aloe Vera through compounds such as aloin.",
-    "activeCompounds": [
-      "acemannan",
-      "aloe-emodin",
-      "aloin",
-      "Emodin",
-      "Rhein"
-    ],
-    "safetyNotes": "General use caution; distinguish inner gel from latex-rich stimulant-laxative fractions",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Oral latex/whole-leaf aloe can cause diarrhea, electrolyte loss, and drug interactions; avoid pregnancy and kidney disease.",
     "interactions": [
-      "antidiabetic medications"
+      "Oral latex may interact with diuretics",
+      "digoxin",
+      "corticosteroids",
+      "laxatives",
+      "and antidiabetics."
     ],
-    "preparation": "Fresh gel applied topically or taken internally (juice form); latex processed separately for laxative use",
-    "primaryActions": [
-      "antioxidant",
-      "nootropic"
+    "contraindications": [
+      "Pregnancy",
+      "inflammatory bowel disease",
+      "kidney disease",
+      "oral latex use in children"
+    ],
+    "preparation": "Inner leaf gel for topical/digestive products; latex/whole-leaf laxative products carry higher risk.",
+    "traditionalUses": [
+      "Skin burns",
+      "wounds",
+      "digestive/laxative use"
     ]
   },
   {
     "slug": "american-ginseng",
-    "name": "American Ginseng",
+    "name": "american ginseng",
+    "region": "North America",
+    "primaryActions": [
+      "stress/adaptogen support",
+      "glycemic support education"
+    ],
     "mechanisms": [
-      "cholinergic modulation",
-      "gabaergic_modulation",
-      "inflammatory_pathway_modulation",
-      "PI3K/Akt modulation",
-      "Nrf2 activation",
-      "NO signaling modulation",
-      "NF-κB inhibition",
-      "VEGF signaling inhibition"
+      "ginsenoside effects on AMPK/glucose uptake",
+      "nitric-oxide/endothelial signaling",
+      "HPA-axis and cognition pathways"
     ],
     "description": "Internal cross-linking supports American Ginseng through compounds such as ginsenosides (including rb1, rg1), rb2.",
-    "activeCompounds": [
-      "ginsenosides (including rb1",
-      "rg1)",
-      "rb2",
-      "Ginsenoside Rb1",
-      "Ginsenoside Rg1",
-      "Ginsenoside Rg3"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May lower glucose; caution with diabetes drugs, anticoagulants/warfarin, stimulants, insomnia, and pregnancy.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Safety review required before publication.",
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "stress/adaptogen",
+      "glycemic"
+    ]
   },
   {
     "slug": "artemisia-annua",
-    "name": "Artemisia Annua",
+    "name": "artemisia annua",
+    "region": "East Asia",
+    "primaryActions": [
+      "antimalarial compound source",
+      "antimicrobial/fever traditional use",
+      "safety education"
+    ],
     "mechanisms": [
-      "immune support",
-      "antimicrobial",
-      "oxidative stress modulation"
+      "artemisinin endoperoxide activation under iron/heme conditions",
+      "parasite oxidative damage pathways",
+      "NF-κB and cytokine modulation reported preclinically"
     ],
     "description": "Internal cross-linking supports Artemisia Annua through compounds such as artemisinin.",
-    "activeCompounds": [
-      "artemisinin",
-      "arteannuin B",
-      "chrysosplenetin"
-    ],
-    "safetyNotes": "Review interactions and contraindications",
+    "safetyNotes": "Do not use crude Artemisia as a substitute for approved antimalarial therapy. Pregnancy, liver disease, and drug-interaction contexts require medical supervision.",
     "interactions": [
-      "CYP-metabolized medications"
+      "Potential CYP/P-gp interactions and additive effects with antimalarials",
+      "hepatotoxic drugs",
+      "and seizure-threshold-lowering agents."
     ],
-    "preparation": "Leaves and aerial parts used in decoctions or standardized extracts (e.g., artemisinin)",
-    "primaryActions": [
-      "immunomodulatory",
-      "antioxidant",
-      "nootropic"
+    "contraindications": [
+      "Pregnancy/breastfeeding unless medically indicated",
+      "serious infection without medical care",
+      "liver disease",
+      "and unsupervised antimalarial use."
+    ],
+    "preparation": "Separate whole-herb Artemisia preparations from purified artemisinin derivatives; evidence and safety are not interchangeable.",
+    "traditionalUses": [
+      "antimalarial compound source",
+      "antimicrobial/fever traditional use",
+      "safety"
     ]
   },
   {
     "slug": "celastrus-paniculatus",
-    "name": "Celastrus Paniculatus",
+    "name": "celastrus paniculatus",
+    "region": "South Asia / Ayurveda",
+    "primaryActions": [
+      "cognitive support tradition",
+      "neuroprotective pathway research"
+    ],
     "mechanisms": [
-      "general or unknown targets"
+      "celastrine/beta-amyrin triterpenoid signaling",
+      "acetylcholinesterase and neuroinflammatory pathway modulation",
+      "NF-κB/oxidative-stress pathway effects"
     ],
     "description": "Internal cross-linking supports Celastrus Paniculatus through compounds such as beta-amyrin, celastrine, lupeol.",
-    "activeCompounds": [
-      "beta-amyrin",
-      "celastrine",
-      "lupeol",
-      "celapanin"
+    "safetyNotes": "Limited human safety data; use conservative preparation-specific framing and avoid pregnancy/breastfeeding or medication stacking without clinician review.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "safetyNotes": "Safety review required before publication.",
-    "preparation": "No direct preparation data. Contextual inference: Used in ayurveda for cognition, focus, and learning... No direct mechanismofaction data. Contextual inference: Used in ayurveda for cognition, focus, and learning... Used in Ayurveda for cognition, focus, and learning.. No direct effects data. Contextual inference: Used in ayurveda for cognition, focus, and learning... No direct mechanismofaction data. Contextual inference: Used in ayurveda for cognition, focus, and learning... Used in Ayurveda for cognition, focus, and learning.. Used in Ayurveda for cognition, focus, and learning.. No direct region data. Contextual inference: Used in ayurveda for cognition, focus, and learning... No direct mechanismofaction data. Contextual inference: Used in ayurveda for cognition, focus, and learning... Used in Ayurveda for cognition, focus, and learning.. No direct effects data. Contextual inference: Used in ayurveda for cognition, focus, and learning... No direct mechanismofaction data. Contextual inference: Used in ayurveda for cognition, focus, and learning... Used in Ayurveda for cognition, focus, and learning.. Used in Ayurveda for cognition, focus, and learning.. Used in Ayurveda for cognition, focus, and learning.. Used in Ayurveda for cognition, focus, and learning",
-    "primaryActions": [
-      "nootropic"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "cognitive tradition",
+      "neuroprotective pathway"
     ]
   },
   {
     "slug": "calamus",
-    "name": "Calamus",
+    "name": "calamus",
+    "region": "Europe / Asia / North America",
+    "primaryActions": [
+      "traditional digestive use",
+      "safety/toxicology education"
+    ],
     "mechanisms": [
-      "gabaergic_modulation",
-      "NF-kB pathway inhibition",
-      "PLCγ2-PKC pathway inhibition",
-      "GABA-A modulation",
-      "acetylcholinesterase inhibition"
+      "asarone-rich volatile oil activity",
+      "GABAergic and cholinergic CNS effects reported preclinically",
+      "smooth-muscle signaling"
     ],
     "description": "Internal cross-linking supports Calamus through compounds such as eugenol, alpha-asarone, beta-asarone.",
-    "activeCompounds": [
-      "eugenol",
-      "alpha-asarone",
-      "beta-asarone"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "High-caution herb because beta-asarone-containing preparations have toxicology and regulatory concerns. Avoid internal use unless verified beta-asarone-free and professionally supervised.",
+    "interactions": [
+      "Potential additive CNS effects with sedatives",
+      "alcohol",
+      "antiepileptics",
+      "and other neuroactive agents."
     ],
-    "safetyNotes": "Safety review required before publication.",
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan"
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "children",
+      "seizure disorder",
+      "liver disease",
+      "and internal high-dose use."
+    ],
+    "preparation": "Distinguish beta-asarone-free Acorus calamus chemotypes from beta-asarone-containing materials; do not generalize safety across chemotypes.",
+    "traditionalUses": [
+      "traditional digestive use",
+      "safety/toxicology"
+    ]
   },
   {
     "slug": "cayenne",
-    "name": "Cayenne",
+    "name": "cayenne",
+    "region": "Central/South America",
+    "primaryActions": [
+      "circulation and topical pain support",
+      "TRPV1 pathway education"
+    ],
     "mechanisms": [
-      "TRPV1 activation"
+      "TRPV1 activation/desensitization",
+      "substance P depletion",
+      "neurogenic inflammation modulation",
+      "local vasodilation signaling"
     ],
     "description": "Internal cross-linking supports Cayenne through compounds such as capsaicin, capsorubin, dihydrocapsaicin.",
-    "activeCompounds": [
-      "capsaicin",
-      "capsorubin",
-      "dihydrocapsaicin",
-      "capsanthin"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Capsaicin can irritate skin, eyes, GI tract, and mucosa. Caution with ulcers/reflux, anticoagulants/antiplatelets, and before surgery; keep topical products away from eyes.",
+    "interactions": [
+      "Potential interaction concern with anticoagulants/antiplatelets",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Safety review required before publication."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "circulation and topical pain",
+      "TRPV1 pathway"
+    ]
   },
   {
     "slug": "corydalis",
-    "name": "Corydalis",
+    "name": "corydalis",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "pain research",
+      "sedative/CNS activity",
+      "traditional analgesic use"
+    ],
     "mechanisms": [
-      "dopaminergic_modulation"
+      "tetrahydropalmatine-related dopamine D1/D2 modulation",
+      "GABAergic and opioid-pathway interaction",
+      "calcium-channel and nociceptive signaling modulation"
     ],
     "description": "Internal cross-linking supports Corydalis through compounds such as corydaline, isocorypalmine, dehydrocorybulbine.",
-    "activeCompounds": [
-      "corydaline",
-      "isocorypalmine",
-      "dehydrocorybulbine",
-      "tetrahydropalmatine"
+    "safetyNotes": "CNS depression, dizziness, sedation, and liver-safety concerns have been reported with Corydalis-containing products. Avoid combining with sedatives or alcohol.",
+    "interactions": [
+      "Potential additive effects with benzodiazepines",
+      "opioids",
+      "sleep aids",
+      "alcohol",
+      "antipsychotics",
+      "and hepatotoxic drugs."
     ],
-    "safetyNotes": "Safety review required before publication."
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "liver disease",
+      "seizure disorder",
+      "heavy alcohol use",
+      "and use of sedatives without medical oversight."
+    ],
+    "preparation": "Evidence and risks depend strongly on species, alkaloid profile, and dose; avoid unstandardized high-dose extracts.",
+    "traditionalUses": [
+      "pain",
+      "sedative/CNS activity",
+      "traditional analgesic use"
+    ]
   },
   {
     "slug": "chinese-skullcap",
-    "name": "Chinese Skullcap",
+    "name": "chinese skullcap",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "inflammation research",
+      "immune signaling support",
+      "antioxidant support"
+    ],
     "mechanisms": [
-      "gabaergic_modulation",
-      "LOX inhibition",
-      "NF-kB inhibition"
+      "baicalin/baicalein/wogonin NF-κB inhibition",
+      "MAPK and PI3K/Akt modulation",
+      "Nrf2 antioxidant signaling",
+      "cytokine modulation"
     ],
     "description": "Internal cross-linking supports Chinese Skullcap through compounds such as baicalein, baicalin, wogonin.",
-    "activeCompounds": [
-      "baicalein",
-      "baicalin",
-      "wogonin"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Use caution with liver disease and poor-quality products; rare liver injury reports exist for skullcap-containing supplements.",
+    "interactions": [
+      "Potential additive effects with sedatives",
+      "anticoagulants/antiplatelets",
+      "hepatotoxic drugs",
+      "and immune-modulating therapies."
     ],
-    "safetyNotes": "Safety review required before publication."
+    "contraindications": [
+      "Liver disease",
+      "pregnancy/breastfeeding",
+      "immunosuppressive therapy without clinician oversight."
+    ],
+    "preparation": "Require verified species identity and extract standardization; avoid products with unclear botanical identity.",
+    "traditionalUses": [
+      "inflammation",
+      "immune signaling",
+      "antioxidant"
+    ]
   },
   {
     "slug": "phellodendron",
-    "name": "Phellodendron",
+    "name": "phellodendron",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "berberine-source metabolic support education",
+      "antimicrobial pathway research"
+    ],
     "mechanisms": [
       "AMPK activation",
       "NF-kB pathway inhibition",
       "mitochondrial complex I inhibition"
     ],
     "description": "Internal cross-linking supports Phellodendron through compounds such as berberine, jatrorrhizine, palmatine.",
-    "activeCompounds": [
-      "berberine",
-      "jatrorrhizine",
-      "palmatine"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Berberine-containing bark; avoid in pregnancy/breastfeeding and infants. Caution with antidiabetic drugs, anticoagulants, CYP/P-gp substrates, and bilirubin-risk contexts.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "CYP/P-gp substrate medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Safety review required before publication."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "berberine-source metabolic",
+      "antimicrobial pathway"
+    ]
   },
   {
     "slug": "coptis",
-    "name": "Coptis",
+    "name": "coptis",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "berberine-source metabolic support education",
+      "antimicrobial pathway research"
+    ],
     "mechanisms": [
       "AMPK activation",
       "NF-kB pathway inhibition",
@@ -2927,135 +4916,173 @@
       "MAPK modulation"
     ],
     "description": "Internal cross-linking supports Coptis through compounds such as berberine, palmatine, coptisine.",
-    "activeCompounds": [
-      "berberine",
-      "palmatine",
-      "coptisine"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Berberine-containing herb; avoid in pregnancy/breastfeeding and infants. Caution with antidiabetic drugs, anticoagulants, CYP/P-gp substrates, and bilirubin-risk contexts.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "CYP/P-gp substrate medicines",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Safety review required before publication."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "berberine-source metabolic",
+      "antimicrobial pathway"
+    ]
   },
   {
     "slug": "saffron",
-    "name": "Saffron",
+    "name": "saffron",
+    "region": "Mediterranean / Southwest Asia",
     "primaryActions": [
       "Neuroactive support",
       "mood-related signaling",
       "antioxidant effects"
     ],
     "mechanisms": [
-      "general or unknown targets",
-      "PI3K/Akt modulation",
-      "NF-κB inhibition",
-      "PPAR activation",
-      "GABA-A modulation",
-      "NMDA modulation"
+      "crocin/crocetin antioxidant signaling",
+      "serotonergic and dopaminergic modulation",
+      "HPA-axis and inflammatory-pathway effects"
     ],
     "description": "Internal cross-linking supports Saffron through compounds such as picrocrocin, crocin, safranal.",
-    "activeCompounds": [
-      "picrocrocin",
-      "crocin",
-      "safranal",
-      "crocetin"
-    ],
-    "safetyNotes": "Safety review required before publication.",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "High doses may cause GI/CNS effects and uterine stimulation; avoid pregnancy-level medicinal dosing; monitor with serotonergic drugs.",
     "interactions": [
       "Use caution with serotonergic medications and anticoagulants."
     ],
-    "preparation": "Threads or standardized extract; aroma-rich preparations emphasize safranal exposure."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Threads or standardized extract; aroma-rich preparations emphasize safranal exposure.",
+    "traditionalUses": [
+      "Neuroactive",
+      "mood-related signaling",
+      "antioxidant effects"
+    ]
   },
   {
     "slug": "papaya-leaf",
-    "name": "Papaya Leaf",
+    "name": "papaya leaf",
+    "region": "Tropical Americas / global tropics",
+    "primaryActions": [
+      "platelet-support research",
+      "dengue-adjunct research",
+      "inflammatory support"
+    ],
     "mechanisms": [
-      "general or unknown targets"
+      "papain/chymopapain proteolytic enzymes",
+      "platelet-support signaling reported in dengue studies",
+      "flavonoid antioxidant signaling",
+      "inflammatory-pathway modulation"
     ],
     "description": "Internal cross-linking supports Papaya Leaf through compounds such as carpaine, papain, benzyl isothiocyanate.",
-    "activeCompounds": [
-      "carpaine",
-      "papain",
-      "benzyl isothiocyanate",
-      "chymopapain"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Claims are dengue/thrombocytopenia-adjunct specific and should not replace medical care. Latex allergy and pregnancy caution are important; monitor bleeding/platelet contexts clinically.",
+    "interactions": [
+      "Potential additive effects with anticoagulant/antiplatelet therapy",
+      "theoretical interaction with diabetes medications."
     ],
-    "safetyNotes": "Safety review required before publication."
+    "contraindications": [
+      "Pregnancy",
+      "papaya/latex allergy",
+      "severe dengue without medical care",
+      "and use with anticoagulants/antiplatelets without supervision."
+    ],
+    "preparation": "Evidence is strongest for standardized Carica papaya leaf extract/juice in dengue-associated thrombocytopenia studies.",
+    "traditionalUses": [
+      "platelet-support",
+      "dengue-adjunct",
+      "inflammatory"
+    ]
   },
   {
     "slug": "kanna",
-    "name": "Kanna",
+    "name": "kanna",
+    "region": "Southern Africa",
+    "primaryActions": [
+      "mood/stress support education",
+      "traditional South African botanical",
+      "serotonergic-risk review"
+    ],
     "mechanisms": [
-      "general or unknown targets",
-      "serotonin reuptake inhibition",
-      "PDE4 inhibition"
+      "mesembrine alkaloid serotonin reuptake modulation",
+      "PDE4 inhibition",
+      "monoamine and stress-response pathway effects"
     ],
     "description": "Internal cross-linking supports Kanna through compounds such as mesembrenone, mesembranol, mesembrine.",
-    "activeCompounds": [
-      "mesembrenone",
-      "mesembranol",
-      "mesembrine",
-      "mesembrenol"
+    "safetyNotes": "CNS-active and potentially serotonergic. Avoid casual stacking with antidepressants or empathogenic/stimulant products.",
+    "interactions": [
+      "Avoid or clinician-review with SSRIs",
+      "SNRIs",
+      "MAOIs",
+      "TCAs",
+      "lithium",
+      "tramadol",
+      "linezolid",
+      "stimulants",
+      "and serotonergic supplements."
     ],
-    "safetyNotes": "Safety review required before publication.",
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan"
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "bipolar/mania risk",
+      "serotonin-syndrome risk",
+      "active psychiatric medication use without clinician oversight."
+    ],
+    "preparation": "Fermented aerial material, capsules, extracts, tinctures, and chewed preparations exist; standardized extracts can be much stronger than traditional use.",
+    "traditionalUses": [
+      "mood/stress",
+      "traditional South African botanical",
+      "serotonergic-risk review"
+    ]
   },
   {
     "slug": "green-tea",
-    "name": "Green Tea",
+    "name": "green tea",
+    "region": "China; Japan",
     "primaryActions": [
       "AMPK support",
       "inflammatory signaling control",
       "redox modulation"
     ],
     "mechanisms": [
-      "adenosine_antagonism",
-      "ADORA1",
-      "ADORA2A (adenosine receptors)",
-      "dopaminergic_modulation",
-      "MAPK pathway modulation",
-      "NF-κB inhibition",
-      "AMPK activation",
-      "Nrf2 activation",
-      "PI3K/Akt modulation",
-      "eNOS activation",
-      "glutamate receptor modulation",
-      "GABA upregulation",
-      "MAPK modulation",
-      "EGFR modulation"
+      "EGCG/catechins activate AMPK",
+      "modulate lipid absorption and oxidation",
+      "support endothelial nitric-oxide signaling",
+      "and provide caffeine-mediated adenosine antagonism."
     ],
     "description": "Internal cross-linking supports Green Tea through compounds such as caffeine, theanine, catechins (egcg).",
-    "activeCompounds": [
-      "caffeine",
-      "theanine",
-      "catechins (egcg)",
-      "Myricetin",
-      "Catechin",
-      "Epicatechin",
-      "Epigallocatechin gallate (EGCG)",
-      "Gallic acid",
-      "epigallocatechin",
-      "epicatechin gallate",
-      "epigallocatechin gallate",
-      "gallocatechin"
-    ],
-    "safetyNotes": "Safety review required before publication.",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Caffeine may worsen insomnia, anxiety, palpitations, or reflux. High-dose green-tea extracts can cause liver injury, especially fasting use; caution with anticoagulants and liver disease.",
     "interactions": [
       "May interact with stimulants and iron absorption timing."
     ],
+    "contraindications": [
+      "Severe caffeine sensitivity",
+      "liver disease with high-EGCG extracts",
+      "pregnancy caffeine limits"
+    ],
     "preparation": "Infusion or standardized extract; lower-temperature steeping preserves catechins and theanine balance.",
-    "affiliateProducts": [
-      {
-        "name": "Green Tea",
-        "type": "tea",
-        "affiliateUrl": "https://www.amazon.com/s?k=green+tea+bags&tag=razzleberry02-20"
-      },
-      {
-        "name": "Green Tea Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=green+tea+extract&tag=razzleberry02-20"
-      }
+    "traditionalUses": [
+      "East Asian beverage",
+      "alertness",
+      "digestion",
+      "longevity"
     ]
   },
   {
     "slug": "goldenseal",
-    "name": "Goldenseal",
+    "name": "goldenseal",
+    "region": "North America",
+    "primaryActions": [
+      "mucosal/antimicrobial traditional use",
+      "berberine-containing herb education",
+      "high-interaction-risk botanical"
+    ],
     "mechanisms": [
       "AMPK activation",
       "NF-kB pathway inhibition",
@@ -3065,745 +5092,1438 @@
       "MAPK pathway modulation"
     ],
     "description": "Internal cross-linking supports Goldenseal through compounds such as berberine, hydrastine.",
-    "activeCompounds": [
-      "berberine",
-      "hydrastine",
-      "Palmatine",
-      "Jatrorrhizine"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Berberine/hydrastine-containing herb; avoid in pregnancy/breastfeeding and infants. High interaction potential with CYP/P-gp substrates, diabetes medicines, anticoagulants, and narrow-therapeutic-index drugs.",
+    "interactions": [
+      "Potential CYP3A4/CYP2D6/P-gp interactions",
+      "caution with cyclosporine",
+      "tacrolimus",
+      "antidiabetics",
+      "anticoagulants",
+      "and many drugs."
     ],
-    "safetyNotes": "Safety review required before publication."
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "infants/newborns",
+      "complex medication regimens without clinician review"
+    ],
+    "preparation": "Root/rhizome powder, tincture, extracts; sustainability and adulteration issues are important.",
+    "traditionalUses": [
+      "North American mucosal",
+      "digestive",
+      "and infection folk use"
+    ]
   },
   {
     "slug": "salacia",
-    "name": "Salacia",
+    "name": "salacia",
+    "region": "South Asia",
+    "primaryActions": [
+      "post-meal glucose support education",
+      "alpha-glucosidase pathway research"
+    ],
     "mechanisms": [
-      "general or unknown targets",
-      "alpha-glucosidase inhibition"
+      "salacinol/kotalanol alpha-glucosidase inhibition",
+      "intestinal carbohydrate absorption modulation",
+      "AMPK/PPAR-related metabolic signaling"
     ],
     "description": "Internal cross-linking supports Salacia through compounds such as mangiferin, kotalanol, salacinol.",
-    "activeCompounds": [
-      "mangiferin",
-      "kotalanol",
-      "salacinol"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May lower post-meal glucose; monitor with antidiabetic medications. GI effects are possible; avoid pregnancy/breastfeeding use without clinician supervision.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Safety review required before publication."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "post-meal glucose",
+      "alpha-glucosidase pathway"
+    ]
   },
   {
     "slug": "chuanxiong",
-    "name": "Chuanxiong",
+    "name": "chuanxiong",
+    "region": "China / Traditional Chinese Medicine",
+    "primaryActions": [
+      "circulation traditional use",
+      "headache research",
+      "vascular support"
+    ],
     "mechanisms": [
-      "circulatory support",
-      "cardiovascular support",
-      "headache support"
+      "ligustilide/tetramethylpyrazine-related vasodilation",
+      "platelet aggregation modulation",
+      "nitric-oxide and calcium-channel signaling",
+      "inflammatory-pathway modulation"
     ],
     "description": "Internal cross-linking supports Chuanxiong through compounds such as ligustilide, ferulic acid, tetramethylpyrazine.",
-    "activeCompounds": [
-      "ligustilide",
-      "ferulic acid",
-      "senkyunolide"
+    "safetyNotes": "Potential bleeding and blood-pressure effects. Use caution with cardiovascular disease or anticoagulant/antiplatelet therapy.",
+    "interactions": [
+      "Potential additive effects with anticoagulants",
+      "antiplatelets",
+      "antihypertensives",
+      "nitrates",
+      "and migraine/circulation formulas."
     ],
-    "safetyNotes": "Review interactions and contraindications"
+    "contraindications": [
+      "Pregnancy",
+      "bleeding disorders",
+      "planned surgery",
+      "and anticoagulant/antiplatelet use unless supervised."
+    ],
+    "preparation": "Most clinical evidence is formula-based; single-herb evidence remains limited.",
+    "traditionalUses": [
+      "circulation traditional use",
+      "headache",
+      "vascular"
+    ]
   },
   {
     "slug": "fingerroot",
-    "name": "Fingerroot",
+    "name": "fingerroot",
+    "region": "Southeast Asia",
+    "primaryActions": [
+      "digestive/respiratory traditional use",
+      "inflammatory pathway research"
+    ],
     "mechanisms": [
-      "general or unknown targets"
+      "panduratin A/pinostrobin NF-κB and MAPK modulation",
+      "COX/LOX inflammatory signaling",
+      "antimicrobial membrane and biofilm-pathway effects"
     ],
     "description": "Internal cross-linking supports Fingerroot through compounds such as pinostrobin, pinocembrin, panduratin a.",
-    "activeCompounds": [
-      "pinostrobin",
-      "pinocembrin",
-      "panduratin a"
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "safetyNotes": "Safety review required before publication."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
+    "traditionalUses": [
+      "digestive/respiratory traditional use",
+      "inflammatory pathway"
+    ]
   },
   {
     "slug": "wormwood",
-    "name": "Wormwood",
+    "name": "wormwood",
+    "region": "Europe / Western Asia / North Africa",
+    "primaryActions": [
+      "digestive bitter",
+      "antiparasitic/traditional use",
+      "safety education"
+    ],
     "mechanisms": [
-      "gabaergic_modulation"
+      "thujone interaction with GABA-A signaling",
+      "bitter-receptor digestive signaling",
+      "sesquiterpene lactone inflammatory-pathway modulation"
     ],
     "description": "Internal cross-linking supports Wormwood through compounds such as alpha-thujone, absinthin, beta-thujone.",
-    "activeCompounds": [
-      "alpha-thujone",
-      "absinthin",
-      "beta-thujone"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Thujone-containing preparations can be neurotoxic at high exposure and may provoke seizures. Avoid concentrated essential oil or high-thujone products.",
+    "interactions": [
+      "Avoid with antiepileptics",
+      "sedatives",
+      "alcohol",
+      "and other neuroactive supplements or medicines."
     ],
-    "safetyNotes": "Safety review required before publication.",
-    "preparation": "No direct preparation data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. No direct region data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine"
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "seizure disorder",
+      "liver disease",
+      "children",
+      "and internal essential-oil use."
+    ],
+    "preparation": "Use only regulated low-thujone preparations; essential oil is not equivalent to tea or standardized extracts.",
+    "traditionalUses": [
+      "digestive bitter",
+      "antiparasitic/traditional use",
+      "safety"
+    ]
   },
   {
     "slug": "horse-chestnut",
-    "name": "Horse Chestnut",
+    "name": "horse chestnut",
+    "region": "Europe",
+    "primaryActions": [
+      "venous/circulation support education",
+      "edema support"
+    ],
     "mechanisms": [
-      "venous support",
-      "cardiovascular support",
-      "inflammation support",
-      "NF-κB inhibition",
-      "endothelial barrier modulation"
+      "aescin venotonic effects",
+      "capillary permeability reduction",
+      "NF-κB/inflammatory edema modulation"
     ],
     "description": "Internal cross-linking supports Horse Chestnut through compounds such as aesculin, aescin, fraxin.",
-    "activeCompounds": [
-      "aescin",
-      "aesculin"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Use only processed seed extract; raw seeds/bark/leaves are toxic; caution with anticoagulants, kidney disease, and pregnancy.",
+    "interactions": [
+      "Potential interaction concern with anticoagulants/antiplatelets",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Review interactions and contraindications"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "bleeding disorder or upcoming surgery"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "venous/circulation",
+      "edema"
+    ]
   },
   {
     "slug": "bael",
-    "name": "Bael",
+    "name": "bael",
+    "region": "South Asia / Ayurveda",
+    "primaryActions": [
+      "digestive support tradition",
+      "antimicrobial pathway research"
+    ],
     "mechanisms": [
-      "general or unknown targets"
+      "tannin and coumarin-related gut barrier effects",
+      "intestinal motility and secretion modulation",
+      "alpha-glucosidase and antioxidant signaling"
     ],
     "description": "Internal cross-linking supports Bael through compounds such as skimmianine, aegeline, marmelosin.",
-    "activeCompounds": [
-      "skimmianine",
-      "aegeline",
-      "marmelosin"
+    "safetyNotes": "Constipating or GI-active effects are possible depending on preparation. Monitor with antidiabetic drugs and avoid pregnancy/breastfeeding use without clinician supervision.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "safetyNotes": "Safety review required before publication."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "digestive tradition",
+      "antimicrobial pathway"
+    ]
   },
   {
     "slug": "guayusa",
-    "name": "Guayusa",
+    "name": "guayusa",
+    "region": "Amazonian South America",
+    "primaryActions": [
+      "energy support",
+      "alertness support",
+      "polyphenol antioxidant support"
+    ],
     "mechanisms": [
-      "ADORA1",
-      "ADORA2A (adenosine receptors)",
-      "adenosine_antagonism",
-      "dopaminergic_modulation"
+      "caffeine-mediated adenosine A1/A2A antagonism",
+      "theobromine methylxanthine effects",
+      "chlorogenic-acid antioxidant signaling"
     ],
     "description": "Internal cross-linking supports Guayusa through compounds such as caffeine, theobromine.",
-    "activeCompounds": [
-      "caffeine",
-      "theobromine"
+    "safetyNotes": "Caffeine-containing herb; may worsen insomnia, anxiety, palpitations, reflux, and blood pressure in sensitive users.",
+    "interactions": [
+      "Additive effects with caffeine",
+      "stimulants",
+      "theophylline",
+      "decongestants",
+      "and stimulant medications."
     ],
-    "safetyNotes": "Safety review required before publication.",
-    "preparation": "No direct preparation data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. No direct region data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine"
+    "contraindications": [
+      "Uncontrolled hypertension",
+      "arrhythmia",
+      "severe anxiety/insomnia",
+      "pregnancy/breastfeeding caution",
+      "and stimulant sensitivity."
+    ],
+    "preparation": "Use moderate brewed preparations or products with disclosed caffeine content; avoid concentrated stimulant blends.",
+    "traditionalUses": [
+      "energy",
+      "alertness",
+      "polyphenol antioxidant"
+    ]
   },
   {
     "slug": "honeysuckle",
-    "name": "Honeysuckle",
+    "name": "honeysuckle",
+    "region": "East Asia",
+    "primaryActions": [
+      "immune/respiratory traditional use",
+      "inflammatory pathway research"
+    ],
     "mechanisms": [
       "MAPK pathway inhibition",
       "NF-kB inhibition"
     ],
     "description": "Internal cross-linking supports Honeysuckle through compounds such as luteolin, chlorogenic acid.",
-    "activeCompounds": [
-      "luteolin",
-      "chlorogenic acid"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Immune-active potential; use caution with autoimmune disease, transplant medicines, immunosuppressants, and during active cancer treatment unless clinician-supervised.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Safety review required before publication."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "immune/respiratory traditional use",
+      "inflammatory pathway"
+    ]
   },
   {
     "slug": "cassia-alata",
-    "name": "Cassia Alata",
+    "name": "cassia alata",
+    "region": "Tropical regions",
+    "primaryActions": [
+      "skin/fungal traditional use",
+      "laxative safety education"
+    ],
     "mechanisms": [
       "MAPK pathway",
       "NF-kB inhibition"
     ],
     "description": "Internal cross-linking supports Cassia Alata through compounds such as aloe-emodin, chrysophanol.",
-    "activeCompounds": [
-      "aloe-emodin",
-      "chrysophanol"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Limited human safety data; use conservative preparation-specific framing and avoid pregnancy/breastfeeding or medication stacking without clinician review.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "safetyNotes": "Safety review required before publication.",
-    "preparation": "No direct preparation data. Contextual inference: Antifungal and laxative properties; used for skin infections. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Antifungal and laxative properties; used for skin infections. No direct region data. Contextual inference: Antifungal and laxative properties; used for skin infections. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Antifungal and laxative properties; used for skin infections. none. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "antioxidant",
-      "nootropic",
-      "antimicrobial"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "skin/fungal traditional use",
+      "laxative safety"
     ]
   },
   {
     "slug": "american-yellow-lotus",
-    "name": "American Yellow Lotus",
+    "name": "american yellow lotus",
+    "region": "North America",
+    "primaryActions": [
+      "calming traditional use",
+      "alkaloid pathway research"
+    ],
     "mechanisms": [
-      "dopaminergic_modulation"
+      "aporphine alkaloid dopaminergic modulation",
+      "CNS sedative signaling",
+      "acetylcholinesterase and oxidative-stress pathway effects"
     ],
     "description": "Internal cross-linking supports American Yellow Lotus through compounds such as nuciferine, roemerine, n-methylasimilobine.",
-    "activeCompounds": [
-      "nuciferine",
-      "roemerine",
-      "n-methylasimilobine",
-      "armepavine"
+    "safetyNotes": "CNS-active alkaloid herb; avoid combining with sedatives, alcohol, dopamine-active drugs, or driving. Avoid pregnancy/breastfeeding and use caution with psychiatric conditions.",
+    "interactions": [
+      "Potential interaction concern with sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Safety review required before publication.",
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "calming traditional use",
+      "alkaloid pathway"
+    ]
   },
   {
     "slug": "anise-hyssop",
-    "name": "Anise Hyssop",
+    "name": "anise hyssop",
+    "region": "North America",
+    "primaryActions": [
+      "digestive/respiratory traditional use",
+      "aromatic support"
+    ],
     "mechanisms": [
       "endocannabinoid_modulation"
     ],
     "description": "Internal cross-linking supports Anise Hyssop through compounds such as limonene, anethole, estragole.",
-    "activeCompounds": [
-      "limonene",
-      "anethole",
-      "estragole"
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "safetyNotes": "Safety review required before publication."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "digestive/respiratory traditional use",
+      "aromatic"
+    ]
   },
   {
     "slug": "marshmallow",
-    "name": "Marshmallow",
+    "name": "marshmallow",
+    "region": "Europe/West Asia",
+    "primaryActions": [
+      "mucosal soothing support",
+      "throat/gut comfort",
+      "demulcent traditional use"
+    ],
     "mechanisms": [
-      "demulcent",
-      "digestive support",
-      "throat support"
+      "mucilage polysaccharide barrier effects",
+      "local soothing demulcent action",
+      "mild anti-inflammatory signaling in mucosal tissues"
     ],
     "description": "Internal cross-linking supports Marshmallow through compounds such as pectin.",
-    "activeCompounds": [
-      "mucilage polysaccharides",
-      "flavonoids",
-      "pectin"
+    "safetyNotes": "May slow absorption of oral medications if taken together. Use caution with diabetes medications because mucilage/fiber may affect glucose handling.",
+    "interactions": [
+      "Separate from oral medications by at least 1–2 hours to reduce absorption interference",
+      "monitor with antidiabetic therapy."
     ],
-    "safetyNotes": "General use caution; separate from medications when timing matters"
+    "contraindications": [
+      "Difficulty swallowing",
+      "severe GI obstruction risk",
+      "and use in infants without supervision."
+    ],
+    "preparation": "Cold infusion or mucilage-rich preparations are most aligned with traditional demulcent use.",
+    "traditionalUses": [
+      "mucosal soothing",
+      "throat/gut comfort",
+      "demulcent traditional use"
+    ]
   },
   {
     "slug": "licorice",
-    "name": "Licorice",
+    "name": "licorice",
+    "region": "Europe; Asia; TCM",
+    "primaryActions": [
+      "digestive/mucosal support",
+      "adrenal/mineralocorticoid safety education",
+      "respiratory soothing"
+    ],
     "mechanisms": [
-      "general or unknown targets",
-      "HMGB1 inhibition",
-      "NF-κB inhibition"
+      "glycyrrhizin/glycyrrhetinic acid 11β-HSD2 inhibition",
+      "mineralocorticoid-like sodium retention and potassium loss",
+      "HMGB1/NF-κB inflammatory modulation"
     ],
     "description": "Internal cross-linking supports Licorice through compounds such as glycyrrhizin.",
-    "activeCompounds": [
-      "glycyrrhizin"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Clinically important risk: hypertension, hypokalemia, edema, arrhythmia, and pseudoaldosteronism, especially with chronic/high-dose glycyrrhizin exposure.",
+    "interactions": [
+      "High-risk with diuretics",
+      "digoxin",
+      "corticosteroids",
+      "antihypertensives",
+      "stimulant laxatives",
+      "and drugs affected by potassium status."
     ],
-    "safetyNotes": "Safety review required before publication."
+    "contraindications": [
+      "Hypertension",
+      "kidney disease",
+      "heart failure",
+      "hypokalemia",
+      "pregnancy",
+      "and use of digoxin or potassium-wasting diuretics unless medically supervised."
+    ],
+    "preparation": "Differentiate glycyrrhizin-containing licorice from deglycyrrhizinated licorice (DGL); safety profile differs.",
+    "traditionalUses": [
+      "Respiratory",
+      "digestive",
+      "adrenal-like tonic",
+      "formula harmonizer"
+    ]
   },
   {
     "slug": "elderberry",
-    "name": "Elderberry",
+    "name": "elderberry",
+    "region": "Europe; North America",
+    "primaryActions": [
+      "upper respiratory immune support",
+      "viral-season symptom education",
+      "antioxidant berry support"
+    ],
     "mechanisms": [
-      "immune support",
-      "respiratory support",
-      "antioxidant"
+      "anthocyanin/flavonoid antiviral and cytokine-modulating effects",
+      "influenza/respiratory symptom pathway support"
     ],
     "description": "Internal cross-linking supports Elderberry through compounds such as sambunigrin.",
-    "activeCompounds": [
-      "cyanidin",
-      "rutin",
-      "quercetin"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Use cooked/standardized berry preparations; raw/unripe parts can contain cyanogenic glycosides; caution in autoimmune/immunosuppressed contexts.",
+    "interactions": [
+      "May counter immunosuppressants",
+      "caution with diuretics or antidiabetics depending product."
     ],
-    "safetyNotes": "General use caution; use properly prepared material only"
+    "contraindications": [
+      "Autoimmune/transplant immunosuppression without clinician review",
+      "pregnancy/breastfeeding without guidance"
+    ],
+    "preparation": "Cooked syrup, lozenges, extracts; avoid raw/unripe berries and non-berry plant parts.",
+    "traditionalUses": [
+      "Colds",
+      "flu-like illness",
+      "immune-season support"
+    ]
   },
   {
     "slug": "punarnava",
-    "name": "Punarnava",
+    "name": "punarnava",
+    "region": "South Asia / Ayurveda",
+    "primaryActions": [
+      "kidney/fluid-balance traditional use",
+      "diuretic pathway education"
+    ],
     "mechanisms": [
       "kidney support",
       "diuretic support",
       "anti-inflammatory"
     ],
     "description": "Internal cross-linking supports Punarnava through compounds such as punarnavine.",
-    "activeCompounds": [
-      "boeravinones",
-      "punarnavine",
-      "quercetin"
+    "safetyNotes": "May affect fluid balance or urinary tract irritation; use caution with kidney disease, diuretics, lithium, pregnancy, and dehydration risk.",
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "General use caution"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "significant kidney disease or unstable electrolytes"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "kidney/fluid-balance traditional use",
+      "diuretic pathway"
+    ]
   },
   {
     "slug": "coffee-cherry",
-    "name": "Coffee Cherry",
+    "name": "coffee cherry",
+    "region": "East Africa/tropical cultivation",
+    "primaryActions": [
+      "polyphenol antioxidant support",
+      "caffeine-related energy support",
+      "metabolic research"
+    ],
     "mechanisms": [
-      "adenosine_antagonism",
-      "ADORA1",
-      "ADORA2A (adenosine receptors)",
-      "dopaminergic_modulation",
-      "Nrf2 activation",
-      "NF-κB inhibition"
+      "chlorogenic-acid antioxidant signaling",
+      "caffeine adenosine-receptor antagonism",
+      "polyphenol Nrf2/AMPK-related pathways"
     ],
     "description": "Internal cross-linking supports Coffee Cherry through compounds such as caffeine, trigonelline, cafestol.",
-    "activeCompounds": [
-      "caffeine",
-      "trigonelline",
-      "cafestol",
-      "kahweol"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Caffeine content varies; concentrated products may cause insomnia, anxiety, palpitations, reflux, or blood-pressure effects.",
+    "interactions": [
+      "Additive effects with caffeine",
+      "stimulants",
+      "decongestants",
+      "theophylline",
+      "and CYP1A2-modulating drugs."
     ],
-    "safetyNotes": "Safety review required before publication."
+    "contraindications": [
+      "Uncontrolled hypertension",
+      "arrhythmias",
+      "severe anxiety/insomnia",
+      "pregnancy/breastfeeding caution",
+      "and stimulant sensitivity."
+    ],
+    "preparation": "Disclose caffeine and polyphenol content; avoid stacking with coffee/energy products.",
+    "traditionalUses": [
+      "polyphenol antioxidant",
+      "caffeine-related energy",
+      "metabolic"
+    ]
   },
   {
     "slug": "capsicum-frutescens",
-    "name": "Capsicum frutescens",
-    "activeCompounds": [
-      "capsaicin",
-      "capsorubin",
-      "dihydrocapsaicin",
-      "capsanthin"
+    "name": "capsicum frutescens",
+    "region": "Tropical Americas",
+    "primaryActions": [
+      "topical pain support",
+      "neuropathic pain education",
+      "musculoskeletal pain support"
+    ],
+    "mechanisms": [
+      "TRPV1 receptor activation followed by nociceptor desensitization",
+      "substance P depletion",
+      "CGRP/neuropeptide modulation",
+      "peripheral nociceptive signaling inhibition"
+    ],
+    "description": "Pepper species used for topical and metabolic effects.",
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "Topical use can cause burning, erythema, coughing, and eye irritation. Avoid mucous membranes, broken skin, occlusive dressings, and immediate hot showers. High-concentration patches require supervised application. Oral high-dose products may worsen reflux/GI irritation.",
+    "interactions": [
+      "Additive skin irritation with other topical rubs",
+      "oral products may theoretically compound antihypertensive or anticoagulant regimens",
+      "but clinical evidence is limited."
+    ],
+    "contraindications": [
+      "Broken or inflamed skin for topical use",
+      "known chili/capsaicin allergy",
+      "uncontrolled reflux for oral products."
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "topical pain",
+      "neuropathic pain",
+      "musculoskeletal pain"
     ]
   },
   {
     "slug": "boswellia-carterii",
-    "name": "Boswellia carterii",
+    "name": "boswellia carterii",
+    "region": "Horn of Africa / Arabian Peninsula",
+    "primaryActions": [
+      "inflammatory/joint support education",
+      "5-LOX pathway research"
+    ],
     "mechanisms": [
-      "anti-inflammatory",
-      "mobility support"
+      "Boswellic acids inhibit 5-lipoxygenase-mediated leukotriene synthesis",
+      "modulate NF-κB",
+      "mPGES-1",
+      "and cytokine-driven inflammatory pathways."
     ],
     "description": "It is best framed around boswellic acids with 5-lipoxygenase relevance.",
-    "activeCompounds": [
-      "boswellic acids",
-      "AKBA",
-      "acetyl-11-keto-beta-boswellic acid"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May cause GI upset or reflux. Use caution with anticoagulants/antiplatelets, NSAIDs, pregnancy, and resin/extract quality variation.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Generally well tolerated."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "inflammatory/joint",
+      "5-LOX pathway"
+    ]
   },
   {
     "slug": "selaginella-tamariscina",
-    "name": "Selaginella tamariscina",
+    "name": "selaginella tamariscina",
+    "region": "East Asia",
+    "primaryActions": [
+      "antioxidant and cytoprotective pathway research"
+    ],
     "mechanisms": [
       "5-lipoxygenase inhibition"
     ],
     "description": "Minimum source-backed intake for ginkgetin and 5-lipoxygenase inhibition cluster completion.",
-    "activeCompounds": [
-      "ginkgetin"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Food-like use is generally lower risk, but concentrated extracts may not match dietary safety. Use caution with pregnancy/breastfeeding, allergy, and chronic high-dose supplementation.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "preparation": "No direct preparation data. Contextual inference: Antioxidant and anti-aging effects; traditional chinese medicine. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Antioxidant and anti-aging effects; traditional Chinese medicine. No direct region data. Contextual inference: Antioxidant and anti-aging effects; traditional chinese medicine. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Antioxidant and anti-aging effects; traditional Chinese medicine. none. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "antioxidant",
-      "nootropic"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "antioxidant and cytoprotective pathway"
     ]
   },
   {
     "slug": "epimedium-brevicornum",
-    "name": "Epimedium brevicornum",
+    "name": "epimedium brevicornum",
+    "region": "China / East Asia",
+    "primaryActions": [
+      "traditional sexual-vitality support",
+      "bone/metabolic research context",
+      "icariin-source education"
+    ],
     "mechanisms": [
       "nitric oxide signaling",
       "PDE5-related signaling"
     ],
     "description": "Minimum source-backed intake for Epimedium brevicornum. Active compounds include epimedin A, epimedin B, and epimedin C. Mechanism support retained at nitric oxide signaling level for cluster activation readiness. Icariin support added to complete the PDE5-related signaling cluster.",
-    "activeCompounds": [
-      "epimedin A",
-      "epimedin B",
-      "epimedin C",
-      "Icariin"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Evidence and safety are extract-specific. Use caution with cardiovascular disease, hormone-sensitive conditions, and sexual-performance stacks.",
+    "interactions": [
+      "Potential additive effects with PDE-5 inhibitors",
+      "antihypertensives",
+      "anticoagulants/antiplatelets",
+      "and stimulant sexual-performance products."
+    ],
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "significant heart rhythm or blood-pressure instability",
+      "hormone-sensitive conditions without clinician review."
+    ],
+    "preparation": "Aerial parts/leaves are used as decoction, granules, capsules, or icariin-standardized extracts.",
+    "traditionalUses": [
+      "traditional sexual-vitality",
+      "bone/metabolic context",
+      "icariin-source"
     ]
   },
   {
     "slug": "piper-longum",
-    "name": "Piper longum",
+    "name": "piper longum",
+    "region": "South Asia / Southeast Asia",
+    "primaryActions": [
+      "bioavailability support",
+      "digestive support",
+      "respiratory/traditional use"
+    ],
     "mechanisms": [
-      "bioavailability modulation",
-      "ROS-mediated signaling modulation",
-      "STAT3 inhibition",
-      "NF-κB inhibition"
+      "piperine/piperlongumine modulation of CYP/P-gp pathways",
+      "TRPV1 sensory signaling",
+      "NF-κB and oxidative-stress signaling"
     ],
     "description": "Minimum source-backed intake for Piper longum. Active compound support includes piperine and the herb is used here only to complete the bioavailability modulation cluster. Chavicine support added to mirror the existing pepper isomer pattern in this cluster.",
-    "activeCompounds": [
-      "piperine",
-      "Chavicine",
-      "Piperlongumine"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Concentrated extracts may alter drug exposure and irritate GI mucosa. Distinguish traditional culinary/low-dose use from high-piperine formulations.",
+    "interactions": [
+      "Potential interactions with CYP/P-gp substrates",
+      "anticoagulants",
+      "antiepileptics",
+      "immunosuppressants",
+      "and other high-bioavailability supplement blends."
+    ],
+    "contraindications": [
+      "Pregnancy/breastfeeding caution",
+      "significant reflux/ulcer disease",
+      "and prescription polypharmacy without supervision."
+    ],
+    "preparation": "Evidence is strongest for piperine-containing extracts rather than all long-pepper preparations.",
+    "traditionalUses": [
+      "bioavailability",
+      "digestive",
+      "respiratory/traditional use"
     ]
   },
   {
     "slug": "brassica-oleracea",
-    "name": "Brassica oleracea",
+    "name": "brassica oleracea",
+    "region": "Mediterranean/Europe",
+    "primaryActions": [
+      "cruciferous vegetable support",
+      "glucosinolate/Nrf2 pathway education"
+    ],
     "mechanisms": [
-      "Nrf2 activation"
+      "glucosinolate-myrosinase conversion to isothiocyanates",
+      "Nrf2 antioxidant-response activation",
+      "phase II detoxification enzyme induction"
     ],
     "description": "Minimum source-backed intake for Brassica oleracea. Active compound support includes sulforaphane. Mechanism support retained at Nrf2 activation level for future cluster completion.",
-    "activeCompounds": [
-      "sulforaphane"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Human safety data are limited for concentrated extracts. Use caution in pregnancy/breastfeeding, significant medical conditions, or prescription polypharmacy.",
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "cruciferous vegetable",
+      "glucosinolate/Nrf2 pathway"
     ]
   },
   {
     "slug": "brassica-juncea",
-    "name": "Brassica juncea",
+    "name": "brassica juncea",
+    "region": "South Asia/East Asia",
+    "primaryActions": [
+      "cruciferous/mustard support",
+      "glucosinolate pathway education"
+    ],
     "mechanisms": [
-      "Nrf2 activation"
+      "glucosinolate-myrosinase isothiocyanate formation",
+      "Nrf2 antioxidant-response activation",
+      "phase II detoxification enzyme induction"
     ],
     "description": "Minimum source-backed intake for Brassica juncea. Active compound support includes sulforaphane under current workbook standards. Mechanism support retained at Nrf2 activation level for second-anchor cluster completion.",
-    "activeCompounds": [
-      "sulforaphane"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Human safety data are limited for concentrated extracts. Use caution in pregnancy/breastfeeding, significant medical conditions, or prescription polypharmacy.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "cruciferous/mustard",
+      "glucosinolate pathway"
     ]
   },
   {
     "slug": "black-seed",
-    "name": "Black Seed",
+    "name": "black seed",
+    "region": "Mediterranean / Southwest Asia",
+    "primaryActions": [
+      "metabolic support",
+      "lipid/glucose support",
+      "inflammation education"
+    ],
     "mechanisms": [
-      "Nrf2 activation",
-      "NF-κB inhibition"
+      "thymoquinone-mediated NF-κB inhibition",
+      "Nrf2/HO-1 antioxidant activation",
+      "AMPK-related glucose/lipid modulation",
+      "PPARγ/adiponectin signaling modulation"
     ],
     "description": "Bulk-ingested support row carrying Thymoquinone with pathway-level mechanism coverage.",
-    "activeCompounds": [
-      "Thymoquinone"
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "May lower glucose and blood pressure; monitor with antidiabetic or antihypertensive therapy. GI upset and allergic dermatitis can occur. Avoid high-dose supplemental oil in pregnancy. Caution with anticoagulants/antiplatelets and perioperative use.",
+    "interactions": [
+      "Antidiabetics",
+      "antihypertensives",
+      "anticoagulants/antiplatelets",
+      "possible additive metabolic or sedative effects."
+    ],
+    "contraindications": [
+      "Pregnancy at supplemental/high doses",
+      "known allergy",
+      "hypoglycemia-prone patients without monitoring."
+    ],
+    "preparation": "Seed/fiber preparations are commonly used as whole seed, powder, capsules, or food ingredients; fluid intake and preparation form matter.",
+    "traditionalUses": [
+      "metabolic",
+      "lipid/glucose",
+      "inflammation"
     ]
   },
   {
     "slug": "olive-leaf",
-    "name": "Olive Leaf",
+    "name": "olive leaf",
+    "region": "Mediterranean",
+    "primaryActions": [
+      "blood pressure/metabolic support",
+      "antimicrobial traditional use",
+      "antioxidant oleuropein support"
+    ],
     "mechanisms": [
-      "AMPK activation",
-      "NF-κB inhibition",
-      "Nrf2 activation",
-      "PI3K/Akt modulation"
+      "oleuropein/hydroxytyrosol antioxidant signaling",
+      "ACE/endothelial nitric oxide modulation",
+      "lipid and blood-pressure pathway effects"
     ],
     "description": "Bulk-ingested support row carrying Oleuropein with pathway-level mechanism coverage.",
-    "activeCompounds": [
-      "Oleuropein",
-      "Hydroxytyrosol"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May lower blood pressure/glucose; monitor with antihypertensive or antidiabetic therapy; GI effects possible.",
+    "interactions": [
+      "May potentiate antihypertensives and antidiabetics",
+      "caution with anticoagulants if product has vascular effects."
+    ],
+    "contraindications": [
+      "Hypotension",
+      "hypoglycemia risk",
+      "pregnancy/breastfeeding without guidance"
+    ],
+    "preparation": "Leaf tea, powder, and oleuropein-standardized extracts.",
+    "traditionalUses": [
+      "Mediterranean fever",
+      "infection",
+      "and cardiometabolic folk use"
     ]
   },
   {
     "slug": "japanese-knotweed",
-    "name": "Japanese Knotweed",
+    "name": "japanese knotweed",
+    "region": "East Asia",
+    "primaryActions": [
+      "resveratrol source",
+      "antioxidant/inflammation research",
+      "metabolic support research"
+    ],
     "mechanisms": [
-      "NF-κB inhibition",
-      "PI3K/Akt modulation",
-      "SIRT1 activation",
-      "AMPK activation"
+      "resveratrol SIRT1/AMPK signaling",
+      "NF-κB modulation",
+      "Nrf2 antioxidant signaling",
+      "platelet-pathway effects"
     ],
     "description": "Bulk-ingested support row carrying Emodin with pathway-level mechanism coverage.",
-    "activeCompounds": [
-      "Emodin",
-      "Resveratrol"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Concentrated resveratrol-rich extracts may affect bleeding risk and drug metabolism. GI upset is possible at higher doses.",
+    "interactions": [
+      "Potential additive bleeding risk with anticoagulants/antiplatelets/NSAIDs",
+      "caution with CYP-metabolized drugs."
+    ],
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "bleeding disorders",
+      "anticoagulant/antiplatelet therapy without supervision",
+      "and surgery."
+    ],
+    "preparation": "Do not equate standardized resveratrol extracts with crude knotweed preparations.",
+    "traditionalUses": [
+      "East Asian root use",
+      "modern resveratrol source"
     ]
   },
   {
     "slug": "thunder-god-vine",
-    "name": "Thunder God Vine",
+    "name": "thunder god vine",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "rheumatoid arthritis evidence education",
+      "immunomodulatory safety education",
+      "specialist-only herb education"
+    ],
     "mechanisms": [
+      "triptolide/celastrol-mediated NF-κB inhibition",
       "HSP90 inhibition",
-      "NF-κB inhibition"
+      "calcineurin/T-cell signaling suppression",
+      "JAK/STAT modulation",
+      "pro-inflammatory cytokine inhibition"
     ],
     "description": "Bulk-ingested support row carrying Celastrol with pathway-level mechanism coverage.",
-    "activeCompounds": [
-      "Celastrol"
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "High-toxicity herb; requires specialist supervision. Reproductive toxicity/infertility, severe GI effects, bone-marrow suppression, hepatotoxicity, nephrotoxicity, infection risk, and clinically important drug interactions are possible. Avoid pregnancy/breastfeeding and fertility attempts.",
+    "interactions": [
+      "Immunosuppressants",
+      "DMARDs",
+      "corticosteroids",
+      "hepatotoxic/nephrotoxic drugs",
+      "anticoagulants",
+      "and antiplatelets",
+      "specialist-only context."
+    ],
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "fertility attempts",
+      "liver or kidney disease",
+      "cytopenias",
+      "immunosuppression unless specialist-managed."
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "rheumatoid arthritis evidence",
+      "immunomodulatory safety",
+      "specialist-only herb"
     ]
   },
   {
     "slug": "clove",
-    "name": "Clove",
+    "name": "clove",
+    "region": "Indonesia; global spice trade",
+    "primaryActions": [
+      "oral pain/aromatic support",
+      "antimicrobial spice use",
+      "digestive carminative support"
+    ],
     "mechanisms": [
-      "COX inhibition",
-      "TRP channel modulation"
+      "Eugenol-mediated COX-2/LOX modulation",
+      "TRPV1/TRPA1 sensory receptor interaction",
+      "platelet aggregation effects."
     ],
     "description": "Bulk-ingested support row carrying Eugenol with pathway-level mechanism coverage.",
-    "activeCompounds": [
-      "Eugenol"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Clove oil can irritate skin/mucosa and high doses may be toxic; caution with anticoagulants/antiplatelets, liver disease, surgery, children, pregnancy, and concentrated essential oil ingestion.",
+    "interactions": [
+      "May increase bleeding risk with anticoagulants/antiplatelets",
+      "caution with hepatotoxic drugs."
+    ],
+    "contraindications": [
+      "Bleeding disorder",
+      "liver disease",
+      "children for clove oil ingestion",
+      "pregnancy supplement dosing without guidance"
+    ],
+    "preparation": "Culinary buds, teas, diluted topical oil; essential oil requires careful dilution.",
+    "traditionalUses": [
+      "Dental/oral",
+      "digestive",
+      "antimicrobial aromatic use"
     ]
   },
   {
     "slug": "orange-peel",
-    "name": "Orange Peel",
+    "name": "orange peel",
+    "region": "China; Mediterranean",
+    "primaryActions": [
+      "digestive aromatic support",
+      "flavonoid/circulation education",
+      "TCM qi-moving use"
+    ],
     "mechanisms": [
       "AMPK activation",
       "PI3K/Akt modulation",
       "NF-κB inhibition"
     ],
     "description": "Bulk-ingested support row carrying Hesperidin with pathway-level mechanism coverage.",
-    "activeCompounds": [
-      "Hesperidin",
-      "Naringenin",
-      "Naringin"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Generally food-like; essential oil can irritate skin and photosensitivity is possible with some citrus oils.",
+    "interactions": [
+      "Lower interaction burden than grapefruit",
+      "but review with CYP-sensitive drugs if concentrated extracts are used."
+    ],
+    "contraindications": [
+      "Citrus allergy",
+      "internal essential-oil use without supervision"
+    ],
+    "preparation": "Dried peel tea/decoction, tincture, zest, and essential oil; bitter orange/sweet orange differ.",
+    "traditionalUses": [
+      "Digestive",
+      "phlegm",
+      "qi-moving",
+      "culinary use"
     ]
   },
   {
     "slug": "scutellaria-baicalensis",
-    "name": "Scutellaria baicalensis",
+    "name": "scutellaria baicalensis",
+    "region": "East Asia",
+    "primaryActions": [
+      "inflammation research",
+      "immune signaling support",
+      "liver/safety quality education"
+    ],
     "mechanisms": [
-      "NF-κB inhibition",
-      "PI3K/Akt modulation",
-      "MAPK pathway modulation"
+      "baicalin/baicalein/wogonin modulation of NF-κB",
+      "MAPK",
+      "PI3K/Akt",
+      "Nrf2",
+      "cytokines",
+      "and oxidative-stress pathways"
     ],
     "description": "Lean bulk ingestion row for Scutellaria baicalensis. Key active compounds include Baicalin; Baicalein; Wogonin.",
-    "activeCompounds": [
-      "Baicalin",
-      "Baicalein",
-      "Wogonin"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Generally studied as extracts/compounds, but liver injury reports and adulteration/quality issues exist for skullcap products. Use caution with liver disease.",
+    "interactions": [
+      "Potential interactions with anticoagulants/antiplatelets",
+      "sedatives",
+      "immunosuppressants",
+      "and hepatotoxic drugs."
     ],
-    "safetyNotes": "Audit later.",
-    "preparation": "Root dried and decocted or tinctured; used in TCM for heat-clearing and inflammation (Huang Qin)",
-    "primaryActions": [
-      "anti-inflammatory",
-      "antioxidant",
-      "hepatoprotective"
+    "contraindications": [
+      "Liver disease",
+      "pregnancy/breastfeeding",
+      "immunosuppressive therapy without supervision",
+      "and complex oncology regimens."
+    ],
+    "preparation": "Species identity matters; distinguish Scutellaria baicalensis from American skullcap and adulterated materials.",
+    "traditionalUses": [
+      "inflammation",
+      "immune signaling",
+      "liver/safety quality"
     ]
   },
   {
     "slug": "nigella-sativa",
-    "name": "Nigella sativa",
+    "name": "nigella sativa",
+    "region": "Mediterranean / Southwest Asia",
+    "primaryActions": [
+      "lipid/glucose metabolic support",
+      "blood-pressure support education",
+      "inflammation support"
+    ],
     "mechanisms": [
-      "NF-κB inhibition",
-      "Nrf2 activation"
+      "thymoquinone-mediated NF-κB inhibition",
+      "Nrf2/HO-1 activation",
+      "AMPK activation",
+      "PPARγ/adiponectin modulation",
+      "pancreatic beta-cell and insulin-sensitivity effects"
     ],
     "description": "Lean bulk ingestion row for Nigella sativa. Key active compounds include Thymoquinone.",
-    "activeCompounds": [
-      "Thymoquinone"
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "May reduce glucose, lipids, and blood pressure; monitor with antidiabetics, antihypertensives, anticoagulants, and antiplatelets. GI upset or allergic rash can occur. Avoid high-dose supplementation during pregnancy.",
+    "interactions": [
+      "Antidiabetics",
+      "antihypertensives",
+      "anticoagulants/antiplatelets",
+      "additive metabolic effects."
     ],
-    "safetyNotes": "Audit later.",
-    "preparation": "Seeds used whole, ground, or as extracted oil (black seed oil); immune and anti-inflammatory support",
-    "primaryActions": [
-      "anti-inflammatory",
-      "immunomodulatory",
-      "antioxidant"
+    "contraindications": [
+      "Pregnancy at supplemental/high doses",
+      "hypoglycemia-prone patients without monitoring",
+      "known allergy."
     ],
-    "affiliateProducts": [
-      {
-        "name": "Black Seed Oil Capsules",
-        "type": "capsule",
-        "affiliateUrl": "https://www.amazon.com/s?k=nigella+sativa+capsules&tag=razzleberry02-20"
-      },
-      {
-        "name": "Black Seed Powder",
-        "type": "powder",
-        "affiliateUrl": "https://www.amazon.com/s?k=nigella+sativa+powder&tag=razzleberry02-20"
-      }
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "lipid/glucose metabolic",
+      "blood-pressure",
+      "inflammation"
     ]
   },
   {
     "slug": "olea-europaea",
-    "name": "Olea europaea",
+    "name": "olea europaea",
+    "region": "Mediterranean",
+    "primaryActions": [
+      "blood pressure/metabolic support",
+      "antimicrobial traditional use",
+      "antioxidant oleuropein support"
+    ],
     "mechanisms": [
-      "NF-κB inhibition",
-      "AMPK activation",
-      "Nrf2 activation",
-      "PI3K/Akt modulation",
-      "COX inhibition"
+      "oleuropein/hydroxytyrosol antioxidant signaling",
+      "ACE/endothelial nitric oxide modulation",
+      "lipid and blood-pressure pathway effects"
     ],
     "description": "Lean bulk ingestion row for Olea europaea. Key active compounds include Oleuropein; Hydroxytyrosol.",
-    "activeCompounds": [
-      "Oleuropein",
-      "Hydroxytyrosol",
-      "Oleocanthal",
-      "Oleacein"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May lower blood pressure/glucose; monitor with antihypertensive or antidiabetic therapy; GI effects possible.",
+    "interactions": [
+      "May potentiate antihypertensives and antidiabetics",
+      "caution with anticoagulants if product has vascular effects."
     ],
-    "safetyNotes": "Audit later."
+    "contraindications": [
+      "Hypotension",
+      "hypoglycemia risk",
+      "pregnancy/breastfeeding without guidance"
+    ],
+    "preparation": "Leaf tea, powder, and oleuropein-standardized extracts.",
+    "traditionalUses": [
+      "Mediterranean fever",
+      "infection",
+      "and cardiometabolic folk use"
+    ]
   },
   {
     "slug": "crocus-sativus",
-    "name": "Crocus sativus",
+    "name": "crocus sativus",
+    "region": "Mediterranean / Southwest Asia",
+    "primaryActions": [
+      "mood support education",
+      "antioxidant/carotenoid pathway research"
+    ],
     "mechanisms": [
-      "PI3K/Akt modulation",
-      "MAPK pathway modulation",
-      "Nrf2 activation"
+      "crocin/crocetin antioxidant signaling",
+      "serotonergic/dopaminergic modulation",
+      "HPA-axis and inflammatory-pathway effects"
     ],
     "description": "Lean bulk ingestion row for Crocus sativus. Key active compounds include Crocin; Crocetin.",
-    "activeCompounds": [
-      "Crocin",
-      "Crocetin"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "High doses may cause GI/CNS effects and uterine stimulation; avoid pregnancy-level medicinal dosing; monitor with serotonergic drugs.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "safetyNotes": "Audit later.",
-    "preparation": "No direct preparation data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. No direct region data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. No direct effects data. Contextual inference: Used in ritual, dreaming or folk medicine.. No direct mechanismofaction data. Contextual inference: Used in ritual, dreaming or folk medicine.. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine. Used in ritual, dreaming or folk medicine",
-    "affiliateProducts": [
-      {
-        "name": "Saffron Capsules",
-        "type": "capsule",
-        "affiliateUrl": "https://www.amazon.com/s?k=crocus+sativus+capsules&tag=razzleberry02-20"
-      },
-      {
-        "name": "Saffron Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=crocus+sativus+extract&tag=razzleberry02-20"
-      }
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "mood",
+      "antioxidant/carotenoid pathway"
     ]
   },
   {
     "slug": "glycyrrhiza-glabra",
-    "name": "Glycyrrhiza glabra",
+    "name": "glycyrrhiza glabra",
+    "region": "Europe; Asia; TCM",
+    "primaryActions": [
+      "mucosal/respiratory support",
+      "adrenal/mineralocorticoid safety education",
+      "digestive demulcent support"
+    ],
     "mechanisms": [
-      "HMGB1 inhibition",
-      "NF-κB inhibition"
+      "glycyrrhizin/glycyrrhetinic-acid 11β-HSD2 inhibition",
+      "mineralocorticoid pathway activation",
+      "anti-inflammatory signaling"
     ],
     "description": "Lean bulk ingestion row for Glycyrrhiza glabra. Key active compounds include Glycyrrhizin.",
-    "activeCompounds": [
-      "Glycyrrhizin",
-      "Glycyrrhetinic acid"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Real risk of hypertension, hypokalemia, edema, arrhythmia; avoid with hypertension, kidney disease, pregnancy, diuretics, digoxin.",
+    "interactions": [
+      "High-risk with diuretics",
+      "corticosteroids",
+      "digoxin",
+      "antihypertensives",
+      "antiarrhythmics",
+      "and stimulant laxatives."
     ],
-    "safetyNotes": "Audit later.",
-    "preparation": "Roots dried and decocted or powdered; commonly used in teas, extracts, and tablets",
-    "primaryActions": [
-      "anti-inflammatory",
-      "antioxidant",
-      "nootropic"
+    "contraindications": [
+      "Hypertension",
+      "kidney disease",
+      "hypokalemia",
+      "heart disease",
+      "pregnancy",
+      "use with diuretics/corticosteroids/digoxin without review"
     ],
-    "affiliateProducts": [
-      {
-        "name": "Licorice Tea",
-        "type": "tea",
-        "affiliateUrl": "https://www.amazon.com/s?k=glycyrrhiza+glabra+tea&tag=razzleberry02-20"
-      },
-      {
-        "name": "Licorice Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=glycyrrhiza+glabra+extract&tag=razzleberry02-20"
-      }
+    "preparation": "Whole root, deglycyrrhizinated licorice (DGL), extracts, teas, and TCM formula components differ in glycyrrhizin exposure.",
+    "traditionalUses": [
+      "Respiratory",
+      "digestive",
+      "adrenal-like tonic",
+      "formula harmonizer"
     ]
   },
   {
     "slug": "rheum-palmatum",
-    "name": "Rheum palmatum",
+    "name": "rheum palmatum",
+    "region": "East Asia",
+    "primaryActions": [
+      "laxative/digestive traditional use",
+      "anthraquinone safety education"
+    ],
     "mechanisms": [
       "NF-κB inhibition",
       "MAPK pathway modulation",
       "PI3K/Akt modulation"
     ],
     "description": "Lean bulk ingestion row for Rheum palmatum. Key active compounds include Emodin; Rhein.",
-    "activeCompounds": [
-      "Emodin",
-      "Rhein"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Culinary or tea use is usually lower risk, but concentrated oils/extracts can irritate GI or mucosal tissue. Avoid pregnancy-dose escalation and use caution with reflux/allergy.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Audit later.",
-    "preparation": "Root dried and decocted in small doses; purgative and liver-stimulating; common in TCM (Chinese rhubarb)",
-    "primaryActions": [
-      "antioxidant",
-      "digestive support",
-      "nootropic"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "laxative/digestive traditional use",
+      "anthraquinone safety"
     ]
   },
   {
     "slug": "schisandra-chinensis",
-    "name": "Schisandra chinensis",
+    "name": "schisandra chinensis",
+    "region": "China; Russia",
+    "primaryActions": [
+      "stress/liver support research",
+      "adaptogen education",
+      "respiratory traditional use"
+    ],
     "mechanisms": [
       "Nrf2 activation",
       "PI3K/Akt modulation"
     ],
     "description": "Lean bulk ingestion row for Schisandra chinensis. Key active compounds include Schisandrin.",
-    "activeCompounds": [
-      "Schisandrin"
-    ],
-    "safetyNotes": "Audit later.",
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Hepatobiliary-active potential; use caution with liver disease, gallbladder disease, bile-duct obstruction, hepatotoxic drugs, and pregnancy.",
     "interactions": [
-      "CYP-metabolized medications"
+      "Potential CYP/P-gp interactions",
+      "caution with immunosuppressants",
+      "sedatives",
+      "anticoagulants",
+      "and hepatically metabolized drugs."
     ],
-    "preparation": "Berries dried and decocted, infused, or tinctured; adaptogenic tonic in TCM for vitality and liver support",
-    "primaryActions": [
-      "adaptogenic",
-      "antioxidant",
-      "hepatoprotective"
+    "contraindications": [
+      "Pregnancy/breastfeeding without guidance",
+      "active reflux/ulcer sensitivity",
+      "complex medication regimens without review"
     ],
-    "affiliateProducts": [
-      {
-        "name": "Schisandra Capsules",
-        "type": "capsule",
-        "affiliateUrl": "https://www.amazon.com/s?k=schisandra+chinensis+capsules&tag=razzleberry02-20"
-      },
-      {
-        "name": "Schisandra Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=schisandra+chinensis+extract&tag=razzleberry02-20"
-      }
+    "preparation": "Berry decoction, powder, tincture, and lignan-standardized extracts.",
+    "traditionalUses": [
+      "TCM five-flavor tonic",
+      "liver",
+      "lung",
+      "kidney",
+      "endurance support"
     ]
   },
   {
     "slug": "tripterygium-wilfordii",
-    "name": "Tripterygium wilfordii",
+    "name": "tripterygium wilfordii",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "rheumatoid arthritis evidence education",
+      "immunomodulatory safety education",
+      "specialist-only herb education"
+    ],
     "mechanisms": [
+      "triptolide/celastrol-mediated NF-κB inhibition",
       "HSP90 inhibition",
-      "NF-κB inhibition"
+      "calcineurin/T-cell signaling suppression",
+      "JAK/STAT modulation",
+      "pro-inflammatory cytokine inhibition"
     ],
     "description": "Lean bulk ingestion row for Tripterygium wilfordii. Key active compounds include Celastrol.",
-    "activeCompounds": [
-      "Celastrol"
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "High-toxicity herb; requires specialist supervision. Reproductive toxicity/infertility, severe GI effects, bone-marrow suppression, hepatotoxicity, nephrotoxicity, infection risk, and clinically important drug interactions are possible. Avoid pregnancy/breastfeeding and fertility attempts.",
+    "interactions": [
+      "Immunosuppressants",
+      "DMARDs",
+      "corticosteroids",
+      "hepatotoxic/nephrotoxic drugs",
+      "anticoagulants",
+      "and antiplatelets",
+      "specialist-only context."
     ],
-    "safetyNotes": "Audit later."
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "fertility attempts",
+      "liver or kidney disease",
+      "cytopenias",
+      "immunosuppression unless specialist-managed."
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "rheumatoid arthritis evidence",
+      "immunomodulatory safety",
+      "specialist-only herb"
+    ]
   },
   {
     "slug": "syzygium-aromaticum",
-    "name": "Syzygium aromaticum",
+    "name": "syzygium aromaticum",
+    "region": "Indonesia; global spice trade",
+    "primaryActions": [
+      "oral pain/aromatic support",
+      "antimicrobial spice use",
+      "digestive carminative support"
+    ],
     "mechanisms": [
-      "COX inhibition",
-      "TRP channel modulation"
+      "Eugenol-mediated COX/LOX modulation",
+      "TRPV1/TRPA1 sensory receptor activity",
+      "platelet aggregation and oxidative-stress pathway effects."
     ],
     "description": "Lean bulk ingestion row for Syzygium aromaticum. Key active compounds include Eugenol.",
-    "activeCompounds": [
-      "Eugenol"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Concentrated clove preparations may cause mucosal irritation, bleeding risk, or liver toxicity at high doses; avoid essential oil ingestion without supervision and use caution with anticoagulants, surgery, pregnancy, children, and liver disease.",
+    "interactions": [
+      "May increase bleeding risk with anticoagulants/antiplatelets",
+      "caution with hepatotoxic drugs."
     ],
-    "safetyNotes": "Audit later.",
-    "preparation": "Dried flower buds (clove) used as spice, infusion, tincture, or essential oil; analgesic and antiseptic",
-    "primaryActions": [
-      "antioxidant",
-      "nootropic",
-      "analgesic"
+    "contraindications": [
+      "Bleeding disorder",
+      "liver disease",
+      "children for clove oil ingestion",
+      "pregnancy supplement dosing without guidance"
+    ],
+    "preparation": "Culinary buds, teas, diluted topical oil; essential oil requires careful dilution.",
+    "traditionalUses": [
+      "Dental/oral",
+      "digestive",
+      "antimicrobial aromatic use"
     ]
   },
   {
     "slug": "lavandula-angustifolia",
-    "name": "Lavandula angustifolia",
+    "name": "lavandula angustifolia",
+    "region": "Mediterranean; Europe",
+    "primaryActions": [
+      "calm/anxiety support",
+      "sleep support",
+      "topical aromatic use"
+    ],
     "mechanisms": [
-      "GABA-A modulation",
-      "voltage-gated calcium channel modulation"
+      "Linalool/linalyl acetate modulate limbic signaling",
+      "voltage-gated calcium-channel activity",
+      "serotonergic tone",
+      "and GABA-A–related anxiolytic pathways."
     ],
     "description": "Lean bulk ingestion row for Lavandula angustifolia. Key active compounds include Linalool.",
-    "activeCompounds": [
-      "Linalool"
-    ],
-    "safetyNotes": "Audit later.",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May cause sedation, GI upset, lavender burps, or allergy. Avoid non-standard oral essential oil use; caution with CNS depressants, alcohol, driving, and pregnancy.",
     "interactions": [
-      "CNS depressants",
-      "serotonergic medications"
+      "May potentiate sedatives",
+      "sleep medications",
+      "and CNS depressants."
     ],
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "anti-inflammatory",
-      "anxiolytic",
-      "sedative"
+    "contraindications": [
+      "Pregnancy/breastfeeding without guidance",
+      "internal essential-oil use",
+      "prepubertal endocrine concerns with topical overuse are debated"
+    ],
+    "preparation": "Flower tea, aromatherapy, topical diluted essential oil, and oral standardized oil capsules.",
+    "traditionalUses": [
+      "Aromatic calming",
+      "sleep",
+      "digestion",
+      "topical skin use"
     ]
   },
   {
     "slug": "bupleurum-falcatum",
-    "name": "Bupleurum falcatum",
+    "name": "bupleurum falcatum",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "liver/inflammatory pathway research",
+      "TCM formula context"
+    ],
     "mechanisms": [
       "NF-κB inhibition",
       "PI3K/Akt modulation"
     ],
     "description": "Lean bulk ingestion row for Bupleurum falcatum. Key active compounds include Saikosaponin A.",
-    "activeCompounds": [
-      "Saikosaponin A"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Hepatobiliary-active potential; use caution with liver disease, gallbladder disease, bile-duct obstruction, hepatotoxic drugs, and pregnancy.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Audit later.",
-    "preparation": "Roots decocted or extracted in Traditional Chinese Medicine",
-    "primaryActions": [
-      "anti-inflammatory",
-      "immunomodulatory",
-      "antioxidant"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "active liver disease"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "liver/inflammatory pathway",
+      "TCM formula context"
     ]
   },
   {
     "slug": "citrus-sinensis",
-    "name": "Citrus sinensis",
+    "name": "citrus sinensis",
+    "region": "East Asia/global cultivation",
+    "primaryActions": [
+      "cardiometabolic beverage support",
+      "flavonoid antioxidant education"
+    ],
     "mechanisms": [
       "PI3K/Akt modulation",
       "NF-κB inhibition"
     ],
     "description": "Lean bulk ingestion row for Citrus sinensis. Key active compounds include Hesperidin.",
-    "activeCompounds": [
-      "Hesperidin"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "May influence glucose or metabolic markers; monitor with antidiabetic medications and avoid pregnancy/breastfeeding use unless clinician-supervised.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "safetyNotes": "Audit later."
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "cardiometabolic beverage",
+      "flavonoid antioxidant"
+    ]
   },
   {
     "slug": "berberis-vulgaris",
-    "name": "Berberis vulgaris",
+    "name": "berberis vulgaris",
+    "region": "Europe / Western Asia",
+    "primaryActions": [
+      "berberine-source metabolic support education",
+      "antimicrobial pathway research"
+    ],
     "mechanisms": [
       "AMPK activation",
       "NF-κB inhibition",
       "PI3K/Akt modulation"
     ],
     "description": "Berberis vulgaris lean herb row for high-speed phytochemical ingestion.",
-    "activeCompounds": [
-      "Berberine",
-      "Columbamine"
-    ],
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May affect glucose, blood pressure, CYP/P-gp drug handling, and GI tolerance. Avoid pregnancy/breastfeeding unless clinician-directed.",
     "interactions": [
-      "anticoagulants/antiplatelets",
-      "antidiabetic medications",
-      "CYP-metabolized medications"
+      "Potential interaction concern with antidiabetic medicines",
+      "CYP/P-gp substrate medicines",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "Root bark decocted or tinctured; berries sometimes eaten or juiced",
-    "primaryActions": [
-      "antioxidant",
-      "digestive support",
-      "hepatoprotective"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "berberine-source metabolic",
+      "antimicrobial pathway"
     ]
   },
   {
     "slug": "phellodendron-amurense",
-    "name": "Phellodendron amurense",
+    "name": "phellodendron amurense",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "berberine-source metabolic support education",
+      "inflammatory pathway research"
+    ],
     "mechanisms": [
       "AMPK activation",
       "NF-κB inhibition",
@@ -3811,21 +6531,32 @@
       "MAPK pathway modulation"
     ],
     "description": "Phellodendron amurense lean herb row for high-speed phytochemical ingestion.",
-    "activeCompounds": [
-      "Berberine",
-      "Palmatine",
-      "Jatrorrhizine"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May affect glucose, blood pressure, CYP/P-gp drug handling, and GI tolerance. Avoid pregnancy/breastfeeding unless clinician-directed.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "CYP/P-gp substrate medicines",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "No direct preparation data. Contextual inference: Anti-inflammatory and antimicrobial; contains berberine. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Anti-inflammatory and antimicrobial; contains berberine. No direct region data. Contextual inference: Anti-inflammatory and antimicrobial; contains berberine. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Anti-inflammatory and antimicrobial; contains berberine. none. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "anti-inflammatory",
-      "antioxidant",
-      "nootropic"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "berberine-source metabolic",
+      "inflammatory pathway"
     ]
   },
   {
     "slug": "coptis-chinensis",
-    "name": "Coptis chinensis",
+    "name": "coptis chinensis",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "berberine-source metabolic support education",
+      "antimicrobial pathway research"
+    ],
     "mechanisms": [
       "AMPK activation",
       "MAPK pathway modulation",
@@ -3833,21 +6564,32 @@
       "PI3K/Akt modulation"
     ],
     "description": "Coptis chinensis lean herb row for high-speed phytochemical ingestion.",
-    "activeCompounds": [
-      "Palmatine",
-      "Columbamine",
-      "Magnoflorine"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May affect glucose, blood pressure, CYP/P-gp drug handling, and GI tolerance. Avoid pregnancy/breastfeeding unless clinician-directed.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "CYP/P-gp substrate medicines",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "No direct preparation data. Contextual inference: Rich in berberine; antimicrobial, anti-diabetic, and digestive tonic. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Rich in berberine; antimicrobial, anti-diabetic, and digestive tonic. No direct region data. Contextual inference: Rich in berberine; antimicrobial, anti-diabetic, and digestive tonic. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Rich in berberine; antimicrobial, anti-diabetic, and digestive tonic. none. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "antioxidant",
-      "digestive support",
-      "nootropic"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "berberine-source metabolic",
+      "antimicrobial pathway"
     ]
   },
   {
     "slug": "andrographis-paniculata",
-    "name": "Andrographis paniculata",
+    "name": "andrographis paniculata",
+    "region": "South Asia / Southeast Asia",
+    "primaryActions": [
+      "upper-respiratory immune support education",
+      "inflammatory pathway research"
+    ],
     "mechanisms": [
       "NF-κB inhibition",
       "JAK/STAT modulation",
@@ -3855,245 +6597,549 @@
       "PI3K/Akt modulation"
     ],
     "description": "Andrographis paniculata lean herb row for high-speed phytochemical ingestion.",
-    "activeCompounds": [
-      "Andrographolide",
-      "Neoandrographolide"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Immune-modulating activity is plausible; use caution with autoimmune disease, transplant medicines, or immunosuppressants.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "upper-respiratory immune",
+      "inflammatory pathway"
     ]
   },
   {
     "slug": "fenugreek",
-    "name": "Fenugreek",
+    "name": "fenugreek",
+    "region": "Mediterranean / South Asia",
+    "primaryActions": [
+      "glucose and lactation tradition",
+      "digestive/metabolic support education"
+    ],
     "mechanisms": [
-      "PI3K/Akt modulation",
-      "PPARγ activation",
-      "NO signaling modulation",
-      "Nrf2 activation",
-      "glucose metabolism modulation"
+      "Galactomannan fiber slows carbohydrate absorption and bile-acid recycling",
+      "4-hydroxyisoleucine may affect insulin secretion/sensitivity",
+      "saponins influence lipid metabolism."
     ],
     "description": "Fenugreek lean herb row for high-speed phytochemical ingestion.",
-    "activeCompounds": [
-      "Diosgenin",
-      "Protodioscin",
-      "trigonelline"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May cause gas, diarrhea, hypoglycemia, or maple-syrup body odor. Use caution with antidiabetic drugs, anticoagulants/antiplatelets, pregnancy, and legume/peanut allergy.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "glucose and lactation tradition",
+      "digestive/metabolic"
     ]
   },
   {
     "slug": "wild-yam",
-    "name": "Wild Yam",
+    "name": "wild yam",
+    "region": "North America / traditional herbalism",
+    "primaryActions": [
+      "women’s health tradition",
+      "diosgenin pathway education"
+    ],
     "mechanisms": [
       "PI3K/Akt modulation",
       "PPARγ activation"
     ],
     "description": "Wild Yam lean herb row for high-speed phytochemical ingestion.",
-    "activeCompounds": [
-      "Diosgenin"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "May lower blood glucose or alter metabolic markers; monitor with diabetes medications and avoid unsupervised use during pregnancy.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "women’s health tradition",
+      "diosgenin pathway"
     ]
   },
   {
     "slug": "tribulus-terrestris",
-    "name": "Tribulus terrestris",
+    "name": "tribulus terrestris",
+    "region": "Mediterranean / Asia traditional use",
+    "primaryActions": [
+      "men’s vitality support education",
+      "libido/performance tradition"
+    ],
     "mechanisms": [
       "NO signaling modulation",
       "PI3K/Akt modulation"
     ],
     "description": "Tribulus terrestris lean herb row for high-speed phytochemical ingestion.",
-    "activeCompounds": [
-      "Protodioscin"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Human safety data are limited for concentrated extracts. Use caution in pregnancy/breastfeeding, significant medical conditions, or prescription polypharmacy.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "men’s vitality",
+      "libido/performance tradition"
     ]
   },
   {
     "slug": "bacopa-monnieri",
-    "name": "Bacopa monnieri",
+    "name": "bacopa monnieri",
+    "region": "South Asia / Ayurveda",
+    "primaryActions": [
+      "cognitive support education",
+      "neuroprotective pathway research"
+    ],
     "mechanisms": [
-      "cholinergic modulation",
-      "ERK pathway modulation",
-      "PI3K/Akt modulation"
+      "Bacosides support cholinergic signaling",
+      "antioxidant defenses",
+      "neuroinflammatory modulation",
+      "ERK/PI3K-Akt signaling",
+      "and BDNF-related synaptic plasticity."
     ],
     "description": "Bacopa monnieri lean herb row for high-speed phytochemical ingestion.",
-    "activeCompounds": [
-      "Bacoside A",
-      "Bacoside B"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May cause nausea, diarrhea, abdominal cramping, fatigue, or sedation. Use caution with sedatives, thyroid-active drugs, pregnancy, and sensitive GI conditions.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
     ],
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "cognitive",
+      "neuroprotective pathway"
+    ]
   },
   {
     "slug": "bayberry",
-    "name": "Bayberry",
+    "name": "bayberry",
+    "region": "North America",
+    "primaryActions": [
+      "astringent/throat traditional use",
+      "tannin safety education"
+    ],
     "mechanisms": [
       "MAPK pathway modulation",
       "NF-κB inhibition"
     ],
     "description": "Conservative evidence framing applied.",
-    "activeCompounds": [
-      "Myricetin"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Immune-modulating activity is plausible; use caution with autoimmune disease, transplant medicines, or immunosuppressants.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Fruit/berry preparations are commonly used as foods, juices, powders, capsules, or extracts; sugar and extract concentration vary.",
+    "traditionalUses": [
+      "astringent/throat traditional use",
+      "tannin safety"
     ]
   },
   {
     "slug": "parsley",
-    "name": "Parsley",
+    "name": "parsley",
+    "region": "Mediterranean / Europe",
+    "primaryActions": [
+      "culinary diuretic tradition",
+      "antioxidant support"
+    ],
     "mechanisms": [
-      "GABA-A modulation",
-      "PI3K/Akt modulation"
+      "Apigenin/flavone-mediated GABA-A modulation",
+      "Nrf2 antioxidant signaling",
+      "PI3K/Akt signaling",
+      "apiol/myristicin activity in concentrated preparations."
     ],
     "description": "Conservative evidence framing applied.",
-    "activeCompounds": [
-      "Apigenin"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Culinary use is usually low risk, but high-dose extracts/essential oil may be unsafe; avoid concentrated use in pregnancy, kidney disease, and with anticoagulants/warfarin-sensitive vitamin K management unless supervised.",
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "significant kidney disease or unstable electrolytes",
+      "seizure disorder or sedative/alcohol use"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "culinary diuretic tradition",
+      "antioxidant"
     ]
   },
   {
     "slug": "grapefruit",
-    "name": "Grapefruit",
+    "name": "grapefruit",
+    "region": "Caribbean; global",
+    "primaryActions": [
+      "drug-interaction education",
+      "citrus flavonoid source",
+      "metabolic research"
+    ],
     "mechanisms": [
-      "AMPK activation",
-      "PI3K/Akt modulation",
-      "NF-κB inhibition"
+      "intestinal CYP3A4 mechanism-based inhibition by furanocoumarins",
+      "P-gp modulation",
+      "OATP transporter effects",
+      "naringin/naringenin flavonoid signaling"
     ],
     "description": "Conservative evidence framing applied.",
-    "activeCompounds": [
-      "Naringenin",
-      "Naringin"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Major food-drug interaction risk: can raise exposure of statins, calcium-channel blockers, immunosuppressants, antiarrhythmics, and other CYP3A4/OATP substrates.",
+    "interactions": [
+      "CYP3A4",
+      "P-gp",
+      "and OATP-mediated interactions",
+      "effects may persist beyond a single serving."
+    ],
+    "contraindications": [
+      "Avoid or medically supervise with drugs labeled for grapefruit interaction",
+      "narrow-therapeutic-index drugs",
+      "and complex cardiovascular/transplant regimens."
+    ],
+    "preparation": "Interaction risk varies by whole fruit, juice, cultivar, dose, and furanocoumarin content.",
+    "traditionalUses": [
+      "Citrus food and digestive/tonic use"
     ]
   },
   {
     "slug": "buckwheat",
-    "name": "Buckwheat",
+    "name": "buckwheat",
+    "region": "Eurasia food crop",
+    "primaryActions": [
+      "cardiometabolic food support",
+      "vascular/flavonoid support"
+    ],
     "mechanisms": [
-      "NF-κB inhibition",
-      "PI3K/Akt modulation"
+      "Rutin/quercetin polyphenol activity",
+      "endothelial nitric oxide signaling",
+      "α-glucosidase/α-amylase modulation",
+      "bile-acid and cholesterol metabolism effects",
+      "NF-κB and Nrf2 pathway modulation."
     ],
     "description": "Conservative evidence framing applied.",
-    "activeCompounds": [
-      "Rutin"
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "Food-level use is usually tolerated, but buckwheat allergy can be serious, including anaphylaxis; caution in known grain/pseudocereal allergy and when using concentrated extracts rather than food forms.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "antihypertensives/diuretics",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "cardiometabolic food",
+      "vascular/flavonoid"
     ]
   },
   {
     "slug": "black-tea",
-    "name": "Black Tea",
+    "name": "black tea",
+    "region": "China; India; global",
+    "primaryActions": [
+      "alertness/cognitive support",
+      "cardiometabolic polyphenol support",
+      "gut/antioxidant tea education"
+    ],
     "mechanisms": [
-      "NF-κB inhibition",
-      "MAPK pathway modulation",
-      "Nrf2 activation"
+      "theaflavin/catechin antioxidant signaling",
+      "endothelial nitric oxide effects",
+      "lipid and blood-pressure pathway modulation"
     ],
     "description": "Conservative evidence framing applied.",
-    "activeCompounds": [
-      "Theaflavin",
-      "Thearubigin"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Caffeine-related insomnia/anxiety/reflux possible; caution with stimulants, iron absorption, and anticoagulant-sensitive users.",
+    "interactions": [
+      "May interact with stimulants",
+      "sedatives",
+      "iron supplements",
+      "and some cardiovascular drugs."
+    ],
+    "contraindications": [
+      "Severe caffeine sensitivity",
+      "pregnancy caffeine limits",
+      "iron deficiency timing caution"
+    ],
+    "preparation": "Oxidized Camellia sinensis leaf infusion; theaflavin/thearubigin content varies with processing.",
+    "traditionalUses": [
+      "Beverage",
+      "alertness",
+      "digestion",
+      "social/ritual use"
     ]
   },
   {
     "slug": "grape",
-    "name": "Grape",
+    "name": "grape",
+    "region": "Mediterranean; global",
+    "primaryActions": [
+      "polyphenol vascular support",
+      "antioxidant fruit/seed support",
+      "resveratrol/OPC education"
+    ],
     "mechanisms": [
-      "SIRT1 activation",
-      "AMPK activation",
-      "NF-κB inhibition",
-      "PPAR activation"
+      "proanthocyanidin endothelial nitric-oxide signaling",
+      "antioxidant/NF-κB modulation",
+      "platelet and lipid pathway effects"
     ],
     "description": "Conservative evidence framing applied.",
-    "activeCompounds": [
-      "Resveratrol",
-      "Pterostilbene"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May interact with anticoagulants/antiplatelets; GI effects possible; supplement dose varies widely.",
+    "interactions": [
+      "Potential additive bleeding risk with anticoagulants/antiplatelets",
+      "may modestly affect blood pressure."
+    ],
+    "contraindications": [
+      "Anticoagulant use without review",
+      "grape allergy",
+      "pregnancy supplement dosing without guidance"
+    ],
+    "preparation": "Fruit, juice, seed extract, skin extract, and wine-derived polyphenols differ substantially.",
+    "traditionalUses": [
+      "Food",
+      "wine",
+      "vascular and antioxidant nutrition"
     ]
   },
   {
     "slug": "blueberry",
-    "name": "Blueberry",
+    "name": "blueberry",
+    "region": "North America; Europe",
+    "primaryActions": [
+      "anthocyanin antioxidant support",
+      "vascular/cognitive nutrition education",
+      "metabolic support research"
+    ],
     "mechanisms": [
-      "AMPK activation",
-      "PPAR activation"
+      "Anthocyanin-polyphenol activity",
+      "endothelial nitric oxide signaling",
+      "Nrf2 antioxidant response",
+      "NF-κB inflammatory modulation",
+      "AMPK and PPAR-related metabolic signaling."
     ],
     "description": "Conservative evidence framing applied.",
-    "activeCompounds": [
-      "Pterostilbene"
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "Food-level use is usually low risk; concentrated extracts may affect glucose or platelet-related endpoints in sensitive users; caution with anticoagulant/antiplatelet therapy, diabetes medication, allergy, and kidney-restricted diets if high-potassium products are used.",
+    "interactions": [
+      "Potential additive effects with antidiabetics or anticoagulants in concentrated extracts."
+    ],
+    "contraindications": [
+      "Anticoagulant use without review for high-dose extracts",
+      "diabetes medication monitoring if large intake changes"
+    ],
+    "preparation": "Whole berries, juice, powder, freeze-dried extracts, anthocyanin-rich concentrates.",
+    "traditionalUses": [
+      "Food berry and urinary/vascular folk nutrition"
     ]
   },
   {
     "slug": "soybean",
-    "name": "Soybean",
+    "name": "soybean",
+    "region": "East Asia",
+    "primaryActions": [
+      "isoflavone menopause support",
+      "cardiometabolic nutrition",
+      "phytoestrogen education"
+    ],
     "mechanisms": [
-      "estrogen receptor modulation",
-      "PI3K/Akt modulation",
-      "MAPK pathway modulation",
-      "NF-κB inhibition"
+      "isoflavone estrogen-receptor modulation",
+      "lipid metabolism and bone-turnover signaling",
+      "antioxidant pathways"
     ],
     "description": "Conservative evidence framing applied.",
-    "activeCompounds": [
-      "Genistein",
-      "Daidzein",
-      "Biochanin A"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Caution in hormone-sensitive conditions and with thyroid medication timing; allergy possible.",
+    "interactions": [
+      "May affect levothyroxine absorption timing",
+      "review with hormone therapies and anticoagulants if diet changes are large."
+    ],
+    "contraindications": [
+      "Soy allergy",
+      "hormone-sensitive conditions without clinician review",
+      "thyroid medication timing caution"
+    ],
+    "preparation": "Whole soy foods, protein isolate, isoflavone extracts; fermented/nonfermented forms differ.",
+    "traditionalUses": [
+      "East Asian food and nutrition use"
     ]
   },
   {
     "slug": "raspberry-leaf",
-    "name": "Raspberry Leaf",
+    "name": "raspberry leaf",
+    "region": "Europe; North America",
+    "primaryActions": [
+      "pregnancy/labor traditional education",
+      "uterine tonic traditional use",
+      "mineral-rich astringent support"
+    ],
     "mechanisms": [
-      "Nrf2 activation",
-      "NF-κB inhibition"
+      "Uterine smooth-muscle tone modulation",
+      "calcium-channel/oxytocin-related uterine signaling uncertainty",
+      "tannin/polyphenol NF-κB and Nrf2 modulation."
     ],
     "description": "Conservative evidence framing applied.",
-    "activeCompounds": [
-      "Ellagic acid"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Use during pregnancy only with obstetric supervision; avoid in high-risk pregnancy, preterm labor risk, prior uterine surgery concerns, bleeding disorders, or concurrent uterotonic/labor-inducing agents unless directed by a clinician.",
+    "interactions": [
+      "Limited interaction data",
+      "caution with uterotonic agents or sedatives if blended products."
+    ],
+    "contraindications": [
+      "High-risk pregnancy",
+      "early pregnancy without clinician guidance",
+      "history of preterm labor"
+    ],
+    "preparation": "Leaf tea/infusion, tablets, tincture; fruit is a separate food entry.",
+    "traditionalUses": [
+      "Women’s reproductive tonic",
+      "pregnancy/labor folk use",
+      "astringent diarrhea support"
     ]
   },
   {
     "slug": "angelica-sinensis",
-    "name": "Angelica sinensis",
-    "mechanisms": [
-      "Nrf2 activation",
-      "PI3K/Akt modulation",
-      "voltage-gated calcium channel modulation",
-      "NF-κB inhibition",
-      "MAPK pathway modulation"
-    ],
-    "description": "Angelica sinensis is typically used for antioxidant and nootropic support, with effects depending on dose and extract profile. It is commonly discussed around Ferulic acid and Ligustilide, while human evidence remains mixed across indications.",
-    "activeCompounds": [
-      "Ferulic acid",
-      "Ligustilide",
-      "Senkyunolide A",
-      "Butylidenephthalide"
-    ],
-    "interactions": [
-      "anticoagulants/antiplatelets"
-    ],
-    "preparation": "Roots sliced, dried, decocted or tinctured; often used in TCM formulas",
+    "name": "angelica sinensis",
+    "region": "China / Traditional Chinese Medicine",
     "primaryActions": [
-      "antioxidant",
-      "nootropic"
+      "women's health traditional use",
+      "circulation support",
+      "menstrual comfort research"
+    ],
+    "mechanisms": [
+      "ligustilide/ferulic-acid smooth-muscle and vascular effects",
+      "platelet-modulating activity",
+      "estrogen-receptor-related signaling",
+      "NF-κB modulation"
+    ],
+    "description": "Conservative evidence framing applied.",
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Bleeding, photosensitivity, and hormone-sensitive-condition cautions are central. Avoid in pregnancy unless medically directed.",
+    "interactions": [
+      "Potential additive bleeding risk with anticoagulants",
+      "antiplatelets",
+      "NSAIDs",
+      "and some herbal blood-thinning stacks."
+    ],
+    "contraindications": [
+      "Pregnancy",
+      "bleeding disorders",
+      "hormone-sensitive conditions",
+      "surgery",
+      "and anticoagulant/antiplatelet therapy without supervision."
+    ],
+    "preparation": "Evidence often comes from traditional formulas; single-herb confidence should remain conservative.",
+    "traditionalUses": [
+      "women's health traditional use",
+      "circulation",
+      "menstrual comfort"
     ]
   },
   {
     "slug": "rice-bran",
-    "name": "Rice Bran",
+    "name": "rice bran",
+    "region": "Asia / global food crop",
+    "primaryActions": [
+      "lipid/metabolic food support",
+      "antioxidant tocotrienol support"
+    ],
     "mechanisms": [
-      "Nrf2 activation",
-      "PI3K/Akt modulation"
+      "γ-oryzanol and phytosterol effects on cholesterol absorption",
+      "bile-acid excretion and lipid metabolism modulation",
+      "AMPK/PPAR metabolic signaling",
+      "Nrf2 antioxidant response",
+      "dietary fiber/prebiotic effects."
     ],
     "description": "Conservative evidence framing applied.",
-    "activeCompounds": [
-      "Ferulic acid"
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "Usually food-derived, but bran products can cause GI effects and may carry contaminant concerns if poorly sourced; use caution with diabetes medications, lipid-lowering therapy, grain allergy, and products lacking contaminant/heavy-metal quality controls.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "lipid/metabolic food",
+      "antioxidant tocotrienol"
     ]
   },
   {
     "slug": "coffee",
-    "name": "Coffee",
+    "name": "coffee",
+    "region": "Ethiopia; Middle East; global",
+    "primaryActions": [
+      "alertness/cognitive support",
+      "metabolic/ergogenic nutrition",
+      "antioxidant beverage support"
+    ],
     "mechanisms": [
-      "AMPK activation",
-      "glucose metabolism modulation",
-      "NF-κB inhibition",
-      "MAPK pathway modulation",
-      "Nrf2 activation"
+      "chlorogenic-acid AMPK/glucose-metabolism effects",
+      "caffeine adenosine-receptor antagonism",
+      "endothelial and antioxidant signaling"
     ],
-    "description": "Coffee is typically used as a supplemental botanical with context-dependent effects. It is commonly discussed around Chlorogenic acid and Caffeic acid, while human evidence remains mixed across indications.",
-    "activeCompounds": [
-      "Chlorogenic acid",
-      "Caffeic acid",
-      "trigonelline"
+    "description": "Conservative evidence framing applied.",
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Caffeine can worsen insomnia, anxiety, reflux, palpitations, and hypertension in sensitive users; pregnancy dose limits apply.",
+    "interactions": [
+      "May interact with stimulants",
+      "sedatives",
+      "beta-agonists",
+      "lithium",
+      "and CYP1A2 substrates."
     ],
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan"
+    "contraindications": [
+      "Severe caffeine sensitivity",
+      "uncontrolled arrhythmia/anxiety",
+      "pregnancy caffeine limits"
+    ],
+    "preparation": "Brewed coffee, espresso, decaf, green coffee extract; caffeine/chlorogenic acid content varies.",
+    "traditionalUses": [
+      "Beverage stimulant and social/ritual use"
+    ]
   },
   {
     "slug": "cnidium-monnieri",
-    "name": "Cnidium monnieri",
+    "name": "cnidium monnieri",
+    "region": "East Asia",
+    "primaryActions": [
+      "skin/sexual health traditional use",
+      "coumarin pathway research"
+    ],
     "mechanisms": [
       "PDE4 inhibition",
       "PI3K/Akt modulation",
@@ -4102,33 +7148,62 @@
       "MAPK pathway modulation"
     ],
     "description": "Cnidium monnieri lean monograph row enriched in bulk mode.",
-    "activeCompounds": [
-      "Osthole",
-      "Imperatorin",
-      "Isoimperatorin"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "May affect bleeding risk or circulation. Use caution with anticoagulants/antiplatelets and before surgery.",
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "anticoagulants/antiplatelets",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "Seeds (She Chuang Zi) decocted or powdered; used in Traditional Chinese Medicine, topically or internally",
-    "primaryActions": [
-      "antioxidant",
-      "nootropic",
-      "antimicrobial"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "bleeding disorder or upcoming surgery"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "skin/sexual health traditional use",
+      "coumarin pathway"
     ]
   },
   {
     "slug": "angelica-pubescens",
-    "name": "Angelica pubescens",
+    "name": "angelica pubescens",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "joint/pain traditional use",
+      "coumarin safety education"
+    ],
     "mechanisms": [
       "PDE4 inhibition",
       "PI3K/Akt modulation"
     ],
     "description": "Angelica pubescens lean monograph row enriched in bulk mode.",
-    "activeCompounds": [
-      "Osthole"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "May affect bleeding risk or circulation. Use caution with anticoagulants/antiplatelets and before surgery.",
+    "interactions": [
+      "Potential interaction concern with anticoagulants/antiplatelets",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "bleeding disorder or upcoming surgery"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "joint/pain traditional use",
+      "coumarin safety"
     ]
   },
   {
     "slug": "angelica-dahurica",
-    "name": "Angelica dahurica",
+    "name": "angelica dahurica",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "headache/sinus traditional use",
+      "furanocoumarin safety education"
+    ],
     "mechanisms": [
       "acetylcholinesterase inhibition",
       "voltage-gated calcium channel modulation",
@@ -4136,92 +7211,202 @@
       "PDE inhibition"
     ],
     "description": "Angelica dahurica lean monograph row enriched in bulk mode.",
-    "activeCompounds": [
-      "Imperatorin",
-      "Isoimperatorin",
-      "Xanthotoxin"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "May affect bleeding risk or circulation. Use caution with anticoagulants/antiplatelets and before surgery.",
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "anticoagulants/antiplatelets",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "bleeding disorder or upcoming surgery"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "headache/sinus traditional use",
+      "furanocoumarin safety"
     ]
   },
   {
     "slug": "psoralea-corylifolia",
-    "name": "Psoralea corylifolia",
+    "name": "psoralea corylifolia",
+    "region": "South Asia / East Asia",
+    "primaryActions": [
+      "skin-pigmentation traditional use",
+      "bone/metabolic research",
+      "high-caution safety education"
+    ],
     "mechanisms": [
-      "estrogen receptor modulation",
-      "MAPK pathway modulation",
-      "NF-κB inhibition"
+      "psoralen/isopsoralen furanocoumarin photosensitization",
+      "estrogenic signaling",
+      "CYP interaction potential",
+      "oxidative-stress and inflammatory-pathway modulation"
     ],
     "description": "Psoralea corylifolia lean monograph row enriched in bulk mode.",
-    "activeCompounds": [
-      "Psoralen",
-      "Angelicin",
-      "Bergapten"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "High caution: photosensitivity, burns, hepatotoxicity reports, and interaction risks. Avoid unsupervised internal use or UV exposure after use.",
+    "interactions": [
+      "Avoid with photosensitizing drugs",
+      "hepatotoxic drugs",
+      "anticoagulants",
+      "and hormone-active therapies unless supervised."
+    ],
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "liver disease",
+      "photosensitivity disorders",
+      "melanoma/skin-cancer risk",
+      "and concurrent phototherapy unless supervised."
+    ],
+    "preparation": "Therapeutic use requires controlled dosing and light-exposure management; crude supplements are not interchangeable with monitored phototherapy.",
+    "traditionalUses": [
+      "skin-pigmentation traditional use",
+      "bone/metabolic",
+      "high-caution safety"
     ]
   },
   {
     "slug": "ficus-carica",
-    "name": "Ficus carica",
+    "name": "ficus carica",
+    "region": "Mediterranean / Western Asia",
+    "primaryActions": [
+      "digestive/food support",
+      "antioxidant pathway education"
+    ],
     "mechanisms": [
-      "estrogen receptor modulation",
-      "MAPK pathway modulation"
+      "Polyphenol-mediated NF-κB/MAPK modulation",
+      "latex protease activity",
+      "antioxidant pathway support",
+      "estrogen-receptor activity remains uncertain."
     ],
     "description": "Ficus carica lean monograph row enriched in bulk mode.",
-    "activeCompounds": [
-      "Psoralen"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Fig latex can trigger allergy or skin irritation; caution with latex/fruit allergy, diabetes medications, anticoagulants, pregnancy/breastfeeding, and concentrated latex or leaf extracts.",
+    "interactions": [
+      "Potential interaction concern with hormonal therapies",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "hormone-sensitive conditions without clinician review"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "digestive/food",
+      "antioxidant pathway"
     ]
   },
   {
     "slug": "angelica-archangelica",
-    "name": "Angelica archangelica",
+    "name": "angelica archangelica",
+    "region": "Europe traditional herbalism",
+    "primaryActions": [
+      "digestive aromatic support",
+      "coumarin safety education"
+    ],
     "mechanisms": [
       "NF-κB inhibition",
       "MAPK pathway modulation",
       "Nrf2 activation"
     ],
     "description": "Angelica archangelica lean monograph row enriched in bulk mode.",
-    "activeCompounds": [
-      "Angelicin",
-      "Umbelliferone"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "May affect bleeding risk or circulation. Use caution with anticoagulants/antiplatelets and before surgery.",
+    "interactions": [
+      "Potential interaction concern with anticoagulants/antiplatelets",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "Roots and seeds decocted, used in tinctures, or added to liquors and tonics",
-    "primaryActions": [
-      "sedative",
-      "antioxidant",
-      "digestive support"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "bleeding disorder or upcoming surgery"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "digestive aromatic",
+      "coumarin safety"
     ]
   },
   {
     "slug": "citrus-bergamia",
-    "name": "Citrus bergamia",
+    "name": "citrus bergamia",
+    "region": "Mediterranean / Italy",
+    "primaryActions": [
+      "lipid/cardiometabolic support education",
+      "flavonoid pathway research"
+    ],
     "mechanisms": [
-      "MAPK pathway modulation",
-      "NF-κB inhibition"
+      "Bergamot flavonoid/polyphenol signaling",
+      "HMG-CoA reductase–related cholesterol synthesis modulation",
+      "AMPK activation",
+      "LDL receptor expression support",
+      "endothelial nitric oxide and NF-κB modulation."
     ],
     "description": "Citrus bergamia lean monograph row enriched in bulk mode.",
-    "activeCompounds": [
-      "Bergapten"
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "Clinically relevant caution: bergamot extracts may cause GI upset; photosensitizing furocoumarins can be present in some citrus preparations; use caution with statins/lipid-lowering therapy, CYP-interacting drugs, pregnancy/breastfeeding, and liver disease unless supervised.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "antihypertensives/diuretics",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "lipid/cardiometabolic",
+      "flavonoid pathway"
     ]
   },
   {
     "slug": "morinda-citrifolia",
-    "name": "Morinda citrifolia",
+    "name": "morinda citrifolia",
+    "region": "Pacific Islands / Southeast Asia",
+    "primaryActions": [
+      "immune/metabolic traditional use",
+      "liver-safety education"
+    ],
     "mechanisms": [
-      "NF-κB inhibition",
-      "voltage-gated calcium channel modulation"
+      "NF-κB/COX inflammatory modulation",
+      "Nrf2-related antioxidant signaling",
+      "potassium-rich juice electrolyte effects",
+      "AKT/NF-κB signaling reported in preclinical contexts."
     ],
     "description": "Morinda citrifolia lean monograph row enriched in bulk mode.",
-    "activeCompounds": [
-      "Scopoletin"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Noni has case reports of liver injury and can be high in potassium; avoid or use caution with liver disease, kidney disease, ACE inhibitors/ARBs, potassium-sparing diuretics, warfarin-sensitive regimens, pregnancy, and breastfeeding.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "Fruit juice fermented or taken fresh; commonly called noni; used in Polynesian medicine",
-    "primaryActions": [
-      "anti-inflammatory",
-      "immunomodulatory",
-      "antioxidant"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "active liver disease"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "immune/metabolic traditional use",
+      "liver-safety"
     ]
   },
   {
     "slug": "artemisia-capillaris",
-    "name": "Artemisia capillaris",
+    "name": "artemisia capillaris",
+    "region": "East Asia",
+    "primaryActions": [
+      "liver/bile traditional use",
+      "coumarin/flavonoid pathway research"
+    ],
     "mechanisms": [
       "NF-κB inhibition",
       "voltage-gated calcium channel modulation",
@@ -4229,166 +7414,359 @@
       "Nrf2 activation"
     ],
     "description": "Artemisia capillaris lean monograph row enriched in bulk mode.",
-    "activeCompounds": [
-      "Scopoletin",
-      "Esculetin",
-      "Fraxetin"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "May affect bleeding risk or circulation. Use caution with anticoagulants/antiplatelets and before surgery.",
+    "interactions": [
+      "Potential interaction concern with anticoagulants/antiplatelets",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "active liver disease",
+      "bleeding disorder or upcoming surgery"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "liver/bile traditional use",
+      "coumarin/flavonoid pathway"
     ]
   },
   {
     "slug": "cichorium-intybus",
-    "name": "Cichorium intybus",
+    "name": "cichorium intybus",
+    "region": "Europe / Mediterranean",
+    "primaryActions": [
+      "prebiotic/gut support",
+      "metabolic support education"
+    ],
     "mechanisms": [
-      "5-lipoxygenase inhibition",
-      "NF-κB inhibition"
+      "Inulin-type fructan prebiotic fermentation to short-chain fatty acids",
+      "bile-acid and lipid metabolism modulation",
+      "Bifidobacterium enrichment",
+      "NF-κB inflammatory modulation",
+      "5-lipoxygenase-related signaling."
     ],
     "description": "Cichorium intybus lean monograph row enriched in bulk mode.",
-    "activeCompounds": [
-      "Esculetin"
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "Inulin/chicory can cause gas, bloating, diarrhea, or IBS/FODMAP intolerance; allergy risk exists in Asteraceae-sensitive users; caution with pregnancy/breastfeeding, gallbladder disease, and diabetes medications when using concentrated products.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "prebiotic/gut",
+      "metabolic"
+    ]
   },
   {
     "slug": "fraxinus-rhynchophylla",
-    "name": "Fraxinus rhynchophylla",
+    "name": "fraxinus rhynchophylla",
+    "region": "East Asia",
+    "primaryActions": [
+      "inflammatory pathway research",
+      "coumarin safety education"
+    ],
     "mechanisms": [
       "Nrf2 activation",
       "NF-κB inhibition"
     ],
     "description": "Fraxinus rhynchophylla lean monograph row enriched in bulk mode.",
-    "activeCompounds": [
-      "Fraxetin"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "May affect bleeding risk or circulation. Use caution with anticoagulants/antiplatelets and before surgery.",
+    "interactions": [
+      "Potential interaction concern with anticoagulants/antiplatelets",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "bleeding disorder or upcoming surgery"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "inflammatory pathway",
+      "coumarin safety"
     ]
   },
   {
     "slug": "coriandrum-sativum",
-    "name": "Coriandrum sativum",
+    "name": "coriandrum sativum",
+    "region": "Mediterranean / South Asia",
+    "primaryActions": [
+      "digestive support",
+      "lipid/glucose education"
+    ],
     "mechanisms": [
-      "Nrf2 activation",
-      "MAPK pathway modulation"
+      "Linalool-mediated GABA-A/glutamatergic modulation",
+      "α-glucosidase and insulin-signaling effects",
+      "Nrf2 and MAPK pathway modulation."
     ],
     "description": "Coriandrum sativum lean monograph row enriched in bulk mode.",
-    "activeCompounds": [
-      "Umbelliferone"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Culinary use is usually low risk; concentrated extracts may affect glucose or sedation; caution with Apiaceae allergy, diabetes medications, sedatives, pregnancy/breastfeeding, and perioperative use.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "seizure disorder or sedative/alcohol use"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "digestive",
+      "lipid/glucose"
     ]
   },
   {
     "slug": "daphne-odora",
-    "name": "Daphne odora",
+    "name": "daphne odora",
+    "region": "East Asia",
+    "primaryActions": [
+      "topical/traditional use only",
+      "high-toxicity safety education"
+    ],
     "mechanisms": [
       "JAK/STAT inhibition",
       "NF-κB inhibition"
     ],
     "description": "Daphne odora lean monograph row enriched in bulk mode.",
-    "activeCompounds": [
-      "Daphnetin"
+    "safetyNotes": "High-caution plant; toxic diterpenes/coumarin-related constituents may irritate skin and mucosa. Avoid internal supplement use outside expert supervision.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "topical/traditional use only",
+      "high-toxicity safety"
     ]
   },
   {
     "slug": "stellera-chamaejasme",
-    "name": "Stellera chamaejasme",
+    "name": "stellera chamaejasme",
+    "region": "East/Central Asia",
+    "primaryActions": [
+      "traditional external-use research",
+      "high-toxicity safety education"
+    ],
     "mechanisms": [
       "JAK/STAT inhibition",
       "NF-κB inhibition"
     ],
     "description": "Stellera chamaejasme lean monograph row enriched in bulk mode.",
-    "activeCompounds": [
-      "Daphnetin"
+    "safetyNotes": "High-caution plant; toxic diterpenoid constituents and irritant effects are possible. Avoid internal supplement use outside expert supervision.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "traditional external-use",
+      "high-toxicity safety"
     ]
   },
   {
     "slug": "sophora-alopecuroides",
-    "name": "Sophora alopecuroides",
+    "name": "sophora alopecuroides",
+    "region": "Central/East Asia",
+    "primaryActions": [
+      "alkaloid antimicrobial pathway research",
+      "toxicity education"
+    ],
     "mechanisms": [
       "PI3K/Akt modulation",
       "NF-κB inhibition",
       "TGF-β signaling modulation"
     ],
     "description": "Sophora alopecuroides lean monograph row enriched in bulk mode.",
-    "activeCompounds": [
-      "Matrine",
-      "Oxymatrine"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Alkaloid-rich herb with toxicity concerns. Avoid pregnancy/breastfeeding and avoid unsupervised high-dose or long-term use.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "alkaloid antimicrobial pathway",
+      "toxicity"
     ]
   },
   {
     "slug": "stephania-tetrandra",
-    "name": "Stephania tetrandra",
+    "name": "stephania tetrandra",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "inflammatory pathway research",
+      "alkaloid safety education"
+    ],
     "mechanisms": [
       "voltage-gated calcium channel modulation",
       "NF-κB inhibition"
     ],
     "description": "Stephania tetrandra lean monograph row enriched in bulk mode.",
-    "activeCompounds": [
-      "Tetrandrine"
+    "safetyNotes": "Alkaloid-rich herb; species substitution and nephrotoxicity/adulteration concerns require caution. Avoid pregnancy and unsupervised use.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "Root decocted in TCM (Han Fang Ji); used for edema, inflammation, and hypertension",
-    "primaryActions": [
-      "anti-inflammatory",
-      "antioxidant",
-      "nootropic"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "inflammatory pathway",
+      "alkaloid safety"
     ]
   },
   {
     "slug": "cyclea-peltata",
-    "name": "Cyclea peltata",
+    "name": "cyclea peltata",
+    "region": "South/Southeast Asia traditional medicine",
+    "primaryActions": [
+      "traditional anti-inflammatory use",
+      "alkaloid safety education"
+    ],
     "mechanisms": [
       "voltage-gated calcium channel modulation",
       "NF-κB inhibition"
     ],
     "description": "Cyclea peltata lean monograph row enriched in bulk mode.",
-    "activeCompounds": [
-      "Tetrandrine"
+    "safetyNotes": "Alkaloid-rich traditional herb; human safety data are limited. Avoid pregnancy/breastfeeding and unsupervised high-dose use.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "traditional anti-inflammatory use",
+      "alkaloid safety"
     ]
   },
   {
     "slug": "stephania-cepharantha",
-    "name": "Stephania cepharantha",
+    "name": "stephania cepharantha",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "alkaloid pathway research",
+      "safety education"
+    ],
     "mechanisms": [
       "NF-κB inhibition",
       "PI3K/Akt modulation"
     ],
     "description": "Stephania cepharantha lean monograph row enriched in bulk mode.",
-    "activeCompounds": [
-      "Cepharanthine"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Alkaloid-rich herb; species substitution and nephrotoxicity/adulteration concerns require caution. Avoid pregnancy and unsupervised use.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "No direct preparation data. Contextual inference: Traditionally used in chinese medicine for inflammation and pain relief. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Traditionally used in Chinese medicine for inflammation and pain relief. No direct region data. Contextual inference: Traditionally used in chinese medicine for inflammation and pain relief. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Traditionally used in Chinese medicine for inflammation and pain relief. none. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "antioxidant",
-      "nootropic",
-      "analgesic"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "alkaloid pathway",
+      "safety"
     ]
   },
   {
     "slug": "stephania-japonica",
-    "name": "Stephania japonica",
+    "name": "stephania japonica",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "traditional anti-inflammatory use",
+      "alkaloid safety education"
+    ],
     "mechanisms": [
       "NF-κB inhibition",
       "PI3K/Akt modulation"
     ],
     "description": "Stephania japonica lean monograph row enriched in bulk mode.",
-    "activeCompounds": [
-      "Cepharanthine"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Alkaloid-rich herb; species substitution and nephrotoxicity/adulteration concerns require caution. Avoid pregnancy and unsupervised use.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "traditional anti-inflammatory use",
+      "alkaloid safety"
     ]
   },
   {
     "slug": "nelumbo-nucifera",
-    "name": "Nelumbo nucifera",
+    "name": "nelumbo nucifera",
+    "region": "South/East Asia",
+    "primaryActions": [
+      "metabolic/calm tradition",
+      "polyphenol and alkaloid pathway research"
+    ],
     "mechanisms": [
       "AMPK activation",
       "NF-κB inhibition"
     ],
     "description": "Nelumbo nucifera lean monograph row enriched in bulk mode.",
-    "activeCompounds": [
-      "Magnoflorine"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "May lower blood glucose or alter metabolic markers; monitor with diabetes medications and avoid unsupervised use during pregnancy.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "No direct preparation data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... No direct mechanismofaction data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... Used in Ayurveda and Buddhist practices for calm and devotion.. No direct effects data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... No direct mechanismofaction data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... Used in Ayurveda and Buddhist practices for calm and devotion.. Used in Ayurveda and Buddhist practices for calm and devotion.. No direct region data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... No direct mechanismofaction data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... Used in Ayurveda and Buddhist practices for calm and devotion.. No direct effects data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... No direct mechanismofaction data. Contextual inference: Used in ayurveda and buddhist practices for calm and devotion... Used in Ayurveda and Buddhist practices for calm and devotion.. Used in Ayurveda and Buddhist practices for calm and devotion.. Used in Ayurveda and Buddhist practices for calm and devotion.. Used in Ayurveda and Buddhist practices for calm and devotion",
-    "primaryActions": [
-      "anxiolytic"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "metabolic/calm tradition",
+      "polyphenol and alkaloid pathway"
     ]
   },
   {
     "slug": "ligusticum-chuanxiong",
-    "name": "Ligusticum chuanxiong",
+    "name": "ligusticum chuanxiong",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "circulation/headache traditional use",
+      "platelet/vasodilation safety education"
+    ],
     "mechanisms": [
       "voltage-gated calcium channel modulation",
       "NF-κB inhibition",
@@ -4396,321 +7774,552 @@
       "PI3K/Akt modulation"
     ],
     "description": "Ligusticum chuanxiong lean monograph row enriched in bulk mode.",
-    "activeCompounds": [
-      "Ligustilide",
-      "Senkyunolide A",
-      "Butylidenephthalide"
-    ],
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "May affect bleeding risk or circulation. Use caution with anticoagulants/antiplatelets and before surgery.",
     "interactions": [
-      "anticoagulants/antiplatelets"
+      "Potential interaction concern with antihypertensives/diuretics",
+      "anticoagulants/antiplatelets",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "No direct preparation data. Contextual inference: Invigorates blood, relieves pain; key herb in tcm. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Invigorates blood, relieves pain; key herb in TCM. No direct region data. Contextual inference: Invigorates blood, relieves pain; key herb in tcm. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Invigorates blood, relieves pain; key herb in TCM. none. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "antioxidant",
-      "nootropic",
-      "analgesic"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "bleeding disorder or upcoming surgery"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "circulation/headache traditional use",
+      "platelet/vasodilation safety"
     ]
   },
   {
     "slug": "pastinaca-sativa",
-    "name": "Pastinaca sativa",
+    "name": "pastinaca sativa",
+    "region": "Europe/West Asia",
+    "primaryActions": [
+      "culinary/root support",
+      "furanocoumarin safety education"
+    ],
     "mechanisms": [
       "MAPK pathway modulation",
       "PDE inhibition"
     ],
     "description": "Pastinaca sativa lean monograph row enriched in bulk mode.",
-    "activeCompounds": [
-      "Xanthotoxin"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "May affect bleeding risk or circulation. Use caution with anticoagulants/antiplatelets and before surgery.",
+    "interactions": [
+      "Potential interaction concern with anticoagulants/antiplatelets",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "bleeding disorder or upcoming surgery"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "culinary/root",
+      "furanocoumarin safety"
     ]
   },
   {
     "slug": "boswellia-serrata",
-    "name": "Boswellia serrata",
+    "name": "boswellia serrata",
+    "region": "India; Arabian Peninsula",
+    "primaryActions": [
+      "joint comfort support",
+      "inflammatory pathway modulation",
+      "gut inflammation education"
+    ],
     "mechanisms": [
-      "5-lipoxygenase inhibition",
-      "NF-κB inhibition",
-      "MAPK pathway modulation"
+      "AKBA/boswellic-acid 5-lipoxygenase inhibition",
+      "leukotriene reduction",
+      "NF-κB and MMP inflammatory-pathway modulation"
     ],
     "description": "Boswellia serrata contains Boswellic acid and is linked here to 5-lipoxygenase inhibition.",
-    "activeCompounds": [
-      "Boswellic acid",
-      "Acetyl-beta-boswellic acid",
-      "11-keto-beta-boswellic acid",
-      "Acetyl-11-keto-beta-boswellic acid"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "GI effects possible; caution with anticoagulants/antiplatelets and pregnancy; product standardization matters.",
+    "interactions": [
+      "Potential additive effects with anti-inflammatory drugs",
+      "anticoagulants",
+      "and immunomodulators."
     ],
-    "preparation": "Resin (frankincense) collected and used in capsules, extracts, or chewed directly",
-    "primaryActions": [
-      "anti-inflammatory",
-      "antioxidant",
-      "nootropic"
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "anticoagulant use without review"
+    ],
+    "preparation": "Resin extracts standardized to boswellic acids/AKBA; gum resin and extract potency differ.",
+    "traditionalUses": [
+      "Ayurvedic joint",
+      "respiratory",
+      "and inflammatory support"
     ]
   },
   {
     "slug": "valeriana-officinalis",
-    "name": "Valeriana officinalis",
+    "name": "valeriana officinalis",
+    "region": "Europe; Western herbalism",
+    "primaryActions": [
+      "sleep latency support",
+      "relaxation support",
+      "mild anxiety symptom education"
+    ],
     "mechanisms": [
-      "GABA-A modulation",
-      "voltage-gated calcium channel modulation",
-      "MAPK pathway modulation"
+      "valerenic-acid GABA-A receptor modulation",
+      "GABA degradation/transport effects",
+      "adenosine and serotonergic sleep-pathway modulation"
     ],
     "description": "Valeriana officinalis contains Valerenic acid and is linked here to GABA-A modulation.",
-    "activeCompounds": [
-      "Valerenic acid",
-      "Valerenol",
-      "Valepotriates"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Sedation and next-day drowsiness possible; avoid alcohol, benzodiazepines, opioids, and other CNS depressants.",
+    "interactions": [
+      "May potentiate alcohol",
+      "benzodiazepines",
+      "barbiturates",
+      "sleep aids",
+      "opioids",
+      "and other CNS depressants."
     ],
-    "preparation": "Root dried and used in teas, tinctures, or capsules; sedative and anxiolytic properties",
-    "primaryActions": [
-      "anxiolytic",
-      "sedative",
-      "antioxidant"
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "heavy sedative use",
+      "upcoming anesthesia"
     ],
-    "affiliateProducts": [
-      {
-        "name": "Valerian Tea",
-        "type": "tea",
-        "affiliateUrl": "https://www.amazon.com/s?k=valeriana+officinalis+tea&tag=razzleberry02-20"
-      },
-      {
-        "name": "Valerian Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=valeriana+officinalis+extract&tag=razzleberry02-20"
-      }
+    "preparation": "Root/rhizome tea, tincture, capsules, and standardized extracts; odor reflects volatile constituents.",
+    "traditionalUses": [
+      "European sleep and nervous-system herb"
     ]
   },
   {
     "slug": "piper-methysticum",
-    "name": "Piper methysticum",
+    "name": "piper methysticum",
+    "region": "Pacific Islands",
+    "primaryActions": [
+      "relaxation/anxiety support education",
+      "GABAergic pathway support"
+    ],
     "mechanisms": [
-      "GABA-A modulation",
-      "voltage-gated sodium channel modulation",
-      "CB1 receptor modulation",
-      "MAO-B inhibition"
+      "GABA-A receptor modulation",
+      "kavalactone effects on voltage-gated ion channels",
+      "MAO-B and glutamate-pathway modulation"
     ],
     "description": "Piper methysticum contains Kavalactones and is linked here to GABA-A modulation.",
-    "activeCompounds": [
-      "Kavalactones",
-      "Kavain",
-      "Yangonin",
-      "Methysticin"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Liver injury risk; avoid liver disease, alcohol, hepatotoxic drugs, and CNS depressants; avoid pregnancy/breastfeeding.",
+    "interactions": [
+      "Potential interaction concern with sedatives/CNS depressants",
+      "CYP/P-gp substrate medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "anxiolytic"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "active liver disease",
+      "seizure disorder or sedative/alcohol use"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "relaxation/anxiety",
+      "GABAergic pathway"
     ]
   },
   {
     "slug": "hypericum-perforatum",
-    "name": "Hypericum perforatum",
+    "name": "hypericum perforatum",
+    "region": "Europe traditional herbalism",
+    "primaryActions": [
+      "mood support education",
+      "CYP/P-gp interaction safety education"
+    ],
     "mechanisms": [
-      "TRPC6 channel modulation",
-      "monoamine reuptake inhibition",
-      "PKC modulation",
-      "apoptosis pathway modulation (caspase activation)"
+      "serotonin/norepinephrine/dopamine reuptake modulation",
+      "CYP3A4 and P-gp induction",
+      "hyperforin-mediated pregnane-X receptor activation"
     ],
     "description": "Hypericum perforatum contains Hyperforin and is linked here to TRPC6 channel modulation.",
-    "activeCompounds": [
-      "Hyperforin",
-      "Hypericin"
-    ],
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Major interaction risk: antidepressants, oral contraceptives, anticoagulants, antiretrovirals, transplant drugs, and many CYP/P-gp substrates.",
     "interactions": [
-      "anticoagulants/antiplatelets",
-      "serotonergic medications"
+      "Potential interaction concern with sedatives/CNS depressants",
+      "CYP/P-gp substrate medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "nootropic"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ],
-    "affiliateProducts": [
-      {
-        "name": "St Johns Wort Capsules",
-        "type": "capsule",
-        "affiliateUrl": "https://www.amazon.com/s?k=hypericum+perforatum+capsules&tag=razzleberry02-20"
-      },
-      {
-        "name": "St Johns Wort Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=hypericum+perforatum+extract&tag=razzleberry02-20"
-      }
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "mood",
+      "CYP/P-gp interaction safety"
     ]
   },
   {
     "slug": "plantago-major",
-    "name": "Plantago major",
+    "name": "plantago major",
+    "region": "Europe/Asia",
+    "primaryActions": [
+      "skin/mucosal traditional use",
+      "wound and anti-inflammatory pathway research"
+    ],
     "mechanisms": [
       "NF-κB inhibition",
       "MAPK pathway modulation"
     ],
     "description": "Plantago major contains Aucubin and is linked here to NF-κB inhibition.",
-    "activeCompounds": [
-      "Aucubin"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Immune-modulating activity is plausible; use caution with autoimmune disease, transplant medicines, or immunosuppressants.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "Leaves fresh or dried for teas, poultices, or tinctures; seeds also used for mucilage (demulcent)",
-    "primaryActions": [
-      "anti-inflammatory",
-      "antioxidant",
-      "nootropic"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "skin/mucosal traditional use",
+      "wound and anti-inflammatory pathway"
     ]
   },
   {
     "slug": "rehmannia-glutinosa",
-    "name": "Rehmannia glutinosa",
+    "name": "rehmannia glutinosa",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "kidney/liver tonic tradition",
+      "metabolic and inflammatory pathway research"
+    ],
     "mechanisms": [
       "PI3K/Akt modulation",
       "AMPK activation"
     ],
     "description": "Rehmannia glutinosa contains Catalpol and is linked here to PI3K/Akt modulation.",
-    "activeCompounds": [
-      "Catalpol"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "May lower blood glucose or alter metabolic markers; monitor with diabetes medications and avoid unsupervised use during pregnancy.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "active liver disease",
+      "significant kidney disease or unstable electrolytes"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "kidney/liver tonic tradition",
+      "metabolic and inflammatory pathway"
     ]
   },
   {
     "slug": "harpagophytum-procumbens",
-    "name": "Harpagophytum procumbens",
+    "name": "harpagophytum procumbens",
+    "region": "Southern Africa",
+    "primaryActions": [
+      "joint/pain support education",
+      "inflammatory pathway research"
+    ],
     "mechanisms": [
-      "COX inhibition",
-      "NF-κB inhibition"
+      "harpagoside-mediated COX/LOX inflammatory modulation",
+      "NF-κB inhibition",
+      "pain-signaling modulation"
     ],
     "description": "Harpagophytum procumbens contains Harpagoside and is linked here to COX inhibition.",
-    "activeCompounds": [
-      "Harpagoside"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Avoid/caution with ulcers, gallstones, anticoagulants, pregnancy, and significant GI disease.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "Dried root tubers decocted or powdered; available in capsules or teas (devil’s claw)",
-    "primaryActions": [
-      "anti-inflammatory",
-      "antioxidant",
-      "nootropic"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "joint/pain",
+      "inflammatory pathway"
     ]
   },
   {
     "slug": "cornus-officinalis",
-    "name": "Cornus officinalis",
+    "name": "cornus officinalis",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "metabolic/kidney tonic tradition",
+      "antioxidant pathway research"
+    ],
     "mechanisms": [
       "PI3K/Akt modulation",
       "Nrf2 activation"
     ],
     "description": "Cornus officinalis contains Loganin and is linked here to PI3K/Akt modulation.",
-    "activeCompounds": [
-      "Loganin",
-      "Morroniside"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "May lower blood glucose or alter metabolic markers; monitor with diabetes medications and avoid unsupervised use during pregnancy.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "Fruit decocted or dried and consumed in Traditional Chinese Medicine (Shan Zhu Yu); often paired with tonic herbs",
-    "primaryActions": [
-      "antioxidant",
-      "hepatoprotective",
-      "nootropic"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "significant kidney disease or unstable electrolytes"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "metabolic/kidney tonic tradition",
+      "antioxidant pathway"
     ]
   },
   {
     "slug": "cistanche-deserticola",
-    "name": "Cistanche deserticola",
+    "name": "cistanche deserticola",
+    "region": "China; Central Asia",
+    "primaryActions": [
+      "fatigue/vitality traditional support",
+      "cognition/neuroprotection research",
+      "bowel-moistening TCM use"
+    ],
     "mechanisms": [
       "PI3K/Akt modulation",
       "Nrf2 activation"
     ],
     "description": "Cistanche deserticola contains Echinacoside and is linked here to PI3K/Akt modulation.",
-    "activeCompounds": [
-      "Echinacoside"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Human evidence is limited; GI effects possible due to laxative/moistening traditional use.",
+    "interactions": [
+      "Limited clinical interaction data",
+      "caution with laxatives and glucose-lowering therapies."
     ],
-    "primaryActions": [
-      "antioxidant"
+    "contraindications": [
+      "Pregnancy/breastfeeding without guidance",
+      "diarrhea-prone conditions"
+    ],
+    "preparation": "Stem decoction, powder, and extracts standardized to echinacoside/acteoside.",
+    "traditionalUses": [
+      "TCM kidney-yang tonic",
+      "fatigue",
+      "bowel dryness"
     ]
   },
   {
     "slug": "verbena-officinalis",
-    "name": "Verbena officinalis",
+    "name": "verbena officinalis",
+    "region": "Europe/Mediterranean",
+    "primaryActions": [
+      "calming/digestive tradition",
+      "CNS pathway research"
+    ],
     "mechanisms": [
       "NF-κB inhibition",
       "MAPK pathway modulation"
     ],
     "description": "Verbena officinalis contains Acteoside and is linked here to NF-κB inhibition.",
-    "activeCompounds": [
-      "Acteoside"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "May cause drowsiness or impaired alertness. Avoid combining high-dose extracts with alcohol, sedatives, or other CNS depressants.",
+    "interactions": [
+      "Potential interaction concern with sedatives/CNS depressants",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "No direct preparation data. Contextual inference: Used in european folk medicine for anxiety and dreaming... No direct mechanismofaction data. Contextual inference: Used in european folk medicine for anxiety and dreaming... Used in European folk medicine for anxiety and dreaming.. No direct effects data. Contextual inference: Used in european folk medicine for anxiety and dreaming... No direct mechanismofaction data. Contextual inference: Used in european folk medicine for anxiety and dreaming... Used in European folk medicine for anxiety and dreaming.. Used in European folk medicine for anxiety and dreaming.. No direct region data. Contextual inference: Used in european folk medicine for anxiety and dreaming... No direct mechanismofaction data. Contextual inference: Used in european folk medicine for anxiety and dreaming... Used in European folk medicine for anxiety and dreaming.. No direct effects data. Contextual inference: Used in european folk medicine for anxiety and dreaming... No direct mechanismofaction data. Contextual inference: Used in european folk medicine for anxiety and dreaming... Used in European folk medicine for anxiety and dreaming.. Used in European folk medicine for anxiety and dreaming.. Used in European folk medicine for anxiety and dreaming.. Used in European folk medicine for anxiety and dreaming"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "calming/digestive tradition",
+      "CNS pathway"
+    ]
   },
   {
     "slug": "plantago-lanceolata",
-    "name": "Plantago lanceolata",
+    "name": "plantago lanceolata",
+    "region": "Europe/Asia",
+    "primaryActions": [
+      "respiratory/mucosal support tradition",
+      "anti-inflammatory pathway research"
+    ],
     "mechanisms": [
       "NF-κB inhibition",
       "MAPK pathway modulation"
     ],
     "description": "Plantago lanceolata contains Verbascoside and is linked here to NF-κB inhibition.",
-    "activeCompounds": [
-      "Verbascoside"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Immune-modulating activity is plausible; use caution with autoimmune disease, transplant medicines, or immunosuppressants.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "respiratory/mucosal tradition",
+      "anti-inflammatory pathway"
     ]
   },
   {
     "slug": "lithospermum-erythrorhizon",
-    "name": "Lithospermum erythrorhizon",
+    "name": "lithospermum erythrorhizon",
+    "region": "East Asia",
+    "primaryActions": [
+      "skin/wound traditional use",
+      "naphthoquinone pathway research"
+    ],
     "mechanisms": [
       "PKM2 inhibition",
       "NF-κB inhibition",
       "apoptosis pathway modulation (caspase activation)"
     ],
     "description": "Lithospermum erythrorhizon contains Shikonin and is linked here to PKM2 inhibition.",
-    "activeCompounds": [
-      "Shikonin",
-      "Acetylshikonin"
+    "safetyNotes": "Immune-modulating activity is plausible; use caution with autoimmune disease, transplant medicines, or immunosuppressants.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "skin/wound traditional use",
+      "naphthoquinone pathway"
     ]
   },
   {
     "slug": "plumbago-zeylanica",
-    "name": "Plumbago zeylanica",
+    "name": "plumbago zeylanica",
+    "region": "South Asia / Ayurveda",
+    "primaryActions": [
+      "digestive traditional use",
+      "high-irritancy/toxicity safety education"
+    ],
     "mechanisms": [
       "NF-κB inhibition",
       "STAT3 inhibition",
       "ROS-mediated signaling modulation"
     ],
     "description": "Plumbago zeylanica contains Plumbagin and is linked here to NF-κB inhibition.",
-    "activeCompounds": [
-      "Plumbagin"
+    "safetyNotes": "Irritant naphthoquinones may damage mucosa/skin at high exposure. Avoid pregnancy and internal high-dose use.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "digestive traditional use",
+      "high-irritancy/toxicity safety"
     ]
   },
   {
     "slug": "lawsonia-inermis",
-    "name": "Lawsonia inermis",
+    "name": "lawsonia inermis",
+    "region": "North Africa/Middle East/South Asia",
+    "primaryActions": [
+      "topical hair/skin use",
+      "dye/allergy safety education"
+    ],
     "mechanisms": [
       "MAPK pathway modulation",
       "NF-κB inhibition"
     ],
     "description": "Lawsonia inermis contains Lawsone and is linked here to MAPK pathway modulation.",
-    "activeCompounds": [
-      "Lawsone"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Immune-modulating activity is plausible; use caution with autoimmune disease, transplant medicines, or immunosuppressants.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "topical hair/skin use",
+      "dye/allergy safety"
     ]
   },
   {
     "slug": "embelia-ribes",
-    "name": "Embelia ribes",
+    "name": "embelia ribes",
+    "region": "South Asia / Ayurveda",
+    "primaryActions": [
+      "digestive/anthelmintic traditional use",
+      "benzoquinone pathway research"
+    ],
     "mechanisms": [
       "XIAP inhibition",
       "NF-κB inhibition"
     ],
     "description": "Embelia ribes contains Embelin and is linked here to XIAP inhibition.",
-    "activeCompounds": [
-      "Embelin"
+    "safetyNotes": "Immune-modulating activity is plausible; use caution with autoimmune disease, transplant medicines, or immunosuppressants.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "digestive/anthelmintic traditional use",
+      "benzoquinone pathway"
     ]
   },
   {
     "slug": "artemisia-absinthium",
-    "name": "Artemisia absinthium",
+    "name": "artemisia absinthium",
+    "region": "Europe / Western Asia",
+    "primaryActions": [
+      "digestive bitter tradition",
+      "thujone safety education"
+    ],
     "mechanisms": [
-      "GABA-A receptor antagonism",
-      "TRP channel modulation"
+      "Thujone-mediated GABA-A antagonism",
+      "bitter sesquiterpene lactone digestive signaling",
+      "TRP channel interaction",
+      "inflammatory pathway modulation."
     ],
     "description": "Artemisia absinthium contains Thujone and is linked here to GABA-A receptor antagonism.",
-    "activeCompounds": [
-      "Thujone"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Thujone-containing wormwood can cause seizures/neurotoxicity at high doses; avoid in pregnancy, breastfeeding, seizure disorders, children, and with alcohol, sedatives, or other CNS-active drugs.",
+    "interactions": [
+      "Potential interaction concern with sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "No direct preparation data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... No direct mechanismofaction data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... Used in absinthe and traditional medicine for digestion and stimulation.. No direct effects data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... No direct mechanismofaction data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... Used in absinthe and traditional medicine for digestion and stimulation.. Used in absinthe and traditional medicine for digestion and stimulation.. No direct region data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... No direct mechanismofaction data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... Used in absinthe and traditional medicine for digestion and stimulation.. No direct effects data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... No direct mechanismofaction data. Contextual inference: Used in absinthe and traditional medicine for digestion and stimulation... Used in absinthe and traditional medicine for digestion and stimulation.. Used in absinthe and traditional medicine for digestion and stimulation.. Used in absinthe and traditional medicine for digestion and stimulation.. Used in absinthe and traditional medicine for digestion and stimulation",
-    "primaryActions": [
-      "digestive support"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "seizure disorder or sedative/alcohol use"
+    ],
+    "preparation": "Aromatic herb/spice forms and essential oils differ greatly; essential oils require conservative topical/diluted use and are not interchangeable with teas.",
+    "traditionalUses": [
+      "digestive bitter tradition",
+      "thujone safety"
     ]
   },
   {
     "slug": "astragalus-membranaceus",
-    "name": "Astragalus membranaceus",
+    "name": "astragalus membranaceus",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "immune/adaptogen support",
+      "TCM tonic education"
+    ],
     "mechanisms": [
       "PI3K/Akt modulation",
       "AMPK activation",
@@ -4720,66 +8329,97 @@
       "MAPK pathway modulation"
     ],
     "description": "Astragalus membranaceus contains Astragaloside IV and is linked here to PI3K/Akt modulation.",
-    "activeCompounds": [
-      "Astragaloside IV",
-      "Calycosin",
-      "Formononetin",
-      "Astragalin"
-    ],
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May lower blood glucose or alter metabolic markers; monitor with diabetes medications and avoid unsupervised use during pregnancy.",
     "interactions": [
-      "immunosuppressants"
+      "Potential interaction concern with antidiabetic medicines",
+      "antihypertensives/diuretics",
+      "hormonal therapies",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "Roots sliced and decocted or simmered in soups; also extracted in capsules and tinctures",
-    "primaryActions": [
-      "adaptogenic",
-      "antioxidant",
-      "nootropic"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "hormone-sensitive conditions without clinician review"
     ],
-    "affiliateProducts": [
-      {
-        "name": "Astragalus Capsules",
-        "type": "capsule",
-        "affiliateUrl": "https://www.amazon.com/s?k=astragalus+capsules&tag=razzleberry02-20"
-      },
-      {
-        "name": "Astragalus Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=astragalus+extract&tag=razzleberry02-20"
-      }
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "immune/adaptogen",
+      "TCM tonic"
     ]
   },
   {
     "slug": "pueraria-lobata",
-    "name": "Pueraria lobata",
+    "name": "pueraria lobata",
+    "region": "East Asia",
+    "primaryActions": [
+      "metabolic support education"
+    ],
     "mechanisms": [
-      "PI3K/Akt modulation",
+      "Puerarin-mediated PI3K/Akt/eNOS signaling",
       "AMPK activation",
       "estrogen receptor modulation",
-      "glucose absorption modulation"
+      "intestinal glucose transport/glucose absorption effects."
     ],
     "description": "Pueraria lobata contains Puerarin and is linked here to PI3K/Akt modulation.",
-    "activeCompounds": [
-      "Puerarin",
-      "Daidzin",
-      "Ononin"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Caution with hormone-sensitive conditions, estrogenic therapies, anticoagulants/antiplatelets, antihypertensives, diabetes medications, pregnancy, and breastfeeding.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "hormonal therapies",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "hormone-sensitive conditions without clinician review"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "metabolic"
     ]
   },
   {
     "slug": "mangifera-indica",
-    "name": "Mangifera indica",
+    "name": "mangifera indica",
+    "region": "South Asia / tropics",
+    "primaryActions": [
+      "antioxidant/metabolic support education",
+      "mangiferin pathway research"
+    ],
     "mechanisms": [
       "AMPK activation",
       "Nrf2 activation",
       "NF-κB inhibition"
     ],
     "description": "Mangifera indica contains Mangiferin and is linked here to AMPK activation.",
-    "activeCompounds": [
-      "Mangiferin"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "May lower blood glucose or alter metabolic markers; monitor with diabetes medications and avoid unsupervised use during pregnancy.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "antioxidant/metabolic",
+      "mangiferin pathway"
     ]
   },
   {
     "slug": "garcinia-mangostana",
-    "name": "Garcinia mangostana",
+    "name": "garcinia mangostana",
+    "region": "Southeast Asia",
+    "primaryActions": [
+      "antioxidant xanthone support",
+      "inflammation research",
+      "skin/digestive traditional use"
+    ],
     "mechanisms": [
       "NF-κB inhibition",
       "PI3K/Akt modulation",
@@ -4787,31 +8427,61 @@
       "STAT3 inhibition"
     ],
     "description": "Garcinia mangostana contains Mangostin and is linked here to NF-κB inhibition.",
-    "activeCompounds": [
-      "Mangostin",
-      "Alpha-mangostin"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Human evidence is limited; concentrated xanthone products may cause GI upset or interact with anticoagulants.",
+    "interactions": [
+      "Theoretical anticoagulant/antiplatelet interactions",
+      "product-specific evidence limited."
     ],
-    "primaryActions": [
-      "anti-inflammatory",
-      "antioxidant"
+    "contraindications": [
+      "Pregnancy/breastfeeding without clinician guidance",
+      "bleeding disorder/anticoagulant use without review"
+    ],
+    "preparation": "Pericarp/rind extracts, juice blends, powders; fruit pulp differs from rind extract.",
+    "traditionalUses": [
+      "Southeast Asian rind use for diarrhea",
+      "skin",
+      "and infections"
     ]
   },
   {
     "slug": "garcinia-indica",
-    "name": "Garcinia indica",
+    "name": "garcinia indica",
+    "region": "India / South Asia",
+    "primaryActions": [
+      "digestive/metabolic traditional use",
+      "antioxidant support"
+    ],
     "mechanisms": [
       "NF-κB inhibition",
       "HAT inhibition",
       "STAT3 inhibition"
     ],
     "description": "Garcinia indica contains Garcinol and is linked here to NF-κB inhibition.",
-    "activeCompounds": [
-      "Garcinol"
+    "safetyNotes": "May lower blood glucose or alter metabolic markers; monitor with diabetes medications and avoid unsupervised use during pregnancy.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "digestive/metabolic traditional use",
+      "antioxidant"
     ]
   },
   {
     "slug": "curcuma-zedoaria",
-    "name": "Curcuma zedoaria",
+    "name": "curcuma zedoaria",
+    "region": "South/Southeast Asia",
+    "primaryActions": [
+      "digestive/inflammatory traditional use",
+      "sesquiterpene pathway research"
+    ],
     "mechanisms": [
       "NF-κB inhibition",
       "MAPK pathway modulation",
@@ -4819,45 +8489,63 @@
       "apoptosis pathway modulation (caspase activation)"
     ],
     "description": "Curcuma zedoaria contains Curcumol and is linked here to NF-κB inhibition.",
-    "activeCompounds": [
-      "Curcumol",
-      "Curdione"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Immune-modulating activity is plausible; use caution with autoimmune disease, transplant medicines, or immunosuppressants.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "digestive/inflammatory traditional use",
+      "sesquiterpene pathway"
     ]
   },
   {
     "slug": "curcuma-longa",
-    "name": "Curcuma longa",
+    "name": "curcuma longa",
+    "region": "South Asia / Southeast Asia",
+    "primaryActions": [
+      "inflammatory pathway research",
+      "antioxidant/cellular stress support",
+      "immune modulation education"
+    ],
     "mechanisms": [
-      "NF-κB inhibition",
-      "Nrf2 activation"
+      "curcuminoid NF-κB inhibition",
+      "Nrf2 activation",
+      "COX/LOX and inflammatory cytokine modulation"
     ],
     "description": "Curcuma longa contains Demethoxycurcumin and is linked here to NF-κB inhibition.",
-    "activeCompounds": [
-      "Demethoxycurcumin",
-      "Bisdemethoxycurcumin"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "GI effects possible; caution with anticoagulants/antiplatelets, gallbladder disease, and liver-safety concerns at high doses.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "Rhizome dried and powdered (turmeric); also decocted or extracted in oil or alcohol-based preparations",
-    "primaryActions": [
-      "anti-inflammatory",
-      "antioxidant",
-      "hepatoprotective"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ],
-    "affiliateProducts": [
-      {
-        "name": "Turmeric Powder",
-        "type": "powder",
-        "affiliateUrl": "https://www.amazon.com/s?k=turmeric+powder&tag=razzleberry02-20"
-      },
-      {
-        "name": "Turmeric Curcumin Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=turmeric+curcumin+extract&tag=razzleberry02-20"
-      }
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "inflammatory pathway",
+      "antioxidant/cellular stress",
+      "immune modulation"
     ]
   },
   {
     "slug": "paeonia-lactiflora",
-    "name": "Paeonia lactiflora",
+    "name": "paeonia lactiflora",
+    "region": "China; TCM",
+    "primaryActions": [
+      "menstrual/cramp traditional support",
+      "liver-blood TCM support",
+      "immune/inflammation research"
+    ],
     "mechanisms": [
       "PI3K/Akt modulation",
       "NF-κB inhibition",
@@ -4865,32 +8553,63 @@
       "monoamine reuptake inhibition"
     ],
     "description": "Paeonia lactiflora contains Paeoniflorin and is linked here to PI3K/Akt modulation.",
-    "activeCompounds": [
-      "Paeoniflorin",
-      "Albiflorin"
-    ],
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "May affect coagulation or immune signaling; use caution around anticoagulation.",
     "interactions": [
-      "anticoagulants/antiplatelets"
+      "Potential additive bleeding risk with anticoagulants/antiplatelets",
+      "may interact with immunomodulators."
     ],
-    "primaryActions": [
-      "anxiolytic"
+    "contraindications": [
+      "Pregnancy without clinician guidance",
+      "anticoagulant use without review"
+    ],
+    "preparation": "Root decoction/extract; often paired with licorice or other TCM herbs.",
+    "traditionalUses": [
+      "TCM blood/liver support",
+      "cramps",
+      "pain",
+      "formulas"
     ]
   },
   {
     "slug": "paeonia-suffruticosa",
-    "name": "Paeonia suffruticosa",
+    "name": "paeonia suffruticosa",
+    "region": "East Asia",
+    "primaryActions": [
+      "inflammatory and hormonal pathway research",
+      "TCM context"
+    ],
     "mechanisms": [
       "NF-κB inhibition",
       "Nrf2 activation"
     ],
     "description": "Paeonia suffruticosa contains Paeonol and is linked here to NF-κB inhibition.",
-    "activeCompounds": [
-      "Paeonol"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Immune-modulating activity is plausible; use caution with autoimmune disease, transplant medicines, or immunosuppressants.",
+    "interactions": [
+      "Potential interaction concern with hormonal therapies",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "hormone-sensitive conditions without clinician review"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "inflammatory and hormonal pathway",
+      "TCM context"
     ]
   },
   {
     "slug": "anemarrhena-asphodeloides",
-    "name": "Anemarrhena asphodeloides",
+    "name": "anemarrhena asphodeloides",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "metabolic/inflammatory pathway research",
+      "TCM context"
+    ],
     "mechanisms": [
       "PI3K/Akt modulation",
       "apoptosis pathway modulation (caspase activation)",
@@ -4898,53 +8617,88 @@
       "Nrf2 activation"
     ],
     "description": "Anemarrhena asphodeloides contains Timosaponin AIII and is linked here to PI3K/Akt modulation.",
-    "activeCompounds": [
-      "Timosaponin AIII",
-      "Mangiferin aglycone"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "May lower blood glucose or alter metabolic markers; monitor with diabetes medications and avoid unsupervised use during pregnancy.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "No direct preparation data. Contextual inference: Antipyretic, anti-inflammatory, and antidiabetic; used in tcm. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Antipyretic, anti-inflammatory, and antidiabetic; used in TCM. No direct region data. Contextual inference: Antipyretic, anti-inflammatory, and antidiabetic; used in tcm. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Antipyretic, anti-inflammatory, and antidiabetic; used in TCM. none. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "anti-inflammatory",
-      "antioxidant",
-      "nootropic"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "metabolic/inflammatory pathway",
+      "TCM context"
     ]
   },
   {
     "slug": "lobelia-inflata",
-    "name": "Lobelia inflata",
+    "name": "lobelia inflata",
+    "region": "North America traditional herbalism",
+    "primaryActions": [
+      "respiratory tradition",
+      "high-caution alkaloid safety education"
+    ],
     "mechanisms": [
       "nicotinic acetylcholine receptor modulation",
       "dopamine transporter modulation"
     ],
     "description": "Lobelia inflata contains Lobeline and is linked here to nicotinic acetylcholine receptor modulation.",
-    "activeCompounds": [
-      "Lobeline"
+    "safetyNotes": "Contains lobeline and related alkaloids; nausea, vomiting, dizziness, and cardiopulmonary toxicity are concerns at excess intake.",
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "cholinergic modulation"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "seizure disorder or sedative/alcohol use"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "respiratory tradition",
+      "high-caution alkaloid safety"
     ]
   },
   {
     "slug": "huperzia-serrata",
-    "name": "Huperzia serrata",
+    "name": "huperzia serrata",
+    "region": "East Asia",
+    "primaryActions": [
+      "cognitive support education",
+      "acetylcholinesterase pathway"
+    ],
     "mechanisms": [
       "acetylcholinesterase inhibition",
       "NMDA receptor modulation"
     ],
     "description": "Huperzia serrata contains Huperzine A and is linked here to acetylcholinesterase inhibition.",
-    "activeCompounds": [
-      "Huperzine A",
-      "Huperzine B"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Human safety data are limited for concentrated extracts. Use caution in pregnancy/breastfeeding, significant medical conditions, or prescription polypharmacy.",
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "No direct preparation data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. No direct region data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. Folk medicine. Folk medicine",
-    "primaryActions": [
-      "cholinergic modulation"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "cognitive",
+      "acetylcholinesterase pathway"
     ]
   },
   {
     "slug": "nicotiana-tabacum",
-    "name": "Nicotiana tabacum",
+    "name": "nicotiana tabacum",
+    "region": "Americas / global cultivated",
+    "primaryActions": [
+      "alkaloid/toxicology education only",
+      "nicotinic receptor pathway"
+    ],
     "mechanisms": [
       "nicotinic acetylcholine receptor modulation",
       "NF-κB inhibition",
@@ -4952,269 +8706,427 @@
       "dopamine release modulation"
     ],
     "description": "Nicotiana tabacum contains Anatabine and is linked here to nicotinic acetylcholine receptor modulation.",
-    "activeCompounds": [
-      "Anatabine",
-      "Nicotine"
+    "safetyNotes": "Nicotine-containing plant; toxic and addictive exposure risk. Not appropriate as a wellness supplement.",
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "cholinergic modulation"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "seizure disorder or sedative/alcohol use"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "alkaloid/toxicology only",
+      "nicotinic receptor pathway"
     ]
   },
   {
     "slug": "nicotiana-glauca",
-    "name": "Nicotiana glauca",
+    "name": "nicotiana glauca",
+    "region": "South America / Southwestern North America",
+    "primaryActions": [
+      "traditional-use and mechanism research profile"
+    ],
     "mechanisms": [
-      "nicotinic acetylcholine receptor modulation"
+      "Anabasine-mediated nicotinic acetylcholine receptor agonism",
+      "autonomic and neuromuscular toxicity pathways",
+      "ganglionic signaling disruption."
     ],
     "description": "Nicotiana glauca contains Anabasine and is linked here to nicotinic acetylcholine receptor modulation.",
-    "activeCompounds": [
-      "Anabasine"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Toxic plant; ingestion can cause serious poisoning, weakness, respiratory failure, and death. Not appropriate for consumer supplement use; avoid all unsupervised internal use.",
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "seizure disorder or sedative/alcohol use"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "traditional-use and mechanism profile"
     ]
   },
   {
     "slug": "piper-nigrum",
-    "name": "Piper nigrum",
+    "name": "piper nigrum",
+    "region": "South Asia / Southeast Asia",
+    "primaryActions": [
+      "bioavailability support",
+      "digestive spice",
+      "interaction education"
+    ],
     "mechanisms": [
-      "CB2 receptor agonism",
-      "NF-κB inhibition",
-      "apoptosis pathway modulation (caspase activation)"
+      "piperine modulation of CYP3A4/CYP2C9/CYP2D6 and P-gp",
+      "UGT/glucuronidation effects",
+      "TRPV1 signaling",
+      "inflammatory-pathway modulation"
     ],
     "description": "Piper nigrum contains Beta-caryophyllene and is linked here to CB2 receptor agonism.",
-    "activeCompounds": [
-      "Beta-caryophyllene",
-      "Caryophyllene oxide"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Food use is low-risk; high-piperine extracts may alter exposure to prescription drugs or other supplements.",
+    "interactions": [
+      "Potentially increases exposure of CYP/P-gp substrates and bioavailability-enhanced botanicals such as curcumin."
     ],
-    "primaryActions": [
-      "digestive support"
+    "contraindications": [
+      "Prescription polypharmacy",
+      "pregnancy/breastfeeding supplement use",
+      "significant reflux/ulcer disease",
+      "and perioperative anticoagulant use."
     ],
-    "affiliateProducts": [
-      {
-        "name": "Black Pepper Powder",
-        "type": "powder",
-        "affiliateUrl": "https://www.amazon.com/s?k=black+pepper+powder&tag=razzleberry02-20"
-      },
-      {
-        "name": "Black Pepper Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=black+pepper+extract&tag=razzleberry02-20"
-      }
+    "preparation": "Culinary black pepper differs from standardized piperine extracts used in studies.",
+    "traditionalUses": [
+      "bioavailability",
+      "digestive spice",
+      "interaction"
     ]
   },
   {
     "slug": "cymbopogon-citratus",
-    "name": "Cymbopogon citratus",
+    "name": "cymbopogon citratus",
+    "region": "Tropical Asia; Africa",
+    "primaryActions": [
+      "digestive comfort",
+      "antimicrobial aromatic support",
+      "metabolic/vascular research"
+    ],
     "mechanisms": [
-      "GABA-A modulation",
-      "PI3K/Akt modulation"
+      "Citral/myrcene activity",
+      "GABA-A-related signaling",
+      "vascular smooth-muscle and ACE-related effects",
+      "PI3K/Akt and NF-κB modulation."
     ],
     "description": "Cymbopogon citratus contains Nerolidol and is linked here to GABA-A modulation.",
-    "activeCompounds": [
-      "Nerolidol"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Tea-level use is usually tolerated, but concentrated essential oil can irritate skin/mucosa and may cause CNS or GI effects; caution in pregnancy, breastfeeding, sedative use, hypotension, and antihypertensive therapy.",
+    "interactions": [
+      "Low documented interaction burden",
+      "caution with sedatives or antihypertensives at high doses."
     ],
-    "preparation": "Leaves used fresh or dried in teas and infusions; also distilled for lemongrass oil",
-    "primaryActions": [
-      "anxiolytic",
-      "antioxidant",
-      "digestive support"
+    "contraindications": [
+      "Pregnancy/breastfeeding supplement dosing without guidance",
+      "internal essential-oil use"
+    ],
+    "preparation": "Leaf tea, culinary herb, tincture, and essential oil for topical/aromatic use.",
+    "traditionalUses": [
+      "Digestive",
+      "fever",
+      "aromatic",
+      "and culinary use"
     ]
   },
   {
     "slug": "matricaria-chamomilla",
-    "name": "Matricaria chamomilla",
+    "name": "matricaria chamomilla",
+    "region": "Europe; Western herbalism",
+    "primaryActions": [
+      "digestive comfort",
+      "sleep/calm support",
+      "topical skin-soothing support"
+    ],
     "mechanisms": [
-      "PPAR activation",
-      "MAPK pathway modulation",
-      "COX inhibition",
-      "NF-κB inhibition",
-      "leukotriene pathway modulation"
+      "apigenin GABA-A receptor interaction",
+      "flavonoid anti-inflammatory signaling",
+      "smooth-muscle and digestive-spasm modulation"
     ],
     "description": "Matricaria chamomilla contains Farnesol and is linked here to PPAR activation.",
-    "activeCompounds": [
-      "Farnesol",
-      "Bisabolol",
-      "Chamazulene"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Allergy risk with Asteraceae sensitivity; sedation possible; caution with CNS depressants and anticoagulants.",
+    "interactions": [
+      "May potentiate sedatives/CNS depressants and anticoagulants/antiplatelets in susceptible users."
     ],
-    "preparation": "Flowers dried and infused for tea or tincture; widely used for calming and digestive support",
-    "primaryActions": [
-      "anti-inflammatory",
-      "anxiolytic",
-      "antioxidant"
+    "contraindications": [
+      "Asteraceae/ragweed allergy",
+      "anticoagulant use without clinician review",
+      "pregnancy at medicinal doses without guidance"
     ],
-    "affiliateProducts": [
-      {
-        "name": "Chamomile Tea",
-        "type": "tea",
-        "affiliateUrl": "https://www.amazon.com/s?k=matricaria+chamomilla+tea&tag=razzleberry02-20"
-      },
-      {
-        "name": "Chamomile Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=matricaria+chamomilla+extract&tag=razzleberry02-20"
-      }
+    "preparation": "Flower infusion, tincture, capsules, steam-distilled essential oil, and topical preparations.",
+    "traditionalUses": [
+      "Digestive spasm",
+      "sleep",
+      "calming",
+      "skin and mucosal irritation"
     ]
   },
   {
     "slug": "atractylodes-macrocephala",
-    "name": "Atractylodes macrocephala",
+    "name": "atractylodes macrocephala",
+    "region": "East Asia / Traditional Chinese Medicine",
+    "primaryActions": [
+      "digestive/tonic support",
+      "immune-gut pathway research"
+    ],
     "mechanisms": [
       "PI3K/Akt modulation",
       "NF-κB inhibition",
       "MAPK pathway modulation"
     ],
     "description": "Atractylodes macrocephala contains Atractylenolide I and is linked here to PI3K/Akt modulation.",
-    "activeCompounds": [
-      "Atractylenolide I",
-      "Atractylenolide II",
-      "Atractylenolide III"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Immune-modulating activity is plausible; use caution with autoimmune disease, transplant medicines, or immunosuppressants.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "No direct preparation data. Contextual inference: Tonic for spleen and digestion in tcm. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Tonic for spleen and digestion in TCM. No direct region data. Contextual inference: Tonic for spleen and digestion in tcm. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. None. ; nan; nan.. Herbs often act via neurotransmitter modulation, antioxidant effects, or enzyme inhibition.. Tonic for spleen and digestion in TCM. none. ; nan; nan. ; nan; nan",
-    "primaryActions": [
-      "antioxidant",
-      "digestive support",
-      "nootropic"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "digestive/tonic",
+      "immune-gut pathway"
     ]
   },
   {
     "slug": "curcuma-wenyujin",
-    "name": "Curcuma wenyujin",
+    "name": "curcuma wenyujin",
+    "region": "East/Southeast Asia",
+    "primaryActions": [
+      "digestive/inflammatory traditional use",
+      "sesquiterpene pathway research"
+    ],
     "mechanisms": [
       "PI3K/Akt modulation",
       "apoptosis pathway modulation (caspase activation)"
     ],
     "description": "Curcuma wenyujin contains Beta-elemene and is linked here to PI3K/Akt modulation.",
-    "activeCompounds": [
-      "Beta-elemene"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Human safety data are limited for concentrated extracts. Use caution in pregnancy/breastfeeding, significant medical conditions, or prescription polypharmacy.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "digestive/inflammatory traditional use",
+      "sesquiterpene pathway"
     ]
   },
   {
     "slug": "myristica-fragrans",
-    "name": "Myristica fragrans",
+    "name": "myristica fragrans",
+    "region": "Southeast Asia",
+    "primaryActions": [
+      "digestive aromatic support",
+      "myristicin safety education"
+    ],
     "mechanisms": [
       "monoamine oxidase inhibition",
       "TRP channel modulation",
       "acetylcholinesterase inhibition"
     ],
     "description": "Myristica fragrans contains Elemicin and is linked here to monoamine oxidase inhibition.",
-    "activeCompounds": [
-      "Elemicin",
-      "Myristicin"
+    "safetyNotes": "High-dose nutmeg/myristicin exposure can cause neuropsychiatric and cardiovascular toxicity.",
+    "interactions": [
+      "Potential interaction concern with antihypertensives/diuretics",
+      "sedatives/CNS depressants",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "No direct preparation data. Contextual inference: Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals... No direct mechanismofaction data. Contextual inference: Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals... Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals.. No direct effects data. Contextual inference: Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals... No direct mechanismofaction data. Contextual inference: Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals... Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals.. Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals.. No direct region data. Contextual inference: Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals... No direct mechanismofaction data. Contextual inference: Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals... Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals.. No direct effects data. Contextual inference: Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals... No direct mechanismofaction data. Contextual inference: Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals... Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals.. Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals.. Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals.. Used in spice blends, aphrodisiacs, and as a psychoactive in folk rituals"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "digestive aromatic",
+      "myristicin safety"
+    ]
   },
   {
     "slug": "ocotea-odorifera",
-    "name": "Ocotea odorifera",
+    "name": "ocotea odorifera",
+    "region": "South America",
+    "primaryActions": [
+      "aromatic/traditional use",
+      "safrole-related safety education"
+    ],
     "mechanisms": [
       "TRP channel modulation",
       "MAPK pathway modulation"
     ],
     "description": "Ocotea odorifera contains Safrole and is linked here to TRP channel modulation.",
-    "activeCompounds": [
-      "Safrole"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Safrole-related safety concerns; avoid concentrated internal use and pregnancy.",
+    "interactions": [
+      "Potential additive effects with medications affecting the same body system",
+      "review high-dose extracts with a clinician."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Aromatic herb/spice forms and essential oils differ greatly; essential oils require conservative topical/diluted use and are not interchangeable with teas.",
+    "traditionalUses": [
+      "aromatic/traditional use",
+      "safrole-related safety"
     ]
   },
   {
     "slug": "ocimum-basilicum",
-    "name": "Ocimum basilicum",
+    "name": "ocimum basilicum",
+    "region": "South Asia / Mediterranean cultivation",
+    "primaryActions": [
+      "inflammatory pathway research",
+      "antioxidant/cellular stress support",
+      "nervous-system support education",
+      "cardiometabolic/circulation education"
+    ],
     "mechanisms": [
-      "TRP channel modulation",
-      "GABA-A modulation"
+      "Linalool/eugenol-mediated TRP channel and GABA-A-related signaling",
+      "NF-κB inflammatory modulation",
+      "Nrf2 antioxidant signaling",
+      "eugenol-related platelet effects."
     ],
     "description": "Ocimum basilicum contains Methyleugenol and is linked here to TRP channel modulation.",
-    "activeCompounds": [
-      "Methyleugenol"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Culinary basil is low risk, but essential oils/extracts differ; caution with anticoagulants/antiplatelets, pregnancy, children, liver disease, and high-methyleugenol concentrated products.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "anticoagulants/antiplatelets",
+      "sedatives/CNS depressants",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family",
+      "bleeding disorder or upcoming surgery",
+      "seizure disorder or sedative/alcohol use"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "inflammatory pathway",
+      "antioxidant/cellular stress",
+      "nervous-system",
+      "cardiometabolic/circulation"
     ]
   },
   {
     "slug": "ocimum-sanctum",
-    "name": "Ocimum sanctum",
+    "name": "ocimum sanctum",
+    "region": "South Asia; Ayurveda",
+    "primaryActions": [
+      "stress response support",
+      "metabolic support",
+      "respiratory traditional use"
+    ],
     "mechanisms": [
-      "AMPK activation",
-      "NF-κB inhibition",
-      "PI3K/Akt modulation"
+      "eugenol/ursolic-acid signaling",
+      "cortisol/stress-axis modulation",
+      "AMPK/glucose and inflammatory-pathway effects"
     ],
     "description": "Ocimum sanctum contains Ursolic acid and is linked here to AMPK activation.",
-    "activeCompounds": [
-      "Ursolic acid"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May lower glucose and affect clotting; caution with diabetes drugs, anticoagulants, pregnancy, and perioperative use.",
+    "interactions": [
+      "May add to antidiabetic",
+      "antihypertensive",
+      "sedative",
+      "anticoagulant",
+      "or antiplatelet effects."
     ],
-    "preparation": "Leaves used fresh or dried in teas, decoctions, tinctures; sacred basil with adaptogenic effects",
-    "primaryActions": [
-      "adaptogenic",
-      "immunomodulatory",
-      "antioxidant"
+    "contraindications": [
+      "Pregnancy attempts/pregnancy without clinician guidance",
+      "hypoglycemia risk",
+      "bleeding disorder",
+      "upcoming surgery"
     ],
-    "affiliateProducts": [
-      {
-        "name": "Holy Basil Tea",
-        "type": "tea",
-        "affiliateUrl": "https://www.amazon.com/s?k=holy+basil+tea&tag=razzleberry02-20"
-      },
-      {
-        "name": "Holy Basil Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=holy+basil+extract&tag=razzleberry02-20"
-      }
+    "preparation": "Leaf tea, tincture, powder, and standardized extracts; seed preparations are a different data object.",
+    "traditionalUses": [
+      "Ayurvedic rasayana/adaptogen",
+      "respiratory and digestive support"
     ]
   },
   {
     "slug": "centella-asiatica",
-    "name": "Centella asiatica",
+    "name": "centella asiatica",
+    "region": "South Asia; Southeast Asia",
+    "primaryActions": [
+      "cognition/circulation support",
+      "wound/skin support",
+      "connective tissue education"
+    ],
     "mechanisms": [
-      "PI3K/Akt modulation",
-      "TGF-β signaling modulation",
-      "NF-κB inhibition"
+      "asiaticoside/madecassoside effects on collagen synthesis",
+      "microcirculation and endothelial signaling",
+      "antioxidant/NF-κB modulation"
     ],
     "description": "Centella asiatica contains Asiatic acid and is linked here to PI3K/Akt modulation.",
-    "activeCompounds": [
-      "Asiatic acid",
-      "Madecassic acid",
-      "Asiaticoside",
-      "Madecassoside"
-    ],
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Rare liver injury reported; avoid pregnancy and liver disease; caution with sedatives and hepatotoxic drugs.",
     "interactions": [
-      "CNS depressants"
+      "May potentiate sedatives and hepatotoxic drugs/supplements",
+      "caution with antidiabetics."
     ],
-    "preparation": "No direct preparation data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. No direct region data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. No direct effects data. Contextual inference: Folk medicine.. No direct mechanismofaction data. Contextual inference: Folk medicine.. Folk medicine. Folk medicine. Folk medicine. Folk medicine",
-    "primaryActions": [
-      "anxiolytic",
-      "cardiovascular support",
-      "nootropic"
+    "contraindications": [
+      "Liver disease",
+      "pregnancy/breastfeeding without guidance",
+      "upcoming surgery"
     ],
-    "affiliateProducts": [
-      {
-        "name": "Gotu Kola Capsules",
-        "type": "capsule",
-        "affiliateUrl": "https://www.amazon.com/s?k=centella+asiatica+capsules&tag=razzleberry02-20"
-      },
-      {
-        "name": "Gotu Kola Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=centella+asiatica+extract&tag=razzleberry02-20"
-      }
+    "preparation": "Leaf tea/powder, tincture, extracts standardized to asiaticoside/madecassoside; topical use differs.",
+    "traditionalUses": [
+      "Ayurveda/TCM wound",
+      "cognition",
+      "circulation",
+      "longevity"
     ]
   },
   {
     "slug": "gymnema-sylvestre",
-    "name": "Gymnema sylvestre",
+    "name": "gymnema sylvestre",
+    "region": "India; Ayurveda",
+    "primaryActions": [
+      "glucose control support",
+      "sugar-craving/sweet-taste education",
+      "metabolic support"
+    ],
     "mechanisms": [
-      "glucose absorption modulation",
+      "gymnemic acid sweet-taste receptor antagonism",
+      "SGLT1/intestinal glucose absorption inhibition",
+      "pancreatic beta-cell and insulin-secretion effects",
       "AMPK activation",
-      "sweet taste receptor modulation"
+      "lipid-metabolism modulation"
     ],
     "description": "Gymnema sylvestre contains Gymnemagenin and is linked here to glucose absorption modulation.",
-    "activeCompounds": [
-      "Gymnemagenin",
-      "Gurmarin"
-    ],
+    "evidenceLevel": "meta_analysis",
+    "safetyNotes": "Hypoglycemia risk increases with insulin, sulfonylureas, GLP-1 agonists, SGLT2 inhibitors, metformin, or other glucose-lowering medicines. Monitor glucose. GI upset can occur. Avoid pregnancy/breastfeeding. Stop before surgery because glucose variability may complicate perioperative management.",
     "interactions": [
-      "antidiabetic medications"
+      "Antidiabetics including insulin",
+      "sulfonylureas",
+      "GLP-1 agonists",
+      "SGLT2 inhibitors",
+      "and metformin",
+      "may compound glucose-lowering effects."
     ],
-    "preparation": "No direct preparation data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. No direct region data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. No direct effects data. Contextual inference: ; nan; nan.. No direct mechanismofaction data. Contextual inference: ; nan; nan.. ; nan; nan. ; nan; nan. ; nan; nan. ; nan; nan"
+    "contraindications": [
+      "Pregnancy/breastfeeding",
+      "hypoglycemia-prone patients without monitoring",
+      "perioperative use without clinician review."
+    ],
+    "preparation": "Leaf powder/extracts standardized to gymnemic acids; chewing/tea can reduce sweet taste temporarily.",
+    "traditionalUses": [
+      "Ayurvedic glucose and metabolic support"
+    ]
   },
   {
     "slug": "lagerstroemia-speciosa",
-    "name": "Lagerstroemia speciosa",
+    "name": "lagerstroemia speciosa",
+    "region": "Southeast Asia",
+    "primaryActions": [
+      "glucose metabolism support",
+      "metabolic syndrome education",
+      "antioxidant polyphenol support"
+    ],
     "mechanisms": [
       "AMPK activation",
       "GLUT4 translocation modulation",
@@ -5222,39 +9134,58 @@
       "glucose uptake modulation"
     ],
     "description": "Lagerstroemia speciosa contains Corosolic acid and is linked here to AMPK activation.",
-    "activeCompounds": [
-      "Corosolic acid",
-      "Lagerstroemin"
-    ],
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "May lower blood glucose; GI upset possible. Use caution with kidney disease until product-specific data are clear.",
     "interactions": [
-      "antidiabetic medications"
+      "May potentiate antidiabetic medications and other glucose-lowering supplements."
     ],
-    "primaryActions": [
-      "glycemic support"
+    "contraindications": [
+      "Hypoglycemia risk",
+      "pregnancy/breastfeeding without clinician guidance"
+    ],
+    "preparation": "Leaf extracts standardized to corosolic acid or ellagitannin content; tea use also occurs.",
+    "traditionalUses": [
+      "Traditional glucose and urinary support"
     ]
   },
   {
     "slug": "morus-alba",
-    "name": "Morus alba",
+    "name": "morus alba",
+    "region": "China; Japan; Korea",
+    "primaryActions": [
+      "postprandial glucose support",
+      "carbohydrate absorption modulation",
+      "metabolic education"
+    ],
     "mechanisms": [
-      "glucose absorption modulation",
-      "alpha-glucosidase inhibition",
-      "PI3K/Akt modulation",
-      "NF-κB inhibition"
+      "1-deoxynojirimycin α-glucosidase inhibition",
+      "postprandial glucose modulation",
+      "AMPK and lipid-metabolism effects"
     ],
     "description": "Morus alba contains Mulberroside A and is linked here to glucose absorption modulation.",
-    "activeCompounds": [
-      "Mulberroside A",
-      "Oxyresveratrol",
-      "Morin"
-    ],
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "May potentiate glucose-lowering drugs; GI effects possible; pregnancy safety uncertain.",
     "interactions": [
-      "antidiabetic medications"
+      "May potentiate antidiabetic drugs and other alpha-glucosidase inhibitors",
+      "monitor glucose."
+    ],
+    "contraindications": [
+      "Hypoglycemia risk",
+      "pregnancy/breastfeeding without clinician guidance"
+    ],
+    "preparation": "Leaf tea, powder, tablets, and extracts standardized to DNJ or flavonoids.",
+    "traditionalUses": [
+      "East Asian metabolic and tea use"
     ]
   },
   {
     "slug": "elephantopus-scaber",
-    "name": "Elephantopus scaber",
+    "name": "elephantopus scaber",
+    "region": "Tropical Asia/Africa/Americas",
+    "primaryActions": [
+      "inflammatory pathway research",
+      "traditional antimicrobial use"
+    ],
     "mechanisms": [
       "NF-κB inhibition",
       "STAT3 inhibition",
@@ -5262,56 +9193,83 @@
       "MAPK pathway modulation"
     ],
     "description": "Elephantopus scaber contains Deoxyelephantopin and is linked here to NF-κB inhibition.",
-    "activeCompounds": [
-      "Deoxyelephantopin",
-      "Elephantopin"
+    "evidenceLevel": "in_vitro",
+    "safetyNotes": "Immune-modulating activity is plausible; use caution with autoimmune disease, transplant medicines, or immunosuppressants.",
+    "interactions": [
+      "Potential interaction concern with immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "inflammatory pathway",
+      "traditional antimicrobial use"
     ]
   },
   {
     "slug": "commiphora-mukul",
-    "name": "Commiphora mukul",
+    "name": "commiphora mukul",
+    "region": "South Asia / Ayurveda",
+    "primaryActions": [
+      "inflammatory pathway research",
+      "cardiometabolic/circulation education"
+    ],
     "mechanisms": [
-      "FXR antagonism",
-      "NF-κB inhibition",
-      "PPAR activation"
+      "guggulsterone FXR/lipid-metabolism effects",
+      "thyroid-axis signaling",
+      "NF-κB inflammatory modulation"
     ],
     "description": "Commiphora mukul contains Guggulsterone and is linked here to FXR antagonism.",
-    "activeCompounds": [
-      "Guggulsterone",
-      "Commipheric acid"
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "Can cause rash/GI effects; may affect thyroid function, CYP enzymes, anticoagulants, and hormone-sensitive contexts.",
+    "interactions": [
+      "Potential interaction concern with antidiabetic medicines",
+      "anticoagulants/antiplatelets",
+      "immunosuppressants",
+      "use clinician review for high-dose extracts or chronic use."
+    ],
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
+    ],
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "inflammatory pathway",
+      "cardiometabolic/circulation"
     ]
   },
   {
     "slug": "serenoa-repens",
-    "name": "Serenoa repens",
+    "name": "serenoa repens",
+    "region": "Southeastern North America",
+    "primaryActions": [
+      "metabolic support education",
+      "inflammatory pathway research",
+      "antioxidant/cellular stress support"
+    ],
     "mechanisms": [
-      "PPAR activation",
-      "NF-κB inhibition",
-      "MAPK pathway modulation"
+      "5-alpha-reductase and androgen-signaling modulation",
+      "prostate inflammatory-pathway effects"
     ],
     "description": "Serenoa repens contains Beta-sitosterol and is linked here to PPAR activation.",
-    "activeCompounds": [
-      "Beta-sitosterol",
-      "Stigmasterol"
-    ],
+    "evidenceLevel": "human_limited",
+    "safetyNotes": "GI upset/headache possible; caution with hormone-sensitive conditions, anticoagulants, and perioperative use.",
     "interactions": [
-      "anticoagulants/antiplatelets"
+      "Potential interaction concern with antidiabetic medicines",
+      "use clinician review for high-dose extracts or chronic use."
     ],
-    "preparation": "Fruit dried and extracted into lipophilic extracts or tinctures; used for benign prostatic hyperplasia (BPH)",
-    "primaryActions": [
-      "anti-inflammatory"
+    "contraindications": [
+      "pregnancy/breastfeeding without clinician supervision",
+      "known allergy to the plant/family"
     ],
-    "affiliateProducts": [
-      {
-        "name": "Saw Palmetto Capsules",
-        "type": "capsule",
-        "affiliateUrl": "https://www.amazon.com/s?k=serenoa+repens+capsules&tag=razzleberry02-20"
-      },
-      {
-        "name": "Saw Palmetto Extract",
-        "type": "extract",
-        "affiliateUrl": "https://www.amazon.com/s?k=serenoa+repens+extract&tag=razzleberry02-20"
-      }
+    "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+    "traditionalUses": [
+      "metabolic",
+      "inflammatory pathway",
+      "antioxidant/cellular stress"
     ]
   }
 ]

--- a/public/feed.xml
+++ b/public/feed.xml
@@ -5,7 +5,7 @@
   <link>https://thehippiescientist.net/blog</link>
   <description>Psychoactive botany, safety, and DIY blend guides</description>
   <language>en</language>
-  <lastBuildDate>Sat, 25 Apr 2026 13:57:53 GMT</lastBuildDate>
+  <lastBuildDate>Sun, 26 Apr 2026 18:18:23 GMT</lastBuildDate>
   
     <item>
       <title><![CDATA[Extraction 101 — Skullcap]]></title>

--- a/public/rss.xml
+++ b/public/rss.xml
@@ -5,7 +5,7 @@
   <link>https://thehippiescientist.net/blog</link>
   <description>Psychoactive botany, safety, and DIY blend guides</description>
   <language>en</language>
-  <lastBuildDate>Sat, 25 Apr 2026 13:57:53 GMT</lastBuildDate>
+  <lastBuildDate>Sun, 26 Apr 2026 18:18:23 GMT</lastBuildDate>
   
     <item>
       <title><![CDATA[Extraction 101 — Skullcap]]></title>

--- a/scripts/data/build-runtime-from-workbook.mjs
+++ b/scripts/data/build-runtime-from-workbook.mjs
@@ -11,13 +11,11 @@ const __dirname = path.dirname(__filename)
 const repoRoot = path.resolve(__dirname, '../..')
 
 const REQUIRED_SHEETS = {
-  herbs: 'Herb Master Clean',
+  herbs: 'Herb Master V3',
   compounds: 'Compound Master V3',
   herbCompoundMap: 'Herb Compound Map V3',
-}
-
-const OPTIONAL_SHEETS = {
   claimRows: 'Claim Rows',
+  researchQueue: 'Research Queue',
 }
 
 const PLACEHOLDER_TOKENS = new Set(['', 'unknown', 'nan', 'null', 'undefined', '[object object]'])
@@ -112,7 +110,11 @@ function readSheetRows(workbook, sheetName, { optional = false } = {}) {
     blankrows: false,
   })
 
-  return rows.map(row => toSimpleRow(row))
+  const normalizedRows = rows.map(row => toSimpleRow(row))
+  if (!optional && normalizedRows.length === 0) {
+    throw new Error(`[data-next] Required sheet has 0 rows: ${sheetName}`)
+  }
+  return normalizedRows
 }
 
 function firstNonEmpty(row, keys) {
@@ -221,7 +223,8 @@ function run() {
   const herbRows = readSheetRows(workbook, REQUIRED_SHEETS.herbs)
   const compoundRows = readSheetRows(workbook, REQUIRED_SHEETS.compounds)
   const mapRows = readSheetRows(workbook, REQUIRED_SHEETS.herbCompoundMap)
-  const claimRows = readSheetRows(workbook, OPTIONAL_SHEETS.claimRows, { optional: true })
+  const claimRows = readSheetRows(workbook, REQUIRED_SHEETS.claimRows)
+  const researchQueueRows = readSheetRows(workbook, REQUIRED_SHEETS.researchQueue)
 
   const herbNameBySlug = new Map()
   const herbs = []
@@ -296,7 +299,8 @@ function run() {
         herbs: REQUIRED_SHEETS.herbs,
         compounds: REQUIRED_SHEETS.compounds,
         herbCompoundMap: REQUIRED_SHEETS.herbCompoundMap,
-        claimRows: workbook.Sheets[OPTIONAL_SHEETS.claimRows] ? OPTIONAL_SHEETS.claimRows : null,
+        claimRows: REQUIRED_SHEETS.claimRows,
+        researchQueue: REQUIRED_SHEETS.researchQueue,
       },
     },
     output: outputLabel,
@@ -308,6 +312,7 @@ function run() {
       herbDetails: herbs.length,
       compoundDetails: compounds.length,
       claimRows: claimRows.length,
+      researchQueueRows: researchQueueRows.length,
       skippedHerbs,
       skippedCompounds,
     },

--- a/scripts/data/report-migration-parity.mjs
+++ b/scripts/data/report-migration-parity.mjs
@@ -71,8 +71,10 @@ const DETAIL_DIRS = {
 }
 
 const WORKBOOK_SHEETS = {
-  herbs: 'Herb Master Clean',
+  herbs: 'Herb Master V3',
   compounds: 'Compound Master V3',
+  claimRows: 'Claim Rows',
+  researchQueue: 'Research Queue',
 }
 
 const ROOT_CAUSES = {

--- a/scripts/data/report-workbook-parser-coverage.mjs
+++ b/scripts/data/report-workbook-parser-coverage.mjs
@@ -11,9 +11,11 @@ const __dirname = path.dirname(__filename)
 const repoRoot = path.resolve(__dirname, '../..')
 
 const SHEETS = {
-  herbs: 'Herb Master Clean',
+  herbs: 'Herb Master V3',
   compounds: 'Compound Master V3',
   herbCompoundMap: 'Herb Compound Map V3',
+  claimRows: 'Claim Rows',
+  researchQueue: 'Research Queue',
 }
 
 const OUTPUTS = {

--- a/scripts/export-workbook-to-json.mjs
+++ b/scripts/export-workbook-to-json.mjs
@@ -18,9 +18,11 @@ const repoRoot = path.resolve(__dirname, '..')
 const workbookPath = resolveWorkbookPath(repoRoot)
 const dataDir = path.join(repoRoot, 'public', 'data')
 const REQUIRED_WORKBOOK_SHEETS = {
-  herbs: ['Herb Monographs', 'Herb Master', 'Herb Master Clean'],
-  compounds: ['Compound Master V3', 'Compound Master'],
-  herbCompoundMap: ['Herb Compound Map V3', 'Herb Compound Map'],
+  herbs: ['Herb Master V3'],
+  compounds: ['Compound Master V3'],
+  herbCompoundMap: ['Herb Compound Map V3'],
+  claimRows: ['Claim Rows'],
+  researchQueue: ['Research Queue'],
 }
 const REQUIRED_SHEET_KEYS = Object.keys(REQUIRED_WORKBOOK_SHEETS)
 const RESOLVED_REQUIRED_COLUMNS = {
@@ -28,15 +30,9 @@ const RESOLVED_REQUIRED_COLUMNS = {
   compounds: ['name'],
   herbCompoundMap: ['herbSlug', 'canonicalCompoundId'],
 }
-const LEGACY_GOAL_BUNDLE_SHEET = 'Production Export V1'
-const EXPORT_WORKBOOK_SHEETS = [
-  ...REQUIRED_SHEET_KEYS.flatMap(sheetKey => REQUIRED_WORKBOOK_SHEETS[sheetKey]),
-  LEGACY_GOAL_BUNDLE_SHEET,
-]
-const OPTIONAL_WORKBOOK_SHEETS = new Set(['Production Export V1'])
-const SHEET_REQUIRED_COLUMNS = {
-  'Production Export V1': ['goal'],
-}
+const EXPORT_WORKBOOK_SHEETS = [...REQUIRED_SHEET_KEYS.flatMap(sheetKey => REQUIRED_WORKBOOK_SHEETS[sheetKey])]
+const OPTIONAL_WORKBOOK_SHEETS = new Set([])
+const SHEET_REQUIRED_COLUMNS = {}
 
 function createDiagnostics() {
   return {
@@ -240,6 +236,10 @@ function readSheetRows(workbook, sheetName, diagnostics, { optional = false, req
     return hasData
   })
 
+  if (!optional && nonEmptyRows.length === 0) {
+    throw new Error(`[export] Required worksheet "${sheetName}" has 0 data rows.`)
+  }
+
   return nonEmptyRows
 }
 
@@ -403,40 +403,6 @@ function exportHerbCompoundMap(workbook, diagnostics, resolvedSheets) {
   return deduped
 }
 
-function cleanGoalValue(value) {
-  if (typeof value === 'string' && value.trim().startsWith('=')) {
-    return null
-  }
-  return cleanScalar(value)
-}
-
-function exportGoalBundles(workbook, diagnostics) {
-  const rows = readSheetRows(workbook, LEGACY_GOAL_BUNDLE_SHEET, diagnostics, { optional: true })
-  const records = rows
-    .map(row => ({
-      goal: cleanGoalValue(row.goal),
-      rank: cleanGoalValue(row.rank),
-      stack: cleanGoalValue(row.stack),
-      score: cleanGoalValue(row.score),
-      segment: cleanGoalValue(row.segment),
-      condition_profile: cleanGoalValue(row.condition_profile),
-      lineup_slot: cleanGoalValue(row.lineup_slot),
-      intent: cleanGoalValue(row.intent),
-      time_of_day: cleanGoalValue(row.time_of_day),
-      balance_profile: cleanGoalValue(row.balance_profile),
-      safety_band: cleanGoalValue(row.safety_band),
-      recommendation_class: cleanGoalValue(row.recommendation_class),
-      goal_winner_flag: cleanGoalValue(row.goal_winner_flag),
-      tag: cleanGoalValue(row.tag),
-      release_version: cleanGoalValue(row.release_version),
-    }))
-    .filter(record => typeof record.goal === 'string' && record.goal.trim() !== '')
-
-  const deduped = dedupeBy(records, record => `${record.goal}::${record.rank}::${record.stack}`)
-  diagnostics.sheets['Production Export V1'].skippedRows += records.length - deduped.length
-  return deduped
-}
-
 function writeJson(filename, records) {
   const outputPath = path.join(dataDir, filename)
   fs.mkdirSync(path.dirname(outputPath), { recursive: true })
@@ -468,12 +434,14 @@ function main() {
 
   const herbsExport = exportHerbs(workbook, diagnostics, resolvedSheets)
   const compoundsExport = exportCompounds(workbook, diagnostics, resolvedSheets)
+  readSheetRows(workbook, resolvedSheets.claimRows, diagnostics)
+  readSheetRows(workbook, resolvedSheets.researchQueue, diagnostics)
   const fallbackUsage = [...herbsExport.fallbackUsage, ...compoundsExport.fallbackUsage]
 
   writeJson('workbook-herbs.json', herbsExport.records)
   writeJson('workbook-compounds.json', compoundsExport.records)
   writeJson('workbook-herb-compound-map.json', exportHerbCompoundMap(workbook, diagnostics, resolvedSheets))
-  writeJson('workbook-goal-bundles.json', exportGoalBundles(workbook, diagnostics))
+  writeJson('workbook-goal-bundles.json', [])
   writeReportJson('reports/workbook-fallback-usage.json', fallbackUsage)
   if (options.allowLegacyFallback) {
     console.warn(`[export] legacy fallback enabled via --allow-legacy-fallback. fallback rows used=${fallbackUsage.length}`)

--- a/scripts/generate-monograph-projection.mjs
+++ b/scripts/generate-monograph-projection.mjs
@@ -284,19 +284,30 @@ function sanitizeHerbCompoundMapRows(rows, { herbSlugSet, compoundSlugSet, compo
 
 function readWorkbookSheets(workbookPath) {
   const workbook = XLSX.readFile(workbookPath)
-  const herbSheet =
-    ['Herb Monographs', 'Herb Master', 'Herb Master Clean'].find((sheetName) => workbook.Sheets[sheetName]) ||
-    'Herb Monographs'
-  const herbRows = parseSheet(workbook, herbSheet)
-  if (herbRows.length === 0) {
-    throw new Error(`Missing worksheet rows: ${herbSheet}`)
+  const requiredSheets = ['Herb Master V3', 'Compound Master V3', 'Herb Compound Map V3', 'Claim Rows', 'Research Queue']
+  for (const sheetName of requiredSheets) {
+    if (!workbook.Sheets[sheetName]) {
+      throw new Error(`[projection] Missing required worksheet: ${sheetName}`)
+    }
+  }
+  const herbRows = parseSheet(workbook, 'Herb Master V3')
+  const compoundRows = parseSheet(workbook, 'Compound Master V3')
+  const mapRows = parseSheet(workbook, 'Herb Compound Map V3')
+  if (herbRows.length === 0 || compoundRows.length === 0 || mapRows.length === 0) {
+    throw new Error('[projection] Required V3 sheet has 0 rows.')
+  }
+  if (parseSheet(workbook, 'Claim Rows').length === 0) {
+    throw new Error('[projection] Required sheet has 0 rows: Claim Rows')
+  }
+  if (parseSheet(workbook, 'Research Queue').length === 0) {
+    throw new Error('[projection] Required sheet has 0 rows: Research Queue')
   }
 
   return {
     herbRows,
-    compoundRows: parseSheet(workbook, 'Compound Master V3'),
-    mapRows: parseSheet(workbook, 'Herb Compound Map V3'),
-    queueRows: parseSheet(workbook, 'Herb Enrichment Queue V3'),
+    compoundRows,
+    mapRows,
+    queueRows: parseSheet(workbook, 'Research Queue'),
   }
 }
 

--- a/scripts/import-xlsx-monographs.mjs
+++ b/scripts/import-xlsx-monographs.mjs
@@ -13,11 +13,13 @@ const repoRoot = path.resolve(__dirname, '..')
 
 const workbookPath = resolveWorkbookPath(repoRoot)
 const SHEET_MAP = {
-  herbs: ['Herb Monographs', 'Herb Master', 'Herb Master Clean'],
-  compounds: ['Compound Master V3', 'Compound Master'],
-  herbCompoundMap: ['Herb Compound Map V3', 'Herb Compound Map'],
+  herbs: ['Herb Master V3'],
+  compounds: ['Compound Master V3'],
+  herbCompoundMap: ['Herb Compound Map V3'],
+  claimRows: ['Claim Rows'],
+  researchQueue: ['Research Queue'],
 }
-const REQUIRED_SHEET_KEYS = ['herbs', 'compounds', 'herbCompoundMap']
+const REQUIRED_SHEET_KEYS = ['herbs', 'compounds', 'herbCompoundMap', 'claimRows', 'researchQueue']
 const RESOLVED_REQUIRED_COLUMNS = {
   herbs: ['name'],
   compounds: ['name'],
@@ -34,26 +36,12 @@ const COLUMN_ALIASES = {
     canonicalCompoundName: ['canonicalcompoundname', 'canonical_compound_name'],
     canonicalCompoundId: ['canonicalcompoundid', 'canonical_compound_id'],
   },
-  'Herb Master': {
+  'Herb Master V3': {
     name: ['name', 'herb', 'herbname', 'herb_name'],
-  },
-  'Herb Monographs': {
-    name: ['name', 'herb', 'herbname', 'herb_name'],
-  },
-  'Herb Master Clean': {
-    name: ['name', 'herb', 'herbname', 'herb_name'],
-  },
-  'Compound Master': {
-    compoundName: ['compoundname', 'compound_name', 'compound', 'name'],
-    name: ['compoundname', 'compound_name', 'compound', 'name'],
   },
   'Compound Master V3': {
     compoundName: ['compoundname', 'compound_name', 'compound', 'name'],
     name: ['compoundname', 'compound_name', 'compound', 'name'],
-  },
-  'Herb Compound Map': {
-    herbName: ['herbname', 'herb_name'],
-    canonicalCompoundName: ['compoundname', 'compound_name'],
   },
   'Herb Compound Map V3': {
     herbName: ['herbname', 'herb_name'],
@@ -63,9 +51,8 @@ const COLUMN_ALIASES = {
 }
 const TARGET_WORKBOOK_SHEETS = [
   ...REQUIRED_SHEET_KEYS.flatMap(sheetKey => SHEET_MAP[sheetKey]),
-  'Production Export V1',
 ]
-const OPTIONAL_WORKBOOK_SHEETS = new Set(['Production Export V1'])
+const OPTIONAL_WORKBOOK_SHEETS = new Set([])
 const SHEET_REQUIRED_COLUMNS = {
   'Production Export V1': ['goal'],
 }
@@ -495,10 +482,10 @@ function canonicalizeRow(row, sheetName) {
   }
 
   const out = canonicalizeWorkbookRow(aliasedRow, sheetName)
-  if ((sheetName === 'Compound Master' || sheetName === 'Compound Master V3') && !out.compoundName && out.name) {
+  if (sheetName === 'Compound Master V3' && !out.compoundName && out.name) {
     out.compoundName = out.name
   }
-  if (sheetName === 'Herb Compound Map' || sheetName === 'Herb Compound Map V3') {
+  if (sheetName === 'Herb Compound Map V3') {
     if (!out.herbName && out.name) out.herbName = out.name
     if (!out.canonicalCompoundName && out.compoundName) out.canonicalCompoundName = out.compoundName
   }
@@ -568,11 +555,17 @@ function parseSheet(workbook, sheetName, diagnostics, { optional = false, requir
     sheetDiagnostics.parseWarnings.push(`Missing required columns: ${missingRequiredColumns.join(', ')}`)
   }
 
-  return canonicalRows.filter(row => {
+  const filteredRows = canonicalRows.filter(row => {
     const hasData = Object.values(row || {}).some(hasMeaningfulWorkbookValue)
     if (!hasData) sheetDiagnostics.skippedRows += 1
     return hasData
   })
+
+  if (!optional && filteredRows.length === 0) {
+    throw new Error(`[import-xlsx-monographs] Required worksheet "${sheetName}" has 0 data rows.`)
+  }
+
+  return filteredRows
 }
 
 function slugify(value) {
@@ -1138,7 +1131,8 @@ function main() {
   const herbCompoundMapRows = parseSheet(workbook, resolvedSheets.herbCompoundMap, diagnostics, {
     requiredColumns: RESOLVED_REQUIRED_COLUMNS.herbCompoundMap,
   })
-  parseSheet(workbook, 'Production Export V1', diagnostics, { optional: OPTIONAL_WORKBOOK_SHEETS.has('Production Export V1') })
+  parseSheet(workbook, resolvedSheets.claimRows, diagnostics)
+  parseSheet(workbook, resolvedSheets.researchQueue, diagnostics)
 
   const herbs = JSON.parse(fs.readFileSync(herbsPath, 'utf8'))
   let compounds = JSON.parse(fs.readFileSync(compoundsPath, 'utf8'))

--- a/scripts/verify-workbook-import-reconciliation.mjs
+++ b/scripts/verify-workbook-import-reconciliation.mjs
@@ -12,8 +12,11 @@ const __dirname = path.dirname(__filename)
 const repoRoot = path.resolve(__dirname, '..')
 const workbookPath = resolveWorkbookPath(repoRoot)
 const REQUIRED_WORKBOOK_SHEETS = {
-  herbs: ['Herb Monographs', 'Herb Master', 'Herb Master Clean'],
-  compounds: ['Compound Master V3', 'Compound Master'],
+  herbs: ['Herb Master V3'],
+  compounds: ['Compound Master V3'],
+  herbCompoundMap: ['Herb Compound Map V3'],
+  claimRows: ['Claim Rows'],
+  researchQueue: ['Research Queue'],
 }
 const herbsPath = path.join(repoRoot, 'public', 'data', 'herbs.json')
 const compoundsPath = path.join(repoRoot, 'public', 'data', 'compounds.json')
@@ -36,12 +39,18 @@ function resolveWorkbookSheet(workbook, candidates, label) {
 
 function baselineCounts() {
   const workbook = XLSX.readFile(workbookPath, {
-    sheets: [...REQUIRED_WORKBOOK_SHEETS.herbs, ...REQUIRED_WORKBOOK_SHEETS.compounds],
+    sheets: Object.values(REQUIRED_WORKBOOK_SHEETS).flat(),
   })
   const herbsSheet = resolveWorkbookSheet(workbook, REQUIRED_WORKBOOK_SHEETS.herbs, 'herbs')
   const compoundsSheet = resolveWorkbookSheet(workbook, REQUIRED_WORKBOOK_SHEETS.compounds, 'compounds')
   const herbRows = XLSX.utils.sheet_to_json(workbook.Sheets[herbsSheet], { defval: '', raw: false, blankrows: false })
   const compoundRows = XLSX.utils.sheet_to_json(workbook.Sheets[compoundsSheet], { defval: '', raw: false, blankrows: false })
+  const herbCompoundMapSheet = resolveWorkbookSheet(workbook, REQUIRED_WORKBOOK_SHEETS.herbCompoundMap, 'herbCompoundMap')
+  const claimRowsSheet = resolveWorkbookSheet(workbook, REQUIRED_WORKBOOK_SHEETS.claimRows, 'claimRows')
+  const researchQueueSheet = resolveWorkbookSheet(workbook, REQUIRED_WORKBOOK_SHEETS.researchQueue, 'researchQueue')
+  const herbCompoundMapRows = XLSX.utils.sheet_to_json(workbook.Sheets[herbCompoundMapSheet], { defval: '', raw: false, blankrows: false })
+  const claimRows = XLSX.utils.sheet_to_json(workbook.Sheets[claimRowsSheet], { defval: '', raw: false, blankrows: false })
+  const researchQueueRows = XLSX.utils.sheet_to_json(workbook.Sheets[researchQueueSheet], { defval: '', raw: false, blankrows: false })
 
   const herbs = JSON.parse(fs.readFileSync(herbsPath, 'utf8'))
   const compounds = JSON.parse(fs.readFileSync(compoundsPath, 'utf8'))
@@ -83,6 +92,9 @@ function baselineCounts() {
     herbRows: herbRows.length,
     herbMatches,
     compoundRows: compoundRows.length,
+    herbCompoundMapRows: herbCompoundMapRows.length,
+    claimRows: claimRows.length,
+    researchQueueRows: researchQueueRows.length,
     compoundMatches,
     missingRequiredHerbFields,
     herbRowsData: herbRows,
@@ -211,6 +223,9 @@ function main() {
   assert(reconciled.compoundMatched <= baseline.compoundRows, 'Suspicious over-matching detected for compounds.')
   assert(baseline.herbRows > 0, 'Herb Master has zero rows.')
   assert(baseline.compoundRows > 0, 'Compound Master has zero rows.')
+  assert(baseline.herbCompoundMapRows > 0, 'Herb Compound Map has zero rows.')
+  assert(baseline.claimRows > 0, 'Claim Rows has zero rows.')
+  assert(baseline.researchQueueRows > 0, 'Research Queue has zero rows.')
   assert(Array.isArray(workbookHerbs) && workbookHerbs.length > 0, 'workbook-herbs.json export is empty.')
   assert(Array.isArray(workbookCompounds) && workbookCompounds.length > 0, 'workbook-compounds.json export is empty.')
   assert(

--- a/src/generated/homepage-data.json
+++ b/src/generated/homepage-data.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-25T13:57:53.111Z",
+  "generatedAt": "2026-04-26T18:18:22.897Z",
   "counts": {
     "herbs": 285,
     "compounds": 235,
@@ -1497,7 +1497,7 @@
       "scientific": "",
       "effects": [],
       "effectsSummary": "",
-      "description": "Artemisia annua contains Artemisinin and is linked here to ROS-mediated signaling modulation.",
+      "description": "Internal cross-linking supports Artemisia Annua through compounds such as artemisinin.",
       "mechanism": "",
       "safety": "",
       "sideEffects": [],
@@ -1514,8 +1514,8 @@
         "name": "artemisia annua",
         "common": "artemisia annua",
         "scientific": "",
-        "summary": "Artemisia annua contains Artemisinin and is linked here to ROS-mediated signaling modulation.",
-        "description": "Artemisia annua contains Artemisinin and is linked here to ROS-mediated signaling modulation.",
+        "summary": "Internal cross-linking supports Artemisia Annua through compounds such as artemisinin.",
+        "description": "Internal cross-linking supports Artemisia Annua through compounds such as artemisinin.",
         "primaryActions": [],
         "mechanisms": [
           "artemisinin endoperoxide activation under iron/heme conditions",
@@ -1538,7 +1538,7 @@
         ],
         "preparation": "Separate whole-herb Artemisia preparations from purified artemisinin derivatives; evidence and safety are not interchangeable.",
         "traditionalUses": [],
-        "evidenceLevel": "in_vitro",
+        "evidenceLevel": "none",
         "relatedHerbs": [],
         "region": ""
       }
@@ -4882,7 +4882,7 @@
       "scientific": "",
       "effects": [],
       "effectsSummary": "",
-      "description": "Coleus forskohlii contains Forskolin and is linked here to adenylyl cyclase activation.",
+      "description": "It is best framed around forskolin with blood-pressure and stimulant-stack caution.",
       "mechanism": "",
       "safety": "",
       "sideEffects": [],
@@ -4899,8 +4899,8 @@
         "name": "coleus forskohlii",
         "common": "coleus forskohlii",
         "scientific": "",
-        "summary": "Coleus forskohlii contains Forskolin and is linked here to adenylyl cyclase activation.",
-        "description": "Coleus forskohlii contains Forskolin and is linked here to adenylyl cyclase activation.",
+        "summary": "It is best framed around forskolin with blood-pressure and stimulant-stack caution.",
+        "description": "It is best framed around forskolin with blood-pressure and stimulant-stack caution.",
         "primaryActions": [],
         "mechanisms": [
           "forskolin activation of adenylate cyclase",
@@ -11579,7 +11579,7 @@
       "scientific": "",
       "effects": [],
       "effectsSummary": "",
-      "description": "Panax ginseng lean herb row for high-speed phytochemical ingestion.",
+      "description": "Energy + stress.",
       "mechanism": "",
       "safety": "",
       "sideEffects": [],
@@ -11596,8 +11596,8 @@
         "name": "panax ginseng",
         "common": "panax ginseng",
         "scientific": "",
-        "summary": "Panax ginseng lean herb row for high-speed phytochemical ingestion.",
-        "description": "Panax ginseng lean herb row for high-speed phytochemical ingestion.",
+        "summary": "Energy + stress.",
+        "description": "Energy + stress.",
         "primaryActions": [],
         "mechanisms": [
           "Ginsenosides modulate AMPK and PI3K/Akt signaling",
@@ -13204,7 +13204,7 @@
       "scientific": "",
       "effects": [],
       "effectsSummary": "",
-      "description": "Rhodiola rosea contains Rosavin and is linked here to AMPK activation.",
+      "description": "Rhodiola Rosea centers on the root. Key reported compounds include rosavin; rosarin; rosin; salidroside; tyrosol. Typical preparation forms: Standardized root extracts. Adaptogen; modulates HPA axis; influences serotonin, dopamine, norepinephrine; antioxidant. Interaction profile: SSRIs, MAOIs, stimulants. Use caution or avoid in: Bipolar disorder; avoid high doses before sleep.",
       "mechanism": "",
       "safety": "",
       "sideEffects": [],
@@ -13221,8 +13221,8 @@
         "name": "rhodiola rosea",
         "common": "rhodiola rosea",
         "scientific": "",
-        "summary": "Rhodiola rosea contains Rosavin and is linked here to AMPK activation.",
-        "description": "Rhodiola rosea contains Rosavin and is linked here to AMPK activation.",
+        "summary": "Rhodiola Rosea centers on the root.",
+        "description": "Rhodiola Rosea centers on the root. Key reported compounds include rosavin; rosarin; rosin; salidroside; tyrosol. Typical preparation forms: Standardized root extracts. Adaptogen; modulates HPA axis; influences serotonin, dopamine, norepinephrine; antioxidant. Interaction profile: SSRIs, MAOIs, stimulants. Use caution or avoid in: Bipolar disorder; avoid high doses before sleep.",
         "primaryActions": [],
         "mechanisms": [
           "HPA-axis stress-response modulation",
@@ -13246,7 +13246,7 @@
           "anxiolytics/sedatives",
           "and therapies affecting blood pressure or glucose."
         ],
-        "preparation": "Preparation varies by tradition and product form; food/tea use should not be treated as equivalent to concentrated extracts.",
+        "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
         "traditionalUses": [],
         "evidenceLevel": "meta_analysis",
         "relatedHerbs": [],
@@ -14263,7 +14263,7 @@
       "scientific": "",
       "effects": [],
       "effectsSummary": "",
-      "description": "Sophora flavescens lean monograph row enriched in bulk mode.",
+      "description": "It should be framed conservatively because alkaloid-rich roots can have stronger tolerability issues.",
       "mechanism": "",
       "safety": "",
       "sideEffects": [],
@@ -14280,32 +14280,27 @@
         "name": "sophora flavescens",
         "common": "sophora flavescens",
         "scientific": "",
-        "summary": "Sophora flavescens lean monograph row enriched in bulk mode.",
-        "description": "Sophora flavescens lean monograph row enriched in bulk mode.",
+        "summary": "It should be framed conservatively because alkaloid-rich roots can have stronger tolerability issues.",
+        "description": "It should be framed conservatively because alkaloid-rich roots can have stronger tolerability issues.",
         "primaryActions": [],
         "mechanisms": [
-          "PI3K/Akt modulation",
-          "NF-κB inhibition",
-          "TGF-β signaling modulation"
+          "traditional skin support",
+          "GI support"
         ],
         "confidence": "low",
         "activeCompounds": [],
-        "safetyNotes": "Alkaloid-rich herb with meaningful safety-review needs; avoid casual internal use or unsupervised high-dose extracts.",
+        "safetyNotes": "Alkaloid-rich herb; use caution with liver disease, immunosuppressants, pregnancy/breastfeeding, and medications with narrow therapeutic windows.",
         "contraindications": [
-          "Pregnancy/breastfeeding",
-          "liver disease",
-          "arrhythmia/cardiac disease without clinician review",
-          "complex medication regimens."
+          "pregnancy/breastfeeding without clinician supervision",
+          "known allergy to the plant/family"
         ],
         "interactions": [
-          "Potential interactions with hepatotoxic drugs",
-          "antiarrhythmics",
-          "immunomodulators",
-          "and sedative/CNS-active medicines are plausible and extract-specific."
+          "Potential additive effects with medications affecting the same body system",
+          "review high-dose extracts with a clinician."
         ],
-        "preparation": "Root is used as decoction, granule, capsule, or alkaloid-standardized extract; standardized alkaloid products are not equivalent to crude root.",
+        "preparation": "Root/rhizome preparations are commonly used as teas, decoctions, powders, capsules, or standardized extracts depending on tradition.",
         "traditionalUses": [],
-        "evidenceLevel": "in_vitro",
+        "evidenceLevel": "none",
         "relatedHerbs": [],
         "region": ""
       }

--- a/src/generated/site-counts.json
+++ b/src/generated/site-counts.json
@@ -2,5 +2,5 @@
   "herbs": 285,
   "compounds": 235,
   "articles": 15,
-  "generatedAt": "2026-04-25T13:57:52.758Z"
+  "generatedAt": "2026-04-26T18:18:22.410Z"
 }


### PR DESCRIPTION
### Motivation
- Stabilize workbook ingestion after replacing `data-sources/herb_monograph_master.xlsx` by ensuring the importer reads only the locked V3 worksheets and stops noisy legacy fallbacks.
- Prevent silent, hard-to-debug data drift by failing fast when any required V3 sheet is missing or contains no data rows.
- Keep changes minimal and localized to data-pipeline scripts so route contracts and UI are unchanged.

### Description
- Restricted sheet resolution to the V3-only set and added `Claim Rows` and `Research Queue` as required sheets by updating importer/exporter/verification/build scripts (`scripts/import-xlsx-monographs.mjs`, `scripts/export-workbook-to-json.mjs`, `scripts/verify-workbook-import-reconciliation.mjs`, `scripts/data/build-runtime-from-workbook.mjs`, `scripts/generate-monograph-projection.mjs`, `scripts/data/report-workbook-parser-coverage.mjs`, `scripts/data/report-migration-parity.mjs`).
- Removed legacy fallback candidates (e.g., `Herb Monographs`, `Herb Master Clean`, `Compound Master`, `Herb Compound Map` fallback paths) so only `Herb Master V3`, `Compound Master V3`, and `Herb Compound Map V3` are consumed.
- Added fail-fast validations that throw clear errors when a required worksheet is missing or when a required worksheet contains zero data rows, and surfaced missing-required-column diagnostics when observed.
- Emit JSON artifacts strictly from the V3 flow (workbook exports updated and `workbook-goal-bundles.json` now emitted as an empty array for the legacy goal source), and updated build metadata to include `claimRows` and `researchQueue` in `public/data/_meta/build-info.json`.

### Testing
- Ran `node scripts/export-workbook-to-json.mjs` which completed successfully and wrote `workbook-herbs.json`, `workbook-compounds.json`, and `workbook-herb-compound-map.json` while logging resolved sheets for the V3 set.
- Ran `npm run build` which executed the data build (`node scripts/data/build-runtime-from-workbook.mjs --out public/data`) and the full site build pipeline and finished successfully (site artifacts and feeds generated). 
- Queried generated artifacts to confirm required sheets and counts: required sheets detected `{ herbs: "Herb Master V3", compounds: "Compound Master V3", herbCompoundMap: "Herb Compound Map V3", claimRows: "Claim Rows", researchQueue: "Research Queue" }`, `herbCount=285`, `compoundCount=235`, `herb-compound-map row count=554`, and overall build result `PASS`.
- Verified the exporter/build printed diagnostics for sheet loads and missing-column warnings where applicable and that the exported JSON payloads are non-empty as asserted by reconciliation checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee56287f608323b56e57920cf2d4bc)