### PR TITLE
Introduce shared PUBLIC_ROUTES, fix nav/footer links, add core route smoke check

### DIFF
--- a/app/(public)/build/page.tsx
+++ b/app/(public)/build/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Build',
+  description: 'Build your herb and compound learning stack.',
+}
+
+export default function BuildPage() {
+  return (
+    <section className='space-y-4'>
+      <h1 className='text-3xl font-semibold tracking-tight'>Build</h1>
+      <p className='max-w-2xl text-white/75'>
+        Build your own learning path by exploring herbs, compounds, and evidence-backed notes.
+      </p>
+    </section>
+  )
+}

--- a/app/compounds/page.tsx
+++ b/app/compounds/page.tsx
@@ -3,6 +3,7 @@ import LibraryBrowser from '@/components/library-browser'
 import { getCompounds } from '@/lib/runtime-data'
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
+import { compoundDetailRoute } from '@/lib/public-routes'
 
 type CompoundListItem = {
   slug: string
@@ -78,7 +79,7 @@ export default async function CompoundsPage() {
     slug: compound.slug,
     title: getCompoundTitle(compound),
     summary: getCompoundSummary(compound),
-    href: `/compounds/${compound.slug}`,
+    href: compoundDetailRoute(compound.slug),
     typeLabel: 'Compound profile',
     domain: inferDomain(compound),
     isATier: aTierSlugs.has(compound.slug),

--- a/app/herbs/page.tsx
+++ b/app/herbs/page.tsx
@@ -3,6 +3,7 @@ import LibraryBrowser from '@/components/library-browser'
 import { getHerbs } from '@/lib/runtime-data'
 import { promises as fs } from 'node:fs'
 import path from 'node:path'
+import { herbDetailRoute } from '@/lib/public-routes'
 
 type HerbListItem = {
   slug: string
@@ -78,7 +79,7 @@ export default async function HerbsPage() {
     slug: herb.slug,
     title: getHerbTitle(herb),
     summary: getHerbSummary(herb),
-    href: `/herbs/${herb.slug}`,
+    href: herbDetailRoute(herb.slug),
     typeLabel: 'Herb profile',
     domain: inferDomain(herb),
     isATier: aTierSlugs.has(herb.slug),

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import type { ReactNode } from 'react'
 import Link from 'next/link'
 import MobileNav from '@/components/mobile-nav'
+import { PUBLIC_ROUTES } from '@/lib/public-routes'
 import '@fontsource/inter/400.css'
 import '@fontsource/inter/500.css'
 import '@fontsource/inter/600.css'
@@ -9,23 +10,26 @@ import '@fontsource/inter/700.css'
 import './globals.css'
 
 const navLinks = [
-  { href: '/', label: 'Home' },
-  { href: '/herbs', label: 'Herbs' },
-  { href: '/compounds', label: 'Compounds' },
-  { href: '/blog', label: 'Blog' },
-  { href: '/about', label: 'About' },
-  { href: '/contact', label: 'Contact' },
+  { href: PUBLIC_ROUTES.home, label: 'Home' },
+  { href: PUBLIC_ROUTES.herbs, label: 'Herbs' },
+  { href: PUBLIC_ROUTES.compounds, label: 'Compounds' },
+  { href: PUBLIC_ROUTES.build, label: 'Build' },
+  { href: PUBLIC_ROUTES.blog, label: 'Blog' },
+  { href: PUBLIC_ROUTES.learning, label: 'Learning' },
+  { href: PUBLIC_ROUTES.about, label: 'About' },
+  { href: PUBLIC_ROUTES.contact, label: 'Contact' },
 ]
 
 const footerLinks = [
-  { href: '/herbs', label: 'Herbs' },
-  { href: '/compounds', label: 'Compounds' },
-  { href: '/blog', label: 'Blog' },
-  { href: '/about', label: 'About' },
-  { href: '/contact', label: 'Contact' },
-  { href: '/faq', label: 'FAQ' },
-  { href: '/disclaimer', label: 'Disclaimer' },
-  { href: '/privacy', label: 'Privacy' },
+  { href: PUBLIC_ROUTES.herbs, label: 'Herbs' },
+  { href: PUBLIC_ROUTES.compounds, label: 'Compounds' },
+  { href: PUBLIC_ROUTES.build, label: 'Build' },
+  { href: PUBLIC_ROUTES.blog, label: 'Blog' },
+  { href: PUBLIC_ROUTES.learning, label: 'Learning' },
+  { href: PUBLIC_ROUTES.about, label: 'About' },
+  { href: PUBLIC_ROUTES.contact, label: 'Contact' },
+  { href: PUBLIC_ROUTES.disclaimer, label: 'Disclaimer' },
+  { href: PUBLIC_ROUTES.privacy, label: 'Privacy' },
 ]
 
 export const metadata: Metadata = {
@@ -90,7 +94,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
         <div className='min-h-screen bg-[var(--bg)] text-[var(--text-primary)]'>
           <header className='border-b border-white/10'>
             <div className='container-page flex min-h-16 items-center justify-between gap-4 py-4'>
-              <Link href='/' className='text-lg font-semibold tracking-tight'>
+              <Link href={PUBLIC_ROUTES.home} className='text-lg font-semibold tracking-tight'>
                 The Hippie Scientist
               </Link>
 

--- a/app/learning/page.tsx
+++ b/app/learning/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Learning',
+  description: 'Learning resources from The Hippie Scientist.',
+}
+
+export default function LearningPage() {
+  return (
+    <section className='space-y-4'>
+      <h1 className='text-3xl font-semibold tracking-tight'>Learning</h1>
+      <p className='max-w-2xl text-white/75'>
+        A growing set of educational resources for herbs, compounds, and safer research habits.
+      </p>
+    </section>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "guard:source-of-truth": "node scripts/data/verify-workbook-only-path.mjs",
     "lint": "eslint . --max-warnings=0",
     "build": "npm run data:build && npm run data:validate && npm run data:audit && npm run guard:source-of-truth && next build && npm run verify:build",
-    "verify:build": "node scripts/verify-redirects.mjs && node scripts/verify-css-assets.mjs && node scripts/ci/validate-deploy-readiness.mjs && npm run data:verify",
+    "verify:build": "node scripts/verify-core-routes.mjs && node scripts/verify-redirects.mjs && node scripts/verify-css-assets.mjs && node scripts/ci/validate-deploy-readiness.mjs && npm run data:verify",
     "data:verify": "node scripts/data/verify-generated-data.mjs"
   },
   "dependencies": {

--- a/scripts/verify-core-routes.mjs
+++ b/scripts/verify-core-routes.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const coreRoutes = [
+  '/',
+  '/herbs',
+  '/compounds',
+  '/build',
+  '/blog',
+  '/learning',
+  '/about',
+  '/contact',
+  '/privacy',
+  '/disclaimer',
+]
+
+const repoRoot = process.cwd()
+const appOutputRoot = path.join(repoRoot, '.next', 'server', 'app')
+
+function routeToBuildPath(route) {
+  if (route === '/') return path.join(appOutputRoot, 'page.js')
+  return path.join(appOutputRoot, route.replace(/^\//, ''), 'page.js')
+}
+
+function assertExists(filePath, label) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`[verify:core-routes] Missing ${label}: ${path.relative(repoRoot, filePath)}`)
+  }
+}
+
+for (const route of coreRoutes) {
+  assertExists(routeToBuildPath(route), `build output for route ${route}`)
+}
+
+assertExists(path.join(repoRoot, 'public', '_redirects'), 'Cloudflare fallback redirects file')
+
+console.log(`[verify:core-routes] Verified ${coreRoutes.length} core routes and public/_redirects.`)

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,22 +4,23 @@ import ConsentManager from './ConsentManager'
 import { onOpenConsent } from '../lib/consentBus'
 import NonEmpty from './NonEmpty'
 import { isAnalyticsRouteEnabled } from '@/lib/analyticsAccess'
+import { PUBLIC_ROUTES } from '@/lib/public-routes'
 
 const exploreLinks = [
-  { href: '/herbs', label: 'Herb Database' },
-  { href: '/compounds', label: 'Compounds' },
-  { href: '/build', label: 'Build a Blend' },
+  { href: PUBLIC_ROUTES.herbs, label: 'Herb Database' },
+  { href: PUBLIC_ROUTES.compounds, label: 'Compounds' },
+  { href: PUBLIC_ROUTES.build, label: 'Build a Blend' },
   { href: '/collections/herbs-for-relaxation', label: 'Collections' },
 ]
 
 const safetyLinks = [
   { href: '/methodology', label: 'Methodology' },
-  { href: '/disclaimer', label: 'Disclaimer' },
-  { href: '/contact', label: 'Contact' },
+  { href: PUBLIC_ROUTES.disclaimer, label: 'Disclaimer' },
+  { href: PUBLIC_ROUTES.contact, label: 'Contact' },
 ]
 
 const legalLinks = [
-  { href: '/privacy', label: 'Privacy Policy' },
+  { href: PUBLIC_ROUTES.privacy, label: 'Privacy Policy' },
   { href: '/sitemap', label: 'Sitemap' },
 ]
 

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { PUBLIC_ROUTES } from "@/lib/public-routes";
 
 const linkBase =
   "rounded-full px-3 py-2 text-sm text-white/70 hover:text-white hover:bg-white/10 transition";
@@ -20,21 +21,21 @@ export default function NavBar() {
       <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
         
         {/* Logo / Brand */}
-        <Link href="/" className="text-sm font-semibold tracking-wide text-white">
+        <Link href={PUBLIC_ROUTES.home} className="text-sm font-semibold tracking-wide text-white">
           The Hippie Scientist
         </Link>
 
         {/* Desktop Nav */}
         <div className="hidden items-center gap-1.5 md:flex">
-          <Link href="/herbs" className={navClass(pathname, "/herbs")}>
+          <Link href={PUBLIC_ROUTES.herbs} className={navClass(pathname, PUBLIC_ROUTES.herbs)}>
             Herbs
           </Link>
 
-          <Link href="/compounds" className={navClass(pathname, "/compounds")}>
+          <Link href={PUBLIC_ROUTES.compounds} className={navClass(pathname, PUBLIC_ROUTES.compounds)}>
             Compounds
           </Link>
 
-          <Link href="/blog" className={navClass(pathname, "/blog")}>
+          <Link href={PUBLIC_ROUTES.blog} className={navClass(pathname, PUBLIC_ROUTES.blog)}>
             Blog
           </Link>
         </div>
@@ -42,7 +43,7 @@ export default function NavBar() {
         {/* Right Side */}
         <div className="flex items-center gap-2">
           <Link
-            href="/build-a-blend"
+            href={PUBLIC_ROUTES.build}
             className="rounded-full bg-white/10 px-3 py-2 text-sm text-white hover:bg-white/20 transition"
           >
             Build a Blend

--- a/src/lib/public-routes.ts
+++ b/src/lib/public-routes.ts
@@ -1,0 +1,22 @@
+export const PUBLIC_ROUTES = {
+  home: '/',
+  herbs: '/herbs',
+  compounds: '/compounds',
+  build: '/build',
+  blog: '/blog',
+  learning: '/learning',
+  about: '/about',
+  contact: '/contact',
+  privacy: '/privacy',
+  disclaimer: '/disclaimer',
+} as const
+
+export type PublicRouteKey = keyof typeof PUBLIC_ROUTES
+
+export function herbDetailRoute(slug: string): string {
+  return `${PUBLIC_ROUTES.herbs}/${slug}`
+}
+
+export function compoundDetailRoute(slug: string): string {
+  return `${PUBLIC_ROUTES.compounds}/${slug}`
+}


### PR DESCRIPTION
### Motivation
- Centralize public route strings to avoid duplication and ensure navigation links remain consistent across header, mobile, and footer.
- Ensure herb/compound detail links are generated from a single source so they match workbook-driven slugs in `public/data`.
- Provide minimal pages for core public routes so primary navigation has no broken targets.
- Add a smoke checker to verify the built app produces outputs for core routes and that `public/_redirects` (Cloudflare fallback) exists.

### Description
- Added `src/lib/public-routes.ts` which exports `PUBLIC_ROUTES` and helper builders `herbDetailRoute` and `compoundDetailRoute` used site-wide.
- Replaced hard-coded route strings in `app/layout.tsx`, `src/components/NavBar.tsx`, and `src/components/Footer.tsx` to use `PUBLIC_ROUTES` and removed the broken `/faq` footer link.
- Updated `app/herbs/page.tsx` and `app/compounds/page.tsx` to use `herbDetailRoute` and `compoundDetailRoute` for detail URLs so slugs are aligned with workbook output.
- Added minimal pages `app/(public)/build/page.tsx` and `app/learning/page.tsx` so `/build` and `/learning` resolve.
- Added `scripts/verify-core-routes.mjs` that asserts built output exists for each core route and that `public/_redirects` exists, and wired it into `verify:build` in `package.json`.

### Testing
- Ran `npm run data:build` which completed and wrote generated data to `public/data` (herbs/compounds/claims etc.).
- Ran `npm run data:validate` which passed structural validation for `public/data`.
- Ran `npm run data:audit` which executed but reported existing issues (`issues=449 blocking=4`) that block the overall `npm run build`, so the Next build and the new smoke checker were not reached in this environment run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2bf49128083239c27d2c24d1f1627)