### PR TITLE
Frontend Pass: standardize Evidence Snapshot modules

### DIFF
--- a/app/compare/[slug]/page.tsx
+++ b/app/compare/[slug]/page.tsx
@@ -20,6 +20,7 @@ import GuidedExplorationPanel from '@/components/guided-exploration-panel'
 import SemanticAssistantPanel from '@/components/semantic-assistant-panel'
 import PathwayVisualChip from '@/components/pathway-visual-chip'
 import EvidenceSnapshotPanel from '@/components/ui/EvidenceSnapshotPanel'
+import { buildCompareEvidenceSnapshotFields } from '@/components/ui/evidence-snapshot-fields'
 
 type Params = { params: Promise<{ slug: string }> }
 
@@ -271,16 +272,16 @@ export default async function Page({ params }: Params) {
       <EvidenceSnapshotPanel
         title="Fast decision snapshot"
         subtitle="Educational comparison only. Individual response, tolerance, and side effects vary."
-        fields={[
-          { label: 'Best fit', value: `Start with ${displayName(winner)} when you want the stronger evidence signal and a clearer starting point for comparison.`, tone: 'best-fit' },
-          { label: 'Human evidence', value: `${displayName(a)}: ${evidenceLabel(evidenceA)} (${evidenceA}/5) • ${displayName(b)}: ${evidenceLabel(evidenceB)} (${evidenceB}/5)` },
-          { label: 'Safety level', value: `Shared baseline: review medications, health conditions, and timing fit before use. ${displayName(a)}: ${cautionA[0]} ${displayName(b)}: ${cautionB[0]}`, tone: 'caution' },
-          { label: 'Tolerance risk', value: `${displayName(a)}: ${formatDisplayLabel(a?.tolerance_risk) || 'Unclear; monitor response.'} ${displayName(b)}: ${formatDisplayLabel(b?.tolerance_risk) || 'Unclear; monitor response.'}` },
-          { label: 'Stimulation/sedation profile', value: `${displayName(a)}: ${profileLabel(a)} • ${displayName(b)}: ${profileLabel(b)}` },
-          { label: 'Typical onset', value: `${displayName(a)}: ${timingA} • ${displayName(b)}: ${timingB}` },
-          { label: 'Use caution if', value: unique([...cautionA, ...cautionB]).slice(0, 3).join(', ') || 'No clear caution flags were surfaced in available profile data.', tone: 'caution' },
-          { label: 'What remains uncertain', value: 'Long-term outcomes, product standardization, and real-world effect size can vary. Choose based on top constraint first and reassess after conservative trials.' },
-        ]}
+        fields={buildCompareEvidenceSnapshotFields({
+          bestFit: `Start with ${displayName(winner)} when you want the stronger evidence signal and a clearer starting point for comparison.`,
+          humanEvidence: `${displayName(a)}: ${evidenceLabel(evidenceA)} (${evidenceA}/5) • ${displayName(b)}: ${evidenceLabel(evidenceB)} (${evidenceB}/5)`,
+          safetyLevel: `Shared baseline: review medications, health conditions, and timing fit before use. ${displayName(a)}: ${cautionA[0]} ${displayName(b)}: ${cautionB[0]}`,
+          toleranceRisk: `${displayName(a)}: ${formatDisplayLabel(a?.tolerance_risk) || 'Unclear; monitor response.'} ${displayName(b)}: ${formatDisplayLabel(b?.tolerance_risk) || 'Unclear; monitor response.'}`,
+          regulationProfile: `${displayName(a)}: ${profileLabel(a)} • ${displayName(b)}: ${profileLabel(b)}`,
+          typicalOnset: `${displayName(a)}: ${timingA} • ${displayName(b)}: ${timingB}`,
+          useCautionIf: unique([...cautionA, ...cautionB]).slice(0, 3).join(', '),
+          uncertain: 'Long-term outcomes, product standardization, and real-world effect size can vary. Choose based on top constraint first and reassess after conservative trials.',
+        })}
         className="compact-card section-rhythm-compact border border-brand-900/15 bg-white/95"
         columnsClassName="grid gap-4 md:grid-cols-2"
       />

--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -44,6 +44,7 @@ import GuidedExplorationPanel from '@/components/guided-exploration-panel'
 import EvidenceAwareCTA from '@/components/evidence-aware-cta'
 import SemanticAssistantPanel from '@/components/semantic-assistant-panel'
 import EvidenceSnapshotPanel from '@/components/ui/EvidenceSnapshotPanel'
+import { buildDetailEvidenceSnapshotFields } from '@/components/ui/evidence-snapshot-fields'
 
 type PageProps = {
   params: Promise<{ slug: string }>
@@ -371,16 +372,16 @@ export default async function CompoundPage({ params }: PageProps) {
               subtitle="Educational overview only. Individual effects and side-effect sensitivity can vary."
               badge="Start here"
               className="rounded-[1.65rem] border border-brand-900/10 bg-white/95 p-4 shadow-[0_18px_45px_rgba(47,64,52,0.12)] sm:p-5 lg:sticky lg:top-6"
-              fields={[
-                { label: 'Best fit', value: effects.slice(0, 3).join(', ') || 'Use context is not clearly specified.', tone: 'best-fit' },
-                { label: 'Human evidence', value: evidenceLevel || 'Human evidence quality is unclear from current profile data.' },
-                { label: `Safety level (${safetyTone})`, value: safetySummary, tone: 'caution' },
-                { label: 'Tolerance risk', value: formatDisplayLabel(compound.tolerance_risk || compound.toleranceRisk) || 'Tolerance risk is not clearly specified; monitor response over time.' },
-                { label: 'Stimulation/sedation profile', value: regulationProfile },
-                { label: 'Typical onset', value: timeline || 'Timing varies by dose, form, and context.' },
-                { label: 'Use caution if', value: avoidIf.length ? avoidIf.slice(0, 3).join(', ') : 'No specific avoid-if flags surfaced in the available profile data.', tone: 'caution' },
-                { label: 'What remains uncertain', value: mechanismHints.length ? `Mechanism hints are preliminary: ${mechanismHints.slice(0, 3).join(', ')}. Real-world response can vary by person and product.` : 'Mechanism signals are not clearly specified and individual response variation is common.' },
-              ]}
+              fields={buildDetailEvidenceSnapshotFields({
+                bestFit: effects.slice(0, 3).join(', '),
+                humanEvidence: evidenceLevel,
+                safetyLevel: `${safetyTone}: ${safetySummary}`,
+                toleranceRisk: formatDisplayLabel(compound.tolerance_risk || compound.toleranceRisk),
+                regulationProfile,
+                typicalOnset: timeline || 'Timing varies by dose, form, and context.',
+                useCautionIf: avoidIf.length ? avoidIf.slice(0, 3).join(', ') : '',
+                uncertain: mechanismHints.length ? `Mechanism hints are preliminary: ${mechanismHints.slice(0, 3).join(', ')}. Real-world response can vary by person and product.` : '',
+              })}
             />
           </div>
         </section>

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -46,6 +46,7 @@ import GuidedExplorationPanel from '@/components/guided-exploration-panel'
 import EvidenceAwareCTA from '@/components/evidence-aware-cta'
 import SemanticAssistantPanel from '@/components/semantic-assistant-panel'
 import EvidenceSnapshotPanel from '@/components/ui/EvidenceSnapshotPanel'
+import { buildDetailEvidenceSnapshotFields } from '@/components/ui/evidence-snapshot-fields'
 
 type PageProps = {
   params: Promise<{ slug: string }>
@@ -497,16 +498,16 @@ export default async function HerbDetailPage({ params }: PageProps) {
               subtitle="Educational overview only. Individual response and tolerance can vary."
               badge="Start here"
               className="rounded-[1.65rem] border border-brand-900/10 bg-white/95 p-4 shadow-[0_18px_45px_rgba(47,64,52,0.12)] sm:p-5 lg:sticky lg:top-6"
-              fields={[
-                { label: 'Best fit', value: topUses.slice(0, 3).join(', ') || 'Use context is not clearly specified.', tone: 'best-fit' },
-                { label: 'Human evidence', value: evidenceStrength || researchMaturity || 'Human evidence quality is unclear from current profile data.' },
-                { label: `Safety level (${safetyTone})`, value: safetySummary, tone: 'caution' },
-                { label: 'Tolerance risk', value: formatDisplayLabel(herb.tolerance_risk || herb.toleranceRisk) || 'Tolerance risk is not clearly specified; monitor response over time.' },
-                { label: 'Stimulation/sedation profile', value: regulationProfile },
-                { label: 'Typical onset', value: timeline || 'Timing varies by preparation, dose, and context.' },
-                { label: 'Use caution if', value: avoidIf.length ? avoidIf.slice(0, 3).join(', ') : 'No specific avoid-if flags surfaced in the available profile data.', tone: 'caution' },
-                { label: 'What remains uncertain', value: mechanisms.length ? `Mechanism hints are preliminary: ${mechanisms.slice(0, 3).join(', ')}. Real-world effects can differ across people and products.` : 'Mechanism signals are not clearly specified and response variation is common.' },
-              ]}
+              fields={buildDetailEvidenceSnapshotFields({
+                bestFit: topUses.slice(0, 3).join(', '),
+                humanEvidence: evidenceStrength || researchMaturity,
+                safetyLevel: `${safetyTone}: ${safetySummary}`,
+                toleranceRisk: formatDisplayLabel(herb.tolerance_risk || herb.toleranceRisk),
+                regulationProfile,
+                typicalOnset: timeline || 'Timing varies by preparation, dose, and context.',
+                useCautionIf: avoidIf.length ? avoidIf.slice(0, 3).join(', ') : '',
+                uncertain: mechanisms.length ? `Mechanism hints are preliminary: ${mechanisms.slice(0, 3).join(', ')}. Real-world effects can differ across people and products.` : '',
+              })}
             />
           </div>
         </div>

--- a/components/ui/evidence-snapshot-fields.ts
+++ b/components/ui/evidence-snapshot-fields.ts
@@ -1,0 +1,60 @@
+import type { EvidenceSnapshotField } from '@/components/ui/EvidenceSnapshotPanel'
+
+type DetailSnapshotInput = {
+  bestFit?: string
+  humanEvidence?: string
+  safetyLevel?: string
+  toleranceRisk?: string
+  regulationProfile?: string
+  typicalOnset?: string
+  useCautionIf?: string
+  uncertain?: string
+}
+
+type CompareSnapshotInput = {
+  bestFit?: string
+  humanEvidence?: string
+  safetyLevel?: string
+  toleranceRisk?: string
+  regulationProfile?: string
+  typicalOnset?: string
+  useCautionIf?: string
+  uncertain?: string
+}
+
+const DEFAULTS = {
+  bestFit: 'Best-fit use case is not clearly specified in the current profile data.',
+  humanEvidence: 'Human evidence quality is unclear from the available profile data.',
+  safetyLevel: 'Safety context is incomplete. Review medications, health conditions, and clinician guidance before use.',
+  toleranceRisk: 'Tolerance risk is not clearly specified; monitor individual response over time.',
+  regulationProfile: 'Stimulation/sedation profile is not clearly defined in the current data.',
+  typicalOnset: 'Typical onset varies by dose, formulation, and individual biology.',
+  useCautionIf: 'No specific avoid-if flags were surfaced in the available profile data.',
+  uncertain: 'Long-term outcomes, product standardization, and individual response can vary.',
+}
+
+export function buildDetailEvidenceSnapshotFields(input: DetailSnapshotInput): EvidenceSnapshotField[] {
+  return [
+    { label: 'Best fit', value: input.bestFit || DEFAULTS.bestFit, tone: 'best-fit' },
+    { label: 'Human evidence', value: input.humanEvidence || DEFAULTS.humanEvidence },
+    { label: 'Safety level', value: input.safetyLevel || DEFAULTS.safetyLevel, tone: 'caution' },
+    { label: 'Tolerance risk', value: input.toleranceRisk || DEFAULTS.toleranceRisk },
+    { label: 'Stimulation/sedation profile', value: input.regulationProfile || DEFAULTS.regulationProfile },
+    { label: 'Typical onset', value: input.typicalOnset || DEFAULTS.typicalOnset },
+    { label: 'Use caution if', value: input.useCautionIf || DEFAULTS.useCautionIf, tone: 'caution' },
+    { label: 'What remains uncertain', value: input.uncertain || DEFAULTS.uncertain },
+  ]
+}
+
+export function buildCompareEvidenceSnapshotFields(input: CompareSnapshotInput): EvidenceSnapshotField[] {
+  return [
+    { label: 'Best fit', value: input.bestFit || DEFAULTS.bestFit, tone: 'best-fit' },
+    { label: 'Human evidence', value: input.humanEvidence || DEFAULTS.humanEvidence },
+    { label: 'Safety level', value: input.safetyLevel || DEFAULTS.safetyLevel, tone: 'caution' },
+    { label: 'Tolerance risk', value: input.toleranceRisk || DEFAULTS.toleranceRisk },
+    { label: 'Stimulation/sedation profile', value: input.regulationProfile || DEFAULTS.regulationProfile },
+    { label: 'Typical onset', value: input.typicalOnset || DEFAULTS.typicalOnset },
+    { label: 'Use caution if', value: input.useCautionIf || DEFAULTS.useCautionIf, tone: 'caution' },
+    { label: 'What remains uncertain', value: input.uncertain || DEFAULTS.uncertain },
+  ]
+}


### PR DESCRIPTION
### Motivation
- Establish a consistent, scan-first Evidence Snapshot pattern across detail and compare pages to improve decision-support language and mobile scanability.
- Provide conservative, conservative fallback copy for the eight target snapshot fields while avoiding new medical claims and preserving citation and affiliate behavior.
- Use the smallest safe shared abstraction to reduce duplication while avoiding broad layout or routing refactors.

### Description
- Added a tiny shared builder module `components/ui/evidence-snapshot-fields.ts` that exports `buildDetailEvidenceSnapshotFields` and `buildCompareEvidenceSnapshotFields` to produce the standardized eight snapshot rows with tone-aware defaults.
- Replaced inline snapshot field arrays with the shared builders in `app/herbs/[slug]/page.tsx`, `app/compounds/[slug]/page.tsx`, and `app/compare/[slug]/page.tsx` while leaving `EvidenceSnapshotPanel` and page rendering/layout intact.
- Kept field order, short row/cards, conservative fallback text, explicit "caution"/"best-fit" tones, and preserved citations/affiliate blocks and other page-specific data lookups.
- Files changed: `components/ui/evidence-snapshot-fields.ts`, `app/herbs/[slug]/page.tsx`, `app/compounds/[slug]/page.tsx`, `app/compare/[slug]/page.tsx`.
- Shared component strategy: minimal helper-only abstraction (field builders) to standardize copy, ordering, and fallbacks while avoiding larger shared UI or layout refactors.
- Risk notes and confirmations: low risk (presentation/data-to-field mapping only); no route contract changes; no workbook or `public/data` edits; no dependency or lockfile changes; no runtime generation scripts changed.

### Testing
- Ran `npm run check:fast` (ESLint + `tsc`) and it passed.
- Ran `npm run check:ui` (lint + typecheck + `validate:static-export` + `validate:route-seo`) and it passed.
- Verified the change is a localized mapping/refactor and introduced no new runtime/route compatibility issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10657134688323bb8fd0532ec697ef)