### PR TITLE
Harden governed static-data stubs to enforce array artifacts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2165,9 +2165,9 @@
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -3623,9 +3623,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.23",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.23.tgz",
-      "integrity": "sha512-xwVXGqevyKPsiuQdLj+dZMVjidjJV508TBqexND5HrF89cGdCYCJFB3qhcxRHSeMctdCfbR1jrxBajhDy7o29g==",
+      "version": "2.10.24",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
+      "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7909,6 +7909,15 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next/node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/scripts/ensure-static-data-stubs.mjs
+++ b/scripts/ensure-static-data-stubs.mjs
@@ -1,21 +1,35 @@
-import fs from "node:fs";
-import path from "node:path";
+import fs from 'node:fs'
+import path from 'node:path'
 
-const dataDir = path.resolve("public/data");
+const dataDir = path.resolve('public/data')
 
-fs.mkdirSync(dataDir, { recursive: true });
+const arrayArtifacts = ['enrichment-governed.json', 'source-registry.json']
 
-const files = {
-  // governedResearch.ts expects this file to be an ARRAY.
-  "enrichment-governed.json": [],
+fs.mkdirSync(dataDir, { recursive: true })
 
-  // governedResearch.ts expects this file to be an ARRAY.
-  "source-registry.json": []
-};
+for (const filename of arrayArtifacts) {
+  const filePath = path.join(dataDir, filename)
 
-for (const [filename, content] of Object.entries(files)) {
-  const filePath = path.join(dataDir, filename);
+  if (!fs.existsSync(filePath)) {
+    fs.writeFileSync(filePath, '[]\n')
+    console.log(`[static-stubs] created missing array artifact: ${filePath}`)
+    continue
+  }
 
-  fs.writeFileSync(filePath, JSON.stringify(content, null, 2) + "\n");
-  console.log(`[static-stubs] ensured ${filePath}`);
+  let parsed
+  try {
+    parsed = JSON.parse(fs.readFileSync(filePath, 'utf8'))
+  } catch {
+    fs.writeFileSync(filePath, '[]\n')
+    console.warn(`[static-stubs] reset invalid JSON artifact to array: ${filePath}`)
+    continue
+  }
+
+  if (!Array.isArray(parsed)) {
+    fs.writeFileSync(filePath, '[]\n')
+    console.warn(`[static-stubs] reset non-array artifact to array: ${filePath}`)
+    continue
+  }
+
+  console.log(`[static-stubs] artifact already valid array: ${filePath}`)
 }


### PR DESCRIPTION
### Motivation
- The Next code imports `public/data/enrichment-governed.json` and `public/data/source-registry.json` as arrays and the build can fail if these generated files are missing or malformed.
- Ensure the build never fails due to missing/generated JSON artifacts while preserving their expected TypeScript shapes.

### Description
- Rewrote `scripts/ensure-static-data-stubs.mjs` to guarantee the two governed artifacts (`enrichment-governed.json`, `source-registry.json`) exist and are JSON arrays.
- The script now creates missing files as `[]`, preserves existing valid arrays, and resets files to `[]` only when JSON is invalid or not an array.
- Targeted artifacts are limited to the two governed files to keep changes minimal and safe for existing data pipelines.
- No `package.json` script edits were required because `prebuild` already runs `npm run data:build` then `node scripts/ensure-static-data-stubs.mjs` before the Next/TypeScript build.

### Testing
- Ran `npm run check` which executes `npm run data:build && npm run data:validate && npm run build` and observed the data build and validation stages succeed.
- The stub script logged creation of missing array artifacts during `prebuild` (`[static-stubs] created missing array artifact: .../enrichment-governed.json` and `.../source-registry.json`).
- The final Next.js build step failed due to an unrelated missing dependency error (`Cannot find module '@headlessui/react'`), so `npm run check` ended with a failing build phase.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1536901b88323856b7b7314a6ccd6)