### PR TITLE
Fix compare page A-tier index lookup key

### DIFF
--- a/app/compare/[slug]/page.tsx
+++ b/app/compare/[slug]/page.tsx
@@ -23,12 +23,12 @@ const getMechanism = (compoundName: string): string => {
 }
 
 const getUseCase = (compoundSlug: string): string => {
-  const match = aTierIndex.global.find(item => item.slug === resolveTierSlug(compoundSlug))
+  const match = aTierIndex.items.find(item => item.slug === resolveTierSlug(compoundSlug))
   return match ? `Primary domain in current dataset: ${match.domain}.` : 'Not available in current dataset.'
 }
 
 const getEvidenceStrength = (compoundSlug: string): string => {
-  const match = aTierIndex.global.find(item => item.slug === resolveTierSlug(compoundSlug))
+  const match = aTierIndex.items.find(item => item.slug === resolveTierSlug(compoundSlug))
   return match ? `Confidence score in current dataset: ${match.confidenceScore}/100.` : 'Not available in current dataset.'
 }
 


### PR DESCRIPTION
### Motivation
- The A-tier index structure uses an `items` array rather than `global`, so lookups on the compare page were failing to find matches for A-tier compounds.  

### Description
- Replaced `aTierIndex.global.find(...)` with `aTierIndex.items.find(...)` in `app/compare/[slug]/page.tsx` for both `getUseCase` and `getEvidenceStrength` to fix A-tier lookups.  

### Testing
- Ran `npm run check` (which runs data build, validation, and Next.js build) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f200fd3f648323909349c320ee5229)