### PR TITLE
Add global metadata base defaults

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -29,8 +29,15 @@ const navLinks = [
 ]
 
 export const metadata: Metadata = {
+  metadataBase: new URL('https://www.thehippiescientist.net'),
   title: { default: 'The Hippie Scientist', template: '%s | The Hippie Scientist' },
   description: 'Evidence-first supplement decision engine.',
+  openGraph: {
+    siteName: 'The Hippie Scientist',
+  },
+  twitter: {
+    card: 'summary_large_image',
+  },
 }
 
 export default function RootLayout({ children }: { children: ReactNode }) {


### PR DESCRIPTION
### Motivation
- Fix Next.js `metadataBase` warnings and provide centralized safe defaults for OpenGraph and Twitter without changing dynamic routes or other site behavior.

### Description
- Update `app/layout.tsx` to add `metadataBase: new URL('https://www.thehippiescientist.net')` and set default `openGraph.siteName` and `twitter.card`, while preserving the existing global `title` template and `description`.

### Testing
- Ran `npm run check` (full build, data pipeline, and verification scripts) which completed successfully and core route verification passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdeedb7ab48323afe6c4ae7a70fb9b)