### PR TITLE
Fix SEO SITE_URL to use www canonical domain

### DIFF
--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,4 +1,4 @@
-export const SITE_URL = 'https://thehippiescientist.net'
+export const SITE_URL = 'https://www.thehippiescientist.net'
 export const SITE_NAME = 'The Hippie Scientist'
 export const TWITTER_HANDLE = '@thehippiescientist'
 


### PR DESCRIPTION
### Motivation
- Align Open Graph `og:url` generation with the `www` canonical used in `app/layout.tsx`, `app/sitemap.ts`, and `app/robots.ts` to avoid mixed-host crawl signals.

### Description
- Change the `SITE_URL` export in `src/lib/seo.ts` from `https://thehippiescientist.net` to `https://www.thehippiescientist.net` as a single-line, single-file edit.

### Testing
- Verified the change with `git diff -- src/lib/seo.ts` and committed the update with `git commit`, and confirmed the commit hash via `git rev-parse --short HEAD` (commit `f2cb032`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c905d59948323b854db22e9ddb446)