### PR TITLE
Add resilient empty states to compounds and stacks pages

### DIFF
--- a/app/compounds/page.tsx
+++ b/app/compounds/page.tsx
@@ -128,6 +128,30 @@ function StatCard({ value, label, description }: { value: number; label: string;
   )
 }
 
+function InlineEmptyState({
+  title,
+  description,
+  links,
+}: {
+  title: string
+  description: string
+  links: { href: string; label: string }[]
+}) {
+  return (
+    <div className="rounded-3xl border border-brand-900/10 bg-card/70 p-6 text-sm leading-6 text-[#5b6b61] shadow-card">
+      <h2 className="text-xl font-semibold tracking-tight text-ink">{title}</h2>
+      <p className="mt-2 max-w-2xl">{description}</p>
+      <div className="mt-5 flex flex-wrap gap-2">
+        {links.map((link) => (
+          <Link key={link.href} href={link.href} className="chip-readable transition hover:border-brand-700/40 hover:text-brand-800">
+            {link.label}
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 function CompoundCard({ compound, compact = false }: { compound: any; compact?: boolean }) {
   const evidence = getEvidenceLabel(compound)
   const profile = getProfileLabel(compound)
@@ -207,6 +231,12 @@ export default async function CompoundsPage() {
   const evidenceForward = compounds.filter((compound: any) => /human|clinical|strong|high/i.test(text(compound?.evidence_tier || compound?.evidence_grade || compound?.evidenceLevel))).length
   const topMatches = compounds.slice(0, 8)
   const libraryCompounds = compounds.slice(8)
+  const recoveryLinks = [
+    { href: '/search', label: 'Search the library' },
+    { href: '/herbs', label: 'Browse herbs' },
+    { href: '/goals', label: 'Explore goals' },
+    { href: '/learn', label: 'Visit learn' },
+  ]
 
   const featuredSignals = [
     'Cognition',
@@ -216,6 +246,20 @@ export default async function CompoundsPage() {
     'Oxidative Stress',
     'Inflammation',
   ]
+
+  if (compounds.length === 0) {
+    return (
+      <div className="min-h-screen bg-background text-ink">
+        <section className="container-page py-10 sm:py-14 lg:py-18">
+          <InlineEmptyState
+            title="Compound profiles are being refreshed."
+            description="The compound library is temporarily unavailable while profiles finish generating. In the meantime, you can continue exploring search, herbs, goals, and learning guides."
+            links={recoveryLinks}
+          />
+        </section>
+      </div>
+    )
+  }
 
   return (
     <div className="min-h-screen bg-background text-ink">
@@ -248,21 +292,23 @@ export default async function CompoundsPage() {
             </div>
           </div>
 
-          <div className="compact-section section-rhythm-compact">
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-              <div>
-                <p className="eyebrow-label">Top Matches</p>
-                <h2 className="compact-heading mt-2">High-signal compound profiles.</h2>
+          {topMatches.length > 0 ? (
+            <div className="compact-section section-rhythm-compact">
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                <div>
+                  <p className="eyebrow-label">Top Matches</p>
+                  <h2 className="compact-heading mt-2">High-signal compound profiles.</h2>
+                </div>
+                <span className="chip-readable">Ranked by evidence and mechanism density</span>
               </div>
-              <span className="chip-readable">Ranked by evidence and mechanism density</span>
-            </div>
 
-            <div className="semantic-rail">
-              {topMatches.map((compound: any) => (
-                <CompoundCard key={compound?.slug || getName(compound)} compound={compound} compact />
-              ))}
+              <div className="semantic-rail">
+                {topMatches.map((compound: any) => (
+                  <CompoundCard key={compound?.slug || getName(compound)} compound={compound} compact />
+                ))}
+              </div>
             </div>
-          </div>
+          ) : null}
 
           <div className="compact-section section-rhythm-compact">
             <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
@@ -298,11 +344,19 @@ export default async function CompoundsPage() {
               <span className="chip-readable">{libraryCompounds.length} remaining profiles</span>
             </div>
 
-            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-              {libraryCompounds.map((compound: any) => (
-                <CompoundCard key={compound?.slug || getName(compound)} compound={compound} />
-              ))}
-            </div>
+            {libraryCompounds.length > 0 ? (
+              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                {libraryCompounds.map((compound: any) => (
+                  <CompoundCard key={compound?.slug || getName(compound)} compound={compound} />
+                ))}
+              </div>
+            ) : (
+              <InlineEmptyState
+                title="More compound profiles are on the way."
+                description="The remaining compound cards are still generating, so this section will fill in as profiles become available. You can continue through search, herbs, goals, or learning guides meanwhile."
+                links={recoveryLinks}
+              />
+            )}
           </section>
         </div>
       </section>

--- a/app/stacks/page.tsx
+++ b/app/stacks/page.tsx
@@ -30,6 +30,31 @@ const roleBadge = (role?: string) => {
   return 'bg-slate-50 text-slate-700 border-slate-200'
 }
 
+
+function InlineEmptyState({
+  title,
+  description,
+  links,
+}: {
+  title: string
+  description: string
+  links: { href: string; label: string }[]
+}) {
+  return (
+    <div className="rounded-3xl border border-slate-200 bg-white p-6 text-sm leading-6 text-slate-600 shadow-sm sm:p-7">
+      <h2 className="text-2xl font-black tracking-tight text-slate-950">{title}</h2>
+      <p className="mt-2 max-w-2xl">{description}</p>
+      <div className="mt-5 flex flex-wrap gap-2">
+        {links.map((link) => (
+          <Link key={link.href} href={link.href} className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-black uppercase tracking-[0.14em] text-emerald-700 transition hover:border-emerald-300 hover:text-emerald-900">
+            {link.label}
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 function StackIngredient({ item }: { item: { compound?: string; dosage?: string; timing?: string; role?: string } }) {
   return (
     <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
@@ -49,6 +74,23 @@ function StackIngredient({ item }: { item: { compound?: string; dosage?: string;
 export default function StacksPage() {
   const featured = stackItems[0]
   const remaining = stackItems.slice(1)
+  const recoveryLinks = [
+    { href: '/goals', label: 'Explore goals' },
+    { href: '/compounds', label: 'Browse compounds' },
+    { href: '/search', label: 'Search the library' },
+  ]
+
+  if (stackItems.length === 0) {
+    return (
+      <main className="space-y-8 px-1 sm:px-0">
+        <InlineEmptyState
+          title="Stack profiles are still being expanded."
+          description="The stack library is temporarily light while profiles finish generating. You can explore goals, compounds, or search while the next stack guides become available."
+          links={recoveryLinks}
+        />
+      </main>
+    )
+  }
 
   return (
     <main className="space-y-8 px-1 sm:px-0">
@@ -115,38 +157,46 @@ export default function StacksPage() {
           <Link href="/goals" className="text-sm font-black text-emerald-700 hover:text-emerald-900">Explore goal guides →</Link>
         </div>
 
-        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-          {remaining.map((s) => (
-            <Link
-              key={s.slug}
-              href={`/stacks/${s.slug}`}
-              className="group flex min-h-72 flex-col rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-300 hover:shadow-md"
-            >
-              <div className="flex items-center justify-between gap-3">
-                <span className="rounded-full bg-emerald-50 px-2.5 py-1 text-[0.68rem] font-black uppercase tracking-[0.16em] text-emerald-800">{formatLabel(s.goal)}</span>
-                <span className="text-xs font-bold text-slate-500">{(s.stack ?? []).length} compounds</span>
-              </div>
+        {remaining.length > 0 ? (
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {remaining.map((s) => (
+              <Link
+                key={s.slug}
+                href={`/stacks/${s.slug}`}
+                className="group flex min-h-72 flex-col rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-300 hover:shadow-md"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <span className="rounded-full bg-emerald-50 px-2.5 py-1 text-[0.68rem] font-black uppercase tracking-[0.16em] text-emerald-800">{formatLabel(s.goal)}</span>
+                  <span className="text-xs font-bold text-slate-500">{(s.stack ?? []).length} compounds</span>
+                </div>
 
-              <h3 className="mt-4 text-2xl font-black tracking-tight text-slate-950 group-hover:text-emerald-800">{s.title}</h3>
-              <p className="mt-2 text-sm leading-6 text-slate-600">{s.short_description}</p>
+                <h3 className="mt-4 text-2xl font-black tracking-tight text-slate-950 group-hover:text-emerald-800">{s.title}</h3>
+                <p className="mt-2 text-sm leading-6 text-slate-600">{s.short_description}</p>
 
-              <div className="mt-4 space-y-2">
-                {(s.stack ?? []).slice(0, 3).map((item, index) => (
-                  <StackIngredient key={`${s.slug}-${item.compound}-${index}`} item={item} />
-                ))}
-              </div>
+                <div className="mt-4 space-y-2">
+                  {(s.stack ?? []).slice(0, 3).map((item, index) => (
+                    <StackIngredient key={`${s.slug}-${item.compound}-${index}`} item={item} />
+                  ))}
+                </div>
 
-              <div className="mt-auto pt-4">
-                {s.avoid_if ? (
-                  <p className="line-clamp-2 rounded-xl bg-amber-50 p-3 text-xs leading-5 text-amber-900">
-                    <span className="font-black">Use caution with:</span> {s.avoid_if}
-                  </p>
-                ) : null}
-                <span className="mt-4 inline-flex text-sm font-black text-emerald-700 transition group-hover:translate-x-1">See dosage, timing & risks →</span>
-              </div>
-            </Link>
-          ))}
-        </div>
+                <div className="mt-auto pt-4">
+                  {s.avoid_if ? (
+                    <p className="line-clamp-2 rounded-xl bg-amber-50 p-3 text-xs leading-5 text-amber-900">
+                      <span className="font-black">Use caution with:</span> {s.avoid_if}
+                    </p>
+                  ) : null}
+                  <span className="mt-4 inline-flex text-sm font-black text-emerald-700 transition group-hover:translate-x-1">See dosage, timing & risks →</span>
+                </div>
+              </Link>
+            ))}
+          </div>
+        ) : (
+          <InlineEmptyState
+            title="More stack profiles are being prepared."
+            description="The featured stack is available now, and the broader stack library will fill in as additional profiles finish generating. Explore goals, compounds, or search meanwhile."
+            links={recoveryLinks}
+          />
+        )}
       </section>
     </main>
   )


### PR DESCRIPTION
### Motivation
- Prevent section headers and empty grids from appearing when runtime-driven library data is temporarily empty, providing calm, premium recovery surfaces scoped to each page.

### Description
- Added a local `InlineEmptyState` surface to `app/compounds/page.tsx` and `app/stacks/page.tsx` that reuses existing premium card and border/muted text styles.
- Compounds page: if `compounds.length === 0` render a primary recovery state instead of the library layout, omit the “Top Matches” section when `topMatches.length === 0`, and replace an empty `libraryCompounds` grid with the inline empty state and recovery links to `/search`, `/herbs`, `/goals`, and `/learn`.
- Stacks page: if no stacks exist render a full-page recovery state, and if `remaining.length === 0` replace the library grid with the inline empty state while preserving the featured stack behavior and current card styling.
- Changes are tightly scoped to the two page files only and do not alter data pipelines, routes, exporters, runtime generation, or card styling systems.

### Testing
- Ran `npm run check` (includes `data:build`, data validation, governance checks, and `next build`) and the build/validation completed successfully.
- Ran `git diff --check` to ensure no whitespace/merge issues and found no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e487f6888323b929bf55a7871f75)