### PR TITLE
chore(deps): remediate Next/PostCSS audit finding via PostCSS override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "fuse.js": "^7.1.0",
         "gray-matter": "^4.0.3",
         "lucide-react": "^0.298.0",
-        "next": "^15.3.2",
+        "next": "^15.5.18",
         "openai": "^4.104.0",
         "react": "^18.2.0",
         "react-countup": "^6.5.3",
@@ -36,7 +36,7 @@
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react-hooks": "^7.0.0",
         "lint-staged": "^15.2.10",
-        "postcss": "^8.4.31",
+        "postcss": "^8.5.15",
         "tailwindcss": "^3.4.3",
         "ts-node": "^10.9.2",
         "tsx": "^4.19.2",
@@ -5745,34 +5745,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -6214,10 +6186,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.14",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
-      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
-      "dev": true,
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -6234,7 +6205,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -63,13 +63,16 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react-hooks": "^7.0.0",
     "lint-staged": "^15.2.10",
-    "postcss": "^8.4.31",
+    "postcss": "^8.5.15",
     "tailwindcss": "^3.4.3",
     "ts-node": "^10.9.2",
     "tsx": "^4.19.2",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.59.1",
     "wrangler": "^3.0.0"
+  },
+  "overrides": {
+    "postcss": "^8.5.15"
   },
   "lint-staged": {
     "*.{ts,tsx}": "eslint --max-warnings=0",


### PR DESCRIPTION
### Motivation
- `npm audit` flagged a moderate vulnerability coming from a nested `postcss` version under `next` (<8.5.10), and the suggested fix path pointed to an incorrect `next@9.3.3`; the goal was to remediate the transitive PostCSS exposure with minimal blast radius while keeping Next on v15.5.x. 
- Avoided any major framework migration or runtime behavior changes by addressing only the PostCSS resolution.

### Description
- Bumped the direct devDependency `postcss` from `^8.4.31` to `^8.5.15` in `package.json` to move to a non-vulnerable patch line. 
- Added an npm `overrides` entry forcing `postcss` to resolve to `^8.5.15` across the dependency graph (including the copy nested under `next`).
- Regenerated the lockfile via `npm install`, which updated `package-lock.json` to reflect the new PostCSS resolution and related checksum changes.
- No changes were made to application runtime code, routes, generated `public/data`, or framework major version constraints.

### Testing
- Captured the audit state before and after with `npm audit --json` and confirmed the `next -> postcss` path no longer appears in the vulnerability list. 
- Verified dependency graph with `npm ls next postcss` and `npm outdated next postcss || true` to ensure PostCSS is deduped to `8.5.15`. 
- Ran `npm install` to produce an updated `package-lock.json` and then ran `npm run typecheck` (`tsc --noEmit`) to ensure type checks passed. 
- Result: total vulnerabilities reported decreased from 8 to 6, and `next`/`postcss` no longer appear among audit findings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c82ceed908323b5d2b71cdc8723fa)