### PR TITLE
Add research-intelligence library + reusable UI components and wire into herb detail pages

### DIFF
--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -3,10 +3,28 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { ExternalLink, Leaf } from 'lucide-react'
 import { DetailCard, EvidenceBadge } from '@/components/ui'
+import CompareWithCard from '@/components/ui/CompareWithCard'
+import RelatedPathways from '@/components/ui/RelatedPathways'
+import ResearchConfidenceMatrix from '@/components/ui/ResearchConfidenceMatrix'
+import ResearchFocusAreas from '@/components/ui/ResearchFocusAreas'
+import ResearchGapsCard from '@/components/ui/ResearchGapsCard'
+import ResearchStyleBadge from '@/components/ui/ResearchStyleBadge'
+import ScientificConsensusCard from '@/components/ui/ScientificConsensusCard'
 import { getClaims, getCompounds, getHerbBySlug, getHerbCompoundMap, getHerbs } from '@/lib/runtime-data'
 import { getHerbSearchLinks } from '@/lib/affiliate'
 import { commonSupplementFaqJsonLd } from '@/lib/seo'
 import { cleanSummary, formatDisplayLabel, isClean, list, text, unique } from '@/lib/display-utils'
+import {
+  deriveComparisonFraming,
+  deriveConfidenceByTopic,
+  deriveEvidenceFraming,
+  derivePathwayClusters,
+  deriveResearchFocusAreas,
+  deriveResearchStyle,
+  generateScientificConsensusSummary,
+  inferEvidenceLimitations,
+  inferResearchGaps,
+} from '@/lib/research-intelligence'
 
 type Params = { params: Promise<{ slug: string }> }
 type HerbDetail = Record<string, any>
@@ -17,17 +35,11 @@ type EditorialCard = {
   text: string
 }
 
-type EvidenceFrame = {
-  maturity: string
-  summary: string
-  notes: string[]
-}
-
 const formatSlugLabel = (slug: string) => slug.split('-').filter(Boolean).map(part => part.charAt(0).toUpperCase() + part.slice(1)).join(' ')
 const getHerbLabel = (herb: HerbDetail) => formatDisplayLabel(herb.displayName) || formatDisplayLabel(herb.name) || formatSlugLabel(herb.slug)
 
 const getLeadText = (herb: HerbDetail) => {
-  const effects = unique(list(herb.primary_effects)).slice(0, 3)
+  const effects = unique([...list(herb.primary_effects), ...list(herb.primaryActions)]).slice(0, 3)
   if (effects.length) {
     return `Traditionally used for ${effects.join(', ')}.`
   }
@@ -62,42 +74,6 @@ const getMechanismText = (label: string) => {
   if (/immune/.test(value)) return 'Immune-signaling context that should be interpreted conservatively.'
 
   return 'Mechanistic signal from the current profile data; not proof of a clinical outcome.'
-}
-
-const getEvidenceFrame = (evidence: string, pmidCount: number, claimCount: number, mechanismCount: number): EvidenceFrame => {
-  const level = evidence.toLowerCase()
-  const signalCount = pmidCount + claimCount + mechanismCount
-
-  if (/strong|high|human/.test(level) || signalCount >= 10) {
-    return {
-      maturity: 'Better studied',
-      summary: 'This profile has multiple visible evidence signals. Individual claims should still be interpreted by outcome, preparation, and study context.',
-      notes: [
-        'Use the strongest human-facing outcomes first when comparing benefits.',
-        'Mechanisms provide context, but they do not automatically prove real-world effects.',
-      ],
-    }
-  }
-
-  if (/moderate|limited|mixed/.test(level) || signalCount >= 5) {
-    return {
-      maturity: 'Moderate / emerging',
-      summary: 'This profile has enough signals for useful research navigation, but the strength likely varies by outcome and product form.',
-      notes: [
-        'Prioritize claims with human or source-backed context where available.',
-        'Treat broad wellness claims more cautiously than specific, repeated signals.',
-      ],
-    }
-  }
-
-  return {
-    maturity: 'Preliminary',
-    summary: 'This profile should be read as early-stage or context-building. It is useful for discovery, not as a settled clinical conclusion.',
-    notes: [
-      'Mechanistic or traditional-use signals may be present without strong human evidence.',
-      'Avoid over-interpreting sparse profiles or broad claims.',
-    ],
-  }
 }
 
 const groupMechanisms = (cards: EditorialCard[]) => {
@@ -185,7 +161,11 @@ export default async function HerbDetailPage({ params }: Params) {
   const label = getHerbLabel(herb)
   const leadText = getLeadText(herb)
   const affiliateLinks = getHerbSearchLinks(label).filter(link => link.url && link.label)
-  const relatedCompounds = await getRelatedCompounds(herb)
+  const [relatedCompounds, allHerbs, allCompounds] = await Promise.all([
+    getRelatedCompounds(herb),
+    getHerbs(),
+    getCompounds(),
+  ])
   const faqJsonLd = commonSupplementFaqJsonLd(`/herbs/${herb.slug}`)
 
   const claims = unique(
@@ -245,7 +225,19 @@ export default async function HerbDetailPage({ params }: Params) {
     ...list(herb.references)
   ].filter(id => /\d/.test(id))).slice(0, 10)
 
-  const evidenceFrame = getEvidenceFrame(evidence, pmids.length, claims.length, mechanisms.length)
+  const researchInputs = { profile: herb, claims, pmids, mechanisms }
+  const evidenceFrame = deriveEvidenceFraming(researchInputs)
+  const researchStyle = deriveResearchStyle(researchInputs)
+  const consensusSummary = generateScientificConsensusSummary(researchInputs)
+  const confidenceTopics = deriveConfidenceByTopic(researchInputs)
+  const pathwayClusters = derivePathwayClusters(researchInputs)
+  const researchGaps = inferResearchGaps(researchInputs)
+  const evidenceLimitations = inferEvidenceLimitations(researchInputs)
+  const focusAreas = deriveResearchFocusAreas(researchInputs)
+  const comparisons = deriveComparisonFraming(herb, [
+    ...allHerbs.map((item: any) => ({ ...item, type: 'herb' })),
+    ...allCompounds.map((item: any) => ({ ...item, type: 'compound' })),
+  ])
 
   const hasForms = Boolean(form || dosage || timeToEffect)
 
@@ -258,8 +250,12 @@ export default async function HerbDetailPage({ params }: Params) {
   const toc = [
     profileOverview ? ['overview', 'Overview'] : null,
     ['evidence-framing', 'Evidence framing'],
+    consensusSummary || confidenceTopics.length > 1 ? ['research-intelligence', 'Research intelligence'] : null,
+    focusAreas.length > 1 || pathwayClusters.length ? ['semantic-signals', 'Semantic signals'] : null,
     outcomeCards.length ? ['best-for', 'Best for'] : null,
     mechanismGroups.length ? ['mechanisms', 'Mechanisms'] : null,
+    researchGaps.length > 1 || evidenceLimitations.length > 1 ? ['research-gaps', 'Research gaps'] : null,
+    comparisons.length > 1 ? ['compare-with', 'Compare with'] : null,
     safetyItems.length ? ['safety', 'Safety'] : null,
     hasForms ? ['forms', 'Forms & dosage'] : null,
     relatedCompounds.length ? ['related-compounds', 'Related compounds'] : null,
@@ -292,6 +288,7 @@ export default async function HerbDetailPage({ params }: Params) {
             <Leaf className="text-brand-700" aria-hidden="true" />
             <h1 className="heading-premium max-w-4xl text-ink">{label}</h1>
             <EvidenceBadge value={evidence} />
+            <ResearchStyleBadge style={researchStyle} />
           </div>
 
           <p className="text-reading mt-5 max-w-reading text-lg text-muted-soft">
@@ -324,6 +321,25 @@ export default async function HerbDetailPage({ params }: Params) {
           </div>
         </DetailCard>
 
+
+        {consensusSummary || confidenceTopics.length > 1 ? (
+          <DetailCard id="research-intelligence" eyebrow="Research Intelligence" title="Scientific interpretation" description="Reusable semantic framing derived from existing structured profile data.">
+            <div className="grid gap-5 lg:grid-cols-2">
+              <ScientificConsensusCard summary={consensusSummary} />
+              <ResearchConfidenceMatrix topics={confidenceTopics} />
+            </div>
+          </DetailCard>
+        ) : null}
+
+        {focusAreas.length > 1 || pathwayClusters.length ? (
+          <DetailCard id="semantic-signals" eyebrow="Semantic Discovery" title="Research focus & pathways" description="Semantic clusters for future browse-by-mechanism and comparative discovery experiences.">
+            <div className="grid gap-5">
+              <ResearchFocusAreas areas={focusAreas} />
+              <RelatedPathways pathways={pathwayClusters} />
+            </div>
+          </DetailCard>
+        ) : null}
+
         {outcomeCards.length > 0 ? (
           <DetailCard id="best-for" eyebrow="Use Cases" title="Best for" description="Signals surfaced from the current profile and linked claim data.">
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -354,6 +370,18 @@ export default async function HerbDetailPage({ params }: Params) {
                 </div>
               ))}
             </div>
+          </DetailCard>
+        ) : null}
+
+        {researchGaps.length > 1 || evidenceLimitations.length > 1 ? (
+          <DetailCard id="research-gaps" eyebrow="Uncertainty" title="Research gaps & limitations" description="Important constraints that keep the profile scientifically conservative.">
+            <ResearchGapsCard gaps={researchGaps} limitations={evidenceLimitations} />
+          </DetailCard>
+        ) : null}
+
+        {comparisons.length > 1 ? (
+          <DetailCard id="compare-with" eyebrow="Comparative Framing" title="Compare with" description="Related herbs and compounds are selected by overlapping effect and mechanism language already present in the data.">
+            <CompareWithCard comparisons={comparisons} />
           </DetailCard>
         ) : null}
 

--- a/components/ui/CompareWithCard.tsx
+++ b/components/ui/CompareWithCard.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link'
+import type { ComparisonFraming } from '@/lib/research-intelligence'
+
+export default function CompareWithCard({ comparisons = [] }: { comparisons?: ComparisonFraming[] }) {
+  const visible = comparisons.slice(0, 4)
+  if (visible.length < 2) return null
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      {visible.map(item => (
+        <Link key={item.href} href={item.href} className="card-premium block p-5 hover:-translate-y-0.5">
+          <p className="eyebrow-label">Compare with</p>
+          <h3 className="mt-2 text-lg font-semibold text-ink">{item.title}</h3>
+          <p className="mt-3 text-sm leading-6 text-[#46574d]"><span className="font-semibold text-ink">Overlap:</span> {item.overlappingFocus}</p>
+          <p className="mt-3 text-sm leading-6 text-[#46574d]"><span className="font-semibold text-ink">Distinction:</span> {item.keyDistinction}</p>
+          <p className="mt-3 text-xs leading-5 text-muted-readable">{item.evidenceEmphasis}</p>
+        </Link>
+      ))}
+    </div>
+  )
+}

--- a/components/ui/RelatedPathways.tsx
+++ b/components/ui/RelatedPathways.tsx
@@ -1,0 +1,24 @@
+import type { PathwayCluster } from '@/lib/research-intelligence'
+
+export default function RelatedPathways({ pathways = [] }: { pathways?: PathwayCluster[] }) {
+  const visible = pathways.filter(pathway => pathway.mechanisms?.length).slice(0, 5)
+  if (!visible.length) return null
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      {visible.map(pathway => (
+        <div key={pathway.title} className="surface-subtle rounded-2xl p-5">
+          <h3 className="text-base font-semibold text-ink">{pathway.title}</h3>
+          <p className="mt-2 text-sm leading-6 text-[#46574d]">{pathway.description}</p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {pathway.mechanisms.slice(0, 4).map(mechanism => (
+              <span key={mechanism} className="rounded-full border border-brand-900/10 bg-white/75 px-3 py-1 text-xs font-medium text-[#46574d]">
+                {mechanism}
+              </span>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/components/ui/ResearchConfidenceMatrix.tsx
+++ b/components/ui/ResearchConfidenceMatrix.tsx
@@ -1,0 +1,38 @@
+import type { TopicConfidenceSummary } from '@/lib/research-intelligence'
+
+const confidenceClasses: Record<string, string> = {
+  Moderate: 'border-emerald-700/15 bg-emerald-50 text-emerald-800',
+  Preliminary: 'border-amber-700/20 bg-amber-50 text-amber-800',
+  Limited: 'border-stone-300 bg-paper-100 text-[#5d5548]',
+}
+
+export default function ResearchConfidenceMatrix({ topics = [] }: { topics?: TopicConfidenceSummary[] }) {
+  const visible = topics.filter(item => item.topic && item.confidence).slice(0, 5)
+  if (visible.length < 2) return null
+
+  return (
+    <div className="card-premium p-5 sm:p-6">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <p className="eyebrow-label">Topic confidence</p>
+          <h3 className="mt-2 text-xl font-semibold tracking-tight text-ink">Research confidence matrix</h3>
+        </div>
+        <p className="max-w-md text-sm leading-6 text-[#46574d]">Confidence is inferred only from recurring profile signals, evidence tier language, PubMed IDs, claims, and mechanisms.</p>
+      </div>
+
+      <div className="mt-5 grid gap-3">
+        {visible.map(item => (
+          <div key={item.topic} className="surface-subtle rounded-2xl p-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <h4 className="text-sm font-semibold text-ink">{item.topic}</h4>
+              <span className={`rounded-full border px-3 py-1 text-xs font-semibold ${confidenceClasses[item.confidence] || confidenceClasses.Limited}`}>
+                {item.confidence}
+              </span>
+            </div>
+            <p className="mt-2 text-sm leading-6 text-[#46574d]">{item.rationale}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/ui/ResearchFocusAreas.tsx
+++ b/components/ui/ResearchFocusAreas.tsx
@@ -1,0 +1,17 @@
+export default function ResearchFocusAreas({ areas = [] }: { areas?: string[] }) {
+  const visible = areas.filter(Boolean).slice(0, 6)
+  if (visible.length < 2) return null
+
+  return (
+    <div className="surface-subtle rounded-2xl p-5 sm:p-6">
+      <p className="eyebrow-label">Research focus</p>
+      <div className="mt-4 flex flex-wrap gap-2">
+        {visible.map(area => (
+          <span key={area} className="rounded-full border border-brand-900/10 bg-white/80 px-3 py-1.5 text-sm font-medium capitalize text-[#46574d]">
+            {area}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/components/ui/ResearchGapsCard.tsx
+++ b/components/ui/ResearchGapsCard.tsx
@@ -1,0 +1,19 @@
+export default function ResearchGapsCard({ gaps = [], limitations = [] }: { gaps?: string[]; limitations?: string[] }) {
+  const visible = [...limitations, ...gaps].filter(Boolean).slice(0, 6)
+  if (visible.length < 2) return null
+
+  return (
+    <div className="surface-depth rounded-2xl p-5 sm:p-6">
+      <p className="eyebrow-label">Research gaps</p>
+      <h3 className="mt-2 text-xl font-semibold tracking-tight text-ink">What remains uncertain</h3>
+      <ul className="mt-5 space-y-3 text-sm leading-7 text-[#46574d]">
+        {visible.map((item, index) => (
+          <li key={`${item}-${index}`} className="flex gap-3">
+            <span className="mt-[0.55rem] h-1.5 w-1.5 flex-none rounded-full bg-amber-600" />
+            <span>{item}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/components/ui/ResearchStyleBadge.tsx
+++ b/components/ui/ResearchStyleBadge.tsx
@@ -1,0 +1,11 @@
+import type { ResearchStyle } from '@/lib/research-intelligence'
+
+export default function ResearchStyleBadge({ style }: { style?: ResearchStyle | null }) {
+  if (!style) return null
+
+  return (
+    <span className="inline-flex rounded-full border border-brand-900/10 bg-paper-100 px-3 py-1 text-xs font-semibold tracking-wide text-brand-800">
+      {style}
+    </span>
+  )
+}

--- a/components/ui/ScientificConsensusCard.tsx
+++ b/components/ui/ScientificConsensusCard.tsx
@@ -1,0 +1,11 @@
+export default function ScientificConsensusCard({ summary }: { summary?: string | null }) {
+  if (!summary) return null
+
+  return (
+    <div className="card-premium p-5 sm:p-6">
+      <p className="eyebrow-label">Scientific consensus</p>
+      <h3 className="mt-2 text-xl font-semibold tracking-tight text-ink">Conservative editorial read</h3>
+      <p className="mt-4 text-sm leading-7 text-[#46574d]">{summary}</p>
+    </div>
+  )
+}

--- a/lib/research-intelligence.ts
+++ b/lib/research-intelligence.ts
@@ -1,0 +1,288 @@
+import { cleanSummary, formatDisplayLabel, isClean, list, text, unique } from '@/lib/display-utils'
+
+export type ResearchMaturity = 'Better studied' | 'Moderate / emerging' | 'Preliminary' | 'Sparse profile'
+export type ResearchStyle = 'Human-clinical leaning' | 'Mechanism-heavy' | 'Traditional-use dominant' | 'Mixed evidence profile' | 'Emerging profile'
+export type TopicConfidence = 'Moderate' | 'Preliminary' | 'Limited'
+
+export type ProfileRecord = Record<string, any>
+
+export type EvidenceInputs = {
+  profile?: ProfileRecord | null
+  claims?: string[]
+  pmids?: string[]
+  mechanisms?: string[]
+}
+
+export type EvidenceFraming = {
+  maturity: ResearchMaturity
+  summary: string
+  notes: string[]
+}
+
+export type PathwayCluster = {
+  title: string
+  description: string
+  mechanisms: string[]
+}
+
+export type TopicConfidenceSummary = {
+  topic: string
+  confidence: TopicConfidence
+  rationale: string
+}
+
+export type ComparisonCandidate = {
+  slug?: string
+  href?: string
+  name?: string
+  displayName?: string
+  title?: string
+  primary_effects?: unknown
+  primaryActions?: unknown
+  traditionalUses?: unknown
+  mechanisms?: unknown
+  evidence_grade?: unknown
+  evidenceLevel?: unknown
+  type?: string
+}
+
+export type ComparisonFraming = {
+  href: string
+  title: string
+  overlappingFocus: string
+  keyDistinction: string
+  evidenceEmphasis: string
+}
+
+const TOPIC_PATTERNS: Array<{ topic: string; matcher: RegExp }> = [
+  { topic: 'Stress & mood', matcher: /stress|mood|anxiety|calm|relax|cortisol|hpa|adrenal|resilien/i },
+  { topic: 'Sleep quality', matcher: /sleep|insomnia|rest|night|sedat/i },
+  { topic: 'Cognitive function', matcher: /cognit|focus|memory|brain|neuro|attention|clarity/i },
+  { topic: 'Inflammatory signaling', matcher: /inflamm|nf.?kb|cytokine|cox|lox|joint|pain|immune/i },
+  { topic: 'Metabolic health', matcher: /metabolic|glucose|insulin|weight|ampk|lipid|cholesterol|blood sugar/i },
+  { topic: 'Athletic performance', matcher: /athletic|performance|stamina|endurance|exercise|strength|recovery|fatigue|energy/i },
+  { topic: 'Hormonal effects', matcher: /hormon|testosterone|estrogen|androgen|menopause|menstrual|thyroid|fertility/i },
+  { topic: 'Digestive support', matcher: /digest|gut|bile|liver|stomach|bowel|microbiome/i },
+]
+
+const PATHWAY_PATTERNS: Array<{ title: string; description: string; matcher: RegExp }> = [
+  { title: 'Cortisol signaling', description: 'Stress-response and neuroendocrine pathway context.', matcher: /cortisol|hpa|adrenal|stress/i },
+  { title: 'GABAergic signaling', description: 'Nervous-system inhibitory signaling context.', matcher: /gaba/i },
+  { title: 'Monoamine signaling', description: 'Serotonin, dopamine, or related neurotransmitter context.', matcher: /serotonin|5-ht|dopamine|monoamine|noradrenaline|norepinephrine/i },
+  { title: 'Oxidative stress pathways', description: 'Cellular defense and antioxidant-response context.', matcher: /antioxidant|oxidative|nrf2|ros|radical/i },
+  { title: 'Inflammatory signaling', description: 'Inflammatory mediator or immune-signaling context.', matcher: /nf.?kb|inflamm|cytokine|cox|lox|mapk|immune|tnf|interleukin|il-\d/i },
+  { title: 'Metabolic signaling', description: 'Energy-balance, glucose, lipid, or AMPK-related context.', matcher: /ampk|glucose|insulin|metabolic|lipid|cholesterol|mitochond/i },
+  { title: 'Vascular signaling', description: 'Endothelial, nitric-oxide, or circulatory pathway context.', matcher: /nitric|endothelial|vascular|blood pressure|circul/i },
+]
+
+const clean = (value: unknown) => formatDisplayLabel(value)
+const cleanList = (value: unknown) => unique(list(value).map(formatDisplayLabel).filter(isClean))
+const words = (items: string[]) => new Set(items.join(' ').toLowerCase().split(/[^a-z0-9α-ωκβ]+/i).filter(word => word.length > 3))
+
+const getEffects = (profile?: ProfileRecord | null) => unique([
+  ...cleanList(profile?.primary_effects),
+  ...cleanList(profile?.primaryActions),
+  ...cleanList(profile?.traditionalUses),
+])
+const getEvidenceLevel = (profile?: ProfileRecord | null) => clean(profile?.evidence_grade || profile?.evidenceLevel || profile?.evidence_tier || profile?.evidence)
+
+export function normalizeResearchInputs(inputs: EvidenceInputs) {
+  const profile = inputs.profile || {}
+  const claims = unique([...(inputs.claims || []), ...cleanList(profile.claims)].map(formatDisplayLabel).filter(isClean))
+  const mechanisms = unique([...(inputs.mechanisms || []), ...cleanList(profile.mechanisms), clean(profile.mechanism_summary)].filter(isClean))
+  const pmids = unique([...(inputs.pmids || []), ...cleanList(profile.pmid_list), ...cleanList(profile.pmids), ...cleanList(profile.references)].filter(item => /\d/.test(item)))
+  const effects = getEffects(profile)
+  const traditionalUses = cleanList(profile.traditionalUses || profile.traditional_uses)
+  const evidence = getEvidenceLevel(profile)
+
+  return { profile, claims, mechanisms, pmids, effects, traditionalUses, evidence }
+}
+
+export function classifyResearchMaturity(inputs: EvidenceInputs): ResearchMaturity {
+  const { claims, mechanisms, pmids, effects, evidence } = normalizeResearchInputs(inputs)
+  const level = evidence.toLowerCase()
+  const signalCount = claims.length + mechanisms.length + effects.length + pmids.length
+
+  if (!signalCount && !level) return 'Sparse profile'
+  if (/strong|high|clinical|human|a-tier|well studied/.test(level) || pmids.length >= 8 || signalCount >= 14) return 'Better studied'
+  if (/moderate|mixed/.test(level) || pmids.length >= 3 || signalCount >= 7) return 'Moderate / emerging'
+  return 'Preliminary'
+}
+
+export function deriveResearchStyle(inputs: EvidenceInputs): ResearchStyle {
+  const { claims, mechanisms, pmids, traditionalUses, evidence } = normalizeResearchInputs(inputs)
+  const level = evidence.toLowerCase()
+
+  if ((/human|clinical|strong|high/.test(level) || pmids.length >= 6) && mechanisms.length <= claims.length + 2) return 'Human-clinical leaning'
+  if (mechanisms.length >= 3 && mechanisms.length >= claims.length + traditionalUses.length) return 'Mechanism-heavy'
+  if (traditionalUses.length >= 2 && pmids.length < 3 && mechanisms.length < 4) return 'Traditional-use dominant'
+  if (claims.length && mechanisms.length && (pmids.length || traditionalUses.length)) return 'Mixed evidence profile'
+  return 'Emerging profile'
+}
+
+export function deriveEvidenceFraming(inputs: EvidenceInputs): EvidenceFraming {
+  const maturity = classifyResearchMaturity(inputs)
+  const style = deriveResearchStyle(inputs)
+  const { claims, mechanisms, pmids } = normalizeResearchInputs(inputs)
+
+  if (maturity === 'Better studied') {
+    return {
+      maturity,
+      summary: 'This profile has several visible research signals, but confidence should still be read by outcome, preparation, and dosage context.',
+      notes: ['Prioritize repeated human-facing outcomes over broad wellness language.', 'Mechanisms are useful context, not proof that every downstream outcome occurs clinically.'],
+    }
+  }
+
+  if (maturity === 'Moderate / emerging') {
+    return {
+      maturity,
+      summary: style === 'Mechanism-heavy'
+        ? 'The profile is useful for pathway-level interpretation, while clinical confidence likely varies by outcome.'
+        : 'The profile has enough signals for research navigation, with uncertainty that varies by outcome and preparation.',
+      notes: ['Read specific recurring effects more strongly than isolated claims.', 'Compare product forms cautiously because preparations may not be equivalent.'],
+    }
+  }
+
+  if (maturity === 'Sparse profile') {
+    return {
+      maturity,
+      summary: 'Available structured data are sparse, so this profile should be treated as an orientation page rather than a settled evidence review.',
+      notes: ['Avoid making clinical conclusions from limited profile fields.', 'Use safety and preparation notes, when present, as context for further review.'],
+    }
+  }
+
+  return {
+    maturity,
+    summary: mechanisms.length > claims.length || !pmids.length
+      ? 'Most visible evidence remains mechanistic, traditional, or preliminary rather than clinically settled.'
+      : 'Early signals are present, but the profile should not be read as established clinical certainty.',
+    notes: ['Mechanistic plausibility can guide research questions but does not establish real-world benefit.', 'Sparse or broad claims should be interpreted conservatively.'],
+  }
+}
+
+export function inferEvidenceLimitations(inputs: EvidenceInputs): string[] {
+  const { claims, mechanisms, pmids, evidence } = normalizeResearchInputs(inputs)
+  const maturity = classifyResearchMaturity(inputs)
+  const limitations = [
+    pmids.length < 3 ? 'Long-term human evidence is limited or not visible in the structured profile.' : '',
+    mechanisms.length > claims.length ? 'Mechanistic evidence exceeds clearly repeated outcome evidence.' : '',
+    /limited|prelim|emerging|mixed/i.test(evidence) || maturity !== 'Better studied' ? 'Clinical confidence likely varies by outcome, preparation, and dosage.' : '',
+    'Product standardization and preparation details may affect how evidence translates to real-world use.',
+  ]
+
+  return unique(limitations.filter(Boolean)).slice(0, 5)
+}
+
+export function inferResearchGaps(inputs: EvidenceInputs): string[] {
+  const { claims, mechanisms, pmids, effects } = normalizeResearchInputs(inputs)
+  const gaps = [
+    pmids.length < 5 ? 'More well-controlled human studies would clarify effect size and consistency.' : '',
+    mechanisms.length > 0 ? 'Pathway findings need careful translation into outcome-specific human evidence.' : '',
+    claims.length + effects.length > 2 ? 'Recurring outcomes should be compared by population, preparation, and dose.' : '',
+    'Long-term safety, interaction, and standardization questions remain important for interpretation.',
+  ]
+
+  return unique(gaps.filter(Boolean)).slice(0, 4)
+}
+
+export function generateScientificConsensusSummary(inputs: EvidenceInputs): string | null {
+  const { claims, mechanisms, effects, pmids } = normalizeResearchInputs(inputs)
+  const focus = deriveResearchFocusAreas(inputs).slice(0, 2)
+  const maturity = classifyResearchMaturity(inputs)
+  const style = deriveResearchStyle(inputs)
+
+  if (!focus.length && !claims.length && !mechanisms.length && !effects.length) return null
+  if (maturity === 'Better studied') return `Current evidence appears most developed around ${focus.join(' and ') || 'the recurring outcomes in this profile'}, while interpretation still depends on preparation and dosage.`
+  if (style === 'Mechanism-heavy') return `Most visible signals are pathway-focused, especially around ${focus.join(' and ') || 'the listed mechanisms'}, so clinical conclusions should remain conservative.`
+  if (!pmids.length) return `The profile is best read as preliminary, with recurring interest in ${focus.join(' and ') || 'the listed use areas'} but limited visible source depth.`
+  return `Available evidence suggests recurring research interest in ${focus.join(' and ') || 'the listed outcomes'}, with confidence varying by endpoint and preparation.`
+}
+
+export function deriveResearchFocusAreas(inputs: EvidenceInputs): string[] {
+  const { claims, mechanisms, effects, traditionalUses } = normalizeResearchInputs(inputs)
+  const haystacks = [...effects, ...claims, ...traditionalUses, ...mechanisms]
+  const focus = TOPIC_PATTERNS.filter(item => haystacks.some(value => item.matcher.test(value))).map(item => item.topic.toLowerCase())
+  return unique(focus.length ? focus : haystacks.map(item => item.toLowerCase()).filter(isClean)).slice(0, 6)
+}
+
+export function derivePathwayClusters(inputs: EvidenceInputs): PathwayCluster[] {
+  const { mechanisms } = normalizeResearchInputs(inputs)
+  if (!mechanisms.length) return []
+
+  const clusters = PATHWAY_PATTERNS.map(pattern => ({
+    title: pattern.title,
+    description: pattern.description,
+    mechanisms: mechanisms.filter(item => pattern.matcher.test(item)).slice(0, 4),
+  })).filter(cluster => cluster.mechanisms.length > 0)
+
+  const matched = new Set(clusters.flatMap(cluster => cluster.mechanisms))
+  const other = mechanisms.filter(item => !matched.has(item)).slice(0, 4)
+  if (other.length) {
+    clusters.push({ title: 'Other mechanistic signals', description: 'Additional mechanisms listed in the profile data.', mechanisms: other })
+  }
+
+  return clusters.slice(0, 5)
+}
+
+export function deriveConfidenceByTopic(inputs: EvidenceInputs): TopicConfidenceSummary[] {
+  const normalized = normalizeResearchInputs(inputs)
+  const haystacks = [...normalized.effects, ...normalized.claims, ...normalized.mechanisms, ...normalized.traditionalUses]
+  if (!haystacks.length) return []
+
+  return TOPIC_PATTERNS.map(({ topic, matcher }) => {
+    const matches = haystacks.filter(value => matcher.test(value))
+    if (!matches.length) return null
+
+    const mechanismMatches = normalized.mechanisms.filter(value => matcher.test(value)).length
+    const outcomeMatches = normalized.effects.concat(normalized.claims).filter(value => matcher.test(value)).length
+    const hasSources = normalized.pmids.length >= 3
+    const isModerateEvidence = /moderate|strong|high|human|clinical/i.test(normalized.evidence) || hasSources
+    const confidence: TopicConfidence = outcomeMatches >= 2 && isModerateEvidence ? 'Moderate' : mechanismMatches > outcomeMatches || outcomeMatches >= 1 ? 'Preliminary' : 'Limited'
+
+    return {
+      topic,
+      confidence,
+      rationale: confidence === 'Moderate'
+        ? 'Repeated outcome signals are visible, but certainty remains outcome- and preparation-specific.'
+        : confidence === 'Preliminary'
+          ? 'The signal appears in the profile, though support may be mechanistic or not yet consistent.'
+          : 'The topic is visible mainly as a limited or indirect profile signal.',
+    }
+  }).filter(Boolean).slice(0, 5) as TopicConfidenceSummary[]
+}
+
+export function deriveComparisonFraming(current: ProfileRecord, candidates: ComparisonCandidate[] = []): ComparisonFraming[] {
+  const currentSignals = unique([...getEffects(current), ...cleanList(current.mechanisms), ...cleanList(current.traditionalUses)])
+  const currentWords = words(currentSignals)
+  if (!currentWords.size || !candidates.length) return []
+
+  return candidates
+    .filter(candidate => candidate?.slug && candidate.slug !== current.slug)
+    .map(candidate => {
+      const candidateName = clean(candidate.displayName || candidate.name || candidate.title)
+      const candidateSignals = unique([...getEffects(candidate as ProfileRecord), ...cleanList(candidate.mechanisms), ...cleanList(candidate.traditionalUses)])
+      const candidateWords = words(candidateSignals)
+      const overlapTerms = [...candidateWords].filter(term => currentWords.has(term))
+      const overlapSignals = candidateSignals.filter(signal => [...currentWords].some(term => signal.toLowerCase().includes(term))).slice(0, 2)
+      const score = overlapTerms.length + overlapSignals.length
+      const currentMechanisms = cleanList(current.mechanisms)
+      const candidateMechanisms = cleanList(candidate.mechanisms)
+      const distinctive = candidateMechanisms.find(item => !currentMechanisms.includes(item)) || candidateSignals.find(item => !currentSignals.includes(item))
+      const href = candidate.href || `/${candidate.type === 'compound' ? 'compounds' : 'herbs'}/${candidate.slug}`
+
+      return {
+        score,
+        item: candidateName && score > 0 ? {
+          href,
+          title: candidateName,
+          overlappingFocus: overlapSignals.length ? overlapSignals.join(', ') : 'Shared effect or mechanism language appears in the available data.',
+          keyDistinction: distinctive ? `${candidateName} has distinct profile emphasis around ${distinctive.toLowerCase()}.` : 'The main distinction is not clear from the available structured fields.',
+          evidenceEmphasis: getEvidenceLevel(candidate as ProfileRecord) ? `Evidence emphasis: ${getEvidenceLevel(candidate as ProfileRecord)}.` : 'Evidence emphasis should be interpreted from the full profile rather than assumed.',
+        } : null,
+      }
+    })
+    .filter(entry => entry.item)
+    .sort((a, b) => b.score - a.score)
+    .map(entry => entry.item as ComparisonFraming)
+    .slice(0, 4)
+}


### PR DESCRIPTION
### Motivation
- Provide a reusable, conservative semantic research layer to surface research maturity, style, confidence, consensus, pathways, focus areas, gaps, and comparison framing from existing runtime fields. 
- Improve scientific/Editorial signal visibility on herb detail pages without changing workbook schema, inventing evidence, or redesigning the UI. 
- Keep pages static-export friendly and ensure sparse profiles degrade gracefully.

### Description
- Added `lib/research-intelligence.ts` which normalizes sparse profile fields and implements: `normalizeResearchInputs`, `classifyResearchMaturity`, `deriveResearchStyle`, `deriveEvidenceFraming`, `inferEvidenceLimitations`, `inferResearchGaps`, `generateScientificConsensusSummary`, `deriveResearchFocusAreas`, `derivePathwayClusters`, `deriveConfidenceByTopic`, and `deriveComparisonFraming`; all functions use only existing runtime fields and return safe defaults for sparse profiles. 
- Added premium-styled, reusable UI components under `components/ui/`: `ResearchConfidenceMatrix.tsx`, `ScientificConsensusCard.tsx`, `ResearchStyleBadge.tsx`, `RelatedPathways.tsx`, `CompareWithCard.tsx`, `ResearchGapsCard.tsx`, and `ResearchFocusAreas.tsx` that follow existing card and surface classes and the warm premium aesthetic. 
- Integrated the semantic layer and components into `app/herbs/[slug]/page.tsx` with non-invasive wiring: derive intelligence from claims, PMIDs, mechanisms, and profile fields, then conditionally render TOC entries and sections only when content is meaningful to avoid clutter on sparse profiles. 
- Conservatism rules preserved: the code infers signals (not new claims), highlights limitations/gaps, and uses conservative copy templates; static export and existing editorial sections (overview, evidence framing, mechanisms, safety, forms, related compounds, sources, product research) are preserved.

### Testing
- Ran targeted lint on the new files: `npx eslint app/herbs/[slug]/page.tsx lib/research-intelligence.ts components/ui/* --max-warnings=0`, which passed for the modified files. 
- Built the site end-to-end with `npm run build`, which completed successfully and produced static prerendered pages. 
- Data validation and generated-data verification completed during the build (`npm run data:build` / `npm run data:validate` / data verification steps), and verified regenerated artifacts match approved outputs. 
- Captured an automated Playwright screenshot of a rendered herb page (`/herbs/ashwagandha/`) to verify visual integration of the new sections. 
- Note: `npm run lint` flagged unrelated repository-wide lint issues in `agent/*` and some scripts outside the touched surface; these pre-existing issues did not affect the added files or the static build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc80d90e108323a4e3f3bf024f2090)