### PR TITLE
fix: restore governed research sections file

### DIFF
--- a/src/components/detail/GovernedResearchSections.tsx
+++ b/src/components/detail/GovernedResearchSections.tsx
@@ -697,4 +697,29 @@ export default function GovernedResearchSections({
         <Collapse title='Sources & Provenance'>
           <div className='space-y-2 text-sm text-white/80'>
             <p>
-             ... (truncated due to tool response token budget)
+              {enrichment.sourceRefs.length} source{enrichment.sourceRefs.length === 1 ? '' : 's'} · Last reviewed{' '}
+              {new Date(enrichment.lastReviewedAt).toLocaleDateString('en-US', {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+              })}
+            </p>
+            <ol className='list-decimal space-y-1 pl-5'>
+              {enrichment.sourceRefs.map(source => (
+                <li key={source.sourceId}>
+                  {source.url ? (
+                    <a href={source.url} target='_blank' rel='noopener noreferrer' className='link'>
+                      {source.title}
+                    </a>
+                  ) : (
+                    source.title
+                  )}
+                </li>
+              ))}
+            </ol>
+          </div>
+        </Collapse>
+      </section>
+    </>
+  )
+}


### PR DESCRIPTION
### Motivation

- Repair an accidentally truncated `src/components/detail/GovernedResearchSections.tsx` and restore the original component so the site builds cleanly. 
- Re-apply the single intended security hardening for external links to PubMed/source references without changing copy, hrefs, layout, or behavior.

### Description

- Restored the complete `src/components/detail/GovernedResearchSections.tsx` from the last known good commit `850646a1151bb795877f9cea2cebaee7f7cd7e8b` and committed the repair on branch `fix/repair-governed-research-sections`.
- Applied only the intended change: updated external links that used `rel='noreferrer'` to `rel='noopener noreferrer'` for PubMed PMIDs and the Sources & Provenance source links.
- Modified only `src/components/detail/GovernedResearchSections.tsx` and preserved imports, exports, copy, className values, hrefs, layout, and component logic.

### Testing

- Ran `git diff --check` and confirmed no whitespace/error issues; the check passed.
- Inspected the tail of the repaired file with `tail -n 80 src/components/detail/GovernedResearchSections.tsx` to confirm complete, valid TSX and absence of truncation markers.
- Verified only one file changed using `git diff --name-only` / `git status --short`, and committed the repair as `fix: restore governed research sections file`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0752071eb48323a0e96713e7546574)