### PR TITLE
Frontend Pass: normalize evidence-language terminology

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -67,7 +67,7 @@ export default async function ComparePage() {
       <section className="rounded-2xl border border-amber-900/15 bg-amber-50/70 p-5 text-sm leading-6 text-amber-950">
         <p className="font-semibold">Use this cautiously.</p>
         <p className="mt-1">
-          This page is educational and does not replace medical advice. Evidence quality differs by compound, product quality varies, and individual response can be unpredictable. Review medications, health conditions, pregnancy or nursing status, and clinician guidance before using supplements.
+          This page is educational and does not replace medical advice. Evidence strength reflects research signal quality, not guaranteed outcomes, and individual response varies. Review medications, health conditions, pregnancy or nursing status, and clinician guidance before using supplements.
         </p>
       </section>
 

--- a/app/goals/[goal]/page.tsx
+++ b/app/goals/[goal]/page.tsx
@@ -166,7 +166,7 @@ export default async function GoalDecisionPage({
       <section className="mt-8 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
         <h2 className="text-xl font-semibold text-slate-900">Quick Comparison Notes</h2>
         <p className="mt-2 text-sm leading-6 text-slate-600">
-          These are starting points for comparison, not recommendations, prescriptions, or guarantees of benefit.
+          These are starting points for comparison, not recommendations, prescriptions, or guaranteed outcomes.
         </p>
         <div className="mt-4 overflow-x-auto">
           <table className="min-w-full text-left text-sm">

--- a/app/natural-anxiolytics-beyond-ashwagandha/page.tsx
+++ b/app/natural-anxiolytics-beyond-ashwagandha/page.tsx
@@ -12,7 +12,7 @@ export default function NaturalAnxiolyticsPage() {
         <p className="eyebrow-label">Discovery path</p>
         <h1 className="mt-3 max-w-3xl text-ink">Natural anxiolytics beyond ashwagandha</h1>
         <p className="mt-5 max-w-3xl text-lg leading-8 text-[#46574d]">
-          Explore calming botanicals through evidence-aware profiles instead of one-size-fits-all recommendations.
+          Explore calming botanicals through consistent evidence-strength profiles instead of one-size-fits-all recommendations.
         </p>
         <div className="mt-7 flex flex-col gap-3 sm:flex-row">
           <Link href="/herbs" className="button-primary rounded-full">Browse herbs</Link>

--- a/app/seo-entry-pages.tsx
+++ b/app/seo-entry-pages.tsx
@@ -62,11 +62,11 @@ const manualSeoEntryPages: SeoEntryConfig[] = [
   {
     route: 'best-supplements-for-fat-loss',
     goalSlug: 'fat-loss',
-    title: 'Best Supplements for Fat Loss (Evidence-Aware Support) | The Hippie Scientist',
+    title: 'Best Supplements for Fat Loss (Evidence-Strength Support) | The Hippie Scientist',
     h1: 'Best Supplements for Fat Loss',
     intro: 'A grounded fat-loss supplement guide that avoids proprietary-blend hype and keeps stimulant safety in view.',
     searchIntent: 'fat loss supplements, thermogenic supplement stack, appetite support',
-    bullets: ['Prioritize modest evidence-aware support over miracle claims.', 'Watch stimulant load, blood pressure, anxiety, and medication interactions.', 'Use the goal guide to compare stacks, compounds, and related evidence.'],
+    bullets: ['Prioritize modest support with limited-to-stronger evidence strength over miracle claims.', 'Watch stimulant load, blood pressure, anxiety, and medication interactions.', 'Use the goal guide to compare stacks, compounds, and related evidence.'],
   },
   {
     route: 'best-supplements-for-blood-pressure',
@@ -98,7 +98,7 @@ const manualSeoEntryPages: SeoEntryConfig[] = [
   {
     route: 'natural-testosterone-boosters',
     goalSlug: 'testosterone-support',
-    title: 'Natural Testosterone Boosters (Evidence-Aware Guide) | The Hippie Scientist',
+    title: 'Natural Testosterone Boosters (Evidence-Strength Guide) | The Hippie Scientist',
     h1: 'Natural Testosterone Boosters',
     intro: 'A skeptical guide to testosterone-support supplements that separates cautious evidence from aggressive booster marketing.',
     searchIntent: 'natural testosterone boosters, testosterone support supplements',
@@ -125,7 +125,7 @@ const manualSeoEntryPages: SeoEntryConfig[] = [
   {
     route: 'best-nootropics-for-focus',
     goalSlug: 'focus',
-    title: 'Best Nootropics for Focus (Evidence-Aware Guide) | The Hippie Scientist',
+    title: 'Best Nootropics for Focus (Evidence-Strength Guide) | The Hippie Scientist',
     h1: 'Best Nootropics for Focus',
     intro: 'A cleaner entry point for focus nootropics that separates stimulation, attention support, and overhyped claims.',
     searchIntent: 'best nootropics for focus, focus supplements, nootropic stack',
@@ -162,9 +162,9 @@ const slugify = (value: string) =>
 const generatedSeoEntryPages: SeoEntryConfig[] = guideTopics.map(([goalSlug, topic]) => ({
   route: `guides/${slugify(topic)}`,
   goalSlug,
-  title: `${titleCase(topic)} (Evidence-Aware Guide) | The Hippie Scientist`,
+  title: `${titleCase(topic)} (Evidence-Strength Guide) | The Hippie Scientist`,
   h1: titleCase(topic),
-  intro: `A practical, evidence-aware guide to ${topic}, with safety context, related compounds, and a clear path into ranked decision pages.`,
+  intro: `A practical guide to ${topic} with evidence-strength context, related compounds, and a clear path into ranked decision pages.`,
   searchIntent: topic,
   bullets: [
     `Use this guide to compare ${topic} without treating every supplement claim as equal.`,
@@ -252,7 +252,7 @@ const sectionFor = (goalSlug: string) => {
     },
     'testosterone-support': {
       quick: ['Testosterone-booster claims are often exaggerated.', 'Sleep, training, deficiency status, and overall health matter first.', 'Minerals and adaptogens should be evaluated separately.'],
-      forWho: ['People skeptical of testosterone-booster marketing.', 'People comparing deficiency support versus hormone claims.', 'People who want safer, evidence-aware framing.'],
+      forWho: ['People skeptical of testosterone-booster marketing.', 'People comparing deficiency support versus hormone claims.', 'People who want safer, evidence-strength framing.'],
       careful: ['People with hormone-sensitive conditions or medication use.', 'People with fertility, prostate, liver, or endocrine concerns.', 'Anyone expecting supplements to replace medical evaluation.'],
       mistakes: ['Buying proprietary booster blends before checking basics.', 'Confusing energy or libido claims with testosterone evidence.', 'Ignoring sleep, alcohol, training, and deficiency status.'],
       comparison: 'Zinc and magnesium mostly make sense in deficiency or broader health context, while ashwagandha-style claims need separate evidence and safety review.',
@@ -269,7 +269,7 @@ function buildFaqs(page: SeoEntryConfig, goalTitle: string): FaqItem[] {
   return [
     {
       question: `Do ${plainGoal} supplements actually work?`,
-      answer: `Some supplements may help with ${plainGoal}, but results depend on the compound, dose, timing, baseline status, and individual response. The ranked guide separates stronger evidence from weaker claims.`,
+      answer: `Some supplements may help with ${plainGoal}, but results depend on the compound, dose, timing, baseline status, and individual response varies. The ranked guide separates stronger research signal from weaker claims.`,
     },
     {
       question: `How long do ${plainGoal} supplements take to work?`,

--- a/components/evidence/EvidenceBadge.tsx
+++ b/components/evidence/EvidenceBadge.tsx
@@ -1,9 +1,11 @@
-type EvidenceLevel = 'Strong' | 'Moderate' | 'Limited' | 'Traditional' | 'Theoretical'
+type EvidenceLevel = 'Strong' | 'Stronger' | 'Moderate' | 'Limited' | 'Mixed' | 'Traditional' | 'Theoretical'
 
 const styles: Record<EvidenceLevel, string> = {
   Strong: 'bg-emerald-100 text-emerald-900 border-emerald-300',
+  Stronger: 'bg-emerald-100 text-emerald-900 border-emerald-300',
   Moderate: 'bg-blue-100 text-blue-900 border-blue-300',
   Limited: 'bg-amber-100 text-amber-900 border-amber-300',
+  Mixed: 'bg-violet-100 text-violet-900 border-violet-300',
   Traditional: 'bg-purple-100 text-purple-900 border-purple-300',
   Theoretical: 'bg-zinc-100 text-zinc-900 border-zinc-300',
 }
@@ -13,11 +15,13 @@ export default function EvidenceBadge({
 }: {
   level: EvidenceLevel
 }) {
+  const label = level === 'Strong' ? 'Stronger' : level
+
   return (
     <span
       className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-semibold tracking-wide ${styles[level]}`}
     >
-      Evidence: {level}
+      Evidence: {label}
     </span>
   )
 }

--- a/components/evidence/EvidenceSection.tsx
+++ b/components/evidence/EvidenceSection.tsx
@@ -23,7 +23,7 @@ export default function EvidenceSection({
   return (
     <section className="card-premium p-6 space-y-5">
       <div className="flex flex-wrap items-center gap-3">
-        <p className="eyebrow-label">Evidence Review</p>
+        <p className="eyebrow-label">Evidence strength review</p>
 
         <EvidenceBadge level={evidenceLevel} />
       </div>

--- a/components/evidence/EvidenceSummaryCard.tsx
+++ b/components/evidence/EvidenceSummaryCard.tsx
@@ -31,7 +31,7 @@ export default function EvidenceSummaryCard({
         {humanEvidence ? (
           <div className="rounded-2xl bg-[#f5f3ec] p-4 space-y-2">
             <p className="text-xs font-semibold tracking-wide uppercase text-[#5c6b63]">
-              Human Evidence
+              Human evidence
             </p>
 
             <p className="text-sm leading-7 text-[#46574d]">
@@ -43,7 +43,7 @@ export default function EvidenceSummaryCard({
         {mechanisticEvidence ? (
           <div className="rounded-2xl bg-[#f5f3ec] p-4 space-y-2">
             <p className="text-xs font-semibold tracking-wide uppercase text-[#5c6b63]">
-              Mechanistic Evidence
+              Research signal
             </p>
 
             <p className="text-sm leading-7 text-[#46574d]">
@@ -55,7 +55,7 @@ export default function EvidenceSummaryCard({
         {safetyProfile ? (
           <div className="rounded-2xl bg-[#f5f3ec] p-4 space-y-2">
             <p className="text-xs font-semibold tracking-wide uppercase text-[#5c6b63]">
-              Safety Profile
+              Safety profile
             </p>
 
             <p className="text-sm leading-7 text-[#46574d]">


### PR DESCRIPTION
### Motivation
- Reduce evidence-language drift across comparison, discovery, goals, SEO, and evidence UI so terminology is consistent site-wide.
- Emphasize that evidence labels describe signal quality and uncertainty rather than guaranteed outcomes.
- Make surgical copy-level updates that preserve routing, data behavior, and Evidence Snapshot structure.

### Description
- Updated user-facing copy in `app/compare/page.tsx`, `app/goals/[goal]/page.tsx`, `app/natural-anxiolytics-beyond-ashwagandha/page.tsx`, and `app/seo-entry-pages.tsx` to use the preferred framing (`evidence strength`, `research signal`, `individual response varies`) and to remove ambiguous/guarantee language.
- Normalized Evidence UI in `components/evidence/EvidenceBadge.tsx`, `components/evidence/EvidenceSection.tsx`, and `components/evidence/EvidenceSummaryCard.tsx` by adding `Stronger`/`Mixed` labels, rendering legacy `Strong` input as visible `Stronger`, renaming the section header to `Evidence strength review`, and standardizing sublabels to `Human evidence`, `Research signal`, and `Safety profile` while preserving component structure.
- Changes are copy/presentation-only and preserve existing types/props and route contracts (no routing, workbook, or public data edits were made).
- Risk: low — edits are small, non-structural, and intended to reduce confusing phrasing without changing behavior or layout.

### Testing
- Ran `npm run check:fast` which ran `eslint` and `tsc --noEmit`, and it passed.
- Ran `npm run check:ui` which runs `lint`, `typecheck`, `validate:static-export`, and `validate:route-seo`, and it passed.
- Commit recorded locally as a single branch `frontend/evidence-language-normalization` with the changes staged and committed.
- Confirmation: no workbook (`data-sources`/`public/data`) edits and no package/dependency changes were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10780b0c4c83238f1058c7a76ab40c)