### PR TITLE
Refine UI: global typography, card system, and detail-page polish

### DIFF
--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -70,17 +70,17 @@ export default async function Page({ params }: Params) {
   return (
     <div className="grid gap-8 lg:grid-cols-[220px_minmax(0,1fr)]">
       <aside className="hidden lg:block">
-        <nav className="sticky top-24 rounded-3xl border border-neutral-200 bg-white p-4 shadow-card">
+        <nav className="sticky top-24 rounded-2xl border border-neutral-200/60 bg-white p-4 shadow-[0_1px_2px_rgba(0,0,0,0.04)]">
           <p className="text-xs font-bold uppercase tracking-[0.16em] text-teal-700">On this page</p>
           <div className="mt-3 grid gap-2 text-sm">
-            {toc.map(([href, label]) => <a key={href} href={`#${href}`} className="rounded-xl px-3 py-2 font-semibold text-muted hover:bg-neutral-50 hover:text-ink">{label}</a>)}
+            {toc.map(([href, label]) => <a key={href} href={`#${href}`} className="rounded-lg px-3 py-2 font-medium text-neutral-600 transition-colors hover:bg-neutral-100 hover:text-black">{label}</a>)}
           </div>
         </nav>
       </aside>
 
-      <main className="space-y-8">
+      <main className="space-y-10">
         <nav className="flex gap-2 overflow-x-auto rounded-2xl border border-neutral-200 bg-white p-2 text-sm lg:hidden">
-          {toc.map(([href, label]) => <a key={href} href={`#${href}`} className="min-h-10 shrink-0 rounded-xl px-3 py-2 font-semibold text-muted hover:bg-neutral-50">{label}</a>)}
+          {toc.map(([href, label]) => <a key={href} href={`#${href}`} className="min-h-10 shrink-0 rounded-lg px-3 py-2 font-medium text-neutral-600 transition-colors hover:bg-neutral-100 hover:text-black">{label}</a>)}
         </nav>
 
         <DetailCard>
@@ -96,7 +96,7 @@ export default async function Page({ params }: Params) {
         {bestFor.length ? (
           <DetailCard id="best-for" title="Best For">
             <div className="flex flex-wrap gap-2">
-              {bestFor.map((item: string) => <span key={item} className="rounded-full bg-neutral-100 px-3 py-1 text-xs font-semibold text-neutral-700">{item}</span>)}
+              {bestFor.map((item: string) => <span key={item} className="rounded-full bg-neutral-100/80 px-3 py-1 text-xs font-medium text-neutral-700">{item}</span>)}
             </div>
           </DetailCard>
         ) : null}

--- a/app/globals.css
+++ b/app/globals.css
@@ -24,6 +24,15 @@ body {
   .container-page { @apply mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8; }
 
   .card {
-    @apply rounded-3xl border border-neutral-200 bg-white shadow-card;
+    @apply rounded-2xl border border-neutral-200/60 bg-white shadow-[0_1px_2px_rgba(0,0,0,0.04)];
+  }
+}
+
+@layer base {
+  h1 { @apply text-4xl font-bold tracking-tight sm:text-5xl; }
+  h2 { @apply text-2xl font-bold tracking-tight sm:text-3xl; }
+  p { @apply text-[15px] leading-7; }
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { animation: none !important; transition: none !important; scroll-behavior: auto !important; }
   }
 }

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -162,37 +162,38 @@ export default async function HerbDetailPage({ params }: Params) {
       {faqJsonLd ? <script type='application/ld+json' dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }} /> : null}
 
       <aside className='hidden lg:block'>
-        <nav className='sticky top-24 rounded-3xl border border-neutral-200 bg-white p-4 shadow-card'>
+        <nav className='sticky top-24 rounded-2xl border border-neutral-200/60 bg-white p-4 shadow-[0_1px_2px_rgba(0,0,0,0.04)]'>
           <p className='text-xs font-bold uppercase tracking-[0.16em] text-teal-700'>On this page</p>
           <div className='mt-3 grid gap-2 text-sm'>
-            {toc.map(([href, title]) => <a key={href} href={`#${href}`} className='rounded-xl px-3 py-2 font-semibold text-muted hover:bg-neutral-50 hover:text-ink'>{title}</a>)}
+            {toc.map(([href, title]) => <a key={href} href={`#${href}`} className='rounded-lg px-3 py-2 font-medium text-neutral-600 transition-colors hover:bg-neutral-100 hover:text-black'>{title}</a>)}
           </div>
         </nav>
       </aside>
 
-      <main className='space-y-8'>
+      <main className='space-y-10'>
         <nav className='flex flex-wrap gap-2 text-sm'>
           <Link href='/herbs' className='min-h-11 rounded-full border border-neutral-200 bg-white px-4 py-2.5 font-bold text-muted shadow-sm hover:border-teal-200 hover:bg-teal-50 hover:text-teal-800'>← Herbs</Link>
           <Link href='/compounds' className='min-h-11 rounded-full border border-neutral-200 bg-white px-4 py-2.5 font-bold text-muted shadow-sm hover:border-teal-200 hover:bg-teal-50 hover:text-teal-800'>Compounds</Link>
         </nav>
 
         <nav className='flex gap-2 overflow-x-auto rounded-2xl border border-neutral-200 bg-white p-2 text-sm lg:hidden'>
-          {toc.map(([href, title]) => <a key={href} href={`#${href}`} className='min-h-10 shrink-0 rounded-xl px-3 py-2 font-semibold text-muted hover:bg-neutral-50'>{title}</a>)}
+          {toc.map(([href, title]) => <a key={href} href={`#${href}`} className='min-h-10 shrink-0 rounded-lg px-3 py-2 font-medium text-neutral-600 transition-colors hover:bg-neutral-100 hover:text-black'>{title}</a>)}
         </nav>
 
         <DetailCard>
           <div className='flex flex-wrap items-center gap-3'>
             <Leaf className='text-teal-600' aria-hidden='true' />
-            <h1 className='text-3xl font-bold text-ink sm:text-5xl'>{label}</h1>
+            <h1 className='text-4xl font-bold tracking-tight text-ink sm:text-5xl'>{label}</h1>
             <EvidenceBadge value={evidence} />
           </div>
-          <p className='mt-4 max-w-3xl text-base leading-7 text-muted'>{leadText}</p>
+          <p className='mt-4 max-w-3xl text-[15px] leading-7 text-muted'>{leadText}</p>
+          <p className='mt-3 text-xs text-neutral-500'>Evidence-based • Human data prioritized • No industry bias</p>
           {updatedAt ? <p className='mt-3 text-xs text-muted'>Last updated {updatedAt}</p> : null}
         </DetailCard>
 
         {bestFor.length ? (
           <DetailCard id='best-for' title='Best For'>
-            <div className='flex flex-wrap gap-2'>{bestFor.map(item => <span key={item} className='rounded-full bg-neutral-100 px-3 py-1 text-xs font-semibold text-neutral-700'>{item}</span>)}</div>
+            <div className='flex flex-wrap gap-2'>{bestFor.map(item => <span key={item} className='rounded-full bg-neutral-100/80 px-3 py-1 text-xs font-medium text-neutral-700'>{item}</span>)}</div>
           </DetailCard>
         ) : null}
 
@@ -212,9 +213,9 @@ export default async function HerbDetailPage({ params }: Params) {
         ) : null}
 
         {(safety.avoidIf.length || safety.useCautionWith.length) ? (
-          <DetailCard id='safety' title='Safety & Side Effects' className='border-amber-200 bg-amber-50'>
+          <DetailCard id='safety' title='Safety & Side Effects' className='border-amber-200/70 bg-amber-50/60'>
             <div className='grid gap-4 sm:grid-cols-2'>
-              {safety.avoidIf.length ? <div><h3 className='text-sm font-bold text-red-800'>Avoid if</h3><ul className='mt-2 list-disc space-y-2 pl-5 text-sm leading-6 text-neutral-700'>{safety.avoidIf.map(item => <li key={item}>{item}</li>)}</ul></div> : null}
+              {safety.avoidIf.length ? <div><h3 className='text-sm font-bold text-amber-800'>Avoid if</h3><ul className='mt-2 list-disc space-y-2 pl-5 text-sm leading-6 text-neutral-700'>{safety.avoidIf.map(item => <li key={item}>{item}</li>)}</ul></div> : null}
               {safety.useCautionWith.length ? <div><h3 className='text-sm font-bold text-amber-800'>Use caution with</h3><ul className='mt-2 list-disc space-y-2 pl-5 text-sm leading-6 text-neutral-700'>{safety.useCautionWith.map(item => <li key={item}>{item}</li>)}</ul></div> : null}
             </div>
           </DetailCard>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,7 +22,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang='en'>
-      <body>
+      <body className="bg-[#fafaf9] text-[#111827] antialiased [font-family:Inter,system-ui,sans-serif]">
         <div className='min-h-screen bg-background text-ink'>
           <header className='sticky top-0 z-50 border-b border-neutral-200 bg-white/90 backdrop-blur-sm'>
             <div className='container-page flex items-center justify-between py-4'>
@@ -44,7 +44,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             </div>
           </header>
 
-          <main className='container-page py-10'>{children}</main>
+          <main className='container-page py-10 text-[15px] leading-7'>{children}</main>
 
           <footer className='mt-10 border-t border-neutral-200 bg-neutral-50'>
             <div className='container-page py-8 text-sm text-muted'>

--- a/components/StackCard.tsx
+++ b/components/StackCard.tsx
@@ -31,7 +31,7 @@ export default function StackCard({ item }: { item: StackItem }) {
   const dosage = item.dosage_range || item.dosage || 'See profile'
 
   return (
-    <article className='rounded-2xl border border-neutral-200 bg-white p-4 shadow-card transition hover:border-teal-200 hover:shadow-lg'>
+    <article className='rounded-2xl border border-neutral-200/60 bg-white p-6 shadow-[0_1px_2px_rgba(0,0,0,0.04)] transition duration-200 motion-safe:hover:-translate-y-[1px] hover:shadow-[0_6px_20px_rgba(0,0,0,0.06)]'>
       <div className='flex items-start justify-between gap-3'>
         <h3 className='text-base font-bold leading-tight text-ink'>{displayName}</h3>
         <EvidenceBadge value={evidence} />

--- a/components/compounds-browser-v2.tsx
+++ b/components/compounds-browser-v2.tsx
@@ -102,7 +102,7 @@ function CompoundCard({ item, index }: { item: CompoundItem; index: number }) {
             </div>
             <div className="rounded-2xl border border-white/10 bg-white/[0.045] p-2.5">
               <p className="text-[9px] font-black uppercase tracking-[0.16em] text-white/35">Onset</p>
-              <p className="mt-1 truncate text-xs font-bold text-white/85">{item.timeToEffect || 'Varies'}</p>
+              <p className="mt-1 truncate text-xs font-bold text-white/85">{item.timeToEffect || 'See profile'}</p>
             </div>
           </div>
 

--- a/components/decision-snapshot.tsx
+++ b/components/decision-snapshot.tsx
@@ -69,9 +69,9 @@ export default function DecisionSnapshot({ verdict, bestFor, safety, timeToEffec
       </div>
 
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mt-4">
-        <SnapshotStat label="Best For" value={clean(bestFor) || 'General'} />
+        {clean(bestFor) ? <SnapshotStat label="Best For" value={clean(bestFor)} /> : null}
         <SnapshotStat label="Safety" value={clean(safety) || 'Review'} />
-        <SnapshotStat label="Works In" value={clean(timeToEffect) || 'Varies'} />
+        <SnapshotStat label="Works In" value={clean(timeToEffect) || 'See profile'} />
         <div className="rounded-2xl border border-white/10 bg-white/[0.045] p-4">
           <p className="text-[11px] text-white/50">Evidence</p>
           <p className="font-bold">{clean(evidence) || 'Limited'}</p>

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -9,7 +9,7 @@ type CardProps = HTMLAttributes<HTMLDivElement> & {
 
 export const Card = ({ children, eyebrow, title, description, className = '', ...props }: CardProps) => {
   return (
-    <div className={`rounded-3xl border border-neutral-200/80 bg-white p-6 shadow-card transition-shadow hover:shadow-lg ${className}`} {...props}>
+    <div className={`rounded-2xl border border-neutral-200/60 bg-white p-6 shadow-[0_1px_2px_rgba(0,0,0,0.04)] transition duration-200 motion-safe:hover:-translate-y-[1px] hover:shadow-[0_6px_20px_rgba(0,0,0,0.06)] ${className}`} {...props}>
       {eyebrow && <p className="text-xs font-bold uppercase tracking-[0.18em] text-teal-700">{eyebrow}</p>}
       {title && <h3 className="mt-2 text-xl font-bold tracking-tight text-ink">{title}</h3>}
       {description && <p className="mt-2 text-sm leading-6 text-muted">{description}</p>}
@@ -20,7 +20,7 @@ export const Card = ({ children, eyebrow, title, description, className = '', ..
 
 export const DetailCard = ({ children, eyebrow, title, description, className = '', ...props }: CardProps) => {
   return (
-    <section className={`rounded-[1.75rem] border border-neutral-200 bg-white p-6 shadow-card sm:p-7 ${className}`} {...props}>
+    <section className={`rounded-2xl border border-neutral-200/60 bg-white p-6 shadow-[0_1px_2px_rgba(0,0,0,0.04)] transition duration-200 motion-safe:hover:-translate-y-[1px] hover:shadow-[0_6px_20px_rgba(0,0,0,0.06)] sm:p-7 ${className}`} {...props}>
       {eyebrow && <p className="text-xs font-bold uppercase tracking-[0.18em] text-teal-700">{eyebrow}</p>}
       {title && <h2 className="mt-2 text-2xl font-bold tracking-tight text-ink sm:text-3xl">{title}</h2>}
       {description && <p className="mt-3 max-w-3xl text-sm leading-7 text-muted sm:text-base">{description}</p>}
@@ -34,12 +34,14 @@ export const EvidenceBadge = ({ value = 'Limited' }: { value?: string }) => {
   const normalized = label.toLowerCase()
 
   const tone = normalized.includes('likely') || normalized.includes('strong') || normalized.includes('high') || normalized.includes('effective')
-    ? 'border-emerald-200 bg-emerald-50 text-emerald-800'
+    ? 'border-emerald-200/70 bg-emerald-50 text-emerald-700'
     : normalized.includes('moderate') || normalized.includes('mixed') || normalized.includes('emerging')
-      ? 'border-amber-200 bg-amber-50 text-amber-800'
+      ? 'border-amber-200/70 bg-amber-50 text-amber-700'
       : 'border-neutral-200 bg-neutral-50 text-neutral-700'
 
-  return <span className={`inline-flex min-h-7 items-center rounded-full border px-3 py-1 text-xs font-bold capitalize ${tone}`}>{label}</span>
+  const mapped = normalized.includes('likely') || normalized.includes('strong') || normalized.includes('high') || normalized.includes('effective') ? 'Likely Effective' : (normalized.includes('moderate') || normalized.includes('mixed') ? 'Moderate Evidence' : 'Limited Evidence')
+
+  return <span className={`inline-flex min-h-6 items-center rounded-full border px-2.5 py-1 text-xs font-semibold ${tone}`}>{mapped}</span>
 }
 
 export const RoleBadge = ({ role = 'SUPPORT' }: { role?: string }) => {
@@ -49,7 +51,7 @@ export const RoleBadge = ({ role = 'SUPPORT' }: { role?: string }) => {
   const tone = normalized.includes('anchor')
     ? 'border-teal-200 bg-teal-50 text-teal-800'
     : normalized.includes('amplifier')
-      ? 'border-emerald-200 bg-emerald-50 text-emerald-800'
+      ? 'border-emerald-200/70 bg-emerald-50 text-emerald-700'
       : 'border-slate-200 bg-slate-50 text-slate-700'
 
   return <span className={`inline-flex min-h-7 items-center rounded-full border px-3 py-1 text-xs font-bold tracking-wide ${tone}`}>{label}</span>

--- a/components/ui/GlassCard.tsx
+++ b/components/ui/GlassCard.tsx
@@ -15,11 +15,11 @@ type GlassCardProps = HTMLMotionProps<'div'> & {
 }
 
 const variantClasses: Record<GlassVariant, string> = {
-  light: 'border-brand/15 bg-glass-light sm:backdrop-blur-md backdrop-blur-sm',
-  standard: 'border-brand/20 bg-glass-standard sm:backdrop-blur-xl backdrop-blur-md',
-  heavy: 'border-brand/25 bg-glass-heavy sm:backdrop-blur-2xl backdrop-blur-md shadow-glass',
-  glow: 'border-brand/35 bg-glass-glow sm:backdrop-blur-xl backdrop-blur-md shadow-glow',
-  frosted: 'border-white/15 bg-white/[0.045] sm:backdrop-blur-lg backdrop-blur-sm',
+  light: 'border-neutral-200/60 bg-white',
+  standard: 'border-neutral-200/60 bg-white',
+  heavy: 'border-neutral-200/60 bg-white',
+  glow: 'border-neutral-200/60 bg-white',
+  frosted: 'border-neutral-200/60 bg-white',
 }
 
 export function GlassCard({
@@ -39,15 +39,15 @@ export function GlassCard({
       ref={ref}
       initial={reduceMotion ? false : { opacity: 0, y: 14, scale: 0.985 }}
       animate={reduceMotion || inView ? { opacity: 1, y: 0, scale: 1 } : undefined}
-      whileHover={reduceMotion ? undefined : { y: -4, scale: 1.01 }}
+      whileHover={reduceMotion ? undefined : { y: -1 }}
       whileTap={reduceMotion ? undefined : { scale: 0.985 }}
       transition={{ ...springConfig.card, delay }}
-      className={`relative isolate overflow-hidden rounded-3xl border ${variantClasses[variant]} ${className}`}
+      className={`relative isolate overflow-hidden rounded-2xl border shadow-[0_1px_2px_rgba(0,0,0,0.04)] transition duration-200 motion-safe:hover:-translate-y-[1px] hover:shadow-[0_6px_20px_rgba(0,0,0,0.06)] ${variantClasses[variant]} ${className}`}
       {...props}
     >
       {enableShine ? (
         <span aria-hidden className="pointer-events-none absolute inset-0 overflow-hidden rounded-3xl">
-          <span className="absolute inset-y-0 left-0 w-1/3 -translate-x-[160%] bg-gradient-to-r from-transparent via-white/10 to-transparent motion-safe:animate-[shine_3.8s_linear_infinite]" />
+          <span className="absolute inset-y-0 left-0 w-1/3 -translate-x-[160%] bg-gradient-to-r from-transparent via-white/20 to-transparent opacity-40" />
         </span>
       ) : null}
       <div className="relative z-10">{children}</div>


### PR DESCRIPTION
### Motivation
- Move the site toward a cleaner, premium design system by normalizing typography, card surfaces, spacing, and minor interactions. 
- Reduce visual noise from glassmorphism/heavy shadows while preserving existing routes, data contracts, and page behavior. 
- Improve small UX details (TOC, Best For tags, safety sections, evidence labels) so content reads more clearly and only renders when meaningful. 

### Description
- Updated root shell and typography by adding body classes and font stack in `app/layout.tsx` and base rules in `app/globals.css` (warm off-white background `#fafaf9`, `#111827` text, `Inter, system-ui, sans-serif`, antialiasing, H1/H2/body sizing and reduced-motion support). 
- Normalized card system in `components/ui/Card.tsx`, `components/ui/GlassCard.tsx` and `components/StackCard.tsx` to `rounded-2xl`, `bg-white`, `border border-neutral-200/60`, subtle shadow `shadow-[0_1px_2px_rgba(0,0,0,0.04)]`, and gentle hover lift `hover:shadow-[0_6px_20px_rgba(0,0,0,0.06)]` with smooth transitions. 
- Simplified `GlassCard` visuals to remove heavy glass/glow effects and shine animation while preserving motion-respectful hover behavior. 
- Normalized `EvidenceBadge` mapping and styling in `components/ui/Card.tsx` to canonical labels: `Likely Effective`, `Moderate Evidence`, and `Limited Evidence`, and tuned tones to softer emerald/amber/neutral palettes. 
- Polished detail pages (`app/herbs/[slug]/page.tsx`, `app/compounds/[slug]/page.tsx`) by enforcing `space-y-10`, softer TOC/nav chips, `Best For` pill styles, amber-toned safety containers, and adding a small trust line under the hero: “Evidence-based • Human data prioritized • No industry bias”. 
- Removed/changed low-quality fallbacks: replaced generic `Varies` with `See profile` in touched components and suppressed empty `Best For` snapshot rendering. 

### Testing
- Ran the full build pipeline with `npm run build`, which includes data generation/validation and the Next.js build/export steps, and the build passed successfully. 
- Data validation steps (`node scripts/data/validate-data-next.mjs`) completed and returned structural validation success for `public/data` during the build. 
- Verified that reduced-motion support and conditional rendering changes did not break compilation or exports (Next.js static generation completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9ec88425083239c51b3f836db0ce7)