### PR TITLE
Introduce data-free effect search, submission hook, and small utils to unblock typecheck

### DIFF
--- a/docs/missing-import-resolution.md
+++ b/docs/missing-import-resolution.md
@@ -8,3 +8,16 @@
 - Removed `console.warn` from `src/components/BundleUpgradeCard.tsx` catch handling; storage failures now no-op safely and still open the bundle link.
 - Removed `console.warn` from `src/lib/analyticsEventStorage.ts` catch handling; analytics storage failures now no-op safely.
 - No product data modules were restored and no fake analytics data was introduced.
+- Re-ran `npm run check`; build now progresses past CuratedProductModule and no-console blockers and currently stops at `./src/components/EffectExplorer.tsx:3:54` missing `@/utils/effectSearch` (next blocker in queue).
+- EffectExplorer status: active in source tree (component exists and remains typechecked); resolved current TS2307 by adding `src/utils/effectSearch.ts` with generic, data-free search helpers operating only on provided herb runtime values.
+- `src/utils/effectSearch.ts` intentionally contains no hardcoded effect taxonomy, no seed effect suggestions, and no herb/compound/effect records.
+- Future `GENERATOR_FIX`: replace this generic matcher with workbook-generated effect taxonomy/search artifacts when an approved generator policy is available.
+- EffectExplorer decision: active fixed. The TS2307 import error for `@/utils/effectSearch` was resolved by creating `src/utils/effectSearch.ts`.
+- Added pure utility shims `src/utils/asStringArray.ts` and `src/utils/extractPrimaryEffects.ts` because they were immediately required by active `EffectExplorer` imports and are data-free wrappers over existing library helpers.
+- Confirmed no hardcoded effect taxonomy, no fake effect suggestions dataset, and no herb/compound/effect records were introduced.
+- Re-ran `npm run check`; next blocker is now `./src/components/EmailCapture.tsx:4:35` missing `@/hooks/useSubmissionForm`.
+- EmailCapture decision: active fixed. `src/components/EmailCapture.tsx` is reachable via `src/components/ContextualLeadMagnet.tsx`, so this batch restored the missing `@/hooks/useSubmissionForm` dependency.
+- Created `src/hooks/useSubmissionForm.ts` with a minimal generic state model (`idle`/`pending`/`success`/`error`) and API compatible with existing capture/signup components (`status`, `message`, `submit`, `clearFeedback`).
+- Endpoint behavior: submission flows through existing `src/lib/formSubmission.ts` endpoint resolution (`VITE_FORM_ENDPOINT` first, then legacy fallbacks). If no endpoint is configured, it returns the existing honest `missingEndpoint` message; no fake success behavior or backend integration was added.
+- No new form service/backend was introduced, and no analytics/product/recommendation/effect data was added in this pass.
+- Re-ran `npm run check`; next blocker is now `./src/components/ErrorBoundary.tsx:2:34` missing `../utils/devMessages` (outside EmailCapture/form-submission scope).

--- a/src/hooks/useSubmissionForm.ts
+++ b/src/hooks/useSubmissionForm.ts
@@ -1,0 +1,84 @@
+import { useCallback, useMemo, useState } from 'react'
+import {
+  FORM_ERROR_COPY,
+  submitFormPayload,
+  type FormSubmissionPayload,
+  validateEmail,
+} from '@/lib/formSubmission'
+
+type SubmissionStatus = 'idle' | 'pending' | 'success' | 'error'
+
+type SubmissionFields = {
+  email: string
+}
+
+type SubmitMeta = {
+  honeypot?: string
+}
+
+type UseSubmissionFormOptions = {
+  successMessage: string
+  buildPayload: (fields: SubmissionFields) => FormSubmissionPayload
+  onSuccess?: () => void
+}
+
+type UseSubmissionFormResult = {
+  status: SubmissionStatus
+  message: string
+  submit: (fields: SubmissionFields, meta?: SubmitMeta) => Promise<boolean>
+  clearFeedback: () => void
+}
+
+export function useSubmissionForm(options: UseSubmissionFormOptions): UseSubmissionFormResult {
+  const [status, setStatus] = useState<SubmissionStatus>('idle')
+  const [message, setMessage] = useState('')
+
+  const clearFeedback = useCallback(() => {
+    setStatus('idle')
+    setMessage('')
+  }, [])
+
+  const submit = useCallback(
+    async (fields: SubmissionFields, meta?: SubmitMeta) => {
+      const emailError = validateEmail(fields.email)
+      if (emailError) {
+        setStatus('error')
+        setMessage(emailError)
+        return false
+      }
+
+      const payload = options.buildPayload(fields)
+      if (!payload.formType) {
+        setStatus('error')
+        setMessage(FORM_ERROR_COPY.requiredFields)
+        return false
+      }
+
+      setStatus('pending')
+      setMessage('')
+
+      const result = await submitFormPayload(payload, meta?.honeypot)
+      if (!result.ok) {
+        setStatus('error')
+        setMessage(result.message || FORM_ERROR_COPY.network)
+        return false
+      }
+
+      setStatus('success')
+      setMessage(options.successMessage)
+      options.onSuccess?.()
+      return true
+    },
+    [options]
+  )
+
+  return useMemo(
+    () => ({
+      status,
+      message,
+      submit,
+      clearFeedback,
+    }),
+    [clearFeedback, message, status, submit]
+  )
+}

--- a/src/utils/asStringArray.ts
+++ b/src/utils/asStringArray.ts
@@ -1,0 +1,5 @@
+import { splitClean } from '@/lib/sanitize'
+
+export function asStringArray(value: unknown): string[] {
+  return splitClean(value)
+}

--- a/src/utils/effectSearch.ts
+++ b/src/utils/effectSearch.ts
@@ -1,0 +1,76 @@
+import type { Herb } from '@/types'
+
+type MatchConfidence = 'high' | 'medium' | 'low'
+
+export type RankedEffectMatch = {
+  herb: Herb
+  normalizedQuery: string
+  matchedEffects: string[]
+  compoundSupportCount: number
+  confidence: MatchConfidence
+}
+
+function toStringList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.map(item => String(item ?? '').trim()).filter(Boolean)
+  }
+
+  const text = String(value ?? '').trim()
+  if (!text) return []
+
+  return text.split(/[;,|/\n]+/).map(item => item.trim()).filter(Boolean)
+}
+
+function normalizeTerm(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9\s-]/g, ' ').replace(/\s+/g, ' ').trim()
+}
+
+function getHerbEffectTerms(herb: Herb): string[] {
+  const rawEffects = toStringList(herb.effects)
+  const summaryTerms = toStringList(herb.effectsSummary)
+  return [...rawEffects, ...summaryTerms].map(normalizeTerm).filter(Boolean)
+}
+
+function getCompoundSupportCount(herb: Herb): number {
+  return toStringList(herb.compounds).length
+}
+
+export function effectSuggestions(herbs: Herb[], limit = 12): string[] {
+  const seen = new Set<string>()
+
+  for (const herb of herbs) {
+    for (const effect of getHerbEffectTerms(herb)) {
+      if (!seen.has(effect)) seen.add(effect)
+      if (seen.size >= limit) return [...seen]
+    }
+  }
+
+  return [...seen]
+}
+
+export function rankHerbsByEffect(herbs: Herb[], query: string): RankedEffectMatch[] {
+  const normalizedQuery = normalizeTerm(query)
+  if (!normalizedQuery) return []
+
+  const queryTokens = normalizedQuery.split(' ').filter(Boolean)
+
+  return herbs
+    .map(herb => {
+      const effectTerms = getHerbEffectTerms(herb)
+      const matchedEffects = effectTerms.filter(effect => queryTokens.every(token => effect.includes(token)))
+      const score = matchedEffects.length
+      const confidence: MatchConfidence = score >= 2 ? 'high' : score === 1 ? 'medium' : 'low'
+
+      return {
+        herb,
+        normalizedQuery,
+        matchedEffects,
+        compoundSupportCount: getCompoundSupportCount(herb),
+        confidence,
+        score,
+      }
+    })
+    .filter(result => result.matchedEffects.length > 0)
+    .sort((a, b) => b.score - a.score || b.compoundSupportCount - a.compoundSupportCount)
+    .map(({ score: _score, ...result }) => result)
+}

--- a/src/utils/extractPrimaryEffects.ts
+++ b/src/utils/extractPrimaryEffects.ts
@@ -1,0 +1,5 @@
+import { extractPrimaryEffects as extractPrimaryEffectsFromDataTrust } from '@/lib/dataTrust'
+
+export function extractPrimaryEffects(value: unknown, maxItems = 3): string[] {
+  return extractPrimaryEffectsFromDataTrust(value, maxItems)
+}


### PR DESCRIPTION
### Motivation
- Unblock TypeScript import errors and `no-console` lints without restoring deleted hand-authored product/effect datasets or adding fake analytics/backend behavior. 
- Provide minimal, data-free shims so active components (`EffectExplorer`, `EmailCapture`, etc.) can remain compiled and testable while awaiting a generator policy for richer artifacts.

### Description
- Added a minimal, generic effect search module `src/utils/effectSearch.ts` that ranks herbs by effect terms and produces suggestions without embedding any hardcoded taxonomy or sample data. 
- Implemented a submission hook `src/hooks/useSubmissionForm.ts` providing `status`, `message`, `submit`, and `clearFeedback`, which validates email, builds payloads via a provided `buildPayload`, and delegates to existing `submitFormPayload` behavior without introducing fake endpoints. 
- Added small utility shims `src/utils/asStringArray.ts` and `src/utils/extractPrimaryEffects.ts` to satisfy imports used by active components and route to existing library helpers where appropriate. 
- Updated documentation `docs/missing-import-resolution.md` to record the changes and decisions made (including removal of some `console.warn` uses and that no product/effect datasets or fake analytics were added).

### Testing
- Ran `npm run check` iteratively during the rollout and verified TypeScript errors for `CuratedProductModule`, `EffectExplorer`, and `EmailCapture` were resolved by these changes. 
- The final `npm run check` progressed past the addressed blockers but currently halts on a remaining import error in `./src/components/ErrorBoundary.tsx` referencing `../utils/devMessages`, so the full typecheck is not yet green. 
- No automated tests other than the TypeScript/lint check were modified or executed in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f385253b0883238094ff08f0274462)