### PR TITLE
fix(data): make build-report.json deterministic

### DIFF
--- a/scripts/data/build-runtime-from-workbook.mjs
+++ b/scripts/data/build-runtime-from-workbook.mjs
@@ -320,7 +320,7 @@ function main() {
   writeJson(path.join(outDir, 'agent-patches.json'), [])
   details(path.join(outDir, 'herb-detail'), herbs)
   details(path.join(outDir, 'compound-detail'), compounds)
-  writeJson(path.join(outDir, 'build-report.json'), { generatedAt: new Date().toISOString(), workbook: path.basename(workbookPath), counts: { herbs: herbs.length, compounds: compounds.length, claims: claims.length, herbCompoundMap: herbCompoundMap.length, topics: (graph.topics || []).length, pathways: (graph.pathways || []).length, supernodes: (graph.supernodes || []).length } })
+  writeJson(path.join(outDir, 'build-report.json'), { buildReportVersion: 1, workbook: path.basename(workbookPath), counts: { herbs: herbs.length, compounds: compounds.length, claims: claims.length, herbCompoundMap: herbCompoundMap.length, topics: (graph.topics || []).length, pathways: (graph.pathways || []).length, supernodes: (graph.supernodes || []).length } })
   console.log(`[data] wrote ${herbs.length} herbs, ${compounds.length} compounds, ${claims.length} claims`)
 }
 


### PR DESCRIPTION
## Problem
CI was failing stale generated artifact checks because `public/data/build-report.json` changed on every build.

Root cause:

```json
"generatedAt": "2026-05-20T17:41:47.969Z"
```

This timestamp introduced nondeterministic output even when workbook data was unchanged.

## Fix
Removed wall-clock timestamp generation and replaced it with:

```json
"buildReportVersion": 1
```

## Result
Running:

```bash
npm run data:build
```

multiple times should now produce identical `public/data` output unless the workbook data actually changes.

This preserves the stale-artifact guard while restoring deterministic CI behavior.
