### PR TITLE
fix(goals): suppress missing profile links

### DIFF
--- a/app/goals/[goal]/page.tsx
+++ b/app/goals/[goal]/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { getGoal, goals } from '@/data/goals'
 import { getCompoundBySlug } from '@/lib/runtime-data'
+import { normalizeDecisionEvidence, normalizeDecisionSafety } from '@/lib/decision-primitives'
 
 type GoalRouteParams = { goal: string }
 type RuntimeCompound = Record<string, any>
@@ -10,15 +11,11 @@ type RuntimeCompound = Record<string, any>
 type EnrichedGoalOption = {
   option: (typeof goals)[number]['options'][number]
   compound?: RuntimeCompound
+  profileHref: string
   evidenceLabel: string
   safetyLabel: string
   mechanismTags: string[]
   pathwayTags: string[]
-}
-
-const cleanValue = (value: unknown): string => {
-  if (typeof value !== 'string') return ''
-  return value.trim()
 }
 
 const cleanList = (value: unknown): string[] => {
@@ -39,33 +36,25 @@ const cleanList = (value: unknown): string[] => {
   return []
 }
 
-const firstNonEmpty = (...values: unknown[]): string => {
-  for (const value of values) {
-    const cleaned = cleanValue(value)
-    if (cleaned) return cleaned
-  }
-
-  return 'Profile pending review'
-}
-
 const unique = (values: string[]): string[] => Array.from(new Set(values.filter(Boolean)))
 
 function buildEnrichedOption(option: (typeof goals)[number]['options'][number], compound?: RuntimeCompound): EnrichedGoalOption {
-  const evidenceLabel = firstNonEmpty(
-    compound?.evidence_level,
-    compound?.evidenceLevel,
-    compound?.evidence_tier,
-    compound?.evidenceTier,
-    compound?.evidence_grade,
-    option.evidence,
+  const evidenceLabel = normalizeDecisionEvidence(
+    compound?.evidence_level ||
+      compound?.evidenceLevel ||
+      compound?.evidence_tier ||
+      compound?.evidenceTier ||
+      compound?.evidence_grade ||
+      option.evidence,
+    'Needs review',
   )
 
-  const safetyLabel = firstNonEmpty(
-    compound?.safety_level,
-    compound?.safetyLevel,
-    compound?.safety_rating,
-    compound?.safetyRating,
-    option.risk,
+  const safetyLabel = normalizeDecisionSafety(
+    compound?.safety_level ||
+      compound?.safetyLevel ||
+      compound?.safety_rating ||
+      compound?.safetyRating ||
+      option.risk,
   )
 
   const mechanismTags = unique([
@@ -84,6 +73,7 @@ function buildEnrichedOption(option: (typeof goals)[number]['options'][number], 
   return {
     option,
     compound,
+    profileHref: compound?.slug ? `/compounds/${compound.slug}` : '',
     evidenceLabel,
     safetyLabel,
     mechanismTags,
@@ -203,12 +193,16 @@ export default async function GoalDecisionPage({
               </tr>
             </thead>
             <tbody>
-              {enrichedOptions.map(({ option, evidenceLabel, safetyLabel }) => (
+              {enrichedOptions.map(({ option, profileHref, evidenceLabel, safetyLabel }) => (
                 <tr key={option.slug} className="border-b border-slate-100 align-top">
                   <td className="py-2 pr-4 font-medium text-slate-900">
-                    <Link href={`/compounds/${option.slug}`} className="text-emerald-800 underline-offset-4 hover:underline">
-                      {option.name}
-                    </Link>
+                    {profileHref ? (
+                      <Link href={profileHref} className="text-emerald-800 underline-offset-4 hover:underline">
+                        {option.name}
+                      </Link>
+                    ) : (
+                      <span>{option.name}</span>
+                    )}
                   </td>
                   <td className="py-2 pr-4 text-slate-700">{option.bestFor}</td>
                   <td className="py-2 pr-4 text-slate-700">{option.speed}</td>
@@ -275,15 +269,22 @@ export default async function GoalDecisionPage({
           mechanisms, and evidence context, review the underlying compound profiles and the site methodology.
         </p>
         <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {enrichedOptions.map(({ option }) => (
-            <Link
-              key={`${option.slug}-profile-link`}
-              href={`/compounds/${option.slug}`}
-              className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700 transition hover:border-emerald-300 hover:bg-white"
-            >
-              <span className="block font-semibold text-slate-900">{option.name}</span>
-              <span className="mt-1 block">Open the profile for sourcing, safety context, and mechanism notes.</span>
-            </Link>
+          {enrichedOptions.map(({ option, profileHref }) => (
+            profileHref ? (
+              <Link
+                key={`${option.slug}-profile-link`}
+                href={profileHref}
+                className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700 transition hover:border-emerald-300 hover:bg-white"
+              >
+                <span className="block font-semibold text-slate-900">{option.name}</span>
+                <span className="mt-1 block">Open the profile for sourcing, safety context, and mechanism notes.</span>
+              </Link>
+            ) : (
+              <article key={`${option.slug}-profile-pending`} className="rounded-2xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+                <span className="block font-semibold text-slate-900">{option.name}</span>
+                <span className="mt-1 block">Canonical profile pending; no profile link is shown until a static route exists.</span>
+              </article>
+            )
           ))}
         </div>
       </section>


### PR DESCRIPTION
## Scope

Fixes the merged goal-page regression where editorial goal options were hardcoded to `/compounds/:slug` even when no static-exported compound profile exists.

## Changes

- Derives `profileHref` only when `getCompoundBySlug(option.slug)` returns a runtime compound with a real slug.
- Renders plain text instead of a link for goal options without canonical static profile routes.
- Shows a conservative pending-profile note in the Evidence Provenance section when no profile route exists.
- Reuses existing canonical decision normalization helpers from `@/lib/decision-primitives` for evidence and safety labels.
- Removes local ad-hoc evidence/safety fallback normalization.

## Guardrails

- No workbook edits.
- No public/data edits.
- No route expansion.
- No affiliate links.
- No dosing claims.
- Static export compatibility preserved.

## Verification

Not run locally in this connector session. CI should run required gates before merge.