### PR TITLE
Improve mobile bottom nav label readability

### DIFF
--- a/src/components/mobile-bottom-nav.tsx
+++ b/src/components/mobile-bottom-nav.tsx
@@ -54,7 +54,7 @@ export default function MobileBottomNav() {
               }`}
             >
               <Icon aria-hidden="true" className="h-[1.05rem] w-[1.05rem]" strokeWidth={2.2} />
-              <span className="max-w-full truncate text-[0.68rem] font-semibold leading-none tracking-tight">
+              <span className="max-w-full truncate text-xs font-semibold leading-none tracking-tight">
                 {item.label}
               </span>
             </Link>


### PR DESCRIPTION
## Scope

Single-file mobile navigation accessibility polish.

Changed:
- `src/components/mobile-bottom-nav.tsx`

## What changed

- Replaced custom tiny label size:
  - `text-[0.68rem]`
- With Tailwind standard:
  - `text-xs`

## Why

Improves readability and touch-navigation clarity on mobile while preserving the existing compact layout and navigation structure.

## Explicit non-goals

- No nav restructuring
- No icon changes
- No routing changes
- No desktop nav changes
- No dependency/config changes
- No unrelated cleanup