### PR TITLE
Centralize public route constants, fix nav/footer links, add /build & /learning pages and route smoke checker

### DIFF
--- a/app/build/page.tsx
+++ b/app/build/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { PUBLIC_ROUTES } from '@/lib/publicRoutes'
+
+export const metadata: Metadata = {
+  title: 'Build',
+  description: 'Start building a personalized educational blend plan.',
+}
+
+export default function BuildPage() {
+  return (
+    <section className='space-y-6'>
+      <h1 className='text-3xl font-semibold tracking-tight'>Build a Blend</h1>
+      <p className='max-w-2xl text-white/75'>
+        This route is reserved for the blend-building workflow. For now, explore herbs and compounds while this tool is being expanded.
+      </p>
+      <div className='flex flex-wrap gap-3'>
+        <Link href={PUBLIC_ROUTES.herbs} className='rounded-full border border-white/15 px-4 py-2 text-sm hover:bg-white/5'>Browse herbs</Link>
+        <Link href={PUBLIC_ROUTES.compounds} className='rounded-full border border-white/15 px-4 py-2 text-sm hover:bg-white/5'>Browse compounds</Link>
+      </div>
+    </section>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,31 +2,13 @@ import type { Metadata } from 'next'
 import type { ReactNode } from 'react'
 import Link from 'next/link'
 import MobileNav from '@/components/mobile-nav'
+import { PRIMARY_FOOTER_LINKS, PRIMARY_NAV_LINKS, PUBLIC_ROUTES } from '@/lib/publicRoutes'
 import '@fontsource/inter/400.css'
 import '@fontsource/inter/500.css'
 import '@fontsource/inter/600.css'
 import '@fontsource/inter/700.css'
 import './globals.css'
 
-const navLinks = [
-  { href: '/', label: 'Home' },
-  { href: '/herbs', label: 'Herbs' },
-  { href: '/compounds', label: 'Compounds' },
-  { href: '/blog', label: 'Blog' },
-  { href: '/about', label: 'About' },
-  { href: '/contact', label: 'Contact' },
-]
-
-const footerLinks = [
-  { href: '/herbs', label: 'Herbs' },
-  { href: '/compounds', label: 'Compounds' },
-  { href: '/blog', label: 'Blog' },
-  { href: '/about', label: 'About' },
-  { href: '/contact', label: 'Contact' },
-  { href: '/faq', label: 'FAQ' },
-  { href: '/disclaimer', label: 'Disclaimer' },
-  { href: '/privacy', label: 'Privacy' },
-]
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://thehippiescientist.net'),
@@ -90,12 +72,12 @@ export default function RootLayout({ children }: RootLayoutProps) {
         <div className='min-h-screen bg-[var(--bg)] text-[var(--text-primary)]'>
           <header className='border-b border-white/10'>
             <div className='container-page flex min-h-16 items-center justify-between gap-4 py-4'>
-              <Link href='/' className='text-lg font-semibold tracking-tight'>
+              <Link href={PUBLIC_ROUTES.home} className='text-lg font-semibold tracking-tight'>
                 The Hippie Scientist
               </Link>
 
               <nav aria-label='Primary' className='hidden items-center gap-2 md:flex'>
-                {navLinks.map(link => (
+                {PRIMARY_NAV_LINKS.map(link => (
                   <Link
                     key={link.href}
                     href={link.href}
@@ -106,7 +88,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
                 ))}
               </nav>
 
-              <MobileNav links={navLinks} />
+              <MobileNav links={PRIMARY_NAV_LINKS} />
             </div>
           </header>
 
@@ -119,7 +101,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
               </p>
 
               <nav aria-label='Footer' className='flex flex-wrap gap-4'>
-                {footerLinks.map(link => (
+                {PRIMARY_FOOTER_LINKS.map(link => (
                   <Link
                     key={link.href}
                     href={link.href}

--- a/app/learning/page.tsx
+++ b/app/learning/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { PUBLIC_ROUTES } from '@/lib/publicRoutes'
+
+export const metadata: Metadata = {
+  title: 'Learning',
+  description: 'Learning hub for plain-English herbal and compound education.',
+}
+
+export default function LearningPage() {
+  return (
+    <section className='space-y-6'>
+      <h1 className='text-3xl font-semibold tracking-tight'>Learning</h1>
+      <p className='max-w-2xl text-white/75'>
+        Browse core guides and educational posts designed for safety-first learning.
+      </p>
+      <Link href={PUBLIC_ROUTES.blog} className='inline-flex rounded-full border border-white/15 px-4 py-2 text-sm hover:bg-white/5'>Go to blog</Link>
+    </section>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "guard:source-of-truth": "node scripts/data/verify-workbook-only-path.mjs",
     "lint": "eslint . --max-warnings=0",
     "build": "npm run data:build && npm run data:validate && npm run data:audit && npm run guard:source-of-truth && next build && npm run verify:build",
-    "verify:build": "node scripts/verify-redirects.mjs && node scripts/ci/validate-deploy-readiness.mjs"
+    "verify:build": "node scripts/ci/route-smoke-check.mjs && node scripts/verify-redirects.mjs && node scripts/ci/validate-deploy-readiness.mjs"
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.8",

--- a/scripts/ci/route-smoke-check.mjs
+++ b/scripts/ci/route-smoke-check.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+
+const OUT_DIR = path.resolve(process.env.STATIC_OUTPUT_DIR || 'out')
+const REQUIRED_ROUTES = ['/', '/herbs', '/compounds', '/build', '/blog', '/learning', '/about', '/contact', '/privacy', '/disclaimer']
+
+function routeToIndex(route) {
+  if (route === '/') return path.join(OUT_DIR, 'index.html')
+  return path.join(OUT_DIR, route.replace(/^\//, ''), 'index.html')
+}
+
+const missing = REQUIRED_ROUTES
+  .map(route => ({ route, file: routeToIndex(route) }))
+  .filter(entry => !fs.existsSync(entry.file))
+
+if (!fs.existsSync(path.join(OUT_DIR, '_redirects'))) {
+  missing.push({ route: '_redirects', file: path.join(OUT_DIR, '_redirects') })
+}
+
+if (missing.length > 0) {
+  for (const entry of missing) {
+    console.error(`[route-smoke-check] Missing output for ${entry.route}: ${entry.file}`)
+  }
+  process.exit(1)
+}
+
+console.log('[route-smoke-check] OK')

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,22 +4,21 @@ import ConsentManager from './ConsentManager'
 import { onOpenConsent } from '../lib/consentBus'
 import NonEmpty from './NonEmpty'
 import { isAnalyticsRouteEnabled } from '@/lib/analyticsAccess'
+import { PUBLIC_ROUTES } from '@/lib/publicRoutes'
 
 const exploreLinks = [
-  { href: '/herbs', label: 'Herb Database' },
-  { href: '/compounds', label: 'Compounds' },
-  { href: '/build', label: 'Build a Blend' },
-  { href: '/collections/herbs-for-relaxation', label: 'Collections' },
-]
+  { href: PUBLIC_ROUTES.herbs, label: 'Herb Database' },
+  { href: PUBLIC_ROUTES.compounds, label: 'Compounds' },
+  { href: PUBLIC_ROUTES.build, label: 'Build a Blend' },
+  ]
 
 const safetyLinks = [
-  { href: '/methodology', label: 'Methodology' },
-  { href: '/disclaimer', label: 'Disclaimer' },
-  { href: '/contact', label: 'Contact' },
+    { href: PUBLIC_ROUTES.disclaimer, label: 'Disclaimer' },
+  { href: PUBLIC_ROUTES.contact, label: 'Contact' },
 ]
 
 const legalLinks = [
-  { href: '/privacy', label: 'Privacy Policy' },
+  { href: PUBLIC_ROUTES.privacy, label: 'Privacy Policy' },
   { href: '/sitemap', label: 'Sitemap' },
 ]
 

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { PUBLIC_ROUTES } from "@/lib/publicRoutes";
 
 const linkBase =
   "rounded-full px-3 py-2 text-sm text-white/70 hover:text-white hover:bg-white/10 transition";
@@ -20,21 +21,21 @@ export default function NavBar() {
       <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
         
         {/* Logo / Brand */}
-        <Link href="/" className="text-sm font-semibold tracking-wide text-white">
+        <Link href={PUBLIC_ROUTES.home} className="text-sm font-semibold tracking-wide text-white">
           The Hippie Scientist
         </Link>
 
         {/* Desktop Nav */}
         <div className="hidden items-center gap-1.5 md:flex">
-          <Link href="/herbs" className={navClass(pathname, "/herbs")}>
+          <Link href={PUBLIC_ROUTES.herbs} className={navClass(pathname, PUBLIC_ROUTES.herbs)}>
             Herbs
           </Link>
 
-          <Link href="/compounds" className={navClass(pathname, "/compounds")}>
+          <Link href={PUBLIC_ROUTES.compounds} className={navClass(pathname, PUBLIC_ROUTES.compounds)}>
             Compounds
           </Link>
 
-          <Link href="/blog" className={navClass(pathname, "/blog")}>
+          <Link href={PUBLIC_ROUTES.blog} className={navClass(pathname, PUBLIC_ROUTES.blog)}>
             Blog
           </Link>
         </div>
@@ -42,7 +43,7 @@ export default function NavBar() {
         {/* Right Side */}
         <div className="flex items-center gap-2">
           <Link
-            href="/build-a-blend"
+            href={PUBLIC_ROUTES.build}
             className="rounded-full bg-white/10 px-3 py-2 text-sm text-white hover:bg-white/20 transition"
           >
             Build a Blend

--- a/src/lib/publicRoutes.ts
+++ b/src/lib/publicRoutes.ts
@@ -1,0 +1,36 @@
+export const PUBLIC_ROUTES = {
+  home: '/',
+  herbs: '/herbs',
+  compounds: '/compounds',
+  build: '/build',
+  blog: '/blog',
+  learning: '/learning',
+  about: '/about',
+  contact: '/contact',
+  privacy: '/privacy',
+  disclaimer: '/disclaimer',
+} as const
+
+export type PublicRoute = (typeof PUBLIC_ROUTES)[keyof typeof PUBLIC_ROUTES]
+
+export const PRIMARY_NAV_LINKS: ReadonlyArray<{ href: PublicRoute; label: string }> = [
+  { href: PUBLIC_ROUTES.home, label: 'Home' },
+  { href: PUBLIC_ROUTES.herbs, label: 'Herbs' },
+  { href: PUBLIC_ROUTES.compounds, label: 'Compounds' },
+  { href: PUBLIC_ROUTES.blog, label: 'Blog' },
+  { href: PUBLIC_ROUTES.learning, label: 'Learning' },
+  { href: PUBLIC_ROUTES.about, label: 'About' },
+  { href: PUBLIC_ROUTES.contact, label: 'Contact' },
+]
+
+export const PRIMARY_FOOTER_LINKS: ReadonlyArray<{ href: PublicRoute; label: string }> = [
+  { href: PUBLIC_ROUTES.herbs, label: 'Herbs' },
+  { href: PUBLIC_ROUTES.compounds, label: 'Compounds' },
+  { href: PUBLIC_ROUTES.build, label: 'Build' },
+  { href: PUBLIC_ROUTES.blog, label: 'Blog' },
+  { href: PUBLIC_ROUTES.learning, label: 'Learning' },
+  { href: PUBLIC_ROUTES.about, label: 'About' },
+  { href: PUBLIC_ROUTES.contact, label: 'Contact' },
+  { href: PUBLIC_ROUTES.disclaimer, label: 'Disclaimer' },
+  { href: PUBLIC_ROUTES.privacy, label: 'Privacy' },
+]


### PR DESCRIPTION
### Motivation
- Centralize all primary public routes to eliminate duplicated string literals across the layout, nav, and footer so primary links remain consistent and easy to update.
- Ensure the active Next app has no broken primary links and that the SPA deep-link fallback for Cloudflare Pages is validated at build time.
- Provide minimal pages for missing public targets (`/build`, `/learning`) so header/footer links resolve without 404s.
- Preserve existing herb and compound detail URL contracts so detail links remain driven by workbook-generated slugs.

### Description
- Added a shared route constants module `src/lib/publicRoutes.ts` exporting `PUBLIC_ROUTES`, `PRIMARY_NAV_LINKS`, and `PRIMARY_FOOTER_LINKS` for canonical route values.
- Updated `app/layout.tsx`, `src/components/NavBar.tsx`, and `src/components/Footer.tsx` to consume the shared route constants and removed duplicated route literals; corrected `/build-a-blend` → `PUBLIC_ROUTES.build` and removed links to non-existent routes from core footer groups.
- Created minimal pages `app/build/page.tsx` and `app/learning/page.tsx` so `/build` and `/learning` resolve in the app.
- Added `scripts/ci/route-smoke-check.mjs` to assert built output exists for core routes and that `_redirects` is present; wired this checker into `verify:build` in `package.json` to run after `next build` (via `npm run verify:build`).
- Kept herb and compound detail link generation unchanged because list/detail rendering already uses `herb.slug` and `compound.slug` from workbook-produced data.

### Testing
- Ran the data pipeline: `node scripts/data/build-runtime-from-workbook.mjs --out public/data` which wrote herb and compound JSON files (e.g. "Wrote 324 herbs" and "Wrote 529 compounds").
- Ran the data validator: `node scripts/data/validate-data-next.mjs --data-dir public/data` which reported structural validation `PASS` for `public/data`.
- Attempted full `npm run build`; data build/validate/audit steps ran but the overall build failed due to existing repository data-audit blockers (`scripts/data/audit-source-of-truth.mjs` reported blocking issues), so the app build/verify steps could not complete.
- Attempted `npx next build && npm run verify:build`; this failed during Next build due to a pre-existing unrelated module resolution error in `app/compare/[slug]/page.tsx` (`Can't resolve '@/data/compounds/compoundData'`), so the new smoke checker was not exercised in a successful static output in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2bdaf95648323b09d44311129cdf8)