### PR TITLE
Add missing CI validation script aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "prebuild": "npm run data:build && node scripts/clean-source-refs.mjs && node scripts/dedupe-entities.mjs && node scripts/generate-entity-payloads.mjs && node scripts/generate-homepage-data-lite.mjs",
     "data:build": "node scripts/data/build-runtime-from-workbook.mjs --out public/data",
     "data:validate": "node scripts/data/validate-data-next.mjs --data-dir public/data",
+    "prebuild:validate": "npm run data:validate",
+    "audit:data": "npm run data:validate",
     "sitemap": "node scripts/generate-sitemap.mjs public",
     "verify:redirects": "echo \"Skipping legacy dist/_redirects check for Next/Cloudflare Pages build\"",
     "lint": "eslint . --max-warnings=0",


### PR DESCRIPTION
### Motivation
- Restore CI compatibility by providing the validation script aliases the pipeline expects (`prebuild:validate` and `audit:data`).

### Description
- Added `"prebuild:validate": "npm run data:validate"` to the `scripts` section in `package.json` without changing any existing scripts.
- Added `"audit:data": "npm run data:validate"` to the `scripts` section in `package.json` without changing any existing scripts.

### Testing
- Executed `npm run prebuild:validate` and `npm run audit:data`, and both ran `data:validate` successfully (validation passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0b92ca9e08323840921d95f19b084)