### PR TITLE
docs(security): audit CSP and static security headers

### DIFF
--- a/docs/security-headers.md
+++ b/docs/security-headers.md
@@ -2,6 +2,62 @@
 
 This project ships Cloudflare Pages-compatible header configuration via `public/_headers`. If you deploy to other platforms, adapt the following snippets to keep equivalent security and caching behavior.
 
+## Current CSP posture
+
+The current deployment model is a static Next.js export hosted behind static headers.
+
+Current CSP goals:
+
+- restrict all origins to `self` by default
+- permit only the analytics and runtime behavior currently observed in the repo
+- preserve JSON-LD structured data support for SEO
+- avoid runtime nonce/hash logic incompatible with static export hosting
+
+Current allowed third-party origins:
+
+| Directive | Allowed origin | Reason |
+| --- | --- | --- |
+| `script-src` | `https://www.googletagmanager.com` | Used by the consent-gated analytics loader in `src/lib/loadAnalytics.ts` to load Google Analytics gtag scripts. |
+| `connect-src` | `https://www.google-analytics.com` | Google Analytics collection endpoint. |
+| `connect-src` | `https://region1.google-analytics.com` | Regional Google Analytics collection endpoint. |
+
+No clearly unused third-party script domains were identified during this audit.
+
+## Inline script posture
+
+`script-src 'unsafe-inline'` remains intentionally enabled.
+
+Reason:
+
+- the app renders multiple inline JSON-LD `<script type="application/ld+json">` tags through Next.js routes/components using `dangerouslySetInnerHTML`
+- examples include:
+  - `app/layout.tsx`
+  - `components/seo/FaqJsonLd.tsx`
+  - `components/seo/AuthorityJsonLd.tsx`
+  - additional route-level SEO components/pages
+
+Because this is a static export deployment, nonce-based runtime CSP approaches are intentionally avoided in the current architecture.
+
+`style-src 'unsafe-inline'` also remains intentionally enabled because the current React/Tailwind runtime stack still relies on inline/runtime style injection patterns.
+
+## Form endpoint posture
+
+The active browser form submission utility is:
+
+- `src/lib/formSubmission.ts`
+
+The endpoint is configured through:
+
+- `NEXT_PUBLIC_FORM_ENDPOINT`
+
+The repository currently documents only a placeholder endpoint:
+
+- `https://example.invalid/forms`
+
+Because deployment-specific form origins are not committed to the repository, this audit intentionally does not guess or hardcode additional `connect-src` origins.
+
+If production deployments use a cross-origin form endpoint, that exact host must be added to `connect-src` before enforcing a stricter CSP.
+
 ## Nginx
 
 ```
@@ -48,9 +104,18 @@ Header always set Content-Security-Policy "default-src 'self'; script-src 'self'
 </IfModule>
 ```
 
+## Remaining risks and future hardening
 
-## Remaining CSP exceptions
+Current residual risks/limitations:
 
-- `script-src 'unsafe-inline'` is still required because the app renders structured data (`<script type='application/ld+json'>`) through the current Next app routes and layout.
-- `style-src 'unsafe-inline'` is still required for current runtime style injection patterns used by the React/Tailwind stack.
-- `connect-src` is intentionally limited to same-origin plus GA collection endpoints. If forms are pointed at a cross-origin endpoint via `NEXT_PUBLIC_FORM_ENDPOINT`, that origin must be explicitly added before deploying with a stricter CSP.
+- `script-src 'unsafe-inline'` weakens CSP protection against inline script injection.
+- `style-src 'unsafe-inline'` weakens CSP protection against style injection.
+- static export hosting limits nonce-based runtime CSP strategies.
+
+Potential future hardening steps:
+
+1. Move JSON-LD generation toward CSP hash-based allowances where practical.
+2. Reduce runtime inline style injection dependencies.
+3. Consider a stricter analytics abstraction that conditionally injects scripts only when analytics is enabled at build/runtime.
+4. Explicitly enumerate deployed cross-origin form endpoints in `connect-src` once production infrastructure is finalized.
+5. Periodically audit CSP origins against actual runtime usage before adding additional third-party services.

--- a/public/_headers
+++ b/public/_headers
@@ -7,7 +7,7 @@
   Cross-Origin-Opener-Policy: same-origin
   Cross-Origin-Resource-Policy: same-origin
   # CSP exceptions documented in docs/security-headers.md
-  # - script-src 'unsafe-inline' is temporarily required for react-helmet JSON-LD inline script tags.
+  # - script-src 'unsafe-inline' is temporarily required for Next-rendered JSON-LD inline script tags.
   # - style-src 'unsafe-inline' is required for current runtime style injection (React/Tailwind stack).
   Content-Security-Policy: default-src 'self'; script-src 'self' https://www.googletagmanager.com 'unsafe-inline'; connect-src 'self' https://www.google-analytics.com https://region1.google-analytics.com; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; font-src 'self' data: https:; frame-src 'self'; frame-ancestors 'none'
 


### PR DESCRIPTION
## Security Headers and CSP Audit

Audited static security headers and CSP configuration.

Changed files:
- `public/_headers`
- `docs/security-headers.md`

Changes:
- inspected CSP/security header configuration
- verified Google Tag Manager allowance is still actively used by analytics loading code
- documented current inline script/JSON-LD posture
- documented current connect-src posture for analytics and configurable form endpoints
- documented remaining risks and future hardening options
- clarified CSP exception comments in `public/_headers`
- preserved static export compatibility
- made no dependency or lockfile changes

Audit findings:
- `script-src 'unsafe-inline'` is still required because the app renders JSON-LD inline scripts through Next.js components/routes
- `style-src 'unsafe-inline'` is still required for the current React/Tailwind runtime style injection posture
- `https://www.googletagmanager.com` is actively used by `src/lib/loadAnalytics.ts`
- no clearly unused third-party script domains were identified
- `NEXT_PUBLIC_FORM_ENDPOINT` is deployment-configurable, so no additional connect-src origin was hardcoded

Validation notes for maintainer:
- npm run build
- npm run lint
- npx tsc --noEmit