### PR TITLE
Export all valid herbs in workbook runtime build and add summary diagnostics

### DIFF
--- a/scripts/data/build-runtime-from-workbook.mjs
+++ b/scripts/data/build-runtime-from-workbook.mjs
@@ -301,22 +301,27 @@ function run() {
   const claimRows = readSheet(workbook, REQUIRED_SHEETS.claimRows)
   const researchQueueRows = readSheet(workbook, REQUIRED_SHEETS.researchQueue)
 
-  const allHerbs = herbRows.map(herbFromRow)
-  const allCompounds = compoundRows.map(compoundFromRow)
+  const herbs = herbRows.map(herbFromRow)
+  const compounds = compoundRows.map(compoundFromRow)
 
-  for (const herb of allHerbs) assertIdentity(herb, 'herb')
-  for (const compound of allCompounds) assertIdentity(compound, 'compound')
+  console.log(
+    `[data] herbs: ${herbs.length} total, ${herbs.filter(h => h.summary).length} with summary`,
+  )
+  console.log(`[data] compounds: ${compounds.length} total`)
+
+  for (const herb of herbs) assertIdentity(herb, 'herb')
+  for (const compound of compounds) assertIdentity(compound, 'compound')
 
   const duplicateSlugs = [
-    ...detectDuplicates(allHerbs, 'herb'),
-    ...detectDuplicates(allCompounds, 'compound'),
+    ...detectDuplicates(herbs, 'herb'),
+    ...detectDuplicates(compounds, 'compound'),
   ]
 
   if (duplicateSlugs.length > 0) {
     throw new Error(`[data] Duplicate slugs found:\n${duplicateSlugs.join('\n')}`)
   }
 
-  const herbNameBySlug = new Map(allHerbs.map(herb => [herb.slug, herb.name]))
+  const herbNameBySlug = new Map(herbs.map(herb => [herb.slug, herb.name]))
   const foundInByCompound = new Map()
 
   for (const row of mapRows) {
@@ -336,14 +341,15 @@ function run() {
     }
   }
 
-  for (const compound of allCompounds) {
+  for (const compound of compounds) {
     compound.foundIn = (foundInByCompound.get(compound.slug) || []).sort((a, b) =>
       a.localeCompare(b),
     )
   }
 
-  const publishableHerbs = allHerbs.filter(isPublishable).map(publicRecord)
-  const publishableCompounds = allCompounds.filter(isPublishable).map(publicRecord)
+  const publishableHerbs = herbs.filter(isPublishable).map(publicRecord)
+  const publishableCompounds = compounds.filter(isPublishable).map(publicRecord)
+  const exportedHerbs = herbs.map(publicRecord)
 
   const invalidPublishable = [
     ...publishableHerbs
@@ -365,12 +371,12 @@ function run() {
   fs.rmSync(outputDir, { recursive: true, force: true })
   fs.mkdirSync(outputDir, { recursive: true })
 
-  writeJson(path.join(outputDir, 'herbs.json'), publishableHerbs)
+  writeJson(path.join(outputDir, 'herbs.json'), exportedHerbs)
   writeJson(path.join(outputDir, 'compounds.json'), publishableCompounds)
-  writeJson(path.join(outputDir, 'herbs-summary.json'), publishableHerbs.map(summaryRecord))
+  writeJson(path.join(outputDir, 'herbs-summary.json'), exportedHerbs.map(summaryRecord))
   writeJson(path.join(outputDir, 'compounds-summary.json'), publishableCompounds.map(summaryRecord))
 
-  for (const herb of publishableHerbs) {
+  for (const herb of exportedHerbs) {
     writeJson(path.join(outputDir, 'herbs-detail', `${herb.slug}.json`), herb)
   }
 
@@ -384,15 +390,16 @@ function run() {
     sourceWorkbook: path.relative(repoRoot, workbookPath),
     output: outputLabel,
     totals: {
-      workbookHerbs: allHerbs.length,
-      workbookCompounds: allCompounds.length,
+      workbookHerbs: herbs.length,
+      workbookCompounds: compounds.length,
+      exportedHerbs: exportedHerbs.length,
       publishableHerbs: publishableHerbs.length,
       publishableCompounds: publishableCompounds.length,
-      needsWorkHerbs: allHerbs.filter(record => !isPublishable(record)).length,
-      needsWorkCompounds: allCompounds.filter(record => !isPublishable(record)).length,
+      needsWorkHerbs: herbs.filter(record => !isPublishable(record)).length,
+      needsWorkCompounds: compounds.filter(record => !isPublishable(record)).length,
       claimRows: claimRows.length,
       researchQueueRows: researchQueueRows.length,
-      missingHerbDosage: allHerbs.filter(record => !record.dosage).length,
+      missingHerbDosage: herbs.filter(record => !record.dosage).length,
       duplicateSlugs: duplicateSlugs.length,
       invalidPublishable: invalidPublishable.length,
     },
@@ -411,8 +418,8 @@ function run() {
 
   console.log(`[data] workbook=${path.relative(repoRoot, workbookPath)}`)
   console.log(`[data] output=${outputLabel}`)
-  console.log(`[data] herbs=${publishableHerbs.length}/${allHerbs.length}`)
-  console.log(`[data] compounds=${publishableCompounds.length}/${allCompounds.length}`)
+  console.log(`[data] herbs=${exportedHerbs.length}/${herbs.length}`)
+  console.log(`[data] compounds=${publishableCompounds.length}/${compounds.length}`)
   console.log(`[data] build-report=${path.join(outputLabel, 'build-report.json')}`)
 }
 


### PR DESCRIPTION
### Motivation
- Add build-time diagnostics to show how many herb/compound rows were parsed and how many herb rows include a non-empty summary. 
- Ensure herb JSON outputs include all identity-valid workbook rows (name+slug) rather than being filtered by publishability at build time. 
- Keep downstream quality gating at render time (`publishQuality.ts`) and avoid silently dropping records during the runtime build.

### Description
- Inserted post-mapping console logs showing total herb rows and how many have a non-empty summary, and total compounds. (`scripts/data/build-runtime-from-workbook.mjs`).
- Renamed `allHerbs`/`allCompounds` to `herbs`/`compounds` and added `exportedHerbs = herbs.map(publicRecord)` to represent the full identity-validated export set. (`scripts/data/build-runtime-from-workbook.mjs`).
- Switched herb outputs to write the full `exportedHerbs` to `herbs.json`, `herbs-summary.json`, and `herbs-detail/*` while leaving compounds still gated by publishability. (`scripts/data/build-runtime-from-workbook.mjs`).
- Kept `DEFAULT_SUMMARY` fallback behavior and added `exportedHerbs` to the build report totals so the exported-vs-publishable counts are explicit. (`scripts/data/build-runtime-from-workbook.mjs`).

### Testing
- Ran `node scripts/data/build-runtime-from-workbook.mjs --out tmp/data-audit` and confirmed the new summary logs and updated output files were created; the build completed successfully. 
- Verified exported counts and summary assignment by loading `tmp/data-audit/herbs.json` and `tmp/data-audit/build-report.json`; the workbook parsed 309 herb rows, `exportedHerbs` = 309, and `publishableHerbs` = 275. 
- Confirmed that `DEFAULT_SUMMARY` remains the fallback and that missing summaries were not the cause of prior row drops; tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f112ae52f88323b17d18a67908f685)