### PR TITLE
fix(lint): remove unused variable build blockers

### DIFF
--- a/app/comparisons/page.tsx
+++ b/app/comparisons/page.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import RelatedComparisonSystems from '@/components/comparisons/related-comparison-systems'
 

--- a/app/education/how-receptors-work/page.tsx
+++ b/app/education/how-receptors-work/page.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
 import EvidenceSection from '@/components/evidence/EvidenceSection'

--- a/lib/collections.ts
+++ b/lib/collections.ts
@@ -1,5 +1,5 @@
 import { getEvidenceTier, hasHumanEvidence, hasMechanismEvidence } from '@/lib/evidence'
-import { cleanSummary, formatDisplayLabel, isClean, list, text, unique } from '@/lib/display-utils'
+import { cleanSummary, formatDisplayLabel, isClean, text, unique } from '@/lib/display-utils'
 import { getPathwayLabel, getSupportedPathways } from '@/lib/pathways'
 import { collectRuntimeSignals, asList, asLowerText, asText } from '@/lib/runtime-normalize'
 import { buildMeta } from '@/lib/seo'

--- a/lib/programmatic-topic-clusters.ts
+++ b/lib/programmatic-topic-clusters.ts
@@ -85,5 +85,5 @@ export function buildProgrammaticTopicClusters(records: any[] = [], limit = 24):
     .filter((cluster) => cluster.score >= 2)
     .sort((a, b) => b.score - a.score || a.title.localeCompare(b.title))
     .slice(0, limit)
-    .map(({ score, ...cluster }) => cluster)
+    .map(({ score: _score, ...cluster }) => cluster)
 }

--- a/lib/research-intelligence.ts
+++ b/lib/research-intelligence.ts
@@ -1,4 +1,4 @@
-import { cleanSummary, formatDisplayLabel, isClean, list, text, unique } from '@/lib/display-utils'
+import { formatDisplayLabel, isClean, list, unique } from '@/lib/display-utils'
 
 export type ResearchMaturity = 'Better studied' | 'Moderate / emerging' | 'Preliminary' | 'Sparse profile'
 export type ResearchStyle = 'Human-clinical leaning' | 'Mechanism-heavy' | 'Traditional-use dominant' | 'Mixed evidence profile' | 'Emerging profile'

--- a/lib/runtime-graph.ts
+++ b/lib/runtime-graph.ts
@@ -431,13 +431,6 @@ function matchesProfile(node: GraphNode, profile: GraphRecord | string): boolean
   return nodeKeys(node).some((key) => targetKeys.includes(key))
 }
 
-function matchesSlug(value: unknown, profile: GraphRecord | string): boolean {
-  const key = normalizeKey(value)
-  if (!key) return false
-
-  return profileKeys(profile).includes(key)
-}
-
 function byNameOrSlug<T extends { id?: string; slug?: string; name?: string }>(
   rows: T[] | undefined,
   key: string

--- a/lib/safety-classification.ts
+++ b/lib/safety-classification.ts
@@ -1,4 +1,4 @@
-import { list, text, unique } from '@/lib/display-utils'
+import { text, unique } from '@/lib/display-utils'
 
 export type SafetyClassification = {
   label: string

--- a/lib/semantic-internal-linking.ts
+++ b/lib/semantic-internal-linking.ts
@@ -68,5 +68,5 @@ export function buildSemanticLinkSuggestions(source: any, candidates: any[] = []
     .filter((item) => item.score > 0)
     .sort((a, b) => b.score - a.score || a.label.localeCompare(b.label))
     .slice(0, limit)
-    .map(({ score, ...item }) => item)
+    .map(({ score: _score, ...item }) => item)
 }


### PR DESCRIPTION
### Motivation
- The build was failing due to strict ESLint `no-unused-vars` errors, so the change aims to remove unused bindings with minimal, surgical edits. 
- Preserve runtime behavior, routes, and data pipeline semantics while only touching the unused imports/helpers and discarded destructures. 
- Avoid touching config, dependencies, generated `public/data` artifacts, or unrelated code.

### Description
- Removed unused `Link` import from `app/comparisons/page.tsx` without changing JSX or content. 
- Removed unused `Link` import from `app/education/how-receptors-work/page.tsx` without changing JSX or content. 
- Dropped unused `list` import from `lib/collections.ts` while keeping `cleanSummary`, `formatDisplayLabel`, `isClean`, `text`, and `unique`. 
- Renamed discarded `score` destructure to `_score` in `lib/programmatic-topic-clusters.ts` to avoid unused-variable warnings while preserving filtering/sorting/outputs. 
- Removed unused `cleanSummary` and `text` imports from `lib/research-intelligence.ts` while keeping used helpers unchanged. 
- Deleted the unused `matchesSlug` helper from `lib/runtime-graph.ts` to remove a dead function without affecting matching/candidate logic. 
- Dropped unused `list` import from `lib/safety-classification.ts` while preserving `text` and `unique`. 
- Renamed discarded `score` destructure to `_score` in `lib/semantic-internal-linking.ts` to silence the unused-variable error without changing behavior. 

### Testing
- Ran `npm run build` and it completed successfully with exit code 0, producing the normal Next.js build output and the non-blocking Next.js ESLint plugin warning. 
- No other automated tests were modified or run as part of this change. 
- No dependencies, configuration, or runtime logic were changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07c3eaa42c8323a0a85255fcd85763)