### PR TITLE
Add minimal devMessages shim and retain ErrorBoundary (unblocks typecheck)

### DIFF
--- a/docs/legacy-cleanup.md
+++ b/docs/legacy-cleanup.md
@@ -1,0 +1,7 @@
+# Legacy Cleanup Log
+
+## 2026-04-30
+
+- ErrorBoundary was **kept** because it is reachable from active infrastructure: `src/components/EntityDatabasePage.tsx` imports and renders `src/components/ErrorBoundary.tsx`.
+- `src/utils/devMessages.ts` was created as a tiny compatibility utility to satisfy active infrastructure imports after legacy cleanup removed the old module.
+- This change is infrastructure-only (diagnostic logging shim); it adds no herb/compound/product/effect/evidence/reference data and does not restore any deleted data modules.

--- a/docs/missing-import-resolution.md
+++ b/docs/missing-import-resolution.md
@@ -21,3 +21,7 @@
 - Endpoint behavior: submission flows through existing `src/lib/formSubmission.ts` endpoint resolution (`VITE_FORM_ENDPOINT` first, then legacy fallbacks). If no endpoint is configured, it returns the existing honest `missingEndpoint` message; no fake success behavior or backend integration was added.
 - No new form service/backend was introduced, and no analytics/product/recommendation/effect data was added in this pass.
 - Re-ran `npm run check`; next blocker is now `./src/components/ErrorBoundary.tsx:2:34` missing `../utils/devMessages` (outside EmailCapture/form-submission scope).
+- ErrorBoundary/devMessages decision: **ErrorBoundary kept as active infrastructure** because `src/components/EntityDatabasePage.tsx` imports and renders `ErrorBoundary`; removing it would break active page rendering.
+- Created `src/utils/devMessages.ts` with a tiny, data-free API (`recordDevMessage`) compatible with active infrastructure imports (`ErrorBoundary`, `consent`, `loadAnalytics`, `fullCounts`, `theme`).
+- Utility behavior is intentionally minimal and infrastructure-only: production no-op plus bounded in-memory dev message buffer for non-production diagnostics; no console calls, no browser-only APIs, and no domain/content datasets.
+- Re-ran `npm run check`; this unblocks the missing `../utils/devMessages` error and allows typechecking to proceed to the next blocker.

--- a/src/utils/devMessages.ts
+++ b/src/utils/devMessages.ts
@@ -1,0 +1,34 @@
+export type DevMessageLevel = 'info' | 'warning' | 'error'
+
+type DevMessageEntry = {
+  level: DevMessageLevel
+  message: string
+  context: unknown[]
+  ts: number
+}
+
+const MAX_DEV_MESSAGES = 100
+const devMessageStore: DevMessageEntry[] = []
+
+export function recordDevMessage(level: DevMessageLevel, message: string, ...context: unknown[]) {
+  if (import.meta.env.MODE === 'production') return
+
+  devMessageStore.push({
+    level,
+    message,
+    context,
+    ts: Date.now(),
+  })
+
+  if (devMessageStore.length > MAX_DEV_MESSAGES) {
+    devMessageStore.splice(0, devMessageStore.length - MAX_DEV_MESSAGES)
+  }
+}
+
+export function getDevMessages(): readonly DevMessageEntry[] {
+  return devMessageStore
+}
+
+export function clearDevMessages() {
+  devMessageStore.length = 0
+}


### PR DESCRIPTION
### Motivation
- `src/components/ErrorBoundary.tsx` imported `../utils/devMessages` after legacy cleanup removed the old helper, causing `npm run check` to fail. 
- `ErrorBoundary` is reachable from active infrastructure (`src/components/EntityDatabasePage.tsx`) so removing it would break rendering of an active page. 

### Description
- Kept `ErrorBoundary` and added a tiny, data-free compatibility shim at `src/utils/devMessages.ts` that exports `recordDevMessage`, `getDevMessages`, and `clearDevMessages` and stores a bounded in-memory buffer for non-production diagnostics. 
- The shim is a production no-op, uses no `console` calls, and does not reference any domain data or browser-only APIs. 
- Updated `docs/legacy-cleanup.md` and `docs/missing-import-resolution.md` to record the keep-vs-remove decision and note that this is infrastructure-only. 

### Testing
- Ran `npm run check`; the `src/components/ErrorBoundary.tsx:2:34 Cannot find module '../utils/devMessages'` blocker is resolved and typechecking/build progressed. 
- `npm run check` completed enough to surface the next blocker: `./src/components/FavoriteStar.tsx:2:34 Cannot find module '../hooks/useHerbFavorites'`, indicating the devMessages issue no longer blocks the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f38c25889483238dd7e5ef0e90ea1e)