### PR TITLE
Migrate deploy pipeline to publish Next.js output (stop using Vite dist)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,7 +49,7 @@ jobs:
           if [ -f "data-sources/herb_monograph_master.xlsx" ]; then
             node scripts/export-workbook-to-json.mjs
             node scripts/build-publication-manifest-from-workbook.mjs
-            node scripts/generate-sitemap.mjs
+            node scripts/generate-sitemap.mjs public
           else
             echo "::warning::data-sources/herb_monograph_master.xlsx not found. Skipping workbook pipeline."
           fi
@@ -57,8 +57,14 @@ jobs:
       - name: Build production site (includes prebuild + postbuild)
         run: npm run build
 
+      - name: Generate sitemap + robots for Next public assets
+        run: npm run sitemap
+
       - name: Verify SPA redirects
         run: npm run verify:redirects
+
+      - name: Build Cloudflare Pages output from Next
+        run: npx @cloudflare/next-on-pages@1
 
       - name: Verify critical generated assets
         run: |
@@ -66,10 +72,11 @@ jobs:
             "public/data/herbs.json"
             "public/data/compounds.json"
             "public/data/indexable-herbs.json"
-            "dist/index.html"
-            "dist/sitemap.xml"
-            "dist/robots.txt"
-            "dist/_redirects"
+            "public/sitemap.xml"
+            "public/robots.txt"
+            ".vercel/output/config.json"
+            ".vercel/output/static"
+            ".vercel/output/functions"
           )
 
           missing=0
@@ -97,4 +104,4 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_PAGES_PROJECT: ${{ secrets.CLOUDFLARE_PAGES_PROJECT }}
-        run: npx wrangler@4 pages deploy dist --project-name "$CLOUDFLARE_PAGES_PROJECT" --branch "$GITHUB_REF_NAME"
+        run: npx wrangler@4 pages deploy .vercel/output/static --project-name "$CLOUDFLARE_PAGES_PROJECT" --branch "$GITHUB_REF_NAME"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "npm run prebuild && next build",
     "postbuild": "npm run verify:enrichment-editorial",
     "verify:build": "npm run verify:enrichment-editorial && npm run verify:enrichment-discovery && npm run verify:structured-data && npm run verify:redirects",
-    "sitemap": "node scripts/generate-sitemap.mjs dist",
+    "sitemap": "node scripts/generate-sitemap.mjs public",
     "build:blog": "node scripts/build-blog.mjs",
     "build:graph": "node scripts/build-graph.mjs",
     "build:compounds": "tsx scripts/extract-compounds.ts",

--- a/scripts/ci/validate-deploy-readiness.mjs
+++ b/scripts/ci/validate-deploy-readiness.mjs
@@ -314,11 +314,11 @@ function main() {
     errors.push('public/data/compounds-detail is missing.')
   }
 
-  const sitemap = countSitemapLocs('dist/sitemap.xml')
+  const sitemap = countSitemapLocs('public/sitemap.xml')
   if (!sitemap.exists) {
-    errors.push('dist/sitemap.xml is missing (build/postbuild output required before deploy).')
+    errors.push('public/sitemap.xml is missing (run `npm run sitemap` before deploy).')
   } else if (sitemap.count <= MIN_SITEMAP_LOC_ENTRIES) {
-    errors.push(`dist/sitemap.xml must contain more than ${MIN_SITEMAP_LOC_ENTRIES} <loc> entries (found ${sitemap.count}).`)
+    errors.push(`public/sitemap.xml must contain more than ${MIN_SITEMAP_LOC_ENTRIES} <loc> entries (found ${sitemap.count}).`)
   }
 
   validatePublicationManifest(readJson('public/data/publication-manifest.json'), warnings)


### PR DESCRIPTION
### Motivation

- The CI/CD deploy flow still treated legacy Vite `dist` as the production artifact while the repository is using Next (App Router) as the primary runtime, so the pipeline needed to be updated to publish Next outputs instead of Vite artifacts. 
- Preserve existing route contracts and avoid UI changes while making minimal, surgical changes to configs and deploy scripts. 

### Description

- Update GitHub Actions workflow (`.github/workflows/deploy.yml`) to generate the sitemap for Next `public` assets, run `npx @cloudflare/next-on-pages@1` to produce Next-on-Pages output, and deploy `.vercel/output/static` to Cloudflare Pages instead of deploying `dist`. 
- Change `package.json` `sitemap` script to `node scripts/generate-sitemap.mjs public` so automation writes `public/sitemap.xml` and `public/robots.txt`. 
- Update `scripts/ci/validate-deploy-readiness.mjs` to validate `public/sitemap.xml` (and update its error text) and to require Next-compatible outputs under `.vercel/output` in the workflow checks. 
- Files changed: `.github/workflows/deploy.yml`, `package.json`, `scripts/ci/validate-deploy-readiness.mjs`.

### Testing

- Ran `npm run sitemap` which wrote `public/sitemap.xml` and `public/robots.txt` successfully. 
- Ran `npm run verify:deploy-readiness` which produced a `[deploy-readiness] PASS ...` result indicating the validation checks passed. 
- Confirmed repository contains a single `app` route tree (no duplicate `pages` tree) and `next` is present in `dependencies`; no UI or route-code changes were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef51012da08323bf62fa9fecf114f7)