### PR TITLE
Refine metadata titles for key routes to avoid brand duplication and improve SEO

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 
 export const metadata: Metadata = {
-  title: 'About The Hippie Scientist',
+  title: { absolute: 'About The Hippie Scientist | Evidence-First Supplement Research' },
   description:
     'Learn what The Hippie Scientist is, what it covers, and how to use it responsibly.',
   alternates: {

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -35,7 +35,7 @@ const inferArticleStyle = (post: any) => {
 }
 
 export const metadata: Metadata = {
-  title: 'Research Notes and Supplement Explainers',
+  title: 'Research Notes & Herb Guides',
   description: 'Editorial research notes, explainers, and scientific continuity for herbs and compounds.',
 }
 

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -4,7 +4,7 @@ import { getCompounds } from '@/lib/runtime-data'
 import { cleanSummary, formatDisplayLabel, isClean, list } from '@/lib/display-utils'
 
 export const metadata: Metadata = {
-  title: 'Compare Supplements, Herbs, and Compounds',
+  title: 'Compare Herbs & Supplements Side by Side',
   description:
     'Compare herbs, supplements, and compounds by effects, evidence tiers, safety considerations, and decision-support factors.',
 }

--- a/app/compounds/page.tsx
+++ b/app/compounds/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import { Suspense } from 'react'
 
 export const metadata: Metadata = {
-  title: 'Compound Profiles and Mechanism Guides',
+  title: 'Compound & Nootropic Profiles',
   description:
     'Browse evidence-aware compound profiles with mechanisms, effects, safety considerations, and practical supplement context.',
   alternates: { canonical: '/compounds' },

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 
 export const metadata: Metadata = {
-  title: 'Contact The Hippie Scientist',
+  title: 'Contact',
   description:
     'Contact The Hippie Scientist for research feedback, corrections, and general questions.',
   alternates: {

--- a/app/disclaimer/page.tsx
+++ b/app/disclaimer/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 
 export const metadata: Metadata = {
-  title: 'Medical and Educational Disclaimer',
+  title: 'Medical Disclaimer',
   description:
     'Important educational and medical disclaimer for The Hippie Scientist.',
   alternates: {

--- a/app/goals/page.tsx
+++ b/app/goals/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link'
 import { goals } from '@/data/goals'
 
 export const metadata: Metadata = {
-  title: 'Supplement Goal Guides and Comparisons',
+  title: 'Supplement Goal Decision Guides',
   description: 'Educational comparison pages for pain, inflammation, focus, and sleep support topics.',
 }
 

--- a/app/herbs/page.tsx
+++ b/app/herbs/page.tsx
@@ -6,7 +6,7 @@ import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 import HerbsIndexClient from './HerbsIndexClient'
 
 export const metadata: Metadata = {
-  title: 'Herb Profiles and Supplement Research',
+  title: 'Herb Profiles & Research Library',
   description: 'Browse evidence-aware herb profiles with mechanisms, safety context, traditional use, and practical supplement research.',
 }
 

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 
 export const metadata: Metadata = {
-  title: 'Learn Supplement Science and Safety Basics',
+  title: 'Supplement Education Hub',
   description:
     'Read plain-English education on supplement science, evidence quality, safety context, and decision-making tradeoffs.',
   alternates: { canonical: '/learn' },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import { getCompoundSummaryIndex, getHerbSummaryIndex } from '@/lib/runtime-summ
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 
 export const metadata: Metadata = {
-  title: 'Herbs, Compounds, and Evidence-Based Supplement Guides',
+  title: { absolute: 'The Hippie Scientist – Evidence-Based Herb & Supplement Research' },
   description:
     'Explore evidence-aware guides on herbs, compounds, stacks, and supplement decisions with mechanism, safety, and tradeoff context.',
   alternates: {

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -5,7 +5,7 @@ import compoundsSummaryData from '@/public/data/compounds-summary.json'
 import SearchClient from './SearchClient'
 
 export const metadata: Metadata = {
-  title: 'Search Herb and Compound Profiles',
+  title: 'Search Herbs & Supplements',
   description: 'Search the herb and compound library with evidence-aware context, safety framing, and mechanism-oriented discovery.',
 }
 

--- a/app/stacks/page.tsx
+++ b/app/stacks/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 
 export const metadata: Metadata = {
-  title: 'Supplement Stack Guides by Goal',
+  title: 'Evidence-Based Supplement Stacks',
   description:
     'Explore supplement stack examples by goal with compound roles, dosing patterns, timing, and safety-first tradeoff notes.',
   alternates: { canonical: '/stacks' },


### PR DESCRIPTION
### Motivation
- Fix generic or duplicated site-brand titles produced by page-level metadata and the root `title.template`, and make each major route use a unique, keyword-rich title for SEO intent.
- Prevent page-level titles from redundantly including the site name when a global template already appends it, while allowing full-brand titles where explicitly required.

### Description
- Updated metadata `title` values for primary App Router index pages to the requested, keyword-rich strings for `/`, `/herbs`, `/compounds`, `/goals`, `/stacks`, `/compare`, `/learn`, `/search`, `/about`, `/blog`, `/disclaimer`, and `/contact`.
- Used `title.absolute` for the homepage (`app/page.tsx`) and the about page (`app/about/page.tsx`) to bypass the root `title.template` and preserve the exact full title strings without duplication.
- Kept descriptive-only titles on other pages so the root layout (`app/layout.tsx`) template appends `| The Hippie Scientist` automatically and avoids repeated brand tokens.
- Changes touch 12 App Router files (e.g., `app/page.tsx`, `app/herbs/page.tsx`, `app/compounds/page.tsx`, `app/goals/page.tsx`, `app/stacks/page.tsx`, `app/compare/page.tsx`, `app/learn/page.tsx`, `app/search/page.tsx`, `app/about/page.tsx`, `app/blog/page.tsx`, `app/disclaimer/page.tsx`, `app/contact/page.tsx`).

### Testing
- Ran the full site build with `npm run build`, which completed successfully and generated the static export.
- Site verification and data pipelines ran during build (semantic governance and data verification) and passed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10a20d0f8c83239d489c8cc545961f)