### PR TITLE
Centralize editorial render gating

### DIFF
--- a/components/authority/AuthorityProfileShell.tsx
+++ b/components/authority/AuthorityProfileShell.tsx
@@ -1,4 +1,5 @@
 import type { AuthorityProfileModel, AuthoritySignal } from '@/lib/authority-profile'
+import { cleanEditorialText, dedupeEditorialItems, isDuplicateTitleBody, isRenderableText, shouldRenderCard } from '@/lib/editorial-rendering'
 import {
   buildCommonMistakesSection,
   buildCompareInsights,
@@ -23,19 +24,29 @@ function toneBadge(tone: AuthoritySignal['tone']) {
 }
 
 function AuthoritySignalCard({ signal }: { signal: AuthoritySignal }) {
+  const label = cleanEditorialText(signal.label)
+  const description = cleanEditorialText(signal.description)
+  const showDescription = isRenderableText(description) && !isDuplicateTitleBody(label, description)
+
+  if (!shouldRenderCard(label, description)) return null
+
   return (
     <article className={`rounded-[1.25rem] border p-4 shadow-sm ${toneClass(signal.tone)}`}>
       <div className="mb-2 flex flex-wrap items-center gap-2">
         <span className="identity-kicker">{toneBadge(signal.tone)}</span>
       </div>
-      <h4 className="max-w-none text-base font-semibold tracking-tight">{signal.label}</h4>
-      <p className="mt-2 text-sm leading-6 opacity-85">{signal.description}</p>
+      <h4 className="max-w-none text-base font-semibold tracking-tight">{label}</h4>
+      {showDescription ? (
+        <p className="mt-2 text-sm leading-6 opacity-85">{description}</p>
+      ) : null}
     </article>
   )
 }
 
 function AuthoritySection({ title, eyebrow, signals, dense = false }: { title: string; eyebrow: string; signals: AuthoritySignal[]; dense?: boolean }) {
-  if (!signals.length) return null
+  const renderableSignals = signals.filter((signal) => shouldRenderCard(signal.label, signal.description))
+
+  if (!renderableSignals.length) return null
 
   return (
     <section className="compact-card section-rhythm-compact">
@@ -44,7 +55,7 @@ function AuthoritySection({ title, eyebrow, signals, dense = false }: { title: s
         <h3 className="max-w-none text-2xl font-semibold tracking-tight text-ink">{title}</h3>
       </div>
       <div className={`grid gap-3 ${dense ? 'md:grid-cols-2' : 'lg:grid-cols-3'}`}>
-        {signals.map((signal, index) => (
+        {renderableSignals.map((signal, index) => (
           <AuthoritySignalCard key={`${signal.label}-${index}`} signal={signal} />
         ))}
       </div>
@@ -53,11 +64,19 @@ function AuthoritySection({ title, eyebrow, signals, dense = false }: { title: s
 }
 
 function InsightCard({ eyebrow, title, body }: { eyebrow: string; title: string; body: string }) {
+  const cleanTitle = cleanEditorialText(title)
+  const cleanBody = cleanEditorialText(body)
+  const showBody = isRenderableText(cleanBody) && !isDuplicateTitleBody(cleanTitle, cleanBody)
+
+  if (!shouldRenderCard(cleanTitle, cleanBody)) return null
+
   return (
     <article className="rounded-[1.5rem] border border-brand-900/10 bg-white/80 p-5 shadow-sm">
       <p className="eyebrow-label">{eyebrow}</p>
-      <h3 className="mt-2 max-w-none text-xl font-semibold tracking-tight text-ink">{title}</h3>
-      <p className="mt-3 text-sm leading-7 text-[#46574d]">{body}</p>
+      <h3 className="mt-2 max-w-none text-xl font-semibold tracking-tight text-ink">{cleanTitle}</h3>
+      {showBody ? (
+        <p className="mt-3 text-sm leading-7 text-[#46574d]">{cleanBody}</p>
+      ) : null}
     </article>
   )
 }
@@ -67,8 +86,14 @@ export default function AuthorityProfileShell({ model, record }: { model: Author
   const realisticExpectations = record ? buildRealisticExpectations(record) : ''
   const compareInsights = record ? buildCompareInsights(record) : null
   const humanEvidence = record ? buildHumanEvidenceSummary(record) : null
-  const commonMistakes = record ? buildCommonMistakesSection(record) : []
+  const commonMistakes = record ? dedupeEditorialItems(buildCommonMistakesSection(record), 4) : []
   const outcomeGuidance = record ? buildOutcomeSpecificGuidance(record) : []
+  const renderableOutcomeGuidance = outcomeGuidance
+    .map((item) => ({
+      outcome: cleanEditorialText(item.outcome),
+      guidance: cleanEditorialText(item.guidance),
+    }))
+    .filter((item) => shouldRenderCard(item.outcome, item.guidance))
 
   return (
     <section className="space-y-5">
@@ -124,17 +149,19 @@ export default function AuthorityProfileShell({ model, record }: { model: Author
         />
       </section>
 
-      {outcomeGuidance.length > 0 ? (
+      {renderableOutcomeGuidance.length > 0 ? (
         <section className="compact-card section-rhythm-compact">
           <div className="space-y-1">
             <p className="eyebrow-label">Outcome guidance</p>
             <h3 className="max-w-none text-2xl font-semibold tracking-tight text-ink">How to judge results without hype.</h3>
           </div>
           <div className="grid gap-3 md:grid-cols-2">
-            {outcomeGuidance.slice(0, 4).map((item) => (
+            {renderableOutcomeGuidance.slice(0, 4).map((item) => (
               <article key={item.outcome} className="rounded-[1.25rem] border border-brand-900/10 bg-white/75 p-4 shadow-sm">
                 <h4 className="max-w-none text-base font-semibold tracking-tight text-ink">{item.outcome}</h4>
-                <p className="mt-2 text-sm leading-6 text-[#46574d]">{item.guidance}</p>
+                {isDuplicateTitleBody(item.outcome, item.guidance) ? null : (
+                  <p className="mt-2 text-sm leading-6 text-[#46574d]">{item.guidance}</p>
+                )}
               </article>
             ))}
           </div>
@@ -212,7 +239,7 @@ export default function AuthorityProfileShell({ model, record }: { model: Author
       <section className={`rounded-[1.5rem] border p-5 shadow-sm ${toneClass(model.editorialInterpretation.tone)}`}>
         <p className="eyebrow-label">Editorial Interpretation</p>
         <h3 className="mt-2 max-w-none text-2xl font-semibold tracking-tight">{model.editorialInterpretation.label}</h3>
-        <p className="mt-3 text-sm leading-7 opacity-90">{model.editorialInterpretation.description}</p>
+        <p className="mt-3 text-sm leading-7 opacity-90">{cleanEditorialText(model.editorialInterpretation.description)}</p>
       </section>
     </section>
   )

--- a/components/authority/AuthoritySidebar.tsx
+++ b/components/authority/AuthoritySidebar.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { cleanEditorialText, isDuplicateTitleBody, isRenderableText, shouldRenderCard } from '@/lib/editorial-rendering'
 
 type SidebarLink = {
   href: string
@@ -21,19 +22,28 @@ function SidebarSection({
   title: string
   items: SidebarLink[]
 }) {
-  if (!items.length) return null
+  const cleanTitle = cleanEditorialText(title)
+  const renderableItems = items
+    .map((item) => ({
+      ...item,
+      label: cleanEditorialText(item.label),
+      meta: cleanEditorialText(item.meta),
+    }))
+    .filter((item) => item.href && shouldRenderCard(item.label, item.meta))
+
+  if (!renderableItems.length || !cleanTitle) return null
 
   return (
     <section className="card-premium p-5 space-y-4">
       <div className="space-y-1">
         <p className="eyebrow-label">Authority Discovery</p>
         <h3 className="text-lg font-semibold tracking-tight text-ink">
-          {title}
+          {cleanTitle}
         </h3>
       </div>
 
       <div className="space-y-3">
-        {items.map((item) => (
+        {renderableItems.map((item) => (
           <Link
             key={item.href}
             href={item.href}
@@ -44,7 +54,7 @@ function SidebarSection({
                 {item.label}
               </p>
 
-              {item.meta ? (
+              {isRenderableText(item.meta) && !isDuplicateTitleBody(item.label, item.meta) ? (
                 <p className="text-xs leading-6 text-[#5c6b63]">
                   {item.meta}
                 </p>

--- a/components/authority/ComparisonRecommendations.tsx
+++ b/components/authority/ComparisonRecommendations.tsx
@@ -1,22 +1,38 @@
 import Link from 'next/link'
+import { cleanEditorialText, dedupeEditorialItems, isDuplicateTitleBody, isRenderableText, shouldRenderCard } from '@/lib/editorial-rendering'
 
-type ComparisonRecommendation = {
+type DiscoveryItem = {
   href: string
   title: string
   rationale?: string
   overlap?: string[]
 }
 
-type ComparisonRecommendationsProps = {
+type UnifiedSemanticDiscoveryPanelProps = {
   title?: string
-  items?: ComparisonRecommendation[]
+  items?: DiscoveryItem[]
 }
 
 export default function ComparisonRecommendations({
   title = 'Comparison Discovery',
   items = [],
-}: ComparisonRecommendationsProps) {
-  if (!items.length) {
+}: UnifiedSemanticDiscoveryPanelProps) {
+  const cleanTitle = cleanEditorialText(title) || 'Comparison Discovery'
+  const renderableItems = items
+    .map((item) => {
+      const itemTitle = cleanEditorialText(item.title)
+      const rationale = cleanEditorialText(item.rationale)
+
+      return {
+        ...item,
+        title: itemTitle,
+        rationale,
+        overlap: dedupeEditorialItems(item.overlap || [], 4),
+      }
+    })
+    .filter((item) => item.href && shouldRenderCard(item.title, item.rationale))
+
+  if (!renderableItems.length) {
     return null
   }
 
@@ -26,12 +42,12 @@ export default function ComparisonRecommendations({
         <p className="eyebrow-label">Semantic Comparisons</p>
 
         <h2 className="text-balance">
-          {title}
+          {cleanTitle}
         </h2>
       </div>
 
       <div className="mt-6 grid gap-5 lg:grid-cols-2 xl:grid-cols-3">
-        {items.map((item) => (
+        {renderableItems.map((item) => (
           <Link
             key={item.href}
             href={item.href}
@@ -43,16 +59,16 @@ export default function ComparisonRecommendations({
                   {item.title}
                 </h3>
 
-                {item.rationale ? (
+                {isRenderableText(item.rationale) && !isDuplicateTitleBody(item.title, item.rationale) ? (
                   <p className="text-sm leading-7 text-[#46574d]">
                     {item.rationale}
                   </p>
                 ) : null}
               </div>
 
-              {item.overlap?.length ? (
+              {item.overlap.length ? (
                 <div className="flex flex-wrap gap-2">
-                  {item.overlap.slice(0, 4).map((label) => (
+                  {item.overlap.map((label) => (
                     <span
                       key={label}
                       className="chip-readable"

--- a/components/authority/EcosystemContinuityPanel.tsx
+++ b/components/authority/EcosystemContinuityPanel.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { cleanEditorialText, dedupeEditorialItems, isDuplicateTitleBody, isRenderableText, shouldRenderCard } from '@/lib/editorial-rendering'
 
 type ContinuityItem = {
   href: string
@@ -18,7 +19,18 @@ export default function EcosystemContinuityPanel({
   description = 'Continue exploring semantically related profiles, pathways, stacks, and comparison systems.',
   items = [],
 }: EcosystemContinuityPanelProps) {
-  if (!items.length) {
+  const cleanTitle = cleanEditorialText(title) || 'Ecosystem Continuity'
+  const cleanDescription = cleanEditorialText(description)
+  const renderableItems = items
+    .map((item) => ({
+      ...item,
+      title: cleanEditorialText(item.title),
+      rationale: cleanEditorialText(item.rationale),
+      overlap: dedupeEditorialItems(item.overlap || [], 4),
+    }))
+    .filter((item) => item.href && shouldRenderCard(item.title, item.rationale))
+
+  if (!renderableItems.length) {
     return null
   }
 
@@ -28,16 +40,18 @@ export default function EcosystemContinuityPanel({
         <p className="eyebrow-label">Semantic Continuity</p>
 
         <h2 className="max-w-3xl text-balance">
-          {title}
+          {cleanTitle}
         </h2>
 
-        <p className="max-w-3xl text-sm leading-7 text-[#46574d]">
-          {description}
-        </p>
+        {isRenderableText(cleanDescription) && !isDuplicateTitleBody(cleanTitle, cleanDescription) ? (
+          <p className="max-w-3xl text-sm leading-7 text-[#46574d]">
+            {cleanDescription}
+          </p>
+        ) : null}
       </div>
 
       <div className="mt-7 grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-        {items.map((item) => (
+        {renderableItems.map((item) => (
           <Link
             key={item.href}
             href={item.href}
@@ -49,16 +63,16 @@ export default function EcosystemContinuityPanel({
                   {item.title}
                 </p>
 
-                {item.rationale ? (
+                {isRenderableText(item.rationale) && !isDuplicateTitleBody(item.title, item.rationale) ? (
                   <p className="text-sm leading-7 text-[#46574d]">
                     {item.rationale}
                   </p>
                 ) : null}
               </div>
 
-              {item.overlap?.length ? (
+              {item.overlap.length ? (
                 <div className="flex flex-wrap gap-2">
-                  {item.overlap.slice(0, 4).map((label) => (
+                  {item.overlap.map((label) => (
                     <span
                       key={label}
                       className="chip-readable"

--- a/components/authority/PeopleAlsoExplore.tsx
+++ b/components/authority/PeopleAlsoExplore.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { cleanEditorialText, isDuplicateTitleBody, isRenderableText, shouldRenderCard } from '@/lib/editorial-rendering'
 
 type ExploreItem = {
   href: string
@@ -16,7 +17,17 @@ export default function PeopleAlsoExplore({
   title = 'People Also Explore',
   items = [],
 }: PeopleAlsoExploreProps) {
-  if (!items.length) {
+  const cleanTitle = cleanEditorialText(title) || 'People Also Explore'
+  const renderableItems = items
+    .map((item) => ({
+      ...item,
+      title: cleanEditorialText(item.title),
+      description: cleanEditorialText(item.description),
+      meta: cleanEditorialText(item.meta),
+    }))
+    .filter((item) => item.href && shouldRenderCard(item.title, item.description))
+
+  if (!renderableItems.length) {
     return null
   }
 
@@ -26,19 +37,19 @@ export default function PeopleAlsoExplore({
         <p className="eyebrow-label">Semantic Discovery</p>
 
         <h2 className="max-w-3xl text-balance">
-          {title}
+          {cleanTitle}
         </h2>
       </div>
 
       <div className="mt-6 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-        {items.map((item) => (
+        {renderableItems.map((item) => (
           <Link
             key={item.href}
             href={item.href}
             className="card-premium p-5 transition hover:-translate-y-0.5"
           >
             <div className="space-y-3">
-              {item.meta ? (
+              {isRenderableText(item.meta) ? (
                 <p className="eyebrow-label">
                   {item.meta}
                 </p>
@@ -48,7 +59,7 @@ export default function PeopleAlsoExplore({
                 {item.title}
               </h3>
 
-              {item.description ? (
+              {isRenderableText(item.description) && !isDuplicateTitleBody(item.title, item.description) ? (
                 <p className="text-sm leading-7 text-[#46574d]">
                   {item.description}
                 </p>

--- a/components/authority/ProtocolRecommendations.tsx
+++ b/components/authority/ProtocolRecommendations.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { cleanEditorialText, dedupeEditorialItems, isDuplicateTitleBody, isRenderableText, shouldRenderCard } from '@/lib/editorial-rendering'
 
 type ProtocolRecommendation = {
   href: string
@@ -16,7 +17,17 @@ export default function ProtocolRecommendations({
   title = 'Related Protocol Systems',
   items = [],
 }: ProtocolRecommendationsProps) {
-  if (!items.length) {
+  const cleanTitle = cleanEditorialText(title) || 'Related Protocol Systems'
+  const renderableItems = items
+    .map((item) => ({
+      ...item,
+      title: cleanEditorialText(item.title),
+      summary: cleanEditorialText(item.summary),
+      tags: dedupeEditorialItems(item.tags || [], 4),
+    }))
+    .filter((item) => item.href && shouldRenderCard(item.title, item.summary))
+
+  if (!renderableItems.length) {
     return null
   }
 
@@ -26,12 +37,12 @@ export default function ProtocolRecommendations({
         <p className="eyebrow-label">Protocol Discovery</p>
 
         <h2 className="text-balance">
-          {title}
+          {cleanTitle}
         </h2>
       </div>
 
       <div className="mt-6 grid gap-5 lg:grid-cols-2">
-        {items.map((item) => (
+        {renderableItems.map((item) => (
           <Link
             key={item.href}
             href={item.href}
@@ -43,16 +54,16 @@ export default function ProtocolRecommendations({
                   {item.title}
                 </h3>
 
-                {item.summary ? (
+                {isRenderableText(item.summary) && !isDuplicateTitleBody(item.title, item.summary) ? (
                   <p className="text-sm leading-7 text-[#46574d]">
                     {item.summary}
                   </p>
                 ) : null}
               </div>
 
-              {item.tags?.length ? (
+              {item.tags.length ? (
                 <div className="flex flex-wrap gap-2">
-                  {item.tags.slice(0, 4).map((tag) => (
+                  {item.tags.map((tag) => (
                     <span
                       key={tag}
                       className="chip-readable"

--- a/components/authority/SemanticEntitySignals.tsx
+++ b/components/authority/SemanticEntitySignals.tsx
@@ -1,3 +1,5 @@
+import { cleanEditorialText, dedupeEditorialItems } from '@/lib/editorial-rendering'
+
 type SemanticEntitySignalsProps = {
   title?: string
   effects?: string[]
@@ -13,7 +15,9 @@ function SignalGroup({
   title: string
   items: string[]
 }) {
-  if (!items.length) {
+  const renderableItems = dedupeEditorialItems(items, 8)
+
+  if (!renderableItems.length) {
     return null
   }
 
@@ -24,7 +28,7 @@ function SignalGroup({
       </h3>
 
       <div className="flex flex-wrap gap-2">
-        {items.slice(0, 8).map((item) => (
+        {renderableItems.map((item) => (
           <span
             key={item}
             className="chip-readable"
@@ -44,11 +48,9 @@ export default function SemanticEntitySignals({
   pathways = [],
   ecosystems = [],
 }: SemanticEntitySignalsProps) {
-  const hasSignals =
-    effects.length ||
-    mechanisms.length ||
-    pathways.length ||
-    ecosystems.length
+  const cleanTitle = cleanEditorialText(title)
+  const groups = [effects, mechanisms, pathways, ecosystems].map((items) => dedupeEditorialItems(items, 8))
+  const hasSignals = groups.some((items) => items.length > 0)
 
   if (!hasSignals) {
     return null
@@ -60,29 +62,29 @@ export default function SemanticEntitySignals({
         <p className="eyebrow-label">Semantic Entity Graph</p>
 
         <h2 className="text-balance">
-          {title}
+          {cleanTitle || 'Semantic Profile Signals'}
         </h2>
       </div>
 
       <div className="mt-6 grid gap-6 lg:grid-cols-2">
         <SignalGroup
           title="Effects"
-          items={effects}
+          items={groups[0]}
         />
 
         <SignalGroup
           title="Mechanisms"
-          items={mechanisms}
+          items={groups[1]}
         />
 
         <SignalGroup
           title="Pathways"
-          items={pathways}
+          items={groups[2]}
         />
 
         <SignalGroup
           title="Ecosystems"
-          items={ecosystems}
+          items={groups[3]}
         />
       </div>
     </section>

--- a/components/authority/TopicContinuityLinks.tsx
+++ b/components/authority/TopicContinuityLinks.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { cleanEditorialText, shouldRenderCard } from '@/lib/editorial-rendering'
 
 type TopicLink = {
   href: string
@@ -14,7 +15,15 @@ export default function TopicContinuityLinks({
   title = 'Continue Exploring',
   items = [],
 }: TopicContinuityLinksProps) {
-  if (!items.length) {
+  const cleanTitle = cleanEditorialText(title) || 'Continue Exploring'
+  const renderableItems = items
+    .map((item) => ({
+      ...item,
+      label: cleanEditorialText(item.label),
+    }))
+    .filter((item) => item.href && shouldRenderCard(item.label))
+
+  if (!renderableItems.length) {
     return null
   }
 
@@ -24,12 +33,12 @@ export default function TopicContinuityLinks({
         <p className="eyebrow-label">Topic Continuity</p>
 
         <h2 className="text-xl font-semibold tracking-tight text-ink">
-          {title}
+          {cleanTitle}
         </h2>
       </div>
 
       <div className="mt-5 flex flex-wrap gap-3">
-        {items.map((item) => (
+        {renderableItems.map((item) => (
           <Link
             key={item.href}
             href={item.href}

--- a/components/authority/UnifiedSemanticDiscoveryPanel.tsx
+++ b/components/authority/UnifiedSemanticDiscoveryPanel.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { cleanEditorialText, dedupeEditorialItems, isDuplicateTitleBody, isRenderableText, shouldRenderCard } from '@/lib/editorial-rendering'
 
 type DiscoveryItem = {
   href: string
@@ -16,7 +17,22 @@ export default function UnifiedSemanticDiscoveryPanel({
   title = 'Unified Semantic Discovery',
   items = [],
 }: UnifiedSemanticDiscoveryPanelProps) {
-  if (!items.length) {
+  const cleanTitle = cleanEditorialText(title) || 'Unified Semantic Discovery'
+  const renderableItems = items
+    .map((item) => {
+      const itemTitle = cleanEditorialText(item.title)
+      const rationale = cleanEditorialText(item.rationale)
+
+      return {
+        ...item,
+        title: itemTitle,
+        rationale,
+        overlap: dedupeEditorialItems(item.overlap || [], 4),
+      }
+    })
+    .filter((item) => item.href && shouldRenderCard(item.title, item.rationale))
+
+  if (!renderableItems.length) {
     return null
   }
 
@@ -26,12 +42,12 @@ export default function UnifiedSemanticDiscoveryPanel({
         <p className="eyebrow-label">Semantic Graph Discovery</p>
 
         <h2 className="text-balance">
-          {title}
+          {cleanTitle}
         </h2>
       </div>
 
       <div className="mt-6 grid gap-5 md:grid-cols-2 xl:grid-cols-3">
-        {items.map((item) => (
+        {renderableItems.map((item) => (
           <Link
             key={item.href}
             href={item.href}
@@ -43,16 +59,16 @@ export default function UnifiedSemanticDiscoveryPanel({
                   {item.title}
                 </h3>
 
-                {item.rationale ? (
+                {isRenderableText(item.rationale) && !isDuplicateTitleBody(item.title, item.rationale) ? (
                   <p className="text-sm leading-7 text-[#46574d]">
                     {item.rationale}
                   </p>
                 ) : null}
               </div>
 
-              {item.overlap?.length ? (
+              {item.overlap.length ? (
                 <div className="flex flex-wrap gap-2">
-                  {item.overlap.slice(0, 4).map((label) => (
+                  {item.overlap.map((label) => (
                     <span
                       key={label}
                       className="chip-readable"

--- a/lib/authority-content-enrichment.ts
+++ b/lib/authority-content-enrichment.ts
@@ -1,4 +1,5 @@
-import { list, text, unique } from '@/lib/display-utils'
+import { list, text } from '@/lib/display-utils'
+import { cleanEditorialText, dedupeEditorialItems, isRenderableText, shouldRenderCard } from '@/lib/editorial-rendering'
 import { buildResearchKnowledgeReport } from '@/lib/research-knowledge-layer'
 
 function title(value: unknown) {
@@ -12,12 +13,14 @@ function first(values: unknown[], fallback: string) {
 }
 
 export function buildPracticalInterpretation(record: any) {
-  const name = title(record?.displayName || record?.name || record?.slug)
-  const effects = unique([
+  const name = isRenderableText(record?.displayName || record?.name || record?.slug)
+    ? title(record?.displayName || record?.name || record?.slug)
+    : 'This profile'
+  const effects = dedupeEditorialItems([
     ...list(record?.best_for),
     ...list(record?.primary_effects),
     ...list(record?.effects),
-  ].map(title).filter(Boolean)).slice(0, 4)
+  ].map(title), 4)
 
   if (effects.length === 0) {
     return `${name} currently has limited practical interpretation context available. Focus on evidence quality and safety before drawing strong conclusions.`
@@ -27,34 +30,36 @@ export function buildPracticalInterpretation(record: any) {
 }
 
 export function buildRealisticExpectations(record: any) {
-  const timing = first([
+  const timing = cleanEditorialText(first([
     record?.time_to_effect,
     record?.timeToEffect,
     record?.onset,
-  ], 'timing varies by formulation and baseline context')
+  ], 'timing varies by formulation and baseline context'))
 
   return `Real-world outcomes are rarely immediate. ${timing}. Acute subjective effects, long-term adaptation, and measurable clinical outcomes should not be treated as interchangeable.`
 }
 
 export function buildOutcomeSpecificGuidance(record: any) {
-  const outcomes = unique([
+  const outcomes = dedupeEditorialItems([
     ...list(record?.best_for),
     ...list(record?.goals),
     ...list(record?.primary_effects),
-  ].map(title).filter(Boolean)).slice(0, 6)
+  ].map(title), 6)
 
-  return outcomes.map((outcome) => ({
+  return outcomes.filter(isRenderableText).map((outcome) => ({
     outcome,
     guidance: `${outcome} outcomes should be evaluated using consistency, recovery context, sleep quality, nutrition status, and realistic timelines rather than expecting dramatic overnight changes.`,
-  }))
+  })).filter((item) => shouldRenderCard(item.outcome, item.guidance))
 }
 
 export function buildCompareInsights(record: any) {
-  const name = title(record?.displayName || record?.name || record?.slug)
-  const mechanisms = unique([
+  const name = isRenderableText(record?.displayName || record?.name || record?.slug)
+    ? title(record?.displayName || record?.name || record?.slug)
+    : 'This profile'
+  const mechanisms = dedupeEditorialItems([
     ...list(record?.mechanisms),
     ...list(record?.pathways),
-  ].map(title).filter(Boolean)).slice(0, 4)
+  ].map(title), 4)
 
   return {
     headline: `How ${name} differs from adjacent options`,
@@ -69,7 +74,7 @@ export function buildHumanEvidenceSummary(record: any) {
 
   return {
     evidenceWeight: research.evidenceWeight,
-    summary: research.summary,
+    summary: cleanEditorialText(research.summary),
     interpretation:
       research.evidenceWeight >= 24
         ? 'Human evidence appears relatively developed compared to many adjacent profiles.'
@@ -80,7 +85,9 @@ export function buildHumanEvidenceSummary(record: any) {
 }
 
 export function buildCommonMistakesSection(record: any) {
-  const name = title(record?.displayName || record?.name || record?.slug)
+  const name = isRenderableText(record?.displayName || record?.name || record?.slug)
+    ? title(record?.displayName || record?.name || record?.slug)
+    : 'This profile'
 
   return [
     `Treating ${name} as a universal solution rather than a context-dependent tool.`,

--- a/lib/authority-profile.ts
+++ b/lib/authority-profile.ts
@@ -1,4 +1,5 @@
-import { list, text, unique } from '@/lib/display-utils'
+import { list, text } from '@/lib/display-utils'
+import { cleanEditorialText, dedupeEditorialItems, isRenderableText, shouldRenderCard } from '@/lib/editorial-rendering'
 import { buildResearchKnowledgeReport } from '@/lib/research-knowledge-layer'
 import { buildSemanticIntelligenceReport } from '@/lib/semantic-intelligence-layer'
 
@@ -28,37 +29,44 @@ function title(value: unknown) {
 }
 
 function cleanSignals(values: unknown[], fallbackTone: AuthoritySignal['tone'] = 'neutral'): AuthoritySignal[] {
-  return unique(values.map(text).filter(Boolean))
-    .slice(0, 6)
-    .map((value) => ({
-      label: title(value),
-      description: title(value),
-      tone: fallbackTone,
-    }))
+  return dedupeEditorialItems(values, 6)
+    .map((value) => {
+      const label = title(value)
+      const description = title(value)
+
+      return {
+        label,
+        description,
+        tone: fallbackTone,
+      }
+    })
+    .filter((signal) => shouldRenderCard(signal.label, signal.description))
 }
 
 export function buildExecutiveSummary(record: any): AuthoritySignal[] {
-  const summary = text(record?.summary || record?.description)
-  const evidence = text(record?.evidence_tier || record?.evidenceTier || record?.summary_quality || 'Evidence context varies')
-  const safety = text(record?.safety_level || record?.safety || record?.safetyNotes || 'Review safety context')
+  const summary = cleanEditorialText(record?.summary || record?.description)
+  const evidence = cleanEditorialText(record?.evidence_tier || record?.evidenceTier || record?.summary_quality || 'Evidence context varies')
+  const safety = cleanEditorialText(record?.safety_level || record?.safety || record?.safetyNotes || 'Review safety context')
 
-  return [
+  const signals: AuthoritySignal[] = [
     {
       label: 'What it is',
-      description: summary || 'A research profile with semantic evidence, mechanism, and safety context.',
+      description: isRenderableText(summary) ? summary : 'A research profile with semantic evidence, mechanism, and safety context.',
       tone: 'neutral',
     },
     {
       label: 'Evidence confidence',
-      description: title(evidence),
+      description: isRenderableText(evidence) ? title(evidence) : 'Evidence context varies',
       tone: /strong|clinical|human|high/i.test(evidence) ? 'strong' : /moderate|mixed/i.test(evidence) ? 'moderate' : 'neutral',
     },
     {
       label: 'Safety posture',
-      description: title(safety),
+      description: isRenderableText(safety) ? title(safety) : 'Review safety context',
       tone: /avoid|caution|review|risk/i.test(safety) ? 'caution' : 'neutral',
     },
   ]
+
+  return signals.filter((signal) => shouldRenderCard(signal.label, signal.description))
 }
 
 export function buildBestForSignals(record: any): AuthoritySignal[] {
@@ -87,11 +95,13 @@ export function buildEvidenceHierarchy(record: any): AuthoritySignal[] {
   const report = buildResearchKnowledgeReport(record)
 
   if (report.hierarchy.length > 0) {
-    return report.hierarchy.slice(0, 5).map((item) => ({
-      label: item.label,
-      description: item.reason,
+    const signals: AuthoritySignal[] = report.hierarchy.slice(0, 5).map((item) => ({
+      label: cleanEditorialText(item.label),
+      description: cleanEditorialText(item.reason),
       tone: item.confidence === 'high' ? 'strong' : item.confidence === 'moderate' ? 'moderate' : 'neutral',
     }))
+
+    return signals.filter((signal) => shouldRenderCard(signal.label, signal.description))
   }
 
   return [{
@@ -139,7 +149,7 @@ export function buildEditorialInterpretation(record: any): AuthoritySignal {
 
   return {
     label: 'Editorial interpretation',
-    description: `${name} currently looks ${semantic.priority} from a semantic authority perspective. ${evidence.summary}`,
+    description: cleanEditorialText(`${name} currently looks ${semantic.priority} from a semantic authority perspective. ${evidence.summary}`),
     tone: semantic.priority === 'high' ? 'strong' : semantic.priority === 'moderate' ? 'moderate' : 'neutral',
   }
 }

--- a/lib/editorial-authority-layer.ts
+++ b/lib/editorial-authority-layer.ts
@@ -1,4 +1,5 @@
-import { list, text, unique } from '@/lib/display-utils'
+import { list, text } from '@/lib/display-utils'
+import { cleanEditorialText, dedupeEditorialItems, isRenderableText, shouldRenderCard } from '@/lib/editorial-rendering'
 import { buildResearchKnowledgeReport } from '@/lib/research-knowledge-layer'
 import { buildSemanticIntelligenceReport } from '@/lib/semantic-intelligence-layer'
 
@@ -17,12 +18,14 @@ function title(value: unknown) {
 export function buildEditorialAuthorityNotes(record: any): EditorialAuthorityNote[] {
   const semantic = buildSemanticIntelligenceReport(record)
   const research = buildResearchKnowledgeReport(record)
-  const name = title(record?.displayName || record?.name || record?.slug || 'This profile')
-  const effects = unique([
+  const name = isRenderableText(record?.displayName || record?.name || record?.slug)
+    ? title(record?.displayName || record?.name || record?.slug)
+    : 'This profile'
+  const effects = dedupeEditorialItems([
     ...list(record?.best_for),
     ...list(record?.primary_effects),
     ...list(record?.effects),
-  ].map(title).filter(Boolean)).slice(0, 4)
+  ].map(title), 4)
 
   return [
     {
@@ -34,7 +37,7 @@ export function buildEditorialAuthorityNotes(record: any): EditorialAuthorityNot
     },
     {
       label: 'Evidence nuance',
-      body: research.summary,
+      body: cleanEditorialText(research.summary),
       tone: research.evidenceWeight >= 24 ? 'interpretation' : 'uncertainty',
     },
     {
@@ -52,5 +55,9 @@ export function buildEditorialAuthorityNotes(record: any): EditorialAuthorityNot
       body: `${name} currently ranks as ${semantic.priority} for semantic authority based on mechanism density, evidence signals, ecosystem alignment, and traversal diversity.`,
       tone: 'interpretation',
     },
-  ]
+  ].map((note) => ({
+    ...note,
+    label: cleanEditorialText(note.label),
+    body: cleanEditorialText(note.body),
+  })).filter((note) => shouldRenderCard(note.label, note.body))
 }

--- a/lib/editorial-rendering.ts
+++ b/lib/editorial-rendering.ts
@@ -1,0 +1,157 @@
+import { text } from '@/lib/display-utils'
+
+const WEAK_EXACT_VALUES = new Set([
+  'unknown',
+  'n/a',
+  'na',
+  'none',
+  'null',
+  'undefined',
+  'tbd',
+  'todo',
+  'placeholder',
+  'not available',
+  'not applicable',
+  'not yet available',
+  'no data',
+  'no evidence',
+  'strong',
+  'moderate',
+  'weak',
+  'limited',
+  'low',
+  'high',
+  'c',
+])
+
+const WEAK_PATTERNS = [
+  /malformed semantic/i,
+  /semantic leftovers?/i,
+  /placeholder/i,
+  /schema artifact/i,
+  /workbook readiness pass/i,
+  /sci\s*space evidence pass/i,
+  /mechanism[-\s]*only pending/i,
+  /research[_\s-]*only/i,
+  /internal cross[-\s]*linking/i,
+  /treat dosing and outcomes as review[-\s]*gated/i,
+  /added as site[-\s]*safe referenced entity/i,
+  /conservative evidence framing/i,
+  /source backed preparation/i,
+  /bulk (?:mode|enrichment|ingested)/i,
+  /lean (?:herb |monograph )?row/i,
+  /tracked for/i,
+  /^(?:grade|tier|score|confidence)\s*[:=-]?\s*[a-f][+-]?$/i,
+  /^[a-f][+-]?\s*(?:grade|tier|score|confidence)$/i,
+]
+
+function normalizedKey(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/&/g, 'and')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function hasRepeatedSeparatorJunk(value: string) {
+  return /(?:[-–—_|/:;,]\s*){3,}/.test(value) || /^(?:[-–—_|/:;,.*#]+\s*)+$/.test(value)
+}
+
+function hasAccidentalDuplicatePhrase(value: string) {
+  const normalized = normalizedKey(value)
+  const words = normalized.split(' ').filter(Boolean)
+
+  if (words.length < 2 || words.length > 12 || words.length % 2 !== 0) {
+    return false
+  }
+
+  const midpoint = words.length / 2
+  return words.slice(0, midpoint).join(' ') === words.slice(midpoint).join(' ')
+}
+
+export function isWeakSemanticValue(value: unknown): boolean {
+  const cleaned = cleanEditorialText(value)
+
+  if (!cleaned) return true
+  if (cleaned.length === 1) return true
+  if (hasRepeatedSeparatorJunk(cleaned)) return true
+
+  const key = normalizedKey(cleaned)
+
+  if (!key) return true
+  if (WEAK_EXACT_VALUES.has(key)) return true
+  if (/^[a-z]$/.test(key)) return true
+  if (/^(?:unknown|none|null|undefined|n\/?a|tbd)(?:\s+|$)/i.test(cleaned)) return true
+  if (WEAK_PATTERNS.some((pattern) => pattern.test(cleaned))) return true
+  if (hasAccidentalDuplicatePhrase(cleaned)) return true
+
+  return false
+}
+
+export function isRenderableText(value: unknown): boolean {
+  return !isWeakSemanticValue(value)
+}
+
+export function cleanEditorialText(value: unknown): string {
+  const raw = text(value)
+
+  if (!raw) return ''
+
+  return raw
+    .split('')
+    .map((char) => {
+      const code = char.charCodeAt(0)
+      return code < 32 || code === 127 ? ' ' : char
+    })
+    .join('')
+    .replace(/[_]+/g, ' ')
+    .replace(/\s*([|/•])\s*(?:\1\s*)+/g, ' $1 ')
+    .replace(/\s*([-–—])\s*(?:[-–—]\s*)+/g, ' — ')
+    .replace(/([!?.,;:])\1{1,}/g, '$1')
+    .replace(/\s+([,.;:!?])/g, '$1')
+    .replace(/([([{"'])\s+/g, '$1')
+    .replace(/\s+([)\]}"'])/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+export function dedupeEditorialItems(items: unknown[], limit = 6): string[] {
+  const seen = new Set<string>()
+  const clean: string[] = []
+
+  for (const item of items) {
+    const value = cleanEditorialText(item)
+    const key = normalizedKey(value)
+
+    if (!value || isWeakSemanticValue(value) || !key || seen.has(key)) {
+      continue
+    }
+
+    seen.add(key)
+    clean.push(value)
+
+    if (clean.length >= limit) break
+  }
+
+  return clean
+}
+
+export function isDuplicateTitleBody(title: string, body: string): boolean {
+  const normalizedTitle = normalizedKey(cleanEditorialText(title))
+  const normalizedBody = normalizedKey(cleanEditorialText(body))
+
+  return Boolean(normalizedTitle && normalizedBody && normalizedTitle === normalizedBody)
+}
+
+export function shouldRenderCard(title: unknown, body?: unknown): boolean {
+  const cleanTitle = cleanEditorialText(title)
+  const cleanBody = cleanEditorialText(body)
+
+  if (!isRenderableText(cleanTitle)) return false
+  if (body === undefined || body === null) return true
+  if (!cleanBody) return true
+  if (isDuplicateTitleBody(cleanTitle, cleanBody) && isWeakSemanticValue(cleanTitle)) return false
+
+  return true
+}

--- a/lib/semantic/buildComparisonRecommendations.ts
+++ b/lib/semantic/buildComparisonRecommendations.ts
@@ -1,15 +1,13 @@
+import { cleanEditorialText, dedupeEditorialItems, isRenderableText, shouldRenderCard } from '@/lib/editorial-rendering'
 type RuntimeRecord = Record<string, any>
 
 function asList(value: unknown): string[] {
   if (Array.isArray(value)) {
-    return value.map((v) => String(v ?? '').trim()).filter(Boolean)
+    return dedupeEditorialItems(value)
   }
 
   if (typeof value === 'string') {
-    return value
-      .split(',')
-      .map((v) => v.trim())
-      .filter(Boolean)
+    return dedupeEditorialItems(value.split(/,|;|\|/))
   }
 
   return []
@@ -29,13 +27,17 @@ function buildSignals(record: RuntimeRecord) {
 
 export function buildComparisonRecommendations(record: RuntimeRecord) {
   const signals = buildSignals(record)
+  const name = cleanEditorialText(record?.name || record?.slug)
+  const slug = cleanEditorialText(record?.slug)
+
+  if (!isRenderableText(name) || !isRenderableText(slug)) return []
 
   return signals.slice(0, 6).map((signal) => ({
-    href: `/compare/${record?.slug}-vs-${signal
+    href: `/compare/${slug}-vs-${signal
       .toLowerCase()
       .replace(/\s+/g, '-')}`,
-    title: `${record?.name || record?.slug} vs ${signal}`,
-    rationale: `Semantic comparison generated through overlap in ${signal}.`,
+    title: cleanEditorialText(`${name} vs ${signal}`),
+    rationale: cleanEditorialText(`Semantic comparison generated through overlap in ${signal}.`),
     overlap: [signal],
-  }))
+  })).filter((item) => shouldRenderCard(item.title, item.rationale))
 }

--- a/lib/semantic/buildProfileRecommendations.ts
+++ b/lib/semantic/buildProfileRecommendations.ts
@@ -1,15 +1,13 @@
+import { cleanEditorialText, dedupeEditorialItems, isRenderableText, shouldRenderCard } from '@/lib/editorial-rendering'
 type RuntimeRecord = Record<string, any>
 
 function asList(value: unknown): string[] {
   if (Array.isArray(value)) {
-    return value.map((v) => String(v ?? '').trim()).filter(Boolean)
+    return dedupeEditorialItems(value)
   }
 
   if (typeof value === 'string') {
-    return value
-      .split(',')
-      .map((v) => v.trim())
-      .filter(Boolean)
+    return dedupeEditorialItems(value.split(/,|;|\|/))
   }
 
   return []
@@ -48,21 +46,21 @@ export function buildProfileRecommendations({
   const currentSignals = getSignals(current)
 
   return candidates
-    .filter((candidate) => candidate?.slug && candidate.slug !== current?.slug)
+    .filter((candidate) => isRenderableText(candidate?.slug) && candidate.slug !== current?.slug)
     .map((candidate) => {
       const matches = overlap(currentSignals, getSignals(candidate))
 
       return {
         href: `${basePath}/${candidate.slug}`,
-        title: candidate.title || candidate.name || candidate.slug,
-        overlap: matches.slice(0, 4),
+        title: cleanEditorialText(candidate.title || candidate.name || candidate.slug),
+        overlap: dedupeEditorialItems(matches, 4),
         rationale: matches.length
           ? `Connected through ${matches.slice(0, 3).join(', ')}.`
           : 'Related through semantic ecosystem continuity.',
         score: matches.length,
       }
     })
-    .filter((candidate) => candidate.score > 0)
+    .filter((candidate) => candidate.score > 0 && shouldRenderCard(candidate.title, candidate.rationale))
     .sort((a, b) => {
       if (b.score !== a.score) {
         return b.score - a.score

--- a/lib/semantic/buildProtocolRecommendations.ts
+++ b/lib/semantic/buildProtocolRecommendations.ts
@@ -1,15 +1,13 @@
+import { dedupeEditorialItems, isRenderableText, shouldRenderCard } from '@/lib/editorial-rendering'
 type RuntimeRecord = Record<string, any>
 
 function asList(value: unknown): string[] {
   if (Array.isArray(value)) {
-    return value.map((v) => String(v ?? '').trim()).filter(Boolean)
+    return dedupeEditorialItems(value)
   }
 
   if (typeof value === 'string') {
-    return value
-      .split(',')
-      .map((v) => v.trim())
-      .filter(Boolean)
+    return dedupeEditorialItems(value.split(/,|;|\|/))
   }
 
   return []
@@ -30,7 +28,7 @@ function buildTags(record: RuntimeRecord) {
 export function buildProtocolRecommendations(record: RuntimeRecord) {
   const tags = buildTags(record)
 
-  return tags.slice(0, 6).map((tag) => ({
+  return tags.slice(0, 6).filter(isRenderableText).map((tag) => ({
     href: `/protocols/${tag
       .toLowerCase()
       .replace(/\s+/g, '-')}`,
@@ -38,5 +36,5 @@ export function buildProtocolRecommendations(record: RuntimeRecord) {
     summary:
       'Evidence-aware protocol exploration generated from semantic ecosystem overlap and pathway continuity.',
     tags: [tag],
-  }))
+  })).filter((item) => shouldRenderCard(item.title, item.summary))
 }

--- a/lib/semantic/buildSemanticEntityMetadata.ts
+++ b/lib/semantic/buildSemanticEntityMetadata.ts
@@ -1,38 +1,33 @@
+import { cleanEditorialText, dedupeEditorialItems } from '@/lib/editorial-rendering'
+
 type RuntimeRecord = Record<string, any>
 
 function asList(value: unknown): string[] {
   if (Array.isArray(value)) {
-    return value.map((v) => String(v ?? '').trim()).filter(Boolean)
+    return value
   }
 
   if (typeof value === 'string') {
-    return value
-      .split(',')
-      .map((v) => v.trim())
-      .filter(Boolean)
+    return value.split(/,|;|\|/)
   }
 
   return []
 }
 
-function unique(values: string[]) {
-  return [...new Set(values)]
-}
-
 export function buildSemanticEntityMetadata(record: RuntimeRecord) {
   return {
-    title: record?.name || record?.title || record?.slug || 'Profile',
+    title: cleanEditorialText(record?.name || record?.title || record?.slug) || 'Profile',
 
-    semanticEffects: unique(asList(record?.primary_effects)).slice(0, 8),
+    semanticEffects: dedupeEditorialItems(asList(record?.primary_effects), 8),
 
-    semanticMechanisms: unique(asList(record?.mechanisms)).slice(0, 8),
+    semanticMechanisms: dedupeEditorialItems(asList(record?.mechanisms), 8),
 
-    semanticPathways: unique(asList(record?.pathways)).slice(0, 8),
+    semanticPathways: dedupeEditorialItems(asList(record?.pathways), 8),
 
-    semanticEcosystems: unique(asList(record?.topic_ecosystems)).slice(0, 8),
+    semanticEcosystems: dedupeEditorialItems(asList(record?.topic_ecosystems), 8),
 
-    semanticComparisons: unique(asList(record?.comparison_groups)).slice(0, 8),
+    semanticComparisons: dedupeEditorialItems(asList(record?.comparison_groups), 8),
 
-    semanticStacks: unique(asList(record?.stack_synergies)).slice(0, 8),
+    semanticStacks: dedupeEditorialItems(asList(record?.stack_synergies), 8),
   }
 }

--- a/lib/semantic/buildTopicContinuity.ts
+++ b/lib/semantic/buildTopicContinuity.ts
@@ -1,15 +1,13 @@
+import { dedupeEditorialItems, isRenderableText, shouldRenderCard } from '@/lib/editorial-rendering'
 type RuntimeRecord = Record<string, any>
 
 function asList(value: unknown): string[] {
   if (Array.isArray(value)) {
-    return value.map((v) => String(v ?? '').trim()).filter(Boolean)
+    return dedupeEditorialItems(value)
   }
 
   if (typeof value === 'string') {
-    return value
-      .split(',')
-      .map((v) => v.trim())
-      .filter(Boolean)
+    return dedupeEditorialItems(value.split(/,|;|\|/))
   }
 
   return []
@@ -24,6 +22,7 @@ export function buildTopicContinuity(record: RuntimeRecord) {
   const pathways = unique(asList(record?.pathways))
 
   return [...ecosystems, ...pathways]
+    .filter(isRenderableText)
     .slice(0, 8)
     .map((label) => ({
       label,
@@ -31,4 +30,5 @@ export function buildTopicContinuity(record: RuntimeRecord) {
         .toLowerCase()
         .replace(/\s+/g, '-')}`,
     }))
+    .filter((item) => shouldRenderCard(item.label))
 }

--- a/lib/semantic/dedupeSemanticRecommendations.ts
+++ b/lib/semantic/dedupeSemanticRecommendations.ts
@@ -1,3 +1,5 @@
+import { cleanEditorialText, dedupeEditorialItems, shouldRenderCard } from '@/lib/editorial-rendering'
+
 type RecommendationRecord = {
   href?: string
   title?: string
@@ -7,9 +9,11 @@ type RecommendationRecord = {
 }
 
 function normalize(value: unknown) {
-  return String(value || '')
-    .trim()
+  return cleanEditorialText(value)
     .toLowerCase()
+    .replace(/[^a-z0-9/]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
 }
 
 export function dedupeSemanticRecommendations<T extends RecommendationRecord>(
@@ -20,6 +24,13 @@ export function dedupeSemanticRecommendations<T extends RecommendationRecord>(
 
   return items
     .filter(Boolean)
+    .map((item) => ({
+      ...item,
+      title: cleanEditorialText(item.title),
+      rationale: cleanEditorialText(item.rationale),
+      overlap: dedupeEditorialItems(item.overlap || [], 4),
+    }))
+    .filter((item) => shouldRenderCard(item.title, item.rationale))
     .filter((item) => {
       const key = normalize(item.href || item.title)
 
@@ -40,5 +51,5 @@ export function dedupeSemanticRecommendations<T extends RecommendationRecord>(
 
       return normalize(a?.title).localeCompare(normalize(b?.title))
     })
-    .slice(0, limit)
+    .slice(0, limit) as T[]
 }

--- a/lib/semantic/getEcosystemContinuity.ts
+++ b/lib/semantic/getEcosystemContinuity.ts
@@ -1,3 +1,4 @@
+import { cleanEditorialText, dedupeEditorialItems, isRenderableText, shouldRenderCard } from '@/lib/editorial-rendering'
 type RuntimeRecord = Record<string, any>
 
 type ContinuityCandidate = {
@@ -13,16 +14,11 @@ const MAX_RESULTS = 6
 
 function asList(value: unknown): string[] {
   if (Array.isArray(value)) {
-    return value
-      .map((item) => String(item ?? '').trim())
-      .filter(Boolean)
+    return dedupeEditorialItems(value)
   }
 
   if (typeof value === 'string') {
-    return value
-      .split(',')
-      .map((item) => item.trim())
-      .filter(Boolean)
+    return dedupeEditorialItems(value.split(/,|;|\|/))
   }
 
   return []
@@ -77,21 +73,21 @@ export function getEcosystemContinuity({
   const currentSignals = buildSignalSet(current)
 
   return candidates
-    .filter((candidate) => candidate?.slug && candidate.slug !== current?.slug)
+    .filter((candidate) => isRenderableText(candidate?.slug) && candidate.slug !== current?.slug)
     .map((candidate) => {
       const candidateSignals = buildSignalSet(candidate)
       const matches = overlap(currentSignals, candidateSignals)
 
       return {
         slug: candidate.slug,
-        title: candidate.title || candidate.name || candidate.slug,
+        title: cleanEditorialText(candidate.title || candidate.name || candidate.slug),
         href: `${routeBase}/${candidate.slug}`,
-        overlap: matches.slice(0, 4),
+        overlap: dedupeEditorialItems(matches, 4),
         rationale: buildRationale(matches),
         score: scoreOverlap(matches),
       }
     })
-    .filter((candidate) => candidate.score > 0)
+    .filter((candidate) => candidate.score > 0 && shouldRenderCard(candidate.title, candidate.rationale))
     .sort((a, b) => {
       if (b.score !== a.score) {
         return b.score - a.score

--- a/src/components/decision-clarity-field-manual.tsx
+++ b/src/components/decision-clarity-field-manual.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import { buildDecisionClarity } from '@/lib/decision-clarity'
+import { cleanEditorialText, dedupeEditorialItems, isDuplicateTitleBody, isRenderableText } from '@/lib/editorial-rendering'
 
 type EntityType = 'herb' | 'compound'
 
@@ -21,22 +22,26 @@ function FieldManualCard({
   title: string
   items: string[]
 }) {
-  if (!items.length) return null
+  const cleanLabel = cleanEditorialText(label)
+  const cleanTitle = cleanEditorialText(title)
+  const renderableItems = dedupeEditorialItems(items, 4)
+
+  if (!renderableItems.length || !isRenderableText(cleanTitle)) return null
 
   return (
     <div className="rounded-3xl border border-brand-900/10 bg-white/75 p-5 shadow-sm">
       <div className="space-y-3">
         <div>
           <p className="text-[0.68rem] font-bold uppercase tracking-[0.18em] text-brand-900/55">
-            {label}
+            {cleanLabel}
           </p>
           <h3 className="mt-1 text-lg font-semibold tracking-tight text-ink">
-            {title}
+            {cleanTitle}
           </h3>
         </div>
 
         <ul className="space-y-3 text-sm leading-7 text-[#46574d]">
-          {items.map((item) => (
+          {renderableItems.map((item) => (
             <li key={item} className="flex gap-3">
               <span className="mt-[0.7rem] h-1.5 w-1.5 shrink-0 rounded-full bg-brand-700/60" />
               <span>{item}</span>
@@ -103,7 +108,14 @@ export default function DecisionClarityFieldManual({
             </div>
 
             <div className="space-y-3">
-              {clarity.nextBestSteps.map((step) => (
+{clarity.nextBestSteps
+                .map((step) => ({
+                  ...step,
+                  label: cleanEditorialText(step.label),
+                  note: cleanEditorialText(step.note),
+                }))
+                .filter((step) => isRenderableText(step.label))
+                .map((step) => (
                 step.href ? (
                   <Link
                     key={`${step.label}-${step.href}`}
@@ -111,7 +123,7 @@ export default function DecisionClarityFieldManual({
                     className="block rounded-2xl border border-brand-900/10 bg-white/80 p-4 transition hover:border-brand-700/25 hover:bg-white"
                   >
                     <p className="text-sm font-semibold text-ink">{step.label}</p>
-                    {step.note ? (
+                    {isRenderableText(step.note) && !isDuplicateTitleBody(step.label, step.note) ? (
                       <p className="mt-1 text-sm leading-6 text-[#5b6b61]">{step.note}</p>
                     ) : null}
                   </Link>
@@ -121,7 +133,7 @@ export default function DecisionClarityFieldManual({
                     className="rounded-2xl border border-brand-900/10 bg-white/80 p-4"
                   >
                     <p className="text-sm font-semibold text-ink">{step.label}</p>
-                    {step.note ? (
+                    {isRenderableText(step.note) && !isDuplicateTitleBody(step.label, step.note) ? (
                       <p className="mt-1 text-sm leading-6 text-[#5b6b61]">{step.note}</p>
                     ) : null}
                   </div>

--- a/src/components/decision-visual-grid.tsx
+++ b/src/components/decision-visual-grid.tsx
@@ -5,6 +5,7 @@ import {
   type TimelineProfile,
 } from '@/lib/decision-visuals'
 import { formatDisplayLabel } from '@/lib/display-utils'
+import { cleanEditorialText, dedupeEditorialItems, isRenderableText } from '@/lib/editorial-rendering'
 
 type DecisionVisualGridProps = {
   record: any
@@ -41,11 +42,15 @@ function SpectrumBar({
   value: StimulationProfile | TimelineProfile
   order: StimulationProfile[] | TimelineProfile[]
 }) {
+  const cleanValue = cleanEditorialText(formatDisplayLabel(value))
+
+  if (!isRenderableText(cleanValue)) return null
+
   return (
     <div className="rounded-2xl border border-brand-900/10 bg-white/75 p-4">
       <div className="flex items-center justify-between gap-3">
         <p className="text-[0.68rem] font-bold uppercase tracking-[0.16em] text-brand-900/55">{label}</p>
-        <p className="text-xs font-semibold text-[#33443a]">{formatDisplayLabel(value)}</p>
+        <p className="text-xs font-semibold text-[#33443a]">{cleanValue}</p>
       </div>
 
       <div className="relative mt-4 h-2 rounded-full bg-brand-900/10">
@@ -65,16 +70,21 @@ function SpectrumBar({
 }
 
 function SignalCard({ label, value }: { label: string; value: string }) {
+  const cleanValue = cleanEditorialText(formatDisplayLabel(value))
+
+  if (!isRenderableText(cleanValue)) return null
+
   return (
     <div className={`rounded-2xl border p-4 ${toneClass(value)}`}>
       <p className="text-[0.68rem] font-bold uppercase tracking-[0.16em] opacity-65">{label}</p>
-      <p className="mt-2 text-sm font-semibold leading-6">{formatDisplayLabel(value)}</p>
+      <p className="mt-2 text-sm font-semibold leading-6">{cleanValue}</p>
     </div>
   )
 }
 
 export default function DecisionVisualGrid({ record, title = 'Visual decision intelligence', compact = false }: DecisionVisualGridProps) {
   const profile: DecisionVisualProfile = buildDecisionVisualProfile(record)
+  const tags = dedupeEditorialItems(profile.tags.map(formatDisplayLabel), 8)
 
   return (
     <section className={`card-premium space-y-5 ${compact ? 'p-5 sm:p-6' : 'p-5 sm:p-7 lg:p-8'}`}>
@@ -103,9 +113,9 @@ export default function DecisionVisualGrid({ record, title = 'Visual decision in
       </div>
 
       <div className="flex flex-wrap gap-2">
-        {profile.tags.map((tag) => (
+        {tags.map((tag) => (
           <span key={tag} className="rounded-full border border-brand-900/10 bg-paper-50/80 px-3 py-1.5 text-xs font-semibold text-[#46574d]">
-            {formatDisplayLabel(tag)}
+            {tag}
           </span>
         ))}
       </div>

--- a/src/components/profile-decision-layer.tsx
+++ b/src/components/profile-decision-layer.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
-import { cleanSummary, formatDisplayLabel, isClean, list, text, unique } from '@/lib/display-utils'
+import { cleanSummary, formatDisplayLabel, list, text } from '@/lib/display-utils'
+import { cleanEditorialText, dedupeEditorialItems, isDuplicateTitleBody, isRenderableText, shouldRenderCard } from '@/lib/editorial-rendering'
 import { getSemanticOrchestrationSignals } from '@/lib/semantic-orchestration'
 
 type EntityType = 'herb' | 'compound'
@@ -19,20 +20,19 @@ type DecisionItem = {
   tone?: 'neutral' | 'strong' | 'caution' | 'muted'
 }
 
-const WEAK_PATTERN = /research[-\s]?pending|placeholder|unknown|not specified|not available|insufficient|needs review|minimal/i
 const CAUTION_PATTERN = /avoid|caution|interaction|contraindication|warning|risk|pregnancy|liver|kidney|sedat|bleed/i
 
 function cleanList(value: unknown, limit = 6) {
-  return unique(
+  return dedupeEditorialItems(
     list(value)
-      .map(formatDisplayLabel)
-      .map((item) => item.trim())
-      .filter((item) => isClean(item) && !WEAK_PATTERN.test(item)),
-  ).slice(0, limit)
+      .map(formatDisplayLabel),
+    limit,
+  )
 }
 
 function getName(record: any) {
-  return formatDisplayLabel(record?.displayName || record?.name || record?.slug)
+  const name = formatDisplayLabel(record?.displayName || record?.name || record?.slug)
+  return isRenderableText(name) ? name : ''
 }
 
 function getSummary(record: any, entityType: EntityType, fallback = '') {
@@ -93,14 +93,14 @@ function getCompareTo(record: any, relatedRecords: any[] = []) {
 
   if (explicit.length > 0) return explicit
 
-  return relatedRecords
-    .map((item) => formatDisplayLabel(item?.name || item?.slug))
-    .filter(Boolean)
-    .slice(0, 3)
+  return dedupeEditorialItems(
+    relatedRecords.map((item) => formatDisplayLabel(item?.name || item?.slug)),
+    3,
+  )
 }
 
 function getEvidenceText(record: any) {
-  return formatDisplayLabel(
+  return cleanEditorialText(formatDisplayLabel(
     record?.evidence_snapshot ||
       record?.evidenceSnapshot ||
       record?.evidence_tier ||
@@ -108,29 +108,29 @@ function getEvidenceText(record: any) {
       record?.confidence ||
       record?.summary_quality ||
       'Evidence review available',
-  )
+  ))
 }
 
 function getSafetyText(record: any, avoidIf: string[]) {
-  return formatDisplayLabel(
+  return cleanEditorialText(formatDisplayLabel(
     record?.safety_snapshot ||
       record?.safetySnapshot ||
       record?.safety_level ||
       record?.safetyLevel ||
       record?.safety?.confidence ||
       (avoidIf.length > 0 ? 'Caution context available' : 'Safety review available'),
-  )
+  ))
 }
 
 function getTimeToNotice(record: any) {
-  return formatDisplayLabel(
+  return cleanEditorialText(formatDisplayLabel(
     record?.time_to_notice ||
       record?.timeToNotice ||
       record?.time_to_effect ||
       record?.timeToEffect ||
       record?.onset ||
       'Timing varies by context',
-  )
+  ))
 }
 
 function evidenceTone(value: string): DecisionItem['tone'] {
@@ -152,18 +152,24 @@ function decisionCardClass(tone: DecisionItem['tone'] = 'neutral') {
 }
 
 function DecisionCard({ item }: { item: DecisionItem }) {
-  if (!item.value) return null
+  const label = cleanEditorialText(item.label)
+  const value = cleanEditorialText(item.value)
+
+  if (!shouldRenderCard(label, value)) return null
 
   return (
     <div className={`rounded-2xl border p-4 ${decisionCardClass(item.tone)}`}>
-      <p className="text-[0.68rem] font-bold uppercase tracking-[0.16em] opacity-65">{item.label}</p>
-      <p className="mt-2 text-sm font-semibold leading-6">{item.value}</p>
+      <p className="text-[0.68rem] font-bold uppercase tracking-[0.16em] opacity-65">{label}</p>
+      {isDuplicateTitleBody(label, value) ? null : (
+        <p className="mt-2 text-sm font-semibold leading-6">{value}</p>
+      )}
     </div>
   )
 }
 
 function formatListValue(items: string[], fallback: string) {
-  return items.length > 0 ? items.slice(0, 3).join(', ') : fallback
+  const clean = dedupeEditorialItems(items, 3)
+  return clean.length > 0 ? clean.join(', ') : fallback
 }
 
 function getRelatedHref(entityType: EntityType, slug: string) {
@@ -209,7 +215,7 @@ export function ProfileDecisionLayer({
   ]
 
   const topRelated = relatedRecords
-    .filter((item) => item?.slug)
+    .filter((item) => isRenderableText(item?.slug) && isRenderableText(item?.name || item?.slug))
     .slice(0, 3)
 
   return (
@@ -221,7 +227,7 @@ export function ProfileDecisionLayer({
             <h2 className="max-w-2xl text-3xl font-semibold tracking-tight text-ink sm:text-4xl">
               {name ? `${name}: quick interpretation` : 'Quick interpretation'}
             </h2>
-            {quickTake ? (
+            {isRenderableText(quickTake) ? (
               <p className="detail-reading max-w-3xl text-[#46574d]">
                 {quickTake}
               </p>
@@ -249,10 +255,10 @@ export function ProfileDecisionLayer({
                 <p className="text-xs font-bold uppercase tracking-[0.16em] text-brand-900/55">Compare next</p>
                 <div className="space-y-2">
                   {topRelated.map((item) => {
-                    const label = formatDisplayLabel(item?.name || item?.slug)
-                    const slug = text(item?.slug)
+                    const label = cleanEditorialText(formatDisplayLabel(item?.name || item?.slug))
+                    const slug = cleanEditorialText(text(item?.slug))
                     const targetType = item?.entityType === 'herb' || item?.entityType === 'compound' ? item.entityType : entityType
-                    if (!label || !slug) return null
+                    if (!isRenderableText(label) || !isRenderableText(slug)) return null
 
                     return (
                       <Link

--- a/src/components/related-links-section.tsx
+++ b/src/components/related-links-section.tsx
@@ -1,11 +1,21 @@
 import Link from 'next/link'
+import { cleanEditorialText, shouldRenderCard } from '@/lib/editorial-rendering'
 
 export default function RelatedLinksSection({ title, items }: any) {
-  if (!items?.length) return null
+  const cleanTitle = cleanEditorialText(title) || 'Related links'
+  const renderableItems = (items || [])
+    .map((item: any) => ({
+      ...item,
+      title: cleanEditorialText(item?.title || item?.label),
+    }))
+    .filter((item: any) => item.href && shouldRenderCard(item.title))
+
+  if (!renderableItems.length) return null
+
   return (
     <div>
-      <h2>{title}</h2>
-      {items.map((item: any) => (
+      <h2>{cleanTitle}</h2>
+      {renderableItems.map((item: any) => (
         <Link key={item.href} href={item.href}>{item.title}</Link>
       ))}
     </div>

--- a/src/lib/decision-clarity.ts
+++ b/src/lib/decision-clarity.ts
@@ -1,4 +1,5 @@
-import { cleanSummary, formatDisplayLabel, isClean, list, text, unique } from '@/lib/display-utils'
+import { cleanSummary, formatDisplayLabel, list, text } from '@/lib/display-utils'
+import { cleanEditorialText, dedupeEditorialItems, isRenderableText } from '@/lib/editorial-rendering'
 
 type EntityType = 'herb' | 'compound'
 
@@ -24,7 +25,6 @@ export type DecisionClarityModel = {
   stackConsiderations: string[]
 }
 
-const WEAK_PATTERN = /research[-\s]?pending|placeholder|unknown|not specified|not available|insufficient|needs review|minimal|n\/a/i
 const STIMULANT_PATTERN = /energy|focus|stimul|alert|performance|fatigue|cognition|cognitive/i
 const SLEEP_PATTERN = /sleep|calm|relax|stress|anxiety|recovery|gaba/i
 const RECOVERY_PATTERN = /recovery|performance|muscle|exercise|mitochond|fatigue|endurance/i
@@ -216,26 +216,27 @@ function normalizeSlug(record: any) {
 }
 
 function cleanItems(items: unknown[], limit = 4) {
-  return unique(
+  return dedupeEditorialItems(
     items
       .flatMap((item) => list(item))
-      .map(formatDisplayLabel)
-      .map((item) => item.trim())
-      .filter((item) => isClean(item) && !WEAK_PATTERN.test(item)),
-  ).slice(0, limit)
+      .map(formatDisplayLabel),
+    limit,
+  )
 }
 
 function compactSentence(value: string) {
-  return value.endsWith('.') ? value : `${value}.`
+  const clean = cleanEditorialText(value)
+  return clean.endsWith('.') ? clean : `${clean}.`
 }
 
 function getName(record: any) {
-  return formatDisplayLabel(record?.displayName || record?.name || record?.slug || 'This profile')
+  const name = formatDisplayLabel(record?.displayName || record?.name || record?.slug)
+  return isRenderableText(name) ? name : 'This profile'
 }
 
 function routeFor(record: any, fallbackType: EntityType) {
-  const slug = text(record?.slug)
-  if (!slug) return undefined
+  const slug = cleanEditorialText(record?.slug)
+  if (!isRenderableText(slug)) return undefined
   const type = record?.entityType === 'herb' || record?.entityType === 'compound' ? record.entityType : fallbackType
   return `/${type === 'herb' ? 'herbs' : 'compounds'}/${slug}`
 }
@@ -488,20 +489,29 @@ function inferNextBestSteps(record: any, entityType: EntityType, relatedRecords:
   ], 3).map((label) => ({ label: compactSentence(label) }))
 
   const related = relatedRecords
-    .filter((item) => item?.slug)
+    .filter((item) => isRenderableText(item?.slug))
     .slice(0, 3)
     .map((item) => ({
-      label: formatDisplayLabel(item?.name || item?.slug),
+      label: cleanEditorialText(formatDisplayLabel(item?.name || item?.slug)),
       href: routeFor(item, entityType),
       note: 'Compare fit, timing, and safety before choosing.',
     }))
 
-  if (explicit.length > 0) return [...explicit, ...related].slice(0, 4)
+  const steps = explicit.length > 0
+    ? [...explicit, ...related]
+    : [
+        ...related,
+        { label: 'Explore the related ecosystem', note: 'Use the connected profiles to understand adjacent goals and tradeoffs.' },
+      ]
 
-  return [
-    ...related,
-    { label: 'Explore the related ecosystem', note: 'Use the connected profiles to understand adjacent goals and tradeoffs.' },
-  ].slice(0, 4)
+  return steps
+    .map((step) => ({
+      ...step,
+      label: cleanEditorialText(step.label),
+      note: cleanEditorialText(step.note),
+    }))
+    .filter((step) => isRenderableText(step.label))
+    .slice(0, 4)
 }
 
 function mergeOverrides(base: DecisionClarityModel, override: Partial<DecisionClarityModel> | undefined): DecisionClarityModel {
@@ -518,6 +528,29 @@ function mergeOverrides(base: DecisionClarityModel, override: Partial<DecisionCl
     beginnerStartingPoints: override.beginnerStartingPoints || base.beginnerStartingPoints,
     nextBestSteps: override.nextBestSteps || base.nextBestSteps,
     stackConsiderations: override.stackConsiderations || base.stackConsiderations,
+  }
+}
+
+
+function cleanModel(model: DecisionClarityModel): DecisionClarityModel {
+  return {
+    bestFitFor: dedupeEditorialItems(model.bestFitFor, 4),
+    usuallyNotIdealFor: dedupeEditorialItems(model.usuallyNotIdealFor, 4),
+    commonMisunderstandings: dedupeEditorialItems(model.commonMisunderstandings, 4),
+    realisticExpectations: dedupeEditorialItems(model.realisticExpectations, 4),
+    acuteVsCumulative: dedupeEditorialItems(model.acuteVsCumulative, 4),
+    responderVariability: dedupeEditorialItems(model.responderVariability, 4),
+    formulationVariability: dedupeEditorialItems(model.formulationVariability, 4),
+    beginnerStartingPoints: dedupeEditorialItems(model.beginnerStartingPoints, 4),
+    stackConsiderations: dedupeEditorialItems(model.stackConsiderations, 4),
+    nextBestSteps: model.nextBestSteps
+      .map((step) => ({
+        ...step,
+        label: cleanEditorialText(step.label),
+        note: cleanEditorialText(step.note),
+      }))
+      .filter((step) => isRenderableText(step.label))
+      .slice(0, 4),
   }
 }
 
@@ -549,5 +582,5 @@ export function buildDecisionClarity({
     stackConsiderations: inferStackConsiderations(recordForInference, normalizedEffects),
   }
 
-  return mergeOverrides(base, FLAGSHIP_OVERRIDES[slug])
+  return cleanModel(mergeOverrides(base, FLAGSHIP_OVERRIDES[slug]))
 }


### PR DESCRIPTION
### Motivation
- Prevent malformed, placeholder, or weak semantic/runtime values from reaching UI components by introducing a centralized, reusable gating layer. 
- Provide deterministic, SSR-safe, dependency-free helpers to normalize, dedupe, and validate editorial strings and lists across authority and semantic UI. 
- Apply conservative filtering only at render time (render-gating pass) without changing data export, workbook systems, or visual design.

### Description
- Add `lib/editorial-rendering.ts` with helpers: `isWeakSemanticValue`, `isRenderableText`, `cleanEditorialText`, `dedupeEditorialItems`, `shouldRenderCard`, and `isDuplicateTitleBody` for normalization, light-weight heuristics, dedupe, and card gating. 
- Wire gating into authority and semantic UI components including `AuthorityProfileShell`, `AuthoritySidebar`, `UnifiedSemanticDiscoveryPanel`, `ComparisonRecommendations`, `ProtocolRecommendations`, `EcosystemContinuityPanel`, `PeopleAlsoExplore`, `SemanticEntitySignals`, `TopicContinuityLinks`, `RelatedLinksSection`, `DecisionClarityFieldManual`, and `DecisionVisualGrid` so titles, bodies, rationales, chips, tags and lists are cleaned, deduped, and suppressed when weak. 
- Harden upstream semantic builders and models to emit cleaned payloads using the same helpers by updating: `lib/semantic/*` (profile/comparison/protocol/topic builders, `dedupeSemanticRecommendations`, `buildSemanticEntityMetadata`, `getEcosystemContinuity`), `lib/authority-profile.ts`, `lib/authority-content-enrichment.ts`, `lib/editorial-authority-layer.ts`, and `src/lib/decision-clarity.ts` so weak or duplicated semantic items are filtered before UI hydration. 
- Keep behavior conservative: only gating rendering and filtering weak/placeholder fragments; preserved authority, ecosystem, decision, and export pipelines without adding runtime dependencies or redesigning UI.

### Testing
- Ran `npm run check` (which executes data build, validation, Next build, and verify steps) and the full build/verification succeeded without regressions. 
- Ran repository static/consistency checks (`git diff --check` / semantic governance scripts) and deterministic JSON/semantic governance checks passed. 
- Attempted a Playwright screenshot of `/herbs/ashwagandha` to visually validate output, but the headless Chromium launch failed in the container due to a missing system library (`libatk-1.0.so.0`); this does not affect the automated `npm run check` build results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0494fe933883239b7179a453f11abf)