### PR TITLE
Frontend Pass: standardize Evidence Snapshot modules

### DIFF
--- a/app/compare/[slug]/page.tsx
+++ b/app/compare/[slug]/page.tsx
@@ -19,6 +19,7 @@ import SemanticVisibilityGate from '@/components/semantic-visibility-gate'
 import GuidedExplorationPanel from '@/components/guided-exploration-panel'
 import SemanticAssistantPanel from '@/components/semantic-assistant-panel'
 import PathwayVisualChip from '@/components/pathway-visual-chip'
+import EvidenceSnapshotPanel from '@/components/ui/EvidenceSnapshotPanel'
 
 type Params = { params: Promise<{ slug: string }> }
 
@@ -267,38 +268,22 @@ export default async function Page({ params }: Params) {
         </article>
       </section>
 
-      <section className="compact-card section-rhythm-compact border border-brand-900/15 bg-white/95">
-        <p className="eyebrow-label">Quick verdict</p>
-        <h2 className="max-w-none text-2xl font-semibold text-ink">Fast decision snapshot</h2>
-        <div className="grid gap-4 md:grid-cols-2">
-          <article className="rounded-2xl border border-brand-900/10 bg-emerald-50/70 p-4">
-            <h3 className="text-sm font-semibold text-ink">Best fit</h3>
-            <p className="mt-1 text-sm leading-6 text-[#46574d]">
-              Start with <strong>{displayName(winner)}</strong> when you want the stronger evidence signal and a clearer starting point for comparison.
-            </p>
-          </article>
-          <article className="rounded-2xl border border-amber-900/15 bg-amber-50/70 p-4">
-            <h3 className="text-sm font-semibold text-ink">Use caution</h3>
-            <ul className="mt-1 space-y-1 text-sm leading-6 text-[#46574d]">
-              {unique([...cautionA, ...cautionB]).slice(0, 3).map((item) => (
-                <li key={item}>• {item}</li>
-              ))}
-            </ul>
-          </article>
-          <article className="rounded-2xl border border-brand-900/10 bg-white p-4">
-            <h3 className="text-sm font-semibold text-ink">Evidence strength</h3>
-            <p className="mt-1 text-sm leading-6 text-[#46574d]">
-              {displayName(a)}: {evidenceLabel(evidenceA)} ({evidenceA}/5) • {displayName(b)}: {evidenceLabel(evidenceB)} ({evidenceB}/5)
-            </p>
-          </article>
-          <article className="rounded-2xl border border-brand-900/10 bg-white p-4">
-            <h3 className="text-sm font-semibold text-ink">Major tradeoffs</h3>
-            <p className="mt-1 text-sm leading-6 text-[#46574d]">
-              Evidence certainty, side-effect sensitivity, onset speed, and cost/value may not move in the same direction. Choose based on your top constraint first.
-            </p>
-          </article>
-        </div>
-      </section>
+      <EvidenceSnapshotPanel
+        title="Fast decision snapshot"
+        subtitle="Educational comparison only. Individual response, tolerance, and side effects vary."
+        fields={[
+          { label: 'Best fit', value: `Start with ${displayName(winner)} when you want the stronger evidence signal and a clearer starting point for comparison.`, tone: 'best-fit' },
+          { label: 'Human evidence', value: `${displayName(a)}: ${evidenceLabel(evidenceA)} (${evidenceA}/5) • ${displayName(b)}: ${evidenceLabel(evidenceB)} (${evidenceB}/5)` },
+          { label: 'Safety level', value: `Shared baseline: review medications, health conditions, and timing fit before use. ${displayName(a)}: ${cautionA[0]} ${displayName(b)}: ${cautionB[0]}`, tone: 'caution' },
+          { label: 'Tolerance risk', value: `${displayName(a)}: ${formatDisplayLabel(a?.tolerance_risk) || 'Unclear; monitor response.'} ${displayName(b)}: ${formatDisplayLabel(b?.tolerance_risk) || 'Unclear; monitor response.'}` },
+          { label: 'Stimulation/sedation profile', value: `${displayName(a)}: ${profileLabel(a)} • ${displayName(b)}: ${profileLabel(b)}` },
+          { label: 'Typical onset', value: `${displayName(a)}: ${timingA} • ${displayName(b)}: ${timingB}` },
+          { label: 'Use caution if', value: unique([...cautionA, ...cautionB]).slice(0, 3).join(', ') || 'No clear caution flags were surfaced in available profile data.', tone: 'caution' },
+          { label: 'What remains uncertain', value: 'Long-term outcomes, product standardization, and real-world effect size can vary. Choose based on top constraint first and reassess after conservative trials.' },
+        ]}
+        className="compact-card section-rhythm-compact border border-brand-900/15 bg-white/95"
+        columnsClassName="grid gap-4 md:grid-cols-2"
+      />
 
       <section className="compact-card section-rhythm-compact">
         <p className="eyebrow-label">Scan-first framing</p>

--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -43,6 +43,7 @@ import SemanticVisibilityGate from '@/components/semantic-visibility-gate'
 import GuidedExplorationPanel from '@/components/guided-exploration-panel'
 import EvidenceAwareCTA from '@/components/evidence-aware-cta'
 import SemanticAssistantPanel from '@/components/semantic-assistant-panel'
+import EvidenceSnapshotPanel from '@/components/ui/EvidenceSnapshotPanel'
 
 type PageProps = {
   params: Promise<{ slug: string }>
@@ -179,60 +180,6 @@ function ChipList({ items, limit = items.length }: { items: string[]; limit?: nu
   )
 }
 
-function DecisionSignalCard({ label, value }: { label: string; value?: string }) {
-  if (!value) return null
-
-  return (
-    <div className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm">
-      <p className="text-[0.68rem] font-bold uppercase tracking-[0.16em] text-muted">{label}</p>
-      <p className="mt-2 text-base font-bold leading-6 text-ink">{value}</p>
-    </div>
-  )
-}
-
-function DecisionSnapshotPanel({
-  commonUse,
-  evidenceLevel,
-  regulation,
-  safetyTone,
-  safetySummary,
-  avoidIf,
-  timeline,
-  mechanismHints,
-}: {
-  commonUse: string
-  evidenceLevel: string
-  regulation: string
-  safetyTone: string
-  safetySummary: string
-  avoidIf: string[]
-  timeline: string
-  mechanismHints: string[]
-}) {
-  return (
-    <aside className="rounded-[1.65rem] border border-brand-900/10 bg-white/95 p-4 shadow-[0_18px_45px_rgba(47,64,52,0.12)] sm:p-5 lg:sticky lg:top-6">
-      <div className="flex items-start justify-between gap-3 border-b border-brand-900/10 pb-3">
-        <div>
-          <p className="eyebrow-label">Decision snapshot</p>
-          <h2 className="mt-1 text-xl font-semibold tracking-tight text-ink">5-second profile read</h2>
-        </div>
-        <span className="rounded-full bg-emerald-700/10 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.14em] text-emerald-900">
-          Start here
-        </span>
-      </div>
-
-      <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-1">
-        <DecisionSignalCard label="Commonly used for" value={commonUse || 'Use context is not clearly specified.'} />
-        <DecisionSignalCard label="Evidence strength" value={evidenceLevel} />
-        <DecisionSignalCard label="Calming vs stimulating" value={regulation} />
-        <DecisionSignalCard label={`Safety level: ${safetyTone}`} value={safetySummary} />
-        <DecisionSignalCard label="Avoid / review first if" value={avoidIf.length ? avoidIf.slice(0, 3).join(', ') : 'No specific avoid-if flags surfaced in the available profile data.'} />
-        <DecisionSignalCard label="Onset / timeline" value={timeline || 'Timing varies by dose, form, and context.'} />
-        <DecisionSignalCard label="Mechanism hints" value={mechanismHints.length ? mechanismHints.slice(0, 3).join(', ') : 'Mechanism signals are not clearly specified.'} />
-      </div>
-    </aside>
-  )
-}
 
 function CompactDisclosure({ title, children }: { title: string; children: ReactNode }) {
   return (
@@ -419,15 +366,21 @@ export default async function CompoundPage({ params }: PageProps) {
               <EvidenceBadgeGroup record={compound} compact />
             </div>
 
-            <DecisionSnapshotPanel
-              commonUse={effects.slice(0, 3).join(', ')}
-              evidenceLevel={evidenceLevel}
-              regulation={regulationProfile}
-              safetyTone={safetyTone}
-              safetySummary={safetySummary}
-              avoidIf={avoidIf}
-              timeline={timeline}
-              mechanismHints={mechanismHints}
+            <EvidenceSnapshotPanel
+              title="5-second profile read"
+              subtitle="Educational overview only. Individual effects and side-effect sensitivity can vary."
+              badge="Start here"
+              className="rounded-[1.65rem] border border-brand-900/10 bg-white/95 p-4 shadow-[0_18px_45px_rgba(47,64,52,0.12)] sm:p-5 lg:sticky lg:top-6"
+              fields={[
+                { label: 'Best fit', value: effects.slice(0, 3).join(', ') || 'Use context is not clearly specified.', tone: 'best-fit' },
+                { label: 'Human evidence', value: evidenceLevel || 'Human evidence quality is unclear from current profile data.' },
+                { label: `Safety level (${safetyTone})`, value: safetySummary, tone: 'caution' },
+                { label: 'Tolerance risk', value: formatDisplayLabel(compound.tolerance_risk || compound.toleranceRisk) || 'Tolerance risk is not clearly specified; monitor response over time.' },
+                { label: 'Stimulation/sedation profile', value: regulationProfile },
+                { label: 'Typical onset', value: timeline || 'Timing varies by dose, form, and context.' },
+                { label: 'Use caution if', value: avoidIf.length ? avoidIf.slice(0, 3).join(', ') : 'No specific avoid-if flags surfaced in the available profile data.', tone: 'caution' },
+                { label: 'What remains uncertain', value: mechanismHints.length ? `Mechanism hints are preliminary: ${mechanismHints.slice(0, 3).join(', ')}. Real-world response can vary by person and product.` : 'Mechanism signals are not clearly specified and individual response variation is common.' },
+              ]}
             />
           </div>
         </section>

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -45,6 +45,7 @@ import SemanticVisibilityGate from '@/components/semantic-visibility-gate'
 import GuidedExplorationPanel from '@/components/guided-exploration-panel'
 import EvidenceAwareCTA from '@/components/evidence-aware-cta'
 import SemanticAssistantPanel from '@/components/semantic-assistant-panel'
+import EvidenceSnapshotPanel from '@/components/ui/EvidenceSnapshotPanel'
 
 type PageProps = {
   params: Promise<{ slug: string }>
@@ -225,61 +226,17 @@ function getRelatedLinks(records: any[], entityType: 'herb' | 'compound', limit 
     .slice(0, limit)
 }
 
-function BriefCard({ label, value, children, prominent = false }: { label: string; value?: string; children?: ReactNode; prominent?: boolean }) {
+function BriefCard({ label, value, children }: { label: string; value?: string; children?: ReactNode }) {
   if (!value && !children) return null
-
   return (
-    <div className={prominent ? 'rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm' : 'border-t border-brand-900/10 pt-3'}>
-      <p className="text-[11px] font-bold uppercase tracking-[0.16em] text-muted">{label}</p>
-      {value ? <p className={prominent ? 'mt-2 text-base font-bold leading-6 text-ink' : 'mt-2 text-sm font-semibold leading-6 text-ink'}>{value}</p> : null}
+    <article className="rounded-2xl border border-brand-900/10 bg-white/90 p-4 shadow-sm">
+      <p className="text-[0.68rem] font-bold uppercase tracking-[0.16em] text-muted">{label}</p>
+      {value ? <p className="mt-2 text-sm leading-6 text-[#46574d]">{value}</p> : null}
       {children ? <div className="mt-2">{children}</div> : null}
-    </div>
+    </article>
   )
 }
 
-function DecisionSnapshotPanel({
-  primaryUse,
-  evidence,
-  regulation,
-  safetyTone,
-  safetySummary,
-  avoidIf,
-  timeline,
-  mechanisms,
-}: {
-  primaryUse: string
-  evidence: string
-  regulation: string
-  safetyTone: string
-  safetySummary: string
-  avoidIf: string[]
-  timeline: string
-  mechanisms: string[]
-}) {
-  return (
-    <aside className="rounded-[1.65rem] border border-brand-900/10 bg-white/95 p-4 shadow-[0_18px_45px_rgba(47,64,52,0.12)] sm:p-5 lg:sticky lg:top-6">
-      <div className="flex items-start justify-between gap-3 border-b border-brand-900/10 pb-3">
-        <div>
-          <p className="eyebrow-label">Decision snapshot</p>
-          <h2 className="mt-1 text-xl font-semibold tracking-tight text-ink">5-second profile read</h2>
-        </div>
-        <span className="rounded-full bg-emerald-700/10 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.14em] text-emerald-900">
-          Start here
-        </span>
-      </div>
-
-      <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-1">
-        <BriefCard label="Commonly used for" value={primaryUse || 'Use context is not clearly specified.'} prominent />
-        <BriefCard label="Evidence strength" value={evidence} prominent />
-        <BriefCard label="Calming vs stimulating" value={regulation} prominent />
-        <BriefCard label={`Safety level: ${safetyTone}`} value={safetySummary} prominent />
-        <BriefCard label="Avoid / review first if" value={avoidIf.length ? avoidIf.slice(0, 3).join(', ') : 'No specific avoid-if flags surfaced in the available profile data.'} prominent />
-        <BriefCard label="Onset / timeline" value={timeline || 'Timing varies by preparation, dose, and context.'} prominent />
-        <BriefCard label="Mechanism hints" value={mechanisms.length ? mechanisms.slice(0, 3).join(', ') : 'Mechanism signals are not clearly specified.'} prominent />
-      </div>
-    </aside>
-  )
-}
 
 function ChipList({ items, limit = items.length }: { items: string[]; limit?: number }) {
   const visible = items.slice(0, limit)
@@ -535,15 +492,21 @@ export default async function HerbDetailPage({ params }: PageProps) {
               </div>
             </div>
 
-            <DecisionSnapshotPanel
-              primaryUse={topUses.slice(0, 3).join(', ')}
-              evidence={evidenceStrength || researchMaturity}
-              regulation={regulationProfile}
-              safetyTone={safetyTone}
-              safetySummary={safetySummary}
-              avoidIf={avoidIf}
-              timeline={timeline}
-              mechanisms={mechanisms}
+            <EvidenceSnapshotPanel
+              title="5-second profile read"
+              subtitle="Educational overview only. Individual response and tolerance can vary."
+              badge="Start here"
+              className="rounded-[1.65rem] border border-brand-900/10 bg-white/95 p-4 shadow-[0_18px_45px_rgba(47,64,52,0.12)] sm:p-5 lg:sticky lg:top-6"
+              fields={[
+                { label: 'Best fit', value: topUses.slice(0, 3).join(', ') || 'Use context is not clearly specified.', tone: 'best-fit' },
+                { label: 'Human evidence', value: evidenceStrength || researchMaturity || 'Human evidence quality is unclear from current profile data.' },
+                { label: `Safety level (${safetyTone})`, value: safetySummary, tone: 'caution' },
+                { label: 'Tolerance risk', value: formatDisplayLabel(herb.tolerance_risk || herb.toleranceRisk) || 'Tolerance risk is not clearly specified; monitor response over time.' },
+                { label: 'Stimulation/sedation profile', value: regulationProfile },
+                { label: 'Typical onset', value: timeline || 'Timing varies by preparation, dose, and context.' },
+                { label: 'Use caution if', value: avoidIf.length ? avoidIf.slice(0, 3).join(', ') : 'No specific avoid-if flags surfaced in the available profile data.', tone: 'caution' },
+                { label: 'What remains uncertain', value: mechanisms.length ? `Mechanism hints are preliminary: ${mechanisms.slice(0, 3).join(', ')}. Real-world effects can differ across people and products.` : 'Mechanism signals are not clearly specified and response variation is common.' },
+              ]}
             />
           </div>
         </div>

--- a/components/ui/EvidenceSnapshotPanel.tsx
+++ b/components/ui/EvidenceSnapshotPanel.tsx
@@ -1,0 +1,64 @@
+import type { ReactNode } from 'react'
+
+export type EvidenceSnapshotField = {
+  label: string
+  value: string
+  tone?: 'default' | 'caution' | 'best-fit'
+}
+
+type Props = {
+  title?: string
+  subtitle?: string
+  badge?: string
+  fields: EvidenceSnapshotField[]
+  className?: string
+  columnsClassName?: string
+  footer?: ReactNode
+}
+
+function fieldToneClasses(tone: EvidenceSnapshotField['tone']) {
+  if (tone === 'caution') return 'border-amber-900/15 bg-amber-50/70'
+  if (tone === 'best-fit') return 'border-emerald-900/15 bg-emerald-50/70'
+  return 'border-brand-900/10 bg-white/90'
+}
+
+export default function EvidenceSnapshotPanel({
+  title = 'Evidence snapshot',
+  subtitle = 'Scan key decision signals first.',
+  badge,
+  fields,
+  className,
+  columnsClassName = 'grid gap-3 sm:grid-cols-2 lg:grid-cols-1',
+  footer,
+}: Props) {
+  const visibleFields = fields.filter(field => field?.label && field?.value)
+  if (visibleFields.length === 0) return null
+
+  return (
+    <aside className={className || 'rounded-[1.65rem] border border-brand-900/10 bg-white/95 p-4 shadow-[0_18px_45px_rgba(47,64,52,0.12)] sm:p-5'}>
+      <div className="flex items-start justify-between gap-3 border-b border-brand-900/10 pb-3">
+        <div>
+          <p className="eyebrow-label">Evidence snapshot</p>
+          <h2 className="mt-1 text-xl font-semibold tracking-tight text-ink">{title}</h2>
+          <p className="mt-1 text-sm leading-6 text-[#46574d]">{subtitle}</p>
+        </div>
+        {badge ? (
+          <span className="rounded-full bg-emerald-700/10 px-3 py-1 text-[10px] font-bold uppercase tracking-[0.14em] text-emerald-900">
+            {badge}
+          </span>
+        ) : null}
+      </div>
+
+      <div className={`mt-4 ${columnsClassName}`}>
+        {visibleFields.map((field) => (
+          <article key={field.label} className={`rounded-2xl border p-4 shadow-sm ${fieldToneClasses(field.tone)}`}>
+            <h3 className="text-[0.68rem] font-bold uppercase tracking-[0.16em] text-muted">{field.label}</h3>
+            <p className="mt-2 text-sm leading-6 text-[#46574d]">{field.value}</p>
+          </article>
+        ))}
+      </div>
+
+      {footer ? <div className="mt-4 border-t border-brand-900/10 pt-3">{footer}</div> : null}
+    </aside>
+  )
+}


### PR DESCRIPTION
### Motivation
- Provide a reusable, consistent Evidence Snapshot pattern so decision-support language is uniform across compare pages and detail pages.
- Keep data derivation and route behavior unchanged while extracting a minimal presentational component to reduce duplication and improve mobile scanability.

### Description
- Added a lightweight presentational component `components/ui/EvidenceSnapshotPanel.tsx` that renders configurable rows with tone variants (`default`, `caution`, `best-fit`) and calm light-card styling.
- Replaced route-local snapshot UI with the shared panel in `app/herbs/[slug]/page.tsx`, `app/compounds/[slug]/page.tsx`, and `app/compare/[slug]/page.tsx` while keeping each page's data assembly local and unchanged.
- Standardized target snapshot fields to: `Human evidence`, `Safety level`, `Tolerance risk`, `Stimulation/sedation profile`, `Typical onset`, `Best fit`, `Use caution if`, and `What remains uncertain`, and added conservative fallback copy and explicit individual-variation phrasing.
- Risk notes: low-to-moderate presentation risk from reordering and copy changes; data model and routing contracts were not modified to avoid cross-route coupling.
- Files changed: `components/ui/EvidenceSnapshotPanel.tsx`, `app/herbs/[slug]/page.tsx`, `app/compounds/[slug]/page.tsx`, `app/compare/[slug]/page.tsx`.
- Shared component strategy: minimal safe abstraction (presentational panel only) so route-local logic remains authoritative and citations/affiliate behavior are preserved.
- Confirmation: no workbook edits, no `public/data` changes, no generated artifacts or dependency (`package.json`/`package-lock.json`) changes were made.

### Testing
- Ran `npm run check:fast` (lint + typecheck) and it passed successfully.
- Ran `npm run check:ui` (lint + typecheck + `validate:static-export` + `validate:route-seo`) and it passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a105dc93f408323b8d980838816eb21)