### PR TITLE
Fix homepage header visual mismatch with route-aware styling

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,149 @@
+import type { Metadata } from 'next'
+import type { ReactNode } from 'react'
+import { Inter, Fraunces } from 'next/font/google'
+import Link from 'next/link'
+import SiteHeader from '@/components/site-header'
+import MobileBottomNav from '@/components/mobile-bottom-nav'
+import './globals.css'
+import '@/styles/foundation-readability.css'
+
+const inter = Inter({
+  subsets: ['latin'],
+  variable: '--font-inter',
+  display: 'swap',
+})
+
+const fraunces = Fraunces({
+  subsets: ['latin'],
+  variable: '--font-fraunces',
+  display: 'swap',
+})
+
+const siteName = 'The Hippie Scientist'
+const siteDescription =
+  'Evidence-aware research on herbs, compounds, mechanisms, safety context, and practical supplement decisions.'
+const siteUrl = 'https://www.thehippiescientist.net'
+
+const websiteJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'WebSite',
+  name: siteName,
+  url: siteUrl,
+  description: siteDescription,
+}
+
+const organizationJsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Organization',
+  name: siteName,
+  url: siteUrl,
+  description: siteDescription,
+}
+
+const navLinks = [
+  { href: '/herbs', label: 'Herbs' },
+  { href: '/compounds', label: 'Compounds' },
+  { href: '/goals', label: 'Goals' },
+  { href: '/stacks', label: 'Stacks' },
+  { href: '/compare', label: 'Compare' },
+  { href: '/learn', label: 'Learn' },
+  { href: '/search', label: 'Search' },
+  { href: '/about', label: 'About' },
+]
+
+export const metadata: Metadata = {
+  metadataBase: new URL(siteUrl),
+  title: { default: siteName, template: `%s | ${siteName}` },
+  description: siteDescription,
+  openGraph: {
+    type: 'website',
+    title: siteName,
+    description: siteDescription,
+    siteName,
+    url: siteUrl,
+  },
+  twitter: {
+    card: 'summary_large_image',
+  },
+}
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang='en'>
+      <body
+        className={`${inter.variable} ${fraunces.variable} font-sans antialiased`}
+      >
+        <script
+          type='application/ld+json'
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }}
+        />
+
+        <script
+          type='application/ld+json'
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
+        />
+
+        <div className='min-h-screen bg-background text-ink'>
+          <SiteHeader links={navLinks} />
+
+          <div className='pb-28 md:pb-10'>
+            {children}
+          </div>
+
+          <footer className='mt-16 border-t border-neutral-200 bg-neutral-50'>
+            <div className='container-page py-12'>
+              <div className='grid gap-10 md:grid-cols-3'>
+                <div className='space-y-4'>
+                  <p className='font-semibold text-ink'>The Hippie Scientist</p>
+
+                  <p className='text-sm text-muted'>
+                    Evidence-first herb & compound reference.
+                  </p>
+
+                  <p className='text-sm leading-6 text-muted'>
+                    Educational content grounded in human evidence, mechanisms, pathways, and scientific review.
+                  </p>
+                </div>
+
+                <div className='space-y-3'>
+                  <p className='font-semibold text-ink'>Explore</p>
+
+                  <div className='flex flex-col gap-2 text-sm'>
+                    <Link href='/herbs' className='text-muted hover:text-ink transition'>Herbs</Link>
+                    <Link href='/compounds' className='text-muted hover:text-ink transition'>Compounds</Link>
+                    <Link href='/goals' className='text-muted hover:text-ink transition'>Goals</Link>
+                    <Link href='/stacks' className='text-muted hover:text-ink transition'>Stacks</Link>
+                    <Link href='/blog' className='text-muted hover:text-ink transition'>Blog</Link>
+                    <Link href='/about' className='text-muted hover:text-ink transition'>About</Link>
+                  </div>
+                </div>
+
+                <div className='space-y-3'>
+                  <p className='font-semibold text-ink'>Legal & Transparency</p>
+
+                  <div className='flex flex-col gap-2 text-sm'>
+                    <Link href='/privacy' className='text-muted hover:text-ink transition'>Privacy Policy</Link>
+                    <Link href='/disclaimer' className='text-muted hover:text-ink transition'>Disclaimer</Link>
+                    <Link href='/contact' className='text-muted hover:text-ink transition'>Contact</Link>
+                  </div>
+                </div>
+              </div>
+
+              <div className='mt-10 border-t border-neutral-200 pt-6 space-y-3'>
+                <p className='text-xs leading-6 text-muted'>
+                  This site contains affiliate links. We may earn a commission on qualifying purchases at no cost to you.
+                </p>
+
+                <p className='text-sm text-muted'>
+                  © 2026 The Hippie Scientist
+                </p>
+              </div>
+            </div>
+          </footer>
+
+          <MobileBottomNav />
+        </div>
+      </body>
+    </html>
+  )
+}

--- a/src/components/desktop-nav.tsx
+++ b/src/components/desktop-nav.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+type NavLink = {
+  href: string
+  label: string
+}
+
+type DesktopNavProps = {
+  links: NavLink[]
+  variant?: 'light' | 'dark'
+}
+
+export default function DesktopNav({ links, variant = 'light' }: DesktopNavProps) {
+  const pathname = usePathname()
+  const isDark = variant === 'dark'
+
+  return (
+    <nav className='hidden items-center gap-1.5 md:flex' aria-label='Primary navigation'>
+      {links.map(link => {
+        const active =
+          pathname === link.href ||
+          (link.href !== '/' && pathname?.startsWith(`${link.href}/`))
+
+        return (
+          <Link
+            key={link.href}
+            href={link.href}
+            aria-current={active ? 'page' : undefined}
+            className={`rounded-full px-3.5 py-2 text-sm font-semibold transition duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 lg:px-4 ${
+              isDark
+                ? `focus-visible:ring-offset-[#04120e] ${
+                    active
+                      ? 'bg-emerald-300/15 text-emerald-100'
+                      : 'text-zinc-200 hover:bg-emerald-400/10 hover:text-emerald-200'
+                  }`
+                : `focus-visible:ring-offset-white ${
+                    active
+                      ? 'bg-brand-900/8 text-emerald-800'
+                      : 'text-[#5c6d63] hover:bg-emerald-50 hover:text-emerald-800'
+                  }`
+            }`}
+          >
+            {link.label}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/src/components/mobile-nav.tsx
+++ b/src/components/mobile-nav.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useRef, useState } from 'react'
+
+type NavLink = {
+  href: string
+  label: string
+}
+
+type MobileNavProps = {
+  links: NavLink[]
+  variant?: 'light' | 'dark'
+}
+
+export default function MobileNav({ links, variant = 'light' }: MobileNavProps) {
+  const [open, setOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const navRef = useRef<HTMLElement>(null)
+
+  const isDark = variant === 'dark'
+
+  useEffect(() => {
+    if (!open) return
+
+    const firstLink = navRef.current?.querySelector<HTMLAnchorElement>('a[href]')
+    firstLink?.focus()
+
+    function handlePointerDown(event: MouseEvent | TouchEvent) {
+      const target = event.target
+
+      if (target instanceof Node && !containerRef.current?.contains(target)) {
+        setOpen(false)
+      }
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        setOpen(false)
+        buttonRef.current?.focus()
+        return
+      }
+
+      if (event.key !== 'Tab') return
+
+      const focusable = containerRef.current?.querySelectorAll<HTMLElement>(
+        'button, a[href]'
+      )
+
+      if (!focusable?.length) return
+
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault()
+        last.focus()
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault()
+        first.focus()
+      }
+    }
+
+    document.addEventListener('mousedown', handlePointerDown)
+    document.addEventListener('touchstart', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown)
+      document.removeEventListener('touchstart', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [open])
+
+  return (
+    <div ref={containerRef} className='md:hidden'>
+      <button
+        ref={buttonRef}
+        type='button'
+        aria-expanded={open}
+        aria-controls='mobile-navigation'
+        onClick={() => setOpen(value => !value)}
+        className={`rounded-full border px-4 py-2 text-sm font-black shadow-sm transition active:scale-[0.98] ${
+          isDark
+            ? 'border-emerald-300/15 bg-[#0b1d17]/90 text-zinc-100 hover:border-emerald-300/30 hover:bg-emerald-400/10'
+            : 'border-slate-200 bg-white text-slate-900 hover:border-emerald-300 hover:bg-emerald-50'
+        }`}
+      >
+        Menu
+      </button>
+
+      {open ? (
+        <nav
+          ref={navRef}
+          id='mobile-navigation'
+          aria-label='Mobile navigation'
+          className={`absolute left-4 right-4 top-20 z-50 rounded-3xl p-2 shadow-2xl backdrop-blur ${
+            isDark
+              ? 'border border-emerald-300/10 bg-[#04120e]/95 shadow-black/40'
+              : 'border border-slate-200 bg-white shadow-slate-900/15'
+          }`}
+        >
+          <div className='grid gap-1'>
+            {links.map(link => (
+              <Link
+                key={link.href}
+                href={link.href}
+                onClick={() => setOpen(false)}
+                className={`rounded-2xl px-4 py-3 text-base font-black transition ${
+                  isDark
+                    ? 'text-zinc-100 hover:bg-emerald-400/10 hover:text-emerald-200'
+                    : 'text-slate-900 hover:bg-emerald-50 hover:text-emerald-800'
+                }`}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </div>
+        </nav>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import DesktopNav from '@/components/desktop-nav'
+import MobileNav from '@/components/mobile-nav'
+
+type NavLink = {
+  href: string
+  label: string
+}
+
+type SiteHeaderProps = {
+  links: NavLink[]
+}
+
+export default function SiteHeader({ links }: SiteHeaderProps) {
+  const pathname = usePathname()
+  const isHome = pathname === '/'
+
+  return (
+    <header
+      className={isHome
+        ? 'sticky top-0 z-50 border-b border-emerald-300/10 bg-[#04120e]/80 text-zinc-100 backdrop-blur-xl'
+        : 'sticky top-0 z-50 border-b border-brand-900/10 bg-white/[0.88] text-ink shadow-[0_1px_0_rgba(17,24,39,0.02)] backdrop-blur-xl supports-[backdrop-filter]:bg-white/[0.78]'}
+    >
+      <div className='container-page flex min-h-[72px] items-center justify-between gap-6 py-3'>
+        <Link
+          href='/'
+          className={isHome
+            ? 'inline-flex items-center rounded-full px-1 py-2 text-lg font-black tracking-tight text-zinc-100 transition hover:text-emerald-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#04120e]'
+            : 'inline-flex items-center rounded-full px-1 py-2 text-lg font-black tracking-tight text-ink transition hover:text-emerald-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white'}
+        >
+          The Hippie Scientist
+        </Link>
+
+        <DesktopNav links={links} variant={isHome ? 'dark' : 'light'} />
+
+        <MobileNav links={links} variant={isHome ? 'dark' : 'light'} />
+      </div>
+    </header>
+  )
+}


### PR DESCRIPTION
## Summary

Implements a route-aware sticky site header.

### Homepage (`/`)
- Dark translucent header
- Emerald-accent hover states
- Light typography/navigation
- Header visually integrates with homepage hero

### Inner pages
- Preserves existing light header treatment
- Preserves current navigation behavior and spacing

## Changes

- Added `src/components/site-header.tsx`
- Moved header rendering out of `app/layout.tsx`
- Added `variant` support to:
  - `DesktopNav`
  - `MobileNav`
- Preserved:
  - sticky behavior
  - focus rings
  - backdrop blur
  - accessibility behavior
  - active nav states

## Acceptance Criteria

- Homepage header visually belongs to dark hero
- Inner pages keep current light styling
- Desktop/mobile nav remain accessible
- No hydration mismatch expected
- Minimal focused diff
