### PR TITLE
Harden safety enum normalization and metadata QA pipeline

### DIFF
--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -13,7 +13,8 @@ import { CompactRelatedPathways } from '@/app/pathways/pathway-hub'
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 import { cleanSummary, formatDisplayLabel, isClean, list, text, unique } from '@/lib/display-utils'
 import { normalizeSlug } from '@/lib/slug-utils'
-import { buildMeta, compoundJsonLd as generateCompoundJsonLd, breadcrumbJsonLd as generateBreadcrumbJsonLd } from '@/lib/seo'
+import { compoundJsonLd as generateCompoundJsonLd, breadcrumbJsonLd as generateBreadcrumbJsonLd } from '@/lib/seo'
+import { buildEntityMetadata } from '@/lib/metadata-engine'
 import {
   normalizeEvidenceLevel,
   normalizeSafetyLevel,
@@ -69,31 +70,7 @@ export async function generateMetadata({ params }: PageProps) {
   if (!compound) return {}
 
   const visibility = getRuntimeVisibility(compound)
-
-  const meta = buildMeta({
-    title: `${formatDisplayLabel(compound.name)} Benefits, Effects & Safety | The Hippie Scientist`,
-    description: cleanSummary(compound.summary || compound.description, 'compound'),
-    path: `/compounds/${compound.slug}`,
-  })
-
-  return {
-    title: meta.title,
-    description: meta.description,
-    alternates: { canonical: meta.url },
-    openGraph: {
-      title: meta.title,
-      description: meta.description,
-      type: 'article',
-      url: meta.url,
-      images: [meta.image],
-    },
-    robots: visibility.canIndex
-      ? undefined
-      : {
-          index: false,
-          follow: true,
-        },
-  }
+  return buildEntityMetadata(compound, { kind: 'compound', path: `/compounds/${compound.slug}`, canIndex: visibility.canIndex })
 }
 
 

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -17,7 +17,8 @@ import {
   buildSemanticAssistantSummary,
   buildSemanticNavigationSuggestions,
 } from '@/lib/ai-semantic-navigation'
-import { buildMeta, herbJsonLd as generateHerbJsonLd, breadcrumbJsonLd as generateBreadcrumbJsonLd } from '@/lib/seo'
+import { herbJsonLd as generateHerbJsonLd, breadcrumbJsonLd as generateBreadcrumbJsonLd } from '@/lib/seo'
+import { buildEntityMetadata } from '@/lib/metadata-engine'
 import { buildAuthorityProfileModel } from '@/lib/authority-profile'
 import { getValidComparisonSlug } from '@/lib/comparison-utils'
 import { buildInternalLinkDensity } from '@/lib/internal-link-density'
@@ -76,30 +77,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   }
 
   const visibility = getRuntimeVisibility(herb)
-  const meta = buildMeta({
-    title: `${formatDisplayLabel(herb.name || herb.slug)} | Herb`,
-    description: cleanSummary(herb.summary || herb.description || '', 'herb'),
-    path: `/herbs/${herb.slug}`,
-  })
-
-  return {
-    title: meta.title,
-    description: meta.description,
-    alternates: { canonical: meta.url },
-    openGraph: {
-      title: meta.title,
-      description: meta.description,
-      type: 'article',
-      url: meta.url,
-      images: [meta.image],
-    },
-    robots: visibility.canIndex
-      ? undefined
-      : {
-          index: false,
-          follow: true,
-        },
-  }
+  return buildEntityMetadata(herb, { kind: 'herb', path: `/herbs/${herb.slug}`, canIndex: visibility.canIndex })
 }
 
 function getEffects(herb: any) {

--- a/lib/decision-primitives.ts
+++ b/lib/decision-primitives.ts
@@ -1,3 +1,5 @@
+import { normalizeSafetyEnum } from './safety-enum'
+
 export const STANDARD_EVIDENCE_LABELS = [
   'Strong evidence',
   'Moderate evidence',
@@ -98,18 +100,9 @@ export function normalizeDecisionSafety(value?: unknown, options: { hasSafetyNot
   const canonical = matchesCanonicalSafety(raw)
   if (canonical) return canonical
 
-  const text = raw.toLowerCase().replace(/[_-]+/g, ' ')
-
-  if (/\b(needs? review|review needed|unknown|tbd|draft|placeholder|profile pending)\b/.test(text)) return 'Needs review'
-  if (/\b(limited safety|limited data|low data|no safety data|insufficient safety)\b/.test(text)) return 'Limited safety data'
-  if (/\b(interaction|interacts|warfarin|ssri|maoi|anticoagul|antiplatelet|cns depressant|sedative stack|polypharmacy)\b/.test(text)) return 'Interaction risk'
-  if (/\b(avoid|contraindicat|caution|consult|clinician|medication|pregnan|breastfeeding|liver|kidney|seizure|bleed|sedat|toxic|risk|high concern|do not)\b/.test(text)) return 'Use caution'
-  if (/\b(generally|well tolerated|low concern|low risk|food use|food derived|safe|high confidence|standard caution)\b/.test(text)) return 'Generally well tolerated'
-  if (/\b(low)\b/.test(text)) return 'Limited safety data'
-  if (/\b(medium|some safety|safety notes available|safety context)\b/.test(text)) return 'Use caution'
-  if (/\b(high)\b/.test(text)) return 'Generally well tolerated'
-
-  return options.hasSafetyNotes ? 'Use caution' : 'Needs review'
+  const normalized = normalizeSafetyEnum(raw).value
+  if (normalized === 'Needs review' && options.hasSafetyNotes) return 'Use caution'
+  return normalized
 }
 
 export function getDecisionSafetyTone(labelOrValue?: unknown, options: { hasSafetyNotes?: boolean } = {}): DecisionSafetyTone {

--- a/lib/metadata-engine.ts
+++ b/lib/metadata-engine.ts
@@ -1,0 +1,43 @@
+import type { Metadata } from 'next'
+import { buildMeta } from '@/lib/seo'
+import { formatDisplayLabel } from '@/lib/display-utils'
+
+type Entity = {
+  slug?: string
+  name?: string
+  scientific_name?: string
+  summary?: string
+  description?: string
+  evidence_tier?: string
+  mechanisms?: string[]
+  primary_effects?: string[]
+  safety_level?: string
+}
+
+export function buildEntityMetadata(entity: Entity, opts: { kind: 'herb'|'compound'; path: string; canIndex: boolean }): Metadata {
+  const display = formatDisplayLabel(entity.name || entity.slug || opts.kind)
+  const title = `${display} ${opts.kind === 'herb' ? 'Herb Profile' : 'Compound Profile'} | The Hippie Scientist`
+  const snippets = [entity.summary, entity.description, entity.scientific_name, entity.evidence_tier, entity.safety_level].filter(Boolean).join(' • ')
+  const description = snippets.slice(0, 158) || `${display} evidence, mechanisms, effects, and safety context.`
+  const meta = buildMeta({ title, description, path: opts.path })
+
+  return {
+    title: meta.title,
+    description: meta.description,
+    alternates: { canonical: meta.url },
+    openGraph: {
+      title: meta.title,
+      description: meta.description,
+      type: 'article',
+      url: meta.url,
+      images: [meta.image],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: meta.title,
+      description: meta.description,
+      images: [meta.image],
+    },
+    robots: opts.canIndex ? undefined : { index: false, follow: true },
+  }
+}

--- a/lib/safety-enum.ts
+++ b/lib/safety-enum.ts
@@ -1,0 +1,29 @@
+import { STANDARD_SAFETY_LABELS, type StandardSafetyLabel } from './decision-primitives'
+
+const SAFETY_SYNONYM_RULES: Array<{ pattern: RegExp; value: StandardSafetyLabel }> = [
+  { pattern: /\b(interaction|interacts|warfarin|ssri|maoi|anticoagul|antiplatelet|polypharmacy|cns depressant)\b/i, value: 'Interaction risk' },
+  { pattern: /\b(limited safety|limited data|low data|no safety data|insufficient safety)\b/i, value: 'Limited safety data' },
+  { pattern: /\b(avoid|contraindicat|caution|consult|clinician|pregnan|breastfeeding|liver|kidney|seizure|bleed|sedat|toxic|risk|do not)\b/i, value: 'Use caution' },
+  { pattern: /\b(generally|well tolerated|low concern|low risk|food use|food derived|safe|standard caution)\b/i, value: 'Generally well tolerated' },
+  { pattern: /\b(needs? review|review needed|unknown|tbd|draft|placeholder|profile pending)\b/i, value: 'Needs review' },
+]
+
+export type SafetyNormalizationResult = {
+  value: StandardSafetyLabel
+  canonical: boolean
+  source: string
+}
+
+export function normalizeSafetyEnum(raw: unknown): SafetyNormalizationResult {
+  const source = String(raw ?? '').trim()
+  if (!source) return { value: 'Needs review', canonical: false, source }
+
+  const canonical = STANDARD_SAFETY_LABELS.find(label => label.toLowerCase() === source.toLowerCase())
+  if (canonical) return { value: canonical, canonical: true, source }
+
+  for (const rule of SAFETY_SYNONYM_RULES) {
+    if (rule.pattern.test(source)) return { value: rule.value, canonical: false, source }
+  }
+
+  return { value: 'Needs review', canonical: false, source }
+}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "verify:types": "npm run typecheck",
     "lint": "eslint . --max-warnings=0",
     "build": "node scripts/build-blog.mjs && npm run data:build && npm run data:validate && npm run guard:source-of-truth && node scripts/build-production.mjs && npm run verify:build",
-    "verify:build": "node scripts/verify-core-routes.mjs && node scripts/verify-redirects.mjs && node scripts/ci/validate-deploy-readiness.mjs && npm run validate:static-export && npm run validate:public-json-imports && npm run validate:quarantine-imports && npm run validate:direct-dependencies && npm run validate:xlsx-boundary && npm run validate:security-headers && npm run data:verify && node scripts/ci/validate-build-seo-metadata.mjs",
+    "verify:build": "node scripts/verify-core-routes.mjs && node scripts/verify-redirects.mjs && node scripts/ci/validate-deploy-readiness.mjs && npm run validate:static-export && npm run validate:public-json-imports && npm run validate:quarantine-imports && npm run validate:direct-dependencies && npm run validate:xlsx-boundary && npm run validate:security-headers && npm run data:verify && node scripts/ci/validate-build-seo-metadata.mjs && npm run validate:safety-enums && npm run audit:metadata",
     "data:verify": "node scripts/data/verify-generated-data.mjs",
     "validate:workbook-source": "node scripts/ci/validate-workbook-source.mjs",
     "check:node": "node scripts/ci/check-node-version.mjs",
@@ -52,7 +52,9 @@
     "validate:direct-dependencies": "node scripts/ci/validate-direct-dependencies.mjs",
     "validate:xlsx-boundary": "node scripts/ci/validate-xlsx-boundary.mjs",
     "validate:security-headers": "node scripts/ci/validate-security-headers.mjs",
-    "typecheck:strict-candidates": "tsc -p tsconfig.strict-candidates.json --noEmit"
+    "typecheck:strict-candidates": "tsc -p tsconfig.strict-candidates.json --noEmit",
+    "validate:safety-enums": "node scripts/ci/validate-safety-enums.mjs",
+    "audit:metadata": "node scripts/ci/audit-metadata-duplicates.mjs"
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.8",

--- a/scripts/ci/audit-metadata-duplicates.mjs
+++ b/scripts/ci/audit-metadata-duplicates.mjs
@@ -1,0 +1,17 @@
+import fs from 'node:fs'
+const manifestPath = 'public/data/runtime-manifests/route-manifest.json'
+const routes = JSON.parse(fs.readFileSync(manifestPath,'utf8'))
+const byTitle = new Map(), byDesc = new Map(), byCanonical = new Map()
+for (const r of routes) {
+  const title = (r.meta_title||'').trim(); const desc=(r.meta_description||'').trim(); const canonical=(r.canonical_url||r.url||'').trim()
+  if (title) byTitle.set(title, [...(byTitle.get(title)||[]), r.route||r.path])
+  if (desc) byDesc.set(desc, [...(byDesc.get(desc)||[]), r.route||r.path])
+  if (canonical) byCanonical.set(canonical, [...(byCanonical.get(canonical)||[]), r.route||r.path])
+}
+const dup = (m)=>[...m.entries()].filter(([,v])=>v.length>1).map(([k,v])=>({value:k,routes:v}))
+const report={generatedAt:new Date().toISOString(), duplicateTitles:dup(byTitle), duplicateDescriptions:dup(byDesc), duplicateCanonicals:dup(byCanonical)}
+fs.mkdirSync('public/data/reports',{recursive:true})
+fs.writeFileSync('public/data/reports/metadata-audit-report.json', JSON.stringify(report,null,2))
+if (report.duplicateCanonicals.length || report.duplicateTitles.length>10) { console.error('[metadata-audit] severe collisions found'); process.exit(1)}
+if (report.duplicateTitles.length || report.duplicateDescriptions.length) console.warn('[metadata-audit] warnings found')
+console.log('[metadata-audit] completed')

--- a/scripts/ci/validate-safety-enums.mjs
+++ b/scripts/ci/validate-safety-enums.mjs
@@ -1,0 +1,24 @@
+import fs from 'node:fs'
+
+const files = ['public/data/workbook-herbs.json', 'public/data/workbook-compounds.json']
+const VALID = new Set(['Generally well tolerated', 'Use caution', 'Interaction risk', 'Needs review', 'Limited safety data'])
+const out = []
+let bad = 0
+for (const file of files) {
+  const rows = JSON.parse(fs.readFileSync(file, 'utf8'))
+  for (const row of rows) {
+    const raw = String(row.safety_level || '').trim()
+    if (!raw) continue
+    if (!VALID.has(raw)) {
+      bad++
+      out.push({ file, slug: row.slug, safety_level: raw })
+    }
+  }
+}
+fs.mkdirSync('public/data/reports', { recursive: true })
+fs.writeFileSync('public/data/reports/invalid-safety-report.json', JSON.stringify({ generatedAt: new Date().toISOString(), invalid: out }, null, 2))
+if (bad > 0) {
+  console.error(`[safety] invalid safety_level values: ${bad}. see public/data/reports/invalid-safety-report.json`)
+  process.exit(1)
+}
+console.log('[safety] safety_level enum validation passed')


### PR DESCRIPTION
### Motivation
- Many profiles were collapsing to a single `Needs review` safety state because safety normalization was dispersed and permissive, causing SEO/EEAT trust regressions. 
- Metadata generation was fragmented across routes and produced inconsistent canonical/OG/Twitter outputs, increasing risk of duplicate or malformed meta that harms discoverability. 
- Add build-time checks and deterministic utilities to fail-fast on malformed enums and severe metadata collisions to improve correctness and CI visibility.

### Description
- Added a strict safety enum normalizer `lib/safety-enum.ts` with `normalizeSafetyEnum` to map non-canonical strings to the defined `STANDARD_SAFETY_LABELS` deterministically. 
- Wired `normalizeDecisionSafety` in `lib/decision-primitives.ts` to delegate to `normalizeSafetyEnum` while preserving `hasSafetyNotes` conservative fallback semantics. 
- Introduced a centralized metadata engine `lib/metadata-engine.ts` exposing `buildEntityMetadata` and replaced per-route metadata assembly in `app/herbs/[slug]/page.tsx` and `app/compounds/[slug]/page.tsx` to unify canonical/OG/Twitter/robots output. 
- Added CI/build checks `scripts/ci/validate-safety-enums.mjs` and `scripts/ci/audit-metadata-duplicates.mjs`, wired `validate:safety-enums` and `audit:metadata` into `package.json` and `verify:build`, and emit audit artifacts under `public/data/reports/`.

### Testing
- Ran `npm run lint` and it passed without new lint errors. 
- Ran `npm run typecheck` and TypeScript checks passed after fixing a metadata typing issue. 
- Ran `npm run build`; an initial run surfaced a manifest path bug in the metadata audit script which was corrected, and subsequent `npm run build` completed successfully. 
- Ran CI verification scripts `npm run verify:build`, `npm run validate:safety-enums`, and `npm run audit:metadata`, all of which completed after the fix and produced audit artifacts at `public/data/reports/invalid-safety-report.json` and `public/data/reports/metadata-audit-report.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16fa9531e08323972620cc5db933f9)