### PR TITLE
Restore curated products compatibility module for missing import

### DIFF
--- a/docs/missing-import-resolution.md
+++ b/docs/missing-import-resolution.md
@@ -1,0 +1,7 @@
+# Missing Import Resolution Log
+
+## 2026-04-30
+
+- Restored `src/data/curatedProducts.ts` as a minimal deferred-data compatibility module.
+- Added only shared types and neutral constants needed by import sites.
+- Exported an empty `curatedProductRecommendations` list to keep deferred curated-product features inactive without recreating deleted hand-authored data.

--- a/src/data/curatedProducts.ts
+++ b/src/data/curatedProducts.ts
@@ -1,0 +1,29 @@
+export type CuratedProductEntityType = 'herb' | 'compound'
+
+export type CuratedProductRecommendation = {
+  productId: string
+  entityType: CuratedProductEntityType
+  entitySlug: string
+  active: boolean
+  confidenceTierRequired: 'low' | 'medium' | 'high'
+  affiliateDisclosure: string
+  rationaleShort: string
+  rationaleLong: string
+  researchStatus: string
+  reviewedAt: string
+  amazonUrl: string
+  bestFor: string[]
+  brand: string
+  productType: string
+  formNotes: string
+  cautionNotes: string[]
+  avoidIf: string[]
+  productTitle: string
+  reviewedBy: string
+}
+
+export const curatedProductRecommendations: CuratedProductRecommendation[] = []
+
+export const DEFAULT_AMAZON_AFFILIATE_TAG = ''
+
+export const CURATED_PRODUCT_STALE_REVIEW_DAYS = 0


### PR DESCRIPTION
### Motivation

- Resolve a TypeScript TS2307 missing import for `@/data/curatedProducts` with a minimal, safe compatibility shim instead of reintroducing deleted hand-authored datasets.

### Description

- Added `src/data/curatedProducts.ts` providing only shared types (`CuratedProductEntityType`, `CuratedProductRecommendation`), neutral constants (`DEFAULT_AMAZON_AFFILIATE_TAG`, `CURATED_PRODUCT_STALE_REVIEW_DAYS`), and an empty `curatedProductRecommendations` array to keep curated-product features inactive.
- Created `docs/missing-import-resolution.md` documenting the change and rationale for future audit.
- Made a minimal, surgical change that avoids restoring production data, mutating generated JSON, or re-enabling deferred features.

### Testing

- Ran `npm run check`, which completed the data build and validation steps and progressed past the original TS2307 import error, confirming the import blocker is resolved.
- The build now fails on ESLint `no-console` errors in `src/components/BundleUpgradeCard.tsx` (line 31) and `src/lib/analyticsEventStorage.ts` (line 23).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37f7025e08323bf8915f331853cf2)