### PR TITLE
ux: reduce visual fragmentation and nested surface fatigue

### DIFF
--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -7,7 +7,6 @@ import { getUnifiedRuntimeRecords } from '@/lib/runtime-record-index'
 import Breadcrumbs from '@/components/ui/Breadcrumbs'
 import TrustBar from '@/components/ui/TrustBar'
 import ReadingProgress from '@/components/ui/ReadingProgress'
-import SectionBlock from '@/components/ui/SectionBlock'
 import CompoundHero from '@/components/ui/CompoundHero'
 import EvidenceSnapshotCard from '@/components/ui/EvidenceSnapshotCard'
 import { EvidenceBadgeGroup } from '@/components/evidence/evidence-badge'
@@ -149,15 +148,15 @@ function DecisionSignalCard({ label, value, tone = 'neutral' }: { label: string;
   if (!value) return null
 
   const toneClass = tone === 'caution'
-    ? 'border-amber-800/20 bg-amber-50/85 text-amber-950'
+    ? 'text-amber-950'
     : tone === 'strong'
-      ? 'border-emerald-700/15 bg-emerald-50/80 text-emerald-950'
+      ? 'text-emerald-950'
       : tone === 'muted'
-        ? 'border-brand-900/10 bg-white/60 text-[#5b6b61]'
-        : 'border-brand-900/10 bg-white/75 text-[#33443a]'
+        ? 'text-[#5b6b61]'
+        : 'text-[#33443a]'
 
   return (
-    <div className={`rounded-2xl border p-4 ${toneClass}`}>
+    <div className={`border-t border-brand-900/10 pt-3 ${toneClass}`}>
       <p className="text-[0.68rem] font-bold uppercase tracking-[0.16em] opacity-65">{label}</p>
       <p className="mt-2 text-sm font-semibold leading-6">{value}</p>
     </div>
@@ -166,14 +165,14 @@ function DecisionSignalCard({ label, value, tone = 'neutral' }: { label: string;
 
 function CompactDisclosure({ title, children }: { title: string; children: ReactNode }) {
   return (
-    <details className="group rounded-[1.5rem] border border-brand-900/10 bg-white/75 p-5 shadow-sm">
+    <details className="group border-t border-brand-900/10 py-6 first:border-t-0 first:pt-0">
       <summary className="cursor-pointer list-none">
         <span className="flex items-center justify-between gap-4 text-base font-semibold tracking-tight text-ink">
           <span>{title}</span>
-          <span className="text-brand-800 transition group-open:rotate-90" aria-hidden="true">›</span>
+          <span className="text-sm font-bold uppercase tracking-[0.14em] text-brand-700">Open</span>
         </span>
       </summary>
-      <div className="mt-5 space-y-5 border-t border-brand-900/10 pt-5">
+      <div className="mt-6 space-y-7">
         {children}
       </div>
     </details>
@@ -319,7 +318,7 @@ export default async function CompoundPage({ params }: PageProps) {
 
       <ReadingProgress />
 
-      <main className="mx-auto max-w-7xl space-y-8 px-4 py-8 pb-24 sm:space-y-10 sm:py-10 sm:pb-32">
+      <main className="mx-auto max-w-7xl space-y-12 px-4 py-8 pb-24 sm:space-y-16 sm:py-10 sm:pb-32">
         <Breadcrumbs
           items={[
             { label: 'Home', href: '/' },
@@ -330,7 +329,7 @@ export default async function CompoundPage({ params }: PageProps) {
 
         <TrustBar />
 
-        <section className="hero-shell rounded-[2rem] border border-brand-900/10 p-5 shadow-card sm:p-7">
+        <section className="hero-shell rounded-[2rem] p-5 sm:p-8">
           <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-start">
             <div className="space-y-5">
               <CompoundHero
@@ -343,7 +342,7 @@ export default async function CompoundPage({ params }: PageProps) {
                 <EvidenceBadgeGroup record={compound} compact />
                 {topSignals.length > 0 ? (
                   <div className="flex flex-wrap gap-2">
-                    {topSignals.slice(0, 8).map((signal:string) => (
+                    {topSignals.slice(0, 5).map((signal:string) => (
                       <span key={signal} className="chip-readable text-xs">
                         {signal}
                       </span>
@@ -353,7 +352,7 @@ export default async function CompoundPage({ params }: PageProps) {
               </div>
             </div>
 
-            <aside className="rounded-3xl border border-brand-900/10 bg-sand-50/85 p-4 shadow-sm">
+            <aside className="rounded-3xl bg-sand-50/70 p-5">
               <p className="eyebrow-label">Decision snapshot</p>
               <div className="mt-3 grid gap-3">
                 <DecisionSignalCard label="Evidence level" value={evidenceLevel} tone={evidenceLevel.toLowerCase().includes('strong') || evidenceLevel.toLowerCase().includes('high') ? 'strong' : 'neutral'} />
@@ -460,19 +459,20 @@ export default async function CompoundPage({ params }: PageProps) {
           <CompactRelatedPathways record={compound} />
 
           {featuredCollections.length > 0 ? (
-            <SectionBlock title="Featured In Collections">
-              <div className="flex flex-wrap gap-3">
+            <div className="border-t border-brand-900/10 pt-5">
+              <p className="eyebrow-label">Featured in collections</p>
+              <div className="mt-3 flex flex-wrap gap-4">
                 {featuredCollections.slice(0, 4).map((collection:any) => (
                   <Link
                     key={collection.slug}
                     href={collection.href}
-                    className="surface-subtle rounded-2xl border border-brand-900/10 px-4 py-3 text-sm font-semibold text-ink transition hover:border-brand-700/30 hover:bg-white/60"
+                    className="border-b border-brand-900/10 py-1 text-sm font-semibold text-ink transition hover:border-brand-700/40"
                   >
                     {collection.title}
                   </Link>
                 ))}
               </div>
-            </SectionBlock>
+            </div>
           ) : null}
         </CompactDisclosure>
 

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -203,7 +203,7 @@ function BriefCard({ label, value, children }: { label: string; value?: string; 
   if (!value && !children) return null
 
   return (
-    <div className="rounded-2xl border border-brand-900/10 bg-white/70 p-4 shadow-sm">
+    <div className="border-t border-brand-900/10 pt-3">
       <p className="text-[11px] font-bold uppercase tracking-[0.16em] text-muted">{label}</p>
       {value ? <p className="mt-2 text-sm font-semibold leading-6 text-ink">{value}</p> : null}
       {children ? <div className="mt-2">{children}</div> : null}
@@ -228,22 +228,22 @@ function ChipList({ items, limit = items.length }: { items: string[]; limit?: nu
 
 function CompactDetails({ title, description, children }: { title: string; description?: string; children: ReactNode }) {
   return (
-    <details className="group rounded-3xl border border-brand-900/10 bg-white/65 p-4 shadow-sm open:bg-white/80 sm:p-5">
+    <details className="group border-t border-brand-900/10 py-6 first:border-t-0 first:pt-0">
       <summary className="cursor-pointer list-none">
         <div className="flex items-start justify-between gap-4">
           <div className="space-y-1">
             <h2 className="text-lg font-semibold tracking-tight text-ink">{title}</h2>
             {description ? <p className="text-sm leading-6 text-muted">{description}</p> : null}
           </div>
-          <span className="rounded-full border border-brand-900/10 bg-white px-3 py-1 text-xs font-bold uppercase tracking-[0.12em] text-muted group-open:hidden">
+          <span className="text-xs font-bold uppercase tracking-[0.14em] text-brand-700 group-open:hidden">
             Open
           </span>
-          <span className="hidden rounded-full border border-brand-900/10 bg-white px-3 py-1 text-xs font-bold uppercase tracking-[0.12em] text-muted group-open:inline-flex">
+          <span className="hidden text-xs font-bold uppercase tracking-[0.14em] text-brand-700 group-open:inline-flex">
             Hide
           </span>
         </div>
       </summary>
-      <div className="mt-5 space-y-5 border-t border-brand-900/10 pt-5">
+      <div className="mt-5 space-y-7 pt-2">
         {children}
       </div>
     </details>
@@ -255,7 +255,7 @@ function LinkDensitySection({ links }: { links: ReturnType<typeof buildInternalL
   if (items.length === 0) return null
 
   return (
-    <section className="compact-card section-rhythm-compact">
+    <section className="section-rhythm-compact border-t border-brand-900/10 pt-5">
       <div className="space-y-1">
         <p className="eyebrow-label">Continue Research</p>
         <h2 className="max-w-none text-2xl font-semibold tracking-tight text-ink">
@@ -267,7 +267,7 @@ function LinkDensitySection({ links }: { links: ReturnType<typeof buildInternalL
           <Link
             key={item.href}
             href={item.href}
-            className="rounded-2xl border border-brand-900/10 bg-white/75 p-4 text-sm font-semibold text-ink shadow-sm transition hover:border-brand-700/30 hover:bg-white"
+            className="border-l border-brand-900/10 py-2 pl-3 text-sm font-semibold text-ink transition hover:border-brand-700/40"
           >
             {item.label}
           </Link>
@@ -414,7 +414,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
   }
 
   return (
-    <main className="mx-auto max-w-6xl space-y-8 px-4 py-8 sm:space-y-10 sm:py-10">
+    <main className="mx-auto max-w-6xl space-y-12 px-4 py-8 sm:space-y-16 sm:py-10">
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(herbJsonLd) }}
@@ -433,18 +433,12 @@ export default async function HerbDetailPage({ params }: PageProps) {
         <span className="text-ink">{displayName}</span>
       </nav>
 
-      <section className="rounded-[1.75rem] border border-brand-900/10 bg-white/70 p-5 shadow-card sm:p-7">
+      <section className="hero-shell rounded-[1.75rem] p-5 sm:p-8">
         <div className="space-y-5">
-          <div className="flex flex-wrap items-center gap-2">
-            <Link href="/herbs" className="rounded-full border border-brand-900/10 bg-white px-3 py-1 text-xs font-bold uppercase tracking-[0.14em] text-muted transition hover:text-ink">
-              Back to herbs
-            </Link>
-            <Link href="/compare" className="rounded-full border border-brand-900/10 bg-white px-3 py-1 text-xs font-bold uppercase tracking-[0.14em] text-muted transition hover:text-ink">
-              Compare
-            </Link>
-            <Link href={`/search?q=${encodeURIComponent(displayName)}`} className="rounded-full border border-brand-900/10 bg-white px-3 py-1 text-xs font-bold uppercase tracking-[0.14em] text-muted transition hover:text-ink">
-              Search related
-            </Link>
+          <div className="flex flex-wrap items-center gap-4 text-xs font-bold uppercase tracking-[0.14em] text-muted">
+            <Link href="/herbs" className="transition hover:text-ink">Back to herbs</Link>
+            <Link href="/compare" className="transition hover:text-ink">Compare</Link>
+            <Link href={`/search?q=${encodeURIComponent(displayName)}`} className="transition hover:text-ink">Search related</Link>
           </div>
 
           <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_260px] lg:items-start">
@@ -463,15 +457,15 @@ export default async function HerbDetailPage({ params }: PageProps) {
 
               <div className="flex flex-wrap items-center gap-2">
                 <EvidenceBadgeGroup record={herb} compact />
-                <span className="rounded-full border border-amber-800/20 bg-amber-50/80 px-2.5 py-1 text-[11px] font-bold uppercase tracking-[0.12em] text-amber-900">
+                <span className="text-[11px] font-bold uppercase tracking-[0.14em] text-amber-900">
                   Safety: {formatDisplayLabel(safetySensitivity)} caution
                 </span>
               </div>
 
-              <ChipList items={topUses} limit={6} />
+              <ChipList items={topUses} limit={4} />
             </div>
 
-            <aside className="rounded-3xl border border-brand-900/10 bg-sand-50/85 p-4 shadow-sm">
+            <aside className="rounded-3xl bg-sand-50/70 p-5">
               <p className="eyebrow-label">Decision cues</p>
               <div className="mt-3 grid gap-3">
                 <BriefCard label="Evidence" value={evidenceStrength || researchMaturity} />
@@ -489,7 +483,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
           <p className="eyebrow-label">Decision snapshot</p>
           <h2 className="text-2xl font-semibold tracking-tight text-ink">Fast orientation before the deep dive</h2>
         </div>
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-5">
+        <div className="grid gap-x-6 gap-y-5 sm:grid-cols-2 lg:grid-cols-5">
           <BriefCard label="Best known for" value={topUses.slice(0, 3).join(', ')} />
           <BriefCard label="Evidence strength" value={evidenceStrength || researchMaturity} />
           <BriefCard label="Safety watchouts" value={safetyGroups.length ? safetyGroups[0].items.slice(0, 2).join(', ') : safetySummary} />
@@ -509,7 +503,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
       </section>
 
       {keyTakeaways.length > 0 ? (
-        <section className="rounded-3xl border border-brand-900/10 bg-white/70 p-5 shadow-sm">
+        <section className="border-t border-brand-900/10 pt-6">
           <p className="eyebrow-label">Key takeaways</p>
           <ul className="mt-3 space-y-2 text-sm leading-6 text-[#46574d]">
             {keyTakeaways.map(item => (
@@ -522,7 +516,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
         </section>
       ) : null}
 
-      <section className="rounded-3xl border border-amber-800/20 bg-amber-50/80 p-5 shadow-sm">
+      <section className="rounded-3xl bg-amber-50/70 p-5 sm:p-6">
         <div className="space-y-2">
           <p className="eyebrow-label text-amber-900">Safety first</p>
           <h2 className="text-2xl font-semibold tracking-tight text-ink">Review cautions before use</h2>
@@ -530,7 +524,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
         </div>
 
         {safetyGroups.length > 0 ? (
-          <details className="mt-4 rounded-2xl border border-amber-900/10 bg-white/60 p-4">
+          <details className="mt-5 border-t border-amber-900/15 pt-4">
             <summary className="cursor-pointer text-sm font-bold text-ink">View full safety notes</summary>
             <div className="mt-4 grid gap-4 md:grid-cols-2">
               {safetyGroups.map(group => (
@@ -546,7 +540,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
         ) : null}
       </section>
 
-      <section className="rounded-3xl border border-brand-900/10 bg-white/70 p-5 shadow-sm">
+      <section className="space-y-5">
         <div className="space-y-2">
           <p className="eyebrow-label">Evidence summary</p>
           <h2 className="text-2xl font-semibold tracking-tight text-ink">What the current profile supports</h2>
@@ -580,7 +574,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
             <CompactDetails title="Mechanism clusters" description="Grouped pathway signals for deeper research.">
               <div className="grid gap-3 md:grid-cols-2">
                 {pathwayClusters.map(cluster => (
-                  <div key={cluster.title} className="rounded-2xl border border-brand-900/10 bg-white/70 p-4">
+                  <div key={cluster.title} className="border-l border-brand-900/10 py-1 pl-4">
                     <h3 className="text-sm font-semibold text-ink">{cluster.title}</h3>
                     <p className="mt-1 text-xs leading-5 text-muted">{cluster.description}</p>
                     <div className="mt-3"><ChipList items={cluster.mechanisms} /></div>
@@ -600,12 +594,12 @@ export default async function HerbDetailPage({ params }: PageProps) {
       </section>
 
       {topUses.length > 0 ? (
-        <section className="rounded-3xl border border-brand-900/10 bg-white/70 p-5 shadow-sm">
+        <section className="border-t border-brand-900/10 pt-6">
           <p className="eyebrow-label">Uses and effects</p>
           <h2 className="mt-1 text-2xl font-semibold tracking-tight text-ink">Most visible signals</h2>
           <div className="mt-4"><ChipList items={topUses} /></div>
           {hiddenUses.length > 0 ? (
-            <details className="mt-4 rounded-2xl border border-brand-900/10 bg-white/60 p-4">
+            <details className="mt-5 border-t border-brand-900/10 pt-4">
               <summary className="cursor-pointer text-sm font-bold text-ink">Show all reported effects</summary>
               <div className="mt-4"><ChipList items={hiddenUses} /></div>
             </details>
@@ -642,11 +636,11 @@ export default async function HerbDetailPage({ params }: PageProps) {
           <RuntimeOrchestratedDiscovery record={herb} />
           <CompactRelatedPathways record={herb} />
           {featuredCollections.length > 0 ? (
-            <div className="rounded-3xl border border-brand-900/10 bg-white/70 p-5">
+            <div className="border-t border-brand-900/10 pt-5">
               <p className="eyebrow-label">Featured in collections</p>
-              <div className="mt-3 flex flex-wrap gap-3">
+              <div className="mt-3 flex flex-wrap gap-4">
                 {featuredCollections.slice(0, 4).map((collection) => (
-                  <Link key={collection.slug} href={collection.href} className="surface-subtle rounded-2xl border border-brand-900/10 px-4 py-3 text-sm font-semibold text-ink transition hover:border-brand-700/30 hover:bg-white/60">
+                  <Link key={collection.slug} href={collection.href} className="border-b border-brand-900/10 py-1 text-sm font-semibold text-ink transition hover:border-brand-700/40">
                     {collection.title}
                   </Link>
                 ))}
@@ -661,7 +655,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
         </CompactDetails>
       </section>
 
-      <section className="rounded-3xl border border-brand-900/10 bg-white/70 p-5 shadow-sm">
+      <section className="border-t border-brand-900/10 pt-6">
         <div className="space-y-1">
           <p className="eyebrow-label">Related navigation</p>
           <h2 className="text-2xl font-semibold tracking-tight text-ink">Keep researching</h2>

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -185,10 +185,10 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
           <div className='absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(16,185,129,0.12),transparent_30rem)]' />
         </div>
 
-        <div className='relative mx-auto max-w-6xl space-y-7 px-4 pb-20 pt-6 sm:px-6 sm:pb-16 sm:pt-10 lg:px-8'>
-          <section className='rounded-[1.75rem] border border-emerald-300/15 bg-white/[0.035] px-4 py-6 shadow-[0_20px_70px_rgba(0,0,0,0.24)] backdrop-blur sm:px-8 sm:py-9 lg:px-10'>
+        <div className='relative mx-auto max-w-6xl space-y-14 px-4 pb-20 pt-10 sm:px-6 sm:space-y-16 sm:pb-20 sm:pt-14 lg:px-8'>
+          <section className='px-2 py-8 sm:px-6 sm:py-12 lg:py-16'>
             <div className='mx-auto flex max-w-4xl flex-col items-center text-center'>
-              <div className='mb-4 inline-flex rounded-full border border-emerald-300/20 bg-emerald-300/8 px-3 py-1.5 text-xs font-bold uppercase tracking-[0.18em] text-emerald-200'>
+              <div className='mb-4 inline-flex text-xs font-bold uppercase tracking-[0.2em] text-emerald-200/85'>
                 Botanical research field guide
               </div>
 
@@ -220,9 +220,9 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
                 ))}
               </div>
 
-              <div className='mt-6 grid w-full max-w-3xl gap-2 text-left sm:grid-cols-3'>
+              <div className='mt-8 grid w-full max-w-3xl gap-6 border-t border-emerald-300/12 pt-6 text-left sm:grid-cols-3'>
                 {reasoningPillars.map((pillar) => (
-                  <div key={pillar.title} className='rounded-2xl border border-emerald-300/12 bg-[#071a14]/72 p-3'>
+                  <div key={pillar.title} className='space-y-1'>
                     <p className='text-sm font-semibold tracking-tight text-white'>{pillar.title}</p>
                     <p className='mt-1 text-xs leading-5 text-emerald-50/62'>{pillar.description}</p>
                   </div>
@@ -231,7 +231,7 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
             </div>
           </section>
 
-          <section className='rounded-[1.35rem] border border-emerald-300/12 bg-[#071a14]/88 p-4 shadow-[0_18px_70px_rgba(0,0,0,0.22)] sm:p-5'>
+          <section className='border-y border-emerald-300/10 py-6'>
             <div className='flex flex-col gap-4 md:flex-row md:items-center md:justify-between'>
               <SectionHeader title='Start your research' as='h2' />
               <div className='grid grid-cols-2 gap-2 sm:grid-cols-3 md:min-w-[28rem]'>
@@ -239,7 +239,7 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
                   <Link
                     key={path.href}
                     href={path.href}
-                    className='group rounded-full border border-emerald-300/14 bg-white/[0.04] px-3 py-2.5 text-center text-sm font-bold text-emerald-50 transition hover:border-emerald-300/40 hover:bg-emerald-300/10'
+                    className='group rounded-full bg-white/[0.045] px-3 py-2.5 text-center text-sm font-bold text-emerald-50 transition hover:bg-emerald-300/10'
                   >
                     {path.title}
                     <span className='ml-1 text-emerald-300 transition group-hover:translate-x-0.5' aria-hidden='true'>→</span>
@@ -261,7 +261,7 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
                 <Link
                   key={card.href}
                   href={card.href}
-                  className='group rounded-[1.25rem] border border-emerald-300/12 bg-white/[0.045] p-4 transition hover:-translate-y-0.5 hover:border-emerald-300/35 hover:bg-white/[0.07]'
+                  className='group border-l border-emerald-300/18 py-1 pl-4 transition hover:border-emerald-300/45'
                 >
                   <h3 className='text-base font-semibold tracking-tight text-white group-hover:text-emerald-200'>{card.title}</h3>
                   <p className='mt-2 text-sm leading-6 text-emerald-50/62'>{card.description}</p>
@@ -291,11 +291,11 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
                 <Link
                   key={item.href}
                   href={item.href}
-                  className='group relative overflow-hidden rounded-[1.25rem] border border-emerald-300/12 bg-[#071a14]/82 p-4 transition hover:-translate-y-0.5 hover:border-emerald-300/35 hover:bg-[#0a2119]'
+                  className='group relative overflow-hidden rounded-[1.25rem] bg-[#071a14]/72 p-5 transition hover:bg-[#0a2119]'
                 >
                   <div className='absolute right-[-3rem] top-[-3rem] h-28 w-28 rounded-full bg-emerald-300/10 blur-2xl transition group-hover:bg-emerald-300/16' />
                   <div className='relative'>
-                    <span className='inline-flex rounded-full border border-emerald-300/16 bg-emerald-300/8 px-2.5 py-1 text-xs font-bold uppercase tracking-[0.14em] text-emerald-200'>
+                    <span className='inline-flex text-xs font-bold uppercase tracking-[0.16em] text-emerald-200/80'>
                       {item.meta}
                     </span>
 
@@ -316,7 +316,7 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
             </div>
           </section>
 
-          <section className='rounded-[1.15rem] border border-emerald-300/14 bg-emerald-950/40 p-4'>
+          <section className='border-t border-emerald-300/10 pt-6'>
             <div className='flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
               <p className='text-sm leading-6 text-emerald-50/72'>
                 Natural does not automatically mean safe or effective. These pages support comparison and pathway understanding — not medical care.

--- a/components/ui/CompoundHero.tsx
+++ b/components/ui/CompoundHero.tsx
@@ -8,12 +8,12 @@ export default function CompoundHero({
 }: any) {
   return (
     <div className="space-y-5">
-      <div className="flex flex-wrap items-center gap-3">
+      <div className="space-y-3">
         <div className="eyebrow-label">
           Compound Profile
         </div>
 
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap gap-3 text-xs font-bold uppercase tracking-[0.12em] text-muted">
           <EvidenceBadge level={evidenceLevel} />
           <SafetyBadge level={safetyLevel} />
         </div>

--- a/components/ui/EvidenceSnapshotCard.tsx
+++ b/components/ui/EvidenceSnapshotCard.tsx
@@ -63,18 +63,18 @@ export default function EvidenceSnapshotCard({ snapshot }: Props) {
   }
 
   return (
-    <div className="surface-depth card-spacing section-spacing">
-      <div className="flex flex-wrap items-center gap-2">
+    <section className="border-y border-brand-900/10 py-7">
+      <div className="flex flex-wrap items-center gap-3">
         {archetype ? (
-          <span className="evidence-pill-strong">
+          <span className="text-xs font-bold uppercase tracking-[0.16em] text-emerald-800">
             {archetype}
           </span>
         ) : null}
 
-        {clusters.map((cluster) => (
+        {clusters.slice(0, 4).map((cluster) => (
           <span
             key={cluster}
-            className="chip-readable"
+            className="text-xs font-semibold text-[#33443a]"
           >
             {cluster}
           </span>
@@ -82,11 +82,11 @@ export default function EvidenceSnapshotCard({ snapshot }: Props) {
       </div>
 
       {items.length > 0 ? (
-        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <div className="mt-6 grid gap-x-8 gap-y-5 sm:grid-cols-2 xl:grid-cols-4">
           {items.map((item) => (
             <div
               key={item.label}
-              className="surface-subtle rounded-2xl p-5"
+              className="border-t border-brand-900/10 pt-3"
             >
               <div className="text-[0.7rem] font-bold uppercase tracking-[0.16em] text-[#66756d]">
                 {item.label}
@@ -99,6 +99,6 @@ export default function EvidenceSnapshotCard({ snapshot }: Props) {
           ))}
         </div>
       ) : null}
-    </div>
+    </section>
   )
 }

--- a/components/ui/TrustBar.tsx
+++ b/components/ui/TrustBar.tsx
@@ -1,6 +1,6 @@
 export default function TrustBar(){
   return(
-    <div className="flex gap-4 text-xs text-neutral-500 border rounded-xl px-4 py-2">
+    <div className="flex flex-wrap gap-x-5 gap-y-2 border-y border-brand-900/10 py-3 text-xs font-semibold uppercase tracking-[0.12em] text-neutral-500">
       <span>✔ Evidence-based</span>
       <span>✔ Safety-reviewed</span>
       <span>✔ Continuously updated</span>

--- a/docs/ux/reduce-visual-fragmentation-pass.md
+++ b/docs/ux/reduce-visual-fragmentation-pass.md
@@ -1,0 +1,43 @@
+# Reduce visual fragmentation pass
+
+## Scope
+
+This pass focused only on the homepage, herb detail pages, compound detail pages, and shared profile/hero surfaces. It preserved runtime data loading, route contracts, workbook semantics, and existing component architecture.
+
+## Fragmentation problems identified
+
+- Homepage sections used multiple equal-weight bordered panels in quick succession: hero shell, research launcher, ecosystem cards, featured cards, and disclaimer all competed as separate surfaces.
+- Profile heroes stacked a bordered hero card, pill navigation, evidence badges, chip groups, and a bordered decision sidebar, creating nested-card fatigue before users reached the actual evidence context.
+- Decision snapshots used many small cardlets with matching border, radius, background, and shadow treatments, making supporting facts feel as important as primary headings.
+- Collapsed long-form profile sections appeared as repeated rounded cards, which made deferred content feel like a dashboard module list instead of a calmer reading flow.
+- Evidence snapshot and trust surfaces used boxed treatments inside already structured profile pages, adding extra visual compartments for supporting trust information.
+
+## Containers removed or simplified
+
+- Removed the homepage hero's bordered glass-card treatment in favor of direct page flow, stronger type, and whitespace.
+- Converted homepage reasoning pillars from boxed mini-cards into a light text row separated by a single top rule.
+- Replaced the homepage research launcher card with a simple horizontal band and softened the secondary navigation buttons.
+- Changed practical-context homepage cards to left-rule text links instead of four competing boxed cards.
+- Simplified featured profile metadata from bordered pills to quieter text labels while retaining the card as the one primary browsing surface.
+- Removed herb and compound profile hero borders and shadows while keeping the warm hero background.
+- Converted herb and compound decision sidebars from nested bordered cards into a single quiet tinted sidebar with divider-led rows.
+- Converted herb and compound disclosure sections from repeated rounded cards into open page-flow sections divided by horizontal rules.
+- Simplified collection links inside profile disclosures from boxed chips to quiet underline-style links.
+- Changed the shared evidence snapshot from a card containing smaller cards into one horizontal evidence band with divider-led metrics.
+- Changed the trust bar from a rounded bordered widget into a simple horizontal trust strip.
+
+## Hierarchy improvements
+
+- Increased macro spacing between major homepage and profile sections so users perceive fewer simultaneous regions.
+- Reduced micro-surface density inside decision sidebars by replacing each small fact card with a row separated by a subtle top rule.
+- Limited highly visible homepage and profile badge/chip density where signals were competing with page titles and summaries.
+- Preserved emphasis for primary decision moments: the hero, safety callout, decision snapshot, and featured profiles remain visually distinct.
+- Made secondary educational and discovery material recede by using borders as separators rather than full containers.
+
+## Intentionally deferred issues
+
+- Deeper nested-card patterns inside authority, discovery, semantic graph, and decision-layer child components were not refactored to avoid broad architecture changes.
+- Collection, goal, stack, comparison, education, and SEO entry page visual systems were left untouched because they were outside scope.
+- Global card/chip utility classes were not rewritten, since many pages outside this pass depend on them.
+- No new design system primitives or animation patterns were introduced.
+- Generated data and workbook semantics were intentionally left unchanged.


### PR DESCRIPTION
### Motivation
- Reduce nested-card density and competing bordered surfaces on the homepage, herb pages, compound pages, and shared hero/profile surfaces to improve visual hierarchy and scanning speed. 
- Make supporting information recede and primary decision surfaces dominate without changing routes, runtime data, or workbook semantics. 
- Keep changes surgical and limited to layout/markup/CSS-class adjustments for the targeted pages and shared UI elements. 

### Description
- Homepage (`components/homepage-v2.tsx`): removed the boxed hero treatment, increased macro spacing, converted the reasoning pillars to a simple top-ruled row, softened the research-launch band, converted ecosystem cards to left-rule links, quieted featured metadata, and changed the disclaimer to a top-rule band. 
- Herb and compound detail pages (`app/herbs/[slug]/page.tsx`, `app/compounds/[slug]/page.tsx`): removed hero card borders/shadows, converted small bordered decision cards into divider-led rows, reduced chip density, simplified disclosure wrappers into flow sections separated by horizontal rules, and converted collection chips into quieter text links. 
- Shared surfaces (`components/ui/CompoundHero.tsx`, `components/ui/EvidenceSnapshotCard.tsx`, `components/ui/TrustBar.tsx`): simplified badge grouping, changed the evidence snapshot from nested cards into a horizontal evidence band with divider-led metrics, and converted the trust bar into a slim trust strip. 
- Documentation: added `docs/ux/reduce-visual-fragmentation-pass.md` with the audit, list of containers removed/simplified, hierarchy improvements, and intentionally deferred items. 

### Testing
- Ran `npm run build`, which completed successfully and included the repository's data-build and verification steps. 
- Semantic governance and runtime payload validations ran as part of the build and passed (route manifest, deterministic JSON, and semantic graph health checks). 
- Noted non-blocking warnings in the build output for the Next.js ESLint plugin and an allowed sitemap deploy-readiness warning; no build errors occurred.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07e3039eec83239fa250c41127deea)