### PR TITLE
docs(env): complete .env.example documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,86 @@
+# Example environment configuration for The Hippie Scientist.
+# Copy to .env.local for local development when needed.
+# Do not commit real secrets.
+
+# -----------------------------------------------------------------------------
+# Public browser-exposed NEXT_PUBLIC_* variables
+# -----------------------------------------------------------------------------
+# WARNING: Every NEXT_PUBLIC_* value is bundled for the browser. Never put secrets
+# in these variables.
+
+# Optional for local dev and production.
 # Canonical endpoint for newsletter/contact/lead-capture form submissions.
-# Runtime code in src/lib/formSubmission.ts reads this Next.js public key.
+# Runtime code in src/lib/formSubmission.ts reads this public key.
 # Cross-origin form endpoints must also be permitted by CSP connect-src.
-NEXT_PUBLIC_FORM_ENDPOINT=
+NEXT_PUBLIC_FORM_ENDPOINT="https://example.invalid/forms"
+
+# Optional production gate for the analytics route.
+# In production, set to "true" only when the analytics route should be exposed.
+# Local development is enabled by NODE_ENV behavior even when this is unset.
+NEXT_PUBLIC_ENABLE_ANALYTICS_ROUTE="false"
+
+# Optional deployment/environment label for browser-visible diagnostics or UI.
+# Leave blank unless active app code or deployment scripts require it.
+NEXT_PUBLIC_ENV="local"
+
+# Optional browser-visible base path for static hosting variants.
+# Leave blank for root-domain deployments.
+NEXT_PUBLIC_BASE_PATH=""
+
+# -----------------------------------------------------------------------------
+# Build/data pipeline variables
+# -----------------------------------------------------------------------------
+
+# Optional for local dev and CI builds.
+# Overrides the default workbook path: data-sources/herb_monograph_master.xlsx.
+# Can be relative to the repo root or an absolute path.
+HERB_XLSX_PATH="data-sources/herb_monograph_master.xlsx"
+
+# Optional for sitemap generation.
+# Caps routes emitted by app/sitemap.ts.
+SITEMAP_MAX_ROUTES="5000"
+
+# Optional for sitemap manifest generation.
+# Controls route chunk size in scripts/data/build-sitemap-manifest.mjs.
+SITEMAP_CHUNK_SIZE="500"
+
+# -----------------------------------------------------------------------------
+# AI/content generation variables
+# -----------------------------------------------------------------------------
+
+# Optional tooling secret for agent-based enrichment/content workflows.
+# Required only when running agent code that calls the OpenAI API.
+OPENAI_API_KEY="sk-fake-openai-key-for-local-docs-only"
+
+# Optional generic LLM tooling endpoint.
+# Required only for scripts that call scripts/ai-client.mjs.
+LLM_API_URL="https://api.example.invalid"
+
+# Optional generic LLM tooling secret.
+# Required only for scripts that call scripts/ai-client.mjs.
+LLM_API_KEY="fake-llm-key-for-local-docs-only"
+
+# Optional generic LLM model override.
+# scripts/ai-client.mjs defaults to gpt-4o-mini when unset.
+LLM_MODEL="gpt-4o-mini"
+
+# Legacy/alternate AI model label used by some tooling discussions.
+# Leave blank unless a script explicitly reads it.
+OPENAI_MODEL=""
+
+# -----------------------------------------------------------------------------
+# Affiliate/revenue variables
+# -----------------------------------------------------------------------------
+
+# Optional for local dev and production.
+# Overrides the Amazon Associates tag used by config/affiliate.ts.
+# Use a fake placeholder here; put the real tag only in local/deploy secrets.
+AMAZON_AFFILIATE_TAG="example-20"
+
+# -----------------------------------------------------------------------------
+# CI/deploy variables
+# -----------------------------------------------------------------------------
+
+# NODE_ENV is normally set by the runtime, Next.js, or CI provider.
+# Do not force this locally unless debugging environment-specific behavior.
+NODE_ENV="development"


### PR DESCRIPTION
## Environment Documentation Cleanup

Completed environment variable documentation.

Changed files:
- .env.example

Changes:
- documented project-specific environment variables
- grouped variables by purpose
- added safe placeholder values
- noted browser-exposed NEXT_PUBLIC variables
- documented workbook, sitemap, AI, affiliate, and CI-related variables
- made no runtime behavior changes

Notes:
- no dependencies changed
- no runtime code paths modified
- package-lock.json untouched
- documentation placeholders are intentionally fake and non-functional

Validation notes for maintainer:
```bash
npm run build
npm run lint
npx tsc --noEmit
```
