### PR TITLE
Frontend Pass: simplify oversized navigation card systems

### DIFF
--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -349,16 +349,16 @@ function GuidedDiscovery({ onSelect }: { onSelect: (query: string) => void }) {
         <Link href="/goals" className="w-fit text-sm font-bold text-brand-800 transition hover:text-brand-900">Browse goal guides →</Link>
       </div>
 
-      <div className="mt-3 grid gap-2.5 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="mt-3 grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
         {discoveryPaths.map(path => (
           <button
             key={path.label}
             type="button"
             onClick={() => onSelect(path.query)}
-            className="group min-h-20 rounded-[1.1rem] border border-brand-900/10 bg-white/80 p-3.5 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-brand-700/20 hover:bg-white sm:min-h-24"
+            className="group rounded-xl border border-brand-900/10 bg-white/90 px-3 py-2.5 text-left transition hover:border-brand-700/20 hover:bg-white"
           >
-            <span className="text-lg font-semibold tracking-tight text-ink transition group-hover:text-brand-800">{path.label}</span>
-            <span className="mt-2 block text-sm leading-6 text-[#46574d]">{path.description}</span>
+            <span className="text-sm font-semibold tracking-tight text-ink transition group-hover:text-brand-800">{path.label}</span>
+            <span className="mt-1 block text-xs leading-5 text-[#46574d]">{path.description}</span>
           </button>
         ))}
       </div>
@@ -368,7 +368,7 @@ function GuidedDiscovery({ onSelect }: { onSelect: (query: string) => void }) {
 
 function EmptySearchState({ onSelect, onReset }: { onSelect: (query: string) => void; onReset: () => void }) {
   return (
-    <section className="rounded-[1.5rem] border border-brand-900/10 bg-white/85 p-4.5 sm:p-7 shadow-[var(--shadow-card-calm)] sm:p-8">
+    <section className="rounded-[1.3rem] border border-brand-900/10 bg-white/85 p-4 sm:p-5 shadow-[var(--shadow-card-calm)]">
       <div className="max-w-2xl space-y-3">
         <p className="eyebrow-label">No matching profiles</p>
         <h2 className="compact-heading">Try a broader discovery path.</h2>
@@ -393,36 +393,36 @@ function EmptySearchState({ onSelect, onReset }: { onSelect: (query: string) => 
         ))}
       </div>
 
-      <div className="mt-5 grid gap-3 lg:grid-cols-3">
-        <div className="rounded-2xl border border-brand-900/10 bg-white/90 p-4">
+      <div className="mt-4 grid gap-2.5 lg:grid-cols-3">
+        <div className="rounded-xl border border-brand-900/10 bg-white/90 p-3">
           <p className="eyebrow-label">Related goals</p>
-          <ul className="mt-3 space-y-3">
+          <ul className="mt-2 space-y-2">
             {crossContentLinks.goals.map((item) => (
               <li key={item.href}>
                 <Link href={item.href} className="text-sm font-semibold text-brand-800 hover:text-brand-900">{item.label} →</Link>
-                <p className="mt-1 text-sm leading-6 text-[#5f6f66]">{item.description}</p>
+                <p className="mt-0.5 text-xs leading-5 text-[#5f6f66]">{item.description}</p>
               </li>
             ))}
           </ul>
         </div>
-        <div className="rounded-2xl border border-brand-900/10 bg-white/90 p-4">
+        <div className="rounded-xl border border-brand-900/10 bg-white/90 p-3">
           <p className="eyebrow-label">Related compare pages</p>
-          <ul className="mt-3 space-y-3">
+          <ul className="mt-2 space-y-2">
             {crossContentLinks.compare.map((item) => (
               <li key={item.href}>
                 <Link href={item.href} className="text-sm font-semibold text-brand-800 hover:text-brand-900">{item.label} →</Link>
-                <p className="mt-1 text-sm leading-6 text-[#5f6f66]">{item.description}</p>
+                <p className="mt-0.5 text-xs leading-5 text-[#5f6f66]">{item.description}</p>
               </li>
             ))}
           </ul>
         </div>
-        <div className="rounded-2xl border border-brand-900/10 bg-white/90 p-4">
+        <div className="rounded-xl border border-brand-900/10 bg-white/90 p-3">
           <p className="eyebrow-label">Beginner guidance</p>
-          <ul className="mt-3 space-y-3">
+          <ul className="mt-2 space-y-2">
             {crossContentLinks.learn.map((item) => (
               <li key={item.href}>
                 <Link href={item.href} className="text-sm font-semibold text-brand-800 hover:text-brand-900">{item.label} →</Link>
-                <p className="mt-1 text-sm leading-6 text-[#5f6f66]">{item.description}</p>
+                <p className="mt-0.5 text-xs leading-5 text-[#5f6f66]">{item.description}</p>
               </li>
             ))}
           </ul>
@@ -510,16 +510,16 @@ export default function SearchPage() {
                 Search herbs and compounds by name, goal, mechanism, evidence signal, or safety context. Start broad, then use light filters only when they help.
               </p>
 
-              <div className="grid gap-2 sm:grid-cols-2 sm:gap-2.5">
+              <div className="grid gap-2 sm:grid-cols-2">
                 {intentPrompts.map((intent) => (
                   <button
                     key={intent.label}
                     type="button"
                     onClick={() => setQuery(intent.query)}
-                    className="rounded-2xl border border-brand-900/10 bg-white/90 p-2.5 sm:p-3 text-left transition hover:border-brand-700/20 hover:bg-white"
+                    className="rounded-xl border border-brand-900/10 bg-white/90 px-3 py-2.5 text-left transition hover:border-brand-700/20 hover:bg-white"
                   >
                     <p className="text-sm font-semibold text-ink">{intent.label}</p>
-                    <p className="mt-1 text-sm leading-6 text-[#5f6f66]">{intent.helper}</p>
+                    <p className="mt-0.5 text-xs leading-5 text-[#5f6f66]">{intent.helper}</p>
                   </button>
                 ))}
               </div>

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -248,20 +248,22 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
             as='h2'
           />
 
-          <div className='grid gap-3 md:grid-cols-2 lg:grid-cols-4'>
+          <div className='rounded-2xl border border-brand-900/10 bg-white/90 p-3 sm:p-4'>
+            <div className='grid gap-2 sm:grid-cols-2 lg:grid-cols-4'>
             {ecosystemCards.map((card) => (
               <Link
                 key={card.href}
                 href={card.href}
-                className='group rounded-2xl border border-brand-900/10 bg-white/90 p-4 transition hover:border-brand-900/20 hover:bg-white'
+                className='group rounded-xl border border-brand-900/10 bg-white px-3 py-2.5 transition hover:border-brand-900/20 hover:bg-brand-50/40'
               >
-                <h3 className='text-base font-semibold tracking-tight text-ink'>{card.title}</h3>
-                <p className='mt-2 text-sm leading-6 text-muted'>{card.description}</p>
-                <div className='mt-3'>
-                  <ActionCue>Open path</ActionCue>
-                </div>
+                <h3 className='text-sm font-semibold tracking-tight text-ink'>{card.title}</h3>
+                <p className='mt-1 text-xs leading-5 text-muted'>{card.description}</p>
+                <span className='mt-2 inline-flex items-center text-xs font-semibold text-brand-700 transition group-hover:translate-x-0.5' aria-hidden='true'>
+                  Explore →
+                </span>
               </Link>
             ))}
+            </div>
           </div>
         </section>
 


### PR DESCRIPTION
### Motivation
- Address issue #1671 by reducing oversized, low-information stacked navigation cards to improve information density and mobile scan speed on discovery-focused pages.
- Preserve navigational clarity, trust/safety framing, and existing route contracts while shifting layouts toward denser editorial/reference-tool modules.

### Description
- Files changed: `components/homepage-v2.tsx` and `app/search/page.tsx`.
- Homepage: compressed the "Explore by practical context" ecosystem module into a compact bordered cluster with smaller card shells, tighter spacing, reduced typography scale, and inline `Explore →` cues to replace large stacked "Open path" blocks.
- Search page: tightened guided-discovery buttons, hero intent prompt cards, and empty-state related-link modules by reducing padding, shrinking type, and converting bulky cards into denser list-like tiles while preserving all discovery queries and links.
- Preserved behavior and static-export compatibility by making only UI/layout changes and keeping search logic, routes, and accessibility attributes intact.

### Testing
- Ran `npm run check:fast` and `npm run check:ui`, and both completed successfully with no lint/type/static-export or route-SEO validation failures.
- Risk notes: changes are localized UI density adjustments limited to two components and may cause minor spacing or text-wrap differences across breakpoints but do not change routes or functionality.
- Confirmation: no workbook files, no `public/data` artifacts, and no dependency (`package.json` / lockfile) changes were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1080e1e32c8323a784711e829dfc63)