### PR TITLE
ci: include static export validator in build verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "verify:types": "npm run typecheck",
     "lint": "eslint . --max-warnings=0",
     "build": "node scripts/build-blog.mjs && npm run data:build && npm run data:validate && npm run guard:source-of-truth && next build && npm run verify:build",
-    "verify:build": "node scripts/verify-core-routes.mjs && node scripts/verify-redirects.mjs && node scripts/ci/validate-deploy-readiness.mjs && npm run validate:public-json-imports && npm run validate:quarantine-imports && npm run data:verify",
+    "verify:build": "node scripts/verify-core-routes.mjs && node scripts/verify-redirects.mjs && node scripts/ci/validate-deploy-readiness.mjs && npm run validate:static-export && npm run validate:public-json-imports && npm run validate:quarantine-imports && npm run data:verify",
     "data:verify": "node scripts/data/verify-generated-data.mjs",
     "validate:workbook-source": "node scripts/ci/validate-workbook-source.mjs",
     "prebuild": "npm run validate:workbook-source",


### PR DESCRIPTION
## Summary

Adds the existing static export compatibility validator into the `verify:build` CI chain.

## Changes

- Added `npm run validate:static-export` into `verify:build`
- Preserved all existing verification checks
- No dependency changes
- No lockfile changes
- No generated runtime payload changes

## Expected verify:build

```json
"verify:build": "node scripts/verify-core-routes.mjs && node scripts/verify-redirects.mjs && node scripts/ci/validate-deploy-readiness.mjs && npm run validate:static-export && npm run validate:public-json-imports && npm run validate:quarantine-imports && npm run data:verify"
```

## Validation Notes

The GitHub connector environment cannot execute npm commands.
The following should run in CI/Codespaces:

```bash
npm run validate:static-export
npm run verify:build
npm run build
```
