### PR TITLE
Publish multiple blog posts by setting frontmatter `draft: false`

### DIFF
--- a/content/blog/2025-08-16-psychoactive-botany-rhodiola-saturday-notes.mdx
+++ b/content/blog/2025-08-16-psychoactive-botany-rhodiola-saturday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Psychoactive botany overview of Rhodiola, covering active compounds like Hordenine, effects profile, and safe use."
 tags: ["Safety","Herbs"]
 cover: "/blog/psychoactive-botany-rhodiola-saturday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Psychoactive Botany — Rhodiola (Saturday Notes)

--- a/content/blog/2025-08-17-traditional-use-calea-zacatechichi-sunday-notes.mdx
+++ b/content/blog/2025-08-17-traditional-use-calea-zacatechichi-sunday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Traditional and ethnobotanical use of Calea zacatechichi, including cultural context, active compounds like Choline, and modern applications."
 tags: ["Blend Ideas","Herbs"]
 cover: "/blog/traditional-use-calea-zacatechichi-sunday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Traditional Use — Calea zacatechichi (Sunday Notes)

--- a/content/blog/2025-08-18-research-digest-cordyceps-monday-notes.mdx
+++ b/content/blog/2025-08-18-research-digest-cordyceps-monday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Research digest for Cordyceps covering recent findings, active compounds like Mesembrine, and evidence-based use guidance."
 tags: ["Safety","Culture"]
 cover: "/blog/research-digest-cordyceps-monday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Research Digest — Cordyceps (Monday Notes)

--- a/content/blog/2025-08-19-formulation-tips-passionflower-tuesday-notes.mdx
+++ b/content/blog/2025-08-19-formulation-tips-passionflower-tuesday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Formulation tips for Passionflower with guidance on preparation, active compounds like Mesembrine, and practical blend considerations."
 tags: ["Research","Herbs"]
 cover: "/blog/formulation-tips-passionflower-tuesday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Formulation Tips — Passionflower (Tuesday Notes)

--- a/content/blog/2025-08-20-blend-craft-kava-wednesday-notes.mdx
+++ b/content/blog/2025-08-20-blend-craft-kava-wednesday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Blend craft notes for Kava, exploring synergistic combinations, active compounds like Hordenine, and usage recommendations."
 tags: ["Field Notes","Herbs"]
 cover: "/blog/blend-craft-kava-wednesday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Blend Craft — Kava (Wednesday Notes)

--- a/content/blog/2025-08-21-pharmacology-basics-gotu-kola-thursday-notes.mdx
+++ b/content/blog/2025-08-21-pharmacology-basics-gotu-kola-thursday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Pharmacology overview of Gotu Kola with attention to active compounds like Eugenol, mechanisms of action, and safe practice."
 tags: ["Safety","Compounds"]
 cover: "/blog/pharmacology-basics-gotu-kola-thursday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Pharmacology Basics — Gotu Kola (Thursday Notes)

--- a/content/blog/2025-08-22-safety-set-setting-cordyceps-friday-notes.mdx
+++ b/content/blog/2025-08-22-safety-set-setting-cordyceps-friday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Safety and set/setting considerations for Cordyceps, including contraindications, active compounds like Apigenin, and responsible use practices."
 tags: ["Safety","Culture"]
 cover: "/blog/safety-set-setting-cordyceps-friday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Safety & Set/Setting — Cordyceps (Friday Notes)

--- a/content/blog/2025-08-23-psychoactive-botany-cordyceps-saturday-notes.mdx
+++ b/content/blog/2025-08-23-psychoactive-botany-cordyceps-saturday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Daily notes on Cordyceps with a focus on practical use, active compounds like Mesembrine, and safe experimentation."
 tags: ["Blend Ideas","Herbs"]
 cover: "/blog/psychoactive-botany-cordyceps-saturday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Psychoactive Botany — Cordyceps (Saturday Notes)

--- a/content/blog/2025-08-24-safety-set-setting-skullcap-sunday-notes.mdx
+++ b/content/blog/2025-08-24-safety-set-setting-skullcap-sunday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Safety and set/setting considerations for Skullcap, including contraindications, active compounds like Myriscin, and responsible use practices."
 tags: ["Research","Compounds"]
 cover: "/blog/safety-set-setting-skullcap-sunday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Safety & Set/Setting — Skullcap (Sunday Notes)

--- a/content/blog/2025-08-25-extraction-101-passionflower-monday-notes.mdx
+++ b/content/blog/2025-08-25-extraction-101-passionflower-monday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Practical extraction guide for Passionflower, covering preparation methods, key active compounds like Hordenine, and safe use considerations."
 tags: ["Blend Ideas","Compounds"]
 cover: "/blog/extraction-101-passionflower-monday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Extraction 101 — Passionflower (Monday Notes)

--- a/content/blog/2025-08-26-pharmacology-basics-rhodiola-tuesday-notes.mdx
+++ b/content/blog/2025-08-26-pharmacology-basics-rhodiola-tuesday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Pharmacology overview of Rhodiola with attention to active compounds like Myriscin, mechanisms of action, and safe practice."
 tags: ["Safety","Compounds"]
 cover: "/blog/pharmacology-basics-rhodiola-tuesday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Pharmacology Basics — Rhodiola (Tuesday Notes)

--- a/content/blog/2025-08-27-blend-craft-calea-zacatechichi-wednesday-notes.mdx
+++ b/content/blog/2025-08-27-blend-craft-calea-zacatechichi-wednesday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Blend craft notes for Calea zacatechichi, exploring synergistic combinations, active compounds like Eugenol, and usage recommendations."
 tags: ["Field Notes","Culture"]
 cover: "/blog/blend-craft-calea-zacatechichi-wednesday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Blend Craft — Calea zacatechichi (Wednesday Notes)

--- a/content/blog/2025-08-28-research-digest-gotu-kola-thursday-notes.mdx
+++ b/content/blog/2025-08-28-research-digest-gotu-kola-thursday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Research digest for Gotu Kola covering recent findings, active compounds like Eugenol, and evidence-based use guidance."
 tags: ["Field Notes","Compounds"]
 cover: "/blog/research-digest-gotu-kola-thursday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Research Digest — Gotu Kola (Thursday Notes)

--- a/content/blog/2025-08-29-blend-craft-passionflower-friday-notes.mdx
+++ b/content/blog/2025-08-29-blend-craft-passionflower-friday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Blend craft notes for Passionflower, exploring synergistic combinations, active compounds like Beta-caryophyllene, and usage recommendations."
 tags: ["Field Notes","Herbs"]
 cover: "/blog/blend-craft-passionflower-friday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Blend Craft — Passionflower (Friday Notes)

--- a/content/blog/2025-08-30-blend-craft-reishi-saturday-notes.mdx
+++ b/content/blog/2025-08-30-blend-craft-reishi-saturday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Blend craft notes for Reishi, exploring synergistic combinations, active compounds like Choline, and usage recommendations."
 tags: ["Research","Compounds"]
 cover: "/blog/blend-craft-reishi-saturday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Blend Craft — Reishi (Saturday Notes)

--- a/content/blog/2025-08-31-safety-set-setting-amanita-muscaria-sunday-notes.mdx
+++ b/content/blog/2025-08-31-safety-set-setting-amanita-muscaria-sunday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Safety and set/setting considerations for Amanita muscaria, including contraindications, active compounds like Mesembrine, and responsible use practices."
 tags: ["Safety","Culture"]
 cover: "/blog/safety-set-setting-amanita-muscaria-sunday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Safety & Set/Setting — Amanita muscaria (Sunday Notes)

--- a/content/blog/2025-09-01-microdosing-log-blue-lotus-monday-notes.mdx
+++ b/content/blog/2025-09-01-microdosing-log-blue-lotus-monday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Daily notes on Blue Lotus with a focus on practical use, active compounds like L-Theanine, and safe experimentation."
 tags: ["Blend Ideas","Culture"]
 cover: "/blog/microdosing-log-blue-lotus-monday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Microdosing Log — Blue Lotus (Monday Notes)

--- a/content/blog/2025-09-02-cultivar-notes-rhodiola-tuesday-notes.mdx
+++ b/content/blog/2025-09-02-cultivar-notes-rhodiola-tuesday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Cultivar and sourcing notes for Rhodiola, with focus on active compounds like Hordenine and quality considerations."
 tags: ["Field Notes","Herbs"]
 cover: "/blog/cultivar-notes-rhodiola-tuesday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Cultivar Notes — Rhodiola (Tuesday Notes)

--- a/content/blog/2025-09-03-pharmacology-basics-damiana-wednesday-notes.mdx
+++ b/content/blog/2025-09-03-pharmacology-basics-damiana-wednesday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Pharmacology overview of Damiana with attention to active compounds like Apigenin, mechanisms of action, and safe practice."
 tags: ["Safety","Herbs"]
 cover: "/blog/pharmacology-basics-damiana-wednesday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Pharmacology Basics — Damiana (Wednesday Notes)

--- a/content/blog/2025-09-04-bioassays-blue-lotus-thursday-notes.mdx
+++ b/content/blog/2025-09-04-bioassays-blue-lotus-thursday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Bioassay log for Blue Lotus documenting subjective effects, active compounds like Eugenol, and safe experimentation notes."
 tags: ["Blend Ideas","Compounds"]
 cover: "/blog/bioassays-blue-lotus-thursday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Bioassays — Blue Lotus (Thursday Notes)

--- a/content/blog/2025-09-05-bioassays-reishi-friday-notes.mdx
+++ b/content/blog/2025-09-05-bioassays-reishi-friday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Bioassay log for Reishi documenting subjective effects, active compounds like L-Theanine, and safe experimentation notes."
 tags: ["Safety","Compounds"]
 cover: "/blog/bioassays-reishi-friday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Bioassays — Reishi (Friday Notes)

--- a/content/blog/2025-09-06-pharmacology-basics-rhodiola-saturday-notes.mdx
+++ b/content/blog/2025-09-06-pharmacology-basics-rhodiola-saturday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Pharmacology overview of Rhodiola with attention to active compounds like Myriscin, mechanisms of action, and safe practice."
 tags: ["Research","Compounds"]
 cover: "/blog/pharmacology-basics-rhodiola-saturday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Pharmacology Basics — Rhodiola (Saturday Notes)

--- a/content/blog/2025-09-07-pharmacology-basics-blue-lotus-sunday-notes.mdx
+++ b/content/blog/2025-09-07-pharmacology-basics-blue-lotus-sunday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Pharmacology overview of Blue Lotus with attention to active compounds like Hordenine, mechanisms of action, and safe practice."
 tags: ["Blend Ideas","Compounds"]
 cover: "/blog/pharmacology-basics-blue-lotus-sunday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Pharmacology Basics — Blue Lotus (Sunday Notes)

--- a/content/blog/2025-09-08-safety-set-setting-gotu-kola-monday-notes.mdx
+++ b/content/blog/2025-09-08-safety-set-setting-gotu-kola-monday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Safety and set/setting considerations for Gotu Kola, including contraindications, active compounds like L-Theanine, and responsible use practices."
 tags: ["Safety","Culture"]
 cover: "/blog/safety-set-setting-gotu-kola-monday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Safety & Set/Setting — Gotu Kola (Monday Notes)

--- a/content/blog/2025-09-09-bioassays-blue-lotus-tuesday-notes.mdx
+++ b/content/blog/2025-09-09-bioassays-blue-lotus-tuesday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Daily notes on Blue Lotus with a focus on practical use, active compounds like Eugenol, and safe experimentation."
 tags: ["Research","Culture"]
 cover: "/blog/bioassays-blue-lotus-tuesday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Bioassays — Blue Lotus (Tuesday Notes)

--- a/content/blog/2025-09-10-field-notes-damiana-wednesday-notes.mdx
+++ b/content/blog/2025-09-10-field-notes-damiana-wednesday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Field notes on Damiana covering practical use, active compounds like Beta-caryophyllene, and real-world observations."
 tags: ["Field Notes","Compounds"]
 cover: "/blog/field-notes-damiana-wednesday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Field Notes — Damiana (Wednesday Notes)

--- a/content/blog/2025-09-11-formulation-tips-skullcap-thursday-notes.mdx
+++ b/content/blog/2025-09-11-formulation-tips-skullcap-thursday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Formulation tips for Skullcap with guidance on preparation, active compounds like Apigenin, and practical blend considerations."
 tags: ["Research","Compounds"]
 cover: "/blog/formulation-tips-skullcap-thursday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Formulation Tips — Skullcap (Thursday Notes)

--- a/content/blog/2025-09-12-safety-set-setting-gotu-kola-friday-notes.mdx
+++ b/content/blog/2025-09-12-safety-set-setting-gotu-kola-friday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Safety and set/setting considerations for Gotu Kola, including contraindications, active compounds like Harmine, and responsible use practices."
 tags: ["Blend Ideas","Compounds"]
 cover: "/blog/safety-set-setting-gotu-kola-friday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Safety & Set/Setting — Gotu Kola (Friday Notes)

--- a/content/blog/2025-09-13-formulation-tips-mugwort-saturday-notes.mdx
+++ b/content/blog/2025-09-13-formulation-tips-mugwort-saturday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Formulation tips for Mugwort with guidance on preparation, active compounds like Harmine, and practical blend considerations."
 tags: ["Blend Ideas","Herbs"]
 cover: "/blog/formulation-tips-mugwort-saturday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Formulation Tips — Mugwort (Saturday Notes)

--- a/content/blog/2025-09-14-bioassays-ashwagandha-sunday-notes.mdx
+++ b/content/blog/2025-09-14-bioassays-ashwagandha-sunday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Bioassay log for Ashwagandha documenting subjective effects, active compounds like Choline, and safe experimentation notes."
 tags: ["Field Notes","Compounds"]
 cover: "/blog/bioassays-ashwagandha-sunday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Bioassays — Ashwagandha (Sunday Notes)

--- a/content/blog/2025-09-15-traditional-use-gotu-kola-monday-notes.mdx
+++ b/content/blog/2025-09-15-traditional-use-gotu-kola-monday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Traditional and ethnobotanical use of Gotu Kola, including cultural context, active compounds like Choline, and modern applications."
 tags: ["Field Notes","Compounds"]
 cover: "/blog/traditional-use-gotu-kola-monday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Traditional Use — Gotu Kola (Monday Notes)

--- a/content/blog/2025-09-16-cultivar-notes-damiana-tuesday-notes.mdx
+++ b/content/blog/2025-09-16-cultivar-notes-damiana-tuesday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Cultivar and sourcing notes for Damiana, with focus on active compounds like Thujone and quality considerations."
 tags: ["Field Notes","Compounds"]
 cover: "/blog/cultivar-notes-damiana-tuesday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Cultivar Notes — Damiana (Tuesday Notes)

--- a/content/blog/2025-09-17-psychoactive-botany-amanita-muscaria-wednesday-notes.mdx
+++ b/content/blog/2025-09-17-psychoactive-botany-amanita-muscaria-wednesday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Psychoactive botany overview of Amanita muscaria, covering active compounds like Eugenol, effects profile, and safe use."
 tags: ["Research","Compounds"]
 cover: "/blog/psychoactive-botany-amanita-muscaria-wednesday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Psychoactive Botany — Amanita muscaria (Wednesday Notes)

--- a/content/blog/2025-09-18-psychoactive-botany-ashwagandha-thursday-notes.mdx
+++ b/content/blog/2025-09-18-psychoactive-botany-ashwagandha-thursday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Psychoactive botany overview of Ashwagandha, covering active compounds like Choline, effects profile, and safe use."
 tags: ["Blend Ideas","Herbs"]
 cover: "/blog/psychoactive-botany-ashwagandha-thursday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Psychoactive Botany — Ashwagandha (Thursday Notes)

--- a/content/blog/2025-09-19-blend-craft-calea-zacatechichi-friday-notes.mdx
+++ b/content/blog/2025-09-19-blend-craft-calea-zacatechichi-friday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Blend craft notes for Calea zacatechichi, exploring synergistic combinations, active compounds like Beta-caryophyllene, and usage recommendations."
 tags: ["Safety","Culture"]
 cover: "/blog/blend-craft-calea-zacatechichi-friday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Blend Craft — Calea zacatechichi (Friday Notes)

--- a/content/blog/2025-09-20-microdosing-log-cordyceps-saturday-notes.mdx
+++ b/content/blog/2025-09-20-microdosing-log-cordyceps-saturday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Microdosing log for Cordyceps with observations on low-dose effects, active compounds like L-Theanine, and protocol guidance."
 tags: ["Field Notes","Culture"]
 cover: "/blog/microdosing-log-cordyceps-saturday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Microdosing Log — Cordyceps (Saturday Notes)

--- a/content/blog/2025-09-21-research-digest-calea-zacatechichi-sunday-notes.mdx
+++ b/content/blog/2025-09-21-research-digest-calea-zacatechichi-sunday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Research digest for Calea zacatechichi covering recent findings, active compounds like Apigenin, and evidence-based use guidance."
 tags: ["Research","Compounds"]
 cover: "/blog/research-digest-calea-zacatechichi-sunday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Research Digest — Calea zacatechichi (Sunday Notes)

--- a/content/blog/2025-09-22-field-notes-lion-s-mane-monday-notes.mdx
+++ b/content/blog/2025-09-22-field-notes-lion-s-mane-monday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Field notes on Lion's Mane covering practical use, active compounds like Myriscin, and real-world observations."
 tags: ["Field Notes","Culture"]
 cover: "/blog/field-notes-lion-s-mane-monday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Field Notes — Lion's Mane (Monday Notes)

--- a/content/blog/2025-09-23-extraction-101-kava-tuesday-notes.mdx
+++ b/content/blog/2025-09-23-extraction-101-kava-tuesday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Daily notes on Kava with a focus on practical use, active compounds like Thujone, and safe experimentation."
 tags: ["Field Notes","Herbs"]
 cover: "/blog/extraction-101-kava-tuesday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Extraction 101 — Kava (Tuesday Notes)

--- a/content/blog/2025-09-24-traditional-use-rhodiola-wednesday-notes.mdx
+++ b/content/blog/2025-09-24-traditional-use-rhodiola-wednesday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Traditional and ethnobotanical use of Rhodiola, including cultural context, active compounds like Myriscin, and modern applications."
 tags: ["Blend Ideas","Culture"]
 cover: "/blog/traditional-use-rhodiola-wednesday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Traditional Use — Rhodiola (Wednesday Notes)

--- a/content/blog/2025-09-25-traditional-use-mugwort-thursday-notes.mdx
+++ b/content/blog/2025-09-25-traditional-use-mugwort-thursday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Traditional and ethnobotanical use of Mugwort, including cultural context, active compounds like L-Theanine, and modern applications."
 tags: ["Blend Ideas","Compounds"]
 cover: "/blog/traditional-use-mugwort-thursday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Traditional Use — Mugwort (Thursday Notes)

--- a/content/blog/2025-09-26-microdosing-log-skullcap-friday-notes.mdx
+++ b/content/blog/2025-09-26-microdosing-log-skullcap-friday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Microdosing log for Skullcap with observations on low-dose effects, active compounds like Beta-caryophyllene, and protocol guidance."
 tags: ["Safety","Herbs"]
 cover: "/blog/microdosing-log-skullcap-friday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Microdosing Log — Skullcap (Friday Notes)

--- a/content/blog/2025-09-27-formulation-tips-cordyceps-saturday-notes.mdx
+++ b/content/blog/2025-09-27-formulation-tips-cordyceps-saturday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Formulation tips for Cordyceps with guidance on preparation, active compounds like Thujone, and practical blend considerations."
 tags: ["Field Notes","Culture"]
 cover: "/blog/formulation-tips-cordyceps-saturday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Formulation Tips — Cordyceps (Saturday Notes)

--- a/content/blog/2025-09-28-field-notes-valerian-sunday-notes.mdx
+++ b/content/blog/2025-09-28-field-notes-valerian-sunday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Field notes on Valerian covering practical use, active compounds like Harmine, and real-world observations."
 tags: ["Field Notes","Herbs"]
 cover: "/blog/field-notes-valerian-sunday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Field Notes — Valerian (Sunday Notes)

--- a/content/blog/2025-09-29-bioassays-mugwort-monday-notes.mdx
+++ b/content/blog/2025-09-29-bioassays-mugwort-monday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Bioassay log for Mugwort documenting subjective effects, active compounds like Myriscin, and safe experimentation notes."
 tags: ["Safety","Herbs"]
 cover: "/blog/bioassays-mugwort-monday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Bioassays — Mugwort (Monday Notes)

--- a/content/blog/2025-09-30-cultivar-notes-amanita-muscaria-tuesday-notes.mdx
+++ b/content/blog/2025-09-30-cultivar-notes-amanita-muscaria-tuesday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Cultivar and sourcing notes for Amanita muscaria, with focus on active compounds like Beta-caryophyllene and quality considerations."
 tags: ["Safety","Culture"]
 cover: "/blog/cultivar-notes-amanita-muscaria-tuesday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Cultivar Notes — Amanita muscaria (Tuesday Notes)

--- a/content/blog/2025-10-01-field-notes-ashwagandha-wednesday-notes.mdx
+++ b/content/blog/2025-10-01-field-notes-ashwagandha-wednesday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Field notes on Ashwagandha covering practical use, active compounds like Mesembrine, and real-world observations."
 tags: ["Field Notes","Culture"]
 cover: "/blog/field-notes-ashwagandha-wednesday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Field Notes — Ashwagandha (Wednesday Notes)

--- a/content/blog/2025-10-02-safety-set-setting-valerian-thursday-notes.mdx
+++ b/content/blog/2025-10-02-safety-set-setting-valerian-thursday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Safety and set/setting considerations for Valerian, including contraindications, active compounds like Apigenin, and responsible use practices."
 tags: ["Research","Herbs"]
 cover: "/blog/safety-set-setting-valerian-thursday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Safety & Set/Setting — Valerian (Thursday Notes)

--- a/content/blog/2025-10-03-safety-set-setting-calea-zacatechichi-friday-notes.mdx
+++ b/content/blog/2025-10-03-safety-set-setting-calea-zacatechichi-friday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Safety and set/setting considerations for Calea zacatechichi, including contraindications, active compounds like Hordenine, and responsible use practices."
 tags: ["Field Notes","Compounds"]
 cover: "/blog/safety-set-setting-calea-zacatechichi-friday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Safety & Set/Setting — Calea zacatechichi (Friday Notes)

--- a/content/blog/2025-10-04-blend-craft-damiana-saturday-notes.mdx
+++ b/content/blog/2025-10-04-blend-craft-damiana-saturday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Blend craft notes for Damiana, exploring synergistic combinations, active compounds like Myriscin, and usage recommendations."
 tags: ["Field Notes","Compounds"]
 cover: "/blog/blend-craft-damiana-saturday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Blend Craft — Damiana (Saturday Notes)

--- a/content/blog/2025-10-05-microdosing-log-kava-sunday-notes.mdx
+++ b/content/blog/2025-10-05-microdosing-log-kava-sunday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Daily notes on Kava with a focus on practical use, active compounds like Thujone, and safe experimentation."
 tags: ["Field Notes","Herbs"]
 cover: "/blog/microdosing-log-kava-sunday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Microdosing Log — Kava (Sunday Notes)

--- a/content/blog/2025-10-06-formulation-tips-lion-s-mane-monday-notes.mdx
+++ b/content/blog/2025-10-06-formulation-tips-lion-s-mane-monday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Formulation tips for Lion's Mane with guidance on preparation, active compounds like Myriscin, and practical blend considerations."
 tags: ["Research","Herbs"]
 cover: "/blog/formulation-tips-lion-s-mane-monday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Formulation Tips — Lion's Mane (Monday Notes)

--- a/content/blog/2025-10-07-cultivar-notes-amanita-muscaria-tuesday-notes.mdx
+++ b/content/blog/2025-10-07-cultivar-notes-amanita-muscaria-tuesday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Cultivar and sourcing notes for Amanita muscaria, with focus on active compounds like Beta-caryophyllene and quality considerations."
 tags: ["Safety","Herbs"]
 cover: "/blog/cultivar-notes-amanita-muscaria-tuesday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Cultivar Notes — Amanita muscaria (Tuesday Notes)

--- a/content/blog/2025-10-08-safety-set-setting-cordyceps-wednesday-notes.mdx
+++ b/content/blog/2025-10-08-safety-set-setting-cordyceps-wednesday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Safety and set/setting considerations for Cordyceps, including contraindications, active compounds like Hordenine, and responsible use practices."
 tags: ["Blend Ideas","Compounds"]
 cover: "/blog/safety-set-setting-cordyceps-wednesday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Safety & Set/Setting — Cordyceps (Wednesday Notes)

--- a/content/blog/2025-10-09-bioassays-rhodiola-thursday-notes.mdx
+++ b/content/blog/2025-10-09-bioassays-rhodiola-thursday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Bioassay log for Rhodiola documenting subjective effects, active compounds like Apigenin, and safe experimentation notes."
 tags: ["Field Notes","Compounds"]
 cover: "/blog/bioassays-rhodiola-thursday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Bioassays — Rhodiola (Thursday Notes)

--- a/content/blog/2025-10-10-bioassays-damiana-friday-notes.mdx
+++ b/content/blog/2025-10-10-bioassays-damiana-friday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Bioassay log for Damiana documenting subjective effects, active compounds like Myriscin, and safe experimentation notes."
 tags: ["Field Notes","Culture"]
 cover: "/blog/bioassays-damiana-friday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Bioassays — Damiana (Friday Notes)

--- a/content/blog/2025-10-11-blend-craft-reishi-saturday-notes.mdx
+++ b/content/blog/2025-10-11-blend-craft-reishi-saturday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Blend craft notes for Reishi, exploring synergistic combinations, active compounds like Mesembrine, and usage recommendations."
 tags: ["Research","Herbs"]
 cover: "/blog/blend-craft-reishi-saturday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Blend Craft — Reishi (Saturday Notes)

--- a/content/blog/2025-10-12-psychoactive-botany-skullcap-sunday-notes.mdx
+++ b/content/blog/2025-10-12-psychoactive-botany-skullcap-sunday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Psychoactive botany overview of Skullcap, covering active compounds like Mesembrine, effects profile, and safe use."
 tags: ["Safety","Herbs"]
 cover: "/blog/psychoactive-botany-skullcap-sunday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Psychoactive Botany — Skullcap (Sunday Notes)

--- a/content/blog/2025-10-13-formulation-tips-valerian-monday-notes.mdx
+++ b/content/blog/2025-10-13-formulation-tips-valerian-monday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Formulation tips for Valerian with guidance on preparation, active compounds like Mesembrine, and practical blend considerations."
 tags: ["Safety","Compounds"]
 cover: "/blog/formulation-tips-valerian-monday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Formulation Tips — Valerian (Monday Notes)

--- a/content/blog/2025-10-14-field-notes-damiana-tuesday-notes.mdx
+++ b/content/blog/2025-10-14-field-notes-damiana-tuesday-notes.mdx
@@ -5,7 +5,7 @@ author: "The Hippie Scientist"
 summary: "Field notes on Damiana covering practical use, active compounds like Beta-caryophyllene, and real-world observations."
 tags: ["Research","Culture"]
 cover: "/blog/field-notes-damiana-tuesday-notes.svg"
-draft: true
+draft: false
 ---
 
 # Field Notes — Damiana (Tuesday Notes)


### PR DESCRIPTION
### Motivation

- Prepare a large batch of scheduled blog posts for publication by flipping the frontmatter draft flag. 
- Make the updated notes/field notes/research posts visible on the site according to the editorial schedule.

### Description

- Updated frontmatter in many `.mdx` blog files, changing `draft: true` to `draft: false` to publish the posts. 
- Changes span numerous daily/weekly notes and category pages (posts dated roughly from `2025-08-16` through `2025-10-14`).
- No other content was modified; only the frontmatter `draft` attribute was toggled.

### Testing

- Ran a local site build with `npm run build`, which completed successfully. 
- Ran linting with `npm run lint` and the test suite with `npm test`, both of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2b0000dc48323869e39a77f363189)