### PR TITLE
SEO P1: fix main-page metadata

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 
 export const metadata: Metadata = {
-  title: 'About',
+  title: 'About The Hippie Scientist',
   description:
     'Learn what The Hippie Scientist is, what it covers, and how to use it responsibly.',
   alternates: {

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -35,7 +35,7 @@ const inferArticleStyle = (post: any) => {
 }
 
 export const metadata: Metadata = {
-  title: 'Research Notes | The Hippie Scientist',
+  title: 'Research Notes and Supplement Explainers',
   description: 'Editorial research notes, explainers, and scientific continuity for herbs and compounds.',
 }
 

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -4,7 +4,7 @@ import { getCompounds } from '@/lib/runtime-data'
 import { cleanSummary, formatDisplayLabel, isClean, list } from '@/lib/display-utils'
 
 export const metadata: Metadata = {
-  title: 'Compare Supplements and Compounds',
+  title: 'Compare Supplements, Herbs, and Compounds',
   description:
     'Compare herbs, supplements, and compounds by effects, evidence tiers, safety considerations, and decision-support factors.',
 }

--- a/app/compounds/page.tsx
+++ b/app/compounds/page.tsx
@@ -1,4 +1,24 @@
+import type { Metadata } from 'next'
 import { Suspense } from 'react'
+
+export const metadata: Metadata = {
+  title: 'Compound Profiles and Mechanism Guides',
+  description:
+    'Browse evidence-aware compound profiles with mechanisms, effects, safety considerations, and practical supplement context.',
+  alternates: { canonical: '/compounds' },
+  openGraph: {
+    title: 'Compound Profiles and Mechanism Guides',
+    description:
+      'Browse evidence-aware compound profiles with mechanisms, effects, safety considerations, and practical supplement context.',
+    url: '/compounds',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Compound Profiles and Mechanism Guides',
+    description:
+      'Browse evidence-aware compound profiles with mechanisms, effects, safety considerations, and practical supplement context.',
+  },
+}
 import { getCompounds } from '@/lib/runtime-data'
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 import CompoundsIndexClient from './CompoundsIndexClient'

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 
 export const metadata: Metadata = {
-  title: 'Contact',
+  title: 'Contact The Hippie Scientist',
   description:
     'Contact The Hippie Scientist for research feedback, corrections, and general questions.',
   alternates: {

--- a/app/disclaimer/page.tsx
+++ b/app/disclaimer/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 
 export const metadata: Metadata = {
-  title: 'Disclaimer',
+  title: 'Medical and Educational Disclaimer',
   description:
     'Important educational and medical disclaimer for The Hippie Scientist.',
   alternates: {

--- a/app/goals/page.tsx
+++ b/app/goals/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import { goals } from '@/data/goals'
 
 export const metadata: Metadata = {
-  title: 'Goal Decision Guides | The Hippie Scientist',
+  title: 'Supplement Goal Guides and Comparisons',
   description: 'Educational comparison pages for pain, inflammation, focus, and sleep support topics.',
 }
 

--- a/app/herbs/page.tsx
+++ b/app/herbs/page.tsx
@@ -5,7 +5,7 @@ import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 import HerbsIndexClient from './HerbsIndexClient'
 
 export const metadata: Metadata = {
-  title: 'Herbs | The Hippie Scientist',
+  title: 'Herb Profiles and Supplement Research',
   description: 'Browse evidence-aware herb profiles with mechanisms, safety context, traditional use, and practical supplement research.',
 }
 

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -1,4 +1,25 @@
+import type { Metadata } from 'next'
 import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: 'Learn Supplement Science and Safety Basics',
+  description:
+    'Read plain-English education on supplement science, evidence quality, safety context, and decision-making tradeoffs.',
+  alternates: { canonical: '/learn' },
+  openGraph: {
+    title: 'Learn Supplement Science and Safety Basics',
+    description:
+      'Read plain-English education on supplement science, evidence quality, safety context, and decision-making tradeoffs.',
+    url: '/learn',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Learn Supplement Science and Safety Basics',
+    description:
+      'Read plain-English education on supplement science, evidence quality, safety context, and decision-making tradeoffs.',
+  },
+}
+
 import { learnPosts } from './data'
 import EducationSupernodeGrid from '@/components/education/education-supernode-grid'
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,28 @@
+import type { Metadata } from 'next'
 import HomepageV2 from '@/components/homepage-v2'
 import { getCompoundSummaryIndex, getHerbSummaryIndex } from '@/lib/runtime-summary-indexes'
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
+
+export const metadata: Metadata = {
+  title: 'Herbs, Compounds, and Evidence-Based Supplement Guides',
+  description:
+    'Explore evidence-aware guides on herbs, compounds, stacks, and supplement decisions with mechanism, safety, and tradeoff context.',
+  alternates: {
+    canonical: '/',
+  },
+  openGraph: {
+    title: 'Herbs, Compounds, and Evidence-Based Supplement Guides',
+    description:
+      'Explore evidence-aware guides on herbs, compounds, stacks, and supplement decisions with mechanism, safety, and tradeoff context.',
+    url: '/',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Herbs, Compounds, and Evidence-Based Supplement Guides',
+    description:
+      'Explore evidence-aware guides on herbs, compounds, stacks, and supplement decisions with mechanism, safety, and tradeoff context.',
+  },
+}
 
 export default async function Page() {
   const [herbs, compounds] = await Promise.all([

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 
 export const metadata: Metadata = {
-  title: 'Privacy',
+  title: 'Privacy Policy',
   description:
     'Privacy information for The Hippie Scientist website.',
   alternates: {

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -5,7 +5,7 @@ import compoundsSummaryData from '@/public/data/compounds-summary.json'
 import SearchClient from './SearchClient'
 
 export const metadata: Metadata = {
-  title: 'Search Herbs and Compounds',
+  title: 'Search Herb and Compound Profiles',
   description: 'Search the herb and compound library with evidence-aware context, safety framing, and mechanism-oriented discovery.',
 }
 

--- a/app/stacks/page.tsx
+++ b/app/stacks/page.tsx
@@ -1,4 +1,25 @@
+import type { Metadata } from 'next'
 import Link from 'next/link'
+
+export const metadata: Metadata = {
+  title: 'Supplement Stack Guides by Goal',
+  description:
+    'Explore supplement stack examples by goal with compound roles, dosing patterns, timing, and safety-first tradeoff notes.',
+  alternates: { canonical: '/stacks' },
+  openGraph: {
+    title: 'Supplement Stack Guides by Goal',
+    description:
+      'Explore supplement stack examples by goal with compound roles, dosing patterns, timing, and safety-first tradeoff notes.',
+    url: '/stacks',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Supplement Stack Guides by Goal',
+    description:
+      'Explore supplement stack examples by goal with compound roles, dosing patterns, timing, and safety-first tradeoff notes.',
+  },
+}
+
 import stacks from '@/public/data/stacks.json'
 
 type StackItem = {


### PR DESCRIPTION
### Motivation
- Summary: Implement a surgical metadata pass to remove duplicate brand repetition, replace weak/generic titles with concise keyword-aware titles, and add missing meta/OG/Twitter fields where the existing Next metadata API already supports them. 
- Risk notes: Low risk change restricted to route-level `metadata` exports only, with no layout, runtime, workbook, or public-data pipeline changes. 
- Confirmation: No `workbook` or `public/data` artifacts were modified and no dependency files (`package.json` / `package-lock.json`) were changed. 

### Description
- Technical changes: added `export const metadata: Metadata = { ... }` blocks to pages that lacked explicit metadata, replaced repetitive brand-heavy titles with concise keyword-aware titles, and added `alternates`, `openGraph`, and `twitter` fields where appropriate while preserving existing route rendering. 
- Metadata improvements by route: `/` (`app/page.tsx`) — new unique title/description plus canonical, Open Graph and Twitter card; `/herbs` — replaced brand-repetitive title with a focused title; `/compounds` — added metadata with title/description and OG/Twitter/canonical; `/goals` — made title keyword-aware and concise; `/stacks` — added metadata with title/description and OG/Twitter/canonical; `/compare` — refined title to include herbs/supplements; `/learn` — added metadata with title/description and OG/Twitter/canonical; `/blog` — replaced generic title with a clearer editorial title; `/search` — clarified title for profile search; `/about`, `/privacy`, `/disclaimer`, `/contact` — updated titles to be unique and explicit (e.g., `Privacy Policy`, `Medical and Educational Disclaimer`, `Contact The Hippie Scientist`). 
- Scope note: only metadata fields were touched; no page layouts, runtime behavior, or data-generation scripts were modified. 

### Testing
- Verification: ran `npm run check:fast` which executed `eslint` and `tsc` and passed. 
- UI/route checks: ran `npm run check:ui` which executed linting, typecheck, `validate:static-export`, and `validate:route-seo` and all checks passed. 
- Result: both automated checks succeeded with no regressions detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1097c24ef883239d1137a9c071f9ef)