### PR TITLE
Add domain and A-tier filters to herb/compound library pages

### DIFF
--- a/app/compounds/page.tsx
+++ b/app/compounds/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next'
 import LibraryBrowser from '@/components/library-browser'
 import { getCompounds } from '@/lib/runtime-data'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
 
 type CompoundListItem = {
   slug: string
@@ -16,7 +18,17 @@ type BrowserItem = {
   summary: string
   href: string
   typeLabel: string
+  domain?: string
+  isATier?: boolean
 }
+type ATierItem = { slug: string }
+const DOMAIN_RULES: Array<{ domain: string; keywords: string[] }> = [
+  { domain: 'cognition', keywords: ['memory', 'focus', 'cognitive', 'neuro', 'brain'] },
+  { domain: 'sleep', keywords: ['sleep', 'insomnia', 'sedative', 'calm', 'rest'] },
+  { domain: 'metabolic', keywords: ['glucose', 'insulin', 'metabolic', 'lipid', 'weight'] },
+  { domain: 'inflammation', keywords: ['inflamm', 'cytokine', 'pain', 'immune'] },
+  { domain: 'performance', keywords: ['exercise', 'endurance', 'strength', 'performance', 'recovery'] },
+]
 
 const formatSlugLabel = (slug: string): string =>
   slug
@@ -35,6 +47,24 @@ const getCompoundSummary = (compound: CompoundListItem): string =>
   compound.description?.trim() ||
   'Profile coming soon.'
 
+const inferDomain = (compound: CompoundListItem & { mechanisms?: string[] }): string | undefined => {
+  const text = [compound.summary, compound.description, ...(compound.mechanisms || [])]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+  return DOMAIN_RULES.find(rule => rule.keywords.some(keyword => text.includes(keyword)))?.domain
+}
+
+const readATierSlugs = async (): Promise<Set<string>> => {
+  const filePath = path.join(process.cwd(), 'public/data/a-tier-index.json')
+  try {
+    const parsed = JSON.parse(await fs.readFile(filePath, 'utf8')) as ATierItem[]
+    return new Set((Array.isArray(parsed) ? parsed : []).map(item => item.slug))
+  } catch {
+    return new Set()
+  }
+}
+
 export const metadata: Metadata = {
   title: 'Compounds',
   description: 'Browse compound profiles and plain-English summaries.',
@@ -42,6 +72,7 @@ export const metadata: Metadata = {
 
 export default async function CompoundsPage() {
   const compounds = (await getCompounds()) as CompoundListItem[]
+  const aTierSlugs = await readATierSlugs()
 
   const items: BrowserItem[] = compounds.map(compound => ({
     slug: compound.slug,
@@ -49,6 +80,8 @@ export default async function CompoundsPage() {
     summary: getCompoundSummary(compound),
     href: `/compounds/${compound.slug}`,
     typeLabel: 'Compound profile',
+    domain: inferDomain(compound),
+    isATier: aTierSlugs.has(compound.slug),
   }))
 
   return (

--- a/app/herbs/page.tsx
+++ b/app/herbs/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next'
 import LibraryBrowser from '@/components/library-browser'
 import { getHerbs } from '@/lib/runtime-data'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
 
 type HerbListItem = {
   slug: string
@@ -16,7 +18,17 @@ type BrowserItem = {
   summary: string
   href: string
   typeLabel: string
+  domain?: string
+  isATier?: boolean
 }
+type ATierItem = { slug: string }
+const DOMAIN_RULES: Array<{ domain: string; keywords: string[] }> = [
+  { domain: 'cognition', keywords: ['memory', 'focus', 'cognitive', 'neuro', 'brain'] },
+  { domain: 'sleep', keywords: ['sleep', 'insomnia', 'sedative', 'calm', 'rest'] },
+  { domain: 'metabolic', keywords: ['glucose', 'insulin', 'metabolic', 'lipid', 'weight'] },
+  { domain: 'inflammation', keywords: ['inflamm', 'cytokine', 'pain', 'immune'] },
+  { domain: 'performance', keywords: ['exercise', 'endurance', 'strength', 'performance', 'recovery'] },
+]
 
 const formatSlugLabel = (slug: string): string =>
   slug
@@ -35,6 +47,24 @@ const getHerbSummary = (herb: HerbListItem): string =>
   herb.description?.trim() ||
   'Profile coming soon.'
 
+const inferDomain = (herb: HerbListItem & { mechanisms?: string[] }): string | undefined => {
+  const text = [herb.summary, herb.description, ...(herb.mechanisms || [])]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+  return DOMAIN_RULES.find(rule => rule.keywords.some(keyword => text.includes(keyword)))?.domain
+}
+
+const readATierSlugs = async (): Promise<Set<string>> => {
+  const filePath = path.join(process.cwd(), 'public/data/a-tier-index.json')
+  try {
+    const parsed = JSON.parse(await fs.readFile(filePath, 'utf8')) as ATierItem[]
+    return new Set((Array.isArray(parsed) ? parsed : []).map(item => item.slug))
+  } catch {
+    return new Set()
+  }
+}
+
 export const metadata: Metadata = {
   title: 'Herbs',
   description: 'Browse herb profiles and plain-English summaries.',
@@ -42,6 +72,7 @@ export const metadata: Metadata = {
 
 export default async function HerbsPage() {
   const herbs = (await getHerbs()) as HerbListItem[]
+  const aTierSlugs = await readATierSlugs()
 
   const items: BrowserItem[] = herbs.map(herb => ({
     slug: herb.slug,
@@ -49,8 +80,10 @@ export default async function HerbsPage() {
     summary: getHerbSummary(herb),
     href: `/herbs/${herb.slug}`,
     typeLabel: 'Herb profile',
+    domain: inferDomain(herb),
+    isATier: aTierSlugs.has(herb.slug),
   }))
-// trigger deploy
+
   return (
     <LibraryBrowser
       eyebrow='Library'

--- a/components/library-browser.tsx
+++ b/components/library-browser.tsx
@@ -9,6 +9,8 @@ type LibraryItem = {
   summary: string
   href: string
   typeLabel: string
+  domain?: string
+  isATier?: boolean
 }
 
 type LibraryBrowserProps = {
@@ -50,6 +52,8 @@ export default function LibraryBrowser({
   const [debouncedQuery, setDebouncedQuery] = useState('')
   const [sortMode, setSortMode] = useState<SortMode>('a-z')
   const [letterFilter, setLetterFilter] = useState<string | LetterFilter>('all')
+  const [domainFilter, setDomainFilter] = useState<string>('all')
+  const [aTierOnly, setATierOnly] = useState(false)
 
   useEffect(() => {
     const timeoutId = window.setTimeout(() => {
@@ -78,12 +82,20 @@ export default function LibraryBrowser({
       const firstChar = getFirstFilterChar(item.title)
       const matchesLetter =
         letterFilter === 'all' ? true : firstChar === letterFilter
+      const matchesDomain = domainFilter === 'all' ? true : item.domain === domainFilter
+      const matchesATier = aTierOnly ? Boolean(item.isATier) : true
 
-      return matchesQuery && matchesLetter
+      return matchesQuery && matchesLetter && matchesDomain && matchesATier
     })
 
     return sortItems(matchingItems, sortMode)
-  }, [debouncedQuery, items, letterFilter, sortMode])
+  }, [aTierOnly, debouncedQuery, domainFilter, items, letterFilter, sortMode])
+
+  const availableDomains = useMemo(() => {
+    return Array.from(
+      new Set(items.map(item => item.domain).filter((domain): domain is string => Boolean(domain)))
+    )
+  }, [items])
 
   const renderHighlightedText = (value: string) => {
     const highlightQuery = debouncedQuery.trim()
@@ -112,6 +124,8 @@ export default function LibraryBrowser({
     setQuery('')
     setSortMode('a-z')
     setLetterFilter('all')
+    setDomainFilter('all')
+    setATierOnly(false)
   }
 
   return (
@@ -154,6 +168,38 @@ export default function LibraryBrowser({
               <option value='z-a'>Z to A</option>
             </select>
           </label>
+
+          <label className='block'>
+            <span className='mb-2 block text-sm font-medium text-white/70'>
+              Domain
+            </span>
+            <select
+              value={domainFilter}
+              onChange={event => setDomainFilter(event.target.value)}
+              className='w-full rounded-2xl border border-white/10 bg-white/[0.04] px-4 py-3 text-sm text-white outline-none transition focus:border-white/30 focus:bg-white/[0.06] sm:min-w-40'
+            >
+              <option value='all'>All domains</option>
+              {availableDomains.map(domain => (
+                <option key={domain} value={domain}>
+                  {domain.charAt(0).toUpperCase() + domain.slice(1)}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <div className='mt-3'>
+          <button
+            type='button'
+            onClick={() => setATierOnly(current => !current)}
+            className={`rounded-full border px-3 py-1.5 text-xs font-medium transition ${
+              aTierOnly
+                ? 'border-white/30 bg-white/10 text-white'
+                : 'border-white/10 text-white/70 hover:border-white/25 hover:bg-white/5 hover:text-white'
+            }`}
+          >
+            A-tier only
+          </button>
         </div>
 
         <div className='mt-6'>
@@ -216,8 +262,10 @@ export default function LibraryBrowser({
           </span>
 
           {letterFilter !== 'all' ? <span>Letter: {letterFilter}</span> : null}
+          {domainFilter !== 'all' ? <span>Domain: {domainFilter}</span> : null}
+          {aTierOnly ? <span>A-tier only</span> : null}
 
-          {(query.trim() || letterFilter !== 'all' || sortMode !== 'a-z') ? (
+          {(query.trim() || letterFilter !== 'all' || domainFilter !== 'all' || aTierOnly || sortMode !== 'a-z') ? (
             <button
               type='button'
               onClick={clearFilters}


### PR DESCRIPTION
### Motivation
- Provide domain-based filtering (cognition, sleep, metabolic, inflammation, performance) for the herbs and compounds library so users can narrow results by intended domain.
- Allow users to combine domain filtering with the existing letter/search/sort pipeline and the curated A-tier toggle for high-trust items.
- Keep the UI minimal and dependency-free by reusing the shared `LibraryBrowser` component and simple runtime inference rules.

### Description
- Added optional `domain` and `isATier` fields to shared `LibraryItem` and wired them through `components/library-browser.tsx` to drive filtering and active-filter UI.
- Implemented a lightweight `DOMAIN_RULES` keyword-based inference and an `readATierSlugs` loader in `app/herbs/page.tsx` and `app/compounds/page.tsx` to populate item metadata from `summary`, `description`, and `mechanisms` and from `public/data/a-tier-index.json`.
- Extended `LibraryBrowser` to expose a `Domain` dropdown, an `A-tier only` toggle pill, included both controls in `clearFilters`, and combined their checks with existing `query`, `letter`, and `sort` logic.
- No new dependencies were added and changes are scoped to `components/library-browser.tsx`, `app/herbs/page.tsx`, and `app/compounds/page.tsx`.

### Testing
- Ran `npm run lint`, which failed due to a pre-existing unrelated lint error in `scripts/build-blog.mjs` (not introduced by this change).
- Ran `npm run typecheck`, which surfaced pre-existing TypeScript issues in `src/lib/governedResearch.ts` and the project’s typecheck step continued with the existing errors (not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f16748e4448323ac9f0f9895a48a86)