### PR TITLE
Enable Next.js static export for Cloudflare Pages

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  output: 'export',
+  trailingSlash: true,
   eslint: {
     ignoreDuringBuilds: true,
   },


### PR DESCRIPTION
### Motivation
- Make Next.js emit a fully static site suitable for Cloudflare Pages by enabling static export and directory-style `index.html` outputs so pre-rendered dynamic routes are deployable.

### Description
- Updated `next.config.mjs` to add `output: 'export'` and `trailingSlash: true`; no other code changes were required because dynamic routes already use `generateStaticParams` and are pre-generated.

### Testing
- Ran `npm run build` (via `npx next build`) which completed with the export step, verified `out/index.html`, `out/herbs/index.html`, and `out/compounds/index.html` were created, and grepped the exported HTML to confirm there are no `_next/data` or `/api/` references.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef561d52508323b67101050370307a)