### PR TITLE
chore(github): add PR verification template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Summary
+
+- 
+
+## Verification
+
+- [ ] `npm run lint`
+- [ ] `npm run check`
+- [ ] no package-lock drift
+- [ ] no unexpected `public/data` diffs
+- [ ] no generated file corruption
+- [ ] static export compatible
+
+## Risk Notes
+
+- 


### PR DESCRIPTION
## Purpose
Add a lightweight PR checklist to reduce merge-related regressions and infrastructure drift.

## Adds
- standard verification checklist
- generated artifact awareness
- static export verification reminder
- package-lock drift reminder

## Why
Recent instability came largely from:
- blind merges
- generated artifact drift
- CI portability issues
- package/script corruption

This adds lightweight process guardrails before merging future PRs.
