### PR TITLE
Polish public site metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# The Hippie Scientistttt
+# The Hippie Scientist
 
 Data-driven educational site for herbs and compounds.
 

--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -60,7 +60,7 @@ export async function generateMetadata({ params }: any) {
   const visibility = getRuntimeVisibility(compound)
 
   const meta = buildMeta({
-    title: `${formatDisplayLabel(compound.name)} Benefits, Effects & Safety | Hippie Scientist`,
+    title: `${formatDisplayLabel(compound.name)} Benefits, Effects & Safety | The Hippie Scientist`,
     description: cleanSummary(compound.summary || compound.description, 'compound'),
     path: `/compounds/${compound.slug}`,
   })

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,19 +19,25 @@ const fraunces = Fraunces({
   display: 'swap',
 })
 
+const siteName = 'The Hippie Scientist'
+const siteDescription =
+  'Evidence-aware research on herbs, compounds, mechanisms, safety context, and practical supplement decisions.'
+const siteUrl = 'https://www.thehippiescientist.net'
+
 const websiteJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'WebSite',
-  name: 'The Hippie Scientist',
-  url: 'https://www.thehippiescientist.net',
-  description: 'Evidence-organized research on herbs, compounds, pathways, cognition, and human health.',
+  name: siteName,
+  url: siteUrl,
+  description: siteDescription,
 }
 
 const organizationJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'Organization',
-  name: 'The Hippie Scientist',
-  url: 'https://www.thehippiescientist.net',
+  name: siteName,
+  url: siteUrl,
+  description: siteDescription,
 }
 
 const navLinks = [
@@ -46,14 +52,15 @@ const navLinks = [
 ]
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://www.thehippiescientist.net'),
-  title: { default: 'The Hippie Scientist', template: '%s | The Hippie Scientist' },
-  description:
-    'Evidence-organized research on herbs, compounds, pathways, cognition, neuroscience, and human health.',
+  metadataBase: new URL(siteUrl),
+  title: { default: siteName, template: `%s | ${siteName}` },
+  description: siteDescription,
   openGraph: {
     type: 'website',
-    siteName: 'The Hippie Scientist',
-    url: 'https://www.thehippiescientist.net',
+    title: siteName,
+    description: siteDescription,
+    siteName,
+    url: siteUrl,
   },
   twitter: {
     card: 'summary_large_image',

--- a/app/natural-anxiolytics-beyond-ashwagandha/page.tsx
+++ b/app/natural-anxiolytics-beyond-ashwagandha/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 
 export const metadata = {
-  title: 'Natural Anxiolytics Beyond Ashwagandha | Hippie Scientist',
+  title: 'Natural Anxiolytics Beyond Ashwagandha | The Hippie Scientist',
   description: 'A safe discovery entry point for calm-support botanicals and related research profiles.',
 }
 

--- a/app/psychedelic-adjacent-herbs/page.tsx
+++ b/app/psychedelic-adjacent-herbs/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 
 export const metadata = {
-  title: 'Psychedelic-Adjacent Herbs | Hippie Scientist',
+  title: 'Psychedelic-Adjacent Herbs | The Hippie Scientist',
   description: 'A harm-reduction-oriented discovery entry point for ritual, dream, and perception-adjacent botanicals.',
 }
 

--- a/app/sleep-herbs-vs-melatonin/page.tsx
+++ b/app/sleep-herbs-vs-melatonin/page.tsx
@@ -1,7 +1,7 @@
 import Link from 'next/link'
 
 export const metadata = {
-  title: 'Sleep Herbs vs Melatonin | Hippie Scientist',
+  title: 'Sleep Herbs vs Melatonin | The Hippie Scientist',
   description: 'A safe discovery entry point for sleep-support herbs, compounds, and comparison research.',
 }
 


### PR DESCRIPTION
### Motivation
- Fix a README title typo so the project name is consistently presented as `The Hippie Scientist`.
- Improve and standardize public-facing metadata (page title, description, Open Graph, and JSON-LD) for clearer, evidence-aware messaging.
- Centralize site-level constants to reduce duplication and make future metadata edits safer and smaller.

### Description
- Corrected the README title from `The Hippie Scientistttt` to `The Hippie Scientist` in `README.md`.
- Added `siteName`, `siteDescription`, and `siteUrl` constants to `app/layout.tsx` and applied them to `websiteJsonLd`, `organizationJsonLd`, export `metadata`, and Open Graph fields.
- Replaced the previous description text with the polished phrase `Evidence-aware research on herbs, compounds, mechanisms, safety context, and practical supplement decisions.` across metadata and JSON-LD.
- Normalized public-facing titles to `The Hippie Scientist` in `app/compounds/[slug]/page.tsx` and discovery pages `app/natural-anxiolytics-beyond-ashwagandha/page.tsx`, `app/psychedelic-adjacent-herbs/page.tsx`, and `app/sleep-herbs-vs-melatonin/page.tsx`.

### Testing
- Ran `npm run lint` which completed without errors.
- Ran `npm run build` which executed the data pipeline, validations, `next build`, and verification steps and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04adac1be883239cf878c5bdc9c439)