### PR TITLE
ci: add full quality gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,23 +6,102 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
-  deterministic-install:
+  quality-gate:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node
+      - name: Setup Node from .nvmrc
         uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
           cache: npm
 
+      - name: Show Node version
+        run: node --version
+
+      - name: Show npm version
+        run: npm --version
+
       - name: Install dependencies
         run: npm ci
 
-      - name: Verify lockfile is unchanged
-        run: git diff --exit-code package-lock.json
+      - name: Verify package metadata is unchanged after install
+        run: git diff --exit-code package-lock.json package.json
 
+      - name: Verify Node engine
+        run: npm run check:node
+
+      - name: Validate workbook source
+        run: npm run validate:workbook-source
+
+      - name: Run lint
+        run: npm run lint
+
+      - name: Run typecheck
+        run: npm run typecheck
+
+      - name: Build data artifacts
+        run: npm run data:build
+
+      - name: Validate data artifacts
+        run: npm run data:validate
+
+      - name: Guard workbook source of truth
+        run: npm run guard:source-of-truth
+
+      - name: Build application
+        run: npm run build
+
+      - name: Verify build output
+        run: npm run verify:build
+
+      - name: Fail if generated data artifacts are stale
+        run: |
+          if ! git diff --quiet -- public/data; then
+            echo "Generated public/data artifacts are stale. Run 'npm run data:build' and commit the results."
+            git diff --stat -- public/data
+            exit 1
+          fi
+
+      - name: Run security audit
+        id: audit
+        run: |
+          set +e
+          npm audit --audit-level=high --json > npm-audit.after.json
+          status=$?
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+          exit $status
+
+      - name: Upload audit artifact
+        if: always() && hashFiles('npm-audit.after.json') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-audit-after
+          path: npm-audit.after.json
+
+      - name: Add audit summary
+        if: always()
+        run: |
+          if [ "${{ steps.audit.outputs.exit_code }}" = "0" ]; then
+            {
+              echo "## Security audit"
+              echo "✅ npm audit passed (no high/critical vulnerabilities found)."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "## Security audit"
+              echo "❌ npm audit failed (high and/or critical vulnerabilities found)."
+              echo "See uploaded artifact: npm-audit-after."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/README.md
+++ b/README.md
@@ -130,3 +130,21 @@ Do **not** commit generated deploy output.
   - `npm run guard:source-of-truth`
 - CI enforces this contract with `npm run validate:workbook-source` before workbook-dependent commands.
 - `HERB_XLSX_PATH` may override the workbook path only when pointing to a local non-empty `.xlsx`; by default it must remain inside `data-sources/` unless `ALLOW_EXTERNAL_WORKBOOK_PATH=true`.
+
+## Local pre-PR quality gate
+
+Run this command sequence before opening a PR:
+
+```bash
+npm ci
+npm run check:node
+npm run validate:workbook-source
+npm run lint
+npm run typecheck
+npm run data:build
+npm run data:validate
+npm run guard:source-of-truth
+npm run build
+npm run verify:build
+npm audit --audit-level=high
+```

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "verify:build": "node scripts/verify-core-routes.mjs && node scripts/verify-redirects.mjs && node scripts/ci/validate-deploy-readiness.mjs && npm run validate:public-json-imports && npm run validate:quarantine-imports && npm run data:verify",
     "data:verify": "node scripts/data/verify-generated-data.mjs",
     "validate:workbook-source": "node scripts/ci/validate-workbook-source.mjs",
-    "prebuild": "npm run validate:workbook-source"
+    "prebuild": "npm run validate:workbook-source",
+    "check:node": "node scripts/ci/check-node-version.mjs"
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.8",

--- a/scripts/ci/check-node-version.mjs
+++ b/scripts/ci/check-node-version.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import process from 'node:process';
+
+const packageJson = JSON.parse(fs.readFileSync(new URL('../../package.json', import.meta.url), 'utf8'));
+const expected = packageJson?.engines?.node;
+
+if (!expected) {
+  console.log('No package.json engines.node constraint found; skipping Node version check.');
+  process.exit(0);
+}
+
+const current = process.version.replace(/^v/, '');
+
+const parseVersion = (value) => value.split('.').map((segment) => Number.parseInt(segment, 10) || 0);
+const compare = (left, right) => {
+  const [la, lb, lc] = parseVersion(left);
+  const [ra, rb, rc] = parseVersion(right);
+  if (la !== ra) return la - ra;
+  if (lb !== rb) return lb - rb;
+  return lc - rc;
+};
+
+const checks = expected
+  .split(/\s+/)
+  .map((token) => token.trim())
+  .filter(Boolean)
+  .map((token) => {
+    const match = token.match(/^(>=|<=|>|<|=)?v?(\d+(?:\.\d+){0,2})$/);
+    if (!match) {
+      throw new Error(`Unsupported engines.node token: "${token}"`);
+    }
+    return { op: match[1] ?? '=', version: match[2] };
+  });
+
+const satisfies = checks.every(({ op, version }) => {
+  const cmp = compare(current, version);
+  switch (op) {
+    case '>': return cmp > 0;
+    case '>=': return cmp >= 0;
+    case '<': return cmp < 0;
+    case '<=': return cmp <= 0;
+    case '=': return cmp === 0;
+    default: return false;
+  }
+});
+
+if (!satisfies) {
+  console.error(`Node ${current} does not satisfy package.json engines.node constraint: ${expected}`);
+  process.exit(1);
+}
+
+console.log(`Node ${current} satisfies package.json engines.node constraint: ${expected}`);


### PR DESCRIPTION
### Motivation
- Ensure GitHub Actions enforces a strict, merge-blocking quality gate that covers install determinism, Node engine, workbook source validation, data generation/validation, TypeScript, lint, static export build, build verification, and high-severity security audits.
- Surface high/critical vulnerability findings and make audit results available to reviewers without changing product behavior or fixing dependencies.
- Fail PRs when generated `public/data` is out of sync with the canonical workbook output to prevent accidental stale data from being merged.

### Description
- Replace the existing CI workflow with a merge-blocking `quality-gate` workflow that uses `actions/checkout@v4`, `actions/setup-node@v4` with `node-version-file: .nvmrc`, `cache: npm`, and runs `npm ci` as the deterministic install step.
- Add an explicit Node engine verification step by introducing `scripts/ci/check-node-version.mjs` and a `package.json` script `check:node` wired to run it; the workflow runs `npm run check:node` immediately after install and will fail when the current Node does not satisfy `package.json` `engines.node`.
- Order CI steps to run `npm ci`, `npm run check:node`, `npm run validate:workbook-source`, `npm run lint`, `npm run typecheck`, `npm run data:build`, `npm run data:validate`, `npm run guard:source-of-truth`, `npm run build`, `npm run verify:build`, and finally `npm audit --audit-level=high` while preserving separate, named steps.
- Add deterministic lockfile/package metadata check (`git diff --exit-code package-lock.json package.json`), stale `public/data` detection that fails with a clear message and `git diff --stat`, automatic upload of `npm-audit.after.json` as an artifact, an audit pass/fail summary appended to `GITHUB_STEP_SUMMARY`, workflow concurrency (`group: ci-${{ github.ref }}` + `cancel-in-progress: true`), and least-privilege permissions (`contents: read`).
- Document the local pre-PR command sequence in `README.md` and keep changes minimal and isolated to CI, the Node check script, and README/`package.json` wiring.

### Testing
- `npm ci` completed successfully but reported `4 vulnerabilities (3 moderate, 1 high)`, which demonstrates audit data exists to be surfaced; the new workflow will run `npm audit --audit-level=high` and fail when high/critical issues are present.
- `npm run check:node` failed as expected on local Node `v24.15.0` because it does not satisfy `engines.node: >=20 <=22`, verifying the Node engine check works.
- `npm run validate:workbook-source` passed and resolved the canonical workbook path successfully.
- `npm run lint` passed with no warnings, and `npm run typecheck` passed (`tsc --noEmit`).
- `npm run data:build`, `npm run data:validate`, `npm run guard:source-of-truth`, `npm run build`, and `npm run verify:build` all completed successfully during local verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ca2ed6ac48323bac2cc4ef33586cf)