### PR TITLE
Fix runtime visibility for string `sitemap_included` and phrase-based `evidence_tier`

### DIFF
--- a/lib/runtime-visibility.ts
+++ b/lib/runtime-visibility.ts
@@ -21,6 +21,24 @@ function getIndexabilityStatus(record: any) {
     : ''
 }
 
+/** Coerce string booleans ("true"/"false") and real booleans to boolean. */
+function coerceBool(value: unknown): boolean | null {
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'string') {
+    if (value.toLowerCase() === 'true') return true
+    if (value.toLowerCase() === 'false') return false
+  }
+  return null
+}
+
+/**
+ * Match evidence tier strings that may be full phrases like
+ * "Strong Human Evidence" or bare keywords like "strong".
+ */
+function isEvidenceSupported(evidenceTier: string): boolean {
+  return /\b(strong|moderate|human|clinical|commercial_ready)\b/i.test(evidenceTier)
+}
+
 export function getRuntimeVisibility(record: any) {
   const exportDecision = text(record?.runtime_export_decision)
   const profileStatus = text(record?.profile_status)
@@ -28,8 +46,7 @@ export function getRuntimeVisibility(record: any) {
   const evidenceTier = text(record?.evidence_tier || record?.evidenceTier || record?.evidence_grade)
   const indexabilityStatus = getIndexabilityStatus(record)
 
-  const hidden =
-    /^hide$/i.test(exportDecision)
+  const hidden = /^hide$/i.test(exportDecision)
 
   const weak =
     /^minimal$/i.test(profileStatus) ||
@@ -38,7 +55,6 @@ export function getRuntimeVisibility(record: any) {
 
   if (indexabilityStatus) {
     const publish = indexabilityStatus === 'PUBLISH'
-
     return {
       canRender: !hidden,
       canIndex: !hidden && publish,
@@ -47,10 +63,11 @@ export function getRuntimeVisibility(record: any) {
     }
   }
 
-  // Respect pre-computed pipeline fields when present
-  const sitemapIncluded = record?.sitemap_included
+  // Handle string booleans from data pipeline (e.g. sitemap_included: "true")
+  const sitemapIncluded = coerceBool(record?.sitemap_included)
   const robotsField = text(record?.robots || '')
-  if (typeof sitemapIncluded === 'boolean' && robotsField) {
+
+  if (sitemapIncluded !== null && robotsField) {
     const publish = sitemapIncluded && /^index/i.test(robotsField)
     return {
       canRender: !hidden,
@@ -62,7 +79,7 @@ export function getRuntimeVisibility(record: any) {
 
   const indexableStatus = hasIndexableStatus(profileStatus)
   const indexableQuality = hasIndexableQuality(summaryQuality)
-  const evidenceSupported = /^(strong|moderate|human|clinical|commercial_ready)$/i.test(evidenceTier) || indexableStatus
+  const evidenceSupported = isEvidenceSupported(evidenceTier) || indexableStatus
 
   const strong =
     indexableStatus &&


### PR DESCRIPTION
### Motivation
- The data pipeline writes `sitemap_included` as string booleans like `"true"` which the old gate treated as non-boolean, causing many records to fall through to a heuristic that marked them `noindex`.
- `evidence_tier` values are often full phrases such as `"Strong Human Evidence"` which did not match the previous strict keyword check.
- This caused a large portion of herb pages to be excluded from sitemap/indexing despite valid robots directives and usable evidence metadata.

### Description
- Replaced `lib/runtime-visibility.ts` logic to coerce string booleans via a new `coerceBool` helper and to match phrase-based evidence tiers via `isEvidenceSupported`.
- Preserved existing decision precedence: explicit `indexability_status` → `sitemap_included` + `robots` → profile/evidence heuristic, and left static-export and route contracts untouched.
- Updated the sitemap publish gate to accept `sitemap_included` when provided as either native boolean or string `"true"`/`"false"` and to treat evidence phrases like `"Strong Human Evidence"` as supported.
- Kept monetization and feature gates consistent with prior weak/strong heuristics and `research-pending` handling via `hasResearchPending`.

### Testing
- Ran full production build with `npm run build` which executed the data pipeline and site build and completed successfully.
- Data pipeline steps including `npm run data:build`, `npm run data:validate`, and `node scripts/data/verify-generated-data.mjs` passed and `data:verify` confirmed regenerated artifacts matched approved outputs.
- Semantic governance checks and runtime manifest/sitemap generation passed during the build (route manifest, payload budgets, deterministic JSON, and semantic graph health).
- Next.js static build/export completed successfully and all verification scripts in `verify:build` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a127441fa5c8323ba2f993a5ce69dfa)