### PR TITLE
Inline CuratedProductEntityType to fix missing type import (TS2307)

### DIFF
--- a/docs/missing-import-resolution.md
+++ b/docs/missing-import-resolution.md
@@ -1,0 +1,6 @@
+# Missing Import Resolution Log
+
+## 2026-04-30
+
+- Resolved the current TS2307 blocker in `src/components/CuratedProductModule.tsx` by removing the missing type-only import from `@/data/curatedProducts` and defining a local `CuratedProductEntityType` union (`'herb' | 'compound' | 'goal'`) in the component.
+- This keeps behavior unchanged while avoiding restoration of deleted hand-authored data modules.

--- a/src/components/CuratedProductModule.tsx
+++ b/src/components/CuratedProductModule.tsx
@@ -1,8 +1,9 @@
 import { useEffect } from 'react'
 import { appendAnalyticsEvent } from '@/lib/analyticsEventStorage'
-import type { CuratedProductEntityType } from '@/data/curatedProducts'
 import { trackAffiliateLinkClick, type AffiliateUseCaseAnchor } from '@/lib/affiliateClickTracking'
 import type { RenderableCuratedProduct } from '@/lib/curatedProducts'
+
+type CuratedProductEntityType = 'herb' | 'compound' | 'goal'
 
 type CuratedProductModuleProps = {
   entityType: CuratedProductEntityType


### PR DESCRIPTION
### Motivation

- The build was blocked by a missing type-only import from `@/data/curatedProducts` (TS2307) in `src/components/CuratedProductModule.tsx`, so a minimal change was needed to unblock type checking without restoring deleted hand-authored data modules.

### Description

- Removed the type-only import from `@/data/curatedProducts` in `src/components/CuratedProductModule.tsx` and inlined a local `CuratedProductEntityType` union (`'herb' | 'compound' | 'goal'`).
- Added a short entry to `docs/missing-import-resolution.md` documenting the resolution and rationale.
- No runtime behavior or data pipelines were changed; the change is purely type-only and surgical to satisfy the compiler.

### Testing

- Ran `npm run check`, which progressed past the original TS2307 error and advanced the build.
- The build reported a non-blocking ESLint/Next.js warning about the Next.js plugin detection, which is informational only.
- The next blocking type error after this change is exactly: `./src/components/CuratedProductModule.tsx:149:45 Type error: Parameter 'item' implicitly has an 'any' type.`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3800122ac8323a2a7b31eeac7c553)