### PR TITLE
Restore missing data:report npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "prebuild": "npm run data:build && node scripts/clean-source-refs.mjs && node scripts/dedupe-entities.mjs && node scripts/generate-entity-payloads.mjs && node scripts/generate-homepage-data-lite.mjs",
     "data:build": "node scripts/data/build-runtime-from-workbook.mjs --out public/data",
     "data:validate": "node scripts/data/validate-data-next.mjs --data-dir public/data",
+    "data:report": "node scripts/data/validate-data-next.mjs --data-dir public/data",
     "prebuild:validate": "npm run data:validate",
     "audit:data": "npm run data:validate",
     "sitemap": "node scripts/generate-sitemap.mjs public",


### PR DESCRIPTION
### Motivation
- Prevent CI/build failures by restoring the missing `data:report` npm script so data validation can be invoked by name.

### Description
- Added a `data:report` entry to `package.json` pointing to `node scripts/data/validate-data-next.mjs --data-dir public/data` and left all existing scripts unchanged.

### Testing
- Ran `npm run data:report` and the script executed successfully, reporting `[data-next-validate] PASS herbs+compounds structural validation (public/data)`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0c069d4a08323941203adc0635f0a)