### PR TITLE
Editorialize scientific discovery experience

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,23 +1,20 @@
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
-import fs from 'fs'
-import path from 'path'
+import posts from '../../../data/blog/posts.json'
+import herbs from '../../../public/data/herbs.json'
+import compounds from '../../../public/data/compounds.json'
+import { ResearchContinuityBlock } from '@/components/scientific-discovery'
+import { findArticleEntities } from '@/lib/editorial-discovery'
 
-const POSTS_PATH = path.join(process.cwd(), 'data/blog/posts.json')
-
-function getPosts() {
-  const raw = fs.readFileSync(POSTS_PATH, 'utf-8')
-  return JSON.parse(raw)
-}
+const allPosts = posts as any[]
 
 export async function generateStaticParams() {
-  const posts = getPosts()
-  return posts.map((p: any) => ({ slug: p.slug }))
+  return allPosts.map((p: any) => ({ slug: p.slug }))
 }
 
 export async function generateMetadata({ params }: any) {
-  const posts = getPosts()
-  const post = posts.find((p: any) => p.slug === params.slug)
+  const resolvedParams = await params
+  const post = allPosts.find((p: any) => p.slug === resolvedParams.slug)
 
   if (!post) return {}
 
@@ -27,29 +24,95 @@ export async function generateMetadata({ params }: any) {
   }
 }
 
-export default function BlogPostPage({ params }: any) {
-  const posts = getPosts()
-  const post = posts.find((p: any) => p.slug === params.slug)
+const formatDate = (value: string | undefined): string => {
+  if (!value) return 'Undated'
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).format(date)
+}
+
+const inferResearchStyle = (post: any) => {
+  const value = `${post.title} ${post.excerpt} ${post.content}`.toLowerCase()
+  if (value.includes('research digest')) return 'Evidence synthesis'
+  if (value.includes('pharmacology')) return 'Mechanism-led'
+  if (value.includes('traditional')) return 'Traditional-use led'
+  if (value.includes('safety')) return 'Safety-first'
+  if (value.includes('extraction')) return 'Methods / preparation'
+  return 'Editorial field note'
+}
+
+const renderBlock = (line: string, index: number) => {
+  if (line.startsWith('## ')) {
+    return <h2 key={index} className="mt-8 max-w-2xl text-2xl font-semibold tracking-tight text-ink">{line.replace(/^##\s+/, '')}</h2>
+  }
+
+  if (line.startsWith('# ')) {
+    return null
+  }
+
+  if (line.startsWith('- ')) {
+    return (
+      <li key={index} className="ml-5 list-disc text-sm leading-7 text-[#46574d]">
+        {line.replace(/^[-]\s+/, '').replace(/_/g, '')}
+      </li>
+    )
+  }
+
+  return <p key={index} className="text-[1.02rem] leading-[1.86] text-[#46574d]">{line.replace(/_/g, '')}</p>
+}
+
+export default async function BlogPostPage({ params }: any) {
+  const resolvedParams = await params
+  const post = allPosts.find((p: any) => p.slug === resolvedParams.slug)
 
   if (!post) return notFound()
 
-  const paragraphs = post.content.split('\n').filter(Boolean)
+  const lines = post.content.split('\n').map((line: string) => line.trim()).filter(Boolean)
+  const relatedHerbs = findArticleEntities(post, herbs as any[], 'herb', 3)
+  const relatedCompounds = findArticleEntities(post, compounds as any[], 'compound', 3)
+  const relatedItems = [...relatedHerbs, ...relatedCompounds]
 
   return (
-    <div className="space-y-6">
-      <Link href="/blog" className="text-sm font-bold text-emerald-700">← Back to Blog</Link>
+    <main className="mx-auto max-w-5xl space-y-8 px-4 pb-20 sm:px-6 lg:px-8">
+      <Link href="/blog" className="text-sm font-bold text-brand-800">← Back to research notes</Link>
 
-      <section className="rounded-2xl border border-slate-200 bg-white p-6">
-        <p className="text-xs font-black uppercase tracking-[0.2em] text-emerald-700">Blog</p>
-        <h1 className="mt-2 text-3xl font-black text-slate-950">{post.title}</h1>
-        <p className="mt-2 text-sm text-slate-500">{post.date} • {post.readingTime}</p>
+      <section className="hero-shell rounded-[2rem] border border-white/50 p-6 shadow-card sm:p-8 lg:p-10">
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="identity-kicker">Article</span>
+          <span className="identity-kicker">{inferResearchStyle(post)}</span>
+          <span className="identity-meta">{formatDate(post.date)} • {post.readingTime}</span>
+        </div>
+        <h1 className="mt-4 heading-premium max-w-4xl">{post.title}</h1>
+        <p className="mt-5 text-reading max-w-3xl text-muted-soft">{post.excerpt}</p>
       </section>
 
-      <section className="rounded-2xl border border-slate-200 bg-white p-6 space-y-4">
-        {paragraphs.map((p: string, i: number) => (
-          <p key={i} className="text-sm leading-7 text-slate-700">{p}</p>
-        ))}
+      <section className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_280px]">
+        <article className="surface-depth card-spacing space-y-4">
+          <div className="pull-quote-science mb-6">
+            This note is part of the scientific graph: use it as context, then follow the related profiles for structured evidence, safety, and mechanism details.
+          </div>
+          {lines.map(renderBlock)}
+        </article>
+
+        <aside className="space-y-4 lg:sticky lg:top-24 lg:self-start">
+          <div className="mobile-reading-card">
+            <p className="eyebrow-label">How to read this</p>
+            <ul className="mt-4 space-y-3 text-sm leading-7 text-[#46574d]">
+              <li>• Treat mechanisms as context, not proof.</li>
+              <li>• Look for safety constraints before practical use.</li>
+              <li>• Continue into profiles for structured comparison.</li>
+            </ul>
+          </div>
+        </aside>
       </section>
-    </div>
+
+      <section className="surface-depth card-spacing">
+        <ResearchContinuityBlock
+          title="Related herbs and compounds"
+          description="These links are selected from overlap between article language, entity names, effects, and mechanism terms."
+          items={relatedItems}
+        />
+      </section>
+    </main>
   )
 }

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,18 +1,11 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import posts from '@/data/blog/posts.json'
+import posts from '../../data/blog/posts.json'
+import { ContentIdentityCard, SemanticBrowseModule } from '@/components/scientific-discovery'
 
-type BlogPost = {
-  slug: string
-  title: string
-  excerpt?: string
-  date?: string
-  readingTime?: string
-}
+const allPosts = posts as any[]
 
-const allPosts = posts as BlogPost[]
-
-const getPostSortValue = (post: BlogPost): number => {
+const getPostSortValue = (post: any): number => {
   if (!post.date) return 0
   const value = new Date(post.date).getTime()
   return Number.isNaN(value) ? 0 : value
@@ -26,119 +19,90 @@ const truncateText = (value: string | undefined, maxLength: number): string => {
 
 const formatDate = (value: string | undefined): string => {
   if (!value) return 'Undated'
-
   const date = new Date(value)
   if (Number.isNaN(date.getTime())) return value
+  return new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).format(date)
+}
 
-  return new Intl.DateTimeFormat('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  }).format(date)
+const inferArticleStyle = (post: any) => {
+  const text = `${post.title} ${post.excerpt} ${post.content}`.toLowerCase()
+  if (text.includes('pharmacology')) return 'Pharmacology primer'
+  if (text.includes('research digest')) return 'Research digest'
+  if (text.includes('traditional')) return 'Traditional context'
+  if (text.includes('safety')) return 'Safety note'
+  if (text.includes('extraction')) return 'Preparation guide'
+  return 'Editorial note'
 }
 
 export const metadata: Metadata = {
-  title: 'Blog | The Hippie Scientist',
-  description: 'Short articles, explainers, and research notes.',
+  title: 'Research Notes | The Hippie Scientist',
+  description: 'Editorial research notes, explainers, and scientific continuity for herbs and compounds.',
 }
 
 export default function BlogPage() {
-  const sortedPosts = [...allPosts].sort(
-    (a, b) => getPostSortValue(b) - getPostSortValue(a),
-  )
-
+  const sortedPosts = [...allPosts].sort((a, b) => getPostSortValue(b) - getPostSortValue(a))
   const featuredPost = sortedPosts[0]
   const remainingPosts = sortedPosts.slice(1)
 
   return (
-    <div className='space-y-8'>
-      <section className='rounded-3xl border border-white/10 bg-white/[0.03] p-6 sm:p-8'>
-        <p className='text-sm font-medium uppercase tracking-[0.2em] text-white/50'>
-          Writing
+    <main className="section-spacing pb-20">
+      <section className="hero-shell rounded-[2rem] border border-white/50 p-6 shadow-card sm:p-8 lg:p-10">
+        <p className="eyebrow-label">Scientific editorial layer</p>
+        <h1 className="mt-3 heading-premium max-w-4xl">Research notes that connect the library.</h1>
+        <p className="mt-5 text-reading max-w-3xl text-muted-soft">
+          Articles are not separate from the database — they are the interpretive layer that explains mechanisms, preparation choices, traditional context, safety limits, and evidence maturity.
         </p>
-
-        <h1 className='mt-2 text-4xl font-bold tracking-tight'>Blog</h1>
-
-        <p className='mt-4 max-w-3xl text-base leading-7 text-white/75'>
-          Short explainers, practical notes, and research-minded articles.
-        </p>
-
-        <p className='mt-3 text-sm text-white/60'>
-          {sortedPosts.length} posts available
-        </p>
+        <p className="mt-4 text-sm font-semibold text-[#46574d]">{sortedPosts.length} research notes available</p>
       </section>
 
       {featuredPost ? (
-        <section>
-          <p className='text-sm font-medium uppercase tracking-[0.2em] text-white/50'>
-            Latest post
-          </p>
-
-          <Link
-            href={`/blog/${featuredPost.slug}`}
-            className='group mt-4 block rounded-3xl border border-white/10 bg-white/[0.03] p-6 transition hover:border-white/30 hover:bg-white/5 sm:p-8'
-          >
-            <div className='flex flex-wrap items-center gap-3 text-xs text-white/50'>
-              <span>{formatDate(featuredPost.date)}</span>
-              {featuredPost.readingTime ? <span>{featuredPost.readingTime}</span> : null}
+        <section className="surface-depth card-spacing">
+          <p className="eyebrow-label">Latest research note</p>
+          <Link href={`/blog/${featuredPost.slug}`} className="identity-article scientific-card mt-5 group">
+            <div className="flex flex-wrap items-center gap-3">
+              <span className="identity-kicker">{inferArticleStyle(featuredPost)}</span>
+              <span className="identity-meta">{formatDate(featuredPost.date)} • {featuredPost.readingTime}</span>
             </div>
-
-            <h2 className='mt-3 text-3xl font-semibold tracking-tight'>
-              {featuredPost.title}
-            </h2>
-
-            <p className='mt-4 max-w-3xl text-sm leading-7 text-white/75 sm:text-base'>
-              {truncateText(featuredPost.excerpt, 260)}
-            </p>
-
-            <span className='mt-5 inline-flex text-sm font-medium text-blue-300 transition group-hover:translate-x-0.5'>
-              Read post →
-            </span>
+            <h2 className="mt-4 max-w-3xl text-3xl font-semibold tracking-tight text-ink group-hover:text-brand-800">{featuredPost.title}</h2>
+            <p className="mt-4 max-w-3xl text-sm leading-7 text-[#46574d] sm:text-base">{truncateText(featuredPost.excerpt, 280)}</p>
+            <span className="mt-5 inline-flex text-sm font-semibold text-brand-800 transition group-hover:translate-x-0.5">Read note →</span>
           </Link>
         </section>
       ) : null}
 
-      <section className='space-y-4'>
+      <SemanticBrowseModule
+        eyebrow="Browse articles by research style"
+        title="Choose the kind of scientific context you need."
+        groups={[
+          { title: 'Research digests', description: 'Evidence summaries with limitations and cautious interpretation.', href: '/blog', meta: 'Evidence' },
+          { title: 'Pharmacology basics', description: 'Mechanism-first explainers for pathways, compounds, and receptor context.', href: '/blog', meta: 'Mechanism' },
+          { title: 'Traditional use', description: 'Historical context kept separate from modern efficacy claims.', href: '/blog', meta: 'Tradition' },
+          { title: 'Extraction & preparation', description: 'Form, solvent, dose visibility, and practical preparation notes.', href: '/blog', meta: 'Methods' },
+          { title: 'Safety / set / setting', description: 'Conservative reading for uncertainty, cautions, and context of use.', href: '/blog', meta: 'Safety' },
+          { title: 'Field notes', description: 'Editorial observations that help turn profiles into memorable learning.', href: '/blog', meta: 'Notes' },
+        ]}
+      />
+
+      <section className="space-y-5">
         <div>
-          <p className='text-sm font-medium uppercase tracking-[0.2em] text-white/50'>
-            Archive
-          </p>
-          <h2 className='mt-2 text-3xl font-semibold'>All posts</h2>
+          <p className="eyebrow-label">Archive</p>
+          <h2 className="mt-2 max-w-3xl">All research notes</h2>
         </div>
-
-        <div className='grid gap-4'>
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           {remainingPosts.map(post => (
-            <Link
+            <ContentIdentityCard
               key={post.slug}
-              href={`/blog/${post.slug}`}
-              className='group ds-card block transition hover:border-white/30 hover:bg-white/5'
-            >
-              <div className='flex flex-wrap items-center gap-3 text-xs text-white/50'>
-                <span>{formatDate(post.date)}</span>
-                {post.readingTime ? <span>{post.readingTime}</span> : null}
-              </div>
-
-              <h3 className='mt-3 text-2xl font-semibold'>{post.title}</h3>
-
-              <p className='mt-3 text-sm leading-6 text-white/70'>
-                {truncateText(post.excerpt, 220)}
-              </p>
-
-              <span className='mt-4 inline-flex text-sm font-medium text-blue-300 transition group-hover:translate-x-0.5'>
-                Read post →
-              </span>
-            </Link>
+              item={{
+                href: `/blog/${post.slug}`,
+                title: post.title,
+                description: truncateText(post.excerpt, 190),
+                meta: `${inferArticleStyle(post)} • ${formatDate(post.date)}`,
+                kind: 'article',
+              }}
+            />
           ))}
-
-          {sortedPosts.length === 0 ? (
-            <div className='ds-card'>
-              <p className='text-sm leading-6 text-white/70'>
-                No blog posts have been added yet.
-              </p>
-            </div>
-          ) : null}
         </div>
       </section>
-    </div>
+    </main>
   )
 }

--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -32,6 +32,8 @@ import {
   classifyArchetype,
 } from '@/lib/semantic-runtime'
 import Link from 'next/link'
+import { EvidenceMaturityRibbon, SemanticBrowseModule } from '@/components/scientific-discovery'
+import { buildSemanticTopics } from '@/lib/editorial-discovery'
 
 export async function generateStaticParams() {
   return (data as any[]).map((c)=>({ slug:c.slug }))
@@ -80,6 +82,7 @@ export default function Page({ params }: any) {
   const stackCandidates = getStackCandidates(compound)
   const comparisonCandidates = getComparisonCandidates(compound)
   const snapshot = getEvidenceSnapshot(compound)
+  const semanticTopics = buildSemanticTopics(compound)
 
   const evidenceLevel = normalizeEvidenceLevel(compound.evidence_tier)
   const safetyLevel = normalizeSafetyLevel(compound.safety)
@@ -136,11 +139,19 @@ export default function Page({ params }: any) {
 
           <TrustBar />
 
-          <CompoundHero
-            compound={compound}
-            evidenceLevel={evidenceLevel}
-            safetyLevel={safetyLevel}
-          />
+          <div className="space-y-4">
+            <CompoundHero
+              compound={compound}
+              evidenceLevel={evidenceLevel}
+              safetyLevel={safetyLevel}
+            />
+            <div className="flex flex-wrap gap-3">
+              <EvidenceMaturityRibbon label={semanticTopics.maturity} />
+              {[semanticTopics.researchStyle, ...semanticTopics.effects.slice(0, 2), ...semanticTopics.mechanisms.slice(0, 2)].map(item => (
+                <span key={item} className="chip-readable">{item}</span>
+              ))}
+            </div>
+          </div>
 
           <EvidenceSnapshotCard snapshot={snapshot} />
 
@@ -184,9 +195,23 @@ export default function Page({ params }: any) {
 
           {mechanisms.length > 0 && (
             <SectionBlock title="Mechanisms">
+              <div className="mb-5 pull-quote-science">
+                Current evidence suggests these pathways are best treated as a research map, not a promise of effect.
+              </div>
               <MechanismGrid mechanisms={mechanisms} />
             </SectionBlock>
           )}
+
+          <SemanticBrowseModule
+            eyebrow="Semantic recommendations"
+            title="Continue researching by relationship"
+            description="Move laterally through effect clusters, pathway families, evidence maturity, and comparison candidates."
+            groups={[
+              { title: semanticTopics.effects[0] || 'Effect cluster', description: 'Explore profiles with similar outcome language and practical intent.', href: '/goals', meta: 'Effect' },
+              { title: semanticTopics.mechanisms[0] || 'Pathway family', description: 'Follow mechanism families without treating mechanistic data as clinical proof.', href: '/explore', meta: 'Mechanism' },
+              { title: semanticTopics.maturity, description: 'Compare this profile against stronger, mixed, and early-stage evidence pages.', href: '/a-tier', meta: 'Evidence' },
+            ]}
+          />
 
           <div id="effects">
             {effects.length > 0 ? (

--- a/app/globals.css
+++ b/app/globals.css
@@ -317,3 +317,65 @@ body {
     @apply text-[0.72rem] font-bold uppercase leading-none tracking-[0.16em];
   }
 }
+
+@layer components {
+  .scientific-card {
+    @apply block rounded-[1.55rem] border border-brand-900/10 bg-white/75 p-5 shadow-sm backdrop-blur-xl transition-all duration-300 hover:-translate-y-0.5 hover:border-brand-900/15 hover:bg-white hover:shadow-card;
+  }
+
+  .identity-herb {
+    @apply border-emerald-800/15;
+    background: linear-gradient(180deg, rgba(255,255,255,.86), rgba(236,253,245,.42));
+  }
+
+  .identity-compound {
+    @apply border-blue-800/15;
+    background: linear-gradient(180deg, rgba(255,255,255,.86), rgba(239,246,255,.48));
+  }
+
+  .identity-article {
+    @apply border-amber-800/15;
+    background: linear-gradient(180deg, rgba(255,255,255,.88), rgba(254,243,199,.42));
+  }
+
+  .identity-path {
+    @apply border-purple-800/15;
+    background: linear-gradient(180deg, rgba(255,255,255,.86), rgba(250,245,255,.46));
+  }
+
+  .identity-kicker {
+    @apply rounded-full border border-brand-900/10 bg-white/75 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.18em] text-brand-800;
+  }
+
+  .identity-meta {
+    @apply text-[11px] font-semibold uppercase tracking-[0.14em] text-[#64766b];
+  }
+
+  .pull-quote-science {
+    @apply rounded-[1.65rem] border-l-4 border-brand-700 bg-white/75 p-5 font-display text-2xl font-semibold leading-snug tracking-tight text-ink shadow-sm sm:p-6;
+  }
+
+  .mobile-reading-card {
+    @apply rounded-[1.5rem] border border-brand-900/10 bg-white/80 p-5 shadow-sm sm:p-6;
+  }
+
+  @media (max-width: 640px) {
+    .detail-stack {
+      @apply space-y-8;
+    }
+
+    .card-spacing {
+      @apply p-5;
+    }
+
+    .scientific-card {
+      @apply p-4;
+    }
+
+    .detail-reading,
+    .text-reading,
+    .content-prose p {
+      line-height: 1.76;
+    }
+  }
+}

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { ExternalLink, Leaf } from 'lucide-react'
+import blogPosts from '../../../data/blog/posts.json'
 import { DetailCard, EvidenceBadge } from '@/components/ui'
 import CompareWithCard from '@/components/ui/CompareWithCard'
 import RelatedPathways from '@/components/ui/RelatedPathways'
@@ -10,6 +11,7 @@ import ResearchFocusAreas from '@/components/ui/ResearchFocusAreas'
 import ResearchGapsCard from '@/components/ui/ResearchGapsCard'
 import ResearchStyleBadge from '@/components/ui/ResearchStyleBadge'
 import ScientificConsensusCard from '@/components/ui/ScientificConsensusCard'
+import { EvidenceMaturityRibbon, ResearchContinuityBlock } from '@/components/scientific-discovery'
 import { getClaims, getCompounds, getHerbBySlug, getHerbCompoundMap, getHerbs } from '@/lib/runtime-data'
 import { getHerbSearchLinks } from '@/lib/affiliate'
 import { commonSupplementFaqJsonLd } from '@/lib/seo'
@@ -25,6 +27,7 @@ import {
   inferEvidenceLimitations,
   inferResearchGaps,
 } from '@/lib/research-intelligence'
+import { buildSemanticTopics, findRelatedArticles } from '@/lib/editorial-discovery'
 
 type Params = { params: Promise<{ slug: string }> }
 type HerbDetail = Record<string, any>
@@ -226,6 +229,8 @@ export default async function HerbDetailPage({ params }: Params) {
   ].filter(id => /\d/.test(id))).slice(0, 10)
 
   const researchInputs = { profile: herb, claims, pmids, mechanisms }
+  const semanticTopics = buildSemanticTopics(herb)
+  const relatedArticles = findRelatedArticles(herb, blogPosts as any[], 4)
   const evidenceFrame = deriveEvidenceFraming(researchInputs)
   const researchStyle = deriveResearchStyle(researchInputs)
   const consensusSummary = generateScientificConsensusSummary(researchInputs)
@@ -258,6 +263,7 @@ export default async function HerbDetailPage({ params }: Params) {
     comparisons.length > 1 ? ['compare-with', 'Compare with'] : null,
     safetyItems.length ? ['safety', 'Safety'] : null,
     hasForms ? ['forms', 'Forms & dosage'] : null,
+    relatedArticles.length ? ['related-articles', 'Related articles'] : null,
     relatedCompounds.length ? ['related-compounds', 'Related compounds'] : null,
     pmids.length ? ['sources', 'Sources'] : null,
     affiliateLinks.length ? ['products', 'Product research'] : null,
@@ -289,22 +295,50 @@ export default async function HerbDetailPage({ params }: Params) {
             <h1 className="heading-premium max-w-4xl text-ink">{label}</h1>
             <EvidenceBadge value={evidence} />
             <ResearchStyleBadge style={researchStyle} />
+            <EvidenceMaturityRibbon label={semanticTopics.maturity} />
           </div>
 
           <p className="text-reading mt-5 max-w-reading text-lg text-muted-soft">
             {leadText}
           </p>
+
+          <div className="mt-7 grid gap-3 sm:grid-cols-3">
+            {[
+              ['Most researched for', semanticTopics.effects[0] || 'General wellness context'],
+              ['Pathway cluster', semanticTopics.mechanisms[0] || 'Whole-system context'],
+              ['Research style', semanticTopics.researchStyle],
+            ].map(([title, value]) => (
+              <div key={title} className="rounded-2xl border border-brand-900/10 bg-white/70 p-4">
+                <p className="identity-meta">{title}</p>
+                <p className="mt-2 text-sm font-semibold leading-6 text-ink">{value}</p>
+              </div>
+            ))}
+          </div>
         </section>
 
         {profileOverview ? (
           <DetailCard id="overview" eyebrow="Profile Overview" title="Scientific snapshot" description="A concise interpretation of the available profile fields without adding unsupported claims.">
-            <p className="detail-reading text-[#46574d]">
-              {profileOverview}
-            </p>
+            <div className="grid gap-5 lg:grid-cols-[1fr_.72fr]">
+              <p className="detail-reading text-[#46574d]">
+                {profileOverview}
+              </p>
+              <aside className="pull-quote-science">
+                Current evidence suggests this profile is best read as a set of signals — not a guaranteed outcome or treatment claim.
+              </aside>
+            </div>
           </DetailCard>
         ) : null}
 
         <DetailCard id="evidence-framing" eyebrow="Evidence Intelligence" title="Evidence framing" description="A conservative reading of the visible profile signals.">
+          <div className="mb-5 grid gap-4 sm:grid-cols-3">
+            {[
+              `Evidence maturity: ${semanticTopics.maturity}`,
+              `Primary cluster: ${semanticTopics.effects[0] || 'Context dependent'}`,
+              `Main pathway: ${semanticTopics.mechanisms[0] || 'Not yet specific'}`,
+            ].map(item => (
+              <div key={item} className="mobile-reading-card text-sm font-semibold leading-7 text-ink">{item}</div>
+            ))}
+          </div>
           <div className="grid gap-5 lg:grid-cols-[0.85fr_1.15fr]">
             <div className="surface-depth rounded-2xl p-5">
               <p className="eyebrow-label">Research maturity</p>
@@ -423,6 +457,16 @@ export default async function HerbDetailPage({ params }: Params) {
               {dosage ? <div className="surface-subtle rounded-2xl p-5"><p className="eyebrow-label">Dosage note</p><p className="mt-3 text-sm leading-7 text-[#46574d]">{dosage}</p></div> : null}
               {timeToEffect ? <div className="surface-subtle rounded-2xl p-5"><p className="eyebrow-label">Time to effect</p><p className="mt-3 text-sm leading-7 text-[#46574d]">{timeToEffect}</p></div> : null}
             </div>
+          </DetailCard>
+        ) : null}
+
+        {relatedArticles.length > 0 ? (
+          <DetailCard id="related-articles" eyebrow="Editorial Graph" title="Related articles" description="Research notes and explainers connected by title, profile language, mechanisms, and effect clusters.">
+            <ResearchContinuityBlock
+              title="Continue researching this topic"
+              description="Move from the profile into publication-style context, then return to related herbs and compounds."
+              items={relatedArticles}
+            />
           </DetailCard>
         ) : null}
 

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -1,146 +1,129 @@
 'use client'
 
 import Link from 'next/link'
+import { ContentIdentityCard, SemanticBrowseModule } from '@/components/scientific-discovery'
+
+const learningPaths = [
+  { href: '/natural-anxiolytics-beyond-ashwagandha', title: 'Calm without flattening', description: 'Compare anxiolytic herbs by sedation, stress physiology, and evidence maturity.', meta: 'Learning path', kind: 'path' as const },
+  { href: '/sleep-herbs-vs-melatonin', title: 'Sleep herbs vs melatonin', description: 'Understand when sleep support is circadian, calming, restorative, or habit-driven.', meta: 'Comparison', kind: 'path' as const },
+  { href: '/psychedelic-adjacent-herbs', title: 'Psychedelic-adjacent herbs', description: 'A harm-reduction lens for dream, ritual, and perception-adjacent botanicals.', meta: 'Safety led', kind: 'path' as const },
+]
+
+const evidenceTopics = [
+  { href: '/blog/2026-03-18-research-digest-passionflower', title: 'How to read a research digest', description: 'A short editorial example of translating mechanisms and limitations without overclaiming.', meta: 'Article', kind: 'article' as const },
+  { href: '/herbs/ashwagandha', title: 'Ashwagandha profile', description: 'A depth-layer example combining traditional use, stress pathways, and conservative evidence framing.', meta: 'Herb profile', kind: 'herb' as const },
+  { href: '/compounds/theanine', title: 'Theanine profile', description: 'Compound-centered scanning for effects, safety, mechanisms, and related recommendations.', meta: 'Compound profile', kind: 'compound' as const },
+]
 
 export default function HomepageV2() {
   return (
     <main className="min-h-screen text-ink section-spacing">
 
-      <section className="hero-shell overflow-hidden rounded-[2.25rem] border border-white/45 px-6 py-18 shadow-soft sm:px-10 lg:px-16 lg:py-28">
-        <div className="max-w-5xl section-spacing">
-          <div className="eyebrow-label inline-flex rounded-full border border-brand-700/10 bg-white/55 px-4 py-2 backdrop-blur-md">
-            Evidence-first supplement intelligence
+      <section className="hero-shell overflow-hidden rounded-[2.25rem] border border-white/45 px-6 py-16 shadow-soft sm:px-10 lg:px-16 lg:py-28">
+        <div className="grid gap-10 lg:grid-cols-[1.15fr_.85fr] lg:items-end">
+          <div className="max-w-5xl section-spacing">
+            <div className="eyebrow-label inline-flex rounded-full border border-brand-700/10 bg-white/55 px-4 py-2 backdrop-blur-md">
+              Scientific editorial library for natural compounds
+            </div>
+
+            <div className="space-y-7">
+              <h1 className="heading-premium max-w-5xl text-balance">
+                A field guide to herbs, compounds, mechanisms, and evidence — written for careful explorers.
+              </h1>
+
+              <p className="text-reading max-w-2xl text-lg leading-relaxed text-muted-soft sm:text-xl">
+                The Hippie Scientist exists to make natural-compound research easier to navigate: human evidence first, mechanisms in context, traditional use labeled clearly, and uncertainty treated as part of the story.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-4 pt-2 sm:flex-row">
+              <Link href="/explore" className="button-primary">
+                Start Exploring
+              </Link>
+
+              <Link href="/blog" className="button-secondary">
+                Read the Research Notes
+              </Link>
+            </div>
           </div>
 
-          <div className="space-y-7">
-            <h1 className="heading-premium max-w-5xl text-balance">
-              Calm, evidence-aware guidance for herbs, compounds, and better decisions.
-            </h1>
-
-            <p className="text-reading max-w-2xl text-lg leading-relaxed text-muted-soft sm:text-xl">
-              Explore natural compounds through transparent evidence tiers, safety context, mechanisms, and practical decision support — without hype, noise, or affiliate-first recommendations.
-            </p>
-          </div>
-
-          <div className="flex flex-col gap-4 pt-2 sm:flex-row">
-            <Link href="/explore" className="button-primary">
-              Explore Goals
-            </Link>
-
-            <Link href="/compounds" className="button-secondary">
-              Browse Compounds
-            </Link>
+          <div className="surface-depth card-spacing">
+            <p className="eyebrow-label">Research philosophy</p>
+            <div className="mt-5 space-y-4">
+              {[
+                ['Evidence before enthusiasm', 'Clinical signals, safety constraints, and uncertainty are surfaced before product intent.'],
+                ['Mechanisms are maps', 'Pathways help exploration, but they are not treated as proof of outcomes.'],
+                ['Traditional use has a label', 'Ethnobotanical context is preserved without pretending it is the same as modern trials.'],
+              ].map(([title, body]) => (
+                <div key={title} className="border-t border-brand-900/10 pt-4 first:border-t-0 first:pt-0">
+                  <h2 className="max-w-none font-sans text-base font-semibold tracking-tight text-ink">{title}</h2>
+                  <p className="mt-1 text-sm leading-7 text-[#46574d]">{body}</p>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
       </section>
 
       <section className="grid gap-5 md:grid-cols-2 xl:grid-cols-4">
         {[
-          {
-            title: 'Sleep Support',
-            slug: 'sleep',
-            description: 'Evidence-aware compounds for recovery, relaxation, and sleep quality.',
-          },
-          {
-            title: 'Stress & Mood',
-            slug: 'anxiety',
-            description: 'Calming and adaptogenic compounds with conservative evidence framing.',
-          },
-          {
-            title: 'Focus & Cognition',
-            slug: 'focus',
-            description: 'Nootropic and cognitive-supportive compounds with mechanism context.',
-          },
-          {
-            title: 'Recovery & Performance',
-            slug: 'recovery',
-            description: 'Performance and recovery support with practical stack exploration.',
-          },
-        ].map((item) => (
-          <Link
-            key={item.slug}
-            href={`/explore/${item.slug}`}
-            className="card-premium card-spacing group"
-          >
-            <div className="space-y-5">
-              <div className="eyebrow-label">
-                Explore
-              </div>
-
-              <div className="space-y-3">
-                <h2 className="font-sans text-2xl font-semibold tracking-tight text-ink transition-colors duration-300 group-hover:text-brand-800">
-                  {item.title}
-                </h2>
-
-                <p className="text-sm leading-7 text-muted-soft">
-                  {item.description}
-                </p>
-              </div>
-            </div>
-          </Link>
-        ))}
+          { title: 'Herbs', href: '/herbs', description: 'Botanical profiles with traditional context, use-case signals, safety notes, and related compounds.', meta: 'Botanical depth', kind: 'herb' as const },
+          { title: 'Compounds', href: '/compounds', description: 'Isolated constituents and supplement compounds organized by evidence, effects, and mechanisms.', meta: 'Molecular depth', kind: 'compound' as const },
+          { title: 'Articles', href: '/blog', description: 'Research digests, pharmacology primers, field notes, and preparation explainers tied back to profiles.', meta: 'Editorial layer', kind: 'article' as const },
+          { title: 'Learning paths', href: '/learn', description: 'Guided reading sequences that turn broad questions into evidence-aware exploration.', meta: 'Discovery layer', kind: 'path' as const },
+        ].map((item) => <ContentIdentityCard key={item.href} item={item} />)}
       </section>
 
-      <section className="grid gap-6 lg:grid-cols-[1.3fr_.7fr]">
+      <section className="grid gap-6 lg:grid-cols-[1.15fr_.85fr]">
         <div className="surface-depth card-spacing">
-          <div className="section-spacing">
-            <div className="eyebrow-label inline-flex rounded-full border border-emerald-700/10 bg-emerald-700/10 px-3 py-1 text-emerald-800">
-              Human evidence prioritized
-            </div>
-
-            <div className="space-y-5">
-              <h2 className="max-w-3xl text-balance">
-                Decision support without wellness-blog hype.
-              </h2>
-
-              <p className="text-reading max-w-2xl text-muted-soft">
-                The Hippie Scientist blends natural wellness exploration with transparent evidence standards, safety context, and practical usability.
-              </p>
-            </div>
-
-            <div className="grid gap-4 sm:grid-cols-3">
-              {[
-                ['Evidence Tiers', 'A–D evidence system with transparent certainty framing'],
-                ['Safety Visibility', 'Warnings and avoid-if context surfaced prominently'],
-                ['Semantic Discovery', 'Explore related compounds, stacks, and goals naturally'],
-              ].map(([title, body]) => (
-                <div
-                  key={title}
-                  className="surface-subtle p-5"
-                >
-                  <div className="text-sm font-semibold tracking-tight text-ink">
-                    {title}
-                  </div>
-
-                  <div className="mt-3 text-sm leading-7 text-muted-soft">
-                    {body}
-                  </div>
-                </div>
-              ))}
-            </div>
+          <p className="eyebrow-label">Featured learning paths</p>
+          <h2 className="mt-3 max-w-3xl text-balance">Start with a question, then move into the research graph.</h2>
+          <div className="mt-7 grid gap-4">
+            {learningPaths.map(item => <ContentIdentityCard key={item.href} item={item} />)}
           </div>
         </div>
 
         <div className="safety-block">
           <div className="section-spacing">
             <div className="eyebrow-label text-amber-700">
-              Safety-first philosophy
+              Scientific trust layer
             </div>
 
             <div className="space-y-4">
               <h3 className="max-w-sm text-balance">
-                Evidence honesty builds long-term trust.
+                Credibility comes from showing the edges of the evidence.
               </h3>
 
               <p className="text-sm leading-7 text-amber-950/85">
-                Human evidence is prioritized. Mechanistic and traditional evidence are clearly labeled. Safety uncertainty is surfaced instead of hidden.
+                Profiles separate human evidence, mechanistic hypotheses, traditional use, practical context, and safety uncertainty so readers can keep claims proportional.
               </p>
             </div>
 
-            <Link href="/evidence-standards" className="button-secondary w-full justify-center">
-              View Evidence Standards
+            <Link href="/disclaimer" className="button-secondary w-full justify-center">
+              Read Educational Scope
             </Link>
           </div>
+        </div>
+      </section>
+
+      <SemanticBrowseModule
+        title="Browse the library semantically"
+        description="Discovery is organized around why a compound is being explored, what pathway is proposed, and how mature the evidence appears."
+        groups={[
+          { title: 'Neuroendocrine / nervous system', description: 'GABA, stress-response, mood, sleep, and cognition-adjacent pathways.', href: '/explore/stress', meta: 'Mechanism' },
+          { title: 'Evidence maturity', description: 'Compare strong, mixed, early, and traditional-use-led profiles without flattening the nuance.', href: '/a-tier', meta: 'Evidence' },
+          { title: 'Effect clusters', description: 'Move from sleep, stress, focus, recovery, or metabolic goals into the depth layer.', href: '/goals', meta: 'Effects' },
+          { title: 'Research style', description: 'Distinguish clinical, mechanism-led, traditional-use-led, and editorial synthesis pages.', href: '/blog', meta: 'Method' },
+          { title: 'Traditional systems', description: 'Keep historical context visible while preserving modern uncertainty boundaries.', href: '/learning', meta: 'Tradition' },
+          { title: 'Currently explored topics', description: 'An evolving editorial map of calming herbs, dream botanicals, adaptogens, and recovery support.', href: '/explore', meta: 'Now' },
+        ]}
+      />
+
+      <section className="surface-depth card-spacing">
+        <p className="eyebrow-label">Featured evidence topics</p>
+        <h2 className="mt-3 max-w-3xl text-balance">Publication-style entry points into the research library.</h2>
+        <div className="mt-7 grid gap-4 md:grid-cols-3">
+          {evidenceTopics.map(item => <ContentIdentityCard key={item.href} item={item} />)}
         </div>
       </section>
 

--- a/components/scientific-discovery.tsx
+++ b/components/scientific-discovery.tsx
@@ -1,0 +1,84 @@
+import Link from 'next/link'
+import type { DiscoveryLink } from '@/lib/editorial-discovery'
+
+type SemanticBrowseModuleProps = {
+  eyebrow?: string
+  title: string
+  description?: string
+  groups: Array<{ title: string; description: string; href: string; meta?: string }>
+}
+
+const kindStyles: Record<string, string> = {
+  herb: 'identity-herb',
+  compound: 'identity-compound',
+  article: 'identity-article',
+  path: 'identity-path',
+}
+
+export function ContentIdentityCard({ item }: { item: DiscoveryLink }) {
+  const style = kindStyles[item.kind || 'path'] || kindStyles.path
+
+  return (
+    <Link href={item.href} className={`scientific-card ${style} group`}>
+      <div className="flex items-center justify-between gap-3">
+        <span className="identity-kicker">{item.kind || 'path'}</span>
+        {item.meta ? <span className="identity-meta">{item.meta}</span> : null}
+      </div>
+      <h3 className="mt-4 text-xl font-semibold tracking-tight text-ink group-hover:text-brand-800">{item.title}</h3>
+      <p className="mt-3 text-sm leading-7 text-[#46574d]">{item.description}</p>
+    </Link>
+  )
+}
+
+export function SemanticBrowseModule({ eyebrow = 'Semantic discovery', title, description, groups }: SemanticBrowseModuleProps) {
+  return (
+    <section className="surface-depth card-spacing">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="eyebrow-label">{eyebrow}</p>
+          <h2 className="mt-3 max-w-2xl text-balance">{title}</h2>
+        </div>
+        {description ? <p className="max-w-xl text-sm leading-7 text-[#46574d]">{description}</p> : null}
+      </div>
+
+      <div className="mt-7 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {groups.map(group => (
+          <Link key={`${group.href}-${group.title}`} href={group.href} className="scientific-card group">
+            <div className="flex items-center justify-between gap-3">
+              <span className="identity-kicker">{group.meta || 'Explore'}</span>
+              <span className="text-brand-800 transition group-hover:translate-x-0.5">→</span>
+            </div>
+            <h3 className="mt-4 text-lg font-semibold tracking-tight text-ink">{group.title}</h3>
+            <p className="mt-3 text-sm leading-7 text-[#46574d]">{group.description}</p>
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export function ResearchContinuityBlock({ title = 'Continue researching', description, items }: { title?: string; description?: string; items: DiscoveryLink[] }) {
+  if (!items.length) return null
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <p className="eyebrow-label">Research continuity</p>
+        <h3 className="mt-2 max-w-2xl text-2xl font-semibold tracking-tight text-ink">{title}</h3>
+        {description ? <p className="mt-2 text-sm leading-7 text-[#46574d]">{description}</p> : null}
+      </div>
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {items.map(item => <ContentIdentityCard key={item.href} item={item} />)}
+      </div>
+    </div>
+  )
+}
+
+export function EvidenceMaturityRibbon({ label }: { label: string }) {
+  return (
+    <div className="inline-flex items-center gap-2 rounded-full border border-emerald-800/10 bg-emerald-700/10 px-3.5 py-1.5 text-xs font-bold uppercase tracking-[0.16em] text-emerald-900">
+      <span className="h-2 w-2 rounded-full bg-emerald-600" />
+      {label}
+    </div>
+  )
+}

--- a/lib/editorial-discovery.ts
+++ b/lib/editorial-discovery.ts
@@ -1,0 +1,147 @@
+import { formatDisplayLabel, isClean, list, text, unique } from './display-utils'
+
+export type EditorialEntity = Record<string, any>
+
+export type DiscoveryLink = {
+  href: string
+  title: string
+  description: string
+  meta?: string
+  kind?: 'herb' | 'compound' | 'article' | 'path'
+}
+
+export type BlogPostRecord = {
+  slug: string
+  title: string
+  excerpt?: string
+  content?: string
+  date?: string
+  readingTime?: string
+}
+
+const normalize = (value = '') => value.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim()
+const words = (value = '') => new Set(normalize(value).split(' ').filter(word => word.length > 2))
+
+export const getEntityLabel = (entity: EditorialEntity) => (
+  formatDisplayLabel(entity.displayName) ||
+  formatDisplayLabel(entity.name) ||
+  formatDisplayLabel(entity.title) ||
+  formatDisplayLabel(entity.slug)
+)
+
+export const getEntitySearchText = (entity: EditorialEntity) => unique([
+  getEntityLabel(entity),
+  text(entity.summary),
+  text(entity.description),
+  text(entity.mechanism_summary),
+  ...list(entity.primary_effects),
+  ...list(entity.primaryActions),
+  ...list(entity.effects),
+  ...list(entity.mechanisms),
+  ...list(entity.tags),
+].filter(Boolean)).join(' ')
+
+export const getMechanismFamily = (value = '') => {
+  const normalized = normalize(value)
+  if (/gaba|glutamate|serotonin|dopamine|cortisol|hpa|stress|brain|sleep|calm|mood/.test(normalized)) return 'Neuroendocrine / nervous system'
+  if (/inflamm|cytokine|immune|nf kb|nfkb/.test(normalized)) return 'Inflammation / immune signaling'
+  if (/glucose|insulin|ampk|metabolic|mitochond|energy/.test(normalized)) return 'Metabolic energy pathways'
+  if (/nitric|vascular|blood pressure|endothelial|circulation/.test(normalized)) return 'Vascular tone & circulation'
+  if (/antioxidant|oxidative|nrf2|cellular/.test(normalized)) return 'Cellular defense & resilience'
+  return 'Whole-system context'
+}
+
+export const getEffectCluster = (value = '') => {
+  const normalized = normalize(value)
+  if (/sleep|dream|night|rest/.test(normalized)) return 'Sleep & recovery'
+  if (/stress|anxiety|mood|calm|cortisol/.test(normalized)) return 'Stress & mood'
+  if (/focus|cognition|memory|brain|fatigue|energy/.test(normalized)) return 'Cognition & energy'
+  if (/immune|inflamm|joint|pain|recovery/.test(normalized)) return 'Recovery & resilience'
+  if (/digest|gut|liver|metabolic|glucose|weight/.test(normalized)) return 'Metabolic & digestive'
+  return 'General wellness context'
+}
+
+export const getEvidenceMaturityLabel = (value = '') => {
+  const normalized = normalize(value)
+  if (/a tier|strong|high|robust|human data|clinical/.test(normalized)) return 'Human evidence visible'
+  if (/moderate|promising|b tier|mixed/.test(normalized)) return 'Promising but uneven'
+  if (/limited|early|c tier|d tier|traditional|preclinical/.test(normalized)) return 'Early / traditional signal'
+  return 'Evidence needs interpretation'
+}
+
+export const getResearchStyleLabel = (entity: EditorialEntity) => {
+  const sourceText = normalize([
+    text(entity.evidence_grade),
+    text(entity.evidenceLevel),
+    text(entity.evidence_tier),
+    getEntitySearchText(entity),
+  ].join(' '))
+
+  if (/traditional|ayurveda|tcm|folk|ethnobot/.test(sourceText)) return 'Traditional-use led'
+  if (/pmid|clinical|trial|human|randomized|meta/.test(sourceText)) return 'Human-study led'
+  if (/mechanism|pathway|receptor|gaba|nrf2|ampk|cytokine/.test(sourceText)) return 'Mechanism-led'
+  return 'Editorial synthesis'
+}
+
+export const buildSemanticTopics = (entity: EditorialEntity) => {
+  const effects = unique([...list(entity.primary_effects), ...list(entity.primaryActions), ...list(entity.effects)].map(formatDisplayLabel).filter(isClean))
+  const mechanisms = unique([...list(entity.mechanisms), formatDisplayLabel(entity.mechanism_summary)].filter(isClean))
+
+  return {
+    mechanisms: unique(mechanisms.map(getMechanismFamily)).slice(0, 4),
+    effects: unique(effects.map(getEffectCluster)).slice(0, 4),
+    maturity: getEvidenceMaturityLabel(text(entity.evidence_grade) || text(entity.evidenceLevel) || text(entity.evidence_tier)),
+    researchStyle: getResearchStyleLabel(entity),
+  }
+}
+
+export const findRelatedArticles = (entity: EditorialEntity, posts: BlogPostRecord[], limit = 4): DiscoveryLink[] => {
+  const label = getEntityLabel(entity)
+  const entityWords = words([label, getEntitySearchText(entity)].join(' '))
+
+  return posts
+    .map(post => {
+      const haystack = [post.title, post.excerpt, post.content].filter(Boolean).join(' ')
+      const postWords = words(haystack)
+      const exactNameScore = normalize(haystack).includes(normalize(label)) ? 8 : 0
+      const overlapScore = [...entityWords].filter(word => postWords.has(word)).length
+      return { post, score: exactNameScore + overlapScore }
+    })
+    .filter(item => item.score > 1)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map(({ post }) => ({
+      href: `/blog/${post.slug}`,
+      title: post.title,
+      description: post.excerpt || 'Editorial research note connected to this profile.',
+      meta: [post.date, post.readingTime].filter(Boolean).join(' • '),
+      kind: 'article',
+    }))
+}
+
+export const findArticleEntities = (post: BlogPostRecord, entities: EditorialEntity[], kind: 'herb' | 'compound', limit = 6): DiscoveryLink[] => {
+  const haystack = [post.title, post.excerpt, post.content].filter(Boolean).join(' ')
+  const postWords = words(haystack)
+
+  return entities
+    .map(entity => {
+      const label = getEntityLabel(entity)
+      const exactNameScore = normalize(haystack).includes(normalize(label)) ? 10 : 0
+      const entityWords = words(getEntitySearchText(entity))
+      const overlapScore = [...entityWords].filter(word => postWords.has(word)).length
+      return { entity, score: exactNameScore + overlapScore }
+    })
+    .filter(item => item.score > 1 && item.entity.slug)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map(({ entity }) => {
+      const topics = buildSemanticTopics(entity)
+      return {
+        href: `/${kind === 'herb' ? 'herbs' : 'compounds'}/${entity.slug}`,
+        title: getEntityLabel(entity),
+        description: [topics.effects[0], topics.mechanisms[0]].filter(Boolean).join(' • ') || 'Related research profile',
+        meta: `${topics.maturity} • ${topics.researchStyle}`,
+        kind,
+      }
+    })
+}


### PR DESCRIPTION
### Motivation
- Turn the site from a directory-style supplement reference into an editorial scientific discovery platform with clearer mission, evidence-first framing, and publication-style reading flow.
- Surface semantic discovery signals (mechanisms, effect clusters, evidence maturity, research style) so readers can move between profiles and interpretive articles with context.
- Improve scanning and memory on long detail pages by adding publication visual anchors (pull quotes, evidence ribbons, concise research snapshots) without changing core routes or data pipeline contracts.

### Description
- Added a reusable editorial discovery layer: new library `lib/editorial-discovery.ts` with semantic utilities (`buildSemanticTopics`, `findRelatedArticles`, `findArticleEntities`) that map mechanisms, effect clusters, evidence maturity, and research style.
- Introduced UI primitives in `components/scientific-discovery.tsx` (identity cards, `SemanticBrowseModule`, `ResearchContinuityBlock`, `EvidenceMaturityRibbon`) and integrated them into the homepage and detail pages to provide consistent content identities and semantic browse panels.
- Editorialized content and integrated articles into the graph by updating `components/homepage-v2.tsx`, `app/blog/page.tsx`, `app/blog/[slug]/page.tsx`, `app/herbs/[slug]/page.tsx`, and `app/compounds/[slug]/page.tsx` to surface research philosophy, related-article rails, evidence ribbons, pull-quotes, and semantic recommendation modules.
- Added lightweight CSS tokens and card styles in `app/globals.css` to support identity cards, pull-quote panels, and mobile reading cadence while preserving the warm premium aesthetic and existing theme tokens.

### Testing
- Ran `npm run build` which executed the data build, validation, and full Next.js production build and completed successfully (static pages generated and build verifications passed).
- Ran type checks with `npx tsc --noEmit --pretty false` and `npx next build` which both succeeded with compilation and type validation passing.
- Installed browser tooling with `npx playwright install chromium` and `npx playwright install-deps chromium` and produced a full-page screenshot via Playwright; the screenshot capture succeeded though the optional `file` utility to inspect the artifact was not present in the environment.
- Confirmed regenerated `public/data` artifacts matched expected outputs via the project's data verification step (`node scripts/data/verify-generated-data.mjs`) which passed during the build run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc9a478bcc8323aba5a24d6caeac11)