### PR TITLE
ux: simplify decision-layer hierarchy and scanability

### DIFF
--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -13,7 +13,7 @@ import EvidenceSnapshotCard from '@/components/ui/EvidenceSnapshotCard'
 import { EvidenceBadgeGroup } from '@/components/evidence/evidence-badge'
 import { CompactRelatedPathways } from '@/app/pathways/pathway-hub'
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
-import { cleanSummary, formatDisplayLabel, isClean, list, text } from '@/lib/display-utils'
+import { cleanSummary, formatDisplayLabel, isClean, list, text, unique } from '@/lib/display-utils'
 import { buildMeta } from '@/lib/seo'
 import {
   normalizeEvidenceLevel,
@@ -89,6 +89,79 @@ export async function generateMetadata({ params }: PageProps) {
           follow: true,
         },
   }
+}
+
+
+const WEAK_PATTERN = /research[-\s]?pending|placeholder|unknown|not specified|not available|insufficient|needs review|minimal/i
+const CAUTION_PATTERN = /avoid|caution|interaction|contraindication|warning|risk|pregnancy|liver|kidney|sedat|bleed/i
+
+function firstSentences(value: string, limit = 2) {
+  const sentences = value.match(/[^.!?]+[.!?]+|[^.!?]+$/g)?.map(sentence => sentence.trim()).filter(Boolean) || []
+  return sentences.slice(0, limit).join(' ')
+}
+
+function cleanItems(value: unknown, limit = 6) {
+  const values = Array.isArray(value) ? value.flatMap(item => list(item)) : list(value)
+
+  return unique(
+    values
+      .map(formatDisplayLabel)
+      .filter(item => item && isClean(item) && !WEAK_PATTERN.test(item)),
+  ).slice(0, limit)
+}
+
+function cleanText(value: unknown) {
+  const formatted = text(value)
+  if (!formatted || !isClean(formatted) || WEAK_PATTERN.test(formatted)) return ''
+  return formatted
+}
+
+function getTimeline(compound: any) {
+  return cleanText(compound.time_to_effect || compound.timeToEffect || compound.time_to_notice || compound.timeToNotice || compound.onset)
+}
+
+function getAvoidIf(compound: any) {
+  return cleanItems([
+    compound.avoid_if,
+    compound.avoidIf,
+    compound.who_should_skip,
+    compound.whoShouldSkip,
+    compound.contraindications,
+    compound.interactions,
+  ], 4)
+}
+
+function getSafetySummary(compound: any, avoidIf: string[]) {
+  const note = cleanText(compound.safetyNotes || compound.safety_notes || compound.safety)
+  if (avoidIf.length) return `Review before use if any apply: ${avoidIf.slice(0, 3).join(', ')}.`
+  if (note) return firstSentences(note, 2)
+  return 'Review medications, pregnancy status, chronic conditions, and clinician guidance before use.'
+}
+
+function getMechanismHints(compound: any, provided: string[]) {
+  return unique([
+    ...provided,
+    ...cleanItems(compound.primary_mechanisms || compound.primaryMechanisms || compound.pathways, 6),
+  ]).slice(0, 6)
+}
+
+function DecisionSignalCard({ label, value, tone = 'neutral' }: { label: string; value?: string; tone?: 'neutral' | 'caution' | 'strong' | 'muted' }) {
+  if (!value) return null
+
+  const toneClass = tone === 'caution'
+    ? 'border-amber-800/20 bg-amber-50/85 text-amber-950'
+    : tone === 'strong'
+      ? 'border-emerald-700/15 bg-emerald-50/80 text-emerald-950'
+      : tone === 'muted'
+        ? 'border-brand-900/10 bg-white/60 text-[#5b6b61]'
+        : 'border-brand-900/10 bg-white/75 text-[#33443a]'
+
+  return (
+    <div className={`rounded-2xl border p-4 ${toneClass}`}>
+      <p className="text-[0.68rem] font-bold uppercase tracking-[0.16em] opacity-65">{label}</p>
+      <p className="mt-2 text-sm font-semibold leading-6">{value}</p>
+    </div>
+  )
 }
 
 function CompactDisclosure({ title, children }: { title: string; children: ReactNode }) {
@@ -194,11 +267,18 @@ export default async function CompoundPage({ params }: PageProps) {
   const sources = getSources(compound)
     .map((source:any) => text(source))
     .filter(isClean)
+  const displayName = formatDisplayLabel(compound.name || compound.slug)
+  const quickSummary = firstSentences(summary, 2) || 'Evidence-informed compound profile with safety, mechanism, and fit context.'
+  const timeline = getTimeline(compound)
+  const avoidIf = getAvoidIf(compound)
+  const safetySummary = getSafetySummary(compound, avoidIf)
+  const mechanismHints = getMechanismHints(compound, mechanisms)
+  const topSignals = unique([...effects, ...mechanismHints]).slice(0, 8)
 
   const compoundJsonLd = {
     '@context': 'https://schema.org',
     '@type': 'DietarySupplement',
-    name: formatDisplayLabel(compound.name || compound.slug),
+    name: displayName,
     description: summary,
     url: `https://www.thehippiescientist.net/compounds/${compound.slug}`,
     ...(effects.length > 0 ? { activeIngredient: effects.join(', ') } : {}),
@@ -219,7 +299,7 @@ export default async function CompoundPage({ params }: PageProps) {
       {
         '@type': 'ListItem',
         position: 2,
-        name: formatDisplayLabel(compound.name || compound.slug),
+        name: displayName,
         item: `https://www.thehippiescientist.net/compounds/${compound.slug}`,
       },
     ],
@@ -250,35 +330,38 @@ export default async function CompoundPage({ params }: PageProps) {
 
         <TrustBar />
 
-        <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-6 shadow-card sm:p-8">
-          <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(280px,420px)] lg:items-stretch">
+        <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-5 shadow-card sm:p-7">
+          <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-start">
             <div className="space-y-5">
               <CompoundHero
-                compound={{ ...compound, summary }}
+                compound={{ ...compound, summary: quickSummary }}
                 evidenceLevel={evidenceLevel}
                 safetyLevel={safetyLevel}
               />
 
-              <EvidenceBadgeGroup record={compound} />
-
-              {effects.length > 0 ? (
-                <div className="flex flex-wrap gap-2">
-                  {effects.slice(0, 6).map((effect:string) => (
-                    <span key={effect} className="chip-readable">
-                      {effect}
-                    </span>
-                  ))}
-                </div>
-              ) : null}
+              <div className="space-y-3">
+                <EvidenceBadgeGroup record={compound} compact />
+                {topSignals.length > 0 ? (
+                  <div className="flex flex-wrap gap-2">
+                    {topSignals.slice(0, 8).map((signal:string) => (
+                      <span key={signal} className="chip-readable text-xs">
+                        {signal}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
             </div>
 
-            <SemanticArtworkPanel
-              slug={compound.slug}
-              kind="compound"
-              title={formatDisplayLabel(compound.name || compound.slug)}
-              subtitle="Compound ecosystem artwork for mechanism-aware pathway exploration."
-              height={300}
-            />
+            <aside className="rounded-3xl border border-brand-900/10 bg-sand-50/85 p-4 shadow-sm">
+              <p className="eyebrow-label">Decision snapshot</p>
+              <div className="mt-3 grid gap-3">
+                <DecisionSignalCard label="Evidence level" value={evidenceLevel} tone={evidenceLevel.toLowerCase().includes('strong') || evidenceLevel.toLowerCase().includes('high') ? 'strong' : 'neutral'} />
+                <DecisionSignalCard label="Safety read" value={safetySummary} tone={CAUTION_PATTERN.test(safetySummary) || avoidIf.length > 0 ? 'caution' : 'neutral'} />
+                <DecisionSignalCard label="Timeline" value={timeline || 'Timing varies by dose, form, and context.'} tone={timeline ? 'neutral' : 'muted'} />
+                <DecisionSignalCard label="Mechanism hints" value={mechanismHints.slice(0, 3).join(', ')} />
+              </div>
+            </aside>
           </div>
         </section>
 
@@ -312,6 +395,14 @@ export default async function CompoundPage({ params }: PageProps) {
         </CompactDisclosure>
 
         <CompactDisclosure title="Authority, exploration, and semantic analysis">
+          <SemanticArtworkPanel
+            slug={compound.slug}
+            kind="compound"
+            title={displayName}
+            subtitle="Compound ecosystem artwork for mechanism-aware pathway exploration."
+            height={260}
+          />
+
           <AuthorityEditorialLayer
             record={compound}
             entityType="compound"

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -471,22 +471,23 @@ export default async function HerbDetailPage({ params }: PageProps) {
               <ChipList items={topUses} limit={6} />
             </div>
 
-            <div className="rounded-3xl border border-brand-900/10 bg-sand-50/80 p-4">
-              <p className="text-[11px] font-bold uppercase tracking-[0.16em] text-muted">Read next</p>
-              <div className="mt-3 space-y-2 text-sm font-semibold text-ink">
-                <Link href="/herbs" className="block rounded-2xl bg-white/70 px-3 py-2 transition hover:bg-white">Herbs library</Link>
-                <Link href="/compare" className="block rounded-2xl bg-white/70 px-3 py-2 transition hover:bg-white">Compare options</Link>
-                {relatedHerbLinks[0] ? <Link href={relatedHerbLinks[0].href} className="block rounded-2xl bg-white/70 px-3 py-2 transition hover:bg-white">Related: {relatedHerbLinks[0].label}</Link> : null}
+            <aside className="rounded-3xl border border-brand-900/10 bg-sand-50/85 p-4 shadow-sm">
+              <p className="eyebrow-label">Decision cues</p>
+              <div className="mt-3 grid gap-3">
+                <BriefCard label="Evidence" value={evidenceStrength || researchMaturity} />
+                <BriefCard label="Safety" value={safetySummary} />
+                <BriefCard label="Timeline" value={timeline || 'Timing varies by preparation, dose, and context.'} />
+                <BriefCard label="Mechanism hints" value={mechanisms.slice(0, 3).join(', ')} />
               </div>
-            </div>
+            </aside>
           </div>
         </div>
       </section>
 
       <section className="space-y-4">
         <div className="space-y-1">
-          <p className="eyebrow-label">At a glance</p>
-          <h2 className="text-2xl font-semibold tracking-tight text-ink">Fast orientation</h2>
+          <p className="eyebrow-label">Decision snapshot</p>
+          <h2 className="text-2xl font-semibold tracking-tight text-ink">Fast orientation before the deep dive</h2>
         </div>
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
           <BriefCard label="Best known for" value={topUses.slice(0, 3).join(', ')} />

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -67,9 +67,9 @@ function interleaveFeatured(herbs: LandingCard[], compounds: LandingCard[]) {
 }
 
 const primaryActions = [
-  { label: 'Explore Herbs', href: '/herbs' },
-  { label: 'Compare Supplements', href: '/compare' },
-  { label: 'Search Library', href: '/search' },
+  { label: 'Browse herb profiles', href: '/herbs' },
+  { label: 'Compare options', href: '/compare' },
+  { label: 'Search evidence notes', href: '/search' },
 ]
 
 const researchPaths: NavCard[] = [
@@ -106,16 +106,16 @@ const ecosystemCards: NavCard[] = [
 
 const reasoningPillars = [
   {
-    title: 'Evidence-aware positioning',
-    description: 'Profiles separate stronger human signals from early or mechanism-only ideas.',
+    title: 'Scan the signal',
+    description: 'Start with use, evidence level, safety context, and stimulation profile before reading deeply.',
   },
   {
-    title: 'Conservative interpretation',
-    description: 'Safety context and uncertainty stay close to claims, not buried at the end.',
+    title: 'Check the boundary',
+    description: 'Human evidence, mechanism clues, and uncertainty are kept separate so claims stay conservative.',
   },
   {
-    title: 'Fit-first reasoning',
-    description: 'Goal, timing, tolerance, medications, and tradeoffs matter before stacking.',
+    title: 'Decide what fits',
+    description: 'Compare timing, tolerance, medications, and tradeoffs before thinking about stacks.',
   },
 ]
 
@@ -179,31 +179,30 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
   return (
     <main className='overflow-x-clip bg-[#04120e] text-emerald-50'>
       <div className='relative isolate'>
-        <div className='pointer-events-none absolute inset-0 opacity-80'>
-          <div className='absolute left-[-7rem] top-10 h-64 w-64 rounded-full bg-emerald-500/18 blur-3xl' />
-          <div className='absolute right-[-8rem] top-48 h-72 w-72 rounded-full bg-teal-300/10 blur-3xl' />
-          <div className='absolute bottom-28 left-1/3 h-80 w-80 rounded-full bg-lime-300/8 blur-3xl' />
-          <div className='absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(16,185,129,0.14),transparent_32rem)]' />
+        <div className='pointer-events-none absolute inset-0 opacity-55'>
+          <div className='absolute left-[-7rem] top-10 h-64 w-64 rounded-full bg-emerald-500/14 blur-3xl' />
+          <div className='absolute right-[-8rem] top-48 h-72 w-72 rounded-full bg-teal-300/8 blur-3xl' />
+          <div className='absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(16,185,129,0.12),transparent_30rem)]' />
         </div>
 
-        <div className='relative mx-auto max-w-6xl space-y-8 px-4 pb-24 pt-8 sm:px-6 sm:pb-16 sm:pt-10 lg:px-8'>
-          <section className='rounded-[1.75rem] border border-emerald-300/15 bg-white/[0.035] px-4 py-7 shadow-[0_24px_90px_rgba(0,0,0,0.28)] backdrop-blur sm:px-8 sm:py-10 lg:px-10'>
+        <div className='relative mx-auto max-w-6xl space-y-7 px-4 pb-20 pt-6 sm:px-6 sm:pb-16 sm:pt-10 lg:px-8'>
+          <section className='rounded-[1.75rem] border border-emerald-300/15 bg-white/[0.035] px-4 py-6 shadow-[0_20px_70px_rgba(0,0,0,0.24)] backdrop-blur sm:px-8 sm:py-9 lg:px-10'>
             <div className='mx-auto flex max-w-4xl flex-col items-center text-center'>
               <div className='mb-4 inline-flex rounded-full border border-emerald-300/20 bg-emerald-300/8 px-3 py-1.5 text-xs font-bold uppercase tracking-[0.18em] text-emerald-200'>
                 Botanical research field guide
               </div>
 
-              <h1 className='font-display text-[2.85rem] font-semibold leading-[0.95] tracking-[-0.06em] text-white sm:text-7xl md:text-8xl'>
+              <h1 className='font-display text-[2.65rem] font-semibold leading-[0.96] tracking-[-0.055em] text-white sm:text-6xl md:text-7xl'>
                 <span className='block'>The Hippie</span>
                 <span className='block text-emerald-200'>Scientist</span>
               </h1>
 
               <p className='mt-5 max-w-2xl text-base leading-7 text-emerald-50/82 sm:text-lg'>
-                A field guide to herbs, compounds, mechanisms, and evidence — written for careful explorers.
+                Evidence-aware profiles for herbs, compounds, mechanisms, and safety — written for careful explorers.
               </p>
 
               <p className='mt-2 max-w-2xl text-sm leading-6 text-emerald-50/62'>
-                No hype. No pseudo-medicine. Just evidence-aware research and honest interpretation.
+                Scan what it is, what it is used for, how strong the evidence is, and where caution starts.
               </p>
 
               <div className='mt-6 grid w-full max-w-2xl gap-2 sm:grid-cols-3'>
@@ -218,6 +217,15 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
                   >
                     {action.label}
                   </Link>
+                ))}
+              </div>
+
+              <div className='mt-6 grid w-full max-w-3xl gap-2 text-left sm:grid-cols-3'>
+                {reasoningPillars.map((pillar) => (
+                  <div key={pillar.title} className='rounded-2xl border border-emerald-300/12 bg-[#071a14]/72 p-3'>
+                    <p className='text-sm font-semibold tracking-tight text-white'>{pillar.title}</p>
+                    <p className='mt-1 text-xs leading-5 text-emerald-50/62'>{pillar.description}</p>
+                  </div>
                 ))}
               </div>
             </div>
@@ -243,8 +251,8 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
 
           <section className='space-y-4'>
             <SectionHeader
-              title='Explore research ecosystems'
-              subtitle='Start from a goal, then move into herbs, compounds, mechanisms, comparisons, and safety context.'
+              title='Explore by practical context'
+              subtitle='Choose a goal first, then move into profiles, mechanisms, comparisons, and safety notes.'
               as='h2'
             />
 
@@ -269,7 +277,7 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
             <div className='flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between'>
               <SectionHeader
                 title='Featured profiles'
-                subtitle='Useful starting points for deeper herb and compound research.'
+                subtitle='Quick entry points with evidence, safety, and mechanism context.'
                 as='h2'
               />
               <div className='flex flex-wrap gap-3 text-sm font-bold'>
@@ -306,15 +314,6 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
                 </Link>
               ))}
             </div>
-          </section>
-
-          <section className='grid gap-3 md:grid-cols-3'>
-            {reasoningPillars.map((pillar) => (
-              <div key={pillar.title} className='rounded-[1.15rem] border border-emerald-300/12 bg-white/[0.035] p-4'>
-                <h3 className='text-base font-semibold tracking-tight text-white'>{pillar.title}</h3>
-                <p className='mt-2 text-sm leading-6 text-emerald-50/62'>{pillar.description}</p>
-              </div>
-            ))}
           </section>
 
           <section className='rounded-[1.15rem] border border-emerald-300/14 bg-emerald-950/40 p-4'>

--- a/components/ui/CompoundHero.tsx
+++ b/components/ui/CompoundHero.tsx
@@ -7,30 +7,26 @@ export default function CompoundHero({
   safetyLevel
 }: any) {
   return (
-    <div className="hero-shell overflow-hidden rounded-[2rem] border border-brand-900/10 p-7 shadow-[0_18px_55px_rgba(16,32,24,0.08)] sm:p-9">
-      <div className="section-spacing">
-
-        <div className="flex flex-wrap items-center gap-3">
-          <div className="eyebrow-label">
-            Compound Profile
-          </div>
-
-          <div className="flex flex-wrap gap-2">
-            <EvidenceBadge level={evidenceLevel} />
-            <SafetyBadge level={safetyLevel} />
-          </div>
+    <div className="space-y-5">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="eyebrow-label">
+          Compound Profile
         </div>
 
-        <div className="space-y-6">
-          <h1 className="heading-premium max-w-4xl text-balance">
-            {compound.name}
-          </h1>
-
-          <p className="text-reading max-w-3xl text-lg leading-relaxed text-[#46574d] sm:text-[1.08rem]">
-            {compound.summary || 'Evidence-informed compound profile.'}
-          </p>
+        <div className="flex flex-wrap gap-2">
+          <EvidenceBadge level={evidenceLevel} />
+          <SafetyBadge level={safetyLevel} />
         </div>
+      </div>
 
+      <div className="space-y-4">
+        <h1 className="heading-premium max-w-4xl text-balance">
+          {compound.name}
+        </h1>
+
+        <p className="text-reading max-w-3xl text-base leading-7 text-[#46574d] sm:text-lg">
+          {compound.summary || 'Evidence-informed compound profile.'}
+        </p>
       </div>
     </div>
   )

--- a/docs/ux/decision-layer-pass-1.md
+++ b/docs/ux/decision-layer-pass-1.md
@@ -1,0 +1,67 @@
+# Decision-layer simplification pass 1
+
+## Scope audited
+
+- Homepage (`app/page.tsx`, `components/homepage-v2.tsx`)
+- Herb detail template (`app/herbs/[slug]/page.tsx`)
+- Compound detail template (`app/compounds/[slug]/page.tsx`, `components/ui/CompoundHero.tsx`)
+
+Runtime data loading, route contracts, workbook scripts, generated data, package files, and SEO/data-pipeline infrastructure were intentionally left unchanged.
+
+## Key UX problems identified
+
+1. **Above-the-fold hierarchy was not decisive enough**
+   - Users could see rich content quickly, but evidence, safety, timing, and mechanism cues did not always feel like the primary scan target.
+   - Compound profiles especially placed practical decision support below a larger hero/artwork area.
+
+2. **Decorative weight competed with comprehension**
+   - The homepage background treatment and compound artwork created visual richness, but they competed with the first 5–10 seconds of orientation.
+
+3. **Too many sections had similar visual weight**
+   - Homepage sections and profile follow-up modules were useful, but the scan order did not always clearly say: start here, then compare, then deep dive.
+
+4. **Long summaries could slow mobile scanning**
+   - Profile hero copy and homepage value proposition needed tighter language so the user can understand the site and profile faster.
+
+5. **Decision-critical signals needed stronger grouping**
+   - Evidence, safety, effects, timeline, avoid-if context, and mechanism hints needed to sit together as a decision layer rather than scattered across separate modules.
+
+## Changes made
+
+### Homepage
+
+- Tightened the hero message to explain the site as evidence-aware profiles for herbs, compounds, mechanisms, and safety.
+- Reduced oversized hero scale and decorative background intensity.
+- Added a compact above-the-fold scan framework: **Scan the signal**, **Check the boundary**, **Decide what fits**.
+- Clarified CTA language around the actual user task: browse profiles, compare options, search evidence notes.
+- Removed the duplicate lower reasoning-pillar section so the page has fewer equal-weight blocks.
+- Retitled ecosystem exploration to “Explore by practical context” to emphasize user intent rather than internal taxonomy.
+
+**Why this improves scanability:** the homepage now communicates what the site is, how to use it, and where to go next without requiring users to read multiple supporting sections first.
+
+### Herb detail template
+
+- Replaced the above-fold “Read next” sidebar with **Decision cues**.
+- Surfaced evidence, safety, timeline, and mechanism hints beside the hero summary.
+- Retitled the following scan section to **Decision snapshot** and clarified that it is fast orientation before deep research.
+
+**Why this improves decision speed:** users can answer “how strong is the evidence?”, “what should I watch out for?”, “how fast or subtle is this?”, and “what pathways are involved?” before encountering long-form sections.
+
+### Compound detail template
+
+- Simplified the compound hero component by removing the nested card shell inside the page hero.
+- Shortened hero summary rendering to the first two sentences for faster initial comprehension.
+- Replaced above-fold artwork with a **Decision snapshot** panel containing evidence level, safety read, timeline, and mechanism hints.
+- Kept artwork available, but moved it into the collapsed authority/exploration section so it no longer competes with first-scan decision signals.
+- Expanded top chips to include both primary effects and mechanism hints.
+
+**Why this improves decision speed:** compound profiles now prioritize practical scan signals over decorative/contextual modules while preserving the deeper educational and semantic exploration content for users who continue reading.
+
+## Intentionally deferred
+
+- No workbook/data semantics were changed.
+- No generated JSON artifacts were edited.
+- No route structure, runtime generators, graph pipelines, or API/data architecture were changed.
+- No new component library, animation system, state system, or dependency was introduced.
+- Broader typography/theme redesign was deferred to avoid scope creep.
+- Deeper consolidation of duplicated herb/compound decision helpers was deferred because this pass prioritizes minimal, surgical UX changes over architecture churn.


### PR DESCRIPTION
### Motivation
- Reduce above-the-fold cognitive load so users can answer decision-critical questions (what it is, common uses, evidence strength, safety, stimulation profile, and time-to-effect) within 5–10 seconds.  
- Improve scan hierarchy on the homepage, herb, and compound detail templates while preserving conservative evidence framing and the existing runtime/data architecture.  

### Description
- Tightened homepage hero and copy, reduced decorative intensity, clarified CTAs, and added a compact “Scan / Check the boundary / Decide what fits” reasoning tier; changes live in `components/homepage-v2.tsx`.  
- Surfaced a small, visible decision panel on herb detail pages that groups evidence, safety, timeline, and mechanism hints above the fold; changes live in `app/herbs/[slug]/page.tsx`.  
- Simplified compound hero and prioritized decision signals by shortening the hero summary, showing a `Decision snapshot` panel (evidence level, safety read, timeline, mechanism hints), and moving semantic artwork into the collapsed authority section; changes live in `app/compounds/[slug]/page.tsx` and `components/ui/CompoundHero.tsx`.  
- Added small helpers and a `DecisionSignalCard` pattern for compact decision cards (local helpers added in the compound page file) and included an audit doc at `docs/ux/decision-layer-pass-1.md`.  
- Preserved route contracts, data-loading calls, generator scripts, and runtime payloads; no workbook semantics, generated JSON, package/dependency, or architecture-level changes were made.  

### Testing
- Ran `npm run build`, which completed successfully and returned a passing build (non-blocking warnings for environment/ESLint/sitemap noted).  
- Validated generated data and governance steps executed during the build (`data:build` and governance checks) and passed.  
- Started local dev and verified key pages responded (manual `curl -I` checks for `/`, `/herbs/ashwagandha/`, `/compounds/theanine/` returned OK during validation).  
- No visual screenshot tooling was available in the environment, noted as an environment limitation (no browser/playwright binary).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d556c79c8323918aef9fc0b47e0e)