### PR TITLE
LLM-backed daily blog generator; append posts to data/blog/posts.json and add npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "verify:redirects": "echo \"Skipping legacy dist/_redirects check for Next/Cloudflare Pages build\"",
     "lint": "eslint . --max-warnings=0",
     "format": "prettier --write .",
-    "typecheck": "tsc --noEmit || echo 'typecheck skipped due to errors'"
+    "typecheck": "tsc --noEmit || echo 'typecheck skipped due to errors'",
+    "blog:generate": "node scripts/generate-daily-post.mjs"
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.8",

--- a/scripts/generate-daily-post.mjs
+++ b/scripts/generate-daily-post.mjs
@@ -1,9 +1,11 @@
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
+import { promptLLM } from './ai-client.mjs';
 
 const BLOG_DIR = path.join(process.cwd(), 'content', 'blog');
 const PUBLIC_BLOG_DIR = path.join(process.cwd(), 'public', 'blog');
 const MANIFEST_PATH = path.join(PUBLIC_BLOG_DIR, 'manifest.json');
+const POSTS_PATH = path.join(process.cwd(), 'data', 'blog', 'posts.json');
 const AUTHOR = 'Auto-Generator';
 
 const topics = [
@@ -13,14 +15,27 @@ const topics = [
   'Pharmacology Basics',
   'Traditional Use',
   'Extraction 101',
-  'Microdosing Log',
-  'Set & Setting',
+  'Materia Medica',
+  'Safety Snapshot',
 ];
-const herbs = ['Kava', 'Blue Lotus', 'Mugwort', 'Damiana', 'Passionflower', 'Skullcap', 'Ashwagandha', 'Valerian', 'Rhodiola', 'Gotu Kola'];
-const compounds = ['L-Theanine', 'Apigenin', 'Harmine', 'Beta-caryophyllene', 'Eugenol', 'Thujone', 'Choline', 'Hordenine'];
 
-function ensureDir(p) {
-  if (!fs.existsSync(p)) fs.mkdirSync(p, { recursive: true });
+const herbs = [
+  'Kava',
+  'Blue Lotus',
+  'Mugwort',
+  'Damiana',
+  'Passionflower',
+  'Skullcap',
+  'Ashwagandha',
+  'Valerian',
+  'Rhodiola',
+  'Gotu Kola',
+  'Lemon Balm',
+  'Holy Basil',
+];
+
+function ensureDir(dirPath) {
+  if (!fs.existsSync(dirPath)) fs.mkdirSync(dirPath, { recursive: true });
 }
 
 function rand(arr) {
@@ -28,36 +43,22 @@ function rand(arr) {
 }
 
 function slugify(str) {
-  return str
+  return String(str)
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/(^-|-$)/g, '');
 }
 
-function todayISO() {
+function nowIso() {
   return new Date().toISOString();
 }
 
 function todayDate() {
-  return todayISO().slice(0, 10);
+  return nowIso().slice(0, 10);
 }
 
-function yaml(str) {
+function yamlSafe(str) {
   return String(str).replace(/"/g, '\\"').replace(/:/g, '\\:');
-}
-
-function titleHerb(title = '') {
-  const match = String(title).match(/—\s*(.+)$/);
-  return match ? match[1].trim() : '';
-}
-
-function isConsistentPost(title = '', summary = '', body = '') {
-  const herb = titleHerb(title);
-  if (!herb) return false;
-  const normalizedHerb = herb.toLowerCase();
-  const summaryMatches = String(summary).toLowerCase().includes(normalizedHerb);
-  const bodyMatches = String(body).toLowerCase().includes(normalizedHerb);
-  return summaryMatches && bodyMatches;
 }
 
 function svg(seed) {
@@ -70,86 +71,195 @@ function svg(seed) {
 <rect width="100%" height="100%" fill="url(#g)"/></svg>`;
 }
 
-function run() {
-  ensureDir(BLOG_DIR);
-  ensureDir(PUBLIC_BLOG_DIR);
+function readJsonArray(filePath) {
+  if (!fs.existsSync(filePath)) return [];
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const parsed = JSON.parse(raw);
+  return Array.isArray(parsed) ? parsed : [];
+}
 
-  const date = todayDate();
-  const hasPost = fs.readdirSync(BLOG_DIR).some((file) => file.startsWith(`${date}-`) && file.endsWith('.mdx'));
-  if (hasPost) {
-    console.log('Post for today already exists.');
-    return;
+function writeJson(filePath, value) {
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function wordCount(text) {
+  return String(text)
+    .replace(/[#*_`>-]/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean).length;
+}
+
+function estimateReadingTime(words) {
+  return `${Math.max(1, Math.round(words / 200))} min read`;
+}
+
+function cleanExcerpt(text, max = 220) {
+  const compact = String(text).replace(/\s+/g, ' ').trim();
+  if (compact.length <= max) return compact;
+  return `${compact.slice(0, max - 1).trimEnd()}…`;
+}
+
+async function generatePostContent({ title, herb, topic }) {
+  const system = `You write educational herb blog posts for The Hippie Scientist. Use clear, grounded language. Avoid dosage instructions and medical advice. Output strict JSON only.`;
+  const prompt = `Create one blog post in JSON format about "${herb}" under the framing "${topic}".
+
+Return ONLY valid JSON with this exact shape:
+{
+  "excerpt": "1-2 sentence teaser, 140-220 chars",
+  "content": "Markdown with an H1 title and 4-6 ## sections"
+}
+
+Rules:
+- Content body must be 400-600 words.
+- Mention ${herb} naturally throughout.
+- Include practical preparation context and a safety section.
+- Use cautious phrasing (may, might, preliminary evidence).
+- No medical claims, no personalized guidance, no dosage recommendations.
+- Keep it educational and specific, not generic filler.
+- Do not include code fences or extra keys.`;
+
+  const output = await promptLLM({ system, prompt });
+  let parsed;
+  try {
+    parsed = JSON.parse(output);
+  } catch {
+    throw new Error('LLM returned invalid JSON for daily post generation.');
   }
 
-  const herb = rand(herbs);
-  const title = `${rand(topics)} — ${herb}`;
-  const summary = `Daily notes on ${herb} with attention to active compounds like ${rand(compounds)} and safe practice.`;
-  const slug = `${date}-${slugify(title)}`;
-  const coverRel = `/blog/${slug}.svg`;
+  const excerpt = String(parsed?.excerpt || '').trim();
+  const content = String(parsed?.content || '').trim();
 
+  if (!excerpt || !content) {
+    throw new Error('LLM response missing excerpt/content.');
+  }
+
+  const words = wordCount(content);
+  if (words < 400 || words > 600) {
+    throw new Error(`LLM content length out of range: expected 400-600 words, received ${words}.`);
+  }
+
+  const herbToken = herb.toLowerCase();
+  if (!excerpt.toLowerCase().includes(herbToken) || !content.toLowerCase().includes(herbToken)) {
+    throw new Error('Generated post failed consistency check (herb missing in excerpt/content).');
+  }
+
+  const normalizedContent = content.startsWith('# ') ? content : `# ${title}\n\n${content}`;
+  return {
+    excerpt,
+    content: normalizedContent,
+    words,
+  };
+}
+
+function appendManifest(entry) {
+  const manifest = readJsonArray(MANIFEST_PATH);
+  const exists = manifest.some(item => item && item.slug === entry.slug);
+  if (exists) return;
+  manifest.unshift(entry);
+  writeJson(MANIFEST_PATH, manifest);
+}
+
+function appendPostsJson(entry) {
+  const posts = readJsonArray(POSTS_PATH);
+  const exists = posts.some(item => item && item.slug === entry.slug);
+  if (exists) return false;
+
+  const filtered = posts.filter(post => post?.slug !== 'coming-soon');
+  filtered.push(entry);
+  writeJson(POSTS_PATH, filtered);
+  return true;
+}
+
+function buildMdx({ title, summary, dateIso, dateOnly, coverRel, body }) {
   const frontmatter = `---
-title: "${yaml(title)}"
-date: "${todayISO()}"
-lastUpdated: "${todayDate()}"
+title: "${yamlSafe(title)}"
+date: "${dateIso}"
+lastUpdated: "${dateOnly}"
 author: "${AUTHOR}"
-summary: "${yaml(summary)}"
+summary: "${yamlSafe(summary)}"
 sources: []
 tags: ["Daily","Field Notes","Herbs"]
 cover: "${coverRel}"
 ---`;
 
-  const body = `
-# ${title}
+  return `${frontmatter}\n\n${body}\n`;
+}
 
-_${summary}_
+async function run() {
+  ensureDir(BLOG_DIR);
+  ensureDir(PUBLIC_BLOG_DIR);
+  ensureDir(path.dirname(POSTS_PATH));
 
-## Highlights
-- Context and traditional notes
-- Quick pharmacology snapshot
-- Practical prep and safety pointers
+  const dateOnly = todayDate();
+  const topic = rand(topics);
+  const herb = rand(herbs);
+  const title = `${topic} — ${herb}`;
+  const slug = `${dateOnly}-${slugify(title)}`;
 
-## Further Reading
-- Placeholder reference A
-- Placeholder reference B
-`;
-
-  if (!isConsistentPost(title, summary, body)) {
-    throw new Error('Generated post failed consistency check (title/summary/body herb mismatch).');
+  const hasPostToday = readJsonArray(POSTS_PATH).some(
+    post => typeof post?.slug === 'string' && post.slug.startsWith(`${dateOnly}-`),
+  );
+  if (hasPostToday) {
+    console.log('Post for today already exists in data/blog/posts.json.');
+    return;
   }
 
-  fs.writeFileSync(path.join(BLOG_DIR, `${slug}.mdx`), `${frontmatter}\n${body}`, 'utf8');
+  const generated = await generatePostContent({ title, herb, topic });
+  const dateIso = nowIso();
+  const coverRel = `/blog/${slug}.svg`;
+
+  const entry = {
+    slug,
+    title,
+    date: dateOnly,
+    lastUpdated: dateOnly,
+    author: AUTHOR,
+    sources: [],
+    excerpt: cleanExcerpt(generated.excerpt, 220),
+    description: cleanExcerpt(generated.excerpt, 180),
+    summary: cleanExcerpt(generated.excerpt, 220),
+    tags: ['Daily', 'Field Notes', 'Herbs'],
+    readingTime: estimateReadingTime(generated.words),
+    content: generated.content,
+    cover: coverRel,
+    featuredImage: coverRel,
+    ogImage: coverRel,
+  };
+
+  const wrotePosts = appendPostsJson(entry);
+  if (!wrotePosts) {
+    console.log('Post slug already exists in data/blog/posts.json:', slug);
+    return;
+  }
+
+  const mdx = buildMdx({
+    title,
+    summary: entry.excerpt,
+    dateIso,
+    dateOnly,
+    coverRel,
+    body: generated.content,
+  });
+
+  fs.writeFileSync(path.join(BLOG_DIR, `${slug}.mdx`), mdx, 'utf8');
   fs.writeFileSync(path.join(PUBLIC_BLOG_DIR, `${slug}.svg`), svg(Date.now()), 'utf8');
+
   appendManifest({
     slug,
     title,
-    date: todayDate(),
-    lastUpdated: todayDate(),
+    date: dateOnly,
+    lastUpdated: dateOnly,
     author: AUTHOR,
-    summary,
+    summary: entry.summary,
     sources: [],
-    tags: ['Daily', 'Field Notes', 'Herbs'],
+    tags: entry.tags,
     cover: coverRel,
   });
+
   console.log('Created blog post:', slug);
 }
 
-function appendManifest(entry) {
-  let manifest = [];
-  if (fs.existsSync(MANIFEST_PATH)) {
-    try {
-      const raw = fs.readFileSync(MANIFEST_PATH, 'utf8');
-      const parsed = JSON.parse(raw);
-      manifest = Array.isArray(parsed) ? parsed : [];
-    } catch {
-      manifest = [];
-    }
-  }
-
-  const exists = manifest.some(item => item && item.slug === entry.slug);
-  if (exists) return;
-
-  manifest.unshift(entry);
-  fs.writeFileSync(MANIFEST_PATH, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
-}
-
-run();
+run().catch(error => {
+  console.error('[generate-daily-post] Failed:', error instanceof Error ? error.message : error);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Fix the broken daily blog pipeline so generated posts provide real article bodies that the homepage and blog index can consume from `data/blog/posts.json`.
- Ensure daily posts include substantive, on-brand content (not placeholders) and are validated for herb relevance and length.
- Keep existing downstream artifacts (MDX files, cover SVGs, public manifest) while making the canonical posts index authoritative.

### Description
- Rewrote `scripts/generate-daily-post.mjs` to call `promptLLM` from `scripts/ai-client.mjs` and request JSON output containing `excerpt` and `content` for a generated post.
- Added strict validation and parsing of the LLM output, enforcing a 400–600 word body, presence of the selected herb in both excerpt and body, and required keys; generation now fails fast on invalid output.
- Updated the flow to append the new post entry to `data/blog/posts.json` (removing the `coming-soon` placeholder when a real post is written) and still write `content/blog/*.mdx`, `public/blog/*.svg`, and update `public/blog/manifest.json`.
- Added `blog:generate` script to `package.json` as `node scripts/generate-daily-post.mjs` and documented required LLM env vars for runtime: `LLM_API_URL`, `LLM_API_KEY` (optional `LLM_MODEL`).

### Testing
- Ran `node --check scripts/generate-daily-post.mjs` which completed without syntax errors.
- Ran `npm run blog:generate` which failed with a clear message when LLM credentials were absent (`LLM_API_URL`/`LLM_API_KEY`), as expected in this environment.
- Ran `npm run build` as a smoke validation and observed build failure due to missing `@fontsource/inter/*.css` resolution in this environment, which is unrelated to the generator changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1117982cc8323a75b7adebf58f74b)