### PR TITLE
Add global metadata defaults

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,9 +31,11 @@ const navLinks = [
 export const metadata: Metadata = {
   metadataBase: new URL('https://www.thehippiescientist.net'),
   title: { default: 'The Hippie Scientist', template: '%s | The Hippie Scientist' },
-  description: 'Evidence-first supplement decision engine.',
+  description: 'Evidence-organized research on herbs, compounds, pathways, and human health.',
   openGraph: {
+    type: 'website',
     siteName: 'The Hippie Scientist',
+    url: 'https://www.thehippiescientist.net',
   },
   twitter: {
     card: 'summary_large_image',


### PR DESCRIPTION
### Motivation
- Provide a small, centralized metadata foundation for the App Router to eliminate localhost/relative metadata warnings while keeping changes minimal and safe. 
- Make a stable default for OpenGraph and Twitter card values without touching routes, prerendering, or any semantic/data pipelines.

### Description
- Update `app/layout.tsx` to set a safer default `description` to `Evidence-organized research on herbs, compounds, pathways, and human health.`. 
- Add minimal OpenGraph defaults in `app/layout.tsx`: `type: 'website'` and `url: 'https://www.thehippiescientist.net'`, while keeping `siteName`. 
- Preserve existing `metadataBase`, title template and Twitter `card: 'summary_large_image'` behavior and avoid touching other files or systems.

### Testing
- Ran `npm run check` (which runs the data build + validation and `next build`) and the build completed successfully. 
- Static export and prerendering completed with no route regressions reported by the verification scripts, and `npm run check` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf5737258832381b982f489f5eae8)