### PR TITLE
Fix Next CSS loading path and add build CSS asset verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "guard:source-of-truth": "node scripts/data/verify-workbook-only-path.mjs",
     "lint": "eslint . --max-warnings=0",
     "build": "npm run data:build && npm run data:validate && npm run data:audit && npm run guard:source-of-truth && next build && npm run verify:build",
-    "verify:build": "node scripts/verify-redirects.mjs && node scripts/ci/validate-deploy-readiness.mjs"
+    "verify:build": "node scripts/verify-redirects.mjs && node scripts/verify-css-assets.mjs && node scripts/ci/validate-deploy-readiness.mjs"
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.8",

--- a/scripts/verify-css-assets.mjs
+++ b/scripts/verify-css-assets.mjs
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const cssDir = path.join(root, '.next', 'static', 'css')
+
+if (!fs.existsSync(cssDir)) {
+  console.error('[verify-css-assets] Missing .next/static/css. Run `next build` before verification.')
+  process.exit(1)
+}
+
+const cssFiles = fs
+  .readdirSync(cssDir)
+  .filter(file => file.endsWith('.css'))
+
+if (cssFiles.length === 0) {
+  console.error('[verify-css-assets] No CSS assets were emitted by Next build.')
+  process.exit(1)
+}
+
+console.log(`[verify-css-assets] OK found ${cssFiles.length} CSS assets: ${cssFiles.join(', ')}`)

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,6 @@
+/* Legacy Vite stylesheet entry (src/main.tsx).
+   The active Next.js app imports CSS only via app/layout.tsx -> app/globals.css.
+   Keep this file quarantined unless the Vite entrypoint is restored. */
 @import './styles/theme.css';
 @import './styles/tokens.css';
 @import './styles/tags.css';

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,7 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   darkMode: 'class',
-  content: ['./app/**/*.{ts,tsx,js,jsx,mdx}', './src/**/*.{ts,tsx,js,jsx,mdx}'],
+  content: ['./app/**/*.{ts,tsx,js,jsx,mdx}', './components/**/*.{ts,tsx,js,jsx,mdx}', './src/**/*.{ts,tsx,js,jsx,mdx}'],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
### Motivation
- The repository uses the Next App Router (rooted at `app/layout.tsx`) and must keep a single CSS entry point while avoiding accidental reliance on legacy Vite styling paths.
- Tailwind must scan all directories that contain active components so required utility classes are included in the generated CSS.
- Builds should fail early if Next emits no CSS assets to prevent unstyled production deploys.

### Description
- Updated `tailwind.config.ts` to include `./components/**/*.{ts,tsx,js,jsx,mdx}` in the `content` array so Tailwind picks up classes used by active components.
- Added `scripts/verify-css-assets.mjs`, a new check that fails when `.next/static/css` is missing or contains no `.css` assets.
- Wired the new CSS check into the build verification flow by updating the `verify:build` script in `package.json` to run the CSS verifier before deploy readiness validation.
- Quarantined the legacy Vite stylesheet entry by prepending a clear header comment to `src/index.css` to discourage accidental use and clarify that `app/layout.tsx -> app/globals.css` is the active import path.

### Testing
- Ran `npm run verify:build`, which failed early due to a missing static export precondition (`out/_redirects`), so the CSS check did not proceed in this environment.
- Ran `npx next build`, which failed with an unrelated module resolution error (`Can't resolve '@/data/compounds/compoundData'`), preventing a full build and CSS emission in this environment.
- Confirmed that the new `scripts/verify-css-assets.mjs` script correctly checks `.next/static/css` presence and would fail the build when no CSS assets are emitted (verification exercised conceptually but not reached due to the environment failures above).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2bd31637c83238681581df8743513)