### PR TITLE
Frontend Pass: improve SEO entry link contrast

### DIFF
--- a/app/seo-entry-pages.tsx
+++ b/app/seo-entry-pages.tsx
@@ -444,7 +444,7 @@ export async function SeoEntryPage({ route }: { route: string }) {
       <section className="rounded-3xl border border-brand-900/10 bg-white/90 p-6">
         <h2 className="text-2xl font-bold text-ink">Comparison context</h2>
         <p className="mt-2 max-w-3xl text-sm leading-6 text-muted">{pageSections.comparison}</p>
-        <Link href={`/goals/${goal.slug}`} className="mt-4 inline-block text-sm font-semibold text-emerald-300">Compare ranked options →</Link>
+        <Link href={`/goals/${goal.slug}`} className="mt-4 inline-block text-sm font-semibold text-emerald-700">Compare ranked options →</Link>
       </section>
 
       <section className="rounded-2xl border border-red-300/40 bg-red-50 p-5">
@@ -482,7 +482,7 @@ export async function SeoEntryPage({ route }: { route: string }) {
               <Link key={guide.route} href={`/${guide.route}`} className="rounded-2xl border border-brand-900/10 bg-white/90 p-5 hover:border-emerald-300/40">
                 <h3 className="font-bold text-ink">{guide.h1}</h3>
                 <p className="mt-2 line-clamp-3 text-sm text-muted">{guide.intro}</p>
-                <span className="mt-3 inline-block text-sm font-semibold text-emerald-300">Read guide →</span>
+                <span className="mt-3 inline-block text-sm font-semibold text-emerald-700">Read guide →</span>
               </Link>
             ))}
           </div>


### PR DESCRIPTION
### Motivation
- Improve text contrast for links on light backgrounds by replacing low-contrast `text-emerald-300` with `text-emerald-700` in the SEO entry pages.

### Description
- Replaced `text-emerald-300` with `text-emerald-700` in two places inside `app/seo-entry-pages.tsx` (the "Compare ranked options →" link and the "Read guide →" text), keeping changes scoped to that single file.

### Testing
- Ran `npm run check:fast` (runs `lint` and `typecheck`) and it passed successfully.
- Ran `npm run check:ui` (runs `lint`, `typecheck`, `validate:static-export`, and `validate:route-seo`) and it passed successfully, with `validate:route-seo` emitting existing route warnings but no new failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fc94693488323aa4d9dd720759c48)