### PR TITLE
SEO P1: improve initial HTML visibility

### DIFF
--- a/app/compounds/page.tsx
+++ b/app/compounds/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import Link from 'next/link'
 import { Suspense } from 'react'
 
 export const metadata: Metadata = {
@@ -33,9 +34,39 @@ export default async function CompoundsPage() {
     }
   })
 
+  const quickLinks = compounds
+    .filter((compound: any) => compound?.slug && (compound?.displayName || compound?.name))
+    .slice(0, 8)
+    .map((compound: any) => ({
+      href: `/compounds/${compound.slug}`,
+      label: (compound.displayName || compound.name) as string,
+    }))
+
   return (
-    <Suspense fallback={null}>
-      <CompoundsIndexClient compounds={compounds} />
-    </Suspense>
+    <main className="mx-auto max-w-6xl space-y-8 px-4 py-8 sm:py-10">
+      <section className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+        <h1 className="text-3xl font-bold tracking-tight text-ink sm:text-5xl">Compound profiles and mechanism guides</h1>
+        <p className="mt-4 max-w-3xl text-base leading-7 text-muted sm:text-lg">
+          Browse evidence-aware compound pages with mechanism notes, safety framing, and practical context before refining with interactive filters.
+        </p>
+      </section>
+
+      {quickLinks.length > 0 ? (
+        <section className="rounded-2xl border border-brand-900/10 bg-white/90 p-5 shadow-sm">
+          <h2 className="text-xl font-semibold text-ink">Popular compound profiles</h2>
+          <ul className="mt-3 grid gap-2 text-sm leading-6 text-muted sm:grid-cols-2 lg:grid-cols-4">
+            {quickLinks.map((item) => (
+              <li key={item.href}>
+                <Link href={item.href} className="hover:text-brand-800 hover:underline">{item.label}</Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <Suspense fallback={null}>
+        <CompoundsIndexClient compounds={compounds} />
+      </Suspense>
+    </main>
   )
 }

--- a/app/herbs/page.tsx
+++ b/app/herbs/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import Link from 'next/link'
 import { Suspense } from 'react'
 import { getHerbSummaryIndex } from '@/lib/runtime-summary-indexes'
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
@@ -13,9 +14,36 @@ export default async function HerbsPage() {
   const allHerbs = await getHerbSummaryIndex()
   const herbs = allHerbs.filter((herb: any) => getRuntimeVisibility(herb).canRender)
 
+  const quickLinks = herbs
+    .filter((herb: any) => herb?.slug && herb?.displayName)
+    .slice(0, 8)
+    .map((herb: any) => ({ href: `/herbs/${herb.slug}`, label: herb.displayName as string }))
+
   return (
-    <Suspense fallback={null}>
-      <HerbsIndexClient herbs={herbs} />
-    </Suspense>
+    <main className="mx-auto max-w-6xl space-y-8 px-4 py-8 sm:py-10">
+      <section className="rounded-[2rem] border border-brand-900/10 bg-white/90 p-6 shadow-sm sm:p-8">
+        <h1 className="text-3xl font-bold tracking-tight text-ink sm:text-5xl">Herb profiles and supplement research</h1>
+        <p className="mt-4 max-w-3xl text-base leading-7 text-muted sm:text-lg">
+          Explore evidence-aware herb profiles with mechanisms, safety context, and practical research notes before moving into interactive filters.
+        </p>
+      </section>
+
+      {quickLinks.length > 0 ? (
+        <section className="rounded-2xl border border-brand-900/10 bg-white/90 p-5 shadow-sm">
+          <h2 className="text-xl font-semibold text-ink">Popular herb profiles</h2>
+          <ul className="mt-3 grid gap-2 text-sm leading-6 text-muted sm:grid-cols-2 lg:grid-cols-4">
+            {quickLinks.map((item) => (
+              <li key={item.href}>
+                <Link href={item.href} className="hover:text-brand-800 hover:underline">{item.label}</Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <Suspense fallback={null}>
+        <HerbsIndexClient herbs={herbs} />
+      </Suspense>
+    </main>
   )
 }


### PR DESCRIPTION
### Motivation
- The SEO audit flagged index routes that were overly dependent on client-side rendering and sometimes returned spinner-only initial HTML, reducing crawlability and visibility for low-JS environments.
- The goal is to ensure meaningful, server-rendered markup (heading, intro, descriptive copy, and crawlable links) is present prior to hydration without changing app architecture or runtime data pipelines.
- Changes should be minimal, additive, route-local, and preserve static export compatibility and existing interactivity.

### Description
- Added lightweight server-rendered shells to `app/herbs/page.tsx` and `app/compounds/page.tsx` that include a visible `<h1>`, a concise intro paragraph, and a short descriptive section to improve initial HTML semantics.
- Each shell now renders a crawlable list of up to 8 “Popular … profiles” links derived from the same runtime summaries the client index uses, so crawlers see internal links pre-hydration.
- Preserved the interactive behavior by keeping `HerbsIndexClient` and `CompoundsIndexClient` under `Suspense` so hydration and client-side filters remain unchanged.
- No other routes, workbook files, generated `public/data`, dependencies, or build/runtime data-generation scripts were modified.

### Testing
- Ran `npm run check:fast` which performs lint and type checks, and the command passed successfully.
- Ran `npm run check:ui` which runs lint, typecheck, `validate:static-export`, and `validate:route-seo`, and the command passed successfully including static-export and route-SEO validations.
- Manually inspected the affected routes to confirm server-rendered H1/intro/links are present for `/herbs` and `/compounds`, and confirmed `/blog`, `/compare`, `/search`, `/privacy`, and `/contact` already had sufficient initial HTML and were not changed.
- All changes are additive and route-local with low risk to runtime or static-export behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a109975e0148323a57d6b3d17ca98e3)