### PR TITLE
Add lightweight compound comparison flow

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -1,19 +1,13 @@
-import Link from 'next/link'
+import { CompareTableClient } from '@/components/compare-table-client'
+import { getCompounds } from '@/lib/runtime-data'
 
-export default function CompareHub() {
+export default async function ComparePage() {
+  const compounds = await getCompounds()
+
   return (
-    <main className="mx-auto max-w-5xl p-6 space-y-6">
-      <h1 className="text-4xl font-black">Compare Supplements</h1>
-      <p className="text-slate-600">Compare compounds side-by-side to find the best option for your goal.</p>
-
-      <div className="grid gap-4 sm:grid-cols-2">
-        <Link href="/compounds" className="rounded-2xl border p-4">
-          Browse compounds →
-        </Link>
-        <Link href="/" className="rounded-2xl border p-4">
-          Start from goals →
-        </Link>
-      </div>
+    <main className="mx-auto max-w-6xl space-y-6 px-4 py-8">
+      <h1 className="text-3xl font-bold text-ink">Compound comparison</h1>
+      <CompareTableClient compounds={compounds} />
     </main>
   )
 }

--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation'
 import { Pill } from 'lucide-react'
 import { getCompoundBySlug, getCompounds } from '@/lib/runtime-data'
 import { DetailCard, EvidenceBadge, RoleBadge } from '@/components/ui'
+import { CompoundCompareButton } from '@/components/compound-compare-button'
 
 type Params = { params: Promise<{ slug: string }> }
 type CompoundDetail = Record<string, any>
@@ -30,6 +31,21 @@ const evidenceSentence = (value?: string) => {
 }
 
 const pmidUrl = (id: string) => `https://pubmed.ncbi.nlm.nih.gov/${id.replace(/\D/g, '')}`
+
+
+const getRelatedCompounds = async (slug: string, compound: CompoundDetail) => {
+  const compounds = await getCompounds()
+  const currentEffects = new Set(list(compound.effects || compound.primary_effects).map((item) => item.toLowerCase()))
+  return compounds
+    .filter((row: any) => row.slug && row.slug !== slug)
+    .map((row: any) => ({
+      slug: row.slug,
+      name: row.name || row.slug,
+      score: list(row.effects || row.primary_effects).reduce((acc: number, item: string) => acc + (currentEffects.has(item.toLowerCase()) ? 1 : 0), 0),
+    }))
+    .sort((a: any, b: any) => b.score - a.score || a.name.localeCompare(b.name))
+    .slice(0, 4)
+}
 
 export async function generateStaticParams() {
   const compounds = await getCompounds()
@@ -58,6 +74,7 @@ export default async function Page({ params }: Params) {
   const evidence = text(data.evidence_tier || data.evidenceTier || data.evidence_grade) || 'Limited'
   const pmids = list(data.pmid_list).filter((id: string) => /\d/.test(id)).slice(0, 10)
   const updatedAt = text(data.updated_at || data.last_updated || data.lastReviewedAt)
+  const relatedCompounds = await getRelatedCompounds(slug, data)
 
   const toc = [
     bestFor.length ? ['best-for', 'Best For'] : null,
@@ -91,6 +108,9 @@ export default async function Page({ params }: Params) {
           </div>
           {data.formula ? <p className="mt-2 text-sm font-semibold text-muted">{data.formula}</p> : null}
           {updatedAt ? <p className="mt-2 text-xs text-muted">Last updated {updatedAt}</p> : null}
+          <div className="mt-4">
+            <CompoundCompareButton slug={slug} />
+          </div>
         </DetailCard>
 
         {bestFor.length ? (
@@ -122,6 +142,20 @@ export default async function Page({ params }: Params) {
                 {mechanisms.map((item: string) => <li key={item}>• {item}</li>)}
               </ul>
             </details>
+          </DetailCard>
+        ) : null}
+
+
+
+        {relatedCompounds.length ? (
+          <DetailCard title="Compare with">
+            <div className="grid gap-2 sm:grid-cols-2">
+              {relatedCompounds.map((item: any) => (
+                <Link key={item.slug} href={`/compare?c=${slug},${item.slug}`} className="rounded-xl border border-neutral-200 bg-neutral-50 px-4 py-3 text-sm font-medium text-neutral-800 hover:border-teal-200 hover:text-teal-700">
+                  Compare {name} vs {item.name}
+                </Link>
+              ))}
+            </div>
           </DetailCard>
         ) : null}
 

--- a/components/compare-table-client.tsx
+++ b/components/compare-table-client.tsx
@@ -1,0 +1,26 @@
+'use client'
+import Link from 'next/link'
+import { useMemo } from 'react'
+import { useSearchParams } from 'next/navigation'
+import { EvidenceBadge } from '@/components/ui'
+
+type Compound = Record<string, any>
+const text = (v: any) => Array.isArray(v) ? v.map(text).filter(Boolean).join(', ') : String(v || '').replace(/\s+/g, ' ').trim()
+const list = (v: any) => Array.isArray(v) ? v.map(text).filter(Boolean) : text(v).split(/\n|;|\|/).map((i:string)=>i.trim()).filter(Boolean)
+const getUseCaseLabel = (c: Compound) => {
+ const h=`${text(c.role)} ${list(c.primary_effects||c.effects).join(' ')}`.toLowerCase()
+ if (/strength|power|performance|muscle/.test(h)) return 'Strength'
+ if (/stress|anxiety|calm|cortisol/.test(h)) return 'Stress'
+ if (/sleep|insomnia|rest/.test(h)) return 'Sleep'
+ if (/focus|cognition|memory|brain/.test(h)) return 'Focus'
+ return text(c.role) || 'General wellness'
+}
+const summary=(v:any)=>{const i=list(v); return i.length?i.slice(0,2).join(' · '):'—'}
+
+export function CompareTableClient({ compounds }: { compounds: Compound[] }) {
+ const searchParams=useSearchParams()
+ const selected=useMemo(()=>{const slugs=(searchParams.get('c')||'').split(',').map(s=>s.trim().toLowerCase()).filter(Boolean).slice(0,3);return compounds.filter(c=>slugs.includes(String(c.slug||'').toLowerCase()))},[compounds,searchParams])
+ if (selected.length<2) return <p className="text-neutral-600">Select at least 2 compounds to compare</p>
+ const rows:[string,(c:Compound)=>any][]=[['Best for',c=>summary(c.primary_effects||c.effects)],['Evidence',c=><EvidenceBadge value={text(c.evidence_tier||c.evidenceTier||c.evidence_grade)||'Limited'} />],['Time to effect',c=>text(c.time_to_effect)||'—'],['Use case',c=>getUseCaseLabel(c)||'—'],['Safety',c=>summary(c.safety_flags||c.safetyNotes||c.contraindications)],['Complexity',c=>text(c.complexity)||'Low'],['Cost',c=>text(c.cost)||'Low']]
+ return <div className="overflow-x-auto rounded-2xl border border-neutral-200 bg-white"><table className="min-w-[720px] w-full text-left text-sm"><thead><tr className="border-b border-neutral-100"><th className="p-4 font-semibold text-neutral-600">Metric</th>{selected.map(c=><th key={c.slug} className="p-4 font-semibold"><Link href={`/compounds/${c.slug}`} className="text-teal-700 underline underline-offset-2">{c.name||c.slug}</Link></th>)}</tr></thead><tbody>{rows.map(([label,render])=><tr key={label} className="border-b border-neutral-100 align-top last:border-0"><th className="p-4 font-medium text-neutral-600">{label}</th>{selected.map(c=><td key={`${c.slug}-${label}`} className="p-4 text-neutral-800">{render(c)}</td>)}</tr>)}</tbody></table></div>
+}

--- a/components/compound-compare-button.tsx
+++ b/components/compound-compare-button.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import { useCallback } from 'react'
+import { useRouter } from 'next/navigation'
+
+const KEY = 'compare-compounds'
+
+export function CompoundCompareButton({ slug }: { slug: string }) {
+  const router = useRouter()
+
+  const onClick = useCallback(() => {
+    const current = JSON.parse(localStorage.getItem(KEY) || '[]') as string[]
+    const unique = current.filter((item) => item !== slug)
+    const next = [...unique, slug].slice(-2)
+    localStorage.setItem(KEY, JSON.stringify(next))
+    if (next.length >= 2) router.push(`/compare?c=${next.join(',')}`)
+  }, [router, slug])
+
+  return (
+    <button onClick={onClick} className="rounded-xl border border-teal-200 bg-teal-50 px-4 py-2 text-sm font-semibold text-teal-700 transition hover:bg-teal-100">
+      Compare
+    </button>
+  )
+}


### PR DESCRIPTION
### Motivation
- Provide a fast, minimal compound comparison UI so users can compare 2–3 compounds side-by-side and make decisions quickly.
- Keep changes surgical and safe: do not modify generated `public/data` artifacts and preserve existing routes and build behaviour.
- Support instant navigation between profiles and simple client-side selection to keep the experience responsive and low-cost.

### Description
- Replace the old compare hub with `app/compare/page.tsx` that loads compounds via `getCompounds()` and renders a client compare component (`CompareTableClient`).
- Add `components/compare-table-client.tsx`, a client-side table that parses `?c=slug1,slug2,...`, limits selection to 2–3 compounds, shows a fallback when fewer than 2 are chosen, and renders rows: `Best for`, `Evidence`, `Time to effect`, `Use case`, `Safety`, `Complexity`, and `Cost` with safe defaults (`—`, `Low`).
- Add `components/compound-compare-button.tsx`, a client `Compare` button that manages a small compare list in `localStorage` and redirects to `/compare?c=...` when at least two items are selected (replacing the oldest when needed).
- Update `app/compounds/[slug]/page.tsx` to include the `Compare` button near the top and a `Compare with` card that computes 3–4 related compounds and links to `/compare?c=current,other` for quick side-by-side comparisons.

### Testing
- Ran the full build pipeline with `npm run build`, which includes data build/validation and Next.js build/export, and the build completed successfully.
- Data validation step `node scripts/data/validate-data-next.mjs` passed as part of the build.
- Route and generated-data verifications ran (`scripts/verify-*`) and passed in the CI-style build verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9f048b7c08323ac116778ca1618d2)