### PR TITLE
Explicit Any Cleanup Batch 3: Dynamic Route Props

### DIFF
--- a/docs/quality/explicit-any-audit.md
+++ b/docs/quality/explicit-any-audit.md
@@ -99,6 +99,24 @@ Changes completed:
 - aligned route access with Next.js 15 async params semantics
 - preserved route behavior, static params behavior, and UI
 
+#### Completed remediation batch 3
+
+Completed additional dynamic route boundary typing for:
+
+1. `src/app/compare/[slug]/page.tsx`
+2. `src/app/protocols/[slug]/page.tsx`
+3. `src/app/stacks/[slug]/page.tsx`
+4. `src/app/ecosystems/[slug]/page.tsx`
+5. `src/app/topics/[slug]/page.tsx`
+
+Changes completed:
+
+- added local Promise-based route param types
+- replaced route-boundary `({ params }: any)` usage only
+- aligned route access with Next.js 15 async params semantics
+- preserved route behavior, metadata behavior, static params behavior, data fetching, and UI
+- intentionally left runtime record-processing `any` usage untouched
+
 Files intentionally skipped in this batch:
 
 - `app/explore/[topic]/page.tsx`

--- a/src/app/compare/[slug]/page.tsx
+++ b/src/app/compare/[slug]/page.tsx
@@ -5,8 +5,13 @@ function normalize(value: string) {
   return String(value || '').trim().toLowerCase()
 }
 
-export default async function ComparePage({ params }: any) {
-  const slug = normalize(params?.slug)
+type ComparePageProps = {
+  params: Promise<{ slug: string }>
+}
+
+export default async function ComparePage({ params }: ComparePageProps) {
+  const resolvedParams = await params
+  const slug = normalize(resolvedParams.slug)
   const rows = await getSearchSummaryIndex()
 
   const [leftSlug, rightSlug] = slug.split('-vs-')

--- a/src/app/ecosystems/[slug]/page.tsx
+++ b/src/app/ecosystems/[slug]/page.tsx
@@ -12,8 +12,13 @@ function titleize(slug: string) {
     .join(' ')
 }
 
-export default async function EcosystemHubPage({ params }: any) {
-  const slug = String(params?.slug || '').toLowerCase()
+type EcosystemHubPageProps = {
+  params: Promise<{ slug: string }>
+}
+
+export default async function EcosystemHubPage({ params }: EcosystemHubPageProps) {
+  const resolvedParams = await params
+  const slug = String(resolvedParams.slug || '').toLowerCase()
 
   const [records, comparisons, stacks] = await Promise.all([
     getAuthorityHubRecords(slug),

--- a/src/app/protocols/[slug]/page.tsx
+++ b/src/app/protocols/[slug]/page.tsx
@@ -8,8 +8,13 @@ function titleize(slug: string) {
     .join(' ')
 }
 
-export default async function ProtocolPage({ params }: any) {
-  const slug = String(params?.slug || '').toLowerCase()
+type ProtocolPageProps = {
+  params: Promise<{ slug: string }>
+}
+
+export default async function ProtocolPage({ params }: ProtocolPageProps) {
+  const resolvedParams = await params
+  const slug = String(resolvedParams.slug || '').toLowerCase()
 
   const records = await getBestForRankings(slug, 12)
 

--- a/src/app/stacks/[slug]/page.tsx
+++ b/src/app/stacks/[slug]/page.tsx
@@ -8,8 +8,13 @@ function titleize(slug: string) {
     .join(' ')
 }
 
-export default async function StackPage({ params }: any) {
-  const slug = String(params?.slug || '').toLowerCase()
+type StackPageProps = {
+  params: Promise<{ slug: string }>
+}
+
+export default async function StackPage({ params }: StackPageProps) {
+  const resolvedParams = await params
+  const slug = String(resolvedParams.slug || '').toLowerCase()
 
   const records = await getAuthorityStacks(slug, 12)
 

--- a/src/app/topics/[slug]/page.tsx
+++ b/src/app/topics/[slug]/page.tsx
@@ -17,12 +17,17 @@ function titleize(slug: string) {
     .join(' ')
 }
 
+type TopicRouteProps = {
+  params: Promise<{ slug: string }>
+}
+
 export async function generateStaticParams() {
   return authorityTopicSlugs.map((slug) => ({ slug }))
 }
 
-export async function generateMetadata({ params }: any): Promise<Metadata> {
-  const slug = String(params?.slug || '')
+export async function generateMetadata({ params }: TopicRouteProps): Promise<Metadata> {
+  const resolvedParams = await params
+  const slug = String(resolvedParams.slug || '')
   const title = `${titleize(slug)} | Topic Authority Hub`
 
   return {
@@ -32,8 +37,9 @@ export async function generateMetadata({ params }: any): Promise<Metadata> {
   }
 }
 
-export default async function TopicHubPage({ params }: any) {
-  const slug = String(params?.slug || '').toLowerCase()
+export default async function TopicHubPage({ params }: TopicRouteProps) {
+  const resolvedParams = await params
+  const slug = String(resolvedParams.slug || '').toLowerCase()
   const title = titleize(slug)
   const description = 'Evidence-aware semantic authority hub generated from the Hippie Scientist runtime graph system.'
 


### PR DESCRIPTION
## Explicit Any Cleanup Batch 3: Dynamic Route Props

Replaced explicit any route-boundary props in a third small batch of dynamic App Router files.

Changed files:
- src/app/compare/[slug]/page.tsx
- src/app/protocols/[slug]/page.tsx
- src/app/stacks/[slug]/page.tsx
- src/app/ecosystems/[slug]/page.tsx
- src/app/topics/[slug]/page.tsx
- docs/quality/explicit-any-audit.md

Changes:
- added typed Promise-based params props for selected dynamic routes
- replaced route-boundary any usage only
- preserved generateStaticParams behavior
- preserved metadata, routing, data fetching, and UI behavior
- kept app/explore/[topic]/page.tsx as a documented manual/truncated follow-up
- updated the explicit-any audit documentation
- made no ESLint config, dependency, or lockfile changes

Validation notes for maintainer:
- npm run build
- npm run lint
- npx tsc --noEmit