### PR TITLE
Prerender-safe focus explore: remove runtime-ranking and add defensive filters

### DIFF
--- a/app/explore/focus/page.tsx
+++ b/app/explore/focus/page.tsx
@@ -1,7 +1,6 @@
 import Link from 'next/link'
 import herbs from '../../../public/data/herbs.json'
 import compounds from '../../../public/data/compounds.json'
-import { rankRuntimeRecords } from '@/lib/runtime-ranking'
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 import { cleanSummary, formatDisplayLabel, isClean, list, unique } from '@/lib/display-utils'
 
@@ -25,18 +24,33 @@ function isFocusRelated(record: any) {
 }
 
 function buildCards(records: any[], type: 'herb' | 'compound') {
-  return rankRuntimeRecords(records)
-    .filter((item: any) => getRuntimeVisibility(item).canRender)
-    .filter(isFocusRelated)
+  return records
+    .filter((item: any) => {
+      try {
+        return getRuntimeVisibility(item).canRender
+      } catch {
+        return false
+      }
+    })
+    .filter((item: any) => {
+      try {
+        return isFocusRelated(item)
+      } catch {
+        return false
+      }
+    })
     .slice(0, 12)
     .map((item: any) => ({
-      slug: item.slug,
-      name: formatDisplayLabel(item.name || item.slug),
-      summary: cleanSummary(item.summary || item.description || '', type),
-      href: `/${type === 'herb' ? 'herbs' : 'compounds'}/${item.slug}`,
+      slug: item?.slug || '',
+      name: formatDisplayLabel(item?.name || item?.slug),
+      summary: cleanSummary(
+        item?.summary || item?.description || '',
+        type
+      ),
+      href: `/${type === 'herb' ? 'herbs' : 'compounds'}/${item?.slug || ''}`,
       effects: unique([
-        ...list(item.primary_effects),
-        ...list(item.effects),
+        ...list(item?.primary_effects),
+        ...list(item?.effects),
       ])
         .filter(isClean)
         .slice(0, 3),


### PR DESCRIPTION
### Motivation
- The focus authority hub was crashing at prerender due to unsafe runtime ranking/filtering that assumed complete workbook records.  
- The goal is to make `/explore/focus` fully prerender-safe without changing the UI surface or data pipeline contracts.  

### Description
- Removed the unsafe import `rankRuntimeRecords` and stopped depending on runtime-ranking in `app/explore/focus/page.tsx`.  
- Replaced `buildCards()` with a defensive implementation that uses `getRuntimeVisibility` and `isFocusRelated` inside `try/catch`, applies optional chaining/defaults, and limits output with `.slice(0, 12)`.  
- Preserved safe normalization by ensuring `normalize()` uses `String(value || '').toLowerCase()`.  
- Changes are limited to `app/explore/focus/page.tsx` and keep route contracts and data sources intact.  

### Testing
- Ran `npm run check` (which runs the full build pipeline) and the build completed successfully with static generation/export passing.  
- The static generation included `/explore/focus` and no `toLowerCase` crashes occurred during the build.  
- Data validation and post-build verification steps (`data:build`, `data:validate`, and `verify:build`) ran as part of the build and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fde8370ec883238df27fb284a59334)