### PR TITLE
Add safe runtime graph helpers

### DIFF
--- a/lib/runtime-graph.ts
+++ b/lib/runtime-graph.ts
@@ -1,6 +1,57 @@
-type GraphRecord = Record<string, unknown>
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 
-export type GraphNode = {
+type GraphRecord = Record<string, unknown>
+type GraphInput = GraphRuntime | null | undefined
+
+type ProfileInput = GraphRecord | string
+
+type ResolvedProfileArgs = {
+  graph: GraphRuntime
+  profile: ProfileInput
+  limit?: number
+}
+
+function resolveProfileArgs(
+  graphOrProfile: GraphInput | ProfileInput,
+  profileOrLimit?: ProfileInput | number,
+  maybeLimit?: number
+): ResolvedProfileArgs {
+  if (typeof profileOrLimit === 'string' || asRecord(profileOrLimit)) {
+    return {
+      graph: normalizeGraphRuntime(graphOrProfile as GraphInput),
+      profile: profileOrLimit as ProfileInput,
+      limit: maybeLimit,
+    }
+  }
+
+  return {
+    graph: loadRuntimeGraph(),
+    profile: graphOrProfile as ProfileInput,
+    limit: typeof profileOrLimit === 'number' ? profileOrLimit : maybeLimit,
+  }
+}
+
+function resolveEcosystemArgs(
+  graphOrKey: GraphInput | string,
+  maybeKey?: string
+): { graph: GraphRuntime; key: string } {
+  if (typeof maybeKey === 'string') {
+    return { graph: normalizeGraphRuntime(graphOrKey as GraphInput), key: maybeKey }
+  }
+
+  return { graph: loadRuntimeGraph(), key: asText(graphOrKey) }
+}
+
+function isGraphLike(value: unknown): boolean {
+  const record = asRecord(value)
+  if (!record) return false
+
+  return ['nodes', 'relationships', 'topics', 'pathways', 'comparisons', 'stacks', 'supernodes']
+    .some((key) => Array.isArray(record[key]))
+}
+
+export type GraphNode = GraphRecord & {
   id?: string
   slug?: string
   name?: string
@@ -14,7 +65,7 @@ export type GraphNode = {
   retrieval_summary?: string
 }
 
-export type GraphRelationship = {
+export type GraphRelationship = GraphRecord & {
   id?: string
   source?: string
   target?: string
@@ -27,7 +78,7 @@ export type GraphRelationship = {
   topics?: string[]
 }
 
-export type GraphEcosystem = {
+export type GraphEcosystem = GraphRecord & {
   id?: string
   slug?: string
   name?: string
@@ -42,13 +93,15 @@ export type GraphEcosystem = {
   topics?: string[]
 }
 
-export type GraphCandidate = {
+export type GraphCandidate = GraphRecord & {
   id?: string
   source?: string
   target?: string
+  type?: string
   rationale?: string
   evidence_context?: string
   framing?: string
+  weight?: string | number
   mechanism_overlap?: string[]
   pathway_overlap?: string[]
   topic_overlap?: string[]
@@ -64,6 +117,25 @@ export type GraphRuntime = {
   comparisons?: GraphCandidate[]
   stacks?: GraphCandidate[]
   supernodes?: GraphEcosystem[]
+}
+
+const GRAPH_DIR = join(process.cwd(), 'public', 'data', 'graph')
+const GRAPH_FILES = {
+  nodes: 'nodes.json',
+  relationships: 'relationships.json',
+  topics: 'topics.json',
+  pathways: 'pathways.json',
+  comparisons: 'comparisons.json',
+  stacks: 'stacks.json',
+  supernodes: 'supernodes.json',
+} as const
+
+let graphCache: GraphRuntime | null = null
+
+function asRecord(value: unknown): GraphRecord | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as GraphRecord)
+    : null
 }
 
 function asText(value: unknown): string {
@@ -108,7 +180,138 @@ function normalizeKey(value: unknown): string {
   return slugify(value)
 }
 
-function nodeKeys(node: GraphNode): string[] {
+function isPresent<T>(value: T | null | undefined): value is T {
+  return value !== null && value !== undefined
+}
+
+function safeJsonArray(fileName: string): GraphRecord[] {
+  try {
+    const parsed = JSON.parse(readFileSync(join(GRAPH_DIR, fileName), 'utf8'))
+    return Array.isArray(parsed) ? parsed.map(asRecord).filter(isPresent) : []
+  } catch {
+    return []
+  }
+}
+
+function normalizeNode(value: unknown): GraphNode | null {
+  const record = asRecord(value)
+  if (!record) return null
+
+  return {
+    ...record,
+    id: asText(record.id),
+    slug: slugify(record.slug || record.id || record.name),
+    name: asText(record.name),
+    type: asText(record.type),
+    aliases: unique(record.aliases),
+    topics: unique(record.topics),
+    pathways: unique(record.pathways),
+    mechanisms: unique(record.mechanisms),
+    effects: unique(record.effects),
+    summary: asText(record.summary),
+    retrieval_summary: asText(record.retrieval_summary),
+  }
+}
+
+function normalizeRelationship(value: unknown): GraphRelationship | null {
+  const record = asRecord(value)
+  if (!record) return null
+
+  return {
+    ...record,
+    id: asText(record.id),
+    source: slugify(record.source),
+    target: slugify(record.target),
+    type: asText(record.type),
+    weight: asText(record.weight) || 0,
+    rationale: asText(record.rationale),
+    evidence_context: asText(record.evidence_context),
+    pathways: unique(record.pathways),
+    mechanisms: unique(record.mechanisms),
+    topics: unique(record.topics),
+  }
+}
+
+function normalizeEcosystem(value: unknown): GraphEcosystem | null {
+  const record = asRecord(value)
+  if (!record) return null
+
+  return {
+    ...record,
+    id: asText(record.id),
+    slug: slugify(record.slug || record.id || record.name),
+    name: asText(record.name),
+    kind: asText(record.kind || record.type),
+    summary: asText(record.summary),
+    retrieval_summary: asText(record.retrieval_summary),
+    anchors: unique(record.anchors),
+    herbs: unique(record.herbs),
+    compounds: unique(record.compounds),
+    mechanisms: unique(record.mechanisms),
+    pathways: unique(record.pathways),
+    topics: unique(record.topics),
+  }
+}
+
+function normalizeCandidate(value: unknown): GraphCandidate | null {
+  const record = asRecord(value)
+  if (!record) return null
+
+  return {
+    ...record,
+    id: asText(record.id),
+    source: slugify(record.source),
+    target: slugify(record.target),
+    type: asText(record.type),
+    weight: asText(record.weight) || 0,
+    rationale: asText(record.rationale),
+    evidence_context: asText(record.evidence_context),
+    framing: asText(record.framing),
+    mechanism_overlap: unique(record.mechanism_overlap),
+    pathway_overlap: unique(record.pathway_overlap),
+    topic_overlap: unique(record.topic_overlap),
+    mechanism_complementarity: unique(record.mechanism_complementarity),
+    pathway_complementarity: unique(record.pathway_complementarity),
+  }
+}
+
+function normalizeRows<T>(value: unknown, normalize: (row: unknown) => T | null): T[] {
+  return Array.isArray(value) ? value.map(normalize).filter(isPresent) : []
+}
+
+export function normalizeGraphRuntime(graph: GraphInput): GraphRuntime {
+  const source = asRecord(graph) || {}
+
+  return {
+    nodes: normalizeRows(source.nodes, normalizeNode),
+    relationships: normalizeRows(source.relationships, normalizeRelationship),
+    topics: normalizeRows(source.topics, normalizeEcosystem),
+    pathways: normalizeRows(source.pathways, normalizeEcosystem),
+    comparisons: normalizeRows(source.comparisons, normalizeCandidate),
+    stacks: normalizeRows(source.stacks, normalizeCandidate),
+    supernodes: normalizeRows(source.supernodes, normalizeEcosystem),
+  }
+}
+
+export function loadRuntimeGraph(): GraphRuntime {
+  if (graphCache) return graphCache
+
+  graphCache = normalizeGraphRuntime({
+    nodes: safeJsonArray(GRAPH_FILES.nodes),
+    relationships: safeJsonArray(GRAPH_FILES.relationships),
+    topics: safeJsonArray(GRAPH_FILES.topics),
+    pathways: safeJsonArray(GRAPH_FILES.pathways),
+    comparisons: safeJsonArray(GRAPH_FILES.comparisons),
+    stacks: safeJsonArray(GRAPH_FILES.stacks),
+    supernodes: safeJsonArray(GRAPH_FILES.supernodes),
+  })
+
+  return graphCache
+}
+
+function nodeKeys(node: GraphNode | null | undefined): string[] {
+  if (!node) return []
+
   return unique([
     node.id,
     node.slug,
@@ -129,16 +332,16 @@ function recordKeys(record: GraphRecord | null | undefined): string[] {
   ]).map(normalizeKey)
 }
 
-function getNodes(graph: GraphRuntime | null | undefined): GraphNode[] {
-  return Array.isArray(graph?.nodes) ? graph.nodes.filter(Boolean) : []
+function profileKeys(profile: GraphRecord | string | null | undefined): string[] {
+  return typeof profile === 'string' ? [normalizeKey(profile)].filter(Boolean) : recordKeys(profile)
 }
 
-function getRelationships(
-  graph: GraphRuntime | null | undefined
-): GraphRelationship[] {
-  return Array.isArray(graph?.relationships)
-    ? graph.relationships.filter(Boolean)
-    : []
+function getNodes(graph: GraphInput): GraphNode[] {
+  return normalizeGraphRuntime(graph).nodes || []
+}
+
+function getRelationships(graph: GraphInput): GraphRelationship[] {
+  return normalizeGraphRuntime(graph).relationships || []
 }
 
 function hasSharedItem(a: unknown, b: unknown): boolean {
@@ -151,9 +354,7 @@ function hasSharedItem(a: unknown, b: unknown): boolean {
 }
 
 function matchesProfile(node: GraphNode, profile: GraphRecord | string): boolean {
-  const targetKeys =
-    typeof profile === 'string' ? [normalizeKey(profile)] : recordKeys(profile)
-
+  const targetKeys = profileKeys(profile)
   if (!targetKeys.length) return false
 
   return nodeKeys(node).some((key) => targetKeys.includes(key))
@@ -163,10 +364,7 @@ function matchesSlug(value: unknown, profile: GraphRecord | string): boolean {
   const key = normalizeKey(value)
   if (!key) return false
 
-  const targetKeys =
-    typeof profile === 'string' ? [normalizeKey(profile)] : recordKeys(profile)
-
-  return targetKeys.includes(key)
+  return profileKeys(profile).includes(key)
 }
 
 function byNameOrSlug<T extends { id?: string; slug?: string; name?: string }>(
@@ -175,6 +373,7 @@ function byNameOrSlug<T extends { id?: string; slug?: string; name?: string }>(
 ): T | null {
   if (!Array.isArray(rows)) return null
   const normalized = normalizeKey(key)
+  if (!normalized) return null
 
   return (
     rows.find((row) =>
@@ -193,22 +392,42 @@ function sortCandidates<T extends GraphCandidate | GraphRelationship>(rows: T[])
   return [...rows].sort((a, b) => candidateScore(b) - candidateScore(a))
 }
 
+export function getGraphNode(profile: ProfileInput): GraphNode | null
 export function getGraphNode(
-  graph: GraphRuntime | null | undefined,
-  profile: GraphRecord | string
+  graph: GraphInput,
+  profile: ProfileInput
+): GraphNode | null
+export function getGraphNode(
+  graphOrProfile: GraphInput | ProfileInput,
+  maybeProfile?: ProfileInput
 ): GraphNode | null {
+  const { graph, profile } = resolveProfileArgs(graphOrProfile, maybeProfile)
   return getNodes(graph).find((node) => matchesProfile(node, profile)) || null
 }
 
 export function getRelatedProfiles(
-  graph: GraphRuntime | null | undefined,
-  profile: GraphRecord | string,
-  limit = 8
+  profile: ProfileInput,
+  limit?: number
+): GraphRelationship[]
+export function getRelatedProfiles(
+  graph: GraphInput,
+  profile: ProfileInput,
+  limit?: number
+): GraphRelationship[]
+export function getRelatedProfiles(
+  graphOrProfile: GraphInput | ProfileInput,
+  profileOrLimit?: ProfileInput | number,
+  maybeLimit?: number
 ): GraphRelationship[] {
+  const { graph, profile, limit = 8 } = resolveProfileArgs(
+    graphOrProfile,
+    profileOrLimit,
+    maybeLimit
+  )
   const node = getGraphNode(graph, profile)
   const keys = new Set([
-    ...(node ? nodeKeys(node) : []),
-    ...(typeof profile === 'string' ? [normalizeKey(profile)] : recordKeys(profile)),
+    ...nodeKeys(node),
+    ...profileKeys(profile),
   ].filter(Boolean))
 
   if (!keys.size) return []
@@ -221,7 +440,7 @@ export function getRelatedProfiles(
 
   const semanticFallback = node
     ? getNodes(graph)
-        .filter((candidate) => candidate !== node)
+        .filter((candidate) => !matchesProfile(candidate, node))
         .filter(
           (candidate) =>
             hasSharedItem(node.mechanisms, candidate.mechanisms) ||
@@ -240,66 +459,133 @@ export function getRelatedProfiles(
         }))
     : []
 
-  return sortCandidates([...direct, ...semanticFallback]).slice(0, limit)
+  return sortCandidates([...direct, ...semanticFallback]).slice(0, Math.max(0, limit))
 }
 
+export function getTopicEcosystem(topic: string): GraphEcosystem | null
 export function getTopicEcosystem(
-  graph: GraphRuntime | null | undefined,
+  graph: GraphInput,
   topic: string
+): GraphEcosystem | null
+export function getTopicEcosystem(
+  graphOrTopic: GraphInput | string,
+  maybeTopic?: string
 ): GraphEcosystem | null {
-  return byNameOrSlug(graph?.topics, topic)
+  const { graph, key } = resolveEcosystemArgs(graphOrTopic, maybeTopic)
+  return byNameOrSlug(graph.topics, key)
 }
 
+export function getPathwayEcosystem(pathway: string): GraphEcosystem | null
 export function getPathwayEcosystem(
-  graph: GraphRuntime | null | undefined,
+  graph: GraphInput,
   pathway: string
+): GraphEcosystem | null
+export function getPathwayEcosystem(
+  graphOrPathway: GraphInput | string,
+  maybePathway?: string
 ): GraphEcosystem | null {
-  return byNameOrSlug(graph?.pathways, pathway)
+  const { graph, key } = resolveEcosystemArgs(graphOrPathway, maybePathway)
+  return byNameOrSlug(graph.pathways, key)
 }
 
 export function getComparisonCandidates(
-  graph: GraphRuntime | null | undefined,
-  profile: GraphRecord | string,
-  limit = 8
+  profile: ProfileInput,
+  limit?: number
+): GraphCandidate[]
+export function getComparisonCandidates(
+  graph: GraphInput,
+  profile: ProfileInput,
+  limit?: number
+): GraphCandidate[]
+export function getComparisonCandidates(
+  graphOrProfile: GraphInput | ProfileInput,
+  profileOrLimit?: ProfileInput | number,
+  maybeLimit?: number
 ): GraphCandidate[] {
-  if (!Array.isArray(graph?.comparisons)) return []
+  const { graph, profile, limit = 8 } = resolveProfileArgs(
+    graphOrProfile,
+    profileOrLimit,
+    maybeLimit
+  )
+  const comparisons = graph.comparisons || []
 
   return sortCandidates(
-    graph.comparisons.filter(
+    comparisons.filter(
       (candidate) =>
         matchesSlug(candidate.source, profile) || matchesSlug(candidate.target, profile)
     )
-  ).slice(0, limit)
+  ).slice(0, Math.max(0, limit))
 }
 
 export function getStackCandidates(
-  graph: GraphRuntime | null | undefined,
-  profile: GraphRecord | string,
-  limit = 8
+  profile: ProfileInput,
+  limit?: number
+): GraphCandidate[]
+export function getStackCandidates(
+  graph: GraphInput,
+  profile: ProfileInput,
+  limit?: number
+): GraphCandidate[]
+export function getStackCandidates(
+  graphOrProfile: GraphInput | ProfileInput,
+  profileOrLimit?: ProfileInput | number,
+  maybeLimit?: number
 ): GraphCandidate[] {
-  if (!Array.isArray(graph?.stacks)) return []
+  const { graph, profile, limit = 8 } = resolveProfileArgs(
+    graphOrProfile,
+    profileOrLimit,
+    maybeLimit
+  )
+  const stacks = graph.stacks || []
 
   return sortCandidates(
-    graph.stacks.filter(
+    stacks.filter(
       (candidate) =>
         matchesSlug(candidate.source, profile) || matchesSlug(candidate.target, profile)
     )
-  ).slice(0, limit)
+  ).slice(0, Math.max(0, limit))
 }
 
+export function getAuthoritySupernodes(limit?: number): GraphEcosystem[]
 export function getAuthoritySupernodes(
-  graph: GraphRuntime | null | undefined,
-  profile?: GraphRecord | string,
-  limit = 12
+  profile?: ProfileInput,
+  limit?: number
+): GraphEcosystem[]
+export function getAuthoritySupernodes(
+  graph: GraphInput,
+  profile?: ProfileInput,
+  limit?: number
+): GraphEcosystem[]
+export function getAuthoritySupernodes(
+  graphOrProfileOrLimit?: GraphInput | ProfileInput | number,
+  profileOrLimit?: ProfileInput | number,
+  maybeLimit?: number
 ): GraphEcosystem[] {
-  if (!Array.isArray(graph?.supernodes)) return []
+  const graphOnly = isGraphLike(graphOrProfileOrLimit) && profileOrLimit === undefined
+  const graphWithProfile =
+    isGraphLike(graphOrProfileOrLimit) &&
+    (typeof profileOrLimit === 'string' || asRecord(profileOrLimit) || maybeLimit !== undefined)
+  const graph = graphOnly || graphWithProfile
+    ? normalizeGraphRuntime(graphOrProfileOrLimit as GraphInput)
+    : loadRuntimeGraph()
+  const profile = graphWithProfile
+    ? (profileOrLimit as ProfileInput | undefined)
+    : typeof graphOrProfileOrLimit === 'string' || asRecord(graphOrProfileOrLimit)
+      ? (graphOrProfileOrLimit as ProfileInput)
+      : undefined
+  const limit = typeof graphOrProfileOrLimit === 'number'
+    ? graphOrProfileOrLimit
+    : typeof profileOrLimit === 'number'
+      ? profileOrLimit
+      : maybeLimit ?? 12
+  const supernodes = graph.supernodes || []
 
-  if (!profile) return graph.supernodes.slice(0, limit)
+  if (!profile) return supernodes.slice(0, Math.max(0, limit))
 
-  const profileKeys =
-    typeof profile === 'string' ? [normalizeKey(profile)] : recordKeys(profile)
+  const keys = profileKeys(profile)
+  if (!keys.length) return []
 
-  return graph.supernodes
+  return supernodes
     .filter((supernode) =>
       [
         supernode.id,
@@ -308,38 +594,34 @@ export function getAuthoritySupernodes(
         ...(Array.isArray(supernode.anchors) ? supernode.anchors : []),
       ]
         .map(normalizeKey)
-        .some((key) => profileKeys.includes(key))
+        .some((key) => keys.includes(key))
     )
-    .slice(0, limit)
+    .slice(0, Math.max(0, limit))
 }
 
 export function getEcosystemsForProfile(
-  graph: GraphRuntime | null | undefined,
+  graph: GraphInput,
   profile: GraphRecord | string
 ): { topics: GraphEcosystem[]; pathways: GraphEcosystem[] } {
-  const node = getGraphNode(graph, profile)
-  const profileKeys =
-    typeof profile === 'string' ? [normalizeKey(profile)] : recordKeys(profile)
+  const normalizedGraph = normalizeGraphRuntime(graph)
+  const node = getGraphNode(normalizedGraph, profile)
+  const keys = profileKeys(profile)
 
-  const topics = Array.isArray(graph?.topics)
-    ? graph.topics.filter(
-        (topic) =>
-          hasSharedItem(topic.topics, node?.topics) ||
-          asList(topic.anchors).map(normalizeKey).some((key) => profileKeys.includes(key)) ||
-          asList(topic.herbs).map(normalizeKey).some((key) => profileKeys.includes(key)) ||
-          asList(topic.compounds).map(normalizeKey).some((key) => profileKeys.includes(key))
-      )
-    : []
+  const topics = (normalizedGraph.topics || []).filter(
+    (topic) =>
+      hasSharedItem(topic.topics, node?.topics) ||
+      asList(topic.anchors).map(normalizeKey).some((key) => keys.includes(key)) ||
+      asList(topic.herbs).map(normalizeKey).some((key) => keys.includes(key)) ||
+      asList(topic.compounds).map(normalizeKey).some((key) => keys.includes(key))
+  )
 
-  const pathways = Array.isArray(graph?.pathways)
-    ? graph.pathways.filter(
-        (pathway) =>
-          hasSharedItem(pathway.pathways, node?.pathways) ||
-          asList(pathway.anchors).map(normalizeKey).some((key) => profileKeys.includes(key)) ||
-          asList(pathway.herbs).map(normalizeKey).some((key) => profileKeys.includes(key)) ||
-          asList(pathway.compounds).map(normalizeKey).some((key) => profileKeys.includes(key))
-      )
-    : []
+  const pathways = (normalizedGraph.pathways || []).filter(
+    (pathway) =>
+      hasSharedItem(pathway.pathways, node?.pathways) ||
+      asList(pathway.anchors).map(normalizeKey).some((key) => keys.includes(key)) ||
+      asList(pathway.herbs).map(normalizeKey).some((key) => keys.includes(key)) ||
+      asList(pathway.compounds).map(normalizeKey).some((key) => keys.includes(key))
+  )
 
   return { topics, pathways }
 }


### PR DESCRIPTION
### Motivation
- Provide a centralized, defensive runtime API to consume the exported graph JSON from `public/data/graph` without touching UI, routes, or components.
- Ensure consumers can safely traverse and match graph entities even when graph exports are missing, malformed, or contain inconsistent fields.
- Preserve current runtime behavior while enabling future integration points for profile/relationship exploration.

### Description
- Added `lib/runtime-graph.ts` which implements safe loading and caching of graph JSON from `public/data/graph` with `loadRuntimeGraph()` and `normalizeGraphRuntime()`.
- Implemented defensive normalizers and helpers: `getGraphNode`, `getRelatedProfiles`, `getTopicEcosystem`, `getPathwayEcosystem`, `getComparisonCandidates`, `getStackCandidates`, `getAuthoritySupernodes`, plus `getEcosystemsForProfile`; all are null-safe, slug-safe, and alias-aware.
- Added robust utilities for safe coercion: `asText`, `asList`, `unique`, `slugify`, `normalizeKey`, `asRecord`, `isPresent`, and `safeJsonArray`, and compact candidate sorting/weight logic.
- Designed APIs to accept either an explicit graph runtime or to auto-load the exported graph, while preserving expected shapes and avoiding runtime exceptions.

### Testing
- Ran full project build check with `npm run check` which completed successfully (data build, validation, and Next.js build passed).
- Type-checked the file via `npx tsc --noEmit --skipLibCheck --target ES2017 --module ESNext --moduleResolution bundler --esModuleInterop --strict lib/runtime-graph.ts` with no errors.
- Performed a runtime smoke test with `npx tsx -e "import { loadRuntimeGraph, getGraphNode, getRelatedProfiles, getTopicEcosystem, getComparisonCandidates, getAuthoritySupernodes } from './lib/runtime-graph.ts'; const graph = loadRuntimeGraph(); console.log(graph.nodes?.length, getGraphNode(graph, 'aescin')?.slug, getGraphNode('aescin')?.slug, getRelatedProfiles('aescin', 2).length, getTopicEcosystem('Cardiovascular Health')?.slug, getComparisonCandidates('astragalin', 1).length, getAuthoritySupernodes(2).length);"` which printed expected counts (e.g. `873 899 aescin 2 cardiovascular-health 1 2`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff36c15af48323b289d2743e0abf89)