### PR TITLE
Polish homepage landing page

### DIFF
--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -1,15 +1,21 @@
 'use client'
 
 import Link from 'next/link'
-import { ContentIdentityCard } from '@/components/scientific-discovery'
 import { cleanSummary, formatDisplayLabel, isClean } from '@/lib/display-utils'
 import { homepageMessaging } from '@/lib/homepage-messaging'
 
-type RuntimeFeature = Record<string, any>
+type RuntimeFeature = Record<string, unknown>
 
 type HomepageV2Props = {
   featuredHerbs?: RuntimeFeature[]
   featuredCompounds?: RuntimeFeature[]
+}
+
+type LandingCard = {
+  href: string
+  title: string
+  description: string
+  meta: string
 }
 
 function getFeatureName(item: RuntimeFeature) {
@@ -23,249 +29,280 @@ function getFeatureDescription(item: RuntimeFeature, type: 'herb' | 'compound') 
   )
 }
 
-function toFeaturedCard(item: RuntimeFeature, type: 'herb' | 'compound') {
+function toFeaturedCard(item: RuntimeFeature, type: 'herb' | 'compound'): LandingCard | null {
   const title = getFeatureName(item)
+  const slug = typeof item.slug === 'string' ? item.slug : ''
 
-  if (!item.slug || !isClean(title)) return null
+  if (!slug || !isClean(title)) return null
 
   return {
-    href: `/${type === 'herb' ? 'herbs' : 'compounds'}/${item.slug}`,
+    href: `/${type === 'herb' ? 'herbs' : 'compounds'}/${slug}`,
     title,
     description: getFeatureDescription(item, type),
-    meta: type === 'herb' ? 'Herb' : 'Compound',
+    meta: type === 'herb' ? 'Herb profile' : 'Compound profile',
   }
 }
 
-
-const beginnerEntries = [
-  { title: 'Start Sleep Support', href: '/start/sleep-support', description: 'Begin with calmer profiles, sleep-adjacent expectations, and recovery-aware comparisons.' },
-  { title: 'Start Cognitive Support', href: '/start/cognitive-support', description: 'Separate calm focus, cumulative cognition, and activating focus before stacking.' },
-  { title: 'Start Recovery Support', href: '/start/recovery-support', description: 'Explore performance support, recovery capacity, and cumulative timelines conservatively.' },
-  { title: 'Start Stress Support', href: '/start/stress-support', description: 'Compare adaptogenic, calming, and recovery-oriented pathways by practical fit.' },
+const primaryActions = [
+  { label: 'Explore Herbs', href: '/herbs' },
+  { label: 'Browse Compounds', href: '/compounds' },
+  { label: 'Compare Supplements', href: '/compare' },
 ]
 
-const ecosystemEntries = [
-  { title: 'Sleep ecosystem', href: '/ecosystems/sleep', description: 'Calming pathways, sleep-adjacent profiles, and realistic evening-support decisions.' },
-  { title: 'Cognition ecosystem', href: '/ecosystems/cognition', description: 'Calm focus, cumulative cognition, activating support, and sustainable mental performance.' },
-  { title: 'Recovery ecosystem', href: '/ecosystems/recovery', description: 'Training support, nervous-system recovery, and cumulative performance resilience.' },
-  { title: 'Stress ecosystem', href: '/ecosystems/stress', description: 'Stress resilience, stimulation sensitivity, and adaptogen comparison logic.' },
+const trustCards = [
+  {
+    title: 'Human evidence',
+    description: 'Profiles distinguish stronger clinical signals from preliminary or mechanism-only research.',
+  },
+  {
+    title: 'Safety context',
+    description: 'Contraindications, interaction themes, and conservative use notes stay close to the decision.',
+  },
+  {
+    title: 'Mechanisms',
+    description: 'Botanical and compound pages connect effects to pathways without pretending biology is simple.',
+  },
+  {
+    title: 'Practical fit',
+    description: 'Use case, timing, stimulation level, and beginner complexity matter before any stack decision.',
+  },
 ]
 
-const comparisonHighlights = [
-  'Calm focus vs activating focus',
-  'Cumulative cognition vs acute stimulation',
-  'Sleep-adjacent relaxation vs daytime recovery',
-  'Beginner-friendly simplicity vs premature stack complexity',
+const goalEntries = [
+  {
+    title: 'Sleep support',
+    href: '/goals/sleep',
+    description: 'Wind-down, sleep quality, next-day grogginess, and sedative-interaction context.',
+  },
+  {
+    title: 'Anxiety & calm',
+    href: '/goals/anxiety',
+    description: 'Calming compounds, adaptogens, interaction risk, and non-sedating options.',
+  },
+  {
+    title: 'Focus & energy',
+    href: '/goals/focus',
+    description: 'Clean stimulation, calm focus, cognitive fatigue, and sleep-sensitive tradeoffs.',
+  },
+  {
+    title: 'Recovery',
+    href: '/goals/recovery',
+    description: 'Performance support, muscle recovery, hydration, and cumulative timelines.',
+  },
 ]
 
-const featuredFallbacks = [
+const featuredFallbacks: LandingCard[] = [
   {
     href: '/herbs/ashwagandha',
     title: 'Ashwagandha',
     description: 'Stress resilience, recovery support, and realistic evidence interpretation.',
-    meta: 'Herb',
+    meta: 'Herb profile',
   },
   {
     href: '/compounds/theanine',
     title: 'Theanine',
     description: 'Calm focus, relaxation pathways, and non-sedating support context.',
-    meta: 'Compound',
+    meta: 'Compound profile',
   },
   {
     href: '/compounds/creatine',
     title: 'Creatine',
     description: 'Performance, recovery, energy buffering, and cognitive support research.',
-    meta: 'Compound',
+    meta: 'Compound profile',
   },
 ]
+
+function ActionCue({ children }: { children: React.ReactNode }) {
+  return (
+    <span className='inline-flex items-center gap-2 text-sm font-bold text-brand-800 transition group-hover:translate-x-1'>
+      {children}
+      <span aria-hidden='true'>→</span>
+    </span>
+  )
+}
 
 export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] }: HomepageV2Props) {
   const featured = [
     ...featuredHerbs.map((item) => toFeaturedCard(item, 'herb')),
     ...featuredCompounds.map((item) => toFeaturedCard(item, 'compound')),
-  ].filter((item): item is NonNullable<typeof item> => Boolean(item)).slice(0, 3)
+  ].filter((item): item is LandingCard => Boolean(item)).slice(0, 3)
 
   const visibleFeatured = featured.length > 0 ? featured : featuredFallbacks
 
   return (
-    <main className='min-h-screen space-y-20 px-4 py-6 text-ink sm:space-y-28 sm:py-10'>
-      <section className='hero-shell relative overflow-hidden rounded-[2.5rem] border border-white/40 px-6 py-16 shadow-soft sm:px-10 lg:px-16 lg:py-24'>
-        <div className='absolute right-[-10%] top-[-10%] hidden h-[30rem] w-[30rem] rounded-full bg-brand-100/30 blur-3xl lg:block' />
+    <main className='min-h-screen px-4 py-5 text-ink sm:py-8'>
+      <div className='mx-auto max-w-7xl space-y-16 sm:space-y-24'>
+        <section className='hero-shell relative overflow-hidden rounded-[2rem] border border-white/50 px-5 py-12 shadow-soft sm:rounded-[2.75rem] sm:px-10 sm:py-16 lg:px-14 lg:py-20'>
+          <div className='absolute left-[-8rem] top-[-8rem] h-72 w-72 rounded-full bg-emerald-200/30 blur-3xl' />
+          <div className='absolute bottom-[-10rem] right-[-8rem] h-96 w-96 rounded-full bg-amber-200/30 blur-3xl' />
 
-        <div className='grid gap-12 lg:grid-cols-[1.05fr_.95fr] lg:items-center'>
-          <div className='relative z-10 max-w-4xl space-y-8'>
-            <div className='inline-flex rounded-full border border-brand-700/10 bg-white/85 px-4 py-2 text-xs font-semibold tracking-wide text-[#5f6f66] backdrop-blur-md'>
-              Evidence-aware supplement research
-            </div>
-
-            <div className='space-y-6'>
-              <h1 className='heading-premium max-w-5xl text-balance'>
-                {homepageMessaging.heroHeadline}
-              </h1>
-
-              <p className='max-w-2xl text-lg leading-relaxed text-[#4e5d55] sm:text-xl'>
-                Explore herbs, compounds, and practical evidence without the hype.
-              </p>
-            </div>
-
-            <div className='flex flex-col gap-4 sm:flex-row'>
-              <Link href='/herbs' className='button-primary'>
-                Explore Herbs
-              </Link>
-
-              <Link href='/compare' className='button-secondary'>
-                Compare Supplements
-              </Link>
-            </div>
-          </div>
-
-          <div className='relative hidden min-h-[420px] overflow-hidden rounded-[2.5rem] border border-brand-900/10 bg-gradient-to-br from-[#f6f3ec] via-[#f8f8f4] to-[#edf3ec] lg:block'>
-            <div className='absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(176,205,177,0.22),transparent_42%)]' />
-            <div className='absolute bottom-8 left-8 max-w-sm rounded-[2rem] border border-white/60 bg-white/75 p-6 backdrop-blur-md'>
-              <p className='text-sm leading-7 text-[#46574d]'>
-                Compare evidence, recovery support, cognition pathways, stress resilience, and realistic expectations through guided research profiles.
-              </p>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className='mx-auto max-w-6xl space-y-8'>
-        <div className='space-y-2'>
-          <p className='eyebrow-label'>Beginner entry systems</p>
-          <h2 className='compact-heading'>Start with a guided pathway, not a random stack.</h2>
-          <p className='detail-reading max-w-3xl text-[#46574d]'>
-            Each entry point frames stimulation, timeline, recovery orientation, and comparison logic before profile depth.
-          </p>
-        </div>
-
-        <div className='grid gap-5 md:grid-cols-2'>
-          {beginnerEntries.map((item) => (
-            <ContentIdentityCard key={item.href} item={{ ...item, meta: 'Onboarding' } as any} />
-          ))}
-        </div>
-      </section>
-
-      <section className='mx-auto max-w-6xl space-y-8'>
-        <div className='space-y-2'>
-          <p className='eyebrow-label'>Ecosystem intelligence</p>
-          <h2 className='compact-heading'>Explore semantic hubs and adjacent pathways.</h2>
-          <p className='detail-reading max-w-3xl text-[#46574d]'>
-            Ecosystem hubs connect beginner starts, adaptive comparisons, common mistakes, and practical field-manual guidance.
-          </p>
-        </div>
-
-        <div className='grid gap-5 md:grid-cols-2'>
-          {ecosystemEntries.map((item) => (
-            <ContentIdentityCard key={item.href} item={{ ...item, meta: 'Ecosystem' } as any} />
-          ))}
-        </div>
-      </section>
-
-      <section className='rounded-[2.5rem] border border-brand-900/10 bg-gradient-to-br from-[#f6f4ee] via-white to-[#eef4ee] p-8 shadow-sm sm:p-12'>
-        <div className='grid gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-center'>
-          <div className='space-y-3'>
-            <p className='eyebrow-label'>Comparative reasoning highlights</p>
-            <h2 className='text-3xl font-semibold tracking-tight text-ink'>This is fit-first supplement navigation.</h2>
-            <p className='text-sm leading-7 text-[#46574d]'>
-              The platform emphasizes conservative interpretation, evidence-aware positioning, and semantic continuity across profiles instead of generic supplement rankings.
-            </p>
-          </div>
-
-          <div className='grid gap-3 sm:grid-cols-2'>
-            {comparisonHighlights.map((item) => (
-              <div key={item} className='rounded-2xl border border-brand-900/10 bg-white/75 p-4 text-sm font-semibold text-[#33443a]'>
-                {item}
+          <div className='relative grid gap-10 lg:grid-cols-[1.05fr_.95fr] lg:items-center'>
+            <div className='max-w-4xl space-y-7'>
+              <div className='inline-flex rounded-full border border-brand-700/10 bg-white/80 px-4 py-2 text-xs font-bold uppercase tracking-[0.18em] text-brand-800 backdrop-blur-md'>
+                Evidence-aware supplement research
               </div>
+
+              <div className='space-y-5'>
+                <h1 className='text-balance font-display text-5xl font-semibold leading-[0.96] tracking-tight text-ink sm:text-6xl lg:text-7xl'>
+                  {homepageMessaging.heroHeadline}
+                </h1>
+
+                <p className='max-w-2xl text-lg leading-8 text-[#46574d] sm:text-xl'>
+                  {homepageMessaging.heroSubhead}
+                </p>
+              </div>
+
+              <div className='grid gap-3 sm:grid-cols-3'>
+                {primaryActions.map((action, index) => (
+                  <Link
+                    key={action.href}
+                    href={action.href}
+                    className={index === 0
+                      ? 'button-primary justify-center text-center'
+                      : 'button-secondary justify-center text-center'
+                    }
+                  >
+                    {action.label}
+                  </Link>
+                ))}
+              </div>
+            </div>
+
+            <div className='rounded-[2rem] border border-brand-900/10 bg-white/70 p-4 shadow-card backdrop-blur sm:p-5'>
+              <div className='rounded-[1.5rem] bg-gradient-to-br from-[#fbfaf6] via-white to-[#eef6ee] p-5 sm:p-7'>
+                <div className='space-y-5'>
+                  <p className='text-xs font-bold uppercase tracking-[0.18em] text-brand-800'>Research product, not wellness hype</p>
+                  <h2 className='text-3xl font-semibold tracking-tight text-ink sm:text-4xl'>Make supplement decisions from evidence, safety, and fit.</h2>
+                  <p className='text-sm leading-7 text-[#46574d]'>
+                    Move from a goal to mechanisms, profile pages, and comparisons with the limits of the evidence kept visible.
+                  </p>
+                </div>
+
+                <div className='mt-8 grid gap-3 sm:grid-cols-2'>
+                  {['Clinical signal', 'Interaction context', 'Mechanism map', 'Practical timeline'].map((item) => (
+                    <div key={item} className='rounded-2xl border border-brand-900/10 bg-white/75 p-4 text-sm font-semibold text-[#33443a]'>
+                      {item}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className='grid gap-4 md:grid-cols-2 xl:grid-cols-4'>
+          {trustCards.map((card) => (
+            <div key={card.title} className='rounded-[1.75rem] border border-brand-900/10 bg-white/75 p-6 shadow-card transition hover:-translate-y-1 hover:border-brand-700/20 hover:bg-white'>
+              <h2 className='text-xl font-semibold tracking-tight text-ink'>{card.title}</h2>
+              <p className='mt-3 text-sm leading-7 text-[#46574d]'>{card.description}</p>
+            </div>
+          ))}
+        </section>
+
+        <section className='rounded-[2.25rem] border border-brand-900/10 bg-gradient-to-br from-white/85 via-[#faf8f1] to-brand-50/40 p-6 shadow-soft sm:p-10'>
+          <div className='flex flex-col gap-4 md:flex-row md:items-end md:justify-between'>
+            <div className='max-w-2xl space-y-3'>
+              <p className='eyebrow-label'>Start by goal</p>
+              <h2 className='compact-heading'>Begin with the outcome, then narrow by evidence and safety.</h2>
+            </div>
+            <Link href='/goals' className='text-sm font-bold text-brand-800 transition hover:text-brand-900'>All goals →</Link>
+          </div>
+
+          <div className='mt-8 grid gap-4 md:grid-cols-2'>
+            {goalEntries.map((goal) => (
+              <Link key={goal.href} href={goal.href} className='group rounded-[1.5rem] border border-brand-900/10 bg-white/75 p-5 shadow-sm transition hover:-translate-y-1 hover:border-brand-700/20 hover:bg-white'>
+                <div className='flex items-start justify-between gap-4'>
+                  <div>
+                    <h3 className='text-xl font-semibold tracking-tight text-ink group-hover:text-brand-800'>{goal.title}</h3>
+                    <p className='mt-3 text-sm leading-7 text-[#46574d]'>{goal.description}</p>
+                  </div>
+                  <span className='mt-1 text-brand-800 transition group-hover:translate-x-1' aria-hidden='true'>→</span>
+                </div>
+              </Link>
             ))}
           </div>
-        </div>
-      </section>
+        </section>
 
-      <section className='mx-auto max-w-6xl space-y-8'>
-        <div className='space-y-2'>
-          <p className='eyebrow-label'>Explore by goal</p>
-          <h2 className='compact-heading'>Start with what you are trying to improve.</h2>
-        </div>
-
-        <div className='grid gap-5 md:grid-cols-2'>
-          <ContentIdentityCard item={{ title: 'Sleep support', href: '/sleep-supplements', description: 'Explore calming pathways, circadian support, and recovery-focused compounds.', meta: 'Goal' } as any} />
-          <ContentIdentityCard item={{ title: 'Stress support', href: '/stress-supplements', description: 'Compare adaptogens, calming compounds, and recovery-oriented support.', meta: 'Goal' } as any} />
-          <ContentIdentityCard item={{ title: 'Focus and cognition', href: '/cognition-supplements', description: 'Explore focus, memory, calm productivity, and cognitive energy support.', meta: 'Goal' } as any} />
-          <ContentIdentityCard item={{ title: 'Inflammation support', href: '/inflammation', description: 'Review inflammatory pathways, recovery support, and evidence-aware options.', meta: 'Goal' } as any} />
-        </div>
-      </section>
-
-      <section className='rounded-[2.5rem] border border-brand-900/10 bg-gradient-to-br from-[#f6f4ee] via-white to-[#eef4ee] p-8 shadow-sm sm:p-12'>
-        <div className='grid gap-5 md:grid-cols-3'>
-          <div className='rounded-[1.5rem] border border-brand-900/10 bg-white/70 p-5'>
-            <h3 className='text-base font-semibold tracking-tight text-ink'>Evidence-aware positioning</h3>
-            <p className='mt-2 text-sm leading-7 text-[#46574d]'>Research context, safety boundaries, and expectation timelines stay visible instead of collapsing into hype.</p>
+        <section className='space-y-8'>
+          <div className='flex flex-col gap-4 md:flex-row md:items-end md:justify-between'>
+            <div className='max-w-2xl space-y-3'>
+              <p className='eyebrow-label'>Featured profiles</p>
+              <h2 className='compact-heading'>Useful starting points for deeper research.</h2>
+            </div>
+            <div className='flex flex-wrap gap-3'>
+              <Link href='/herbs' className='text-sm font-bold text-brand-800 transition hover:text-brand-900'>Herb library →</Link>
+              <Link href='/compounds' className='text-sm font-bold text-brand-800 transition hover:text-brand-900'>Compound library →</Link>
+            </div>
           </div>
 
-          <div className='rounded-[1.5rem] border border-brand-900/10 bg-white/70 p-5'>
-            <h3 className='text-base font-semibold tracking-tight text-ink'>Conservative interpretation</h3>
-            <p className='mt-2 text-sm leading-7 text-[#46574d]'>Profiles are framed as decision-support field notes, not pseudo-medical promises or universal rankings.</p>
+          <div className='grid gap-5 lg:grid-cols-3'>
+            {visibleFeatured.map((item) => (
+              <Link key={item.href} href={item.href} className='group relative overflow-hidden rounded-[2rem] border border-brand-900/10 bg-gradient-to-br from-white via-[#fbfaf6] to-brand-50/30 p-6 shadow-card transition hover:-translate-y-1 hover:border-brand-700/20 hover:bg-white'>
+                <div className='absolute right-[-3rem] top-[-3rem] h-32 w-32 rounded-full bg-brand-100/40 blur-2xl transition group-hover:bg-brand-100/60' />
+                <div className='relative'>
+                  <span className='inline-flex rounded-full border border-brand-900/10 bg-white/70 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.16em] text-[#5f6f66]'>
+                    {item.meta}
+                  </span>
+
+                  <h3 className='mt-5 text-2xl font-semibold tracking-tight text-ink group-hover:text-brand-800'>
+                    {item.title}
+                  </h3>
+
+                  <p className='mt-3 text-sm leading-7 text-[#46574d]'>
+                    {item.description}
+                  </p>
+
+                  <div className='mt-6'>
+                    <ActionCue>Open profile</ActionCue>
+                  </div>
+                </div>
+              </Link>
+            ))}
           </div>
+        </section>
 
-          <div className='rounded-[1.5rem] border border-brand-900/10 bg-white/70 p-5'>
-            <h3 className='text-base font-semibold tracking-tight text-ink'>Fit-first reasoning</h3>
-            <p className='mt-2 text-sm leading-7 text-[#46574d]'>Stimulation, timeline, recovery orientation, and beginner difficulty shape exploration before product decisions.</p>
-          </div>
-        </div>
-      </section>
-
-      <section className='mx-auto max-w-6xl space-y-8'>
-        <div className='space-y-2'>
-          <p className='eyebrow-label'>Featured profiles</p>
-          <h2 className='compact-heading'>Popular starting points.</h2>
-        </div>
-
-        <div className='grid gap-6 lg:grid-cols-3'>
-          {visibleFeatured.map((item) => (
-            <Link key={item.href} href={item.href} className='group relative overflow-hidden rounded-[2rem] border border-brand-900/10 bg-gradient-to-br from-white via-[#fafaf7] to-brand-50/30 p-6 shadow-sm transition hover:-translate-y-1 hover:border-brand-700/20'>
-              <span className='inline-flex rounded-full border border-brand-900/10 bg-white/70 px-3 py-1 text-[11px] font-semibold tracking-wide text-[#5f6f66]'>
-                {item.meta}
-              </span>
-
-              <h3 className='mt-5 text-2xl font-semibold tracking-tight text-ink'>
-                {item.title}
-              </h3>
-
-              <p className='mt-3 text-sm leading-7 text-[#46574d]'>
-                {item.description}
+        <section className='rounded-[2.25rem] border border-brand-900/10 bg-white/75 p-6 shadow-soft sm:p-10'>
+          <div className='grid gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-center'>
+            <div className='space-y-3'>
+              <p className='eyebrow-label'>Compare before you stack</p>
+              <h2 className='compact-heading'>Similar supplements can have very different tradeoffs.</h2>
+              <p className='text-sm leading-7 text-[#46574d]'>
+                Use comparison pages to separate acute effects from cumulative support, calming from sedating, and plausible mechanisms from stronger human data.
               </p>
-            </Link>
-          ))}
-        </div>
-      </section>
+            </div>
 
-      <section className='grid gap-5 lg:grid-cols-4'>
-        {[
-          { title: 'Herbs', href: '/herbs', description: 'Browse botanical profiles and evidence-aware summaries.' },
-          { title: 'Compounds', href: '/compounds', description: 'Explore compounds, mechanisms, and practical guidance.' },
-          { title: 'Compare', href: '/compare', description: 'Review differences between related supplements and pathways.' },
-          { title: 'Learn', href: '/learn', description: 'Follow guided introductions into evidence-aware supplement research.' },
-        ].map((item) => (
-          <ContentIdentityCard key={item.href} item={item as any} />
-        ))}
-      </section>
-
-      <section className='rounded-[2rem] border border-amber-700/15 bg-gradient-to-br from-amber-50/70 to-white p-8 shadow-sm'>
-        <div className='flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between'>
-          <div className='max-w-2xl space-y-3'>
-            <p className='eyebrow-label text-amber-700'>Educational scope</p>
-            <h2 className='text-3xl font-semibold tracking-tight text-amber-950'>Natural does not automatically mean safe or effective.</h2>
-            <p className='text-base leading-8 text-amber-950/80'>
-              Use these pages to compare evidence and understand pathways — not as a replacement for medical care.
-            </p>
+            <div className='grid gap-3 sm:grid-cols-2'>
+              {[
+                { label: 'Rhodiola vs ashwagandha', href: '/compare/rhodiola-vs-ashwagandha' },
+                { label: 'L-theanine vs magnesium', href: '/compare/l-theanine-vs-magnesium' },
+                { label: 'Kava vs alcohol', href: '/compare/kava-vs-alcohol' },
+                { label: 'Kanna vs SSRIs', href: '/compare/kanna-vs-ssris' },
+              ].map((item) => (
+                <Link key={item.href} href={item.href} className='group rounded-2xl border border-brand-900/10 bg-[#fbfaf6] p-4 text-sm font-semibold text-[#33443a] transition hover:-translate-y-1 hover:border-brand-700/20 hover:bg-white'>
+                  {item.label}
+                  <span className='ml-2 text-brand-800 transition group-hover:translate-x-1' aria-hidden='true'>→</span>
+                </Link>
+              ))}
+            </div>
           </div>
+        </section>
 
-          <Link href='/disclaimer' className='button-secondary whitespace-nowrap'>
-            Read Disclaimer
-          </Link>
-        </div>
-      </section>
+        <section className='rounded-[2rem] border border-amber-700/15 bg-gradient-to-br from-amber-50/80 via-white to-[#fbfaf6] p-6 shadow-sm sm:p-8'>
+          <div className='flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between'>
+            <div className='max-w-3xl space-y-3'>
+              <p className='eyebrow-label text-amber-700'>Safety note</p>
+              <h2 className='text-2xl font-semibold tracking-tight text-amber-950 sm:text-3xl'>Natural does not automatically mean safe or effective.</h2>
+              <p className='text-sm leading-7 text-amber-950/80 sm:text-base'>
+                The Hippie Scientist is educational research support. It does not diagnose, treat, or replace medical care—especially for pregnancy, medications, chronic conditions, or complex mental health concerns.
+              </p>
+            </div>
+
+            <Link href='/disclaimer' className='button-secondary whitespace-nowrap text-center'>
+              Read disclaimer
+            </Link>
+          </div>
+        </section>
+      </div>
     </main>
   )
 }


### PR DESCRIPTION
### Motivation
- Refresh the homepage to feel polished, credible, and evidence-aware while preserving existing routes and the light botanical brand. 
- Improve visual hierarchy, spacing, and mobile-first responsiveness so the landing page reads like a research product rather than a wellness blog.

### Description
- Rewrote `components/homepage-v2.tsx` into a cleaner landing page with a stronger hero, `homepageMessaging` subhead, and three primary CTAs: `Explore Herbs`, `Browse Compounds`, and `Compare Supplements`.
- Added trust/value cards (Human evidence, Safety context, Mechanisms, Practical fit), a compact research panel, a concise “Start by goal” section linking to existing `/goals/:slug` routes, and a featured profiles grid that uses the existing `featuredHerbs` / `featuredCompounds` props with safe fallbacks.
- Added a comparison section with links to existing comparison routes and a bottom safety/disclaimer callout linking to `/disclaimer` to keep copy non-affiliate-forward and safety-first.
- Improved spacing, softer premium card styles, and mobile-first layout using the existing Tailwind utilities and existing display helpers (`cleanSummary`, `formatDisplayLabel`, `isClean`).

### Testing
- Ran `npm run lint`, which surfaced pre-existing repo-wide lint errors unrelated to this change (agent and legacy script files); the homepage change itself passes localized lint checks.
- Ran `npx eslint components/homepage-v2.tsx --max-warnings=0`, which passed for the modified component.
- Ran full `npm run build`, which completed successfully (data build + validation + Next.js build succeeded).
- Captured a visual smoke-test with Playwright (`npx -y playwright@1.57.0 screenshot --full-page --viewport-size=1440,1400 http://127.0.0.1:3000 homepage-v2-screenshot.png`), which produced a screenshot confirming the rendered landing page.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a049f16a6a483239b758e2903fbf067)