### PR TITLE
Polish mobile usability surfaces

### DIFF
--- a/app/compounds/CompoundsIndexClient.tsx
+++ b/app/compounds/CompoundsIndexClient.tsx
@@ -214,9 +214,9 @@ function buildFilterHref(value: string, query: string) {
 
 function StatCard({ value, label }: { value: number; label: string }) {
   return (
-    <div className="rounded-[1.1rem] border border-brand-900/10 bg-white/75 p-3 shadow-sm backdrop-blur sm:p-4">
+    <div className="min-w-0 rounded-[1.1rem] border border-brand-900/10 bg-white/75 p-3 shadow-sm backdrop-blur sm:p-4">
       <p className="text-2xl font-semibold tracking-tight text-ink sm:text-3xl">{value}</p>
-      <p className="mt-1 text-[0.68rem] font-bold uppercase tracking-[0.14em] text-[#5f6f66]">{label}</p>
+      <p className="mt-1 text-[0.66rem] font-bold uppercase leading-snug tracking-[0.12em] text-[#5f6f66] sm:text-[0.68rem] sm:tracking-[0.14em]">{label}</p>
     </div>
   )
 }
@@ -305,7 +305,7 @@ export default function CompoundsIndexClient({ compounds: sourceCompounds }: { c
   const libraryCompounds = hasActiveFilters ? visibleCompounds : compounds.slice(featuredCompounds.length)
 
   return (
-    <div className="min-h-screen px-4 py-5 text-ink sm:py-8">
+    <div className="min-h-screen px-3 py-5 text-ink sm:px-4 sm:py-8">
       <div className="mx-auto max-w-7xl space-y-8 sm:space-y-12">
         <section className="hero-shell relative overflow-hidden rounded-[1.7rem] border border-white/50 px-5 py-7 shadow-sm sm:rounded-[2.2rem] sm:px-8 sm:py-10 lg:px-12">
           <div className="!absolute right-[-8rem] top-[-8rem] h-72 w-72 rounded-full bg-emerald-200/25 blur-3xl" />

--- a/app/globals.css
+++ b/app/globals.css
@@ -521,7 +521,8 @@ body {
     }
 
     .chip-readable {
-      @apply px-3 py-1.5 text-xs;
+      @apply min-h-9 px-3 py-2 text-xs leading-snug;
+      white-space: normal;
     }
   }
 }

--- a/app/herbs/HerbsIndexClient.tsx
+++ b/app/herbs/HerbsIndexClient.tsx
@@ -191,9 +191,9 @@ function buildFilterHref(value: string, query: string) {
 
 function StatCard({ value, label }: { value: number; label: string }) {
   return (
-    <div className="rounded-[1.1rem] border border-brand-900/10 bg-white/75 p-3 shadow-sm backdrop-blur sm:p-4">
+    <div className="min-w-0 rounded-[1.1rem] border border-brand-900/10 bg-white/75 p-3 shadow-sm backdrop-blur sm:p-4">
       <p className="text-2xl font-semibold tracking-tight text-ink sm:text-3xl">{value}</p>
-      <p className="mt-1 text-[0.68rem] font-bold uppercase tracking-[0.14em] text-[#5f6f66]">{label}</p>
+      <p className="mt-1 text-[0.66rem] font-bold uppercase leading-snug tracking-[0.12em] text-[#5f6f66] sm:text-[0.68rem] sm:tracking-[0.14em]">{label}</p>
     </div>
   )
 }
@@ -295,7 +295,7 @@ export default function HerbsIndexClient({ herbs: sourceHerbs }: { herbs: any[] 
   const libraryHerbs = hasActiveFilters ? visibleHerbs : herbs.slice(featuredHerbs.length)
 
   return (
-    <div className="min-h-screen px-4 py-5 text-ink sm:py-8">
+    <div className="min-h-screen px-3 py-5 text-ink sm:px-4 sm:py-8">
       <div className="mx-auto max-w-7xl space-y-8 sm:space-y-12">
         <section className="hero-shell relative overflow-hidden rounded-[1.7rem] border border-white/50 px-5 py-7 shadow-sm sm:rounded-[2.2rem] sm:px-8 sm:py-10 lg:px-12">
           <div className="!absolute right-[-8rem] top-[-8rem] h-72 w-72 rounded-full bg-emerald-200/25 blur-3xl" />

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -100,7 +100,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             </div>
           </header>
 
-          <div className='pb-28 md:pb-10'>
+          <div className='pb-[calc(env(safe-area-inset-bottom)+6rem)] md:pb-10'>
             {children}
           </div>
 

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -7,12 +7,8 @@ import compoundsSummaryData from '@/public/data/compounds-summary.json'
 import herbsSummaryData from '@/public/data/herbs-summary.json'
 import { cleanSummary, formatDisplayLabel, isClean, labelize, list, text, unique } from '@/lib/display-utils'
 import {
-  evidenceToneClasses,
-  getDecisionEvidenceTone,
-  getDecisionSafetyTone,
   normalizeDecisionEvidence,
   normalizeDecisionSafety,
-  safetyToneClasses,
 } from '@/lib/decision-primitives'
 import { getSemanticOrchestrationSignals } from '@/lib/semantic-orchestration'
 
@@ -146,18 +142,10 @@ function getQuality(item: any) {
   return labelize(item.profile_status || item.summary_quality || item.review_status || item.status || item.confidence, 'Profile Review')
 }
 
-function evidenceClass(level: string) {
-  return `rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] ${evidenceToneClasses(getDecisionEvidenceTone(level))}`
-}
-
-function safetyClass(level: string) {
-  return `rounded-full border px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] ${safetyToneClasses(getDecisionSafetyTone(level))}`
-}
-
 function typeClass(type: SearchType) {
   return type === 'Herb'
-    ? 'rounded-full border border-brand-700/10 bg-brand-50 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-brand-800'
-    : 'rounded-full border border-blue-700/10 bg-blue-50 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-blue-800'
+    ? 'rounded-full border border-brand-700/10 bg-brand-50 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-brand-800'
+    : 'rounded-full border border-blue-700/10 bg-blue-50 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-blue-800'
 }
 
 function compareAuthority(a: SearchItem, b: SearchItem) {
@@ -253,17 +241,15 @@ function ResultCard({ item }: { item: SearchItem }) {
   return (
     <Link
       href={item.href}
-      className="group flex h-full min-h-[16rem] flex-col rounded-[1.3rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition duration-300 hover:-translate-y-0.5 hover:border-brand-700/20 hover:bg-white hover:shadow-[var(--shadow-card-calm)] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 sm:p-5"
+      className="group flex h-full min-h-[15rem] flex-col rounded-[1.3rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition duration-300 hover:-translate-y-0.5 hover:border-brand-700/20 hover:bg-white hover:shadow-[var(--shadow-card-calm)] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 sm:min-h-[16rem] sm:p-5"
     >
       <div className="flex flex-1 flex-col">
         <div className="flex flex-wrap gap-2">
           <span className={typeClass(item.type)}>{item.type}</span>
-          <span className={evidenceClass(item.evidence)}>{item.evidence}</span>
-          <span className={safetyClass(item.safety)}>{item.safety}</span>
         </div>
 
-        <div className="mt-4 flex items-start justify-between gap-3">
-          <h2 className="text-[1.35rem] font-semibold leading-tight tracking-tight text-ink transition group-hover:text-brand-800 sm:text-2xl">
+        <div className="mt-4 flex min-w-0 items-start justify-between gap-3">
+          <h2 className="min-w-0 break-words text-[1.3rem] font-semibold leading-tight tracking-tight text-ink transition group-hover:text-brand-800 sm:text-2xl">
             {item.name}
           </h2>
         </div>
@@ -320,7 +306,7 @@ function GuidedDiscovery({ onSelect }: { onSelect: (query: string) => void }) {
             key={path.label}
             type="button"
             onClick={() => onSelect(path.query)}
-            className="group min-h-28 rounded-[1.1rem] border border-brand-900/10 bg-white/80 p-4 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-brand-700/20 hover:bg-white"
+            className="group min-h-24 rounded-[1.1rem] border border-brand-900/10 bg-white/80 p-4 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-brand-700/20 hover:bg-white sm:min-h-28"
           >
             <span className="text-lg font-semibold tracking-tight text-ink transition group-hover:text-brand-800">{path.label}</span>
             <span className="mt-2 block text-sm leading-6 text-[#46574d]">{path.description}</span>
@@ -451,21 +437,21 @@ export default function SearchPage() {
                 />
               </div>
 
-              <details className="rounded-[1.2rem] border border-brand-900/10 bg-[#fbfaf6]/80 p-4" open={hasActiveSearch || undefined}>
-                <summary className="flex min-h-11 cursor-pointer items-center justify-between gap-4 text-sm font-bold text-ink">
+              <details className="rounded-[1.2rem] border border-brand-900/10 bg-[#fbfaf6]/80 p-3 sm:p-4" open={hasActiveSearch || undefined}>
+                <summary className="flex min-h-12 cursor-pointer items-center justify-between gap-4 text-sm font-bold text-ink">
                   <span>Refine results</span>
                   <span className="text-brand-800" aria-hidden="true">↓</span>
                 </summary>
                 <div className="mt-4 space-y-4">
-                  <div className="flex flex-wrap gap-2">
+                  <div className="grid gap-2 sm:flex sm:flex-wrap">
                     {filterOptions.map(filter => (
                       <button
                         key={filter}
                         type="button"
                         onClick={() => setActiveFilter(filter)}
                         className={activeFilter === filter
-                          ? 'button-primary min-h-11 rounded-full px-4 py-2 text-sm'
-                          : 'min-h-11 rounded-full border border-brand-900/10 bg-white/80 px-4 py-2 text-sm font-semibold text-[#33443a] transition hover:border-brand-700/20 hover:bg-white hover:text-brand-800'}
+                          ? 'button-primary min-h-12 rounded-full px-4 py-2 text-sm'
+                          : 'min-h-12 rounded-full border border-brand-900/10 bg-white/80 px-4 py-2 text-sm font-semibold text-[#33443a] transition hover:border-brand-700/20 hover:bg-white hover:text-brand-800'}
                       >
                         {filter === 'All' ? 'All profiles' : `${filter}s only`}
                       </button>

--- a/components/ui/DecisionPrimitives.tsx
+++ b/components/ui/DecisionPrimitives.tsx
@@ -82,15 +82,15 @@ export function DecisionFilterGroup({
   open?: boolean
 }) {
   const itemClass = (active: boolean) =>
-    `min-h-11 rounded-[1rem] border px-3 py-3 text-sm font-semibold transition ${active ? 'border-brand-700/25 bg-brand-50 text-brand-900' : 'border-brand-900/10 bg-white/80 text-[#33443a] hover:border-brand-700/20'}`
+    `min-h-12 rounded-[1rem] border px-3 py-3 text-sm font-semibold leading-snug transition ${active ? 'border-brand-700/25 bg-brand-50 text-brand-900' : 'border-brand-900/10 bg-white/80 text-[#33443a] hover:border-brand-700/20'}`
 
   return (
-    <details className="mt-4 rounded-[1.2rem] border-brand-900/10 bg-[#fbfaf6]/80 p-4 shadow-none" open={open || undefined}>
-      <summary className="flex min-h-11 items-center justify-between gap-4 text-sm font-bold text-ink">
+    <details className="mt-4 rounded-[1.2rem] border border-brand-900/10 bg-[#fbfaf6]/80 p-3 shadow-none sm:p-4" open={open || undefined}>
+      <summary className="flex min-h-12 items-center justify-between gap-4 text-sm font-bold text-ink">
         <span>Refine by context</span>
         <span className="text-brand-800" aria-hidden="true">↓</span>
       </summary>
-      <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
+      <div className="mt-3 grid gap-2 sm:mt-4 sm:grid-cols-2 lg:grid-cols-5">
         <Link href={buildHref('all', query)} className={itemClass(activeFilter === 'all')}>
           All contexts
           <span className="mt-1 block text-xs font-medium leading-5 text-[#64746a]">Keep the scan broad.</span>
@@ -134,11 +134,11 @@ export function DecisionProfileCard({
   return (
     <Link
       href={href}
-      className="group flex h-full min-h-[16rem] flex-col rounded-[1.3rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition duration-300 hover:-translate-y-0.5 hover:border-brand-700/20 hover:bg-white hover:shadow-[var(--shadow-card-calm)] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 sm:p-5"
+      className="group flex h-full min-h-[15rem] flex-col rounded-[1.3rem] border border-brand-900/10 bg-white/90 p-4 shadow-sm transition duration-300 hover:-translate-y-0.5 hover:border-brand-700/20 hover:bg-white hover:shadow-[var(--shadow-card-calm)] focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-700/40 sm:min-h-[16rem] sm:p-5"
     >
       <div className="flex flex-1 flex-col">
-        <div className="flex items-start justify-between gap-3">
-          <h3 className="text-[1.35rem] font-semibold leading-tight tracking-tight text-ink transition group-hover:text-brand-800 sm:text-2xl">
+        <div className="flex min-w-0 items-start justify-between gap-3">
+          <h3 className="min-w-0 break-words text-[1.3rem] font-semibold leading-tight tracking-tight text-ink transition group-hover:text-brand-800 sm:text-2xl">
             {name}
           </h3>
           {featured ? (

--- a/docs/ux/mobile-usability-polish-pass.md
+++ b/docs/ux/mobile-usability-polish-pass.md
@@ -1,0 +1,52 @@
+# Mobile usability polish pass
+
+## Scope
+
+This pass is limited to active runtime UI surfaces for the mobile experience on:
+
+- `/herbs`
+- `/compounds`
+- `/search`
+- Mobile header menu navigation
+- Mobile bottom navigation
+- Shared decision-card, chip, filter, and search-result interaction surfaces
+
+## Goals
+
+- Improve thumb ergonomics for filters, mobile menu links, search controls, and bottom navigation.
+- Reduce visual noise in search result cards while preserving conservative evidence and safety context.
+- Improve wrapping behavior for chips and compact metadata on narrow screens.
+- Stabilize vertical rhythm across stacked cards, filters, and result sections.
+- Preserve existing route contracts, runtime data contracts, workbook generation, and information architecture.
+
+## Major refinements
+
+- Increased mobile tap target consistency for filter rows, menu links, and bottom navigation items.
+- Adjusted bottom navigation spacing to use flexible equal-width items, stronger safe-area padding, and a calmer elevated surface.
+- Reduced duplicate metadata pressure in `/search` result cards by keeping profile type as the top badge while retaining evidence and safety metrics inside the card body.
+- Added safer heading wrapping for shared profile cards and search cards to avoid clipped or cramped long names.
+- Relaxed mobile chip wrapping so long metadata chips can wrap instead of forcing horizontal overflow on narrow screens.
+- Tightened mobile page gutters on `/herbs` and `/compounds` to reduce cramped card edges without changing desktop layout.
+- Normalized shared filter disclosure padding and touch target heights for calmer mobile scanning.
+
+## Non-goals
+
+- No route changes.
+- No redesign of the brand direction, component system, or navigation architecture.
+- No workbook, runtime data generation, or package changes.
+- No new dependencies.
+- No broad refactors or inactive-code cleanup.
+
+## Validation status
+
+Validation completed on this branch with the required commands:
+
+- `npm run lint` — passed.
+- `npx tsc --noEmit` — passed.
+- `npm run build` — passed. Build output included the existing MVP deploy-readiness warning that `sitemap.xml` is missing, followed by `[deploy-readiness] PASS (MVP relaxed mode)`.
+
+## Known remaining risks
+
+- This pass included one automated mobile screenshot check of `/search`; remaining issues may still appear only on specific physical viewport widths or device safe-area implementations.
+- Existing global CSS has multiple layers that define chip/button behavior; this pass only added narrow mobile wrapping safeguards and did not consolidate the styling sources.
+- Search result ordering and data payloads were intentionally left unchanged, so any data-quality issues remain outside this UX polish scope.

--- a/src/components/mobile-bottom-nav.tsx
+++ b/src/components/mobile-bottom-nav.tsx
@@ -36,8 +36,8 @@ export default function MobileBottomNav() {
   const pathname = usePathname()
 
   return (
-    <nav className="fixed inset-x-0 bottom-0 z-[90] border-t border-brand-900/10 bg-white/[0.88] backdrop-blur-xl supports-[backdrop-filter]:bg-white/75 md:hidden">
-      <div className="mx-auto flex max-w-2xl items-center justify-around px-2 py-2 pb-[calc(env(safe-area-inset-bottom)+0.5rem)]">
+    <nav className="fixed inset-x-0 bottom-0 z-[90] border-t border-brand-900/10 bg-white/[0.92] shadow-[0_-10px_30px_rgba(17,24,39,0.08)] backdrop-blur-xl supports-[backdrop-filter]:bg-white/80 md:hidden">
+      <div className="mx-auto flex max-w-2xl items-stretch gap-1 px-2 pb-[calc(env(safe-area-inset-bottom)+0.65rem)] pt-2">
         {navItems.map((item) => {
           const active = pathname === item.href || pathname?.startsWith(`${item.href}/`)
           const Icon = item.Icon
@@ -47,14 +47,14 @@ export default function MobileBottomNav() {
               key={item.href}
               href={item.href}
               aria-current={active ? 'page' : undefined}
-              className={`flex min-w-[64px] flex-col items-center gap-1 rounded-2xl px-3 py-2 text-center transition-all duration-200 ${
+              className={`flex min-h-[3.25rem] min-w-0 flex-1 flex-col items-center justify-center gap-1 rounded-2xl px-1.5 py-2 text-center transition-all duration-200 ${
                 active
                   ? 'bg-brand-900/8 text-brand-800 shadow-sm'
                   : 'text-[#5c6d63] hover:bg-black/[0.03] hover:text-ink'
               }`}
             >
-              <Icon aria-hidden="true" className="h-4 w-4" strokeWidth={2.2} />
-              <span className="text-xs font-semibold tracking-tight">
+              <Icon aria-hidden="true" className="h-[1.05rem] w-[1.05rem]" strokeWidth={2.2} />
+              <span className="max-w-full truncate text-[0.68rem] font-semibold leading-none tracking-tight">
                 {item.label}
               </span>
             </Link>

--- a/src/components/mobile-nav.tsx
+++ b/src/components/mobile-nav.tsx
@@ -79,7 +79,7 @@ export default function MobileNav({ links }: MobileNavProps) {
         aria-expanded={open}
         aria-controls='mobile-navigation'
         onClick={() => setOpen(value => !value)}
-        className='rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-black text-slate-900 shadow-sm transition hover:border-emerald-300 hover:bg-emerald-50 active:scale-[0.98]'
+        className='min-h-11 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-black text-slate-900 shadow-sm transition hover:border-emerald-300 hover:bg-emerald-50 active:scale-[0.98]'
       >
         Menu
       </button>
@@ -89,7 +89,7 @@ export default function MobileNav({ links }: MobileNavProps) {
           ref={navRef}
           id='mobile-navigation'
           aria-label='Mobile navigation'
-          className='absolute left-4 right-4 top-20 z-50 rounded-3xl border border-slate-200 bg-white p-2 shadow-2xl shadow-slate-900/15 backdrop-blur'
+          className='absolute left-4 right-4 top-20 z-[95] rounded-3xl border border-slate-200 bg-white p-2 shadow-2xl shadow-slate-900/15 backdrop-blur'
         >
           <div className='grid gap-1'>
             {links.map(link => (
@@ -97,7 +97,7 @@ export default function MobileNav({ links }: MobileNavProps) {
                 key={link.href}
                 href={link.href}
                 onClick={() => setOpen(false)}
-                className='rounded-2xl px-4 py-3 text-base font-black text-slate-900 transition hover:bg-emerald-50 hover:text-emerald-800'
+                className='flex min-h-12 items-center rounded-2xl px-4 py-3 text-base font-black text-slate-900 transition hover:bg-emerald-50 hover:text-emerald-800'
               >
                 {link.label}
               </Link>

--- a/styles/foundation-readability.css
+++ b/styles/foundation-readability.css
@@ -217,4 +217,10 @@ canvas {
     font-size: 0.68rem;
     letter-spacing: 0.1em;
   }
+
+  .chip-readable {
+    line-height: 1.2;
+    min-height: 2.25rem;
+    white-space: normal;
+  }
 }

--- a/styles/premium-cards.css
+++ b/styles/premium-cards.css
@@ -154,6 +154,7 @@
   justify-content: center;
 
   min-height: 2rem;
+  max-width: 100%;
 
   border-radius: 999px;
   padding: 0.45rem 0.82rem;
@@ -174,6 +175,15 @@
 .evidence-pill-strong:hover,
 .evidence-pill-moderate:hover {
   transform: translateY(-1px);
+}
+
+
+@media (max-width: 480px) {
+  .chip-readable {
+    line-height: 1.2;
+    min-height: 2.25rem;
+    white-space: normal;
+  }
 }
 
 .button-primary,


### PR DESCRIPTION
### Motivation

- Reduce mobile friction across the primary discovery and depth surfaces (`/herbs`, `/compounds`, `/search`) by improving touch targets, spacing, and wrapping behavior.  
- Calm visual noise in result cards and filters so mobile scanning and thumb reach are more reliable.  
- Ensure bottom navigation respects device safe-area and presents consistent, tappable items.

### Description

- Normalized filter disclosure and button touch targets to `min-h-12`, tightened disclosure padding, and adjusted grid spacing in `components/ui/DecisionPrimitives.tsx`.  
- Made profile card headings resilient to long names by adding `min-w-0`/`break-words` and slightly adjusted mobile heading sizing in `components/ui/DecisionPrimitives.tsx` and shared card usage.  
- Reduced top-level duplicate badges in search result cards (kept the type badge visible; evidence/safety remain in metric area) and improved result-card min-height/wrapping in `app/search/page.tsx`.  
- Tightened mobile gutters (`px-3` on smallest viewport) and softened stat-card label typography on the herb and compound index clients in `app/herbs/HerbsIndexClient.tsx` and `app/compounds/CompoundsIndexClient.tsx`.  
- Polished mobile bottom nav to use equal-width flexible items, stronger safe-area padding, smaller icon sizing, truncate-friendly labels, and a calmer elevated surface in `src/components/mobile-bottom-nav.tsx`.  
- Increased mobile menu button and menu-link tap areas and raised the menu panel stacking context in `src/components/mobile-nav.tsx`.  
- Added mobile chip-wrapping safeguards and small density adjustments in `app/globals.css`, `styles/foundation-readability.css`, and `styles/premium-cards.css` to avoid horizontal overflow on narrow screens.  
- Adjusted page bottom padding to account for the improved bottom nav safe-area in `app/layout.tsx`.  
- Added documentation of scope, goals, changes, validation, and remaining risks in `docs/ux/mobile-usability-polish-pass.md`.

### Testing

- Ran `npm run lint` and it passed with zero warnings.  
- Ran `npx tsc --noEmit` and the typecheck passed.  
- Ran `npm run build` which performed the blog/data generation and full Next.js build; the build completed successfully and included the project’s existing MVP deploy-readiness warning about a missing `sitemap.xml` but returned a final pass (`[deploy-readiness] PASS (MVP relaxed mode)`).  
- Performed an automated mobile visual check with Playwright: installing Playwright browsers and OS dependencies was required in the environment, `npx playwright install chromium` and `npx playwright install-deps chromium` were executed, and a mobile viewport screenshot of `/search` was successfully captured with `npx playwright screenshot --viewport-size=390,844 http://127.0.0.1:3000/search artifacts/mobile-search-polish.png`.  

All automated checks listed in the task (`lint`, `tsc`, `build`) passed on this branch; Playwright screenshot was taken after installing required runtime dependencies in the environment.  

Known remaining risks are documented in `docs/ux/mobile-usability-polish-pass.md` and include device-specific safe-area variations and remaining multi-source CSS layering for chips/buttons.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09a72e66bc832394f6195f0c29f12a)