### PR TITLE
fix(ci): remove ripgrep dependency from route inventory

### DIFF
--- a/scripts/ci/generate-route-inventory.mjs
+++ b/scripts/ci/generate-route-inventory.mjs
@@ -1,14 +1,36 @@
 #!/usr/bin/env node
 import fs from 'node:fs'
 import path from 'node:path'
-import { execSync } from 'node:child_process'
 
 const root = process.cwd()
 const appDir = path.join(root, 'app')
 const outFile = path.join(root, 'docs/generated/route-inventory.md')
 
-const pageFiles = execSync("rg --files app -g '**/page.tsx' -g '**/page.ts' -g '**/page.jsx' -g '**/page.js'", { encoding: 'utf8' })
-  .trim().split('\n').filter(Boolean).sort()
+const pageFilePattern = /^page\.(tsx|ts|jsx|js)$/
+
+const collectPageFiles = (dir) => {
+  if (!fs.existsSync(dir)) return []
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+  const files = []
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name)
+
+    if (entry.isDirectory()) {
+      files.push(...collectPageFiles(fullPath))
+      continue
+    }
+
+    if (entry.isFile() && pageFilePattern.test(entry.name)) {
+      files.push(path.relative(root, fullPath).split(path.sep).join('/'))
+    }
+  }
+
+  return files
+}
+
+const pageFiles = collectPageFiles(appDir).sort()
 
 const toRoute = (file) => {
   const rel = file.replace(/^app\//, '').replace(/\/page\.(tsx|ts|jsx|js)$/, '')


### PR DESCRIPTION
## Problem
CI was failing because `scripts/ci/generate-route-inventory.mjs` depended on `rg` (ripgrep), which is not installed in the GitHub Actions environment.

Error:

```bash
/bin/sh: 1: rg: not found
```

## Fix
Replaced the `rg` shell dependency with a pure Node.js recursive filesystem traversal.

## Benefits
- Removes external binary dependency
- More portable across CI providers
- Works in GitHub Actions, Codespaces, local environments, and containers
- No behavior change to generated route inventory semantics
