### PR TITLE
Add concise Safety section to herb and compound detail pages

### DIFF
--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -21,6 +21,8 @@ import {
 type Params = { params: Promise<{ slug: string }> }
 
 type CompoundDetail = {
+  contraindications?: unknown
+  interactions?: unknown
   slug: string
   displayName?: string | null
   name?: string | null
@@ -237,6 +239,9 @@ export default async function CompoundDetailPage({ params }: Params) {
   const targets = normalizeProfileList(compound.targets)
   const foundIn = normalizeProfileList(compound.foundIn)
   const safetyNotes = normalizeProfileText(compound.safetyNotes)
+  const contraindications = normalizeProfileList(compound.contraindications)
+  const interactions = normalizeProfileList(compound.interactions)
+  const warnings = safetyNotes ? [safetyNotes] : []
   const evidenceLevel = normalizeProfileText(compound.evidenceLevel)
   const evidenceType = normalizeProfileText(compound.evidenceType)
   const confidenceTier = normalizeProfileText(compound.confidenceTier)
@@ -342,15 +347,52 @@ export default async function CompoundDetailPage({ params }: Params) {
           <SectionList title='Targets' items={targets} />
           <SectionList title='Found in' items={foundIn} />
 
-          {safetyNotes ? (
+          {contraindications.length || interactions.length || warnings.length ? (
             <section className='ds-card'>
               <p className='text-sm font-medium uppercase tracking-[0.2em] text-white/50'>
-                Safety notes
+                Safety
               </p>
 
-              <p className='mt-4 whitespace-pre-line text-sm leading-7 text-white/75 sm:text-base'>
-                {safetyNotes}
-              </p>
+              <div className='mt-4 space-y-4'>
+                {contraindications.length ? (
+                  <div>
+                    <p className='text-xs font-medium uppercase tracking-[0.2em] text-white/45'>
+                      Contraindications
+                    </p>
+                    <ul className='mt-2 list-disc space-y-2 pl-5 text-sm leading-6 text-white/75 sm:text-base'>
+                      {contraindications.map(item => (
+                        <li key={item}>{item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+
+                {interactions.length ? (
+                  <div>
+                    <p className='text-xs font-medium uppercase tracking-[0.2em] text-white/45'>
+                      Interactions
+                    </p>
+                    <ul className='mt-2 list-disc space-y-2 pl-5 text-sm leading-6 text-white/75 sm:text-base'>
+                      {interactions.map(item => (
+                        <li key={item}>{item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+
+                {warnings.length ? (
+                  <div>
+                    <p className='text-xs font-medium uppercase tracking-[0.2em] text-white/45'>
+                      Warnings
+                    </p>
+                    <ul className='mt-2 list-disc space-y-2 pl-5 text-sm leading-6 text-white/75 sm:text-base'>
+                      {warnings.map(item => (
+                        <li key={item}>{item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+              </div>
             </section>
           ) : null}
 
@@ -402,7 +444,10 @@ export default async function CompoundDetailPage({ params }: Params) {
               },
               {
                 label: 'Safety section',
-                value: safetyNotes ? 'Included' : 'Not yet',
+                value:
+                  contraindications.length || interactions.length || warnings.length
+                    ? 'Included'
+                    : 'Not yet',
               },
             ]}
           />

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -250,6 +250,7 @@ export default async function HerbDetailPage({ params }: Params) {
   const safetyNotes = normalizeProfileText(herb.safetyNotes)
   const contraindications = normalizeProfileList(herb.contraindications)
   const interactions = normalizeProfileList(herb.interactions)
+  const warnings = safetyNotes ? [safetyNotes] : []
   const dosage = normalizeProfileText(herb.dosage)
   const preparation = normalizeProfileText(herb.preparation)
   const evidenceLevel = normalizeProfileText(herb.evidenceLevel)
@@ -347,20 +348,54 @@ export default async function HerbDetailPage({ params }: Params) {
 
           <SectionList title='Mechanisms' items={mechanisms} />
 
-          {safetyNotes ? (
+          {contraindications.length || interactions.length || warnings.length ? (
             <section className='ds-card'>
               <p className='text-sm font-medium uppercase tracking-[0.2em] text-white/50'>
-                Safety notes
+                Safety
               </p>
 
-              <p className='mt-4 whitespace-pre-line text-sm leading-7 text-white/75 sm:text-base'>
-                {safetyNotes}
-              </p>
+              <div className='mt-4 space-y-4'>
+                {contraindications.length ? (
+                  <div>
+                    <p className='text-xs font-medium uppercase tracking-[0.2em] text-white/45'>
+                      Contraindications
+                    </p>
+                    <ul className='mt-2 list-disc space-y-2 pl-5 text-sm leading-6 text-white/75 sm:text-base'>
+                      {contraindications.map(item => (
+                        <li key={item}>{item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+
+                {interactions.length ? (
+                  <div>
+                    <p className='text-xs font-medium uppercase tracking-[0.2em] text-white/45'>
+                      Interactions
+                    </p>
+                    <ul className='mt-2 list-disc space-y-2 pl-5 text-sm leading-6 text-white/75 sm:text-base'>
+                      {interactions.map(item => (
+                        <li key={item}>{item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+
+                {warnings.length ? (
+                  <div>
+                    <p className='text-xs font-medium uppercase tracking-[0.2em] text-white/45'>
+                      Warnings
+                    </p>
+                    <ul className='mt-2 list-disc space-y-2 pl-5 text-sm leading-6 text-white/75 sm:text-base'>
+                      {warnings.map(item => (
+                        <li key={item}>{item}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ) : null}
+              </div>
             </section>
           ) : null}
-
-          <SectionList title='Contraindications' items={contraindications} />
-          <SectionList title='Interactions' items={interactions} />
 
           <KeyValueSection
             title='Use and preparation'
@@ -418,7 +453,10 @@ export default async function HerbDetailPage({ params }: Params) {
               },
               {
                 label: 'Safety section',
-                value: safetyNotes ? 'Included' : 'Not yet',
+                value:
+                  contraindications.length || interactions.length || warnings.length
+                    ? 'Included'
+                    : 'Not yet',
               },
             ]}
           />


### PR DESCRIPTION
### Motivation
- Make safety information more visible on entity pages to increase trust and credibility. 
- Surface existing safety fields together (contraindications, interactions, and warnings) without inventing data. 
- Keep the change minimal and UI-only, preserving existing route contracts and data pipelines.

### Description
- Added a `Safety` section to herb and compound detail pages in `app/herbs/[slug]/page.tsx` and `app/compounds/[slug]/page.tsx` that displays `contraindications`, `interactions`, and `warnings` (with `warnings` derived from existing `safetyNotes`).
- Normalized lists/text via existing helpers (`normalizeProfileList` / `normalizeProfileText`) and added `warnings = safetyNotes ? [safetyNotes] : []` to surface concise warnings.
- Updated the compound type to accept `contraindications` and `interactions` and consolidated the previous separate lists into the single `Safety` card layout. 
- Updated the “At a glance” summary so the `Safety section` reports `Included` when any of `contraindications`, `interactions`, or `warnings` are present.

### Testing
- Ran ESLint on the modified files with `npx eslint app/herbs/[slug]/page.tsx app/compounds/[slug]/page.tsx` which completed successfully (only non-blocking warnings about npm/ESLint migration were reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f167712d748323b38e64018a73d0ef)