### PR TITLE
Unify SEO canonical host and metadata audit signals

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import posts from '../../../data/blog/posts.json'
 import { getAllCompounds, getAllHerbs } from '@/lib/server/runtime-data'
 import { ResearchContinuityBlock } from '@/components/scientific-discovery'
+import { SITE_URL } from '@/lib/seo'
 import { findArticleEntities } from '@/lib/editorial-discovery'
 
 const allPosts = posts as any[]
@@ -105,12 +106,12 @@ export default async function BlogPostPage({ params }: BlogRouteProps) {
     publisher: {
       '@type': 'Organization',
       name: 'The Hippie Scientist',
-      url: 'https://www.thehippiescientist.net',
+      url: SITE_URL,
     },
     articleSection: inferResearchStyle(post),
     datePublished: post.date || '2026-01-01',
     dateModified: post.updatedAt || post.date || '2026-01-01',
-    mainEntityOfPage: `https://www.thehippiescientist.net/blog/${post.slug}`,
+    mainEntityOfPage: `${SITE_URL}/blog/${post.slug}`,
   }
 
   const breadcrumbJsonLd = {
@@ -121,13 +122,13 @@ export default async function BlogPostPage({ params }: BlogRouteProps) {
         '@type': 'ListItem',
         position: 1,
         name: 'Blog',
-        item: 'https://www.thehippiescientist.net/blog',
+        item: `${SITE_URL}/blog`,
       },
       {
         '@type': 'ListItem',
         position: 2,
         name: post.title,
-        item: `https://www.thehippiescientist.net/blog/${post.slug}`,
+        item: `${SITE_URL}/blog/${post.slug}`,
       },
     ],
   }

--- a/app/blog/categories/page.tsx
+++ b/app/blog/categories/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from 'next'
+import { SITE_URL } from '@/lib/seo'
 import { getBlogCategories } from '@/lib/blog-taxonomy'
 
 export const metadata: Metadata = {
   title: 'Blog Categories | The Hippie Scientist',
   description: 'Browse static blog categories with canonical archive links and topic-specific article coverage.',
-  alternates: { canonical: 'https://www.thehippiescientist.net/blog/categories' },
+  alternates: { canonical: `${SITE_URL}/blog/categories` },
 }
 
 export default function BlogCategoriesPage() {

--- a/app/blog/tags/page.tsx
+++ b/app/blog/tags/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from 'next'
+import { SITE_URL } from '@/lib/seo'
 import { getBlogTags } from '@/lib/blog-taxonomy'
 
 export const metadata: Metadata = {
   title: 'Blog Tags | The Hippie Scientist',
   description: 'Browse static blog tags to explore herb research notes by theme, mechanism, and safety context.',
-  alternates: { canonical: 'https://www.thehippiescientist.net/blog/tags' },
+  alternates: { canonical: `${SITE_URL}/blog/tags` },
 }
 
 export default function BlogTagsPage() {

--- a/app/compounds/[slug]/page.tsx
+++ b/app/compounds/[slug]/page.tsx
@@ -13,7 +13,7 @@ import { CompactRelatedPathways } from '@/app/pathways/pathway-hub'
 import { getRuntimeVisibility } from '@/lib/runtime-visibility'
 import { cleanSummary, formatDisplayLabel, isClean, list, text, unique } from '@/lib/display-utils'
 import { normalizeSlug } from '@/lib/slug-utils'
-import { compoundJsonLd as generateCompoundJsonLd, breadcrumbJsonLd as generateBreadcrumbJsonLd, generateDetailMetadata } from '@/lib/seo'
+import { SITE_URL, compoundJsonLd as generateCompoundJsonLd, breadcrumbJsonLd as generateBreadcrumbJsonLd, generateDetailMetadata } from '@/lib/seo'
 import {
   normalizeEvidenceLevel,
   normalizeSafetyLevel,
@@ -75,7 +75,7 @@ export async function generateMetadata({ params }: PageProps) {
 }
 
 
-const WEAK_PATTERN = /research[-\s]?pending|placeholder|unknown|not specified|not available|insufficient|needs review|minimal/i
+const WEAK_PATTERN = /research[-\s]?pending|placeholder|unknown|not specified|not available|insufficient|needs review|minimal|developing/i
 const CAUTION_PATTERN = /avoid|caution|interaction|contraindication|warning|risk|pregnancy|liver|kidney|sedat|bleed/i
 
 
@@ -285,8 +285,8 @@ export default async function CompoundPage({ params }: PageProps) {
   })
 
   const breadcrumbJsonLd = generateBreadcrumbJsonLd([
-    { name: 'Compounds', url: 'https://www.thehippiescientist.net/compounds' },
-    { name: displayName, url: `https://www.thehippiescientist.net/compounds/${compound.slug}` },
+    { name: 'Compounds', url: `${SITE_URL}/compounds` },
+    { name: displayName, url: `${SITE_URL}/compounds/${compound.slug}` },
   ])
 
   const tabs = [

--- a/app/goals/[goal]/page.tsx
+++ b/app/goals/[goal]/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from 'next/navigation'
 import { getGoal, goals } from '@/data/goals'
 import { getHerbBySlug, getCompoundBySlug } from '@/lib/runtime-data'
 import { normalizeDecisionEvidence, normalizeDecisionSafety } from '@/lib/decision-primitives'
-import { faqPageJsonLd, breadcrumbJsonLd, collectionPageJsonLd, itemListJsonLd } from '@/lib/seo'
+import { SITE_URL, faqPageJsonLd, breadcrumbJsonLd, collectionPageJsonLd, itemListJsonLd } from '@/lib/seo'
 import { rankEntitiesForGoal } from '@/lib/goal-matching-engine'
 
 type GoalRouteParams = { goal: string }
@@ -192,20 +192,20 @@ export default async function GoalDecisionPage({
   })
 
   const goalBreadcrumbJsonLd = breadcrumbJsonLd([
-    { name: 'Goals', url: 'https://www.thehippiescientist.net/goals' },
-    { name: goal.title, url: `https://www.thehippiescientist.net/goals/${goal.slug}` },
-  ], { id: `https://www.thehippiescientist.net/goals/${goal.slug}#breadcrumb` })
+    { name: 'Goals', url: `${SITE_URL}/goals` },
+    { name: goal.title, url: `${SITE_URL}/goals/${goal.slug}` },
+  ], { id: `${SITE_URL}/goals/${goal.slug}#breadcrumb` })
 
   const goalCollectionJsonLd = collectionPageJsonLd({
     title: `${goal.title} | The Hippie Scientist`,
     description: goal.description,
     path: `/goals/${goal.slug}`,
-    itemListId: `https://www.thehippiescientist.net/goals/${goal.slug}#item-list`,
-    breadcrumbId: `https://www.thehippiescientist.net/goals/${goal.slug}#breadcrumb`,
+    itemListId: `${SITE_URL}/goals/${goal.slug}#item-list`,
+    breadcrumbId: `${SITE_URL}/goals/${goal.slug}#breadcrumb`,
   })
 
   const goalItemListJsonLd = itemListJsonLd({
-    id: `https://www.thehippiescientist.net/goals/${goal.slug}#item-list`,
+    id: `${SITE_URL}/goals/${goal.slug}#item-list`,
     name: `${goal.title} Options`,
     path: `/goals/${goal.slug}`,
     items: enrichedOptions.map(opt => ({

--- a/app/herbs/[slug]/page.tsx
+++ b/app/herbs/[slug]/page.tsx
@@ -17,7 +17,7 @@ import {
   buildSemanticAssistantSummary,
   buildSemanticNavigationSuggestions,
 } from '@/lib/ai-semantic-navigation'
-import { herbJsonLd as generateHerbJsonLd, breadcrumbJsonLd as generateBreadcrumbJsonLd, generateDetailMetadata } from '@/lib/seo'
+import { SITE_URL, herbJsonLd as generateHerbJsonLd, breadcrumbJsonLd as generateBreadcrumbJsonLd, generateDetailMetadata } from '@/lib/seo'
 import { buildAuthorityProfileModel } from '@/lib/authority-profile'
 import { getValidComparisonSlug } from '@/lib/comparison-utils'
 import { buildInternalLinkDensity } from '@/lib/internal-link-density'
@@ -93,7 +93,7 @@ function getEffects(herb: any) {
 }
 
 
-const WEAK_PATTERN = /research[-\s]?pending|placeholder|unknown|not specified|not available|insufficient|needs review|minimal/i
+const WEAK_PATTERN = /research[-\s]?pending|placeholder|unknown|not specified|not available|insufficient|needs review|minimal|developing/i
 
 function cleanItems(value: unknown, limit = 8) {
   const values = Array.isArray(value) ? value.flatMap(item => list(item)) : list(value)
@@ -398,8 +398,8 @@ export default async function HerbDetailPage({ params }: PageProps) {
   })
 
   const breadcrumbJsonLd = generateBreadcrumbJsonLd([
-    { name: 'Herbs', url: 'https://www.thehippiescientist.net/herbs' },
-    { name: displayName, url: `https://www.thehippiescientist.net/herbs/${herb.slug}` },
+    { name: 'Herbs', url: `${SITE_URL}/herbs` },
+    { name: displayName, url: `${SITE_URL}/herbs/${herb.slug}` },
   ])
 
   const tabs = [

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import Header from '@/components/Header'
 import MobileBottomNav from '@/components/mobile-bottom-nav'
 import CitationDrawer from '@/components/education/CitationDrawer'
+import { SITE_URL } from '@/lib/seo'
 import './globals.css'
 import '@/styles/foundation-readability.css'
 
@@ -11,23 +12,19 @@ const siteName = 'The Hippie Scientist'
 const siteDescription =
   'Evidence-aware research on herbs, compounds, mechanisms, safety context, and practical supplement decisions.'
 
-// Canonical domain is thehippiescientist.net (no www).
-// A 301 www→bare redirect should be configured in Cloudflare.
-const siteUrl = 'https://thehippiescientist.net'
-
 // Enhanced JSON-LD: logo + SearchAction for Google Knowledge Panel and Sitelinks Searchbox
 const websiteJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'WebSite',
   name: siteName,
-  url: siteUrl,
+  url: SITE_URL,
   description: siteDescription,
-  image: `${siteUrl}/og-default.png`,
+  image: `${SITE_URL}/og-default.png`,
   potentialAction: {
     '@type': 'SearchAction',
     target: {
       '@type': 'EntryPoint',
-      urlTemplate: `${siteUrl}/search?q={search_term_string}`,
+      urlTemplate: `${SITE_URL}/search?q={search_term_string}`,
     },
     'query-input': 'required name=search_term_string',
   },
@@ -37,11 +34,11 @@ const organizationJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'Organization',
   name: siteName,
-  url: siteUrl,
+  url: SITE_URL,
   description: siteDescription,
   logo: {
     '@type': 'ImageObject',
-    url: `${siteUrl}/logo.png`,
+    url: `${SITE_URL}/logo.png`,
     width: 512,
     height: 512,
   },
@@ -52,7 +49,7 @@ const organizationJsonLd = {
 }
 
 export const metadata: Metadata = {
-  metadataBase: new URL(siteUrl),
+  metadataBase: new URL(SITE_URL),
   title: { default: siteName, template: `%s | ${siteName}` },
   description: siteDescription,
   openGraph: {
@@ -60,7 +57,7 @@ export const metadata: Metadata = {
     title: siteName,
     description: siteDescription,
     siteName,
-    url: siteUrl,
+    url: SITE_URL,
   },
   twitter: {
     card: 'summary_large_image',

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,10 +1,7 @@
 import type { MetadataRoute } from 'next'
+import { SITE_URL } from '@/lib/seo'
 
 export const dynamic = 'force-static'
-
-// Bare domain (no www) — consistent with layout.tsx and sitemap.ts.
-// Configure a 301 www→bare redirect in Cloudflare.
-const siteUrl = 'https://thehippiescientist.net'
 
 const disallowedRoutes = [
   '/analytics',
@@ -32,7 +29,7 @@ export default function robots(): MetadataRoute.Robots {
         disallow: disallowedRoutes,
       },
     ],
-    sitemap: `${siteUrl}/sitemap.xml`,
-    host: siteUrl,
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
   }
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -8,6 +8,7 @@ import { supplementComparisons } from '@/data/comparisons'
 import { goalConfigs } from '@/data/goals'
 import { seoEntryPages } from './seo-entry-pages'
 import { scientificCollections } from '@/lib/collections'
+import { SITE_URL } from '@/lib/seo'
 import {
   authorityEcosystemSlugs,
   authorityTopicSlugs,
@@ -19,11 +20,19 @@ import {
 
 export const dynamic = 'force-static'
 
-// Bare domain (no www) — consistent with layout.tsx and robots.ts.
-// Configure a 301 www→bare redirect in Cloudflare.
-const siteUrl = 'https://thehippiescientist.net'
-
-const editorialDate = new Date('2026-04-01')
+// Static shell routes use a build-aware fallback when no per-record updatedAt exists.
+// SOURCE_DATE_EPOCH supports reproducible builds; BUILD_TIME can be injected by CI
+// (for example, Cloudflare Pages or GitHub Actions); otherwise this snapshots at build time.
+const editorialDate = (() => {
+  if (process.env.SOURCE_DATE_EPOCH) {
+    return new Date(Number(process.env.SOURCE_DATE_EPOCH) * 1000)
+  }
+  if (process.env.BUILD_TIME) {
+    const d = new Date(process.env.BUILD_TIME)
+    if (!Number.isNaN(d.getTime())) return d
+  }
+  return new Date()
+})()
 const MAX_SITEMAP_ROUTES = Number.parseInt(process.env.SITEMAP_MAX_ROUTES || '5000', 10)
 
 type SlugRecord = {
@@ -51,7 +60,7 @@ const route = (
     changeFrequency?: MetadataRoute.Sitemap[number]['changeFrequency']
   },
 ): MetadataRoute.Sitemap[number] => ({
-  url: path === '/' ? `${siteUrl}/` : `${siteUrl}${path}`,
+  url: path === '/' ? `${SITE_URL}/` : `${SITE_URL}${path}`,
   lastModified: options?.lastModified || editorialDate,
   changeFrequency: options?.changeFrequency || 'monthly',
   priority: options?.priority || 0.6,

--- a/app/stacks/[slug]/page.tsx
+++ b/app/stacks/[slug]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import { getStacks } from '@/lib/runtime-data'
-import { itemListJsonLd, breadcrumbJsonLd } from '@/lib/seo'
+import { SITE_URL, itemListJsonLd, breadcrumbJsonLd } from '@/lib/seo'
 import { mergeStackEcosystems } from '@/lib/stack-ecosystems'
 import { buildSemanticAssistantSummary, buildSemanticNavigationSuggestions } from '@/lib/ai-semantic-navigation'
 import { buildSemanticGraphVisual } from '@/lib/semantic-graph-visuals'
@@ -114,8 +114,8 @@ export default async function StackPage({ params }: Params) {
   })
 
   const stackBreadcrumbJsonLd = breadcrumbJsonLd([
-    { name: 'Stacks', url: 'https://www.thehippiescientist.net/stacks' },
-    { name: stack.title, url: `https://www.thehippiescientist.net/stacks/${stack.slug}` },
+    { name: 'Stacks', url: `${SITE_URL}/stacks` },
+    { name: stack.title, url: `${SITE_URL}/stacks/${stack.slug}` },
   ])
 
   return (

--- a/components/authority/AuthorityProfileShell.tsx
+++ b/components/authority/AuthorityProfileShell.tsx
@@ -1,4 +1,4 @@
-import type { AuthorityProfileModel, AuthoritySignal } from '@/lib/authority-profile'
+import { formatAuthorityReadinessLabel, type AuthorityProfileModel, type AuthoritySignal } from '@/lib/authority-profile'
 import { cleanEditorialText, dedupeEditorialItems, isDuplicateTitleBody, isRenderableText, shouldRenderCard } from '@/lib/editorial-rendering'
 import {
   buildCommonMistakesSection,
@@ -88,6 +88,7 @@ export default function AuthorityProfileShell({ model, record }: { model: Author
   const humanEvidence = record ? buildHumanEvidenceSummary(record) : null
   const commonMistakes = record ? dedupeEditorialItems(buildCommonMistakesSection(record), 4) : []
   const outcomeGuidance = record ? buildOutcomeSpecificGuidance(record) : []
+  const readinessBadge = formatAuthorityReadinessLabel(model.readinessLabel)
   const renderableOutcomeGuidance = outcomeGuidance
     .map((item) => ({
       outcome: cleanEditorialText(item.outcome),
@@ -107,7 +108,7 @@ export default function AuthorityProfileShell({ model, record }: { model: Author
             </p>
           </div>
           <div className="rounded-2xl border border-brand-900/10 bg-white/80 px-4 py-3 text-sm font-semibold text-ink shadow-sm">
-            {model.readinessLabel.replace(/-/g, ' ')} · {model.readinessScore}
+            {readinessBadge}
           </div>
         </div>
       </section>

--- a/lib/authority-profile.ts
+++ b/lib/authority-profile.ts
@@ -9,6 +9,8 @@ export type AuthoritySignal = {
   tone?: 'strong' | 'moderate' | 'caution' | 'neutral'
 }
 
+export type AuthorityReadinessLabel = 'authority-ready' | 'developing' | 'research-needed'
+
 export type AuthorityProfileModel = {
   executiveSummary: AuthoritySignal[]
   bestFor: AuthoritySignal[]
@@ -19,7 +21,7 @@ export type AuthorityProfileModel = {
   stackCompatibility: AuthoritySignal[]
   editorialInterpretation: AuthoritySignal
   readinessScore: number
-  readinessLabel: 'authority-ready' | 'developing' | 'research-needed'
+  readinessLabel: AuthorityReadinessLabel
 }
 
 function title(value: unknown) {
@@ -154,11 +156,17 @@ export function buildEditorialInterpretation(record: any): AuthoritySignal {
   }
 }
 
+export function formatAuthorityReadinessLabel(label: AuthorityReadinessLabel): string {
+  if (label === 'authority-ready') return 'Authority profile ready'
+  if (label === 'research-needed') return 'Research review needed'
+  return 'Profile in review'
+}
+
 export function buildAuthorityProfileModel(record: any): AuthorityProfileModel {
   const semantic = buildSemanticIntelligenceReport(record)
   const evidence = buildResearchKnowledgeReport(record)
   const readinessScore = semantic.totalScore + Math.min(30, evidence.evidenceWeight)
-  const readinessLabel: AuthorityProfileModel['readinessLabel'] =
+  const readinessLabel: AuthorityReadinessLabel =
     readinessScore >= 48 ? 'authority-ready' : readinessScore >= 28 ? 'developing' : 'research-needed'
 
   return {

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,4 +1,4 @@
-const DEFAULT_SITE_URL = 'https://www.thehippiescientist.net'
+export const SITE_URL = 'https://thehippiescientist.net'
 const DEFAULT_SITE_NAME = 'The Hippie Scientist'
 const DEFAULT_DESCRIPTION_MAX_LENGTH = 155
 
@@ -48,7 +48,7 @@ const withLeadingSlash = (value: string) => {
 const compactWhitespace = (value: string) => value.replace(/\s+/g, ' ').trim()
 
 export function buildCanonicalUrl(path = '/', options: CanonicalUrlOptions = {}): string {
-  const siteUrl = options.siteUrl || DEFAULT_SITE_URL
+  const siteUrl = options.siteUrl || SITE_URL
   const url = new URL(isAbsoluteUrl(path) ? path : withLeadingSlash(path), siteUrl)
   const allowedParams = new Set((options.keepQueryParams || []).map(param => param.toLowerCase()))
   const canonicalSearch = new URLSearchParams()

--- a/scripts/ci/audit-metadata-duplicates.mjs
+++ b/scripts/ci/audit-metadata-duplicates.mjs
@@ -9,9 +9,31 @@ for (const r of routes) {
   if (canonical) byCanonical.set(canonical, [...(byCanonical.get(canonical)||[]), r.route||r.path])
 }
 const dup = (m)=>[...m.entries()].filter(([,v])=>v.length>1).map(([k,v])=>({value:k,routes:v}))
-const report={generatedAt:new Date().toISOString(), duplicateTitles:dup(byTitle), duplicateDescriptions:dup(byDesc), duplicateCanonicals:dup(byCanonical)}
+const sample = (duplicates, limit = 5) => duplicates.slice(0, limit).map(({ value, routes }) => ({ value, routes: routes.slice(0, 5) }))
+const duplicateTitles = dup(byTitle)
+const duplicateDescriptions = dup(byDesc)
+const duplicateCanonicals = dup(byCanonical)
+const report={
+  generatedAt:new Date().toISOString(),
+  duplicateTitles,
+  duplicateDescriptions,
+  duplicateCanonicals,
+  summary: {
+    duplicateTitleCount: duplicateTitles.length,
+    duplicateDescriptionCount: duplicateDescriptions.length,
+    duplicateCanonicalCount: duplicateCanonicals.length,
+    duplicateDescriptionSample: sample(duplicateDescriptions),
+  },
+}
 fs.mkdirSync('public/data/reports',{recursive:true})
 fs.writeFileSync('public/data/reports/metadata-audit-report.json', JSON.stringify(report,null,2))
-if (report.duplicateCanonicals.length || report.duplicateTitles.length>10) { console.error('[metadata-audit] severe collisions found'); process.exit(1)}
+// Grace threshold: allows up to DUPLICATE_TITLE_BLOCK_THRESHOLD duplicate titles
+// before failing the build. Reduce toward 0 as workbook data quality improves.
+const DUPLICATE_TITLE_BLOCK_THRESHOLD = 10
+if (report.duplicateCanonicals.length || report.duplicateTitles.length>DUPLICATE_TITLE_BLOCK_THRESHOLD) { console.error('[metadata-audit] severe collisions found'); process.exit(1)}
 if (report.duplicateTitles.length || report.duplicateDescriptions.length) console.warn('[metadata-audit] warnings found')
+if (report.duplicateDescriptions.length) {
+  console.warn(`[metadata-audit] duplicate descriptions: ${report.duplicateDescriptions.length}`)
+  console.warn('[metadata-audit] duplicate description sample:', JSON.stringify(report.summary.duplicateDescriptionSample))
+}
 console.log('[metadata-audit] completed')

--- a/src/lib/__tests__/seo.test.ts
+++ b/src/lib/__tests__/seo.test.ts
@@ -35,7 +35,7 @@ describe('SEO Metadata & JSON-LD Utilities', () => {
       expect(meta.description).toContain('Ashwagandha is an adaptogenic herb.')
       expect(meta.description).toContain('Rated with strong')
       expect(meta.description).toContain('Review safety and drug interactions before use.')
-      expect(meta.alternates?.canonical).toBe('https://www.thehippiescientist.net/herbs/ashwagandha')
+      expect(meta.alternates?.canonical).toBe('https://thehippiescientist.net/herbs/ashwagandha')
     })
 
     it('generates correct metadata for a compound', () => {
@@ -43,7 +43,7 @@ describe('SEO Metadata & JSON-LD Utilities', () => {
 
       expect(meta.title).toContain('L Theanine')
       expect(meta.title).toContain('Evidence-Based Guide')
-      expect(meta.alternates?.canonical).toBe('https://www.thehippiescientist.net/compounds/l-theanine')
+      expect(meta.alternates?.canonical).toBe('https://thehippiescientist.net/compounds/l-theanine')
     })
 
     it('sets robots to noindex if record is not indexable', () => {

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -3,7 +3,7 @@ import { getRuntimeVisibility } from './runtime-visibility'
 import { cleanSummary, formatDisplayLabel, isClean, list, text, unique } from '@/lib/display-utils'
 import { getEvidenceLabel } from '@/lib/evidence'
 
-export const SITE_URL = 'https://www.thehippiescientist.net'
+export const SITE_URL = 'https://thehippiescientist.net'
 export const SITE_NAME = 'The Hippie Scientist'
 export const TWITTER_HANDLE = '@thehippiescientist'
 


### PR DESCRIPTION
### Motivation
- Resolve conflicting canonical host signals (www vs bare) by centralizing a single SITE_URL constant to avoid search-engine canonical confusion.
- Make sitemap lastModified fallbacks build-aware so static shell routes get realistic build-time dates instead of a stale hardcoded date.
- Suppress internal or noisy readiness/status labels like `developing · 45` from UI and ensure weak/placeholder labels are filtered consistently.
- Make the metadata-duplicates audit explicit about its grace threshold and include richer reporting for CI visibility.

### Description
- Export a single `SITE_URL` (bare `https://thehippiescientist.net`) in `lib/seo.ts` and `src/lib/seo.ts`, and update consumers to import and use `SITE_URL` instead of local host constants or hardcoded strings in `app/sitemap.ts`, `app/layout.tsx`, `app/robots.ts`, `app/herbs/[slug]/page.tsx`, `app/compounds/[slug]/page.tsx`, `app/goals/[goal]/page.tsx`, `app/stacks/[slug]/page.tsx`, `app/blog/[slug]/page.tsx`, `app/blog/categories/page.tsx`, `app/blog/tags/page.tsx`, and related pages and tests.
- Replace the sitemap fallback `new Date('2026-04-01')` with a build-aware fallback that prefers `SOURCE_DATE_EPOCH`, then `process.env.BUILD_TIME`, then the build-time clock, and add explanatory comments in `app/sitemap.ts`.
- Extend `WEAK_PATTERN` to include `developing` in both `app/herbs/[slug]/page.tsx` and `app/compounds/[slug]/page.tsx` so editorial placeholders are filtered consistently.
- Add `formatAuthorityReadinessLabel` and a small type alias in `lib/authority-profile.ts` and update `components/authority/AuthorityProfileShell.tsx` to render a human-friendly readiness badge instead of raw enum + score, removing outputs like `developing · 45`.
- Tighten `scripts/ci/audit-metadata-duplicates.mjs` by introducing `DUPLICATE_TITLE_BLOCK_THRESHOLD` with a comment, emitting a `summary` and a sample of duplicate descriptions into the JSON report, and logging a sample to the console.
- Update `src/lib/__tests__/seo.test.ts` to expect the bare-domain canonical URLs.
- Commits made (one per task): `Unify canonical site URL`, `Use build-aware sitemap dates`, `Sanitize authority readiness labels`, `Clarify metadata duplicate threshold`.

### Testing
- Ran domain search to verify canonical usage with: `grep -rn 'thehippiescientist.net' --include='*.ts' --include='*.tsx' --include='*.mjs' .` and confirmed source code now imports/uses `SITE_URL` and no longer contains `www.thehippiescientist.net` as the canonical in the edited TS/TSX sources (remaining literal occurrences are in generated/public artifacts or unrelated text).
- Type checking: `npm run typecheck` executed and completed without errors, output included the `tsc --noEmit` invocation and no failures.
- Linting: `npm run lint` executed and completed without warnings (ran `eslint . --max-warnings=0`) and returned successfully.
- Build verification: `if [ -d out ]; then npm run verify:build; else echo 'out missing; skipping npm run verify:build'; fi` reported `out missing; skipping npm run verify:build` so `npm run verify:build` was skipped per the validation order.
- All automated checks above passed or were intentionally skipped per instructions; no further failures were observed in the recorded outputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19b4212ef08323b2490d48f608c564)