### PR TITLE
Integrate graph signals into related profile ranking

### DIFF
--- a/lib/related-runtime.ts
+++ b/lib/related-runtime.ts
@@ -1,6 +1,17 @@
 import { list, text, unique } from '@/lib/display-utils'
 import { safeArray, safeLower, safeScore, safeSlug } from '@/lib/search-safe'
 import { calculateDiscoveryScore } from '@/lib/discovery-score'
+import {
+  getComparisonCandidates as getGraphComparisonCandidates,
+  getRelatedProfiles as getGraphRelatedProfiles,
+  getStackCandidates as getGraphStackCandidates,
+  type GraphCandidate,
+  type GraphRelationship,
+} from '@/lib/runtime-graph'
+
+const MAX_RELATED_PROFILES = 12
+const MAX_COMPARISON_CANDIDATES = 8
+const MAX_STACK_CANDIDATES = 6
 
 function normalize(value: unknown) {
   return safeLower(value)
@@ -25,11 +36,111 @@ function collectSignals(record: any) {
     .filter(Boolean)
 }
 
+function collectGraphSignals(edge: GraphRelationship | GraphCandidate | undefined) {
+  if (!edge) return []
+
+  return unique([
+    ...list((edge as GraphRelationship)?.mechanisms),
+    ...list((edge as GraphRelationship)?.pathways),
+    ...list((edge as GraphRelationship)?.topics),
+    ...list((edge as GraphCandidate)?.mechanism_overlap),
+    ...list((edge as GraphCandidate)?.pathway_overlap),
+    ...list((edge as GraphCandidate)?.topic_overlap),
+    ...list((edge as GraphCandidate)?.mechanism_complementarity),
+    ...list((edge as GraphCandidate)?.pathway_complementarity),
+  ])
+    .map(normalize)
+    .filter(Boolean)
+}
+
+function edgeOtherSlug(edge: GraphRelationship | GraphCandidate, sourceSlug: string) {
+  const source = safeSlug(edge?.source)
+  const target = safeSlug(edge?.target)
+
+  if (!source || !target) return ''
+  if (source === sourceSlug) return target
+  if (target === sourceSlug) return source
+  return ''
+}
+
+function evidenceWeight(value: unknown) {
+  const evidence = safeLower(value)
+
+  if (evidence.includes('strong')) return 3
+  if (evidence.includes('moderate')) return 2
+  if (evidence.includes('limited')) return 1
+  if (evidence.includes('mechanistic')) return 0.5
+  return 0
+}
+
+function graphWeight(edge: GraphRelationship | GraphCandidate | undefined) {
+  if (!edge) return 0
+
+  const numericWeight = Number(text(edge.weight))
+  const weightedSignal = Number.isFinite(numericWeight) ? Math.min(numericWeight / 25, 10) : 0
+  const mechanisms = list((edge as GraphRelationship)?.mechanisms || (edge as GraphCandidate)?.mechanism_overlap).length
+  const pathways = list((edge as GraphRelationship)?.pathways || (edge as GraphCandidate)?.pathway_overlap).length
+  const complementaryMechanisms = list((edge as GraphCandidate)?.mechanism_complementarity).length
+  const complementaryPathways = list((edge as GraphCandidate)?.pathway_complementarity).length
+  const rationale = text(edge.rationale) ? 0.75 : 0
+
+  return (
+    weightedSignal +
+    Math.min(mechanisms, 4) * 2 +
+    Math.min(pathways, 4) * 1.5 +
+    Math.min(complementaryMechanisms, 3) * 1.5 +
+    Math.min(complementaryPathways, 3) +
+    evidenceWeight(edge.evidence_context) +
+    rationale
+  )
+}
+
+function hasBiologicalGraphSupport(edge: GraphRelationship | GraphCandidate | undefined) {
+  if (!edge) return false
+
+  const mechanismCount = list((edge as GraphRelationship)?.mechanisms || (edge as GraphCandidate)?.mechanism_overlap).length +
+    list((edge as GraphCandidate)?.mechanism_complementarity).length
+  const pathwayCount = list((edge as GraphRelationship)?.pathways || (edge as GraphCandidate)?.pathway_overlap).length +
+    list((edge as GraphCandidate)?.pathway_complementarity).length
+  const topicCount = list((edge as GraphRelationship)?.topics || (edge as GraphCandidate)?.topic_overlap).length
+  const type = safeLower(edge.type)
+
+  return mechanismCount > 0 || pathwayCount > 0 || (topicCount >= 2 && !type.includes('topic-only'))
+}
+
+function collectGraphEdges(record: any) {
+  const sourceSlug = safeSlug(record?.slug)
+  if (!sourceSlug) return new Map<string, { related?: GraphRelationship; comparison?: GraphCandidate; stack?: GraphCandidate }>()
+
+  const edges = new Map<string, { related?: GraphRelationship; comparison?: GraphCandidate; stack?: GraphCandidate }>()
+
+  const merge = (slug: string, value: { related?: GraphRelationship; comparison?: GraphCandidate; stack?: GraphCandidate }) => {
+    if (!slug || slug === sourceSlug) return
+    edges.set(slug, { ...(edges.get(slug) || {}), ...value })
+  }
+
+  getGraphRelatedProfiles(record, MAX_RELATED_PROFILES).forEach((edge) => {
+    merge(edgeOtherSlug(edge, sourceSlug), { related: edge })
+  })
+
+  getGraphComparisonCandidates(record, MAX_COMPARISON_CANDIDATES).forEach((edge) => {
+    merge(edgeOtherSlug(edge, sourceSlug), { comparison: edge })
+  })
+
+  getGraphStackCandidates(record, MAX_STACK_CANDIDATES).forEach((edge) => {
+    merge(edgeOtherSlug(edge, sourceSlug), { stack: edge })
+  })
+
+  return edges
+}
+
 export function getRelatedRuntimeRecords(record: any, records: any[], limit = 6) {
   const sourceSlug = safeSlug(record?.slug)
   const sourceSignals = collectSignals(record)
+  const graphEdges = collectGraphEdges(record)
+  const requestedLimit = Math.min(MAX_RELATED_PROFILES, Math.max(0, safeScore(limit, 6)))
 
-  if (!sourceSignals.length) {
+  if (!sourceSignals.length && graphEdges.size === 0) {
     return []
   }
 
@@ -48,28 +159,55 @@ export function getRelatedRuntimeRecords(record: any, records: any[], limit = 6)
       }
 
       const candidateSignals = collectSignals(candidate)
-
-      const matched = candidateSignals.some((signal) =>
+      const fallbackMatched = candidateSignals.some((signal) =>
         sourceSignals.includes(signal)
       )
+      const graphMatch = graphEdges.get(candidateSlug)
+      const graphMatched = Boolean(
+        hasBiologicalGraphSupport(graphMatch?.related) ||
+        hasBiologicalGraphSupport(graphMatch?.comparison) ||
+        hasBiologicalGraphSupport(graphMatch?.stack)
+      )
 
-      if (matched) {
+      if (fallbackMatched || graphMatched) {
         seen.add(candidateSlug)
       }
 
-      return matched
+      return fallbackMatched || graphMatched
     })
     .map((candidate: any) => {
       const candidateSignals = collectSignals(candidate)
+      const graphMatch = graphEdges.get(safeSlug(candidate?.slug))
+      const graphSignals = unique([
+        ...collectGraphSignals(graphMatch?.related),
+        ...collectGraphSignals(graphMatch?.comparison),
+        ...collectGraphSignals(graphMatch?.stack),
+      ])
 
-      const overlap = candidateSignals.filter((signal) =>
-        sourceSignals.includes(signal)
-      )
+      const overlap = unique([
+        ...candidateSignals.filter((signal) => sourceSignals.includes(signal)),
+        ...graphSignals,
+      ])
+
+      const relationshipKinds = [
+        graphMatch?.related ? 'graph-related' : '',
+        graphMatch?.comparison ? 'comparison-candidate' : '',
+        graphMatch?.stack ? 'stack-candidate' : '',
+      ].filter(Boolean)
+
+      const graphScore =
+        graphWeight(graphMatch?.related) +
+        graphWeight(graphMatch?.comparison) +
+        graphWeight(graphMatch?.stack)
 
       return {
         ...candidate,
         relatedOverlap: overlap,
-        relatedScore: safeScore(overlap.length) + calculateDiscoveryScore(record, candidate),
+        relatedGraphKinds: relationshipKinds,
+        relatedScore:
+          safeScore(overlap.length) +
+          calculateDiscoveryScore(record, candidate) +
+          graphScore,
       }
     })
     .sort((a: any, b: any) => {
@@ -79,9 +217,12 @@ export function getRelatedRuntimeRecords(record: any, records: any[], limit = 6)
         return scoreDelta
       }
 
-      return safeLower(a?.name).localeCompare(safeLower(b?.name))
+      const nameDelta = safeLower(a?.name).localeCompare(safeLower(b?.name))
+      if (nameDelta !== 0) return nameDelta
+
+      return safeSlug(a?.slug).localeCompare(safeSlug(b?.slug))
     })
-    .slice(0, Math.max(0, safeScore(limit, 6)))
+    .slice(0, requestedLimit)
 }
 
 export function getRelatedLabel(record: any) {

--- a/lib/runtime-graph.ts
+++ b/lib/runtime-graph.ts
@@ -130,6 +130,11 @@ const GRAPH_FILES = {
   supernodes: 'supernodes.json',
 } as const
 
+const MAX_RELATED_PROFILES = 12
+const MAX_COMPARISON_CANDIDATES = 8
+const MAX_STACK_CANDIDATES = 6
+const MAX_PATHWAY_COMPANIONS = 10
+
 let graphCache: GraphRuntime | null = null
 
 function asRecord(value: unknown): GraphRecord | null {
@@ -344,13 +349,52 @@ function getRelationships(graph: GraphInput): GraphRelationship[] {
   return normalizeGraphRuntime(graph).relationships || []
 }
 
-function hasSharedItem(a: unknown, b: unknown): boolean {
+function sharedItems(a: unknown, b: unknown): string[] {
   const left = new Set(asList(a).map(normalizeKey).filter(Boolean))
-  if (!left.size) return false
+  if (!left.size) return []
 
-  return asList(b)
-    .map(normalizeKey)
-    .some((key) => key && left.has(key))
+  return unique(
+    asList(b).filter((value) => {
+      const key = normalizeKey(value)
+      return key && left.has(key)
+    })
+  )
+}
+
+function hasSharedItem(a: unknown, b: unknown): boolean {
+  return sharedItems(a, b).length > 0
+}
+
+function clampLimit(limit: number | undefined, fallback: number, max: number): number {
+  const value = Number(limit ?? fallback)
+  if (!Number.isFinite(value)) return fallback
+  return Math.min(max, Math.max(0, value))
+}
+
+function otherEndpoint(
+  edge: GraphRelationship | GraphCandidate,
+  keys: Set<string>
+): string {
+  const source = normalizeKey(edge.source)
+  const target = normalizeKey(edge.target)
+
+  if (source && keys.has(source) && target && !keys.has(target)) return target
+  if (target && keys.has(target) && source && !keys.has(source)) return source
+  return ''
+}
+
+function dedupeByOtherEndpoint<T extends GraphCandidate | GraphRelationship>(
+  rows: T[],
+  keys: Set<string>
+): T[] {
+  const seen = new Set<string>()
+
+  return rows.filter((row) => {
+    const endpoint = otherEndpoint(row, keys)
+    if (!endpoint || seen.has(endpoint)) return false
+    seen.add(endpoint)
+    return true
+  })
 }
 
 function matchesProfile(node: GraphNode, profile: GraphRecord | string): boolean {
@@ -385,11 +429,31 @@ function byNameOrSlug<T extends { id?: string; slug?: string; name?: string }>(
 function candidateScore(candidate: GraphCandidate | GraphRelationship): number {
   const weight = Number(asText(candidate.weight))
   const rationale = asText(candidate.rationale)
-  return (Number.isFinite(weight) ? weight : 0) + (rationale ? 1 : 0)
+  const mechanisms = asList((candidate as GraphRelationship).mechanisms || (candidate as GraphCandidate).mechanism_overlap).length
+  const pathways = asList((candidate as GraphRelationship).pathways || (candidate as GraphCandidate).pathway_overlap).length
+  const complementaryMechanisms = asList((candidate as GraphCandidate).mechanism_complementarity).length
+  const complementaryPathways = asList((candidate as GraphCandidate).pathway_complementarity).length
+
+  return (Number.isFinite(weight) ? weight : 0) +
+    mechanisms * 3 +
+    pathways * 2 +
+    complementaryMechanisms * 2 +
+    complementaryPathways +
+    (rationale ? 1 : 0)
+}
+
+function candidateSortKey(candidate: GraphCandidate | GraphRelationship): string {
+  return [candidate.source, candidate.target, candidate.id, candidate.type]
+    .map(asLowerText)
+    .join('|')
 }
 
 function sortCandidates<T extends GraphCandidate | GraphRelationship>(rows: T[]): T[] {
-  return [...rows].sort((a, b) => candidateScore(b) - candidateScore(a))
+  return [...rows].sort((a, b) => {
+    const scoreDelta = candidateScore(b) - candidateScore(a)
+    if (scoreDelta !== 0) return scoreDelta
+    return candidateSortKey(a).localeCompare(candidateSortKey(b))
+  })
 }
 
 export function getGraphNode(profile: ProfileInput): GraphNode | null
@@ -434,32 +498,45 @@ export function getRelatedProfiles(
 
   const direct = getRelationships(graph).filter(
     (relationship) =>
-      keys.has(normalizeKey(relationship.source)) ||
-      keys.has(normalizeKey(relationship.target))
+      otherEndpoint(relationship, keys) &&
+      (keys.has(normalizeKey(relationship.source)) ||
+        keys.has(normalizeKey(relationship.target)))
   )
 
   const semanticFallback = node
     ? getNodes(graph)
         .filter((candidate) => !matchesProfile(candidate, node))
-        .filter(
-          (candidate) =>
-            hasSharedItem(node.mechanisms, candidate.mechanisms) ||
-            hasSharedItem(node.pathways, candidate.pathways) ||
-            hasSharedItem(node.topics, candidate.topics)
-        )
-        .map((candidate) => ({
-          id: `${node.slug || node.id}-${candidate.slug || candidate.id}`,
-          source: node.slug || node.id,
-          target: candidate.slug || candidate.id,
-          type: 'semantic-overlap',
-          rationale: 'Related by shared mechanisms, pathways, or topic ecosystem context.',
-          mechanisms: candidate.mechanisms,
-          pathways: candidate.pathways,
-          topics: candidate.topics,
-        }))
+        .map((candidate) => {
+          const mechanisms = sharedItems(node.mechanisms, candidate.mechanisms)
+          const pathways = sharedItems(node.pathways, candidate.pathways)
+          const topics = sharedItems(node.topics, candidate.topics)
+          const overlapScore = mechanisms.length * 3 + pathways.length * 2 + topics.length
+
+          return {
+            id: `${node.slug || node.id}-${candidate.slug || candidate.id}`,
+            source: node.slug || node.id,
+            target: candidate.slug || candidate.id,
+            type: 'semantic-overlap',
+            weight: overlapScore,
+            rationale: 'Related by shared mechanisms, pathways, or topic ecosystem context.',
+            mechanisms,
+            pathways,
+            topics,
+          }
+        })
+        .filter((candidate) => {
+          const mechanismCount = asList(candidate.mechanisms).length
+          const pathwayCount = asList(candidate.pathways).length
+          const topicCount = asList(candidate.topics).length
+
+          return mechanismCount > 0 || pathwayCount > 0 || topicCount >= 2
+        })
     : []
 
-  return sortCandidates([...direct, ...semanticFallback]).slice(0, Math.max(0, limit))
+  return dedupeByOtherEndpoint(
+    sortCandidates([...direct, ...semanticFallback]),
+    keys
+  ).slice(0, clampLimit(limit, 8, MAX_RELATED_PROFILES))
 }
 
 export function getTopicEcosystem(topic: string): GraphEcosystem | null
@@ -508,13 +585,18 @@ export function getComparisonCandidates(
     maybeLimit
   )
   const comparisons = graph.comparisons || []
+  const keys = new Set(profileKeys(profile))
 
-  return sortCandidates(
-    comparisons.filter(
-      (candidate) =>
-        matchesSlug(candidate.source, profile) || matchesSlug(candidate.target, profile)
-    )
-  ).slice(0, Math.max(0, limit))
+  return dedupeByOtherEndpoint(
+    sortCandidates(
+      comparisons.filter(
+        (candidate) =>
+          otherEndpoint(candidate, keys) &&
+          (matchesSlug(candidate.source, profile) || matchesSlug(candidate.target, profile))
+      )
+    ),
+    keys
+  ).slice(0, clampLimit(limit, 8, MAX_COMPARISON_CANDIDATES))
 }
 
 export function getStackCandidates(
@@ -537,13 +619,18 @@ export function getStackCandidates(
     maybeLimit
   )
   const stacks = graph.stacks || []
+  const keys = new Set(profileKeys(profile))
 
-  return sortCandidates(
-    stacks.filter(
-      (candidate) =>
-        matchesSlug(candidate.source, profile) || matchesSlug(candidate.target, profile)
-    )
-  ).slice(0, Math.max(0, limit))
+  return dedupeByOtherEndpoint(
+    sortCandidates(
+      stacks.filter(
+        (candidate) =>
+          otherEndpoint(candidate, keys) &&
+          (matchesSlug(candidate.source, profile) || matchesSlug(candidate.target, profile))
+      )
+    ),
+    keys
+  ).slice(0, clampLimit(limit, 6, MAX_STACK_CANDIDATES))
 }
 
 export function getAuthoritySupernodes(limit?: number): GraphEcosystem[]
@@ -580,7 +667,7 @@ export function getAuthoritySupernodes(
       : maybeLimit ?? 12
   const supernodes = graph.supernodes || []
 
-  if (!profile) return supernodes.slice(0, Math.max(0, limit))
+  if (!profile) return supernodes.slice(0, clampLimit(limit, 12, MAX_RELATED_PROFILES))
 
   const keys = profileKeys(profile)
   if (!keys.length) return []
@@ -596,7 +683,7 @@ export function getAuthoritySupernodes(
         .map(normalizeKey)
         .some((key) => keys.includes(key))
     )
-    .slice(0, Math.max(0, limit))
+    .slice(0, clampLimit(limit, 12, MAX_RELATED_PROFILES))
 }
 
 export function getEcosystemsForProfile(
@@ -623,5 +710,8 @@ export function getEcosystemsForProfile(
       asList(pathway.compounds).map(normalizeKey).some((key) => keys.includes(key))
   )
 
-  return { topics, pathways }
+  return {
+    topics: topics.slice(0, MAX_PATHWAY_COMPANIONS),
+    pathways: pathways.slice(0, MAX_PATHWAY_COMPANIONS),
+  }
 }


### PR DESCRIPTION
### Motivation
- Improve related-profile recommendations by safely blending exporter-generated graph signals (relationship edges, comparison candidates, stack candidates) with the existing runtime signal-overlap fallback. 
- Preserve current rendering, routing, and hydration behavior when graph data is missing or incomplete. 
- Limit noise and duplication by capping counts, deduplicating endpoints, and preferring biologically meaningful overlaps.

### Description
- Enhance `lib/related-runtime.ts` to collect graph edges via `lib/runtime-graph.ts`, merge graph signals with local record signal overlap, and compute a combined `relatedScore` that includes `graphWeight`, `calculateDiscoveryScore`, and overlap counts, while exposing `relatedGraphKinds` and `relatedOverlap` for downstream use. 
- Add defensive helpers and heuristics to `lib/related-runtime.ts` including `collectGraphSignals`, `edgeOtherSlug`, `evidenceWeight`, `graphWeight`, `hasBiologicalGraphSupport`, `collectGraphEdges`, and hard caps (`MAX_RELATED_PROFILES`, `MAX_COMPARISON_CANDIDATES`, `MAX_STACK_CANDIDATES`). 
- Harden `lib/runtime-graph.ts` with safer normalization and deterministic selection: `sharedItems`, `clampLimit`, `otherEndpoint`, `dedupeByOtherEndpoint`, improved `candidateScore` and stable tie-break keys, endpoint deduplication, and caps for related/comparison/stack/pathway outputs. 
- Integration is server-side and runtime-lightweight only, preserves the original fallback behavior when the graph is absent, avoids UI or route changes, and keeps outputs deterministic and de-duplicated.

### Testing
- Ran the full build/check with `npm run check`, which completed successfully (data build, validation, Next.js build, and verification steps passed). 
- Executed a smoke check using `npx tsx` to load `public/data` and call `getRelatedRuntimeRecords(...)` for a representative herb, which returned graph-enhanced related results and completed without error. 
- Verified deterministic selection and caps by exercising `lib/runtime-graph.ts` helpers and ensuring no self-links, duplicates, or crashes during static page generation (page generation completed in the `npm run check` build run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff3aee2dec8323b2218ef8011b7d88)