### PR TITLE
Map affiliate workbook fields into runtime and render conditional sourcing CTA

### DIFF
--- a/config/runtime-compound-fields.mjs
+++ b/config/runtime-compound-fields.mjs
@@ -107,6 +107,8 @@ export const COMPOUND_RUNTIME_FIELDS = [
 
   // Affiliate/runtime product display
   'affiliate_ready',
+  'affiliate_url',
+  'affiliate_label',
   'affiliate_query',
   'default_product_type',
   'preferred_vendor_url',

--- a/config/runtime-herb-fields.mjs
+++ b/config/runtime-herb-fields.mjs
@@ -101,6 +101,8 @@ export const HERB_RUNTIME_FIELDS = [
 
   // Affiliate/runtime product display
   'affiliate_ready',
+  'affiliate_url',
+  'affiliate_label',
   'affiliate_query',
   'default_product_type',
   'preferred_vendor_url',

--- a/scripts/data/build-runtime-from-workbook.mjs
+++ b/scripts/data/build-runtime-from-workbook.mjs
@@ -235,7 +235,9 @@ function visibility(base, type) {
 function affiliate(base) {
   return {
     ...base,
-    affiliate_ready: Boolean(base.affiliate_ready),
+    affiliate_ready: bool(base.affiliate_ready),
+    affiliate_url: clean(base.affiliate_url),
+    affiliate_label: clean(base.affiliate_label) || 'Check sourcing options',
   }
 }
 
@@ -291,6 +293,8 @@ function profile(row, type, taxonomy) {
     conditions: firstList(row, ['conditions', 'best_for', 'best for']),
     tags: firstList(row, ['tags']), keywords: firstList(row, ['keywords']),
     affiliate_ready: bool(first(row, ['affiliate_ready', 'affiliate ready'])),
+    affiliate_url: clean(first(row, ['affiliate_url', 'affiliate url'])),
+    affiliate_label: clean(first(row, ['affiliate_label', 'affiliate label'])) || 'Check sourcing options',
     affiliate_query: clean(first(row, ['affiliate_query', 'affiliate query'])),
     default_product_type: clean(first(row, ['default_product_type', 'default product type'])),
     buying_criteria: firstList(row, ['buying_criteria', 'buying criteria']),

--- a/src/components/evidence-aware-cta.tsx
+++ b/src/components/evidence-aware-cta.tsx
@@ -1,4 +1,5 @@
 import { buildDecisionVisualProfile } from '@/lib/decision-visuals'
+import { getAffiliateSourcingContext } from '@/lib/monetization-context'
 
 type EvidenceAwareCTAProps = {
   title?: string
@@ -46,6 +47,8 @@ export default function EvidenceAwareCTA({
   record,
 }: EvidenceAwareCTAProps) {
   const visuals = buildDecisionVisualProfile(record || {})
+  const affiliate = getAffiliateSourcingContext(record || {})
+  const showAffiliateButton = affiliate.affiliateReady && affiliate.affiliateUrl
   const recommendationCards = [
     {
       label: 'Formulation Notes',
@@ -79,6 +82,29 @@ export default function EvidenceAwareCTA({
         <p className="compact-copy">
           {description}
         </p>
+      
+
+      {showAffiliateButton ? (
+        <div className="rounded-3xl border border-brand-900/10 bg-white/80 p-4 shadow-sm">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="max-w-2xl">
+              <p className="eyebrow-label">Optional sourcing link</p>
+              <p className="mt-1 text-sm leading-6 text-[#46574d]">
+                This link is provided for sourcing review only. Compare labels, ingredient form,
+                serving context, and seller transparency before considering any product.
+              </p>
+            </div>
+            <a
+              href={affiliate.affiliateUrl}
+              target="_blank"
+              rel="nofollow sponsored noopener noreferrer"
+              className="inline-flex items-center justify-center rounded-full border border-brand-900/15 bg-brand-950 px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:-translate-y-0.5 hover:bg-brand-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-700"
+            >
+              {affiliate.affiliateLabel}
+            </a>
+          </div>
+        </div>
+      ) : null}
       </div>
 
       <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">

--- a/src/lib/monetization-context.ts
+++ b/src/lib/monetization-context.ts
@@ -7,8 +7,20 @@ export type MonetizationReadiness = {
   cautions: string[]
 }
 
+export type AffiliateSourcingContext = {
+  affiliateReady: boolean
+  affiliateUrl: string
+  affiliateLabel: string
+}
+
 function normalize(value: unknown) {
   return text(value).toLowerCase()
+}
+
+function booleanish(value: unknown) {
+  if (typeof value === 'boolean') return value
+  const normalized = normalize(value)
+  return ['1', 'true', 'yes', 'y'].includes(normalized)
 }
 
 function evidenceLevel(record: any) {
@@ -94,4 +106,12 @@ export function buildSourcingNotes(record: any) {
     'Prefer standardization details when relevant',
     'Avoid products relying on exaggerated benefit claims',
   ]
+}
+
+export function getAffiliateSourcingContext(record: any): AffiliateSourcingContext {
+  return {
+    affiliateReady: booleanish(record?.affiliate_ready || record?.affiliateReady),
+    affiliateUrl: text(record?.affiliate_url || record?.affiliateUrl),
+    affiliateLabel: text(record?.affiliate_label || record?.affiliateLabel) || 'Check sourcing options',
+  }
 }


### PR DESCRIPTION
### Motivation
- Surface newly added workbook affiliate fields in the runtime JSON so the frontend can render deterministic sourcing UI. 
- Provide a normalized, typed affiliate sourcing context for UI code to consume without leaking raw workbook values. 
- Keep affiliate CTA conservative and educational by gating outbound links on readiness + a valid URL. 

### Description
- `scripts/data/build-runtime-from-workbook.mjs`: read and normalize `affiliate_url` and `affiliate_label` from the workbook, add them to the `affiliate(base)` pass, and include them in the `profile(...)` output so runtime JSON contains `affiliate_ready`, `affiliate_url`, and `affiliate_label` with sane defaults. 
- `config/runtime-herb-fields.mjs` and `config/runtime-compound-fields.mjs`: add `affiliate_url` and `affiliate_label` to the runtime-safe export field lists. 
- `src/lib/monetization-context.ts`: add `AffiliateSourcingContext` type, a `booleanish` helper, and `getAffiliateSourcingContext(record)` to expose normalized `affiliateReady`, `affiliateUrl`, and `affiliateLabel` to UI consumers. 
- `src/components/evidence-aware-cta.tsx`: consume `getAffiliateSourcingContext`, compute `showAffiliateButton` when `affiliateReady` and `affiliateUrl` are present, and render a conservative “Optional sourcing link” block with proper `rel` attributes and label fallback. 

### Testing
- Ran the workbook/data pipeline with `npm run data:build` and structural validation; the data pipeline completed and regenerated `public/data` artifacts successfully. 
- Ran `npm run check:data` and semantic governance checks; they passed. 
- Ran type checking with `npm run typecheck`; it passed. 
- Built the site with `npm run build`; the Next.js production build completed successfully. 
- Inspected generated runtime records with `node -e "const h=require('./public/data/herbs.json'); console.log(h.find(x=>x.affiliate_ready && x.affiliate_url))"`; this returned `undefined` with the current workbook meaning no herb in the workbook currently has both `affiliate_ready: true` and a populated `affiliate_url` (the fields are present and deterministically emitted when set).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14802bd19083238a715c118d7941f7)