### PR TITLE
Add noindex metadata for thin blog stub posts

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -210,6 +210,11 @@ const getHtmlContent = (post: BlogPost): string =>
 const getTextContent = (post: BlogPost): string =>
   toText(post.content) || toText(post.body) || toText(post.markdown)
 
+const isStubPost = (post: BlogPost): boolean => {
+  const content = getTextContent(post)
+  return !content || content.split(/\s+/).filter(Boolean).length < 300
+}
+
 const getSections = (post: BlogPost): RenderSection[] => {
   const structuredSections = buildSectionsFromStructuredData(post.sections)
   if (structuredSections.length > 0) return structuredSections
@@ -307,6 +312,7 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
     title: `${post.title} | The Hippie Scientist`,
     description: getLeadText(post),
     alternates: { canonical: `/blog/${post.slug}` },
+    robots: isStubPost(post) ? { index: false, follow: false } : undefined,
   }
 }
 

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -32,6 +32,8 @@ type BlogPost = {
   html?: unknown
   sections?: unknown
   summary?: unknown
+  profile_status?: string
+  summary_quality?: string
   researchDigest?: unknown
   fieldNotes?: unknown
   traditionalContext?: unknown
@@ -212,7 +214,13 @@ const getTextContent = (post: BlogPost): string =>
 
 const isStubPost = (post: BlogPost): boolean => {
   const content = getTextContent(post)
-  return !content || content.split(/\s+/).filter(Boolean).length < 300
+  const wordCount = content.split(/\s+/).filter(Boolean).length
+
+  return (
+    wordCount < 300 ||
+    post.profile_status === 'minimal' ||
+    post.summary_quality === 'none'
+  )
 }
 
 const getSections = (post: BlogPost): RenderSection[] => {
@@ -312,7 +320,7 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
     title: `${post.title} | The Hippie Scientist`,
     description: getLeadText(post),
     alternates: { canonical: `/blog/${post.slug}` },
-    robots: isStubPost(post) ? { index: false, follow: false } : undefined,
+    robots: isStubPost(post) ? { index: false, follow: true } : undefined,
   }
 }
 


### PR DESCRIPTION
### Motivation
- Prevent thin-content blog stubs (missing body or under 300 words) from being indexed by search engines to reduce SEO risk.

### Description
- Added `isStubPost` in `app/blog/[slug]/page.tsx` that reuses `getTextContent` to detect posts with no content or fewer than 300 words, and updated `generateMetadata` to return `robots: { index: false, follow: false }` for stub posts.

### Testing
- Ran `npx eslint app/blog/[slug]/page.tsx --max-warnings=0` (passed) and ran `npm run lint` which failed due to a pre-existing unrelated lint error in `scripts/build-blog.mjs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f160de951c83238c19ac64fc89773f)