### PR TITLE
Upgrade semantic authority hubs

### DIFF
--- a/app/collections/[slug]/page.tsx
+++ b/app/collections/[slug]/page.tsx
@@ -2,13 +2,23 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { seoCollections } from '@/data/seoCollections'
 import { getCompounds, getHerbs } from '@/lib/runtime-data'
-import { cleanSummary } from '@/lib/display-utils'
+import { cleanSummary, formatDisplayLabel, isClean, list, unique } from '@/lib/display-utils'
+import { SemanticHubIntro, SignalPanel } from '@/components/semantic-hubs/semantic-hub-sections'
 
 type Params = { params: Promise<{ slug: string }> }
 
 function textMatchesAny(text: string, filters: string[]) {
   const value = text.toLowerCase()
   return filters.some(filter => value.includes(filter.toLowerCase()))
+}
+
+function recordSignals(item: any) {
+  return unique([
+    ...list(item?.primary_effects),
+    ...list(item?.effects),
+    ...list(item?.mechanisms),
+    ...list(item?.pathways),
+  ]).filter(isClean)
 }
 
 export async function generateStaticParams() {
@@ -35,21 +45,65 @@ export default async function CollectionPage({ params }: Params) {
     })
     .slice(0, 40)
 
+  const themes = unique(items.flatMap(recordSignals).map(formatDisplayLabel)).slice(0, 8)
+
   return (
-    <section className='container-page py-10'>
-      <h1 className='text-3xl font-semibold text-white'>{collection.title}</h1>
-      <p className='mt-3 max-w-3xl text-white/75'>{collection.description}</p>
-      <div className='mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3'>
-        {items.map(item => {
-          const href = collection.itemType === 'compound' ? `/compounds/${item.slug}` : `/herbs/${item.slug}`
-          return (
-            <Link key={item.slug} href={href} className='ds-card block'>
-              <h2 className='font-semibold text-white'>{item.displayName ?? item.name ?? item.slug}</h2>
-              <p className='mt-2 line-clamp-3 text-sm text-white/70'>{cleanSummary(item.summary ?? item.description, collection.itemType === 'compound' ? 'compound' : 'herb')}</p>
-            </Link>
-          )
-        })}
-      </div>
-    </section>
+    <main className="mx-auto max-w-7xl space-y-10 px-4 py-10 sm:space-y-12 sm:py-14">
+      <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8 lg:p-10">
+        <div className="max-w-4xl space-y-5">
+          <p className="eyebrow-label">Curated collection</p>
+          <h1 className="heading-premium text-ink">{collection.title}</h1>
+          <p className="max-w-3xl text-lg leading-8 text-[#46574d]">{collection.description}</p>
+        </div>
+      </section>
+
+      <SemanticHubIntro
+        sections={[
+          { title: 'Biological context', body: `This collection groups ${collection.itemType} profiles around shared workbook signals so readers can compare adjacent biology before opening individual profiles.` },
+          { title: 'Research focus', body: 'Matching records are filtered by collection intent and summarized with concise profile excerpts rather than unsupported recommendations.' },
+          { title: 'Discovery method', body: 'Theme chips and profile cards make the route useful as a crawlable bridge between broad search intent and evidence-aware depth pages.' },
+        ]}
+      />
+
+      <SignalPanel
+        eyebrow="Related scientific themes"
+        title="Shared signals in this collection"
+        description="These compact terms come from visible matching records and help recover context on otherwise sparse collection routes."
+        signals={themes}
+      />
+
+      <section className="space-y-6">
+        <div className="flex flex-wrap items-end justify-between gap-3">
+          <div className="space-y-2">
+            <p className="eyebrow-label">Matching profiles</p>
+            <h2 className="text-3xl font-semibold tracking-tight text-ink">Evidence-aware collection cards</h2>
+          </div>
+          <span className="chip-readable">{items.length} matches</span>
+        </div>
+
+        <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {items.map(item => {
+            const href = collection.itemType === 'compound' ? `/compounds/${item.slug}` : `/herbs/${item.slug}`
+            const signals = recordSignals(item).slice(0, 3)
+            return (
+              <Link key={item.slug} href={href} className="card-premium group block p-5">
+                <div className="space-y-4">
+                  <div className="flex flex-wrap gap-2">
+                    {signals.map((signal) => (
+                      <span key={signal} className="chip-readable">{formatDisplayLabel(signal)}</span>
+                    ))}
+                  </div>
+
+                  <div>
+                    <h3 className="text-xl font-semibold text-ink transition group-hover:text-brand-700">{item.displayName ?? item.name ?? item.slug}</h3>
+                    <p className="mt-3 line-clamp-4 text-sm leading-7 text-[#46574d]">{cleanSummary(item.summary ?? item.description, collection.itemType === 'compound' ? 'compound' : 'herb')}</p>
+                  </div>
+                </div>
+              </Link>
+            )
+          })}
+        </div>
+      </section>
+    </main>
   )
 }

--- a/app/collections/scientific-collection-page.tsx
+++ b/app/collections/scientific-collection-page.tsx
@@ -13,6 +13,7 @@ import {
   type ScientificCollection,
 } from '@/lib/collections'
 import { formatDisplayLabel, isClean, list, unique } from '@/lib/display-utils'
+import { KnowledgeGraphLinks, SemanticHubIntro, SignalPanel } from '@/components/semantic-hubs/semantic-hub-sections'
 
 type CollectionPageProps = {
   slug: string
@@ -36,6 +37,34 @@ function getMechanisms(record: any) {
   ])
     .filter(isClean)
     .slice(0, 4)
+}
+
+
+function buildCollectionIntro(collection: ScientificCollection) {
+  const subject = collection.primaryType === 'herb' ? 'botanical records' : collection.primaryType === 'compound' ? 'compound records' : 'matching records'
+
+  return [
+    {
+      title: 'Biological context',
+      body: `${collection.title} groups ${subject} by shared effect language, pathway signals, and evidence-aware research context rather than by alphabetical browsing.`,
+    },
+    {
+      title: 'Research focus',
+      body: 'This collection is strongest when matching profiles expose clean mechanisms, associated effects, and publication-ready summaries from the workbook pipeline.',
+    },
+    {
+      title: 'Common mechanisms',
+      body: 'Mechanism and effect chips provide relationship context while preserving the profile pages as the source for evidence strength, cautions, and interpretation.',
+    },
+  ]
+}
+
+function getAdjacentThemes(collection: ScientificCollection, mechanisms: string[], effects: string[]) {
+  return unique([
+    ...collection.chips,
+    ...mechanisms.map(formatDisplayLabel),
+    ...effects.map(formatDisplayLabel),
+  ]).slice(0, 8)
 }
 
 function visible(records: any[]) {
@@ -132,6 +161,7 @@ export async function ScientificCollectionPage({ slug }: CollectionPageProps) {
   const effects = unique(allCards.flatMap(card => getEffects(card.record))).slice(0, 12)
   const primaryCards = allCards.filter(card => !collection.primaryType || card.type === collection.primaryType).slice(0, 12)
   const supportingCards = allCards.filter(card => collection.primaryType && card.type !== collection.primaryType).slice(0, 6)
+  const adjacentThemes = getAdjacentThemes(collection, mechanisms, effects)
 
   return (
     <main className="mx-auto max-w-7xl space-y-12 px-4 py-10 sm:space-y-14 sm:py-14">
@@ -156,6 +186,15 @@ export async function ScientificCollectionPage({ slug }: CollectionPageProps) {
           </div>
         </div>
       </section>
+
+      <SemanticHubIntro sections={buildCollectionIntro(collection)} />
+
+      <SignalPanel
+        eyebrow="Related scientific themes"
+        title="How this collection connects"
+        description="These terms summarize the strongest adjacent systems, effects, and mechanism language present in the matching runtime records."
+        signals={adjacentThemes}
+      />
 
       <section className="grid gap-5 md:grid-cols-2">
         <div className="card-premium p-6">
@@ -201,21 +240,11 @@ export async function ScientificCollectionPage({ slug }: CollectionPageProps) {
         </section>
       ) : null}
 
-      <section className="space-y-5">
-        <div className="space-y-2">
-          <p className="eyebrow-label">Related Collections</p>
-          <h2 className="text-3xl font-semibold tracking-tight text-ink">Continue the scientific graph</h2>
-        </div>
-
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-          {collection.related.map((item) => (
-            <Link key={item.href} href={item.href} className="surface-subtle rounded-2xl border border-brand-900/10 p-4 transition hover:border-brand-700/30 hover:bg-white/60">
-              <p className="text-sm font-semibold leading-6 text-ink">{item.title}</p>
-              <p className="mt-2 text-xs leading-5 text-muted-readable">{item.description}</p>
-            </Link>
-          ))}
-        </div>
-      </section>
+      <KnowledgeGraphLinks
+        eyebrow="Related Collections"
+        title="Continue the scientific graph"
+        links={collection.related.map((item) => ({ label: item.title, href: item.href, description: item.description }))}
+      />
     </main>
   )
 }

--- a/app/explore/[topic]/page.tsx
+++ b/app/explore/[topic]/page.tsx
@@ -7,12 +7,72 @@ import {
 } from '@/lib/semantic-runtime'
 import { cleanSummary, isClean } from '@/lib/display-utils'
 import { safeArray, safeIncludes, safeLower, safeSlug, safeTrim } from '@/lib/search-safe'
+import { KnowledgeGraphLinks, SemanticHubIntro, SignalPanel } from '@/components/semantic-hubs/semantic-hub-sections'
 
 const TITLES: Record<string, string> = {
   sleep: 'Sleep Support',
   focus: 'Focus & Cognition',
   anxiety: 'Stress & Mood',
   recovery: 'Recovery & Performance',
+}
+
+const TOPIC_CONTEXT: Record<string, { intro: string; sections: { title: string; body: string }[]; signals: string[]; links: { label: string; href: string; description: string }[] }> = {
+  sleep: {
+    intro: 'Sleep support is organized around relaxation signaling, sleep latency, circadian context, and recovery-adjacent physiology. The page helps readers compare compounds without implying that pathway overlap equals clinical effect.',
+    sections: [
+      { title: 'Biological context', body: 'Sleep-related research often spans inhibitory neurotransmission, arousal regulation, circadian rhythm, and nighttime recovery.' },
+      { title: 'Research focus', body: 'Compounds are surfaced when their workbook signals mention sleep, relaxation, GABA, melatonin-adjacent context, or restorative effects.' },
+      { title: 'Pathway relevance', body: 'Use the cluster as a starting map, then evaluate individual profile evidence, dosing notes, cautions, and interaction context.' },
+    ],
+    signals: ['GABA', 'Circadian rhythm', 'Sleep latency', 'Relaxation', 'Nighttime recovery', 'Stress overlap'],
+    links: [
+      { label: 'GABA pathway', href: '/pathways/gaba', description: 'Inhibitory-tone and relaxation context that commonly overlaps with sleep-support profiles.' },
+      { label: 'Sleep goal guide', href: '/goals/sleep', description: 'Outcome-led guide for comparing sleep quality, latency, and nighttime relaxation.' },
+      { label: 'Sleep compounds collection', href: '/collections/best-studied-sleep-compounds', description: 'Evidence-aware collection for compounds frequently researched in sleep contexts.' },
+    ],
+  },
+  focus: {
+    intro: 'Focus and cognition pages group compounds by attention, memory, neurotransmitter, and mental-performance signals while keeping the evidence layer separate from mechanism plausibility.',
+    sections: [
+      { title: 'Biological context', body: 'Cognition research can involve neurotransmitter tone, energy metabolism, neuroprotection, attention, and fatigue resistance.' },
+      { title: 'Research focus', body: 'The cluster prioritizes profiles with focus, cognition, dopamine, cholinergic, nootropic, memory, or brain-health language.' },
+      { title: 'Pathway relevance', body: 'Mechanism labels help navigation, but profile-level evidence and safety context determine how strongly a record should be interpreted.' },
+    ],
+    signals: ['Dopamine', 'Acetylcholine', 'Attention', 'Memory', 'Mental clarity', 'Fatigue overlap'],
+    links: [
+      { label: 'Dopamine pathway', href: '/pathways/dopamine', description: 'Motivation, reward, attention, and cognitive-performance pathway relationships.' },
+      { label: 'Focus goal guide', href: '/goals/focus', description: 'Outcome-led guide for focus, attention, brain fog, and cognition support.' },
+      { label: 'Cholinergic compounds', href: '/collections/cholinergic-compounds', description: 'Collection centered on acetylcholine-adjacent compounds and cognition context.' },
+    ],
+  },
+  anxiety: {
+    intro: 'Stress and mood discovery connects calming, adaptation, cortisol, relaxation, and nervous-system signals without overstating psychiatric benefit.',
+    sections: [
+      { title: 'Biological context', body: 'Stress-support research often spans HPA-axis language, inhibitory tone, sleep overlap, inflammation, and autonomic balance.' },
+      { title: 'Research focus', body: 'Records are grouped by stress, calm, mood, relaxation, adaptogen, and anxiety-adjacent workbook signals.' },
+      { title: 'Pathway relevance', body: 'The hub supports exploration and comparison; it is not a substitute for medical evaluation of anxiety or mood disorders.' },
+    ],
+    signals: ['Stress signaling', 'Adaptogens', 'GABA overlap', 'Cortisol context', 'Mood support', 'Sleep overlap'],
+    links: [
+      { label: 'GABA pathway', href: '/pathways/gaba', description: 'Calming and inhibitory signaling context related to stress and relaxation.' },
+      { label: 'Stress supplement guide', href: '/best-supplements-for-stress', description: 'Decision guide for stress resilience and evidence-aware supplement comparisons.' },
+      { label: 'Adaptogens for stress', href: '/collections/adaptogens-for-stress', description: 'Botanical collection organized around adaptation and resilience language.' },
+    ],
+  },
+  recovery: {
+    intro: 'Recovery and performance discovery connects exercise stress, inflammation, hydration, antioxidant tone, and tissue-support signals.',
+    sections: [
+      { title: 'Biological context', body: 'Recovery-oriented research commonly intersects with inflammatory signaling, oxidative stress, fluid balance, sleep quality, and muscle function.' },
+      { title: 'Research focus', body: 'The cluster highlights records with recovery, performance, inflammation, antioxidant, hydration, energy, or mobility signals.' },
+      { title: 'Pathway relevance', body: 'Adjacent pathways help readers distinguish performance plausibility from direct outcome evidence.' },
+    ],
+    signals: ['Inflammation', 'Oxidative stress', 'Hydration', 'Muscle function', 'Energy metabolism', 'Mobility'],
+    links: [
+      { label: 'Inflammation pathway', href: '/pathways/inflammation', description: 'Immune, oxidative-stress, and recovery-adjacent pathway relationships.' },
+      { label: 'Recovery goal guide', href: '/goals/recovery', description: 'Outcome-led guide for repair, performance recovery, and mobility support.' },
+      { label: 'Joint support guide', href: '/best-supplements-for-joint-support', description: 'Inflammation-adjacent guide for mobility and joint-support decisions.' },
+    ],
+  },
 }
 
 export async function generateStaticParams() {
@@ -48,6 +108,7 @@ export default async function TopicExplorePage({ params }: any) {
 
   if (!TITLES[topic]) notFound()
 
+  const context = TOPIC_CONTEXT[topic]
   const filtered = safeArray<any>(compounds)
     .filter((compound) => safeSlug(compound?.slug) && safeTrim(compound?.name))
     .map((compound) => ({
@@ -71,10 +132,25 @@ export default async function TopicExplorePage({ params }: any) {
           </h1>
 
           <p className="max-w-3xl text-lg leading-8 text-[#46574d]">
-            Discover compounds grouped by shared outcomes, relationship signals, mechanisms, and conservative evidence patterns.
+            {context.intro}
           </p>
         </div>
       </section>
+
+      <SemanticHubIntro sections={context.sections} />
+
+      <SignalPanel
+        eyebrow="Related scientific themes"
+        title="How this cluster is organized"
+        description="High-signal terms summarize the biological systems and adjacent outcomes most useful for exploring this topic."
+        signals={context.signals}
+      />
+
+      <KnowledgeGraphLinks
+        eyebrow="Often explored together"
+        title="Continue through related hubs"
+        links={context.links}
+      />
 
       <section className="space-y-5">
         <div className="flex flex-wrap items-end justify-between gap-3">

--- a/app/explore/focus/page.tsx
+++ b/app/explore/focus/page.tsx
@@ -4,6 +4,7 @@ import compounds from '../../../public/data/compounds.json'
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 import { cleanSummary, formatDisplayLabel, isClean, list, unique } from '@/lib/display-utils'
 import { EvidenceBadgeGroup } from '@/components/evidence/evidence-badge'
+import { KnowledgeGraphLinks, SemanticHubIntro } from '@/components/semantic-hubs/semantic-hub-sections'
 
 function normalize(value: unknown) {
   return String(value || '').toLowerCase()
@@ -62,6 +63,19 @@ function buildCards(records: any[], type: 'herb' | 'compound') {
 const herbCards = buildCards(herbs as any[], 'herb')
 const compoundCards = buildCards(compounds as any[], 'compound')
 
+const hubIntro = [
+  { title: 'Biological context', body: 'Cognition-support exploration spans neurotransmitter signaling, attention, mental energy, neuroprotection, and fatigue resistance.' },
+  { title: 'Research focus', body: 'Cards are selected from records with focus, memory, nootropic, dopamine, cholinergic, brain-health, or clarity signals.' },
+  { title: 'Common mechanisms', body: 'Mechanistic overlap is used for discovery and internal linking, not as a shortcut for evidence strength.' },
+]
+
+const graphLinks = [
+  { label: 'Dopamine pathway', href: '/pathways/dopamine', description: 'Motivation, attention, reward, and cognitive-performance pathway relationships.' },
+  { label: 'Focus goal guide', href: '/goals/focus', description: 'Outcome-led guide for focus, attention, brain fog, and cognition support.' },
+  { label: 'Cholinergic compounds', href: '/collections/cholinergic-compounds', description: 'Collection centered on acetylcholine-adjacent compounds and cognition context.' },
+  { label: 'Supplements for brain fog', href: '/guides/supplements-for-brain-fog-and-fatigue', description: 'Editorial guide for fatigue, clarity, and cognitive-energy overlap.' },
+]
+
 const semanticSignals = [
   'Cognitive Performance',
   'Attention Support',
@@ -99,6 +113,14 @@ export default function FocusExplorePage() {
           </div>
         </div>
       </section>
+
+      <SemanticHubIntro sections={hubIntro} />
+
+      <KnowledgeGraphLinks
+        eyebrow="Mechanism overlap"
+        title="Follow adjacent cognition research"
+        links={graphLinks}
+      />
 
       <section className="space-y-6">
         <div className="space-y-2">

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -5,6 +5,31 @@ import {
   getTopicClusters,
 } from '@/lib/semantic-runtime'
 import { cleanSummary, isClean } from '@/lib/display-utils'
+import { KnowledgeGraphLinks, SemanticHubIntro } from '@/components/semantic-hubs/semantic-hub-sections'
+
+const hubIntro = [
+  {
+    title: 'Biological context',
+    body: 'The explore layer groups records by outcomes and plausible biological systems so readers can move from broad intent to profile-level evidence without treating mechanism labels as proof.',
+  },
+  {
+    title: 'Research focus',
+    body: 'Clusters emphasize evidence maturity, recurring pathway language, and common research contexts such as inhibitory tone, cognition, inflammatory signaling, and metabolic support.',
+  },
+  {
+    title: 'Discovery method',
+    body: 'This hub is designed as a crawlable map: outcome pages, pathway hubs, collections, and individual profiles reinforce one another through shared semantic signals.',
+  },
+]
+
+const graphLinks = [
+  { label: 'GABA pathway', href: '/pathways/gaba', description: 'Calming, inhibitory tone, relaxation, and sleep-adjacent neurotransmitter context.' },
+  { label: 'Dopamine pathway', href: '/pathways/dopamine', description: 'Motivation, attention, reward, and cognition-oriented pathway relationships.' },
+  { label: 'Inflammation pathway', href: '/pathways/inflammation', description: 'Immune tone, oxidative stress, cytokine, recovery, and joint-support relationships.' },
+  { label: 'Best studied sleep compounds', href: '/collections/best-studied-sleep-compounds', description: 'Collection view for sleep-related compounds with stronger evidence and semantic signals.' },
+  { label: 'Adaptogens for stress', href: '/collections/adaptogens-for-stress', description: 'Botanical stress-support cluster organized around adaptation, resilience, and calm.' },
+  { label: 'Cholinergic compounds', href: '/collections/cholinergic-compounds', description: 'Cognition-adjacent compounds commonly explored with acetylcholine and attention context.' },
+]
 
 const TOPICS = [
   {
@@ -69,6 +94,8 @@ export default function ExplorePage() {
         </div>
       </section>
 
+      <SemanticHubIntro sections={hubIntro} />
+
       <section className="surface-depth card-spacing">
         <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
           <div className="max-w-3xl space-y-3">
@@ -126,6 +153,12 @@ export default function ExplorePage() {
           </Link>
         ))}
       </section>
+
+      <KnowledgeGraphLinks
+        eyebrow="Often explored together"
+        title="Move through the scientific graph"
+        links={graphLinks}
+      />
 
       <section className="space-y-6">
         <div className="flex items-end justify-between gap-4 flex-wrap">

--- a/app/explore/sleep/page.tsx
+++ b/app/explore/sleep/page.tsx
@@ -4,6 +4,7 @@ import compounds from '../../../public/data/compounds.json'
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 import { cleanSummary, formatDisplayLabel, isClean, list, unique } from '@/lib/display-utils'
 import { EvidenceBadgeGroup } from '@/components/evidence/evidence-badge'
+import { KnowledgeGraphLinks, SemanticHubIntro } from '@/components/semantic-hubs/semantic-hub-sections'
 
 function normalize(value: unknown) {
   return String(value || '').toLowerCase()
@@ -59,6 +60,19 @@ function buildCards(records: any[], type: 'herb' | 'compound') {
 const herbCards = buildCards(herbs as any[], 'herb')
 const compoundCards = buildCards(compounds as any[], 'compound')
 
+const hubIntro = [
+  { title: 'Biological context', body: 'Sleep-support exploration intersects with inhibitory neurotransmission, arousal state, circadian rhythm, and recovery biology.' },
+  { title: 'Research focus', body: 'Cards are selected from records with sleep, relaxation, GABA, circadian, melatonin-adjacent, or restorative workbook signals.' },
+  { title: 'Common mechanisms', body: 'Mechanism chips improve navigation, but individual evidence badges and profile cautions should carry the interpretive weight.' },
+]
+
+const graphLinks = [
+  { label: 'GABA pathway', href: '/pathways/gaba', description: 'Inhibitory-tone and relaxation pathway context for sleep-adjacent profiles.' },
+  { label: 'Sleep goal guide', href: '/goals/sleep', description: 'Outcome-led sleep guide for comparing latency, quality, and relaxation support.' },
+  { label: 'Sleep herbs vs melatonin', href: '/sleep-herbs-vs-melatonin', description: 'Comparison cluster linking botanical sleep supports with melatonin context.' },
+  { label: 'Best studied sleep compounds', href: '/collections/best-studied-sleep-compounds', description: 'Collection view for sleep-related compounds with stronger evidence signals.' },
+]
+
 const semanticSignals = [
   'GABA Signaling',
   'Circadian Rhythm',
@@ -96,6 +110,14 @@ export default function SleepExplorePage() {
           </div>
         </div>
       </section>
+
+      <SemanticHubIntro sections={hubIntro} />
+
+      <KnowledgeGraphLinks
+        eyebrow="Pathway companions"
+        title="Follow adjacent sleep research"
+        links={graphLinks}
+      />
 
       <section className="space-y-6">
         <div className="space-y-2">

--- a/app/pathways/pathway-hub.tsx
+++ b/app/pathways/pathway-hub.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/lib/pathways'
 import { buildMeta } from '@/lib/seo'
 import { EvidenceBadgeGroup } from '@/components/evidence/evidence-badge'
+import { KnowledgeGraphLinks, SemanticHubIntro, SignalPanel } from '@/components/semantic-hubs/semantic-hub-sections'
 
 type RelatedPathwayLink = {
   label: string
@@ -26,6 +27,7 @@ type PathwayConfig = {
   eyebrow: string
   summary: string
   clusters: string[]
+  introSections: { title: string; body: string }[]
   related: RelatedPathwayLink[]
 }
 
@@ -36,6 +38,11 @@ const configs: Record<'gaba' | 'dopamine' | 'inflammation', PathwayConfig> = {
     eyebrow: 'Neurotransmitter cluster',
     summary: 'Explore herbs and compounds with workbook signals around GABA, calming, inhibitory tone, relaxation, and sleep-adjacent mechanisms.',
     clusters: ['GABAergic signaling', 'Inhibitory tone', 'Relaxation and sleep context', 'Calming botanicals and compounds'],
+    introSections: [
+      { title: 'Biological context', body: 'GABA is an inhibitory neurotransmitter system commonly used to frame calming, relaxation, arousal, and sleep-support research.' },
+      { title: 'Research focus', body: 'This hub surfaces records with clean workbook signals for GABA, inhibitory tone, calming botanicals, relaxation, or sleep-adjacent mechanisms.' },
+      { title: 'Mechanism overlap', body: 'GABA labels are discovery signals; profile evidence and safety details remain necessary for interpreting any specific herb or compound.' },
+    ],
     related: [
       { label: 'Dopamine', href: '/pathways/dopamine', description: 'Motivation, focus, reward, and cognition-adjacent neurotransmitter signals.' },
       { label: 'Stress', href: '/best-supplements-for-stress', description: 'Goal guide for cortisol, adaptation, anxiety, and stress-resilience context.' },
@@ -49,6 +56,11 @@ const configs: Record<'gaba' | 'dopamine' | 'inflammation', PathwayConfig> = {
     eyebrow: 'Neurotransmitter cluster',
     summary: 'Explore records with existing signals around dopamine, reward, motivation, cognition, focus, and attention-related mechanisms.',
     clusters: ['Dopaminergic signaling', 'Reward and motivation', 'Cognitive performance', 'Focus and attention context'],
+    introSections: [
+      { title: 'Biological context', body: 'Dopamine-related research often intersects with reward, motivation, attention, movement, and cognitive-performance signaling.' },
+      { title: 'Research focus', body: 'This hub groups records that expose dopamine, focus, cognition, motivation, nootropic, or attention-adjacent workbook signals.' },
+      { title: 'Mechanism overlap', body: 'The page is a relationship map, not a claim that every associated profile changes dopamine in humans.' },
+    ],
     related: [
       { label: 'GABA', href: '/pathways/gaba', description: 'Calming and inhibitory signaling that often frames sleep and relaxation context.' },
       { label: 'Inflammation', href: '/pathways/inflammation', description: 'Immune and oxidative-stress signals that can intersect with brain-health research.' },
@@ -61,6 +73,11 @@ const configs: Record<'gaba' | 'dopamine' | 'inflammation', PathwayConfig> = {
     eyebrow: 'Inflammatory systems cluster',
     summary: 'Explore records with workbook signals around inflammatory tone, cytokines, immune activity, oxidative stress, and antioxidant mechanisms.',
     clusters: ['Inflammatory signaling', 'Cytokine and immune context', 'Oxidative stress', 'Antioxidant-response mechanisms'],
+    introSections: [
+      { title: 'Biological context', body: 'Inflammation research connects immune signaling, cytokine language, oxidative stress, tissue recovery, and mobility outcomes.' },
+      { title: 'Research focus', body: 'Records appear here when workbook signals mention inflammatory tone, antioxidant response, immune activity, cytokines, or recovery-adjacent effects.' },
+      { title: 'Mechanism overlap', body: 'Inflammatory-pathway labels support discovery and comparison; clinical relevance depends on each profile’s evidence maturity.' },
+    ],
     related: [
       { label: 'GABA', href: '/pathways/gaba', description: 'Neurotransmitter and sleep-adjacent signals with calming pathway context.' },
       { label: 'Dopamine', href: '/pathways/dopamine', description: 'Motivation, focus, and cognition-adjacent neurotransmitter context.' },
@@ -186,6 +203,15 @@ export async function PathwayHub({ pathway }: { pathway: PathwaySlug }) {
         </div>
       </section>
 
+      <SemanticHubIntro sections={config.introSections} />
+
+      <SignalPanel
+        eyebrow="Pathway relevance"
+        title="Signals used to organize this hub"
+        description="These themes summarize the biological relationships behind this page and help readers move into adjacent profiles, goals, and collections."
+        signals={config.clusters}
+      />
+
       <section className="grid gap-5 md:grid-cols-2">
         <div className="card-premium p-6">
           <p className="eyebrow-label">Mechanism clusters</p>
@@ -206,21 +232,11 @@ export async function PathwayHub({ pathway }: { pathway: PathwaySlug }) {
         </div>
       </section>
 
-      <section className="space-y-5">
-        <div className="space-y-2">
-          <p className="eyebrow-label">Scientific discovery graph</p>
-          <h2 className="text-3xl font-semibold tracking-tight text-ink">Related pathways</h2>
-        </div>
-
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-          {supportedRelated.map((item) => (
-            <Link key={item.href} href={item.href} className="surface-subtle rounded-2xl border border-brand-900/10 p-4 transition hover:border-brand-700/30 hover:bg-white/60">
-              <p className="text-sm font-semibold leading-6 text-ink">{item.label}</p>
-              <p className="mt-2 text-xs leading-5 text-muted-readable">{item.description}</p>
-            </Link>
-          ))}
-        </div>
-      </section>
+      <KnowledgeGraphLinks
+        eyebrow="Scientific discovery graph"
+        title="Related pathways and outcome hubs"
+        links={supportedRelated}
+      />
 
       {relatedHerbs.length > 0 ? (
         <section className="space-y-5">

--- a/components/semantic-hubs/semantic-hub-sections.tsx
+++ b/components/semantic-hubs/semantic-hub-sections.tsx
@@ -1,0 +1,77 @@
+import Link from 'next/link'
+
+type MicroSection = {
+  title: string
+  body: string
+}
+
+export type GraphLink = {
+  label: string
+  href: string
+  description: string
+}
+
+export function SemanticHubIntro({ sections }: { sections: MicroSection[] }) {
+  const strongSections = sections.filter((section) => section.title && section.body).slice(0, 3)
+
+  if (!strongSections.length) return null
+
+  return (
+    <section className="grid gap-4 md:grid-cols-3">
+      {strongSections.map((section) => (
+        <article key={section.title} className="surface-subtle rounded-2xl border border-brand-900/10 p-5">
+          <p className="eyebrow-label">{section.title}</p>
+          <p className="mt-3 text-sm leading-7 text-[#46574d]">{section.body}</p>
+        </article>
+      ))}
+    </section>
+  )
+}
+
+export function KnowledgeGraphLinks({ eyebrow = 'Knowledge graph', title, links }: { eyebrow?: string; title: string; links: GraphLink[] }) {
+  const strongLinks = links.filter((link) => link.label && link.href && link.description).slice(0, 6)
+
+  if (!strongLinks.length) return null
+
+  return (
+    <section className="space-y-5">
+      <div className="space-y-2">
+        <p className="eyebrow-label">{eyebrow}</p>
+        <h2 className="text-3xl font-semibold tracking-tight text-ink">{title}</h2>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {strongLinks.map((link) => (
+          <Link key={link.href} href={link.href} className="surface-subtle rounded-2xl border border-brand-900/10 p-4 transition hover:border-brand-700/30 hover:bg-white/60">
+            <p className="text-sm font-semibold leading-6 text-ink">{link.label}</p>
+            <p className="mt-2 text-xs leading-5 text-muted-readable">{link.description}</p>
+          </Link>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+export function SignalPanel({ eyebrow, title, description, signals }: { eyebrow: string; title: string; description: string; signals: string[] }) {
+  const cleanSignals = signals.filter(Boolean).slice(0, 8)
+
+  if (!cleanSignals.length) return null
+
+  return (
+    <section className="surface-depth card-spacing">
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)] lg:items-center">
+        <div className="space-y-3">
+          <p className="eyebrow-label">{eyebrow}</p>
+          <h2 className="text-3xl font-semibold tracking-tight text-ink">{title}</h2>
+          <p className="detail-reading text-base">{description}</p>
+        </div>
+
+        <div className="flex flex-wrap gap-2 lg:justify-end">
+          {cleanSignals.map((signal) => (
+            <span key={signal} className="chip-readable">{signal}</span>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
### Motivation
- Non-profile discovery and hub pages felt thin and disconnected compared to the profile system and needed editorial framing and semantic linking to improve crawl depth and internal authority.
- Introduce compact, reusable micro-sections that add biological context, evidence-aware framing, and knowledge-graph style links without altering routes, data contracts, or workbook sources.

### Description
- Added reusable hub primitives in `components/semantic-hubs/semantic-hub-sections.tsx` providing `SemanticHubIntro`, `KnowledgeGraphLinks`, and `SignalPanel` components for concise editorial intros, graph links, and signal panels.
- Enhanced the top-level `app/explore/page.tsx` with a hub intro and knowledge-graph links to improve landing-page authority and discovery rhythm.
- Upgraded topic hubs in `app/explore/[topic]/page.tsx` and the dedicated `sleep`/`focus` pages to include evidence-aware intro sections, signal panels, and related-hub links to strengthen semantic context and internal linking.
- Strengthened pathway hubs in `app/pathways/pathway-hub.tsx` by adding intro sections and a `SignalPanel`, and replaced the static related-section with the reusable `KnowledgeGraphLinks` component.
- Reworked collection pages: created generated intros and adjacent-theme extraction in `app/collections/scientific-collection-page.tsx` and moved the generic collection route `app/collections/[slug]/page.tsx` to the site design language with match counts, signal chips, and curated cards.
- Changes are intentionally small and additive, preserving route contracts, workbook pipelines, JSON exports, and the site’s light-mode design language.

### Testing
- Ran `npm run check` which triggers the data build, validation, and full Next build; the command completed successfully without errors.
- Verified there were no lint/type/build failures during the run and `git diff --check` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fead0e43108323828bb7eacc9a8be7)