### PR TITLE
feat(goals): add reusable decision-focused goal pages

### DIFF
--- a/app/goals/[goal]/page.tsx
+++ b/app/goals/[goal]/page.tsx
@@ -3,18 +3,27 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { getGoal, goals } from '@/data/goals'
 
-type Params = { params: Promise<{ goal: string }> }
+type GoalRouteParams = { goal: string }
 
-export function generateStaticParams() {
+export const dynamicParams = false
+
+export function generateStaticParams(): GoalRouteParams[] {
   return goals.map((goal) => ({ goal: goal.slug }))
 }
 
-export async function generateMetadata({ params }: Params): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<GoalRouteParams>
+}): Promise<Metadata> {
   const { goal: goalSlug } = await params
   const goal = getGoal(goalSlug)
 
   if (!goal) {
-    return { title: 'Goal Guide | The Hippie Scientist' }
+    return {
+      title: 'Goal Guide | The Hippie Scientist',
+      description: 'Decision-focused goal guide.',
+    }
   }
 
   return {
@@ -23,35 +32,43 @@ export async function generateMetadata({ params }: Params): Promise<Metadata> {
   }
 }
 
-export default async function GoalDecisionPage({ params }: Params) {
+export default async function GoalDecisionPage({
+  params,
+}: {
+  params: Promise<GoalRouteParams>
+}) {
   const { goal: goalSlug } = await params
   const goal = getGoal(goalSlug)
 
-  if (!goal) notFound()
+  if (!goal) {
+    notFound()
+  }
 
   return (
     <main className="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8">
-      <section className="rounded-3xl border border-slate-200 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-800 p-6 text-slate-100 shadow-sm sm:p-10">
-        <p className="text-xs uppercase tracking-[0.2em] text-emerald-300">{goal.eyebrow}</p>
-        <h1 className="mt-3 text-3xl font-semibold tracking-tight sm:text-4xl">{goal.title}</h1>
-        <p className="mt-4 max-w-3xl text-sm leading-6 text-slate-300 sm:text-base">{goal.description}</p>
+      <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-10">
+        <p className="text-xs uppercase tracking-[0.2em] text-emerald-700">{goal.eyebrow}</p>
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
+          {goal.title}
+        </h1>
+        <p className="mt-4 max-w-3xl text-sm leading-6 text-slate-700 sm:text-base">{goal.description}</p>
       </section>
 
-      <section className="mt-8 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Quick Picks</h2>
+      <section className="mt-8 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="text-xl font-semibold text-slate-900">Quick Picks</h2>
         <div className="mt-4 overflow-x-auto">
           <table className="min-w-full text-left text-sm">
-            <thead className="text-slate-500 dark:text-slate-400">
-              <tr className="border-b border-slate-200 dark:border-slate-700">
+            <thead className="text-slate-500">
+              <tr className="border-b border-slate-200">
                 <th className="py-2 pr-4 font-medium">Need</th>
                 <th className="py-2 font-medium">Suggested Option</th>
               </tr>
             </thead>
             <tbody>
               {goal.quickPicks.map((pick) => (
-                <tr key={pick.need} className="border-b border-slate-100 dark:border-slate-800">
-                  <td className="py-2 pr-4 text-slate-700 dark:text-slate-200">{pick.need}</td>
-                  <td className="py-2 text-slate-900 dark:text-slate-100">{pick.option}</td>
+                <tr key={pick.need} className="border-b border-slate-100">
+                  <td className="py-2 pr-4 text-slate-700">{pick.need}</td>
+                  <td className="py-2 text-slate-900">{pick.option}</td>
                 </tr>
               ))}
             </tbody>
@@ -59,12 +76,12 @@ export default async function GoalDecisionPage({ params }: Params) {
         </div>
       </section>
 
-      <section className="mt-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Comparison Table</h2>
+      <section className="mt-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="text-xl font-semibold text-slate-900">Comparison Table</h2>
         <div className="mt-4 overflow-x-auto">
           <table className="min-w-full text-left text-sm">
-            <thead className="text-slate-500 dark:text-slate-400">
-              <tr className="border-b border-slate-200 dark:border-slate-700">
+            <thead className="text-slate-500">
+              <tr className="border-b border-slate-200">
                 <th className="py-2 pr-4 font-medium">Compound</th>
                 <th className="py-2 pr-4 font-medium">Best For</th>
                 <th className="py-2 pr-4 font-medium">Speed</th>
@@ -74,12 +91,12 @@ export default async function GoalDecisionPage({ params }: Params) {
             </thead>
             <tbody>
               {goal.options.map((option) => (
-                <tr key={option.slug} className="border-b border-slate-100 align-top dark:border-slate-800">
-                  <td className="py-2 pr-4 font-medium text-slate-900 dark:text-slate-100">{option.name}</td>
-                  <td className="py-2 pr-4 text-slate-700 dark:text-slate-200">{option.bestFor}</td>
-                  <td className="py-2 pr-4 text-slate-700 dark:text-slate-200">{option.speed}</td>
-                  <td className="py-2 pr-4 text-slate-700 dark:text-slate-200">{option.evidence}</td>
-                  <td className="py-2 text-slate-700 dark:text-slate-200">{option.risk}</td>
+                <tr key={option.slug} className="border-b border-slate-100 align-top">
+                  <td className="py-2 pr-4 font-medium text-slate-900">{option.name}</td>
+                  <td className="py-2 pr-4 text-slate-700">{option.bestFor}</td>
+                  <td className="py-2 pr-4 text-slate-700">{option.speed}</td>
+                  <td className="py-2 pr-4 text-slate-700">{option.evidence}</td>
+                  <td className="py-2 text-slate-700">{option.risk}</td>
                 </tr>
               ))}
             </tbody>
@@ -89,41 +106,52 @@ export default async function GoalDecisionPage({ params }: Params) {
 
       <section className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {goal.options.map((option) => (
-          <article key={`${option.slug}-avoid`} className="rounded-2xl border border-rose-200 bg-rose-50/70 p-4 dark:border-rose-900/40 dark:bg-rose-950/20">
-            <h3 className="text-sm font-semibold text-rose-900 dark:text-rose-200">Avoid If — {option.name}</h3>
-            <p className="mt-2 text-sm leading-6 text-rose-800 dark:text-rose-300">{option.avoidIf}</p>
+          <article key={`${option.slug}-avoid`} className="rounded-2xl border border-rose-200 bg-rose-50/70 p-4">
+            <h3 className="text-sm font-semibold text-rose-900">Avoid If — {option.name}</h3>
+            <p className="mt-2 text-sm leading-6 text-rose-800">{option.avoidIf}</p>
           </article>
         ))}
       </section>
 
       <section className="mt-6 grid gap-4 sm:grid-cols-2">
-        <article className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900">
-          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Why People Stop Using It</h2>
-          <ul className="mt-4 space-y-2 text-sm text-slate-700 dark:text-slate-200">
+        <article className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 className="text-xl font-semibold text-slate-900">Why People Stop Using It</h2>
+          <ul className="mt-4 space-y-2 text-sm text-slate-700">
             {goal.options.map((option) => (
-              <li key={`${option.slug}-stop`}><span className="font-medium">{option.name}:</span> {option.whyPeopleStop}</li>
+              <li key={`${option.slug}-stop`}>
+                <span className="font-medium">{option.name}:</span> {option.whyPeopleStop}
+              </li>
             ))}
           </ul>
         </article>
 
-        <article className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900">
-          <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Commonly Chosen Forms</h2>
-          <ul className="mt-4 space-y-2 text-sm text-slate-700 dark:text-slate-200">
+        <article className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <h2 className="text-xl font-semibold text-slate-900">Commonly Chosen Forms</h2>
+          <ul className="mt-4 space-y-2 text-sm text-slate-700">
             {goal.options.map((option) => (
-              <li key={`${option.slug}-form`}><span className="font-medium">{option.name}:</span> {option.form}</li>
+              <li key={`${option.slug}-form`}>
+                <span className="font-medium">{option.name}:</span> {option.form}
+              </li>
             ))}
           </ul>
         </article>
       </section>
 
-      <section className="mt-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-700 dark:bg-slate-900">
-        <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100">Related Goals</h2>
+      <section className="mt-6 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <h2 className="text-xl font-semibold text-slate-900">Related Goals</h2>
         <div className="mt-4 flex flex-wrap gap-2">
           {goal.relatedGoals.map((relatedSlug) => {
             const related = getGoal(relatedSlug)
-            if (!related) return null
+            if (!related) {
+              return null
+            }
+
             return (
-              <Link key={related.slug} href={`/goals/${related.slug}`} className="rounded-full border border-slate-300 px-3 py-1.5 text-sm text-slate-700 transition hover:border-emerald-400 hover:text-emerald-700 dark:border-slate-600 dark:text-slate-200 dark:hover:border-emerald-500 dark:hover:text-emerald-300">
+              <Link
+                key={related.slug}
+                href={`/goals/${related.slug}`}
+                className="rounded-full border border-slate-300 px-3 py-1.5 text-sm text-slate-700 transition hover:border-emerald-400 hover:text-emerald-700"
+              >
                 {related.title}
               </Link>
             )
@@ -131,7 +159,7 @@ export default async function GoalDecisionPage({ params }: Params) {
         </div>
       </section>
 
-      <footer className="mt-8 rounded-2xl border border-slate-200 bg-slate-50 p-4 text-xs leading-5 text-slate-600 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-400">
+      <footer className="mt-8 rounded-2xl border border-slate-200 bg-slate-50 p-4 text-xs leading-5 text-slate-600">
         Educational only. Not medical advice. Evidence varies.
       </footer>
     </main>

--- a/app/goals/page.tsx
+++ b/app/goals/page.tsx
@@ -10,18 +10,27 @@ export const metadata: Metadata = {
 export default function GoalsPage() {
   return (
     <main className="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8">
-      <section className="rounded-3xl border border-slate-200 bg-gradient-to-b from-slate-950 via-slate-900 to-slate-900 p-6 text-slate-100 shadow-sm sm:p-10">
-        <p className="text-xs uppercase tracking-[0.2em] text-emerald-300">Goal decision system</p>
-        <h1 className="mt-3 text-3xl font-semibold tracking-tight sm:text-4xl">Choose by outcome, then compare options clearly.</h1>
-        <p className="mt-4 max-w-3xl text-sm leading-6 text-slate-300 sm:text-base">Each page is designed for fast scanning: quick picks first, then side-by-side tradeoffs, risks, and practical form choices.</p>
+      <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm sm:p-10">
+        <p className="text-xs uppercase tracking-[0.2em] text-emerald-700">Goal decision system</p>
+        <h1 className="mt-3 text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
+          Choose by outcome, then compare options clearly.
+        </h1>
+        <p className="mt-4 max-w-3xl text-sm leading-6 text-slate-700 sm:text-base">
+          Each page is designed for fast scanning: quick picks first, then side-by-side tradeoffs,
+          risks, and practical form choices.
+        </p>
       </section>
 
       <section className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         {goals.map((goal) => (
-          <Link key={goal.slug} href={`/goals/${goal.slug}`} className="group rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-300 hover:shadow-md dark:border-slate-700 dark:bg-slate-900">
-            <h2 className="text-lg font-semibold text-slate-900 dark:text-slate-100">{goal.title}</h2>
-            <p className="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300">{goal.description}</p>
-            <ul className="mt-4 space-y-1.5 text-xs text-slate-500 dark:text-slate-400">
+          <Link
+            key={goal.slug}
+            href={`/goals/${goal.slug}`}
+            className="group rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:-translate-y-0.5 hover:border-emerald-300 hover:shadow-md"
+          >
+            <h2 className="text-lg font-semibold text-slate-900">{goal.title}</h2>
+            <p className="mt-2 text-sm leading-6 text-slate-600">{goal.description}</p>
+            <ul className="mt-4 space-y-1.5 text-xs text-slate-500">
               {goal.options.slice(0, 3).map((option) => (
                 <li key={option.slug} className="flex items-center gap-2">
                   <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />


### PR DESCRIPTION
### Motivation
- Provide a simple, reusable decision-focused system for common user goals (pain, inflammation, focus, sleep) so readers can choose by outcome and compare practical tradeoffs.
- Keep pages server-rendered and fully compatible with the site's static export and existing data pipeline without introducing new dependencies.

### Description
- Added goal data/types and helpers in `data/goals.ts`, including `GoalOption`, `Goal`, `goals`, `getGoal`, and `goalConfigs` with initial entries for `pain`, `inflammation`, `focus`, and `sleep`.
- Implemented the goals index at `app/goals/page.tsx` with an intro hero and card grid linking to per-goal pages and showing the top 3 options.
- Implemented a reusable per-goal template at `app/goals/[goal]/page.tsx` with `dynamicParams = false`, `generateStaticParams`, `generateMetadata`, and sections for hero, quick picks, comparison table, avoid-if cards, why-people-stop, common forms, related goals, and an educational disclaimer.
- Styling is Tailwind-only, mobile-first, light-mode editorial aesthetic, server-side only, and makes no changes to workbook/public data or dependencies.

### Testing
- Ran `npm run lint` and the lint step passed successfully.
- Ran `npm run check` (project build, data pipeline validation, and export verification) and the command completed successfully with static pages generated and data verification passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e34a1be38832380e0b4dd933316f5)