### PR TITLE
Standardize shared decision UI primitives

### DIFF
--- a/app/compounds/CompoundsIndexClient.tsx
+++ b/app/compounds/CompoundsIndexClient.tsx
@@ -3,6 +3,8 @@
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 import { cleanSummary, formatDisplayLabel, isClean, labelize, list, text, unique } from '@/lib/display-utils'
+import { normalizeDecisionEvidence, normalizeDecisionSafety } from '@/lib/decision-primitives'
+import { DecisionEmptyState, DecisionFilterGroup, DecisionProfileCard } from '@/components/ui/DecisionPrimitives'
 import '@/styles/premium-cards.css'
 
 type FilterOption = {
@@ -71,47 +73,27 @@ function getSummary(item: any) {
   )
 }
 
-function normalizeEvidenceLabel(value: string) {
-  if (/^none$/i.test(value)) return 'Insufficient evidence'
-  if (/traditional/i.test(value)) return 'Traditional use'
-  if (/preclinical|animal|cell|mechanistic/i.test(value)) return 'Preliminary evidence'
-  if (/mixed|conflict/i.test(value)) return 'Mixed evidence'
-  if (/review|unknown|tbd|profile/i.test(value)) return 'Needs review'
-
-  return value
-}
-
 function getEvidence(item: any) {
-  const label = labelize(
+  return normalizeDecisionEvidence(
     item?.evidence_tier ||
       item?.evidenceTier ||
       item?.evidence_grade ||
       item?.evidenceLevel ||
       item?.humanEvidenceLevel ||
-      item?.summary_quality,
-    'Limited evidence'
+      item?.summary_quality
   )
-
-  return normalizeEvidenceLabel(label)
 }
 
 function getSafety(item: any) {
-  const label = labelize(
+  return normalizeDecisionSafety(
     item?.safety_level ||
       item?.safetyLevel ||
       item?.safety?.confidence ||
       item?.safetyStatus ||
       item?.contraindicationLevel ||
       item?.profile_status,
-    item?.safetyNotes ? 'Safety notes available' : 'Needs review'
+    { hasSafetyNotes: Boolean(item?.safetyNotes || item?.safety_notes || item?.safety) }
   )
-
-  if (/review|unknown|tbd|profile/i.test(label)) return 'Needs review'
-  if (/^low$/i.test(label)) return 'Limited safety data'
-  if (/^medium$/i.test(label)) return 'Some safety context'
-  if (/^high$/i.test(label)) return 'Safety context'
-
-  return label
 }
 
 function getEffects(item: any) {
@@ -241,123 +223,51 @@ function StatCard({ value, label }: { value: number; label: string }) {
 
 function EmptyLibraryState() {
   return (
-    <div className="rounded-[1.5rem] border border-brand-900/10 bg-white/85 p-6 shadow-[var(--shadow-card-calm)] sm:p-8">
-      <div className="max-w-2xl space-y-3">
-        <p className="eyebrow-label">Profiles unavailable</p>
-        <h2 className="compact-heading">Compound profiles are temporarily unavailable.</h2>
-        <p className="text-sm leading-6 text-[#46574d] sm:text-base">
-          The compound library is still being generated or the runtime data did not return renderable profiles for this build. This is temporary and does not mean the compound database is empty.
-        </p>
-      </div>
-
-      <div className="mt-6 flex flex-wrap gap-3">
-        <Link href="/search" className="button-primary min-h-11 px-4 py-2 text-sm">
-          Search the site
-        </Link>
-        <Link href="/herbs" className="button-secondary min-h-11 px-4 py-2 text-sm">
-          Browse herbs
-        </Link>
-        <Link href="/goals" className="button-secondary min-h-11 px-4 py-2 text-sm">
-          Explore goals
-        </Link>
-      </div>
-    </div>
+    <DecisionEmptyState
+      eyebrow="Profiles unavailable"
+      title="Compound profiles are temporarily unavailable."
+      description="The compound library is still being generated or the runtime data did not return renderable profiles for this build. This is temporary and does not mean the compound database is empty."
+      actions={[
+        { href: '/search', label: 'Search the site', variant: 'primary' },
+        { href: '/herbs', label: 'Browse herbs' },
+        { href: '/goals', label: 'Explore goals' },
+      ]}
+    />
   )
 }
 
 function EmptyFilteredState({ query, context }: { query: string; context: string }) {
   const activeContext = filterOptions.find(option => option.value === context)?.label
+  const currentScan = [query ? `“${query}”` : '', activeContext || ''].filter(Boolean).join(' + ')
 
   return (
-    <div className="rounded-[1.5rem] border border-brand-900/10 bg-white/85 p-6 shadow-sm sm:p-8">
-      <div className="max-w-2xl space-y-3">
-        <p className="eyebrow-label">No matching profiles</p>
-        <h2 className="compact-heading">No compounds matched this scan.</h2>
-        <p className="text-sm leading-6 text-[#46574d] sm:text-base">
-          Try a broader compound name, mechanism, source herb, or pathway. Evidence and safety labels stay conservative when source data is incomplete.
-        </p>
-        {query || activeContext ? (
-          <p className="text-sm leading-6 text-[#5f6f66]">
-            Current scan: {[query ? `“${query}”` : '', activeContext || ''].filter(Boolean).join(' + ')}
-          </p>
-        ) : null}
-      </div>
-
-      <div className="mt-6 flex flex-wrap gap-3">
-        <Link href="/compounds" className="button-primary min-h-11 px-4 py-2 text-sm">
-          Reset filters
-        </Link>
-        <Link href="/herbs" className="button-secondary min-h-11 px-4 py-2 text-sm">
-          Browse herbs
-        </Link>
-      </div>
-    </div>
-  )
-}
-
-function DecisionMetric({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="min-w-0 rounded-[1rem] border border-brand-900/10 bg-[#fbfaf6]/85 px-3 py-2.5">
-      <p className="text-[0.66rem] font-bold uppercase tracking-[0.13em] text-[#68786f]">{label}</p>
-      <p className="mt-1 truncate text-sm font-semibold leading-5 text-[#26382f]">{value}</p>
-    </div>
+    <DecisionEmptyState
+      eyebrow="No matching profiles"
+      title="No compounds matched this scan."
+      description="Try a broader compound name, mechanism, source herb, or pathway. Evidence and safety labels stay conservative when source data is incomplete."
+      currentScan={currentScan || undefined}
+      actions={[
+        { href: '/compounds', label: 'Reset filters', variant: 'primary' },
+        { href: '/herbs', label: 'Browse herbs' },
+      ]}
+    />
   )
 }
 
 function CompoundCard({ compound, featured = false }: { compound: any; featured?: boolean }) {
-  const evidence = getEvidence(compound)
-  const safety = getSafety(compound)
-  const bestFor = getBestFor(compound)
-  const timeToEffect = getTimeToEffect(compound)
-  const mechanisms = getMechanismSignals(compound)
-  const name = getName(compound)
-  const summary = getSummary(compound) || 'A conservative compound profile with mechanism, evidence, and safety context.'
-
   return (
-    <Link
+    <DecisionProfileCard
       href={`/compounds/${compound?.slug || ''}`}
-      className="group flex h-full min-h-[16rem] flex-col rounded-[1.3rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition duration-300 hover:-translate-y-0.5 hover:border-brand-700/20 hover:bg-white hover:shadow-[var(--shadow-card-calm)] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 sm:p-5"
-    >
-      <div className="flex flex-1 flex-col">
-        <div className="flex items-start justify-between gap-3">
-          <h3 className="text-[1.35rem] font-semibold leading-tight tracking-tight text-ink transition group-hover:text-brand-800 sm:text-2xl">
-            {name}
-          </h3>
-          {featured ? (
-            <span className="shrink-0 rounded-full border border-brand-700/10 bg-brand-50 px-2.5 py-1 text-[0.68rem] font-bold text-brand-800">Start here</span>
-          ) : null}
-        </div>
-
-        <p className="mt-3 line-clamp-2 text-[0.95rem] leading-6 text-[#46574d]">
-          {summary}
-        </p>
-
-        <div className="mt-4 rounded-[1.1rem] border border-brand-900/10 bg-brand-50/45 p-3">
-          <p className="text-[0.66rem] font-bold uppercase tracking-[0.13em] text-brand-800">Best-for context</p>
-          <p className="mt-1.5 text-base font-semibold leading-6 text-[#203329]">{bestFor}</p>
-        </div>
-
-        <div className="mt-3 grid gap-2 sm:grid-cols-2">
-          <DecisionMetric label="Evidence" value={evidence} />
-          <DecisionMetric label="Safety" value={safety} />
-          {timeToEffect ? <DecisionMetric label="Time" value={timeToEffect} /> : null}
-        </div>
-
-        {mechanisms.length > 0 ? (
-          <div className="mt-3 flex flex-wrap gap-2 border-t border-brand-900/10 pt-3">
-            {mechanisms.map((mechanism: string) => (
-              <span key={mechanism} className="rounded-full bg-white/70 px-2.5 py-1 text-xs font-semibold text-[#64746a]">
-                {mechanism}
-              </span>
-            ))}
-          </div>
-        ) : null}
-      </div>
-
-      <div className="mt-4 flex min-h-11 items-center justify-center rounded-full bg-brand-800 px-4 py-3 text-sm font-bold text-white transition group-hover:bg-brand-900 group-focus-visible:bg-brand-900">
-        View profile <span className="ml-2 transition group-hover:translate-x-0.5" aria-hidden="true">→</span>
-      </div>
-    </Link>
+      name={getName(compound)}
+      summary={getSummary(compound)}
+      bestFor={getBestFor(compound)}
+      evidence={getEvidence(compound)}
+      safety={getSafety(compound)}
+      timeToEffect={getTimeToEffect(compound)}
+      mechanisms={getMechanismSignals(compound)}
+      featured={featured}
+      fallbackSummary="A conservative compound profile with mechanism, evidence, and safety context."
+    />
   )
 }
 
@@ -447,31 +357,13 @@ export default function CompoundsIndexClient({ compounds: sourceCompounds }: { c
             </button>
           </form>
 
-          <details className="mt-4 rounded-[1.2rem] border-brand-900/10 bg-[#fbfaf6]/80 p-4 shadow-none" open={hasActiveFilters || undefined}>
-            <summary className="flex min-h-11 items-center justify-between gap-4 text-sm font-bold text-ink">
-              <span>Refine by context</span>
-              <span className="text-brand-800" aria-hidden="true">↓</span>
-            </summary>
-            <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
-              <Link
-                href={buildFilterHref('all', query)}
-                className={`rounded-[1rem] border px-3 py-3 text-sm font-semibold transition ${activeFilter === 'all' ? 'border-brand-700/25 bg-brand-50 text-brand-900' : 'border-brand-900/10 bg-white/80 text-[#33443a] hover:border-brand-700/20'}`}
-              >
-                All contexts
-                <span className="mt-1 block text-xs font-medium leading-5 text-[#64746a]">Keep the scan broad.</span>
-              </Link>
-              {filterOptions.map(option => (
-                <Link
-                  key={option.value}
-                  href={buildFilterHref(option.value, query)}
-                  className={`rounded-[1rem] border px-3 py-3 text-sm font-semibold transition ${activeFilter === option.value ? 'border-brand-700/25 bg-brand-50 text-brand-900' : 'border-brand-900/10 bg-white/80 text-[#33443a] hover:border-brand-700/20'}`}
-                >
-                  {option.label}
-                  <span className="mt-1 block text-xs font-medium leading-5 text-[#64746a]">{option.hint}</span>
-                </Link>
-              ))}
-            </div>
-          </details>
+          <DecisionFilterGroup
+            options={filterOptions}
+            activeFilter={activeFilter}
+            query={query}
+            buildHref={buildFilterHref}
+            open={hasActiveFilters}
+          />
         </section>
 
         <section className="rounded-[1.5rem] border border-brand-900/10 bg-white/70 p-4 shadow-sm sm:p-5">

--- a/app/herbs/HerbsIndexClient.tsx
+++ b/app/herbs/HerbsIndexClient.tsx
@@ -3,6 +3,8 @@
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 import { cleanSummary, formatDisplayLabel, isClean, labelize, list, text, unique } from '@/lib/display-utils'
+import { normalizeDecisionEvidence, normalizeDecisionSafety } from '@/lib/decision-primitives'
+import { DecisionEmptyState, DecisionFilterGroup, DecisionProfileCard } from '@/components/ui/DecisionPrimitives'
 import '@/styles/premium-cards.css'
 
 type FilterOption = {
@@ -56,39 +58,25 @@ function getSummary(item: any) {
 }
 
 function getEvidence(item: any) {
-  const label = labelize(
+  return normalizeDecisionEvidence(
     item.evidence_tier ||
       item.evidenceTier ||
       item.safety?.evidenceTier ||
       item.evidence_grade ||
       item.evidenceLevel ||
-      item.summary_quality,
-    'Limited evidence'
+      item.summary_quality
   )
-
-  if (/^none$/i.test(label)) return 'Insufficient evidence'
-  if (/^traditional$/i.test(label)) return 'Traditional use'
-  if (/review|unknown|tbd/i.test(label)) return 'Needs review'
-
-  return label
 }
 
 function getSafety(item: any) {
-  const label = labelize(
+  return normalizeDecisionSafety(
     item.safety_level ||
       item.safetyLevel ||
       item.safety?.confidence ||
       item.confidence ||
       item.profile_status,
-    'Needs review'
+    { hasSafetyNotes: Boolean(item.safetyNotes || item.safety_notes || item.safety) }
   )
-
-  if (/review|unknown|tbd/i.test(label)) return 'Needs review'
-  if (/^low$/i.test(label)) return 'Limited safety data'
-  if (/^medium$/i.test(label)) return 'Some safety context'
-  if (/^high$/i.test(label)) return 'Safety context'
-
-  return label
 }
 
 function getEffects(item: any) {
@@ -212,123 +200,51 @@ function StatCard({ value, label }: { value: number; label: string }) {
 
 function EmptyLibraryState() {
   return (
-    <div className="rounded-[1.5rem] border border-brand-900/10 bg-white/85 p-6 shadow-[var(--shadow-card-calm)] sm:p-8">
-      <div className="max-w-2xl space-y-3">
-        <p className="eyebrow-label">Profiles unavailable</p>
-        <h2 className="compact-heading">Herb profiles are temporarily unavailable.</h2>
-        <p className="text-sm leading-6 text-[#46574d] sm:text-base">
-          The herb library is still being generated or the runtime data did not return renderable profiles for this build. This is temporary and does not mean the herb database is empty.
-        </p>
-      </div>
-
-      <div className="mt-6 flex flex-wrap gap-3">
-        <Link href="/search" className="button-primary min-h-11 px-4 py-2 text-sm">
-          Search the site
-        </Link>
-        <Link href="/compounds" className="button-secondary min-h-11 px-4 py-2 text-sm">
-          Browse compounds
-        </Link>
-        <Link href="/goals" className="button-secondary min-h-11 px-4 py-2 text-sm">
-          Explore goals
-        </Link>
-      </div>
-    </div>
+    <DecisionEmptyState
+      eyebrow="Profiles unavailable"
+      title="Herb profiles are temporarily unavailable."
+      description="The herb library is still being generated or the runtime data did not return renderable profiles for this build. This is temporary and does not mean the herb database is empty."
+      actions={[
+        { href: '/search', label: 'Search the site', variant: 'primary' },
+        { href: '/compounds', label: 'Browse compounds' },
+        { href: '/goals', label: 'Explore goals' },
+      ]}
+    />
   )
 }
 
 function EmptyFilteredState({ query, context }: { query: string; context: string }) {
   const activeContext = filterOptions.find(option => option.value === context)?.label
+  const currentScan = [query ? `“${query}”` : '', activeContext || ''].filter(Boolean).join(' + ')
 
   return (
-    <div className="rounded-[1.5rem] border border-brand-900/10 bg-white/85 p-6 shadow-sm sm:p-8">
-      <div className="max-w-2xl space-y-3">
-        <p className="eyebrow-label">No matching profiles</p>
-        <h2 className="compact-heading">No herbs matched this scan.</h2>
-        <p className="text-sm leading-6 text-[#46574d] sm:text-base">
-          Try a broader herb name, mechanism, or goal. Evidence and safety labels stay conservative when source data is incomplete.
-        </p>
-        {query || activeContext ? (
-          <p className="text-sm leading-6 text-[#5f6f66]">
-            Current scan: {[query ? `“${query}”` : '', activeContext || ''].filter(Boolean).join(' + ')}
-          </p>
-        ) : null}
-      </div>
-
-      <div className="mt-6 flex flex-wrap gap-3">
-        <Link href="/herbs" className="button-primary min-h-11 px-4 py-2 text-sm">
-          Reset filters
-        </Link>
-        <Link href="/goals" className="button-secondary min-h-11 px-4 py-2 text-sm">
-          Browse by goal
-        </Link>
-      </div>
-    </div>
-  )
-}
-
-function DecisionMetric({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="min-w-0 rounded-[1rem] border border-brand-900/10 bg-[#fbfaf6]/85 px-3 py-2.5">
-      <p className="text-[0.66rem] font-bold uppercase tracking-[0.13em] text-[#68786f]">{label}</p>
-      <p className="mt-1 truncate text-sm font-semibold leading-5 text-[#26382f]">{value}</p>
-    </div>
+    <DecisionEmptyState
+      eyebrow="No matching profiles"
+      title="No herbs matched this scan."
+      description="Try a broader herb name, mechanism, or goal. Evidence and safety labels stay conservative when source data is incomplete."
+      currentScan={currentScan || undefined}
+      actions={[
+        { href: '/herbs', label: 'Reset filters', variant: 'primary' },
+        { href: '/goals', label: 'Browse by goal' },
+      ]}
+    />
   )
 }
 
 function HerbCard({ herb, featured = false }: { herb: any; featured?: boolean }) {
-  const evidence = getEvidence(herb)
-  const safety = getSafety(herb)
-  const bestFor = getBestFor(herb)
-  const timeToEffect = getTimeToEffect(herb)
-  const mechanisms = getMechanisms(herb)
-  const name = getName(herb)
-  const summary = getSummary(herb) || 'A conservative botanical profile with research context and safety notes.'
-
   return (
-    <Link
+    <DecisionProfileCard
       href={`/herbs/${herb.slug}`}
-      className="group flex h-full min-h-[16rem] flex-col rounded-[1.3rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition duration-300 hover:-translate-y-0.5 hover:border-brand-700/20 hover:bg-white hover:shadow-[var(--shadow-card-calm)] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 sm:p-5"
-    >
-      <div className="flex flex-1 flex-col">
-        <div className="flex items-start justify-between gap-3">
-          <h3 className="text-[1.35rem] font-semibold leading-tight tracking-tight text-ink transition group-hover:text-brand-800 sm:text-2xl">
-            {name}
-          </h3>
-          {featured ? (
-            <span className="shrink-0 rounded-full border border-brand-700/10 bg-brand-50 px-2.5 py-1 text-[0.68rem] font-bold text-brand-800">Start here</span>
-          ) : null}
-        </div>
-
-        <p className="mt-3 line-clamp-2 text-[0.95rem] leading-6 text-[#46574d]">
-          {summary}
-        </p>
-
-        <div className="mt-4 rounded-[1.1rem] border border-brand-900/10 bg-brand-50/45 p-3">
-          <p className="text-[0.66rem] font-bold uppercase tracking-[0.13em] text-brand-800">Best-for context</p>
-          <p className="mt-1.5 text-base font-semibold leading-6 text-[#203329]">{bestFor}</p>
-        </div>
-
-        <div className="mt-3 grid gap-2 sm:grid-cols-2">
-          <DecisionMetric label="Evidence" value={evidence} />
-          <DecisionMetric label="Safety" value={safety} />
-          {timeToEffect ? <DecisionMetric label="Time" value={timeToEffect} /> : null}
-        </div>
-
-        {mechanisms.length > 0 ? (
-          <div className="mt-3 flex flex-wrap gap-2 border-t border-brand-900/10 pt-3">
-            {mechanisms.map((mechanism: string) => (
-              <span key={mechanism} className="rounded-full bg-white/70 px-2.5 py-1 text-xs font-semibold text-[#64746a]">
-                {formatDisplayLabel(mechanism)}
-              </span>
-            ))}
-          </div>
-        ) : null}
-      </div>
-
-      <div className="mt-4 flex min-h-11 items-center justify-center rounded-full bg-brand-800 px-4 py-3 text-sm font-bold text-white transition group-hover:bg-brand-900 group-focus-visible:bg-brand-900">
-        View profile <span className="ml-2 transition group-hover:translate-x-0.5" aria-hidden="true">→</span>
-      </div>
-    </Link>
+      name={getName(herb)}
+      summary={getSummary(herb)}
+      bestFor={getBestFor(herb)}
+      evidence={getEvidence(herb)}
+      safety={getSafety(herb)}
+      timeToEffect={getTimeToEffect(herb)}
+      mechanisms={getMechanisms(herb)}
+      featured={featured}
+      fallbackSummary="A conservative botanical profile with research context and safety notes."
+    />
   )
 }
 
@@ -431,31 +347,13 @@ export default function HerbsIndexClient({ herbs: sourceHerbs }: { herbs: any[] 
             </button>
           </form>
 
-          <details className="mt-4 rounded-[1.2rem] border-brand-900/10 bg-[#fbfaf6]/80 p-4 shadow-none" open={hasActiveFilters || undefined}>
-            <summary className="flex min-h-11 items-center justify-between gap-4 text-sm font-bold text-ink">
-              <span>Refine by context</span>
-              <span className="text-brand-800" aria-hidden="true">↓</span>
-            </summary>
-            <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
-              <Link
-                href={buildFilterHref('all', query)}
-                className={`rounded-[1rem] border px-3 py-3 text-sm font-semibold transition ${activeFilter === 'all' ? 'border-brand-700/25 bg-brand-50 text-brand-900' : 'border-brand-900/10 bg-white/80 text-[#33443a] hover:border-brand-700/20'}`}
-              >
-                All contexts
-                <span className="mt-1 block text-xs font-medium leading-5 text-[#64746a]">Keep the scan broad.</span>
-              </Link>
-              {filterOptions.map(option => (
-                <Link
-                  key={option.value}
-                  href={buildFilterHref(option.value, query)}
-                  className={`rounded-[1rem] border px-3 py-3 text-sm font-semibold transition ${activeFilter === option.value ? 'border-brand-700/25 bg-brand-50 text-brand-900' : 'border-brand-900/10 bg-white/80 text-[#33443a] hover:border-brand-700/20'}`}
-                >
-                  {option.label}
-                  <span className="mt-1 block text-xs font-medium leading-5 text-[#64746a]">{option.hint}</span>
-                </Link>
-              ))}
-            </div>
-          </details>
+          <DecisionFilterGroup
+            options={filterOptions}
+            activeFilter={activeFilter}
+            query={query}
+            buildHref={buildFilterHref}
+            open={hasActiveFilters}
+          />
         </section>
 
         <section className="rounded-[1.5rem] border border-brand-900/10 bg-white/70 p-4 shadow-sm sm:p-5">

--- a/components/evidence/evidence-badge.tsx
+++ b/components/evidence/evidence-badge.tsx
@@ -5,11 +5,14 @@ import { getSafetyLabels } from '@/lib/safety-classification'
 type EvidenceBadgeKind =
   | 'Human Evidence'
   | 'Mechanism-Mapped'
-  | 'Preliminary Research'
-  | 'Traditional Use'
-  | 'Emerging Research'
-  | 'Strong Safety Profile'
-  | 'Evidence-Limited'
+  | 'Preliminary evidence'
+  | 'Traditional use'
+  | 'Strong evidence'
+  | 'Moderate evidence'
+  | 'Limited evidence'
+  | 'Mixed evidence'
+  | 'Insufficient evidence'
+  | 'Needs review'
   | 'Mechanistic Focus'
   | 'Interaction-Aware'
   | 'Safety-Sensitive'
@@ -22,15 +25,20 @@ type EvidenceBadgeProps = {
 const BADGE_STYLES: Record<string, string> = {
   'Human Evidence': 'border-emerald-800/15 bg-emerald-50/80 text-emerald-900',
   'Mechanism-Mapped': 'border-blue-800/15 bg-blue-50/70 text-blue-900',
-  'Preliminary Research': 'border-amber-800/20 bg-amber-50/80 text-amber-900',
-  'Traditional Use': 'border-stone-700/15 bg-stone-100/70 text-stone-800',
-  'Emerging Research': 'border-violet-800/15 bg-violet-50/70 text-violet-900',
-  'Strong Safety Profile': 'border-teal-800/15 bg-teal-50/75 text-teal-900',
-  'Evidence-Limited': 'border-amber-800/20 bg-amber-50/80 text-amber-900',
+  'Preliminary evidence': 'border-amber-800/20 bg-amber-50/80 text-amber-900',
+  'Traditional use': 'border-stone-700/15 bg-stone-100/70 text-stone-800',
+  'Strong evidence': 'border-emerald-800/15 bg-emerald-50/80 text-emerald-900',
+  'Moderate evidence': 'border-blue-800/15 bg-blue-50/70 text-blue-900',
+  'Limited evidence': 'border-amber-800/20 bg-amber-50/80 text-amber-900',
+  'Mixed evidence': 'border-violet-800/15 bg-violet-50/70 text-violet-900',
+  'Insufficient evidence': 'border-slate-500/20 bg-slate-50 text-slate-700',
+  'Needs review': 'border-slate-500/20 bg-slate-50 text-slate-700',
   'Mechanistic Focus': 'border-blue-800/15 bg-blue-50/70 text-blue-900',
   'Interaction-Aware': 'border-rose-800/15 bg-rose-50/75 text-rose-900',
   'Safety-Sensitive': 'border-amber-800/20 bg-amber-50/80 text-amber-900',
+  'Generally well tolerated': 'border-teal-800/15 bg-teal-50/75 text-teal-900',
 }
+
 
 export function EvidenceBadge({ label, className = '' }: EvidenceBadgeProps) {
   const style = BADGE_STYLES[label] || 'border-brand-900/10 bg-white/70 text-[#46574d]'
@@ -50,9 +58,8 @@ export function getEvidenceBadges(record: any): string[] {
 
   getSemanticTrustLabels(record, 4).forEach(badge => badges.add(badge))
   getSafetyLabels(record, 2).forEach(badge => badges.add(badge))
-  if (/traditional/i.test(label)) badges.add('Traditional Use')
-  if (/emerging/i.test(label)) badges.add('Emerging Research')
-  if (hasStrongSafetyProfile(record)) badges.add('Strong Safety Profile')
+  if (/traditional/i.test(label)) badges.add('Traditional use')
+  if (hasStrongSafetyProfile(record)) badges.add('Generally well tolerated')
 
   if (!badges.size) badges.add(label)
 

--- a/components/ui/DecisionPrimitives.tsx
+++ b/components/ui/DecisionPrimitives.tsx
@@ -1,0 +1,180 @@
+import Link from 'next/link'
+import { formatDisplayLabel } from '@/lib/display-utils'
+
+type DecisionMetricProps = {
+  label: string
+  value?: string
+}
+
+export function DecisionMetric({ label, value }: DecisionMetricProps) {
+  if (!value) return null
+
+  return (
+    <div className="min-w-0 rounded-[1rem] border border-brand-900/10 bg-[#fbfaf6]/85 px-3 py-2.5">
+      <p className="text-[0.66rem] font-bold uppercase tracking-[0.13em] text-[#68786f]">{label}</p>
+      <p className="mt-1 line-clamp-2 text-sm font-semibold leading-5 text-[#26382f]">{value}</p>
+    </div>
+  )
+}
+
+type DecisionEmptyStateAction = {
+  href: string
+  label: string
+  variant?: 'primary' | 'secondary'
+}
+
+export function DecisionEmptyState({
+  eyebrow,
+  title,
+  description,
+  currentScan,
+  actions,
+}: {
+  eyebrow: string
+  title: string
+  description: string
+  currentScan?: string
+  actions: DecisionEmptyStateAction[]
+}) {
+  return (
+    <div className="rounded-[1.5rem] border border-brand-900/10 bg-white/85 p-6 shadow-[var(--shadow-card-calm)] sm:p-8">
+      <div className="max-w-2xl space-y-3">
+        <p className="eyebrow-label">{eyebrow}</p>
+        <h2 className="compact-heading">{title}</h2>
+        <p className="text-sm leading-6 text-[#46574d] sm:text-base">{description}</p>
+        {currentScan ? (
+          <p className="text-sm leading-6 text-[#5f6f66]">Current scan: {currentScan}</p>
+        ) : null}
+      </div>
+
+      <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+        {actions.map(action => (
+          <Link
+            key={`${action.href}-${action.label}`}
+            href={action.href}
+            className={`${action.variant === 'primary' ? 'button-primary' : 'button-secondary'} min-h-11 justify-center px-4 py-2 text-sm`}
+          >
+            {action.label}
+          </Link>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+type DecisionFilterOption = {
+  label: string
+  value: string
+  hint: string
+}
+
+export function DecisionFilterGroup({
+  options,
+  activeFilter,
+  query,
+  buildHref,
+  open,
+}: {
+  options: DecisionFilterOption[]
+  activeFilter: string
+  query: string
+  buildHref: (value: string, query: string) => string
+  open?: boolean
+}) {
+  const itemClass = (active: boolean) =>
+    `min-h-11 rounded-[1rem] border px-3 py-3 text-sm font-semibold transition ${active ? 'border-brand-700/25 bg-brand-50 text-brand-900' : 'border-brand-900/10 bg-white/80 text-[#33443a] hover:border-brand-700/20'}`
+
+  return (
+    <details className="mt-4 rounded-[1.2rem] border-brand-900/10 bg-[#fbfaf6]/80 p-4 shadow-none" open={open || undefined}>
+      <summary className="flex min-h-11 items-center justify-between gap-4 text-sm font-bold text-ink">
+        <span>Refine by context</span>
+        <span className="text-brand-800" aria-hidden="true">↓</span>
+      </summary>
+      <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
+        <Link href={buildHref('all', query)} className={itemClass(activeFilter === 'all')}>
+          All contexts
+          <span className="mt-1 block text-xs font-medium leading-5 text-[#64746a]">Keep the scan broad.</span>
+        </Link>
+        {options.map(option => (
+          <Link key={option.value} href={buildHref(option.value, query)} className={itemClass(activeFilter === option.value)}>
+            {option.label}
+            <span className="mt-1 block text-xs font-medium leading-5 text-[#64746a]">{option.hint}</span>
+          </Link>
+        ))}
+      </div>
+    </details>
+  )
+}
+
+export function DecisionProfileCard({
+  href,
+  name,
+  summary,
+  bestFor,
+  evidence,
+  safety,
+  timeToEffect,
+  mechanisms = [],
+  featured = false,
+  fallbackSummary,
+}: {
+  href: string
+  name: string
+  summary?: string
+  bestFor: string
+  evidence: string
+  safety: string
+  timeToEffect?: string
+  mechanisms?: string[]
+  featured?: boolean
+  fallbackSummary: string
+}) {
+  const visibleMechanisms = mechanisms.map(formatDisplayLabel).filter(Boolean).slice(0, 2)
+
+  return (
+    <Link
+      href={href}
+      className="group flex h-full min-h-[16rem] flex-col rounded-[1.3rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition duration-300 hover:-translate-y-0.5 hover:border-brand-700/20 hover:bg-white hover:shadow-[var(--shadow-card-calm)] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 sm:p-5"
+    >
+      <div className="flex flex-1 flex-col">
+        <div className="flex items-start justify-between gap-3">
+          <h3 className="text-[1.35rem] font-semibold leading-tight tracking-tight text-ink transition group-hover:text-brand-800 sm:text-2xl">
+            {name}
+          </h3>
+          {featured ? (
+            <span className="shrink-0 rounded-full border border-brand-700/10 bg-brand-50 px-2.5 py-1 text-[0.68rem] font-bold text-brand-800">Start here</span>
+          ) : null}
+        </div>
+
+        <p className="mt-3 line-clamp-2 text-[0.95rem] leading-6 text-[#46574d]">
+          {summary || fallbackSummary}
+        </p>
+
+        <div className="mt-4 rounded-[1.1rem] border border-brand-900/10 bg-brand-50/45 p-3">
+          <p className="text-[0.66rem] font-bold uppercase tracking-[0.13em] text-brand-800">Best-for context</p>
+          <p className="mt-1.5 text-base font-semibold leading-6 text-[#203329]">{bestFor}</p>
+        </div>
+
+        <div className="mt-3 grid gap-2 sm:grid-cols-2">
+          <DecisionMetric label="Evidence" value={evidence} />
+          <DecisionMetric label="Safety" value={safety} />
+          <DecisionMetric label="Time" value={timeToEffect} />
+        </div>
+
+        {visibleMechanisms.length > 0 ? (
+          <div className="mt-3 flex flex-wrap gap-2 border-t border-brand-900/10 pt-3">
+            {visibleMechanisms.map(mechanism => (
+              <span key={mechanism} className="rounded-full bg-white/70 px-2.5 py-1 text-xs font-semibold text-[#64746a]">
+                {mechanism}
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      <div className="mt-4 flex min-h-11 items-center justify-center rounded-full bg-brand-800 px-4 py-3 text-sm font-bold text-white transition group-hover:bg-brand-900 group-focus-visible:bg-brand-900">
+        View profile <span className="ml-2 transition group-hover:translate-x-0.5" aria-hidden="true">→</span>
+      </div>
+    </Link>
+  )
+}

--- a/components/ui/EvidenceBadge.tsx
+++ b/components/ui/EvidenceBadge.tsx
@@ -1,51 +1,9 @@
 import Link from 'next/link'
-
-type EvidenceTier = 'strong' | 'moderate' | 'limited' | 'theoretical'
-
-const TIER_MAP: Record<EvidenceTier, {
-  label: string
-  className: string
-  tooltip: string
-}> = {
-  strong: {
-    label: 'Strong',
-    className: 'border-emerald-700/15 bg-emerald-700/10 text-emerald-800',
-    tooltip: 'Higher-confidence human evidence or stronger clinical support.',
-  },
-  moderate: {
-    label: 'Moderate',
-    className: 'border-blue-700/15 bg-blue-700/10 text-blue-800',
-    tooltip: 'Useful human evidence with limitations or mixed certainty.',
-  },
-  limited: {
-    label: 'Limited',
-    className: 'border-amber-700/20 bg-amber-700/10 text-amber-800',
-    tooltip: 'Preliminary, incomplete, or lower-confidence human evidence.',
-  },
-  theoretical: {
-    label: 'Theoretical',
-    className: 'border-slate-500/20 bg-slate-500/10 text-slate-700',
-    tooltip: 'Traditional, mechanistic, or low-direct-human-evidence support.',
-  },
-}
-
-function normalizeTier(value?: string): EvidenceTier {
-  const text = String(value || '').toLowerCase()
-
-  if (/strong|high|tier\s*a|grade\s*a|\ba\b/.test(text)) {
-    return 'strong'
-  }
-
-  if (/moderate|medium|tier\s*b|grade\s*b|\bb\b/.test(text)) {
-    return 'moderate'
-  }
-
-  if (/theoretical|traditional|mechanistic|tier\s*d|grade\s*d|\bd\b/.test(text)) {
-    return 'theoretical'
-  }
-
-  return 'limited'
-}
+import {
+  evidenceToneClasses,
+  getDecisionEvidenceTone,
+  normalizeDecisionEvidence,
+} from '@/lib/decision-primitives'
 
 export default function EvidenceBadge({
   level,
@@ -56,17 +14,18 @@ export default function EvidenceBadge({
   tier?: string
   className?: string
 }) {
-  const normalized = normalizeTier(tier || level)
-  const meta = TIER_MAP[normalized]
+  const label = normalizeDecisionEvidence(tier || level)
+  const tone = getDecisionEvidenceTone(label)
+  const tooltip = 'Conservative evidence label based on the available profile signals.'
 
   return (
     <Link
-      href="/evidence-standards"
-      title={meta.tooltip}
-      aria-label={`${meta.label} evidence. ${meta.tooltip}`}
-      className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold leading-none transition hover:scale-[1.02] ${meta.className} ${className}`}
+      href="/education/evidence-levels"
+      title={tooltip}
+      aria-label={`${label}. ${tooltip}`}
+      className={`inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-semibold leading-none transition hover:scale-[1.02] ${evidenceToneClasses(tone)} ${className}`}
     >
-      {meta.label}
+      {label}
     </Link>
   )
 }

--- a/components/ui/PremiumCard.tsx
+++ b/components/ui/PremiumCard.tsx
@@ -1,8 +1,7 @@
 import Link from 'next/link'
 import EvidenceBadge from '@/components/ui/EvidenceBadge'
 import { cleanSummary as sanitizeSummary, editorialUseCaseLabel, formatDisplayLabel, isClean } from '@/lib/display-utils'
-
-type SafetyTone = 'ok' | 'caution' | 'avoid' | 'unknown'
+import { getDecisionSafetyTone, normalizeDecisionSafety, safetyToneClasses } from '@/lib/decision-primitives'
 
 export type PremiumCardProps = {
   href: string
@@ -16,29 +15,6 @@ export type PremiumCardProps = {
   ctaLabel?: string
 }
 
-function normalizeSafety(value?: string): SafetyTone {
-  const text = String(value || '').toLowerCase()
-  if (/avoid|contraindicat|high concern|do not|pregnan/.test(text)) return 'avoid'
-  if (/caution|interaction|review|consult|medication|unknown|limited/.test(text)) return 'caution'
-  if (/generally|well tolerated|low concern|ok|safe/.test(text)) return 'ok'
-  return 'unknown'
-}
-
-function safetyClasses(tone: SafetyTone) {
-  if (tone === 'avoid') return 'border-rose-700/15 bg-rose-50 text-rose-800'
-  if (tone === 'caution') return 'border-amber-700/20 bg-amber-50 text-amber-800'
-  if (tone === 'ok') return 'border-emerald-700/15 bg-emerald-50 text-emerald-800'
-  return 'border-slate-300 bg-slate-50 text-slate-700'
-}
-
-function safetyLabel(tone: SafetyTone) {
-  if (tone === 'avoid') return 'Avoid'
-  if (tone === 'caution') return 'Caution'
-  if (tone === 'ok') return 'Low concern'
-  return 'Review safety'
-}
-
-
 export default function PremiumCard({
   href,
   title,
@@ -49,7 +25,8 @@ export default function PremiumCard({
   tags = [],
   ctaLabel = 'Open profile',
 }: PremiumCardProps) {
-  const safetyTone = normalizeSafety(safety)
+  const safetyLabel = normalizeDecisionSafety(safety)
+  const safetyTone = getDecisionSafetyTone(safetyLabel)
   const cleanSummary = sanitizeSummary(summary, 'compound')
   const cleanBestFor = isClean(bestFor) ? editorialUseCaseLabel(bestFor) : ''
   const visibleTags = tags.map(formatDisplayLabel).filter(isClean).slice(0, 3)
@@ -66,10 +43,10 @@ export default function PremiumCard({
 
           <span
             title={formatDisplayLabel(safety) || 'Safety context should be reviewed before use.'}
-            aria-label={`Safety indicator: ${safetyLabel(safetyTone)}`}
-            className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold leading-none ${safetyClasses(safetyTone)}`}
+            aria-label={`Safety indicator: ${safetyLabel}`}
+            className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold leading-none ${safetyToneClasses(safetyTone)}`}
           >
-            {safetyLabel(safetyTone)}
+            {safetyLabel}
           </span>
         </div>
       </div>

--- a/components/ui/SafetyBadge.tsx
+++ b/components/ui/SafetyBadge.tsx
@@ -1,19 +1,16 @@
-export default function SafetyBadge({ level = 'safe' }: any) {
-  const map: any = {
-    safe: 'bg-green-100 text-green-800',
-    caution: 'bg-yellow-100 text-yellow-800',
-    avoid: 'bg-red-100 text-red-800'
-  }
+import {
+  getDecisionSafetyTone,
+  normalizeDecisionSafety,
+  safetyToneClasses,
+} from '@/lib/decision-primitives'
 
-  const label: any = {
-    safe: 'Generally Safe',
-    caution: 'Use With Caution',
-    avoid: 'Avoid / Contraindicated'
-  }
+export default function SafetyBadge({ level = 'Needs review' }: { level?: string }) {
+  const label = normalizeDecisionSafety(level)
+  const tone = getDecisionSafetyTone(label)
 
   return (
-    <div className={`inline-block text-xs px-3 py-1 rounded-full font-semibold ${map[level]}`}>
-      {label[level]}
-    </div>
+    <span className={`inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold leading-none ${safetyToneClasses(tone)}`}>
+      {label}
+    </span>
   )
 }

--- a/docs/ux/shared-decision-primitives-pass.md
+++ b/docs/ux/shared-decision-primitives-pass.md
@@ -1,0 +1,73 @@
+# Shared decision primitives pass
+
+This pass stabilizes the decision-engine UI shared by the herb and compound libraries without changing workbook/runtime generation or route contracts.
+
+## Standardized evidence semantics
+
+Use the following evidence labels across scan cards, profile badges, and snapshot summaries:
+
+- **Strong evidence** — stronger human or clinical signals are present.
+- **Moderate evidence** — useful evidence exists but remains bounded by limitations.
+- **Limited evidence** — direct support is incomplete or lower confidence.
+- **Mixed evidence** — profile signals conflict or remain inconsistent.
+- **Preliminary evidence** — mechanistic, preclinical, animal, cell, in-vitro, early, or exploratory signals.
+- **Traditional use** — historical or ethnobotanical framing without implying modern efficacy.
+- **Insufficient evidence** — no meaningful support is surfaced by the profile data.
+- **Needs review** — source fields are unknown, draft-like, or not ready to classify.
+
+Avoid synonym drift such as “theoretical,” “emerging research,” “low evidence,” or unlabeled raw workbook tiers on user-facing decision cards. If a source value is ambiguous, normalize downward rather than upward.
+
+## Standardized safety semantics
+
+Use restrained safety labels that preserve uncertainty:
+
+- **Generally well tolerated** — only when the source text suggests low concern, food-like use, or well-tolerated framing.
+- **Use caution** — the default when notes exist but do not cleanly indicate low concern.
+- **Interaction risk** — medication, polypharmacy, anticoagulant, CNS depressant, SSRI/MAOI, or similar interaction signals.
+- **Needs review** — missing, unknown, or draft-like safety status.
+- **Limited safety data** — sparse safety data or explicit low-data framing.
+
+Avoid absolute safety language. Do not convert contraindication language into deterministic medical advice; keep it as cautious review framing.
+
+## Shared hierarchy rules
+
+Herb and compound decision cards should keep the same scan order:
+
+1. **Primary** — title, short summary, and best-for context.
+2. **Secondary** — evidence, safety, and timing metrics.
+3. **Tertiary** — mechanism hints and supporting metadata.
+4. **CTA** — one consistent full-width card action placed after the scan content.
+
+The profile snapshot pattern should also start with practical fit, then evidence, then safety, then timing/mechanism context. Safety and evidence should remain visible without turning the card into badge soup.
+
+## Mobile rhythm rules
+
+- Keep search inputs and CTA buttons at a minimum comfortable tap height.
+- Stack empty-state actions vertically on narrow screens, then wrap horizontally on larger screens.
+- Use small, consistent gaps between decision metrics; avoid dense multi-row badge clusters.
+- Let metric values wrap to two lines instead of truncating critical safety/evidence language.
+- Preserve a single card CTA at the bottom so mobile users do not hunt for the next action.
+
+## Empty-state philosophy
+
+Empty states should be calm, explanatory, and recovery-oriented:
+
+- State what happened in plain language.
+- Explain that conservative evidence/safety handling may reduce matches.
+- Show the current scan when filters are active.
+- Provide clear recovery actions such as reset, browse the paired library, search, or goals.
+
+Avoid dead-end empty shells or language that implies the database is broken.
+
+## Abstraction constraints
+
+This is not a full design-system migration. Reuse is intentionally small and localized:
+
+- Use `lib/decision-primitives.ts` for label normalization and tone classes.
+- Use `components/ui/DecisionPrimitives.tsx` for repeated library-card, filter, metric, and empty-state UI.
+- Keep entity-specific extraction logic inside the herb and compound index clients because source fields still differ.
+- Do not centralize workbook/runtime generation or introduce new generic component trees for unrelated pages.
+
+## Reuse philosophy
+
+Centralize stable semantics; localize unstable data extraction. The shared layer should make herbs and compounds feel like one product system while leaving each library free to map its own source fields conservatively.

--- a/lib/decision-primitives.ts
+++ b/lib/decision-primitives.ts
@@ -1,0 +1,121 @@
+export const STANDARD_EVIDENCE_LABELS = [
+  'Strong evidence',
+  'Moderate evidence',
+  'Limited evidence',
+  'Mixed evidence',
+  'Preliminary evidence',
+  'Traditional use',
+  'Insufficient evidence',
+  'Needs review',
+] as const
+
+export type StandardEvidenceLabel = (typeof STANDARD_EVIDENCE_LABELS)[number]
+
+export const STANDARD_SAFETY_LABELS = [
+  'Generally well tolerated',
+  'Use caution',
+  'Interaction risk',
+  'Needs review',
+  'Limited safety data',
+] as const
+
+export type StandardSafetyLabel = (typeof STANDARD_SAFETY_LABELS)[number]
+export type DecisionSafetyTone = 'ok' | 'caution' | 'interaction' | 'review' | 'limited'
+export type DecisionEvidenceTone = 'strong' | 'moderate' | 'limited' | 'mixed' | 'preliminary' | 'traditional' | 'insufficient' | 'review'
+
+function compactText(value?: unknown) {
+  if (value == null) return ''
+  if (Array.isArray(value)) return value.map(compactText).filter(Boolean).join(' ')
+  if (typeof value === 'object') return Object.values(value as Record<string, unknown>).map(compactText).filter(Boolean).join(' ')
+  return String(value).trim()
+}
+
+function matchesCanonicalEvidence(value: string): StandardEvidenceLabel | '' {
+  const match = STANDARD_EVIDENCE_LABELS.find(label => label.toLowerCase() === value.toLowerCase())
+  return match || ''
+}
+
+function matchesCanonicalSafety(value: string): StandardSafetyLabel | '' {
+  const match = STANDARD_SAFETY_LABELS.find(label => label.toLowerCase() === value.toLowerCase())
+  return match || ''
+}
+
+export function normalizeDecisionEvidence(value?: unknown, fallback: StandardEvidenceLabel = 'Limited evidence'): StandardEvidenceLabel {
+  const raw = compactText(value)
+  if (!raw) return fallback
+
+  const canonical = matchesCanonicalEvidence(raw)
+  if (canonical) return canonical
+
+  const text = raw.toLowerCase().replace(/[_-]+/g, ' ')
+
+  if (/\b(needs? review|review needed|unknown|tbd|draft|placeholder|profile pending)\b/.test(text)) return 'Needs review'
+  if (/\b(none|no evidence|insufficient|minimal|not established)\b/.test(text)) return 'Insufficient evidence'
+  if (/\b(mixed|conflict|inconsistent|equivocal)\b/.test(text)) return 'Mixed evidence'
+  if (/\b(traditional|ethnobotanical|historical|folk use)\b/.test(text)) return 'Traditional use'
+  if (/\b(strong|high|robust|meta analysis|systematic review|grade\s*a|tier\s*a|\ba\b)\b/.test(text)) return 'Strong evidence'
+  if (/\b(moderate|medium|developing|grade\s*b|tier\s*b|\bb\b)\b/.test(text)) return 'Moderate evidence'
+  if (/\b(preliminary|preclinical|animal|cell|in vitro|mechanistic|theoretical|emerging|early|exploratory|grade\s*c|tier\s*c|\bc\b|grade\s*d|tier\s*d|\bd\b)\b/.test(text)) return 'Preliminary evidence'
+  if (/\b(limited|low|weak|partial|human limited)\b/.test(text)) return 'Limited evidence'
+
+  return fallback
+}
+
+export function getDecisionEvidenceTone(labelOrValue?: unknown): DecisionEvidenceTone {
+  const label = normalizeDecisionEvidence(labelOrValue)
+  if (label === 'Strong evidence') return 'strong'
+  if (label === 'Moderate evidence') return 'moderate'
+  if (label === 'Mixed evidence') return 'mixed'
+  if (label === 'Preliminary evidence') return 'preliminary'
+  if (label === 'Traditional use') return 'traditional'
+  if (label === 'Insufficient evidence') return 'insufficient'
+  if (label === 'Needs review') return 'review'
+  return 'limited'
+}
+
+export function normalizeDecisionSafety(value?: unknown, options: { hasSafetyNotes?: boolean } = {}): StandardSafetyLabel {
+  const raw = compactText(value)
+  if (!raw) return options.hasSafetyNotes ? 'Use caution' : 'Needs review'
+
+  const canonical = matchesCanonicalSafety(raw)
+  if (canonical) return canonical
+
+  const text = raw.toLowerCase().replace(/[_-]+/g, ' ')
+
+  if (/\b(needs? review|review needed|unknown|tbd|draft|placeholder|profile pending)\b/.test(text)) return 'Needs review'
+  if (/\b(limited safety|limited data|low data|no safety data|insufficient safety)\b/.test(text)) return 'Limited safety data'
+  if (/\b(interaction|interacts|warfarin|ssri|maoi|anticoagul|antiplatelet|cns depressant|sedative stack|polypharmacy)\b/.test(text)) return 'Interaction risk'
+  if (/\b(avoid|contraindicat|caution|consult|clinician|medication|pregnan|breastfeeding|liver|kidney|seizure|bleed|sedat|toxic|risk|high concern|do not)\b/.test(text)) return 'Use caution'
+  if (/\b(generally|well tolerated|low concern|low risk|food use|food derived|safe|high confidence|standard caution)\b/.test(text)) return 'Generally well tolerated'
+  if (/\b(low)\b/.test(text)) return 'Limited safety data'
+  if (/\b(medium|some safety|safety notes available|safety context)\b/.test(text)) return 'Use caution'
+  if (/\b(high)\b/.test(text)) return 'Generally well tolerated'
+
+  return options.hasSafetyNotes ? 'Use caution' : 'Needs review'
+}
+
+export function getDecisionSafetyTone(labelOrValue?: unknown, options: { hasSafetyNotes?: boolean } = {}): DecisionSafetyTone {
+  const label = normalizeDecisionSafety(labelOrValue, options)
+  if (label === 'Generally well tolerated') return 'ok'
+  if (label === 'Interaction risk') return 'interaction'
+  if (label === 'Limited safety data') return 'limited'
+  if (label === 'Needs review') return 'review'
+  return 'caution'
+}
+
+export function evidenceToneClasses(tone: DecisionEvidenceTone) {
+  if (tone === 'strong') return 'border-emerald-700/15 bg-emerald-50 text-emerald-800'
+  if (tone === 'moderate') return 'border-blue-700/15 bg-blue-50 text-blue-800'
+  if (tone === 'mixed') return 'border-violet-700/15 bg-violet-50 text-violet-800'
+  if (tone === 'preliminary') return 'border-amber-700/20 bg-amber-50 text-amber-800'
+  if (tone === 'traditional') return 'border-stone-700/15 bg-stone-100 text-stone-800'
+  if (tone === 'insufficient' || tone === 'review') return 'border-slate-500/20 bg-slate-50 text-slate-700'
+  return 'border-amber-700/20 bg-amber-50 text-amber-800'
+}
+
+export function safetyToneClasses(tone: DecisionSafetyTone) {
+  if (tone === 'ok') return 'border-emerald-700/15 bg-emerald-50 text-emerald-800'
+  if (tone === 'interaction') return 'border-rose-700/15 bg-rose-50 text-rose-800'
+  if (tone === 'limited' || tone === 'review') return 'border-slate-500/20 bg-slate-50 text-slate-700'
+  return 'border-amber-700/20 bg-amber-50 text-amber-800'
+}

--- a/lib/evidence-utils.ts
+++ b/lib/evidence-utils.ts
@@ -1,15 +1,11 @@
+import { normalizeDecisionEvidence, normalizeDecisionSafety } from './decision-primitives'
+
 export function normalizeEvidenceLevel(value?: string) {
-  const text = String(value || '').toLowerCase()
-  if (text.includes('strong') || text.includes('high')) return 'strong'
-  if (text.includes('limited') || text.includes('low') || text.includes('weak')) return 'limited'
-  return 'moderate'
+  return normalizeDecisionEvidence(value)
 }
 
 export function normalizeSafetyLevel(value?: string) {
-  const text = String(value || '').toLowerCase()
-  if (text.includes('avoid') || text.includes('contraindicat')) return 'avoid'
-  if (text.includes('caution') || text.includes('interaction') || text.includes('pregnan') || text.includes('liver')) return 'caution'
-  return 'safe'
+  return normalizeDecisionSafety(value)
 }
 
 export function getEffects(row: any) {

--- a/lib/evidence.ts
+++ b/lib/evidence.ts
@@ -1,4 +1,4 @@
-type EvidenceTier = 'strong' | 'moderate' | 'limited' | 'preliminary' | 'traditional' | 'emerging'
+type EvidenceTier = 'strong' | 'moderate' | 'limited' | 'preliminary' | 'traditional' | 'mixed' | 'insufficient' | 'review'
 
 type EvidenceColor = 'emerald' | 'blue' | 'amber' | 'sand' | 'violet' | 'slate'
 
@@ -88,10 +88,13 @@ export function isPreliminaryResearch(record: any): boolean {
 export function getEvidenceTier(record: any): EvidenceTier {
   const evidence = evidenceText(record)
 
+  if (/\b(needs? review|unknown|tbd|draft|placeholder|profile pending)\b/.test(evidence)) return 'review'
+  if (/\b(none|no evidence|insufficient|minimal|not established)\b/.test(evidence)) return 'insufficient'
+  if (/\b(mixed|conflict|inconsistent|equivocal)\b/.test(evidence)) return 'mixed'
   if (/\b(strong|high|robust|grade\s*a|tier\s*a)\b/.test(evidence)) return 'strong'
   if (/\b(moderate|medium|grade\s*b|tier\s*b)\b/.test(evidence)) return 'moderate'
   if (/\b(traditional|ethnobotanical|historical)\b/.test(evidence)) return 'traditional'
-  if (/\b(emerging|early)\b/.test(evidence)) return 'emerging'
+  if (/\b(emerging|early)\b/.test(evidence)) return 'preliminary'
   if (isPreliminaryResearch(record)) return 'preliminary'
   if (hasHumanEvidence(record)) return 'moderate'
   if (hasMechanismEvidence(record)) return 'limited'
@@ -101,12 +104,14 @@ export function getEvidenceTier(record: any): EvidenceTier {
 
 export function getEvidenceLabel(record: any): string {
   const labels: Record<EvidenceTier, string> = {
-    strong: 'Strong Evidence',
-    moderate: 'Moderate Evidence',
-    limited: 'Limited Evidence',
-    preliminary: 'Preliminary Research',
-    traditional: 'Traditional Use',
-    emerging: 'Emerging Research',
+    strong: 'Strong evidence',
+    moderate: 'Moderate evidence',
+    limited: 'Limited evidence',
+    preliminary: 'Preliminary evidence',
+    traditional: 'Traditional use',
+    mixed: 'Mixed evidence',
+    insufficient: 'Insufficient evidence',
+    review: 'Needs review',
   }
 
   return labels[getEvidenceTier(record)]
@@ -119,7 +124,9 @@ export function getEvidenceColor(record: any): EvidenceColor {
     limited: 'slate',
     preliminary: 'amber',
     traditional: 'sand',
-    emerging: 'violet',
+    mixed: 'violet',
+    insufficient: 'slate',
+    review: 'slate',
   }
 
   return colors[getEvidenceTier(record)]


### PR DESCRIPTION
### Motivation
- Stabilize the decision-engine presentation shared by the herbs and compounds libraries so both surfaces read and scan consistently without a broad redesign. 
- Standardize conservative evidence and safety semantics to prevent synonym drift and preserve uncertainty-aware language on cards and badges. 
- Provide a small, localized reuse layer that enforces hierarchy, spacing rhythm, CTA placement, and calm empty states while keeping source-field mapping local to each index page.

### Description
- Add `lib/decision-primitives.ts` to normalize evidence/safety labels, expose tone mappings, and provide CSS class helpers (`normalizeDecisionEvidence`, `normalizeDecisionSafety`, `evidenceToneClasses`, `safetyToneClasses`).
- Add `components/ui/DecisionPrimitives.tsx` containing `DecisionMetric`, `DecisionEmptyState`, `DecisionFilterGroup`, and `DecisionProfileCard` to consolidate card layout, filter group UI, metric rhythm, and empty-state actions. 
- Update `app/herbs/HerbsIndexClient.tsx` and `app/compounds/CompoundsIndexClient.tsx` to consume the shared normalizers and UI primitives so herb and compound library cards, filters, and empty states behave consistently. 
- Replace ad-hoc evidence/safety pills and badge logic with standardized consumers (`components/ui/EvidenceBadge.tsx`, `components/ui/SafetyBadge.tsx`, `components/ui/PremiumCard.tsx`, and `components/evidence/evidence-badge.tsx`) and align `lib/evidence.ts`/`lib/evidence-utils.ts` to the new canonical labels. 
- Add UX documentation at `docs/ux/shared-decision-primitives-pass.md` describing evidence/safety label set, hierarchy rules, mobile rhythm, empty-state philosophy, and abstraction constraints.

### Testing
- Ran `npm run lint` and the lint pass completed successfully. 
- Ran `npx tsc --noEmit` and TypeScript checks completed with no errors. 
- Ran `npm run build` (which also executes the site data build/verifications) and the full build finished successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08849b3c488323bdd288c6412f4bb2)