### PR TITLE
fix(runtime): replace broad public JSON route imports with server runtime loaders

### DIFF
--- a/app/best/[slug]/page.tsx
+++ b/app/best/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import compounds from '../../../public/data/compounds.json'
+import { getAllCompounds } from '@/lib/server/runtime-data'
 import ConversionStickyCTA from '@/components/conversion-sticky-cta'
 import SectionBlock from '@/components/ui/SectionBlock'
 import { getProductPicks, groupProductPicks } from '@/lib/product-ranking'
@@ -37,7 +37,8 @@ function getAuthorityLinks(slug: string) {
   })
 }
 
-export default function Page({ params }: any) {
+export default async function Page({ params }: any) {
+  const compounds = await getAllCompounds()
   const ranked = (compounds as any[]).slice(0, 10)
   const slug = String(params?.slug || '')
 

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,8 +1,7 @@
 import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import posts from '../../../data/blog/posts.json'
-import herbs from '../../../public/data/herbs.json'
-import compounds from '../../../public/data/compounds.json'
+import { getAllCompounds, getAllHerbs } from '@/lib/server/runtime-data'
 import { ResearchContinuityBlock } from '@/components/scientific-discovery'
 import { findArticleEntities } from '@/lib/editorial-discovery'
 
@@ -68,6 +67,10 @@ export default async function BlogPostPage({ params }: any) {
   if (!post) return notFound()
 
   const lines = post.content.split('\n').map((line: string) => line.trim()).filter(Boolean)
+  const [herbs, compounds] = await Promise.all([
+    getAllHerbs(),
+    getAllCompounds(),
+  ])
   const relatedHerbs = findArticleEntities(post, herbs as any[], 'herb', 3)
   const relatedCompounds = findArticleEntities(post, compounds as any[], 'compound', 3)
   const relatedItems = [...relatedHerbs, ...relatedCompounds]

--- a/app/explore/[topic]/page.tsx
+++ b/app/explore/[topic]/page.tsx
@@ -1,7 +1,6 @@
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
-import compounds from '../../../public/data/compounds.json'
-import herbs from '../../../public/data/herbs.json'
+import { getAllCompounds, getAllHerbs } from '@/lib/server/runtime-data'
 import {
   classifyArchetype,
   getTopicClusters,
@@ -108,10 +107,15 @@ function matchesTopic(cluster: unknown, topic: string) {
 }
 
 export default async function TopicExplorePage({ params }: any) {
-  const topic = safeLower(params?.topic)
+  const resolvedParams = await params
+  const topic = safeLower(resolvedParams?.topic)
 
   if (!TITLES[topic]) notFound()
 
+  const [compounds, herbs] = await Promise.all([
+    getAllCompounds(),
+    getAllHerbs(),
+  ])
   const context = TOPIC_CONTEXT[topic]
   const filtered = safeArray<any>(compounds)
     .filter((compound) => safeSlug(compound?.slug) && safeTrim(compound?.name))

--- a/app/explore/focus/page.tsx
+++ b/app/explore/focus/page.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link'
-import herbs from '../../../public/data/herbs.json'
-import compounds from '../../../public/data/compounds.json'
+import { getAllCompounds, getAllHerbs } from '@/lib/server/runtime-data'
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 import { cleanSummary, formatDisplayLabel, isClean, list, unique } from '@/lib/display-utils'
 import { EvidenceBadgeGroup } from '@/components/evidence/evidence-badge'
@@ -60,8 +59,6 @@ function buildCards(records: any[], type: 'herb' | 'compound') {
     }))
 }
 
-const herbCards = buildCards(herbs as any[], 'herb')
-const compoundCards = buildCards(compounds as any[], 'compound')
 
 const hubIntro = [
   { title: 'Biological context', body: 'Cognition-support exploration spans neurotransmitter signaling, attention, mental energy, neuroprotection, and fatigue resistance.' },
@@ -85,7 +82,15 @@ const semanticSignals = [
   'Neuroplasticity',
 ]
 
-export default function FocusExplorePage() {
+export default async function FocusExplorePage() {
+  const [herbs, compounds] = await Promise.all([
+    getAllHerbs(),
+    getAllCompounds(),
+  ])
+
+  const herbCards = buildCards(herbs as any[], 'herb')
+  const compoundCards = buildCards(compounds as any[], 'compound')
+
   return (
     <main className="mx-auto max-w-7xl space-y-12 px-4 py-10 sm:space-y-16 sm:py-14">
       <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8 lg:p-10">

--- a/app/explore/page.tsx
+++ b/app/explore/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import compounds from '../../public/data/compounds.json'
+import { getAllCompounds } from '@/lib/server/runtime-data'
 import {
   classifyArchetype,
   getTopicClusters,
@@ -114,7 +114,8 @@ const TOPICS = [
   },
 ]
 
-export default function ExplorePage() {
+export default async function ExplorePage() {
+  const compounds = await getAllCompounds()
   const featured = cappedExpansion(
     (compounds as any[])
       .filter((compound) => compound.slug && compound.name)

--- a/app/explore/sleep/page.tsx
+++ b/app/explore/sleep/page.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link'
-import herbs from '../../../public/data/herbs.json'
-import compounds from '../../../public/data/compounds.json'
+import { getAllCompounds, getAllHerbs } from '@/lib/server/runtime-data'
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 import { cleanSummary, formatDisplayLabel, isClean, list, unique } from '@/lib/display-utils'
 import { EvidenceBadgeGroup } from '@/components/evidence/evidence-badge'
@@ -57,8 +56,6 @@ function buildCards(records: any[], type: 'herb' | 'compound') {
     }))
 }
 
-const herbCards = buildCards(herbs as any[], 'herb')
-const compoundCards = buildCards(compounds as any[], 'compound')
 
 const hubIntro = [
   { title: 'Biological context', body: 'Sleep-support exploration intersects with inhibitory neurotransmission, arousal state, circadian rhythm, and recovery biology.' },
@@ -82,7 +79,15 @@ const semanticSignals = [
   'Recovery Support',
 ]
 
-export default function SleepExplorePage() {
+export default async function SleepExplorePage() {
+  const [herbs, compounds] = await Promise.all([
+    getAllHerbs(),
+    getAllCompounds(),
+  ])
+
+  const herbCards = buildCards(herbs as any[], 'herb')
+  const compoundCards = buildCards(compounds as any[], 'compound')
+
   return (
     <main className="mx-auto max-w-7xl space-y-12 px-4 py-10 sm:space-y-16 sm:py-14">
       <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8 lg:p-10">

--- a/app/learn/[slug]/page.tsx
+++ b/app/learn/[slug]/page.tsx
@@ -1,13 +1,15 @@
-import compounds from '../../../public/data/compounds.json'
+import { getAllCompounds } from '@/lib/server/runtime-data'
 
 export async function generateStaticParams() {
-  return (compounds as any[]).slice(0,50).map((c)=>({slug:c.slug}))
+  const compounds = await getAllCompounds()
+  return (compounds as any[]).slice(0, 50).map((c) => ({ slug: c.slug }))
 }
 
-export default function Page({ params }: any) {
+export default async function Page({ params }: any) {
+  const resolvedParams = await params
   return (
     <main className="max-w-3xl mx-auto px-4">
-      <h1 className="text-2xl font-bold">Learn: {params.slug}</h1>
+      <h1 className="text-2xl font-bold">Learn: {resolvedParams.slug}</h1>
     </main>
   )
 }

--- a/lib/server/runtime-data.ts
+++ b/lib/server/runtime-data.ts
@@ -1,0 +1,43 @@
+import 'server-only'
+
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+type RuntimeRecord = Record<string, any>
+
+const dataRoot = path.join(process.cwd(), 'public', 'data')
+
+let herbsCache: RuntimeRecord[] | null = null
+let compoundsCache: RuntimeRecord[] | null = null
+
+async function readRuntimeJson<T>(fileName: string): Promise<T> {
+  const filePath = path.join(dataRoot, fileName)
+  const raw = await readFile(filePath, 'utf8')
+  return JSON.parse(raw) as T
+}
+
+export async function getAllHerbs(): Promise<RuntimeRecord[]> {
+  if (!herbsCache) {
+    herbsCache = await readRuntimeJson<RuntimeRecord[]>('herbs.json')
+  }
+
+  return herbsCache
+}
+
+export async function getAllCompounds(): Promise<RuntimeRecord[]> {
+  if (!compoundsCache) {
+    compoundsCache = await readRuntimeJson<RuntimeRecord[]>('compounds.json')
+  }
+
+  return compoundsCache
+}
+
+export async function getHerbBySlug(slug: string): Promise<RuntimeRecord | undefined> {
+  const herbs = await getAllHerbs()
+  return herbs.find((herb) => String(herb?.slug || '') === slug)
+}
+
+export async function getCompoundBySlug(slug: string): Promise<RuntimeRecord | undefined> {
+  const compounds = await getAllCompounds()
+  return compounds.find((compound) => String(compound?.slug || '') === slug)
+}


### PR DESCRIPTION
### Motivation
- Remove disallowed broad `public/data/*.json` imports from app route modules to satisfy `validate-public-json-imports` while preserving existing route behavior and static-generation compatibility. 
- Keep changes minimal and server-only so runtime JSON remains a build artifact under `public/data/` and workbook generation is untouched.

### Description
- Added a server-only runtime loader `lib/server/runtime-data.ts` that reads and caches `public/data/herbs.json` and `public/data/compounds.json` using `node:fs/promises` and `server-only` semantics. 
- Refactored affected app routes to use the runtime loader: `app/best/[slug]/page.tsx`, `app/blog/[slug]/page.tsx`, `app/explore/page.tsx`, `app/explore/[topic]/page.tsx`, `app/explore/focus/page.tsx`, `app/explore/sleep/page.tsx`, and `app/learn/[slug]/page.tsx`. 
- Converted pages/generators to `async` where required, resolved `params` for Next 15 compatibility (`const resolvedParams = await params`), moved dataset-dependent work into the server-side function scope, and preserved existing card/ranking logic and `generateStaticParams`/`generateMetadata` behavior. 

### Testing
- Ran `grep -R "public/data/herbs.json\|public/data/compounds.json" app` to confirm no remaining direct imports in `app/**` routes (no matches). 
- Ran `npm run validate:public-json-imports` and received `Public JSON import governance OK`. 
- Ran full checks with `npm run check` (which runs the build pipeline) and the build, data validation, semantic governance, and static page generation completed successfully (exit 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07a3081910832394a471173f224c8d)