### PR TITLE
Add reusable client MobileNav and use it in RootLayout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import type { ReactNode } from 'react'
 import Link from 'next/link'
+import MobileNav from '@/components/mobile-nav'
 import '@fontsource/inter/400.css'
 import '@fontsource/inter/500.css'
 import '@fontsource/inter/600.css'
@@ -105,26 +106,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
                 ))}
               </nav>
 
-              <details className='relative md:hidden'>
-                <summary className='list-none rounded-full border border-white/15 px-4 py-2 text-sm font-medium text-white/90 transition hover:border-white/30 hover:bg-white/5'>
-                  Menu
-                </summary>
-
-                <nav
-                  aria-label='Mobile'
-                  className='absolute right-0 top-full z-20 mt-2 w-52 rounded-2xl border border-white/10 bg-[var(--surface-2)] p-2 shadow-2xl'
-                >
-                  {navLinks.map(link => (
-                    <Link
-                      key={link.href}
-                      href={link.href}
-                      className='block rounded-xl px-4 py-3 text-sm font-medium text-white/80 transition hover:bg-white/5 hover:text-white'
-                    >
-                      {link.label}
-                    </Link>
-                  ))}
-                </nav>
-              </details>
+              <MobileNav links={navLinks} />
             </div>
           </header>
 

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+
+type NavLink = { href: string; label: string }
+
+export default function MobileNav({ links }: { links: NavLink[] }) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className='relative md:hidden'>
+      <button
+        onClick={() => setOpen(o => !o)}
+        className='list-none rounded-full border border-white/15 px-4 py-2 text-sm font-medium text-white/90 transition hover:border-white/30 hover:bg-white/5'
+      >
+        Menu
+      </button>
+      {open && (
+        <nav
+          aria-label='Mobile'
+          className='absolute right-0 top-full z-20 mt-2 w-52 rounded-2xl border border-white/10 bg-[var(--surface-2)] p-2 shadow-2xl'
+        >
+          {links.map(link => (
+            <Link
+              key={link.href}
+              href={link.href}
+              onClick={() => setOpen(false)}
+              className='block rounded-xl px-4 py-3 text-sm font-medium text-white/80 transition hover:bg-white/5 hover:text-white'
+            >
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
### Motivation
- Replace the inline `<details>` mobile menu with a small, reusable client component to enable controlled open/close state and improved behavior on link click.
- Keep the change minimal and surgical by introducing a single new component and swapping it into the existing header.

### Description
- Add `components/mobile-nav.tsx`, a client component that uses `useState` to toggle the mobile menu and closes the menu when a link is clicked.
- Update `app/layout.tsx` to import `MobileNav` and replace the inline `<details>` block with `<MobileNav links={navLinks} />`.
- Commit includes only the new component and the single change in the root layout.

### Testing
- Ran `npm run lint`, which failed due to a pre-existing ESLint error in `scripts/build-blog.mjs` (`no-useless-escape`) that is unrelated to these edits.
- No other automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1628cbc908323be17bb96de9beef4)