### PR TITLE
Create A-tier landing page grouped by goal domains

### DIFF
--- a/app/a-tier/page.tsx
+++ b/app/a-tier/page.tsx
@@ -1,10 +1,24 @@
 import fs from 'fs'
 import path from 'path'
+import Link from 'next/link'
+import Card from '@/components/ui/Card'
+
+type Domain = 'cognition' | 'sleep' | 'metabolic' | 'inflammation' | 'performance'
+const DOMAIN_ORDER: Domain[] = ['cognition', 'sleep', 'metabolic', 'inflammation', 'performance']
+
+const DOMAIN_LABELS: Record<Domain, string> = {
+  cognition: 'Cognition',
+  sleep: 'Sleep',
+  metabolic: 'Metabolic',
+  inflammation: 'Inflammation',
+  performance: 'Performance',
+}
 
 type TierItem = {
   slug: string
   name?: string
   domain?: string
+  confidenceScore?: number
 }
 
 type TierPayload = {
@@ -15,35 +29,47 @@ type TierPayload = {
 export default function ATierPage() {
   const filePath = path.join(process.cwd(), 'public/data/a-tier-index.json')
   const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as TierPayload
+  const allItems = [...(data.global ?? []), ...(data.contextual ?? [])]
 
-  const globalItems = Array.isArray(data.global) ? data.global : []
-  const contextualItems = Array.isArray(data.contextual) ? data.contextual : []
+  const grouped = DOMAIN_ORDER.reduce<Record<Domain, TierItem[]>>((acc, domain) => {
+    acc[domain] = allItems
+      .filter(item => item.domain === domain)
+      .sort((a, b) => (b.confidenceScore ?? 0) - (a.confidenceScore ?? 0))
+    return acc
+  }, {
+    cognition: [],
+    sleep: [],
+    metabolic: [],
+    inflammation: [],
+    performance: [],
+  })
 
   return (
-    <main className="p-6 text-white">
-      <h1 className="text-3xl font-bold mb-6">Top Evidence Compounds</h1>
+    <main className='mx-auto max-w-6xl px-6 py-10 text-white'>
+      <h1 className='mb-2 text-3xl font-semibold'>A-Tier Compounds</h1>
+      <p className='mb-8 text-white/75'>Curated, high-trust compounds grouped by domain.</p>
 
-      <section className="mb-10">
-        <h2 className="text-xl font-semibold mb-4">Global A-Tier</h2>
-        <ul>
-          {globalItems.map(item => (
-            <li key={item.slug}>
-              {item.name ?? item.slug} — {item.domain ?? 'General'}
-            </li>
-          ))}
-        </ul>
-      </section>
-
-      <section>
-        <h2 className="text-xl font-semibold mb-4">Context-Specific A-Tier</h2>
-        <ul>
-          {contextualItems.map(item => (
-            <li key={item.slug}>
-              {item.name ?? item.slug} — {item.domain ?? 'General'}
-            </li>
-          ))}
-        </ul>
-      </section>
+      <div className='space-y-10'>
+        {DOMAIN_ORDER.map(domain => (
+          <section key={domain}>
+            <h2 className='mb-4 text-xl font-semibold'>{DOMAIN_LABELS[domain]}</h2>
+            {grouped[domain].length === 0 ? (
+              <p className='text-sm text-white/60'>No A-tier entries yet.</p>
+            ) : (
+              <div className='grid gap-3 sm:grid-cols-2 lg:grid-cols-3'>
+                {grouped[domain].map(item => (
+                  <Card key={`${domain}-${item.slug}`} className='p-4'>
+                    <Link href={`/compounds/${item.slug}`} className='block'>
+                      <h3 className='text-base font-medium text-white'>{item.name ?? item.slug}</h3>
+                      <p className='mt-1 text-sm text-white/65'>/{item.slug}</p>
+                    </Link>
+                  </Card>
+                ))}
+              </div>
+            )}
+          </section>
+        ))}
+      </div>
     </main>
   )
 }


### PR DESCRIPTION
### Motivation
- Provide a curated, high-trust landing page for A-tier compounds to make top evidence compounds discoverable by goal domain.
- Reuse existing UI primitives and preserve existing route contracts rather than adding new dependencies or complex pipelines.
- Keep the page layout simple and deterministic so content is easy to review and maintain.

### Description
- Added a focused `app/a-tier/page.tsx` that reads `public/data/a-tier-index.json` and combines `global` and `contextual` entries into a single list.
- Groups entries into the requested domains (`cognition`, `sleep`, `metabolic`, `inflammation`, `performance`) with a deterministic `DOMAIN_ORDER` and human-friendly labels.
- Reuses the existing `Card` component (`@/components/ui/Card`) and links each entry to the compound route at `/compounds/:slug` while showing the name and slug.
- Sorts items within each domain by `confidenceScore` when present and uses a lightweight responsive grid for layout, with no new dependencies introduced.

### Testing
- Ran the full build with `npm run build`, which completed successfully and included generation of `public/data/a-tier-index.json`.
- Next.js production build completed and pages were prerendered without errors (build passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f164d9d3bc832385a5ae9c540bc939)