### PR TITLE
Add centralized evidence trust badges

### DIFF
--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -41,6 +41,7 @@ import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 import { generatedComparisons } from '@/data/generated-comparisons'
 import { supplementComparisons } from '@/data/comparisons'
 import { buildMeta } from '@/lib/seo'
+import { EvidenceBadgeGroup } from '@/components/evidence/evidence-badge'
 
 export async function generateStaticParams() {
   return (data as any[])
@@ -209,6 +210,8 @@ export default function Page({ params }: any) {
               safetyLevel={safetyLevel}
             />
 
+            <EvidenceBadgeGroup record={compound} />
+
             <div className="flex flex-wrap gap-3">
               <EvidenceMaturityRibbon label={semanticTopics.maturity} />
 
@@ -255,6 +258,8 @@ export default function Page({ params }: any) {
                     className="card-premium group p-5"
                   >
                     <div className="space-y-4">
+                      <EvidenceBadgeGroup record={item} compact />
+
                       <div className="flex flex-wrap gap-2">
                         {(item.overlap || []).slice(0, 2).map((signal:string) => (
                           <span key={signal} className="chip-readable">

--- a/app/explore/focus/page.tsx
+++ b/app/explore/focus/page.tsx
@@ -3,6 +3,7 @@ import herbs from '../../../public/data/herbs.json'
 import compounds from '../../../public/data/compounds.json'
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 import { cleanSummary, formatDisplayLabel, isClean, list, unique } from '@/lib/display-utils'
+import { EvidenceBadgeGroup } from '@/components/evidence/evidence-badge'
 
 function normalize(value: unknown) {
   return String(value || '').toLowerCase()
@@ -41,6 +42,7 @@ function buildCards(records: any[], type: 'herb' | 'compound') {
     })
     .slice(0, 12)
     .map((item: any) => ({
+      record: item,
       slug: item?.slug || '',
       name: formatDisplayLabel(item?.name || item?.slug),
       summary: cleanSummary(
@@ -117,6 +119,8 @@ export default function FocusExplorePage() {
               className="card-premium group p-5"
             >
               <div className="space-y-4">
+                <EvidenceBadgeGroup record={item.record} compact />
+
                 <div className="flex flex-wrap gap-2">
                   {item.effects.map((effect) => (
                     <span key={effect} className="chip-readable">
@@ -159,6 +163,8 @@ export default function FocusExplorePage() {
               className="card-premium group p-5"
             >
               <div className="space-y-4">
+                <EvidenceBadgeGroup record={item.record} compact />
+
                 <div className="flex flex-wrap gap-2">
                   {item.effects.map((effect) => (
                     <span key={effect} className="chip-readable">

--- a/app/explore/sleep/page.tsx
+++ b/app/explore/sleep/page.tsx
@@ -3,6 +3,7 @@ import herbs from '../../../public/data/herbs.json'
 import compounds from '../../../public/data/compounds.json'
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 import { cleanSummary, formatDisplayLabel, isClean, list, unique } from '@/lib/display-utils'
+import { EvidenceBadgeGroup } from '@/components/evidence/evidence-badge'
 
 function normalize(value: unknown) {
   return String(value || '').toLowerCase()
@@ -41,6 +42,7 @@ function buildCards(records: any[], type: 'herb' | 'compound') {
     })
     .slice(0, 12)
     .map((item: any) => ({
+      record: item,
       slug: item?.slug || '',
       name: formatDisplayLabel(item?.name || item?.slug),
       summary: cleanSummary(item?.summary || item?.description || '', type),
@@ -114,6 +116,8 @@ export default function SleepExplorePage() {
               className="card-premium group p-5"
             >
               <div className="space-y-4">
+                <EvidenceBadgeGroup record={item.record} compact />
+
                 <div className="flex flex-wrap gap-2">
                   {item.effects.map((effect) => (
                     <span key={effect} className="chip-readable">
@@ -156,6 +160,8 @@ export default function SleepExplorePage() {
               className="card-premium group p-5"
             >
               <div className="space-y-4">
+                <EvidenceBadgeGroup record={item.record} compact />
+
                 <div className="flex flex-wrap gap-2">
                   {item.effects.map((effect) => (
                     <span key={effect} className="chip-readable">

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { cleanSummary, formatDisplayLabel, isClean, list, unique } from '@/lib/d
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 import { getRelatedRuntimeRecords } from '@/lib/related-runtime'
 import { buildMeta } from '@/lib/seo'
+import { EvidenceBadgeGroup } from '@/components/evidence/evidence-badge'
 
 export async function generateStaticParams() {
   const herbs = await getHerbs()
@@ -85,6 +86,8 @@ export default async function HerbDetailPage({ params }: any) {
             {formatDisplayLabel(herb.name || herb.slug)}
           </h1>
 
+          <EvidenceBadgeGroup record={herb} />
+
           <p className="detail-reading text-lg text-[#46574d]">
             {cleanSummary(herb.summary || herb.description || '', 'herb')}
           </p>
@@ -119,6 +122,8 @@ export default async function HerbDetailPage({ params }: any) {
                 className="card-premium group p-5"
               >
                 <div className="space-y-4">
+                  <EvidenceBadgeGroup record={item} compact />
+
                   <div className="flex flex-wrap gap-2">
                     {(item.relatedOverlap || []).slice(0, 2).map((signal: string) => (
                       <span key={signal} className="chip-readable">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,6 +18,21 @@ const fraunces = Fraunces({
   display: 'swap',
 })
 
+const websiteJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: 'The Hippie Scientist',
+  url: 'https://www.thehippiescientist.net',
+  description: 'Evidence-organized research on herbs, compounds, pathways, and human health.',
+}
+
+const organizationJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: 'The Hippie Scientist',
+  url: 'https://www.thehippiescientist.net',
+}
+
 const navLinks = [
   { href: '/', label: 'Home' },
   { href: '/learn', label: 'Learn' },
@@ -46,6 +61,14 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang='en'>
       <body className={`${inter.variable} ${fraunces.variable} bg-[#fafaf9] text-[#111827] font-sans antialiased`}>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
+        />
         <div className='min-h-screen bg-background text-ink'>
           <header className='sticky top-0 z-50 border-b border-neutral-200 bg-white/90 backdrop-blur-sm'>
             <div className='container-page flex items-center justify-between py-4'>

--- a/components/evidence/evidence-badge.tsx
+++ b/components/evidence/evidence-badge.tsx
@@ -1,0 +1,83 @@
+import {
+  getEvidenceLabel,
+  hasHumanEvidence,
+  hasMechanismEvidence,
+  hasStrongSafetyProfile,
+  isPreliminaryResearch,
+} from '@/lib/evidence'
+
+type EvidenceBadgeKind =
+  | 'Human Evidence'
+  | 'Mechanism-Mapped'
+  | 'Preliminary Research'
+  | 'Traditional Use'
+  | 'Emerging Research'
+  | 'Strong Safety Profile'
+
+type EvidenceBadgeProps = {
+  label: EvidenceBadgeKind | string
+  className?: string
+}
+
+const BADGE_STYLES: Record<string, string> = {
+  'Human Evidence': 'border-emerald-800/15 bg-emerald-50/80 text-emerald-900',
+  'Mechanism-Mapped': 'border-blue-800/15 bg-blue-50/70 text-blue-900',
+  'Preliminary Research': 'border-amber-800/20 bg-amber-50/80 text-amber-900',
+  'Traditional Use': 'border-stone-700/15 bg-stone-100/70 text-stone-800',
+  'Emerging Research': 'border-violet-800/15 bg-violet-50/70 text-violet-900',
+  'Strong Safety Profile': 'border-teal-800/15 bg-teal-50/75 text-teal-900',
+}
+
+export function EvidenceBadge({ label, className = '' }: EvidenceBadgeProps) {
+  const style = BADGE_STYLES[label] || 'border-brand-900/10 bg-white/70 text-[#46574d]'
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-bold uppercase tracking-[0.12em] ${style} ${className}`}
+    >
+      {label}
+    </span>
+  )
+}
+
+export function getEvidenceBadges(record: any): string[] {
+  const badges = new Set<string>()
+  const label = getEvidenceLabel(record)
+
+  if (hasHumanEvidence(record)) badges.add('Human Evidence')
+  if (hasMechanismEvidence(record)) badges.add('Mechanism-Mapped')
+  if (isPreliminaryResearch(record)) badges.add('Preliminary Research')
+  if (/traditional/i.test(label)) badges.add('Traditional Use')
+  if (/emerging/i.test(label)) badges.add('Emerging Research')
+  if (hasStrongSafetyProfile(record)) badges.add('Strong Safety Profile')
+
+  if (!badges.size) badges.add(label)
+
+  return Array.from(badges).slice(0, 3)
+}
+
+export function EvidenceBadgeGroup({
+  record,
+  compact = false,
+  className = '',
+}: {
+  record: any
+  compact?: boolean
+  className?: string
+}) {
+  const badges = getEvidenceBadges(record)
+
+  if (!badges.length) return null
+
+  return (
+    <div className={`flex flex-wrap gap-2 ${className}`} aria-label='Evidence indicators'>
+      {badges.map(badge => (
+        <EvidenceBadge
+          key={badge}
+          label={badge}
+          className={compact ? 'px-2 py-0.5 text-[10px]' : ''}
+        />
+      ))}
+    </div>
+  )
+}

--- a/lib/evidence.ts
+++ b/lib/evidence.ts
@@ -1,0 +1,151 @@
+type EvidenceTier = 'strong' | 'moderate' | 'limited' | 'preliminary' | 'traditional' | 'emerging'
+
+type EvidenceColor = 'emerald' | 'blue' | 'amber' | 'sand' | 'violet' | 'slate'
+
+function readPath(record: any, path: string[]): unknown {
+  return path.reduce(
+    (value, key) => (value && typeof value === 'object' ? (value as any)[key] : undefined),
+    record,
+  )
+}
+
+function text(value: unknown): string {
+  if (value == null) return ''
+  if (Array.isArray(value)) return value.map(text).filter(Boolean).join(' ')
+  if (typeof value === 'object')
+    return Object.values(value as Record<string, unknown>)
+      .map(text)
+      .filter(Boolean)
+      .join(' ')
+  return String(value).trim()
+}
+
+function list(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value.filter(Boolean)
+  if (typeof value === 'string')
+    return value
+      .split(/[|;,]/)
+      .map(item => item.trim())
+      .filter(Boolean)
+  return value ? [value] : []
+}
+
+function evidenceText(record: any): string {
+  return [
+    readPath(record, ['safety', 'confidence']),
+    readPath(record, ['safety', 'evidenceTier']),
+    record?.evidenceTier,
+    record?.evidence_tier,
+    record?.evidence_grade,
+    record?.evidenceLevel,
+    record?.confidenceTier,
+    record?.profile_status,
+    record?.review_status,
+    record?.summary_quality,
+    record?.source_status,
+  ]
+    .map(text)
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+}
+
+export function hasHumanEvidence(record: any): boolean {
+  const evidence = evidenceText(record)
+
+  if (/\b(no|none|theoretical|traditional|preclinical|in\s*vitro|animal)\b/.test(evidence)) {
+    return false
+  }
+
+  if (
+    /\b(human|clinical|trial|rct|randomi[sz]ed|meta|systematic|strong|high|moderate|grade\s*[ab]|tier\s*[ab])\b/.test(
+      evidence,
+    )
+  ) {
+    return true
+  }
+
+  const sourceCount = Number(record?.sourceCount ?? record?.source_count ?? record?.sources_count)
+  return (
+    Number.isFinite(sourceCount) && sourceCount >= 5 && !/\b(low|limited|partial)\b/.test(evidence)
+  )
+}
+
+export function hasMechanismEvidence(record: any): boolean {
+  return [record?.mechanisms, record?.primary_effects, record?.effects, record?.pathways].some(
+    value => list(value).map(text).some(Boolean),
+  )
+}
+
+export function isPreliminaryResearch(record: any): boolean {
+  const evidence = evidenceText(record)
+
+  return /\b(preliminary|emerging|limited|low|weak|partial|draft|none|preclinical|animal|in\s*vitro|theoretical|grade\s*[cd]|tier\s*[cd])\b/.test(
+    evidence,
+  )
+}
+
+export function getEvidenceTier(record: any): EvidenceTier {
+  const evidence = evidenceText(record)
+
+  if (/\b(strong|high|robust|grade\s*a|tier\s*a)\b/.test(evidence)) return 'strong'
+  if (/\b(moderate|medium|grade\s*b|tier\s*b)\b/.test(evidence)) return 'moderate'
+  if (/\b(traditional|ethnobotanical|historical)\b/.test(evidence)) return 'traditional'
+  if (/\b(emerging|early)\b/.test(evidence)) return 'emerging'
+  if (isPreliminaryResearch(record)) return 'preliminary'
+  if (hasHumanEvidence(record)) return 'moderate'
+  if (hasMechanismEvidence(record)) return 'limited'
+
+  return 'limited'
+}
+
+export function getEvidenceLabel(record: any): string {
+  const labels: Record<EvidenceTier, string> = {
+    strong: 'Strong Evidence',
+    moderate: 'Moderate Evidence',
+    limited: 'Limited Evidence',
+    preliminary: 'Preliminary Research',
+    traditional: 'Traditional Use',
+    emerging: 'Emerging Research',
+  }
+
+  return labels[getEvidenceTier(record)]
+}
+
+export function getEvidenceColor(record: any): EvidenceColor {
+  const colors: Record<EvidenceTier, EvidenceColor> = {
+    strong: 'emerald',
+    moderate: 'blue',
+    limited: 'slate',
+    preliminary: 'amber',
+    traditional: 'sand',
+    emerging: 'violet',
+  }
+
+  return colors[getEvidenceTier(record)]
+}
+
+export function hasStrongSafetyProfile(record: any): boolean {
+  const safety = [
+    record?.safety,
+    record?.safetyNotes,
+    record?.safety_notes,
+    record?.contraindications,
+    record?.interactions,
+  ]
+    .map(text)
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+  const confidence = text(
+    readPath(record, ['safety', 'confidence']) || record?.confidenceTier,
+  ).toLowerCase()
+
+  if (
+    /\b(avoid|contraindicat|caution|interaction|pregnan|liver|kidney|risk|toxic)\b/.test(safety)
+  ) {
+    return false
+  }
+
+  return /\b(strong|high|safe|well\s*tolerated|low\s*risk)\b/.test(`${safety} ${confidence}`)
+}


### PR DESCRIPTION
### Motivation
- Centralize evidence/trust signals to improve perceived authority and readability while preserving the workbook-first static export architecture. 
- Surface compact, defensive indicators (human evidence, mechanisms, preliminary/traditional/emerging research, safety) without changing page ordering or adding client-side ranking. 
- Keep changes additive and surgical to avoid breaking prerendering, data pipelines, or route contracts. 

### Description
- Add a defensive evidence helper module `lib/evidence.ts` that provides `getEvidenceTier`, `getEvidenceLabel`, `getEvidenceColor`, `hasHumanEvidence`, `hasMechanismEvidence`, `isPreliminaryResearch`, and `hasStrongSafetyProfile` and reads common runtime/workbook fields null-safely. 
- Add a small, reusable badge system in `components/evidence/evidence-badge.tsx` exposing `EvidenceBadge`, `getEvidenceBadges`, and `EvidenceBadgeGroup` with a compact style palette and limited variants. 
- Integrate `EvidenceBadgeGroup` into herb and compound detail pages (`app/herbs/[slug]/page.tsx`, `app/compounds/[slug]/page.tsx`) near the hero/summary and into `/explore/sleep` and `/explore/focus` cards as compact indicators without changing filters or ordering. 
- Add minimal server-rendered JSON-LD for `WebSite` and `Organization` in `app/layout.tsx` using safe App Router server-side script tags. 

### Testing
- Ran `npm run check` (which runs the data build, validation, guard checks, Next.js build, and verify steps) and the build completed successfully with static pages generated. 
- Data validation (`node scripts/data/validate-data-next.mjs`) and generated-data verification passed as part of the build. 
- Executed a Playwright-based screenshot generation to visually verify badges, which produced `/tmp/evidence-badges-acerola.png`; Playwright required installing browsers and OS deps which completed, and the screenshot file was created (environment utilities such as `file` were not available in the runner).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdf8c3a91c8323b6bac6ebcf403bb5)