### PR TITLE
Remove SPA fallback from public/_redirects

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,1 @@
 /atom.xml /feed.xml 301
-/* /index.html 200


### PR DESCRIPTION
### Motivation
- Next.js static export generates per-route `index.html` files and the catch-all SPA fallback can override those route-specific static outputs, breaking page resolution.

### Description
- Removed the catch-all SPA fallback line `/* /index.html 200` from `public/_redirects`, leaving only the Atom feed redirect `/atom.xml /feed.xml 301`.

### Testing
- Verified the file contents with `cat -n public/_redirects` and confirmed it contains only the Atom redirect line; changes were committed (`c29579e`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1112161008323af7236b82128b084)