### PR TITLE
Stabilize public trust surfaces — strengthen sanitizer and sanitize UI outputs

### DIFF
--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -34,7 +34,7 @@ import {
 import Link from 'next/link'
 import { EvidenceMaturityRibbon, SemanticBrowseModule } from '@/components/scientific-discovery'
 import { buildSemanticTopics } from '@/lib/editorial-discovery'
-import { cleanSummary, formatDisplayLabel, isClean, isSafeInternalHref, list } from '@/lib/display-utils'
+import { cleanSummary, formatDisplayLabel, isClean, isSafeInternalHref, list, text } from '@/lib/display-utils'
 import { generatedComparisons } from '@/data/generated-comparisons'
 import { supplementComparisons } from '@/data/comparisons'
 
@@ -73,24 +73,42 @@ export default function Page({ params }: any) {
   const effects = getEffects(compound)
     .map((effect:string) => cleanLabel(effect))
     .filter((effect:string) => isClean(effect) && !/^no\s+strong\s+effects\s+established\s+yet$/i.test(effect))
-  const sources = getSources(compound).filter((source:any) => isClean(typeof source === 'string' ? source : JSON.stringify(source)))
+  const sources = getSources(compound)
+    .map((source:any) => text(source))
+    .filter(isClean)
 
   const related = getRelatedCompounds(compound)
-    .filter((item:any) => item.slug && item.name && isClean(item.name))
-    .map((item:any)=>({
+    .map((item:any) => ({
       ...item,
-      archetype: classifyArchetype(item),
+      name: formatDisplayLabel(item.name || item.slug),
+      relationship_reason: cleanSummary(item.relationship_reason, 'compound'),
+      evidence_tier: formatDisplayLabel(item.evidence_tier),
+      archetype: formatDisplayLabel(classifyArchetype(item)),
     }))
+    .filter((item:any) => item.slug && item.name && isClean(item.name))
 
-  const stackCandidates = getStackCandidates(compound).filter((candidate:any) => candidate.slug && candidate.name && isClean(candidate.reason))
+  const stackCandidates = getStackCandidates(compound)
+    .map((candidate:any) => ({
+      ...candidate,
+      name: formatDisplayLabel(candidate.name || candidate.slug),
+      reason: text(candidate.reason) ? cleanSummary(candidate.reason, 'compound') : '',
+      confidence: formatDisplayLabel(candidate.confidence || 'Exploratory'),
+    }))
+    .filter((candidate:any) => candidate.slug && candidate.name && isClean(candidate.reason))
   const comparisonCandidates = getComparisonCandidates(compound).filter((candidate:any) => candidate.slug && knownComparisonSlugs.has(candidate.slug) && isSafeInternalHref(candidate.href))
   const snapshot = getEvidenceSnapshot(compound)
-  const semanticTopics = buildSemanticTopics(compound)
+  const rawSemanticTopics = buildSemanticTopics(compound)
+  const semanticTopics = {
+    maturity: formatDisplayLabel(rawSemanticTopics.maturity) || 'Evidence maturity',
+    researchStyle: formatDisplayLabel(rawSemanticTopics.researchStyle) || 'Research context',
+    effects: rawSemanticTopics.effects.map(formatDisplayLabel).filter(isClean),
+    mechanisms: rawSemanticTopics.mechanisms.map(formatDisplayLabel).filter(isClean),
+  }
 
   const evidenceLevel = normalizeEvidenceLevel(compound.evidence_tier)
   const safetyLevel = normalizeSafetyLevel(compound.safety)
 
-  const mechanisms = list(compound.mechanisms)
+  const mechanisms = list(compound.mechanisms).filter(isClean)
 
   const summary = cleanSummary(compound.summary || compound.description, 'compound')
 
@@ -122,13 +140,18 @@ export default function Page({ params }: any) {
       ? compound.time_to_effect
       : []
 
-  const meaningfulTimeline = timelineData.filter((item:any) => isClean(item?.title) && isClean(item?.text))
+  const meaningfulTimeline = timelineData
+    .map((item:any) => ({
+      title: formatDisplayLabel(item?.title),
+      text: text(item?.text),
+    }))
+    .filter((item:any) => isClean(item.title) && isClean(item.text))
 
   return (
     <>
       <ReadingProgress />
 
-      <main className="mx-auto flex max-w-7xl gap-10 px-4 pb-40 sm:pb-32">
+      <main className="mx-auto flex max-w-7xl gap-10 px-4 pb-28 sm:pb-32">
 
         <TableOfContents />
 
@@ -150,9 +173,11 @@ export default function Page({ params }: any) {
             />
             <div className="flex flex-wrap gap-3">
               <EvidenceMaturityRibbon label={semanticTopics.maturity} />
-              {[semanticTopics.researchStyle, ...semanticTopics.effects.slice(0, 2), ...semanticTopics.mechanisms.slice(0, 2)].filter(isClean).map(item => (
-                <span key={item} className="chip-readable">{item}</span>
-              ))}
+              {[semanticTopics.researchStyle, ...semanticTopics.effects.slice(0, 2), ...semanticTopics.mechanisms.slice(0, 2)]
+                .filter(isClean)
+                .map(item => (
+                  <span key={item} className="chip-readable">{item}</span>
+                ))}
             </div>
           </div>
 
@@ -242,7 +267,7 @@ export default function Page({ params }: any) {
                       </h3>
 
                       <span className="chip-readable text-[10px] uppercase tracking-wide">
-                        {cleanLabel(candidate.confidence || 'Exploratory')}
+                        {candidate.confidence || 'Exploratory'}
                       </span>
                     </div>
 
@@ -302,7 +327,7 @@ export default function Page({ params }: any) {
             <SectionBlock title="Sources">
               <ul className="space-y-2 text-sm leading-7 text-[#46574d]">
                 {sources.slice(0,10).map((source:any,index:number)=>(
-                  <li key={index}>• {typeof source==='string'?source:JSON.stringify(source)}</li>
+                  <li key={index}>• {source}</li>
                 ))}
               </ul>
             </SectionBlock>

--- a/app/compounds/page.tsx
+++ b/app/compounds/page.tsx
@@ -4,7 +4,7 @@ import { cleanSummary, formatDisplayLabel, isClean, labelize, list, text, unique
 import '@/styles/premium-cards.css'
 
 function getName(item: any) {
-  return text(item.displayName) || text(item.name) || formatDisplayLabel(item.slug)
+  return formatDisplayLabel(item.displayName) || formatDisplayLabel(item.name) || formatDisplayLabel(item.slug)
 }
 
 function getSummary(item: any) {

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -228,7 +228,13 @@ export default async function HerbDetailPage({ params }: Params) {
   ].filter(id => /\d/.test(id))).slice(0, 10)
 
   const researchInputs = { profile: herb, claims, pmids, mechanisms }
-  const semanticTopics = buildSemanticTopics(herb)
+  const rawSemanticTopics = buildSemanticTopics(herb)
+  const semanticTopics = {
+    maturity: formatDisplayLabel(rawSemanticTopics.maturity) || 'Evidence maturity',
+    researchStyle: formatDisplayLabel(rawSemanticTopics.researchStyle) || 'Research context',
+    effects: rawSemanticTopics.effects.map(formatDisplayLabel).filter(isClean),
+    mechanisms: rawSemanticTopics.mechanisms.map(formatDisplayLabel).filter(isClean),
+  }
   const relatedArticles = findRelatedArticles(herb, blogPosts as any[], 4)
   const evidenceFrame = deriveEvidenceFraming(researchInputs)
   const researchStyle = deriveResearchStyle(researchInputs)

--- a/app/herbs/page.tsx
+++ b/app/herbs/page.tsx
@@ -1,10 +1,10 @@
 import Link from 'next/link'
 import { getHerbs } from '@/lib/runtime-data'
-import { cleanSummary, isClean, labelize, list, text, unique } from '@/lib/display-utils'
+import { cleanSummary, formatDisplayLabel, isClean, labelize, list, text, unique } from '@/lib/display-utils'
 import '@/styles/premium-cards.css'
 
 function getName(item: any) {
-  return text(item.displayName) || text(item.name) || text(item.slug).replace(/-/g, ' ')
+  return formatDisplayLabel(item.displayName) || formatDisplayLabel(item.name) || formatDisplayLabel(item.slug)
 }
 
 function getSummary(item: any) {

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link'
 import Fuse from 'fuse.js'
 import compoundsData from '@/public/data/compounds.json'
 import herbsData from '@/public/data/herbs.json'
-import { cleanSummary, isClean, labelize, list, text, unique } from '@/lib/display-utils'
+import { cleanSummary, formatDisplayLabel, isClean, labelize, list, text, unique } from '@/lib/display-utils'
 
 type SearchType = 'Herb' | 'Compound'
 type SearchItem = {
@@ -24,7 +24,7 @@ type SearchItem = {
 const suggestedSearches = ['sleep', 'stress', 'inflammation', 'focus', 'digestion', 'metabolism']
 
 function getName(item: any) {
-  return text(item.displayName) || text(item.name) || text(item.slug).replace(/-/g, ' ')
+  return formatDisplayLabel(item.displayName) || formatDisplayLabel(item.name) || formatDisplayLabel(item.slug)
 }
 
 function getSummary(item: any, type: SearchType) {
@@ -105,6 +105,8 @@ function normalizeItem(item: any, type: SearchType): SearchItem | null {
   if (!slug) return null
 
   const name = getName(item)
+  if (!name || !isClean(name)) return null
+
   const summary = getSummary(item, type)
   const effects = getEffects(item)
   const evidence = getEvidence(item)

--- a/components/scientific-discovery.tsx
+++ b/components/scientific-discovery.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import type { DiscoveryLink } from '@/lib/editorial-discovery'
-import { isClean, isSafeInternalHref } from '@/lib/display-utils'
+import { cleanSummary, formatDisplayLabel, isClean, isSafeInternalHref } from '@/lib/display-utils'
 
 type SemanticBrowseModuleProps = {
   eyebrow?: string
@@ -19,7 +19,10 @@ const kindStyles: Record<string, string> = {
 export function ContentIdentityCard({ item }: { item: DiscoveryLink }) {
   const style = kindStyles[item.kind || 'path'] || kindStyles.path
 
-  if (!isSafeInternalHref(item.href) || !isClean(item.title)) return null
+  const title = formatDisplayLabel(item.title)
+  const description = cleanSummary(item.description, item.kind === 'herb' ? 'herb' : 'compound')
+
+  if (!isSafeInternalHref(item.href) || !title || !isClean(title)) return null
 
   return (
     <Link href={item.href} className={`scientific-card ${style} group`}>
@@ -27,14 +30,21 @@ export function ContentIdentityCard({ item }: { item: DiscoveryLink }) {
         <span className="identity-kicker">{item.kind || 'path'}</span>
         {item.meta ? <span className="identity-meta">{item.meta}</span> : null}
       </div>
-      <h3 className="mt-4 text-xl font-semibold tracking-tight text-ink group-hover:text-brand-800">{item.title}</h3>
-      <p className="mt-3 text-sm leading-7 text-[#46574d]">{item.description}</p>
+      <h3 className="mt-4 text-xl font-semibold tracking-tight text-ink group-hover:text-brand-800">{title}</h3>
+      <p className="mt-3 text-sm leading-7 text-[#46574d]">{description}</p>
     </Link>
   )
 }
 
 export function SemanticBrowseModule({ eyebrow = 'Semantic discovery', title, description, groups }: SemanticBrowseModuleProps) {
-  const visibleGroups = groups.filter(group => isSafeInternalHref(group.href) && isClean(group.title) && isClean(group.description))
+  const visibleGroups = groups
+    .map(group => ({
+      ...group,
+      title: formatDisplayLabel(group.title),
+      description: cleanSummary(group.description, 'compound'),
+      meta: formatDisplayLabel(group.meta),
+    }))
+    .filter(group => isSafeInternalHref(group.href) && isClean(group.title) && isClean(group.description))
 
   if (!visibleGroups.length) return null
 
@@ -84,10 +94,14 @@ export function ResearchContinuityBlock({ title = 'Continue researching', descri
 }
 
 export function EvidenceMaturityRibbon({ label }: { label: string }) {
+  const cleanLabel = formatDisplayLabel(label)
+
+  if (!cleanLabel) return null
+
   return (
     <div className="inline-flex items-center gap-2 rounded-full border border-emerald-800/10 bg-emerald-700/10 px-3.5 py-1.5 text-xs font-bold uppercase tracking-[0.16em] text-emerald-900">
       <span className="h-2 w-2 rounded-full bg-emerald-600" />
-      {label}
+      {cleanLabel}
     </div>
   )
 }

--- a/components/ui/CompareBar.tsx
+++ b/components/ui/CompareBar.tsx
@@ -23,18 +23,18 @@ export default function CompareBar({ items = [] }: any) {
   if (!isSafeInternalHref(href)) return null
 
   return (
-    <aside className="fixed inset-x-4 bottom-[calc(0.5rem+env(safe-area-inset-bottom))] z-40 mx-auto max-w-sm rounded-2xl border border-brand-900/10 bg-[#fffdf7]/95 p-2.5 pb-[calc(0.625rem+env(safe-area-inset-bottom))] shadow-[0_10px_28px_rgba(25,48,35,0.14)] backdrop-blur-xl sm:bottom-[calc(1rem+env(safe-area-inset-bottom))] sm:max-w-md sm:p-3.5 lg:left-auto lg:right-5 lg:mx-0 lg:w-[22rem]">
-      <div className="flex items-center gap-3">
+    <aside className="fixed inset-x-3 bottom-[calc(0.35rem+env(safe-area-inset-bottom))] z-40 mx-auto max-w-[min(22rem,calc(100vw-1.5rem))] rounded-2xl border border-brand-900/10 bg-[#fffdf7]/95 p-2 shadow-[0_8px_22px_rgba(25,48,35,0.12)] backdrop-blur-xl sm:bottom-[calc(0.75rem+env(safe-area-inset-bottom))] sm:max-w-md sm:p-3 lg:left-auto lg:right-5 lg:mx-0 lg:w-[22rem]">
+      <div className="flex min-h-0 items-center gap-2.5">
         <div className="min-w-0 flex-1">
-          <p className="eyebrow-label text-[0.62rem]">Compare</p>
-          <p className="mt-1 truncate text-sm font-semibold text-ink">
+          <p className="eyebrow-label text-[0.58rem] leading-none">Compare</p>
+          <p className="mt-0.5 truncate text-xs font-semibold leading-5 text-ink sm:text-sm">
             {compareItems.map((item: any) => item.name).join(' vs ')}
           </p>
         </div>
 
         <Link
           href={href}
-          className="flex-none rounded-full bg-brand-800 px-3.5 py-2 text-xs font-bold text-white shadow-sm transition hover:bg-brand-700 sm:px-4"
+          className="flex-none rounded-full bg-brand-800 px-3 py-1.5 text-[11px] font-bold text-[#fffdf7] shadow-sm transition hover:bg-brand-700 sm:px-4 sm:py-2 sm:text-xs"
         >
           Open
         </Link>

--- a/components/ui/CompareWithCard.tsx
+++ b/components/ui/CompareWithCard.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { cleanSummary, formatDisplayLabel, isClean, isSafeInternalHref } from '@/lib/display-utils'
 
 type CompareWithItem = {
   href: string
@@ -11,7 +12,14 @@ type CompareWithCardProps = {
 }
 
 export default function CompareWithCard({ items = [] }: CompareWithCardProps) {
-  const visible = items.filter(item => item.href && item.title && item.description).slice(0, 6)
+  const visible = items
+    .map(item => ({
+      href: item.href,
+      title: formatDisplayLabel(item.title),
+      description: cleanSummary(item.description, 'compound'),
+    }))
+    .filter(item => isSafeInternalHref(item.href) && item.title && item.description && isClean(item.title) && isClean(item.description))
+    .slice(0, 6)
   if (!visible.length) return null
 
   return (

--- a/components/ui/CompoundStats.tsx
+++ b/components/ui/CompoundStats.tsx
@@ -1,25 +1,10 @@
-function formatLabel(value: string) {
-  if (!value) return ''
-
-  const normalized = value.toLowerCase().trim()
-
-  if (normalized === 'research only') return ''
-
-  return normalized
-    .replace(/_/g, ' ')
-    .replace(/\bhealthy aging\b/g, 'Healthy aging')
-    .replace(/\bfat loss\b/g, 'Fat loss')
-    .replace(/\bstress mood\b/g, 'Stress & mood')
-    .replace(/\bsleep quality\b/g, 'Sleep quality')
-    .replace(/\bgeneral wellness\b/g, 'General wellness')
-    .replace(/\b\w/g, char => char.toUpperCase())
-}
+import { formatDisplayLabel } from '@/lib/display-utils'
 
 export default function CompoundStats({ compound }: any) {
   const stats = [
     {
       label: 'Evidence',
-      value: formatLabel(compound.evidence_tier || compound.evidenceLevel || 'Moderate'),
+      value: formatDisplayLabel(compound.evidence_tier || compound.evidenceLevel || 'Moderate'),
     },
     {
       label: 'Effects',

--- a/components/ui/EvidenceSnapshotCard.tsx
+++ b/components/ui/EvidenceSnapshotCard.tsx
@@ -1,3 +1,5 @@
+import { formatDisplayLabel, isClean } from '@/lib/display-utils'
+
 type Props = {
   snapshot: {
     archetype?: string
@@ -10,22 +12,6 @@ type Props = {
   }
 }
 
-function formatLabel(value?: string) {
-  if (!value) return ''
-
-  const normalized = value.toLowerCase().trim()
-
-  if (normalized === 'research only') return ''
-
-  return normalized
-    .replace(/_/g, ' ')
-    .replace(/\bhealthy aging\b/g, 'Healthy aging')
-    .replace(/\bfat loss\b/g, 'Fat loss')
-    .replace(/\bstress mood\b/g, 'Stress & mood')
-    .replace(/\bsleep quality\b/g, 'Sleep quality')
-    .replace(/\bgeneral wellness\b/g, 'General wellness')
-    .replace(/\b\w/g, char => char.toUpperCase())
-}
 
 function freshnessLabel(score?: number) {
   if (score === null || score === undefined) return null
@@ -67,10 +53,10 @@ export default function EvidenceSnapshotCard({ snapshot }: Props) {
   ].filter(Boolean) as { label: string; value: string | number }[]
 
   const clusters = (snapshot.clusters || [])
-    .map(cluster => formatLabel(cluster))
-    .filter(Boolean)
+    .map(cluster => formatDisplayLabel(cluster))
+    .filter(isClean)
 
-  const archetype = formatLabel(snapshot.archetype || 'General wellness')
+  const archetype = formatDisplayLabel(snapshot.archetype || 'General wellness')
 
   if (!archetype && items.length === 0 && clusters.length === 0) {
     return null

--- a/components/ui/MechanismGrid.tsx
+++ b/components/ui/MechanismGrid.tsx
@@ -1,9 +1,13 @@
+import { formatDisplayLabel, isClean } from '@/lib/display-utils'
+
 export default function MechanismGrid({ mechanisms = [] }: any) {
-  if (!mechanisms?.length) return null
+  const visibleMechanisms = mechanisms.map(formatDisplayLabel).filter(isClean).slice(0, 6)
+
+  if (!visibleMechanisms.length) return null
 
   return (
     <div className="grid gap-4 sm:grid-cols-2">
-      {mechanisms.slice(0, 6).map((m: any, i: number) => (
+      {visibleMechanisms.map((m: string, i: number) => (
         <div
           key={i}
           className="surface-depth card-spacing space-y-4"
@@ -13,7 +17,7 @@ export default function MechanismGrid({ mechanisms = [] }: any) {
           </div>
 
           <div className="text-sm leading-7 text-[#435246]">
-            {typeof m === 'string' ? m : JSON.stringify(m)}
+            {m}
           </div>
         </div>
       ))}

--- a/components/ui/PremiumCard.tsx
+++ b/components/ui/PremiumCard.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import EvidenceBadge from '@/components/ui/EvidenceBadge'
-import { cleanSummary as sanitizeSummary, editorialUseCaseLabel, isClean } from '@/lib/display-utils'
+import { cleanSummary as sanitizeSummary, editorialUseCaseLabel, formatDisplayLabel, isClean } from '@/lib/display-utils'
 
 type SafetyTone = 'ok' | 'caution' | 'avoid' | 'unknown'
 
@@ -38,7 +38,6 @@ function safetyLabel(tone: SafetyTone) {
   return 'Review safety'
 }
 
-const clean = (value?: string) => String(value || '').replace(/\s+/g, ' ').trim()
 
 export default function PremiumCard({
   href,
@@ -51,9 +50,9 @@ export default function PremiumCard({
   ctaLabel = 'Open profile',
 }: PremiumCardProps) {
   const safetyTone = normalizeSafety(safety)
-  const cleanSummary = isClean(summary) ? sanitizeSummary(summary, 'compound') : ''
+  const cleanSummary = sanitizeSummary(summary, 'compound')
   const cleanBestFor = isClean(bestFor) ? editorialUseCaseLabel(bestFor) : ''
-  const visibleTags = tags.map(clean).filter(isClean).slice(0, 3)
+  const visibleTags = tags.map(formatDisplayLabel).filter(isClean).slice(0, 3)
 
   return (
     <article className="group flex h-full flex-col overflow-hidden rounded-card border border-brand-900/10 bg-[rgba(255,253,247,0.92)] p-6 sm:p-7 shadow-[0_10px_30px_rgba(29,74,47,0.08)] backdrop-blur-xl transition duration-300 hover:-translate-y-[3px] hover:border-brand-700/25 hover:bg-white hover:shadow-glow">
@@ -66,7 +65,7 @@ export default function PremiumCard({
           <EvidenceBadge tier={evidence} />
 
           <span
-            title={clean(safety) || 'Safety context should be reviewed before use.'}
+            title={formatDisplayLabel(safety) || 'Safety context should be reviewed before use.'}
             aria-label={`Safety indicator: ${safetyLabel(safetyTone)}`}
             className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold leading-none ${safetyClasses(safetyTone)}`}
           >

--- a/components/ui/ResearchHighlights.tsx
+++ b/components/ui/ResearchHighlights.tsx
@@ -1,9 +1,16 @@
+import { isClean, text } from '@/lib/display-utils'
+
 export default function ResearchHighlights({ sources = [] }: any) {
-  if (!sources?.length) return null
+  const visibleSources = sources
+    .map((source: any) => text(source))
+    .filter(isClean)
+    .slice(0, 3)
+
+  if (!visibleSources.length) return null
 
   return (
     <div className="grid gap-4">
-      {sources.slice(0, 3).map((source: any, i: number) => (
+      {visibleSources.map((source: string, i: number) => (
         <div
           key={i}
           className="surface-depth card-spacing space-y-4"
@@ -13,9 +20,7 @@ export default function ResearchHighlights({ sources = [] }: any) {
           </div>
 
           <div className="text-sm leading-7 text-[#435246] break-words">
-            {typeof source === 'string'
-              ? source
-              : JSON.stringify(source)}
+            {source}
           </div>
         </div>
       ))}

--- a/components/ui/SemanticRecommendationCard.tsx
+++ b/components/ui/SemanticRecommendationCard.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { cleanSummary, formatDisplayLabel, isClean, isSafeInternalHref } from '@/lib/display-utils'
 
 type Props = {
   item: {
@@ -12,16 +13,9 @@ type Props = {
 }
 
 function cleanLabel(value?: string) {
-  if (!value) return ''
-
-  return value
-    .replace(/_/g, ' ')
-    .replace(/\bhealthy aging\b/gi, 'Healthy aging')
-    .replace(/\bfat loss\b/gi, 'Fat loss')
-    .replace(/\bstress mood\b/gi, 'Stress & mood')
-    .replace(/\bsleep quality\b/gi, 'Sleep quality')
-    .replace(/\bgeneral wellness\b/gi, 'General wellness')
+  return formatDisplayLabel(value)
 }
+
 
 export default function SemanticRecommendationCard({ item }: Props) {
   const confidence =
@@ -31,29 +25,38 @@ export default function SemanticRecommendationCard({ item }: Props) {
         ? 'Moderate confidence'
         : 'Exploratory'
 
+  const name = cleanLabel(item.name || item.slug)
+  const archetype = cleanLabel(item.archetype)
+  const evidenceTier = cleanLabel(item.evidence_tier)
+  const reason = cleanSummary(item.relationship_reason, 'compound')
+
+  const href = `/compounds/${item.slug}`
+
+  if (!isSafeInternalHref(href) || !name || !isClean(name)) return null
+
   return (
     <Link
-      href={`/compounds/${item.slug}`}
+      href={href}
       className="card-premium block p-5 transition-all duration-300 hover:-translate-y-1"
     >
       <div className="flex items-start justify-between gap-3">
         <div>
           <div className="text-base font-semibold text-ink transition group-hover:text-brand-700">
-            {item.name || item.slug}
+            {name}
           </div>
 
           <div className="mt-2 flex flex-wrap gap-2">
-            {item.archetype && (
+            {archetype ? (
               <span className="evidence-pill-strong">
-                {cleanLabel(item.archetype)}
+                {archetype}
               </span>
-            )}
+            ) : null}
 
-            {item.evidence_tier && (
+            {evidenceTier ? (
               <span className="chip-readable">
-                {cleanLabel(item.evidence_tier)}
+                {evidenceTier}
               </span>
-            )}
+            ) : null}
           </div>
         </div>
 
@@ -63,7 +66,7 @@ export default function SemanticRecommendationCard({ item }: Props) {
       </div>
 
       <div className="mt-4 text-sm leading-7 text-[#46574d]">
-        {item.relationship_reason || 'Related through shared mechanisms, pathways, or overlapping wellness targets.'}
+        {reason}
       </div>
 
       <div className="mt-5 h-2 overflow-hidden rounded-full bg-brand-900/10">

--- a/components/ui/TimelineCard.tsx
+++ b/components/ui/TimelineCard.tsx
@@ -1,12 +1,17 @@
+import { formatDisplayLabel, isClean, text } from '@/lib/display-utils'
+
 type Phase = {
   title: string
   text: string
 }
 
 export default function TimelineCard({ phases = [] }: { phases?: Phase[] }) {
-  const meaningfulPhases = phases.filter(
-    phase => phase?.title?.trim() && phase?.text?.trim()
-  )
+  const meaningfulPhases = phases
+    .map(phase => ({
+      title: formatDisplayLabel(phase?.title),
+      text: text(phase?.text),
+    }))
+    .filter(phase => isClean(phase.title) && isClean(phase.text))
 
   if (meaningfulPhases.length === 0) {
     return null

--- a/components/ui/UseCases.tsx
+++ b/components/ui/UseCases.tsx
@@ -1,9 +1,13 @@
+import { formatDisplayLabel, isClean } from '@/lib/display-utils'
+
 export default function UseCases({ effects = [] }: any) {
-  if (!effects?.length) return null
+  const visibleEffects = effects.map(formatDisplayLabel).filter(isClean).slice(0, 8)
+
+  if (!visibleEffects.length) return null
 
   return (
     <div className="flex flex-wrap gap-2">
-      {effects.slice(0, 8).map((effect: string, i: number) => (
+      {visibleEffects.map((effect: string, i: number) => (
         <div
           key={i}
           className="rounded-full border px-4 py-2 text-xs bg-neutral-50 hover:bg-neutral-100 transition"

--- a/lib/display-utils.ts
+++ b/lib/display-utils.ts
@@ -73,6 +73,39 @@ export function hideInternalValue(value: unknown): boolean {
 
   if (!normalized) return true
 
+  const simplified = normalized
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  const compact = simplified.replace(/\s+/g, '')
+
+  const internalPhrases = [
+    'internal cross linking',
+    'workbook readiness pass',
+    'added as site safe referenced entity during workbook readiness pass',
+    'scispace evidence pass',
+    'conservative evidence framing',
+    'treat dosing and outcomes as review gated',
+    'is tracked for',
+    'tracked for',
+    'mechanism only pending stronger human',
+    'pmid backed human evidence is present',
+    'lean row',
+    'lean herb row',
+    'lean monograph row',
+    'high speed phytochemical ingestion',
+    'bulk enrichment',
+    'bulk mode',
+    'schema artifact',
+    'placeholder',
+  ]
+
+  if (internalPhrases.some(phrase => simplified.includes(phrase) || compact.includes(phrase.replace(/\s+/g, '')))) {
+    return true
+  }
+
   return INTERNAL_PATTERNS.some(pattern => pattern.test(normalized))
 }
 


### PR DESCRIPTION
### Motivation
- Remove accidental exposure of internal workbook/generated pipeline language and placeholder signals in public pages. 
- Ensure all public summaries, labels, chips, and related UI surfaces use the shared sanitizer and fallbacks to avoid leaking internal phrases. 
- Make small, surgical UI tweaks so secondary chrome (compare tray, low-contrast text, empty lists) no longer degrade trust or block content on mobile.

### Description
- Strengthened `hideInternalValue()` in `lib/display-utils.ts` to detect exact and near variants of internal phrases (cross-linking, workbook readiness/SciSpace passes, tracked/treating language, lean rows, bulk mode/enrichment, schema artifacts, `placeholder`) and preserved herb/compound fallback text via `cleanSummary()` returning the required fallbacks. 
- Routed public names and summaries through shared helpers (`cleanSummary`, `formatDisplayLabel`, `isClean`, `text`) on library/search listings and detail pages (`app/herbs/page.tsx`, `app/compounds/page.tsx`, `app/search/page.tsx`, `app/herbs/[slug]/page.tsx`, `app/compounds/[slug]/page.tsx`) so internal/generated text falls back and chips/tags are normalized. 
- Sanitized and filtered list-like UI surfaces (timelines, mechanisms, use-case chips, research highlights, related/compare cards, stack candidates, sources) to avoid rendering empty/placeholder items and to suppress warning lists when they would be empty. 
- Hardened semantic/identity cards and recommendation cards to validate `href` with `isSafeInternalHref()` and to emit only cleaned `title`/`description`/`reason` content. 
- Replaced local label-cleaning code in multiple UI components (`PremiumCard`, `CompoundStats`, `EvidenceSnapshotCard`, `MechanismGrid`, `TimelineCard`, `UseCases`, `ResearchHighlights`, `CompareWithCard`, `SemanticRecommendationCard`) to reuse `formatDisplayLabel`, `cleanSummary`, and `isClean`. 
- Reduced the compare tray mobile footprint and added safe-area-aware bottom spacing plus smaller touch targets so it is secondary rather than obstructive (`components/ui/CompareBar.tsx`).

### Testing
- Ran `npm run check` which runs the full data build and `next build`, and the build completed successfully with static pages generated and verification scripts (`verify:build`) passing. 
- Ran `npx eslint` for the targeted files (`lib/display-utils.ts`, `app/herbs/page.tsx`, `app/compounds/page.tsx`, `app/search/page.tsx`, `app/herbs/[slug]/page.tsx`, `app/compounds/[slug]/page.tsx`, `components/ui/CompareBar.tsx`) and no new lint failures were produced. 
- Executed a sanitizer smoke test via `npx tsx -e` to assert `hideInternalValue()` matches the requested internal phrases and confirmed `cleanSummary()` fallbacks and `formatDisplayLabel()` mapping behave as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcedc19ce883238065685162c80ba0)