### PR TITLE
Add “Best for” summary section to herb and compound detail pages

### DIFF
--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -40,6 +40,8 @@ type CompoundDetail = {
   review_status?: unknown
   source_status?: unknown
   sources?: unknown
+  primaryDomain?: unknown
+  claimRows?: unknown
 }
 
 type BlogPost = {
@@ -73,6 +75,48 @@ const getCompoundLabel = (compound: Partial<CompoundDetail>): string => {
 
 const normalizeText = (value?: string | null): string =>
   value?.replace(/\s+/g, ' ').trim() ?? ''
+
+const VAGUE_BEST_FOR_TERMS = new Set([
+  'general wellness',
+  'wellness',
+  'overall health',
+  'balance',
+  'support',
+])
+
+const toBestForLine = (value: string): string => {
+  const cleaned = normalizeText(value).replace(/\.$/, '')
+  if (!cleaned) return ''
+  const prefixed = cleaned.toLowerCase().startsWith('best for ')
+    ? cleaned
+    : `Best for ${cleaned.charAt(0).toLowerCase()}${cleaned.slice(1)}`
+  return prefixed
+}
+
+const getBestForItems = (
+  compound: CompoundDetail,
+  existingText: string[],
+): string[] => {
+  const existing = existingText.map(text => normalizeText(text).toLowerCase()).filter(Boolean)
+  const primaryDomain = normalizeProfileText(compound.primaryDomain)
+  const claimRows = normalizeProfileList(compound.claimRows)
+  const candidates = [primaryDomain, ...claimRows]
+
+  const results: string[] = []
+  const seen = new Set<string>()
+  for (const candidate of candidates) {
+    const line = toBestForLine(candidate)
+    const compact = normalizeText(line).toLowerCase()
+    if (!compact) continue
+    if ([...VAGUE_BEST_FOR_TERMS].some(term => compact.endsWith(term))) continue
+    if (existing.some(text => text.includes(compact) || compact.includes(text))) continue
+    if (seen.has(compact)) continue
+    seen.add(compact)
+    results.push(line)
+    if (results.length === 3) break
+  }
+  return results
+}
 
 const getLeadText = (compound: CompoundDetail): string =>
   compound.description?.trim() ||
@@ -246,6 +290,13 @@ export default async function CompoundDetailPage({ params }: Params) {
   const reviewStatus = normalizeProfileText(compound.review_status)
   const sourceStatus = normalizeProfileText(compound.source_status)
   const sources = normalizeSources(compound.sources)
+  const bestForItems = getBestForItems(compound, [
+    leadText,
+    overviewText,
+    ...mechanisms,
+    ...targets,
+    ...foundIn,
+  ])
 
   const hasDetails = Boolean(
     overviewText ||
@@ -339,6 +390,7 @@ export default async function CompoundDetailPage({ params }: Params) {
           ) : null}
 
           <SectionList title='Mechanisms' items={mechanisms} />
+          <SectionList title='Best for' items={bestForItems} />
           <SectionList title='Targets' items={targets} />
           <SectionList title='Found in' items={foundIn} />
 

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -39,6 +39,8 @@ type HerbDetail = {
   review_status?: unknown
   source_status?: unknown
   sources?: unknown
+  primaryDomain?: unknown
+  claimRows?: unknown
 }
 
 type BlogPost = {
@@ -93,6 +95,48 @@ const getHerbLabel = (herb: Partial<HerbDetail>): string => {
 
 const normalizeText = (value?: string | null): string =>
   value?.replace(/\s+/g, ' ').trim() ?? ''
+
+const VAGUE_BEST_FOR_TERMS = new Set([
+  'general wellness',
+  'wellness',
+  'overall health',
+  'balance',
+  'support',
+])
+
+const toBestForLine = (value: string): string => {
+  const cleaned = normalizeText(value).replace(/\.$/, '')
+  if (!cleaned) return ''
+  const prefixed = cleaned.toLowerCase().startsWith('best for ')
+    ? cleaned
+    : `Best for ${cleaned.charAt(0).toLowerCase()}${cleaned.slice(1)}`
+  return prefixed
+}
+
+const getBestForItems = (
+  herb: HerbDetail,
+  existingText: string[],
+): string[] => {
+  const existing = existingText.map(text => normalizeText(text).toLowerCase()).filter(Boolean)
+  const primaryDomain = normalizeProfileText(herb.primaryDomain)
+  const claimRows = normalizeProfileList(herb.claimRows)
+  const candidates = [primaryDomain, ...claimRows]
+
+  const results: string[] = []
+  const seen = new Set<string>()
+  for (const candidate of candidates) {
+    const line = toBestForLine(candidate)
+    const compact = normalizeText(line).toLowerCase()
+    if (!compact) continue
+    if ([...VAGUE_BEST_FOR_TERMS].some(term => compact.endsWith(term))) continue
+    if (existing.some(text => text.includes(compact) || compact.includes(text))) continue
+    if (seen.has(compact)) continue
+    seen.add(compact)
+    results.push(line)
+    if (results.length === 3) break
+  }
+  return results
+}
 
 const getLeadText = (herb: HerbDetail): string =>
   herb.description?.trim() ||
@@ -258,6 +302,13 @@ export default async function HerbDetailPage({ params }: Params) {
   const reviewStatus = normalizeProfileText(herb.review_status)
   const sourceStatus = normalizeProfileText(herb.source_status)
   const sources = normalizeSources(herb.sources)
+  const bestForItems = getBestForItems(herb, [
+    leadText,
+    overviewText,
+    ...mechanisms,
+    ...contraindications,
+    ...interactions,
+  ])
 
   const hasDetails = Boolean(
     overviewText ||
@@ -346,6 +397,7 @@ export default async function HerbDetailPage({ params }: Params) {
           ) : null}
 
           <SectionList title='Mechanisms' items={mechanisms} />
+          <SectionList title='Best for' items={bestForItems} />
 
           {safetyNotes ? (
             <section className='ds-card'>


### PR DESCRIPTION
### Motivation
- Provide instant, scannable guidance on entity pages so users can quickly see likely use-cases. 
- Derive concise recommendations from existing enrichment fields (`primaryDomain` + `claimRows`) without changing data pipelines. 
- Keep changes surgical and non-disruptive to existing route contracts (`/herbs/:slug`, `/compounds/:slug`).

### Description
- Added a new `Best for` section to herb and compound detail pages by updating `app/herbs/[slug]/page.tsx` and `app/compounds/[slug]/page.tsx`. 
- Implemented helper logic (`VAGUE_BEST_FOR_TERMS`, `toBestForLine`, `getBestForItems`) to build up to three normalized bullets in the form `Best for …` from `primaryDomain` and `claimRows`. 
- Applied filtering to remove vague endings (e.g., “general wellness”) and de-duplication against already-rendered content (Overview, Mechanisms, Targets, etc.). 
- The change is additive and optional: it consumes `primaryDomain`/`claimRows` when present and preserves all existing UI and data contracts.

### Testing
- Ran targeted linting with `npx eslint app/herbs/[slug]/page.tsx app/compounds/[slug]/page.tsx`, which completed successfully. 
- Ran the repo lint script `npm run lint -- app/herbs/[slug]/page.tsx app/compounds/[slug]/page.tsx`, which failed due to an existing unrelated lint error in `scripts/build-blog.mjs` (not caused by these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f16759c2888323b0047aa3f859d38a)