### PR TITLE
Improve accessibility landmarks, focus, and link semantics

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -123,8 +123,8 @@ body {
   }
 
   :where(a, button, summary, input, textarea, select):focus-visible {
-    outline: 2px solid rgba(53, 143, 82, 0.72);
-    outline-offset: 3px;
+    outline: 2px solid #1d4a2f;
+    outline-offset: 4px;
   }
 
   strong {
@@ -142,7 +142,7 @@ body {
   input,
   textarea,
   select {
-    @apply focus:outline-none focus:ring-4;
+    @apply focus:outline-none focus-visible:ring-4;
     --tw-ring-color: var(--ring-brand);
   }
 
@@ -157,6 +157,17 @@ body {
 
   summary::-webkit-details-marker {
     display: none;
+  }
+
+  summary::after {
+    content: 'Open';
+    margin-left: 0.5rem;
+    font-size: 0.8em;
+    color: var(--text-muted);
+  }
+
+  details[open] summary::after {
+    content: 'Close';
   }
 
   details > * + * {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -71,6 +71,8 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationJsonLd) }}
         />
 
+        <a href='#main-content' className='sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-ink focus:shadow-lg'>Skip to main content</a>
+
         <div className='min-h-screen bg-background text-ink'>
           <header className='sticky top-0 z-50 border-b border-brand-900/10 bg-white/[0.88] shadow-[0_1px_0_rgba(17,24,39,0.02)] backdrop-blur-xl supports-[backdrop-filter]:bg-white/[0.78]'>
             <div className='container-page flex min-h-[72px] items-center justify-between gap-6 py-3'>
@@ -87,9 +89,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             </div>
           </header>
 
-          <div className='pb-[calc(env(safe-area-inset-bottom)+4rem)] md:pb-8'>
+          <main id='main-content' className='pb-[calc(env(safe-area-inset-bottom)+4rem)] md:pb-8'>
             {children}
-          </div>
+          </main>
 
           <footer className='mt-8 border-t border-neutral-200 bg-neutral-50 sm:mt-12'>
             <div className='container-page py-8 sm:py-12'>
@@ -107,7 +109,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
                 </div>
 
                 <div className='space-y-3'>
-                  <p className='font-semibold text-ink'>Explore</p>
+                  <h2 className='font-semibold text-ink'>Explore</h2>
 
                   <div className='flex flex-col gap-2 text-sm'>
                     <Link href='/herbs' className='text-muted hover:text-ink transition'>Herbs</Link>
@@ -123,7 +125,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
                 </div>
 
                 <div className='space-y-3'>
-                  <p className='font-semibold text-ink'>Legal & Transparency</p>
+                  <h2 className='font-semibold text-ink'>Legal & Transparency</h2>
 
                   <div className='flex flex-col gap-2 text-sm'>
                     <Link href='/privacy' className='text-muted hover:text-ink transition'>Privacy Policy</Link>
@@ -133,7 +135,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
                 </div>
               </div>
 
-              <div className='mt-7 space-y-2.5 border-t border-neutral-200 pt-5 sm:mt-10 sm:pt-6'>
+              <section aria-label='Affiliate disclosure' className='mt-7 space-y-2.5 border-t border-neutral-200 pt-5 sm:mt-10 sm:pt-6'>
                 <p className='text-xs leading-6 text-muted'>
                   This site contains affiliate links. We may earn a commission on qualifying purchases at no cost to you.
                 </p>
@@ -141,7 +143,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
                 <p className='text-sm text-muted'>
                   © 2026 The Hippie Scientist
                 </p>
-              </div>
+              </section>
             </div>
           </footer>
 

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,12 +1,12 @@
 export default function Loading() {
   return (
-    <main className='min-h-screen bg-stone-950 px-6 py-16 text-stone-100'>
+    <main role='status' aria-live='polite' aria-busy='true' className='min-h-screen bg-stone-950 px-6 py-16 text-stone-100'>
       <div className='mx-auto max-w-5xl space-y-8'>
         <section className='rounded-3xl border border-white/10 bg-white/[0.03] p-6 sm:p-8'>
-          <div className='h-4 w-28 animate-pulse rounded-full bg-white/10' />
-          <div className='mt-4 h-10 w-72 animate-pulse rounded-2xl bg-white/10 sm:w-96' />
-          <div className='mt-4 h-4 w-full max-w-2xl animate-pulse rounded-full bg-white/10' />
-          <div className='mt-3 h-4 w-full max-w-xl animate-pulse rounded-full bg-white/10' />
+          <div aria-hidden='true' className='h-4 w-28 animate-pulse rounded-full bg-white/10' />
+          <div aria-hidden='true' className='mt-4 h-10 w-72 animate-pulse rounded-2xl bg-white/10 sm:w-96' />
+          <div aria-hidden='true' className='mt-4 h-4 w-full max-w-2xl animate-pulse rounded-full bg-white/10' />
+          <div aria-hidden='true' className='mt-3 h-4 w-full max-w-xl animate-pulse rounded-full bg-white/10' />
 
           <p className='mt-6 text-sm tracking-wide text-stone-400'>
             Loading evidence-driven research…
@@ -17,7 +17,7 @@ export default function Loading() {
           {Array.from({ length: 6 }).map((_, index) => (
             <div
               key={index}
-              className='rounded-3xl border border-white/10 bg-white/[0.03] p-6'
+              aria-hidden='true' className='rounded-3xl border border-white/10 bg-white/[0.03] p-6'
             >
               <div className='h-3 w-24 animate-pulse rounded-full bg-white/10' />
               <div className='mt-4 h-7 w-2/3 animate-pulse rounded-2xl bg-white/10' />

--- a/components/homepage-v2.tsx
+++ b/components/homepage-v2.tsx
@@ -140,9 +140,9 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
       <div className='mx-auto max-w-6xl space-y-6 px-4 pb-6 pt-7 sm:px-6 sm:space-y-8 sm:pb-8 sm:pt-10 lg:px-8'>
         <section className='rounded-[2rem] border border-brand-900/10 bg-white/90 px-4 py-5 shadow-sm sm:px-7 sm:py-8 lg:py-10'>
           <div className='mx-auto flex max-w-4xl flex-col items-center text-center'>
-            <div className='mb-4 inline-flex text-xs font-semibold uppercase tracking-[0.2em] text-brand-700'>
+            <p role='doc-subtitle' className='mb-4 inline-flex text-xs font-semibold uppercase tracking-[0.2em] text-brand-700'>
               Evidence-aware botanical research
-            </div>
+            </p>
 
             <h1 className='font-display text-[2.65rem] font-semibold leading-[0.96] tracking-[-0.055em] text-ink sm:text-6xl md:text-7xl'>
               <span className='block'>The Hippie Scientist</span>
@@ -185,8 +185,8 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
               as='h2'
             />
             <div className='flex flex-wrap gap-3 text-sm font-semibold'>
-              <Link href='/herbs' className='text-brand-700 transition hover:text-brand-800'>Herb library →</Link>
-              <Link href='/compounds' className='text-brand-700 transition hover:text-brand-800'>Compound library →</Link>
+              <Link href='/herbs' className='text-brand-700 transition hover:text-brand-800'>Herb library <span aria-hidden='true'>→</span></Link>
+              <Link href='/compounds' className='text-brand-700 transition hover:text-brand-800'>Compound library <span aria-hidden='true'>→</span></Link>
             </div>
           </div>
 
@@ -195,7 +195,7 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
               <Link
                 key={item.href}
                 href={item.href}
-                className='group rounded-2xl border border-brand-900/10 bg-white/90 p-3 transition hover:border-brand-900/20 hover:bg-white'
+                aria-label={`View ${item.meta} for ${item.title}`} className='group rounded-2xl border border-brand-900/10 bg-white/90 p-3 transition hover:border-brand-900/20 hover:bg-white'
               >
                 <div className='relative'>
                   <span className='inline-flex text-xs font-semibold uppercase tracking-[0.16em] text-brand-700'>
@@ -231,8 +231,8 @@ export default function HomepageV2({ featuredHerbs = [], featuredCompounds = [] 
           >
             <h3 className='text-sm font-semibold tracking-tight text-ink'>{goalsBridge.title}</h3>
             <p className='mt-1 text-sm leading-5 text-muted'>{goalsBridge.description}</p>
-            <span className='mt-2 inline-flex items-center text-sm font-semibold text-brand-700 transition group-hover:translate-x-0.5' aria-hidden='true'>
-              Open goals guides →
+            <span className='mt-2 inline-flex items-center text-sm font-semibold text-brand-700 transition group-hover:translate-x-0.5'>
+              Open goals guides <span aria-hidden='true'>→</span>
             </span>
           </Link>
         </section>


### PR DESCRIPTION
### Motivation
- Address multiple accessibility issues discovered in an audit to provide clear landmarks, keyboard bypass, and better assistive-tech semantics across the site.
- Make minimal, surgical changes that preserve route contracts and static-export architecture while improving focus styling and disclosure affordances.

### Description
- Added a skip link and wrapped page content in a semantic `<main id="main-content">` in `app/layout.tsx`, and converted footer label rows into headings and a labeled affiliate `section` to improve document structure.
- Enhanced loading UX in `app/loading.tsx` by adding `role="status"`, `aria-live="polite"`, `aria-busy="true"` and marking decorative skeleton elements `aria-hidden` to avoid noisy AT output.
- Fixed homepage CTAs in `components/homepage-v2.tsx` by promoting the eyebrow to a semantic subtitle, hiding decorative arrows with `aria-hidden`, restoring visible CTA text for the goals link, and adding contextual `aria-label` values for featured profile links.
- Tightened focus and disclosure CSS in `app/globals.css` by switching to `focus-visible` ring utilities, increasing focus outline contrast/offset, and restoring open/close text via `summary::after` to replace the removed native marker.

### Testing
- Ran the full production build and verification pipeline via `npm run build`, which includes `npm run validate:workbook-source`, `npm run data:build`, `npm run data:validate`, Next.js production build/export, and post-build verification scripts, and the build completed successfully.
- Data validations and semantic governance checks ran as part of the build (`data` generation, `semantic:governance`, and related checks) and passed during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12833882588323b489870fdef58e99)