### PR TITLE
Refine scientific profile rendering: editorial variation, safety narratives, and evidence-sensitive discovery

### DIFF
--- a/lib/discovery-classification.ts
+++ b/lib/discovery-classification.ts
@@ -22,8 +22,59 @@ function overlap(a: string[], b: string[]) {
   return a.filter(item => b.includes(item)).length
 }
 
+function evidenceSensitiveAdjustment(base: any, candidate: any) {
+  const baseMaturity = getEvidenceMaturity(base)
+  const candidateMaturity = getEvidenceMaturity(candidate)
+  const baseSafety = getSafetySensitivity(base)
+  const candidateSafety = getSafetySensitivity(candidate)
+  const baseMechanismDepth = getMechanismDepth(base)
+  const candidateMechanismDepth = getMechanismDepth(candidate)
+  const candidateCompleteness = getProfileCompleteness(candidate)
+
+  let score = 0
+
+  if (baseMaturity === 'mature') {
+    if (candidateMaturity === 'mature') score += 8
+    if (candidateMaturity === 'exploratory') score -= 3
+  }
+
+  if (baseMaturity === 'moderate') {
+    if (candidateMaturity === 'moderate' || candidateMaturity === 'mature') score += 4
+  }
+
+  if (baseMaturity === 'exploratory') {
+    if (candidateMechanismDepth !== 'light') score += 7
+    if (candidateMaturity === 'mature' && baseMechanismDepth === 'light') score -= 2
+    if (candidateCompleteness === 'sparse') score -= 2
+  }
+
+  if (baseSafety !== 'low') {
+    if (candidateSafety !== 'low') score += 6
+    if (candidateSafety === 'low') score -= 2
+  }
+
+  return score
+}
+
 function sortByDiscoveryScore(base: any, items: any[]) {
-  return [...items].sort((a, b) => calculateDiscoveryScore(base, b) - calculateDiscoveryScore(base, a))
+  return [...items].sort((a, b) => {
+    const scoreB = calculateDiscoveryScore(base, b) + evidenceSensitiveAdjustment(base, b)
+    const scoreA = calculateDiscoveryScore(base, a) + evidenceSensitiveAdjustment(base, a)
+    return scoreB - scoreA
+  })
+}
+
+export function rankEvidenceSensitiveRelatedRecords(base: any, relatedRecords: any[] = [], limit = 8) {
+  const seen = new Set<string>()
+
+  return sortByDiscoveryScore(base, relatedRecords)
+    .filter(record => {
+      const key = `${record?.entityType || ''}:${record?.slug || record?.name || ''}`
+      if (!record?.slug || seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+    .slice(0, Math.max(0, limit))
 }
 
 export function classifyDiscoveryGroups(base: any, relatedRecords: any[] = []): DiscoveryGroup[] {

--- a/lib/profile-synthesis.ts
+++ b/lib/profile-synthesis.ts
@@ -1,4 +1,8 @@
+import { buildVariedEvidenceFraming, buildVariedMechanismFraming, buildVariedPracticalRelevance, buildVariedSummary } from '@/lib/editorial-variation'
+
 type SynthesisInput = {
+  name?: string
+  seed?: string
   summary?: string
   evidenceTier?: string
   effects?: string[]
@@ -40,6 +44,9 @@ function getEvidenceTone(evidenceTier = '', density = '') {
 export function buildScientificSummary(input: SynthesisInput) {
   const effects = clean(input.effects)
   const mechanisms = clean(input.mechanisms)
+  const varied = buildVariedSummary(input)
+  if (varied) return varied
+
   const tone = getEvidenceTone(input.evidenceTier, input.density)
 
   if (tone === 'strong') {
@@ -50,18 +57,23 @@ export function buildScientificSummary(input: SynthesisInput) {
     return `Current research most commonly explores ${joinNatural(effects)} alongside mechanistic interest in ${joinNatural(mechanisms)}.`
   }
 
-  return `This profile is primarily discussed in mechanistic and emerging research contexts involving ${joinNatural(mechanisms || effects)}.`
+  return `This profile is framed as mechanistic or exploratory context involving ${joinNatural(mechanisms.length > 0 ? mechanisms : effects)}, not as settled clinical guidance.`
 }
 
 export function buildMechanismContext(input: SynthesisInput) {
   const mechanisms = clean(input.mechanisms, 5)
+  const varied = buildVariedMechanismFraming(input)
 
+  if (varied) return varied
   if (mechanisms.length === 0) return ''
 
-  return `Mechanistic interest frequently centers on ${joinNatural(mechanisms)} signaling pathways and related biological response systems.`
+  return `Mechanistic interest centers on ${joinNatural(mechanisms)}, framed as biological plausibility rather than standalone proof.`
 }
 
 export function buildEvidenceContext(input: SynthesisInput) {
+  const varied = buildVariedEvidenceFraming(input)
+  if (varied) return varied
+
   const tone = getEvidenceTone(input.evidenceTier, input.density)
 
   if (tone === 'strong') {
@@ -77,18 +89,28 @@ export function buildEvidenceContext(input: SynthesisInput) {
 
 export function buildPracticalRelevance(input: SynthesisInput) {
   const effects = clean(input.effects, 3)
+  const varied = buildVariedPracticalRelevance(input)
 
+  if (varied) return varied
   if (effects.length === 0) return ''
 
-  return `Research and public interest most commonly focus on ${joinNatural(effects)} applications.`
+  return `Research and public interest most commonly focus on ${joinNatural(effects)}, with interpretation calibrated to evidence strength.`
 }
 
-export function buildDiscoveryNarrative(relatedCount: number) {
+export function buildDiscoveryNarrative(relatedCount: number, input: SynthesisInput = {}) {
   if (relatedCount <= 0) return ''
 
+  const tone = getEvidenceTone(input.evidenceTier, input.density)
+
   if (relatedCount <= 3) {
-    return 'A small set of closely related profiles share overlapping mechanisms or research themes.'
+    return tone === 'emerging'
+      ? 'A compact set of related profiles is shown so exploratory context stays focused rather than inflated.'
+      : 'A small set of closely related profiles share overlapping mechanisms, cautions, or research themes.'
   }
 
-  return 'Related profiles below are frequently explored alongside similar pathways, mechanisms, or evidence patterns.'
+  if (tone === 'strong') {
+    return 'Related profiles are prioritized for comparable evidence maturity, shared mechanisms, and caution-aware context.'
+  }
+
+  return 'Related profiles below emphasize mechanism fit and evidence-aware comparison rather than implying equivalent clinical confidence.'
 }

--- a/lib/safety-narratives.ts
+++ b/lib/safety-narratives.ts
@@ -1,0 +1,31 @@
+import { getSafetyClassifications } from '@/lib/safety-classification'
+
+export type SafetyNarrative = {
+  label: string
+  narrative: string
+}
+
+const NARRATIVES: Record<string, string> = {
+  'Interaction-Aware': 'Interaction language is present, so this profile keeps medication-adjacent context visible without turning it into individualized guidance.',
+  'Stimulant-Like Profile': 'Activating or stimulant-sensitive language is treated as a caution context, especially where sleep, anxiety, or cardiovascular sensitivity may matter.',
+  'Liver-Sensitive': 'Liver-related language is framed conservatively because organ-specific cautions depend on dose, duration, health status, and concurrent exposures.',
+  'Anticoagulant Caution': 'Bleeding or anticoagulant-adjacent language is surfaced as a caution signal rather than a prediction of individual risk.',
+  'Pregnancy/Breastfeeding Caution': 'Pregnancy and breastfeeding references are handled with extra restraint because suitability depends on individualized clinical context.',
+  'Hormonal Activity Context': 'Hormone-adjacent wording is presented as context only, not as evidence of predictable endocrine effects in a given person.',
+}
+
+export function buildSafetyNarratives(record: any, limit = 3): SafetyNarrative[] {
+  return getSafetyClassifications(record, limit)
+    .map(classification => ({
+      label: classification.label,
+      narrative: NARRATIVES[classification.label] || classification.description,
+    }))
+    .filter(item => item.narrative)
+}
+
+export function buildSafetyNarrativeSummary(record: any) {
+  const narratives = buildSafetyNarratives(record, 2)
+  if (narratives.length === 0) return ''
+
+  return narratives.map(item => item.narrative).join(' ')
+}

--- a/src/components/profile-authority-sections.tsx
+++ b/src/components/profile-authority-sections.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 import { cleanSummary, formatDisplayLabel, isClean, list, text, unique } from '@/lib/display-utils'
 import { EvidenceBadgeGroup } from '@/components/evidence/evidence-badge'
-import { classifyDiscoveryGroups } from '@/lib/discovery-classification'
+import { classifyDiscoveryGroups, rankEvidenceSensitiveRelatedRecords } from '@/lib/discovery-classification'
 import { compressEditorialCopy } from '@/lib/editorial-compression'
 import {
   buildVariedEvidenceFraming,
@@ -10,6 +10,7 @@ import {
   buildVariedSummary,
 } from '@/lib/editorial-variation'
 import { getSafetyClassifications, getSafetyLabels } from '@/lib/safety-classification'
+import { buildSafetyNarratives, buildSafetyNarrativeSummary } from '@/lib/safety-narratives'
 import { getSemanticTrustBadges, getSemanticTrustLabels } from '@/lib/semantic-trust-badges'
 import { getEvidenceDisciplineSummary, getEvidenceStrata } from '@/lib/evidence-stratification'
 import { clusterMechanisms } from '@/lib/mechanism-clusters'
@@ -144,12 +145,12 @@ function AuthorityCard({
   children: React.ReactNode
 }) {
   return (
-    <section className={`card-premium ${compact ? 'p-4 sm:p-5' : 'p-5 sm:p-6'}`}>
-      <div className="space-y-3">
+    <section className={`card-premium ${compact ? 'p-4 sm:p-5' : 'p-5 sm:p-7'}`}>
+      <div className={compact ? 'space-y-3' : 'space-y-4'}>
         <div className="space-y-2">
           <p className="eyebrow-label">{title}</p>
           {description ? (
-            <p className="max-w-3xl text-sm leading-7 text-[#5b6b61]">
+            <p className="max-w-2xl text-sm leading-7 text-[#5b6b61]">
               {description}
             </p>
           ) : null}
@@ -216,6 +217,8 @@ function EvidenceOverview({ record }: { record: any }) {
   const disciplineSummary = getEvidenceDisciplineSummary(strata)
   const trustBadges = getSemanticTrustBadges(record, 4)
   const safetyClassifications = getSafetyClassifications(record, 4)
+  const safetyNarratives = buildSafetyNarratives(record, 3)
+  const narrativeSummary = buildSafetyNarrativeSummary(record)
 
   if (strata.length === 0) return null
 
@@ -227,7 +230,7 @@ function EvidenceOverview({ record }: { record: any }) {
   }
 
   return (
-    <AuthorityCard title="Evidence Overview" description={disciplineSummary} compact>
+    <AuthorityCard title="Evidence Overview" description={compressEditorialCopy(narrativeSummary || disciplineSummary)} compact>
       {trustBadges.length > 0 ? (
         <div className="flex flex-wrap gap-2">
           {trustBadges.map(signal => (
@@ -266,9 +269,13 @@ function EvidenceOverview({ record }: { record: any }) {
               </span>
             ))}
           </div>
-          <p className="mt-3 text-sm leading-7 text-[#5b4632]">
-            Safety labels are only shown when caution language is present in the profile data.
-          </p>
+          <div className="mt-3 space-y-2">
+            {(safetyNarratives.length > 0 ? safetyNarratives : [{ label: 'Safety context', narrative: 'Safety labels are only shown when caution language is present in the profile data.' }]).map(item => (
+              <p key={item.label} className="max-w-2xl text-sm leading-7 text-[#5b4632]">
+                {item.narrative}
+              </p>
+            ))}
+          </div>
         </div>
       ) : null}
     </AuthorityCard>
@@ -284,6 +291,7 @@ function ScientificSnapshot({
   authoritySignals,
   synthesis,
   safetyLabels,
+  safetyNarrative,
 }: {
   evidence: string
   effects: string[]
@@ -293,6 +301,7 @@ function ScientificSnapshot({
   authoritySignals: string[]
   synthesis: string
   safetyLabels: string[]
+  safetyNarrative: string
 }) {
   return (
     <AuthorityCard
@@ -324,7 +333,7 @@ function ScientificSnapshot({
           <div className="rounded-2xl border border-amber-700/15 bg-amber-50/70 p-4">
             <p className="text-xs font-semibold uppercase tracking-[0.18em] text-amber-900/60">Safety snapshot</p>
             <p className="mt-2 text-sm leading-7 text-[#5b4632]">
-              {(safetyLabels.length > 0 ? safetyLabels : safetySignals).slice(0, 2).join(', ')}
+              {compressEditorialCopy(safetyNarrative || (safetyLabels.length > 0 ? safetyLabels : safetySignals).slice(0, 2).join(', '))}
             </p>
           </div>
         ) : null}
@@ -368,13 +377,15 @@ function WhyItMatters({
 }: any) {
   if (!summary && effects.length === 0 && mechanisms.length === 0) return null
 
+  const displaySummary = compact ? compressEditorialCopy(summary).split(/(?<=[.!?])\s+/).slice(0, 1).join(' ') : summary
+
   return (
     <AuthorityCard
       title="Why It Matters"
       compact={compact}
       description={compressEditorialCopy(practicalRelevance || 'Mechanism-level findings are separated from stronger human-evidence framing to reduce hype and improve scientific credibility.')}
     >
-      {summary ? <p className="detail-reading text-[#46574d]">{summary}</p> : null}
+      {displaySummary ? <p className="detail-reading max-w-3xl text-[#46574d]">{displaySummary}</p> : null}
 
       {!compact ? (
         <div className="grid gap-4 pt-2 md:grid-cols-2">
@@ -439,9 +450,8 @@ function DiscoveryCard({ item, entityType }: { item: any; entityType: EntityType
 }
 
 function DiscoveryRails({ relatedRecords, entityType, compact = false, narrative = '', baseRecord }: any) {
-  const visible = (relatedRecords || [])
+  const visible = rankEvidenceSensitiveRelatedRecords(baseRecord, relatedRecords || [], compact ? 3 : 8)
     .filter((item: any) => item?.slug && isClean(formatDisplayLabel(item?.name || item?.slug)))
-    .slice(0, compact ? 3 : 8)
 
   if (visible.length === 0) return null
 
@@ -459,7 +469,7 @@ function DiscoveryRails({ relatedRecords, entityType, compact = false, narrative
     <AuthorityCard
       title="Semantic Discovery"
       compact={compact}
-      description={compressEditorialCopy(narrative || 'Related profiles are grouped by shared mechanisms, pathway context, evidence maturity, or adjacent research themes.')}
+      description={compressEditorialCopy(narrative || 'Related profiles are filtered for evidence maturity, mechanism fit, and caution-aware context before they appear in this discovery rail.')}
     >
       <div className="space-y-5">
         {groups.slice(0, compact ? 1 : 4).map(group => (
@@ -525,7 +535,7 @@ export default function ProfileAuthoritySections({
   const practicalRelevance = buildVariedPracticalRelevance(variationInput) || buildPracticalRelevance(synthesisInput)
   const mechanismContext = buildVariedMechanismFraming(variationInput) || buildMechanismContext(synthesisInput)
   const safetyLabels = getSafetyLabels(record, 4)
-  const discoveryNarrative = buildDiscoveryNarrative(relatedRecords.length)
+  const discoveryNarrative = buildDiscoveryNarrative(relatedRecords.length, synthesisInput)
 
   const hasContent =
     Boolean(summary) ||
@@ -547,6 +557,7 @@ export default function ProfileAuthoritySections({
         authoritySignals={authoritySignals}
         synthesis={scientificSummary}
         safetyLabels={safetyLabels}
+        safetyNarrative={buildSafetyNarrativeSummary(record)}
       />
 
       <EvidenceOverview record={record} />

--- a/src/lib/enrichmentRecommendations.ts
+++ b/src/lib/enrichmentRecommendations.ts
@@ -170,6 +170,49 @@ function describeSharedTheme(prefix: string, themes: string[]) {
   return `${prefix} (${themes.slice(0, 2).join(', ')}).`
 }
 
+
+function evidenceSensitivityScore(
+  source: GovernedRecommendationRow,
+  candidate: GovernedRecommendationRow,
+  signalType: RecommendationSignalType,
+) {
+  const sourceLabel = source.researchEnrichment.pageEvidenceJudgment.evidenceLabel
+  const candidateLabel = candidate.researchEnrichment.pageEvidenceJudgment.evidenceLabel
+  const sourceRank = EVIDENCE_LABEL_RANK[sourceLabel]
+  const candidateRank = EVIDENCE_LABEL_RANK[candidateLabel]
+  const sourceWeakOnly = WEAK_ONLY_LABELS.has(sourceLabel)
+  const sourceCaution = CAUTION_LABELS.has(sourceLabel)
+  const candidateCaution = CAUTION_LABELS.has(candidateLabel)
+
+  let score = 0
+
+  if (sourceRank >= 7 && candidateRank >= 7) score += 12
+  if (sourceRank >= 7 && candidateRank <= 3 && signalType !== 'shared_safety_theme') score -= 8
+
+  if (sourceWeakOnly && signalType === 'shared_mechanism_or_constituent') score += 10
+  if (sourceWeakOnly && signalType === 'shared_supported_use' && candidateRank >= 7) score -= 4
+  if (sourceWeakOnly && signalType === 'evidence_strength_comparison') score += 4
+
+  if (sourceCaution && candidateCaution && signalType === 'shared_safety_theme') score += 12
+  if (sourceCaution && signalType === 'contrast_conflicting_or_uncertain') score += 5
+
+  return score
+}
+
+function withEvidenceSensitiveScore(
+  recommendation: EnrichmentRecommendation,
+  source: GovernedRecommendationRow,
+  candidate: GovernedRecommendationRow,
+): EnrichmentRecommendation {
+  const adjustment = evidenceSensitivityScore(source, candidate, recommendation.signalType)
+  if (adjustment === 0) return recommendation
+
+  return {
+    ...recommendation,
+    score: recommendation.score + adjustment,
+  }
+}
+
 function evaluatePair(
   source: GovernedRecommendationRow,
   candidate: GovernedRecommendationRow,
@@ -291,7 +334,7 @@ function evaluatePair(
     })
   }
 
-  return recs
+  return recs.map(recommendation => withEvidenceSensitiveScore(recommendation, source, candidate))
 }
 
 function dedupeRecommendations(recommendations: EnrichmentRecommendation[]) {
@@ -329,15 +372,14 @@ function filterRelatedRecommendations(
     .filter(item => item.targetType === targetType)
     .filter(item => {
       if (item.signalType === 'herb_compound_relationship') return true
-      if (item.signalType === 'shared_supported_use') return true
-      if (
-        item.signalType === 'shared_safety_theme' ||
-        item.signalType === 'shared_mechanism_or_constituent'
-      ) {
+      if (item.signalType === 'shared_supported_use') {
         return !sourceWeakOnly
       }
+      if (item.signalType === 'shared_safety_theme') return true
+      if (item.signalType === 'shared_mechanism_or_constituent') return true
       return false
     })
+    .sort((a, b) => b.score - a.score || a.targetSlug.localeCompare(b.targetSlug))
     .slice(0, limit)
 }
 


### PR DESCRIPTION
### Motivation
- Improve profile editorial quality by rotating phrasing and avoiding repetitive AI-template language while preserving scientific restraint and YMYL caution. 
- Surface concise, reusable safety narratives so safety signals are presented as contextual caution rather than implicit recommendations. 
- Make discovery and recommendation lists evidence-sensitive so mature profiles surface mature neighbors and exploratory profiles surface mechanism-rich neighbors. 

### Description
- Integrated `lib/editorial-variation.ts` into the synthesis fallback paths and live rendering by updating `lib/profile-synthesis.ts` to call the varied builders and prefer them when available. 
- Added reusable safety narratives in a new `lib/safety-narratives.ts` and surfaced those summaries and individual narratives in `src/components/profile-authority-sections.tsx` (Evidence Overview and Safety Snapshot). 
- Implemented evidence-sensitive discovery ranking in `lib/discovery-classification.ts` by adding `evidenceSensitiveAdjustment` and exported `rankEvidenceSensitiveRelatedRecords` used by the profile discovery rails. 
- Enhanced governed enrichment recommendations in `src/lib/enrichmentRecommendations.ts` with `evidenceSensitivityScore` and per-recommendation score adjustments and tightened filtering/sorting to prefer higher-quality, caution-aware candidates. 
- Improved sparse-profile handling and typography rhythm in `src/components/profile-authority-sections.tsx` by compacting low-information summaries, tightening max widths, and increasing card spacing to improve readability. 

### Testing
- Ran `npm run check`, which executed the data build/validation (`npm run data:build` / `data:validate`), workbook-only guard, Next.js production build, and verification scripts, and the command completed successfully. 
- The production build compiled and prerendered static pages (1191 pages) and the verification steps (`verify-core-routes`, `verify-redirects`, `verify-css-assets`, `ci/validate-deploy-readiness`, and `data:verify`) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe5a458e78832384acadebd8dcab78)