### PR TITLE
Fix herb publishability fallback when workbook omits quality tier

### DIFF
--- a/scripts/data/build-runtime-from-workbook.mjs
+++ b/scripts/data/build-runtime-from-workbook.mjs
@@ -152,6 +152,12 @@ function qualityTier(row) {
   if (direct.includes('a')) return 'strong'
   if (direct.includes('b')) return 'publishable'
 
+  const hasName = Boolean(cleanText(row.name || row.commonName))
+  const hasSlug = Boolean(cleanText(row.slug))
+  const hasSummary = Boolean(cleanText(row.summary || row.description))
+  const hasSafety = Boolean(cleanText(row.safetyNotes))
+  if (hasName && hasSlug && hasSummary && hasSafety) return 'publishable'
+
   return 'needs_work'
 }
 


### PR DESCRIPTION
### Motivation
- The source workbook does not export a `qualityTier` column for herbs, which caused all herb rows to fall back to `needs_work` and therefore fail the publishable gating.
- The intent is to consider rows with minimal, meaningful content as publishable even when an explicit tier is not provided.

### Description
- Updated `qualityTier(row)` in `scripts/data/build-runtime-from-workbook.mjs` to keep existing explicit-tier parsing but add a minimum-content fallback that returns `publishable` when `name`/`commonName`, `slug`, `summary`/`description`, and `safetyNotes` are present.
- The new checks use `cleanText(...)` to validate fields before deciding the fallback tier so existing behavior for explicit tier flags remains unchanged.
- Only a small, surgical change was made to `scripts/data/build-runtime-from-workbook.mjs` to preserve existing pipelines and route contracts.

### Testing
- Ran the data build with `npm run data:build` and it completed successfully.
- Verified the generated `public/data/build-report.json` shows `totals.publishableHerbs: 308`, which meets the expected threshold, and `public/data/herbs.json` contains `309` records.
- No other automated test failures were observed during the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f15fe48a9c8323923b325196e1b1f0)