### PR TITLE
Respect pipeline sitemap/robots fields in getRuntimeVisibility

### DIFF
--- a/lib/runtime-visibility.ts
+++ b/lib/runtime-visibility.ts
@@ -47,6 +47,19 @@ export function getRuntimeVisibility(record: any) {
     }
   }
 
+  // Respect pre-computed pipeline fields when present
+  const sitemapIncluded = record?.sitemap_included
+  const robotsField = text(record?.robots || '')
+  if (typeof sitemapIncluded === 'boolean' && robotsField) {
+    const publish = sitemapIncluded && /^index/i.test(robotsField)
+    return {
+      canRender: !hidden,
+      canIndex: !hidden && publish,
+      canFeature: !hidden && publish,
+      canMonetize: !hidden && !weak,
+    }
+  }
+
   const indexableStatus = hasIndexableStatus(profileStatus)
   const indexableQuality = hasIndexableQuality(summaryQuality)
   const evidenceSupported = /^(strong|moderate|human|clinical|commercial_ready)$/i.test(evidenceTier) || indexableStatus


### PR DESCRIPTION
### Motivation
- The data pipeline already marks authoritative publication decisions with `sitemap_included` and `robots`, and the fallback heuristics undercount indexable records (35 vs 243), so `getRuntimeVisibility` should prefer those pre-computed fields when present.

### Description
- Inserted a short check in `lib/runtime-visibility.ts` inside `getRuntimeVisibility` that reads `record?.sitemap_included` and `text(record?.robots || '')` and, when `sitemap_included` is a boolean and `robots` is present, computes `publish = sitemap_included && /^index/i.test(robots)` and returns the visibility object accordingly, placed after the existing `indexabilityStatus` branch and before the fallback heuristics.

### Testing
- No automated tests were run for this surgical logic-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c9566d4548323a1a3ab60daf628eb)