### PR TITLE
Add JSON-LD structured data to herb, compound, and blog detail pages

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -338,6 +338,25 @@ export default async function BlogPostPage({ params }: Params) {
 
   return (
     <div className='space-y-8'>
+      <script
+        type='application/ld+json'
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'BlogPosting',
+            headline: post.title,
+            description: getLeadText(post),
+            url: `https://thehippiescientist.net/blog/${post.slug}`,
+            datePublished: post.date,
+            publisher: {
+              '@type': 'Organization',
+              name: 'The Hippie Scientist',
+              url: 'https://thehippiescientist.net',
+            },
+            mainEntityOfPage: `https://thehippiescientist.net/blog/${post.slug}`,
+          }),
+        }}
+      />
       <nav className='flex flex-wrap gap-3 text-sm text-white/60'>
         <Link
           href='/blog'

--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -245,6 +245,24 @@ export default async function CompoundDetailPage({ params }: Params) {
 
   return (
     <div className='space-y-8'>
+      <script
+        type='application/ld+json'
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'Article',
+            headline: getCompoundLabel(compound),
+            description: getLeadText(compound),
+            url: `https://thehippiescientist.net/compounds/${compound.slug}`,
+            publisher: {
+              '@type': 'Organization',
+              name: 'The Hippie Scientist',
+              url: 'https://thehippiescientist.net',
+            },
+            mainEntityOfPage: `https://thehippiescientist.net/compounds/${compound.slug}`,
+          }),
+        }}
+      />
       <nav className='flex flex-wrap gap-3 text-sm text-white/60'>
         <Link
           href='/compounds'

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -230,6 +230,24 @@ export default async function HerbDetailPage({ params }: Params) {
 
   return (
     <div className='space-y-8'>
+      <script
+        type='application/ld+json'
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'Article',
+            headline: getHerbLabel(herb),
+            description: getLeadText(herb),
+            url: `https://thehippiescientist.net/herbs/${herb.slug}`,
+            publisher: {
+              '@type': 'Organization',
+              name: 'The Hippie Scientist',
+              url: 'https://thehippiescientist.net',
+            },
+            mainEntityOfPage: `https://thehippiescientist.net/herbs/${herb.slug}`,
+          }),
+        }}
+      />
       <nav className='flex flex-wrap gap-3 text-sm text-white/60'>
         <Link
           href='/herbs'


### PR DESCRIPTION
### Motivation
- Improve SEO and shared metadata on detail pages by embedding schema.org JSON-LD for herbs, compounds, and blog posts.
- Keep the change small and local to the page components to avoid touching data pipelines or route contracts.

### Description
- Inserted a `<script type="application/ld+json">` block into the returned JSX of `app/herbs/[slug]/page.tsx` using `@type: 'Article'` with `headline`, `description`, canonical `url`, `publisher`, and `mainEntityOfPage` populated from the herb data.
- Added the same `Article` JSON-LD block to `app/compounds/[slug]/page.tsx` with compound-specific labels and URLs using `getCompoundLabel(compound)` and `getLeadText(compound)`.
- Added a `BlogPosting` JSON-LD block to `app/blog/[slug]/page.tsx` that includes `headline`, `description`, `url`, `publisher`, `mainEntityOfPage`, and `datePublished` sourced from `post.date`.
- Changes are minimal and localized to the top of each page component's returned JSX and preserve existing route contracts (`/herbs/:slug`, `/compounds/:slug`, `/blog/:slug`).

### Testing
- Ran a production build with `npm run -s build`, which compiled successfully and completed static page generation (prerendered pages reported during the build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1645053948323a9b6755d9e1a9f5d)