### PR TITLE
Refine scientific profile trust rendering

### DIFF
--- a/components/evidence/evidence-badge.tsx
+++ b/components/evidence/evidence-badge.tsx
@@ -1,10 +1,6 @@
-import {
-  getEvidenceLabel,
-  hasHumanEvidence,
-  hasMechanismEvidence,
-  hasStrongSafetyProfile,
-  isPreliminaryResearch,
-} from '@/lib/evidence'
+import { getEvidenceLabel, hasStrongSafetyProfile } from '@/lib/evidence'
+import { getSemanticTrustLabels } from '@/lib/semantic-trust-badges'
+import { getSafetyLabels } from '@/lib/safety-classification'
 
 type EvidenceBadgeKind =
   | 'Human Evidence'
@@ -13,6 +9,10 @@ type EvidenceBadgeKind =
   | 'Traditional Use'
   | 'Emerging Research'
   | 'Strong Safety Profile'
+  | 'Evidence-Limited'
+  | 'Mechanistic Focus'
+  | 'Interaction-Aware'
+  | 'Safety-Sensitive'
 
 type EvidenceBadgeProps = {
   label: EvidenceBadgeKind | string
@@ -26,6 +26,10 @@ const BADGE_STYLES: Record<string, string> = {
   'Traditional Use': 'border-stone-700/15 bg-stone-100/70 text-stone-800',
   'Emerging Research': 'border-violet-800/15 bg-violet-50/70 text-violet-900',
   'Strong Safety Profile': 'border-teal-800/15 bg-teal-50/75 text-teal-900',
+  'Evidence-Limited': 'border-amber-800/20 bg-amber-50/80 text-amber-900',
+  'Mechanistic Focus': 'border-blue-800/15 bg-blue-50/70 text-blue-900',
+  'Interaction-Aware': 'border-rose-800/15 bg-rose-50/75 text-rose-900',
+  'Safety-Sensitive': 'border-amber-800/20 bg-amber-50/80 text-amber-900',
 }
 
 export function EvidenceBadge({ label, className = '' }: EvidenceBadgeProps) {
@@ -44,16 +48,15 @@ export function getEvidenceBadges(record: any): string[] {
   const badges = new Set<string>()
   const label = getEvidenceLabel(record)
 
-  if (hasHumanEvidence(record)) badges.add('Human Evidence')
-  if (hasMechanismEvidence(record)) badges.add('Mechanism-Mapped')
-  if (isPreliminaryResearch(record)) badges.add('Preliminary Research')
+  getSemanticTrustLabels(record, 4).forEach(badge => badges.add(badge))
+  getSafetyLabels(record, 2).forEach(badge => badges.add(badge))
   if (/traditional/i.test(label)) badges.add('Traditional Use')
   if (/emerging/i.test(label)) badges.add('Emerging Research')
   if (hasStrongSafetyProfile(record)) badges.add('Strong Safety Profile')
 
   if (!badges.size) badges.add(label)
 
-  return Array.from(badges).slice(0, 3)
+  return Array.from(badges).slice(0, 4)
 }
 
 export function EvidenceBadgeGroup({

--- a/lib/discovery-classification.ts
+++ b/lib/discovery-classification.ts
@@ -1,3 +1,7 @@
+import { calculateDiscoveryScore } from '@/lib/discovery-score'
+import { getEvidenceMaturity, getMechanismDepth, getProfileCompleteness } from '@/lib/semantic-trust-badges'
+import { getSafetySensitivity } from '@/lib/safety-classification'
+
 type DiscoveryGroup = {
   title: string
   description: string
@@ -18,14 +22,24 @@ function overlap(a: string[], b: string[]) {
   return a.filter(item => b.includes(item)).length
 }
 
+function sortByDiscoveryScore(base: any, items: any[]) {
+  return [...items].sort((a, b) => calculateDiscoveryScore(base, b) - calculateDiscoveryScore(base, a))
+}
+
 export function classifyDiscoveryGroups(base: any, relatedRecords: any[] = []): DiscoveryGroup[] {
   const baseEffects = normalize(base?.primary_effects || base?.effects)
   const baseMechanisms = normalize(base?.mechanisms)
   const basePathways = normalize(base?.pathways)
+  const baseMaturity = getEvidenceMaturity(base)
+  const baseCompleteness = getProfileCompleteness(base)
+  const baseSafety = getSafetySensitivity(base)
+  const baseMechanismDepth = getMechanismDepth(base)
 
   const mechanismMatches: any[] = []
   const pathwayMatches: any[] = []
   const evidenceMatches: any[] = []
+  const safetyMatches: any[] = []
+  const completenessMatches: any[] = []
   const contextualMatches: any[] = []
 
   relatedRecords.forEach(record => {
@@ -36,8 +50,12 @@ export function classifyDiscoveryGroups(base: any, relatedRecords: any[] = []): 
     const mechanismOverlap = overlap(baseMechanisms, mechanisms)
     const pathwayOverlap = overlap(basePathways, pathways)
     const effectOverlap = overlap(baseEffects, effects)
+    const recordMaturity = getEvidenceMaturity(record)
+    const recordSafety = getSafetySensitivity(record)
+    const recordCompleteness = getProfileCompleteness(record)
+    const recordMechanismDepth = getMechanismDepth(record)
 
-    if (mechanismOverlap >= 2) {
+    if (mechanismOverlap >= 2 || (baseMaturity === 'exploratory' && recordMechanismDepth !== 'light')) {
       mechanismMatches.push(record)
     }
 
@@ -45,11 +63,19 @@ export function classifyDiscoveryGroups(base: any, relatedRecords: any[] = []): 
       pathwayMatches.push(record)
     }
 
-    if (/strong|moderate|clinical|human/i.test(String(record?.evidence_tier || ''))) {
+    if (recordMaturity === baseMaturity || (baseMaturity === 'mature' && recordMaturity === 'mature')) {
       evidenceMatches.push(record)
     }
 
-    if (effectOverlap >= 1 || mechanismOverlap >= 1 || pathwayOverlap >= 1) {
+    if (baseSafety !== 'low' && recordSafety !== 'low') {
+      safetyMatches.push(record)
+    }
+
+    if (recordCompleteness === baseCompleteness || (baseCompleteness === 'complete' && recordCompleteness === 'complete')) {
+      completenessMatches.push(record)
+    }
+
+    if (effectOverlap >= 1 || mechanismOverlap >= 1 || pathwayOverlap >= 1 || baseMechanismDepth === recordMechanismDepth) {
       contextualMatches.push(record)
     }
   })
@@ -57,7 +83,7 @@ export function classifyDiscoveryGroups(base: any, relatedRecords: any[] = []): 
   const dedupe = (items: any[]) => {
     const seen = new Set()
 
-    return items.filter(item => {
+    return sortByDiscoveryScore(base, items).filter(item => {
       if (!item?.slug || seen.has(item.slug)) return false
       seen.add(item.slug)
       return true
@@ -66,8 +92,10 @@ export function classifyDiscoveryGroups(base: any, relatedRecords: any[] = []): 
 
   return [
     {
-      title: 'Mechanistically Adjacent',
-      description: 'These profiles share overlapping signaling pathways or biological-response mechanisms.',
+      title: baseMaturity === 'exploratory' ? 'Mechanistic Neighbors' : 'Mechanistically Adjacent',
+      description: baseMaturity === 'exploratory'
+        ? 'Exploratory profiles are paired with records that offer richer mechanism or pathway context.'
+        : 'These profiles share overlapping signaling pathways or biological-response mechanisms.',
       items: dedupe(mechanismMatches).slice(0, 4),
     },
     {
@@ -76,13 +104,18 @@ export function classifyDiscoveryGroups(base: any, relatedRecords: any[] = []): 
       items: dedupe(pathwayMatches).slice(0, 4),
     },
     {
-      title: 'Similar Evidence Profiles',
-      description: 'Profiles with comparable evidence maturity or human-research depth.',
-      items: dedupe(evidenceMatches).slice(0, 4),
+      title: 'Similar Evidence Maturity',
+      description: 'Profiles are grouped by comparable human-research depth, evidence maturity, and profile completeness.',
+      items: dedupe([...evidenceMatches, ...completenessMatches]).slice(0, 4),
+    },
+    {
+      title: 'Safety-Adjacent Profiles',
+      description: 'Caution-sensitive profiles surface neighbors with similarly visible safety or interaction context.',
+      items: dedupe(safetyMatches).slice(0, 4),
     },
     {
       title: 'Research Context Profiles',
-      description: 'Related profiles commonly discussed alongside overlapping mechanisms or effects.',
+      description: 'Related profiles commonly discussed alongside overlapping mechanisms, effects, evidence patterns, or completeness signals.',
       items: dedupe(contextualMatches).slice(0, 6),
     },
   ].filter(group => group.items.length > 0)

--- a/lib/discovery-score.ts
+++ b/lib/discovery-score.ts
@@ -1,3 +1,6 @@
+import { getEvidenceMaturity, getMechanismDepth, getProfileCompleteness } from '@/lib/semantic-trust-badges'
+import { getSafetySensitivity } from '@/lib/safety-classification'
+
 export function calculateDiscoveryScore(base: any, candidate: any) {
   let score = 0
 
@@ -14,13 +17,35 @@ export function calculateDiscoveryScore(base: any, candidate: any) {
   score += overlapScore(baseMechanisms, candidateMechanisms) * 4
   score += overlapScore(basePathways, candidatePathways) * 2
 
-  if (/strong|moderate|clinical|human/i.test(String(candidate?.evidence_tier || ''))) {
+  if (/strong|moderate|clinical|human/i.test(String(candidate?.evidence_tier || candidate?.evidenceTier || ''))) {
     score += 3
   }
 
-  if (/complete/i.test(String(candidate?.profile_status || ''))) {
+  if (/complete/i.test(String(candidate?.profile_status || candidate?.review_status || ''))) {
     score += 2
   }
+
+  const baseMaturity = getEvidenceMaturity(base)
+  const candidateMaturity = getEvidenceMaturity(candidate)
+  const baseCompleteness = getProfileCompleteness(base)
+  const candidateCompleteness = getProfileCompleteness(candidate)
+  const baseSafety = getSafetySensitivity(base)
+  const candidateSafety = getSafetySensitivity(candidate)
+  const baseMechanismDepth = getMechanismDepth(base)
+  const candidateMechanismDepth = getMechanismDepth(candidate)
+
+  if (baseMaturity === candidateMaturity) score += baseMaturity === 'mature' ? 4 : 2
+  if (baseMaturity === 'mature' && candidateMaturity === 'mature') score += 2
+  if (baseMaturity === 'exploratory' && candidateMechanismDepth !== 'light') score += 3
+
+  if (baseCompleteness === candidateCompleteness) score += 2
+  if (baseCompleteness === 'complete' && candidateCompleteness === 'complete') score += 2
+
+  if (baseSafety === candidateSafety && baseSafety !== 'low') score += 3
+  if (baseSafety === 'high' && candidateSafety !== 'low') score += 2
+
+  if (baseMechanismDepth === candidateMechanismDepth) score += 2
+  if (baseMechanismDepth !== 'light' && candidateMechanismDepth !== 'light') score += 2
 
   return score
 }

--- a/lib/editorial-variation.ts
+++ b/lib/editorial-variation.ts
@@ -1,0 +1,102 @@
+type EditorialInput = {
+  name?: string
+  evidenceTier?: string
+  effects?: string[]
+  mechanisms?: string[]
+  safety?: string[]
+  density?: string
+  seed?: string
+}
+
+function clean(items?: string[], limit = 4) {
+  return (items || []).map(item => String(item).trim()).filter(Boolean).slice(0, limit)
+}
+
+function join(items: string[]) {
+  if (items.length === 0) return ''
+  if (items.length === 1) return items[0]
+  if (items.length === 2) return `${items[0]} and ${items[1]}`
+  return `${items.slice(0, -1).join(', ')}, and ${items[items.length - 1]}`
+}
+
+function variant(input: EditorialInput, count: number) {
+  const seed = `${input.seed || input.name || ''}${input.evidenceTier || ''}${input.density || ''}`
+  return Array.from(seed).reduce((sum, char) => sum + char.charCodeAt(0), 0) % count
+}
+
+function evidenceTone(input: EditorialInput) {
+  const evidence = `${input.evidenceTier || ''} ${input.density || ''}`.toLowerCase()
+
+  if (/\b(strong|high|clinical|human|comprehensive|grade\s*a|tier\s*a)\b/.test(evidence)) return 'strong'
+  if (/\b(moderate|developing|grade\s*b|tier\s*b)\b/.test(evidence)) return 'moderate'
+  return 'weak'
+}
+
+export function buildVariedSummary(input: EditorialInput) {
+  const effects = clean(input.effects, 3)
+  const mechanisms = clean(input.mechanisms, 3)
+  const focus = mechanisms.length > 0 ? mechanisms : effects
+  const tone = evidenceTone(input)
+
+  if (focus.length === 0) {
+    return tone === 'weak'
+      ? 'This profile is framed conservatively because structured evidence signals remain limited.'
+      : 'Evidence context is presented with restraint and separated from practical interpretation.'
+  }
+
+  const choices = [
+    tone === 'strong'
+      ? effects.length > 0
+        ? `The strongest profile signals cluster around ${join(effects)} while mechanism notes add context around ${join(focus)}.`
+        : `The strongest profile signals are organized around ${join(focus)}, with safety and context still kept visible.`
+      : `This profile is best read through a cautious lens: ${join(focus)} are research-context signals, not settled clinical claims.`,
+    tone === 'strong'
+      ? effects.length > 0
+        ? `Human-facing evidence signals give this profile more editorial weight, especially around ${join(effects)}.`
+        : `Human-facing evidence signals give this profile more editorial weight without turning mechanism context into advice.`
+      : `Current coverage leans exploratory, with ${join(focus)} providing biological plausibility rather than proof of effect.`,
+    tone === 'strong'
+      ? `Evidence maturity is comparatively higher here, though safety and applicability still require context.`
+      : `The useful reading frame is mechanistic and evidence-aware, with restraint around practical conclusions.`,
+  ]
+
+  return choices[variant(input, choices.length)]
+}
+
+export function buildVariedEvidenceFraming(input: EditorialInput) {
+  const tone = evidenceTone(input)
+
+  if (tone === 'strong') {
+    return variant(input, 2) === 0
+      ? 'Human research signals are surfaced first, with mechanism notes treated as supporting context.'
+      : 'Clinical-leaning evidence is given more weight while avoiding treatment-style conclusions.'
+  }
+
+  if (tone === 'moderate') {
+    return variant(input, 2) === 0
+      ? 'Evidence is mixed enough to separate practical interest from stronger efficacy language.'
+      : 'Moderate signals are presented with caveats where mechanism or study depth remains incomplete.'
+  }
+
+  return variant(input, 2) === 0
+    ? 'Evidence appears early or incomplete, so the profile emphasizes exploratory context over outcomes.'
+    : 'Mechanistic plausibility is kept distinct from clinical confidence to avoid overstatement.'
+}
+
+export function buildVariedMechanismFraming(input: EditorialInput) {
+  const mechanisms = clean(input.mechanisms, 4)
+  if (mechanisms.length === 0) return ''
+
+  return variant(input, 2) === 0
+    ? `Mechanism discussion centers on ${join(mechanisms)}, framed as plausibility signals rather than standalone proof.`
+    : `${join(mechanisms)} help organize the biology, but they should be read below the evidence-strength layer.`
+}
+
+export function buildVariedPracticalRelevance(input: EditorialInput) {
+  const effects = clean(input.effects, 3)
+  if (effects.length === 0) return ''
+
+  return evidenceTone(input) === 'weak'
+    ? `Interest around ${join(effects)} remains exploratory and should not be read as a recommendation.`
+    : `Practical interest most often centers on ${join(effects)}, with safety context kept visible and non-prescriptive.`
+}

--- a/lib/related-runtime.ts
+++ b/lib/related-runtime.ts
@@ -1,5 +1,6 @@
 import { list, text, unique } from '@/lib/display-utils'
 import { safeArray, safeLower, safeScore, safeSlug } from '@/lib/search-safe'
+import { calculateDiscoveryScore } from '@/lib/discovery-score'
 
 function normalize(value: unknown) {
   return safeLower(value)
@@ -61,7 +62,7 @@ export function getRelatedRuntimeRecords(record: any, records: any[], limit = 6)
       return {
         ...candidate,
         relatedOverlap: overlap,
-        relatedScore: safeScore(overlap.length),
+        relatedScore: safeScore(overlap.length) + calculateDiscoveryScore(record, candidate),
       }
     })
     .sort((a: any, b: any) => {

--- a/lib/safety-classification.ts
+++ b/lib/safety-classification.ts
@@ -1,0 +1,87 @@
+import { list, text, unique } from '@/lib/display-utils'
+
+export type SafetyClassification = {
+  label: string
+  description: string
+  tone: 'caution' | 'context' | 'neutral'
+}
+
+function safetyText(record: any): string {
+  return [
+    record?.safety,
+    record?.safetyNotes,
+    record?.safety_notes,
+    record?.contraindications,
+    record?.interactions,
+    record?.avoid,
+    record?.cautions,
+    record?.warnings,
+    record?.summary,
+    record?.description,
+  ]
+    .map(text)
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+}
+
+function item(label: string, description: string, tone: SafetyClassification['tone'] = 'caution'): SafetyClassification {
+  return { label, description, tone }
+}
+
+export function getSafetyClassifications(record: any, limit = 6): SafetyClassification[] {
+  const source = safetyText(record)
+  const classifications: SafetyClassification[] = []
+
+  if (/\b(interaction|interacts|medication|drug|cyp\d|ssri|snri|maoi|sedative|antidepressant)\b/.test(source)) {
+    classifications.push(item('Interaction-Aware', 'Medication or interaction context is explicitly noted.'))
+  }
+
+  if (/\b(liver|hepatic|hepatotoxic|transaminase|alt|ast)\b/.test(source)) {
+    classifications.push(item('Liver-Sensitive', 'Liver-related caution language appears in the profile.'))
+  }
+
+  if (/\b(hormone|hormonal|estrogen|androgen|testosterone|thyroid|endocrine)\b/.test(source)) {
+    classifications.push(item('Hormonal Activity Context', 'Hormone-adjacent wording is present and should be interpreted carefully.', 'context'))
+  }
+
+  if (/\b(stimulant|stimulating|caffeine|adrenergic|jitters|insomnia|tachycardia)\b/.test(source)) {
+    classifications.push(item('Stimulant-Like Profile', 'Stimulant-like or activating caution language is present.', 'context'))
+  }
+
+  if (/\b(anticoagul|antiplatelet|warfarin|bleed|bleeding|blood thinner|clotting)\b/.test(source)) {
+    classifications.push(item('Anticoagulant Caution', 'Bleeding or anticoagulant-adjacent caution language is present.'))
+  }
+
+  if (/\b(pregnan|breastfeeding|lactation|nursing)\b/.test(source)) {
+    classifications.push(item('Pregnancy/Breastfeeding Caution', 'Pregnancy or breastfeeding caution language is present.'))
+  }
+
+  const seen = new Set<string>()
+  return classifications
+    .filter(classification => {
+      if (seen.has(classification.label)) return false
+      seen.add(classification.label)
+      return true
+    })
+    .slice(0, Math.max(0, limit))
+}
+
+export function getSafetyLabels(record: any, limit = 6): string[] {
+  return unique(getSafetyClassifications(record, limit).map(classification => classification.label))
+}
+
+export function getSafetySensitivity(record: any): 'high' | 'moderate' | 'low' {
+  const labels = getSafetyLabels(record, 6)
+  const source = safetyText(record)
+
+  if (labels.length >= 2 || /\b(avoid|contraindicat|warning|do not use|serious)\b/.test(source)) {
+    return 'high'
+  }
+
+  if (labels.length === 1 || /\b(caution|consult|monitor|sensitive)\b/.test(source)) {
+    return 'moderate'
+  }
+
+  return 'low'
+}

--- a/lib/semantic-trust-badges.ts
+++ b/lib/semantic-trust-badges.ts
@@ -1,0 +1,133 @@
+import { list, text, unique } from '@/lib/display-utils'
+import { hasHumanEvidence, hasMechanismEvidence, isPreliminaryResearch } from '@/lib/evidence'
+
+export type SemanticTrustBadge = {
+  label: string
+  description: string
+  tone: 'clinical' | 'mechanistic' | 'caution' | 'traditional' | 'emerging' | 'neutral'
+}
+
+function joined(record: any): string {
+  return [
+    record?.evidence_tier,
+    record?.evidenceTier,
+    record?.evidence_grade,
+    record?.confidence,
+    record?.profile_status,
+    record?.review_status,
+    record?.summary,
+    record?.description,
+    record?.traditional_use,
+    record?.traditionalUse,
+    record?.safety,
+    record?.safetyNotes,
+    record?.safety_notes,
+    record?.contraindications,
+    record?.interactions,
+    record?.mechanisms,
+    record?.pathways,
+    record?.sources,
+  ]
+    .map(text)
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+}
+
+function hasAny(record: any, fields: string[]): boolean {
+  return fields.some(field => list(record?.[field]).map(text).some(Boolean))
+}
+
+function badge(label: string, description: string, tone: SemanticTrustBadge['tone']): SemanticTrustBadge {
+  return { label, description, tone }
+}
+
+export function getSemanticTrustBadges(record: any, limit = 5): SemanticTrustBadge[] {
+  const source = joined(record)
+  const badges: SemanticTrustBadge[] = []
+
+  if (hasHumanEvidence(record)) {
+    badges.push(badge('Human Research', 'Includes human or clinically oriented evidence signals.', 'clinical'))
+  }
+
+  if (hasMechanismEvidence(record) || hasAny(record, ['mechanisms', 'primary_mechanisms', 'pathways'])) {
+    badges.push(badge('Mechanistic Focus', 'Mechanism or pathway context is available for cautious interpretation.', 'mechanistic'))
+  }
+
+  if (isPreliminaryResearch(record) || /\b(limited|weak|insufficient|low|partial|draft|needs review|not established)\b/.test(source)) {
+    badges.push(badge('Evidence-Limited', 'Evidence is framed as incomplete rather than clinically settled.', 'caution'))
+  }
+
+  if (/\b(traditional|ethnobotanical|historical|ayurveda|ayurvedic|tcm|folk)\b/.test(source)) {
+    badges.push(badge('Traditional Medicine Context', 'Traditional-use context is separated from modern clinical evidence.', 'traditional'))
+  }
+
+  if (/\b(interaction|interacts|contraindicat|avoid with|cyp|ssri|maoi|warfarin|medication)\b/.test(source)) {
+    badges.push(badge('Interaction-Aware', 'Interaction or medication-adjacent caution language is present.', 'caution'))
+  }
+
+  if (/\b(caution|warning|avoid|pregnan|breastfeeding|liver|kidney|bleed|anticoagul|hormone|stimulant)\b/.test(source)) {
+    badges.push(badge('Safety-Sensitive', 'Safety context should be read alongside any benefit framing.', 'caution'))
+  }
+
+  if (/\b(preliminary|preclinical|animal|in\s*vitro|early)\b/.test(source)) {
+    badges.push(badge('Preliminary Literature', 'Findings appear early-stage or non-definitive.', 'emerging'))
+  }
+
+  if (/\b(emerging|novel|early research|developing literature)\b/.test(source)) {
+    badges.push(badge('Emerging Research', 'Research context is developing and should be interpreted conservatively.', 'emerging'))
+  }
+
+  const seen = new Set<string>()
+  return badges
+    .filter(item => {
+      if (seen.has(item.label)) return false
+      seen.add(item.label)
+      return true
+    })
+    .slice(0, Math.max(0, limit))
+}
+
+export function getSemanticTrustLabels(record: any, limit = 5): string[] {
+  return unique(getSemanticTrustBadges(record, limit).map(item => item.label))
+}
+
+export function getEvidenceMaturity(record: any): 'mature' | 'moderate' | 'exploratory' {
+  const source = joined(record)
+
+  if (hasHumanEvidence(record) && /\b(strong|high|robust|clinical|rct|randomi[sz]ed|meta|systematic|grade\s*a|tier\s*a)\b/.test(source)) {
+    return 'mature'
+  }
+
+  if (hasHumanEvidence(record) || /\b(moderate|grade\s*b|tier\s*b)\b/.test(source)) {
+    return 'moderate'
+  }
+
+  return 'exploratory'
+}
+
+export function getProfileCompleteness(record: any): 'complete' | 'developing' | 'sparse' {
+  const filled = [
+    record?.summary || record?.description,
+    record?.evidence_tier || record?.evidenceTier,
+    record?.mechanisms,
+    record?.primary_effects || record?.effects,
+    record?.safety,
+    record?.sources,
+  ].filter(value => text(value) || list(value).length > 0).length
+
+  if (/\b(complete|comprehensive|published|ready)\b/i.test(text(record?.profile_status || record?.review_status)) || filled >= 5) {
+    return 'complete'
+  }
+
+  if (filled >= 3) return 'developing'
+  return 'sparse'
+}
+
+export function getMechanismDepth(record: any): 'deep' | 'mapped' | 'light' {
+  const mechanisms = unique([...list(record?.mechanisms), ...list(record?.primary_mechanisms), ...list(record?.pathways)].map(text).filter(Boolean))
+
+  if (mechanisms.length >= 5) return 'deep'
+  if (mechanisms.length >= 2 || hasMechanismEvidence(record)) return 'mapped'
+  return 'light'
+}

--- a/src/components/profile-authority-sections.tsx
+++ b/src/components/profile-authority-sections.tsx
@@ -3,6 +3,14 @@ import { cleanSummary, formatDisplayLabel, isClean, list, text, unique } from '@
 import { EvidenceBadgeGroup } from '@/components/evidence/evidence-badge'
 import { classifyDiscoveryGroups } from '@/lib/discovery-classification'
 import { compressEditorialCopy } from '@/lib/editorial-compression'
+import {
+  buildVariedEvidenceFraming,
+  buildVariedMechanismFraming,
+  buildVariedPracticalRelevance,
+  buildVariedSummary,
+} from '@/lib/editorial-variation'
+import { getSafetyClassifications, getSafetyLabels } from '@/lib/safety-classification'
+import { getSemanticTrustBadges, getSemanticTrustLabels } from '@/lib/semantic-trust-badges'
 import { getEvidenceDisciplineSummary, getEvidenceStrata } from '@/lib/evidence-stratification'
 import { clusterMechanisms } from '@/lib/mechanism-clusters'
 import {
@@ -80,18 +88,16 @@ function getEvidenceText(record: any) {
 }
 
 function getAuthoritySignals(record: any, density: string) {
-  const signals: string[] = []
-  const evidence = text(record?.evidence_tier || record?.evidenceTier)
-  const safety = text(record?.safety?.confidence || record?.safety)
+  const signals = [
+    ...getSemanticTrustLabels(record, 5),
+    ...getSafetyLabels(record, 3),
+  ]
 
-  if (/human|clinical|moderate|strong/i.test(evidence)) signals.push('Clinically Studied')
-  if (/mechan/i.test(evidence) || density === 'concise') signals.push('Mechanistic Evidence')
-  if (/traditional|ayurveda|tcm/i.test(text(record?.traditional_use))) signals.push('Traditional Use Context')
-  if (/emerging|preliminary|limited/i.test(evidence)) signals.push('Emerging Research')
-  if (/caution|interaction|avoid|warning/i.test(safety)) signals.push('Safety Sensitive')
-  if (density === 'comprehensive') signals.push('High Confidence Profile')
+  if (density === 'comprehensive' && !signals.includes('Evidence-Limited')) {
+    signals.push('Publication-Ready Profile')
+  }
 
-  return unique(signals).slice(0, 5)
+  return unique(signals).slice(0, 7)
 }
 
 function getProfileDensity({
@@ -208,6 +214,8 @@ function MechanismClusters({ mechanisms }: { mechanisms: string[] }) {
 function EvidenceOverview({ record }: { record: any }) {
   const strata = getEvidenceStrata(record)
   const disciplineSummary = getEvidenceDisciplineSummary(strata)
+  const trustBadges = getSemanticTrustBadges(record, 4)
+  const safetyClassifications = getSafetyClassifications(record, 4)
 
   if (strata.length === 0) return null
 
@@ -220,6 +228,16 @@ function EvidenceOverview({ record }: { record: any }) {
 
   return (
     <AuthorityCard title="Evidence Overview" description={disciplineSummary} compact>
+      {trustBadges.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {trustBadges.map(signal => (
+            <span key={signal.label} className="chip-readable" title={signal.description}>
+              {signal.label}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
       <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
         {strata.map(stratum => (
           <div
@@ -235,6 +253,24 @@ function EvidenceOverview({ record }: { record: any }) {
           </div>
         ))}
       </div>
+
+      {safetyClassifications.length > 0 ? (
+        <div className="rounded-2xl border border-amber-700/15 bg-amber-50/70 p-4">
+          <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-amber-950">
+            Safety intelligence
+          </h3>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {safetyClassifications.map(classification => (
+              <span key={classification.label} className="rounded-full border border-amber-800/20 bg-white/55 px-3 py-1 text-xs font-semibold text-amber-950">
+                {classification.label}
+              </span>
+            ))}
+          </div>
+          <p className="mt-3 text-sm leading-7 text-[#5b4632]">
+            Safety labels are only shown when caution language is present in the profile data.
+          </p>
+        </div>
+      ) : null}
     </AuthorityCard>
   )
 }
@@ -247,6 +283,7 @@ function ScientificSnapshot({
   density,
   authoritySignals,
   synthesis,
+  safetyLabels,
 }: {
   evidence: string
   effects: string[]
@@ -255,6 +292,7 @@ function ScientificSnapshot({
   density: string
   authoritySignals: string[]
   synthesis: string
+  safetyLabels: string[]
 }) {
   return (
     <AuthorityCard
@@ -282,10 +320,12 @@ function ScientificSnapshot({
           </div>
         ) : null}
 
-        {safetySignals.length > 0 ? (
+        {safetySignals.length > 0 || safetyLabels.length > 0 ? (
           <div className="rounded-2xl border border-amber-700/15 bg-amber-50/70 p-4">
             <p className="text-xs font-semibold uppercase tracking-[0.18em] text-amber-900/60">Safety snapshot</p>
-            <p className="mt-2 text-sm leading-7 text-[#5b4632]">{safetySignals.slice(0, 2).join(', ')}</p>
+            <p className="mt-2 text-sm leading-7 text-[#5b4632]">
+              {(safetyLabels.length > 0 ? safetyLabels : safetySignals).slice(0, 2).join(', ')}
+            </p>
           </div>
         ) : null}
       </div>
@@ -384,6 +424,13 @@ function DiscoveryCard({ item, entityType }: { item: any; entityType: EntityType
           ))}
         </div>
       ) : null}
+      <div className="mt-3 flex flex-wrap gap-2">
+        {getSemanticTrustLabels(item, 2).map(label => (
+          <span key={label} className="rounded-full border border-brand-900/10 bg-white/55 px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.12em] text-brand-900/65">
+            {label}
+          </span>
+        ))}
+      </div>
       <p className="mt-3 line-clamp-3 text-sm leading-7 text-[#46574d]">
         {cleanSummary(item.summary || item.description || '', targetType)}
       </p>
@@ -464,10 +511,20 @@ export default function ProfileAuthoritySections({
     density,
   }
 
-  const scientificSummary = buildScientificSummary(synthesisInput)
-  const evidenceContext = buildEvidenceContext(synthesisInput)
-  const practicalRelevance = buildPracticalRelevance(synthesisInput)
-  const mechanismContext = buildMechanismContext(synthesisInput)
+  const variationInput = {
+    name: formatDisplayLabel(record?.name || record?.slug),
+    evidenceTier: evidence,
+    effects,
+    mechanisms,
+    safety: safetySignals,
+    density,
+    seed: record?.slug,
+  }
+  const scientificSummary = buildVariedSummary(variationInput) || buildScientificSummary(synthesisInput)
+  const evidenceContext = buildVariedEvidenceFraming(variationInput) || buildEvidenceContext(synthesisInput)
+  const practicalRelevance = buildVariedPracticalRelevance(variationInput) || buildPracticalRelevance(synthesisInput)
+  const mechanismContext = buildVariedMechanismFraming(variationInput) || buildMechanismContext(synthesisInput)
+  const safetyLabels = getSafetyLabels(record, 4)
   const discoveryNarrative = buildDiscoveryNarrative(relatedRecords.length)
 
   const hasContent =
@@ -489,6 +546,7 @@ export default function ProfileAuthoritySections({
         density={density}
         authoritySignals={authoritySignals}
         synthesis={scientificSummary}
+        safetyLabels={safetyLabels}
       />
 
       <EvidenceOverview record={record} />


### PR DESCRIPTION
### Motivation
- Improve trust signaling, evidence-aware discovery, and safety visibility for herb/compound profiles while preserving existing routes and data/export pipeline.
- Add conservative, null-safe classifications and editorial variation to make profiles feel publication-grade and YMYL-conscious.
- Surface these signals in existing presentation areas (scientific snapshot, evidence overview, discovery cards) without changing workbook schema or routing.

### Description
- Added `lib/semantic-trust-badges.ts` to provide conservative semantic trust badges and helpers for evidence maturity, profile completeness, and mechanism depth. 
- Added `lib/safety-classification.ts` to detect interaction-, liver-, hormonal-, stimulant-, anticoagulant-, and pregnancy/breastfeeding-related safety context.
- Added `lib/editorial-variation.ts` to produce rotating, restrained editorial phrasings for summaries, evidence framing, mechanism framing, and practical relevance.
- Upgraded discovery logic by updating `lib/discovery-score.ts` and `lib/discovery-classification.ts` to weight evidence maturity, completeness, safety similarity, and mechanism-depth similarity, and wired the score into `lib/related-runtime.ts`.
- Integrated trust/safety badges and editorial variation into UI: `components/evidence/evidence-badge.tsx` (badges/styles), and `src/components/profile-authority-sections.tsx` (scientific snapshot, evidence overview, safety snapshot, discovery cards).

### Testing
- Ran `npm run check` which executed data build/validation, source-of-truth guard, Next.js production build/static export, route/CSS/deploy readiness checks, and generated-data verification, and completed successfully; non-fatal environment warnings about npm `http-proxy` and Next.js ESLint plugin were emitted but did not block the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe50fbace48323b3a76fcb31802733)