### PR TITLE
Improve related-content discovery; add RelatedDiscoveryGroups UI

### DIFF
--- a/app/compare/[slug]/page.tsx
+++ b/app/compare/[slug]/page.tsx
@@ -21,6 +21,7 @@ import SemanticAssistantPanel from '@/components/semantic-assistant-panel'
 import PathwayVisualChip from '@/components/pathway-visual-chip'
 import EvidenceSnapshotPanel from '@/components/ui/EvidenceSnapshotPanel'
 import { buildCompareEvidenceSnapshotFields } from '@/components/ui/evidence-snapshot-fields'
+import RelatedDiscoveryGroups from '@/components/ui/RelatedDiscoveryGroups'
 
 type Params = { params: Promise<{ slug: string }> }
 
@@ -397,7 +398,7 @@ export default async function Page({ params }: Params) {
 
         {relatedComparisons.length > 0 && (
           <article className="compact-card section-rhythm-compact">
-            <h2 className="max-w-none text-xl font-semibold text-ink">You may also compare</h2>
+            <h2 className="max-w-none text-xl font-semibold text-ink">Related comparisons</h2>
             <div className="grid gap-2">
               {relatedComparisons.map(item => (
                 <Link key={item.slug} href={`/compare/${item.slug}`} className="text-sm font-semibold text-brand-800">{item.title} →</Link>
@@ -417,6 +418,42 @@ export default async function Page({ params }: Params) {
           </article>
         )}
       </section>
+
+      <RelatedDiscoveryGroups
+        eyebrow="Continue comparison research"
+        title="Explore nearby decision paths"
+        groups={[
+          {
+            title: 'Related comparisons',
+            description: 'Compare close alternatives without forcing a single winner.',
+            links: relatedComparisons.map(item => ({ href: `/compare/${item.slug}`, label: item.title })),
+          },
+          {
+            title: 'Beginner-friendly next reads',
+            description: 'Start with practical overviews before advanced stacking.',
+            links: [
+              { href: `/compounds/${winner.slug}`, label: `${displayName(winner)} profile` },
+              { href: '/learn', label: 'Learn evidence basics' },
+            ],
+          },
+          {
+            title: 'Safety context',
+            description: 'Read safety framing before trial decisions.',
+            links: [
+              { href: '/sleep-herbs-vs-melatonin', label: 'Sleep safety tradeoffs' },
+              { href: '/psychedelic-adjacent-herbs', label: 'Harm-reduction herb context' },
+            ],
+          },
+          {
+            title: 'Related goals pages',
+            description: 'Use goal pages when choosing by outcome instead of ingredient.',
+            links: [
+              { href: '/goals', label: 'Browse goal guides' },
+              { href: '/goals', label: 'Find a beginner-friendly goal path' },
+            ],
+          },
+        ]}
+      />
     </main>
   )
 }

--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -45,6 +45,7 @@ import EvidenceAwareCTA from '@/components/evidence-aware-cta'
 import SemanticAssistantPanel from '@/components/semantic-assistant-panel'
 import EvidenceSnapshotPanel from '@/components/ui/EvidenceSnapshotPanel'
 import { buildDetailEvidenceSnapshotFields } from '@/components/ui/evidence-snapshot-fields'
+import RelatedDiscoveryGroups from '@/components/ui/RelatedDiscoveryGroups'
 
 type PageProps = {
   params: Promise<{ slug: string }>
@@ -558,6 +559,33 @@ export default async function CompoundPage({ params }: PageProps) {
             </div>
           ) : null}
         </CompactDisclosure>
+
+
+
+        <RelatedDiscoveryGroups
+          eyebrow="Related navigation"
+          title="Keep exploring with evidence context"
+          groups={[
+            {
+              title: 'Related comparisons',
+              description: 'Side-by-side pages for closer tradeoff decisions.',
+              links: comparisonRecords.slice(0, 4).map((item:any) => ({ href: `/compare/${item.slug}`, label: formatDisplayLabel(item.name || item.title || item.slug) })),
+            },
+            {
+              title: 'Alternatives and adjacencies',
+              description: 'Compounds and herbs with overlapping pathway signals.',
+              links: semanticRelated.slice(0, 4).map((item:any) => ({ href: item.entityType === 'herb' ? `/herbs/${item.slug}` : `/compounds/${item.slug}`, label: formatDisplayLabel(item.name || item.displayName || item.slug) })),
+            },
+            {
+              title: 'Beginner-friendly next reads',
+              description: 'Start with educational explainers before stacking.',
+              links: [
+                { href: '/learn', label: 'Learn evidence and safety basics' },
+                { href: '/goals', label: 'Browse goals guides' },
+              ],
+            },
+          ]}
+        />
 
         {sources.length > 0 ? (
           <CompactDisclosure title="Research and source context">

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -46,6 +46,7 @@ import GuidedExplorationPanel from '@/components/guided-exploration-panel'
 import EvidenceAwareCTA from '@/components/evidence-aware-cta'
 import SemanticAssistantPanel from '@/components/semantic-assistant-panel'
 import EvidenceSnapshotPanel from '@/components/ui/EvidenceSnapshotPanel'
+import RelatedDiscoveryGroups from '@/components/ui/RelatedDiscoveryGroups'
 import { buildDetailEvidenceSnapshotFields } from '@/components/ui/evidence-snapshot-fields'
 
 type PageProps = {
@@ -666,35 +667,20 @@ export default async function HerbDetailPage({ params }: PageProps) {
         </CompactDetails>
       </section>
 
-      <section className="border-t border-brand-900/10 pt-6">
-        <div className="space-y-1">
-          <p className="eyebrow-label">Related navigation</p>
-          <h2 className="text-2xl font-semibold tracking-tight text-ink">Keep researching</h2>
-        </div>
-        <div className="mt-4 grid gap-4 md:grid-cols-3">
-          {relatedHerbLinks.length > 0 ? (
-            <div className="space-y-2">
-              <h3 className="text-sm font-semibold text-ink">Related herbs</h3>
-              {relatedHerbLinks.map(item => <Link key={item.href} href={item.href} className="block text-sm text-[#46574d] underline-offset-4 hover:underline">{item.label}</Link>)}
-            </div>
-          ) : null}
-          {relatedCompoundLinks.length > 0 ? (
-            <div className="space-y-2">
-              <h3 className="text-sm font-semibold text-ink">Related compounds</h3>
-              {relatedCompoundLinks.map(item => <Link key={item.href} href={item.href} className="block text-sm text-[#46574d] underline-offset-4 hover:underline">{item.label}</Link>)}
-            </div>
-          ) : null}
-          {comparisonLinks.length > 0 ? (
-            <div className="space-y-2">
-              <h3 className="text-sm font-semibold text-ink">Relevant comparisons</h3>
-              {comparisonLinks.map(item => <Link key={item.href} href={item.href} className="block text-sm text-[#46574d] underline-offset-4 hover:underline">{item.label}</Link>)}
-            </div>
-          ) : null}
-        </div>
-        <Link href="/herbs" className="mt-5 inline-flex rounded-full border border-brand-900/10 bg-white px-4 py-2 text-sm font-bold text-ink transition hover:bg-sand-50">
-          Back to herbs library
-        </Link>
-      </section>
+      <RelatedDiscoveryGroups
+        eyebrow="Related navigation"
+        title="Keep researching with context"
+        groups={[
+          { title: 'Related herbs', description: 'Profiles with overlapping effects or decision signals.', links: relatedHerbLinks },
+          { title: 'Related compounds', description: 'Mechanism-adjacent compounds to contrast with this herb.', links: relatedCompoundLinks },
+          { title: 'Related comparisons', description: 'Direct side-by-side pages when the tradeoff is close.', links: comparisonLinks },
+          { title: 'Learn safety context', description: 'Educational pages on safety and evidence interpretation.', links: [{ href: '/learn', label: 'Browse learn guides' }, { href: '/sleep-herbs-vs-melatonin', label: 'Sleep herbs vs melatonin' }, { href: '/psychedelic-adjacent-herbs', label: 'Psychedelic-adjacent herbs' }] },
+        ]}
+      />
+
+      <Link href="/herbs" className="inline-flex rounded-full border border-brand-900/10 bg-white px-4 py-2 text-sm font-bold text-ink transition hover:bg-sand-50">
+        Back to herbs library
+      </Link>
     </main>
   )
 }

--- a/app/learn/[slug]/page.tsx
+++ b/app/learn/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
-import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { getLearnPost, learnPosts } from '../data'
+import RelatedDiscoveryGroups from '@/components/ui/RelatedDiscoveryGroups'
 
 type LearnRouteParams = Promise<{ slug: string }>
 
@@ -35,6 +35,8 @@ export default async function Page({ params }: LearnRouteProps) {
   const post = getLearnPost(slug)
 
   if (!post) notFound()
+
+  const relatedArticles = learnPosts.filter((item) => item.slug !== post.slug).slice(0, 3).map((item) => ({ href: `/learn/${item.slug}`, label: item.title }))
 
   return (
     <main className="container-page py-10 sm:py-14">
@@ -88,19 +90,31 @@ export default async function Page({ params }: LearnRouteProps) {
           </aside>
         </section>
 
-        <section className="card-premium p-6">
-          <p className="eyebrow-label">Continue exploring</p>
-          <div className="mt-3 flex flex-wrap gap-3">
-            {post.relatedLinks.map((link) => (
-              <Link key={link.href} href={link.href} className="text-sm font-medium text-emerald-700 underline-offset-4 hover:underline">
-                {link.label}
-              </Link>
-            ))}
-            <Link href="/learn" className="text-sm font-medium text-emerald-700 underline-offset-4 hover:underline">
-              Browse all learn guides
-            </Link>
-          </div>
-        </section>
+        <RelatedDiscoveryGroups
+          eyebrow="Continue exploring"
+          title="Choose your next educational step"
+          groups={[
+            {
+              title: 'Related concepts',
+              description: 'Educational deep-dives that connect to this topic.',
+              links: relatedArticles,
+            },
+            {
+              title: 'Apply what you learned',
+              description: 'Move from concepts into evidence-aware profiles.',
+              links: post.relatedLinks,
+            },
+            {
+              title: 'Read safety context',
+              description: 'Use safety-first pages before trialing new compounds.',
+              links: [
+                { href: '/sleep-herbs-vs-melatonin', label: 'Sleep herbs vs melatonin' },
+                { href: '/psychedelic-adjacent-herbs', label: 'Psychedelic-adjacent herbs' },
+                { href: '/learn', label: 'Browse all learn guides' },
+              ],
+            },
+          ]}
+        />
       </article>
     </main>
   )

--- a/components/ui/RelatedDiscoveryGroups.tsx
+++ b/components/ui/RelatedDiscoveryGroups.tsx
@@ -1,0 +1,53 @@
+import Link from 'next/link'
+
+type DiscoveryLink = {
+  href: string
+  label: string
+}
+
+type DiscoveryGroup = {
+  title: string
+  description?: string
+  links: DiscoveryLink[]
+}
+
+type RelatedDiscoveryGroupsProps = {
+  eyebrow?: string
+  title?: string
+  groups: DiscoveryGroup[]
+  className?: string
+}
+
+export default function RelatedDiscoveryGroups({
+  eyebrow = 'Continue exploring',
+  title = 'Choose a useful next step',
+  groups,
+  className = '',
+}: RelatedDiscoveryGroupsProps) {
+  const visibleGroups = groups.filter((group) => group.links.length > 0)
+  if (visibleGroups.length === 0) return null
+
+  return (
+    <section className={`rounded-[2rem] border border-brand-900/10 bg-white/90 p-5 sm:p-6 ${className}`.trim()}>
+      <div className="space-y-1">
+        <p className="eyebrow-label">{eyebrow}</p>
+        <h2 className="text-2xl font-semibold tracking-tight text-ink">{title}</h2>
+      </div>
+      <div className="mt-4 grid gap-3 md:grid-cols-2 lg:grid-cols-4">
+        {visibleGroups.map((group) => (
+          <article key={group.title} className="rounded-2xl border border-brand-900/10 bg-white/90 p-4">
+            <h3 className="text-sm font-semibold text-ink">{group.title}</h3>
+            {group.description ? <p className="mt-1 text-xs leading-5 text-muted">{group.description}</p> : null}
+            <div className="mt-3 space-y-2">
+              {group.links.slice(0, 4).map((item) => (
+                <Link key={item.href} href={item.href} className="block text-sm text-[#46574d] underline-offset-4 hover:underline">
+                  {item.label}
+                </Link>
+              ))}
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
### Motivation
- Help users naturally continue exploring herbs, compounds, comparisons, and educational pages with calm, evidence-first navigation that avoids spammy recommendation language.
- Preserve existing runtime relationship lookups, affiliate/evidence behavior, and static-export route contracts while improving session continuity and mobile readability.

### Description
- Add a lightweight shared UI primitive `components/ui/RelatedDiscoveryGroups.tsx` that renders compact grouped discovery cards with the site visual style (`bg-white/90`, `border-brand-900/10`, `rounded-2xl` / `rounded-[2rem]`).
- Replace/augment related-navigation on `app/herbs/[slug]/page.tsx`, `app/compounds/[slug]/page.tsx`, `app/compare/[slug]/page.tsx`, and `app/learn/[slug]/page.tsx` to use the new component and present purposeful groups (e.g., related comparisons, alternatives/adjacencies, beginner-friendly reads, safety/learn links, goals).
- Reuse existing runtime data sources (`related`, `comparisonRecords`, `semanticRelated`, `post.relatedLinks`, etc.) and limit group sizes to keep layouts compact and scannable on mobile.
- No data-pipeline, generated public data, or dependency changes are introduced.

### Testing
- Ran `npm run check:fast` (lint + typecheck); checks passed.
- Ran `npm run check:ui` (lint + typecheck + static-export compatibility + route SEO validation); checks passed.
- No additional automated tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a106935e7b88323bb1769fbe5604007)