### PR TITLE
ci: add static export compatibility guard

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -48,5 +48,8 @@ jobs:
       - name: Validate workbook source
         run: npm run validate:workbook-source
 
+      - name: Validate static export compatibility
+        run: npm run validate:static-export
+
       - name: Build and verify
         run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Validate workbook source
         run: npm run validate:workbook-source
 
+      - name: Validate static export compatibility
+        run: npm run validate:static-export
+
       - name: Run lint
         run: npm run lint
 
@@ -95,7 +98,7 @@ jobs:
             echo "## CI quality gate"
             echo "- Purpose: enforce lint, typecheck, workbook/data correctness, build verification, and security audit"
             echo "- Branch/ref: $GITHUB_REF"
-            echo "- Key commands: npm ci; npm run check:node; npm run validate:workbook-source; npm run lint; npm run typecheck; npm run data:build; npm run data:validate; npm run guard:source-of-truth; npm run build; npm run verify:build; npm run audit:high"
+            echo "- Key commands: npm ci; npm run check:node; npm run validate:workbook-source; npm run validate:static-export; npm run lint; npm run typecheck; npm run data:build; npm run data:validate; npm run guard:source-of-truth; npm run build; npm run verify:build; npm run audit:high"
             echo "- Artifact: npm-audit-after"
             echo "- Status: ${{ job.status }}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Validate workbook source
         run: npm run validate:workbook-source
 
+      - name: Validate static export compatibility
+        run: npm run validate:static-export
+
       - name: Lint
         run: npm run lint
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@
 - Run build checks after data-pipeline edits.
 - Avoid unrelated refactors.
 - Favor lean payloads for initial shipping.
+- This project uses static export. Do not add API routes, middleware, server actions, next/headers, next/server runtime code, force-dynamic pages, or runtime revalidation unless the architecture is intentionally changed away from static export.
 
 ## Site architecture
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ npm run dev
 - Framework/runtime: **Next.js App Router** with static export.
 - Canonical production host: **Cloudflare Pages**.
 - Build command: `npm run build`.
+- Static export guardrail: `npm run validate:static-export` (must pass before build).
 - Verification command: `npm run verify:build`.
 - Static deploy directory: `out/` (Cloudflare deploy target).
 - Data source of truth: `data-sources/herb_monograph_master.xlsx` (workbook-only policy).
@@ -148,6 +149,7 @@ Local pre-deploy command sequence:
 npm ci
 npm run check:node
 npm run validate:workbook-source
+npm run validate:static-export
 npm run lint
 npm run typecheck
 npm run data:build

--- a/docs/ci/static-export-guardrails.md
+++ b/docs/ci/static-export-guardrails.md
@@ -1,0 +1,43 @@
+# Static export guardrails
+
+## Why static export is required
+
+This site deploys with Next.js `output: "export"` and publishes static files to Cloudflare Pages. Static export keeps deploys deterministic, fast, and aligned with the workbook-first content pipeline.
+
+## Forbidden runtime/server features
+
+`npm run validate:static-export` fails if active static-export code introduces:
+
+- `app/**/route.(ts|tsx|js|jsx)` API route handlers
+- `middleware.ts` or `middleware.js`
+- `"use server"` server actions
+- imports from `next/headers` or `next/server`
+- runtime request APIs: `cookies()`, `headers()`, `draftMode()`
+- dynamic rendering directives: `dynamic = "force-dynamic"`
+- cache-busting runtime APIs: `unstable_noStore()`, `noStore()`
+- runtime revalidation patterns such as `export const revalidate = ...` or `revalidateTag()/revalidatePath()`
+
+## Allowed alternatives
+
+- Build-time data generation through existing scripts in `scripts/data/**`
+- Static App Router pages under `app/**/page.tsx`
+- Compile-time JSON/runtime payload consumption from generated `public/data/**`
+- Route generation with static params patterns already used by the project
+
+## How to add static pages safely
+
+1. Add route files as `app/**/page.tsx` only.
+2. Keep data access build-time/static.
+3. Run:
+   - `npm run validate:workbook-source`
+   - `npm run validate:static-export`
+   - `npm run build`
+
+## If server-side features are needed in the future
+
+Do not bypass this guard in normal PRs. Propose an explicit architecture change PR that:
+
+1. Documents migration away from static export
+2. Updates `next.config.mjs` and deployment/runtime assumptions
+3. Updates CI, security model, and operational docs accordingly
+4. Gets maintainers' explicit approval before merging runtime-server features

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "prebuild": "npm run validate:workbook-source",
     "check:node": "node scripts/ci/check-node-version.mjs",
     "audit:high": "node scripts/ci/audit-high-with-allowlist.mjs",
-    "check:node:self-test": "node scripts/ci/check-node-version.mjs --self-test"
+    "check:node:self-test": "node scripts/ci/check-node-version.mjs --self-test",
+    "validate:static-export": "node scripts/ci/validate-static-export-compatibility.mjs"
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.8",

--- a/scripts/ci/validate-static-export-compatibility.mjs
+++ b/scripts/ci/validate-static-export-compatibility.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+
+const repoRoot = process.cwd()
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'])
+const IGNORE_DIRS = new Set(['node_modules', '.next', 'out', 'coverage', '.git'])
+const ROOT_SCAN_DIRS = ['app', 'components', 'lib']
+const SRC_ROOT = 'src'
+
+const BLOCK_RULES = [
+  { id: 'app-route-file', test: (rel) => /(^|\/)app\/.+\/route\.(ts|tsx|js|jsx)$/.test(rel) },
+  { id: 'middleware-file', test: (rel) => /(^|\/)middleware\.(ts|js)$/.test(rel) },
+  { id: 'use-server', pattern: /['"]use server['"]/ },
+  { id: 'next-headers-import', pattern: /from\s+['"]next\/headers['"]/ },
+  { id: 'next-server-import', pattern: /from\s+['"]next\/server['"]/ },
+  { id: 'cookies-call', pattern: /\bcookies\s*\(/ },
+  { id: 'headers-call', pattern: /\bheaders\s*\(/ },
+  { id: 'draftMode-call', pattern: /\bdraftMode\s*\(/ },
+  { id: 'force-dynamic', pattern: /(?:export\s+const\s+)?dynamic\s*=\s*['"]force-dynamic['"]/ },
+  { id: 'unstable_noStore-call', pattern: /\bunstable_noStore\s*\(/ },
+  { id: 'noStore-call', pattern: /\bnoStore\s*\(/ },
+  { id: 'revalidate-export', pattern: /export\s+const\s+revalidate\s*=/ },
+  { id: 'next-revalidate-tag', pattern: /\brevalidate(Tag|Path)\s*\(/ },
+]
+
+const importRegex = /(?:import\s+(?:[^'";]+\s+from\s+)?|export\s+[^'";]*from\s+|import\s*\()\s*['"]([^'"]+)['"]/g
+
+function normalize(rel) { return rel.split(path.sep).join('/') }
+function isSourceFile(file) { return SOURCE_EXTENSIONS.has(path.extname(file)) }
+
+async function exists(p) { try { await fs.access(p); return true } catch { return false } }
+
+async function walk(dir, files, ignoredCounter) {
+  const entries = await fs.readdir(dir, { withFileTypes: true })
+  for (const entry of entries) {
+    if (IGNORE_DIRS.has(entry.name)) { ignoredCounter.count += 1; continue }
+    const abs = path.join(dir, entry.name)
+    if (entry.isDirectory()) { await walk(abs, files, ignoredCounter); continue }
+    if (!entry.isFile()) continue
+    if (!isSourceFile(entry.name)) { ignoredCounter.count += 1; continue }
+    if (entry.name.endsWith('.audit.json')) { ignoredCounter.count += 1; continue }
+    files.add(abs)
+  }
+}
+
+function resolveImport(fromFile, spec) {
+  if (!spec || spec.startsWith('node:') || (!spec.startsWith('.') && !spec.startsWith('@/') && !spec.startsWith('/'))) return null
+  let base
+  if (spec.startsWith('@/')) base = path.join(repoRoot, spec.slice(2))
+  else if (spec.startsWith('/')) base = path.join(repoRoot, spec.slice(1))
+  else base = path.resolve(path.dirname(fromFile), spec)
+
+  const candidates = [base, ...[...SOURCE_EXTENSIONS].map(ext => `${base}${ext}`), ...[...SOURCE_EXTENSIONS].map(ext => path.join(base, `index${ext}`))]
+  return candidates
+}
+
+async function collectActiveSrcFiles(seedFiles) {
+  const queue = [...seedFiles]
+  const visited = new Set()
+  const included = new Set()
+
+  while (queue.length) {
+    const current = queue.pop()
+    if (!current || visited.has(current)) continue
+    visited.add(current)
+    if (!(await exists(current))) continue
+    const rel = normalize(path.relative(repoRoot, current))
+    if (!rel.startsWith(`${SRC_ROOT}/`)) continue
+    included.add(current)
+    const content = await fs.readFile(current, 'utf8')
+    for (const match of content.matchAll(importRegex)) {
+      const spec = match[1]
+      const resolvedCandidates = resolveImport(current, spec)
+      if (!resolvedCandidates) continue
+      for (const c of resolvedCandidates) {
+        if (await exists(c)) { queue.push(c); break }
+      }
+    }
+  }
+  return included
+}
+
+async function main() {
+  const candidateFiles = new Set()
+  const ignoredCounter = { count: 0 }
+
+  for (const dir of ROOT_SCAN_DIRS) {
+    const abs = path.join(repoRoot, dir)
+    if (await exists(abs)) await walk(abs, candidateFiles, ignoredCounter)
+  }
+
+  const seedFiles = []
+  for (const rootDir of ['app', 'components', 'lib']) {
+    for (const file of candidateFiles) {
+      const rel = normalize(path.relative(repoRoot, file))
+      if (rel.startsWith(`${rootDir}/`)) seedFiles.push(file)
+    }
+  }
+
+  const activeSrcFiles = await collectActiveSrcFiles(seedFiles)
+  for (const srcFile of activeSrcFiles) candidateFiles.add(srcFile)
+
+  const sorted = [...candidateFiles].sort()
+  const violations = []
+
+  for (const file of sorted) {
+    const rel = normalize(path.relative(repoRoot, file))
+    for (const rule of BLOCK_RULES) {
+      if (rule.test && rule.test(rel)) {
+        violations.push(`${rel}: [${rule.id}] matched forbidden file pattern`)
+      }
+    }
+
+    const content = await fs.readFile(file, 'utf8')
+    const lines = content.split('\n')
+    lines.forEach((line, i) => {
+      for (const rule of BLOCK_RULES) {
+        if (rule.pattern && rule.pattern.test(line)) {
+          violations.push(`${rel}:${i + 1}: [${rule.id}] ${line.trim()}`)
+        }
+      }
+    })
+  }
+
+  console.log(`[static-export-guard] scanned files: ${sorted.length}`)
+  console.log(`[static-export-guard] ignored entries: ${ignoredCounter.count}`)
+
+  if (violations.length > 0) {
+    console.error('[static-export-guard] static export compatibility violations found:')
+    for (const v of violations) console.error(`- ${v}`)
+    process.exit(1)
+  }
+
+  console.log('[static-export-guard] PASS: no static export compatibility violations found.')
+}
+
+main().catch((error) => {
+  console.error('[static-export-guard] unexpected failure')
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
### Motivation
- Prevent server-only or dynamic Next.js features from being introduced into the active static-export codebase to keep Cloudflare Pages static deploys deterministic and safe. 
- Provide an automated CI guard that scans the active app surface and flags runtime/server APIs, API routes, middleware, and dynamic directives incompatible with `output: "export"`.

### Description
- Add `scripts/ci/validate-static-export-compatibility.mjs` which scans `app/**`, `components/**`, `lib/**` and any reachable `src/**` imports and fails on forbidden patterns (API route files, `middleware.*`, `"use server"`, imports from `next/headers` or `next/server`, `cookies()`, `headers()`, `draftMode()`, `dynamic = "force-dynamic"`, `unstable_noStore()/noStore()`, and runtime revalidation like `export const revalidate` and `revalidateTag()/revalidatePath()`).
- Add `validate:static-export` to `package.json` and wire it into CI/deploy/workflow checks so it runs after `validate:workbook-source` and before `build` in `.github/workflows/ci.yml`, `.github/workflows/deploy.yml`, and `.github/workflows/build-check.yml`.
- Update docs and developer guidance: add `docs/ci/static-export-guardrails.md`, insert the guard into `README.md` local pre-deploy sequence, and add a short rule to `AGENTS.md` warning contributors about static-export constraints.

### Testing
- Ran the requested local quality sequence: `npm ci`, `npm run check:node:self-test`, `npm run validate:workbook-source`, `npm run validate:static-export`, `npm run lint`, `npm run typecheck`, `npm run data:build`, `npm run data:validate`, `npm run guard:source-of-truth`, `npm run build`, `npm run verify:build`, and `npm run audit:high`, all of which completed successfully in the test environment. 
- `validate:static-export` printed the scanned files and ignored entry counts (example: `scanned files: 327`, `ignored entries: 1`) and returned `PASS: no static export compatibility violations found` for the current codebase. 
- Verified the guard fails when a temporary server-only file is added by creating `app/api/test/route.ts` and confirming `npm run validate:static-export` returned non-zero, then removed the file and confirmed the guard passed again. 
- Documented local Node engine note: local runs showed engine warnings on Node v24 (expected), while CI is configured to use the Node version from `.nvmrc` via `actions/setup-node`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0da7f720e0832393f4baff95b90554)