### PR TITLE
Fix static SEO audit regressions

### DIFF
--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -3,6 +3,8 @@ import Link from 'next/link'
 import posts from '../../data/blog/posts.json'
 import { ContentIdentityCard, SemanticBrowseModule } from '@/components/scientific-discovery'
 
+export const dynamic = 'force-static'
+
 const allPosts = posts as any[]
 
 const getPostSortValue = (post: any): number => {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,9 +11,8 @@ const siteName = 'The Hippie Scientist'
 const siteDescription =
   'Evidence-aware research on herbs, compounds, mechanisms, safety context, and practical supplement decisions.'
 
-// Canonical domain is thehippiescientist.net (no www).
-// A 301 www→bare redirect should be configured in Cloudflare.
-const siteUrl = 'https://thehippiescientist.net'
+// Canonical production domain. Cloudflare redirects should resolve to this host.
+const siteUrl = 'https://www.thehippiescientist.net'
 
 // Enhanced JSON-LD: logo + SearchAction for Google Knowledge Panel and Sitelinks Searchbox
 const websiteJsonLd = {

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -19,11 +19,16 @@ import {
 
 export const dynamic = 'force-static'
 
-// Bare domain (no www) — consistent with layout.tsx and robots.ts.
-// Configure a 301 www→bare redirect in Cloudflare.
-const siteUrl = 'https://thehippiescientist.net'
+// Canonical production domain. Keep sitemap URLs aligned with Cloudflare's www canonical host.
+const siteUrl = 'https://www.thehippiescientist.net'
 
-const editorialDate = new Date('2026-04-01')
+const sourceDateEpoch = process.env.SOURCE_DATE_EPOCH
+  ? Number.parseInt(process.env.SOURCE_DATE_EPOCH, 10)
+  : Number.NaN
+const buildTimestamp = Number.isFinite(sourceDateEpoch)
+  ? sourceDateEpoch * 1000
+  : Date.now()
+const editorialDate = new Date(buildTimestamp)
 const MAX_SITEMAP_ROUTES = Number.parseInt(process.env.SITEMAP_MAX_ROUTES || '5000', 10)
 
 type SlugRecord = {
@@ -95,6 +100,12 @@ const clusterRoutes = [
   '/psychedelic-adjacent-herbs',
 ]
 
+const staticMvpRoutes = [
+  '/a-tier',
+  '/faq',
+  '/learn',
+]
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const [herbs, runtimeCompounds] = await Promise.all([
     getHerbSummaryIndex(),
@@ -134,6 +145,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     route('/protocols', { priority: 0.7, changeFrequency: 'monthly' }),
     // /safety-checker added — working tool previously missing from sitemap
     route('/safety-checker', { priority: 0.7, changeFrequency: 'monthly' }),
+
+    ...staticMvpRoutes.map((path) =>
+      route(path, { priority: 0.65, changeFrequency: 'monthly' }),
+    ),
 
     ...seoEntryPages.map(page =>
       route(`/${page.route}`, { priority: 0.7, changeFrequency: 'monthly' }),

--- a/components/authority/AuthorityProfileShell.tsx
+++ b/components/authority/AuthorityProfileShell.tsx
@@ -23,6 +23,13 @@ function toneBadge(tone: AuthoritySignal['tone']) {
   return 'Context'
 }
 
+function formatReadinessLabel(label: string) {
+  const normalized = label.replace(/-/g, ' ').trim().toLowerCase()
+  if (!normalized || normalized === 'developing') return 'Evidence profile developing'
+  if (normalized === 'concise') return 'Concise evidence profile'
+  return normalized.replace(/\b\w/g, character => character.toUpperCase())
+}
+
 function AuthoritySignalCard({ signal }: { signal: AuthoritySignal }) {
   const label = cleanEditorialText(signal.label)
   const description = cleanEditorialText(signal.description)
@@ -107,7 +114,7 @@ export default function AuthorityProfileShell({ model, record }: { model: Author
             </p>
           </div>
           <div className="rounded-2xl border border-brand-900/10 bg-white/80 px-4 py-3 text-sm font-semibold text-ink shadow-sm">
-            {model.readinessLabel.replace(/-/g, ' ')} · {model.readinessScore}
+            {formatReadinessLabel(model.readinessLabel)}
           </div>
         </div>
       </section>


### PR DESCRIPTION
### Motivation
- Align runtime-generated metadata and sitemap URLs with the live production host to remove canonical mismatch signals. 
- Replace a stale hardcoded sitemap `lastmod` fallback so lastModified values reflect the current build time (or `SOURCE_DATE_EPOCH`).
- Ensure the blog index and compound/herb library pages are fully present in the static export HTML (avoid client-only skeletons). 
- Remove a raw internal readiness score string leaking into production authority UI and surface a formatted, user-facing label instead.

### Description
- Updated site base URL in `app/layout.tsx` from `https://thehippiescientist.net` to `https://www.thehippiescientist.net` so metadata/JSON-LD use the `www` canonical host. 
- Reworked `app/sitemap.ts` to emit `www` URLs, use a build-time timestamp for `lastModified` (honoring `SOURCE_DATE_EPOCH` when present), and add `'/a-tier'`, `'/faq'`, and `'/learn'` to the sitemap. 
- Marked the blog index as static in `app/blog/page.tsx` by adding `export const dynamic = 'force-static'` so article content is rendered into the exported HTML. 
- Replaced the raw readiness display in `components/authority/AuthorityProfileShell.tsx` with `formatReadinessLabel()` to avoid debug-style strings like `developing · 45` in production. 

### Testing
- Ran `npm run lint -- --max-warnings=0` and it succeeded. 
- Ran `npm run typecheck` (`tsc --noEmit`) and it succeeded. 
- Built a static export with `npm run build:fast` and the export completed successfully. 
- Executed static-export assertions (Python) verifying sitemap `www` URLs, no hardcoded `2026-04-01` lastmod, presence of `/a-tier`, `/faq`, `/learn`, blog index content, and removal of the `developing ·` debug text, and all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19a9d13b5883239f4e7348a7c9a3d5)