### PR TITLE
Harden Cloudflare Pages deploy workflow safety checks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
   deploy:
     if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    environment: production
     env:
       STATIC_OUTPUT_DIR: out
       DEPLOY_MODE: cloudflare-direct
@@ -63,11 +64,30 @@ jobs:
       - name: Verify build
         run: npm run verify:build
 
-      - name: Pre-deploy verification
+      - name: Validate deployment secrets
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_PAGES_PROJECT: ${{ secrets.CLOUDFLARE_PAGES_PROJECT }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
+            echo "❌ Missing required secret: CLOUDFLARE_API_TOKEN"
+            exit 1
+          fi
+
+          if [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
+            echo "❌ Missing required secret: CLOUDFLARE_ACCOUNT_ID"
+            exit 1
+          fi
+
+          if [ -z "${CLOUDFLARE_PAGES_PROJECT:-}" ]; then
+            echo "❌ Missing required secret: CLOUDFLARE_PAGES_PROJECT"
+            exit 1
+          fi
+
+      - name: Pre-deploy verification
         run: |
           set -euo pipefail
 
@@ -80,6 +100,9 @@ jobs:
             echo "❌ Missing required file: $STATIC_OUTPUT_DIR/index.html"
             exit 1
           fi
+
+          echo "ℹ️ Top-level deploy files:"
+          find "$STATIC_OUTPUT_DIR" -maxdepth 1 -type f -printf ' - %f\n' | sort
 
           if [ -f "public/_headers" ]; then
             echo "ℹ️ public/_headers exists; requiring $STATIC_OUTPUT_DIR/_headers"
@@ -99,21 +122,6 @@ jobs:
             fi
           else
             echo "ℹ️ public/_redirects not present; $STATIC_OUTPUT_DIR/_redirects not required"
-          fi
-
-          if [ -z "${CLOUDFLARE_API_TOKEN:-}" ]; then
-            echo "❌ Missing required secret: CLOUDFLARE_API_TOKEN"
-            exit 1
-          fi
-
-          if [ -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]; then
-            echo "❌ Missing required secret: CLOUDFLARE_ACCOUNT_ID"
-            exit 1
-          fi
-
-          if [ -z "${CLOUDFLARE_PAGES_PROJECT:-}" ]; then
-            echo "❌ Missing required secret: CLOUDFLARE_PAGES_PROJECT"
-            exit 1
           fi
 
       - name: Deployment summary
@@ -157,4 +165,4 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_PAGES_PROJECT: ${{ secrets.CLOUDFLARE_PAGES_PROJECT }}
-        run: npx wrangler pages deploy out --project-name "$CLOUDFLARE_PAGES_PROJECT"
+        run: npx --no-install wrangler pages deploy out --project-name "$CLOUDFLARE_PAGES_PROJECT"


### PR DESCRIPTION
### Motivation
- Reduce deployment risk for production Cloudflare Pages releases by enforcing required secrets and verifying static output before upload.  
- Make deploys reproducible and easier to debug by pinning the Wrangler CLI resolution to the lockfile and surfacing top-level deploy artifacts.

### Description
- Attach `environment: production` to the deploy job to allow environment-level protections and approvals for mainline releases.  
- Add a dedicated `Validate deployment secrets` step that fails fast if `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`, or `CLOUDFLARE_PAGES_PROJECT` are not present.  
- Enhance pre-deploy verification to ensure the `out/` directory and `out/index.html` exist and to print top-level files in `out/` for easier debugging.  
- Use `npx --no-install wrangler pages deploy ...` so the deploy uses the lockfile-pinned Wrangler version instead of resolving an unpinned global package.

### Testing
- Inspected and validated the workflow diff with `git diff` and reviewed the updated YAML with `sed`/`nl` to confirm steps and ordering, and those checks passed.  
- Verified the modified deploy job contains the new `environment` and secret-validation logic via `nl -ba .github/workflows/deploy.yml`, which showed the expected changes.  
- Confirmed the change is workflow-only and does not modify application runtime, build, or data-pipeline code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a127e1f3430832399c42afd41e75f1a)