### PR TITLE
Add A-tier badges and 'A-tier only' filter to herbs & compounds library

### DIFF
--- a/app/compounds/page.tsx
+++ b/app/compounds/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import LibraryBrowser from '@/components/library-browser'
+import { isATier } from '@/lib/a-tier'
 import { getCompounds } from '@/lib/runtime-data'
 
 type CompoundListItem = {
@@ -16,6 +17,7 @@ type BrowserItem = {
   summary: string
   href: string
   typeLabel: string
+  aTier: boolean
 }
 
 const formatSlugLabel = (slug: string): string =>
@@ -49,6 +51,7 @@ export default async function CompoundsPage() {
     summary: getCompoundSummary(compound),
     href: `/compounds/${compound.slug}`,
     typeLabel: 'Compound profile',
+    aTier: isATier(compound.slug),
   }))
 
   return (

--- a/app/herbs/page.tsx
+++ b/app/herbs/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import LibraryBrowser from '@/components/library-browser'
+import { isATier } from '@/lib/a-tier'
 import { getHerbs } from '@/lib/runtime-data'
 
 type HerbListItem = {
@@ -16,6 +17,7 @@ type BrowserItem = {
   summary: string
   href: string
   typeLabel: string
+  aTier: boolean
 }
 
 const formatSlugLabel = (slug: string): string =>
@@ -49,8 +51,9 @@ export default async function HerbsPage() {
     summary: getHerbSummary(herb),
     href: `/herbs/${herb.slug}`,
     typeLabel: 'Herb profile',
+    aTier: isATier(herb.slug),
   }))
-// trigger deploy
+
   return (
     <LibraryBrowser
       eyebrow='Library'

--- a/components/library-browser.tsx
+++ b/components/library-browser.tsx
@@ -9,6 +9,7 @@ type LibraryItem = {
   summary: string
   href: string
   typeLabel: string
+  aTier?: boolean
 }
 
 type LibraryBrowserProps = {
@@ -49,6 +50,7 @@ export default function LibraryBrowser({
   const [query, setQuery] = useState('')
   const [sortMode, setSortMode] = useState<SortMode>('a-z')
   const [letterFilter, setLetterFilter] = useState<string | LetterFilter>('all')
+  const [aTierOnly, setATierOnly] = useState(false)
 
   const availableLetters = useMemo(() => {
     const letters = new Set(items.map(item => getFirstFilterChar(item.title)))
@@ -70,16 +72,19 @@ export default function LibraryBrowser({
       const matchesLetter =
         letterFilter === 'all' ? true : firstChar === letterFilter
 
-      return matchesQuery && matchesLetter
+      const matchesATier = aTierOnly ? item.aTier === true : true
+
+      return matchesQuery && matchesLetter && matchesATier
     })
 
     return sortItems(matchingItems, sortMode)
-  }, [items, letterFilter, query, sortMode])
+  }, [aTierOnly, items, letterFilter, query, sortMode])
 
   const clearFilters = () => {
     setQuery('')
     setSortMode('a-z')
     setLetterFilter('all')
+    setATierOnly(false)
   }
 
   return (
@@ -121,6 +126,18 @@ export default function LibraryBrowser({
               <option value='a-z'>A to Z</option>
               <option value='z-a'>Z to A</option>
             </select>
+          </label>
+        </div>
+
+        <div className='mt-6'>
+          <label className='inline-flex items-center gap-2 text-sm text-white/80'>
+            <input
+              type='checkbox'
+              checked={aTierOnly}
+              onChange={event => setATierOnly(event.target.checked)}
+              className='h-4 w-4 rounded border-white/20 bg-white/[0.04] accent-blue-300'
+            />
+            A-tier only
           </label>
         </div>
 
@@ -184,8 +201,9 @@ export default function LibraryBrowser({
           </span>
 
           {letterFilter !== 'all' ? <span>Letter: {letterFilter}</span> : null}
+          {aTierOnly ? <span>A-tier only</span> : null}
 
-          {(query.trim() || letterFilter !== 'all' || sortMode !== 'a-z') ? (
+          {(query.trim() || letterFilter !== 'all' || sortMode !== 'a-z' || aTierOnly) ? (
             <button
               type='button'
               onClick={clearFilters}
@@ -210,6 +228,11 @@ export default function LibraryBrowser({
               </p>
 
               <h2 className='mt-3 text-xl font-semibold'>{item.title}</h2>
+              {item.aTier ? (
+                <span className='mt-2 inline-flex w-fit rounded-full border border-blue-300/40 bg-blue-400/10 px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-blue-200'>
+                  A-tier
+                </span>
+              ) : null}
 
               <p className='mt-3 flex-1 text-sm leading-6 text-white/70'>
                 {item.summary}

--- a/src/lib/a-tier.ts
+++ b/src/lib/a-tier.ts
@@ -1,0 +1,21 @@
+import aTierIndex from '@/public/data/a-tier-index.json'
+
+type ATierEntry = {
+  slug?: string | null
+}
+
+type ATierIndex = {
+  global?: ATierEntry[]
+  contextual?: ATierEntry[]
+}
+
+const index = aTierIndex as ATierIndex
+
+const aTierSlugSet = new Set(
+  [...(index.global ?? []), ...(index.contextual ?? [])]
+    .map(entry => entry.slug?.trim().toLowerCase())
+    .filter((slug): slug is string => Boolean(slug))
+)
+
+export const isATier = (slug: string): boolean =>
+  aTierSlugSet.has(slug.trim().toLowerCase())


### PR DESCRIPTION
### Motivation
- Surface clinically-strong (A-tier) entries prominently in the library views so users can quickly find high-confidence herbs and compounds.
- Keep changes minimal and UI-focused without touching the data pipeline or route contracts.

### Description
- Added a lookup helper `isATier` in `src/lib/a-tier.ts` that loads `public/data/a-tier-index.json` and normalizes slugs for boolean membership checks.
- Wired an `aTier` flag into the item mapping on `app/herbs/page.tsx` and `app/compounds/page.tsx` by calling `isATier(slug)` during list construction.
- Updated the shared UI in `components/library-browser.tsx` to render an `A-tier` badge on cards, add an `A-tier only` checkbox, include the toggle in the filter pipeline and `Clear filters` behavior, and keep styling minimal.

### Testing
- Ran the full automated check via `npm run check`, which completed successfully and included `data:build`, `data:validate`, and the Next.js build without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f164c422b48323ab897fdbf457b428)