### PR TITLE
fix: enforce strict noImplicitAny and remove private webpack import

### DIFF
--- a/app/pathways/pathway-hub.tsx
+++ b/app/pathways/pathway-hub.tsx
@@ -145,8 +145,14 @@ function RecordCard({ record, href, type }: { record: any; href: string; type: '
   )
 }
 
+
+function getPathwayConfig(pathway: PathwaySlug): PathwayConfig {
+  const normalizedPathway = normalizePathway(pathway)
+  return configs[normalizedPathway as keyof typeof configs] ?? configs.gaba
+}
+
 export function generatePathwayMetadata(pathway: PathwaySlug): Metadata {
-  const config = configs[pathway]
+  const config = getPathwayConfig(pathway)
   const meta = buildMeta({
     title: `${config.title} | The Hippie Scientist`,
     description: config.summary,
@@ -168,8 +174,7 @@ export function generatePathwayMetadata(pathway: PathwaySlug): Metadata {
 }
 
 export async function PathwayHub({ pathway }: { pathway: PathwaySlug }) {
-  const normalizedPathway = normalizePathway(pathway)
-  const config = configs[normalizedPathway as keyof typeof configs]
+  const config = getPathwayConfig(pathway)
   const [herbs, compounds] = await Promise.all([getHerbs(), getCompounds()])
 
   const relatedHerbs = getRelatedPathwayRecords(herbs, pathway)

--- a/lib/decision-primitives.ts
+++ b/lib/decision-primitives.ts
@@ -41,7 +41,7 @@ export const decisionMetricShellClass =
 export const decisionMetadataClusterClass =
   'flex flex-wrap items-center gap-2.5 sm:gap-3'
 
-function compactText(value?: unknown) {
+function compactText(value?: unknown): string {
   if (value == null) return ''
   if (Array.isArray(value)) return value.map(compactText).filter(Boolean).join(' ')
   if (typeof value === 'object') return Object.values(value as Record<string, unknown>).map(compactText).filter(Boolean).join(' ')

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,12 +1,10 @@
-import webpack from 'next/dist/compiled/webpack/webpack-lib.js'
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   poweredByHeader: false,
   reactStrictMode: true,
   output: 'export',
   trailingSlash: true,
-  webpack: (config) => {
+  webpack: (config, { webpack }) => {
     const buildDate = new Date().toISOString().split('T')[0]
     const buildTime = new Date().toISOString()
     const commitHash = process.env.COMMIT_HASH || 'unknown'

--- a/src/components/explore/ContinuityMapSection.tsx
+++ b/src/components/explore/ContinuityMapSection.tsx
@@ -1,6 +1,12 @@
 import { clampScore } from '@/lib/runtime-render-guards'
 
-function buildContinuityMap(source: any, candidates: any[]) {
+type ContinuityMap = {
+  cluster: string
+  continuity: number
+  related: any[]
+}
+
+function buildContinuityMap(source: any, candidates: any[]): ContinuityMap[] {
   const baseClusters = Array.isArray(source?.clusters)
     ? source.clusters.slice(0, 4)
     : []

--- a/src/lib/decision-clarity.ts
+++ b/src/lib/decision-clarity.ts
@@ -508,7 +508,7 @@ function inferNextBestSteps(record: any, entityType: EntityType, relatedRecords:
     .map((step) => ({
       ...step,
       label: cleanEditorialText(step.label),
-      note: cleanEditorialText(step.note),
+      note: cleanEditorialText('note' in step ? step.note : ""),
     }))
     .filter((step) => isRenderableText(step.label))
     .slice(0, 4)
@@ -547,7 +547,7 @@ function cleanModel(model: DecisionClarityModel): DecisionClarityModel {
       .map((step) => ({
         ...step,
         label: cleanEditorialText(step.label),
-        note: cleanEditorialText(step.note),
+        note: cleanEditorialText('note' in step ? step.note : ""),
       }))
       .filter((step) => isRenderableText(step.label))
       .slice(0, 4),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "strict": true,
-    "noImplicitAny": false,
     "skipLibCheck": true,
     "allowJs": true,
     "noEmit": true,


### PR DESCRIPTION
### Motivation
- Ensure TypeScript `strict` truly enforces no-implicit-any checks by removing the undermining `noImplicitAny: false` setting (BUG-07).
- Remove a private Next.js internal webpack import and use the official `webpack` object passed into the Next config callback to avoid relying on internals (BUG-09) while preserving static-export behavior.

### Description
- Removed `"noImplicitAny": false` from `tsconfig.json` so `strict: true` fully applies to the codebase.
- Reworked `next.config.mjs` to stop importing `next/dist/compiled/...` and instead use the `webpack` argument provided by Next’s config callback while preserving `DefinePlugin` usage and `output: 'export'`/`trailingSlash: true` settings.
- Fixed TypeScript errors surfaced by stricter checking by adding a safe pathway accessor in `app/pathways/pathway-hub.tsx` (added `getPathwayConfig` with fallback), added an explicit return type for `compactText` in `lib/decision-primitives.ts`, introduced a `ContinuityMap` type and typed `buildContinuityMap` in `src/components/explore/ContinuityMapSection.tsx`, and guarded optional `note` access in `src/lib/decision-clarity.ts` using `'note' in step`.
- Files changed: `tsconfig.json`, `next.config.mjs`, `app/pathways/pathway-hub.tsx`, `lib/decision-primitives.ts`, `src/components/explore/ContinuityMapSection.tsx`, and `src/lib/decision-clarity.ts`.

### Testing
- Ran `npm run check` (project build + validations) and it completed successfully with type checks passing.
- Ran `npm run build` and the Next build, static export generation and post-build verification scripts completed successfully (build and verification passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15d13a671483238f1d5574c44ce8af)