### PR TITLE
ci: add manual runtime data refresh workflow

### DIFF
--- a/.github/workflows/refresh-runtime-data.yml
+++ b/.github/workflows/refresh-runtime-data.yml
@@ -1,0 +1,76 @@
+name: Refresh runtime data artifacts
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh-runtime-data:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build runtime data artifacts
+        run: npm run data:build
+
+      - name: Validate runtime data artifacts
+        run: npm run data:validate
+
+      - name: Verify runtime data artifacts
+        run: npm run data:verify
+
+      - name: Exclude non-artifact files from changes
+        run: |
+          set -euo pipefail
+          git restore package.json package-lock.json || true
+
+      - name: Check for generated public/data changes
+        id: changes
+        run: |
+          set -euo pipefail
+
+          if [ -n "$(git status --porcelain -- public/data)" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create pull request for runtime data artifacts
+        if: steps.changes.outputs.has_changes == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/runtime-data-refresh-${{ github.run_id }}
+          commit-message: 'chore(data): refresh generated runtime artifacts'
+          title: 'chore(data): refresh generated runtime artifacts'
+          body: |
+            ## Summary
+            - refresh generated artifacts in `public/data` via `npm run data:build`
+            - validated with `npm run data:validate`
+            - verified with `npm run data:verify`
+
+            ## Notes
+            - This PR was created automatically by the `Refresh runtime data artifacts` workflow.
+            - It intentionally includes only generated files under `public/data`.
+          add-paths: |
+            public/data/**
+          delete-branch: true
+
+      - name: No changes detected
+        if: steps.changes.outputs.has_changes == 'false'
+        run: echo "No generated public/data changes detected. Exiting successfully."


### PR DESCRIPTION
### Motivation
- Provide a manual, repository-native workflow to refresh generated `public/data` artifacts and open a narrow PR. 
- Ensure only generated artifacts are committed so workbook/source and package files are not accidentally changed.
- Allow maintainers to run the refresh without Codespaces or local builds via `workflow_dispatch`.

### Description
- Add `.github/workflows/refresh-runtime-data.yml` with name `Refresh runtime data artifacts` and trigger `workflow_dispatch` only. 
- Grant `contents: write` and `pull-requests: write` permissions and run steps to checkout, setup Node 22, run `npm ci`, then `npm run data:build`, `npm run data:validate`, and `npm run data:verify`.
- Restore `package.json` and `package-lock.json` before checking changes, detect changes limited to `public/data`, and exit successfully when no generated changes exist.
- When changes are present, create a branch `chore/runtime-data-refresh-${{ github.run_id }}` and open a PR titled `chore(data): refresh generated runtime artifacts` using `peter-evans/create-pull-request@v6` with `add-paths: public/data/**` and `delete-branch: true`.
- Commit was created with message `ci: add manual runtime data refresh workflow`.

### Testing
- Committed the new workflow file via `git commit` which succeeded. 
- Printed and inspected the new workflow using `nl -ba .github/workflows/refresh-runtime-data.yml | sed -n '1,200p'` which succeeded. 
- Verified repository status via `git status --short` which returned no unexpected changes and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f012ea5488323a0d3b70a67e2addd)