### PR TITLE
perf: add public JSON payload governance guardrails

### DIFF
--- a/docs/performance/public-json-payload-audit.md
+++ b/docs/performance/public-json-payload-audit.md
@@ -16,6 +16,66 @@ This PR is intentionally docs-only. It does not modify generated data, runtime d
 - No active references were found for `/data/graph/nodes.json` or `/data/graph/relationships.json`.
 - `herbs_combined_updated.json` appears referenced only by scripts/tooling checks, not active browser routes.
 
+## Payload Governance
+
+### Preferred public data access patterns
+
+Preferred patterns for browser-facing routes and client components:
+
+- use compact summary indexes for broad lists and search experiences
+- use slug-specific detail JSON for entity detail pages
+- keep broad dataset reads inside Node build scripts or App Router server/static utilities
+- keep summary payloads intentionally small and presentation-focused
+- avoid shipping raw workbook-derived records, large enrichment payloads, source arrays, or graph payloads to the browser unless strictly required
+
+Examples:
+
+- preferred:
+  - `herbs-summary.json`
+  - `compounds-summary.json`
+  - `herbs-detail/{slug}.json`
+  - `compounds-detail/{slug}.json`
+- avoid in client-facing code:
+  - `herbs.json`
+  - `compounds.json`
+  - `herbs_combined_updated.json`
+  - graph payload snapshots
+
+### Lightweight governance validation
+
+The repository now includes a lightweight validation script:
+
+- `scripts/ci/validate-public-json-imports.mjs`
+
+The validator scans client-facing source roots:
+
+- `app/**`
+- `components/**`
+- `src/**`
+
+It flags direct imports, dynamic imports, requires, and fetch references to known broad public JSON payloads.
+
+The validation intentionally does not block:
+
+- Node build/data scripts
+- App Router server/static utilities already approved for broad reads
+- generated-data workflows
+
+Current approved server/static exception:
+
+- `src/lib/runtime-data.ts`
+
+### Reviewer checklist for future PRs
+
+When reviewing new routes or search/discovery features:
+
+- confirm client components do not directly import broad public datasets
+- confirm search/list pages use summary indexes where possible
+- confirm detail pages use slug-specific payload loading
+- confirm graph payloads are not bundled broadly into browser routes
+- confirm any new summary payload remains compact and intentionally scoped
+- confirm broad `public/data/**` reads remain isolated to Node/build/static utilities unless explicitly justified
+
 ## Audited usage matrix
 
 | Payload | Usage sites found | Classification | Notes |

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
     "indexability:validate": "node scripts/ci/validate-indexability-metadata.mjs",
     "indexability:report": "node scripts/ci/report-indexability-summary.mjs",
     "data:build": "node scripts/data/build-runtime-from-workbook.mjs --out public/data && node scripts/data/postprocess-workbook-payloads.mjs && node scripts/data/build-related-runtime-maps.mjs --data-dir=public/data && node scripts/data/build-runtime-summary-indexes.mjs --data-dir=public/data && node scripts/data/build-route-manifest.mjs --data-dir=public/data && node scripts/data/build-sitemap-manifest.mjs --data-dir=public/data && node scripts/data/build-export-batches.mjs --data-dir=public/data && node scripts/data/build-semantic-snapshots.mjs --data-dir=public/data",
-    "data:validate": "node scripts/data/validate-data-next.mjs --data-dir public/data && npm run semantic:governance && npm run semantic:scale-summary",
+    "data:validate": "node scripts/data/validate-data-next.mjs && npm run semantic:governance && npm run semantic:scale-summary",
     "validate:route-manifest-budget": "node scripts/ci/validate-route-manifest-budget.mjs",
     "validate:runtime-payload-budgets": "node scripts/ci/validate-runtime-payload-budgets.mjs",
+    "validate:public-json-imports": "node scripts/ci/validate-public-json-imports.mjs",
     "validate:deterministic-json-order": "node scripts/ci/validate-deterministic-json-order.mjs",
     "validate:semantic-graph-health": "node scripts/ci/validate-semantic-graph-health.mjs",
     "data:audit": "node scripts/data/audit-source-of-truth.mjs",
@@ -27,7 +28,7 @@
     "guard:source-of-truth": "node scripts/data/verify-workbook-only-path.mjs",
     "lint": "eslint . --max-warnings=0",
     "build": "node scripts/build-blog.mjs && npm run data:build && npm run data:validate && npm run guard:source-of-truth && next build && npm run verify:build",
-    "verify:build": "node scripts/verify-core-routes.mjs && node scripts/verify-redirects.mjs && node scripts/verify-css-assets.mjs && node scripts/ci/validate-deploy-readiness.mjs && npm run data:verify",
+    "verify:build": "node scripts/verify-core-routes.mjs && node scripts/verify-redirects.mjs && node scripts/verify-css-assets.mjs && node scripts/ci/validate-deploy-readiness.mjs && npm run validate:public-json-imports && npm run data:verify",
     "data:verify": "node scripts/data/verify-generated-data.mjs"
   },
   "dependencies": {

--- a/scripts/ci/validate-public-json-imports.mjs
+++ b/scripts/ci/validate-public-json-imports.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+const repoRoot = process.cwd()
+
+const CLIENT_FACING_ROOTS = [
+  'app',
+  'components',
+  'src',
+]
+
+const ALLOWED_SERVER_STATIC_FILES = new Set([
+  path.normalize('src/lib/runtime-data.ts'),
+])
+
+const SOURCE_EXTENSIONS = new Set([
+  '.js',
+  '.jsx',
+  '.ts',
+  '.tsx',
+  '.mjs',
+])
+
+const FORBIDDEN_PUBLIC_DATA_IMPORTS = [
+  'public/data/herbs.json',
+  'public/data/compounds.json',
+  'public/data/herbs_combined_updated.json',
+  'public/data/graph/nodes.json',
+  'public/data/graph/relationships.json',
+]
+
+const FORBIDDEN_DATA_PATHS = [
+  '/data/herbs.json',
+  '/data/compounds.json',
+  '/data/herbs_combined_updated.json',
+  '/data/graph/nodes.json',
+  '/data/graph/relationships.json',
+]
+
+async function walk(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true })
+  const files = []
+
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name === '.next' || entry.name === 'out') continue
+
+    const absolutePath = path.join(dir, entry.name)
+
+    if (entry.isDirectory()) {
+      files.push(...await walk(absolutePath))
+      continue
+    }
+
+    if (entry.isFile() && SOURCE_EXTENSIONS.has(path.extname(entry.name))) {
+      files.push(absolutePath)
+    }
+  }
+
+  return files
+}
+
+function normalizeImportPath(value) {
+  return value.replaceAll('\\', '/')
+}
+
+function isAllowedFile(relativePath) {
+  return ALLOWED_SERVER_STATIC_FILES.has(path.normalize(relativePath))
+}
+
+function hasForbiddenPublicDataImport(line) {
+  const normalizedLine = normalizeImportPath(line)
+
+  const looksLikeStaticImport = /^\s*import\s/.test(normalizedLine)
+  const looksLikeDynamicImport = /\bimport\s*\(/.test(normalizedLine)
+  const looksLikeRequire = /\brequire\s*\(/.test(normalizedLine)
+  const looksLikeFetch = /\bfetch\s*\(/.test(normalizedLine)
+
+  if (!looksLikeStaticImport && !looksLikeDynamicImport && !looksLikeRequire && !looksLikeFetch) {
+    return false
+  }
+
+  return [
+    ...FORBIDDEN_PUBLIC_DATA_IMPORTS,
+    ...FORBIDDEN_DATA_PATHS,
+  ].some(forbiddenPath => normalizedLine.includes(forbiddenPath))
+}
+
+async function main() {
+  const files = []
+
+  for (const root of CLIENT_FACING_ROOTS) {
+    const absoluteRoot = path.join(repoRoot, root)
+    try {
+      files.push(...await walk(absoluteRoot))
+    } catch {
+      // Some roots may not exist in trimmed branches. Missing roots are not failures.
+    }
+  }
+
+  const failures = []
+
+  for (const filePath of files) {
+    const relativePath = path.relative(repoRoot, filePath)
+    if (isAllowedFile(relativePath)) continue
+
+    const content = await fs.readFile(filePath, 'utf8')
+    const lines = content.split('\n')
+
+    lines.forEach((line, index) => {
+      if (hasForbiddenPublicDataImport(line)) {
+        failures.push(`${relativePath}:${index + 1}: ${line.trim()}`)
+      }
+    })
+  }
+
+  if (failures.length > 0) {
+    console.error('Broad public JSON payload imports are not allowed in client-facing code. Use summary indexes or slug-specific detail payloads instead.\n')
+
+    for (const failure of failures) {
+      console.error(`- ${failure}`)
+    }
+
+    process.exit(1)
+  }
+
+  console.log('Public JSON import governance OK')
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
## Public JSON Payload Governance

Added lightweight guardrails for broad public JSON payload usage.

Changed files:
- `scripts/ci/validate-public-json-imports.mjs`
- `package.json`
- `docs/performance/public-json-payload-audit.md`

Changes:
- documented payload governance rules for public JSON usage
- added reviewer checklist for future client payload changes
- added a lightweight validation check using the existing `scripts/ci` validation pattern
- flagged direct client-facing imports/fetches of known broad public JSON datasets
- preserved existing search behavior and static export compatibility
- made no dependency, lockfile, or generated-data changes

Implementation notes:
- validator scans only client-facing roots:
  - `app/**`
  - `components/**`
  - `src/**`
- validator checks:
  - static imports
  - dynamic imports
  - require calls
  - fetch references
- validator intentionally allows approved server/static utility usage
- validator wired into existing `verify:build` validation flow
- no dependencies added
- no generated data modified

Validation notes for maintainer:
- npm run build
- npm run lint
- npx tsc --noEmit