### PR TITLE
ux: strengthen decision snapshot hierarchy

### DIFF
--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -94,6 +94,26 @@ export async function generateMetadata({ params }: PageProps) {
 const WEAK_PATTERN = /research[-\s]?pending|placeholder|unknown|not specified|not available|insufficient|needs review|minimal/i
 const CAUTION_PATTERN = /avoid|caution|interaction|contraindication|warning|risk|pregnancy|liver|kidney|sedat|bleed/i
 
+
+const CALMING_PATTERN = /calm|relax|sleep|sedat|anxiolytic|anxiety|stress|gaba|parasympathetic/i
+const STIMULATING_PATTERN = /stimulat|energ|fatigue|alert|caffeine|adrenergic|dopaminergic|nootropic|performance/i
+
+function getRegulationProfile(signals: string[]) {
+  const joined = signals.join(' ').toLowerCase()
+  const calming = CALMING_PATTERN.test(joined)
+  const stimulating = STIMULATING_PATTERN.test(joined)
+
+  if (calming && stimulating) return 'Mixed: calming and stimulating signals both appear in the profile.'
+  if (calming) return 'Leans calming / down-shifting based on listed effects and pathways.'
+  if (stimulating) return 'Leans stimulating / activating based on listed effects and pathways.'
+  return 'No clear calming or stimulating tilt in the available profile data.'
+}
+
+function getSafetyTone(summary: string, avoidIf: string[]) {
+  if (avoidIf.length || CAUTION_PATTERN.test(summary)) return 'Use extra caution'
+  return 'Standard caution'
+}
+
 function firstSentences(value: string, limit = 2) {
   const sentences = value.match(/[^.!?]+[.!?]+|[^.!?]+$/g)?.map(sentence => sentence.trim()).filter(Boolean) || []
   return sentences.slice(0, limit).join(' ')
@@ -144,22 +164,58 @@ function getMechanismHints(compound: any, provided: string[]) {
   ]).slice(0, 6)
 }
 
-function DecisionSignalCard({ label, value, tone = 'neutral' }: { label: string; value?: string; tone?: 'neutral' | 'caution' | 'strong' | 'muted' }) {
+function DecisionSignalCard({ label, value }: { label: string; value?: string }) {
   if (!value) return null
 
-  const toneClass = tone === 'caution'
-    ? 'text-amber-950'
-    : tone === 'strong'
-      ? 'text-emerald-950'
-      : tone === 'muted'
-        ? 'text-[#5b6b61]'
-        : 'text-[#33443a]'
-
   return (
-    <div className={`border-t border-brand-900/10 pt-3 ${toneClass}`}>
-      <p className="text-[0.68rem] font-bold uppercase tracking-[0.16em] opacity-65">{label}</p>
-      <p className="mt-2 text-sm font-semibold leading-6">{value}</p>
+    <div className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm">
+      <p className="text-[0.68rem] font-bold uppercase tracking-[0.16em] text-muted">{label}</p>
+      <p className="mt-2 text-base font-bold leading-6 text-ink">{value}</p>
     </div>
+  )
+}
+
+function DecisionSnapshotPanel({
+  commonUse,
+  evidenceLevel,
+  regulation,
+  safetyTone,
+  safetySummary,
+  avoidIf,
+  timeline,
+  mechanismHints,
+}: {
+  commonUse: string
+  evidenceLevel: string
+  regulation: string
+  safetyTone: string
+  safetySummary: string
+  avoidIf: string[]
+  timeline: string
+  mechanismHints: string[]
+}) {
+  return (
+    <aside className="rounded-[1.65rem] border border-brand-900/10 bg-white/95 p-4 shadow-[0_18px_45px_rgba(47,64,52,0.12)] sm:p-5 lg:sticky lg:top-6">
+      <div className="flex items-start justify-between gap-3 border-b border-brand-900/10 pb-3">
+        <div>
+          <p className="eyebrow-label">Decision snapshot</p>
+          <h2 className="mt-1 text-xl font-semibold tracking-tight text-ink">5-second profile read</h2>
+        </div>
+        <span className="rounded-full bg-emerald-700/10 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.14em] text-emerald-900">
+          Start here
+        </span>
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-1">
+        <DecisionSignalCard label="Commonly used for" value={commonUse || 'Use context is not clearly specified.'} />
+        <DecisionSignalCard label="Evidence strength" value={evidenceLevel} />
+        <DecisionSignalCard label="Calming vs stimulating" value={regulation} />
+        <DecisionSignalCard label={`Safety level: ${safetyTone}`} value={safetySummary} />
+        <DecisionSignalCard label="Avoid / review first if" value={avoidIf.length ? avoidIf.slice(0, 3).join(', ') : 'No specific avoid-if flags surfaced in the available profile data.'} />
+        <DecisionSignalCard label="Onset / timeline" value={timeline || 'Timing varies by dose, form, and context.'} />
+        <DecisionSignalCard label="Mechanism hints" value={mechanismHints.length ? mechanismHints.slice(0, 3).join(', ') : 'Mechanism signals are not clearly specified.'} />
+      </div>
+    </aside>
   )
 }
 
@@ -273,6 +329,8 @@ export default async function CompoundPage({ params }: PageProps) {
   const safetySummary = getSafetySummary(compound, avoidIf)
   const mechanismHints = getMechanismHints(compound, mechanisms)
   const topSignals = unique([...effects, ...mechanismHints]).slice(0, 8)
+  const regulationProfile = getRegulationProfile([...topSignals, safetySummary])
+  const safetyTone = getSafetyTone(safetySummary, avoidIf)
 
   const compoundJsonLd = {
     '@context': 'https://schema.org',
@@ -327,44 +385,36 @@ export default async function CompoundPage({ params }: PageProps) {
           ]}
         />
 
-        <TrustBar />
-
-        <section className="hero-shell rounded-[2rem] p-5 sm:p-8">
-          <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px] lg:items-start">
-            <div className="space-y-5">
+        <section className="hero-shell rounded-[2rem] p-4 sm:p-6 lg:p-8">
+          <div className="grid gap-5 lg:grid-cols-[minmax(0,0.82fr)_minmax(340px,1.18fr)] lg:items-start">
+            <div className="space-y-4 lg:pt-2">
               <CompoundHero
                 compound={{ ...compound, summary: quickSummary }}
                 evidenceLevel={evidenceLevel}
                 safetyLevel={safetyLevel}
               />
 
-              <div className="space-y-3">
-                <EvidenceBadgeGroup record={compound} compact />
-                {topSignals.length > 0 ? (
-                  <div className="flex flex-wrap gap-2">
-                    {topSignals.slice(0, 5).map((signal:string) => (
-                      <span key={signal} className="chip-readable text-xs">
-                        {signal}
-                      </span>
-                    ))}
-                  </div>
-                ) : null}
-              </div>
+              <EvidenceBadgeGroup record={compound} compact />
             </div>
 
-            <aside className="rounded-3xl bg-sand-50/70 p-5">
-              <p className="eyebrow-label">Decision snapshot</p>
-              <div className="mt-3 grid gap-3">
-                <DecisionSignalCard label="Evidence level" value={evidenceLevel} tone={evidenceLevel.toLowerCase().includes('strong') || evidenceLevel.toLowerCase().includes('high') ? 'strong' : 'neutral'} />
-                <DecisionSignalCard label="Safety read" value={safetySummary} tone={CAUTION_PATTERN.test(safetySummary) || avoidIf.length > 0 ? 'caution' : 'neutral'} />
-                <DecisionSignalCard label="Timeline" value={timeline || 'Timing varies by dose, form, and context.'} tone={timeline ? 'neutral' : 'muted'} />
-                <DecisionSignalCard label="Mechanism hints" value={mechanismHints.slice(0, 3).join(', ')} />
-              </div>
-            </aside>
+            <DecisionSnapshotPanel
+              commonUse={effects.slice(0, 3).join(', ')}
+              evidenceLevel={evidenceLevel}
+              regulation={regulationProfile}
+              safetyTone={safetyTone}
+              safetySummary={safetySummary}
+              avoidIf={avoidIf}
+              timeline={timeline}
+              mechanismHints={mechanismHints}
+            />
           </div>
         </section>
 
-        <EvidenceSnapshotCard snapshot={snapshot} />
+        <TrustBar />
+
+        <CompactDisclosure title="Evidence snapshot metrics">
+          <EvidenceSnapshotCard snapshot={snapshot} />
+        </CompactDisclosure>
 
         <CompactDisclosure title="Decision support and practical notes">
           <ProfileDecisionLayer

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -151,6 +151,39 @@ function getSafetySummary(herb: any) {
   return 'Review personal medications, pregnancy status, chronic conditions, and clinician guidance before use.'
 }
 
+
+function getAvoidIf(herb: any) {
+  return cleanItems([
+    herb.avoid_if,
+    herb.avoidIf,
+    herb.who_should_skip,
+    herb.whoShouldSkip,
+    herb.contraindications,
+    herb.interactions,
+    herb.avoid,
+  ], 5)
+}
+
+const CALMING_PATTERN = /calm|relax|sleep|sedat|anxiolytic|anxiety|stress|gaba|parasympathetic/i
+const STIMULATING_PATTERN = /stimulat|energ|fatigue|alert|caffeine|adrenergic|dopaminergic|nootropic|performance/i
+
+function getRegulationProfile(signals: string[]) {
+  const joined = signals.join(' ').toLowerCase()
+  const calming = CALMING_PATTERN.test(joined)
+  const stimulating = STIMULATING_PATTERN.test(joined)
+
+  if (calming && stimulating) return 'Mixed: calming and stimulating signals both appear in the profile.'
+  if (calming) return 'Leans calming / down-shifting based on listed effects and pathways.'
+  if (stimulating) return 'Leans stimulating / activating based on listed effects and pathways.'
+  return 'No clear calming or stimulating tilt in the available profile data.'
+}
+
+function getSafetyTone(summary: string, avoidIf: string[]) {
+  const highCaution = /avoid|contraindicat|pregnancy|breastfeeding|liver|kidney|bleed|sedative|interaction|medication/i
+  if (avoidIf.length || highCaution.test(summary)) return 'Use extra caution'
+  return 'Standard caution'
+}
+
 function getSafetyDetailGroups(herb: any) {
   const safetyNotes = cleanText(herb.safetyNotes || herb.safety_notes || herb.safety)
   const interactions = cleanItems(herb.interactions, 10)
@@ -173,13 +206,6 @@ function getTimeline(herb: any) {
   return cleanText(herb.time_to_effect || herb.onset || herb.timeline || herb.minimum_effective_dose)
 }
 
-function getStackContext(stackRecords: any[]) {
-  return stackRecords
-    .map(record => ({ label: formatDisplayLabel(record?.name || record?.title || record?.slug), href: record?.slug ? `/stacks/${record.slug}` : '' }))
-    .filter(item => item.label && item.href)
-    .slice(0, 3)
-}
-
 function getMechanisms(herb: any) {
   return cleanItems([herb.mechanisms, herb.primary_mechanisms, herb.pathways], 16)
 }
@@ -199,15 +225,59 @@ function getRelatedLinks(records: any[], entityType: 'herb' | 'compound', limit 
     .slice(0, limit)
 }
 
-function BriefCard({ label, value, children }: { label: string; value?: string; children?: ReactNode }) {
+function BriefCard({ label, value, children, prominent = false }: { label: string; value?: string; children?: ReactNode; prominent?: boolean }) {
   if (!value && !children) return null
 
   return (
-    <div className="border-t border-brand-900/10 pt-3">
+    <div className={prominent ? 'rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm' : 'border-t border-brand-900/10 pt-3'}>
       <p className="text-[11px] font-bold uppercase tracking-[0.16em] text-muted">{label}</p>
-      {value ? <p className="mt-2 text-sm font-semibold leading-6 text-ink">{value}</p> : null}
+      {value ? <p className={prominent ? 'mt-2 text-base font-bold leading-6 text-ink' : 'mt-2 text-sm font-semibold leading-6 text-ink'}>{value}</p> : null}
       {children ? <div className="mt-2">{children}</div> : null}
     </div>
+  )
+}
+
+function DecisionSnapshotPanel({
+  primaryUse,
+  evidence,
+  regulation,
+  safetyTone,
+  safetySummary,
+  avoidIf,
+  timeline,
+  mechanisms,
+}: {
+  primaryUse: string
+  evidence: string
+  regulation: string
+  safetyTone: string
+  safetySummary: string
+  avoidIf: string[]
+  timeline: string
+  mechanisms: string[]
+}) {
+  return (
+    <aside className="rounded-[1.65rem] border border-brand-900/10 bg-white/95 p-4 shadow-[0_18px_45px_rgba(47,64,52,0.12)] sm:p-5 lg:sticky lg:top-6">
+      <div className="flex items-start justify-between gap-3 border-b border-brand-900/10 pb-3">
+        <div>
+          <p className="eyebrow-label">Decision snapshot</p>
+          <h2 className="mt-1 text-xl font-semibold tracking-tight text-ink">5-second profile read</h2>
+        </div>
+        <span className="rounded-full bg-emerald-700/10 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.14em] text-emerald-900">
+          Start here
+        </span>
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-1">
+        <BriefCard label="Commonly used for" value={primaryUse || 'Use context is not clearly specified.'} prominent />
+        <BriefCard label="Evidence strength" value={evidence} prominent />
+        <BriefCard label="Calming vs stimulating" value={regulation} prominent />
+        <BriefCard label={`Safety level: ${safetyTone}`} value={safetySummary} prominent />
+        <BriefCard label="Avoid / review first if" value={avoidIf.length ? avoidIf.slice(0, 3).join(', ') : 'No specific avoid-if flags surfaced in the available profile data.'} prominent />
+        <BriefCard label="Onset / timeline" value={timeline || 'Timing varies by preparation, dose, and context.'} prominent />
+        <BriefCard label="Mechanism hints" value={mechanisms.length ? mechanisms.slice(0, 3).join(', ') : 'Mechanism signals are not clearly specified.'} prominent />
+      </div>
+    </aside>
   )
 }
 
@@ -356,16 +426,18 @@ export default async function HerbDetailPage({ params }: PageProps) {
   const safetySummary = getSafetySummary(herb)
   const safetySensitivity = getSafetySensitivity(herb)
   const safetyGroups = getSafetyDetailGroups(herb)
+  const avoidIf = getAvoidIf(herb)
   const timeline = getTimeline(herb)
   const mechanisms = getMechanisms(herb)
   const traditionalUses = getTraditionalUses(herb)
-  const stackContext = getStackContext(stackRecords)
   const researchMaturity = classifyResearchMaturity({ profile: herb })
   const researchStyle = deriveResearchStyle({ profile: herb })
   const focusAreas = deriveResearchFocusAreas({ profile: herb })
   const evidenceLimitations = deriveEvidenceLimitations({ profile: herb })
   const pathwayClusters = derivePathwayClusters({ profile: herb })
   const topUses = unique([...effects, ...traditionalUses, ...focusAreas]).slice(0, 8)
+  const regulationProfile = getRegulationProfile([...topUses, ...mechanisms, safetySummary])
+  const safetyTone = getSafetyTone(safetySummary, avoidIf)
   const hiddenUses = unique([...effects, ...traditionalUses, ...focusAreas]).slice(8)
   const keyTakeaways = unique([
     topUses.length ? `Most often explored for ${topUses.slice(0, 3).join(', ')}.` : '',
@@ -433,16 +505,16 @@ export default async function HerbDetailPage({ params }: PageProps) {
         <span className="text-ink">{displayName}</span>
       </nav>
 
-      <section className="hero-shell rounded-[1.75rem] p-5 sm:p-8">
-        <div className="space-y-5">
+      <section className="hero-shell rounded-[1.75rem] p-4 sm:p-6 lg:p-8">
+        <div className="space-y-4">
           <div className="flex flex-wrap items-center gap-4 text-xs font-bold uppercase tracking-[0.14em] text-muted">
             <Link href="/herbs" className="transition hover:text-ink">Back to herbs</Link>
             <Link href="/compare" className="transition hover:text-ink">Compare</Link>
             <Link href={`/search?q=${encodeURIComponent(displayName)}`} className="transition hover:text-ink">Search related</Link>
           </div>
 
-          <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_260px] lg:items-start">
-            <div className="space-y-4">
+          <div className="grid gap-5 lg:grid-cols-[minmax(0,0.82fr)_minmax(340px,1.18fr)] lg:items-start">
+            <div className="space-y-3 lg:pt-2">
               <div className="space-y-2">
                 <p className="eyebrow-label">Herb research brief</p>
                 <h1 className="text-4xl font-semibold tracking-tight text-ink sm:text-5xl">
@@ -451,7 +523,7 @@ export default async function HerbDetailPage({ params }: PageProps) {
                 {botanicalName ? <p className="text-sm italic text-muted">{botanicalName}</p> : null}
               </div>
 
-              <p className="max-w-3xl text-base leading-7 text-[#46574d] sm:text-lg">
+              <p className="max-w-2xl text-sm leading-6 text-[#46574d] sm:text-base">
                 {briefSummary}
               </p>
 
@@ -461,44 +533,19 @@ export default async function HerbDetailPage({ params }: PageProps) {
                   Safety: {formatDisplayLabel(safetySensitivity)} caution
                 </span>
               </div>
-
-              <ChipList items={topUses} limit={4} />
             </div>
 
-            <aside className="rounded-3xl bg-sand-50/70 p-5">
-              <p className="eyebrow-label">Decision cues</p>
-              <div className="mt-3 grid gap-3">
-                <BriefCard label="Evidence" value={evidenceStrength || researchMaturity} />
-                <BriefCard label="Safety" value={safetySummary} />
-                <BriefCard label="Timeline" value={timeline || 'Timing varies by preparation, dose, and context.'} />
-                <BriefCard label="Mechanism hints" value={mechanisms.slice(0, 3).join(', ')} />
-              </div>
-            </aside>
+            <DecisionSnapshotPanel
+              primaryUse={topUses.slice(0, 3).join(', ')}
+              evidence={evidenceStrength || researchMaturity}
+              regulation={regulationProfile}
+              safetyTone={safetyTone}
+              safetySummary={safetySummary}
+              avoidIf={avoidIf}
+              timeline={timeline}
+              mechanisms={mechanisms}
+            />
           </div>
-        </div>
-      </section>
-
-      <section className="space-y-4">
-        <div className="space-y-1">
-          <p className="eyebrow-label">Decision snapshot</p>
-          <h2 className="text-2xl font-semibold tracking-tight text-ink">Fast orientation before the deep dive</h2>
-        </div>
-        <div className="grid gap-x-6 gap-y-5 sm:grid-cols-2 lg:grid-cols-5">
-          <BriefCard label="Best known for" value={topUses.slice(0, 3).join(', ')} />
-          <BriefCard label="Evidence strength" value={evidenceStrength || researchMaturity} />
-          <BriefCard label="Safety watchouts" value={safetyGroups.length ? safetyGroups[0].items.slice(0, 2).join(', ') : safetySummary} />
-          <BriefCard label="Timeline / onset" value={timeline} />
-          <BriefCard label="Stack context">
-            {stackContext.length ? (
-              <div className="space-y-2">
-                {stackContext.map(item => (
-                  <Link key={item.href} href={item.href} className="block text-sm font-semibold text-ink underline-offset-4 hover:underline">
-                    {item.label}
-                  </Link>
-                ))}
-              </div>
-            ) : null}
-          </BriefCard>
         </div>
       </section>
 

--- a/components/ui/CompoundHero.tsx
+++ b/components/ui/CompoundHero.tsx
@@ -7,7 +7,7 @@ export default function CompoundHero({
   safetyLevel
 }: any) {
   return (
-    <div className="space-y-5">
+    <div className="space-y-4">
       <div className="space-y-3">
         <div className="eyebrow-label">
           Compound Profile
@@ -19,12 +19,12 @@ export default function CompoundHero({
         </div>
       </div>
 
-      <div className="space-y-4">
+      <div className="space-y-3">
         <h1 className="heading-premium max-w-4xl text-balance">
           {compound.name}
         </h1>
 
-        <p className="text-reading max-w-3xl text-base leading-7 text-[#46574d] sm:text-lg">
+        <p className="max-w-2xl text-sm leading-6 text-[#46574d] sm:text-base">
           {compound.summary || 'Evidence-informed compound profile.'}
         </p>
       </div>

--- a/docs/ux/decision-snapshot-pass.md
+++ b/docs/ux/decision-snapshot-pass.md
@@ -1,0 +1,33 @@
+# Decision snapshot hierarchy pass
+
+## Scope
+
+This pass audits the herb and compound profile hero areas and strengthens the above-the-fold decision layer without changing route contracts, data pipelines, or runtime data shapes.
+
+## Findings
+
+- Herb profiles split quick decision cues between a small hero aside and a second section below the hero, which diluted the intended "start here" behavior.
+- Compound profiles showed summary prose, badges, signal chips, and a separate evidence snapshot metric card near the top, so the practical fit signals did not clearly dominate.
+- Both profile types had important scan cues available at runtime, but they were not grouped into a single mobile-first decision read.
+
+## Changes made
+
+- Promoted a larger `Decision snapshot` panel into the hero on herb and compound detail pages.
+- Grouped the first-read cues into consistent scan cards:
+  - commonly used for
+  - evidence strength
+  - calming vs stimulating
+  - safety level
+  - avoid / review first if
+  - onset / timeline
+  - mechanism hints
+- Reduced surrounding hero prose sizing so summary copy supports the decision layer instead of competing with it.
+- Removed the duplicate herb decision-snapshot section below the hero.
+- Moved the compound evidence metrics card behind a disclosure so it remains available without competing above the fold.
+
+## Data and framing notes
+
+- No new data fields were added.
+- The calming/stimulating read is derived conservatively from existing runtime text signals such as effects, mechanisms, and safety notes.
+- Fallback copy explicitly says when a signal is not clearly specified instead of inventing details.
+- Safety copy preserves conservative educational framing and keeps avoid-if context in the first-read panel.


### PR DESCRIPTION
### Motivation
- Make the Decision Snapshot the dominant above-the-fold element on herb and compound detail pages so users understand fit, evidence, and safety within ~5 seconds.  
- Reduce visual competition from educational prose and duplicate cues so the decision layer is the clear starting point.  
- Preserve conservative scientific framing and use only existing runtime fields while improving mobile-first scanability and grouping (evidence, safety, effects, timing, stimulation/calming, avoid-if, mechanisms).

### Description
- Promoted a single, prominent `Decision snapshot` panel into the hero area for both herb and compound pages by adding a reusable panel component (`DecisionSnapshotPanel`) and compact signal cards (`DecisionSignalCard` / updated `BriefCard`).
- Added conservative, runtime-derived helpers `getAvoidIf`, `getRegulationProfile`, and `getSafetyTone` to expose avoid-if, calming vs stimulating, and a safety-level hint based on existing fields and text signals (no new data fields introduced).  
- Rebalanced hero prose (smaller summary text) and updated `components/ui/CompoundHero.tsx` so the title/summary support rather than compete with the snapshot, and removed the redundant herb decision snapshot section below the hero.  
- Reduced above-the-fold clutter on compound pages by moving the numeric evidence snapshot behind a `CompactDisclosure` and placing the `TrustBar` after the hero; added `docs/ux/decision-snapshot-pass.md` documenting the audit and pass.

### Testing
- Ran `npm run build` (which includes `node scripts/data/build-runtime-from-workbook.mjs`, `npm run data:validate`, `next build`, and post-build verifications) and the build completed successfully.  
- Data validation and governance steps passed during the build (`data:build`, `data:validate`, semantic governance checks, deterministic JSON validations, and `data:verify`).  
- Static site generation and `verify:build` checks completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0862a1fae0832396b90af92bca2089)