### PR TITLE
A-tier: read generated `items` payload instead of legacy `.global`/`.contextual`

### DIFF
--- a/app/a-tier/page.tsx
+++ b/app/a-tier/page.tsx
@@ -22,14 +22,15 @@ type TierItem = {
 }
 
 type TierPayload = {
-  global?: TierItem[]
-  contextual?: TierItem[]
+  generatedAt?: string
+  count?: number
+  items?: TierItem[]
 }
 
 export default function ATierPage() {
   const filePath = path.join(process.cwd(), 'public/data/a-tier-index.json')
   const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as TierPayload
-  const allItems = [...(data.global ?? []), ...(data.contextual ?? [])]
+  const allItems = data.items ?? []
 
   const grouped = DOMAIN_ORDER.reduce<Record<Domain, TierItem[]>>((acc, domain) => {
     acc[domain] = allItems


### PR DESCRIPTION
### Motivation
- Align the A-tier page with the generated `a-tier-index.json` shape (`generatedAt`, `count`, `items`) to remove a stale `.global`/`.contextual` data-index assumption and keep stub-posts crawlability behavior intact.

### Description
- Updated `app/a-tier/page.tsx` to change the `TierPayload` type to include `generatedAt?: string`, `count?: number`, and `items?: TierItem[]`, and replaced the legacy `...[data.global ?? [] , data.contextual ?? []]` reader with `data.items ?? []`, and confirmed `app/blog/[slug]/page.tsx` already uses `robots: { index: false, follow: true }` so no SEO code changes were needed.

### Testing
- Searched the repo for `.global` with `rg` and updated only the A-tier reader; ran `npm run check` which executed the data build, data validation, and Next.js build (static page generation) and completed successfully with no TypeScript/build errors to fix, and the single file changed was `app/a-tier/page.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f20bf58af88323b41e53786c36f46a)