### PR TITLE
Frontend Pass: normalize trust framing on top discovery routes

### DIFF
--- a/app/top/best-herbs-for-cortisol/page.tsx
+++ b/app/top/best-herbs-for-cortisol/page.tsx
@@ -89,10 +89,23 @@ export default async function CortisolPage() {
         </p>
       </section>
 
+
+      <section className='rounded-3xl border border-white/10 bg-white/[0.035] p-5 sm:p-6'>
+        <h2 className='text-2xl font-bold text-white'>How to use this ranking responsibly</h2>
+        <p className='mt-3 text-sm leading-6 text-white/70'>
+          This page is an educational comparison starting point. Ranking position reflects dataset signals, not a guarantee that one option will work best for you.
+        </p>
+        <ul className='mt-3 space-y-2 text-sm leading-6 text-white/65'>
+          <li>Evidence quality and study design vary by herb or compound.</li>
+          <li>Safety context matters: medications, health conditions, and pregnancy or nursing status can change fit.</li>
+          <li>Individual response varies, so use full profiles and clinical guidance before decisions.</li>
+        </ul>
+      </section>
+
       <AffiliateConversionCard
-        eyebrow='Best overall cortisol pick'
+        eyebrow='Featured cortisol pick'
         title={bestLabel}
-        description='Best overall starting point for cortisol, stress-response, and adaptogen-support research.'
+        description='Educational first-look option for cortisol, stress-response, and adaptogen-support research.'
         href={bestLinks[0]?.url || '#'}
         cta={`View ${bestLabel} options →`}
         secondaryHref='/compare/ashwagandha-vs-rhodiola-rosea'

--- a/app/top/best-supplements-for-fatigue/page.tsx
+++ b/app/top/best-supplements-for-fatigue/page.tsx
@@ -45,12 +45,25 @@ export default async function Page() {
         <p className='mt-4 max-w-3xl text-base leading-7 text-white/70'>A practical guide to herbs and supplements commonly discussed for low energy, fatigue, burnout, and stress-linked tiredness. Educational only, not medical advice.</p>
       </section>
 
+
+      <section className='rounded-3xl border border-white/10 bg-white/[0.035] p-5 sm:p-6'>
+        <h2 className='text-2xl font-bold text-white'>How to use this ranking responsibly</h2>
+        <p className='mt-3 text-sm leading-6 text-white/70'>
+          This page is an educational comparison starting point. Ranking position reflects dataset signals, not a guarantee that one option will work best for you.
+        </p>
+        <ul className='mt-3 space-y-2 text-sm leading-6 text-white/65'>
+          <li>Evidence quality and study design vary by herb or compound.</li>
+          <li>Safety context matters: medications, health conditions, and pregnancy or nursing status can change fit.</li>
+          <li>Individual response varies, so use full profiles and clinical guidance before decisions.</li>
+        </ul>
+      </section>
+
       <section className='rounded-3xl border border-white/10 bg-white/[0.035] p-5 sm:p-6'>
         <h2 className='text-2xl font-bold'>Fast answer</h2>
         <ul className='mt-4 space-y-3 text-sm leading-6 text-white/70'>
           <li><strong className='text-white'>Rhodiola rosea</strong> is often framed around fatigue and stress resilience.</li>
           <li><strong className='text-white'>Creatine</strong> is commonly discussed for performance, energy systems, and cognitive context.</li>
-          <li><strong className='text-white'>Caffeine</strong> is the obvious short-term energy option, but context matters.</li>
+          <li><strong className='text-white'>Caffeine</strong> may support short-term alertness for some people, but context and tolerance matter.</li>
         </ul>
       </section>
 

--- a/app/top/focus/page.tsx
+++ b/app/top/focus/page.tsx
@@ -42,8 +42,21 @@ export default async function FocusPage() {
       <section className='rounded-[2rem] border border-white/10 bg-white/[0.04] p-6'>
         <h1 className='text-4xl font-bold'>Best Supplements for Focus</h1>
         <p className='mt-4 text-white/70'>
-          These supplements are commonly used for focus, memory, and cognitive performance. Rankings are based on dataset signals and research context.
+          These supplements are often discussed for focus, memory, and cognitive performance. Rankings are based on dataset signals and research context.
         </p>
+      </section>
+
+
+      <section className='rounded-3xl border border-white/10 bg-white/[0.035] p-5 sm:p-6'>
+        <h2 className='text-2xl font-bold text-white'>How to use this ranking responsibly</h2>
+        <p className='mt-3 text-sm leading-6 text-white/70'>
+          This page is an educational comparison starting point. Ranking position reflects dataset signals, not a guarantee that one option will work best for you.
+        </p>
+        <ul className='mt-3 space-y-2 text-sm leading-6 text-white/65'>
+          <li>Evidence quality and study design vary by herb or compound.</li>
+          <li>Safety context matters: medications, health conditions, and pregnancy or nursing status can change fit.</li>
+          <li>Individual response varies, so use full profiles and clinical guidance before decisions.</li>
+        </ul>
       </section>
 
       <section className='rounded-3xl border border-white/10 bg-white/[0.035] p-5'>

--- a/app/top/sleep/page.tsx
+++ b/app/top/sleep/page.tsx
@@ -72,8 +72,21 @@ export default async function TopSleepPage() {
       <section className='rounded-[2rem] border border-white/10 bg-white/[0.04] p-6'>
         <h1 className='text-4xl font-bold'>Best Herbs for Sleep</h1>
         <p className='mt-4 text-white/70'>
-          These herbs are commonly used as natural sleep aids for insomnia, relaxation, and improving sleep quality.
+          These herbs are often discussed as natural sleep aids for insomnia, relaxation, and sleep-quality support.
         </p>
+      </section>
+
+
+      <section className='rounded-3xl border border-white/10 bg-white/[0.035] p-5 sm:p-6'>
+        <h2 className='text-2xl font-bold text-white'>How to use this ranking responsibly</h2>
+        <p className='mt-3 text-sm leading-6 text-white/70'>
+          This page is an educational comparison starting point. Ranking position reflects dataset signals, not a guarantee that one option will work best for you.
+        </p>
+        <ul className='mt-3 space-y-2 text-sm leading-6 text-white/65'>
+          <li>Evidence quality and study design vary by herb or compound.</li>
+          <li>Safety context matters: medications, health conditions, and pregnancy or nursing status can change fit.</li>
+          <li>Individual response varies, so use full profiles and clinical guidance before decisions.</li>
+        </ul>
       </section>
 
       <section className='rounded-3xl border border-white/10 bg-white/[0.035] p-5'>

--- a/app/top/stress/page.tsx
+++ b/app/top/stress/page.tsx
@@ -76,6 +76,19 @@ export default async function StressPage() {
         </p>
       </section>
 
+
+      <section className='rounded-3xl border border-white/10 bg-white/[0.035] p-5 sm:p-6'>
+        <h2 className='text-2xl font-bold text-white'>How to use this ranking responsibly</h2>
+        <p className='mt-3 text-sm leading-6 text-white/70'>
+          This page is an educational comparison starting point. Ranking position reflects dataset signals, not a guarantee that one option will work best for you.
+        </p>
+        <ul className='mt-3 space-y-2 text-sm leading-6 text-white/65'>
+          <li>Evidence quality and study design vary by herb or compound.</li>
+          <li>Safety context matters: medications, health conditions, and pregnancy or nursing status can change fit.</li>
+          <li>Individual response varies, so use full profiles and clinical guidance before decisions.</li>
+        </ul>
+      </section>
+
       <section className='rounded-3xl border border-white/10 bg-white/[0.035] p-5 sm:p-6'>
         <h2 className='text-2xl font-bold text-white'>What herbs help with stress and anxiety?</h2>
         <p className='mt-3 text-sm leading-6 text-white/65'>

--- a/app/top/top-3-herbs-for-anxiety/page.tsx
+++ b/app/top/top-3-herbs-for-anxiety/page.tsx
@@ -76,9 +76,22 @@ export default async function TopThreeAnxietyHerbsPage() {
         <p className='mt-4 max-w-3xl text-base leading-7 text-white/70'>A practical starting point for calm, relaxation, and anxiety-related herb research. Educational context only, not medical advice.</p>
       </section>
 
+
+      <section className='rounded-3xl border border-white/10 bg-white/[0.035] p-5 sm:p-6'>
+        <h2 className='text-2xl font-bold text-white'>How to use this ranking responsibly</h2>
+        <p className='mt-3 text-sm leading-6 text-white/70'>
+          This page is an educational comparison starting point. Ranking position reflects dataset signals, not a guarantee that one option will work best for you.
+        </p>
+        <ul className='mt-3 space-y-2 text-sm leading-6 text-white/65'>
+          <li>Evidence quality and study design vary by herb or compound.</li>
+          <li>Safety context matters: medications, health conditions, and pregnancy or nursing status can change fit.</li>
+          <li>Individual response varies, so use full profiles and clinical guidance before decisions.</li>
+        </ul>
+      </section>
+
       <AffiliateConversionCard
         title={bestLabel}
-        description='Best overall starting point for calm, relaxation, and stress-linked anxiety research.'
+        description='Educational first-look option for calm, relaxation, and stress-linked anxiety research.'
         href={bestLinks[0]?.url || '#'}
         cta={`View ${bestLabel} options →`}
         secondaryHref='/top/stress'

--- a/app/top/top-3-herbs-for-stress/page.tsx
+++ b/app/top/top-3-herbs-for-stress/page.tsx
@@ -79,9 +79,22 @@ export default async function TopThreeStressHerbsPage() {
         <p className='mt-4 max-w-3xl text-base leading-7 text-white/70'>A practical starting point for stress, anxiety, calm, and adaptogen-style support. This is educational research context, not medical advice.</p>
       </section>
 
+
+      <section className='rounded-3xl border border-white/10 bg-white/[0.035] p-5 sm:p-6'>
+        <h2 className='text-2xl font-bold text-white'>How to use this ranking responsibly</h2>
+        <p className='mt-3 text-sm leading-6 text-white/70'>
+          This page is an educational comparison starting point. Ranking position reflects dataset signals, not a guarantee that one option will work best for you.
+        </p>
+        <ul className='mt-3 space-y-2 text-sm leading-6 text-white/65'>
+          <li>Evidence quality and study design vary by herb or compound.</li>
+          <li>Safety context matters: medications, health conditions, and pregnancy or nursing status can change fit.</li>
+          <li>Individual response varies, so use full profiles and clinical guidance before decisions.</li>
+        </ul>
+      </section>
+
       <AffiliateConversionCard
         title={bestLabel}
-        description='Best overall starting point for long-term stress, calm, and cortisol-support research.'
+        description='Educational first-look option for stress, calm, and cortisol-support research.'
         href={bestLinks[0]?.url || '#'}
         cta={`View ${bestLabel} options →`}
         secondaryHref='/compare/ashwagandha-vs-rhodiola-rosea'

--- a/app/top/top-3-natural-sleep-aids/page.tsx
+++ b/app/top/top-3-natural-sleep-aids/page.tsx
@@ -39,10 +39,23 @@ export default async function Page() {
         <p className='mt-4 max-w-3xl text-base leading-7 text-white/70'>A simple starting point for herbs commonly discussed around sleep onset, relaxation, and nighttime calm. Educational only, not medical advice.</p>
       </section>
 
+
+      <section className='rounded-3xl border border-white/10 bg-white/[0.035] p-5 sm:p-6'>
+        <h2 className='text-2xl font-bold text-white'>How to use this ranking responsibly</h2>
+        <p className='mt-3 text-sm leading-6 text-white/70'>
+          This page is an educational comparison starting point. Ranking position reflects dataset signals, not a guarantee that one option will work best for you.
+        </p>
+        <ul className='mt-3 space-y-2 text-sm leading-6 text-white/65'>
+          <li>Evidence quality and study design vary by herb or compound.</li>
+          <li>Safety context matters: medications, health conditions, and pregnancy or nursing status can change fit.</li>
+          <li>Individual response varies, so use full profiles and clinical guidance before decisions.</li>
+        </ul>
+      </section>
+
       <AffiliateConversionCard
-        eyebrow='Best overall sleep pick'
+        eyebrow='Featured sleep pick'
         title={bestLabel}
-        description='Best overall starting point for natural sleep-aid research and nighttime relaxation support.'
+        description='Educational first-look option for natural sleep-aid research and nighttime relaxation context.'
         href={bestLinks[0]?.url || '#'}
         cta={`View ${bestLabel} options →`}
         secondaryHref='/top/sleep'


### PR DESCRIPTION
### Motivation
- Implement Phase 1 quick wins from the content trust and consistency audit to reduce deterministic/promotional language on high-intent discovery pages. 
- Make ranking interpretation and safety context explicit so readers treat lists as educational starting points, not guarantees of effectiveness. 
- Improve above-the-fold safety framing and evidence-first tone while preserving existing UI patterns and components. 
- Keep changes minimal and surgical, confined to route-local copy edits without touching data pipelines or generated artifacts.

### Description
- Added a standardized "How to use this ranking responsibly" trust/safety block to each target page and used the site’s existing calm light-card styling for the block. 
- Reworded above-the-fold copy and affiliate/card labels to neutral phrasing (e.g., `Best overall` → `Featured` / `Educational first-look`) and softened deterministic statements (including a small change to the caffeine line). 
- Files changed: `app/top/focus/page.tsx`, `app/top/sleep/page.tsx`, `app/top/stress/page.tsx`, `app/top/top-3-herbs-for-stress/page.tsx`, `app/top/top-3-herbs-for-anxiety/page.tsx`, `app/top/top-3-natural-sleep-aids/page.tsx`, `app/top/best-supplements-for-fatigue/page.tsx`, and `app/top/best-herbs-for-cortisol/page.tsx`. 
- Risk notes: low risk because edits are copy-only and route-local; no runtime, routing, or data-pipeline behavior was changed, and UI components/structure were preserved; follow-up audits can extend framing to additional routes if desired. 
- Confirmation: no edits were made to workbook sources, `public/data`, generated files, or dependency manifests (`package.json` / `package-lock.json`).

### Testing
- Ran `npm run check:fast` (ESLint + typecheck) and it passed. 
- Ran `npm run check:ui` (lint, typecheck, `validate:static-export`, `validate:route-seo`) and it passed. 
- All automated checks passed with no modifications required to build or route configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1074ccba14832390c14cca0ae63c8d)