### PR TITLE
seo: add metadata coverage batch 1 for public pages

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -1,6 +1,13 @@
+import type { Metadata } from 'next'
 import { CompareTableClient } from '@/components/compare-table-client'
 import { getCompounds } from '@/lib/runtime-data'
 import { cleanSummary, formatDisplayLabel, isClean, list } from '@/lib/display-utils'
+
+export const metadata: Metadata = {
+  title: 'Compare Supplements and Compounds',
+  description:
+    'Compare herbs, supplements, and compounds by effects, evidence tiers, safety considerations, and decision-support factors.',
+}
 
 export default async function ComparePage() {
   const compounds = await getCompounds()

--- a/app/education/page.tsx
+++ b/app/education/page.tsx
@@ -1,6 +1,13 @@
+import type { Metadata } from 'next'
 import Link from 'next/link'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import EducationSupernodeGrid from '@/components/education/education-supernode-grid'
+
+export const metadata: Metadata = {
+  title: 'Neuroscience and Neuropharmacology Education',
+  description:
+    'Explore evidence-aware education on neurochemistry, cognition, stress biology, recovery systems, and psychoactive neuroscience.',
+}
 
 const supernodes = [
   {

--- a/app/pathways/dopamine/page.tsx
+++ b/app/pathways/dopamine/page.tsx
@@ -1,6 +1,13 @@
+import type { Metadata } from 'next'
 import Link from 'next/link'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
+
+export const metadata: Metadata = {
+  title: 'Dopamine Pathway Education',
+  description:
+    'Explore educational content on dopaminergic signaling, focus, motivation, reward systems, and related herbs and compounds.',
+}
 
 const profiles = [
   {

--- a/app/pathways/gaba/page.tsx
+++ b/app/pathways/gaba/page.tsx
@@ -1,7 +1,14 @@
+import type { Metadata } from 'next'
 import Link from 'next/link'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 import FaqJsonLd from '@/components/seo/FaqJsonLd'
+
+export const metadata: Metadata = {
+  title: 'GABA Pathway Education',
+  description:
+    'Learn about GABAergic signaling, calming neurochemistry, inhibitory neurotransmission, sleep-related pathways, and related herbs and compounds.',
+}
 
 const faqItems = [
   {

--- a/app/pathways/page.tsx
+++ b/app/pathways/page.tsx
@@ -1,5 +1,12 @@
+import type { Metadata } from 'next'
 import Link from 'next/link'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
+
+export const metadata: Metadata = {
+  title: 'Neurochemical Pathways',
+  description:
+    'Explore educational guides to serotonin, dopamine, GABA, and neurochemical signaling systems related to cognition, mood, stress, and recovery.',
+}
 
 const pathways = [
   {

--- a/app/pathways/serotonin/page.tsx
+++ b/app/pathways/serotonin/page.tsx
@@ -1,6 +1,13 @@
+import type { Metadata } from 'next'
 import Link from 'next/link'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
+
+export const metadata: Metadata = {
+  title: 'Serotonin Pathway Education',
+  description:
+    'Learn about serotonergic signaling, mood regulation, emotional processing, and herbs and compounds associated with the serotonin pathway.',
+}
 
 const profiles = [
   {

--- a/docs/seo/metadata-coverage.md
+++ b/docs/seo/metadata-coverage.md
@@ -1,0 +1,49 @@
+# SEO Metadata Coverage Audit
+
+## Metadata coverage batch 1
+
+This PR adds route-level metadata coverage to a small first batch of important public App Router pages.
+
+Updated pages:
+
+- `app/education/page.tsx`
+- `app/pathways/page.tsx`
+- `app/pathways/serotonin/page.tsx`
+- `app/pathways/dopamine/page.tsx`
+- `app/pathways/gaba/page.tsx`
+- `app/compare/page.tsx`
+
+## Intentionally skipped in this PR
+
+Skipped because metadata already exists:
+
+- `app/compare/[slug]/page.tsx`
+
+Skipped because they are internal/demo/admin-oriented or outside this narrowly scoped batch:
+
+- `app/dashboard/**`
+- analytics/admin-like routes
+- internal demo pages
+
+## Candidate groups for future metadata PRs
+
+Potential future metadata coverage work:
+
+- additional `app/education/**` article routes
+- `app/protocols/**`
+- `app/psychoactive/**`
+- `app/goals/**`
+- `app/stacks/**`
+- `app/topics/**`
+- `app/blog/**`
+- static informational/legal pages
+
+## Notes
+
+This audit intentionally avoids:
+
+- layout changes
+- routing changes
+- content rewrites
+- dependency changes
+- broad repository-wide SEO refactors


### PR DESCRIPTION
## SEO Metadata Coverage Batch 1

Added route-level metadata to a small first batch of important public pages.

Changed files:
- `app/education/page.tsx`
- `app/pathways/page.tsx`
- `app/pathways/serotonin/page.tsx`
- `app/pathways/dopamine/page.tsx`
- `app/pathways/gaba/page.tsx`
- `app/compare/page.tsx`
- `docs/seo/metadata-coverage.md`

Changes:
- audited public App Router page metadata coverage
- added unique title and description metadata to selected public pages
- documented updated and remaining metadata coverage
- skipped internal/demo/admin-like pages
- preserved existing page logic and routing behavior
- made no content, layout, routing, dependency, or lockfile changes

Audit notes:
- `app/compare/[slug]/page.tsx` already exposes `generateMetadata` and was intentionally skipped
- this batch focused on high-value public hubs and pathway pages
- internal/dashboard/demo routes were intentionally excluded

Validation notes for maintainer:
- npm run build
- npm run lint
- npx tsc --noEmit