### PR TITLE
Add reusable COA verification components, types, docs, and example integration

### DIFF
--- a/app/compare/kanna-vs-ssris/page.tsx
+++ b/app/compare/kanna-vs-ssris/page.tsx
@@ -1,6 +1,38 @@
 import Link from 'next/link'
 import AuthorityJsonLd from '@/components/seo/AuthorityJsonLd'
 import AuthorityBreadcrumbs from '@/components/navigation/AuthorityBreadcrumbs'
+import COAList from '@/components/coa/COAList'
+import type { COADocument } from '@/types/coa'
+
+const exampleCOAEntries: COADocument[] = [
+  {
+    id: 'vendor-a-lot-2402',
+    labName: 'Aurora Analytics Lab',
+    isIso17025Accredited: true,
+    testDate: '2026-03-08',
+    batchLot: 'KAN-2402-A',
+    pdfUrl: '#',
+    confidence: 'high',
+    confidenceRationale: 'Accredited lab, recent date, and complete potency/heavy-metal/microbial panel fields.',
+    availability: 'verified',
+    testResults: [
+      { category: 'potency', analyte: 'Mesembrine', measuredValue: '0.42%', limit: 'Label claim ±10%', status: 'pass' },
+      { category: 'heavy_metals', analyte: 'Lead', measuredValue: '<0.05 ppm', limit: '<0.5 ppm', status: 'pass' },
+      { category: 'microbes', analyte: 'Total yeast and mold', measuredValue: '<100 CFU/g', limit: '<1000 CFU/g', status: 'pass' },
+    ],
+  },
+  {
+    id: 'vendor-b-lot-unknown',
+    labName: 'Lab not listed',
+    isIso17025Accredited: false,
+    testDate: 'Not listed',
+    batchLot: 'Not listed',
+    confidence: 'low',
+    confidenceRationale: 'Missing lab verification and limited report metadata reduce confidence.',
+    availability: 'unverified_lab',
+    testResults: [],
+  },
+]
 
 export default function KannaVsSSRIsPage() {
   return (
@@ -61,6 +93,8 @@ export default function KannaVsSSRIsPage() {
           </p>
         </div>
       </section>
+
+      <COAList entries={exampleCOAEntries} title="COA verification snapshot" />
 
       <section className="surface-subtle rounded-3xl p-6 space-y-5">
         <h2 className="text-2xl font-semibold tracking-tight text-ink">

--- a/docs/methodology/coa-verification.md
+++ b/docs/methodology/coa-verification.md
@@ -1,0 +1,36 @@
+# COA Verification Methodology
+
+This document describes how The Hippie Scientist evaluates Certificate of Analysis (COA) transparency for trust-facing UI primitives.
+
+## Verification criteria
+
+COA confidence is based on four signals:
+
+1. **Lab identity and accreditation**
+   - Named lab preferred.
+   - ISO/IEC 17025 accreditation is treated as a stronger trust signal.
+2. **Panel completeness**
+   - Core panel expects potency, heavy metals, and microbial fields.
+   - Missing measured values or limits lowers confidence.
+3. **Document recency**
+   - Recently dated reports are preferred over undated or stale documents.
+4. **Batch traceability**
+   - Batch/lot linkage improves confidence that the report maps to a specific product run.
+
+## Confidence levels
+
+- **High**: accredited or otherwise verifiable lab + complete core panel + traceable batch metadata.
+- **Medium**: partial verification (for example, one missing field or unconfirmed accreditation) with mostly complete testing data.
+- **Low**: missing or weak lab verification, incomplete data, undated report, or no accessible COA.
+
+## Special states
+
+- **No COA**: seller does not provide a report.
+- **Insufficient Data**: report exists but required fields are missing/unreadable.
+- **Unverified Lab**: report exists, but lab identity/accreditation cannot be verified.
+
+## UX notes
+
+- Language should remain neutral and evidence-aware.
+- COA components communicate transparency quality and verification confidence; they do not provide medical guidance.
+- Full report links should open the original source PDF where available.

--- a/src/components/coa/COACard.tsx
+++ b/src/components/coa/COACard.tsx
@@ -1,0 +1,83 @@
+import Card from '@/components/ui/Card'
+import COAVerificationBadge from '@/components/coa/COAVerificationBadge'
+import type { COADocument, COATestResult } from '@/types/coa'
+
+type COACardProps = {
+  coa: COADocument
+}
+
+const testLabelByCategory: Record<COATestResult['category'], string> = {
+  potency: 'Potency',
+  heavy_metals: 'Heavy metals',
+  microbes: 'Microbes',
+}
+
+function statusClasses(status: COATestResult['status']) {
+  if (status === 'pass') return 'text-emerald-700 bg-emerald-100 border-emerald-200'
+  if (status === 'fail') return 'text-rose-700 bg-rose-100 border-rose-200'
+  return 'text-amber-700 bg-amber-100 border-amber-200'
+}
+
+function availabilityCopy(coa: COADocument) {
+  if (coa.availability === 'no_coa') return 'No COA provided by the seller for this batch.'
+  if (coa.availability === 'insufficient_data') return 'COA is available, but required fields are missing or unreadable.'
+  if (coa.availability === 'unverified_lab') return 'Lab identity or accreditation could not be confirmed.'
+  return null
+}
+
+export default function COACard({ coa }: COACardProps) {
+  const availabilityMessage = availabilityCopy(coa)
+
+  return (
+    <Card className='rounded-2xl p-4 sm:p-5 space-y-4'>
+      <div className='flex flex-wrap items-start justify-between gap-3'>
+        <div>
+          <h3 className='text-lg font-semibold text-ink'>{coa.labName || 'Lab not disclosed'}</h3>
+          <p className='text-sm text-[#46574d] mt-1'>
+            {coa.isIso17025Accredited ? 'ISO 17025 accredited' : 'ISO 17025 not confirmed'}
+          </p>
+        </div>
+        <COAVerificationBadge confidence={coa.confidence} rationale={coa.confidenceRationale} />
+      </div>
+
+      <dl className='grid gap-2 sm:grid-cols-2 text-sm'>
+        <div className='rounded-xl border border-[var(--border-default)] bg-[var(--surface-1)] p-2.5'>
+          <dt className='text-xs uppercase tracking-wide text-[var(--text-muted)]'>Test date</dt>
+          <dd className='mt-1 text-ink font-medium'>{coa.testDate || 'Not listed'}</dd>
+        </div>
+        <div className='rounded-xl border border-[var(--border-default)] bg-[var(--surface-1)] p-2.5'>
+          <dt className='text-xs uppercase tracking-wide text-[var(--text-muted)]'>Batch / lot</dt>
+          <dd className='mt-1 text-ink font-medium'>{coa.batchLot || 'Not listed'}</dd>
+        </div>
+      </dl>
+
+      {availabilityMessage ? (
+        <p className='rounded-xl border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900'>{availabilityMessage}</p>
+      ) : (
+        <ul className='space-y-2' aria-label='COA key results'>
+          {coa.testResults.map((result) => (
+            <li key={`${result.category}-${result.analyte}`} className='rounded-xl border border-[var(--border-default)] p-3'>
+              <div className='flex flex-wrap items-center justify-between gap-2'>
+                <p className='text-sm font-medium text-ink'>
+                  {testLabelByCategory[result.category]} · {result.analyte}
+                </p>
+                <span className={`rounded-full border px-2 py-0.5 text-xs font-semibold uppercase tracking-wide ${statusClasses(result.status)}`}>
+                  {result.status.replace('_', ' ')}
+                </span>
+              </div>
+              <p className='mt-1 text-xs text-[#46574d]'>
+                Measured: {result.measuredValue || 'Not listed'} · Limit: {result.limit || 'Not listed'}
+              </p>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {coa.pdfUrl && (
+        <a href={coa.pdfUrl} target='_blank' rel='noreferrer' className='text-sm font-semibold text-brand-800 hover:text-brand-700 underline'>
+          Open full COA PDF
+        </a>
+      )}
+    </Card>
+  )
+}

--- a/src/components/coa/COAList.tsx
+++ b/src/components/coa/COAList.tsx
@@ -1,0 +1,23 @@
+import COACard from '@/components/coa/COACard'
+import type { COADocument } from '@/types/coa'
+
+type COAListProps = {
+  entries: COADocument[]
+  title?: string
+}
+
+export default function COAList({ entries, title = 'COA verification' }: COAListProps) {
+  return (
+    <section className='space-y-4' aria-label={title}>
+      <div>
+        <p className='eyebrow-label'>Trust infrastructure</p>
+        <h2 className='text-2xl font-semibold tracking-tight text-ink'>{title}</h2>
+      </div>
+      <div className='grid gap-4'>
+        {entries.map((entry) => (
+          <COACard key={entry.id} coa={entry} />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/coa/COAVerificationBadge.tsx
+++ b/src/components/coa/COAVerificationBadge.tsx
@@ -1,0 +1,30 @@
+import Badge from '@/components/ui/Badge'
+import type { COAVerificationConfidence } from '@/types/coa'
+
+type COAVerificationBadgeProps = {
+  confidence: COAVerificationConfidence
+  rationale: string
+  compact?: boolean
+}
+
+const styleByConfidence: Record<COAVerificationConfidence, { dot: string; label: string; badgeVariant: 'teal' | 'amber' | 'default' }> = {
+  high: { dot: 'bg-emerald-600', label: 'High confidence', badgeVariant: 'teal' },
+  medium: { dot: 'bg-amber-500', label: 'Medium confidence', badgeVariant: 'amber' },
+  low: { dot: 'bg-rose-500', label: 'Low confidence', badgeVariant: 'default' },
+}
+
+export default function COAVerificationBadge({ confidence, rationale, compact = false }: COAVerificationBadgeProps) {
+  const style = styleByConfidence[confidence]
+
+  return (
+    <Badge
+      variant={style.badgeVariant}
+      className='inline-flex items-center gap-1.5'
+      title={rationale}
+      aria-label={`${style.label}. ${rationale}`}
+    >
+      <span className={`inline-block h-2 w-2 rounded-full ${style.dot}`} aria-hidden />
+      {compact ? confidence.toUpperCase() : style.label}
+    </Badge>
+  )
+}

--- a/src/types/coa.ts
+++ b/src/types/coa.ts
@@ -1,0 +1,28 @@
+export type COAVerificationConfidence = 'high' | 'medium' | 'low'
+
+export type COATestCategory = 'potency' | 'heavy_metals' | 'microbes'
+
+export type COATestStatus = 'pass' | 'fail' | 'insufficient_data'
+
+export type COAAvailabilityState = 'verified' | 'no_coa' | 'insufficient_data' | 'unverified_lab'
+
+export interface COATestResult {
+  category: COATestCategory
+  analyte: string
+  measuredValue?: string
+  limit?: string
+  status: COATestStatus
+}
+
+export interface COADocument {
+  id: string
+  labName?: string
+  isIso17025Accredited?: boolean
+  testDate?: string
+  batchLot?: string
+  pdfUrl?: string
+  confidence: COAVerificationConfidence
+  confidenceRationale: string
+  availability: COAAvailabilityState
+  testResults: COATestResult[]
+}


### PR DESCRIPTION
### Motivation
- Provide reusable UI primitives to surface Certificate of Analysis (COA) transparency and feed Trust Score/Label Reality Check systems. 
- Encourage consistent, neutral language and accessibility when showing COA confidence, lab accreditation, and key test results. 
- Ship a small, static-friendly integration example without changing route contracts or runtime architecture.

### Description
- Add typed COA contracts in `src/types/coa.ts` including `COADocument`, `COATestResult`, confidence levels, availability states, and test categories. 
- Implement `COAVerificationBadge` (`src/components/coa/COAVerificationBadge.tsx`) as a compact, accessible confidence indicator that reuses the existing `Badge` primitive and exposes rationale via `title`/`aria-label`. 
- Implement `COACard` (`src/components/coa/COACard.tsx`) to render lab name, ISO 17025 status, test date, batch/lot, per-category test rows (potency/heavy metals/microbes) with PASS/FAIL/insufficient styling, PDF link, and fallback states for No COA / Insufficient Data / Unverified Lab. 
- Implement `COAList` (`src/components/coa/COAList.tsx`) wrapper and add methodology docs at `docs/methodology/coa-verification.md`, plus a static example integration in `app/compare/kanna-vs-ssris/page.tsx` showing two fixture entries. 

### Testing
- Ran type checks with `npm run typecheck` and the TypeScript build passed. 
- Ran linter with `npm run lint` and ESLint passed with zero warnings. 
- Performed full site build with `npm run build` (including data build/validation) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f0ba86f908323b306d0ec75b645a5)