### PR TITLE
Add 'limited' runtime decision to indexability publish set

### DIFF
--- a/scripts/data/indexability-policy.mjs
+++ b/scripts/data/indexability-policy.mjs
@@ -11,6 +11,7 @@ const PUBLISH_DECISIONS = new Set([
   'publish',
   'publishable',
   'ready',
+  'limited',
 ])
 
 const NOINDEX_DECISIONS = new Set([


### PR DESCRIPTION
### Motivation
- Workbook herb rows use `runtime_export_decision = 'limited'`, and because `'limited'` was missing from the publish decision set those records never reached `PUBLISH` and were excluded from the sitemap.

### Description
- Add `'limited'` to the `PUBLISH_DECISIONS` Set in `scripts/data/indexability-policy.mjs` as a minimal one-line change so `runtime_export_decision = 'limited'` is treated as a publish decision.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c9253bfc88323a013baa66e0a067c)