### PR TITLE
Add graph-powered comparison and stack intelligence

### DIFF
--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -18,7 +18,7 @@ import {
   getSources,
 } from '@/lib/evidence-utils'
 import { getEvidenceSnapshot } from '@/lib/semantic-runtime'
-import { getRelatedRuntimeRecords } from '@/lib/related-runtime'
+import { getComparisonRuntimeRecords, getRelatedRuntimeRecords, getStackRuntimeRecords } from '@/lib/related-runtime'
 import { getFeaturedCollections } from '@/lib/collections'
 import ProfileAuthoritySections from '@/components/profile-authority-sections'
 
@@ -96,6 +96,14 @@ export default async function CompoundPage({ params }: any) {
     .map((item:any) => ({ ...item, entityType: 'herb' }))
 
   const semanticRelated = [...relatedCompounds, ...relatedHerbs].slice(0, 6)
+  const graphCandidateRecords = [
+    ...compounds.map((item:any) => ({ ...item, entityType: 'compound' })),
+    ...herbs.map((item:any) => ({ ...item, entityType: 'herb' })),
+  ]
+  const comparisonRecords = getComparisonRuntimeRecords(compound, graphCandidateRecords, 8)
+    .filter((item:any) => getRuntimeVisibility(item).canRender)
+  const stackRecords = getStackRuntimeRecords(compound, graphCandidateRecords, 6)
+    .filter((item:any) => getRuntimeVisibility(item).canRender)
 
   const featuredCollections = getFeaturedCollections(compound)
 
@@ -142,6 +150,8 @@ export default async function CompoundPage({ params }: any) {
           record={compound}
           entityType="compound"
           relatedRecords={semanticRelated}
+          comparisonRecords={comparisonRecords}
+          stackRecords={stackRecords}
           effects={effects}
           mechanisms={mechanisms}
           summary={summary}

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from 'next/navigation'
 import { getCompounds, getHerbBySlug, getHerbs } from '@/lib/runtime-data'
 import { cleanSummary, formatDisplayLabel, isClean, list, unique } from '@/lib/display-utils'
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
-import { getRelatedRuntimeRecords } from '@/lib/related-runtime'
+import { getComparisonRuntimeRecords, getRelatedRuntimeRecords, getStackRuntimeRecords } from '@/lib/related-runtime'
 import { buildMeta } from '@/lib/seo'
 import { EvidenceBadgeGroup } from '@/components/evidence/evidence-badge'
 import { CompactRelatedPathways } from '@/app/pathways/pathway-hub'
@@ -83,6 +83,14 @@ export default async function HerbDetailPage({ params }: any) {
     .map((item: any) => ({ ...item, entityType: 'compound' }))
 
   const relatedProfiles = [...relatedHerbs, ...relatedCompounds].slice(0, 6)
+  const graphCandidateRecords = [
+    ...herbs.map((item: any) => ({ ...item, entityType: 'herb' })),
+    ...compounds.map((item: any) => ({ ...item, entityType: 'compound' })),
+  ]
+  const comparisonRecords = getComparisonRuntimeRecords(herb, graphCandidateRecords, 8)
+    .filter((item: any) => getRuntimeVisibility(item).canRender)
+  const stackRecords = getStackRuntimeRecords(herb, graphCandidateRecords, 6)
+    .filter((item: any) => getRuntimeVisibility(item).canRender)
 
   const featuredCollections = getFeaturedCollections(herb)
   const effects = getEffects(herb)
@@ -122,6 +130,8 @@ export default async function HerbDetailPage({ params }: any) {
         record={herb}
         entityType="herb"
         relatedRecords={relatedProfiles}
+        comparisonRecords={comparisonRecords}
+        stackRecords={stackRecords}
         effects={effects}
         summary={summary}
       />

--- a/lib/related-runtime.ts
+++ b/lib/related-runtime.ts
@@ -225,6 +225,138 @@ export function getRelatedRuntimeRecords(record: any, records: any[], limit = 6)
     .slice(0, requestedLimit)
 }
 
+
+function getEdgeByKind(
+  match: { related?: GraphRelationship; comparison?: GraphCandidate; stack?: GraphCandidate } | undefined,
+  kind: 'comparison' | 'stack'
+) {
+  return kind === 'comparison' ? match?.comparison : match?.stack
+}
+
+function collectCandidateSignals(edge: GraphCandidate | undefined, kind: 'comparison' | 'stack') {
+  if (!edge) return []
+
+  return unique([
+    ...list(edge.mechanism_overlap),
+    ...list(edge.pathway_overlap),
+    ...list(edge.topic_overlap),
+    ...list(edge.ecosystem_overlap),
+    ...(kind === 'stack' ? list(edge.mechanism_complementarity) : []),
+    ...(kind === 'stack' ? list(edge.pathway_complementarity) : []),
+  ]).filter(Boolean)
+}
+
+function hasCandidateSupport(edge: GraphCandidate | undefined, kind: 'comparison' | 'stack') {
+  if (!edge) return false
+
+  const mechanismOverlap = list(edge.mechanism_overlap).length
+  const pathwayOverlap = list(edge.pathway_overlap).length
+  const topicOverlap = list(edge.topic_overlap).length + list(edge.ecosystem_overlap).length
+  const mechanismComplementarity = list(edge.mechanism_complementarity).length
+  const pathwayComplementarity = list(edge.pathway_complementarity).length
+
+  if (kind === 'stack') {
+    return mechanismComplementarity > 0 || pathwayComplementarity > 0 || mechanismOverlap >= 2 || pathwayOverlap >= 2
+  }
+
+  return mechanismOverlap > 0 || pathwayOverlap > 0 || topicOverlap >= 2
+}
+
+function enrichGraphCandidateRecord(candidate: any, edge: GraphCandidate, kind: 'comparison' | 'stack', sourceSignals: string[]) {
+  const candidateSignals = collectSignals(candidate)
+  const overlap = unique([
+    ...candidateSignals.filter((signal) => sourceSignals.includes(signal)),
+    ...collectCandidateSignals(edge, kind).map(normalize),
+  ])
+
+  const shared = {
+    ...candidate,
+    graphCandidateType: kind,
+    graphCandidateRationale: text(edge.rationale),
+    graphEvidenceContext: text(edge.evidence_context),
+    graphFraming: text(edge.framing),
+    graphSafetyGate: text(edge.safety_gate),
+    graphMechanismOverlap: list(edge.mechanism_overlap),
+    graphPathwayOverlap: list(edge.pathway_overlap),
+    graphEcosystemOverlap: unique([...list(edge.ecosystem_overlap), ...list(edge.topic_overlap)]),
+    graphMechanismComplementarity: list(edge.mechanism_complementarity),
+    graphPathwayComplementarity: list(edge.pathway_complementarity),
+    relatedOverlap: overlap,
+    relatedGraphKinds: [kind === 'comparison' ? 'comparison-candidate' : 'stack-candidate'],
+    relatedScore: safeScore(overlap.length) + calculateDiscoveryScore({ slug: edge.source }, candidate) + graphWeight(edge),
+  }
+
+  return shared
+}
+
+export function getComparisonRuntimeRecords(record: any, records: any[], limit = MAX_COMPARISON_CANDIDATES) {
+  const sourceSlug = safeSlug(record?.slug)
+  const sourceSignals = collectSignals(record)
+  const graphEdges = collectGraphEdges(record)
+  const requestedLimit = Math.min(MAX_COMPARISON_CANDIDATES, Math.max(0, safeScore(limit, MAX_COMPARISON_CANDIDATES)))
+
+  if (!sourceSlug || graphEdges.size === 0) return []
+
+  const seen = new Set<string>()
+
+  return safeArray(records)
+    .map((candidate: any) => {
+      const candidateSlug = safeSlug(candidate?.slug)
+      if (!candidate || !candidateSlug || candidateSlug === sourceSlug || seen.has(candidateSlug)) return null
+
+      const edge = getEdgeByKind(graphEdges.get(candidateSlug), 'comparison')
+      if (!hasCandidateSupport(edge, 'comparison')) return null
+
+      seen.add(candidateSlug)
+      return enrichGraphCandidateRecord(candidate, edge as GraphCandidate, 'comparison', sourceSignals)
+    })
+    .filter(Boolean)
+    .sort((a: any, b: any) => {
+      const scoreDelta = safeScore(b?.relatedScore) - safeScore(a?.relatedScore)
+      if (scoreDelta !== 0) return scoreDelta
+
+      const nameDelta = safeLower(a?.name).localeCompare(safeLower(b?.name))
+      if (nameDelta !== 0) return nameDelta
+
+      return safeSlug(a?.slug).localeCompare(safeSlug(b?.slug))
+    })
+    .slice(0, requestedLimit)
+}
+
+export function getStackRuntimeRecords(record: any, records: any[], limit = MAX_STACK_CANDIDATES) {
+  const sourceSlug = safeSlug(record?.slug)
+  const sourceSignals = collectSignals(record)
+  const graphEdges = collectGraphEdges(record)
+  const requestedLimit = Math.min(MAX_STACK_CANDIDATES, Math.max(0, safeScore(limit, MAX_STACK_CANDIDATES)))
+
+  if (!sourceSlug || graphEdges.size === 0) return []
+
+  const seen = new Set<string>()
+
+  return safeArray(records)
+    .map((candidate: any) => {
+      const candidateSlug = safeSlug(candidate?.slug)
+      if (!candidate || !candidateSlug || candidateSlug === sourceSlug || seen.has(candidateSlug)) return null
+
+      const edge = getEdgeByKind(graphEdges.get(candidateSlug), 'stack')
+      if (!hasCandidateSupport(edge, 'stack')) return null
+
+      seen.add(candidateSlug)
+      return enrichGraphCandidateRecord(candidate, edge as GraphCandidate, 'stack', sourceSignals)
+    })
+    .filter(Boolean)
+    .sort((a: any, b: any) => {
+      const scoreDelta = safeScore(b?.relatedScore) - safeScore(a?.relatedScore)
+      if (scoreDelta !== 0) return scoreDelta
+
+      const nameDelta = safeLower(a?.name).localeCompare(safeLower(b?.name))
+      if (nameDelta !== 0) return nameDelta
+
+      return safeSlug(a?.slug).localeCompare(safeSlug(b?.slug))
+    })
+    .slice(0, requestedLimit)
+}
+
 export function getRelatedLabel(record: any) {
   const primary = collectSignals(record)[0]
 

--- a/lib/runtime-graph.ts
+++ b/lib/runtime-graph.ts
@@ -107,6 +107,8 @@ export type GraphCandidate = GraphRecord & {
   topic_overlap?: string[]
   mechanism_complementarity?: string[]
   pathway_complementarity?: string[]
+  ecosystem_overlap?: string[]
+  safety_gate?: string
 }
 
 export type GraphRuntime = {
@@ -277,6 +279,8 @@ function normalizeCandidate(value: unknown): GraphCandidate | null {
     topic_overlap: unique(record.topic_overlap),
     mechanism_complementarity: unique(record.mechanism_complementarity),
     pathway_complementarity: unique(record.pathway_complementarity),
+    ecosystem_overlap: unique(record.ecosystem_overlap || record.ecosystems || record.topics),
+    safety_gate: asText(record.safety_gate),
   }
 }
 
@@ -426,17 +430,111 @@ function byNameOrSlug<T extends { id?: string; slug?: string; name?: string }>(
   )
 }
 
+
+function relationshipToCandidate(
+  relationship: GraphRelationship,
+  type = relationship.type || 'relationship-overlap'
+): GraphCandidate {
+  return {
+    id: relationship.id,
+    source: relationship.source,
+    target: relationship.target,
+    type,
+    weight: relationship.weight,
+    rationale: relationship.rationale || 'Shared mechanism, pathway, or ecosystem context; frame as a comparison prompt rather than an outcome claim.',
+    evidence_context: relationship.evidence_context,
+    mechanism_overlap: unique(relationship.mechanisms),
+    pathway_overlap: unique(relationship.pathways),
+    topic_overlap: unique(relationship.topics),
+    ecosystem_overlap: unique(relationship.topics),
+  }
+}
+
+function nodeComparisonFallback(graph: GraphRuntime, node: GraphNode | null, keys: Set<string>): GraphCandidate[] {
+  if (!node) return []
+
+  return getNodes(graph)
+    .filter((candidate) => !matchesProfile(candidate, node))
+    .map((candidate) => {
+      const mechanisms = sharedItems(node.mechanisms, candidate.mechanisms)
+      const pathways = sharedItems(node.pathways, candidate.pathways)
+      const topics = sharedItems(node.topics, candidate.topics)
+      const overlapScore = mechanisms.length * 3 + pathways.length * 2 + topics.length
+
+      return {
+        id: `${node.slug || node.id}-compare-${candidate.slug || candidate.id}`,
+        source: node.slug || node.id,
+        target: candidate.slug || candidate.id,
+        type: 'semantic-comparison',
+        weight: overlapScore,
+        rationale: 'Semantic comparison candidate based on shared mechanisms, pathways, or ecosystem context; not an efficacy or superiority claim.',
+        evidence_context: 'Evidence context should be read from each profile before interpretation.',
+        mechanism_overlap: mechanisms,
+        pathway_overlap: pathways,
+        topic_overlap: topics,
+        ecosystem_overlap: topics,
+      }
+    })
+    .filter((candidate) => {
+      if (!otherEndpoint(candidate, keys)) return false
+      return asList(candidate.mechanism_overlap).length > 0 ||
+        asList(candidate.pathway_overlap).length > 0 ||
+        asList(candidate.topic_overlap).length >= 2
+    })
+}
+
+function nodeStackFallback(graph: GraphRuntime, node: GraphNode | null, keys: Set<string>): GraphCandidate[] {
+  if (!node) return []
+
+  return getNodes(graph)
+    .filter((candidate) => !matchesProfile(candidate, node))
+    .map((candidate) => {
+      const mechanisms = sharedItems(node.mechanisms, candidate.mechanisms)
+      const pathways = sharedItems(node.pathways, candidate.pathways)
+      const topics = sharedItems(node.topics, candidate.topics)
+      const overlapScore = mechanisms.length * 2 + pathways.length * 2 + topics.length
+
+      return {
+        id: `${node.slug || node.id}-stack-${candidate.slug || candidate.id}`,
+        source: node.slug || node.id,
+        target: candidate.slug || candidate.id,
+        type: 'biological-adjacency',
+        weight: overlapScore,
+        rationale: 'Biologically adjacent research candidate; use only as exploratory education context, not stack advice.',
+        framing: topics.join('; '),
+        evidence_context: 'Exploratory graph context; review profile-specific evidence and safety notes.',
+        mechanism_complementarity: mechanisms,
+        pathway_complementarity: pathways,
+        topic_overlap: topics,
+        ecosystem_overlap: topics,
+        safety_gate: 'review safety context before combining',
+      }
+    })
+    .filter((candidate) => {
+      if (!otherEndpoint(candidate, keys)) return false
+      const mechanismCount = asList(candidate.mechanism_complementarity).length
+      const pathwayCount = asList(candidate.pathway_complementarity).length
+      const topicCount = asList(candidate.topic_overlap).length
+
+      return mechanismCount >= 2 || pathwayCount >= 2 || (mechanismCount + pathwayCount >= 2 && topicCount > 0)
+    })
+}
+
 function candidateScore(candidate: GraphCandidate | GraphRelationship): number {
   const weight = Number(asText(candidate.weight))
   const rationale = asText(candidate.rationale)
   const mechanisms = asList((candidate as GraphRelationship).mechanisms || (candidate as GraphCandidate).mechanism_overlap).length
   const pathways = asList((candidate as GraphRelationship).pathways || (candidate as GraphCandidate).pathway_overlap).length
+  const topics = asList((candidate as GraphRelationship).topics || (candidate as GraphCandidate).topic_overlap).length
+  const ecosystems = asList((candidate as GraphCandidate).ecosystem_overlap).length
   const complementaryMechanisms = asList((candidate as GraphCandidate).mechanism_complementarity).length
   const complementaryPathways = asList((candidate as GraphCandidate).pathway_complementarity).length
 
   return (Number.isFinite(weight) ? weight : 0) +
     mechanisms * 3 +
     pathways * 2 +
+    topics +
+    ecosystems +
     complementaryMechanisms * 2 +
     complementaryPathways +
     (rationale ? 1 : 0)
@@ -584,17 +682,34 @@ export function getComparisonCandidates(
     profileOrLimit,
     maybeLimit
   )
-  const comparisons = graph.comparisons || []
-  const keys = new Set(profileKeys(profile))
+  const node = getGraphNode(graph, profile)
+  const keys = new Set([
+    ...nodeKeys(node),
+    ...profileKeys(profile),
+  ].filter(Boolean))
+
+  if (!keys.size) return []
+
+  const explicit = (graph.comparisons || []).filter(
+    (candidate) =>
+      otherEndpoint(candidate, keys) &&
+      (keys.has(normalizeKey(candidate.source)) || keys.has(normalizeKey(candidate.target)))
+  )
+
+  const relationshipFallback = getRelationships(graph)
+    .filter((relationship) =>
+      otherEndpoint(relationship, keys) &&
+      (keys.has(normalizeKey(relationship.source)) || keys.has(normalizeKey(relationship.target))) &&
+      (asList(relationship.mechanisms).length > 0 || asList(relationship.pathways).length > 0 || asList(relationship.topics).length >= 2)
+    )
+    .map((relationship) => relationshipToCandidate(relationship, 'relationship-overlap'))
 
   return dedupeByOtherEndpoint(
-    sortCandidates(
-      comparisons.filter(
-        (candidate) =>
-          otherEndpoint(candidate, keys) &&
-          (matchesSlug(candidate.source, profile) || matchesSlug(candidate.target, profile))
-      )
-    ),
+    sortCandidates([
+      ...explicit,
+      ...relationshipFallback,
+      ...nodeComparisonFallback(graph, node, keys),
+    ]),
     keys
   ).slice(0, clampLimit(limit, 8, MAX_COMPARISON_CANDIDATES))
 }
@@ -618,17 +733,41 @@ export function getStackCandidates(
     profileOrLimit,
     maybeLimit
   )
-  const stacks = graph.stacks || []
-  const keys = new Set(profileKeys(profile))
+  const node = getGraphNode(graph, profile)
+  const keys = new Set([
+    ...nodeKeys(node),
+    ...profileKeys(profile),
+  ].filter(Boolean))
+
+  if (!keys.size) return []
+
+  const explicit = (graph.stacks || []).filter(
+    (candidate) =>
+      otherEndpoint(candidate, keys) &&
+      (keys.has(normalizeKey(candidate.source)) || keys.has(normalizeKey(candidate.target))) &&
+      (asList(candidate.mechanism_complementarity).length > 0 || asList(candidate.pathway_complementarity).length > 0)
+  )
+
+  const relationshipFallback = getRelationships(graph)
+    .filter((relationship) =>
+      otherEndpoint(relationship, keys) &&
+      (keys.has(normalizeKey(relationship.source)) || keys.has(normalizeKey(relationship.target))) &&
+      (asList(relationship.mechanisms).length >= 2 || asList(relationship.pathways).length >= 2)
+    )
+    .map((relationship) => ({
+      ...relationshipToCandidate(relationship, 'biological-adjacency'),
+      rationale: 'Biologically adjacent research candidate; use only as exploratory education context, not stack advice.',
+      mechanism_complementarity: unique(relationship.mechanisms),
+      pathway_complementarity: unique(relationship.pathways),
+      safety_gate: 'review safety context before combining',
+    }))
 
   return dedupeByOtherEndpoint(
-    sortCandidates(
-      stacks.filter(
-        (candidate) =>
-          otherEndpoint(candidate, keys) &&
-          (matchesSlug(candidate.source, profile) || matchesSlug(candidate.target, profile))
-      )
-    ),
+    sortCandidates([
+      ...explicit,
+      ...relationshipFallback,
+      ...nodeStackFallback(graph, node, keys),
+    ]),
     keys
   ).slice(0, clampLimit(limit, 6, MAX_STACK_CANDIDATES))
 }

--- a/src/components/profile-authority-sections.tsx
+++ b/src/components/profile-authority-sections.tsx
@@ -28,6 +28,8 @@ type ProfileAuthoritySectionsProps = {
   record: any
   entityType: EntityType
   relatedRecords?: any[]
+  comparisonRecords?: any[]
+  stackRecords?: any[]
   effects?: string[]
   mechanisms?: string[]
   summary?: string
@@ -588,6 +590,104 @@ function DiscoveryCard({ item, entityType }: { item: any; entityType: EntityType
   )
 }
 
+
+function GraphCandidateCard({ item, entityType, kind }: { item: any; entityType: EntityType; kind: 'comparison' | 'stack' }) {
+  const targetType = item.entityType === 'herb' || item.entityType === 'compound' ? item.entityType : entityType
+  const mechanismSignals = cleanList(kind === 'stack' ? item.graphMechanismComplementarity : item.graphMechanismOverlap, 3)
+  const pathwaySignals = cleanList(kind === 'stack' ? item.graphPathwayComplementarity : item.graphPathwayOverlap, 3)
+  const ecosystemSignals = cleanList(item.graphEcosystemOverlap, 2)
+  const evidenceContext = text(item.graphEvidenceContext)
+  const rationale = text(item.graphCandidateRationale)
+
+  return (
+    <Link
+      href={getRelatedHref(targetType, item.slug)}
+      className="surface-subtle group rounded-2xl border border-brand-900/10 p-4 transition hover:border-brand-700/30 hover:bg-white/70"
+    >
+      <p className="text-[10px] font-bold uppercase tracking-[0.16em] text-brand-900/50">
+        {kind === 'comparison' ? 'Contextual comparison' : 'Exploratory stack context'}
+      </p>
+      <h3 className="mt-2 text-lg font-semibold text-ink transition group-hover:text-brand-700">
+        {formatDisplayLabel(item.name || item.slug)}
+      </h3>
+      <p className="mt-2 text-sm leading-7 text-[#46574d]">
+        {compressEditorialCopy(
+          rationale ||
+            (kind === 'comparison'
+              ? 'Shared graph signals make this a conservative comparison candidate, not an efficacy or superiority claim.'
+              : 'Complementary graph signals make this an exploratory research pairing, not dosing or treatment advice.'),
+        )}
+      </p>
+      {evidenceContext ? (
+        <p className="mt-2 text-xs font-semibold uppercase tracking-[0.12em] text-brand-900/55">
+          {compressEditorialCopy(evidenceContext)}
+        </p>
+      ) : null}
+      <div className="mt-3 space-y-2">
+        <SignalList items={[...mechanismSignals, ...pathwaySignals, ...ecosystemSignals].slice(0, 6)} />
+      </div>
+    </Link>
+  )
+}
+
+function GraphIntelligenceRails({ comparisonRecords, stackRecords, entityType, compact }: {
+  comparisonRecords: any[]
+  stackRecords: any[]
+  entityType: EntityType
+  compact: boolean
+}) {
+  const comparisons = (comparisonRecords || [])
+    .filter((item: any) => item?.slug && isClean(formatDisplayLabel(item?.name || item?.slug)))
+    .slice(0, 8)
+  const stacks = (stackRecords || [])
+    .filter((item: any) => item?.slug && isClean(formatDisplayLabel(item?.name || item?.slug)))
+    .slice(0, 6)
+
+  if (comparisons.length === 0 && stacks.length === 0) return null
+
+  return (
+    <AuthorityCard
+      title="Graph Intelligence"
+      compact={compact}
+      description="Graph candidates are shown as evidence-aware context only. They do not imply superiority, treatment recommendations, or dosing guidance."
+    >
+      <div className="space-y-6">
+        {comparisons.length > 0 ? (
+          <section className="space-y-3">
+            <div className="space-y-1">
+              <h3 className="text-lg font-semibold tracking-tight text-ink">Comparison candidates</h3>
+              <p className="text-sm leading-7 text-[#5b6b61]">
+                Conservative candidates based on relationship, mechanism, pathway, and ecosystem overlap.
+              </p>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              {comparisons.slice(0, compact ? 3 : 8).map((item: any) => (
+                <GraphCandidateCard key={`comparison-${item.slug}`} item={item} entityType={entityType} kind="comparison" />
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        {stacks.length > 0 ? (
+          <section className="space-y-3">
+            <div className="space-y-1">
+              <h3 className="text-lg font-semibold tracking-tight text-ink">Stack and synergy context</h3>
+              <p className="text-sm leading-7 text-[#5b6b61]">
+                Exploratory pairings require biological adjacency and complementary mechanism or pathway signals before display.
+              </p>
+            </div>
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+              {stacks.slice(0, compact ? 3 : 6).map((item: any) => (
+                <GraphCandidateCard key={`stack-${item.slug}`} item={item} entityType={entityType} kind="stack" />
+              ))}
+            </div>
+          </section>
+        ) : null}
+      </div>
+    </AuthorityCard>
+  )
+}
+
 function DiscoveryRails({ relatedRecords, entityType, compact = false, narrative = '', baseRecord }: any) {
   const visible = rankEvidenceSensitiveRelatedRecords(baseRecord, relatedRecords || [], compact ? 3 : 8)
     .filter((item: any) => item?.slug && isClean(formatDisplayLabel(item?.name || item?.slug)))
@@ -637,6 +737,8 @@ export default function ProfileAuthoritySections({
   record,
   entityType,
   relatedRecords = [],
+  comparisonRecords = [],
+  stackRecords = [],
   effects: providedEffects,
   mechanisms: providedMechanisms,
   summary: providedSummary,
@@ -699,7 +801,9 @@ export default function ProfileAuthoritySections({
     mechanisms.length > 0 ||
     safetySignals.length > 0 ||
     contextualSignals.length > 0 ||
-    relatedRecords.length > 0
+    relatedRecords.length > 0 ||
+    comparisonRecords.length > 0 ||
+    stackRecords.length > 0
 
   if (!hasContent) return null
 
@@ -764,6 +868,13 @@ export default function ProfileAuthoritySections({
           </div>
         </AuthorityCard>
       ) : null}
+
+      <GraphIntelligenceRails
+        comparisonRecords={comparisonRecords}
+        stackRecords={stackRecords}
+        entityType={entityType}
+        compact={compact}
+      />
 
       <MonetizationInsertionZone zone="affiliate-product-cards" />
       <MonetizationInsertionZone zone="stack-modules" />


### PR DESCRIPTION
### Motivation
- Provide conservative, runtime-safe graph-driven comparison and stack/synergy context for herb and compound profiles without redesigning pages or changing routes. 
- Surface only evidence-aware, exploratory signals (mechanism/pathway/ecosystem overlap and complementary mechanisms) while preserving existing fallbacks and visibility rules. 

### Description
- Extend `lib/runtime-graph.ts` to normalize `ecosystem_overlap` and `safety_gate`, add `relationshipToCandidate`, `nodeComparisonFallback`, and `nodeStackFallback`, and incorporate topics/ecosystems into candidate scoring and deterministic sorting. 
- Add enrichment and runtime helpers in `lib/related-runtime.ts`: `getComparisonRuntimeRecords` and `getStackRuntimeRecords` that validate support signals, dedupe by other endpoint, enrich candidate records with rationale/evidence/safety, and cap results (max 8 comparisons, max 6 stacks). 
- Add a minimal, conservative UI surface in `src/components/profile-authority-sections.tsx` (`GraphCandidateCard`, `GraphIntelligenceRails`) and wire `comparisonRecords`/`stackRecords` through `app/herbs/[slug]/page.tsx` and `app/compounds/[slug]/page.tsx` so profiles render graph candidates only when available. 
- Maintain defensive patterns across the change: null-safe traversal, `safeArray`/`safeSlug`, deterministic sorting, strict caps, conservative copy (no efficacy/superiority/advice language), and no route or architecture changes. 

### Testing
- Ran TypeScript checks with `npx tsc --noEmit --pretty false --incremental false`, which passed. 
- Ran full build/validation via `npm run check` (includes `data:build`, `data:validate`, and `next build`), which completed successfully and produced static pages. 
- Verified runtime/static output contains the new Graph Intelligence rails and that data verification (`data:verify`) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff3e505acc83238c60876d345966b5)