### PR TITLE
audit: capture baseline health

### DIFF
--- a/docs/audit/baseline-health.md
+++ b/docs/audit/baseline-health.md
@@ -1,0 +1,23 @@
+# Baseline Health Audit
+
+Branch: `audit/baseline-health`  
+Date (UTC): 2026-05-19
+
+| command | pass/fail | failure excerpt | likely owner area |
+|---|---|---|---|
+| `node --version` | pass | none | deploy |
+| `npm --version` | pass | none | deploy |
+| `npm ci` | pass | none (warnings observed: `EBADENGINE` for Node `v24.15.0` vs required `>=20 <=22`; 4 vulnerabilities reported) | deps |
+| `npm run lint` | pass | none | lint |
+| `npm run typecheck` | pass | none | TypeScript |
+| `npm run data:build` | pass | none | data pipeline |
+| `npm run data:validate` | pass | none | data pipeline |
+| `npm run guard:source-of-truth` | pass | none | data pipeline |
+| `npm run build` | pass | none (warnings observed: Next.js ESLint plugin not detected; deploy-readiness warns `sitemap.xml` missing but allowed in MVP) | static export |
+| `npm run verify:build` | pass | none (warning observed: deploy-readiness warns `sitemap.xml` missing but allowed in MVP) | static export |
+| `npm audit --json > npm-audit.after.json` | fail | Exit code `1` from `npm audit` (JSON written to `npm-audit.after.json`; vulnerabilities present) | deps |
+
+## Notes
+
+- Repeated npm warning on multiple commands: `npm warn Unknown env config "http-proxy". This will stop working in the next major version of npm.`
+- No product code was modified for this audit.

--- a/npm-audit.after.json
+++ b/npm-audit.after.json
@@ -1,0 +1,141 @@
+{
+  "auditReportVersion": 2,
+  "vulnerabilities": {
+    "miniflare": {
+      "name": "miniflare",
+      "severity": "moderate",
+      "isDirect": false,
+      "via": [
+        "ws"
+      ],
+      "effects": [
+        "wrangler"
+      ],
+      "range": "<=0.0.0-fff677e35 || >=3.20250204.0",
+      "nodes": [
+        "node_modules/miniflare"
+      ],
+      "fixAvailable": {
+        "name": "wrangler",
+        "version": "3.107.3",
+        "isSemVerMajor": true
+      }
+    },
+    "wrangler": {
+      "name": "wrangler",
+      "severity": "moderate",
+      "isDirect": true,
+      "via": [
+        "miniflare"
+      ],
+      "effects": [],
+      "range": "<=0.0.0-kickoff-demo || >=3.108.0",
+      "nodes": [
+        "node_modules/wrangler"
+      ],
+      "fixAvailable": {
+        "name": "wrangler",
+        "version": "3.107.3",
+        "isSemVerMajor": true
+      }
+    },
+    "ws": {
+      "name": "ws",
+      "severity": "moderate",
+      "isDirect": false,
+      "via": [
+        {
+          "source": 1119108,
+          "name": "ws",
+          "dependency": "ws",
+          "title": "ws: Uninitialized memory disclosure",
+          "url": "https://github.com/advisories/GHSA-58qx-3vcg-4xpx",
+          "severity": "moderate",
+          "cwe": [
+            "CWE-908"
+          ],
+          "cvss": {
+            "score": 4.4,
+            "vectorString": "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:N/A:N"
+          },
+          "range": ">=8.0.0 <8.20.1"
+        }
+      ],
+      "effects": [
+        "miniflare"
+      ],
+      "range": "8.0.0 - 8.20.0",
+      "nodes": [
+        "node_modules/ws"
+      ],
+      "fixAvailable": {
+        "name": "wrangler",
+        "version": "3.107.3",
+        "isSemVerMajor": true
+      }
+    },
+    "xlsx": {
+      "name": "xlsx",
+      "severity": "high",
+      "isDirect": true,
+      "via": [
+        {
+          "source": 1108110,
+          "name": "xlsx",
+          "dependency": "xlsx",
+          "title": "Prototype Pollution in sheetJS",
+          "url": "https://github.com/advisories/GHSA-4r6h-8v6p-xvw6",
+          "severity": "high",
+          "cwe": [
+            "CWE-1321"
+          ],
+          "cvss": {
+            "score": 7.8,
+            "vectorString": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+          },
+          "range": "<0.19.3"
+        },
+        {
+          "source": 1108111,
+          "name": "xlsx",
+          "dependency": "xlsx",
+          "title": "SheetJS Regular Expression Denial of Service (ReDoS)",
+          "url": "https://github.com/advisories/GHSA-5pgg-2g8v-p4x9",
+          "severity": "high",
+          "cwe": [
+            "CWE-1333"
+          ],
+          "cvss": {
+            "score": 7.5,
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+          },
+          "range": "<0.20.2"
+        }
+      ],
+      "effects": [],
+      "range": "*",
+      "nodes": [
+        "node_modules/xlsx"
+      ],
+      "fixAvailable": false
+    }
+  },
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 3,
+      "high": 1,
+      "critical": 0,
+      "total": 4
+    },
+    "dependencies": {
+      "prod": 91,
+      "dev": 474,
+      "optional": 93,
+      "peer": 0,
+      "peerOptional": 0,
+      "total": 574
+    }
+  }
+}


### PR DESCRIPTION
### Motivation

- Capture a reproducible baseline of repository health by running the requested audit command sequence and recording outcomes without changing product code. 
- Keep the change minimal and reviewable by adding only audit artifacts under `docs/` and the generated `npm-audit.after.json` file.

### Description

- Added `docs/audit/baseline-health.md` with a pass/fail table for each requested command and brief failure excerpts. 
- Added `npm-audit.after.json` containing the raw `npm audit --json` output with the discovered vulnerabilities. 
- No product code or build pipelines were refactored or modified; this PR is strictly an audit artifact.

### Testing

- Ran the requested commands: `node --version`, `npm --version`, `npm ci`, `npm run lint`, `npm run typecheck`, `npm run data:build`, `npm run data:validate`, `npm run guard:source-of-truth`, `npm run build`, `npm run verify:build`, and `npm audit --json > npm-audit.after.json` and recorded results in `docs/audit/baseline-health.md`. 
- All commands passed except `npm audit --json > npm-audit.after.json`, which exited with code `1` and produced `npm-audit.after.json` showing 4 vulnerabilities (3 moderate, 1 high). 
- Observed non-failing warnings during runs: `EBADENGINE` due to Node `v24.15.0` vs required `>=20 <=22`, repeated `npm warn Unknown env config "http-proxy"`, Next.js ESLint plugin not detected, and a deploy-readiness warning about `sitemap.xml` missing (allowed in MVP).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c998214188323ae5869878ec001c9)