### PR TITLE
fix: enforce workbook source-of-truth contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,5 +84,6 @@ DATA_QUALITY_REPORT.md
 # Portable local source inputs (keep directory scaffold tracked)
 data-sources/*
 !data-sources/.gitkeep
+!data-sources/herb_monograph_master.xlsx
 data-sources/*.csv
 data-sources/*.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@
 - Generated JSON lives in `public/data/` — treat as build artifact, not source
 - Do NOT modify `public/data/workbook-herbs.json` or `public/data/workbook-compounds.json` directly
 - Run `npm run data:build` after workbook changes, before `npm run build`
+- CI/workflows enforce workbook source-of-truth via `npm run validate:workbook-source` before workbook-dependent commands
 
 ## Affiliate config
 - Affiliate tag is in `config/affiliate.ts` — use `AFFILIATE_TAGS.amazon` not hardcoded strings

--- a/README.md
+++ b/README.md
@@ -119,3 +119,14 @@ This repository is a **source repo**. Deploy static output from `out/`.
 - Redirect and header infrastructure is static and Cloudflare-compatible via `public/_redirects` and `public/_headers` (exported into `out/`)
 
 Do **not** commit generated deploy output.
+
+## Workbook source-of-truth contract
+
+- Canonical production source: `data-sources/herb_monograph_master.xlsx` (tracked in git).
+- Generated runtime artifacts under `public/data/**` are build/runtime outputs and are never canonical input.
+- Contractors should update herb/compound content by editing the workbook, then running:
+  - `npm run data:build`
+  - `npm run data:validate`
+  - `npm run guard:source-of-truth`
+- CI enforces this contract with `npm run validate:workbook-source` before workbook-dependent commands.
+- `HERB_XLSX_PATH` may override the workbook path only when pointing to a local non-empty `.xlsx`; by default it must remain inside `data-sources/` unless `ALLOW_EXTERNAL_WORKBOOK_PATH=true`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -71,6 +71,8 @@ data-sources/herb_monograph_master.xlsx
 
 The workbook controls production data for herbs, compounds, mappings, claims, safety summaries, evidence fields, and normalized exports.
 
+The workbook file is committed and required for CI/build workflows. `npm run validate:workbook-source` enforces presence, `.xlsx` extension, non-empty file size, and local-path rules before workbook-dependent steps run. Generated files in `public/data/**` are runtime artifacts and are not canonical source input.
+
 ### Pipeline
 
 ```text

--- a/docs/build-and-verification.md
+++ b/docs/build-and-verification.md
@@ -13,8 +13,9 @@ Contractor-facing source of truth for build and deploy verification.
 ## Canonical scripts
 
 - `npm run check` → alias to `npm run build`
-- `npm run build` → workbook data generation + validation + source-of-truth guards + `next build` + `npm run verify:build`
+- `npm run build` → workbook source validation + workbook data generation + validation + source-of-truth guards + `next build` + `npm run verify:build`
 - `npm run verify:build` → core route checks + redirect checks + CSS asset checks + deploy readiness + generated-data verification
+- `npm run validate:workbook-source` → validates workbook path/presence/extension/size and rejects generated `public/data` workbook artifacts as canonical input
 
 ## Workbook-only source of truth
 

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "semantic:scale-summary": "node scripts/ci/report-semantic-scale-summary.mjs",
     "indexability:validate": "node scripts/ci/validate-indexability-metadata.mjs",
     "indexability:report": "node scripts/ci/report-indexability-summary.mjs",
-    "data:build": "node scripts/data/build-runtime-from-workbook.mjs --out public/data && node scripts/data/postprocess-workbook-payloads.mjs && node scripts/data/build-related-runtime-maps.mjs --data-dir=public/data && node scripts/data/build-runtime-summary-indexes.mjs --data-dir=public/data && node scripts/data/build-route-manifest.mjs --data-dir=public/data && node scripts/data/build-sitemap-manifest.mjs --data-dir=public/data && node scripts/data/build-export-batches.mjs --data-dir=public/data && node scripts/data/build-semantic-snapshots.mjs --data-dir=public/data",
-    "data:validate": "node scripts/data/validate-data-next.mjs && npm run semantic:governance && npm run semantic:scale-summary",
+    "data:build": "npm run validate:workbook-source && node scripts/data/build-runtime-from-workbook.mjs --out public/data && node scripts/data/postprocess-workbook-payloads.mjs && node scripts/data/build-related-runtime-maps.mjs --data-dir=public/data && node scripts/data/build-runtime-summary-indexes.mjs --data-dir=public/data && node scripts/data/build-route-manifest.mjs --data-dir=public/data && node scripts/data/build-sitemap-manifest.mjs --data-dir=public/data && node scripts/data/build-export-batches.mjs --data-dir=public/data && node scripts/data/build-semantic-snapshots.mjs --data-dir=public/data",
+    "data:validate": "npm run validate:workbook-source && node scripts/data/validate-data-next.mjs && npm run semantic:governance && npm run semantic:scale-summary",
     "validate:route-manifest-budget": "node scripts/ci/validate-route-manifest-budget.mjs",
     "validate:runtime-payload-budgets": "node scripts/ci/validate-runtime-payload-budgets.mjs",
     "validate:public-json-imports": "node scripts/ci/validate-public-json-imports.mjs",
@@ -26,13 +26,15 @@
     "validate:semantic-graph-health": "node scripts/ci/validate-semantic-graph-health.mjs",
     "data:audit": "node scripts/data/audit-source-of-truth.mjs",
     "audit:source-of-truth": "STRICT_SOURCE_AUDIT=true node scripts/data/audit-source-of-truth.mjs",
-    "guard:source-of-truth": "node scripts/data/verify-workbook-only-path.mjs",
+    "guard:source-of-truth": "npm run validate:workbook-source && node scripts/data/verify-workbook-only-path.mjs",
     "typecheck": "tsc --noEmit",
     "verify:types": "npm run typecheck",
     "lint": "eslint . --max-warnings=0",
     "build": "node scripts/build-blog.mjs && npm run data:build && npm run data:validate && npm run guard:source-of-truth && next build && npm run verify:build",
     "verify:build": "node scripts/verify-core-routes.mjs && node scripts/verify-redirects.mjs && node scripts/ci/validate-deploy-readiness.mjs && npm run validate:public-json-imports && npm run validate:quarantine-imports && npm run data:verify",
-    "data:verify": "node scripts/data/verify-generated-data.mjs"
+    "data:verify": "node scripts/data/verify-generated-data.mjs",
+    "validate:workbook-source": "node scripts/ci/validate-workbook-source.mjs",
+    "prebuild": "npm run validate:workbook-source"
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.8",

--- a/scripts/ci/validate-workbook-source.mjs
+++ b/scripts/ci/validate-workbook-source.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  DEFAULT_WORKBOOK_RELATIVE_PATH,
+  assertWorkbookExists,
+  resolveWorkbookPath,
+} from '../workbook-source.mjs'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const repoRoot = path.resolve(__dirname, '../..')
+const dataSourcesRoot = path.resolve(repoRoot, 'data-sources')
+
+const allowExternalWorkbook = String(process.env.ALLOW_EXTERNAL_WORKBOOK_PATH || '')
+  .trim()
+  .toLowerCase() === 'true'
+
+const resolvedWorkbookPath = resolveWorkbookPath(repoRoot)
+assertWorkbookExists(resolvedWorkbookPath)
+
+const normalizedWorkbookPath = path.resolve(resolvedWorkbookPath)
+const extension = path.extname(normalizedWorkbookPath).toLowerCase()
+if (extension !== '.xlsx') {
+  throw new Error(
+    `[validate-workbook-source] Workbook must be a .xlsx file. Received: ${normalizedWorkbookPath}`
+  )
+}
+
+const stats = fs.statSync(normalizedWorkbookPath)
+if (stats.size <= 0) {
+  throw new Error(
+    `[validate-workbook-source] Workbook file is empty (0 bytes): ${normalizedWorkbookPath}`
+  )
+}
+
+const relativeToDataSources = path.relative(dataSourcesRoot, normalizedWorkbookPath)
+const insideDataSources =
+  relativeToDataSources &&
+  !relativeToDataSources.startsWith('..') &&
+  !path.isAbsolute(relativeToDataSources)
+
+if (!insideDataSources && !allowExternalWorkbook) {
+  throw new Error(
+    '[validate-workbook-source] Workbook path must be inside repo/data-sources unless ALLOW_EXTERNAL_WORKBOOK_PATH=true is set.'
+  )
+}
+
+const forbiddenCanonicalSources = [
+  path.resolve(repoRoot, 'public/data/workbook-herbs.json'),
+  path.resolve(repoRoot, 'public/data/workbook-compounds.json'),
+]
+
+if (forbiddenCanonicalSources.includes(normalizedWorkbookPath)) {
+  throw new Error(
+    '[validate-workbook-source] Generated public/data workbook artifacts cannot be used as the canonical source.'
+  )
+}
+
+if (normalizedWorkbookPath === path.resolve(repoRoot, DEFAULT_WORKBOOK_RELATIVE_PATH)) {
+  console.log(`[validate-workbook-source] PASS default workbook: ${normalizedWorkbookPath}`)
+} else {
+  console.log(`[validate-workbook-source] PASS workbook from HERB_XLSX_PATH: ${normalizedWorkbookPath}`)
+}
+console.log(`[validate-workbook-source] file size bytes: ${stats.size}`)
+console.log(`[validate-workbook-source] external workbook allowed: ${allowExternalWorkbook}`)


### PR DESCRIPTION
### Motivation

- Ensure `data-sources/herb_monograph_master.xlsx` is the single canonical production workbook and that builds/CI cannot silently use generated `public/data` artifacts as source input. 
- Fail early and clearly in CI/builds when the workbook is missing, empty, wrong extension, or outside the repo unless explicitly allowed.

### Description

- Added `scripts/ci/validate-workbook-source.mjs` which resolves `HERB_XLSX_PATH` (or default), asserts `.xlsx` extension, non-zero size, enforces repo `data-sources/` location unless `ALLOW_EXTERNAL_WORKBOOK_PATH=true`, and rejects `public/data/workbook-*.json` as canonical sources. 
- Wired a new npm script `validate:workbook-source` and prepended it to `data:build`, `data:validate`, `guard:source-of-truth`, and added `prebuild` to ensure validation runs before build-time workbook-dependent steps. 
- Updated `.gitignore` to explicitly allow committing `data-sources/herb_monograph_master.xlsx` while still ignoring other data-sources artifacts and temp/export files. 
- Updated docs (`README.md`, `SPEC.md`, `AGENTS.md`, `docs/build-and-verification.md`) to state the canonical workbook policy, generated-artifact policy, contractor workflow, and CI validation behavior.

### Testing

- Ran `npm ci` which completed successfully (note: produced an `EBADENGINE` warning for Node v24 vs declared engines). 
- Ran `npm run validate:workbook-source` which passed and reported the workbook path and size. 
- Ran `npm run data:build`, `npm run data:validate`, and `npm run guard:source-of-truth`, all of which completed successfully. 
- Ran `npm run lint`, `npm run typecheck`, `npm run build`, and `npm run verify:build`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c9c8f45fc83239f4e41133c74d2ac)