### PR TITLE
Harden workbook path validation and isolate xlsx parsing

### DIFF
--- a/docs/security/xlsx-audit.md
+++ b/docs/security/xlsx-audit.md
@@ -18,7 +18,7 @@ Direct `xlsx` imports or requires found in source files:
 | File | Usage | Input source | Exposure assessment |
 | --- | --- | --- | --- |
 | `scripts/data/workbook-parser.mjs` | Central adapter: `XLSX.readFile(filePath)` and `XLSX.utils.sheet_to_json(...)` | Caller-provided local filesystem path | Build/local tooling only. No request, upload, browser, or remote URL path found. |
-| `scripts/data/build-runtime-from-workbook.mjs` | Uses `readWorkbook(...)` from the adapter | `resolveWorkbookPath(repoRoot)` | Main data build path. Local workbook source only. |
+| `scripts/data/build-runtime-from-workbook.mjs` | Uses `readWorkbook(...)` from the adapter after `resolveWorkbookPath(repoRoot)` and `assertWorkbookExists(...)` | Validated local workbook under `data-sources` | Main data build path. Local workbook source only. |
 | `scripts/build-runtime-data.mjs` | Direct `XLSX.readFile(workbookPath)` and `sheet_to_json(...)` | `resolveWorkbookPath(repoRoot)` | Legacy/alternate data build script. Local workbook source only. |
 | `scripts/export-workbook-to-json.mjs` | Direct `XLSX` import for workbook export pipeline | `resolveWorkbookPath(repoRoot)` | Local export script. No user-controlled runtime input found. |
 | `scripts/import-xlsx-monographs.mjs` | Direct `XLSX` import for monograph import pipeline | `resolveWorkbookPath(repoRoot)` | Local import script. No user-controlled runtime input found. |
@@ -33,7 +33,7 @@ Related files:
 
 | File | Relevance |
 | --- | --- |
-| `scripts/workbook-source.mjs` | Resolves workbook path from `options.envPath`, `process.env.HERB_XLSX_PATH`, or default `data-sources/herb_monograph_master.xlsx`; asserts absolute path, `.xlsx` extension, file existence, and file type when `assertWorkbookExists(...)` is called. |
+| `scripts/workbook-source.mjs` | Resolves workbook path from `options.envPath`, `process.env.HERB_XLSX_PATH`, or default `data-sources/herb_monograph_master.xlsx`; rejects empty paths, HTTP/HTTPS URLs, paths outside the repository, and paths outside `data-sources`; asserts absolute path, `.xlsx` extension, file existence, and file type when `assertWorkbookExists(...)` is called. |
 | `.env.example` | Documents `HERB_XLSX_PATH`; this is an operator/build-time configuration value, not browser input. |
 | `docs/xlsx-migration-plan.md` | Existing migration planning document for parser replacement/parity work. |
 
@@ -50,7 +50,7 @@ No confirmed path was found where any of the following reach `xlsx` parsing:
 - server action input
 - client component input
 
-The current parsing surface appears to be local filesystem paths used by scripts. The most important build path is `npm run data:build`, which runs `scripts/data/build-runtime-from-workbook.mjs`; that script uses the workbook parser adapter and a local workbook path resolved by `scripts/workbook-source.mjs`.
+The current parsing surface appears to be local filesystem paths used by scripts. The most important build path is `npm run data:build`, which runs `scripts/data/build-runtime-from-workbook.mjs`; that script uses the workbook parser adapter and a local workbook path resolved by `scripts/workbook-source.mjs`. The primary resolver now rejects empty workbook paths, HTTP/HTTPS workbook URLs, and workbook paths outside the repository `data-sources` directory.
 
 ## Risk analysis
 
@@ -59,8 +59,7 @@ Because `xlsx` parses complex spreadsheet formats, it should still be treated as
 Main residual risks:
 
 1. A malicious or corrupted workbook committed to the repository or provided through build environment configuration could be parsed during local/CI data builds.
-2. `HERB_XLSX_PATH` can point outside the repository when set by a trusted operator or CI environment.
-3. Some older scripts still import `xlsx` directly instead of going through `scripts/data/workbook-parser.mjs`, which weakens the adapter boundary and makes future migration harder.
+2. Some older scripts still import `xlsx` directly instead of going through `scripts/data/workbook-parser.mjs`, which weakens the adapter boundary and makes future migration harder.
 
 ## Recommendation
 
@@ -78,14 +77,17 @@ No emergency runtime patch is required based on this audit. Use one of these rem
   - deterministic JSON output ordering remains stable
 - Run parity checks before removing `xlsx`.
 
-### Acceptable interim hardening: keep `xlsx` isolated
+### Added interim hardening: keep `xlsx` isolated
 
+- Documented the xlsx boundary near the parser adapter and primary build usage: xlsx is allowed only in trusted local Node build/data scripts.
 - Route all workbook reads through `scripts/data/workbook-parser.mjs`.
 - Avoid adding new direct `xlsx` imports outside that adapter.
-- Constrain workbook input paths to trusted local files.
+- Constrain workbook input paths to trusted local files under `data-sources`.
+- Reject empty workbook path values and HTTP/HTTPS workbook URLs in `scripts/workbook-source.mjs`.
 - Prefer default `data-sources/herb_monograph_master.xlsx` for CI.
 - Treat `HERB_XLSX_PATH` as trusted maintainer/CI configuration only, never as user input.
 - Do not parse spreadsheets from uploads, request bodies, remote URLs, or browser inputs with `xlsx`.
+- Future runtime spreadsheet parsing must use a reviewed safer boundary.
 
 ## Security decision
 

--- a/scripts/data/build-runtime-from-workbook.mjs
+++ b/scripts/data/build-runtime-from-workbook.mjs
@@ -9,7 +9,7 @@ import {
   readWorkbook,
   sheetToRows,
 } from './workbook-parser.mjs'
-import { resolveWorkbookPath } from '../workbook-source.mjs'
+import { assertWorkbookExists, resolveWorkbookPath } from '../workbook-source.mjs'
 import { HERB_RUNTIME_FIELDS } from '../../config/runtime-herb-fields.mjs'
 import { COMPOUND_RUNTIME_FIELDS } from '../../config/runtime-compound-fields.mjs'
 import { scoreIndexability } from './indexability-policy.mjs'
@@ -346,11 +346,14 @@ function args() {
 function main() {
   const outDir = args()
   const workbookPath = resolveWorkbookPath(repoRoot)
-  if (!fs.existsSync(workbookPath)) throw new Error(`[data] workbook missing: ${workbookPath}`)
+  assertWorkbookExists(workbookPath)
 
   // Workbook loading is intentionally routed through the parser adapter.
-  // This keeps xlsx isolated so a future exceljs migration can swap parser
-  // internals without rewriting normalization/export logic.
+  // xlsx is allowed here only for trusted local Node build/data scripts; do
+  // not use it for uploads, request bodies, browser input, or remote URLs.
+  // Runtime spreadsheet parsing needs a reviewed safer boundary. This keeps
+  // xlsx isolated so a future exceljs migration can swap parser internals
+  // without rewriting normalization/export logic.
   const wb = readWorkbook(workbookPath)
 
   for (const required of ['Herb Master V3', 'Compound Master V3']) {

--- a/scripts/data/workbook-parser.mjs
+++ b/scripts/data/workbook-parser.mjs
@@ -1,5 +1,10 @@
 import XLSX from 'xlsx'
 
+// xlsx parser boundary: allowed only in Node build/data scripts for trusted
+// local workbook files. Do not use xlsx for user uploads, request bodies,
+// browser input, or remote URLs; future runtime spreadsheet parsing must use
+// a reviewed safer boundary.
+//
 // Workbook parser adapter boundary.
 //
 // This module intentionally isolates direct xlsx usage so the workbook

--- a/scripts/workbook-source.mjs
+++ b/scripts/workbook-source.mjs
@@ -4,6 +4,11 @@ import { fileURLToPath } from 'node:url'
 
 export const DEFAULT_WORKBOOK_RELATIVE_PATH = 'data-sources/herb_monograph_master.xlsx'
 
+// Workbook path boundary for xlsx consumers: only trusted local files in the
+// repository data source directory are valid. Never pass user uploads, request
+// bodies, browser input, or remote URLs into workbook parsing. Runtime
+// spreadsheet parsing needs a separately reviewed safer boundary.
+
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
@@ -11,14 +16,41 @@ export function getRepoRoot() {
   return path.resolve(__dirname, '..')
 }
 
+function isHttpUrl(value) {
+  return /^https?:\/\//i.test(value)
+}
+
+function isPathInside(parentDir, childPath) {
+  const relativePath = path.relative(parentDir, childPath)
+  return Boolean(relativePath) && !relativePath.startsWith('..') && !path.isAbsolute(relativePath)
+}
+
 export function resolveWorkbookPath(rootDir, options = {}) {
   const candidatePath =
     options.envPath ?? process.env.HERB_XLSX_PATH ?? DEFAULT_WORKBOOK_RELATIVE_PATH
 
   const normalizedCandidate = String(candidatePath).trim()
+  if (!normalizedCandidate) {
+    throw new Error('Invalid workbook path (empty paths are not allowed)')
+  }
+
+  if (isHttpUrl(normalizedCandidate)) {
+    throw new Error(`Invalid workbook path (remote URLs are not allowed): ${normalizedCandidate}`)
+  }
+
+  const repoRoot = path.resolve(rootDir)
+  const dataSourceDir = path.join(repoRoot, 'data-sources')
   const absolutePath = path.isAbsolute(normalizedCandidate)
     ? path.normalize(normalizedCandidate)
-    : path.resolve(rootDir, normalizedCandidate)
+    : path.resolve(repoRoot, normalizedCandidate)
+
+  if (!isPathInside(repoRoot, absolutePath)) {
+    throw new Error(`Invalid workbook path (must stay inside repository): ${absolutePath}`)
+  }
+
+  if (!isPathInside(dataSourceDir, absolutePath)) {
+    throw new Error(`Invalid workbook path (must stay inside data-sources): ${absolutePath}`)
+  }
 
   console.log(`[workbook-source] Resolved: ${absolutePath}`)
   return absolutePath


### PR DESCRIPTION
### Motivation

- Reduce risk from the `xlsx` dependency by ensuring only trusted local files in the repository are parsed.
- Prevent accidental or malicious usage of remote or out-of-repo workbook paths during build/CI runs.

### Description

- Added strict workbook path validation in `scripts/workbook-source.mjs` to reject empty paths, HTTP/HTTPS URLs, paths outside the repository, and paths outside the `data-sources` directory, and to log resolved absolute paths.
- Exported and used `assertWorkbookExists` from `scripts/workbook-source.mjs` in `scripts/data/build-runtime-from-workbook.mjs` to enforce existence, file extension, and file type before reading.
- Added a clear parser-boundary comment to `scripts/data/workbook-parser.mjs` and tightened comments in `scripts/data/build-runtime-from-workbook.mjs` to document that `xlsx` is allowed only for trusted local Node build/data scripts.
- Updated `docs/security/xlsx-audit.md` to reflect the new validation behavior and the tightened isolation policy for workbook inputs.

### Testing

- No automated tests were added or executed as part of this change; existing CI/test configuration was not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07571d5f34832386b506b249acef8a)