### PR TITLE
SEO P2: canonicalization and internal linking cleanup

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -19,7 +19,7 @@ export default function AboutPage() {
         </p>
 
         <h1 className='mt-2 text-4xl font-bold tracking-tight sm:text-5xl'>
-          What this site is for
+          About The Hippie Scientist
         </h1>
 
         <p className='mt-4 max-w-3xl text-base leading-7 text-white/75 sm:text-lg'>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -8,6 +8,10 @@ export const metadata: Metadata = {
   alternates: {
     canonical: '/contact',
   },
+  robots: {
+    index: false,
+    follow: true,
+  },
 }
 
 export default function ContactPage() {

--- a/app/disclaimer/page.tsx
+++ b/app/disclaimer/page.tsx
@@ -8,6 +8,10 @@ export const metadata: Metadata = {
   alternates: {
     canonical: '/disclaimer',
   },
+  robots: {
+    index: false,
+    follow: true,
+  },
 }
 
 export default function DisclaimerPage() {
@@ -19,7 +23,7 @@ export default function DisclaimerPage() {
         </p>
 
         <h1 className='mt-2 text-4xl font-bold tracking-tight sm:text-5xl'>
-          Educational use only
+          Educational &amp; Medical Disclaimer
         </h1>
 
         <p className='mt-4 max-w-3xl text-base leading-7 text-white/75 sm:text-lg'>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -114,6 +114,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
                     <Link href='/compounds' className='text-muted hover:text-ink transition'>Compounds</Link>
                     <Link href='/goals' className='text-muted hover:text-ink transition'>Goals</Link>
                     <Link href='/stacks' className='text-muted hover:text-ink transition'>Stacks</Link>
+                    <Link href='/compare' className='text-muted hover:text-ink transition'>Compare</Link>
+                    <Link href='/learn' className='text-muted hover:text-ink transition'>Learn</Link>
+                    <Link href='/search' className='text-muted hover:text-ink transition'>Search</Link>
                     <Link href='/blog' className='text-muted hover:text-ink transition'>Blog</Link>
                     <Link href='/about' className='text-muted hover:text-ink transition'>About</Link>
                   </div>

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -8,6 +8,10 @@ export const metadata: Metadata = {
   alternates: {
     canonical: '/privacy',
   },
+  robots: {
+    index: false,
+    follow: true,
+  },
 }
 
 export default function PrivacyPage() {

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -7,6 +7,13 @@ import SearchClient from './SearchClient'
 export const metadata: Metadata = {
   title: 'Search Herbs & Supplements',
   description: 'Search 500+ herb and supplement profiles by name, compound, mechanism, or use case. Evidence-first research database with fast filtering.',
+  alternates: {
+    canonical: '/search',
+  },
+  robots: {
+    index: false,
+    follow: true,
+  },
 }
 
 function getTopLinks() {

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,4 +1,4 @@
-const DEFAULT_SITE_URL = 'https://thehippiescientist.net'
+const DEFAULT_SITE_URL = 'https://www.thehippiescientist.net'
 const DEFAULT_SITE_NAME = 'The Hippie Scientist'
 const DEFAULT_DESCRIPTION_MAX_LENGTH = 155
 


### PR DESCRIPTION
### Motivation
- Align helper-generated canonical URLs with the production domain already used by the app and reduce SEO ambiguity around canonicals and utility pages.
- Improve internal footer navigation discoverability by surfacing Compare/Learn/Search without changing layout or styling.
- Strengthen weak H1s on lightweight utility pages to improve clarity and trust signals.
- Limit index coverage for utility/support pages that aren't priority landing content while keeping them accessible to users and crawlers via `follow: true`.

### Description
- Updated default canonical base in `lib/seo.ts` to `https://www.thehippiescientist.net` so helper-built canonical URLs match the app root domain.
- Added footer links `Compare`, `Learn`, and `Search` to the existing Explore column without altering layout or styling in `app/layout.tsx`.
- Strengthened H1s by updating the About page H1 to `About The Hippie Scientist` in `app/about/page.tsx` and the Disclaimer H1 to `Educational & Medical Disclaimer` in `app/disclaimer/page.tsx`.
- Added explicit route metadata `robots: { index: false, follow: true }` to utility pages: `/search` (`app/search/page.tsx`), `/privacy` (`app/privacy/page.tsx`), `/contact` (`app/contact/page.tsx`), and `/disclaimer` (`app/disclaimer/page.tsx`) so these pages remain accessible but are marked noindex.
- Files changed: `lib/seo.ts`, `app/layout.tsx`, `app/about/page.tsx`, `app/disclaimer/page.tsx`, `app/privacy/page.tsx`, `app/contact/page.tsx`, and `app/search/page.tsx`.

### Testing
- Ran `npm run check:fast` which performed `eslint` and `tsc --noEmit` and completed successfully.
- Ran `npm run check:ui` which ran lint, typecheck, `validate:static-export`, and `validate:route-seo`, and all checks passed.
- Verified in code that footer contains the added links, H1s were updated, canonical helper default matches production domain, and utility pages retain normal rendering and accessibility.

Notes: low risk changes limited to metadata, copy, and footer link additions; no route URLs, runtime data, workbook files, generated `public/data`, or dependency/lockfile changes were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10a7684cf08323aa823ea968f97fd4)