### PR TITLE
Strengthen semantic ecosystem navigation

### DIFF
--- a/app/collections/[slug]/page.tsx
+++ b/app/collections/[slug]/page.tsx
@@ -3,7 +3,8 @@ import Link from 'next/link'
 import { seoCollections } from '@/data/seoCollections'
 import { getCompounds, getHerbs } from '@/lib/runtime-data'
 import { cleanSummary, formatDisplayLabel, isClean, list, unique } from '@/lib/display-utils'
-import { SemanticHubIntro, SignalPanel } from '@/components/semantic-hubs/semantic-hub-sections'
+import { EcosystemPanelGrid, SemanticHubIntro, SignalPanel } from '@/components/semantic-hubs/semantic-hub-sections'
+import { getAdjacentEcosystemPanels } from '@/lib/ecosystem-context'
 
 type Params = { params: Promise<{ slug: string }> }
 
@@ -70,6 +71,13 @@ export default async function CollectionPage({ params }: Params) {
         title="Shared signals in this collection"
         description="These compact terms come from visible matching records and help recover context on otherwise sparse collection routes."
         signals={themes}
+      />
+
+      <EcosystemPanelGrid
+        eyebrow="Research adjacencies"
+        title="Adjacent systems for this collection"
+        panels={getAdjacentEcosystemPanels(themes, 4)}
+        limit={4}
       />
 
       <section className="space-y-6">

--- a/app/collections/scientific-collection-page.tsx
+++ b/app/collections/scientific-collection-page.tsx
@@ -13,7 +13,8 @@ import {
   type ScientificCollection,
 } from '@/lib/collections'
 import { formatDisplayLabel, isClean, list, unique } from '@/lib/display-utils'
-import { KnowledgeGraphLinks, SemanticHubIntro, SignalPanel } from '@/components/semantic-hubs/semantic-hub-sections'
+import { EcosystemPanelGrid, KnowledgeGraphLinks, SemanticHubIntro, SignalPanel } from '@/components/semantic-hubs/semantic-hub-sections'
+import { getAdjacentEcosystemPanels } from '@/lib/ecosystem-context'
 
 type CollectionPageProps = {
   slug: string
@@ -194,6 +195,13 @@ export async function ScientificCollectionPage({ slug }: CollectionPageProps) {
         title="How this collection connects"
         description="These terms summarize the strongest adjacent systems, effects, and mechanism language present in the matching runtime records."
         signals={adjacentThemes}
+      />
+
+      <EcosystemPanelGrid
+        eyebrow="Category ecosystems"
+        title="Where this collection sits in the larger map"
+        panels={getAdjacentEcosystemPanels(adjacentThemes, 4)}
+        limit={4}
       />
 
       <section className="grid gap-5 md:grid-cols-2">

--- a/app/compounds/page.tsx
+++ b/app/compounds/page.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link'
 import { getCompounds } from '@/lib/runtime-data'
 import { cleanSummary, formatDisplayLabel } from '@/lib/display-utils'
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
+import { EcosystemPanelGrid } from '@/components/semantic-hubs/semantic-hub-sections'
+import { getEcosystemPanels } from '@/lib/ecosystem-context'
 import '@/styles/premium-cards.css'
 
 function safeString(value: unknown) {
@@ -101,6 +103,13 @@ export default async function CompoundsPage() {
               </p>
             </div>
           </div>
+
+          <EcosystemPanelGrid
+            eyebrow="Associated pathways"
+            title="Compound ecosystem pathways"
+            panels={getEcosystemPanels(['cognition sleep neurobiology mitochondrial function metabolism oxidative stress cardiovascular function inflammation'], 4)}
+            limit={4}
+          />
 
           <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 xl:gap-6">
             {compounds.map((compound: any) => {

--- a/app/explore/[topic]/page.tsx
+++ b/app/explore/[topic]/page.tsx
@@ -7,7 +7,8 @@ import {
 } from '@/lib/semantic-runtime'
 import { cleanSummary, isClean } from '@/lib/display-utils'
 import { safeArray, safeIncludes, safeLower, safeSlug, safeTrim } from '@/lib/search-safe'
-import { KnowledgeGraphLinks, SemanticHubIntro, SignalPanel } from '@/components/semantic-hubs/semantic-hub-sections'
+import { EcosystemPanelGrid, KnowledgeGraphLinks, SemanticHubIntro, SignalPanel } from '@/components/semantic-hubs/semantic-hub-sections'
+import { getAdjacentEcosystemPanels } from '@/lib/ecosystem-context'
 
 const TITLES: Record<string, string> = {
   sleep: 'Sleep Support',
@@ -144,6 +145,13 @@ export default async function TopicExplorePage({ params }: any) {
         title="How this cluster is organized"
         description="High-signal terms summarize the biological systems and adjacent outcomes most useful for exploring this topic."
         signals={context.signals}
+      />
+
+      <EcosystemPanelGrid
+        eyebrow="Mechanistically adjacent topics"
+        title="Research adjacencies for this cluster"
+        panels={getAdjacentEcosystemPanels(context.signals, 4)}
+        limit={4}
       />
 
       <KnowledgeGraphLinks

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -5,7 +5,8 @@ import {
   getTopicClusters,
 } from '@/lib/semantic-runtime'
 import { cleanSummary, isClean } from '@/lib/display-utils'
-import { KnowledgeGraphLinks, SemanticHubIntro } from '@/components/semantic-hubs/semantic-hub-sections'
+import { EcosystemPanelGrid, KnowledgeGraphLinks, SemanticHubIntro } from '@/components/semantic-hubs/semantic-hub-sections'
+import { getEcosystemPanels, getTopicClusterLinks } from '@/lib/ecosystem-context'
 
 const hubIntro = [
   {
@@ -154,10 +155,17 @@ export default function ExplorePage() {
         ))}
       </section>
 
+      <EcosystemPanelGrid
+        eyebrow="Topic-cluster depth"
+        title="Core scientific ecosystems"
+        panels={getEcosystemPanels(['inflammation cognition metabolism stress response longevity mitochondrial function oxidative stress sleep neurobiology cardiovascular function'], 10)}
+        limit={10}
+      />
+
       <KnowledgeGraphLinks
         eyebrow="Often explored together"
         title="Move through the scientific graph"
-        links={graphLinks}
+        links={[...graphLinks, ...getTopicClusterLinks(4)].slice(0, 6)}
       />
 
       <section className="space-y-6">

--- a/app/goals/page.tsx
+++ b/app/goals/page.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link'
 import { goalConfigs } from '@/data/goals'
 import { seoEntryPages } from '../seo-entry-pages'
+import { EcosystemPanelGrid, KnowledgeGraphLinks, SemanticHubIntro } from '@/components/semantic-hubs/semantic-hub-sections'
+import { getEcosystemPanels, getTopicClusterLinks } from '@/lib/ecosystem-context'
 
 export default function GoalsIndex() {
   const featuredGuides = seoEntryPages.slice(0, 12)
@@ -24,6 +26,26 @@ export default function GoalsIndex() {
           </div>
         </div>
       </section>
+
+      <SemanticHubIntro
+        sections={[
+          { title: 'Decision context', body: 'Goal pages connect broad reader intent to evidence-aware profiles, mechanisms, safety notes, and adjacent outcome guides.' },
+          { title: 'Biological relevance', body: 'Each path is framed as a research map across overlapping systems rather than a promise that one supplement solves a goal.' },
+          { title: 'Discovery continuity', body: 'Guides, pathways, collections, herbs, and compounds are linked so readers can move from outcome to mechanism to profile.' },
+        ]}
+      />
+
+      <EcosystemPanelGrid
+        eyebrow="Frequently explored together"
+        title="Goal ecosystems across the site"
+        panels={getEcosystemPanels(['sleep stress cognition inflammation metabolism cardiovascular recovery oxidative stress neurobiology mitochondrial function'], 6)}
+      />
+
+      <KnowledgeGraphLinks
+        eyebrow="Scientific themes"
+        title="Browse by adjacent biology"
+        links={getTopicClusterLinks(6)}
+      />
 
       <section className="space-y-5">
         <div>

--- a/app/herbs/page.tsx
+++ b/app/herbs/page.tsx
@@ -2,6 +2,8 @@ import Link from 'next/link'
 import { getHerbs } from '@/lib/runtime-data'
 import { cleanSummary, formatDisplayLabel, isClean, labelize, list, text, unique } from '@/lib/display-utils'
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
+import { EcosystemPanelGrid } from '@/components/semantic-hubs/semantic-hub-sections'
+import { getEcosystemPanels } from '@/lib/ecosystem-context'
 import '@/styles/premium-cards.css'
 
 function getName(item: any) {
@@ -204,6 +206,13 @@ export default async function HerbsPage() {
               </div>
             </div>
           </div>
+
+          <EcosystemPanelGrid
+            eyebrow="Associated pathways"
+            title="Botanical ecosystem pathways"
+            panels={getEcosystemPanels(['stress adaptogens sleep recovery cognition inflammation metabolism traditional botanical use'], 4)}
+            limit={4}
+          />
 
           <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 xl:gap-6">
             {herbs.map((herb: any, index: number) => {

--- a/app/pathways/pathway-hub.tsx
+++ b/app/pathways/pathway-hub.tsx
@@ -13,7 +13,8 @@ import {
 } from '@/lib/pathways'
 import { buildMeta } from '@/lib/seo'
 import { EvidenceBadgeGroup } from '@/components/evidence/evidence-badge'
-import { KnowledgeGraphLinks, SemanticHubIntro, SignalPanel } from '@/components/semantic-hubs/semantic-hub-sections'
+import { EcosystemPanelGrid, KnowledgeGraphLinks, SemanticHubIntro, SignalPanel } from '@/components/semantic-hubs/semantic-hub-sections'
+import { getAdjacentEcosystemPanels } from '@/lib/ecosystem-context'
 
 type RelatedPathwayLink = {
   label: string
@@ -231,6 +232,13 @@ export async function PathwayHub({ pathway }: { pathway: PathwaySlug }) {
           </div>
         </div>
       </section>
+
+      <EcosystemPanelGrid
+        eyebrow="Related biological systems"
+        title="Adjacent systems to keep in view"
+        panels={getAdjacentEcosystemPanels([...config.clusters, ...mechanisms, ...effects], 4)}
+        limit={4}
+      />
 
       <KnowledgeGraphLinks
         eyebrow="Scientific discovery graph"

--- a/components/semantic-hubs/semantic-hub-sections.tsx
+++ b/components/semantic-hubs/semantic-hub-sections.tsx
@@ -11,6 +11,14 @@ export type GraphLink = {
   description: string
 }
 
+export type EcosystemPanel = {
+  eyebrow: string
+  title: string
+  body: string
+  signals?: string[]
+  href?: string
+}
+
 export function SemanticHubIntro({ sections }: { sections: MicroSection[] }) {
   const strongSections = sections.filter((section) => section.title && section.body).slice(0, 3)
 
@@ -71,6 +79,56 @@ export function SignalPanel({ eyebrow, title, description, signals }: { eyebrow:
             <span key={signal} className="chip-readable">{signal}</span>
           ))}
         </div>
+      </div>
+    </section>
+  )
+}
+
+export function EcosystemPanelGrid({ title, eyebrow = 'Ecosystem context', panels, limit = 6 }: { title: string; eyebrow?: string; panels: EcosystemPanel[]; limit?: number }) {
+  const strongPanels = panels
+    .filter((panel) => panel.eyebrow && panel.title && panel.body)
+    .slice(0, limit)
+
+  if (!strongPanels.length) return null
+
+  return (
+    <section className="space-y-5">
+      <div className="space-y-2">
+        <p className="eyebrow-label">{eyebrow}</p>
+        <h2 className="text-3xl font-semibold tracking-tight text-ink">{title}</h2>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+        {strongPanels.map((panel) => {
+          const content = (
+            <div className="space-y-3">
+              <p className="identity-kicker">{panel.eyebrow}</p>
+              <h3 className="text-lg font-semibold leading-7 text-ink">{panel.title}</h3>
+              <p className="text-sm leading-7 text-[#46574d]">{panel.body}</p>
+              {panel.signals?.length ? (
+                <div className="flex flex-wrap gap-2 pt-1">
+                  {panel.signals.filter(Boolean).slice(0, 4).map((signal) => (
+                    <span key={signal} className="chip-readable text-[10px] uppercase tracking-wide">{signal}</span>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+          )
+
+          if (panel.href) {
+            return (
+              <Link key={`${panel.eyebrow}-${panel.title}`} href={panel.href} className="surface-subtle rounded-2xl border border-brand-900/10 p-5 transition hover:border-brand-700/30 hover:bg-white/60">
+                {content}
+              </Link>
+            )
+          }
+
+          return (
+            <article key={`${panel.eyebrow}-${panel.title}`} className="surface-subtle rounded-2xl border border-brand-900/10 p-5">
+              {content}
+            </article>
+          )
+        })}
       </div>
     </section>
   )

--- a/lib/ecosystem-context.ts
+++ b/lib/ecosystem-context.ts
@@ -1,0 +1,126 @@
+import type { EcosystemPanel, GraphLink } from '@/components/semantic-hubs/semantic-hub-sections'
+
+export type TopicCluster = {
+  slug: string
+  label: string
+  href: string
+  description: string
+  systems: string[]
+  keywords: string[]
+}
+
+export const topicClusters: TopicCluster[] = [
+  {
+    slug: 'inflammation',
+    label: 'Inflammation',
+    href: '/pathways/inflammation',
+    description: 'Immune signaling, cytokine language, recovery, mobility, and oxidative-stress relationships.',
+    systems: ['Immune tone', 'Cytokines', 'Recovery'],
+    keywords: ['inflammation', 'inflammatory', 'cytokine', 'immune', 'joint', 'recovery'],
+  },
+  {
+    slug: 'cognition',
+    label: 'Cognition',
+    href: '/explore/focus',
+    description: 'Attention, memory, mental clarity, fatigue resistance, and neurotransmitter-adjacent research.',
+    systems: ['Attention', 'Memory', 'Neurotransmitters'],
+    keywords: ['cognition', 'focus', 'memory', 'attention', 'nootropic', 'clarity'],
+  },
+  {
+    slug: 'metabolism',
+    label: 'Metabolism',
+    href: '/best-supplements-for-fat-loss',
+    description: 'Energy balance, glucose context, body-composition research, and metabolic resilience signals.',
+    systems: ['Energy balance', 'Glucose context', 'Body composition'],
+    keywords: ['metabolism', 'metabolic', 'glucose', 'insulin', 'fat', 'weight'],
+  },
+  {
+    slug: 'stress-response',
+    label: 'Stress response',
+    href: '/best-supplements-for-stress',
+    description: 'HPA-axis language, adaptation, calm, sleep overlap, and nervous-system resilience.',
+    systems: ['HPA axis', 'Adaptation', 'Calm'],
+    keywords: ['stress', 'cortisol', 'adaptogen', 'anxiety', 'calm', 'relaxation'],
+  },
+  {
+    slug: 'longevity',
+    label: 'Longevity',
+    href: '/explore/recovery',
+    description: 'Aging-adjacent research themes including repair, oxidative stress, metabolism, and resilience.',
+    systems: ['Repair', 'Resilience', 'Healthy aging'],
+    keywords: ['longevity', 'aging', 'cellular', 'repair', 'resilience'],
+  },
+  {
+    slug: 'mitochondrial-function',
+    label: 'Mitochondrial function',
+    href: '/performance-supplements',
+    description: 'Cellular energy, fatigue, exercise performance, and recovery-adjacent mechanism context.',
+    systems: ['Cellular energy', 'Fatigue', 'Performance'],
+    keywords: ['mitochondria', 'mitochondrial', 'atp', 'energy', 'fatigue', 'performance'],
+  },
+  {
+    slug: 'oxidative-stress',
+    label: 'Oxidative stress',
+    href: '/pathways/inflammation',
+    description: 'Antioxidant response, redox balance, inflammation overlap, and tissue-stress research language.',
+    systems: ['Redox balance', 'Antioxidant response', 'Tissue stress'],
+    keywords: ['oxidative', 'antioxidant', 'redox', 'ros', 'free radical'],
+  },
+  {
+    slug: 'sleep',
+    label: 'Sleep',
+    href: '/explore/sleep',
+    description: 'Latency, sleep quality, relaxation, circadian context, and nighttime recovery overlap.',
+    systems: ['Sleep quality', 'Circadian context', 'Relaxation'],
+    keywords: ['sleep', 'circadian', 'melatonin', 'night', 'insomnia'],
+  },
+  {
+    slug: 'neurobiology',
+    label: 'Neurobiology',
+    href: '/pathways/dopamine',
+    description: 'Neurotransmitter systems, mood-adjacent signals, cognition, calm, and arousal regulation.',
+    systems: ['Dopamine', 'GABA', 'Arousal'],
+    keywords: ['neuro', 'dopamine', 'gaba', 'serotonin', 'brain', 'mood'],
+  },
+  {
+    slug: 'cardiovascular-function',
+    label: 'Cardiovascular function',
+    href: '/best-supplements-for-blood-pressure',
+    description: 'Blood-pressure context, vascular tone, circulation, metabolic overlap, and endothelial themes.',
+    systems: ['Vascular tone', 'Circulation', 'Blood pressure'],
+    keywords: ['cardio', 'vascular', 'blood pressure', 'circulation', 'heart', 'endothelial'],
+  },
+]
+
+export function getTopicClusterLinks(limit = 10): GraphLink[] {
+  return topicClusters.slice(0, limit).map((cluster) => ({
+    label: cluster.label,
+    href: cluster.href,
+    description: cluster.description,
+  }))
+}
+
+export function getEcosystemPanels(signals: string[], limit = 6): EcosystemPanel[] {
+  const haystack = signals.join(' ').toLowerCase()
+  const matches = topicClusters.filter((cluster) =>
+    cluster.keywords.some((keyword) => haystack.includes(keyword)) ||
+    haystack.includes(cluster.label.toLowerCase())
+  )
+
+  const selected = (matches.length ? matches : topicClusters).slice(0, limit)
+
+  return selected.map((cluster) => ({
+    eyebrow: 'Related scientific theme',
+    title: cluster.label,
+    body: cluster.description,
+    href: cluster.href,
+    signals: cluster.systems,
+  }))
+}
+
+export function getAdjacentEcosystemPanels(signals: string[], limit = 4): EcosystemPanel[] {
+  return getEcosystemPanels(signals, limit).map((panel) => ({
+    ...panel,
+    eyebrow: 'Research adjacency',
+  }))
+}


### PR DESCRIPTION
### Motivation
- Improve discovery continuity and topical authority across the discovery and collection layer so ecosystem pages feel cohesive and research-forward rather than thin or isolated.
- Introduce concise, suppressible editorial panels that surface high-signal context (related systems, adjacencies, and frequently-explored topics) without altering data or runtime contracts.
- Preserve existing routes, workbook-driven data exports, and profile semantics while increasing semantic cross-linking and crawlable discovery paths.

### Description
- Added a reusable `EcosystemPanelGrid` component to `components/semantic-hubs/semantic-hub-sections.tsx` for rendering concise ecosystem/context panels with optional signals and links.
- Introduced `lib/ecosystem-context.ts` which defines a small topic-cluster map and helper functions `getEcosystemPanels`, `getAdjacentEcosystemPanels`, and `getTopicClusterLinks` to produce conservative, evidence-aware panel content.
- Integrated ecosystem panels across discovery and landing routes by adding panels to `app/explore/page.tsx`, `app/explore/[topic]/page.tsx`, `app/pathways/pathway-hub.tsx`, `app/collections/scientific-collection-page.tsx`, `app/collections/[slug]/page.tsx`, `app/goals/page.tsx`, `app/herbs/page.tsx`, and `app/compounds/page.tsx` to improve semantic traversal and category cohesion.
- Kept editorial tone conservative (labels use "signals", "adjacency", and "research themes"), suppressed empty/weak panels, and avoided changes to workbook schema, JSON exports, route contracts, or data pipelines.

### Testing
- Ran `npm run check`, which executes the full build pipeline including `npm run data:build`, `npm run data:validate`, `next build`, and the repository verification steps, and the command completed successfully.
- Data validation passed (`data-next-validate`), the static page generation completed (all routes collected/generated), and the `verify:build` checks finished without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feb1bacd388323948a8fddb2bfe5a3)