### PR TITLE
Frontend: thin-content cleanup on top discovery routes

### DIFF
--- a/app/top/best-herbs-for-cortisol/page.tsx
+++ b/app/top/best-herbs-for-cortisol/page.tsx
@@ -87,6 +87,9 @@ export default async function CortisolPage() {
         <p className='mt-4 max-w-3xl text-base leading-7 text-white/70'>
           A quick guide to herbs commonly discussed for stress response, cortisol context, and adaptogen-style support. Educational only, not medical advice.
         </p>
+        <p className='mt-3 max-w-3xl text-sm leading-6 text-white/60'>
+          Cortisol is usually about pattern and timing, not one “cortisol herb.” This page helps you compare common options before deeper profile reading.
+        </p>
       </section>
 
 
@@ -116,6 +119,9 @@ export default async function CortisolPage() {
         <h2 className='text-2xl font-bold'>Fast answer</h2>
         <p className='mt-3 text-sm leading-6 text-white/70'>
           Ashwagandha, rhodiola, and holy basil are commonly discussed when people search for herbs related to cortisol and stress resilience.
+        </p>
+        <p className='mt-3 text-sm leading-6 text-white/60'>
+          Beginner guidance: compare how each option aligns with your day (wired-but-tired evenings, pressure-heavy workdays, or general tension) before choosing.
         </p>
       </section>
 

--- a/app/top/best-supplements-for-fatigue/page.tsx
+++ b/app/top/best-supplements-for-fatigue/page.tsx
@@ -43,6 +43,7 @@ export default async function Page() {
         <p className='text-xs font-bold uppercase tracking-[0.2em] text-emerald-100/70'>Energy guide</p>
         <h1 className='mt-3 text-4xl font-black tracking-tight sm:text-6xl'>Best Supplements for Fatigue & Burnout</h1>
         <p className='mt-4 max-w-3xl text-base leading-7 text-white/70'>A practical guide to herbs and supplements commonly discussed for low energy, fatigue, burnout, and stress-linked tiredness. Educational only, not medical advice.</p>
+        <p className='mt-3 max-w-3xl text-sm leading-6 text-white/60'>Use this page to separate short-lift options from recovery-oriented options. Fatigue stacks usually work better when matched to pattern, not hype.</p>
       </section>
 
 
@@ -64,6 +65,14 @@ export default async function Page() {
           <li><strong className='text-white'>Rhodiola rosea</strong> is often framed around fatigue and stress resilience.</li>
           <li><strong className='text-white'>Creatine</strong> is commonly discussed for performance, energy systems, and cognitive context.</li>
           <li><strong className='text-white'>Caffeine</strong> may support short-term alertness for some people, but context and tolerance matter.</li>
+        </ul>
+      </section>
+      <section className='rounded-3xl border border-white/10 bg-white/[0.035] p-5 sm:p-6'>
+        <h2 className='text-2xl font-bold'>How the three picks differ</h2>
+        <ul className='mt-3 space-y-2 text-sm leading-6 text-white/65'>
+          <li><strong className='text-white'>Rhodiola:</strong> usually framed for stress-linked fatigue and resilience.</li>
+          <li><strong className='text-white'>Creatine:</strong> often discussed as baseline energy-system support over time.</li>
+          <li><strong className='text-white'>Caffeine:</strong> fast alertness, but with tolerance and timing tradeoffs.</li>
         </ul>
       </section>
 

--- a/app/top/focus/page.tsx
+++ b/app/top/focus/page.tsx
@@ -44,6 +44,9 @@ export default async function FocusPage() {
         <p className='mt-4 text-white/70'>
           These supplements are often discussed for focus, memory, and cognitive performance. Rankings are based on dataset signals and research context.
         </p>
+        <p className='mt-3 text-sm leading-6 text-white/60'>
+          For beginners: separate short-term alertness tools from longer-horizon support. A useful stack decision is often about tradeoffs (speed vs steadiness), not just “strongest” effect.
+        </p>
       </section>
 
 
@@ -69,6 +72,14 @@ export default async function FocusPage() {
           <Link href='/top/stress'>Best herbs for stress</Link>
           <Link href='/top/sleep'>Best herbs for sleep</Link>
         </div>
+      </section>
+      <section className='rounded-3xl border border-white/10 bg-white/[0.035] p-5'>
+        <h2 className='text-2xl font-bold'>How approaches differ</h2>
+        <ul className='mt-3 space-y-2 text-sm leading-6 text-white/65'>
+          <li><strong className='text-white'>Stimulant-forward:</strong> faster perceived alertness, but tolerance and timing are practical constraints.</li>
+          <li><strong className='text-white'>Stress-buffering:</strong> can feel gentler and steadier when focus drops are stress-linked.</li>
+          <li><strong className='text-white'>Energy-metabolism support:</strong> usually framed as consistency over time, not immediate “kick.”</li>
+        </ul>
       </section>
 
       <div className='grid md:grid-cols-2 lg:grid-cols-3 gap-4'>

--- a/app/top/sleep/page.tsx
+++ b/app/top/sleep/page.tsx
@@ -74,6 +74,9 @@ export default async function TopSleepPage() {
         <p className='mt-4 text-white/70'>
           These herbs are often discussed as natural sleep aids for insomnia, relaxation, and sleep-quality support.
         </p>
+        <p className='mt-3 text-sm leading-6 text-white/60'>
+          Quick framing: most options are better understood as “sleep context” tools (wind-down, calm, stress load) rather than direct insomnia treatments.
+        </p>
       </section>
 
 
@@ -99,6 +102,14 @@ export default async function TopSleepPage() {
           <Link href='/top/stress'>Best herbs for stress</Link>
           <Link href='/top/focus'>Best supplements for focus</Link>
         </div>
+      </section>
+      <section className='rounded-3xl border border-white/10 bg-white/[0.035] p-5 sm:p-6'>
+        <h2 className='text-2xl font-bold text-white'>Beginner decision notes</h2>
+        <ul className='mt-3 space-y-2 text-sm leading-6 text-white/65'>
+          <li>If your issue is a racing mind, start with calmer, gentler profiles first.</li>
+          <li>If the issue is stress spillover, prioritize stress-support context over “strongest sleep herb.”</li>
+          <li>Keep timing and next-day grogginess in mind when comparing options.</li>
+        </ul>
       </section>
 
       <section>

--- a/app/top/stress/page.tsx
+++ b/app/top/stress/page.tsx
@@ -74,6 +74,9 @@ export default async function StressPage() {
         <p className='mt-4 max-w-3xl text-base leading-7 text-white/70'>
           These herbs are commonly connected with stress, anxiety, calm, cortisol, and adaptogen-style support. Rankings use the current workbook dataset as a discovery layer, not as personal medical advice.
         </p>
+        <p className='mt-3 max-w-3xl text-sm leading-6 text-white/60'>
+          Practical use: treat this page as a shortlist builder. The right fit often depends on whether stress shows up as tension, fatigue, or sleep disruption.
+        </p>
       </section>
 
 
@@ -99,6 +102,14 @@ export default async function StressPage() {
           <Link href='/top/sleep' className='rounded-2xl border border-white/10 px-4 py-2 text-sm font-bold text-white/70 hover:bg-white/5'>Best herbs for sleep</Link>
           <Link href='/top/focus' className='rounded-2xl border border-white/10 px-4 py-2 text-sm font-bold text-white/70 hover:bg-white/5'>Best supplements for focus</Link>
         </div>
+      </section>
+      <section className='rounded-3xl border border-white/10 bg-white/[0.035] p-5 sm:p-6'>
+        <h2 className='text-2xl font-bold text-white'>How stress-support approaches differ</h2>
+        <ul className='mt-3 space-y-2 text-sm leading-6 text-white/65'>
+          <li><strong className='text-white'>Adaptogen-leaning picks:</strong> often discussed for resilience and all-day load management.</li>
+          <li><strong className='text-white'>Calming botanicals:</strong> usually used for situational tension or evening downshift.</li>
+          <li><strong className='text-white'>Mixed-profile options:</strong> can overlap with sleep and focus goals, so context matters.</li>
+        </ul>
       </section>
 
       <section className='grid gap-4 md:grid-cols-2 lg:grid-cols-3'>

--- a/app/top/top-3-herbs-for-anxiety/page.tsx
+++ b/app/top/top-3-herbs-for-anxiety/page.tsx
@@ -105,6 +105,9 @@ export default async function TopThreeAnxietyHerbsPage() {
           <li><strong className='text-white'>Lemon balm</strong> is commonly associated with gentle relaxation.</li>
           <li><strong className='text-white'>Passionflower</strong> is often connected with calm and nervous-system support.</li>
         </ul>
+        <p className='mt-4 text-sm leading-6 text-white/60'>
+          Route-specific note: these three are common “entry” herbs, but they are not interchangeable. Some people prioritize daytime composure, others prioritize evening calm and sleep carryover.
+        </p>
       </section>
 
       <section className='grid gap-4'>

--- a/app/top/top-3-herbs-for-stress/page.tsx
+++ b/app/top/top-3-herbs-for-stress/page.tsx
@@ -108,6 +108,9 @@ export default async function TopThreeStressHerbsPage() {
           <li><strong className='text-white'>Rhodiola rosea</strong> is often framed around fatigue, resilience, and stress-linked energy.</li>
           <li><strong className='text-white'>Lemon balm</strong> is a gentler calming herb often connected with relaxation.</li>
         </ul>
+        <p className='mt-4 text-sm leading-6 text-white/60'>
+          Interpretation tip: “best” depends on stress pattern. For many beginners, the useful first split is steady resilience support versus quick calming support.
+        </p>
       </section>
 
       <section className='grid gap-4'>

--- a/app/top/top-3-natural-sleep-aids/page.tsx
+++ b/app/top/top-3-natural-sleep-aids/page.tsx
@@ -69,6 +69,9 @@ export default async function Page() {
           <li><strong className='text-white'>Lemon balm</strong> is often connected with gentle calm and relaxation.</li>
           <li><strong className='text-white'>Passionflower</strong> is often framed around relaxation and nervous-system support.</li>
         </ul>
+        <p className='mt-4 text-sm leading-6 text-white/60'>
+          Sleep-note nuance: these are often chosen for different reasons (sleep onset, tension reduction, nighttime calm), so matching the pattern is usually more helpful than rotating randomly.
+        </p>
       </section>
 
       <section className='grid gap-4'>


### PR DESCRIPTION
### Motivation
- Reduce template-like, generic copy on high-traffic `/top` discovery pages to improve perceived editorial quality and usefulness. 
- Provide small, route-specific interpretation and beginner guidance that helps readers match options to common patterns without making medical claims. 
- Keep changes surgical and safe for the static-export site: preserve data pipelines, route contracts, layout, and existing evidence-first tone.

### Description
- Edited eight discovery page components to add brief, route-specific editorial context and improve scanability: `app/top/focus/page.tsx`, `app/top/sleep/page.tsx`, `app/top/stress/page.tsx`, `app/top/top-3-herbs-for-anxiety/page.tsx`, `app/top/top-3-herbs-for-stress/page.tsx`, `app/top/top-3-natural-sleep-aids/page.tsx`, `app/top/best-supplements-for-fatigue/page.tsx`, and `app/top/best-herbs-for-cortisol/page.tsx`. 
- Added concise intros, compact “how approaches differ” or “beginner decision notes” lists, and short interpretation tips in “Fast answer” sections to reduce template tone and add practical context while keeping lists and short paragraphs for scanability. 
- Preserved all data/logic/ranking behavior, Evidence Snapshot and trust/safety framing, component styling and layout, and static-export compatibility. 
- Risk notes and confirmations: low risk content-only changes; no edits to `public/data`, generated workbook JSON, workbook source, or dependencies; routing/data fetchers and route contracts remain unchanged.

### Testing
- Ran `npm run check:fast` (lint + typecheck); the command completed successfully. 
- Ran `npm run check:ui` (lint + typecheck + static-export and route SEO validations); the command completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a107a4d003483239ebb91d1ae219dc3)