### PR TITLE
Integrate topic/pathway ecosystems and authority supernodes into runtime graph discovery

### DIFF
--- a/lib/related-runtime.ts
+++ b/lib/related-runtime.ts
@@ -24,6 +24,10 @@ function collectSignals(record: any) {
     ...list(record?.effects),
     ...list(record?.mechanisms),
     ...list(record?.pathways),
+    ...list(record?.pathwayTargets),
+    ...list(record?.mechanismTags),
+    ...list(record?.topics),
+    ...list(record?.topicTags),
     ...list(record?.targets),
     ...list(record?.biologicalTargets),
     ...list(record?.compoundClass),
@@ -46,6 +50,7 @@ function collectGraphSignals(edge: GraphRelationship | GraphCandidate | undefine
     ...list((edge as GraphCandidate)?.mechanism_overlap),
     ...list((edge as GraphCandidate)?.pathway_overlap),
     ...list((edge as GraphCandidate)?.topic_overlap),
+    ...list((edge as GraphCandidate)?.ecosystem_overlap),
     ...list((edge as GraphCandidate)?.mechanism_complementarity),
     ...list((edge as GraphCandidate)?.pathway_complementarity),
   ])
@@ -82,6 +87,9 @@ function graphWeight(edge: GraphRelationship | GraphCandidate | undefined) {
   const pathways = list((edge as GraphRelationship)?.pathways || (edge as GraphCandidate)?.pathway_overlap).length
   const complementaryMechanisms = list((edge as GraphCandidate)?.mechanism_complementarity).length
   const complementaryPathways = list((edge as GraphCandidate)?.pathway_complementarity).length
+  const topics = list((edge as GraphRelationship)?.topics || (edge as GraphCandidate)?.topic_overlap).length
+  const ecosystems = list((edge as GraphCandidate)?.ecosystem_overlap).length
+  const authorityHub = safeLower(edge.type).includes('authority') ? 2 : 0
   const rationale = text(edge.rationale) ? 0.75 : 0
 
   return (
@@ -90,6 +98,8 @@ function graphWeight(edge: GraphRelationship | GraphCandidate | undefined) {
     Math.min(pathways, 4) * 1.5 +
     Math.min(complementaryMechanisms, 3) * 1.5 +
     Math.min(complementaryPathways, 3) +
+    Math.min(topics + ecosystems, 4) * 0.75 +
+    authorityHub +
     evidenceWeight(edge.evidence_context) +
     rationale
   )
@@ -105,7 +115,7 @@ function hasBiologicalGraphSupport(edge: GraphRelationship | GraphCandidate | un
   const topicCount = list((edge as GraphRelationship)?.topics || (edge as GraphCandidate)?.topic_overlap).length
   const type = safeLower(edge.type)
 
-  return mechanismCount > 0 || pathwayCount > 0 || (topicCount >= 2 && !type.includes('topic-only'))
+  return mechanismCount > 0 || pathwayCount > 0 || type.includes('authority') || (topicCount >= 2 && !type.includes('topic-only'))
 }
 
 function collectGraphEdges(record: any) {

--- a/lib/runtime-graph.ts
+++ b/lib/runtime-graph.ts
@@ -91,6 +91,11 @@ export type GraphEcosystem = GraphRecord & {
   mechanisms?: string[]
   pathways?: string[]
   topics?: string[]
+  companions?: string[]
+  related_pathways?: string[]
+  profile_type?: string
+  graph_score?: string | number
+  relationship_density?: string | number
 }
 
 export type GraphCandidate = GraphRecord & {
@@ -112,6 +117,7 @@ export type GraphCandidate = GraphRecord & {
 }
 
 export type GraphRuntime = {
+  __normalized?: boolean
   nodes?: GraphNode[]
   relationships?: GraphRelationship[]
   topics?: GraphEcosystem[]
@@ -136,8 +142,13 @@ const MAX_RELATED_PROFILES = 12
 const MAX_COMPARISON_CANDIDATES = 8
 const MAX_STACK_CANDIDATES = 6
 const MAX_PATHWAY_COMPANIONS = 10
+const MAX_ECOSYSTEM_SUGGESTIONS = 10
+const MAX_AUTHORITY_HUBS = 6
 
 let graphCache: GraphRuntime | null = null
+const relatedProfilesCache = new Map<string, GraphRelationship[]>()
+const comparisonCandidatesCache = new Map<string, GraphCandidate[]>()
+const stackCandidatesCache = new Map<string, GraphCandidate[]>()
 
 function asRecord(value: unknown): GraphRecord | null {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -257,6 +268,11 @@ function normalizeEcosystem(value: unknown): GraphEcosystem | null {
     mechanisms: unique(record.mechanisms),
     pathways: unique(record.pathways),
     topics: unique(record.topics),
+    companions: unique(record.companions),
+    related_pathways: unique(record.related_pathways || record.relatedPathways),
+    profile_type: asText(record.profile_type || record.profileType),
+    graph_score: asText(record.graph_score || record.graphScore) || 0,
+    relationship_density: asText(record.relationship_density || record.relationshipDensity) || 0,
   }
 }
 
@@ -291,7 +307,10 @@ function normalizeRows<T>(value: unknown, normalize: (row: unknown) => T | null)
 export function normalizeGraphRuntime(graph: GraphInput): GraphRuntime {
   const source = asRecord(graph) || {}
 
+  if (source.__normalized) return source as GraphRuntime
+
   return {
+    __normalized: true,
     nodes: normalizeRows(source.nodes, normalizeNode),
     relationships: normalizeRows(source.relationships, normalizeRelationship),
     topics: normalizeRows(source.topics, normalizeEcosystem),
@@ -373,6 +392,10 @@ function clampLimit(limit: number | undefined, fallback: number, max: number): n
   const value = Number(limit ?? fallback)
   if (!Number.isFinite(value)) return fallback
   return Math.min(max, Math.max(0, value))
+}
+
+function profileCacheKey(kind: string, profile: ProfileInput, limit: number | undefined): string {
+  return [kind, clampLimit(limit, 8, MAX_RELATED_PROFILES), ...profileKeys(profile)].join('|')
 }
 
 function otherEndpoint(
@@ -520,6 +543,71 @@ function nodeStackFallback(graph: GraphRuntime, node: GraphNode | null, keys: Se
     })
 }
 
+
+function numericSignal(value: unknown): number {
+  const numeric = Number(asText(value))
+  return Number.isFinite(numeric) ? numeric : 0
+}
+
+function ecosystemEntityKeys(ecosystem: GraphEcosystem | null | undefined): string[] {
+  if (!ecosystem) return []
+
+  return unique([
+    ...(Array.isArray(ecosystem.anchors) ? ecosystem.anchors : []),
+    ...(Array.isArray(ecosystem.herbs) ? ecosystem.herbs : []),
+    ...(Array.isArray(ecosystem.compounds) ? ecosystem.compounds : []),
+    ...(Array.isArray(ecosystem.companions) ? ecosystem.companions : []),
+  ]).map(normalizeKey)
+}
+
+function ecosystemKeys(ecosystem: GraphEcosystem | null | undefined): string[] {
+  if (!ecosystem) return []
+
+  return unique([
+    ecosystem.id,
+    ecosystem.slug,
+    ecosystem.name,
+    ...(Array.isArray(ecosystem.topics) ? ecosystem.topics : []),
+    ...(Array.isArray(ecosystem.pathways) ? ecosystem.pathways : []),
+  ]).map(normalizeKey)
+}
+
+function ecosystemMatchScore(
+  ecosystem: GraphEcosystem,
+  node: GraphNode | null,
+  keys: string[],
+  relationshipSignals: { topics: string[]; pathways: string[]; mechanisms: string[] } = { topics: [], pathways: [], mechanisms: [] }
+): number {
+  const normalizedKeys = new Set(keys.map(normalizeKey).filter(Boolean))
+  const directEntityMatch = ecosystemEntityKeys(ecosystem).some((key) => normalizedKeys.has(key)) ? 8 : 0
+  const directNameMatch = ecosystemKeys(ecosystem).some((key) => normalizedKeys.has(key)) ? 6 : 0
+  const topicOverlap = sharedItems(ecosystem.topics, [...(node?.topics || []), ...relationshipSignals.topics]).length
+  const pathwayOverlap = sharedItems(ecosystem.pathways, [...(node?.pathways || []), ...relationshipSignals.pathways]).length
+  const mechanismOverlap = sharedItems(ecosystem.mechanisms, [...(node?.mechanisms || []), ...relationshipSignals.mechanisms]).length
+
+  return directEntityMatch +
+    directNameMatch +
+    topicOverlap * 3 +
+    pathwayOverlap * 3 +
+    mechanismOverlap * 2 +
+    Math.min(numericSignal(ecosystem.relationship_density) / 25, 4) +
+    Math.min(numericSignal(ecosystem.graph_score) / 50, 2)
+}
+
+function ecosystemSortKey(ecosystem: GraphEcosystem): string {
+  return [ecosystem.kind, ecosystem.name, ecosystem.slug, ecosystem.id]
+    .map(asLowerText)
+    .join('|')
+}
+
+function sortEcosystems<T extends GraphEcosystem>(rows: T[], score: (row: T) => number): T[] {
+  return [...rows].sort((a, b) => {
+    const scoreDelta = score(b) - score(a)
+    if (scoreDelta !== 0) return scoreDelta
+    return ecosystemSortKey(a).localeCompare(ecosystemSortKey(b))
+  })
+}
+
 function candidateScore(candidate: GraphCandidate | GraphRelationship): number {
   const weight = Number(asText(candidate.weight))
   const rationale = asText(candidate.rationale)
@@ -594,6 +682,12 @@ export function getRelatedProfiles(
 
   if (!keys.size) return []
 
+  const canUseCache = !isGraphLike(graphOrProfile)
+  const cacheKey = profileCacheKey('related', profile, limit)
+  if (canUseCache && relatedProfilesCache.has(cacheKey)) {
+    return [...(relatedProfilesCache.get(cacheKey) || [])]
+  }
+
   const direct = getRelationships(graph).filter(
     (relationship) =>
       otherEndpoint(relationship, keys) &&
@@ -631,10 +725,53 @@ export function getRelatedProfiles(
         })
     : []
 
-  return dedupeByOtherEndpoint(
-    sortCandidates([...direct, ...semanticFallback]),
+  const ecosystemFallback = getEcosystemsForProfile(graph, profile)
+    .topics
+    .slice(0, 3)
+    .flatMap((ecosystem) =>
+      unique([
+        ...(ecosystem.anchors || []),
+        ...(ecosystem.herbs || []),
+        ...(ecosystem.compounds || []),
+      ])
+        .map(normalizeKey)
+        .filter((slug) => slug && !keys.has(slug))
+        .slice(0, 4)
+        .map((slug) => ({
+          id: `${node?.slug || profileKeys(profile)[0]}-${ecosystem.slug || ecosystem.id}-${slug}`,
+          source: node?.slug || profileKeys(profile)[0],
+          target: slug,
+          type: 'ecosystem-continuity',
+          weight: 20 + sharedItems(ecosystem.topics, node?.topics).length * 3 + sharedItems(ecosystem.pathways, node?.pathways).length * 2,
+          rationale: 'Related by topic ecosystem continuity; use as contextual discovery rather than outcome equivalence.',
+          evidence_context: ecosystem.retrieval_summary,
+          mechanisms: unique(ecosystem.mechanisms).slice(0, 6),
+          pathways: unique(ecosystem.pathways).slice(0, 6),
+          topics: unique([ecosystem.name, ...(ecosystem.topics || [])]).slice(0, 6),
+        }))
+    )
+
+  const authorityFallback = getAuthoritySupernodes(graph, profile, MAX_AUTHORITY_HUBS)
+    .map((supernode) => ({
+      id: `${node?.slug || profileKeys(profile)[0]}-authority-${supernode.slug || supernode.id}`,
+      source: node?.slug || profileKeys(profile)[0],
+      target: supernode.slug || supernode.id,
+      type: 'authority-hub',
+      weight: 30 + numericSignal(supernode.relationship_density),
+      rationale: 'Authority hub with dense relationship coverage for nearby topics and pathways; evidence tier should control interpretation.',
+      evidence_context: supernode.retrieval_summary,
+      mechanisms: unique(supernode.mechanisms).slice(0, 6),
+      pathways: unique(supernode.pathways).slice(0, 6),
+      topics: unique(supernode.topics).slice(0, 6),
+    }))
+
+  const results = dedupeByOtherEndpoint(
+    sortCandidates([...direct, ...semanticFallback, ...ecosystemFallback, ...authorityFallback]),
     keys
   ).slice(0, clampLimit(limit, 8, MAX_RELATED_PROFILES))
+
+  if (canUseCache) relatedProfilesCache.set(cacheKey, results)
+  return [...results]
 }
 
 export function getTopicEcosystem(topic: string): GraphEcosystem | null
@@ -690,6 +827,12 @@ export function getComparisonCandidates(
 
   if (!keys.size) return []
 
+  const canUseCache = !isGraphLike(graphOrProfile)
+  const cacheKey = profileCacheKey('comparison', profile, limit)
+  if (canUseCache && comparisonCandidatesCache.has(cacheKey)) {
+    return [...(comparisonCandidatesCache.get(cacheKey) || [])]
+  }
+
   const explicit = (graph.comparisons || []).filter(
     (candidate) =>
       otherEndpoint(candidate, keys) &&
@@ -704,7 +847,7 @@ export function getComparisonCandidates(
     )
     .map((relationship) => relationshipToCandidate(relationship, 'relationship-overlap'))
 
-  return dedupeByOtherEndpoint(
+  const results = dedupeByOtherEndpoint(
     sortCandidates([
       ...explicit,
       ...relationshipFallback,
@@ -712,6 +855,9 @@ export function getComparisonCandidates(
     ]),
     keys
   ).slice(0, clampLimit(limit, 8, MAX_COMPARISON_CANDIDATES))
+
+  if (canUseCache) comparisonCandidatesCache.set(cacheKey, results)
+  return [...results]
 }
 
 export function getStackCandidates(
@@ -741,6 +887,12 @@ export function getStackCandidates(
 
   if (!keys.size) return []
 
+  const canUseCache = !isGraphLike(graphOrProfile)
+  const cacheKey = profileCacheKey('stack', profile, limit)
+  if (canUseCache && stackCandidatesCache.has(cacheKey)) {
+    return [...(stackCandidatesCache.get(cacheKey) || [])]
+  }
+
   const explicit = (graph.stacks || []).filter(
     (candidate) =>
       otherEndpoint(candidate, keys) &&
@@ -762,7 +914,7 @@ export function getStackCandidates(
       safety_gate: 'review safety context before combining',
     }))
 
-  return dedupeByOtherEndpoint(
+  const results = dedupeByOtherEndpoint(
     sortCandidates([
       ...explicit,
       ...relationshipFallback,
@@ -770,6 +922,9 @@ export function getStackCandidates(
     ]),
     keys
   ).slice(0, clampLimit(limit, 6, MAX_STACK_CANDIDATES))
+
+  if (canUseCache) stackCandidatesCache.set(cacheKey, results)
+  return [...results]
 }
 
 export function getAuthoritySupernodes(limit?: number): GraphEcosystem[]
@@ -803,54 +958,125 @@ export function getAuthoritySupernodes(
     ? graphOrProfileOrLimit
     : typeof profileOrLimit === 'number'
       ? profileOrLimit
-      : maybeLimit ?? 12
+      : maybeLimit ?? MAX_AUTHORITY_HUBS
+  const requestedLimit = clampLimit(limit, MAX_AUTHORITY_HUBS, MAX_AUTHORITY_HUBS)
   const supernodes = graph.supernodes || []
 
-  if (!profile) return supernodes.slice(0, clampLimit(limit, 12, MAX_RELATED_PROFILES))
+  if (!profile) {
+    return sortEcosystems(supernodes, (supernode) =>
+      numericSignal(supernode.graph_score) + numericSignal(supernode.relationship_density)
+    ).slice(0, requestedLimit)
+  }
 
-  const keys = profileKeys(profile)
+  const node = getGraphNode(graph, profile)
+  const keys = unique([...nodeKeys(node), ...profileKeys(profile)]).filter(Boolean)
   if (!keys.length) return []
 
-  return supernodes
-    .filter((supernode) =>
-      [
-        supernode.id,
-        supernode.slug,
-        supernode.name,
-        ...(Array.isArray(supernode.anchors) ? supernode.anchors : []),
-      ]
+  const relationshipSignals = { topics: [], pathways: [], mechanisms: [] }
+  const keySet = new Set(keys.map(normalizeKey).filter(Boolean))
+
+  return sortEcosystems(
+    supernodes.filter((supernode) => {
+      const selfMatch = [supernode.id, supernode.slug, supernode.name]
         .map(normalizeKey)
-        .some((key) => keys.includes(key))
-    )
-    .slice(0, clampLimit(limit, 12, MAX_RELATED_PROFILES))
+        .some((key) => keySet.has(key))
+      if (selfMatch) return false
+
+      return ecosystemMatchScore(supernode, node, keys, relationshipSignals) >= 5
+    }),
+    (supernode) => ecosystemMatchScore(supernode, node, keys, relationshipSignals)
+  ).slice(0, requestedLimit)
 }
 
 export function getEcosystemsForProfile(
+  profile: GraphRecord | string
+): { topics: GraphEcosystem[]; pathways: GraphEcosystem[] }
+export function getEcosystemsForProfile(
   graph: GraphInput,
   profile: GraphRecord | string
+): { topics: GraphEcosystem[]; pathways: GraphEcosystem[] }
+export function getEcosystemsForProfile(
+  graphOrProfile: GraphInput | GraphRecord | string,
+  maybeProfile?: GraphRecord | string
 ): { topics: GraphEcosystem[]; pathways: GraphEcosystem[] } {
-  const normalizedGraph = normalizeGraphRuntime(graph)
-  const node = getGraphNode(normalizedGraph, profile)
-  const keys = profileKeys(profile)
+  const { graph, profile } = resolveProfileArgs(graphOrProfile, maybeProfile)
+  const node = getGraphNode(graph, profile)
+  const keys = unique([...nodeKeys(node), ...profileKeys(profile)]).filter(Boolean)
+  if (!keys.length) return { topics: [], pathways: [] }
 
-  const topics = (normalizedGraph.topics || []).filter(
-    (topic) =>
-      hasSharedItem(topic.topics, node?.topics) ||
-      asList(topic.anchors).map(normalizeKey).some((key) => keys.includes(key)) ||
-      asList(topic.herbs).map(normalizeKey).some((key) => keys.includes(key)) ||
-      asList(topic.compounds).map(normalizeKey).some((key) => keys.includes(key))
+  const relationshipSignals = { topics: [], pathways: [], mechanisms: [] }
+  const scoredTopics = sortEcosystems(
+    (graph.topics || []).filter((topic) => ecosystemMatchScore(topic, node, keys, relationshipSignals) > 0),
+    (topic) => ecosystemMatchScore(topic, node, keys, relationshipSignals)
   )
-
-  const pathways = (normalizedGraph.pathways || []).filter(
-    (pathway) =>
-      hasSharedItem(pathway.pathways, node?.pathways) ||
-      asList(pathway.anchors).map(normalizeKey).some((key) => keys.includes(key)) ||
-      asList(pathway.herbs).map(normalizeKey).some((key) => keys.includes(key)) ||
-      asList(pathway.compounds).map(normalizeKey).some((key) => keys.includes(key))
+  const scoredPathways = sortEcosystems(
+    (graph.pathways || []).filter((pathway) => ecosystemMatchScore(pathway, node, keys, relationshipSignals) > 0),
+    (pathway) => ecosystemMatchScore(pathway, node, keys, relationshipSignals)
   )
 
   return {
-    topics: topics.slice(0, MAX_PATHWAY_COMPANIONS),
-    pathways: pathways.slice(0, MAX_PATHWAY_COMPANIONS),
+    topics: scoredTopics.slice(0, MAX_ECOSYSTEM_SUGGESTIONS),
+    pathways: scoredPathways.slice(0, MAX_ECOSYSTEM_SUGGESTIONS),
   }
+}
+
+export function getPathwayCompanions(pathway: string, limit?: number): string[]
+export function getPathwayCompanions(graph: GraphInput, pathway: string, limit?: number): string[]
+export function getPathwayCompanions(
+  graphOrPathway: GraphInput | string,
+  pathwayOrLimit?: string | number,
+  maybeLimit?: number
+): string[] {
+  const { graph, key } = resolveEcosystemArgs(
+    graphOrPathway,
+    typeof pathwayOrLimit === 'string' ? pathwayOrLimit : undefined
+  )
+  const limit = typeof pathwayOrLimit === 'number' ? pathwayOrLimit : maybeLimit
+  const ecosystem = getPathwayEcosystem(graph, key)
+  const companions = unique([
+    ...(ecosystem?.companions || []),
+    ...(ecosystem?.anchors || []),
+    ...(ecosystem?.herbs || []),
+    ...(ecosystem?.compounds || []),
+  ])
+
+  return companions
+    .map(normalizeKey)
+    .filter(Boolean)
+    .filter((slug) => slug !== normalizeKey(key))
+    .slice(0, clampLimit(limit, MAX_PATHWAY_COMPANIONS, MAX_PATHWAY_COMPANIONS))
+}
+
+export function getRelatedEcosystemTraversal(ecosystem: string, limit?: number): GraphEcosystem[]
+export function getRelatedEcosystemTraversal(graph: GraphInput, ecosystem: string, limit?: number): GraphEcosystem[]
+export function getRelatedEcosystemTraversal(
+  graphOrEcosystem: GraphInput | string,
+  ecosystemOrLimit?: string | number,
+  maybeLimit?: number
+): GraphEcosystem[] {
+  const { graph, key } = resolveEcosystemArgs(
+    graphOrEcosystem,
+    typeof ecosystemOrLimit === 'string' ? ecosystemOrLimit : undefined
+  )
+  const limit = typeof ecosystemOrLimit === 'number' ? ecosystemOrLimit : maybeLimit
+  const source = getTopicEcosystem(graph, key) || getPathwayEcosystem(graph, key)
+  if (!source) return []
+
+  const sourceKeys = new Set(ecosystemKeys(source).filter(Boolean))
+  const rows = [...(graph.topics || []), ...(graph.pathways || [])].filter((candidate) => {
+    const candidateKey = normalizeKey(candidate.slug || candidate.id || candidate.name)
+    if (!candidateKey || sourceKeys.has(candidateKey)) return false
+
+    return hasSharedItem(source.topics, candidate.topics) ||
+      hasSharedItem(source.pathways, candidate.pathways) ||
+      hasSharedItem(source.mechanisms, candidate.mechanisms) ||
+      hasSharedItem(source.related_pathways, [candidate.name, candidate.slug, candidate.id])
+  })
+
+  return sortEcosystems(rows, (candidate) =>
+    sharedItems(source.topics, candidate.topics).length * 3 +
+    sharedItems(source.pathways, candidate.pathways).length * 3 +
+    sharedItems(source.mechanisms, candidate.mechanisms).length * 2 +
+    sharedItems(source.related_pathways, [candidate.name, candidate.slug, candidate.id]).length * 4
+  ).slice(0, clampLimit(limit, MAX_ECOSYSTEM_SUGGESTIONS, MAX_ECOSYSTEM_SUGGESTIONS))
 }


### PR DESCRIPTION
### Motivation
- Surface topic and pathway ecosystem context and authority supernodes in semantic discovery to improve related-item continuity and ecosystem-aware recommendations without changing routes or UI.
- Use workbook graph exports (topics, pathways, supernodes) as static, defensive signals so discovery remains exporter-first and runtime-lightweight.
- Preserve existing fallbacks and static export behavior while adding ecosystem-aware fallbacks and authority hubs for higher-quality recommendations.

### Description
- Expanded the graph runtime model to carry ecosystem metadata and scoring fields by adding `companions`, `related_pathways`, `profile_type`, `graph_score`, and `relationship_density` to `GraphEcosystem` and normalizers in `lib/runtime-graph.ts`.
- Added deterministic ecosystem scoring/sorting helpers (`ecosystemMatchScore`, `sortEcosystems`, numeric helpers) and capped constants (`MAX_ECOSYSTEM_SUGGESTIONS`, `MAX_AUTHORITY_HUBS`, `MAX_PATHWAY_COMPANIONS`) to keep results compact and predictable.
- Integrated two new discovery fallbacks into `getRelatedProfiles`: an `ecosystem-continuity` fallback (anchors/herbs/compounds from top topic ecosystems) and an `authority-hub` fallback (top authority supernodes) while preserving direct relationships and previous semantic fallbacks.
- Exposed new retrieval helpers and improvements: improved `getAuthoritySupernodes`, `getEcosystemsForProfile`, `getPathwayCompanions`, and `getRelatedEcosystemTraversal`, and extended candidate scoring to include ecosystem overlap and authority signals; added lightweight memo caches and normalized-graph reuse to avoid repeated normalization during static generation.

### Testing
- Ran the full build/check pipeline with `npm run check` (which executes data build/validation and `next build`), and it completed successfully.
- Executed smoke invocations of runtime helpers (`getRelatedProfiles`, `getAuthoritySupernodes`, `getEcosystemsForProfile`, `getPathwayCompanions`, `getRelatedEcosystemTraversal`) via `npx tsx` to verify non-empty, capped outputs and stable behavior.
- Ran `git diff --check` and repository verification scripts used by the build, and no check failures were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff46dda10c8323bbadb3dbda89561e)