### PR TITLE
Fix CuratedProductModule implicit-any and remove no-console usages

### DIFF
--- a/docs/missing-import-resolution.md
+++ b/docs/missing-import-resolution.md
@@ -4,3 +4,7 @@
 
 - Resolved the current TS2307 blocker in `src/components/CuratedProductModule.tsx` by removing the missing type-only import from `@/data/curatedProducts` and defining a local `CuratedProductEntityType` union (`'herb' | 'compound' | 'goal'`) in the component.
 - This keeps behavior unchanged while avoiding restoration of deleted hand-authored data modules.
+- Added explicit `string` typing for `item` callback parameters in `CuratedProductModule` list rendering to resolve the current implicit-`any` TypeScript blocker without introducing product data.
+- Removed `console.warn` from `src/components/BundleUpgradeCard.tsx` catch handling; storage failures now no-op safely and still open the bundle link.
+- Removed `console.warn` from `src/lib/analyticsEventStorage.ts` catch handling; analytics storage failures now no-op safely.
+- No product data modules were restored and no fake analytics data was introduced.

--- a/src/components/BundleUpgradeCard.tsx
+++ b/src/components/BundleUpgradeCard.tsx
@@ -27,8 +27,8 @@ export default function BundleUpgradeCard({
           timestamp: new Date().toISOString(),
         })
       )
-    } catch (error) {
-      console.warn('Unable to store bundle interest', error)
+    } catch {
+      // Ignore storage failures and continue to checkout link.
     }
 
     window.open(BUNDLE_LINK, '_blank', 'noopener,noreferrer')

--- a/src/components/CuratedProductModule.tsx
+++ b/src/components/CuratedProductModule.tsx
@@ -146,7 +146,7 @@ export default function CuratedProductModule({
               <div className='mt-2 rounded-lg border border-rose-300/30 bg-rose-500/10 p-2'>
                 <p className='text-xs font-medium text-rose-100'>Caution notes</p>
                 <ul className='mt-1 list-disc space-y-1 pl-4 text-xs text-rose-100/90'>
-                  {product.cautionNotes.map(item => (
+                  {product.cautionNotes.map((item: string) => (
                     <li key={`${product.productId}-caution-${item}`}>{item}</li>
                   ))}
                 </ul>
@@ -162,7 +162,7 @@ export default function CuratedProductModule({
             <div className='mt-2'>
               <p className='text-xs font-medium text-white/80'>Who it may fit</p>
               <ul className='mt-1 list-disc space-y-1 pl-4 text-xs text-white/70'>
-                {product.bestFor.map(item => (
+                {product.bestFor.map((item: string) => (
                   <li key={`${product.productId}-fit-${item}`}>{item}</li>
                 ))}
               </ul>

--- a/src/lib/analyticsEventStorage.ts
+++ b/src/lib/analyticsEventStorage.ts
@@ -19,7 +19,7 @@ export function appendAnalyticsEvent(event: AnalyticsEvent): void {
     ].slice(-MAX_EVENTS)
 
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
-  } catch (error) {
-    console.warn('Unable to store analytics event', error)
+  } catch {
+    // Ignore storage failures to avoid disrupting the current interaction.
   }
 }


### PR DESCRIPTION
### Motivation
- Remove a TypeScript implicit-`any` in `CuratedProductModule` and eliminate `no-console` lint violations without restoring product data or weakening lint/TS settings.
- Keep the change minimal and surgical, preserving runtime behavior and avoiding creation of any product or analytics test data.

### Description
- Added explicit `string` annotations for the `item` callback parameters in `src/components/CuratedProductModule.tsx` list renderings to resolve the implicit-`any` error. 
- Replaced `console.warn` usage in `src/components/BundleUpgradeCard.tsx` with a safe no-op catch comment so localStorage failures do not log to the console. 
- Replaced `console.warn` usage in `src/lib/analyticsEventStorage.ts` with a safe no-op catch comment so analytics storage failures do not log to the console. 
- Updated `docs/missing-import-resolution.md` to record the implicit-any and no-console fixes and to confirm no product data or fake analytics data were introduced.

### Testing
- Ran `npm run check`; the run progressed past the targeted implicit-`any` and `no-console` issues and the changes compiled successfully up to the next blocking error. 
- The next blocking error (exact) is: `./src/components/EffectExplorer.tsx:3:54` — `Type error: Cannot find module '@/utils/effectSearch' or its corresponding type declarations.` 
- No additional automated tests were added or modified and no lint/TypeScript rules were weakened.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3822c685083238d1d3b70643d7a81)