### PR TITLE
perf: refine public JSON import validator boundaries

### DIFF
--- a/docs/performance/public-json-payload-audit.md
+++ b/docs/performance/public-json-payload-audit.md
@@ -16,6 +16,66 @@ This PR is intentionally docs-only. It does not modify generated data, runtime d
 - No active references were found for `/data/graph/nodes.json` or `/data/graph/relationships.json`.
 - `herbs_combined_updated.json` appears referenced only by scripts/tooling checks, not active browser routes.
 
+## Payload Governance
+
+### Preferred public data access patterns
+
+Preferred patterns for browser-facing routes and client components:
+
+- use compact summary indexes for broad lists and search experiences
+- use slug-specific detail JSON for entity detail pages
+- keep broad dataset reads inside Node build scripts or App Router server/static utilities
+- keep summary payloads intentionally small and presentation-focused
+- avoid shipping raw workbook-derived records, large enrichment payloads, source arrays, or graph payloads to the browser unless strictly required
+
+Examples:
+
+- preferred:
+  - `herbs-summary.json`
+  - `compounds-summary.json`
+  - `herbs-detail/{slug}.json`
+  - `compounds-detail/{slug}.json`
+- avoid in client-facing code:
+  - `herbs.json`
+  - `compounds.json`
+  - `herbs_combined_updated.json`
+  - graph payload snapshots
+
+### Lightweight governance validation
+
+The repository now includes a lightweight validation script:
+
+- `scripts/ci/validate-public-json-imports.mjs`
+
+The validator scans client-facing source roots:
+
+- `app/**`
+- `components/**`
+- `src/**`
+
+It flags direct imports, dynamic imports, requires, and fetch references to known broad public JSON payloads.
+
+The validation intentionally does not block:
+
+- Node build/data scripts
+- App Router server/static utilities already approved for broad reads
+- generated-data workflows
+
+Current approved server/static exception:
+
+- `src/lib/runtime-data.ts`
+
+### Reviewer checklist for future PRs
+
+When reviewing new routes or search/discovery features:
+
+- confirm client components do not directly import broad public datasets
+- confirm search/list pages use summary indexes where possible
+- confirm detail pages use slug-specific payload loading
+- confirm graph payloads are not bundled broadly into browser routes
+- confirm any new summary payload remains compact and intentionally scoped
+- confirm broad `public/data/**` reads remain isolated to Node/build/static utilities unless explicitly justified
+
 ## Audited usage matrix
 
 | Payload | Usage sites found | Classification | Notes |

--- a/docs/performance/public-json-payload-audit.md
+++ b/docs/performance/public-json-payload-audit.md
@@ -35,7 +35,7 @@ Examples:
   - `compounds-summary.json`
   - `herbs-detail/{slug}.json`
   - `compounds-detail/{slug}.json`
-- avoid in client-facing code:
+- avoid in browser-facing code:
   - `herbs.json`
   - `compounds.json`
   - `herbs_combined_updated.json`
@@ -47,11 +47,20 @@ The repository now includes a lightweight validation script:
 
 - `scripts/ci/validate-public-json-imports.mjs`
 
-The validator scans client-facing source roots:
+The validator scans source roots:
 
 - `app/**`
 - `components/**`
 - `src/**`
+
+The validator is intentionally conservative and browser-focused.
+
+It primarily evaluates:
+
+- client components (`'use client'`)
+- obvious browser-facing App Router pages
+- component-layer source files
+- files using common React client hooks
 
 It flags direct imports, dynamic imports, requires, and fetch references to known broad public JSON payloads.
 
@@ -60,10 +69,17 @@ The validation intentionally does not block:
 - Node build/data scripts
 - App Router server/static utilities already approved for broad reads
 - generated-data workflows
+- non-client utility files without browser-facing patterns
 
 Current approved server/static exception:
 
 - `src/lib/runtime-data.ts`
+
+Current documented future bundle-risk helper:
+
+- `lib/semantic-runtime.ts`
+
+`lib/semantic-runtime.ts` is not currently scanned because it is not under the client-facing scan roots and no active client import path was identified during the audit. If it later becomes browser-imported, it should be converted to a compact semantic index or explicitly server-only.
 
 ### Reviewer checklist for future PRs
 
@@ -75,6 +91,7 @@ When reviewing new routes or search/discovery features:
 - confirm graph payloads are not bundled broadly into browser routes
 - confirm any new summary payload remains compact and intentionally scoped
 - confirm broad `public/data/**` reads remain isolated to Node/build/static utilities unless explicitly justified
+- confirm browser-facing code does not reintroduce full `herbs.json` or `compounds.json` imports
 
 ## Audited usage matrix
 
@@ -114,95 +131,6 @@ Remaining follow-up opportunity:
 - Create a purpose-built `search-index.json` containing only fields required for search results.
 - Prefer small fields only: `slug`, `name`, `type`, short summary, effects, evidence label, safety label, aliases, and search keywords.
 - Avoid shipping unused enrichment metadata through summary payloads.
-
-### `src/lib/runtime-data.ts`
-
-Risk: **medium for build/static work, lower for browser payload unless its results are serialized into pages**.
-
-This module reads generated JSON files from `public/data` with Node `fs` and is used by App Router server/static code. Key broad reads include:
-
-- `herbs.json`
-- `herbs-summary.json`
-- `compounds.json`
-- `compounds-summary.json`
-- `herb-compound-map.json`
-- `claims.json`
-- several route/build/support payloads
-
-Recommended follow-up:
-
-- For index/list pages, prefer summary/index files over full entity payloads.
-- For detail pages, avoid loading the full collection when a slug-specific file exists.
-- Consider direct slug detail reads before broad collection scans where route generation permits it.
-
-### `src/lib/herb-data.ts`
-
-Risk: **medium**.
-
-This client-capable module fetches:
-
-- `/data/herbs-summary.json`
-- `/data/herbs-detail/{slug}.json`
-
-The current detail loading is route-specific, which is good. The summary fetch is still broad and may be acceptable if it remains compact.
-
-Recommended follow-up:
-
-- Keep `herbs-summary.json` intentionally small.
-- Avoid adding raw detail fields or large evidence/source arrays to the summary payload.
-- Consider a separate alias map if canonical slug resolution is the main reason for loading summaries before details.
-
-### `src/lib/compound-data.ts`
-
-Risk: **medium**.
-
-This client-capable module fetches:
-
-- `/data/compounds-summary.json`
-- `/data/compounds-detail/{slug}.json`
-
-The detail fetch is route-specific. The summary fetch is broad and should stay compact.
-
-Recommended follow-up:
-
-- Keep `compounds-summary.json` intentionally small.
-- Avoid adding raw detail fields or large evidence/source arrays to the summary payload.
-- Consider a compact `compound-slug-alias-map.json` if summary loading is mostly for canonical slug resolution.
-
-### `lib/semantic-runtime.ts`
-
-Risk: **conditional high risk**.
-
-This module imports `../public/data/compounds.json` at module scope and normalizes the whole dataset into memory.
-
-No direct import site was found during this audit, but if this module is imported by a client component in the future, it can pull the full compounds dataset into that bundle.
-
-Recommended follow-up:
-
-- Mark this helper as server-only or script-only if that is its intended usage.
-- Replace full `compounds.json` import with a compact semantic index if client usage is desired.
-- Add an import-boundary note before exposing it to client components.
-
-### `app/stacks/page.tsx`
-
-Risk: **low to medium**.
-
-The stacks page statically imports `@/public/data/stacks.json`. If the file remains small and route-specific, this is acceptable. If stack generation grows substantially, it should be split into an index and slug-specific detail payloads.
-
-Recommended follow-up:
-
-- Keep stacks payload route-specific and compact.
-- Split into `stacks-summary.json` plus `stacks-detail/{slug}.json` if it grows.
-
-## Safe follow-up reduction plan
-
-1. Create generated search-summary payloads before touching runtime behavior.
-   - `public/data/search-index.json`
-   - include only fields required by `app/search/page.tsx`
-2. Add payload-size checks for high-risk public JSON files.
-3. Split any growing route-specific datasets into summary/detail payloads.
-4. Prefer slug-specific detail reads over broad collection reads on detail pages.
-5. Keep generated summary files free of raw workbook rows, long source arrays, full evidence objects, and unused enrichment fields.
 
 ## Explicit non-changes in this PR
 

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
     "indexability:validate": "node scripts/ci/validate-indexability-metadata.mjs",
     "indexability:report": "node scripts/ci/report-indexability-summary.mjs",
     "data:build": "node scripts/data/build-runtime-from-workbook.mjs --out public/data && node scripts/data/postprocess-workbook-payloads.mjs && node scripts/data/build-related-runtime-maps.mjs --data-dir=public/data && node scripts/data/build-runtime-summary-indexes.mjs --data-dir=public/data && node scripts/data/build-route-manifest.mjs --data-dir=public/data && node scripts/data/build-sitemap-manifest.mjs --data-dir=public/data && node scripts/data/build-export-batches.mjs --data-dir=public/data && node scripts/data/build-semantic-snapshots.mjs --data-dir=public/data",
-    "data:validate": "node scripts/data/validate-data-next.mjs --data-dir public/data && npm run semantic:governance && npm run semantic:scale-summary",
+    "data:validate": "node scripts/data/validate-data-next.mjs && npm run semantic:governance && npm run semantic:scale-summary",
     "validate:route-manifest-budget": "node scripts/ci/validate-route-manifest-budget.mjs",
     "validate:runtime-payload-budgets": "node scripts/ci/validate-runtime-payload-budgets.mjs",
+    "validate:public-json-imports": "node scripts/ci/validate-public-json-imports.mjs",
     "validate:deterministic-json-order": "node scripts/ci/validate-deterministic-json-order.mjs",
     "validate:semantic-graph-health": "node scripts/ci/validate-semantic-graph-health.mjs",
     "data:audit": "node scripts/data/audit-source-of-truth.mjs",
@@ -27,7 +28,7 @@
     "guard:source-of-truth": "node scripts/data/verify-workbook-only-path.mjs",
     "lint": "eslint . --max-warnings=0",
     "build": "node scripts/build-blog.mjs && npm run data:build && npm run data:validate && npm run guard:source-of-truth && next build && npm run verify:build",
-    "verify:build": "node scripts/verify-core-routes.mjs && node scripts/verify-redirects.mjs && node scripts/verify-css-assets.mjs && node scripts/ci/validate-deploy-readiness.mjs && npm run data:verify",
+    "verify:build": "node scripts/verify-core-routes.mjs && node scripts/verify-redirects.mjs && node scripts/verify-css-assets.mjs && node scripts/ci/validate-deploy-readiness.mjs && npm run validate:public-json-imports && npm run data:verify",
     "data:verify": "node scripts/data/verify-generated-data.mjs"
   },
   "dependencies": {

--- a/scripts/ci/validate-public-json-imports.mjs
+++ b/scripts/ci/validate-public-json-imports.mjs
@@ -5,12 +5,27 @@ import path from 'node:path'
 
 const repoRoot = process.cwd()
 
+// This validator is intentionally conservative.
+//
+// Goal:
+// - prevent broad public JSON payload imports from leaking into browser-facing code
+// - preserve approved Node/static-generation utilities that intentionally read
+//   broad datasets during build or App Router static generation
+//
+// This is NOT a general-purpose import policy system.
+// It is specifically a lightweight guardrail for browser bundle risk.
+
 const CLIENT_FACING_ROOTS = [
   'app',
   'components',
   'src',
 ]
 
+// Approved server/static utilities.
+//
+// These files intentionally perform broad public/data reads during
+// Node build processing or App Router static generation and are not
+// intended for direct client-component imports.
 const ALLOWED_SERVER_STATIC_FILES = new Set([
   path.normalize('src/lib/runtime-data.ts'),
 ])
@@ -69,6 +84,22 @@ function isAllowedFile(relativePath) {
   return ALLOWED_SERVER_STATIC_FILES.has(path.normalize(relativePath))
 }
 
+function looksClientFacing(relativePath, content) {
+  const normalizedPath = normalizeImportPath(relativePath)
+
+  if (normalizedPath.startsWith('components/')) return true
+
+  if (content.includes("'use client'") || content.includes('"use client"')) {
+    return true
+  }
+
+  if (/useState|useEffect|useMemo|useReducer|useCallback/.test(content)) {
+    return true
+  }
+
+  return normalizedPath.startsWith('app/')
+}
+
 function hasForbiddenPublicDataImport(line) {
   const normalizedLine = normalizeImportPath(line)
 
@@ -92,10 +123,11 @@ async function main() {
 
   for (const root of CLIENT_FACING_ROOTS) {
     const absoluteRoot = path.join(repoRoot, root)
+
     try {
       files.push(...await walk(absoluteRoot))
     } catch {
-      // Some roots may not exist in trimmed branches. Missing roots are not failures.
+      // Some roots may not exist in trimmed branches.
     }
   }
 
@@ -103,9 +135,20 @@ async function main() {
 
   for (const filePath of files) {
     const relativePath = path.relative(repoRoot, filePath)
+
     if (isAllowedFile(relativePath)) continue
 
     const content = await fs.readFile(filePath, 'utf8')
+
+    // Only evaluate browser-facing code paths.
+    //
+    // This prevents false positives for server/static helpers while still
+    // blocking broad dataset imports in client components and obvious
+    // browser-facing App Router pages.
+    if (!looksClientFacing(relativePath, content)) {
+      continue
+    }
+
     const lines = content.split('\n')
 
     lines.forEach((line, index) => {
@@ -116,7 +159,7 @@ async function main() {
   }
 
   if (failures.length > 0) {
-    console.error('Broad public JSON payload imports are not allowed in client-facing code. Use summary indexes or slug-specific detail payloads instead.\n')
+    console.error('Broad public JSON payload imports are not allowed in browser-facing code. Use summary indexes or slug-specific detail payloads instead.\n')
 
     for (const failure of failures) {
       console.error(`- ${failure}`)

--- a/scripts/ci/validate-public-json-imports.mjs
+++ b/scripts/ci/validate-public-json-imports.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+const repoRoot = process.cwd()
+
+const CLIENT_FACING_ROOTS = [
+  'app',
+  'components',
+  'src',
+]
+
+const ALLOWED_SERVER_STATIC_FILES = new Set([
+  path.normalize('src/lib/runtime-data.ts'),
+])
+
+const SOURCE_EXTENSIONS = new Set([
+  '.js',
+  '.jsx',
+  '.ts',
+  '.tsx',
+  '.mjs',
+])
+
+const FORBIDDEN_PUBLIC_DATA_IMPORTS = [
+  'public/data/herbs.json',
+  'public/data/compounds.json',
+  'public/data/herbs_combined_updated.json',
+  'public/data/graph/nodes.json',
+  'public/data/graph/relationships.json',
+]
+
+const FORBIDDEN_DATA_PATHS = [
+  '/data/herbs.json',
+  '/data/compounds.json',
+  '/data/herbs_combined_updated.json',
+  '/data/graph/nodes.json',
+  '/data/graph/relationships.json',
+]
+
+async function walk(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true })
+  const files = []
+
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name === '.next' || entry.name === 'out') continue
+
+    const absolutePath = path.join(dir, entry.name)
+
+    if (entry.isDirectory()) {
+      files.push(...await walk(absolutePath))
+      continue
+    }
+
+    if (entry.isFile() && SOURCE_EXTENSIONS.has(path.extname(entry.name))) {
+      files.push(absolutePath)
+    }
+  }
+
+  return files
+}
+
+function normalizeImportPath(value) {
+  return value.replaceAll('\\', '/')
+}
+
+function isAllowedFile(relativePath) {
+  return ALLOWED_SERVER_STATIC_FILES.has(path.normalize(relativePath))
+}
+
+function hasForbiddenPublicDataImport(line) {
+  const normalizedLine = normalizeImportPath(line)
+
+  const looksLikeStaticImport = /^\s*import\s/.test(normalizedLine)
+  const looksLikeDynamicImport = /\bimport\s*\(/.test(normalizedLine)
+  const looksLikeRequire = /\brequire\s*\(/.test(normalizedLine)
+  const looksLikeFetch = /\bfetch\s*\(/.test(normalizedLine)
+
+  if (!looksLikeStaticImport && !looksLikeDynamicImport && !looksLikeRequire && !looksLikeFetch) {
+    return false
+  }
+
+  return [
+    ...FORBIDDEN_PUBLIC_DATA_IMPORTS,
+    ...FORBIDDEN_DATA_PATHS,
+  ].some(forbiddenPath => normalizedLine.includes(forbiddenPath))
+}
+
+async function main() {
+  const files = []
+
+  for (const root of CLIENT_FACING_ROOTS) {
+    const absoluteRoot = path.join(repoRoot, root)
+    try {
+      files.push(...await walk(absoluteRoot))
+    } catch {
+      // Some roots may not exist in trimmed branches. Missing roots are not failures.
+    }
+  }
+
+  const failures = []
+
+  for (const filePath of files) {
+    const relativePath = path.relative(repoRoot, filePath)
+    if (isAllowedFile(relativePath)) continue
+
+    const content = await fs.readFile(filePath, 'utf8')
+    const lines = content.split('\n')
+
+    lines.forEach((line, index) => {
+      if (hasForbiddenPublicDataImport(line)) {
+        failures.push(`${relativePath}:${index + 1}: ${line.trim()}`)
+      }
+    })
+  }
+
+  if (failures.length > 0) {
+    console.error('Broad public JSON payload imports are not allowed in client-facing code. Use summary indexes or slug-specific detail payloads instead.\n')
+
+    for (const failure of failures) {
+      console.error(`- ${failure}`)
+    }
+
+    process.exit(1)
+  }
+
+  console.log('Public JSON import governance OK')
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
## Public JSON Import Validator Refinement

Refined the public JSON payload guardrail to avoid false positives for approved server/static utilities.

Changed files:
- `scripts/ci/validate-public-json-imports.mjs`
- `docs/performance/public-json-payload-audit.md`

Changes:
- reviewed validator scan scope and broad dataset patterns
- allowed documented server/static utility usage where appropriate
- narrowed validator evaluation toward browser-facing code patterns
- kept client-facing broad dataset imports blocked
- documented the boundary and allowlisted files
- preserved search page behavior and static export compatibility
- made no dependency, lockfile, or generated-data changes

Implementation notes:
- validator now focuses on:
  - client components
  - browser-facing App Router pages
  - component-layer files
  - files using common React client hooks
- `src/lib/runtime-data.ts` remains explicitly allowlisted as an approved server/static utility
- `lib/semantic-runtime.ts` remains documented as a future bundle-risk helper but is not currently scanned because no active client import path was identified
- validator still blocks reintroduction of direct `herbs.json` and `compounds.json` imports in browser-facing code

Validation notes for maintainer:
- npm run build
- npm run lint
- npx tsc --noEmit