### PR TITLE
Stabilize homepage field-guide design

### DIFF
--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -2,7 +2,6 @@
 
 import Link from 'next/link'
 import { cleanSummary, formatDisplayLabel, isClean } from '@/lib/display-utils'
-import { homepageMessaging } from '@/lib/homepage-messaging'
 
 type RuntimeFeature = Record<string, unknown>
 
@@ -16,6 +15,12 @@ type LandingCard = {
   title: string
   description: string
   meta: string
+}
+
+type NavCard = {
+  href: string
+  title: string
+  description?: string
 }
 
 function getFeatureName(item: RuntimeFeature) {
@@ -43,51 +48,68 @@ function toFeaturedCard(item: RuntimeFeature, type: 'herb' | 'compound'): Landin
   }
 }
 
+function interleaveFeatured(herbs: LandingCard[], compounds: LandingCard[]) {
+  const mixed: LandingCard[] = []
+  const maxLength = Math.max(herbs.length, compounds.length)
+
+  for (let index = 0; index < maxLength; index += 1) {
+    if (herbs[index]) mixed.push(herbs[index])
+    if (compounds[index]) mixed.push(compounds[index])
+  }
+
+  return mixed.slice(0, 6)
+}
+
 const primaryActions = [
   { label: 'Explore Herbs', href: '/herbs' },
-  { label: 'Browse Compounds', href: '/compounds' },
   { label: 'Compare Supplements', href: '/compare' },
+  { label: 'Search Library', href: '/search' },
 ]
 
-const trustCards = [
+const researchPaths: NavCard[] = [
+  { title: 'Herbs', href: '/herbs' },
+  { title: 'Compounds', href: '/compounds' },
+  { title: 'Compare', href: '/compare' },
+  { title: 'Search', href: '/search' },
+  { title: 'Goals', href: '/goals' },
+  { title: 'Learn', href: '/learn' },
+]
+
+const ecosystemCards: NavCard[] = [
   {
-    title: 'Human evidence',
-    description: 'Profiles distinguish stronger clinical signals from preliminary or mechanism-only research.',
+    title: 'Sleep Ecosystem',
+    href: '/search?q=sleep',
+    description: 'Nighttime herbs, calming compounds, timing, and safety context.',
   },
   {
-    title: 'Safety context',
-    description: 'Contraindications, interaction themes, and conservative use notes stay close to the decision.',
+    title: 'Cognition Ecosystem',
+    href: '/search?q=focus',
+    description: 'Focus support, stimulation tradeoffs, and mechanism clues.',
   },
   {
-    title: 'Mechanisms',
-    description: 'Botanical and compound pages connect effects to pathways without pretending biology is simple.',
+    title: 'Recovery Ecosystem',
+    href: '/search?q=recovery',
+    description: 'Training support, fatigue, adaptation, and practical fit.',
   },
   {
-    title: 'Practical fit',
-    description: 'Use case, timing, stimulation level, and beginner complexity matter before any stack decision.',
+    title: 'Stress Ecosystem',
+    href: '/search?q=stress',
+    description: 'Calm support, adaptogens, interaction risk, and evidence limits.',
   },
 ]
 
-const goalEntries = [
+const reasoningPillars = [
   {
-    title: 'Sleep support',
-    href: '/goals/sleep',
-    description: 'Wind-down, sleep quality, next-day grogginess, and sedative-interaction context.',
+    title: 'Evidence-aware positioning',
+    description: 'Profiles separate stronger human signals from early or mechanism-only ideas.',
   },
   {
-    title: 'Anxiety & calm',
-    href: '/goals/anxiety',
-    description: 'Calming compounds, adaptogens, interaction risk, and non-sedating options.',
+    title: 'Conservative interpretation',
+    description: 'Safety context and uncertainty stay close to claims, not buried at the end.',
   },
   {
-    title: 'Focus & energy',
-    href: '/goals/focus',
-    description: 'Clean stimulation, calm focus, cognitive fatigue, and sleep-sensitive tradeoffs.',
-  },
-  {
-    title: 'Recovery',
-    href: '/goals/recovery',
-    description: 'Performance support, muscle recovery, hydration, and cumulative timelines.',
+    title: 'Fit-first reasoning',
+    description: 'Goal, timing, tolerance, medications, and tradeoffs matter before stacking.',
   },
 ]
 
@@ -95,12 +117,12 @@ const featuredFallbacks: LandingCard[] = [
   {
     href: '/herbs/ashwagandha',
     title: 'Ashwagandha',
-    description: 'Stress resilience, recovery support, and realistic evidence interpretation.',
+    description: 'Stress support, recovery context, and realistic evidence interpretation.',
     meta: 'Herb profile',
   },
   {
     href: '/compounds/theanine',
-    title: 'Theanine',
+    title: 'L-Theanine',
     description: 'Calm focus, relaxation pathways, and non-sedating support context.',
     meta: 'Compound profile',
   },
@@ -112,9 +134,18 @@ const featuredFallbacks: LandingCard[] = [
   },
 ]
 
+function SectionHeader({ title, subtitle }: { title: string, subtitle?: string }) {
+  return (
+    <div className='max-w-3xl space-y-2'>
+      <h2 className='text-xl font-semibold tracking-tight text-emerald-50 sm:text-2xl'>{title}</h2>
+      {subtitle ? <p className='text-sm leading-6 text-emerald-50/68 sm:text-base'>{subtitle}</p> : null}
+    </div>
+  )
+}
+
 function ActionCue({ children }: { children: React.ReactNode }) {
   return (
-    <span className='inline-flex items-center gap-2 text-sm font-bold text-brand-800 transition group-hover:translate-x-1'>
+    <span className='inline-flex items-center gap-2 text-sm font-bold text-emerald-300 transition group-hover:translate-x-1 group-hover:text-emerald-200'>
       {children}
       <span aria-hidden='true'>→</span>
     </span>
@@ -122,137 +153,140 @@ function ActionCue({ children }: { children: React.ReactNode }) {
 }
 
 export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] }: HomepageV2Props) {
-  const featured = [
-    ...featuredHerbs.map((item) => toFeaturedCard(item, 'herb')),
-    ...featuredCompounds.map((item) => toFeaturedCard(item, 'compound')),
-  ].filter((item): item is LandingCard => Boolean(item)).slice(0, 3)
+  const herbCards = featuredHerbs
+    .map((item) => toFeaturedCard(item, 'herb'))
+    .filter((item): item is LandingCard => Boolean(item))
+    .slice(0, 3)
 
+  const compoundCards = featuredCompounds
+    .map((item) => toFeaturedCard(item, 'compound'))
+    .filter((item): item is LandingCard => Boolean(item))
+    .slice(0, 3)
+
+  const featured = interleaveFeatured(herbCards, compoundCards)
   const visibleFeatured = featured.length > 0 ? featured : featuredFallbacks
 
   return (
-    <main className='min-h-screen px-4 py-5 text-ink sm:py-8'>
-      <div className='mx-auto max-w-7xl space-y-14 sm:space-y-20'>
-        <section className='hero-shell relative overflow-hidden rounded-[2rem] border border-white/50 px-5 py-12 shadow-[var(--shadow-card-calm)] sm:rounded-[2.5rem] sm:px-10 sm:py-16 lg:px-14 lg:py-20'>
-          <div className='absolute left-[-8rem] top-[-8rem] h-72 w-72 rounded-full bg-emerald-200/30 blur-3xl' />
-          <div className='absolute bottom-[-10rem] right-[-8rem] h-96 w-96 rounded-full bg-amber-200/30 blur-3xl' />
+    <div className='relative left-1/2 w-screen -translate-x-1/2 overflow-hidden bg-[#04120e] text-emerald-50 -my-8 sm:-my-10'>
+      <div className='pointer-events-none absolute inset-0 opacity-80'>
+        <div className='absolute left-[-7rem] top-10 h-64 w-64 rounded-full bg-emerald-500/18 blur-3xl' />
+        <div className='absolute right-[-8rem] top-48 h-72 w-72 rounded-full bg-teal-300/10 blur-3xl' />
+        <div className='absolute bottom-28 left-1/3 h-80 w-80 rounded-full bg-lime-300/8 blur-3xl' />
+        <div className='absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(16,185,129,0.14),transparent_32rem)]' />
+      </div>
 
-          <div className='relative grid gap-10 lg:grid-cols-[1.05fr_.95fr] lg:items-center'>
-            <div className='max-w-4xl space-y-7'>
-              <div className='inline-flex rounded-full border border-brand-700/10 bg-white/80 px-4 py-2 text-xs font-bold uppercase tracking-[0.18em] text-brand-800 backdrop-blur-md'>
-                Evidence-aware supplement research
-              </div>
-
-              <div className='space-y-5'>
-                <h1 className='max-w-[15ch] text-balance font-display text-5xl font-semibold leading-[1.02] tracking-tight text-ink sm:text-6xl lg:max-w-[17ch] lg:text-7xl'>
-                  {homepageMessaging.heroHeadline}
-                </h1>
-
-                <p className='max-w-2xl text-lg leading-8 text-[#46574d] sm:text-xl'>
-                  {homepageMessaging.heroSubhead}
-                </p>
-              </div>
-
-              <div className='grid gap-3 sm:grid-cols-3'>
-                {primaryActions.map((action, index) => (
-                  <Link
-                    key={action.href}
-                    href={action.href}
-                    className={index === 0
-                      ? 'button-primary justify-center text-center'
-                      : 'button-secondary justify-center text-center'
-                    }
-                  >
-                    {action.label}
-                  </Link>
-                ))}
-              </div>
+      <div className='relative mx-auto max-w-6xl space-y-8 px-4 pb-24 pt-6 sm:px-6 sm:pb-16 sm:pt-8 lg:px-8'>
+        <section className='rounded-[1.75rem] border border-emerald-300/15 bg-white/[0.035] px-4 py-7 shadow-[0_24px_90px_rgba(0,0,0,0.28)] backdrop-blur sm:px-8 sm:py-10 lg:px-10'>
+          <div className='mx-auto flex max-w-4xl flex-col items-center text-center'>
+            <div className='mb-4 inline-flex rounded-full border border-emerald-300/20 bg-emerald-300/8 px-3 py-1.5 text-[11px] font-bold uppercase tracking-[0.18em] text-emerald-200'>
+              Botanical research field guide
             </div>
 
-            <div className='rounded-[1.75rem] border border-brand-900/10 bg-white/70 p-4 shadow-[var(--shadow-card-calm)] backdrop-blur sm:p-5'>
-              <div className='rounded-[1.5rem] bg-gradient-to-br from-[#fbfaf6] via-white to-[#eef6ee] p-5 sm:p-7'>
-                <div className='space-y-5'>
-                  <p className='text-xs font-bold uppercase tracking-[0.18em] text-brand-800'>Research product, not wellness hype</p>
-                  <h2 className='text-3xl font-semibold tracking-tight text-ink sm:text-4xl'>Make supplement decisions from evidence, safety, and fit.</h2>
-                  <p className='text-sm leading-[1.75] text-[#46574d]'>
-                    Move from a goal to mechanisms, profile pages, and comparisons with the limits of the evidence kept visible.
-                  </p>
-                </div>
+            <h1 className='font-display text-[2.85rem] font-semibold uppercase leading-[0.86] tracking-[-0.06em] text-white sm:text-7xl md:text-8xl'>
+              <span className='block'>The Hippie</span>
+              <span className='block text-emerald-200'>Scientist</span>
+            </h1>
 
-                <div className='mt-8 grid gap-3 sm:grid-cols-2'>
-                  {['Clinical signal', 'Interaction context', 'Mechanism map', 'Practical timeline'].map((item) => (
-                    <div key={item} className='rounded-2xl border border-brand-900/10 bg-white/75 p-4 text-sm font-semibold text-[#33443a]'>
-                      {item}
-                    </div>
-                  ))}
-                </div>
-              </div>
+            <p className='mt-5 max-w-2xl text-base leading-7 text-emerald-50/82 sm:text-lg'>
+              A field guide to herbs, compounds, mechanisms, and evidence — written for careful explorers.
+            </p>
+
+            <p className='mt-2 max-w-2xl text-sm leading-6 text-emerald-50/62'>
+              No hype. No pseudo-medicine. Just evidence-aware research and honest interpretation.
+            </p>
+
+            <div className='mt-6 grid w-full max-w-2xl gap-2 sm:grid-cols-3'>
+              {primaryActions.map((action, index) => (
+                <Link
+                  key={action.href}
+                  href={action.href}
+                  className={index === 0
+                    ? 'rounded-full bg-emerald-300 px-4 py-3 text-sm font-black text-[#062018] shadow-[0_12px_35px_rgba(16,185,129,0.22)] transition hover:-translate-y-0.5 hover:bg-emerald-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-200 focus-visible:ring-offset-2 focus-visible:ring-offset-[#04120e]'
+                    : 'rounded-full border border-emerald-200/20 bg-white/[0.045] px-4 py-3 text-sm font-bold text-emerald-50 transition hover:-translate-y-0.5 hover:border-emerald-200/40 hover:bg-white/[0.08] focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-200 focus-visible:ring-offset-2 focus-visible:ring-offset-[#04120e]'
+                  }
+                >
+                  {action.label}
+                </Link>
+              ))}
             </div>
           </div>
         </section>
 
-        <section className='grid gap-4 md:grid-cols-2 xl:grid-cols-4'>
-          {trustCards.map((card) => (
-            <div key={card.title} className='rounded-[1.65rem] border border-brand-900/10 bg-white/75 p-6 shadow-[var(--shadow-card-calm)] transition hover:-translate-y-0.5 hover:border-brand-700/20 hover:bg-white hover:shadow-[var(--shadow-card-calm-hover)]'>
-              <h2 className='text-xl font-semibold tracking-tight text-ink'>{card.title}</h2>
-              <p className='mt-3 text-sm leading-[1.75] text-[#46574d]'>{card.description}</p>
+        <section className='rounded-[1.35rem] border border-emerald-300/12 bg-[#071a14]/88 p-4 shadow-[0_18px_70px_rgba(0,0,0,0.22)] sm:p-5'>
+          <div className='flex flex-col gap-4 md:flex-row md:items-center md:justify-between'>
+            <SectionHeader title='Start your research' />
+            <div className='grid grid-cols-2 gap-2 sm:grid-cols-3 md:min-w-[28rem]'>
+              {researchPaths.map((path) => (
+                <Link
+                  key={path.href}
+                  href={path.href}
+                  className='group rounded-full border border-emerald-300/14 bg-white/[0.04] px-3 py-2.5 text-center text-sm font-bold text-emerald-50 transition hover:border-emerald-300/40 hover:bg-emerald-300/10'
+                >
+                  {path.title}
+                  <span className='ml-1 text-emerald-300 transition group-hover:translate-x-0.5' aria-hidden='true'>→</span>
+                </Link>
+              ))}
             </div>
-          ))}
+          </div>
         </section>
 
-        <section className='rounded-[2rem] border border-brand-900/10 bg-gradient-to-br from-white/85 via-[#faf8f1] to-brand-50/40 p-6 shadow-[var(--shadow-card-calm)] sm:p-10'>
-          <div className='flex flex-col gap-4 md:flex-row md:items-end md:justify-between'>
-            <div className='max-w-2xl space-y-3'>
-              <p className='eyebrow-label'>Start by goal</p>
-              <h2 className='compact-heading'>Begin with the outcome, then narrow by evidence and safety.</h2>
-            </div>
-            <Link href='/goals' className='text-sm font-bold text-brand-800 transition hover:text-brand-900'>All goals →</Link>
-          </div>
+        <section className='space-y-4'>
+          <SectionHeader
+            title='Explore research ecosystems'
+            subtitle='Start from a goal, then move into herbs, compounds, mechanisms, comparisons, and safety context.'
+          />
 
-          <div className='mt-8 grid gap-4 md:grid-cols-2'>
-            {goalEntries.map((goal) => (
-              <Link key={goal.href} href={goal.href} className='group rounded-[1.5rem] border border-brand-900/10 bg-white/75 p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-brand-700/20 hover:bg-white hover:shadow-[var(--shadow-card-calm)]'>
-                <div className='flex items-start justify-between gap-4'>
-                  <div>
-                    <h3 className='text-xl font-semibold tracking-tight text-ink group-hover:text-brand-800'>{goal.title}</h3>
-                    <p className='mt-3 text-sm leading-[1.75] text-[#46574d]'>{goal.description}</p>
-                  </div>
-                  <span className='mt-1 text-brand-800 transition group-hover:translate-x-1' aria-hidden='true'>→</span>
+          <div className='grid gap-3 md:grid-cols-2 lg:grid-cols-4'>
+            {ecosystemCards.map((card) => (
+              <Link
+                key={card.href}
+                href={card.href}
+                className='group rounded-[1.25rem] border border-emerald-300/12 bg-white/[0.045] p-4 transition hover:-translate-y-0.5 hover:border-emerald-300/35 hover:bg-white/[0.07]'
+              >
+                <h3 className='text-base font-semibold tracking-tight text-white group-hover:text-emerald-200'>{card.title}</h3>
+                <p className='mt-2 text-sm leading-6 text-emerald-50/62'>{card.description}</p>
+                <div className='mt-3'>
+                  <ActionCue>Open path</ActionCue>
                 </div>
               </Link>
             ))}
           </div>
         </section>
 
-        <section className='space-y-8'>
-          <div className='flex flex-col gap-4 md:flex-row md:items-end md:justify-between'>
-            <div className='max-w-2xl space-y-3'>
-              <p className='eyebrow-label'>Featured profiles</p>
-              <h2 className='compact-heading'>Useful starting points for deeper research.</h2>
-            </div>
-            <div className='flex flex-wrap gap-3'>
-              <Link href='/herbs' className='text-sm font-bold text-brand-800 transition hover:text-brand-900'>Herb library →</Link>
-              <Link href='/compounds' className='text-sm font-bold text-brand-800 transition hover:text-brand-900'>Compound library →</Link>
+        <section className='space-y-4'>
+          <div className='flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between'>
+            <SectionHeader
+              title='Featured profiles'
+              subtitle='Useful starting points for deeper herb and compound research.'
+            />
+            <div className='flex flex-wrap gap-3 text-sm font-bold'>
+              <Link href='/herbs' className='text-emerald-300 transition hover:text-emerald-200'>Herb library →</Link>
+              <Link href='/compounds' className='text-emerald-300 transition hover:text-emerald-200'>Compound library →</Link>
             </div>
           </div>
 
-          <div className='grid gap-5 lg:grid-cols-3'>
+          <div className='grid gap-3 md:grid-cols-2 lg:grid-cols-3'>
             {visibleFeatured.map((item) => (
-              <Link key={item.href} href={item.href} className='group relative overflow-hidden rounded-[1.65rem] border border-brand-900/10 bg-gradient-to-br from-white via-[#fbfaf6] to-brand-50/30 p-6 shadow-[var(--shadow-card-calm)] transition hover:-translate-y-0.5 hover:border-brand-700/20 hover:bg-white hover:shadow-[var(--shadow-card-calm-hover)]'>
-                <div className='absolute right-[-3rem] top-[-3rem] h-32 w-32 rounded-full bg-brand-100/40 blur-2xl transition group-hover:bg-brand-100/60' />
+              <Link
+                key={item.href}
+                href={item.href}
+                className='group relative overflow-hidden rounded-[1.25rem] border border-emerald-300/12 bg-[#071a14]/82 p-4 transition hover:-translate-y-0.5 hover:border-emerald-300/35 hover:bg-[#0a2119]'
+              >
+                <div className='absolute right-[-3rem] top-[-3rem] h-28 w-28 rounded-full bg-emerald-300/10 blur-2xl transition group-hover:bg-emerald-300/16' />
                 <div className='relative'>
-                  <span className='inline-flex rounded-full border border-brand-900/10 bg-white/70 px-3 py-1 text-[11px] font-bold uppercase tracking-[0.16em] text-[#5f6f66]'>
+                  <span className='inline-flex rounded-full border border-emerald-300/16 bg-emerald-300/8 px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.14em] text-emerald-200'>
                     {item.meta}
                   </span>
 
-                  <h3 className='mt-5 text-2xl font-semibold tracking-tight text-ink group-hover:text-brand-800'>
+                  <h3 className='mt-3 text-xl font-semibold tracking-tight text-white group-hover:text-emerald-200'>
                     {item.title}
                   </h3>
 
-                  <p className='mt-3 text-sm leading-[1.75] text-[#46574d]'>
+                  <p className='mt-2 text-sm leading-6 text-emerald-50/64'>
                     {item.description}
                   </p>
 
-                  <div className='mt-6'>
+                  <div className='mt-4'>
                     <ActionCue>Open profile</ActionCue>
                   </div>
                 </div>
@@ -261,48 +295,26 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
           </div>
         </section>
 
-        <section className='rounded-[2rem] border border-brand-900/10 bg-white/75 p-6 shadow-[var(--shadow-card-calm)] sm:p-10'>
-          <div className='grid gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-center'>
-            <div className='space-y-3'>
-              <p className='eyebrow-label'>Compare before you stack</p>
-              <h2 className='compact-heading'>Similar supplements can have very different tradeoffs.</h2>
-              <p className='text-sm leading-[1.75] text-[#46574d]'>
-                Use comparison pages to separate acute effects from cumulative support, calming from sedating, and plausible mechanisms from stronger human data.
-              </p>
+        <section className='grid gap-3 md:grid-cols-3'>
+          {reasoningPillars.map((pillar) => (
+            <div key={pillar.title} className='rounded-[1.15rem] border border-emerald-300/12 bg-white/[0.035] p-4'>
+              <h2 className='text-base font-semibold tracking-tight text-white'>{pillar.title}</h2>
+              <p className='mt-2 text-sm leading-6 text-emerald-50/62'>{pillar.description}</p>
             </div>
-
-            <div className='grid gap-3 sm:grid-cols-2'>
-              {[
-                { label: 'Rhodiola vs ashwagandha', href: '/compare/rhodiola-vs-ashwagandha' },
-                { label: 'L-theanine vs magnesium', href: '/compare/l-theanine-vs-magnesium' },
-                { label: 'Kava vs alcohol', href: '/compare/kava-vs-alcohol' },
-                { label: 'Kanna vs SSRIs', href: '/compare/kanna-vs-ssris' },
-              ].map((item) => (
-                <Link key={item.href} href={item.href} className='group rounded-2xl border border-brand-900/10 bg-[#fbfaf6] p-4 text-sm font-semibold leading-[1.55] text-[#33443a] transition hover:-translate-y-0.5 hover:border-brand-700/20 hover:bg-white hover:shadow-sm'>
-                  {item.label}
-                  <span className='ml-2 text-brand-800 transition group-hover:translate-x-1' aria-hidden='true'>→</span>
-                </Link>
-              ))}
-            </div>
-          </div>
+          ))}
         </section>
 
-        <section className='rounded-[1.75rem] border border-amber-700/15 bg-gradient-to-br from-amber-50/80 via-white to-[#fbfaf6] p-6 shadow-sm sm:p-8'>
-          <div className='flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between'>
-            <div className='max-w-3xl space-y-3'>
-              <p className='eyebrow-label text-amber-700'>Safety note</p>
-              <h2 className='text-2xl font-semibold tracking-tight text-amber-950 sm:text-3xl'>Natural does not automatically mean safe or effective.</h2>
-              <p className='text-sm leading-7 text-amber-950/80 sm:text-base'>
-                The Hippie Scientist is educational research support. It does not diagnose, treat, or replace medical care—especially for pregnancy, medications, chronic conditions, or complex mental health concerns.
-              </p>
-            </div>
-
-            <Link href='/disclaimer' className='button-secondary whitespace-nowrap text-center'>
-              Read disclaimer
+        <section className='rounded-[1.15rem] border border-emerald-300/14 bg-emerald-950/40 p-4'>
+          <div className='flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
+            <p className='text-sm leading-6 text-emerald-50/72'>
+              Natural does not automatically mean safe or effective. These pages support comparison and pathway understanding — not medical care.
+            </p>
+            <Link href='/disclaimer' className='shrink-0 text-sm font-bold text-emerald-300 transition hover:text-emerald-200'>
+              Read disclaimer →
             </Link>
           </div>
         </section>
       </div>
-    </main>
+    </div>
   )
 }


### PR DESCRIPTION
### Motivation
- Lock the homepage visual direction to a dark, compact botanical research field guide that is mobile-first and immediately useful, scoped only to the homepage and not the rest of the site. 
- Reduce visual churn by replacing the oversized beige editorial layout with a tight, emerald-on-charcoal design that surfaces clear research actions in the first viewport.

### Description
- Rewrote the homepage UI in `components/homepage-v2.tsx` to implement a full-bleed, homepage-scoped dark wrapper, fixed hero copy (THE HIPPIE / SCIENTIST), and compact CTAs (`Explore Herbs`, `Compare Supplements`, `Search Library`).
- Replaced the previous dynamic `homepageMessaging` dependency with the requested static hero copy and preserved `featuredHerbs` / `featuredCompounds` props behavior while adding `interleaveFeatured` to mix herb and compound cards. 
- Added compact research navigation (`researchPaths`), ecosystem cards (`ecosystemCards` routing to `/search?q=...`), concise reasoning pillars (`reasoningPillars`), a small disclaimer strip, and a `SectionHeader` helper for consistent section headings. 
- Kept routing strict to existing routes (`/herbs`, `/compounds`, `/compare`, `/search`, `/goals`, `/learn`, `/disclaimer`), used internal profile routes when available, and avoided global CSS or app-wide layout changes.

### Testing
- Ran `npm run lint` and the linting completed without errors. 
- Ran `npm run build` and the Next.js build completed successfully. 
- Ran `npm run verify:build` and all verification scripts passed. 
- Captured a mobile homepage screenshot using `npx -y playwright@1.56.1 screenshot --viewport-size=390,844 http://127.0.0.1:3000 /tmp/hippie-scientist-homepage-mobile.png`, which produced a valid image file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04c3470f948323ae69cc6c9e5544bb)