### PR TITLE
Add ecosystem decision intelligence UI

### DIFF
--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -33,6 +33,8 @@ import {
 import ProfileAuthoritySections from '@/components/profile-authority-sections'
 import { ProfileDecisionLayer } from '@/components/profile-decision-layer'
 import DecisionClarityFieldManual from '@/components/decision-clarity-field-manual'
+import DecisionVisualGrid from '@/components/decision-visual-grid'
+import WhyThisInsteadPanel from '@/components/why-this-instead-panel'
 import RuntimeOrchestratedDiscovery from '@/components/runtime/runtime-orchestrated-discovery'
 import AuthorityEditorialLayer from '@/components/profile/AuthorityEditorialLayer'
 import SemanticArtworkPanel from '@/components/semantic-artwork-panel'
@@ -266,6 +268,13 @@ export default async function CompoundPage({ params }: any) {
           summary={summary}
         />
 
+        <DecisionVisualGrid record={compound} />
+
+        <WhyThisInsteadPanel
+          record={compound}
+          alternatives={semanticRelated}
+        />
+
         <DecisionClarityFieldManual
           record={compound}
           entityType="compound"
@@ -320,6 +329,7 @@ export default async function CompoundPage({ params }: any) {
         <EvidenceAwareCTA
           readiness={readiness}
           sourcingNotes={sourcingNotes}
+          record={compound}
         />
 
         <RuntimeOrchestratedDiscovery

--- a/app/ecosystems/[slug]/page.tsx
+++ b/app/ecosystems/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { getEcosystemHub, getEcosystemHubs } from '@/lib/ecosystem-hubs'
+import EcosystemSupernode from '@/components/ecosystem-supernode'
 
 export async function generateStaticParams() {
   return getEcosystemHubs().map((hub) => ({
@@ -94,6 +95,8 @@ export default function EcosystemHubPage({ params }: any) {
           </div>
         </div>
       </section>
+
+      <EcosystemSupernode hub={hub} profileHref={profileHref} />
 
       <section className="space-y-5">
         <div className="space-y-2">

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -24,6 +24,8 @@ import { getFeaturedCollections } from '@/lib/collections'
 import ProfileAuthoritySections from '@/components/profile-authority-sections'
 import { ProfileDecisionLayer } from '@/components/profile-decision-layer'
 import DecisionClarityFieldManual from '@/components/decision-clarity-field-manual'
+import DecisionVisualGrid from '@/components/decision-visual-grid'
+import WhyThisInsteadPanel from '@/components/why-this-instead-panel'
 import RuntimeOrchestratedDiscovery from '@/components/runtime/runtime-orchestrated-discovery'
 import AuthorityEditorialLayer from '@/components/profile/AuthorityEditorialLayer'
 import AuthorityProfileShell from '@/components/authority/AuthorityProfileShell'
@@ -288,6 +290,13 @@ export default async function HerbDetailPage({ params }: any) {
         summary={summary}
       />
 
+      <DecisionVisualGrid record={herb} />
+
+      <WhyThisInsteadPanel
+        record={herb}
+        alternatives={relatedProfiles}
+      />
+
       <DecisionClarityFieldManual
         record={herb}
         entityType="herb"
@@ -343,6 +352,7 @@ export default async function HerbDetailPage({ params }: any) {
       <EvidenceAwareCTA
         readiness={readiness}
         sourcingNotes={sourcingNotes}
+        record={herb}
       />
 
       <RuntimeOrchestratedDiscovery

--- a/app/start/[slug]/page.tsx
+++ b/app/start/[slug]/page.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { getBeginnerPathways } from '@/lib/beginner-pathways'
+import DecisionVisualGrid from '@/components/decision-visual-grid'
+import WhyThisInsteadPanel from '@/components/why-this-instead-panel'
 
 function getPathway(slug: string) {
   return getBeginnerPathways().find((pathway) => pathway.slug === slug)
@@ -80,6 +82,24 @@ export default function BeginnerPathwayPage({ params }: any) {
           </div>
         </div>
       </section>
+
+      <DecisionVisualGrid
+        record={{
+          slug: pathway.slug,
+          name: pathway.title,
+          description: pathway.description,
+          topic_ecosystems: pathway.signals,
+        }}
+        title={`${pathway.title}: beginner decision map`}
+        compact
+      />
+
+      <WhyThisInsteadPanel
+        record={{ slug: pathway.starterProfiles[0], name: pathway.starterProfiles[0] }}
+        alternatives={pathway.starterProfiles.slice(1).map((profile) => ({ slug: profile, name: profile }))}
+        title="Why start here instead?"
+        limit={2}
+      />
 
       <section className="space-y-5">
         <div className="space-y-2">

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -36,6 +36,28 @@ function toFeaturedCard(item: RuntimeFeature, type: 'herb' | 'compound') {
   }
 }
 
+
+const beginnerEntries = [
+  { title: 'Start Sleep Support', href: '/start/sleep-support', description: 'Begin with calmer profiles, sleep-adjacent expectations, and recovery-aware comparisons.' },
+  { title: 'Start Cognitive Support', href: '/start/cognitive-support', description: 'Separate calm focus, cumulative cognition, and activating focus before stacking.' },
+  { title: 'Start Recovery Support', href: '/start/recovery-support', description: 'Explore performance support, recovery capacity, and cumulative timelines conservatively.' },
+  { title: 'Start Stress Support', href: '/start/stress-support', description: 'Compare adaptogenic, calming, and recovery-oriented pathways by practical fit.' },
+]
+
+const ecosystemEntries = [
+  { title: 'Sleep ecosystem', href: '/ecosystems/sleep', description: 'Calming pathways, sleep-adjacent profiles, and realistic evening-support decisions.' },
+  { title: 'Cognition ecosystem', href: '/ecosystems/cognition', description: 'Calm focus, cumulative cognition, activating support, and sustainable mental performance.' },
+  { title: 'Recovery ecosystem', href: '/ecosystems/recovery', description: 'Training support, nervous-system recovery, and cumulative performance resilience.' },
+  { title: 'Stress ecosystem', href: '/ecosystems/stress', description: 'Stress resilience, stimulation sensitivity, and adaptogen comparison logic.' },
+]
+
+const comparisonHighlights = [
+  'Calm focus vs activating focus',
+  'Cumulative cognition vs acute stimulation',
+  'Sleep-adjacent relaxation vs daytime recovery',
+  'Beginner-friendly simplicity vs premature stack complexity',
+]
+
 const featuredFallbacks = [
   {
     href: '/herbs/ashwagandha',
@@ -61,7 +83,7 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
   const featured = [
     ...featuredHerbs.map((item) => toFeaturedCard(item, 'herb')),
     ...featuredCompounds.map((item) => toFeaturedCard(item, 'compound')),
-  ].filter(Boolean).slice(0, 3)
+  ].filter((item): item is NonNullable<typeof item> => Boolean(item)).slice(0, 3)
 
   const visibleFeatured = featured.length > 0 ? featured : featuredFallbacks
 
@@ -110,6 +132,58 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
 
       <section className='mx-auto max-w-6xl space-y-8'>
         <div className='space-y-2'>
+          <p className='eyebrow-label'>Beginner entry systems</p>
+          <h2 className='compact-heading'>Start with a guided pathway, not a random stack.</h2>
+          <p className='detail-reading max-w-3xl text-[#46574d]'>
+            Each entry point frames stimulation, timeline, recovery orientation, and comparison logic before profile depth.
+          </p>
+        </div>
+
+        <div className='grid gap-5 md:grid-cols-2'>
+          {beginnerEntries.map((item) => (
+            <ContentIdentityCard key={item.href} item={{ ...item, meta: 'Onboarding' } as any} />
+          ))}
+        </div>
+      </section>
+
+      <section className='mx-auto max-w-6xl space-y-8'>
+        <div className='space-y-2'>
+          <p className='eyebrow-label'>Ecosystem intelligence</p>
+          <h2 className='compact-heading'>Explore semantic hubs and adjacent pathways.</h2>
+          <p className='detail-reading max-w-3xl text-[#46574d]'>
+            Ecosystem hubs connect beginner starts, adaptive comparisons, common mistakes, and practical field-manual guidance.
+          </p>
+        </div>
+
+        <div className='grid gap-5 md:grid-cols-2'>
+          {ecosystemEntries.map((item) => (
+            <ContentIdentityCard key={item.href} item={{ ...item, meta: 'Ecosystem' } as any} />
+          ))}
+        </div>
+      </section>
+
+      <section className='rounded-[2.5rem] border border-brand-900/10 bg-gradient-to-br from-[#f6f4ee] via-white to-[#eef4ee] p-8 shadow-sm sm:p-12'>
+        <div className='grid gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-center'>
+          <div className='space-y-3'>
+            <p className='eyebrow-label'>Comparative reasoning highlights</p>
+            <h2 className='text-3xl font-semibold tracking-tight text-ink'>This is fit-first supplement navigation.</h2>
+            <p className='text-sm leading-7 text-[#46574d]'>
+              The platform emphasizes conservative interpretation, evidence-aware positioning, and semantic continuity across profiles instead of generic supplement rankings.
+            </p>
+          </div>
+
+          <div className='grid gap-3 sm:grid-cols-2'>
+            {comparisonHighlights.map((item) => (
+              <div key={item} className='rounded-2xl border border-brand-900/10 bg-white/75 p-4 text-sm font-semibold text-[#33443a]'>
+                {item}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className='mx-auto max-w-6xl space-y-8'>
+        <div className='space-y-2'>
           <p className='eyebrow-label'>Explore by goal</p>
           <h2 className='compact-heading'>Start with what you are trying to improve.</h2>
         </div>
@@ -125,18 +199,18 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
       <section className='rounded-[2.5rem] border border-brand-900/10 bg-gradient-to-br from-[#f6f4ee] via-white to-[#eef4ee] p-8 shadow-sm sm:p-12'>
         <div className='grid gap-5 md:grid-cols-3'>
           <div className='rounded-[1.5rem] border border-brand-900/10 bg-white/70 p-5'>
-            <h3 className='text-base font-semibold tracking-tight text-ink'>Start with your goal</h3>
-            <p className='mt-2 text-sm leading-7 text-[#46574d]'>Sleep, stress, cognition, recovery, and inflammation pages help you begin with practical intent.</p>
+            <h3 className='text-base font-semibold tracking-tight text-ink'>Evidence-aware positioning</h3>
+            <p className='mt-2 text-sm leading-7 text-[#46574d]'>Research context, safety boundaries, and expectation timelines stay visible instead of collapsing into hype.</p>
           </div>
 
           <div className='rounded-[1.5rem] border border-brand-900/10 bg-white/70 p-5'>
-            <h3 className='text-base font-semibold tracking-tight text-ink'>Compare nearby options</h3>
-            <p className='mt-2 text-sm leading-7 text-[#46574d]'>Review similar herbs and compounds before relying on one supplement narrative.</p>
+            <h3 className='text-base font-semibold tracking-tight text-ink'>Conservative interpretation</h3>
+            <p className='mt-2 text-sm leading-7 text-[#46574d]'>Profiles are framed as decision-support field notes, not pseudo-medical promises or universal rankings.</p>
           </div>
 
           <div className='rounded-[1.5rem] border border-brand-900/10 bg-white/70 p-5'>
-            <h3 className='text-base font-semibold tracking-tight text-ink'>Check evidence and safety</h3>
-            <p className='mt-2 text-sm leading-7 text-[#46574d]'>Human evidence and realistic expectations stay separated from hype.</p>
+            <h3 className='text-base font-semibold tracking-tight text-ink'>Fit-first reasoning</h3>
+            <p className='mt-2 text-sm leading-7 text-[#46574d]'>Stimulation, timeline, recovery orientation, and beginner difficulty shape exploration before product decisions.</p>
           </div>
         </div>
       </section>

--- a/src/components/decision-visual-grid.tsx
+++ b/src/components/decision-visual-grid.tsx
@@ -1,0 +1,114 @@
+import {
+  buildDecisionVisualProfile,
+  type DecisionVisualProfile,
+  type StimulationProfile,
+  type TimelineProfile,
+} from '@/lib/decision-visuals'
+import { formatDisplayLabel } from '@/lib/display-utils'
+
+type DecisionVisualGridProps = {
+  record: any
+  title?: string
+  compact?: boolean
+}
+
+const stimulationOrder: StimulationProfile[] = ['calming', 'balanced', 'activating']
+const timelineOrder: TimelineProfile[] = ['acute', 'mixed', 'cumulative']
+
+function position<T extends string>(order: T[], value: T) {
+  const index = Math.max(0, order.indexOf(value))
+  return `${(index / Math.max(1, order.length - 1)) * 100}%`
+}
+
+function toneClass(value: string) {
+  if (value.includes('calming') || value.includes('beginner') || value.includes('recovery') || value.includes('sleep')) {
+    return 'border-emerald-700/15 bg-emerald-50/70 text-emerald-950'
+  }
+
+  if (value.includes('activating') || value.includes('aggressive') || value.includes('advanced')) {
+    return 'border-amber-700/20 bg-amber-50/80 text-amber-950'
+  }
+
+  return 'border-brand-900/10 bg-white/75 text-[#33443a]'
+}
+
+function SpectrumBar({
+  label,
+  value,
+  order,
+}: {
+  label: string
+  value: StimulationProfile | TimelineProfile
+  order: StimulationProfile[] | TimelineProfile[]
+}) {
+  return (
+    <div className="rounded-2xl border border-brand-900/10 bg-white/75 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-[0.68rem] font-bold uppercase tracking-[0.16em] text-brand-900/55">{label}</p>
+        <p className="text-xs font-semibold text-[#33443a]">{formatDisplayLabel(value)}</p>
+      </div>
+
+      <div className="relative mt-4 h-2 rounded-full bg-brand-900/10">
+        <span
+          className="absolute top-1/2 h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full border-2 border-white bg-brand-700 shadow-sm"
+          style={{ left: position(order as any, value as any) }}
+        />
+      </div>
+
+      <div className="mt-3 flex justify-between text-[0.68rem] font-semibold uppercase tracking-[0.12em] text-brand-900/45">
+        {order.map((item) => (
+          <span key={item}>{item.split('-')[0]}</span>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function SignalCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className={`rounded-2xl border p-4 ${toneClass(value)}`}>
+      <p className="text-[0.68rem] font-bold uppercase tracking-[0.16em] opacity-65">{label}</p>
+      <p className="mt-2 text-sm font-semibold leading-6">{formatDisplayLabel(value)}</p>
+    </div>
+  )
+}
+
+export default function DecisionVisualGrid({ record, title = 'Visual decision intelligence', compact = false }: DecisionVisualGridProps) {
+  const profile: DecisionVisualProfile = buildDecisionVisualProfile(record)
+
+  return (
+    <section className={`card-premium space-y-5 ${compact ? 'p-5 sm:p-6' : 'p-5 sm:p-7 lg:p-8'}`}>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div className="space-y-2">
+          <p className="eyebrow-label">Decision Visuals</p>
+          <h2 className="max-w-2xl text-2xl font-semibold tracking-tight text-ink sm:text-3xl">
+            {title}
+          </h2>
+        </div>
+        <p className="max-w-md text-sm leading-7 text-[#46574d]">
+          Compact semantic signals for comparing fit, timeline, and experimentation complexity without implying medical precision.
+        </p>
+      </div>
+
+      <div className="grid gap-3 lg:grid-cols-2">
+        <SpectrumBar label="Stimulation" value={profile.stimulation} order={stimulationOrder} />
+        <SpectrumBar label="Timeline" value={profile.timeline} order={timelineOrder} />
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <SignalCard label="Beginner Difficulty" value={profile.difficulty} />
+        <SignalCard label="Stack Complexity" value={profile.stackComplexity} />
+        <SignalCard label="Responder Variability" value={profile.responderVariability} />
+        <SignalCard label="Orientation" value={profile.recoveryOrientation} />
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        {profile.tags.map((tag) => (
+          <span key={tag} className="rounded-full border border-brand-900/10 bg-paper-50/80 px-3 py-1.5 text-xs font-semibold text-[#46574d]">
+            {formatDisplayLabel(tag)}
+          </span>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/ecosystem-supernode.tsx
+++ b/src/components/ecosystem-supernode.tsx
@@ -1,0 +1,173 @@
+import type { ReactNode } from 'react'
+import Link from 'next/link'
+import DecisionVisualGrid from '@/components/decision-visual-grid'
+import WhyThisInsteadPanel from '@/components/why-this-instead-panel'
+import { formatDisplayLabel } from '@/lib/display-utils'
+
+type EcosystemSupernodeProps = {
+  hub: {
+    slug: string
+    title: string
+    description: string
+    onboardingPathway: string
+    beginnerProfiles: string[]
+    comparisonProfiles: string[]
+    guidance: string[]
+    stimulationProfile?: string
+    timelineProfile?: string
+  }
+  profileHref: (profile: string) => string
+}
+
+const MISTAKES = [
+  'Overstimulation from stacking too many activating profiles before testing individual fit.',
+  'Unrealistic expectations when cumulative profiles are judged like acute stimulants.',
+  'Premature overstacking before sleep, workload, tolerance, and baseline recovery are understood.',
+]
+
+const STACK_CAUTIONS = [
+  'Avoid stimulant overload and redundant activation pathways.',
+  'Avoid redundant calming stacks when sedation or next-day grogginess would be a problem.',
+  'Keep first experiments simple enough that response signals remain interpretable.',
+]
+
+function SectionCard({ title, eyebrow, children }: { title: string; eyebrow: string; children: ReactNode }) {
+  return (
+    <section className="rounded-3xl border border-brand-900/10 bg-white/75 p-5 shadow-sm">
+      <p className="text-[0.68rem] font-bold uppercase tracking-[0.18em] text-brand-900/55">{eyebrow}</p>
+      <h3 className="mt-1 text-xl font-semibold tracking-tight text-ink">{title}</h3>
+      <div className="mt-4">{children}</div>
+    </section>
+  )
+}
+
+function BulletList({ items }: { items: string[] }) {
+  return (
+    <ul className="space-y-3 text-sm leading-7 text-[#46574d]">
+      {items.map((item) => (
+        <li key={item} className="flex gap-3">
+          <span className="mt-[0.7rem] h-1.5 w-1.5 shrink-0 rounded-full bg-brand-700/60" />
+          <span>{item}</span>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function LinkGrid({ profiles, profileHref }: { profiles: string[]; profileHref: (profile: string) => string }) {
+  return (
+    <div className="grid gap-3 sm:grid-cols-2">
+      {profiles.map((profile) => (
+        <Link
+          key={profile}
+          href={profileHref(profile)}
+          className="rounded-2xl border border-brand-900/10 bg-paper-50/80 px-4 py-3 text-sm font-semibold text-[#33443a] transition hover:border-brand-700/25 hover:bg-white hover:text-brand-800"
+        >
+          {formatDisplayLabel(profile)}
+        </Link>
+      ))}
+    </div>
+  )
+}
+
+function faqSchema(hub: EcosystemSupernodeProps['hub']) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: [
+      {
+        '@type': 'Question',
+        name: `How should beginners start the ${hub.title}?`,
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Start with the beginner pathway, compare nearby profiles, and avoid building complex stacks before individual response is clear.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: `What is the most common mistake in the ${hub.title}?`,
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'The common mistake is treating different stimulation profiles and timelines as interchangeable, especially when cumulative options are judged like acute effects.',
+        },
+      },
+    ],
+  }
+}
+
+export default function EcosystemSupernode({ hub, profileHref }: EcosystemSupernodeProps) {
+  const alternatives = [...hub.beginnerProfiles, ...hub.comparisonProfiles].map((slug) => ({ slug, name: slug }))
+  const record = {
+    slug: hub.slug,
+    name: hub.title,
+    description: hub.description,
+    stimulationProfile: hub.stimulationProfile,
+    timelineProfile: hub.timelineProfile,
+    topic_ecosystems: [hub.slug],
+  }
+
+  return (
+    <div className="space-y-6">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema(hub)) }}
+      />
+
+      <DecisionVisualGrid record={record} title={`${hub.title}: decision map`} compact />
+
+      <WhyThisInsteadPanel
+        record={alternatives[0] || record}
+        alternatives={alternatives.slice(1)}
+        title="Adaptive comparison pathways"
+        limit={2}
+      />
+
+      <section className="grid gap-4 lg:grid-cols-3">
+        <SectionCard eyebrow="Beginner Starts" title="Guided onboarding">
+          <div className="space-y-4">
+            <p className="text-sm leading-7 text-[#46574d]">
+              Begin with a pathway instead of a stack. Compare one profile at a time, then expand only when the response pattern is interpretable.
+            </p>
+            <Link href={`/start/${hub.onboardingPathway}`} className="button-secondary inline-flex">
+              Open onboarding
+            </Link>
+          </div>
+        </SectionCard>
+
+        <SectionCard eyebrow="Common Mistakes" title="Avoid noisy experiments">
+          <BulletList items={MISTAKES} />
+        </SectionCard>
+
+        <SectionCard eyebrow="Stack Cautions" title="Keep combinations readable">
+          <BulletList items={STACK_CAUTIONS} />
+        </SectionCard>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <SectionCard eyebrow="Best Fit Groupings" title="Who may compare here first">
+          <div className="flex flex-wrap gap-2">
+            {['stimulant-sensitive', 'recovery-oriented', 'sleep-adjacent', 'cumulative cognition', 'stress-modulating'].map((item) => (
+              <span key={item} className="chip-readable">{item}</span>
+            ))}
+          </div>
+        </SectionCard>
+
+        <SectionCard eyebrow="Relationship Map" title="Overlap and adjacency">
+          <p className="text-sm leading-7 text-[#46574d]">
+            This hub connects profiles through pathway overlap, stimulation adjacency, timeline differences, and beginner-to-advanced continuity.
+          </p>
+        </SectionCard>
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <SectionCard eyebrow="Comparison Navigation" title="Strong adjacent profiles">
+          <LinkGrid profiles={hub.comparisonProfiles} profileHref={profileHref} />
+        </SectionCard>
+
+        <SectionCard eyebrow="Alternative Pathways" title="Starter profiles">
+          <LinkGrid profiles={hub.beginnerProfiles} profileHref={profileHref} />
+        </SectionCard>
+      </section>
+    </div>
+  )
+}

--- a/src/components/evidence-aware-cta.tsx
+++ b/src/components/evidence-aware-cta.tsx
@@ -1,3 +1,5 @@
+import { buildDecisionVisualProfile } from '@/lib/decision-visuals'
+
 type EvidenceAwareCTAProps = {
   title?: string
   description?: string
@@ -7,6 +9,7 @@ type EvidenceAwareCTAProps = {
     cautions: string[]
   }
   sourcingNotes?: string[]
+  record?: any
 }
 
 function levelLabel(level: EvidenceAwareCTAProps['readiness']['level']) {
@@ -40,7 +43,27 @@ export default function EvidenceAwareCTA({
   description = 'Product and sourcing context should remain secondary to evidence quality, safety considerations, and mechanism uncertainty.',
   readiness,
   sourcingNotes = [],
+  record,
 }: EvidenceAwareCTAProps) {
+  const visuals = buildDecisionVisualProfile(record || {})
+  const recommendationCards = [
+    {
+      label: 'Formulation Notes',
+      value: sourcingNotes[0] || 'Prefer transparent labels, conservative serving context, and forms that match the profile goal.',
+    },
+    {
+      label: 'Beginner Fit',
+      value: visuals.difficulty,
+    },
+    {
+      label: 'Stimulation Profile',
+      value: visuals.stimulation,
+    },
+    {
+      label: 'Timeline Profile',
+      value: visuals.timeline,
+    },
+  ]
   return (
     <section className="compact-section section-rhythm-balanced overflow-hidden">
       <div className="space-y-2">
@@ -56,6 +79,15 @@ export default function EvidenceAwareCTA({
         <p className="compact-copy">
           {description}
         </p>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {recommendationCards.map((card) => (
+          <article key={card.label} className="rounded-2xl border border-brand-900/10 bg-white/75 p-4 shadow-sm">
+            <p className="text-[0.68rem] font-bold uppercase tracking-[0.16em] text-brand-900/55">{card.label}</p>
+            <p className="mt-2 text-sm font-semibold leading-6 text-[#33443a]">{card.value}</p>
+          </article>
+        ))}
       </div>
 
       <div className="grid gap-4 lg:grid-cols-[1fr_0.9fr]">

--- a/src/components/why-this-instead-panel.tsx
+++ b/src/components/why-this-instead-panel.tsx
@@ -1,0 +1,92 @@
+import Link from 'next/link'
+import { buildAlternativeReasoningSet, type AlternativeReasoning } from '@/lib/why-this-instead'
+import { formatDisplayLabel } from '@/lib/display-utils'
+
+type WhyThisInsteadPanelProps = {
+  record: any
+  alternatives?: any[]
+  title?: string
+  limit?: number
+}
+
+function MetricPill({ label, value }: { label: string; value: string }) {
+  return (
+    <span className="rounded-full border border-brand-900/10 bg-white/75 px-3 py-1 text-[0.72rem] font-semibold text-[#46574d]">
+      {label}: {formatDisplayLabel(value)}
+    </span>
+  )
+}
+
+function NameBlock({ node, eyebrow }: { node: AlternativeReasoning['source']; eyebrow: string }) {
+  const content = (
+    <div className="rounded-2xl border border-brand-900/10 bg-white/75 p-4 transition hover:border-brand-700/20 hover:bg-white">
+      <p className="text-[0.68rem] font-bold uppercase tracking-[0.16em] text-brand-900/55">{eyebrow}</p>
+      <h3 className="mt-1 text-xl font-semibold tracking-tight text-ink">{node.label}</h3>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <MetricPill label="Stimulation" value={node.visuals.stimulation} />
+        <MetricPill label="Timeline" value={node.visuals.timeline} />
+      </div>
+    </div>
+  )
+
+  return node.href ? <Link href={node.href}>{content}</Link> : content
+}
+
+function ComparisonCard({ item }: { item: AlternativeReasoning }) {
+  return (
+    <article className="rounded-3xl border border-brand-900/10 bg-paper-50/80 p-5 shadow-sm">
+      <div className="grid gap-3 md:grid-cols-2">
+        <NameBlock node={item.source} eyebrow="Why this" />
+        <NameBlock node={item.alternative} eyebrow="Instead of" />
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        {item.contrastChips.map((chip) => (
+          <span key={chip} className="rounded-full border border-brand-900/10 bg-white/70 px-3 py-1 text-xs font-semibold text-[#46574d]">
+            {formatDisplayLabel(chip)}
+          </span>
+        ))}
+      </div>
+
+      <ul className="mt-4 space-y-2 text-sm leading-7 text-[#46574d]">
+        {item.rationale.map((reason) => (
+          <li key={reason} className="flex gap-3">
+            <span className="mt-[0.7rem] h-1.5 w-1.5 shrink-0 rounded-full bg-brand-700/60" />
+            <span>{reason}</span>
+          </li>
+        ))}
+      </ul>
+
+      <p className="mt-4 rounded-2xl border border-brand-900/10 bg-white/70 p-4 text-sm leading-7 text-[#33443a]">
+        {item.fitFrame}
+      </p>
+    </article>
+  )
+}
+
+export default function WhyThisInsteadPanel({ record, alternatives = [], title = 'Why this instead?', limit = 3 }: WhyThisInsteadPanelProps) {
+  const comparisons = buildAlternativeReasoningSet(record, alternatives, limit)
+  if (comparisons.length === 0) return null
+
+  return (
+    <section className="card-premium space-y-5 p-5 sm:p-7 lg:p-8">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div className="space-y-2">
+          <p className="eyebrow-label">Comparative Reasoning</p>
+          <h2 className="max-w-2xl text-2xl font-semibold tracking-tight text-ink sm:text-3xl">
+            {title}
+          </h2>
+        </div>
+        <p className="max-w-md text-sm leading-7 text-[#46574d]">
+          Fit-first comparisons that explain direction, tolerance context, and expectations without ranking one option as universally better.
+        </p>
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        {comparisons.map((item) => (
+          <ComparisonCard key={`${item.source.slug}-${item.alternative.slug}`} item={item} />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/lib/decision-visuals.ts
+++ b/src/lib/decision-visuals.ts
@@ -1,0 +1,296 @@
+import { list, text, unique } from '@/lib/display-utils'
+
+export type StimulationProfile = 'calming' | 'balanced' | 'activating'
+export type TimelineProfile = 'acute' | 'mixed' | 'cumulative'
+export type BeginnerDifficulty = 'beginner-friendly' | 'context-sensitive' | 'advanced experimentation'
+export type StackComplexity = 'simple' | 'moderate' | 'aggressive'
+export type ResponderVariabilityLevel = 'relatively consistent' | 'moderately variable' | 'highly context-dependent'
+export type RecoveryOrientation =
+  | 'recovery-oriented'
+  | 'cognition-oriented'
+  | 'sleep-adjacent'
+  | 'performance-oriented'
+  | 'stress-modulating'
+
+export type DecisionVisualProfile = {
+  stimulation: StimulationProfile
+  timeline: TimelineProfile
+  difficulty: BeginnerDifficulty
+  stackComplexity: StackComplexity
+  responderVariability: ResponderVariabilityLevel
+  recoveryOrientation: RecoveryOrientation
+  tags: string[]
+}
+
+type RuntimeRecord = Record<string, any>
+
+const CALMING_TERMS = [
+  'calm',
+  'relax',
+  'sleep',
+  'sedat',
+  'anxiety',
+  'stress',
+  'gaba',
+  'glycine',
+  'magnesium',
+  'theanine',
+]
+const ACTIVATING_TERMS = [
+  'energy',
+  'stimul',
+  'focus',
+  'alert',
+  'performance',
+  'adaptogen',
+  'dopamine',
+  'rhodiola',
+  'caffeine',
+]
+const ACUTE_TERMS = ['acute', 'same day', 'within', 'onset', 'notice', 'calm focus', 'relaxation']
+const CUMULATIVE_TERMS = ['cumulative', 'weeks', 'consistent', 'training', 'memory', 'adaptation', 'resilience', 'creatine', 'bacopa', 'lion']
+const CAUTION_TERMS = ['interaction', 'contraindication', 'avoid', 'caution', 'pregnancy', 'liver', 'kidney', 'sedat', 'bleed', 'thyroid']
+const VARIABILITY_TERMS = ['variable', 'context', 'individual', 'depends', 'may', 'mixed', 'tolerance', 'sensitive']
+
+const PROFILE_OVERRIDES: Record<string, Partial<DecisionVisualProfile>> = {
+  creatine: {
+    stimulation: 'balanced',
+    timeline: 'cumulative',
+    difficulty: 'beginner-friendly',
+    stackComplexity: 'simple',
+    responderVariability: 'relatively consistent',
+    recoveryOrientation: 'performance-oriented',
+  },
+  theanine: {
+    stimulation: 'calming',
+    timeline: 'acute',
+    difficulty: 'beginner-friendly',
+    stackComplexity: 'simple',
+    responderVariability: 'relatively consistent',
+    recoveryOrientation: 'cognition-oriented',
+  },
+  glycine: {
+    stimulation: 'calming',
+    timeline: 'acute',
+    difficulty: 'beginner-friendly',
+    stackComplexity: 'simple',
+    responderVariability: 'moderately variable',
+    recoveryOrientation: 'sleep-adjacent',
+  },
+  magnesium: {
+    stimulation: 'calming',
+    timeline: 'mixed',
+    difficulty: 'beginner-friendly',
+    stackComplexity: 'simple',
+    responderVariability: 'moderately variable',
+    recoveryOrientation: 'recovery-oriented',
+  },
+  'magnesium-glycinate': {
+    stimulation: 'calming',
+    timeline: 'mixed',
+    difficulty: 'beginner-friendly',
+    stackComplexity: 'simple',
+    responderVariability: 'moderately variable',
+    recoveryOrientation: 'sleep-adjacent',
+  },
+  rhodiola: {
+    stimulation: 'activating',
+    timeline: 'mixed',
+    difficulty: 'context-sensitive',
+    stackComplexity: 'moderate',
+    responderVariability: 'highly context-dependent',
+    recoveryOrientation: 'stress-modulating',
+  },
+  ashwagandha: {
+    stimulation: 'balanced',
+    timeline: 'cumulative',
+    difficulty: 'context-sensitive',
+    stackComplexity: 'moderate',
+    responderVariability: 'moderately variable',
+    recoveryOrientation: 'stress-modulating',
+  },
+  bacopa: {
+    stimulation: 'calming',
+    timeline: 'cumulative',
+    difficulty: 'context-sensitive',
+    stackComplexity: 'moderate',
+    responderVariability: 'moderately variable',
+    recoveryOrientation: 'cognition-oriented',
+  },
+  'lions-mane': {
+    stimulation: 'balanced',
+    timeline: 'cumulative',
+    difficulty: 'context-sensitive',
+    stackComplexity: 'moderate',
+    responderVariability: 'highly context-dependent',
+    recoveryOrientation: 'cognition-oriented',
+  },
+  'lion’s-mane': {
+    stimulation: 'balanced',
+    timeline: 'cumulative',
+    difficulty: 'context-sensitive',
+    stackComplexity: 'moderate',
+    responderVariability: 'highly context-dependent',
+    recoveryOrientation: 'cognition-oriented',
+  },
+  taurine: {
+    stimulation: 'calming',
+    timeline: 'mixed',
+    difficulty: 'beginner-friendly',
+    stackComplexity: 'simple',
+    responderVariability: 'moderately variable',
+    recoveryOrientation: 'recovery-oriented',
+  },
+  nac: {
+    stimulation: 'balanced',
+    timeline: 'cumulative',
+    difficulty: 'context-sensitive',
+    stackComplexity: 'moderate',
+    responderVariability: 'highly context-dependent',
+    recoveryOrientation: 'recovery-oriented',
+  },
+}
+
+function corpus(record: RuntimeRecord) {
+  return [
+    record?.slug,
+    record?.name,
+    record?.displayName,
+    record?.summary,
+    record?.description,
+    record?.short_earthy_summary,
+    record?.time_to_notice,
+    record?.timeToNotice,
+    record?.evidence_snapshot,
+    record?.safety_snapshot,
+    ...list(record?.primary_effects),
+    ...list(record?.effects),
+    ...list(record?.mechanisms),
+    ...list(record?.pathways),
+    ...list(record?.topic_ecosystems),
+    ...list(record?.best_for),
+    ...list(record?.avoid_if),
+  ]
+    .map((value) => text(value).toLowerCase())
+    .filter(Boolean)
+    .join(' ')
+}
+
+function hasAny(source: string, terms: string[]) {
+  return terms.some((term) => source.includes(term))
+}
+
+function score(source: string, terms: string[]) {
+  return terms.reduce((total, term) => total + (source.includes(term) ? 1 : 0), 0)
+}
+
+function slugOf(record: RuntimeRecord) {
+  return text(record?.slug || record?.name || record?.displayName).toLowerCase()
+}
+
+function explicit<T extends string>(record: RuntimeRecord, keys: string[], allowed: readonly T[]): T | null {
+  const values = keys.map((key) => text(record?.[key]).toLowerCase()).filter(Boolean)
+  return allowed.find((value) => values.includes(value)) || null
+}
+
+export function getStimulationProfile(record: RuntimeRecord = {}): StimulationProfile {
+  const allowed = ['calming', 'balanced', 'activating'] as const
+  const value = explicit(record, ['stimulationProfile', 'stimulation_profile', 'stimulation'], allowed)
+  if (value) return value
+
+  const override = PROFILE_OVERRIDES[slugOf(record)]?.stimulation
+  if (override) return override
+
+  const source = corpus(record)
+  const calming = score(source, CALMING_TERMS)
+  const activating = score(source, ACTIVATING_TERMS)
+
+  if (activating >= calming + 2) return 'activating'
+  if (calming >= activating + 1) return 'calming'
+  return 'balanced'
+}
+
+export function getTimelineProfile(record: RuntimeRecord = {}): TimelineProfile {
+  const allowed = ['acute', 'mixed', 'cumulative'] as const
+  const value = explicit(record, ['timelineProfile', 'timeline_profile', 'timeline'], allowed)
+  if (value) return value
+
+  const override = PROFILE_OVERRIDES[slugOf(record)]?.timeline
+  if (override) return override
+
+  const source = corpus(record)
+  const acute = score(source, ACUTE_TERMS)
+  const cumulative = score(source, CUMULATIVE_TERMS)
+
+  if (cumulative >= acute + 2) return 'cumulative'
+  if (acute >= cumulative + 1) return 'acute'
+  return 'mixed'
+}
+
+export function getBeginnerDifficulty(record: RuntimeRecord = {}): BeginnerDifficulty {
+  const override = PROFILE_OVERRIDES[slugOf(record)]?.difficulty
+  if (override) return override
+
+  const source = corpus(record)
+  if (hasAny(source, CAUTION_TERMS) && hasAny(source, ACTIVATING_TERMS)) return 'advanced experimentation'
+  if (hasAny(source, CAUTION_TERMS) || getResponderVariabilityLevel(record) === 'highly context-dependent') return 'context-sensitive'
+  return getStimulationProfile(record) === 'activating' ? 'context-sensitive' : 'beginner-friendly'
+}
+
+export function getStackComplexity(record: RuntimeRecord = {}): StackComplexity {
+  const override = PROFILE_OVERRIDES[slugOf(record)]?.stackComplexity
+  if (override) return override
+
+  const source = corpus(record)
+  const cautions = score(source, CAUTION_TERMS)
+  const stacks = list(record?.stacks || record?.stacking || record?.stack_guidance).length
+  if (cautions >= 2 || stacks >= 5 || getBeginnerDifficulty(record) === 'advanced experimentation') return 'aggressive'
+  if (cautions > 0 || stacks >= 2 || getTimelineProfile(record) === 'cumulative') return 'moderate'
+  return 'simple'
+}
+
+export function getResponderVariabilityLevel(record: RuntimeRecord = {}): ResponderVariabilityLevel {
+  const override = PROFILE_OVERRIDES[slugOf(record)]?.responderVariability
+  if (override) return override
+
+  const source = corpus(record)
+  const variability = score(source, VARIABILITY_TERMS)
+  if (variability >= 4 || hasAny(source, ['adaptogen', 'hormone', 'thyroid'])) return 'highly context-dependent'
+  if (variability >= 2 || getTimelineProfile(record) === 'mixed') return 'moderately variable'
+  return 'relatively consistent'
+}
+
+export function getRecoveryOrientation(record: RuntimeRecord = {}): RecoveryOrientation {
+  const override = PROFILE_OVERRIDES[slugOf(record)]?.recoveryOrientation
+  if (override) return override
+
+  const source = corpus(record)
+  if (hasAny(source, ['sleep', 'evening', 'insomnia', 'glycine', 'magnesium'])) return 'sleep-adjacent'
+  if (hasAny(source, ['memory', 'focus', 'cognition', 'nootropic', 'attention'])) return 'cognition-oriented'
+  if (hasAny(source, ['exercise', 'training', 'muscle', 'performance', 'energy'])) return 'performance-oriented'
+  if (hasAny(source, ['stress', 'adaptogen', 'resilience', 'anxiety'])) return 'stress-modulating'
+  return 'recovery-oriented'
+}
+
+export function buildDecisionVisualProfile(record: RuntimeRecord = {}): DecisionVisualProfile {
+  const profile: DecisionVisualProfile = {
+    stimulation: getStimulationProfile(record),
+    timeline: getTimelineProfile(record),
+    difficulty: getBeginnerDifficulty(record),
+    stackComplexity: getStackComplexity(record),
+    responderVariability: getResponderVariabilityLevel(record),
+    recoveryOrientation: getRecoveryOrientation(record),
+    tags: [],
+  }
+
+  profile.tags = unique([
+    profile.stimulation,
+    profile.timeline,
+    profile.difficulty,
+    profile.stackComplexity === 'simple' ? 'simple stack fit' : `${profile.stackComplexity} stack fit`,
+    profile.responderVariability,
+    profile.recoveryOrientation,
+  ]).slice(0, 8)
+
+  return profile
+}

--- a/src/lib/why-this-instead.ts
+++ b/src/lib/why-this-instead.ts
@@ -1,0 +1,228 @@
+import { formatDisplayLabel, text, unique } from '@/lib/display-utils'
+import {
+  buildDecisionVisualProfile,
+  type DecisionVisualProfile,
+  type RecoveryOrientation,
+  type StimulationProfile,
+  type TimelineProfile,
+} from '@/lib/decision-visuals'
+
+export type AlternativeReasoning = {
+  source: {
+    slug: string
+    label: string
+    href?: string
+    visuals: DecisionVisualProfile
+  }
+  alternative: {
+    slug: string
+    label: string
+    href?: string
+    visuals: DecisionVisualProfile
+  }
+  rationale: string[]
+  contrastChips: string[]
+  fitFrame: string
+}
+
+type RuntimeRecord = Record<string, any>
+
+const PROFILE_KIND: Record<string, 'herb' | 'compound'> = {
+  ashwagandha: 'herb',
+  rhodiola: 'herb',
+  bacopa: 'herb',
+  'lions-mane': 'herb',
+  saffron: 'herb',
+  creatine: 'compound',
+  theanine: 'compound',
+  glycine: 'compound',
+  magnesium: 'compound',
+  'magnesium-glycinate': 'compound',
+  taurine: 'compound',
+  nac: 'compound',
+}
+
+const PROFILE_LABELS: Record<string, string> = {
+  'lions-mane': "Lion's Mane",
+  nac: 'NAC',
+}
+
+const RELATIONSHIPS: Record<string, string[]> = {
+  creatine: ['rhodiola', 'theanine', 'bacopa'],
+  theanine: ['rhodiola', 'glycine', 'taurine'],
+  rhodiola: ['theanine', 'ashwagandha', 'creatine'],
+  ashwagandha: ['rhodiola', 'theanine', 'magnesium'],
+  magnesium: ['glycine', 'theanine', 'taurine'],
+  'magnesium-glycinate': ['glycine', 'theanine', 'taurine'],
+  glycine: ['magnesium-glycinate', 'theanine', 'taurine'],
+  bacopa: ['theanine', 'rhodiola', 'lions-mane'],
+  'lions-mane': ['bacopa', 'creatine', 'rhodiola'],
+  taurine: ['theanine', 'glycine', 'magnesium'],
+  nac: ['creatine', 'taurine', 'ashwagandha'],
+}
+
+const SYNTHETIC_RECORDS: Record<string, RuntimeRecord> = {
+  ...Object.fromEntries(
+    Object.keys(PROFILE_KIND).map((slug) => [slug, { slug, name: PROFILE_LABELS[slug] || slug }]),
+  ),
+}
+
+function normalizeSlug(value: unknown) {
+  return text(value).toLowerCase().replace(/lion'?s? mane|lion’s mane/g, 'lions-mane').replace(/\s+/g, '-')
+}
+
+function labelFor(record: RuntimeRecord) {
+  const slug = normalizeSlug(record?.slug || record?.name)
+  return PROFILE_LABELS[slug] || formatDisplayLabel(record?.displayName || record?.name || record?.slug)
+}
+
+function hrefFor(slug: string) {
+  const kind = PROFILE_KIND[slug]
+  if (!kind) return undefined
+  return `/${kind === 'herb' ? 'herbs' : 'compounds'}/${slug}`
+}
+
+function makeNode(record: RuntimeRecord) {
+  const slug = normalizeSlug(record?.slug || record?.name)
+  return {
+    slug,
+    label: labelFor(record),
+    href: hrefFor(slug),
+    visuals: buildDecisionVisualProfile(record),
+  }
+}
+
+function directionText(source: DecisionVisualProfile, alternative: DecisionVisualProfile) {
+  const rationales: string[] = []
+
+  if (source.stimulation !== alternative.stimulation) {
+    rationales.push(`${source.stimulation} stimulation framing instead of a ${alternative.stimulation} profile.`)
+  }
+
+  if (source.timeline !== alternative.timeline) {
+    rationales.push(`${source.timeline} expectation timeline rather than ${alternative.timeline} expectations.`)
+  }
+
+  if (source.recoveryOrientation !== alternative.recoveryOrientation) {
+    rationales.push(`${source.recoveryOrientation} fit compared with a more ${alternative.recoveryOrientation} pathway.`)
+  }
+
+  if (source.difficulty !== alternative.difficulty) {
+    rationales.push(`${source.difficulty} exploration style versus ${alternative.difficulty} framing.`)
+  }
+
+  if (source.responderVariability !== alternative.responderVariability) {
+    rationales.push(`${source.responderVariability} response expectations instead of ${alternative.responderVariability} assumptions.`)
+  }
+
+  return rationales.slice(0, 4)
+}
+
+function fitFrameFor(source: DecisionVisualProfile, alternative: DecisionVisualProfile) {
+  if (source.stimulation === 'calming' && alternative.stimulation === 'activating') {
+    return 'Potentially better fit when stimulant sensitivity, evening use, or nervous-system downshifting matters more than an activating push.'
+  }
+
+  if (source.timeline === 'cumulative' && alternative.timeline === 'acute') {
+    return 'Potentially better fit when the goal is consistency and recovery capacity rather than a same-day perceptual effect.'
+  }
+
+  if (source.recoveryOrientation === 'sleep-adjacent') {
+    return 'Potentially better fit when sleep context and relaxation style are central to the decision.'
+  }
+
+  if (source.recoveryOrientation === 'performance-oriented') {
+    return 'Potentially better fit when the decision is anchored in training load, energy buffering, or sustainable output.'
+  }
+
+  return 'Potentially better fit when this semantic profile matches the user context; not a universal superiority claim.'
+}
+
+export function buildAlternativeReasoning(sourceRecord: RuntimeRecord, alternativeRecord: RuntimeRecord): AlternativeReasoning {
+  const source = makeNode(sourceRecord)
+  const alternative = makeNode(alternativeRecord)
+  const rationale = directionText(source.visuals, alternative.visuals)
+
+  return {
+    source,
+    alternative,
+    rationale: rationale.length > 0
+      ? rationale
+      : ['Different practical fit, expectation timeline, and tolerance context rather than a simple stronger/weaker ranking.'],
+    contrastChips: unique([
+      source.visuals.stimulation,
+      source.visuals.timeline,
+      source.visuals.recoveryOrientation,
+      `vs ${alternative.visuals.stimulation}`,
+      `vs ${alternative.visuals.timeline}`,
+    ]).slice(0, 6),
+    fitFrame: fitFrameFor(source.visuals, alternative.visuals),
+  }
+}
+
+function candidatesFor(sourceRecord: RuntimeRecord, records: RuntimeRecord[] = []) {
+  const sourceSlug = normalizeSlug(sourceRecord?.slug || sourceRecord?.name)
+  const bySlug = new Map<string, RuntimeRecord>()
+
+  records.forEach((record) => {
+    const slug = normalizeSlug(record?.slug || record?.name)
+    if (slug && slug !== sourceSlug) bySlug.set(slug, record)
+  })
+
+  ;(RELATIONSHIPS[sourceSlug] || []).forEach((slug) => {
+    if (!bySlug.has(slug)) bySlug.set(slug, SYNTHETIC_RECORDS[slug])
+  })
+
+  return Array.from(bySlug.values()).filter(Boolean)
+}
+
+function pickAlternative(sourceRecord: RuntimeRecord, records: RuntimeRecord[], predicate: (visuals: DecisionVisualProfile) => boolean) {
+  return candidatesFor(sourceRecord, records).find((record) => predicate(buildDecisionVisualProfile(record))) || candidatesFor(sourceRecord, records)[0]
+}
+
+export function buildGentlerAlternative(sourceRecord: RuntimeRecord, records: RuntimeRecord[] = []) {
+  const alternative = pickAlternative(sourceRecord, records, (visuals) => visuals.stimulation === 'calming')
+  return alternative ? buildAlternativeReasoning(sourceRecord, alternative) : null
+}
+
+export function buildMoreActivatingAlternative(sourceRecord: RuntimeRecord, records: RuntimeRecord[] = []) {
+  const alternative = pickAlternative(sourceRecord, records, (visuals) => visuals.stimulation === 'activating')
+  return alternative ? buildAlternativeReasoning(sourceRecord, alternative) : null
+}
+
+export function buildMoreCumulativeAlternative(sourceRecord: RuntimeRecord, records: RuntimeRecord[] = []) {
+  const alternative = pickAlternative(sourceRecord, records, (visuals) => visuals.timeline === 'cumulative')
+  return alternative ? buildAlternativeReasoning(sourceRecord, alternative) : null
+}
+
+export function buildBeginnerAlternative(sourceRecord: RuntimeRecord, records: RuntimeRecord[] = []) {
+  const alternative = pickAlternative(sourceRecord, records, (visuals) => visuals.difficulty === 'beginner-friendly')
+  return alternative ? buildAlternativeReasoning(sourceRecord, alternative) : null
+}
+
+export function buildRecoveryAlternative(sourceRecord: RuntimeRecord, records: RuntimeRecord[] = []) {
+  const alternative = pickAlternative(sourceRecord, records, (visuals) => {
+    const orientation: RecoveryOrientation = visuals.recoveryOrientation
+    return orientation === 'recovery-oriented' || orientation === 'sleep-adjacent' || orientation === 'stress-modulating'
+  })
+  return alternative ? buildAlternativeReasoning(sourceRecord, alternative) : null
+}
+
+export function buildAlternativeReasoningSet(sourceRecord: RuntimeRecord, records: RuntimeRecord[] = [], limit = 3) {
+  const source = buildDecisionVisualProfile(sourceRecord)
+  const builders = source.stimulation === 'activating'
+    ? [buildGentlerAlternative, buildBeginnerAlternative, buildMoreCumulativeAlternative, buildRecoveryAlternative]
+    : [buildMoreActivatingAlternative, buildMoreCumulativeAlternative, buildGentlerAlternative, buildBeginnerAlternative, buildRecoveryAlternative]
+
+  const seen = new Set<string>()
+  return builders
+    .map((builder) => builder(sourceRecord, records))
+    .filter((item): item is AlternativeReasoning => Boolean(item))
+    .filter((item) => {
+      const key = `${item.source.slug}:${item.alternative.slug}`
+      if (seen.has(key)) return false
+      seen.add(key)
+      return item.source.slug !== item.alternative.slug
+    })
+    .slice(0, limit)
+}


### PR DESCRIPTION
### Motivation

- Surface compact, evidence-aware visual signals (stimulation, timeline, beginner difficulty, stack complexity, responder variability, recovery orientation) to make supplement profiles instantly scannable. 
- Provide fit-first comparative reasoning (“Why this instead?”) so users can choose alternatives based on context rather than promotional ranking. 
- Integrate visual decision intelligence into existing profile, ecosystem, and onboarding surfaces while preserving runtime/data contracts and conservative UX constraints.

### Description

- Added deterministic visual helpers in `src/lib/decision-visuals.ts` with exported helpers `getStimulationProfile()`, `getTimelineProfile()`, `getBeginnerDifficulty()`, `getStackComplexity()`, `getResponderVariabilityLevel()`, `getRecoveryOrientation()`, and `buildDecisionVisualProfile()`.
- Added comparative-reasoning builders in `src/lib/why-this-instead.ts` (`buildAlternativeReasoning()`, `buildGentlerAlternative()`, `buildMoreActivatingAlternative()`, `buildMoreCumulativeAlternative()`, `buildBeginnerAlternative()`, `buildRecoveryAlternative()`, `buildAlternativeReasoningSet()`).
- Added new UI components: `src/components/decision-visual-grid.tsx` (compact spectrum bars, signal cards, tags), `src/components/why-this-instead-panel.tsx` (side-by-side comparison cards), and `src/components/ecosystem-supernode.tsx` (ecosystem hub supernode with FAQ schema and onboarding guidance).
- Integrated visuals and comparative panels into existing pages: `app/herbs/[slug]/page.tsx`, `app/compounds/[slug]/page.tsx`, `app/ecosystems/[slug]/page.tsx`, `app/start/[slug]/page.tsx`, and updated `components/homepage-v2.tsx` to surface beginner entry systems and ecosystem discovery.
- Added lightweight evidence-aware recommendation cards to `src/components/evidence-aware-cta.tsx` and passed `record` so sourcing guidance can surface `buildDecisionVisualProfile` outputs.
- Conservative integration approach: preserved existing `ProfileDecisionLayer`, kept routing and data pipeline untouched, and avoided changes to workbook structure or hand-editing generated `public/data` artifacts.

### Testing

- Ran `npm run check` (which executes the data build and validation steps, `next build`, and verify scripts); the build completed successfully and compilation passed. 
- Data pipeline steps during the build (`data:build` and `data:validate`) completed and semantic governance checks passed (runtime payload budgets, deterministic JSON ordering, semantic graph health). 
- Static export / page generation completed with no build-time route regressions or type errors reported.
- No automated runtime/hydration failures were observed during the build verification steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a048cc2cc008323adbf40a8f1cd71c0)