### PR TITLE
ci: expose workflow failures

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -14,7 +14,6 @@ jobs:
   orchestrator:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    continue-on-error: true
 
     steps:
       - name: Checkout
@@ -23,15 +22,18 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: .nvmrc
           cache: npm
 
       - name: Install dependencies
-        run: |
-          npm install --prefer-offline --no-audit
+        run: npm ci
+
+      - name: Check Node version contract
+        run: npm run check:node
 
       - name: Create patch directories
         run: |
+          set -euo pipefail
           mkdir -p agent/patches
           mkdir -p ops/agent-review
 
@@ -39,22 +41,36 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           NODE_OPTIONS: --max-old-space-size=4096
-        run: |
-          npm run agent:run -- --mode=fast --batch=50 || true
+        run: npm run agent:run -- --mode=fast --batch=50
 
       - name: Review generated patches
-        run: |
-          node scripts/review-patches.mjs || true
+        run: node scripts/review-patches.mjs
 
       - name: Commit standalone patches
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git add agent/patches
-          git add ops/agent-review
+          git add agent/patches ops/agent-review
 
-          git diff --cached --quiet && exit 0
+          if git diff --cached --quiet; then
+            echo "No patch changes to commit."
+            exit 0
+          fi
 
           git commit -m "agent: metadata harvest patches"
           git push
+
+      - name: Workflow summary
+        if: always()
+        run: |
+          {
+            echo "## Agent Metadata Harvester"
+            echo "- Purpose: run agent metadata harvest and commit resulting patches"
+            echo "- Branch/ref: $GITHUB_REF"
+            echo "- Commands: npm ci; npm run check:node; npm run agent:run -- --mode=fast --batch=50; node scripts/review-patches.mjs"
+            echo "- Outputs: agent/patches, ops/agent-review"
+            echo "- Status: ${{ job.status }}"
+            echo "- Next action: Review committed patches in repository history."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-candidates.yml
+++ b/.github/workflows/build-candidates.yml
@@ -3,6 +3,9 @@ name: Build Candidate Queue
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   queue:
     runs-on: ubuntu-latest
@@ -10,6 +13,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
-      - run: npm install --prefer-offline --no-audit
-      - run: npm run agent:run -- --mode=fast --batch=50 || true
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm run check:node
+      - run: npm run agent:run -- --mode=fast --batch=50
+      - name: Workflow summary
+        if: always()
+        run: |
+          {
+            echo "## Build Candidate Queue"
+            echo "- Purpose: generate build-candidate patches"
+            echo "- Branch/ref: $GITHUB_REF"
+            echo "- Commands: npm ci; npm run check:node; npm run agent:run -- --mode=fast --batch=50"
+            echo "- Status: ${{ job.status }}"
+            echo "- Output path: agent/patches"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -10,6 +10,9 @@ concurrency:
   group: build-check-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Validate production build
@@ -23,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: .nvmrc
           cache: npm
           cache-dependency-path: package-lock.json
 
@@ -38,6 +41,12 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Verify Node engine
+        run: npm run check:node
+
+      - name: Validate workbook source
+        run: npm run validate:workbook-source
 
       - name: Build and verify
         run: npm run build

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -16,10 +19,14 @@ jobs:
       - name: Use Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version-file: .nvmrc
+          cache: npm
 
       - name: Install deps
-        run: npm install
+        run: npm ci
+
+      - name: Verify Node engine
+        run: npm run check:node
 
       - name: Run full check
         run: npm run check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,13 +75,7 @@ jobs:
           fi
 
       - name: Run security audit
-        id: audit
-        run: |
-          set +e
-          npm audit --audit-level=high --json > npm-audit.after.json
-          status=$?
-          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
-          exit $status
+        run: npm audit --audit-level=high --json > npm-audit.after.json
 
       - name: Upload audit artifact
         if: always() && hashFiles('npm-audit.after.json') != ''
@@ -90,18 +84,14 @@ jobs:
           name: npm-audit-after
           path: npm-audit.after.json
 
-      - name: Add audit summary
+      - name: Add workflow summary
         if: always()
         run: |
-          if [ "${{ steps.audit.outputs.exit_code }}" = "0" ]; then
-            {
-              echo "## Security audit"
-              echo "✅ npm audit passed (no high/critical vulnerabilities found)."
-            } >> "$GITHUB_STEP_SUMMARY"
-          else
-            {
-              echo "## Security audit"
-              echo "❌ npm audit failed (high and/or critical vulnerabilities found)."
-              echo "See uploaded artifact: npm-audit-after."
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
+          {
+            echo "## CI quality gate"
+            echo "- Purpose: enforce lint, typecheck, workbook/data correctness, build verification, and security audit"
+            echo "- Branch/ref: $GITHUB_REF"
+            echo "- Key commands: npm ci; npm run check:node; npm run validate:workbook-source; npm run lint; npm run typecheck; npm run data:build; npm run data:validate; npm run guard:source-of-truth; npm run build; npm run verify:build; npm audit --audit-level=high"
+            echo "- Artifact: npm-audit-after"
+            echo "- Status: ${{ job.status }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deep-enrichment.yml
+++ b/.github/workflows/deep-enrichment.yml
@@ -7,6 +7,9 @@ on:
         required: false
         default: '3'
 
+permissions:
+  contents: read
+
 jobs:
   enrich:
     runs-on: ubuntu-latest
@@ -14,6 +17,18 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
-      - run: npm install --prefer-offline --no-audit
-      - run: npm run agent:run -- --mode=deep --batch=${{ github.event.inputs.batch }} || true
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm run check:node
+      - run: npm run agent:run -- --mode=deep --batch=${{ github.event.inputs.batch }}
+      - name: Workflow summary
+        if: always()
+        run: |
+          {
+            echo "## Deep Enrichment"
+            echo "- Purpose: run deep enrichment agent batch"
+            echo "- Branch/ref: $GITHUB_REF"
+            echo "- Command: npm run agent:run -- --mode=deep --batch=${{ github.event.inputs.batch }}"
+            echo "- Status: ${{ job.status }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/master-research-pipeline.yml
+++ b/.github/workflows/master-research-pipeline.yml
@@ -4,8 +4,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: write
-  contents: write
+  contents: read
 
 jobs:
   metadata_harvest:

--- a/.github/workflows/patch-packaging.yml
+++ b/.github/workflows/patch-packaging.yml
@@ -3,6 +3,9 @@ name: Patch Packaging
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   package:
     runs-on: ubuntu-latest
@@ -10,6 +13,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
-      - run: npm install --prefer-offline --no-audit
-      - run: node scripts/merge-patches.mjs --all || true
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm run check:node
+      - run: node scripts/merge-patches.mjs --all
+      - name: Workflow summary
+        if: always()
+        run: |
+          {
+            echo "## Patch Packaging"
+            echo "- Purpose: merge approved patches for packaging"
+            echo "- Branch/ref: $GITHUB_REF"
+            echo "- Command: node scripts/merge-patches.mjs --all"
+            echo "- Status: ${{ job.status }}"
+            echo "- Output path: ops/agent-review"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/patch-qa.yml
+++ b/.github/workflows/patch-qa.yml
@@ -3,6 +3,9 @@ name: Patch QA Audit
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   qa:
     runs-on: ubuntu-latest
@@ -10,6 +13,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
-      - run: npm install --prefer-offline --no-audit
-      - run: node scripts/review-patches.mjs || true
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm run check:node
+      - run: node scripts/review-patches.mjs
+      - name: Workflow summary
+        if: always()
+        run: |
+          {
+            echo "## Patch QA Audit"
+            echo "- Purpose: review generated agent patches"
+            echo "- Branch/ref: $GITHUB_REF"
+            echo "- Command: node scripts/review-patches.mjs"
+            echo "- Status: ${{ job.status }}"
+            echo "- Output path: ops/agent-review"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/product-intelligence.yml
+++ b/.github/workflows/product-intelligence.yml
@@ -3,6 +3,9 @@ name: Product Intelligence
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   products:
     runs-on: ubuntu-latest
@@ -10,6 +13,18 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
-      - run: npm install --prefer-offline --no-audit
-      - run: npm run agent:run -- --mode=standard --batch=15 || true
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm run check:node
+      - run: npm run agent:run -- --mode=standard --batch=15
+      - name: Workflow summary
+        if: always()
+        run: |
+          {
+            echo "## Product Intelligence"
+            echo "- Purpose: run product-intelligence enrichment"
+            echo "- Branch/ref: $GITHUB_REF"
+            echo "- Command: npm run agent:run -- --mode=standard --batch=15"
+            echo "- Status: ${{ job.status }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/relationship-graph.yml
+++ b/.github/workflows/relationship-graph.yml
@@ -3,6 +3,9 @@ name: Relationship Graph Builder
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   graph:
     runs-on: ubuntu-latest
@@ -10,6 +13,18 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
-      - run: npm install --prefer-offline --no-audit
-      - run: npm run agent:run -- --mode=standard --batch=30 || true
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm run check:node
+      - run: npm run agent:run -- --mode=standard --batch=30
+      - name: Workflow summary
+        if: always()
+        run: |
+          {
+            echo "## Relationship Graph Builder"
+            echo "- Purpose: run relationship graph expansion"
+            echo "- Branch/ref: $GITHUB_REF"
+            echo "- Command: npm run agent:run -- --mode=standard --batch=30"
+            echo "- Status: ${{ job.status }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/review-patches.yml
+++ b/.github/workflows/review-patches.yml
@@ -23,7 +23,6 @@ jobs:
   review:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    continue-on-error: true
 
     steps:
       - name: Checkout
@@ -32,35 +31,52 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version-file: .nvmrc
           cache: npm
 
       - name: Install dependencies
-        run: |
-          npm install --prefer-offline --no-audit
+        run: npm ci
+
+      - name: Check Node version contract
+        run: npm run check:node
 
       - name: Review patches
-        run: |
-          node scripts/review-patches.mjs || true
+        run: node scripts/review-patches.mjs
 
       - name: Export approved patches (all)
         if: ${{ github.event.inputs.merge_mode == 'all' }}
-        run: |
-          node scripts/merge-patches.mjs --all || true
+        run: node scripts/merge-patches.mjs --all
 
       - name: Export approved patch (single slug)
         if: ${{ github.event.inputs.merge_mode == 'single' }}
-        run: |
-          node scripts/merge-patches.mjs --slug=${{ github.event.inputs.slug }} || true
+        run: node scripts/merge-patches.mjs --slug=${{ github.event.inputs.slug }}
 
       - name: Commit review exports
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git add ops/agent-review
 
-          git diff --cached --quiet && exit 0
+          if git diff --cached --quiet; then
+            echo "No review export changes to commit."
+            exit 0
+          fi
 
           git commit -m "agent: review export updates"
           git push
+
+      - name: Workflow summary
+        if: always()
+        run: |
+          {
+            echo "## Review Agent Patches"
+            echo "- Purpose: review and optionally merge agent patches"
+            echo "- Branch/ref: $GITHUB_REF"
+            echo "- Merge mode: ${{ github.event.inputs.merge_mode }}"
+            echo "- Commands: node scripts/review-patches.mjs; node scripts/merge-patches.mjs"
+            echo "- Status: ${{ job.status }}"
+            echo "- Output path: ops/agent-review"
+            echo "- Next action: inspect committed review exports before downstream automation."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/seo-assets.yml
+++ b/.github/workflows/seo-assets.yml
@@ -3,6 +3,9 @@ name: SEO Asset Generator
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   seo:
     runs-on: ubuntu-latest
@@ -10,6 +13,18 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
-      - run: npm install --prefer-offline --no-audit
-      - run: npm run agent:run -- --mode=standard --batch=25 || true
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm run check:node
+      - run: npm run agent:run -- --mode=standard --batch=25
+      - name: Workflow summary
+        if: always()
+        run: |
+          {
+            echo "## SEO Asset Generator"
+            echo "- Purpose: generate SEO-focused agent assets"
+            echo "- Branch/ref: $GITHUB_REF"
+            echo "- Command: npm run agent:run -- --mode=standard --batch=25"
+            echo "- Status: ${{ job.status }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sitemap-seo.yml
+++ b/.github/workflows/sitemap-seo.yml
@@ -3,6 +3,9 @@ name: Sitemap SEO Builder
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   sitemap:
     runs-on: ubuntu-latest
@@ -10,6 +13,20 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
-      - run: npm install --prefer-offline --no-audit
-      - run: npm run build || true
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm run check:node
+      - run: npm run validate:workbook-source
+      - run: npm run build
+      - name: Workflow summary
+        if: always()
+        run: |
+          {
+            echo "## Sitemap SEO Builder"
+            echo "- Purpose: build sitemap-related SEO output"
+            echo "- Branch/ref: $GITHUB_REF"
+            echo "- Commands: npm run check:node; npm run validate:workbook-source; npm run build"
+            echo "- Status: ${{ job.status }}"
+            echo "- Output path: out/"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/source-expansion.yml
+++ b/.github/workflows/source-expansion.yml
@@ -3,6 +3,9 @@ name: Source Expansion
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   expand:
     runs-on: ubuntu-latest
@@ -10,6 +13,18 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
-      - run: npm install --prefer-offline --no-audit
-      - run: npm run agent:run -- --mode=fast --batch=100 || true
+          node-version-file: .nvmrc
+          cache: npm
+      - run: npm ci
+      - run: npm run check:node
+      - run: npm run agent:run -- --mode=fast --batch=100
+      - name: Workflow summary
+        if: always()
+        run: |
+          {
+            echo "## Source Expansion"
+            echo "- Purpose: run fast source-expansion enrichment"
+            echo "- Branch/ref: $GITHUB_REF"
+            echo "- Command: npm run agent:run -- --mode=fast --batch=100"
+            echo "- Status: ${{ job.status }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/ci/workflow-failure-policy.md
+++ b/docs/ci/workflow-failure-policy.md
@@ -1,0 +1,53 @@
+# Workflow Failure Visibility Policy
+
+## Scope
+This policy applies to production, CI, deploy, release, build, data, SEO, security, and agent-assist GitHub Actions workflows in this repository.
+
+## Hidden failures are disallowed in production-impacting workflows
+- Do not use `|| true`, `set +e` without explicit re-fail logic, or other masking patterns.
+- Commands that fail must fail the step and job.
+- Multi-line shell steps must use `set -euo pipefail` when they contain control flow or multiple commands.
+
+## `continue-on-error`
+- Default: do not use `continue-on-error`.
+- Allowed only for intentionally non-blocking experimental/manual diagnostics.
+- Any non-blocking step must include a nearby comment explaining:
+  - why non-blocking behavior is intentional,
+  - where failure evidence is recorded (summary/artifact),
+  - who is responsible for review.
+
+## Required workflow summary output for important workflows
+For workflows that produce deploy/data/agent outputs, write a GitHub Actions job summary (`$GITHUB_STEP_SUMMARY`) including:
+- workflow purpose,
+- branch/ref,
+- key commands run,
+- pass/fail status,
+- artifact names or output paths,
+- next manual action (if needed).
+
+## Least-privilege permissions
+- Default workflow permissions:
+
+```yaml
+permissions:
+  contents: read
+```
+
+- Elevate only when required:
+  - `contents: write` only for workflows that commit/push changes.
+  - `pull-requests: write` only for workflows that create/comment on PRs.
+  - `issues: write` only for workflows that comment on issues.
+
+## Node and install policy
+- Use `actions/setup-node@v4`.
+- For Node/npm workflows use:
+  - `node-version-file: .nvmrc`
+  - `cache: npm` (where installs are performed)
+- Use `npm ci` in CI/deploy/release workflows.
+- Do not use `npm install` in CI/deploy/release unless explicitly justified by a workflow comment.
+- Run `npm run check:node` where quality/build/deploy correctness matters.
+
+## Workbook/data guardrails
+- Run `npm run validate:workbook-source` before workbook-dependent commands.
+- Run `npm run data:validate` after data generation where applicable.
+- Fail the job if generated artifacts change unexpectedly and are uncommitted.


### PR DESCRIPTION
### Motivation

- Remove hidden failure handling in GitHub workflows so CI/deploy/data/agent tasks cannot silently pass when commands fail.
- Standardize Node/npm behavior and tighten workflow permissions to reduce environment-induced false positives.
- Add clear workflow summaries and a policy document to make failures and next steps visible in job output.

### Description

- Audited and updated all files under `.github/workflows/*.yml` to remove `|| true`, `continue-on-error: true`, and `set +e` masking in production/CI/deploy/data/agent paths and to add explicit failure handling where needed. 
- Standardized Node setup to `actions/setup-node@v4` with `node-version-file: .nvmrc`, `cache: npm`, replaced `npm install` with `npm ci` in CI/deploy/release flows, and added `npm run check:node` to workflows where correctness matters. 
- Tightened permissions to least privilege (`permissions: contents: read` by default) and retained `contents: write` only for workflows that commit/push changes; added `$GITHUB_STEP_SUMMARY` job summaries to key workflows. 
- Added `set -euo pipefail` and explicit exit/conditional handling for multi-line bash steps that perform control flow or commits, and created `docs/ci/workflow-failure-policy.md` documenting the policy and allowed exceptions.

### Testing

- Ran the requested local checks: `npm ci` (succeeded), `npm run validate:workbook-source` (succeeded), `npm run lint` (succeeded), `npm run typecheck` (succeeded), `npm run data:build` (succeeded), `npm run data:validate` (succeeded), `npm run guard:source-of-truth` (succeeded), `npm run build` (succeeded), and `npm run verify:build` (succeeded).
- `npm run check:node` failed locally as expected because the local environment is Node `v24.15.0` while the project `engines` require `>=20 <=22`; workflows now use `.nvmrc` + `check:node` to enforce the contract.
- Performed YAML syntax inspection manually; no local YAML linter/tool was available in the environment to run a workflow linter, and this is documented in the PR notes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0cae549d8c8323bd451ba95c376d96)