### PR TITLE
Remove Google font build dependency for offline builds

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,6 +3,8 @@
 @tailwind utilities;
 
 :root {
+  --font-inter: Inter, "Inter Variable", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --font-fraunces: Fraunces, "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Palatino, "Times New Roman", serif;
   --bg: #fffdf7;
   --surface: #fbf6e9;
   --surface-elevated: rgba(255,255,255,0.72);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,24 +1,11 @@
 import type { Metadata } from 'next'
 import type { ReactNode } from 'react'
-import { Inter, Fraunces } from 'next/font/google'
 import Link from 'next/link'
 import DesktopNav from '@/components/desktop-nav'
 import MobileNav from '@/components/mobile-nav'
 import MobileBottomNav from '@/components/mobile-bottom-nav'
 import './globals.css'
 import '@/styles/foundation-readability.css'
-
-const inter = Inter({
-  subsets: ['latin'],
-  variable: '--font-inter',
-  display: 'swap',
-})
-
-const fraunces = Fraunces({
-  subsets: ['latin'],
-  variable: '--font-fraunces',
-  display: 'swap',
-})
 
 const siteName = 'The Hippie Scientist'
 const siteDescription =
@@ -72,7 +59,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang='en'>
       <body
-        className={`${inter.variable} ${fraunces.variable} font-sans antialiased`}
+        className='font-sans antialiased'
       >
         <script
           type='application/ld+json'


### PR DESCRIPTION
### Motivation
- Prevent Next.js build-time network calls to `fonts.googleapis.com` caused by `next/font/google` while preserving the site's typography intent.
- Keep changes minimal and surgical to avoid touching routes, metadata, or global theme behavior.

### Description
- Removed `next/font/google` imports and the `Inter`/`Fraunces` initializers from `app/layout.tsx` and reverted the body class to a static `font-sans antialiased` usage.
- Added offline-safe CSS custom properties `--font-inter` and `--font-fraunces` to `:root` in `app/globals.css` with robust fallback font stacks so Tailwind `fontFamily` references remain consistent.
- Did not add remote downloads or new runtime behavior, and preserved existing Tailwind `fontFamily` wiring that uses `var(--font-inter)` and `var(--font-fraunces)`.
- Because no committed local WOFF2/Fraunces assets were present, the change preserves the display font stack as a CSS fallback rather than blocking builds or adding network fetches.

### Testing
- Ran `npm run typecheck` and it completed successfully.
- Ran `npm run lint` and it completed successfully.
- Ran `npm run build` and it completed successfully, including `next build` static generation/export, without attempting to fetch Google Fonts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f9136bf088323a111c958a2711d0b)