### PR TITLE
Add related herb↔compound internal linking on detail pages

### DIFF
--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -11,7 +11,12 @@ import {
   normalizeProfileText,
   normalizeSources,
 } from '@/components/profile-data-sections'
-import { getCompoundBySlug, getCompounds } from '@/lib/runtime-data'
+import {
+  getCompoundBySlug,
+  getCompounds,
+  getHerbCompoundMap,
+  getHerbs,
+} from '@/lib/runtime-data'
 
 type Params = { params: Promise<{ slug: string }> }
 
@@ -153,6 +158,23 @@ const getRelatedPosts = (compound: CompoundDetail): RelatedLinkItem[] => {
     }))
 }
 
+
+const getRelatedHerbs = async (compound: CompoundDetail): Promise<RelatedLinkItem[]> => {
+  const [compoundMap, herbs] = await Promise.all([getHerbCompoundMap(), getHerbs()])
+  const validHerbSlugs = new Set(herbs.map(herb => herb.slug))
+
+  return compoundMap
+    .filter(entry => entry.canonicalCompoundId === compound.slug)
+    .filter(entry => validHerbSlugs.has(entry.herbSlug))
+    .slice(0, 6)
+    .map(entry => ({
+      href: `/herbs/${entry.herbSlug}`,
+      title: entry.herbName?.trim() || formatSlugLabel(entry.herbSlug),
+      description: `See how ${entry.herbName?.trim() || formatSlugLabel(entry.herbSlug)} relates to ${getCompoundLabel(compound)}.`,
+      eyebrow: 'Related herb',
+    }))
+}
+
 const getExploreLinks = (): RelatedLinkItem[] => [
   {
     href: '/compounds',
@@ -241,6 +263,7 @@ export default async function CompoundDetailPage({ params }: Params) {
   )
 
   const relatedPosts = getRelatedPosts(compound)
+  const relatedHerbs = await getRelatedHerbs(compound)
   const exploreLinks = getExploreLinks()
 
   return (
@@ -396,6 +419,12 @@ export default async function CompoundDetailPage({ params }: Params) {
           </section>
         </aside>
       </div>
+
+      <RelatedLinksSection
+        eyebrow='Related'
+        title='Herbs containing this compound'
+        items={relatedHerbs}
+      />
 
       <RelatedLinksSection
         eyebrow='Related writing'

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -11,7 +11,13 @@ import {
   normalizeProfileText,
   normalizeSources,
 } from '@/components/profile-data-sections'
-import { getHerbBySlug, getHerbs } from '@/lib/runtime-data'
+import {
+  getCompoundBySlug,
+  getCompounds,
+  getHerbBySlug,
+  getHerbCompoundMap,
+  getHerbs,
+} from '@/lib/runtime-data'
 
 type Params = { params: Promise<{ slug: string }> }
 
@@ -146,6 +152,26 @@ const getRelatedPosts = (herb: HerbDetail): RelatedLinkItem[] => {
     }))
 }
 
+
+const getRelatedCompounds = async (herb: HerbDetail): Promise<RelatedLinkItem[]> => {
+  const [compoundMap, compounds] = await Promise.all([
+    getHerbCompoundMap(),
+    getCompounds(),
+  ])
+  const validCompoundSlugs = new Set(compounds.map(compound => compound.slug))
+
+  return compoundMap
+    .filter(entry => entry.herbSlug === herb.slug)
+    .filter(entry => validCompoundSlugs.has(entry.canonicalCompoundId))
+    .slice(0, 6)
+    .map(entry => ({
+      href: `/compounds/${entry.canonicalCompoundId}`,
+      title: entry.canonicalCompoundName?.trim() || formatSlugLabel(entry.canonicalCompoundId),
+      description: `Explore ${entry.canonicalCompoundName?.trim() || formatSlugLabel(entry.canonicalCompoundId)} and its role in ${getHerbLabel(herb)}.`,
+      eyebrow: 'Related compound',
+    }))
+}
+
 const getExploreLinks = (): RelatedLinkItem[] => [
   {
     href: '/herbs',
@@ -226,6 +252,7 @@ export default async function HerbDetailPage({ params }: Params) {
   )
 
   const relatedPosts = getRelatedPosts(herb)
+  const relatedCompounds = await getRelatedCompounds(herb)
   const exploreLinks = getExploreLinks()
 
   return (
@@ -385,6 +412,12 @@ export default async function HerbDetailPage({ params }: Params) {
           </section>
         </aside>
       </div>
+
+      <RelatedLinksSection
+        eyebrow='Related'
+        title='Compounds linked to this herb'
+        items={relatedCompounds}
+      />
 
       <RelatedLinksSection
         eyebrow='Related writing'

--- a/src/lib/runtime-data.ts
+++ b/src/lib/runtime-data.ts
@@ -12,6 +12,14 @@ type RuntimeHerb = {
   safetyNotes?: string
 }
 
+
+type RuntimeHerbCompoundMapEntry = {
+  herbSlug: string
+  herbName?: string
+  canonicalCompoundId: string
+  canonicalCompoundName?: string
+}
+
 type RuntimeCompound = {
   slug: string
   displayName?: string
@@ -41,6 +49,16 @@ export const getCompounds = cache(async (): Promise<RuntimeCompound[]> => {
   return Array.isArray(compounds) ? compounds : []
 })
 
+
+export const getHerbCompoundMap = cache(async (): Promise<RuntimeHerbCompoundMapEntry[]> => {
+  try {
+    const rows = await readJsonFile<RuntimeHerbCompoundMapEntry[]>('workbook-herb-compound-map.json')
+    return Array.isArray(rows) ? rows : []
+  } catch {
+    return []
+  }
+})
+
 export async function getHerbBySlug(slug: string) {
   const herbs = await getHerbs()
   return herbs.find(herb => herb.slug === slug)
@@ -51,4 +69,4 @@ export async function getCompoundBySlug(slug: string) {
   return compounds.find(compound => compound.slug === slug)
 }
 
-export type { RuntimeHerb, RuntimeCompound }
+export type { RuntimeHerb, RuntimeCompound, RuntimeHerbCompoundMapEntry }


### PR DESCRIPTION
### Motivation
- Improve site navigation and SEO authority by surfacing direct internal links between herb and compound detail pages. 
- Provide a focused “Related” section on entity pages to help users discover connected content (herb → compounds and compound → herbs). 
- Ensure links are safe and non‑breaking by validating slugs against runtime datasets and handling missing mapping artifacts gracefully. 

### Description
- Add a runtime loader and type for the herb↔compound mapping (`getHerbCompoundMap`, `RuntimeHerbCompoundMapEntry`) with a safe fallback when `workbook-herb-compound-map.json` is absent in `src/lib/runtime-data.ts`. 
- Implement `getRelatedCompounds` on the herb detail page (`app/herbs/[slug]/page.tsx`) which reads the map, validates compound slugs via `getCompounds()`, limits results, and returns link items for `RelatedLinksSection`. 
- Implement `getRelatedHerbs` on the compound detail page (`app/compounds/[slug]/page.tsx`) which reads the map, validates herb slugs via `getHerbs()`, limits results, and returns link items for `RelatedLinksSection`. 
- Preserve existing related writing/explore sections and cap/validate cross-entity link lists to avoid broken internal links. 

### Testing
- Ran a full production build with `npm run build`, which completed successfully and prerendered herb and compound detail routes (SSG). 
- No automated unit tests were added or modified; the change was validated by the successful build output.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1654359f4832383b02eeb36b678e6)