### PR TITLE
fix(data): commit deterministic build-report artifact

### DIFF
--- a/public/data/build-report.json
+++ b/public/data/build-report.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-20T17:41:47.969Z",
+  "buildReportVersion": 1,
   "workbook": "herb_monograph_master.xlsx",
   "counts": {
     "herbs": 295,


### PR DESCRIPTION
## Problem
CI still failed stale generated artifact validation after deterministic build-report logic was introduced.

Reason:
- the generator logic changed
- but the generated artifact itself (`public/data/build-report.json`) was not regenerated and committed

CI therefore detected:

```bash
Generated public/data artifacts are stale.
```

## Fix
Committed the regenerated deterministic artifact.

Old shape:

```json
{
  "generatedAt": "..."
}
```

New deterministic shape:

```json
{
  "buildReportVersion": 1
}
```

## Result
`npm run data:build` should now produce stable output without triggering stale-artifact diffs for build-report.json.
