### PR TITLE
fix(links): harden external target blank rel attributes

### DIFF
--- a/app/top/best-herbs-for-overthinking/page.tsx
+++ b/app/top/best-herbs-for-overthinking/page.tsx
@@ -30,7 +30,7 @@ export default async function Page(){
             <p className='mt-2 text-white/70'>{h.summary}</p>
             <div className='mt-3 flex gap-2'>
               <Link href={`/herbs/${h.slug}`}>Read profile</Link>
-              {links[0] && <a href={links[0].url} target='_blank'>Compare →</a>}
+              {links[0] && <a href={links[0].url} target='_blank' rel='noopener noreferrer nofollow sponsored'>Compare →</a>}
             </div>
           </div>
         )

--- a/app/top/best-supplements-for-brain-fog/page.tsx
+++ b/app/top/best-supplements-for-brain-fog/page.tsx
@@ -27,7 +27,7 @@ export default async function Page(){
           <p className='mt-2 text-white/70'>{c.summary}</p>
           <div className='mt-3 flex gap-2'>
             <Link href={`/compounds/${c.slug}`}>Read profile</Link>
-            <a href={buildAmazonSearchUrl(c.slug)} target='_blank'>Compare →</a>
+            <a href={buildAmazonSearchUrl(c.slug)} target='_blank' rel='noopener noreferrer nofollow sponsored'>Compare →</a>
           </div>
         </div>
       ))}

--- a/app/top/focus/page.tsx
+++ b/app/top/focus/page.tsx
@@ -63,7 +63,7 @@ export default async function FocusPage() {
           <div key={c.slug} className='border p-4 rounded-xl'>
             <h2 className='font-bold'>#{i + 1} {titleFor(c)}</h2>
             <p className='text-sm text-white/70'>{cleanSummary(c.summary || c.description, 'compound')}</p>
-            <a href={buildAmazonSearchUrl(c.slug)} target='_blank' className='mt-3 inline-block bg-emerald-300 text-black px-3 py-1 rounded'>Compare {titleFor(c)} products →</a>
+            <a href={buildAmazonSearchUrl(c.slug)} target='_blank' rel='noopener noreferrer nofollow sponsored' className='mt-3 inline-block bg-emerald-300 text-black px-3 py-1 rounded'>Compare {titleFor(c)} products →</a>
             <Link href={`/compounds/${c.slug}`} className='block mt-2 text-sm'>Read full profile →</Link>
           </div>
         ))}

--- a/app/top/sleep/page.tsx
+++ b/app/top/sleep/page.tsx
@@ -103,7 +103,7 @@ export default async function TopSleepPage() {
                 <div className='mt-3 flex gap-2 flex-wrap'>
                   <Link href={`/herbs/${herb.slug}`}>Read {label} profile</Link>
                   {links[0] && (
-                    <a href={links[0].url} target='_blank'>Compare {label} products →</a>
+                    <a href={links[0].url} target='_blank' rel='noopener noreferrer nofollow sponsored'>Compare {label} products →</a>
                   )}
                 </div>
               </article>

--- a/components/AffiliateProductCard.tsx
+++ b/components/AffiliateProductCard.tsx
@@ -13,7 +13,7 @@ export default function AffiliateProductCard({ product }: { product: Product }) 
     <a
       href={product.link}
       target="_blank"
-      rel="noopener noreferrer sponsored"
+      rel="noopener noreferrer nofollow sponsored"
       className='block rounded-2xl border border-brand/20 bg-glass-standard p-4 space-y-2 transition hover:bg-glass-heavy active:scale-[0.99]'
     >
       <h4 className='font-bold text-[color:var(--text-primary)]'>{product.name}</h4>

--- a/components/evidence/EvidenceSection.tsx
+++ b/components/evidence/EvidenceSection.tsx
@@ -62,7 +62,7 @@ export default function EvidenceSection({
                 key={study.href}
                 href={study.href}
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 className="chip-readable"
               >
                 {study.label}

--- a/components/evidence/ReferencedStudies.tsx
+++ b/components/evidence/ReferencedStudies.tsx
@@ -25,7 +25,7 @@ export default function ReferencedStudies({
             key={study.href}
             href={study.href}
             target="_blank"
-            rel="noreferrer"
+            rel="noopener noreferrer"
             className="block rounded-2xl border border-[#d8d3c4] bg-white px-5 py-4 transition hover:-translate-y-0.5"
           >
             <div className="space-y-2">

--- a/src/components/BlogPost.tsx
+++ b/src/components/BlogPost.tsx
@@ -25,7 +25,7 @@ export default function BlogPost({ children, title, author, sources }: BlogPostL
           <ol>
             {sources.map((source, index) => (
               <li key={`${source.url}-${index}`}>
-                <a href={source.url} target='_blank' rel='noreferrer'>
+                <a href={source.url} target='_blank' rel='noopener noreferrer'>
                   {source.title}
                 </a>
                 {source.note ? ` — ${source.note}` : ''}


### PR DESCRIPTION
## External Link Security Cleanup

Hardened external links that open in a new tab.

Changed files:
- components/AffiliateProductCard.tsx
- components/evidence/EvidenceSection.tsx
- components/evidence/ReferencedStudies.tsx
- src/components/BlogPost.tsx
- app/top/focus/page.tsx
- app/top/best-herbs-for-overthinking/page.tsx
- app/top/best-supplements-for-brain-fog/page.tsx
- app/top/sleep/page.tsx

Changes:
- added noopener noreferrer to target blank external links
- added nofollow sponsored only to affiliate/product/commerce links where applicable
- preserved link destinations, copy, styles, and routing
- made no unrelated UI or code changes

Notes:
- evidence/reference links were kept free of nofollow/sponsored
- one large file (src/components/detail/GovernedResearchSections.tsx) was intentionally not patched because the connector response was truncated; manual follow-up may be needed for PubMed links currently using rel='noreferrer'

Validation notes for maintainer:
```bash
npm run build
npm run lint
npx tsc --noEmit
```
