### PR TITLE
Remove stale /build entry from core route verification

### DIFF
--- a/scripts/verify-core-routes.mjs
+++ b/scripts/verify-core-routes.mjs
@@ -7,7 +7,6 @@ const coreRoutes = [
   '/',
   '/herbs',
   '/compounds',
-  '/build',
   '/blog',
   '/learn',
   '/about',


### PR DESCRIPTION
### Motivation
- The `/build` entry in `coreRoutes` was a stale reference and does not correspond to any app route, so it should be removed to keep verification accurate.

### Description
- Removed the `'/build'` item from the `coreRoutes` array in `scripts/verify-core-routes.mjs` so the script only verifies existing routes.

### Testing
- Ran `node --check scripts/verify-core-routes.mjs` to validate script syntax and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bd5bb31c08323a1f1b741ad1599ab)