### PR TITLE
Wire centralized SEO helpers into herb and compound detail routes

### DIFF
--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -40,6 +40,7 @@ import { cleanSummary, formatDisplayLabel, isClean, isSafeInternalHref, list, te
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 import { generatedComparisons } from '@/data/generated-comparisons'
 import { supplementComparisons } from '@/data/comparisons'
+import { buildMeta } from '@/lib/seo'
 
 export async function generateStaticParams() {
   return (data as any[])
@@ -52,10 +53,23 @@ export function generateMetadata({ params }: any) {
   if (!compound) return {}
 
   const visibility = getRuntimeVisibility(compound)
-
-  return {
+  const meta = buildMeta({
     title: `${compound.name} Benefits, Effects & Safety | Hippie Scientist`,
     description: cleanSummary(compound.summary || compound.description, 'compound'),
+    path: `/compounds/${compound.slug}`,
+  })
+
+  return {
+    title: meta.title,
+    description: meta.description,
+    alternates: { canonical: meta.url },
+    openGraph: {
+      title: meta.title,
+      description: meta.description,
+      type: 'article',
+      url: meta.url,
+      images: [meta.image],
+    },
     robots: visibility.canIndex
       ? undefined
       : {

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { getHerbBySlug, getHerbs } from '@/lib/runtime-data'
 import { cleanSummary, formatDisplayLabel, isClean, list, unique } from '@/lib/display-utils'
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 import { getRelatedRuntimeRecords } from '@/lib/related-runtime'
+import { buildMeta } from '@/lib/seo'
 
 export async function generateStaticParams() {
   const herbs = await getHerbs()
@@ -24,10 +25,23 @@ export async function generateMetadata({ params }: any): Promise<Metadata> {
   }
 
   const visibility = getRuntimeVisibility(herb)
-
-  return {
+  const meta = buildMeta({
     title: `${formatDisplayLabel(herb.name || herb.slug)} | Herb`,
     description: cleanSummary(herb.summary || herb.description || '', 'herb'),
+    path: `/herbs/${herb.slug}`,
+  })
+
+  return {
+    title: meta.title,
+    description: meta.description,
+    alternates: { canonical: meta.url },
+    openGraph: {
+      title: meta.title,
+      description: meta.description,
+      type: 'article',
+      url: meta.url,
+      images: [meta.image],
+    },
     robots: visibility.canIndex
       ? undefined
       : {


### PR DESCRIPTION
### Motivation
- Replace duplicated metadata normalization in herb and compound detail routes with the centralized SEO helpers to ensure consistent canonical URLs and OpenGraph data while keeping changes minimal.
- Preserve existing runtime visibility gating, `noindex` behavior, static export semantics, and the route-level rendering/semantic rails for `/herbs/:slug` and `/compounds/:slug`.

### Description
- Replaced in-file metadata assembly with `buildMeta` from `src/lib/seo.ts` in `app/herbs/[slug]/page.tsx` and `app/compounds/[slug]/page.tsx`, and imported `buildMeta` where needed.
- Returned `alternates: { canonical: meta.url }` and a minimal `openGraph` block (`title`, `description`, `type`, `url`, `images`) derived from `buildMeta` while keeping the original titles/descriptions and robots logic intact.
- Changes are focused to metadata only and do not alter rendering, static params, runtime visibility checks, or existing semantic systems.

### Testing
- Ran the full build/check pipeline with `npm run check`, which completed successfully (build, data generation/validation, and verification steps passed).
- ESLint/type checks and `git diff --check` reported no issues during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf1c005888323ba02d537fc6c2efe)