### PR TITLE
Deduplicate compounds by canonical name and add canonical URL metadata

### DIFF
--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -189,11 +189,15 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
 
   const label = getCompoundLabel(compound)
   const description = getLeadText(compound)
+  const canonicalPath = `/compounds/${compound.slug}`
 
   return {
     title: `${label} | Compound`,
     description,
-    alternates: { canonical: `/compounds/${compound.slug}` },
+    alternates: { canonical: canonicalPath },
+    openGraph: {
+      url: canonicalPath,
+    },
   }
 }
 

--- a/scripts/data/build-runtime-from-workbook.mjs
+++ b/scripts/data/build-runtime-from-workbook.mjs
@@ -303,18 +303,31 @@ function run() {
 
   const herbs = herbRows.map(herbFromRow)
   const compounds = compoundRows.map(compoundFromRow)
+  const seenCompoundNames = new Map()
+  const dedupedCompounds = compounds.filter(compound => {
+    const key = compound.name.toLowerCase().trim()
+    if (seenCompoundNames.has(key)) {
+      console.warn(
+        `[data] duplicate compound dropped: ${compound.slug} (dupe of ${seenCompoundNames.get(key)})`,
+      )
+      return false
+    }
+    seenCompoundNames.set(key, compound.slug)
+    return true
+  })
 
   console.log(
     `[data] herbs: ${herbs.length} total, ${herbs.filter(h => h.summary).length} with summary`,
   )
   console.log(`[data] compounds: ${compounds.length} total`)
+  console.log(`[data] compounds: ${dedupedCompounds.length} after canonical-name dedupe`)
 
   for (const herb of herbs) assertIdentity(herb, 'herb')
-  for (const compound of compounds) assertIdentity(compound, 'compound')
+  for (const compound of dedupedCompounds) assertIdentity(compound, 'compound')
 
   const duplicateSlugs = [
     ...detectDuplicates(herbs, 'herb'),
-    ...detectDuplicates(compounds, 'compound'),
+    ...detectDuplicates(dedupedCompounds, 'compound'),
   ]
 
   if (duplicateSlugs.length > 0) {
@@ -341,14 +354,14 @@ function run() {
     }
   }
 
-  for (const compound of compounds) {
+  for (const compound of dedupedCompounds) {
     compound.foundIn = (foundInByCompound.get(compound.slug) || []).sort((a, b) =>
       a.localeCompare(b),
     )
   }
 
   const publishableHerbs = herbs.filter(isPublishable).map(publicRecord)
-  const publishableCompounds = compounds.filter(isPublishable).map(publicRecord)
+  const publishableCompounds = dedupedCompounds.filter(isPublishable).map(publicRecord)
   const exportedHerbs = herbs.map(publicRecord)
 
   const invalidPublishable = [
@@ -392,11 +405,12 @@ function run() {
     totals: {
       workbookHerbs: herbs.length,
       workbookCompounds: compounds.length,
+      dedupedWorkbookCompounds: dedupedCompounds.length,
       exportedHerbs: exportedHerbs.length,
       publishableHerbs: publishableHerbs.length,
       publishableCompounds: publishableCompounds.length,
       needsWorkHerbs: herbs.filter(record => !isPublishable(record)).length,
-      needsWorkCompounds: compounds.filter(record => !isPublishable(record)).length,
+      needsWorkCompounds: dedupedCompounds.filter(record => !isPublishable(record)).length,
       claimRows: claimRows.length,
       researchQueueRows: researchQueueRows.length,
       missingHerbDosage: herbs.filter(record => !record.dosage).length,
@@ -419,7 +433,7 @@ function run() {
   console.log(`[data] workbook=${path.relative(repoRoot, workbookPath)}`)
   console.log(`[data] output=${outputLabel}`)
   console.log(`[data] herbs=${exportedHerbs.length}/${herbs.length}`)
-  console.log(`[data] compounds=${publishableCompounds.length}/${compounds.length}`)
+  console.log(`[data] compounds=${publishableCompounds.length}/${dedupedCompounds.length}`)
   console.log(`[data] build-report=${path.join(outputLabel, 'build-report.json')}`)
 }
 


### PR DESCRIPTION
### Motivation
- Reduce duplicate compound profiles that share the same canonical name to avoid duplicate content and inconsistent exports.
- Ensure compound detail pages declare a consistent canonical URL to help SEO and Open Graph consumers.

### Description
- Added canonical-name deduplication in `scripts/data/build-runtime-from-workbook.mjs` using a `Map` keyed by `compound.name.toLowerCase().trim()` and logging dropped duplicates with `console.warn` including the preserved slug.
- Switched downstream compound processing (identity checks, slug-duplicate detection, `foundIn` hydration, publishable filtering, and exports) to operate on the deduped compound list (`dedupedCompounds`).
- Added `dedupedWorkbookCompounds` to the build report totals and updated console logging to show the post-dedupe compound count.
- Updated `app/compounds/[slug]/page.tsx` to compute a single `canonicalPath` and use it for `alternates.canonical` and `openGraph.url` so Next will emit a `<link rel="canonical">` and align Open Graph URL metadata.

### Testing
- Ran `npm run data:build`, which completed successfully and logged duplicates dropped and final counts without build errors.
- Ran `npm run data:validate`, which passed structural validation for `public/data`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f116bdb7d0832393e1095cd25d7317)