### PR TITLE
Frontend Pass: SEO entry page visual polish

### DIFF
--- a/app/seo-entry-pages.tsx
+++ b/app/seo-entry-pages.tsx
@@ -354,34 +354,34 @@ export async function SeoEntryPage({ route }: { route: string }) {
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema(faqs)) }} />
       <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbSchema(page)) }} />
 
-      <section className="rounded-3xl border border-white/10 bg-white/[0.03] p-6">
-        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-300">Supplement guide</p>
-        <h1 className="mt-3 text-4xl font-black text-white">{page.h1}</h1>
-        <p className="mt-4 max-w-3xl text-base leading-7 text-white/75">{page.intro}</p>
-        <p className="mt-3 text-xs text-white/45">Search intent: {page.searchIntent}</p>
+      <section className="rounded-3xl border border-brand-900/10 bg-white/90 p-6 shadow-sm">
+        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-700">Supplement guide</p>
+        <h1 className="mt-3 text-4xl font-black text-ink">{page.h1}</h1>
+        <p className="mt-4 max-w-3xl text-base leading-7 text-muted">{page.intro}</p>
+        <p className="mt-3 text-xs text-muted">Search intent: {page.searchIntent}</p>
         <div className="mt-5 flex flex-wrap gap-3">
           <Link href={`/goals/${goal.slug}`} className="rounded-full bg-emerald-300 px-4 py-2 text-sm font-bold text-black hover:bg-emerald-200">View ranked picks</Link>
-          <Link href="/compounds" className="rounded-full border border-white/10 px-4 py-2 text-sm font-semibold text-white/75 hover:bg-white/10">Browse compounds</Link>
+          <Link href="/compounds" className="rounded-full border border-brand-900/10 px-4 py-2 text-sm font-semibold text-ink hover:bg-brand-50">Browse compounds</Link>
         </div>
       </section>
 
-      <section className="rounded-2xl border border-emerald-300/30 bg-emerald-300/[0.08] p-5">
-        <h2 className="text-xl font-black text-white">Quick answer</h2>
-        <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-6 text-white/75">
+      <section className="rounded-2xl border border-emerald-200 bg-emerald-50 p-5">
+        <h2 className="text-xl font-black text-ink">Quick answer</h2>
+        <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-6 text-muted">
           {pageSections.quick.map((item) => <li key={item}>{item}</li>)}
         </ul>
       </section>
 
       <div className="grid gap-4 md:grid-cols-2">
-        <section className="rounded-2xl border border-white/10 bg-white/[0.03] p-5">
-          <h2 className="text-xl font-bold text-white">Who this guide is for</h2>
-          <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-6 text-white/70">
+        <section className="rounded-2xl border border-brand-900/10 bg-white/90 p-5">
+          <h2 className="text-xl font-bold text-ink">Who this guide is for</h2>
+          <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-6 text-muted">
             {pageSections.forWho.map((item) => <li key={item}>{item}</li>)}
           </ul>
         </section>
-        <section className="rounded-2xl border border-amber-300/30 bg-amber-300/[0.06] p-5">
-          <h2 className="text-xl font-bold text-amber-100">Who should be careful</h2>
-          <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-6 text-white/70">
+        <section className="rounded-2xl border border-amber-300/40 bg-amber-50 p-5">
+          <h2 className="text-xl font-bold text-amber-900">Who should be careful</h2>
+          <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-6 text-amber-900/80">
             {pageSections.careful.map((item) => <li key={item}>{item}</li>)}
           </ul>
         </section>
@@ -389,21 +389,21 @@ export async function SeoEntryPage({ route }: { route: string }) {
 
       <section className="grid gap-4 md:grid-cols-3">
         {page.bullets.map((bullet) => (
-          <div key={bullet} className="rounded-2xl border border-white/10 bg-white/[0.03] p-5 text-sm leading-6 text-white/70">{bullet}</div>
+          <div key={bullet} className="rounded-2xl border border-brand-900/10 bg-white/90 p-5 text-sm leading-6 text-muted">{bullet}</div>
         ))}
       </section>
 
       <ConversionAffiliateCard name={page.h1} intent={page.searchIntent} variant="dark" />
 
       {linkedCompounds.length > 0 ? (
-        <section className="space-y-4 rounded-3xl border border-white/10 bg-white/[0.03] p-6">
-          <h2 className="text-2xl font-bold text-white">Related compounds</h2>
-          <p className="max-w-3xl text-sm leading-6 text-white/70">These links are generated from the current compound dataset and goal mapping, so this guide points into real dataset-linked profiles.</p>
+        <section className="space-y-4 rounded-3xl border border-brand-900/10 bg-white/90 p-6">
+          <h2 className="text-2xl font-bold text-ink">Related compounds</h2>
+          <p className="max-w-3xl text-sm leading-6 text-muted">These links are generated from the current compound dataset and goal mapping, so this guide points into real dataset-linked profiles.</p>
           <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
             {linkedCompounds.map((compound) => (
-              <Link key={compound.slug} href={`/compounds/${compound.slug}`} className="rounded-2xl border border-white/10 bg-white/[0.03] p-4 hover:border-emerald-300/40">
-                <h3 className="font-bold text-white">{compoundLabel(compound)}</h3>
-                <p className="mt-2 line-clamp-2 text-xs leading-5 text-white/60">{clean(compound.summary || compound.mechanism || compound.evidence) || 'Open profile for evidence, dose, and safety context.'}</p>
+              <Link key={compound.slug} href={`/compounds/${compound.slug}`} className="rounded-2xl border border-brand-900/10 bg-white p-4 hover:border-emerald-300/40">
+                <h3 className="font-bold text-ink">{compoundLabel(compound)}</h3>
+                <p className="mt-2 line-clamp-2 text-xs leading-5 text-muted">{clean(compound.summary || compound.mechanism || compound.evidence) || 'Open profile for evidence, dose, and safety context.'}</p>
               </Link>
             ))}
           </div>
@@ -431,44 +431,44 @@ export async function SeoEntryPage({ route }: { route: string }) {
         </section>
       ) : null}
 
-      <section className="space-y-4 rounded-3xl border border-white/10 bg-white/[0.03] p-6">
-        <h2 className="text-2xl font-bold text-white">How to choose supplements for {goal.title.toLowerCase()}</h2>
-        <p className="max-w-3xl leading-7 text-white/75">Not all supplements targeting {goal.title.toLowerCase()} work the same way. Some are designed for short-term support, some require consistent use, and some only make sense for specific situations or populations. Match the compound, timing, and safety profile to the problem you are actually trying to solve.</p>
-        <ul className="list-disc space-y-2 pl-5 text-sm leading-6 text-white/70">
+      <section className="space-y-4 rounded-3xl border border-brand-900/10 bg-white/90 p-6">
+        <h2 className="text-2xl font-bold text-ink">How to choose supplements for {goal.title.toLowerCase()}</h2>
+        <p className="max-w-3xl leading-7 text-muted">Not all supplements targeting {goal.title.toLowerCase()} work the same way. Some are designed for short-term support, some require consistent use, and some only make sense for specific situations or populations. Match the compound, timing, and safety profile to the problem you are actually trying to solve.</p>
+        <ul className="list-disc space-y-2 pl-5 text-sm leading-6 text-muted">
           <li>Check whether the expected effect is acute, gradual, or dependent on baseline deficiency.</li>
           <li>Compare stimulant, calming, fiber, adaptogen, or nutrient-style approaches before stacking products.</li>
           <li>Look at interaction risks, medical context, and safety notes before combining multiple compounds.</li>
         </ul>
       </section>
 
-      <section className="rounded-3xl border border-white/10 bg-white/[0.03] p-6">
-        <h2 className="text-2xl font-bold text-white">Comparison context</h2>
-        <p className="mt-2 max-w-3xl text-sm leading-6 text-white/70">{pageSections.comparison}</p>
+      <section className="rounded-3xl border border-brand-900/10 bg-white/90 p-6">
+        <h2 className="text-2xl font-bold text-ink">Comparison context</h2>
+        <p className="mt-2 max-w-3xl text-sm leading-6 text-muted">{pageSections.comparison}</p>
         <Link href={`/goals/${goal.slug}`} className="mt-4 inline-block text-sm font-semibold text-emerald-300">Compare ranked options →</Link>
       </section>
 
-      <section className="rounded-2xl border border-red-300/20 bg-red-400/[0.06] p-5">
-        <h2 className="text-xl font-bold text-white">Common mistakes</h2>
-        <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-6 text-white/70">
+      <section className="rounded-2xl border border-red-300/40 bg-red-50 p-5">
+        <h2 className="text-xl font-bold text-red-900">Common mistakes</h2>
+        <ul className="mt-3 list-disc space-y-2 pl-5 text-sm leading-6 text-red-900/80">
           {pageSections.mistakes.map((item) => <li key={item}>{item}</li>)}
         </ul>
       </section>
 
-      <section className="rounded-3xl border border-amber-300/20 bg-amber-300/[0.06] p-5">
-        <h2 className="font-bold text-amber-100">Safety considerations</h2>
-        <p className="mt-2 text-sm leading-6 text-white/75">{sentence(goal.safetyNote)} Supplements are not risk-free, especially when combined with medications, medical conditions, pregnancy, surgery, sedatives, stimulants, or blood-pressure concerns.</p>
-        <Link href={`/goals/${goal.slug}`} className="mt-4 inline-block text-sm font-semibold text-emerald-300">Review full safety guidance →</Link>
+      <section className="rounded-3xl border border-amber-300/40 bg-amber-50 p-5">
+        <h2 className="font-bold text-amber-900">Safety considerations</h2>
+        <p className="mt-2 text-sm leading-6 text-amber-900/85">{sentence(goal.safetyNote)} Supplements are not risk-free, especially when combined with medications, medical conditions, pregnancy, surgery, sedatives, stimulants, or blood-pressure concerns.</p>
+        <Link href={`/goals/${goal.slug}`} className="mt-4 inline-block text-sm font-semibold text-emerald-700">Review full safety guidance →</Link>
       </section>
 
       <ConversionAffiliateCard name={page.h1} intent={page.searchIntent} variant="dark" />
 
-      <section className="space-y-4 rounded-3xl border border-white/10 bg-white/[0.03] p-6">
-        <h2 className="text-2xl font-bold text-white">Frequently asked questions</h2>
+      <section className="space-y-4 rounded-3xl border border-brand-900/10 bg-white/90 p-6">
+        <h2 className="text-2xl font-bold text-ink">Frequently asked questions</h2>
         <div className="space-y-4">
           {faqs.map((faq) => (
-            <div key={faq.question} className="rounded-2xl border border-white/10 p-4">
-              <h3 className="font-semibold text-white">{faq.question}</h3>
-              <p className="mt-2 text-sm leading-6 text-white/70">{faq.answer}</p>
+            <div key={faq.question} className="rounded-2xl border border-brand-900/10 bg-white p-4">
+              <h3 className="font-semibold text-ink">{faq.question}</h3>
+              <p className="mt-2 text-sm leading-6 text-muted">{faq.answer}</p>
             </div>
           ))}
         </div>
@@ -476,12 +476,12 @@ export async function SeoEntryPage({ route }: { route: string }) {
 
       {relatedGuides.length > 0 ? (
         <section>
-          <h2 className="text-2xl font-bold text-white">Related supplement guides</h2>
+          <h2 className="text-2xl font-bold text-ink">Related supplement guides</h2>
           <div className="mt-4 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
             {relatedGuides.map((guide) => (
-              <Link key={guide.route} href={`/${guide.route}`} className="rounded-2xl border border-white/10 bg-white/[0.03] p-5 hover:border-emerald-300/40">
-                <h3 className="font-bold text-white">{guide.h1}</h3>
-                <p className="mt-2 line-clamp-3 text-sm text-white/65">{guide.intro}</p>
+              <Link key={guide.route} href={`/${guide.route}`} className="rounded-2xl border border-brand-900/10 bg-white/90 p-5 hover:border-emerald-300/40">
+                <h3 className="font-bold text-ink">{guide.h1}</h3>
+                <p className="mt-2 line-clamp-3 text-sm text-muted">{guide.intro}</p>
                 <span className="mt-3 inline-block text-sm font-semibold text-emerald-300">Read guide →</span>
               </Link>
             ))}


### PR DESCRIPTION
### Motivation
- Convert the shared SEO entry page presentation from dark/glassy cards to the calmer light-card visual system used by upgraded Compare and Learn pages.
- Keep all page behavior, helpers, schemas, linked-compounds logic, and affiliate card usage unchanged while improving light-mode readability.
- Make safety/caution blocks visually distinct but readable in light mode and adopt the site’s semantic color tokens and rounded card styles.

### Description
- Updated styling classes in `app/seo-entry-pages.tsx` to replace dark/glassy tokens with light-card tokens (e.g. `text-white` → `text-ink`, `text-white/75` → `text-muted`, `bg-white/[0.03]` → `bg-white/90`, `border-white/10` → `border-brand-900/10`, and `rounded-2xl`/`rounded-3xl` card usage). 
- Converted hero, quick answer, audience/caution, bullet cards, related compounds, FAQ cards, and related guides to use the light-card system while preserving copy, arrays, and helper usage. 
- Preserved `SeoEntryPage` routing behavior, `generateSeoEntryMetadata`, FAQ and breadcrumb schema JSON-LD, `linkedCompounds` logic, and `ConversionAffiliateCard` usage. 
- Change scope is styling-only in a single component file (`app/seo-entry-pages.tsx`) and intentionally avoids any workbook, `public/data`, or dependency edits.

### Testing
- Ran `npm run lint` and the linter completed successfully.
- Ran `npm run typecheck` and TypeScript checks passed with no errors.
- Ran `npm run build` and the full build (including data pipeline validation and static export checks) completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fb905845c8323a5a184be7119b3ae)