### PR TITLE
Fix dependency validator scanning and re-exported generateStaticParams detection

### DIFF
--- a/docs/generated/route-inventory.md
+++ b/docs/generated/route-inventory.md
@@ -1,9 +1,9 @@
 # Route Inventory
 
-Generated: 2026-05-24T04:12:15.542Z
+Generated: 2026-05-24T04:42:33.952Z
 
 Total routes: 161
-Dynamic routes missing generateStaticParams: 1
+Dynamic routes missing generateStaticParams: 0
 
 | Route | Source file | Type | Dynamic params | generateStaticParams | Indexability | Notes |
 |---|---|---|---|---|---|---|
@@ -166,9 +166,9 @@ Dynamic routes missing generateStaticParams: 1
 | `/top/top-3-herbs-for-stress` | `app/top/top-3-herbs-for-stress/page.tsx` | static | - | n/a | indexable | - |
 | `/top/top-3-natural-sleep-aids` | `app/top/top-3-natural-sleep-aids/page.tsx` | static | - | n/a | indexable | - |
 | `/top/top-3-supplements-for-focus` | `app/top/top-3-supplements-for-focus/page.tsx` | static | - | n/a | indexable | - |
-| `/topics/[slug]` | `app/topics/[slug]/page.tsx` | dynamic | slug | no | indexable | - |
+| `/topics/[slug]` | `app/topics/[slug]/page.tsx` | dynamic | slug | yes | indexable | - |
 | `/topics` | `app/topics/page.tsx` | static | - | n/a | indexable | - |
 
 ## Dynamic routes missing generateStaticParams
 
-- `/topics/[slug]` (app/topics/[slug]/page.tsx)
+- None

--- a/scripts/ci/generate-route-inventory.mjs
+++ b/scripts/ci/generate-route-inventory.mjs
@@ -39,18 +39,55 @@ const toRoute = (file) => {
   return '/' + segs.join('/')
 }
 
-const hasGenerateStaticParams = (txt) => /export\s+(async\s+)?function\s+generateStaticParams/.test(txt) || /export\s+const\s+generateStaticParams\s*=/.test(txt)
+const hasLocalGenerateStaticParams = (txt) => /export\s+(async\s+)?function\s+generateStaticParams/.test(txt) || /export\s+const\s+generateStaticParams\s*=/.test(txt)
+
+const resolveImportTarget = (sourceFile, spec) => {
+  if (!spec) return null
+
+  let base = null
+  if (spec.startsWith('@/')) {
+    base = path.join(root, spec.slice(2))
+  } else if (spec.startsWith('.')) {
+    base = path.resolve(path.dirname(path.join(root, sourceFile)), spec)
+  } else {
+    return null
+  }
+
+  const candidates = [base, `${base}.ts`, `${base}.tsx`, `${base}.js`, `${base}.jsx`, path.join(base, 'index.ts'), path.join(base, 'index.tsx'), path.join(base, 'index.js'), path.join(base, 'index.jsx')]
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return path.relative(root, candidate).split(path.sep).join('/')
+    }
+  }
+
+  return null
+}
+
+const hasGenerateStaticParams = (file, seen = new Set()) => {
+  if (seen.has(file)) return false
+  seen.add(file)
+
+  const txt = fs.readFileSync(path.join(root, file), 'utf8')
+  if (hasLocalGenerateStaticParams(txt)) return true
+
+  const reExportMatch = txt.match(/export\s*\{[^}]*\bgenerateStaticParams\b[^}]*\}\s*from\s*['"]([^'"]+)['"]/)
+  if (!reExportMatch) return false
+
+  const target = resolveImportTarget(file, reExportMatch[1])
+  return target ? hasGenerateStaticParams(target, seen) : false
+}
+
 const isDynamicRoute = (route) => /\[[^\]]+\]/.test(route)
 
 const rows = pageFiles.map((file) => {
-  const txt = fs.readFileSync(path.join(root, file), 'utf8')
   const route = toRoute(file)
   const dynamic = isDynamicRoute(route)
   const params = [...route.matchAll(/\[([^\]]+)\]/g)].map((m) => m[1])
   const isPrivate = route.startsWith('/dashboard')
   const likelyIndexable = isPrivate ? 'excluded' : 'indexable'
   const notes = route.includes('(') ? 'route group path omitted' : (isPrivate ? 'internal/private' : '')
-  return { route, file, type: dynamic ? 'dynamic' : 'static', params, gsp: dynamic ? (hasGenerateStaticParams(txt) ? 'yes' : 'no') : 'n/a', likelyIndexable, notes }
+  return { route, file, type: dynamic ? 'dynamic' : 'static', params, gsp: dynamic ? (hasGenerateStaticParams(file) ? 'yes' : 'no') : 'n/a', likelyIndexable, notes }
 })
 
 const dynamicMissing = rows.filter((r) => r.type === 'dynamic' && r.gsp === 'no')

--- a/scripts/ci/validate-direct-dependencies.mjs
+++ b/scripts/ci/validate-direct-dependencies.mjs
@@ -1,32 +1,82 @@
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import { builtinModules } from 'node:module'
-import { execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
+
+const builtinSet = new Set([...builtinModules, ...builtinModules.map(m => `node:${m}`)])
+const optionalProbes = new Set(['exceljs'])
+const sourceRoots = ['app', 'components', 'src', 'lib', 'scripts', 'data', 'config']
+const sourceFiles = ['next.config.mjs', 'tailwind.config.ts', 'postcss.config.js']
+const ignored = ['node_modules', '.next', 'out', 'dist', 'coverage', '.git']
+
+const parseUndeclaredDependencies = ({ root, declared }) => {
+  const scanTargets = [
+    ...sourceRoots.filter((dir) => fs.existsSync(path.join(root, dir))),
+    ...sourceFiles.filter((file) => fs.existsSync(path.join(root, file)))
+  ]
+
+  if (scanTargets.length === 0) return []
+
+  const args = [
+    '-l',
+    'import\\s+|require\\(',
+    '--glob',
+    '*.{js,mjs,cjs,ts,tsx}',
+    ...ignored.flatMap((dir) => ['--glob', `!${dir}/**`]),
+    ...scanTargets
+  ]
+
+  const output = execFileSync('rg', args, { encoding: 'utf8', cwd: root, stdio: ['ignore', 'pipe', 'pipe'] })
+  const files = output.trim().split('\n').filter(Boolean).map((f) => f.replace(/^\.\//, ''))
+  const unresolved = []
+  const re = /from\s+['"]([^'"]+)['"]|require\(['"]([^'"]+)['"]\)/g
+
+  for (const rel of files) {
+    const txt = fs.readFileSync(path.join(root, rel), 'utf8')
+    let m
+    while ((m = re.exec(txt))) {
+      const spec = m[1] || m[2]
+      if (!spec || spec.startsWith('.') || spec.startsWith('@/') || spec.startsWith('/')) continue
+      const name = spec.startsWith('@') ? spec.split('/').slice(0, 2).join('/') : spec.split('/')[0]
+      if (builtinSet.has(spec) || builtinSet.has(name) || optionalProbes.has(name) || declared.has(name)) continue
+      unresolved.push(`${rel}: ${name}`)
+    }
+  }
+
+  return [...new Set(unresolved)]
+}
+
+const runSelfTest = () => {
+  const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'dep-validator-'))
+  fs.mkdirSync(path.join(fixtureRoot, 'app'), { recursive: true })
+  fs.mkdirSync(path.join(fixtureRoot, 'node_modules', 'badpkg'), { recursive: true })
+  fs.writeFileSync(path.join(fixtureRoot, 'package.json'), JSON.stringify({ dependencies: { react: '1.0.0' } }))
+
+  const missingImport = "const req = " + "requ" + "ire('missing-package')\n"
+  fs.writeFileSync(path.join(fixtureRoot, 'app', 'page.tsx'), "import React from 'react'\n" + missingImport)
+
+  const ignoredImport = "const dep = " + "requ" + "ire('another-missing')\n"
+  fs.writeFileSync(path.join(fixtureRoot, 'node_modules', 'badpkg', 'index.js'), ignoredImport)
+
+  const unresolved = parseUndeclaredDependencies({ root: fixtureRoot, declared: new Set(['react']) })
+  if (!unresolved.some((line) => line.includes('missing-package'))) throw new Error('Expected missing-package to be reported')
+  if (unresolved.some((line) => line.includes('another-missing'))) throw new Error('node_modules should be excluded from scan')
+  console.log('validate-direct-dependencies: self-test OK')
+}
+
+if (process.argv.includes('--self-test')) {
+  runSelfTest()
+  process.exit(0)
+}
 
 const root = process.cwd()
 const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'))
 const declared = new Set([...Object.keys(pkg.dependencies || {}), ...Object.keys(pkg.devDependencies || {})])
-const builtins = new Set([...builtinModules, ...builtinModules.map(m => `node:${m}`)])
-const optionalProbes = new Set(['exceljs'])
-const output = execSync("rg -l 'import |require\\(' --glob '*.{js,mjs,cjs,ts,tsx}' .", { encoding: 'utf8' })
-const files = output.trim().split('\n').filter(Boolean).map(f => f.replace(/^\.\//, ''))
-const unresolved = []
-const re = /from\s+['\"]([^'\"]+)['\"]|require\(['\"]([^'\"]+)['\"]\)/g
-
-for (const rel of files) {
-  const txt = fs.readFileSync(path.join(root, rel), 'utf8')
-  let m
-  while ((m = re.exec(txt))) {
-    const spec = m[1] || m[2]
-    if (!spec || spec.startsWith('.') || spec.startsWith('@/') || spec.startsWith('/')) continue
-    const name = spec.startsWith('@') ? spec.split('/').slice(0, 2).join('/') : spec.split('/')[0]
-    if (builtins.has(spec) || builtins.has(name) || optionalProbes.has(name) || declared.has(name)) continue
-    unresolved.push(`${rel}: ${name}`)
-  }
-}
+const unresolved = parseUndeclaredDependencies({ root, declared })
 
 if (unresolved.length) {
-  console.error('Undeclared direct dependencies:\n' + [...new Set(unresolved)].join('\n'))
+  console.error('Undeclared direct dependencies:\n' + unresolved.join('\n'))
   process.exit(1)
 }
 


### PR DESCRIPTION
### Motivation
- Remove a lint-triggering, shell-quoted ripgrep invocation and stop scanning installed packages so the direct-dependency validator reports only project source. 
- Ensure route inventory recognizes `generateStaticParams` when it is re-exported from another file so dynamic routes aren't falsely reported as missing params. 
- Keep changes minimal and surgical to CI scripts under `scripts/ci` and regenerate the route inventory artifact only.

### Description
- Replaced the shell-quoted `execSync` ripgrep call with an `execFileSync('rg', args)` invocation that uses explicit argument arrays and explicit `--glob` excludes for `node_modules`, `.next`, `out`, `dist`, `coverage`, and `.git` in `scripts/ci/validate-direct-dependencies.mjs`. 
- Restricted the dependency scan to a controlled set of source roots/files (`app`, `components`, `src`, `lib`, `scripts`, `data`, `config`, plus `next.config.mjs`, `tailwind.config.ts`, `postcss.config.js`) and added a `--self-test` fixture to prevent regressions. 
- Updated `scripts/ci/generate-route-inventory.mjs` to detect `generateStaticParams` when re-exported (handles `export { ... generateStaticParams } from '...'` patterns) and to resolve `@/` and relative targets into actual files when present. 
- Regenerated `docs/generated/route-inventory.md` to reflect the fix (for example, `/topics/[slug]` now shows `generateStaticParams: yes`). 

### Testing
- Ran `npm run lint` and it passed with no ESLint rules disabled. (Success) 
- Ran `npm run validate:direct-dependencies` and it now reports only project source; transitive packages under `node_modules` are no longer scanned. (Success) 
- Ran `node scripts/ci/validate-direct-dependencies.mjs --self-test` to ensure the validator catches a real missing import and ignores `node_modules`. (Success) 
- Ran `npm run routes:inventory` which regenerated `docs/generated/route-inventory.md` and reports zero dynamic routes missing `generateStaticParams` (e.g. `/topics/[slug]` marked `yes`). (Success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1281297f708323a437962b8193e45e)