### PR TITLE
feat(graph): add semantic internal-link infrastructure

### DIFF
--- a/src/lib/compare-relationships.ts
+++ b/src/lib/compare-relationships.ts
@@ -1,0 +1,228 @@
+import {
+  getEffectOverlap,
+  getGoalOverlap,
+  getMechanismOverlap,
+  getPrimaryEffectTokens,
+  getGoalTokens,
+  getMechanismTokens,
+  type SemanticEntity,
+} from './semantic-relationships'
+
+export type CompareProfile = SemanticEntity & {
+  leftSlug?: string
+  rightSlug?: string
+  left?: SemanticEntity
+  right?: SemanticEntity
+  safety?: unknown
+  safetyNotes?: unknown
+  cautions?: unknown
+  stimulation?: unknown
+  sedation?: unknown
+  tone?: unknown
+}
+
+export type RelatedComparison<T extends CompareProfile> = {
+  item: T
+  slug: string
+  label: string
+  score: number
+  sharedEffects: string[]
+  sharedMechanisms: string[]
+  sharedGoals: string[]
+  safetyOverlap: string[]
+  stimulationSedationOverlap: string[]
+  reasons: string[]
+}
+
+export type CompareCluster<T extends CompareProfile> = {
+  key: string
+  label: string
+  items: RelatedComparison<T>[]
+}
+
+const DEFAULT_LIMIT = 8
+
+function clean(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'string') return value.trim()
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value).trim()
+  return ''
+}
+
+function slugify(value: unknown): string {
+  return clean(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+function list(value: unknown): string[] {
+  if (Array.isArray(value)) return unique(value.flatMap(item => list(item)))
+  if (value && typeof value === 'object') return []
+  return unique(clean(value).split(/[;,|]/g))
+}
+
+function unique(values: unknown[]): string[] {
+  const seen = new Set<string>()
+  const output: string[] = []
+
+  values.forEach(value => {
+    const token = clean(value).toLowerCase().replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim()
+    if (!token || seen.has(token)) return
+    seen.add(token)
+    output.push(token)
+  })
+
+  return output
+}
+
+function compareSlug(profile: CompareProfile): string {
+  const explicit = slugify(profile.slug || profile.id)
+  if (explicit) return explicit
+
+  const left = slugify(profile.leftSlug || profile.left?.slug || profile.left?.name)
+  const right = slugify(profile.rightSlug || profile.right?.slug || profile.right?.name)
+  return left && right ? `${left}-vs-${right}` : slugify(profile.name || profile.title)
+}
+
+function compareLabel(profile: CompareProfile): string {
+  const explicit = clean(profile.name || profile.title)
+  if (explicit) return explicit
+
+  const left = clean(profile.left?.name || profile.left?.title || profile.leftSlug)
+  const right = clean(profile.right?.name || profile.right?.title || profile.rightSlug)
+  return left && right ? `${left} vs ${right}` : compareSlug(profile)
+}
+
+function combinedEntity(profile: CompareProfile): SemanticEntity {
+  return {
+    ...profile,
+    primary_effects: [
+      ...getPrimaryEffectTokens(profile),
+      ...getPrimaryEffectTokens(profile.left || {}),
+      ...getPrimaryEffectTokens(profile.right || {}),
+    ],
+    mechanisms: [
+      ...getMechanismTokens(profile),
+      ...getMechanismTokens(profile.left || {}),
+      ...getMechanismTokens(profile.right || {}),
+    ],
+    best_for: [
+      ...getGoalTokens(profile),
+      ...getGoalTokens(profile.left || {}),
+      ...getGoalTokens(profile.right || {}),
+    ],
+  }
+}
+
+function overlap(left: unknown[], right: unknown[]): string[] {
+  const rightSet = new Set(unique(right))
+  return unique(left).filter(item => rightSet.has(item))
+}
+
+export function getSafetyTokens(profile: CompareProfile): string[] {
+  return list(profile.safety ?? profile.safetyNotes ?? profile.cautions)
+}
+
+export function getSafetyOverlap(left: CompareProfile, right: CompareProfile): string[] {
+  return overlap(getSafetyTokens(left), getSafetyTokens(right))
+}
+
+export function getStimulationSedationTokens(profile: CompareProfile): string[] {
+  return list([profile.stimulation, profile.sedation, profile.tone])
+    .filter(token => ['stimulating', 'stimulation', 'sedating', 'sedation', 'calming', 'neutral'].includes(token))
+}
+
+export function getStimulationSedationOverlap(left: CompareProfile, right: CompareProfile): string[] {
+  return overlap(getStimulationSedationTokens(left), getStimulationSedationTokens(right))
+}
+
+export function getMechanismSimilarity(left: CompareProfile, right: CompareProfile): number {
+  const leftMechanisms = getMechanismTokens(combinedEntity(left))
+  const rightMechanisms = getMechanismTokens(combinedEntity(right))
+  if (leftMechanisms.length === 0 || rightMechanisms.length === 0) return 0
+
+  const shared = overlap(leftMechanisms, rightMechanisms).length
+  const total = new Set([...leftMechanisms, ...rightMechanisms]).size
+  return total === 0 ? 0 : Number((shared / total).toFixed(3))
+}
+
+export function scoreRelatedComparison<T extends CompareProfile>(base: CompareProfile, candidate: T): RelatedComparison<T> {
+  const baseEntity = combinedEntity(base)
+  const candidateEntity = combinedEntity(candidate)
+  const sharedEffects = getEffectOverlap(baseEntity, candidateEntity)
+  const mechanismOverlap = getMechanismOverlap(baseEntity, candidateEntity)
+  const sharedGoals = getGoalOverlap(baseEntity, candidateEntity)
+  const safetyOverlap = getSafetyOverlap(base, candidate)
+  const stimulationSedationOverlap = getStimulationSedationOverlap(base, candidate)
+
+  // Trust-first comparison architecture: every score comes from visible overlap counts.
+  // This avoids hidden efficacy claims, opaque recommendation ranking, or medicalized winner/loser framing.
+  const score =
+    sharedEffects.length +
+    mechanismOverlap.count +
+    sharedGoals.length +
+    safetyOverlap.length +
+    stimulationSedationOverlap.length
+
+  const reasons: string[] = []
+  if (sharedEffects.length) reasons.push('shared effects')
+  if (mechanismOverlap.count) reasons.push('shared mechanisms')
+  if (sharedGoals.length) reasons.push('shared goals')
+  if (safetyOverlap.length) reasons.push('shared safety context')
+  if (stimulationSedationOverlap.length) reasons.push('similar stimulation/sedation framing')
+
+  return {
+    item: candidate,
+    slug: compareSlug(candidate),
+    label: compareLabel(candidate),
+    score,
+    sharedEffects,
+    sharedMechanisms: mechanismOverlap.sharedMechanisms,
+    sharedGoals,
+    safetyOverlap,
+    stimulationSedationOverlap,
+    reasons,
+  }
+}
+
+export function getRelatedComparisons<T extends CompareProfile>(base: CompareProfile, candidates: T[], limit = DEFAULT_LIMIT): RelatedComparison<T>[] {
+  const baseSlug = compareSlug(base)
+
+  return candidates
+    .map(candidate => scoreRelatedComparison(base, candidate))
+    .filter(result => result.slug && result.slug !== baseSlug && result.score > 0)
+    .sort((a, b) => b.score - a.score || b.sharedMechanisms.length - a.sharedMechanisms.length || a.label.localeCompare(b.label))
+    .slice(0, limit)
+}
+
+export function buildCompareClusters<T extends CompareProfile>(base: CompareProfile, candidates: T[], limit = DEFAULT_LIMIT): CompareCluster<T>[] {
+  const related = getRelatedComparisons(base, candidates, limit)
+  const clusters: CompareCluster<T>[] = [
+    {
+      key: 'mechanism-overlap',
+      label: 'Mechanism overlap',
+      items: related.filter(item => item.sharedMechanisms.length > 0),
+    },
+    {
+      key: 'effect-overlap',
+      label: 'Effect overlap',
+      items: related.filter(item => item.sharedEffects.length > 0),
+    },
+    {
+      key: 'goal-overlap',
+      label: 'Goal overlap',
+      items: related.filter(item => item.sharedGoals.length > 0),
+    },
+    {
+      key: 'safety-context',
+      label: 'Safety context overlap',
+      items: related.filter(item => item.safetyOverlap.length > 0),
+    },
+  ]
+
+  // Conservative graph expansion: remove empty clusters and cap each cluster to avoid crawl-noise explosions.
+  return clusters
+    .map(cluster => ({ ...cluster, items: cluster.items.slice(0, limit) }))
+    .filter(cluster => cluster.items.length > 0)
+}

--- a/src/lib/internal-link-graph.ts
+++ b/src/lib/internal-link-graph.ts
@@ -1,0 +1,183 @@
+import {
+  getGoalOverlap,
+  getMechanismOverlap,
+  scoreRelatedProfile,
+  type SemanticEntity,
+} from './semantic-relationships'
+
+export type SemanticNodeType =
+  | 'goal'
+  | 'compare'
+  | 'stack'
+  | 'compound'
+  | 'herb'
+  | 'mechanism'
+
+export type SemanticLinkNode = SemanticEntity & {
+  type: SemanticNodeType
+  href?: string
+}
+
+export type SemanticLink = {
+  source: string
+  target: string
+  sourceType: SemanticNodeType
+  targetType: SemanticNodeType
+  score: number
+  relationship: string
+  reasons: string[]
+}
+
+const MAX_LINKS_PER_NODE = 12
+
+function clean(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'string') return value.trim()
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value).trim()
+  return ''
+}
+
+function slugify(value: unknown): string {
+  return clean(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+function nodeSlug(node: SemanticLinkNode): string {
+  return slugify(node.slug || node.id || node.name || node.title)
+}
+
+function nodeHref(node: SemanticLinkNode): string {
+  if (node.href) return node.href
+
+  const slug = nodeSlug(node)
+
+  switch (node.type) {
+    case 'goal':
+      return `/goals/${slug}`
+    case 'compare':
+      return `/compare/${slug}`
+    case 'stack':
+      return `/stacks/${slug}`
+    case 'compound':
+      return `/compounds/${slug}`
+    case 'herb':
+      return `/herbs/${slug}`
+    case 'mechanism':
+      return `/mechanisms/${slug}`
+    default:
+      return `/${slug}`
+  }
+}
+
+function pairKey(source: SemanticLinkNode, target: SemanticLinkNode): string {
+  return [source.type, nodeSlug(source), target.type, nodeSlug(target)].join(':')
+}
+
+function allowedRelationship(source: SemanticNodeType, target: SemanticNodeType): boolean {
+  const valid: Array<[SemanticNodeType, SemanticNodeType]> = [
+    ['goal', 'goal'],
+    ['goal', 'compare'],
+    ['goal', 'stack'],
+    ['goal', 'compound'],
+    ['goal', 'herb'],
+    ['compare', 'compare'],
+    ['stack', 'compare'],
+    ['mechanism', 'compound'],
+  ]
+
+  return valid.some(([left, right]) => left === source && right === target)
+}
+
+export function createSemanticLink(source: SemanticLinkNode, target: SemanticLinkNode): SemanticLink | null {
+  if (!allowedRelationship(source.type, target.type)) return null
+
+  const score = scoreRelatedProfile(source, target)
+  if (score.score <= 0) return null
+
+  // Semantic graph philosophy:
+  // relationships are deterministic, crawlable, SSR-safe, and explainable.
+  // The graph exists to strengthen semantic clustering and discovery traversal,
+  // not to create opaque recommendation systems.
+  return {
+    source: nodeHref(source),
+    target: nodeHref(target),
+    sourceType: source.type,
+    targetType: target.type,
+    score: score.score,
+    relationship: `${source.type}-to-${target.type}`,
+    reasons: score.reasons,
+  }
+}
+
+export function buildSemanticLinks(source: SemanticLinkNode, targets: SemanticLinkNode[]): SemanticLink[] {
+  const seen = new Set<string>()
+
+  return targets
+    .map(target => createSemanticLink(source, target))
+    .filter((link): link is SemanticLink => Boolean(link))
+    .filter(link => {
+      const key = `${link.source}:${link.target}`
+      if (seen.has(key)) return false
+      seen.add(key)
+      return true
+    })
+    .sort((a, b) => b.score - a.score || a.target.localeCompare(b.target))
+    .slice(0, MAX_LINKS_PER_NODE)
+}
+
+export function getGoalToGoalLinks(goal: SemanticLinkNode, goals: SemanticLinkNode[]): SemanticLink[] {
+  return buildSemanticLinks(goal, goals.filter(item => item.type === 'goal'))
+}
+
+export function getGoalDiscoveryLinks(goal: SemanticLinkNode, nodes: SemanticLinkNode[]): SemanticLink[] {
+  return buildSemanticLinks(
+    goal,
+    nodes.filter(item => ['goal', 'compare', 'stack', 'compound', 'herb'].includes(item.type)),
+  )
+}
+
+export function getCompareTraversalLinks(compare: SemanticLinkNode, compares: SemanticLinkNode[]): SemanticLink[] {
+  return buildSemanticLinks(compare, compares.filter(item => item.type === 'compare'))
+}
+
+export function getStackCompareLinks(stack: SemanticLinkNode, compares: SemanticLinkNode[]): SemanticLink[] {
+  return buildSemanticLinks(stack, compares.filter(item => item.type === 'compare'))
+}
+
+export function getMechanismCompoundLinks(mechanism: SemanticLinkNode, compounds: SemanticLinkNode[]): SemanticLink[] {
+  return buildSemanticLinks(mechanism, compounds.filter(item => item.type === 'compound'))
+}
+
+export function pruneCircularTraversal(links: SemanticLink[]): SemanticLink[] {
+  const seen = new Set<string>()
+
+  // Prevent traversal explosions and duplicate semantic loops.
+  return links.filter(link => {
+    const reverseKey = `${link.target}:${link.source}`
+    if (seen.has(reverseKey)) return false
+
+    seen.add(`${link.source}:${link.target}`)
+    return true
+  })
+}
+
+export function buildSemanticTraversalMap(nodes: SemanticLinkNode[]): Record<string, SemanticLink[]> {
+  const map: Record<string, SemanticLink[]> = {}
+
+  nodes.forEach(node => {
+    const slug = nodeSlug(node)
+
+    const related = nodes.filter(candidate => {
+      if (nodeSlug(candidate) === slug) return false
+
+      const overlap = getMechanismOverlap(node, candidate).count + getGoalOverlap(node, candidate).length
+      return overlap > 0
+    })
+
+    map[slug] = pruneCircularTraversal(buildSemanticLinks(node, related))
+  })
+
+  return map
+}

--- a/src/lib/semantic-relationships.ts
+++ b/src/lib/semantic-relationships.ts
@@ -1,0 +1,216 @@
+export type SemanticEntity = {
+  slug?: string
+  id?: string
+  name?: string
+  title?: string
+  primary_effects?: unknown
+  primaryEffects?: unknown
+  effects?: unknown
+  mechanisms?: unknown
+  mechanism?: unknown
+  best_for?: unknown
+  bestFor?: unknown
+  goals?: unknown
+  categories?: unknown
+  category?: unknown
+  stacks?: unknown
+  stackReferences?: unknown
+  related_stacks?: unknown
+  relatedStacks?: unknown
+}
+
+export type RelationshipScore = {
+  slug: string
+  name: string
+  score: number
+  sharedEffects: string[]
+  sharedMechanisms: string[]
+  sharedGoals: string[]
+  sharedCategories: string[]
+  sharedStacks: string[]
+  reasons: string[]
+}
+
+export type ScoredRelationship<T extends SemanticEntity> = RelationshipScore & {
+  item: T
+}
+
+export type MechanismOverlap = {
+  count: number
+  sharedMechanisms: string[]
+}
+
+const DEFAULT_LIMIT = 6
+
+function readString(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'string') return value.trim()
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value).trim()
+  return ''
+}
+
+function readList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return normalizeList(value.flatMap(item => readList(item)))
+  }
+
+  if (value && typeof value === 'object') return []
+
+  const text = readString(value)
+  if (!text) return []
+
+  return normalizeList(text.split(/[;,|]/g))
+}
+
+function normalizeToken(value: unknown): string {
+  return readString(value)
+    .toLowerCase()
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function normalizeList(values: unknown[]): string[] {
+  const seen = new Set<string>()
+  const output: string[] = []
+
+  values.forEach(value => {
+    const token = normalizeToken(value)
+    if (!token || seen.has(token)) return
+    seen.add(token)
+    output.push(token)
+  })
+
+  return output
+}
+
+function labelFor(entity: SemanticEntity): string {
+  return readString(entity.name || entity.title || entity.slug || entity.id)
+}
+
+function slugFor(entity: SemanticEntity): string {
+  const raw = readString(entity.slug || entity.id || entity.name || entity.title)
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+export function getPrimaryEffectTokens(entity: SemanticEntity): string[] {
+  return readList(entity.primary_effects ?? entity.primaryEffects ?? entity.effects)
+}
+
+export function getMechanismTokens(entity: SemanticEntity): string[] {
+  return readList(entity.mechanisms ?? entity.mechanism)
+}
+
+export function getGoalTokens(entity: SemanticEntity): string[] {
+  return readList(entity.best_for ?? entity.bestFor ?? entity.goals)
+}
+
+export function getCategoryTokens(entity: SemanticEntity): string[] {
+  return readList(entity.categories ?? entity.category)
+}
+
+export function getStackTokens(entity: SemanticEntity): string[] {
+  return readList(entity.stacks ?? entity.stackReferences ?? entity.related_stacks ?? entity.relatedStacks)
+}
+
+export function getOverlap(left: unknown[], right: unknown[]): string[] {
+  const leftTokens = normalizeList(left)
+  const rightSet = new Set(normalizeList(right))
+  return leftTokens.filter(token => rightSet.has(token))
+}
+
+export function getEffectOverlap(left: SemanticEntity, right: SemanticEntity): string[] {
+  return getOverlap(getPrimaryEffectTokens(left), getPrimaryEffectTokens(right))
+}
+
+export function getMechanismOverlap(left: SemanticEntity, right: SemanticEntity): MechanismOverlap {
+  const sharedMechanisms = getOverlap(getMechanismTokens(left), getMechanismTokens(right))
+  return {
+    count: sharedMechanisms.length,
+    sharedMechanisms,
+  }
+}
+
+export function getGoalOverlap(left: SemanticEntity, right: SemanticEntity): string[] {
+  return getOverlap(getGoalTokens(left), getGoalTokens(right))
+}
+
+export function getStackOverlap(left: SemanticEntity, right: SemanticEntity): string[] {
+  return getOverlap(getStackTokens(left), getStackTokens(right))
+}
+
+function buildReasons(score: RelationshipScore): string[] {
+  const reasons: string[] = []
+  if (score.sharedEffects.length) reasons.push(`${score.sharedEffects.length} shared effect${score.sharedEffects.length === 1 ? '' : 's'}`)
+  if (score.sharedMechanisms.length) reasons.push(`${score.sharedMechanisms.length} shared mechanism${score.sharedMechanisms.length === 1 ? '' : 's'}`)
+  if (score.sharedGoals.length) reasons.push(`${score.sharedGoals.length} shared goal${score.sharedGoals.length === 1 ? '' : 's'}`)
+  if (score.sharedCategories.length) reasons.push(`${score.sharedCategories.length} shared categor${score.sharedCategories.length === 1 ? 'y' : 'ies'}`)
+  if (score.sharedStacks.length) reasons.push(`${score.sharedStacks.length} shared stack reference${score.sharedStacks.length === 1 ? '' : 's'}`)
+  return reasons
+}
+
+export function scoreRelatedProfile(left: SemanticEntity, right: SemanticEntity): RelationshipScore {
+  const sharedEffects = getEffectOverlap(left, right)
+  const mechanism = getMechanismOverlap(left, right)
+  const sharedGoals = getGoalOverlap(left, right)
+  const sharedCategories = getOverlap(getCategoryTokens(left), getCategoryTokens(right))
+  const sharedStacks = getStackOverlap(left, right)
+
+  // Deterministic by design: transparent overlap counts preserve trust because every point can be explained.
+  // No embeddings, AI ranking, hidden priors, or opaque authority boosts are used here.
+  const baseScore =
+    sharedEffects.length +
+    mechanism.count +
+    sharedGoals.length +
+    sharedCategories.length +
+    sharedStacks.length
+
+  const score: RelationshipScore = {
+    slug: slugFor(right),
+    name: labelFor(right),
+    score: baseScore,
+    sharedEffects,
+    sharedMechanisms: mechanism.sharedMechanisms,
+    sharedGoals,
+    sharedCategories,
+    sharedStacks,
+    reasons: [],
+  }
+
+  return {
+    ...score,
+    reasons: buildReasons(score),
+  }
+}
+
+function getRelatedItems<T extends SemanticEntity>(base: SemanticEntity, candidates: T[], limit = DEFAULT_LIMIT): ScoredRelationship<T>[] {
+  const baseSlug = slugFor(base)
+
+  return candidates
+    .map(item => ({
+      ...scoreRelatedProfile(base, item),
+      item,
+    }))
+    .filter(result => result.slug && result.slug !== baseSlug && result.score > 0)
+    .sort((a, b) => b.score - a.score || a.name.localeCompare(b.name) || a.slug.localeCompare(b.slug))
+    .slice(0, limit)
+}
+
+export function getRelatedCompounds<T extends SemanticEntity>(compound: SemanticEntity, compounds: T[], limit = DEFAULT_LIMIT): ScoredRelationship<T>[] {
+  return getRelatedItems(compound, compounds, limit)
+}
+
+export function getRelatedHerbs<T extends SemanticEntity>(herb: SemanticEntity, herbs: T[], limit = DEFAULT_LIMIT): ScoredRelationship<T>[] {
+  return getRelatedItems(herb, herbs, limit)
+}
+
+export function getRelatedGoals<T extends SemanticEntity>(goal: SemanticEntity, goals: T[], limit = DEFAULT_LIMIT): ScoredRelationship<T>[] {
+  return getRelatedItems(goal, goals, limit)
+}
+
+export function getRelatedStacks<T extends SemanticEntity>(stack: SemanticEntity, stacks: T[], limit = DEFAULT_LIMIT): ScoredRelationship<T>[] {
+  return getRelatedItems(stack, stacks, limit)
+}


### PR DESCRIPTION
## Summary

Adds reusable semantic internal-link infrastructure:

- `src/lib/internal-link-graph.ts`

This is an SSR-safe deterministic graph utility layer intended to support semantic traversal, crawl density, and relationship continuity.

## Included

Supported relationships:

- Goal ↔ Goal
- Goal ↔ Compare
- Goal ↔ Stack
- Goal ↔ Compound
- Goal ↔ Herb
- Compare ↔ Compare
- Stack ↔ Compare
- Mechanism ↔ Compound

Exports include:

- `createSemanticLink()`
- `buildSemanticLinks()`
- `getGoalToGoalLinks()`
- `getGoalDiscoveryLinks()`
- `getCompareTraversalLinks()`
- `getStackCompareLinks()`
- `getMechanismCompoundLinks()`
- `buildSemanticTraversalMap()`
- `pruneCircularTraversal()`

## Architecture

The graph remains:

- deterministic
- lightweight
- SSR-friendly
- explainable

No client-heavy traversal systems, embeddings, or opaque recommendation layers were introduced.

Circular traversal guards and per-node caps were added to avoid semantic graph explosions and crawl-noise inflation.

## Validation

Static validation only.
No executable npm runtime was available through the connector environment.
No fabricated lint/typecheck execution claims were made.