### PR TITLE
Simplify herbs index card UX

### DIFF
--- a/app/herbs/page.tsx
+++ b/app/herbs/page.tsx
@@ -27,45 +27,77 @@ function getSummary(item: any) {
 }
 
 function getEvidence(item: any) {
-  return labelize(
+  const label = labelize(
     item.evidence_tier ||
       item.evidenceTier ||
       item.safety?.evidenceTier ||
       item.evidence_grade ||
       item.evidenceLevel ||
       item.summary_quality,
-    'Evidence Review'
+    'Limited evidence'
   )
+
+  if (/^none$/i.test(label)) return 'Insufficient evidence'
+  if (/^traditional$/i.test(label)) return 'Traditional use'
+  if (/review|unknown|tbd/i.test(label)) return 'Needs review'
+
+  return label
 }
 
 function getSafety(item: any) {
-  return labelize(
+  const label = labelize(
     item.safety_level ||
       item.safetyLevel ||
       item.safety?.confidence ||
+      item.confidence ||
       item.profile_status,
-    'Safety Review'
+    'Needs review'
   )
+
+  if (/review|unknown|tbd/i.test(label)) return 'Needs review'
+  if (/^low$/i.test(label)) return 'Limited safety data'
+  if (/^medium$/i.test(label)) return 'Some safety context'
+  if (/^high$/i.test(label)) return 'Safety context'
+
+  return label
 }
 
 function getEffects(item: any) {
   return unique([
     ...list(item.primary_effects),
     ...list(item.primaryEffects),
+    ...list(item.primaryActions),
     ...list(item.effects),
     ...list(item.primaryDomain),
+    ...list(item.mechanisms),
   ])
     .filter(isClean)
-    .slice(0, 3)
+    .slice(0, 2)
 }
 
-function evidenceClass(level: string) {
-  const value = level.toLowerCase()
+function getBestFor(item: any) {
+  const effects = getEffects(item)
 
-  if (value.includes('strong') || value.includes('high')) return 'border-emerald-700/20 bg-emerald-50 text-emerald-900'
-  if (value.includes('moderate') || value.includes('human')) return 'border-brand-700/20 bg-brand-50 text-brand-900'
+  if (effects.length > 0) return effects.join(' • ')
 
-  return 'border-amber-700/20 bg-amber-50 text-amber-950'
+  const traditionalUses = list(item.traditionalUses || item.traditional_uses)
+    .filter(isClean)
+    .slice(0, 2)
+
+  return traditionalUses.length > 0 ? traditionalUses.join(' • ') : 'Research context'
+}
+
+function getTimeToEffect(item: any) {
+  const value = labelize(
+    item.time_to_effect ||
+      item.timeToEffect ||
+      item.onset ||
+      item.practical?.timeToEffect ||
+      item.timeline,
+    ''
+  )
+
+  return value && isClean(value) ? value : ''
 }
 
 function scoreHerb(item: any) {
@@ -80,14 +112,6 @@ function scoreHerb(item: any) {
   score += getEffects(item).length
 
   return score
-}
-
-function getPrimaryLabel(item: any) {
-  const evidence = getEvidence(item)
-
-  if (evidence && evidence !== 'Evidence Review') return evidence
-
-  return getSafety(item)
 }
 
 function StatCard({ value, label }: { value: number; label: string }) {
@@ -128,49 +152,54 @@ function EmptyLibraryState() {
   )
 }
 
+function DecisionRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-2xl border border-brand-900/10 bg-white/70 p-3">
+      <p className="text-[0.68rem] font-bold uppercase tracking-[0.14em] text-[#68786f]">{label}</p>
+      <p className="mt-1 text-sm font-semibold leading-5 text-[#26382f]">{value}</p>
+    </div>
+  )
+}
+
 function HerbCard({ herb, featured = false }: { herb: any; featured?: boolean }) {
-  const label = getPrimaryLabel(herb)
-  const effects = getEffects(herb)
+  const evidence = getEvidence(herb)
+  const safety = getSafety(herb)
+  const bestFor = getBestFor(herb)
+  const timeToEffect = getTimeToEffect(herb)
   const name = getName(herb)
-  const summary = getSummary(herb) || 'Evidence-aware botanical profile with mechanisms, safety context, and practical research notes.'
+  const summary = getSummary(herb) || 'A conservative botanical profile with research context and safety notes.'
 
   return (
     <Link
       href={`/herbs/${herb.slug}`}
-      className="group flex h-full min-h-[17rem] flex-col rounded-[1.65rem] border border-brand-900/10 bg-gradient-to-br from-white via-[#fbfaf6] to-brand-50/25 p-6 shadow-[var(--shadow-card-calm)] transition duration-300 hover:-translate-y-0.5 hover:border-brand-700/20 hover:bg-white hover:shadow-[var(--shadow-card-calm-hover)] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40"
+      className="group flex h-full min-h-[18rem] flex-col rounded-[1.35rem] border border-brand-900/10 bg-white/85 p-5 shadow-[var(--shadow-card-calm)] transition duration-300 hover:-translate-y-0.5 hover:border-brand-700/20 hover:bg-white hover:shadow-[var(--shadow-card-calm-hover)] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 sm:p-6"
     >
       <div className="flex flex-1 flex-col">
-        <div className="flex items-center justify-between gap-3">
-          <span className={`inline-flex rounded-full border px-3 py-1 text-[11px] font-bold uppercase tracking-[0.14em] ${evidenceClass(label)}`}>
-            {label}
-          </span>
+        <div className="flex items-start justify-between gap-3">
+          <h3 className="text-2xl font-semibold tracking-tight text-ink transition group-hover:text-brand-800">
+            {name}
+          </h3>
           {featured ? (
-            <span className="text-xs font-semibold text-brand-800">Featured</span>
+            <span className="shrink-0 rounded-full bg-brand-50 px-2.5 py-1 text-xs font-bold text-brand-800">Featured</span>
           ) : null}
         </div>
 
-        <h3 className="mt-5 text-2xl font-semibold tracking-tight text-ink transition group-hover:text-brand-800">
-          {name}
-        </h3>
-
-        <p className="mt-3 line-clamp-4 text-sm leading-[1.75] text-[#46574d]">
+        <p className="mt-3 line-clamp-2 text-[0.95rem] leading-6 text-[#46574d]">
           {summary}
         </p>
 
-        {effects.length > 0 ? (
-          <div className="mt-5 flex flex-wrap gap-2">
-            {effects.map(effect => (
-              <span key={effect} className="rounded-full border border-brand-900/10 bg-white/75 px-3 py-1 text-xs font-medium text-[#33443a]">
-                {effect}
-              </span>
-            ))}
+        <div className="mt-5 grid gap-2">
+          <DecisionRow label="Best for" value={bestFor} />
+          <div className="grid gap-2 sm:grid-cols-2">
+            <DecisionRow label="Evidence" value={evidence} />
+            <DecisionRow label="Safety" value={safety} />
           </div>
-        ) : null}
+          {timeToEffect ? <DecisionRow label="Time to effect" value={timeToEffect} /> : null}
+        </div>
       </div>
 
-      <div className="mt-6 inline-flex items-center gap-2 text-sm font-bold text-brand-800 transition group-hover:translate-x-1">
-        Open profile
-        <span aria-hidden="true">→</span>
+      <div className="mt-5 flex min-h-11 items-center justify-center rounded-full bg-brand-800 px-4 py-3 text-sm font-bold text-white transition group-hover:bg-brand-900 group-focus-visible:bg-brand-900">
+        View herb profile <span className="ml-2 transition group-hover:translate-x-0.5" aria-hidden="true">→</span>
       </div>
     </Link>
   )
@@ -235,24 +264,24 @@ export default async function HerbsPage() {
 
   return (
     <div className="min-h-screen px-4 py-5 text-ink sm:py-8">
-      <div className="mx-auto max-w-7xl space-y-14 sm:space-y-20">
-        <section className="hero-shell relative overflow-hidden rounded-[2rem] border border-white/50 px-5 py-12 shadow-[var(--shadow-card-calm)] sm:rounded-[2.5rem] sm:px-10 sm:py-16 lg:px-14 lg:py-20">
+      <div className="mx-auto max-w-7xl space-y-10 sm:space-y-16">
+        <section className="hero-shell relative overflow-hidden rounded-[2rem] border border-white/50 px-5 py-9 shadow-[var(--shadow-card-calm)] sm:rounded-[2.5rem] sm:px-10 sm:py-14 lg:px-14">
           <div className="!absolute left-[-8rem] top-[-8rem] h-72 w-72 rounded-full bg-emerald-200/30 blur-3xl" />
           <div className="!absolute bottom-[-10rem] right-[-8rem] h-96 w-96 rounded-full bg-amber-200/30 blur-3xl" />
 
-          <div className="relative grid gap-10 lg:grid-cols-[1.08fr_.92fr] lg:items-center">
-            <div className="max-w-4xl space-y-7">
+          <div className="relative grid gap-7 lg:grid-cols-[1.08fr_.92fr] lg:items-center">
+            <div className="max-w-4xl space-y-5">
               <div className="inline-flex rounded-full border border-brand-700/10 bg-white/80 px-4 py-2 text-xs font-bold uppercase tracking-[0.18em] text-brand-800 backdrop-blur-md">
                 Botanical profiles
               </div>
 
               <div className="space-y-5">
-                <h1 className="max-w-[13ch] text-balance font-display text-5xl font-semibold leading-[1.02] tracking-tight text-ink sm:text-6xl lg:text-7xl">
+                <h1 className="max-w-[13ch] text-balance font-display text-4xl font-semibold leading-[1.04] tracking-tight text-ink sm:text-6xl lg:text-7xl">
                   Herbal research library
                 </h1>
 
-                <p className="max-w-2xl text-lg leading-8 text-[#46574d] sm:text-xl">
-                  Browse evidence-aware herb profiles with mechanisms, safety context, traditional use, and practical supplement research kept in one clean library.
+                <p className="max-w-2xl text-base leading-7 text-[#46574d] sm:text-xl sm:leading-8">
+                  Scan herbs by use case, evidence, and safety context before opening a full profile. Conservative summaries first; deeper mechanisms after the click.
                 </p>
               </div>
             </div>
@@ -270,7 +299,7 @@ export default async function HerbsPage() {
           </div>
         </section>
 
-        <section className="rounded-[2rem] border border-brand-900/10 bg-gradient-to-br from-white/85 via-[#faf8f1] to-brand-50/40 p-6 shadow-[var(--shadow-card-calm)] sm:p-10">
+        <section className="rounded-[2rem] border border-brand-900/10 bg-white/75 p-5 shadow-[var(--shadow-card-calm)] sm:p-8">
           <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
             <div className="max-w-2xl space-y-3">
               <p className="eyebrow-label">Start with a goal</p>
@@ -279,12 +308,12 @@ export default async function HerbsPage() {
             <Link href="/goals" className="text-sm font-bold text-brand-800 transition hover:text-brand-900">All goals →</Link>
           </div>
 
-          <div className="mt-8 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          <div className="mt-6 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
             {browsePaths.map(path => (
               <Link
                 key={path.label}
                 href={path.href}
-                className="group rounded-[1.35rem] border border-brand-900/10 bg-white/75 p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-brand-700/20 hover:bg-white hover:shadow-[var(--shadow-card-calm)]"
+                className="group rounded-[1.25rem] border border-brand-900/10 bg-white/80 p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-brand-700/20 hover:bg-white hover:shadow-[var(--shadow-card-calm)]"
               >
                 <div className="flex items-start justify-between gap-4">
                   <div>
@@ -314,7 +343,7 @@ export default async function HerbsPage() {
                   </p>
                 </div>
 
-                <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+                <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
                   {featuredHerbs.map((herb: any) => (
                     <HerbCard key={herb.slug} herb={herb} featured />
                   ))}
@@ -333,7 +362,7 @@ export default async function HerbsPage() {
                 </span>
               </div>
 
-              <div className="grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+              <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
                 {herbs.map((herb: any) => (
                   <HerbCard key={herb.slug} herb={herb} />
                 ))}

--- a/docs/ux/herbs-index-simplification-pass.md
+++ b/docs/ux/herbs-index-simplification-pass.md
@@ -1,0 +1,34 @@
+# Herbs index simplification pass
+
+## Goals
+
+- Make `/herbs` easier to scan, especially on mobile.
+- Reframe herb cards as fast decision tools instead of compact article previews.
+- Preserve conservative evidence and safety framing without adding new claims.
+- Keep the change scoped to the index experience and avoid touching runtime/workbook generation.
+
+## Hierarchy changes
+
+Herb cards now prioritize the sequence a visitor needs for a quick decision:
+
+1. **Name** — the clearest anchor at the top of each card.
+2. **One-line practical summary** — capped to two lines so cards stay compact.
+3. **Best for** — derived from existing effect/action/mechanism fields with a conservative fallback.
+4. **Evidence** — normalized into cautious labels such as `Insufficient evidence`, `Traditional use`, and `Needs review` when source data is sparse.
+5. **Safety** — displayed as its own decision row rather than mixed into a badge system.
+6. **Time to effect** — shown only when available from existing runtime fields.
+7. **CTA** — a full-width tap target so the next action is obvious on mobile.
+
+## Constraints
+
+- No workbook files, runtime generation scripts, `package.json`, or lockfiles were changed.
+- No dosage guidance or new medical promises were added.
+- Existing route contracts remain unchanged, including `/herbs/:slug`.
+- Generated data remains treated as a build artifact.
+- The page still uses the existing herb summary index and runtime visibility filter.
+
+## Reasoning
+
+The previous card design gave evidence/status badges, summaries, and effect chips similar visual weight. That made each card feel like an information dump and increased mobile scanning effort. The revised layout uses repeated labeled rows so visitors can compare cards by the same small set of questions: what it is, what it may be relevant for, how strong the evidence framing is, what the safety context looks like, and whether to open the profile.
+
+The hero and goal-entry sections were also tightened so the first mobile viewport feels calmer and less visually dense before the herb grid appears.


### PR DESCRIPTION
### Motivation

- Make the `/herbs` index faster to scan on mobile by reframing herb cards as simple decision tools rather than dense previews.
- Surface the small set of signals readers need to decide whether to open a profile: name, short summary, what it’s best for, evidence framing, safety, optional time-to-effect, and a clear CTA.
- Preserve conservative evidence/safety language and avoid adding any new claims or runtime/workbook changes.

### Description

- Reworked `HerbCard` in `app/herbs/page.tsx` into a decision-row layout and introduced `DecisionRow` to display labeled rows (`Best for`, `Evidence`, `Safety`, optional `Time to effect`) and a stronger full-width CTA.
- Added conservative normalizations and fallbacks for evidence and safety via updated `getEvidence` and `getSafety` logic (e.g. `Insufficient evidence`, `Traditional use`, `Needs review`, `Limited safety data`).
- Added `getBestFor` and `getTimeToEffect`, reduced effect chips to a compact `Best for` line, and simplified the card visual styling for cleaner mobile-first spacing and tap targets.
- Toned down above-the-fold density by tightening hero and goal-section spacing/copy and adjusted grid gaps/padding to reduce visual clutter; added UX doc at `docs/ux/herbs-index-simplification-pass.md` describing goals, hierarchy, constraints, and reasoning.

### Testing

- Ran `npm run lint` and it completed successfully.
- Ran `npx tsc --noEmit` and type-checking passed with no errors.
- Ran `npm run build` which completed successfully (data build/validation and Next.js build were included and passed as part of the script).
- Captured a mobile screenshot with Playwright using `npx --yes playwright screenshot --viewport-size=390,1200 http://127.0.0.1:4173/herbs /tmp/hippie-screenshots/herbs-mobile.png` and the capture completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a086f04aa648323b1b246e685257ce4)