### PR TITLE
Polish semantic discovery: contrast, sanitizers, empty-section guards, and safer compare tray

### DIFF
--- a/app/a-tier/page.tsx
+++ b/app/a-tier/page.tsx
@@ -30,7 +30,7 @@ type TierPayload = {
 export default function ATierPage() {
   const filePath = path.join(process.cwd(), 'public/data/a-tier-index.json')
   const data = JSON.parse(fs.readFileSync(filePath, 'utf-8')) as TierPayload
-  const allItems = data.items ?? []
+  const allItems = (data.items ?? []).filter(item => item.slug)
 
   const grouped = DOMAIN_ORDER.reduce<Record<Domain, TierItem[]>>((acc, domain) => {
     acc[domain] = allItems
@@ -46,23 +46,26 @@ export default function ATierPage() {
   })
 
   return (
-    <main className='mx-auto max-w-6xl px-6 py-10 text-white'>
-      <h1 className='mb-2 text-3xl font-semibold'>A-Tier Compounds</h1>
-      <p className='mb-8 text-white/75'>Curated, high-trust compounds grouped by domain.</p>
+    <main className='mx-auto max-w-6xl space-y-9 px-4 py-10 text-ink sm:px-6'>
+      <section className='hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8'>
+        <p className='eyebrow-label'>Evidence explorer</p>
+        <h1 className='heading-premium mt-3 text-ink'>A-Tier Compounds</h1>
+        <p className='mt-4 max-w-3xl text-base leading-7 text-[#46574d]'>Curated, higher-trust compounds grouped by domain for conservative comparison.</p>
+      </section>
 
-      <div className='space-y-10'>
+      <div className='space-y-8'>
         {DOMAIN_ORDER.map(domain => (
           <section key={domain}>
-            <h2 className='mb-4 text-xl font-semibold'>{DOMAIN_LABELS[domain]}</h2>
+            <h2 className='mb-4 text-xl font-semibold text-ink'>{DOMAIN_LABELS[domain]}</h2>
             {grouped[domain].length === 0 ? (
-              <p className='text-sm text-white/60'>No A-tier entries yet.</p>
+              <p className='text-sm text-[#46574d]'>No A-tier entries surfaced yet.</p>
             ) : (
               <div className='grid gap-3 sm:grid-cols-2 lg:grid-cols-3'>
                 {grouped[domain].map(item => (
                   <Card key={`${domain}-${item.slug}`} className='p-4'>
                     <Link href={`/compounds/${item.slug}`} className='block'>
-                      <h3 className='text-base font-medium text-white'>{item.name ?? item.slug}</h3>
-                      <p className='mt-1 text-sm text-white/65'>/{item.slug}</p>
+                      <h3 className='text-base font-semibold text-ink'>{item.name ?? item.slug}</h3>
+                      <p className='mt-1 text-sm text-[#46574d]'>/{item.slug}</p>
                     </Link>
                   </Card>
                 ))}

--- a/app/best/[slug]/page.tsx
+++ b/app/best/[slug]/page.tsx
@@ -4,6 +4,7 @@ import SectionBlock from '@/components/ui/SectionBlock'
 import { getProductPicks, groupProductPicks } from '@/lib/product-ranking'
 import { generateAmazonProductPicks } from '@/lib/amazon-auto'
 import Link from 'next/link'
+import { cleanSummary } from '@/lib/display-utils'
 
 export async function generateStaticParams() {
   return [{ slug: 'best-supplements-for-focus' }]
@@ -52,7 +53,7 @@ export default function Page() {
             </h2>
 
             <SectionBlock title="Summary">
-              {c.summary}
+              {cleanSummary(c.summary, 'compound')}
             </SectionBlock>
 
             <p className="text-xs text-neutral-500">

--- a/app/collections/[slug]/page.tsx
+++ b/app/collections/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { seoCollections } from '@/data/seoCollections'
 import { getCompounds, getHerbs } from '@/lib/runtime-data'
+import { cleanSummary } from '@/lib/display-utils'
 
 type Params = { params: Promise<{ slug: string }> }
 
@@ -44,7 +45,7 @@ export default async function CollectionPage({ params }: Params) {
           return (
             <Link key={item.slug} href={href} className='ds-card block'>
               <h2 className='font-semibold text-white'>{item.displayName ?? item.name ?? item.slug}</h2>
-              <p className='mt-2 line-clamp-3 text-sm text-white/70'>{item.summary ?? item.description}</p>
+              <p className='mt-2 line-clamp-3 text-sm text-white/70'>{cleanSummary(item.summary ?? item.description, collection.itemType === 'compound' ? 'compound' : 'herb')}</p>
             </Link>
           )
         })}

--- a/app/compare/[comparison]/page.tsx
+++ b/app/compare/[comparison]/page.tsx
@@ -5,6 +5,7 @@ import {
   getEvidenceSnapshot,
   getTopicClusters,
 } from '@/lib/semantic-runtime'
+import { cleanSummary, isClean } from '@/lib/display-utils'
 
 function findCompound(slug:string) {
   return (compounds as any[]).find((c)=>c.slug===slug)
@@ -33,7 +34,7 @@ export default function ComparePage({ params }: any) {
 
   if (!left || !right) {
     return (
-      <main className="mx-auto max-w-4xl px-4 py-24 text-center text-neutral-300">
+      <main className="mx-auto max-w-4xl px-4 py-24 text-center text-[#46574d]">
         Comparison not found.
       </main>
     )
@@ -50,8 +51,8 @@ export default function ComparePage({ params }: any) {
     },
     {
       label: 'Topical Clusters',
-      left: getTopicClusters(left).join(', '),
-      right: getTopicClusters(right).join(', '),
+      left: getTopicClusters(left).filter(isClean).join(', '),
+      right: getTopicClusters(right).filter(isClean).join(', '),
     },
     {
       label: 'Citation Density',
@@ -68,15 +69,15 @@ export default function ComparePage({ params }: any) {
   return (
     <main className="mx-auto max-w-7xl px-4 py-16 space-y-10">
       <div className="space-y-4">
-        <div className="text-xs uppercase tracking-[0.2em] text-emerald-300">
+        <div className="text-xs uppercase tracking-[0.2em] text-brand-700">
           Semantic Comparison Engine
         </div>
 
-        <h1 className="text-5xl font-semibold tracking-tight text-white">
+        <h1 className="text-5xl font-semibold tracking-tight text-ink">
           {left.name} vs {right.name}
         </h1>
 
-        <p className="max-w-3xl text-lg leading-8 text-neutral-400">
+        <p className="max-w-3xl text-lg leading-8 text-[#46574d]">
           Evidence-aware semantic comparison across archetypes, topical clusters, source depth, and discovery context.
         </p>
       </div>
@@ -85,18 +86,18 @@ export default function ComparePage({ params }: any) {
         {[left, right].map((compound:any)=>(
           <div
             key={compound.slug}
-            className="rounded-3xl border border-white/10 bg-white/[0.04] p-7 backdrop-blur-xl"
+            className="rounded-3xl border border-brand-900/10 bg-white/80 p-7 backdrop-blur-xl"
           >
             <div className="space-y-4">
               <div className="flex flex-wrap gap-2">
-                <span className="rounded-full border border-emerald-500/20 bg-emerald-500/10 px-3 py-1 text-[10px] uppercase tracking-wide text-emerald-300">
+                <span className="rounded-full border border-emerald-500/20 bg-emerald-500/10 px-3 py-1 text-[10px] uppercase tracking-wide text-brand-700">
                   {classifyArchetype(compound)}
                 </span>
 
                 {getTopicClusters(compound).slice(0,2).map((cluster:string)=>(
                   <span
                     key={cluster}
-                    className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[10px] uppercase tracking-wide text-neutral-300"
+                    className="rounded-full border border-brand-900/10 bg-white/75 px-3 py-1 text-[10px] uppercase tracking-wide text-[#46574d]"
                   >
                     {cluster}
                   </span>
@@ -104,18 +105,18 @@ export default function ComparePage({ params }: any) {
               </div>
 
               <div>
-                <h2 className="text-3xl font-semibold text-white">
+                <h2 className="text-3xl font-semibold text-ink">
                   {compound.name}
                 </h2>
 
-                <p className="mt-4 text-sm leading-7 text-neutral-400">
-                  {compound.summary || 'Evidence-aware compound profile.'}
+                <p className="mt-4 text-sm leading-7 text-[#46574d]">
+                  {cleanSummary(compound.summary, 'compound')}
                 </p>
               </div>
 
               <Link
                 href={`/compounds/${compound.slug}`}
-                className="inline-flex rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs uppercase tracking-wide text-neutral-200 hover:bg-white/10 transition"
+                className="inline-flex rounded-full border border-brand-900/10 bg-white/75 px-4 py-2 text-xs uppercase tracking-wide text-[#33443a] hover:bg-white transition"
               >
                 Open Compound
               </Link>
@@ -124,17 +125,17 @@ export default function ComparePage({ params }: any) {
         ))}
       </div>
 
-      <div className="rounded-3xl border border-white/10 bg-white/[0.04] p-6 backdrop-blur-xl overflow-hidden">
+      <div className="rounded-3xl border border-brand-900/10 bg-white/80 p-6 backdrop-blur-xl overflow-hidden">
         <table className="w-full text-left">
           <thead>
-            <tr className="border-b border-white/10">
-              <th className="py-4 text-xs uppercase tracking-[0.2em] text-neutral-500">
+            <tr className="border-b border-brand-900/10">
+              <th className="py-4 text-xs uppercase tracking-[0.2em] text-[#66756d]">
                 Metric
               </th>
-              <th className="py-4 text-xs uppercase tracking-[0.2em] text-neutral-500">
+              <th className="py-4 text-xs uppercase tracking-[0.2em] text-[#66756d]">
                 {left.name}
               </th>
-              <th className="py-4 text-xs uppercase tracking-[0.2em] text-neutral-500">
+              <th className="py-4 text-xs uppercase tracking-[0.2em] text-[#66756d]">
                 {right.name}
               </th>
             </tr>
@@ -144,17 +145,17 @@ export default function ComparePage({ params }: any) {
             {rows.map((row)=>(
               <tr
                 key={row.label}
-                className="border-b border-white/5 last:border-none"
+                className="border-b border-brand-900/10 last:border-none"
               >
-                <td className="py-5 text-sm font-medium text-white">
+                <td className="py-5 text-sm font-medium text-ink">
                   {row.label}
                 </td>
 
-                <td className="py-5 text-sm text-neutral-300">
+                <td className="py-5 text-sm text-[#46574d]">
                   {row.left}
                 </td>
 
-                <td className="py-5 text-sm text-neutral-300">
+                <td className="py-5 text-sm text-[#46574d]">
                   {row.right}
                 </td>
               </tr>

--- a/app/compare/[slug]/page.tsx
+++ b/app/compare/[slug]/page.tsx
@@ -6,6 +6,7 @@ import AffiliateBlock from '@/components/AffiliateBlock'
 import { generatedComparisons } from '@/data/generated-comparisons'
 import { supplementComparisons } from '@/data/comparisons'
 import { bestPages } from '@/data/best'
+import { cleanSummary } from '@/lib/display-utils'
 
 type Params = { params: Promise<{ slug: string }> }
 
@@ -20,7 +21,7 @@ const formatSlug = (value: string) =>
 const normalize = (value?: string) => (value ?? '').toLowerCase().replace(/[^a-z0-9]/g, '')
 
 const displayName = (compound: any) => compound?.displayName || compound?.name || formatSlug(compound?.slug || 'Compound')
-const summary = (compound: any) => compound?.summary || compound?.description || 'Open the compound profile for more detail.'
+const summary = (compound: any) => cleanSummary(compound?.summary || compound?.description, 'compound') || 'Open the compound profile for more detail.'
 
 const evidenceScore = (compound: any) => {
   const text = `${compound?.evidence_grade ?? ''} ${compound?.evidenceTier ?? ''} ${compound?.tier_level ?? ''} ${compound?.evidence ?? ''} ${compound?.summary_quality ?? ''}`.toLowerCase()

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -1,13 +1,28 @@
 import { CompareTableClient } from '@/components/compare-table-client'
 import { getCompounds } from '@/lib/runtime-data'
+import { cleanSummary, formatDisplayLabel, isClean, list } from '@/lib/display-utils'
 
 export default async function ComparePage() {
   const compounds = await getCompounds()
+  const safeCompounds = compounds
+    .filter((compound: any) => compound.slug && isClean(compound.name || compound.displayName || compound.slug))
+    .map((compound: any) => ({
+      slug: compound.slug,
+      name: formatDisplayLabel(compound.displayName || compound.name || compound.slug),
+      summary: cleanSummary(compound.summary || compound.description, 'compound'),
+      effects: list(compound.primary_effects || compound.effects).slice(0, 4),
+      evidence_tier: formatDisplayLabel(compound.evidence_tier || compound.evidenceTier || compound.evidence_grade),
+      time_to_effect: formatDisplayLabel(compound.time_to_effect),
+      role: formatDisplayLabel(compound.role),
+      safety_flags: list(compound.safety_flags || compound.safetyNotes || compound.contraindications).slice(0, 3),
+      complexity: formatDisplayLabel(compound.complexity),
+      cost: formatDisplayLabel(compound.cost),
+    }))
 
   return (
     <main className="mx-auto max-w-6xl space-y-6 px-4 py-8">
       <h1 className="text-3xl font-bold text-ink">Compound comparison</h1>
-      <CompareTableClient compounds={compounds} />
+      <CompareTableClient compounds={safeCompounds} />
     </main>
   )
 }

--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -34,6 +34,9 @@ import {
 import Link from 'next/link'
 import { EvidenceMaturityRibbon, SemanticBrowseModule } from '@/components/scientific-discovery'
 import { buildSemanticTopics } from '@/lib/editorial-discovery'
+import { cleanSummary, formatDisplayLabel, isClean, isSafeInternalHref, list } from '@/lib/display-utils'
+import { generatedComparisons } from '@/data/generated-comparisons'
+import { supplementComparisons } from '@/data/comparisons'
 
 export async function generateStaticParams() {
   return (data as any[]).map((c)=>({ slug:c.slug }))
@@ -45,22 +48,18 @@ export function generateMetadata({ params }: any) {
 
   return {
     title: `${compound.name} Benefits, Effects & Safety | Hippie Scientist`,
-    description: compound.summary || 'Detailed breakdown of effects, safety, and usage.'
+    description: cleanSummary(compound.summary || compound.description, 'compound')
   }
 }
 
-function cleanLabel(value: string = '') {
-  return value
-    .replace(/research[_\s-]*only/gi, '')
-    .replace(/_/g, ' ')
-    .replace(/\bhealthy aging\b/gi, 'Healthy aging')
-    .replace(/\bfat loss\b/gi, 'Fat loss')
-    .replace(/\bstress mood\b/gi, 'Stress & mood')
-    .replace(/\bsleep quality\b/gi, 'Sleep quality')
-    .replace(/\bgeneral wellness\b/gi, 'General wellness')
-    .replace(/\s+/g, ' ')
-    .trim()
+function cleanLabel(value: unknown) {
+  return formatDisplayLabel(value)
 }
+
+const knownComparisonSlugs = new Set([
+  ...generatedComparisons,
+  ...supplementComparisons.map((comparison) => comparison.slug),
+])
 
 function normalizeText(value: string = '') {
   return value.toLowerCase().replace(/[^a-z0-9]/g, '')
@@ -71,25 +70,29 @@ export default function Page({ params }: any) {
   const compound = compounds.find(c => c.slug === params.slug)
   if (!compound) return null
 
-  const effects = getEffects(compound).map((effect:string) => cleanLabel(effect)).filter(Boolean)
-  const sources = getSources(compound)
+  const effects = getEffects(compound)
+    .map((effect:string) => cleanLabel(effect))
+    .filter((effect:string) => isClean(effect) && !/^no\s+strong\s+effects\s+established\s+yet$/i.test(effect))
+  const sources = getSources(compound).filter((source:any) => isClean(typeof source === 'string' ? source : JSON.stringify(source)))
 
-  const related = getRelatedCompounds(compound).map((item:any)=>({
-    ...item,
-    archetype: classifyArchetype(item),
-  }))
+  const related = getRelatedCompounds(compound)
+    .filter((item:any) => item.slug && item.name && isClean(item.name))
+    .map((item:any)=>({
+      ...item,
+      archetype: classifyArchetype(item),
+    }))
 
-  const stackCandidates = getStackCandidates(compound)
-  const comparisonCandidates = getComparisonCandidates(compound)
+  const stackCandidates = getStackCandidates(compound).filter((candidate:any) => candidate.slug && candidate.name && isClean(candidate.reason))
+  const comparisonCandidates = getComparisonCandidates(compound).filter((candidate:any) => candidate.slug && knownComparisonSlugs.has(candidate.slug) && isSafeInternalHref(candidate.href))
   const snapshot = getEvidenceSnapshot(compound)
   const semanticTopics = buildSemanticTopics(compound)
 
   const evidenceLevel = normalizeEvidenceLevel(compound.evidence_tier)
   const safetyLevel = normalizeSafetyLevel(compound.safety)
 
-  const mechanisms = compound.mechanisms || []
+  const mechanisms = list(compound.mechanisms)
 
-  const summary = cleanLabel(compound.summary || '')
+  const summary = cleanSummary(compound.summary || compound.description, 'compound')
 
   const quickVerdict =
     summary && summary.length > 140
@@ -119,7 +122,7 @@ export default function Page({ params }: any) {
       ? compound.time_to_effect
       : []
 
-  const meaningfulTimeline = timelineData.filter((item:any) => item?.title && item?.text)
+  const meaningfulTimeline = timelineData.filter((item:any) => isClean(item?.title) && isClean(item?.text))
 
   return (
     <>
@@ -141,13 +144,13 @@ export default function Page({ params }: any) {
 
           <div className="space-y-4">
             <CompoundHero
-              compound={compound}
+              compound={{ ...compound, summary }}
               evidenceLevel={evidenceLevel}
               safetyLevel={safetyLevel}
             />
             <div className="flex flex-wrap gap-3">
               <EvidenceMaturityRibbon label={semanticTopics.maturity} />
-              {[semanticTopics.researchStyle, ...semanticTopics.effects.slice(0, 2), ...semanticTopics.mechanisms.slice(0, 2)].map(item => (
+              {[semanticTopics.researchStyle, ...semanticTopics.effects.slice(0, 2), ...semanticTopics.mechanisms.slice(0, 2)].filter(isClean).map(item => (
                 <span key={item} className="chip-readable">{item}</span>
               ))}
             </div>
@@ -207,10 +210,10 @@ export default function Page({ params }: any) {
             title="Continue researching by relationship"
             description="Move laterally through effect clusters, pathway families, evidence maturity, and comparison candidates."
             groups={[
-              { title: semanticTopics.effects[0] || 'Effect cluster', description: 'Explore profiles with similar outcome language and practical intent.', href: '/goals', meta: 'Effect' },
-              { title: semanticTopics.mechanisms[0] || 'Pathway family', description: 'Follow mechanism families without treating mechanistic data as clinical proof.', href: '/explore', meta: 'Mechanism' },
-              { title: semanticTopics.maturity, description: 'Compare this profile against stronger, mixed, and early-stage evidence pages.', href: '/a-tier', meta: 'Evidence' },
-            ]}
+              { title: semanticTopics.effects[0] || 'Outcome pathways', description: 'Explore profiles with similar outcome language and practical intent.', href: '/goals', meta: 'Outcome' },
+              { title: semanticTopics.mechanisms[0] || 'Mechanism families', description: 'Follow pathway context without treating mechanisms as clinical proof.', href: '/explore', meta: 'Mechanism' },
+              { title: semanticTopics.maturity, description: 'Compare stronger, mixed, and early-stage evidence profiles.', href: '/a-tier', meta: 'Evidence' },
+            ].filter(group => isClean(group.title) && isSafeInternalHref(group.href))}
           />
 
           <div id="effects">
@@ -284,7 +287,7 @@ export default function Page({ params }: any) {
           <div id="safety">
             <SectionBlock title="Safety">
               <p className="text-sm leading-7 text-[#46574d]">
-                {cleanLabel(compound.safety || 'No major cautions surfaced in the current profile.')}
+                {isClean(compound.safety) ? cleanLabel(compound.safety) : 'No major cautions surfaced in the current profile.'}
               </p>
             </SectionBlock>
           </div>

--- a/app/explore/[topic]/page.tsx
+++ b/app/explore/[topic]/page.tsx
@@ -1,9 +1,11 @@
 import Link from 'next/link'
+import { notFound } from 'next/navigation'
 import compounds from '../../../public/data/compounds.json'
 import {
   classifyArchetype,
   getTopicClusters,
 } from '@/lib/semantic-runtime'
+import { cleanSummary, isClean } from '@/lib/display-utils'
 
 const TITLES: Record<string, string> = {
   sleep: 'Sleep Support',
@@ -13,22 +15,20 @@ const TITLES: Record<string, string> = {
 }
 
 export async function generateStaticParams() {
-  return [
-    { topic: 'sleep' },
-    { topic: 'focus' },
-    { topic: 'anxiety' },
-    { topic: 'recovery' },
-  ]
+  return Object.keys(TITLES).map((topic) => ({ topic }))
 }
 
 export default async function TopicExplorePage({ params }: any) {
   const topic = String(params.topic || '').toLowerCase()
 
+  if (!TITLES[topic]) notFound()
+
   const filtered = (compounds as any[])
+    .filter((compound) => compound.slug && compound.name)
     .map((compound) => ({
       ...compound,
       archetype: classifyArchetype(compound),
-      clusters: getTopicClusters(compound),
+      clusters: getTopicClusters(compound).filter(isClean),
     }))
     .filter((compound) => {
       return (compound.clusters || []).some((cluster: string) => {
@@ -45,57 +45,66 @@ export default async function TopicExplorePage({ params }: any) {
     .slice(0, 24)
 
   return (
-    <main className="mx-auto max-w-7xl px-4 py-16 space-y-10">
-      <div className="space-y-4">
-        <div className="text-xs uppercase tracking-[0.2em] text-emerald-300">
-          Semantic Explore Hub
+    <main className="mx-auto max-w-7xl space-y-9 px-4 py-10 sm:py-14">
+      <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8 lg:p-10">
+        <div className="max-w-4xl space-y-4">
+          <p className="eyebrow-label">Semantic Explore Hub</p>
+
+          <h1 className="heading-premium text-ink">
+            {TITLES[topic]}
+          </h1>
+
+          <p className="max-w-3xl text-lg leading-8 text-[#46574d]">
+            Discover compounds grouped by shared outcomes, relationship signals, mechanisms, and conservative evidence patterns.
+          </p>
+        </div>
+      </section>
+
+      <section className="space-y-5">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <p className="eyebrow-label">Profiles</p>
+            <h2 className="mt-2 text-2xl font-semibold tracking-tight text-ink sm:text-3xl">Related discovery cards</h2>
+          </div>
+          <span className="chip-readable">{filtered.length} matches</span>
         </div>
 
-        <h1 className="text-5xl font-semibold tracking-tight text-white">
-          {TITLES[topic] || 'Explore Compounds'}
-        </h1>
+        <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+          {filtered.map((compound) => (
+            <Link
+              key={compound.slug}
+              href={`/compounds/${compound.slug}`}
+              className="card-premium group p-6"
+            >
+              <div className="space-y-4">
+                <div className="flex flex-wrap gap-2">
+                  {isClean(compound.archetype) ? (
+                    <span className="evidence-pill-strong">
+                      {compound.archetype}
+                    </span>
+                  ) : null}
 
-        <p className="max-w-3xl text-lg leading-8 text-neutral-400">
-          Discover compounds grouped by shared outcomes, semantic relationships, mechanisms, and evidence-aware patterns.
-        </p>
-      </div>
+                  {(compound.clusters || []).slice(0, 2).map((cluster:string) => (
+                    <span key={cluster} className="chip-readable text-[10px] uppercase tracking-wide">
+                      {cluster}
+                    </span>
+                  ))}
+                </div>
 
-      <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-        {filtered.map((compound) => (
-          <Link
-            key={compound.slug}
-            href={`/compounds/${compound.slug}`}
-            className="group rounded-3xl border border-white/10 bg-white/[0.04] p-6 backdrop-blur-xl transition hover:-translate-y-1 hover:bg-white/[0.08]"
-          >
-            <div className="space-y-4">
-              <div className="flex flex-wrap gap-2">
-                <span className="rounded-full border border-emerald-500/20 bg-emerald-500/10 px-3 py-1 text-[10px] uppercase tracking-wide text-emerald-300">
-                  {compound.archetype}
-                </span>
+                <div>
+                  <h2 className="text-2xl font-semibold text-ink transition group-hover:text-brand-800">
+                    {compound.name}
+                  </h2>
 
-                {(compound.clusters || []).slice(0, 2).map((cluster:string) => (
-                  <span
-                    key={cluster}
-                    className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-[10px] uppercase tracking-wide text-neutral-300"
-                  >
-                    {cluster}
-                  </span>
-                ))}
+                  <p className="mt-3 line-clamp-4 text-sm leading-7 text-[#46574d]">
+                    {cleanSummary(compound.summary, 'compound')}
+                  </p>
+                </div>
               </div>
-
-              <div>
-                <h2 className="text-2xl font-semibold text-white group-hover:text-emerald-300 transition">
-                  {compound.name}
-                </h2>
-
-                <p className="mt-3 line-clamp-4 text-sm leading-7 text-neutral-400">
-                  {compound.summary || 'Semantic compound profile with evidence-aware discovery.'}
-                </p>
-              </div>
-            </div>
-          </Link>
-        ))}
-      </div>
+            </Link>
+          ))}
+        </div>
+      </section>
     </main>
   )
 }

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -4,6 +4,7 @@ import {
   classifyArchetype,
   getTopicClusters,
 } from '@/lib/semantic-runtime'
+import { cleanSummary, isClean } from '@/lib/display-utils'
 
 const TOPICS = [
   {
@@ -30,26 +31,24 @@ const TOPICS = [
 
 export default function ExplorePage() {
   const featured = (compounds as any[])
+    .filter((compound) => compound.slug && compound.name)
     .slice(0, 12)
     .map((compound) => ({
       ...compound,
       archetype: classifyArchetype(compound),
-      clusters: getTopicClusters(compound),
+      clusters: getTopicClusters(compound).filter(isClean),
     }))
 
   return (
-    <main className="mx-auto max-w-7xl px-4 py-16 space-y-14">
-      <section className="space-y-5">
-        <div className="inline-flex rounded-full border border-emerald-500/20 bg-emerald-500/10 px-4 py-2 text-xs uppercase tracking-[0.2em] text-emerald-600">
-          Semantic Discovery
-        </div>
-
-        <div className="space-y-4">
+    <main className="mx-auto max-w-7xl space-y-10 px-4 py-10 sm:py-14">
+      <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8 lg:p-10">
+        <div className="max-w-4xl space-y-4">
+          <p className="eyebrow-label">Semantic Discovery</p>
           <h1 className="heading-premium max-w-4xl text-ink">
             Explore Compounds by Goal
           </h1>
 
-          <p className="max-w-3xl text-lg leading-8 text-muted-soft">
+          <p className="max-w-3xl text-lg leading-8 text-[#46574d]">
             Navigate compounds through semantic relationships, archetypes, evidence patterns, mechanisms, and shared outcomes.
           </p>
         </div>
@@ -71,7 +70,7 @@ export default function ExplorePage() {
                 {topic.title}
               </h2>
 
-              <p className="text-sm leading-7 text-muted-soft">
+              <p className="text-sm leading-7 text-[#46574d]">
                 {topic.description}
               </p>
             </div>
@@ -82,7 +81,7 @@ export default function ExplorePage() {
       <section className="space-y-6">
         <div className="flex items-center justify-between gap-4">
           <div>
-            <div className="eyebrow text-neutral-500">
+            <div className="eyebrow text-brand-700">
               Discovery Rail
             </div>
 
@@ -120,8 +119,8 @@ export default function ExplorePage() {
                     {compound.name}
                   </h3>
 
-                  <p className="mt-3 line-clamp-4 text-sm leading-7 text-muted-soft">
-                    {compound.summary || 'Evidence-aware compound profile with semantic discovery support.'}
+                  <p className="mt-3 line-clamp-4 text-sm leading-7 text-[#46574d]">
+                    {cleanSummary(compound.summary, 'compound')}
                   </p>
                 </div>
               </div>

--- a/app/goals/[slug]/page.tsx
+++ b/app/goals/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation'
 import { getStacks, getCompounds } from '@/lib/runtime-data'
 import { supplementComparisons } from '@/data/comparisons'
 import { goalConfigs } from '@/data/goals'
+import { cleanSummary, editorialUseCaseLabel, formatDisplayLabel, isClean } from '@/lib/display-utils'
 
 type Params = { params: Promise<{ slug: string }> }
 
@@ -146,18 +147,27 @@ const getEvidenceLabel = (compound: CompoundRecord) => {
   return `Evidence: ${raw}`
 }
 
-const getBestFor = (compound: CompoundRecord) => clean(compound.best_for ?? compound.bestFor)
-const getAvoidIf = (compound: CompoundRecord) => clean(compound.avoid_if ?? compound.avoidIf)
-const getSafetySummary = (compound: CompoundRecord) => clean(compound.safety_summary ?? compound.safetySummary ?? compound.safety_notes ?? compound.safetyNotes)
+const getBestFor = (compound: CompoundRecord) => {
+  const value = clean(compound.best_for ?? compound.bestFor)
+  return isClean(value) ? editorialUseCaseLabel(value) : ''
+}
+const getAvoidIf = (compound: CompoundRecord) => {
+  const value = clean(compound.avoid_if ?? compound.avoidIf)
+  return isClean(value) ? formatDisplayLabel(value) : ''
+}
+const getSafetySummary = (compound: CompoundRecord) => {
+  const value = clean(compound.safety_summary ?? compound.safetySummary ?? compound.safety_notes ?? compound.safetyNotes)
+  return isClean(value) ? value : ''
+}
 
 const getBestPickLabel = (compound: CompoundRecord, compounds: CompoundRecord[], index: number, goalSlug: string, candidates: string[]) => {
   if (index === 0) return 'Best Match'
   const strongestEvidence = compounds.reduce((best, item) => getEvidenceRank(item) > getEvidenceRank(best) ? item : best, compounds[0])
   if (compound.slug === strongestEvidence.slug) return 'Strongest Evidence'
   const safest = compounds.reduce((best, item) => getSafetyRank(item) > getSafetyRank(best) ? item : best, compounds[0])
-  if (compound.slug === safest.slug) return 'Best for Safety'
+  if (compound.slug === safest.slug) return 'Safety-forward'
   const strongestIntent = compounds.reduce((best, item) => intentScore(item, goalSlug, candidates) > intentScore(best, goalSlug, candidates) ? item : best, compounds[0])
-  if (compound.slug === strongestIntent.slug) return 'Best Intent Fit'
+  if (compound.slug === strongestIntent.slug) return 'Closest goal fit'
   const fastest = compounds.reduce((best, item) => getSpeedRank(item) > getSpeedRank(best) ? item : best, compounds[0])
   if (getSpeedRank(compound) > 0 && compound.slug === fastest.slug) return 'Fastest Acting'
   return ''
@@ -200,7 +210,7 @@ export default async function GoalPage({ params }: Params) {
           <div className="flex flex-wrap items-end justify-between gap-3">
             <div>
               <p className="text-xs font-black uppercase tracking-[0.2em] text-emerald-700/60">Intent-ranked picks</p>
-              <h2 className="mt-1 text-3xl font-black text-slate-950">Best options for this goal</h2>
+              <h2 className="mt-1 text-3xl font-black text-slate-950">Most relevant options for this goal</h2>
               <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600">Ranked by goal fit, evidence, safety, speed, and completeness. Missing data is never guessed.</p>
             </div>
             <Link href="/compounds" className="text-sm font-black text-emerald-700">All compounds →</Link>
@@ -212,7 +222,7 @@ export default async function GoalPage({ params }: Params) {
               const bestFor = getBestFor(compound)
               const avoidIf = getAvoidIf(compound)
               const safetySummary = getSafetySummary(compound)
-              const summary = clean(compound.summary) || clean(compound.description)
+              const summary = cleanSummary(compound.summary || compound.description, 'compound')
               const pickLabel = getBestPickLabel(compound, topCompounds, index, goal.slug, goal.compoundCandidates)
 
               return (
@@ -229,7 +239,7 @@ export default async function GoalPage({ params }: Params) {
                   {(avoidIf || safetySummary) ? (
                     <div className="mt-4 rounded-2xl bg-amber-50/90 p-3 ring-1 ring-amber-900/10">
                       <p className="text-xs font-black uppercase tracking-[0.16em] text-amber-800">Safety check</p>
-                      <p className="mt-1 line-clamp-2 text-sm font-semibold leading-6 text-slate-700">{avoidIf ? `Avoid if: ${avoidIf}` : safetySummary}</p>
+                      <p className="mt-1 line-clamp-2 text-sm font-semibold leading-6 text-slate-700">{avoidIf ? `Use caution with ${avoidIf}.` : safetySummary}</p>
                     </div>
                   ) : null}
 
@@ -254,11 +264,11 @@ export default async function GoalPage({ params }: Params) {
       </section>
 
       {relatedStacks.length > 0 || relatedComparisons.length > 0 ? (
-        <section className="rounded-[2rem] bg-slate-950 p-5 text-white shadow-xl shadow-slate-900/10 sm:p-6">
-          <h2 className="text-3xl font-black text-white">Next decision step</h2>
+        <section className="surface-depth rounded-[2rem] p-5 shadow-card sm:p-6">
+          <h2 className="text-3xl font-black text-ink">Next decision step</h2>
           <div className="mt-4 grid gap-3 md:grid-cols-2">
-            {relatedStacks.slice(0, 2).map((stack) => <Link key={stack.slug} href={`/stacks/${stack.slug}`} className="rounded-2xl border border-white/10 bg-white/[0.06] p-5"><h3 className="text-xl font-black text-white">{stack.title}</h3><span className="mt-4 inline-flex text-sm font-black text-emerald-200">View routine →</span></Link>)}
-            {relatedComparisons.slice(0, 2).map((comparison) => <Link key={comparison.slug} href={`/compare/${comparison.slug}`} className="rounded-2xl border border-white/10 bg-white/[0.06] p-5"><h3 className="text-xl font-black text-white">{comparison.title}</h3><span className="mt-4 inline-flex text-sm font-black text-emerald-200">Compare →</span></Link>)}
+            {relatedStacks.slice(0, 2).map((stack) => <Link key={stack.slug} href={`/stacks/${stack.slug}`} className="rounded-2xl border border-brand-900/10 bg-white/75 p-5 transition hover:bg-white"><h3 className="text-xl font-black text-ink">{stack.title}</h3><span className="mt-4 inline-flex text-sm font-black text-emerald-700">View routine →</span></Link>)}
+            {relatedComparisons.slice(0, 2).map((comparison) => <Link key={comparison.slug} href={`/compare/${comparison.slug}`} className="rounded-2xl border border-brand-900/10 bg-white/75 p-5 transition hover:bg-white"><h3 className="text-xl font-black text-ink">{comparison.title}</h3><span className="mt-4 inline-flex text-sm font-black text-emerald-700">Compare →</span></Link>)}
           </div>
         </section>
       ) : null}

--- a/app/goals/page.tsx
+++ b/app/goals/page.tsx
@@ -18,7 +18,7 @@ export default function GoalsIndex() {
               Goals
             </h1>
 
-            <p className="text-reading mt-4 text-lg text-muted-soft">
+            <p className="text-reading mt-4 text-lg text-[#46574d]">
               Start with a goal. Then move into structured guides, compounds, stacks, comparisons, and evidence-aware safety context.
             </p>
           </div>
@@ -56,7 +56,7 @@ export default function GoalsIndex() {
                     {page.h1}
                   </h3>
 
-                  <p className="text-reading mt-4 line-clamp-4 text-sm text-muted-soft">
+                  <p className="text-reading mt-4 line-clamp-4 text-sm text-[#46574d]">
                     {page.intro}
                   </p>
                 </div>
@@ -93,7 +93,7 @@ export default function GoalsIndex() {
                   {goal.title}
                 </h3>
 
-                <p className="text-reading line-clamp-4 text-sm text-muted-soft">
+                <p className="text-reading line-clamp-4 text-sm text-[#46574d]">
                   {goal.summary}
                 </p>
 

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -251,7 +251,7 @@ export default async function HerbDetailPage({ params }: Params) {
     consensusSummary ? ['scientific-consensus', 'Consensus'] : null,
     focusAreas.length ? ['research-focus', 'Research focus'] : null,
     relatedPathways.length ? ['related-pathways', 'Related pathways'] : null,
-    outcomeCards.length ? ['best-for', 'Best for'] : null,
+    outcomeCards.length ? ['best-for', 'Explored for'] : null,
     mechanismGroups.length ? ['mechanisms', 'Mechanisms'] : null,
     researchGaps.length || evidenceLimitations.length ? ['research-gaps', 'Research gaps'] : null,
     compareItems.length ? ['compare-with', 'Compare with'] : null,
@@ -292,7 +292,7 @@ export default async function HerbDetailPage({ params }: Params) {
             <EvidenceMaturityRibbon label={semanticTopics.maturity} />
           </div>
 
-          <p className="text-reading mt-5 max-w-reading text-lg text-muted-soft">
+          <p className="text-reading mt-5 max-w-reading text-lg text-[#46574d]">
             {leadText}
           </p>
 
@@ -382,7 +382,7 @@ export default async function HerbDetailPage({ params }: Params) {
 
 
         {outcomeCards.length > 0 ? (
-          <DetailCard id="best-for" eyebrow="Use Cases" title="Best for" description="Signals surfaced from the current profile and linked claim data.">
+          <DetailCard id="best-for" eyebrow="Use Cases" title="Commonly explored for" description="Conservative use-case signals surfaced from the current profile and linked claim data.">
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
               {outcomeCards.map(card => (
                 <div key={card.title} className="surface-subtle rounded-2xl p-5">

--- a/app/seo-entry-pages.tsx
+++ b/app/seo-entry-pages.tsx
@@ -4,6 +4,7 @@ import { notFound } from 'next/navigation'
 import { goalConfigs } from '@/data/goals'
 import { getCompounds } from '@/lib/runtime-data'
 import ConversionAffiliateCard from '@/components/conversion-affiliate-card'
+import { isClean } from '@/lib/display-utils'
 
 type SeoEntryConfig = {
   route: string
@@ -180,7 +181,8 @@ const clean = (value: unknown): string => {
   if (value === null || value === undefined) return ''
   if (Array.isArray(value)) return value.map(clean).filter(Boolean).join(', ')
   if (typeof value === 'object') return ''
-  return String(value).replace(/\s+/g, ' ').trim()
+  const normalized = String(value).replace(/\s+/g, ' ').trim()
+  return isClean(normalized) ? normalized : ''
 }
 
 const sentence = (text: string) => text.endsWith('.') ? text : `${text}.`
@@ -396,7 +398,7 @@ export async function SeoEntryPage({ route }: { route: string }) {
       {linkedCompounds.length > 0 ? (
         <section className="space-y-4 rounded-3xl border border-white/10 bg-white/[0.03] p-6">
           <h2 className="text-2xl font-bold text-white">Related compounds</h2>
-          <p className="max-w-3xl text-sm leading-6 text-white/70">These links are generated from the current compound dataset and goal mapping, so this guide points into real workbook-backed profiles.</p>
+          <p className="max-w-3xl text-sm leading-6 text-white/70">These links are generated from the current compound dataset and goal mapping, so this guide points into real dataset-linked profiles.</p>
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
             {linkedCompounds.map((compound) => (
               <Link key={compound.slug} href={`/compounds/${compound.slug}`} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4 hover:border-emerald-300/40">

--- a/app/stacks/page.tsx
+++ b/app/stacks/page.tsx
@@ -139,7 +139,7 @@ export default function StacksPage() {
               <div className="mt-auto pt-4">
                 {s.avoid_if ? (
                   <p className="line-clamp-2 rounded-xl bg-amber-50 p-3 text-xs leading-5 text-amber-900">
-                    <span className="font-black">Avoid if:</span> {s.avoid_if}
+                    <span className="font-black">Use caution with:</span> {s.avoid_if}
                   </p>
                 ) : null}
                 <span className="mt-4 inline-flex text-sm font-black text-emerald-700 transition group-hover:translate-x-1">See dosage, timing & risks →</span>

--- a/app/top/best-herbs-for-cortisol/page.tsx
+++ b/app/top/best-herbs-for-cortisol/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { getHerbs } from '@/lib/runtime-data'
 import { getHerbSearchLinks } from '@/lib/affiliate'
 import { AffiliateConversionCard } from '@/components/affiliate-conversion-card'
+import { cleanSummary } from '@/lib/display-utils'
 
 type Herb = {
   slug: string
@@ -54,7 +55,7 @@ const matches = (herb: Herb): boolean => {
 }
 
 const summaryFor = (herb: Herb): string => {
-  const value = text(herb.mechanism_summary) || text(herb.summary) || text(herb.description) || 'Profile details are still being expanded from the workbook.'
+  const value = cleanSummary(text(herb.mechanism_summary) || text(herb.summary) || text(herb.description), 'herb')
   return value.length > 220 ? `${value.slice(0, 219).trimEnd()}…` : value
 }
 

--- a/app/top/best-supplements-for-fatigue/page.tsx
+++ b/app/top/best-supplements-for-fatigue/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { getCompounds, getHerbs } from '@/lib/runtime-data'
 import { buildAmazonSearchUrl, getHerbSearchLinks } from '@/lib/affiliate'
+import { cleanSummary } from '@/lib/display-utils'
 
 type RecordItem = {
   slug: string
@@ -20,7 +21,7 @@ const PICKS = [
 ]
 
 const label = (item: RecordItem): string => item.displayName || item.name || item.slug
-const summary = (item: RecordItem): string => item.mechanism_summary || item.summary || item.description || 'Profile details are still being expanded from the workbook.'
+const summary = (item: RecordItem): string => cleanSummary(item.mechanism_summary || item.summary || item.description, item.kind)
 const href = (item: RecordItem): string => item.kind === 'herb' ? `/herbs/${item.slug}/` : `/compounds/${item.slug}/`
 const affiliateUrl = (item: RecordItem): string => item.kind === 'herb' ? getHerbSearchLinks(label(item))[0]?.url || buildAmazonSearchUrl(label(item)) : buildAmazonSearchUrl(`${label(item)} supplement`)
 

--- a/app/top/focus/page.tsx
+++ b/app/top/focus/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { getCompounds } from '@/lib/runtime-data'
 import { buildAmazonSearchUrl } from '@/lib/affiliate'
+import { cleanSummary } from '@/lib/display-utils'
 
 type CompoundRecord = {
   slug: string
@@ -61,7 +62,7 @@ export default async function FocusPage() {
         {ranked.map((c, i) => (
           <div key={c.slug} className='border p-4 rounded-xl'>
             <h2 className='font-bold'>#{i + 1} {titleFor(c)}</h2>
-            <p className='text-sm text-white/70'>{c.summary}</p>
+            <p className='text-sm text-white/70'>{cleanSummary(c.summary || c.description, 'compound')}</p>
             <a href={buildAmazonSearchUrl(c.slug)} target='_blank' className='mt-3 inline-block bg-emerald-300 text-black px-3 py-1 rounded'>Compare {titleFor(c)} products →</a>
             <Link href={`/compounds/${c.slug}`} className='block mt-2 text-sm'>Read full profile →</Link>
           </div>

--- a/app/top/sleep/page.tsx
+++ b/app/top/sleep/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { getHerbs } from '@/lib/runtime-data'
 import { getHerbSearchLinks } from '@/lib/affiliate'
+import { cleanSummary } from '@/lib/display-utils'
 
 type SleepHerb = {
   slug: string
@@ -12,6 +13,7 @@ type SleepHerb = {
   primary_effects?: string[] | string
   goal_tags?: string[] | string
   mechanism_summary?: string
+  summary?: string
 }
 
 const EVIDENCE_WEIGHT: Record<string, number> = { A: 3, B: 2, C: 1 }
@@ -96,7 +98,7 @@ export default async function TopSleepPage() {
               <article key={herb.slug} className='border p-4 rounded-xl'>
                 <h3 className='text-lg font-semibold'>{label}</h3>
                 <p className='mt-2 text-sm text-white/70'>
-                  {herb.mechanism_summary || 'Mechanism summary not yet available.'}
+                  {cleanSummary(herb.mechanism_summary || herb.summary, 'herb')}
                 </p>
                 <div className='mt-3 flex gap-2 flex-wrap'>
                   <Link href={`/herbs/${herb.slug}`}>Read {label} profile</Link>

--- a/app/top/stress/page.tsx
+++ b/app/top/stress/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { getHerbs } from '@/lib/runtime-data'
 import { getHerbSearchLinks } from '@/lib/affiliate'
+import { cleanSummary } from '@/lib/display-utils'
 
 type HerbRecord = {
   slug: string
@@ -97,7 +98,7 @@ export default async function StressPage() {
                 <h2 className='text-xl font-bold text-white'>#{index + 1} {label}</h2>
                 <span className='rounded-full border border-white/10 bg-black/20 px-3 py-1 text-xs text-white/55'>Score {scoreFor(herb) || 'N/A'}</span>
               </div>
-              <p className='mt-3 text-sm leading-6 text-white/65'>{text(herb.summary) || text(herb.description) || 'Profile summary coming soon.'}</p>
+              <p className='mt-3 text-sm leading-6 text-white/65'>{cleanSummary(text(herb.summary) || text(herb.description), 'herb')}</p>
               <div className='mt-4 flex flex-wrap gap-2'>
                 <Link href={`/herbs/${herb.slug}/`} className='rounded-2xl border border-white/10 px-4 py-2 text-sm font-bold text-white/75 transition hover:bg-white/5 hover:text-white'>Read {label} profile</Link>
                 {links[0] ? <a href={links[0].url} target='_blank' rel='noopener noreferrer sponsored' className='rounded-2xl bg-emerald-300 px-4 py-2 text-sm font-bold text-slate-950 transition hover:bg-emerald-200'>Compare {label} products →</a> : null}

--- a/app/top/top-3-herbs-for-anxiety/page.tsx
+++ b/app/top/top-3-herbs-for-anxiety/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { getHerbs } from '@/lib/runtime-data'
 import { getHerbSearchLinks } from '@/lib/affiliate'
 import { AffiliateConversionCard } from '@/components/affiliate-conversion-card'
+import { cleanSummary } from '@/lib/display-utils'
 
 type Herb = {
   slug: string
@@ -47,7 +48,7 @@ const matches = (herb: Herb): boolean => {
 }
 
 const summaryFor = (herb: Herb): string => {
-  const value = text(herb.mechanism_summary) || text(herb.summary) || text(herb.description) || 'Profile details are still being expanded from the workbook.'
+  const value = cleanSummary(text(herb.mechanism_summary) || text(herb.summary) || text(herb.description), 'herb')
   return value.length > 220 ? `${value.slice(0, 219).trimEnd()}…` : value
 }
 

--- a/app/top/top-3-herbs-for-stress/page.tsx
+++ b/app/top/top-3-herbs-for-stress/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { getHerbs } from '@/lib/runtime-data'
 import { getHerbSearchLinks } from '@/lib/affiliate'
 import { AffiliateConversionCard } from '@/components/affiliate-conversion-card'
+import { cleanSummary } from '@/lib/display-utils'
 
 type Herb = {
   slug: string
@@ -47,7 +48,7 @@ const matchesStress = (herb: Herb): boolean => {
 }
 
 const summaryFor = (herb: Herb): string => {
-  const value = text(herb.mechanism_summary) || text(herb.summary) || text(herb.description) || 'Profile details are still being expanded from the workbook.'
+  const value = cleanSummary(text(herb.mechanism_summary) || text(herb.summary) || text(herb.description), 'herb')
   return value.length > 220 ? `${value.slice(0, 219).trimEnd()}…` : value
 }
 

--- a/app/top/top-3-natural-sleep-aids/page.tsx
+++ b/app/top/top-3-natural-sleep-aids/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { getHerbs } from '@/lib/runtime-data'
 import { getHerbSearchLinks } from '@/lib/affiliate'
+import { cleanSummary } from '@/lib/display-utils'
 import { AffiliateConversionCard } from '@/components/affiliate-conversion-card'
 
 type Herb = {
@@ -14,7 +15,7 @@ type Herb = {
 
 const PICKS = ['valerian', 'lemon-balm', 'passionflower']
 const label = (h: Herb): string => h.displayName || h.name || h.slug
-const summary = (h: Herb): string => h.mechanism_summary || h.summary || 'Profile details are still being expanded from the workbook.'
+const summary = (h: Herb): string => cleanSummary(h.mechanism_summary || h.summary, 'herb')
 
 export const metadata: Metadata = {
   title: 'Top 3 Natural Sleep Aids (2026 Guide)',

--- a/components/compare-table-client.tsx
+++ b/components/compare-table-client.tsx
@@ -3,10 +3,14 @@ import Link from 'next/link'
 import { useMemo } from 'react'
 import { useSearchParams } from 'next/navigation'
 import { EvidenceBadge } from '@/components/ui'
+import { formatDisplayLabel, isClean, list as cleanList, text as cleanText } from '@/lib/display-utils'
 
 type Compound = Record<string, any>
-const text = (v: any) => Array.isArray(v) ? v.map(text).filter(Boolean).join(', ') : String(v || '').replace(/\s+/g, ' ').trim()
-const list = (v: any) => Array.isArray(v) ? v.map(text).filter(Boolean) : text(v).split(/\n|;|\|/).map((i:string)=>i.trim()).filter(Boolean)
+const text = (v: any) => {
+ const value = cleanText(v)
+ return isClean(value) ? formatDisplayLabel(value) : ''
+}
+const list = (v: any) => cleanList(v)
 const getUseCaseLabel = (c: Compound) => {
  const h=`${text(c.role)} ${list(c.primary_effects||c.effects).join(' ')}`.toLowerCase()
  if (/strength|power|performance|muscle/.test(h)) return 'Strength'

--- a/components/compounds/CompoundCard.tsx
+++ b/components/compounds/CompoundCard.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { motion, useReducedMotion } from 'framer-motion'
 import EvidenceBadge from '@/components/ui/EvidenceBadge'
+import { cleanSummary, editorialUseCaseLabel, isClean, list } from '@/lib/display-utils'
 
 type CompoundCardProps = {
   compound: {
@@ -25,7 +26,7 @@ const clean = (value?: string) => String(value || '').replace(/\s+/g, ' ').trim(
 export default function CompoundCard({ compound }: CompoundCardProps) {
   const reduceMotion = useReducedMotion()
 
-  const tags = (compound.primary_effects || compound.effects || compound.tags || []).map(clean).filter(Boolean).slice(0, 3)
+  const tags = list(compound.primary_effects || compound.effects || compound.tags).slice(0, 3)
 
   return (
     <motion.article
@@ -52,12 +53,12 @@ export default function CompoundCard({ compound }: CompoundCardProps) {
         </div>
 
         <p className="text-reading line-clamp-4 text-sm sm:text-base">
-          {clean(compound.summary) || 'Evidence-aware compound profile with mechanism and safety context.'}
+          {cleanSummary(compound.summary, 'compound')}
         </p>
 
-        {compound.bestFor ? (
-          <div className="rounded-2xl border border-brand-900/10 bg-paper-100/80 px-4 py-3 text-sm leading-6 text-muted-soft">
-            {clean(compound.bestFor)}
+        {isClean(compound.bestFor) ? (
+          <div className="rounded-2xl border border-brand-900/10 bg-paper-100/80 px-4 py-3 text-sm leading-6 text-[#46574d]">
+            {editorialUseCaseLabel(compound.bestFor)}
           </div>
         ) : null}
 

--- a/components/herbs/HerbCard.tsx
+++ b/components/herbs/HerbCard.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { motion, useReducedMotion } from 'framer-motion'
 import EvidenceBadge from '@/components/ui/EvidenceBadge'
+import { cleanSummary, editorialUseCaseLabel, isClean, list } from '@/lib/display-utils'
 
 type HerbCardProps = {
   herb: {
@@ -40,9 +41,9 @@ function safetyLabel(value?: string) {
 
 export default function HerbCard({ herb }: HerbCardProps) {
   const reduceMotion = useReducedMotion()
-  const tags = (herb.primary_effects || herb.effects || herb.tags || []).map(clean).filter(Boolean).slice(0, 3)
-  const summary = clean(herb.summary) || 'Evidence-aware herbal profile with mechanism and safety context.'
-  const context = clean(herb.bestFor) || tags[0]
+  const tags = list(herb.primary_effects || herb.effects || herb.tags).slice(0, 3)
+  const summary = cleanSummary(herb.summary, 'herb')
+  const context = isClean(herb.bestFor) ? editorialUseCaseLabel(herb.bestFor) : tags[0]
 
   return (
     <motion.article
@@ -75,7 +76,7 @@ export default function HerbCard({ herb }: HerbCardProps) {
         </p>
 
         {context ? (
-          <div className="rounded-2xl border border-brand-900/10 bg-paper-100/80 px-4 py-3 text-sm leading-6 text-muted-soft">
+          <div className="rounded-2xl border border-brand-900/10 bg-paper-100/80 px-4 py-3 text-sm leading-6 text-[#46574d]">
             {context}
           </div>
         ) : null}

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -11,7 +11,7 @@ const learningPaths = [
 
 const evidenceTopics = [
   { href: '/blog/2026-03-18-research-digest-passionflower', title: 'How to read a research digest', description: 'A short editorial example of translating mechanisms and limitations without overclaiming.', meta: 'Article', kind: 'article' as const },
-  { href: '/herbs/ashwagandha', title: 'Ashwagandha profile', description: 'A depth-layer example combining traditional use, stress pathways, and conservative evidence framing.', meta: 'Herb profile', kind: 'herb' as const },
+  { href: '/herbs/ashwagandha', title: 'Ashwagandha profile', description: 'A depth-layer example combining traditional use, stress pathways, and cautious evidence context.', meta: 'Herb profile', kind: 'herb' as const },
   { href: '/compounds/theanine', title: 'Theanine profile', description: 'Compound-centered scanning for effects, safety, mechanisms, and related recommendations.', meta: 'Compound profile', kind: 'compound' as const },
 ]
 

--- a/components/scientific-discovery.tsx
+++ b/components/scientific-discovery.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import type { DiscoveryLink } from '@/lib/editorial-discovery'
+import { isClean, isSafeInternalHref } from '@/lib/display-utils'
 
 type SemanticBrowseModuleProps = {
   eyebrow?: string
@@ -18,6 +19,8 @@ const kindStyles: Record<string, string> = {
 export function ContentIdentityCard({ item }: { item: DiscoveryLink }) {
   const style = kindStyles[item.kind || 'path'] || kindStyles.path
 
+  if (!isSafeInternalHref(item.href) || !isClean(item.title)) return null
+
   return (
     <Link href={item.href} className={`scientific-card ${style} group`}>
       <div className="flex items-center justify-between gap-3">
@@ -31,18 +34,22 @@ export function ContentIdentityCard({ item }: { item: DiscoveryLink }) {
 }
 
 export function SemanticBrowseModule({ eyebrow = 'Semantic discovery', title, description, groups }: SemanticBrowseModuleProps) {
+  const visibleGroups = groups.filter(group => isSafeInternalHref(group.href) && isClean(group.title) && isClean(group.description))
+
+  if (!visibleGroups.length) return null
+
   return (
     <section className="surface-depth card-spacing">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <p className="eyebrow-label">{eyebrow}</p>
-          <h2 className="mt-3 max-w-2xl text-balance">{title}</h2>
+          <h2 className="mt-3 max-w-2xl text-balance text-3xl font-semibold tracking-tight text-ink sm:text-4xl">{title}</h2>
         </div>
         {description ? <p className="max-w-xl text-sm leading-7 text-[#46574d]">{description}</p> : null}
       </div>
 
       <div className="mt-7 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-        {groups.map(group => (
+        {visibleGroups.map(group => (
           <Link key={`${group.href}-${group.title}`} href={group.href} className="scientific-card group">
             <div className="flex items-center justify-between gap-3">
               <span className="identity-kicker">{group.meta || 'Explore'}</span>
@@ -58,7 +65,9 @@ export function SemanticBrowseModule({ eyebrow = 'Semantic discovery', title, de
 }
 
 export function ResearchContinuityBlock({ title = 'Continue researching', description, items }: { title?: string; description?: string; items: DiscoveryLink[] }) {
-  if (!items.length) return null
+  const visibleItems = items.filter(item => isSafeInternalHref(item.href) && isClean(item.title))
+
+  if (!visibleItems.length) return null
 
   return (
     <div className="space-y-5">
@@ -68,7 +77,7 @@ export function ResearchContinuityBlock({ title = 'Continue researching', descri
         {description ? <p className="mt-2 text-sm leading-7 text-[#46574d]">{description}</p> : null}
       </div>
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-        {items.map(item => <ContentIdentityCard key={item.href} item={item} />)}
+        {visibleItems.map(item => <ContentIdentityCard key={item.href} item={item} />)}
       </div>
     </div>
   )

--- a/components/ui/CompareBar.tsx
+++ b/components/ui/CompareBar.tsx
@@ -1,16 +1,44 @@
-export default function CompareBar({items=[]}:any){
-  if(!items.length) return null
+import Link from 'next/link'
+import { isSafeInternalHref } from '@/lib/display-utils'
+import { generatedComparisons } from '@/data/generated-comparisons'
+import { supplementComparisons } from '@/data/comparisons'
 
-  return(
-    <div className="fixed bottom-16 left-1/2 -translate-x-1/2 bg-white border shadow-lg rounded-xl px-4 py-2 flex gap-3 text-xs">
-      {items.slice(0,3).map((i:any)=>(
-        <span key={i.slug} className="bg-neutral-100 px-2 py-1 rounded">
-          {i.name}
-        </span>
-      ))}
-      <button className="bg-black text-white px-3 py-1 rounded">
-        Compare
-      </button>
-    </div>
+const knownComparisonSlugs = new Set([
+  ...generatedComparisons,
+  ...supplementComparisons.map((comparison) => comparison.slug),
+])
+
+export default function CompareBar({ items = [] }: any) {
+  const compareItems = items
+    .filter((item: any) => item?.slug && item?.name)
+    .slice(0, 2)
+
+  if (compareItems.length < 2) return null
+
+  const slug = `${compareItems[0].slug}-vs-${compareItems[1].slug}`
+  const reverseSlug = `${compareItems[1].slug}-vs-${compareItems[0].slug}`
+  const comparisonSlug = knownComparisonSlugs.has(slug) ? slug : knownComparisonSlugs.has(reverseSlug) ? reverseSlug : ''
+  const href = comparisonSlug ? `/compare/${comparisonSlug}` : ''
+
+  if (!isSafeInternalHref(href)) return null
+
+  return (
+    <aside className="fixed inset-x-3 bottom-[calc(0.75rem+env(safe-area-inset-bottom))] z-40 mx-auto max-w-md rounded-[1.25rem] border border-brand-900/10 bg-[#fffdf7]/95 p-3 shadow-[0_14px_40px_rgba(25,48,35,0.16)] backdrop-blur-xl sm:bottom-[calc(1rem+env(safe-area-inset-bottom))] sm:p-3.5 lg:left-auto lg:right-5 lg:mx-0 lg:w-[22rem]">
+      <div className="flex items-center gap-3">
+        <div className="min-w-0 flex-1">
+          <p className="eyebrow-label text-[0.62rem]">Compare</p>
+          <p className="mt-1 truncate text-sm font-semibold text-ink">
+            {compareItems.map((item: any) => item.name).join(' vs ')}
+          </p>
+        </div>
+
+        <Link
+          href={href}
+          className="flex-none rounded-full bg-brand-800 px-4 py-2 text-xs font-bold text-white shadow-sm transition hover:bg-brand-700"
+        >
+          Open
+        </Link>
+      </div>
+    </aside>
   )
 }

--- a/components/ui/CompoundHero.tsx
+++ b/components/ui/CompoundHero.tsx
@@ -26,7 +26,7 @@ export default function CompoundHero({
             {compound.name}
           </h1>
 
-          <p className="text-reading max-w-3xl text-lg leading-relaxed text-muted-soft sm:text-[1.08rem]">
+          <p className="text-reading max-w-3xl text-lg leading-relaxed text-[#46574d] sm:text-[1.08rem]">
             {compound.summary || 'Evidence-informed compound profile.'}
           </p>
         </div>

--- a/components/ui/ConfidencePanel.tsx
+++ b/components/ui/ConfidencePanel.tsx
@@ -28,7 +28,7 @@ export default function ConfidencePanel({ level = 'moderate' }: any) {
         </div>
       </div>
 
-      <p className="max-w-2xl text-sm leading-7 text-muted-soft">
+      <p className="max-w-2xl text-sm leading-7 text-[#46574d]">
         {item.text}
       </p>
     </div>

--- a/components/ui/DecisionCard.tsx
+++ b/components/ui/DecisionCard.tsx
@@ -1,11 +1,7 @@
+import { editorialUseCaseLabel, formatDisplayLabel, isClean } from '@/lib/display-utils'
+
 function cleanLabel(value: string) {
-  return value
-    .replace(/_/g, ' ')
-    .replace(/\bhealthy aging\b/gi, 'Healthy aging')
-    .replace(/\bfat loss\b/gi, 'Fat loss')
-    .replace(/\bstress mood\b/gi, 'Stress & mood')
-    .replace(/\bsleep quality\b/gi, 'Sleep quality')
-    .replace(/\bgeneral wellness\b/gi, 'General wellness')
+  return formatDisplayLabel(value)
 }
 
 export default function DecisionCard({
@@ -15,12 +11,12 @@ export default function DecisionCard({
   evidence = ''
 }: any) {
   const cleanedBestFor = bestFor
-    .filter(Boolean)
-    .map((item:any) => cleanLabel(String(item)))
+    .filter(isClean)
+    .map((item:any) => editorialUseCaseLabel(item))
     .slice(0, 3)
 
   const cleanedAvoid = avoid
-    .filter(Boolean)
+    .filter(isClean)
     .map((item:any) => cleanLabel(String(item)))
 
   return (

--- a/components/ui/EvidenceMeter.tsx
+++ b/components/ui/EvidenceMeter.tsx
@@ -19,7 +19,7 @@ export default function EvidenceMeter({ level='moderate' }: any) {
             Evidence Strength
           </div>
 
-          <p className="max-w-md text-sm leading-7 text-muted-soft">
+          <p className="max-w-md text-sm leading-7 text-[#46574d]">
             Confidence estimate based on available human and mechanistic evidence.
           </p>
         </div>

--- a/components/ui/PremiumCard.tsx
+++ b/components/ui/PremiumCard.tsx
@@ -82,14 +82,14 @@ export default function PremiumCard({
         </Link>
 
         {cleanSummary ? (
-          <p className="text-reading mt-4 line-clamp-4 text-base text-muted-soft">
+          <p className="text-reading mt-4 line-clamp-4 text-base text-[#46574d]">
             {cleanSummary}
           </p>
         ) : null}
 
         {cleanBestFor ? (
           <div className="mt-5 rounded-2xl border border-brand-900/10 bg-[rgba(251,246,233,0.85)] px-4 py-3">
-            <p className="text-sm leading-6 text-muted-soft">
+            <p className="text-sm leading-6 text-[#46574d]">
               <span className="font-semibold text-ink">Best for:</span> {cleanBestFor}
             </p>
           </div>
@@ -100,7 +100,7 @@ export default function PremiumCard({
             {visibleTags.map((tag) => (
               <span
                 key={tag}
-                className="rounded-full border border-brand-900/10 bg-paper-100 px-3 py-1 text-xs font-medium tracking-wide text-muted-soft"
+                className="rounded-full border border-brand-900/10 bg-paper-100 px-3 py-1 text-xs font-medium tracking-wide text-[#46574d]"
               >
                 {tag}
               </span>

--- a/components/ui/RecommendationRail.tsx
+++ b/components/ui/RecommendationRail.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { isClean } from '@/lib/display-utils'
 
 type Item = {
   slug: string
@@ -14,54 +15,56 @@ type Props = {
 }
 
 export default function RecommendationRail({ title, subtitle, items }: Props) {
-  if (!items?.length) return null
+  const visibleItems = items.filter((item) => item.slug && isClean(item.name || item.slug))
+
+  if (!visibleItems.length) return null
 
   return (
     <section className="space-y-5">
       <div>
-        <div className="text-xs uppercase tracking-[0.2em] text-emerald-300">
+        <div className="eyebrow-label">
           Semantic Discovery
         </div>
 
-        <h2 className="mt-2 text-3xl font-semibold text-white">
+        <h2 className="mt-2 text-3xl font-semibold text-ink">
           {title}
         </h2>
 
         {subtitle && (
-          <p className="mt-3 max-w-3xl text-sm leading-7 text-neutral-400">
+          <p className="mt-3 max-w-3xl text-sm leading-7 text-[#46574d]">
             {subtitle}
           </p>
         )}
       </div>
 
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-        {items.map((item) => {
+        {visibleItems.map((item) => {
           const strength = Math.min(100, (item.relationship_score || 1) * 15)
 
           return (
             <Link
               key={item.slug}
               href={`/compounds/${item.slug}`}
-              className="group rounded-3xl border border-white/10 bg-white/[0.04] p-5 backdrop-blur-xl transition hover:-translate-y-1 hover:bg-white/[0.08]"
+              className="card-premium group p-5"
             >
               <div className="space-y-4">
                 <div className="flex items-start justify-between gap-3">
-                  <h3 className="text-lg font-semibold text-white group-hover:text-emerald-300 transition">
+                  <h3 className="text-lg font-semibold text-ink transition group-hover:text-brand-800">
                     {item.name || item.slug}
                   </h3>
 
-                  <div className="rounded-full border border-white/10 bg-black/20 px-2 py-1 text-[10px] uppercase tracking-wide text-neutral-300">
+                  <div className="chip-readable text-[10px] uppercase tracking-wide">
                     {strength >= 60 ? 'Strong' : strength >= 30 ? 'Moderate' : 'Exploratory'}
                   </div>
                 </div>
 
-                <p className="text-sm leading-7 text-neutral-400">
-                  {item.relationship_reason || 'Semantically related compound profile.'}
+                <p className="text-sm leading-7 text-[#46574d]">
+                  {isClean(item.relationship_reason) ? item.relationship_reason : 'Related through shared mechanisms, pathways, or overlapping wellness targets.'}
                 </p>
 
-                <div className="h-2 overflow-hidden rounded-full bg-white/5">
+                <div className="h-2 overflow-hidden rounded-full bg-brand-900/10">
                   <div
-                    className="h-full rounded-full bg-gradient-to-r from-emerald-400 via-cyan-400 to-sky-400"
+                    className="h-full rounded-full bg-gradient-to-r from-brand-600 to-emerald-500"
                     style={{ width: `${strength}%` }}
                   />
                 </div>

--- a/components/ui/StackCompatibility.tsx
+++ b/components/ui/StackCompatibility.tsx
@@ -8,15 +8,15 @@ export default function StackCompatibility({ related = [] }: any) {
           key={i}
           className="rounded-2xl border p-4 bg-white/70 backdrop-blur"
         >
-          <div className="text-xs uppercase tracking-wide text-neutral-400 mb-2">
+          <div className="text-xs uppercase tracking-wide text-[#46574d] mb-2">
             Potential Stack Pairing
           </div>
 
-          <div className="font-semibold text-sm">
+          <div className="font-semibold text-sm text-ink">
             {item.name}
           </div>
 
-          <div className="text-xs text-neutral-500 mt-2 leading-5">
+          <div className="text-xs text-[#46574d] mt-2 leading-5">
             May complement related mechanisms, goals, or wellness contexts.
           </div>
         </div>

--- a/lib/display-utils.ts
+++ b/lib/display-utils.ts
@@ -4,29 +4,31 @@ const INTERNAL_PATTERNS = [
   /lean\s+herb\s+row/i,
   /lean\s+monograph\s+row/i,
   /high\s+speed\s+phytochemical\s+ingestion/i,
-  /is\s+tracked\s+for/i,
-  /is\s+tracked\s+for\s+.*conservative\s+evidence\s+framing/i,
+  /(?:is\s+)?tracked\s+for/i,
   /conservative\s+evidence\s+framing/i,
   /keep\s+claims\s+tied/i,
   /source\s+backed\s+preparation\s+and\s+safety\s+context/i,
   /bulk\s+ingested\s+support\s+row/i,
   /sci\s*space\s+evidence\s+pass/i,
-  /mechanism\s+only\s+pending\s+stronger\s+human/i,
+  /scispace\s+evidence\s+pass/i,
+  /mechanism[-\s]*only\s+pending\s+stronger\s+human/i,
   /pmid\s+backed\s+human\s+evidence\s+is\s+present/i,
   /minimum\s+source\s+backed\s+intake/i,
   /bulk\s+mode/i,
   /bulk\s+enrichment/i,
+  /workbook\s+readiness\s+pass/i,
   /enriched\s+in\s+bulk\s+mode/i,
   /schema\s+artifact/i,
   /placeholder/i,
-  /internal\s+cross[-\s]*linking/i,
-  /internal\s+cross[-\s]*linking\s+supports/i,
+  /internal\s+cross[-\s]*linking(?:\s+supports)?/i,
   /treat\s+dosing\s+and\s+outcomes\s+as\s+review\s+gated/i,
   /added\s+as\s+site\s+safe\s+referenced\s+entity\s+during\s+workbook\s+readiness\s+pass/i,
   /^n\/?a$/i,
   /^unknown$/i,
   /^tbd$/i,
   /^none$/i,
+  /^no\s+major\s+flags$/i,
+  /^not\s+yet\s+available$/i,
 ]
 
 const LABEL_MAP: Record<string, string> = {
@@ -144,4 +146,30 @@ export function cleanSummary(value: unknown, type: 'herb' | 'compound' = 'compou
   }
 
   return 'Evidence-aware compound profile with mechanism, safety, and practical context.'
+}
+
+
+export function editorialUseCaseLabel(value: unknown): string {
+  const label = formatDisplayLabel(value)
+
+  if (!isClean(label)) return ''
+
+  const lower = label.toLowerCase()
+  if (/metabolic|glucose|insulin|weight|fat loss/.test(lower)) return 'Most commonly explored for metabolic support.'
+  if (/sleep|insomnia|night/.test(lower)) return 'Most commonly explored for sleep and nighttime support.'
+  if (/stress|mood|anxiety|calm/.test(lower)) return 'Most commonly explored for stress resilience and calm support.'
+  if (/focus|cognition|memory|brain|attention/.test(lower)) return 'Most commonly explored for cognitive and focus support.'
+  if (/recovery|performance|exercise|muscle/.test(lower)) return 'Most commonly explored for recovery and performance support.'
+
+  return `Most commonly explored for ${label.toLowerCase()} support.`
+}
+
+export function isSafeInternalHref(value: unknown): value is string {
+  const href = text(value)
+
+  if (!href || !href.startsWith('/') || href.includes('//')) return false
+  if (/\/(undefined|null|nan)(?:\/|$)/i.test(href)) return false
+  if (/\s/.test(href)) return false
+
+  return true
 }

--- a/lib/semantic-runtime.ts
+++ b/lib/semantic-runtime.ts
@@ -1,4 +1,5 @@
 import compoundsData from '../public/data/compounds.json'
+import { cleanSummary, formatDisplayLabel, isClean, list as cleanList } from './display-utils'
 
 export type RuntimeCompoundInput = {
   slug?: string
@@ -58,21 +59,7 @@ function slugify(value: unknown): string {
 }
 
 function splitList(value: unknown): string[] {
-  if (!value) return []
-
-  if (Array.isArray(value)) {
-    return value
-      .flatMap((entry) => splitList(entry))
-      .map(clean)
-      .filter(Boolean)
-  }
-
-  if (typeof value === 'object') return []
-
-  return clean(value)
-    .split(/[|;,]/)
-    .map((entry) => entry.trim())
-    .filter(Boolean)
+  return cleanList(value)
 }
 
 function unique(values: string[]): string[] {
@@ -129,19 +116,20 @@ function inferClusters(record: Pick<RuntimeCompound, 'effects' | 'mechanisms' | 
 export function normalizeCompound(input: RuntimeCompoundInput): RuntimeCompound {
   const effects = unique(splitList(input.effects || input.primary_effects || input.effect))
   const mechanisms = unique(splitList(input.mechanisms || input.mechanism))
-  const summary = clean(input.summary || input.coreInsight)
+  const summary = cleanSummary(input.summary || input.coreInsight, 'compound')
 
   const base = {
     slug: slugify(input.slug || input.name || input.title),
-    name: clean(input.name || input.title || input.slug),
-    summary: summary || 'No summary available yet.',
+    name: formatDisplayLabel(input.name || input.title || input.slug),
+    summary,
     effects,
     mechanisms,
-    evidence_tier: clean(input.evidence_tier || input.evidence),
-    safety: clean(
+    evidence_tier: formatDisplayLabel(input.evidence_tier || input.evidence),
+    safety: cleanSummary(
       typeof input.safety === 'object' && input.safety && 'notes' in input.safety
         ? (input.safety as { notes?: unknown }).notes
-        : input.safety
+        : input.safety,
+      'compound'
     ),
     sources: sourceArray(input.sources || input.references),
     related_compounds: unique(splitList(input.related_compounds || input.relatedCompounds)),
@@ -162,7 +150,7 @@ export function normalizeCompound(input: RuntimeCompoundInput): RuntimeCompound 
 
 const compounds = (compoundsData as RuntimeCompoundInput[])
   .map(normalizeCompound)
-  .filter((compound) => compound.slug && compound.name)
+  .filter((compound) => compound.slug && compound.name && isClean(compound.name))
 
 export function getAllCompoundsRuntime() {
   return compounds


### PR DESCRIPTION
### Motivation

- Improve visual contrast and readability across semantic discovery and profile pages to eliminate faded text on warm paper backgrounds and strengthen hierarchy.  
- Prevent internal/workbook-only language and placeholder signals from leaking into the public site.  
- Reduce mobile compare-tray intrusiveness and remove empty/placeholder UI to raise trust and stabilize semantic routes.  

### Description

- Tightened typography and color tokens across discovery and profile components by replacing faded classes with readable tokens (`text-ink`, `text-[#46574d]`, `muted-readable`) and updated card / hero styles to preserve the warm aesthetic while improving contrast.  
- Hardened display sanitizers in `lib/display-utils.ts`: expanded internal-patterns, added `cleanSummary` fallbacks for `herb`/`compound`, added `editorialUseCaseLabel` and `isSafeInternalHref`, and improved `isClean`/`list` handling to block workbook/internal phrases.  
- Guarded rendering of empty or placeholder sections and lists (mechanisms, safety bullets, best-for, timelines, chips, research continuity) so empty arrays or internal text produce no UI.  
- Reworked compare UI: replaced the previous floating CompareBar with a compact, safe-area aware tray (`components/ui/CompareBar.tsx`) that collapses to a single action, uses known comparison slugs, and validates internal hrefs before rendering to avoid 404s and reduce visual dominance on mobile.  
- Improved semantic recommendation and exploration modules to filter out unsafe/empty group items, use editorial phrasing for use-cases (`Most commonly explored for ...`), and prefer `cleanSummary` when showing profile summaries.  
- Introduced conservative editorial phrasing and safer label normalization across decision cards, recommendation rails, goal pages, and compound/herb cards (uses `editorialUseCaseLabel`, `formatDisplayLabel`, `cleanSummary`).  
- Minor route/content fixes: validate and filter generated comparison slugs before linking, filter related compound/stack candidates for safety, and ensure topic/semantic links only render when slugs/hrefs are valid.  

### Testing

- Ran the full project check via `npm run check` which runs data build/validation and `next build`; the build and verification steps completed successfully (static pages generated and verification scripts passed).  
- Verified that generated pages no longer surface internal workbook strings or empty placeholder sections during the build, and that compare tray only appears when a validated comparison slug exists; automated data validations (`data:validate` and `data:verify`) passed.  
- Performed focused source edits and local static generation to ensure core semantic routes (`/explore/*`, `/goals/:slug`, `/herbs/:slug`, `/compounds/:slug`, `/compare/*`) render without producing invalid internal links or empty UI; build succeeded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcca00ee28832384534ec6dd1fc9ff)