### PR TITLE
Add scientific collection pages and centralized collection helpers

### DIFF
--- a/app/collections/adaptogens-for-stress/page.tsx
+++ b/app/collections/adaptogens-for-stress/page.tsx
@@ -1,0 +1,11 @@
+import { generateCollectionMetadata, ScientificCollectionPage } from '../scientific-collection-page'
+
+const slug = 'adaptogens-for-stress'
+
+export function generateMetadata() {
+  return generateCollectionMetadata(slug)
+}
+
+export default function Page() {
+  return <ScientificCollectionPage slug={slug} />
+}

--- a/app/collections/best-studied-sleep-compounds/page.tsx
+++ b/app/collections/best-studied-sleep-compounds/page.tsx
@@ -1,0 +1,11 @@
+import { generateCollectionMetadata, ScientificCollectionPage } from '../scientific-collection-page'
+
+const slug = 'best-studied-sleep-compounds'
+
+export function generateMetadata() {
+  return generateCollectionMetadata(slug)
+}
+
+export default function Page() {
+  return <ScientificCollectionPage slug={slug} />
+}

--- a/app/collections/cholinergic-compounds/page.tsx
+++ b/app/collections/cholinergic-compounds/page.tsx
@@ -1,0 +1,11 @@
+import { generateCollectionMetadata, ScientificCollectionPage } from '../scientific-collection-page'
+
+const slug = 'cholinergic-compounds'
+
+export function generateMetadata() {
+  return generateCollectionMetadata(slug)
+}
+
+export default function Page() {
+  return <ScientificCollectionPage slug={slug} />
+}

--- a/app/collections/high-evidence-anti-inflammatory-herbs/page.tsx
+++ b/app/collections/high-evidence-anti-inflammatory-herbs/page.tsx
@@ -1,0 +1,11 @@
+import { generateCollectionMetadata, ScientificCollectionPage } from '../scientific-collection-page'
+
+const slug = 'high-evidence-anti-inflammatory-herbs'
+
+export function generateMetadata() {
+  return generateCollectionMetadata(slug)
+}
+
+export default function Page() {
+  return <ScientificCollectionPage slug={slug} />
+}

--- a/app/collections/scientific-collection-page.tsx
+++ b/app/collections/scientific-collection-page.tsx
@@ -1,0 +1,221 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { EvidenceBadgeGroup } from '@/components/evidence/evidence-badge'
+import { getCompounds, getHerbs } from '@/lib/runtime-data'
+import { getRuntimeVisibility } from '@/lib/runtime-visibility'
+import {
+  buildCollectionMetadata,
+  findCollectionBySlug,
+  getCollectionCard,
+  getCollectionRecords,
+  normalizeCollection,
+  type ScientificCollection,
+} from '@/lib/collections'
+import { formatDisplayLabel, isClean, list, unique } from '@/lib/display-utils'
+
+type CollectionPageProps = {
+  slug: string
+}
+
+function getEffects(record: any) {
+  return unique([
+    ...list(record?.primary_effects),
+    ...list(record?.effects),
+    ...list(record?.primaryActions),
+  ])
+    .filter(isClean)
+    .slice(0, 4)
+}
+
+function getMechanisms(record: any) {
+  return unique([
+    ...list(record?.mechanisms),
+    ...list(record?.mechanism),
+    ...list(record?.pathway_bucket),
+  ])
+    .filter(isClean)
+    .slice(0, 4)
+}
+
+function visible(records: any[]) {
+  return records.filter((record) => getRuntimeVisibility(record).canRender)
+}
+
+function primaryFirst<T extends { type: 'herb' | 'compound' }>(cards: T[], collection: ScientificCollection) {
+  if (!collection.primaryType) return cards
+  return [
+    ...cards.filter(card => card.type === collection.primaryType),
+    ...cards.filter(card => card.type !== collection.primaryType),
+  ]
+}
+
+function CollectionCards({ cards }: { cards: ReturnType<typeof getCollectionCard>[] }) {
+  if (!cards.length) {
+    return (
+      <div className="surface-subtle rounded-2xl border border-brand-900/10 p-5 text-sm leading-7 text-[#46574d]">
+        No runtime-visible records currently expose enough matching evidence and semantic context for this section.
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+      {cards.map((item) => (
+        <Link key={`${item.type}-${item.slug}`} href={item.href} className="card-premium group p-5">
+          <div className="space-y-4">
+            <div className="flex items-center justify-between gap-3">
+              <EvidenceBadgeGroup record={item.record} compact />
+              <span className="identity-meta capitalize">{item.type}</span>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              {item.signals.slice(0, 3).map((signal) => (
+                <span key={signal} className="chip-readable">{signal}</span>
+              ))}
+            </div>
+
+            <div>
+              <h3 className="text-xl font-semibold text-ink transition group-hover:text-brand-700">
+                {item.name}
+              </h3>
+
+              <p className="mt-3 line-clamp-4 text-sm leading-7 text-[#46574d]">
+                {item.summary}
+              </p>
+            </div>
+
+            {item.pathways.length > 0 ? (
+              <div className="flex flex-wrap gap-2 border-t border-brand-900/10 pt-3">
+                {item.pathways.map((pathway) => (
+                  <span key={pathway} className="identity-meta">{pathway} pathway</span>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </Link>
+      ))}
+    </div>
+  )
+}
+
+export function generateCollectionMetadata(slug: string): Metadata {
+  const collection = findCollectionBySlug(slug)
+  if (!collection) return {}
+
+  const meta = buildCollectionMetadata(collection)
+
+  return {
+    title: meta.title,
+    description: meta.description,
+    alternates: { canonical: meta.url },
+    openGraph: {
+      title: meta.title,
+      description: meta.description,
+      type: 'article',
+      url: meta.url,
+      images: [meta.image],
+    },
+  }
+}
+
+export async function ScientificCollectionPage({ slug }: CollectionPageProps) {
+  const collection = normalizeCollection(findCollectionBySlug(slug))
+  if (!collection) notFound()
+
+  const [herbs, compounds] = await Promise.all([getHerbs(), getCompounds()])
+  const herbMatches = visible(getCollectionRecords(herbs, collection)).map(record => getCollectionCard(record, 'herb', collection))
+  const compoundMatches = visible(getCollectionRecords(compounds, collection)).map(record => getCollectionCard(record, 'compound', collection))
+  const allCards = primaryFirst([...compoundMatches, ...herbMatches], collection).filter(card => card.slug && card.href)
+
+  const mechanisms = unique(allCards.flatMap(card => getMechanisms(card.record))).slice(0, 12)
+  const effects = unique(allCards.flatMap(card => getEffects(card.record))).slice(0, 12)
+  const primaryCards = allCards.filter(card => !collection.primaryType || card.type === collection.primaryType).slice(0, 12)
+  const supportingCards = allCards.filter(card => collection.primaryType && card.type !== collection.primaryType).slice(0, 6)
+
+  return (
+    <main className="mx-auto max-w-7xl space-y-12 px-4 py-10 sm:space-y-14 sm:py-14">
+      <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8 lg:p-10">
+        <div className="max-w-4xl space-y-6">
+          <div className="space-y-3">
+            <p className="eyebrow-label">{collection.eyebrow}</p>
+
+            <h1 className="heading-premium text-ink">
+              {collection.title}
+            </h1>
+          </div>
+
+          <p className="max-w-3xl text-lg leading-8 text-[#46574d]">
+            {collection.description}
+          </p>
+
+          <div className="flex flex-wrap gap-2">
+            {collection.chips.map((chip) => (
+              <span key={chip} className="chip-readable">{chip}</span>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-5 md:grid-cols-2">
+        <div className="card-premium p-6">
+          <p className="eyebrow-label">Mechanism relationships</p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {mechanisms.length > 0 ? mechanisms.map(mechanism => (
+              <span key={mechanism} className="chip-readable">{formatDisplayLabel(mechanism)}</span>
+            )) : <p className="text-sm leading-7 text-[#46574d]">Mechanism chips appear when matching workbook records expose clean semantic signals.</p>}
+          </div>
+        </div>
+
+        <div className="card-premium p-6">
+          <p className="eyebrow-label">Related effects</p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {effects.length > 0 ? effects.map(effect => (
+              <span key={effect} className="chip-readable">{formatDisplayLabel(effect)}</span>
+            )) : <p className="text-sm leading-7 text-[#46574d]">Effect chips appear when matching workbook records expose clean associated-effect fields.</p>}
+          </div>
+        </div>
+      </section>
+
+      <section className="space-y-6">
+        <div className="space-y-2">
+          <p className="eyebrow-label">Evidence-aware discovery</p>
+          <h2 className="text-3xl font-semibold tracking-tight text-ink">
+            {collection.primaryType === 'herb' ? 'Primary herbs' : collection.primaryType === 'compound' ? 'Primary compounds' : 'Matching records'}
+          </h2>
+        </div>
+
+        <CollectionCards cards={primaryCards} />
+      </section>
+
+      {supportingCards.length > 0 ? (
+        <section className="space-y-6">
+          <div className="space-y-2">
+            <p className="eyebrow-label">Semantic overlap</p>
+            <h2 className="text-3xl font-semibold tracking-tight text-ink">
+              Supporting {collection.primaryType === 'herb' ? 'compounds' : 'herbs'}
+            </h2>
+          </div>
+
+          <CollectionCards cards={supportingCards} />
+        </section>
+      ) : null}
+
+      <section className="space-y-5">
+        <div className="space-y-2">
+          <p className="eyebrow-label">Related Collections</p>
+          <h2 className="text-3xl font-semibold tracking-tight text-ink">Continue the scientific graph</h2>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {collection.related.map((item) => (
+            <Link key={item.href} href={item.href} className="surface-subtle rounded-2xl border border-brand-900/10 p-4 transition hover:border-brand-700/30 hover:bg-white/60">
+              <p className="text-sm font-semibold leading-6 text-ink">{item.title}</p>
+              <p className="mt-2 text-xs leading-5 text-muted-readable">{item.description}</p>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -43,6 +43,7 @@ import { supplementComparisons } from '@/data/comparisons'
 import { buildMeta } from '@/lib/seo'
 import { EvidenceBadgeGroup } from '@/components/evidence/evidence-badge'
 import { CompactRelatedPathways } from '@/app/pathways/pathway-hub'
+import { getFeaturedCollections } from '@/lib/collections'
 
 export async function generateStaticParams() {
   return (data as any[])
@@ -123,6 +124,7 @@ export default function Page({ params }: any) {
       name: formatDisplayLabel(item.name || item.slug),
       overlap: (item.relatedOverlap || []).map(formatDisplayLabel).filter(isClean),
     }))
+  const featuredCollections = getFeaturedCollections(compound)
 
   const stackCandidates = getStackCandidates(compound)
     .map((candidate:any) => ({
@@ -227,6 +229,22 @@ export default function Page({ params }: any) {
           <EvidenceSnapshotCard snapshot={snapshot} />
 
           <CompactRelatedPathways record={compound} />
+
+          {featuredCollections.length > 0 ? (
+            <SectionBlock title="Featured In Collections">
+              <div className="flex flex-wrap gap-3">
+                {featuredCollections.slice(0, 4).map((collection:any) => (
+                  <Link
+                    key={collection.slug}
+                    href={collection.href}
+                    className="surface-subtle rounded-2xl border border-brand-900/10 px-4 py-3 text-sm font-semibold text-ink transition hover:border-brand-700/30 hover:bg-white/60"
+                  >
+                    {collection.title}
+                  </Link>
+                ))}
+              </div>
+            </SectionBlock>
+          ) : null}
 
           <div className="space-y-5">
             <EvidenceMeter level={evidenceLevel} />

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { getRelatedRuntimeRecords } from '@/lib/related-runtime'
 import { buildMeta } from '@/lib/seo'
 import { EvidenceBadgeGroup } from '@/components/evidence/evidence-badge'
 import { CompactRelatedPathways } from '@/app/pathways/pathway-hub'
+import { getFeaturedCollections } from '@/lib/collections'
 
 export async function generateStaticParams() {
   const herbs = await getHerbs()
@@ -74,6 +75,7 @@ export default async function HerbDetailPage({ params }: any) {
 
   const relatedHerbs = getRelatedRuntimeRecords(herb, herbs, 6)
     .filter((item: any) => getRuntimeVisibility(item).canRender)
+  const featuredCollections = getFeaturedCollections(herb)
 
   return (
     <main className="mx-auto max-w-6xl space-y-10 px-4 py-10">
@@ -104,6 +106,27 @@ export default async function HerbDetailPage({ params }: any) {
       </section>
 
       <CompactRelatedPathways record={herb} />
+
+      {featuredCollections.length > 0 ? (
+        <section className="card-premium space-y-4 p-5">
+          <div className="space-y-1">
+            <p className="eyebrow-label">Featured In Collections</p>
+            <h2 className="text-2xl font-semibold tracking-tight text-ink">Evidence-aware collection links</h2>
+          </div>
+
+          <div className="flex flex-wrap gap-3">
+            {featuredCollections.slice(0, 4).map((collection) => (
+              <Link
+                key={collection.slug}
+                href={collection.href}
+                className="surface-subtle rounded-2xl border border-brand-900/10 px-4 py-3 text-sm font-semibold text-ink transition hover:border-brand-700/30 hover:bg-white/60"
+              >
+                {collection.title}
+              </Link>
+            ))}
+          </div>
+        </section>
+      ) : null}
 
       {relatedHerbs.length > 0 ? (
         <section className="space-y-5">

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -7,6 +7,7 @@ import { bestPages } from '@/data/best'
 import { supplementComparisons } from '@/data/comparisons'
 import { goalConfigs } from '@/data/goals'
 import { seoEntryPages } from './seo-entry-pages'
+import { scientificCollections } from '@/lib/collections'
 
 export const dynamic = 'force-static'
 
@@ -73,6 +74,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     ...seoEntryPages.map(page => route(`/${page.route}`)),
     ...clusterRoutes.map(route),
     ...pathwayRoutes.map(route),
+    ...scientificCollections.map(collection => route(`/collections/${collection.slug}`)),
     ...goalConfigs.map(g => route(`/goals/${g.slug}`)),
     ...bestPages.map(p => route(`/best/${p.slug}`)),
     ...supplementComparisons.map(c => route(`/compare/${c.slug}`)),

--- a/lib/collections.ts
+++ b/lib/collections.ts
@@ -1,0 +1,262 @@
+import { getEvidenceTier, hasHumanEvidence, hasMechanismEvidence } from '@/lib/evidence'
+import { cleanSummary, formatDisplayLabel, isClean, list, text, unique } from '@/lib/display-utils'
+import { getPathwayLabel, getSupportedPathways } from '@/lib/pathways'
+import { buildMeta } from '@/lib/seo'
+
+export type CollectionKind = 'sleep' | 'stress' | 'cholinergic' | 'inflammation' | 'gaba' | 'recovery' | 'relaxation'
+export type CollectionRecordType = 'herb' | 'compound' | 'mixed'
+export type CollectionEvidence = 'mechanism' | 'human' | 'moderate_or_strong'
+
+export type ScientificCollection = {
+  slug: string
+  title: string
+  eyebrow: string
+  itemType: CollectionRecordType
+  primaryType?: 'herb' | 'compound'
+  kinds: CollectionKind[]
+  description: string
+  chips: string[]
+  related: Array<{ title: string; href: string; description: string }>
+  evidence?: CollectionEvidence
+}
+
+const COLLECTION_KEYWORDS: Record<CollectionKind, string[]> = {
+  sleep: ['gaba', 'sleep', 'relaxation', 'calming', 'circadian'],
+  stress: ['cortisol', 'adaptogen', 'stress', 'anxiety', 'resilience'],
+  cholinergic: ['acetylcholine', 'cholinergic', 'cognition', 'memory', 'focus', 'neuro'],
+  inflammation: ['inflammatory', 'anti inflammatory', 'antioxidant', 'cytokine', 'oxidative', 'immune'],
+  gaba: ['gaba', 'gabaergic', 'relaxation', 'calming', 'inhibitory'],
+  recovery: ['recovery', 'repair', 'exercise', 'muscle', 'oxidative', 'inflammation'],
+  relaxation: ['relaxation', 'calming', 'calm', 'anxiety', 'sleep'],
+}
+
+export const scientificCollections: ScientificCollection[] = [
+  {
+    slug: 'best-studied-sleep-compounds',
+    title: 'Best-Studied Sleep Compounds',
+    eyebrow: 'Sleep evidence collection',
+    itemType: 'mixed',
+    primaryType: 'compound',
+    kinds: ['sleep', 'gaba', 'relaxation'],
+    evidence: 'mechanism',
+    description: 'A workbook-first collection of compounds and botanicals with visible sleep, GABA, calming, relaxation, or circadian signals. Items are included only when the runtime record exposes evidence or mechanism context; this is not a ranked efficacy list.',
+    chips: ['GABA signaling', 'Sleep quality', 'Relaxation', 'Circadian context', 'Nighttime recovery'],
+    related: [
+      { title: 'Adaptogens for Stress', href: '/collections/adaptogens-for-stress', description: 'Stress and resilience records with adaptogenic or cortisol-adjacent signals.' },
+      { title: 'GABA Pathways', href: '/pathways/gaba', description: 'Pathway hub for GABA, inhibitory tone, relaxation, and sleep-adjacent records.' },
+      { title: 'Recovery Support', href: '/explore/recovery', description: 'Recovery and repair signals that overlap with sleep quality and nighttime restoration.' },
+      { title: 'Relaxation Mechanisms', href: '/explore/sleep', description: 'Broader semantic navigation for calming and sleep-support discovery.' },
+    ],
+  },
+  {
+    slug: 'adaptogens-for-stress',
+    title: 'Adaptogens for Stress',
+    eyebrow: 'Stress resilience collection',
+    itemType: 'mixed',
+    primaryType: 'herb',
+    kinds: ['stress', 'relaxation'],
+    evidence: 'mechanism',
+    description: 'Herbs and compounds with workbook signals around stress, cortisol, adaptogenic use, anxiety, calm, or resilience. Inclusion reflects semantic and evidence-context overlap, not a promise of clinical effect.',
+    chips: ['Cortisol context', 'Adaptogenic language', 'Stress resilience', 'Calming support', 'HPA-axis adjacency'],
+    related: [
+      { title: 'Best-Studied Sleep Compounds', href: '/collections/best-studied-sleep-compounds', description: 'Sleep and relaxation records that often overlap with stress physiology.' },
+      { title: 'GABA Pathways', href: '/pathways/gaba', description: 'Calming pathway records related to inhibitory tone and relaxation.' },
+      { title: 'Stress Goal Guide', href: '/best-supplements-for-stress', description: 'Intent-oriented stress support navigation from the goal layer.' },
+      { title: 'Natural Anxiolytics', href: '/natural-anxiolytics-beyond-ashwagandha', description: 'Broader harm-aware discovery for calming botanicals beyond one headline herb.' },
+    ],
+  },
+  {
+    slug: 'cholinergic-compounds',
+    title: 'Cholinergic Compounds',
+    eyebrow: 'Cognition mechanism collection',
+    itemType: 'mixed',
+    primaryType: 'compound',
+    kinds: ['cholinergic'],
+    evidence: 'mechanism',
+    description: 'A cognition-focused collection for records with acetylcholine, cholinergic, memory, focus, or neuro-related workbook signals. The page organizes mechanism-adjacent discovery without asserting unsupported nootropic outcomes.',
+    chips: ['Acetylcholine', 'Memory', 'Focus', 'Neuro signaling', 'Cognition'],
+    related: [
+      { title: 'Dopamine Pathways', href: '/pathways/dopamine', description: 'Cognition and attention records with dopaminergic or motivation-adjacent signals.' },
+      { title: 'Focus Supplements', href: '/best-supplements-for-focus', description: 'Intent entry page for focus-oriented supplement discovery.' },
+      { title: 'Cognition Compounds', href: '/collections/cognition-compounds', description: 'Existing compound collection for cognition, attention, and memory signals.' },
+      { title: 'Brain Fog Guide', href: '/top/best-supplements-for-brain-fog', description: 'Decision-oriented discovery for cognitive clarity intent.' },
+    ],
+  },
+  {
+    slug: 'high-evidence-anti-inflammatory-herbs',
+    title: 'High-Evidence Anti-Inflammatory Herbs',
+    eyebrow: 'Inflammation evidence collection',
+    itemType: 'mixed',
+    primaryType: 'herb',
+    kinds: ['inflammation', 'recovery'],
+    evidence: 'moderate_or_strong',
+    description: 'Herbs and related compounds with inflammation, antioxidant, cytokine, oxidative-stress, or immune signals plus stronger evidence labeling when available in the runtime payload. This remains an evidence-organizing page, not a treatment ranking.',
+    chips: ['Inflammation', 'Antioxidant systems', 'Cytokine context', 'Oxidative stress', 'Immune signaling'],
+    related: [
+      { title: 'Inflammation Pathways', href: '/pathways/inflammation', description: 'Pathway hub for inflammatory, immune, oxidative, and antioxidant records.' },
+      { title: 'Recovery Support', href: '/explore/recovery', description: 'Recovery signals that can overlap with inflammatory and oxidative-stress context.' },
+      { title: 'Joint Support Supplements', href: '/best-supplements-for-joint-support', description: 'Intent entry page for joint-support discovery.' },
+      { title: 'Gut Health Supplements', href: '/best-supplements-for-gut-health', description: 'Adjacent discovery for immune and inflammation-adjacent wellness intent.' },
+    ],
+  },
+]
+
+function asArray(records: unknown): any[] {
+  return Array.isArray(records) ? records.filter(Boolean) : []
+}
+
+function safeLower(value: unknown) {
+  return text(value).toLowerCase()
+}
+
+function signalValues(record: any) {
+  if (!record || typeof record !== 'object') return []
+
+  return unique([
+    text(record.slug),
+    text(record.name),
+    text(record.displayName),
+    text(record.domain),
+    text(record.pathway_bucket),
+    ...list(record.pathways),
+    ...list(record.pathwayTargets),
+    ...list(record.mechanisms),
+    ...list(record.mechanism),
+    ...list(record.primary_effects),
+    ...list(record.primaryEffects),
+    ...list(record.effects),
+    ...list(record.best_for),
+    ...list(record.bestFor),
+    ...list(record.population_tags),
+    text(record.summary),
+    text(record.description),
+  ].filter(Boolean))
+}
+
+function keywordMatch(record: any, keywords: string[]) {
+  const normalizedSignals = signalValues(record).map(safeLower).join(' ')
+  if (!normalizedSignals) return false
+
+  return keywords.some((keyword) => {
+    const normalizedKeyword = safeLower(keyword)
+    return normalizedKeyword ? normalizedSignals.includes(normalizedKeyword) : false
+  })
+}
+
+function evidenceMatches(record: any, requirement?: CollectionEvidence) {
+  if (!requirement) return true
+  if (!record || typeof record !== 'object') return false
+
+  if (requirement === 'human') return hasHumanEvidence(record)
+  if (requirement === 'mechanism') return hasMechanismEvidence(record) || hasHumanEvidence(record)
+
+  const tier = getEvidenceTier(record)
+  return tier === 'strong' || tier === 'moderate' || hasHumanEvidence(record)
+}
+
+export function normalizeCollection(collection: unknown): ScientificCollection | null {
+  if (!collection || typeof collection !== 'object') return null
+
+  const raw = collection as Partial<ScientificCollection>
+  const slug = text(raw.slug)
+  const title = text(raw.title)
+  const kinds = asArray(raw.kinds).map(kind => safeLower(kind) as CollectionKind).filter(kind => Boolean(COLLECTION_KEYWORDS[kind]))
+
+  if (!slug || !title || !kinds.length) return null
+
+  return {
+    slug,
+    title,
+    eyebrow: text(raw.eyebrow) || 'Scientific collection',
+    itemType: raw.itemType === 'herb' || raw.itemType === 'compound' || raw.itemType === 'mixed' ? raw.itemType : 'mixed',
+    primaryType: raw.primaryType === 'herb' || raw.primaryType === 'compound' ? raw.primaryType : undefined,
+    kinds,
+    description: getCollectionDescription(raw),
+    chips: asArray(raw.chips).map(formatDisplayLabel).filter(isClean),
+    related: asArray(raw.related)
+      .map((item) => ({
+        title: formatDisplayLabel(item?.title),
+        href: text(item?.href),
+        description: text(item?.description),
+      }))
+      .filter((item) => item.title && item.href.startsWith('/')),
+    evidence: raw.evidence === 'human' || raw.evidence === 'mechanism' || raw.evidence === 'moderate_or_strong' ? raw.evidence : undefined,
+  }
+}
+
+export function getCollectionDescription(collection: unknown) {
+  const raw = collection && typeof collection === 'object' ? collection as Partial<ScientificCollection> : {}
+  const description = text(raw.description)
+  if (description) return description
+
+  const title = text(raw.title) || 'Scientific collection'
+  return `${title} groups workbook-visible records by conservative semantic overlap and evidence context.`
+}
+
+export function buildCollectionMetadata(collection: unknown) {
+  const normalized = normalizeCollection(collection)
+  const title = normalized?.title || 'Scientific Collection'
+  const description = getCollectionDescription(normalized || collection)
+  const path = normalized?.slug ? `/collections/${normalized.slug}` : '/collections'
+
+  return buildMeta({ title: `${title} | Scientific Collections`, description, path })
+}
+
+export function isCollectionMatch(record: any, collection: unknown) {
+  const normalized = normalizeCollection(collection)
+  if (!normalized || !record || typeof record !== 'object') return false
+  if (!text(record.slug)) return false
+
+  const keywords = unique(normalized.kinds.flatMap(kind => COLLECTION_KEYWORDS[kind] || []))
+  if (!keywordMatch(record, keywords)) return false
+
+  return evidenceMatches(record, normalized.evidence)
+}
+
+export function getCollectionRecords(records: unknown, collection: unknown) {
+  return asArray(records).filter(record => isCollectionMatch(record, collection))
+}
+
+export function findCollectionBySlug(slug: unknown) {
+  const value = text(slug)
+  return scientificCollections.find(collection => collection.slug === value) || null
+}
+
+export function getFeaturedCollections(record: any) {
+  return scientificCollections
+    .filter(collection => isCollectionMatch(record, collection))
+    .map(collection => ({
+      slug: collection.slug,
+      title: collection.title,
+      href: `/collections/${collection.slug}`,
+      description: getCollectionDescription(collection),
+    }))
+}
+
+export function getCollectionRecordSignals(record: any, collection: ScientificCollection) {
+  const keywords = unique(collection.kinds.flatMap(kind => COLLECTION_KEYWORDS[kind] || []))
+  const signals = signalValues(record)
+    .filter(value => keywordMatch({ summary: value }, keywords))
+    .map(formatDisplayLabel)
+    .filter(isClean)
+
+  const pathways = getSupportedPathways(record).map(getPathwayLabel).filter(isClean)
+
+  return unique([...signals, ...pathways]).slice(0, 4)
+}
+
+export function getCollectionCard(record: any, type: 'herb' | 'compound', collection: ScientificCollection) {
+  const slug = text(record?.slug)
+  const label = formatDisplayLabel(record?.displayName || record?.name || slug)
+
+  return {
+    record,
+    type,
+    slug,
+    name: label || slug,
+    href: slug ? `/${type === 'herb' ? 'herbs' : 'compounds'}/${slug}` : '',
+    summary: cleanSummary(record?.summary || record?.description || '', type),
+    signals: getCollectionRecordSignals(record, collection),
+    pathways: getSupportedPathways(record).map(getPathwayLabel).filter(isClean).slice(0, 3),
+  }
+}


### PR DESCRIPTION
### Motivation
- Introduce first-generation scientific collection pages that combine evidence organization, semantic clustering, pathway relationships, and authority-focused internal linking.
- Centralize defensive collection matching and metadata helpers to keep the site workbook-first, static-export-friendly, and to avoid unsafe runtime ranking.
- Surface evidence-aware collection links on detail pages to strengthen the internal crawl graph and semantic discovery without changing UI or client-side fetching.

### Description
- Added `lib/collections.ts` with null-safe, defensive helpers including `normalizeCollection`, `isCollectionMatch`, `getCollectionRecords`, `getCollectionCard`, `getFeaturedCollections`, `getCollectionRecordSignals`, and `buildCollectionMetadata`, using conservative keyword matching, pathway signals, and evidence checks. 
- Added four curated collection configs inside `lib/collections.ts`: `best-studied-sleep-compounds`, `adaptogens-for-stress`, `cholinergic-compounds`, and `high-evidence-anti-inflammatory-herbs`, each with chips and related-collection links. 
- Implemented a shared renderer at `app/collections/scientific-collection-page.tsx` and four route wrappers under `app/collections/*/page.tsx` that render evidence badges, semantic chips, mechanism/effect sections, primary/supporting cards, and a related-collections graph with SEO metadata and OpenGraph. 
- Added compact “Featured In Collections” blocks to herb and compound detail pages and registered collection routes in the sitemap, while respecting `getRuntimeVisibility` and existing evidence filters and gating.

### Testing
- Ran `npm run check`, which executed the data build, validation, and Next.js build; the build completed successfully. 
- `npm run data:validate` passed as part of the build pipeline. 
- Data verification (`data:verify`) passed when regenerating approved public/data artifacts and build verification scripts completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe03a980e88323b3248e9736df1e70)