### PR TITLE
Next.js 15 dynamic params compatibility

### DIFF
--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -45,6 +45,10 @@ import GuidedExplorationPanel from '@/components/guided-exploration-panel'
 import EvidenceAwareCTA from '@/components/evidence-aware-cta'
 import SemanticAssistantPanel from '@/components/semantic-assistant-panel'
 
+type PageProps = {
+  params: Promise<{ slug: string }>
+}
+
 export async function generateStaticParams() {
   const { compounds } = await getUnifiedRuntimeRecords()
 
@@ -53,9 +57,9 @@ export async function generateStaticParams() {
     .map((compound:any) => ({ slug: compound.slug }))
 }
 
-export async function generateMetadata({ params }: any) {
-  const resolvedParams = await params
-  const compound = await getCompoundMetadataRecord(resolvedParams.slug)
+export async function generateMetadata({ params }: PageProps) {
+  const { slug } = await params
+  const compound = await getCompoundMetadataRecord(slug)
 
   if (!compound) return {}
 
@@ -103,9 +107,9 @@ function CompactDisclosure({ title, children }: { title: string; children: React
   )
 }
 
-export default async function CompoundPage({ params }: any) {
-  const resolvedParams = await params
-  const compound = await getCompoundBySlug(resolvedParams.slug)
+export default async function CompoundPage({ params }: PageProps) {
+  const { slug } = await params
+  const compound = await getCompoundBySlug(slug)
 
   if (!compound || !getRuntimeVisibility(compound).canRender) {
     notFound()

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -46,6 +46,10 @@ import GuidedExplorationPanel from '@/components/guided-exploration-panel'
 import EvidenceAwareCTA from '@/components/evidence-aware-cta'
 import SemanticAssistantPanel from '@/components/semantic-assistant-panel'
 
+type PageProps = {
+  params: Promise<{ slug: string }>
+}
+
 export async function generateStaticParams() {
   const { herbs } = await getUnifiedRuntimeRecords()
 
@@ -54,9 +58,9 @@ export async function generateStaticParams() {
     .map((herb: any) => ({ slug: herb.slug }))
 }
 
-export async function generateMetadata({ params }: any): Promise<Metadata> {
-  const resolvedParams = await params
-  const herb = await getHerbMetadataRecord(resolvedParams.slug)
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params
+  const herb = await getHerbMetadataRecord(slug)
 
   if (!herb) {
     return {
@@ -273,9 +277,9 @@ function LinkDensitySection({ links }: { links: ReturnType<typeof buildInternalL
   )
 }
 
-export default async function HerbDetailPage({ params }: any) {
-  const resolvedParams = await params
-  const herb = await getHerbBySlug(resolvedParams.slug)
+export default async function HerbDetailPage({ params }: PageProps) {
+  const { slug } = await params
+  const herb = await getHerbBySlug(slug)
 
   if (!herb || !getRuntimeVisibility(herb).canRender) {
     notFound()


### PR DESCRIPTION
### Motivation

- Prepare the two dynamic App Router routes for Next.js 15 by adding proper Promise-based param typing to avoid `any` in route boundaries.
- Keep the change minimal and surgical so route behavior, `generateStaticParams`, and metadata remain unchanged.

### Description

- Added `type PageProps = { params: Promise<{ slug: string }> }` immediately after the import block in both `app/herbs/[slug]/page.tsx` and `app/compounds/[slug]/page.tsx`.
- Replaced `({ params }: any)` with `({ params }: PageProps)` in `generateMetadata` and the page component signatures in both files.
- Replaced the intermediate `resolvedParams = await params` usage with `const { slug } = await params` to keep the awaited-param pattern while simplifying local usage and preserving all runtime behavior and metadata content.
- Changed files: `app/herbs/[slug]/page.tsx` and `app/compounds/[slug]/page.tsx`.

### Testing

- Ran `npm run build` and the production build completed successfully.
- Ran `npm run lint` and ESLint passed with zero warnings/errors.
- Ran `npx tsc --noEmit` and TypeScript checks passed with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0738daa2a483239f150f028993109e)