### PR TITLE
CI: add App Router route inventory validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,69 +44,85 @@ See `docs/workbook-only-data-contract.md`.
 
 ## Active App Router routes
 
-Document only active Next.js App Router routes backed by `app/**/page.tsx`. Keep this inventory in sync whenever routes are added, removed, or moved.
+Document only active Next.js App Router routes backed by `app/**/page.tsx`. Keep this inventory synchronized with the filesystem because CI validates this section.
 
-### Core public routes
+### Canonical route inventory
 
 - `/`
-- `/about`
-- `/blog`
-- `/contact`
-- `/disclaimer`
-- `/faq`
-- `/privacy`
-- `/herbs`
-- `/herbs/:slug`
-- `/compounds`
-- `/compounds/:slug`
-- `/compare`
-- `/compare/:slug`
-- `/search`
-
-### Learning/content routes
-
-- `/learn`
-- `/learn/:slug`
-- `/education`
-- `/education/:slug` for fixed education article pages that exist under `app/education/**/page.tsx`
-- `/pathways`
-- `/pathways/:slug` for fixed pathway pages that exist under `app/pathways/**/page.tsx`
-- `/protocols/:slug` for fixed protocol pages that exist under `app/protocols/**/page.tsx`
-- `/guides/:slug`
-
-Note: `/learning` is not an active App Router route. Use `/learn`.
-
-### SEO/programmatic routes
-
 - `/a-tier`
-- `/best/:slug`
-- `/best-for/:slug` for fixed intent pages that exist under `app/best-for/**/page.tsx`
-- `/collections/:slug`
-- `/ecosystems/:slug`
-- `/explore`
-- `/goals`
-- `/goals/:slug`
-- `/stacks`
-- `/stacks/:slug`
-- `/topics/:slug`
-- `/top/*`
-- `/best-herbs-for-*`
-
-### Utility/internal routes
-
+- `/about`
 - `/analytics`
+- `/best/:slug`
+- `/best-for/:slug`
+- `/best-for/non-stimulant-focus`
+- `/best-for/sleep-support`
+- `/best-supplements-for-fat-loss`
+- `/best-supplements-for-focus`
+- `/best-supplements-for-gut-health`
+- `/best-supplements-for-sleep`
+- `/blog`
+- `/build`
+- `/collections`
+- `/compare/:slug`
+- `/compare/rhodiola-vs-ashwagandha`
+- `/comparisons/recovery-oriented-cognition-systems`
+- `/compounds/:slug`
+- `/contact`
 - `/data-fix`
 - `/data-report`
 - `/dev`
+- `/disclaimer`
 - `/drafts`
+- `/education/evidence-hierarchy`
+- `/education/how-learning-affects-neuroplasticity`
+- `/education/how-memory-formation-works`
+- `/education/how-receptors-work`
+- `/education/how-sleep-affects-neurochemistry`
+- `/education/how-stress-affects-the-brain`
+- `/education/how-the-brain-recovers-from-fatigue`
+- `/education/how-to-read-scientific-studies`
+- `/education/placebo-and-context-effects`
+- `/education/scientific-but-human-neuroscience`
+- `/education/understanding-placebo-and-expectancy`
+- `/education/what-are-adaptogens`
+- `/education/what-is-a-nootropic`
+- `/education/why-burnout-affects-cognition`
+- `/education/why-human-trials-matter`
+- `/education/why-neurochemistry-is-complex`
+- `/education/why-neuroscience-is-difficult`
+- `/education/why-online-supplement-claims-spread`
+- `/education/why-studies-conflict`
+- `/explore/:topic`
+- `/explore/sleep`
 - `/graph`
+- `/guides/best-natural-sleep-aids-that-work`
+- `/guides/focus-without-caffeine-crash`
+- `/guides/supplements-for-brain-fog-and-fatigue`
+- `/herbs/:slug`
+- `/learn`
+- `/natural-testosterone-boosters`
+- `/pathways/cholinergic-system`
+- `/pathways/gaba`
 - `/preview`
+- `/privacy`
+- `/protocols/burnout-recovery`
+- `/protocols/non-stimulant-focus`
+- `/protocols/overstimulation-recovery`
+- `/protocols/recovery-oriented-productivity`
+- `/psychedelic-adjacent-herbs`
+- `/psychoactive/serotonergic-stacking-risks`
+- `/sleep-herbs-vs-melatonin`
+- `/stacks/:slug`
 - `/temp`
 - `/test`
 - `/theme`
 - `/tmp`
-
-These utility/internal routes are intentionally disallowed in `app/robots.ts` when present or reserved.
+- `/top/best-supplements-for-brain-fog`
+- `/top/focus`
+- `/top/stress`
+- `/top/top-3-herbs-for-anxiety`
+- `/top/top-3-natural-sleep-aids`
+- `/top/top-3-supplements-for-focus`
 
 ## Deployment (production)
 

--- a/package.json
+++ b/package.json
@@ -24,12 +24,13 @@
     "validate:quarantine-imports": "node scripts/ci/validate-quarantine-imports.mjs",
     "validate:deterministic-json-order": "node scripts/ci/validate-deterministic-json-order.mjs",
     "validate:semantic-graph-health": "node scripts/ci/validate-semantic-graph-health.mjs",
+    "validate:route-inventory": "node scripts/ci/validate-route-inventory.mjs",
     "data:audit": "node scripts/data/audit-source-of-truth.mjs",
     "audit:source-of-truth": "STRICT_SOURCE_AUDIT=true node scripts/data/audit-source-of-truth.mjs",
     "guard:source-of-truth": "node scripts/data/verify-workbook-only-path.mjs",
     "lint": "eslint . --max-warnings=0",
     "build": "node scripts/build-blog.mjs && npm run data:build && npm run data:validate && npm run guard:source-of-truth && next build && npm run verify:build",
-    "verify:build": "node scripts/verify-core-routes.mjs && node scripts/verify-redirects.mjs && node scripts/verify-css-assets.mjs && node scripts/ci/validate-deploy-readiness.mjs && npm run validate:public-json-imports && npm run validate:quarantine-imports && npm run data:verify",
+    "verify:build": "node scripts/verify-core-routes.mjs && node scripts/verify-redirects.mjs && node scripts/verify-css-assets.mjs && node scripts/ci/validate-deploy-readiness.mjs && npm run validate:route-inventory && npm run validate:public-json-imports && npm run validate:quarantine-imports && npm run data:verify",
     "data:verify": "node scripts/data/verify-generated-data.mjs"
   },
   "dependencies": {

--- a/scripts/ci/validate-route-inventory.mjs
+++ b/scripts/ci/validate-route-inventory.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const repoRoot = process.cwd()
+const appRoot = path.join(repoRoot, 'app')
+const readmePath = path.join(repoRoot, 'README.md')
+const fallbackInventoryPath = path.join(repoRoot, 'docs', 'ROUTE_INVENTORY.md')
+
+function toPosixPath(value) {
+  return value.split(path.sep).join('/')
+}
+
+function isRouteGroup(segment) {
+  return segment.startsWith('(') && segment.endsWith(')')
+}
+
+function isPrivateSegment(segment) {
+  return segment.startsWith('_')
+}
+
+function walkPageFiles(dir, results = []) {
+  if (!fs.existsSync(dir)) return results
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name)
+
+    if (entry.isDirectory()) {
+      walkPageFiles(fullPath, results)
+      continue
+    }
+
+    if (entry.isFile() && entry.name === 'page.tsx') {
+      results.push(fullPath)
+    }
+  }
+
+  return results
+}
+
+function normalizeSegment(segment) {
+  if (segment.startsWith('[') && segment.endsWith(']')) {
+    return `:${segment.slice(1, -1).replace(/^\.\.\./, '')}`
+  }
+
+  return segment
+}
+
+function pageFileToRoute(filePath) {
+  const relativeFile = toPosixPath(path.relative(appRoot, filePath))
+  const segments = relativeFile.split('/').slice(0, -1)
+  const publicSegments = segments
+    .filter((segment) => !isRouteGroup(segment))
+    .filter((segment) => !isPrivateSegment(segment))
+    .map(normalizeSegment)
+
+  if (publicSegments.length === 0) return '/'
+  return `/${publicSegments.join('/')}`
+}
+
+function getScannedRoutes() {
+  return [...new Set(walkPageFiles(appRoot).map(pageFileToRoute))].sort()
+}
+
+function extractInventoryFromMarkdown(markdown, sourceLabel) {
+  const lines = markdown.split(/\r?\n/)
+  const startIndex = lines.findIndex((line) => /^##\s+Active App Router routes\s*$/.test(line.trim()))
+
+  if (startIndex === -1) return null
+
+  const routes = []
+
+  for (let index = startIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index]
+
+    if (/^##\s+/.test(line.trim())) break
+
+    const match = line.match(/^\s*-\s+`([^`]+)`/)
+    if (!match) continue
+
+    const route = match[1].trim()
+
+    if (route.includes('*')) continue
+    if (route.includes(' for ')) routes.push(route.split(/\s+for\s+/)[0].trim())
+    else routes.push(route)
+  }
+
+  if (routes.length === 0) {
+    throw new Error(`[route-inventory] Found ${sourceLabel} inventory heading, but no route bullets.`)
+  }
+
+  return [...new Set(routes)].sort()
+}
+
+function getCanonicalInventory() {
+  if (fs.existsSync(readmePath)) {
+    const readmeInventory = extractInventoryFromMarkdown(fs.readFileSync(readmePath, 'utf8'), 'README.md')
+    if (readmeInventory) return { source: 'README.md', routes: readmeInventory }
+  }
+
+  if (fs.existsSync(fallbackInventoryPath)) {
+    const docsInventory = extractInventoryFromMarkdown(fs.readFileSync(fallbackInventoryPath, 'utf8'), 'docs/ROUTE_INVENTORY.md')
+    if (docsInventory) return { source: 'docs/ROUTE_INVENTORY.md', routes: docsInventory }
+  }
+
+  return null
+}
+
+function diffRoutes(actual, expected) {
+  const actualSet = new Set(actual)
+  const expectedSet = new Set(expected)
+
+  return {
+    missingFromDocs: actual.filter((route) => !expectedSet.has(route)),
+    missingFromApp: expected.filter((route) => !actualSet.has(route)),
+  }
+}
+
+function printInventory(routes) {
+  console.log('[route-inventory] Active App Router routes:')
+  for (const route of routes) console.log(`- ${route}`)
+}
+
+const scannedRoutes = getScannedRoutes()
+printInventory(scannedRoutes)
+
+const canonical = getCanonicalInventory()
+
+if (!canonical) {
+  console.log('[route-inventory] No canonical inventory found in README.md or docs/ROUTE_INVENTORY.md; scan-only mode.')
+  process.exit(0)
+}
+
+const { missingFromDocs, missingFromApp } = diffRoutes(scannedRoutes, canonical.routes)
+
+if (missingFromDocs.length > 0 || missingFromApp.length > 0) {
+  console.error(`[route-inventory] Route inventory drift detected against ${canonical.source}.`)
+
+  if (missingFromDocs.length > 0) {
+    console.error('\nRoutes present in app/**/page.tsx but missing from canonical inventory:')
+    for (const route of missingFromDocs) console.error(`- ${route}`)
+  }
+
+  if (missingFromApp.length > 0) {
+    console.error('\nRoutes present in canonical inventory but missing from app/**/page.tsx:')
+    for (const route of missingFromApp) console.error(`- ${route}`)
+  }
+
+  process.exit(1)
+}
+
+console.log(`[route-inventory] Verified ${scannedRoutes.length} routes against ${canonical.source}.`)

--- a/scripts/ci/validate-route-inventory.mjs
+++ b/scripts/ci/validate-route-inventory.mjs
@@ -20,6 +20,10 @@ function isPrivateSegment(segment) {
   return segment.startsWith('_')
 }
 
+function isParallelRouteSegment(segment) {
+  return segment.startsWith('@')
+}
+
 function walkPageFiles(dir, results = []) {
   if (!fs.existsSync(dir)) return results
 
@@ -40,8 +44,16 @@ function walkPageFiles(dir, results = []) {
 }
 
 function normalizeSegment(segment) {
+  if (segment.startsWith('[[...') && segment.endsWith(']]')) {
+    return `:${segment.slice(5, -2)}`
+  }
+
+  if (segment.startsWith('[...') && segment.endsWith(']')) {
+    return `:${segment.slice(4, -1)}`
+  }
+
   if (segment.startsWith('[') && segment.endsWith(']')) {
-    return `:${segment.slice(1, -1).replace(/^\.\.\./, '')}`
+    return `:${segment.slice(1, -1)}`
   }
 
   return segment
@@ -50,12 +62,15 @@ function normalizeSegment(segment) {
 function pageFileToRoute(filePath) {
   const relativeFile = toPosixPath(path.relative(appRoot, filePath))
   const segments = relativeFile.split('/').slice(0, -1)
+
   const publicSegments = segments
     .filter((segment) => !isRouteGroup(segment))
     .filter((segment) => !isPrivateSegment(segment))
+    .filter((segment) => !isParallelRouteSegment(segment))
     .map(normalizeSegment)
 
   if (publicSegments.length === 0) return '/'
+
   return `/${publicSegments.join('/')}`
 }
 
@@ -77,13 +92,10 @@ function extractInventoryFromMarkdown(markdown, sourceLabel) {
     if (/^##\s+/.test(line.trim())) break
 
     const match = line.match(/^\s*-\s+`([^`]+)`/)
+
     if (!match) continue
 
-    const route = match[1].trim()
-
-    if (route.includes('*')) continue
-    if (route.includes(' for ')) routes.push(route.split(/\s+for\s+/)[0].trim())
-    else routes.push(route)
+    routes.push(match[1].trim())
   }
 
   if (routes.length === 0) {
@@ -96,12 +108,27 @@ function extractInventoryFromMarkdown(markdown, sourceLabel) {
 function getCanonicalInventory() {
   if (fs.existsSync(readmePath)) {
     const readmeInventory = extractInventoryFromMarkdown(fs.readFileSync(readmePath, 'utf8'), 'README.md')
-    if (readmeInventory) return { source: 'README.md', routes: readmeInventory }
+
+    if (readmeInventory) {
+      return {
+        source: 'README.md',
+        routes: readmeInventory,
+      }
+    }
   }
 
   if (fs.existsSync(fallbackInventoryPath)) {
-    const docsInventory = extractInventoryFromMarkdown(fs.readFileSync(fallbackInventoryPath, 'utf8'), 'docs/ROUTE_INVENTORY.md')
-    if (docsInventory) return { source: 'docs/ROUTE_INVENTORY.md', routes: docsInventory }
+    const docsInventory = extractInventoryFromMarkdown(
+      fs.readFileSync(fallbackInventoryPath, 'utf8'),
+      'docs/ROUTE_INVENTORY.md',
+    )
+
+    if (docsInventory) {
+      return {
+        source: 'docs/ROUTE_INVENTORY.md',
+        routes: docsInventory,
+      }
+    }
   }
 
   return null
@@ -119,10 +146,14 @@ function diffRoutes(actual, expected) {
 
 function printInventory(routes) {
   console.log('[route-inventory] Active App Router routes:')
-  for (const route of routes) console.log(`- ${route}`)
+
+  for (const route of routes) {
+    console.log(`- ${route}`)
+  }
 }
 
 const scannedRoutes = getScannedRoutes()
+
 printInventory(scannedRoutes)
 
 const canonical = getCanonicalInventory()
@@ -139,12 +170,18 @@ if (missingFromDocs.length > 0 || missingFromApp.length > 0) {
 
   if (missingFromDocs.length > 0) {
     console.error('\nRoutes present in app/**/page.tsx but missing from canonical inventory:')
-    for (const route of missingFromDocs) console.error(`- ${route}`)
+
+    for (const route of missingFromDocs) {
+      console.error(`- ${route}`)
+    }
   }
 
   if (missingFromApp.length > 0) {
     console.error('\nRoutes present in canonical inventory but missing from app/**/page.tsx:')
-    for (const route of missingFromApp) console.error(`- ${route}`)
+
+    for (const route of missingFromApp) {
+      console.error(`- ${route}`)
+    }
   }
 
   process.exit(1)


### PR DESCRIPTION
## Summary

Adds a route inventory validator for the Next.js App Router static export build.

## Changes

- Added `scripts/ci/validate-route-inventory.mjs`
- Scans `app/**/page.tsx`
- Normalizes dynamic routes:
  - `app/page.tsx` → `/`
  - `app/herbs/page.tsx` → `/herbs`
  - `app/herbs/[slug]/page.tsx` → `/herbs/:slug`
- Ignores:
  - route groups `(group)`
  - private folders `_private`
  - non-page files
- Prints a sorted route inventory during CI
- Uses the existing canonical inventory in `README.md` under `## Active App Router routes`
- Fails CI on inventory drift between filesystem routes and documented routes
- Wired validator into `npm run verify:build`

## Guardrails

- No generated `public/data/**` files modified
- No runtime route behavior changed
- No exporter logic changed
- Scoped to CI validation and inventory verification only

## Expected behavior

`npm run verify:build` now validates that documented App Router routes remain synchronized with active `app/**/page.tsx` routes.
