### PR TITLE
chore(next): prepare Next.js 15.5.18 upgrade

### DIFF
--- a/docs/upgrade-next-15-5-18.md
+++ b/docs/upgrade-next-15-5-18.md
@@ -1,0 +1,46 @@
+# Next.js 15.5.18 Upgrade
+
+This repository is being prepared for a narrow patch upgrade from Next.js 15.3.2 to Next.js 15.5.18.
+
+Scope:
+- upgrade Next.js only
+- preserve React 18
+- preserve React DOM 18
+- preserve static export configuration
+- preserve current App Router architecture
+
+## Required Local Lockfile Regeneration
+
+The GitHub connector intentionally did not modify `package-lock.json`.
+
+Before merge:
+- regenerate `package-lock.json` locally or in Codespaces
+- commit the regenerated lockfile
+- verify CI passes
+
+## Constraints
+
+- Do not upgrade to Next 16.
+- Do not upgrade React or React DOM.
+- Preserve `output: "export"`.
+- Do not run `npm update`.
+- Do not manually edit `package-lock.json`.
+
+## Maintainer Validation
+
+```bash
+npm install next@15.5.18 --save
+npm ci
+npm run build
+npm run lint
+npx tsc --noEmit
+```
+
+## Expected Validation Areas
+
+Validate:
+- App Router static export behavior
+- Dynamic route params compatibility
+- Data build scripts
+- Runtime payload generation
+- Existing route verification scripts

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "fuse.js": "^7.1.0",
     "gray-matter": "^4.0.3",
     "lucide-react": "^0.298.0",
-    "next": "^15.3.2",
+    "next": "^15.5.18",
     "openai": "^4.104.0",
     "react": "^18.2.0",
     "react-countup": "^6.5.3",


### PR DESCRIPTION
## Next.js 15.5.18 Upgrade Preparation

Prepared the repo for a Next.js 15.5.18 patch upgrade.

Changed files:
- package.json
- docs/upgrade-next-15-5-18.md

Changes:
- updated package.json next dependency from ^15.3.2 to ^15.5.18
- preserved React and React DOM versions
- preserved static export configuration
- documented required local package-lock.json regeneration
- documented validation steps and upgrade constraints
- made no lockfile changes through the connector

Validation notes for maintainer:
- npm install next@15.5.18 --save
- npm ci
- npm run build
- npm run lint
- npx tsc --noEmit

Important:
Do not merge until package-lock.json has been regenerated locally or in Codespaces, committed, and CI passes.