### PR TITLE
Enforce evidence-tier rendering rules for herb cards

### DIFF
--- a/src/components/HerbCard.tsx
+++ b/src/components/HerbCard.tsx
@@ -7,6 +7,17 @@ import { normalizeTagList } from '@/lib/tagNormalization'
 import { getProfileStatus, getSummaryQuality, shouldRenderSummary } from '@/lib/workbookRender'
 import { hasPlaceholderText, sanitizeSurfaceText } from '@/lib/summary'
 
+const normalizeEvidenceTier = (rawTier?: string): 'a' | 'b' | 'c' | null => {
+  if (!rawTier) return null
+  const value = rawTier.toLowerCase()
+
+  if (value.includes('tier-a') || value.includes('a-tier') || value.includes('tier a') || value == 'a') return 'a'
+  if (value.includes('tier-b') || value.includes('b-tier') || value.includes('tier b') || value == 'b') return 'b'
+  if (value.includes('tier-c') || value.includes('c-tier') || value.includes('tier c') || value == 'c') return 'c'
+
+  return null
+}
+
 interface HerbCardProps {
   name: string
   summary: string
@@ -66,9 +77,19 @@ function HerbCard({
 
   const chipClass =
     'inline-flex items-center gap-1 rounded-full border border-white/10 bg-white/5 px-2 py-0.5 text-[0.68rem] font-medium text-white/55'
+  const evidenceTier = normalizeEvidenceTier(evidence_tier || evidenceLevel)
+
+  if (evidenceTier === 'c') return null
+
+  const evidenceCardClass =
+    evidenceTier === 'a'
+      ? 'border-emerald-300/35 bg-emerald-500/[0.07] shadow-[0_0_0_1px_rgba(16,185,129,0.15)]'
+      : evidenceTier === 'b'
+        ? 'border-white/8 bg-white/[0.02] opacity-80'
+        : 'border-white/8 bg-white/[0.03]'
 
   return (
-    <Card className='group relative flex h-full flex-col gap-2.5 rounded-[var(--radius-lg)] border border-white/8 bg-white/[0.03] p-4 transition-all duration-200 hover:-translate-y-0.5 hover:border-white/16 hover:bg-white/[0.055] hover:shadow-[0_8px_32px_rgba(0,0,0,0.4)]'>
+    <Card className={`group relative flex h-full flex-col gap-2.5 rounded-[var(--radius-lg)] p-4 transition-all duration-200 hover:-translate-y-0.5 hover:border-white/16 hover:bg-white/[0.055] hover:shadow-[0_8px_32px_rgba(0,0,0,0.4)] ${evidenceCardClass}`}>
       <div
         aria-hidden
         className='pointer-events-none absolute inset-0 rounded-[var(--radius-lg)] opacity-0 transition-opacity duration-300 group-hover:opacity-100 shadow-[inset_0_0_0_1px_rgba(14,207,179,0.12)]'


### PR DESCRIPTION
### Motivation
- Prevent weak (C-tier) evidence from appearing as strong in browse UI by applying a tier-based display policy at render-time.
- Keep dataset and data-pipeline unchanged and make a minimal UI-only change so rendering controls visibility and styling only.
- Support multiple evidence-string formats by normalizing free-text evidence values to A/B/C tiers.

### Description
- Added `normalizeEvidenceTier` helper to `src/components/HerbCard.tsx` to map common text variants (e.g., `tier-a`, `a-tier`, `tier a`, `a`) to canonical tiers `a | b | c | null`.
- Applied tier rules in `HerbCard`: A-tier cards render with highlighted styling, B-tier cards render with a muted presentation, and C-tier cards are hidden by returning `null`.
- Updated the card container class to conditionally apply the A/B visual treatments while preserving existing behavior for non-tiered entries.

### Testing
- Ran `npm run build` (which includes data build and Next.js production build) and it completed successfully.
- The change was limited to `src/components/HerbCard.tsx` and did not modify dataset generation logic during the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f16764cdec83238512e9eaa8a3cf9e)