### PR TITLE
Add unique 120–160 char meta descriptions to 13 primary pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 export const metadata: Metadata = {
   title: { absolute: 'About The Hippie Scientist | Evidence-First Supplement Research' },
   description:
-    'Learn what The Hippie Scientist is, what it covers, and how to use it responsibly.',
+    'Learn how The Hippie Scientist approaches herb and supplement research — plain English, science-first, with honest disclaimers and evidence context.',
   alternates: {
     canonical: '/about',
   },

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -36,7 +36,7 @@ const inferArticleStyle = (post: any) => {
 
 export const metadata: Metadata = {
   title: 'Research Notes & Herb Guides',
-  description: 'Editorial research notes, explainers, and scientific continuity for herbs and compounds.',
+  description: '75+ evidence-aware research notes on herbs, compounds, mechanisms, safety, and preparation — organized by research style and topic.',
 }
 
 export default function BlogPage() {

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -6,7 +6,7 @@ import { cleanSummary, formatDisplayLabel, isClean, list } from '@/lib/display-u
 export const metadata: Metadata = {
   title: 'Compare Herbs & Supplements Side by Side',
   description:
-    'Compare herbs, supplements, and compounds by effects, evidence tiers, safety considerations, and decision-support factors.',
+    'Compare herbs and supplements side by side by evidence strength, mechanism, stimulation profile, safety, and dosing. Free research tool.',
 }
 
 

--- a/app/compounds/page.tsx
+++ b/app/compounds/page.tsx
@@ -5,7 +5,7 @@ import { Suspense } from 'react'
 export const metadata: Metadata = {
   title: 'Compound & Nootropic Profiles',
   description:
-    'Browse evidence-aware compound profiles with mechanisms, effects, safety considerations, and practical supplement context.',
+    'Explore 500+ supplement and compound profiles with mechanisms, evidence strength, safety notes, and dosing context. Research-first, hype-free.',
   alternates: { canonical: '/compounds' },
   openGraph: {
     title: 'Compound Profiles and Mechanism Guides',

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 export const metadata: Metadata = {
   title: 'Contact',
   description:
-    'Contact The Hippie Scientist for research feedback, corrections, and general questions.',
+    'Get in touch with The Hippie Scientist — submit corrections, feedback, partnership inquiries, or research questions for our evidence-focused site.',
   alternates: {
     canonical: '/contact',
   },

--- a/app/disclaimer/page.tsx
+++ b/app/disclaimer/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 export const metadata: Metadata = {
   title: 'Medical Disclaimer',
   description:
-    'Important educational and medical disclaimer for The Hippie Scientist.',
+    'The Hippie Scientist is an educational resource only. Nothing on this site is medical advice, diagnosis, or treatment. Always consult a professional.',
   alternates: {
     canonical: '/disclaimer',
   },

--- a/app/goals/page.tsx
+++ b/app/goals/page.tsx
@@ -4,7 +4,7 @@ import { goals } from '@/data/goals'
 
 export const metadata: Metadata = {
   title: 'Supplement Goal Decision Guides',
-  description: 'Educational comparison pages for pain, inflammation, focus, and sleep support topics.',
+  description: 'Start with your goal — sleep, focus, stress, inflammation, or pain — then compare herbs and compounds by evidence, safety, and tradeoffs.',
 }
 
 export default function GoalsPage() {

--- a/app/herbs/page.tsx
+++ b/app/herbs/page.tsx
@@ -7,7 +7,7 @@ import HerbsIndexClient from './HerbsIndexClient'
 
 export const metadata: Metadata = {
   title: 'Herb Profiles & Research Library',
-  description: 'Browse evidence-aware herb profiles with mechanisms, safety context, traditional use, and practical supplement research.',
+  description: 'Browse evidence-aware profiles for 100+ herbs — mechanisms, safety notes, active compounds, and research context in plain language.',
 }
 
 export default async function HerbsPage() {

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 export const metadata: Metadata = {
   title: 'Supplement Education Hub',
   description:
-    'Read plain-English education on supplement science, evidence quality, safety context, and decision-making tradeoffs.',
+    'No hype, no marketing. Learn how to read supplement claims, evaluate evidence, compare adaptogens, nootropics, and herbs, and build safer stacks.',
   alternates: { canonical: '/learn' },
   openGraph: {
     title: 'Learn Supplement Science and Safety Basics',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 export const metadata: Metadata = {
   title: { absolute: 'The Hippie Scientist – Evidence-Based Herb & Supplement Research' },
   description:
-    'Explore evidence-aware guides on herbs, compounds, stacks, and supplement decisions with mechanism, safety, and tradeoff context.',
+    'Research-backed profiles for herbs, nootropics, and compounds. Compare evidence, safety, and mechanisms — without the hype.',
   alternates: {
     canonical: '/',
   },

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 export const metadata: Metadata = {
   title: 'Privacy Policy',
   description:
-    'Privacy information for The Hippie Scientist website.',
+    'Privacy policy for The Hippie Scientist — how we handle data, cookies, and any affiliate links on this site, written in clear plain English.',
   alternates: {
     canonical: '/privacy',
   },

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -6,7 +6,7 @@ import SearchClient from './SearchClient'
 
 export const metadata: Metadata = {
   title: 'Search Herbs & Supplements',
-  description: 'Search the herb and compound library with evidence-aware context, safety framing, and mechanism-oriented discovery.',
+  description: 'Search 500+ herb and supplement profiles by name, compound, mechanism, or use case. Evidence-first research database with fast filtering.',
 }
 
 function getTopLinks() {

--- a/app/stacks/page.tsx
+++ b/app/stacks/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 export const metadata: Metadata = {
   title: 'Evidence-Based Supplement Stacks',
   description:
-    'Explore supplement stack examples by goal with compound roles, dosing patterns, timing, and safety-first tradeoff notes.',
+    'Browse goal-based supplement stacks for sleep, stress, cognition, performance, and fat loss — with dosing, timing, and safety context.',
   alternates: { canonical: '/stacks' },
   openGraph: {
     title: 'Supplement Stack Guides by Goal',


### PR DESCRIPTION
### Motivation
- Provide a unique, SEO-friendly `description` meta for each primary site route to improve search summaries and clarity. 
- Ensure every description is plain English, keyword-relevant, 120–160 characters long, and does not truncate.
- Apply the descriptions in a minimal, surgical way using the App Router `metadata` shape so runtime semantics are unchanged.

### Description
- Updated `metadata.description` in 13 App Router page files to the supplied copy for the routes: `/`, `/herbs`, `/compounds`, `/goals`, `/stacks`, `/compare`, `/learn`, `/about`, `/blog`, `/search`, `/privacy`, `/disclaimer`, and `/contact`.
- Adjusted wording where needed to guarantee each description is between 120–160 characters and remains plain-English and keyword-relevant.
- Made only metadata edits (no UI, data pipeline, or routing changes) to preserve the static export architecture and route contracts.

### Testing
- Ran a validation script that extracted all 13 `description` values and verified each is 120–160 characters and that there are no duplicates; the script reported `PASS`.
- Performed a full production build with `npm run -s build` which completed successfully and the project compiled without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10a448ec908323a349140b426c7fcb)