### PR TITLE
Enrich sparse herb and compound profile rendering

### DIFF
--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
-import data from '../../../public/data/compounds.json'
+import { getCompoundBySlug, getCompounds, getHerbs } from '@/lib/runtime-data'
 import Breadcrumbs from '@/components/ui/Breadcrumbs'
 import TrustBar from '@/components/ui/TrustBar'
 import ReadingProgress from '@/components/ui/ReadingProgress'
@@ -15,7 +15,6 @@ import { buildMeta } from '@/lib/seo'
 import {
   normalizeEvidenceLevel,
   normalizeSafetyLevel,
-  getEffects,
   getSources,
 } from '@/lib/evidence-utils'
 import { getEvidenceSnapshot } from '@/lib/semantic-runtime'
@@ -24,13 +23,15 @@ import { getFeaturedCollections } from '@/lib/collections'
 import ProfileAuthoritySections from '@/components/profile-authority-sections'
 
 export async function generateStaticParams() {
-  return (data as any[])
+  const compounds = await getCompounds()
+
+  return compounds
     .filter((compound:any) => getRuntimeVisibility(compound).canRender)
     .map((compound:any) => ({ slug: compound.slug }))
 }
 
-export function generateMetadata({ params }: any) {
-  const compound = (data as any[]).find((item:any) => item.slug === params.slug)
+export async function generateMetadata({ params }: any) {
+  const compound = await getCompoundBySlug(params.slug)
 
   if (!compound) return {}
 
@@ -62,10 +63,10 @@ export function generateMetadata({ params }: any) {
   }
 }
 
-export default function CompoundPage({ params }: any) {
-  const compounds = data as any[]
+export default async function CompoundPage({ params }: any) {
+  const [compounds, herbs] = await Promise.all([getCompounds(), getHerbs()])
 
-  const compound = compounds.find((item:any) => item.slug === params.slug)
+  const compound = await getCompoundBySlug(params.slug)
 
   if (!compound || !getRuntimeVisibility(compound).canRender) {
     notFound()
@@ -73,7 +74,7 @@ export default function CompoundPage({ params }: any) {
 
   const summary = cleanSummary(compound.summary || compound.description, 'compound')
 
-  const effects = getEffects(compound)
+  const effects = list(compound.effects || compound.primary_effects || compound.primaryActions)
     .map((effect:string) => formatDisplayLabel(effect))
     .filter(isClean)
 
@@ -81,13 +82,20 @@ export default function CompoundPage({ params }: any) {
     .map((item:any) => formatDisplayLabel(item))
     .filter(isClean)
 
-  const evidenceLevel = normalizeEvidenceLevel(compound.evidence_tier)
-  const safetyLevel = normalizeSafetyLevel(compound.safety)
+  const evidenceLevel = normalizeEvidenceLevel(compound.evidence_tier || compound.evidenceLevel || compound.evidence_grade)
+  const safetyLevel = normalizeSafetyLevel(compound.safety || compound.safetyNotes)
 
   const snapshot = getEvidenceSnapshot(compound)
 
-  const semanticRelated = getRelatedRuntimeRecords(compound, compounds, 6)
+  const relatedCompounds = getRelatedRuntimeRecords(compound, compounds, 4)
     .filter((item:any) => getRuntimeVisibility(item).canRender)
+    .map((item:any) => ({ ...item, entityType: 'compound' }))
+
+  const relatedHerbs = getRelatedRuntimeRecords(compound, herbs, 4)
+    .filter((item:any) => getRuntimeVisibility(item).canRender)
+    .map((item:any) => ({ ...item, entityType: 'herb' }))
+
+  const semanticRelated = [...relatedCompounds, ...relatedHerbs].slice(0, 6)
 
   const featuredCollections = getFeaturedCollections(compound)
 

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
-import { getHerbBySlug, getHerbs } from '@/lib/runtime-data'
+import { getCompounds, getHerbBySlug, getHerbs } from '@/lib/runtime-data'
 import { cleanSummary, formatDisplayLabel, isClean, list, unique } from '@/lib/display-utils'
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 import { getRelatedRuntimeRecords } from '@/lib/related-runtime'
@@ -72,10 +72,17 @@ export default async function HerbDetailPage({ params }: any) {
     notFound()
   }
 
-  const herbs = await getHerbs()
+  const [herbs, compounds] = await Promise.all([getHerbs(), getCompounds()])
 
-  const relatedHerbs = getRelatedRuntimeRecords(herb, herbs, 6)
+  const relatedHerbs = getRelatedRuntimeRecords(herb, herbs, 4)
     .filter((item: any) => getRuntimeVisibility(item).canRender)
+    .map((item: any) => ({ ...item, entityType: 'herb' }))
+
+  const relatedCompounds = getRelatedRuntimeRecords(herb, compounds, 4)
+    .filter((item: any) => getRuntimeVisibility(item).canRender)
+    .map((item: any) => ({ ...item, entityType: 'compound' }))
+
+  const relatedProfiles = [...relatedHerbs, ...relatedCompounds].slice(0, 6)
 
   const featuredCollections = getFeaturedCollections(herb)
   const effects = getEffects(herb)
@@ -114,7 +121,7 @@ export default async function HerbDetailPage({ params }: any) {
       <ProfileAuthoritySections
         record={herb}
         entityType="herb"
-        relatedRecords={relatedHerbs}
+        relatedRecords={relatedProfiles}
         effects={effects}
         summary={summary}
       />

--- a/lib/profile-synthesis.ts
+++ b/lib/profile-synthesis.ts
@@ -44,20 +44,30 @@ function getEvidenceTone(evidenceTier = '', density = '') {
 export function buildScientificSummary(input: SynthesisInput) {
   const effects = clean(input.effects)
   const mechanisms = clean(input.mechanisms)
+  const pathways = clean(input.pathways)
+  const contextSignals = mechanisms.length > 0 ? mechanisms : pathways.length > 0 ? pathways : effects
   const varied = buildVariedSummary(input)
   if (varied) return varied
 
   const tone = getEvidenceTone(input.evidenceTier, input.density)
 
-  if (tone === 'strong') {
-    return `Research interest is strongest around ${joinNatural(effects)} with additional focus on ${joinNatural(mechanisms)} pathways.`
+  if (tone === 'strong' && contextSignals.length > 0) {
+    const focus = effects.length > 0 ? joinNatural(effects) : joinNatural(contextSignals)
+    const mechanismFocus = contextSignals.length > 0 ? ` with additional focus on ${joinNatural(contextSignals)} pathways` : ''
+    return `Research interest is strongest around ${focus}${mechanismFocus}.`
   }
 
-  if (tone === 'moderate') {
-    return `Current research most commonly explores ${joinNatural(effects)} alongside mechanistic interest in ${joinNatural(mechanisms)}.`
+  if (tone === 'moderate' && contextSignals.length > 0) {
+    const focus = effects.length > 0 ? joinNatural(effects) : joinNatural(contextSignals)
+    const mechanismFocus = contextSignals.length > 0 ? ` alongside mechanistic interest in ${joinNatural(contextSignals)}` : ''
+    return `Current research most commonly explores ${focus}${mechanismFocus}.`
   }
 
-  return `This profile is framed as mechanistic or exploratory context involving ${joinNatural(mechanisms.length > 0 ? mechanisms : effects)}, not as settled clinical guidance.`
+  if (contextSignals.length > 0) {
+    return `This profile is framed as mechanistic or exploratory context involving ${joinNatural(contextSignals)}, not as settled clinical guidance.`
+  }
+
+  return 'This profile is framed conservatively because only limited runtime context is available; interpretation should stay exploratory rather than clinical.'
 }
 
 export function buildMechanismContext(input: SynthesisInput) {

--- a/lib/related-runtime.ts
+++ b/lib/related-runtime.ts
@@ -13,6 +13,13 @@ function collectSignals(record: any) {
     ...list(record?.effects),
     ...list(record?.mechanisms),
     ...list(record?.pathways),
+    ...list(record?.targets),
+    ...list(record?.biologicalTargets),
+    ...list(record?.compoundClass),
+    ...list(record?.class),
+    ...list(record?.foundIn),
+    ...list(record?.activeCompounds),
+    ...list(record?.traditionalUses),
   ])
     .map(normalize)
     .filter(Boolean)

--- a/src/components/profile-authority-sections.tsx
+++ b/src/components/profile-authority-sections.tsx
@@ -71,10 +71,81 @@ function getSafetySignals(record: any) {
     ...list(record?.safety?.cautionSignals),
     ...list(record?.cautionSignals),
     ...list(record?.avoid),
+    ...list(record?.contraindications),
     ...list(record?.interactions),
+    text(record?.safetyNotes),
     text(record?.safety?.notes),
     text(record?.safety),
   ], 5)
+}
+
+function getAliases(record: any) {
+  const primaryName = formatDisplayLabel(record?.name || record?.slug).toLowerCase()
+
+  return cleanList([
+    ...list(record?.aliases),
+    text(record?.common),
+    text(record?.scientific),
+    text(record?.compoundName),
+    text(record?.canonicalCompoundName),
+    text(record?.displayName),
+  ], 6).filter(item => item.toLowerCase() !== primaryName)
+}
+
+function getPathwaySignals(record: any) {
+  return cleanList([
+    ...list(record?.pathways),
+    ...list(record?.pathway_bucket),
+  ], 6)
+}
+
+function getBiologicalTargets(record: any) {
+  return cleanList([
+    ...list(record?.targets),
+    ...list(record?.biologicalTargets),
+  ], 6)
+}
+
+function getResearchFocus(record: any) {
+  return cleanList([
+    text(record?.evidenceLevel),
+    text(record?.evidence_tier),
+    text(record?.evidenceTier),
+    text(record?.evidence_grade),
+    text(record?.confidenceTier),
+    text(record?.confidence),
+    record?.sourceCount ? `${record.sourceCount} source signals` : '',
+    text(record?.review_status),
+    text(record?.source_status),
+  ], 6)
+}
+
+function getTraditionalContext(record: any) {
+  return cleanList([
+    ...list(record?.traditionalUses),
+    text(record?.preparation),
+    text(record?.region),
+  ], 6)
+}
+
+function getAssociationSignals(record: any, entityType: EntityType) {
+  return cleanList([
+    ...list(record?.activeCompounds),
+    ...list(record?.foundIn),
+    ...list(entityType === 'herb' ? record?.relatedHerbs : record?.relatedCompounds),
+  ], 8)
+}
+
+function getPharmacologyContext(record: any) {
+  return cleanList([
+    text(record?.compoundClass),
+    text(record?.class),
+    text(record?.bioavailability),
+    text(record?.minimum_effective_dose),
+    text(record?.time_to_effect),
+    ...list(record?.population_tags),
+    text(record?.interaction_type),
+  ], 6)
 }
 
 function getEvidenceText(record: any) {
@@ -106,17 +177,20 @@ function getProfileDensity({
   effects,
   mechanisms,
   safetySignals,
+  contextualSignals,
 }: {
   summary: string
   effects: string[]
   mechanisms: string[]
   safetySignals: string[]
+  contextualSignals?: string[]
 }) {
   const score =
     (summary ? 2 : 0) +
     Math.min(effects.length, 3) +
     Math.min(mechanisms.length, 2) +
-    Math.min(safetySignals.length, 2)
+    Math.min(safetySignals.length, 2) +
+    Math.min(contextualSignals?.length || 0, 2)
 
   if (score >= 6) return 'comprehensive'
   if (score >= 3) return 'developing'
@@ -172,6 +246,71 @@ function SignalList({ items }: { items: string[] }) {
         </span>
       ))}
     </div>
+  )
+}
+
+
+function MicroSection({ title, description, items }: { title: string; description?: string; items: string[] }) {
+  if (items.length === 0) return null
+
+  return (
+    <div className="surface-subtle rounded-2xl border border-brand-900/10 p-4">
+      <h3 className="text-sm font-semibold uppercase tracking-[0.16em] text-brand-800/70">{title}</h3>
+      {description ? (
+        <p className="mt-2 text-sm leading-7 text-[#5b6b61]">{description}</p>
+      ) : null}
+      <div className="mt-3">
+        <SignalList items={items} />
+      </div>
+    </div>
+  )
+}
+
+function ContextualMicroSections({
+  aliases,
+  pathways,
+  targets,
+  researchFocus,
+  traditionalContext,
+  associations,
+  pharmacology,
+  safetySignals,
+  compact,
+}: {
+  aliases: string[]
+  pathways: string[]
+  targets: string[]
+  researchFocus: string[]
+  traditionalContext: string[]
+  associations: string[]
+  pharmacology: string[]
+  safetySignals: string[]
+  compact: boolean
+}) {
+  const sections = [
+    { title: 'Also Known As', description: 'Alias and naming context already present in the runtime payload.', items: aliases },
+    { title: 'Biological Context', description: 'Targets and pathway signals are shown as research context, not clinical claims.', items: [...targets, ...pharmacology].slice(0, 6) },
+    { title: 'Research Focus', description: 'Evidence metadata and review status signals help calibrate interpretation.', items: researchFocus },
+    { title: 'Pathway Associations', description: 'Pathway tags connect this profile to broader mechanism clusters.', items: pathways },
+    { title: 'Traditional Context', description: 'Traditional-use and preparation fields are separated from efficacy claims.', items: traditionalContext },
+    { title: 'Safety Notes', description: 'Caution fields are elevated when available so sparse pages still carry risk context.', items: safetySignals },
+    { title: 'Frequently Associated With', description: 'Related herbs, compounds, or source botanicals from the runtime data.', items: associations },
+  ].filter(section => section.items.length > 0)
+
+  if (sections.length === 0) return null
+
+  return (
+    <AuthorityCard
+      title="Context Map"
+      compact={compact}
+      description="High-signal runtime fields are surfaced only when populated, giving sparse profiles compact scientific context without filler."
+    >
+      <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        {sections.slice(0, compact ? 4 : 7).map(section => (
+          <MicroSection key={section.title} {...section} />
+        ))}
+      </div>
+    </AuthorityCard>
   )
 }
 
@@ -507,8 +646,24 @@ export default function ProfileAuthoritySections({
   const mechanisms = getMechanisms(record, providedMechanisms)
   const safetySignals = getSafetySignals(record)
   const evidence = getEvidenceText(record)
+  const aliases = getAliases(record)
+  const pathways = getPathwaySignals(record)
+  const targets = getBiologicalTargets(record)
+  const researchFocus = getResearchFocus(record)
+  const traditionalContext = getTraditionalContext(record)
+  const associations = getAssociationSignals(record, entityType)
+  const pharmacology = getPharmacologyContext(record)
+  const contextualSignals = [
+    ...aliases,
+    ...pathways,
+    ...targets,
+    ...researchFocus,
+    ...traditionalContext,
+    ...associations,
+    ...pharmacology,
+  ]
 
-  const density = getProfileDensity({ summary, effects, mechanisms, safetySignals })
+  const density = getProfileDensity({ summary, effects, mechanisms, safetySignals, contextualSignals })
   const compact = density === 'concise'
   const authoritySignals = getAuthoritySignals(record, density)
   const synthesisInput = {
@@ -516,7 +671,7 @@ export default function ProfileAuthoritySections({
     evidenceTier: evidence,
     effects,
     mechanisms,
-    pathways: cleanList(record?.pathways, 5),
+    pathways,
     safety: safetySignals,
     density,
   }
@@ -526,6 +681,7 @@ export default function ProfileAuthoritySections({
     evidenceTier: evidence,
     effects,
     mechanisms,
+    pathways,
     safety: safetySignals,
     density,
     seed: record?.slug,
@@ -542,6 +698,7 @@ export default function ProfileAuthoritySections({
     effects.length > 0 ||
     mechanisms.length > 0 ||
     safetySignals.length > 0 ||
+    contextualSignals.length > 0 ||
     relatedRecords.length > 0
 
   if (!hasContent) return null
@@ -561,6 +718,18 @@ export default function ProfileAuthoritySections({
       />
 
       <EvidenceOverview record={record} />
+
+      <ContextualMicroSections
+        aliases={aliases}
+        pathways={pathways}
+        targets={targets}
+        researchFocus={researchFocus}
+        traditionalContext={traditionalContext}
+        associations={associations}
+        pharmacology={pharmacology}
+        safetySignals={safetySignals}
+        compact={compact}
+      />
 
       {!compact ? <HighIntentFraming effects={effects} mechanisms={mechanisms} /> : null}
 

--- a/src/lib/runtime-data.ts
+++ b/src/lib/runtime-data.ts
@@ -17,14 +17,70 @@ async function readJsonFile(fileName: string): Promise<unknown> {
   }
 }
 
+function isSafeSlug(slug: string) {
+  return /^[a-z0-9][a-z0-9-]*$/.test(slug)
+}
+
+function mergeBySlug(baseRows: RuntimeRecord[], enrichmentRows: RuntimeRecord[]) {
+  const bySlug = new Map<string, RuntimeRecord>()
+
+  for (const row of enrichmentRows) {
+    if (typeof row?.slug === 'string') {
+      bySlug.set(row.slug, row)
+    }
+  }
+
+  const merged = baseRows.map(row => {
+    const slug = typeof row?.slug === 'string' ? row.slug : ''
+    const enrichment = bySlug.get(slug)
+
+    return enrichment ? { ...row, ...enrichment } : row
+  })
+
+  const knownSlugs = new Set(merged.map(row => row?.slug).filter(Boolean))
+
+  for (const row of enrichmentRows) {
+    if (typeof row?.slug === 'string' && !knownSlugs.has(row.slug)) {
+      merged.push(row)
+    }
+  }
+
+  return merged
+}
+
+async function readDetailRecord(kind: 'herbs' | 'compounds', slug: string): Promise<RuntimeRecord | undefined> {
+  if (!isSafeSlug(slug)) return undefined
+
+  const detail = await readJsonFile(`${kind}-detail/${slug}.json`)
+
+  return detail && !Array.isArray(detail) && typeof detail === 'object' ? detail as RuntimeRecord : undefined
+}
+
 export const getHerbs = cache(async (): Promise<RuntimeRecord[]> => {
-  const herbs = await readJsonFile('herbs.json')
-  return Array.isArray(herbs) ? herbs : []
+  const [herbs, summary] = await Promise.all([
+    readJsonFile('herbs.json'),
+    readJsonFile('herbs-summary.json'),
+  ])
+
+  const baseRows = Array.isArray(herbs) ? herbs : []
+  const enrichmentRows = Array.isArray(summary) ? summary : []
+
+  return mergeBySlug(baseRows, enrichmentRows)
 })
 
 export const getCompounds = cache(async (): Promise<RuntimeRecord[]> => {
-  const compounds = await readJsonFile('compounds.json')
-  return Array.isArray(compounds) ? compounds : []
+  const [compounds, summary] = await Promise.all([
+    readJsonFile('compounds.json'),
+    readJsonFile('compounds-summary.json'),
+  ])
+
+  const baseRows = Array.isArray(compounds) ? compounds : []
+  const enrichmentRows = Array.isArray(summary) ? summary : []
+
+  return mergeBySlug(baseRows, enrichmentRows).map(row => ({
+    name: row?.name || row?.compoundName || row?.canonicalCompoundName || row?.slug,
+    ...row,
+  }))
 })
 
 export const getHerbCompoundMap = cache(async (): Promise<RuntimeRecord[]> => {
@@ -70,17 +126,21 @@ export const getRouteBuildManifest = cache(async (): Promise<RuntimeRecord[]> =>
 export async function getHerbBySlug(slug: string): Promise<RuntimeRecord | undefined> {
   const herbs = await getHerbs()
   const herb = herbs.find(herb => herb.slug === slug)
+  const detail = await readDetailRecord('herbs', slug)
+  const mergedHerb = detail ? { ...herb, ...detail } : herb
 
-  if (!herb || !getRuntimeVisibility(herb).canRender) return undefined
+  if (!mergedHerb || !getRuntimeVisibility(mergedHerb).canRender) return undefined
 
-  return herb
+  return mergedHerb
 }
 
 export async function getCompoundBySlug(slug: string): Promise<RuntimeRecord | undefined> {
   const compounds = await getCompounds()
   const compound = compounds.find(compound => compound.slug === slug)
+  const detail = await readDetailRecord('compounds', slug)
+  const mergedCompound = detail ? { ...compound, ...detail } : compound
 
-  if (!compound || !getRuntimeVisibility(compound).canRender) return undefined
+  if (!mergedCompound || !getRuntimeVisibility(mergedCompound).canRender) return undefined
 
-  return compound
+  return mergedCompound
 }


### PR DESCRIPTION
### Motivation
- Many herb and compound depth pages were visually sparse despite available runtime signals such as aliases, pathways, mechanisms, safety, and evidence metadata. 
- The intent is to surface high-signal runtime fields and provide conservative, publication-ready fallbacks for thin profiles without changing schemas or routes. 
- Changes should be minimal and surgical, reusing exported JSON in `public/data` and preserving route contracts such as `/herbs/:slug` and `/compounds/:slug`.

### Description
- Merge enrichment payloads at read time by combining `herbs.json`/`compounds.json` with `herbs-summary.json`/`compounds-summary.json` and layering per-slug detail files from `public/data/*-detail/` in `src/lib/runtime-data.ts`, exposing `getHerbs`, `getCompounds`, `getHerbBySlug`, and `getCompoundBySlug` that return merged records. 
- Add contextual micro-sections and fallback signals in `src/components/profile-authority-sections.tsx` including: "Also Known As", "Biological Context", "Research Focus", "Pathway Associations", "Traditional Context", "Safety Notes", and "Frequently Associated With", and suppress each section when its source data is empty. 
- Improve relationship enrichment in `lib/related-runtime.ts` to consider additional signals (targets, biological targets, compound class, found-in, active compounds, traditional uses) and surface cross-type related profiles; update herb and compound pages to build mixed herb/compound related rails. 
- Strengthen synthesis fallbacks in `lib/profile-synthesis.ts` so pathways and other contextual signals are used when effects/mechanisms are lacking, and refine page logic to surface aliases, pathways, targets, pharmacology, and evidence metadata without changing export contracts or routes.

### Testing
- Ran `npm run check` which executes the data build, validation, and Next.js build and completed successfully. 
- Ran `npx tsc --noEmit --pretty false` and TypeScript checks passed with no errors. 
- Ran `git diff --check` (lint/check integration) and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe5c1839908323abd55ef89402a1cb)