### PR TITLE
Precompute semantic graph candidates

### DIFF
--- a/lib/runtime-graph.ts
+++ b/lib/runtime-graph.ts
@@ -47,7 +47,7 @@ function isGraphLike(value: unknown): boolean {
   const record = asRecord(value)
   if (!record) return false
 
-  return ['nodes', 'relationships', 'topics', 'pathways', 'comparisons', 'stacks', 'supernodes']
+  return ['nodes', 'relationships', 'topics', 'pathways', 'comparisons', 'stacks', 'supernodes', 'semantic']
     .some((key) => Array.isArray(record[key]))
 }
 
@@ -125,6 +125,7 @@ export type GraphRuntime = {
   comparisons?: GraphCandidate[]
   stacks?: GraphCandidate[]
   supernodes?: GraphEcosystem[]
+  semantic?: GraphCandidate[]
 }
 
 const GRAPH_DIR = join(process.cwd(), 'public', 'data', 'graph')
@@ -136,6 +137,7 @@ const GRAPH_FILES = {
   comparisons: 'comparisons.json',
   stacks: 'stacks.json',
   supernodes: 'supernodes.json',
+  semantic: 'semantic.json',
 } as const
 
 const MAX_RELATED_PROFILES = 12
@@ -318,6 +320,7 @@ export function normalizeGraphRuntime(graph: GraphInput): GraphRuntime {
     comparisons: normalizeRows(source.comparisons, normalizeCandidate),
     stacks: normalizeRows(source.stacks, normalizeCandidate),
     supernodes: normalizeRows(source.supernodes, normalizeEcosystem),
+    semantic: normalizeRows(source.semantic, normalizeCandidate),
   }
 }
 
@@ -332,6 +335,7 @@ export function loadRuntimeGraph(): GraphRuntime {
     comparisons: safeJsonArray(GRAPH_FILES.comparisons),
     stacks: safeJsonArray(GRAPH_FILES.stacks),
     supernodes: safeJsonArray(GRAPH_FILES.supernodes),
+    semantic: safeJsonArray(GRAPH_FILES.semantic),
   })
 
   return graphCache
@@ -453,6 +457,41 @@ function byNameOrSlug<T extends { id?: string; slug?: string; name?: string }>(
   )
 }
 
+
+
+function hasPrecomputedSemantic(graph: GraphRuntime): boolean {
+  return Array.isArray(graph.semantic) && graph.semantic.length > 0
+}
+
+function getPrecomputedSemanticCandidates(
+  graph: GraphRuntime,
+  type: string,
+  keys: Set<string>
+): GraphCandidate[] {
+  if (!hasPrecomputedSemantic(graph)) return []
+
+  return (graph.semantic || []).filter(
+    (candidate) =>
+      candidate.type === type &&
+      otherEndpoint(candidate, keys) &&
+      (keys.has(normalizeKey(candidate.source)) || keys.has(normalizeKey(candidate.target)))
+  )
+}
+
+function semanticCandidateToRelationship(candidate: GraphCandidate): GraphRelationship {
+  return {
+    id: candidate.id,
+    source: candidate.source,
+    target: candidate.target,
+    type: candidate.type || 'semantic-overlap',
+    weight: candidate.weight,
+    rationale: candidate.rationale || 'Related by shared mechanisms, pathways, or topic ecosystem context.',
+    evidence_context: candidate.evidence_context,
+    mechanisms: unique((candidate as GraphRecord).mechanisms || candidate.mechanism_overlap || candidate.mechanism_complementarity),
+    pathways: unique((candidate as GraphRecord).pathways || candidate.pathway_overlap || candidate.pathway_complementarity),
+    topics: unique((candidate as GraphRecord).topics || candidate.topic_overlap || candidate.ecosystem_overlap),
+  }
+}
 
 function relationshipToCandidate(
   relationship: GraphRelationship,
@@ -695,8 +734,11 @@ export function getRelatedProfiles(
         keys.has(normalizeKey(relationship.target)))
   )
 
-  const semanticFallback = node
-    ? getNodes(graph)
+  const precomputedSemantic = getPrecomputedSemanticCandidates(graph, 'semantic-overlap', keys)
+  const semanticFallback = precomputedSemantic.length
+    ? precomputedSemantic.map(semanticCandidateToRelationship)
+    : node
+      ? getNodes(graph)
         .filter((candidate) => !matchesProfile(candidate, node))
         .map((candidate) => {
           const mechanisms = sharedItems(node.mechanisms, candidate.mechanisms)
@@ -847,11 +889,15 @@ export function getComparisonCandidates(
     )
     .map((relationship) => relationshipToCandidate(relationship, 'relationship-overlap'))
 
+  const precomputedSemantic = getPrecomputedSemanticCandidates(graph, 'semantic-comparison', keys)
+
   const results = dedupeByOtherEndpoint(
     sortCandidates([
       ...explicit,
       ...relationshipFallback,
-      ...nodeComparisonFallback(graph, node, keys),
+      ...(precomputedSemantic.length
+        ? precomputedSemantic
+        : nodeComparisonFallback(graph, node, keys)),
     ]),
     keys
   ).slice(0, clampLimit(limit, 8, MAX_COMPARISON_CANDIDATES))
@@ -914,11 +960,15 @@ export function getStackCandidates(
       safety_gate: 'review safety context before combining',
     }))
 
+  const precomputedSemantic = getPrecomputedSemanticCandidates(graph, 'biological-adjacency', keys)
+
   const results = dedupeByOtherEndpoint(
     sortCandidates([
       ...explicit,
       ...relationshipFallback,
-      ...nodeStackFallback(graph, node, keys),
+      ...(precomputedSemantic.length
+        ? precomputedSemantic
+        : nodeStackFallback(graph, node, keys)),
     ]),
     keys
   ).slice(0, clampLimit(limit, 6, MAX_STACK_CANDIDATES))

--- a/scripts/data/build-runtime-from-workbook.mjs
+++ b/scripts/data/build-runtime-from-workbook.mjs
@@ -679,16 +679,148 @@ function mergeSparseRecoveryIntoNodes(nodes, sparseRecovery) {
   return merged.sort(sortById)
 }
 
+
+const SEMANTIC_RELATED_LIMIT = 12
+const SEMANTIC_COMPARISON_LIMIT = 8
+const SEMANTIC_STACK_LIMIT = 6
+
+function nodeIdentity(node) {
+  return slug(node?.slug || node?.id || node?.name)
+}
+
+function sharedGraphItems(a, b) {
+  const left = new Set(splitList(a).map(slug).filter(Boolean))
+  if (!left.size) return []
+
+  return uniqueList(b).filter((value) => left.has(slug(value)))
+}
+
+function semanticScore(candidate) {
+  const weight = Number(candidate.weight || 0)
+  const mechanisms = splitList(candidate.mechanism_overlap || candidate.mechanism_complementarity || candidate.mechanisms).length
+  const pathways = splitList(candidate.pathway_overlap || candidate.pathway_complementarity || candidate.pathways).length
+  const topics = splitList(candidate.topic_overlap || candidate.topics).length
+
+  return (Number.isFinite(weight) ? weight : 0) + mechanisms * 3 + pathways * 2 + topics
+}
+
+function semanticSort(a, b) {
+  const scoreDelta = semanticScore(b) - semanticScore(a)
+  if (scoreDelta !== 0) return scoreDelta
+  return clean(a.id || `${a.source}-${a.target}`).localeCompare(clean(b.id || `${b.source}-${b.target}`))
+}
+
+function semanticBaseCandidates(nodes, source) {
+  const sourceSlug = nodeIdentity(source)
+  if (!sourceSlug) return []
+
+  return nodes
+    .filter((candidate) => nodeIdentity(candidate) && nodeIdentity(candidate) !== sourceSlug)
+    .map((candidate) => {
+      const targetSlug = nodeIdentity(candidate)
+      const mechanisms = sharedGraphItems(source.mechanisms, candidate.mechanisms)
+      const pathways = sharedGraphItems(source.pathways, candidate.pathways)
+      const topics = sharedGraphItems(source.topics, candidate.topics)
+
+      return {
+        source: sourceSlug,
+        target: targetSlug,
+        mechanisms,
+        pathways,
+        topics,
+        relatedWeight: mechanisms.length * 3 + pathways.length * 2 + topics.length,
+        comparisonWeight: mechanisms.length * 3 + pathways.length * 2 + topics.length,
+        stackWeight: mechanisms.length * 2 + pathways.length * 2 + topics.length,
+      }
+    })
+}
+
+function buildPrecomputedSemanticCandidates(nodes) {
+  const rows = []
+  const mergedNodes = Array.isArray(nodes) ? nodes : []
+
+  for (const node of mergedNodes) {
+    const sourceSlug = nodeIdentity(node)
+    if (!sourceSlug) continue
+
+    const base = semanticBaseCandidates(mergedNodes, node)
+
+    rows.push(
+      ...base
+        .filter((candidate) => candidate.mechanisms.length > 0 || candidate.pathways.length > 0 || candidate.topics.length >= 2)
+        .map((candidate) => removeEmptyInternalFields({
+          id: `${sourceSlug}-semantic-${candidate.target}`,
+          source: sourceSlug,
+          target: candidate.target,
+          type: 'semantic-overlap',
+          weight: candidate.relatedWeight,
+          rationale: 'Related by shared mechanisms, pathways, or topic ecosystem context.',
+          evidence_context: 'Precomputed semantic graph context; use profile evidence and safety notes for interpretation.',
+          mechanisms: candidate.mechanisms,
+          pathways: candidate.pathways,
+          topics: candidate.topics,
+        }))
+        .sort(semanticSort)
+        .slice(0, SEMANTIC_RELATED_LIMIT),
+      ...base
+        .filter((candidate) => candidate.mechanisms.length > 0 || candidate.pathways.length > 0 || candidate.topics.length >= 2)
+        .map((candidate) => removeEmptyInternalFields({
+          id: `${sourceSlug}-compare-${candidate.target}`,
+          source: sourceSlug,
+          target: candidate.target,
+          type: 'semantic-comparison',
+          weight: candidate.comparisonWeight,
+          rationale: 'Semantic comparison candidate based on shared mechanisms, pathways, or ecosystem context; not an efficacy or superiority claim.',
+          evidence_context: 'Evidence context should be read from each profile before interpretation.',
+          mechanism_overlap: candidate.mechanisms,
+          pathway_overlap: candidate.pathways,
+          topic_overlap: candidate.topics,
+          ecosystem_overlap: candidate.topics,
+        }))
+        .sort(semanticSort)
+        .slice(0, SEMANTIC_COMPARISON_LIMIT),
+      ...base
+        .filter((candidate) => {
+          const mechanismCount = candidate.mechanisms.length
+          const pathwayCount = candidate.pathways.length
+          const topicCount = candidate.topics.length
+          return mechanismCount >= 2 || pathwayCount >= 2 || (mechanismCount + pathwayCount >= 2 && topicCount > 0)
+        })
+        .map((candidate) => removeEmptyInternalFields({
+          id: `${sourceSlug}-stack-${candidate.target}`,
+          source: sourceSlug,
+          target: candidate.target,
+          type: 'biological-adjacency',
+          weight: candidate.stackWeight,
+          rationale: 'Biologically adjacent research candidate; use only as exploratory education context, not stack advice.',
+          framing: candidate.topics.join('; '),
+          evidence_context: 'Exploratory graph context; review profile-specific evidence and safety notes.',
+          mechanism_complementarity: candidate.mechanisms,
+          pathway_complementarity: candidate.pathways,
+          topic_overlap: candidate.topics,
+          ecosystem_overlap: candidate.topics,
+          safety_gate: 'review safety context before combining',
+        }))
+        .sort(semanticSort)
+        .slice(0, SEMANTIC_STACK_LIMIT)
+    )
+  }
+
+  return normalizeGraphRows(rows, (row) => row)
+}
+
 function writeWorkbookGraphPayloads(outDir, graph) {
   const graphDir = path.join(outDir, 'graph')
+  const nodes = mergeSparseRecoveryIntoNodes(graph.nodes, graph.sparseRecovery)
   const payloads = {
-    'nodes.json': mergeSparseRecoveryIntoNodes(graph.nodes, graph.sparseRecovery),
+    'nodes.json': nodes,
     'relationships.json': graph.relationships,
     'topics.json': graph.topics,
     'pathways.json': graph.pathways,
     'comparisons.json': graph.comparisons,
     'stacks.json': graph.stacks,
     'supernodes.json': graph.supernodes,
+    'semantic.json': buildPrecomputedSemanticCandidates(nodes),
   }
 
   for (const [filename, payload] of Object.entries(payloads)) {


### PR DESCRIPTION
### Motivation
- Improve runtime semantic candidate performance by allowing the graph exporter to precompute bounded semantic candidate rows while keeping the existing dynamic fallbacks intact. 
- Avoid regenerating or committing large generated runtime JSON artifacts while enabling the runtime to consume an optional semantic payload when present. 

### Description
- Add optional `semantic` graph payload support to the runtime loader and normalizer (`lib/runtime-graph.ts`) so `semantic.json` is read alongside existing graph files. 
- Introduce helpers `hasPrecomputedSemantic`, `getPrecomputedSemanticCandidates`, and `semanticCandidateToRelationship` and prefer precomputed semantic candidates for related profiles, comparison candidates, and stack candidates while preserving node-based fallbacks. 
- Extend the workbook exporter (`scripts/data/build-runtime-from-workbook.mjs`) to compute bounded semantic related/comparison/stack candidate rows from graph node overlaps and emit `public/data/graph/semantic.json` during `data:build` without committing generated payloads. 
- Keep the committed diff focused to source-only changes (runtime loader and exporter logic) and do not commit regenerated bulk `public/data` artifacts. 

### Testing
- Ran `npm run check` (full build pipeline including data build and Next.js build) which completed successfully. 
- Ran type check with `npx tsc --noEmit --pretty false` which passed. 
- Exporter ran during the build and produced `public/data/graph/semantic.json` in the local run, but generated runtime artifacts were explicitly not committed to the repo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff82fd2968832380269180d13f2062)