### PR TITLE
Add compact evidence display for entity claim rows

### DIFF
--- a/src/components/detail/GovernedResearchSections.tsx
+++ b/src/components/detail/GovernedResearchSections.tsx
@@ -13,6 +13,50 @@ type ClaimSectionConfig = {
   items: ResearchClaim[]
 }
 
+function EvidenceMeta({ item }: { item: ResearchClaim }) {
+  const pmids = item.primaryPmids || []
+  const hasEvidence = Boolean(
+    item.evidenceGrade || item.population || pmids.length > 0,
+  )
+  if (!hasEvidence) return null
+
+  return (
+    <div className='mt-2 rounded-lg border border-white/10 bg-white/[0.02] px-2.5 py-2 text-xs text-white/75'>
+      <p className='font-semibold uppercase tracking-[0.14em] text-white/55'>Evidence</p>
+      <div className='mt-1 flex flex-wrap gap-x-3 gap-y-1'>
+        {item.evidenceGrade && (
+          <span>
+            <span className='text-white/55'>Grade:</span> {item.evidenceGrade}
+          </span>
+        )}
+        {item.population && (
+          <span>
+            <span className='text-white/55'>Population:</span> {item.population}
+          </span>
+        )}
+        {pmids.length > 0 && (
+          <span>
+            <span className='text-white/55'>PMID:</span>{' '}
+            {pmids.map((pmid, index) => (
+              <span key={pmid}>
+                <a
+                  href={`https://pubmed.ncbi.nlm.nih.gov/${pmid}/`}
+                  target='_blank'
+                  rel='noreferrer'
+                  className='text-cyan-200 underline-offset-2 hover:underline'
+                >
+                  {pmid}
+                </a>
+                {index < pmids.length - 1 ? ', ' : ''}
+              </span>
+            ))}
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}
+
 function ClaimList({
   items,
   topicType,
@@ -35,6 +79,7 @@ function ClaimList({
           <li key={item.claim}>
             <span>{item.claim}</span>
             {item.strengthNote && <span className='block text-xs text-white/65'>{item.strengthNote}</span>}
+            <EvidenceMeta item={item} />
           </li>
         ))}
       </ul>

--- a/src/lib/researchEnrichment.ts
+++ b/src/lib/researchEnrichment.ts
@@ -144,12 +144,22 @@ function asClaims(value: unknown): ResearchClaim[] {
         ? row.sourceRefIds.map(id => cleanText(id)).filter(Boolean)
         : []
       const strengthNote = cleanText(row.strengthNote)
+      const evidenceGradeText = cleanText(row.evidence_grade)
+      const evidenceGrade =
+        evidenceGradeText === 'A' || evidenceGradeText === 'B' ? evidenceGradeText : null
+      const population = cleanText(row.population)
+      const primaryPmids = Array.isArray(row.primary_pmids)
+        ? row.primary_pmids.map(item => cleanText(item)).filter(Boolean)
+        : []
       if (!claim || !evidenceClass || sourceRefIds.length === 0) return null
       return {
         claim,
         evidenceClass,
         sourceRefIds: Array.from(new Set(sourceRefIds)),
         ...(strengthNote ? { strengthNote } : {}),
+        ...(evidenceGrade ? { evidenceGrade } : {}),
+        ...(population ? { population } : {}),
+        ...(primaryPmids.length > 0 ? { primaryPmids: Array.from(new Set(primaryPmids)) } : {}),
       }
     })
     .filter((item): item is ResearchClaim => Boolean(item))

--- a/src/types/researchEnrichment.ts
+++ b/src/types/researchEnrichment.ts
@@ -39,6 +39,9 @@ export type ResearchClaim = {
   evidenceClass: EvidenceClass
   sourceRefIds: string[]
   strengthNote?: string
+  evidenceGrade?: 'A' | 'B'
+  population?: string
+  primaryPmids?: string[]
 }
 
 export type EvidenceLabel =


### PR DESCRIPTION
### Motivation
- Surface concise credibility context for research claims on entity pages without dumping raw data, mapping existing claim-row fields `evidence_grade`, `population`, and `primary_pmids` into the runtime shape. 

### Description
- Added a compact `EvidenceMeta` component to `src/components/detail/GovernedResearchSections.tsx` that conditionally renders Grade (`A`/`B`), Population, and PubMed-linked PMIDs inline on each claim row. 
- Extended the `ResearchClaim` type in `src/types/researchEnrichment.ts` to include optional `evidenceGrade`, `population`, and `primaryPmids` fields. 
- Updated claim parsing in `src/lib/researchEnrichment.ts` (`asClaims`) to read `evidence_grade`, `population`, and `primary_pmids`, validate grade as `A` or `B`, normalize/dedupe PMIDs, and attach the new fields to the claim object only when present. 
- Made a small TypeScript-safe change in the UI to guard against undefined PMIDs and kept the UI styling compact to avoid clutter. 

### Testing
- Ran a full production build via `npm run build` (includes prebuild/data build and Next.js production build), and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f164ef099c8323b5b1b81848400ead)