### PR TITLE
Add data reproducibility verification script to build checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "guard:source-of-truth": "node scripts/data/verify-workbook-only-path.mjs",
     "lint": "eslint . --max-warnings=0",
     "build": "npm run data:build && npm run data:validate && npm run data:audit && npm run guard:source-of-truth && next build && npm run verify:build",
-    "verify:build": "node scripts/verify-redirects.mjs && node scripts/verify-css-assets.mjs && node scripts/ci/validate-deploy-readiness.mjs"
+    "verify:build": "node scripts/verify-redirects.mjs && node scripts/verify-css-assets.mjs && node scripts/ci/validate-deploy-readiness.mjs && npm run data:verify",
+    "data:verify": "node scripts/data/verify-generated-data.mjs"
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.8",

--- a/scripts/data/verify-generated-data.mjs
+++ b/scripts/data/verify-generated-data.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const repoRoot = path.resolve(__dirname, '../..')
+
+const GENERATED_OUTPUT_FILES = [
+  'public/data/herbs.json',
+  'public/data/compounds.json',
+  'public/data/claims.json',
+  'public/data/herb-compound-map.json',
+  'public/data/build-report.json',
+]
+
+function run(cmd, args, cwd) {
+  const result = spawnSync(cmd, args, { cwd, stdio: 'inherit', env: process.env })
+  if (result.status !== 0) throw new Error(`[data:verify] Command failed: ${cmd} ${args.join(' ')}`)
+}
+
+function normalizeForComparison(value) {
+  if (Array.isArray(value)) return value.map(normalizeForComparison)
+  if (value && typeof value === 'object') {
+    const out = {}
+    for (const [key, v] of Object.entries(value)) {
+      if (key === 'generatedAt' || key === 'generated_at') continue
+      out[key] = normalizeForComparison(v)
+    }
+    return out
+  }
+  return value
+}
+
+function readComparable(file) {
+  const text = fs.readFileSync(file, 'utf8')
+  if (!file.endsWith('.json')) return text
+  return `${JSON.stringify(normalizeForComparison(JSON.parse(text)), null, 2)}\n`
+}
+
+function main() {
+  const tracked = GENERATED_OUTPUT_FILES.filter(rel => fs.existsSync(path.join(repoRoot, rel)))
+  if (tracked.length === 0) {
+    console.log('[data:verify] No approved generated output files are committed; skipping.')
+    return
+  }
+
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hippie-scientist-data-verify-'))
+  const tmpRepo = path.join(tmpRoot, 'repo')
+  fs.cpSync(repoRoot, tmpRepo, {
+    recursive: true,
+    filter: src => !src.includes(`${path.sep}.git${path.sep}`) && !src.endsWith(`${path.sep}.git`),
+  })
+
+  fs.rmSync(path.join(tmpRepo, 'public/data'), { recursive: true, force: true })
+
+  console.log('[data:verify] Regenerating approved public/data artifacts from workbook in temp copy...')
+  run('npm', ['run', 'data:build'], tmpRepo)
+
+  const drift = []
+  for (const rel of tracked) {
+    const expected = path.join(repoRoot, rel)
+    const actual = path.join(tmpRepo, rel)
+    if (!fs.existsSync(actual)) {
+      drift.push(`${rel}: missing from regenerated output`)
+      continue
+    }
+    if (readComparable(expected) !== readComparable(actual)) {
+      drift.push(`${rel}: content differs`)
+    }
+  }
+
+  if (drift.length) {
+    console.error('[data:verify] Drift detected:')
+    for (const item of drift) console.error(`- ${item}`)
+    process.exit(1)
+  }
+
+  console.log(`[data:verify] PASS: ${tracked.length} approved generated files match regenerated output.`)
+}
+
+main()


### PR DESCRIPTION
### Motivation
- Ensure workbook-generated artifacts under `public/data` are reproducible from the workbook and detect any manual edits to those artifacts.
- Provide a lightweight gate in the existing verification chain so drift is detected during CI/build verification.
- Ignore expected nondeterministic timestamp fields when checking equivalence so semantically identical regenerations pass.

### Description
- Add `scripts/data/verify-generated-data.mjs` which copies the repo to a temp directory, removes `public/data`, runs `npm run data:build` in the copy, and compares regenerated artifacts to the approved committed artifacts.
- The script only verifies an approved set of generated files when present (`public/data/herbs.json`, `public/data/compounds.json`, `public/data/claims.json`, `public/data/herb-compound-map.json`, `public/data/build-report.json`) and strips `generatedAt` / `generated_at` from JSON before comparison.
- Add an npm script `data:verify` and wire it into the existing `verify:build` script so the reproducibility check runs as part of build verification.

### Testing
- Ran `npm run data:verify`, which regenerated data in a temp copy and failed as expected due to drift between committed and regenerated artifacts (differences reported for `public/data/herbs.json` and `public/data/compounds.json`), demonstrating detection of non-reproducible/edited output.
- Ran `npm run verify:build`, which executes the verification chain (including the new `data:verify`) and surfaced verification issues (the redirect asset check reported a missing `out/_redirects`, and the `data:verify` step fails on drift when reached).
- The verifier exits non-zero on drift so CI/builds will fail when approved generated artifacts diverge from a clean regeneration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2be70f6448323b706747ec202e3d6)