### PR TITLE
fix(lint): ignore generated next-env.d.ts

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,7 @@ export default [
       'out/**',
       '.next/**',
       'node_modules/**',
+      'next-env.d.ts',
       'scripts/data/build-runtime-from-workbook.mjs',
     ],
   },


### PR DESCRIPTION
## Problem
ESLint failed on the framework-generated `next-env.d.ts` file:

```text
@typescript-eslint/triple-slash-reference
```

Next.js intentionally generates this file with triple-slash references.

## Fix
Added `next-env.d.ts` to ESLint ignores.

## Why
- preserves strict linting elsewhere
- avoids modifying framework-generated files
- keeps Next.js regeneration behavior intact
- avoids disabling the rule globally
